### PR TITLE
fix(memory): switch stamps.last() to next_back() to satisfy clippy

### DIFF
--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -581,7 +581,12 @@ impl SessionStore {
                 let duration_ms: Option<i64> = {
                     let mut stamps = messages.iter().filter_map(|m| m.timestamp);
                     let first = stamps.next();
-                    let last = stamps.last().or(first);
+                    // next_back() on the same iterator instead of last(): the
+                    // adapter is DoubleEndedIterator (Vec::iter + filter_map),
+                    // so walking from the tail finds the latest stamped
+                    // message in O(k) rather than scanning every remaining
+                    // element. clippy::double_ended_iterator_last enforces.
+                    let last = stamps.next_back().or(first);
                     match (first, last) {
                         (Some(a), Some(b)) if b > a => Some((b - a).num_milliseconds()),
                         _ => None,


### PR DESCRIPTION
## Summary
- Fixes the regression introduced by #4141: \`stamps.last()\` on \`messages.iter().filter_map(|m| m.timestamp)\` triggers \`clippy::double_ended_iterator_last\` under \`-D warnings\`. CI's Quality job hard-fails, taking out every PR that has synced against main.
- Use \`next_back()\` — the iterator chain is DoubleEndedIterator (Vec iter + filter_map), so we get the last stamped message in O(k) without scanning the tail.

## Why it slipped through
PR #4141's own Quality job was FAILURE at merge time, but the PR was merged anyway. Local \`cargo clippy -p librefang-memory -p librefang-kernel\` did not catch it because the lint fires only under \`--all-targets --all-features\` (the CI config).

## Test plan
- [x] \`RUSTFLAGS=-D warnings cargo clippy --all-targets --all-features -- -D warnings\` passes locally
- [ ] Quality CI green on this PR
- [ ] After merge, downstream PRs that previously failed Quality clear once they re-sync (auto-update workflow handles this)