### PR TITLE
ci: auto-update-branches uses PAT so merges trigger CI

### DIFF
--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
+          # Use a PAT (not the default GITHUB_TOKEN) so the resulting merge
+          # commit is authored under the bot account's identity instead of
+          # `github-actions[bot]`. GitHub silently suppresses workflow runs
+          # for any commit pushed by GITHUB_TOKEN to prevent recursion, so
+          # auto-updated PRs were ending up with empty CI rollups (no
+          # pull_request event fires for the merge SHA). The PAT bypasses
+          # that protection.
+          github-token: ${{ secrets.WEBSITE_REPO_TOKEN }}
           script: |
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
GitHub silently suppresses workflow runs for any commit pushed by the default `GITHUB_TOKEN` (recursion-prevention). The 6-hourly Auto Update PR Branches job calls `pulls.updateBranch`, which produces a merge commit authored as `github-actions[bot]`; that commit's push event never fires `on: pull_request`, so the PR's CI rollup ends up empty even though the branch is up to date with main.

## Repro / evidence
PRs #4126, #4127, #4129, #4131 all share head SHAs from the 2026-04-29T19:05:22-27Z auto-update window — every one has a `Merge branch 'main'` head commit authored by `github-actions[bot]` and **zero** check runs (`gh api ...check-runs` returns `total_count: 0`).

## Fix
Pass `WEBSITE_REPO_TOKEN` as `github-token` to the `actions/github-script` step. The merge commit is then authored by the PAT owner, the recursion guard does not apply, and `pull_request` CI fires.

## Test plan
- [ ] Manually `workflow_dispatch` Auto Update PR Branches once on main after merge
- [ ] Pick any open PR that gets re-updated and confirm its CI rollup populates this time
- [ ] Confirm WEBSITE_REPO_TOKEN has `repo:write` scope on librefang/librefang (otherwise updateBranch 403s and we'll revert)