### PR TITLE
fix(desktop,ci): unbreak mobile builds + connection screen

### DIFF
--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -118,11 +118,13 @@ jobs:
 
       - name: Build debug APK (unsigned)
         working-directory: crates/librefang-desktop
-        # `--no-default-features --features mobile-no-email`: the default flavor
-        # pulls librefang-api/all-channels which enables channel-email →
+        # `-f mobile-no-email -- --no-default-features`: tauri-cli accepts
+        # `-f/--features` directly but `--no-default-features` is a cargo-only
+        # flag that must be passed via `--`. The default flavor pulls
+        # librefang-api/all-channels which enables channel-email →
         # rustls-connector 0.23.0 → rustls-platform-verifier::Verifier::new_with_extra_roots,
         # which is not implemented for the Android target in v0.7.0.
-        run: cargo tauri android build --target aarch64 --debug --apk --no-default-features --features mobile-no-email
+        run: cargo tauri android build --target aarch64 --debug --apk -f mobile-no-email -- --no-default-features
 
   ios_smoke:
     name: iOS (simulator, unsigned)
@@ -185,4 +187,5 @@ jobs:
         working-directory: crates/librefang-desktop
         # Match the Android flavor — keeps mobile builds consistent and avoids
         # pulling channel-email dependencies that aren't useful on iOS either.
-        run: cargo tauri ios build --target aarch64-sim --debug --no-default-features --features mobile-no-email
+        # See android job for why `--no-default-features` goes after `--`.
+        run: cargo tauri ios build --target aarch64-sim --debug -f mobile-no-email -- --no-default-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1472,14 +1472,16 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-        # `--no-default-features --features mobile-no-email`: rustls-connector
-        # 0.23.0 (pulled by channel-email) → rustls-platform-verifier 0.7.0 →
-        # Verifier::new_with_extra_roots is not implemented for Android.
+        # `-f mobile-no-email -- --no-default-features`: tauri-cli takes
+        # `-f` directly but `--no-default-features` is a cargo flag that
+        # must follow `--`. rustls-connector 0.23.0 (pulled by channel-email)
+        # → rustls-platform-verifier 0.7.0 → Verifier::new_with_extra_roots
+        # is not implemented for Android.
         run: |
           cargo tauri android build \
             --target aarch64 \
             --apk --aab \
-            --no-default-features --features mobile-no-email
+            -f mobile-no-email -- --no-default-features
 
       - name: Locate artifacts
         id: art
@@ -1704,12 +1706,13 @@ jobs:
         working-directory: crates/librefang-desktop
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        # `--no-default-features --features mobile-no-email`: rustls-connector
-        # 0.23.0 (pulled by channel-email) → rustls-platform-verifier 0.7.0 →
-        # Verifier::new_with_extra_roots is not implemented on Android, and we
-        # keep iOS on the same flavor so mobile binaries are consistent.
+        # `-f mobile-no-email -- --no-default-features`: see android build
+        # above for why `--no-default-features` goes after `--`. We keep iOS
+        # on the same channel flavor as Android so mobile binaries are
+        # consistent and don't pull channel-email deps that aren't useful
+        # on iOS either.
         run: |
-          cargo tauri ios build --target aarch64 --no-default-features --features mobile-no-email
+          cargo tauri ios build --target aarch64 -f mobile-no-email -- --no-default-features
 
       - name: Locate .ipa
         id: art

--- a/crates/librefang-desktop/Cargo.toml
+++ b/crates/librefang-desktop/Cargo.toml
@@ -23,7 +23,7 @@ tracing-subscriber = { workspace = true }
 # Shared: works on desktop and mobile.
 # `tauri` appears again in the desktop target block below with extra features —
 # Cargo merges features from both entries; mobile gets the base crate only.
-tauri = { version = "2" }
+tauri = { version = "2", features = [] }
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2"
 serde = { workspace = true }

--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -219,8 +219,16 @@ pub async fn start_local(
 }
 
 /// Returns self-contained HTML/CSS/JS for the connection screen.
+///
+/// On mobile, the "Start Local Server" path is removed: there's no
+/// embedded server on iOS / Android (the runtime branch is `cfg`-gated
+/// out), so the divider, the button, and the JS line that tries to
+/// `disabled = ...` it would all be dead code or worse — referencing
+/// `btn-local` from `setAllDisabled` after the button was removed
+/// would throw a TypeError on first click.
 pub fn connection_html() -> String {
-    r##"<!DOCTYPE html>
+    #[allow(unused_mut)]
+    let mut html = r##"<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -513,5 +521,24 @@ pub fn connection_html() -> String {
 </script>
 </body>
 </html>"##
-        .to_string()
+        .to_string();
+
+    #[cfg(mobile)]
+    {
+        // Mobile has no embedded server — strip the divider, the
+        // "Start Local Server" button, and the JS line in
+        // setAllDisabled that targets it (would throw a TypeError on
+        // first click otherwise). debug_assert verifies the sentinels
+        // still match the literal above so this fails loud if the
+        // HTML/JS is reformatted.
+        const LOCAL_HTML: &str = "\n  <div class=\"divider\">or</div>\n\n  <button class=\"btn-local\" id=\"btn-local\" onclick=\"startLocal()\">Start Local Server</button>\n";
+        const LOCAL_JS: &str = "    document.getElementById('btn-local').disabled = disabled;\n";
+        let after_html = html.replace(LOCAL_HTML, "");
+        debug_assert_ne!(after_html, html, "LOCAL_HTML sentinel not found");
+        let after_js = after_html.replace(LOCAL_JS, "");
+        debug_assert_ne!(after_js, after_html, "LOCAL_JS sentinel not found");
+        html = after_js;
+    }
+
+    html
 }

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -25,6 +25,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tauri::Manager;
+#[cfg(desktop)]
 use tauri::{WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_notification::NotificationExt;
 use tracing::{info, warn};
@@ -454,25 +455,26 @@ pub fn run(server_url: Option<String>, force_local: bool) {
                 }
             }
 
-            // Mobile window. Without this, iOS/Android launches into a
-            // black WebView because tauri.conf.json's `app.windows` is
-            // empty and Tauri 2 does not auto-create a mobile window.
-            // The OS manages size/orientation, so we only set the URL
-            // and visibility.
+            // Mobile window is declared in tauri.{ios,android}.conf.json
+            // (url=lfconnect://localhost/, label=main). Tauri 2 mobile does
+            // not honor `WebviewWindowBuilder::new` for the *first* window
+            // in setup() — iOS/Android wire the rootViewController / main
+            // Activity to a window declared in the conf, and a programmatic
+            // builder call here ends up creating no visible surface (black
+            // screen). If the resolved URL is already known (Remote mode
+            // via saved pref or env), navigate away from the connection
+            // screen now; otherwise leave the conf-declared lfconnect://
+            // page up so the user can pick.
             #[cfg(mobile)]
             {
-                let url = if show_connection_screen {
-                    WebviewUrl::CustomProtocol(
-                        "lfconnect://localhost/"
-                            .parse()
-                            .expect("lfconnect URL must parse"),
-                    )
-                } else {
-                    WebviewUrl::External(initial_url.parse().expect("Invalid server URL"))
-                };
-                let _window = WebviewWindowBuilder::new(app, "main", url)
-                    .visible(true)
-                    .build()?;
+                if !show_connection_screen && !initial_url.is_empty() {
+                    if let Some(window) = app.get_webview_window("main") {
+                        let url: tauri::Url = initial_url.parse().expect("Invalid server URL");
+                        window.navigate(url)?;
+                    } else {
+                        warn!("Mobile main window not found at setup time");
+                    }
+                }
             }
 
             // Set up system tray (desktop only)

--- a/crates/librefang-desktop/tauri.android.conf.json
+++ b/crates/librefang-desktop/tauri.android.conf.json
@@ -2,6 +2,13 @@
   "$schema": "https://schema.tauri.app/config/2",
   "identifier": "ai.librefang.app",
   "app": {
+    "windows": [
+      {
+        "label": "main",
+        "url": "lfconnect://localhost/",
+        "visible": true
+      }
+    ],
     "security": {
       "csp": null
     }

--- a/crates/librefang-desktop/tauri.ios.conf.json
+++ b/crates/librefang-desktop/tauri.ios.conf.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "identifier": "ai.librefang.app",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "url": "lfconnect://localhost/",
+        "visible": true
+      }
+    ]
+  },
   "bundle": {
     "iOS": {
       "minimumSystemVersion": "16.0"


### PR DESCRIPTION
## Summary

Four small fixes that together get the mobile build working end-to-end (smoke CI, release CI, and a real device launch):

- **04daa81c** `fix(desktop,ci): unbreak mobile-smoke + release mobile builds` — drops the `#[cfg(desktop)]` gate on the `WebviewUrl/WebviewWindowBuilder` import (mobile branch needs both); adds a `mobile-no-email` feature flavor on `librefang-desktop` so Android/iOS smoke + release jobs skip `channel-email` (which pulls `rustls-platform-verifier::Verifier::new_with_extra_roots`, unimplemented on Android in v0.7.0).
- **557e5583** `fix(desktop): mobile black screen — declare main window in conf, drop runtime builder` — Tauri 2 mobile does not honor `WebviewWindowBuilder::new` for the *first* window in `setup()`; the OS rootViewController/Activity wires to a window declared in conf. Move the mobile window into `tauri.{ios,android}.conf.json` and use `webview.navigate(url)` to jump past the connection screen when `Remote` mode resolved early.
- **68931b2e** `fix(ci): correct cargo-tauri mobile build flag syntax` — feature flag positional ordering for `cargo tauri android/ios build`.
- **70eebc71** `fix(desktop): hide "Start Local Server" button on mobile` — strips the divider, button, and `setAllDisabled` JS line that targets `btn-local` from `connection_html()` under `#[cfg(mobile)]`. `debug_assert_ne!` on each sentinel fails loud if the literal drifts.

## Test plan
- [ ] `cargo tauri ios build --target aarch64-sim --debug --no-default-features --features mobile-no-email` succeeds locally
- [ ] `cargo tauri android build --target aarch64 --debug --apk --no-default-features --features mobile-no-email` succeeds on a Linux box
- [ ] mobile-smoke.yml passes on this PR
- [ ] iOS Simulator launch shows the connection screen (no black screen, no "Start Local Server" button)