### PR TITLE
feat(dashboard): mobile bottom-tab nav + adapt Overview/Agents/Chat/Approvals

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -689,6 +689,52 @@ function SidebarUserBlock({
   );
 }
 
+// Mobile bottom-tab nav. Mirrors the design canvas
+// (`shell.jsx::BottomTabs` + `data.jsx::MOBILE_TABS`): five primary tabs,
+// the fifth (`More`) opens the full nav drawer.
+const MOBILE_TAB_ITEMS = [
+  { to: "/overview", labelKey: "nav.overview", icon: Home },
+  { to: "/agents", labelKey: "nav.agents", icon: Users },
+  { to: "/chat", labelKey: "nav.chat", icon: MessageCircle },
+  { to: "/approvals", labelKey: "nav.approvals", icon: CheckCircle },
+] as const;
+
+function MobileBottomTabs({ onMore }: { onMore: () => void }) {
+  const { t } = useTranslation();
+  return (
+    <nav
+      className="flex shrink-0 border-t border-border-subtle bg-surface/95 backdrop-blur-md lg:hidden"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      aria-label={t("nav.mobile_tabs", { defaultValue: "Bottom navigation" })}
+    >
+      {MOBILE_TAB_ITEMS.map((tab) => {
+        const Icon = tab.icon;
+        return (
+          <Link
+            key={tab.to}
+            to={tab.to}
+            activeOptions={{ exact: false, includeSearch: false }}
+            activeProps={{ "aria-current": "page" }}
+            className="group relative flex flex-1 flex-col items-center justify-center gap-1 py-2 text-text-dim transition-colors aria-[current=page]:text-brand active:bg-surface-hover/40"
+          >
+            <span className="absolute top-0 left-1/2 h-0.5 w-6 -translate-x-1/2 rounded-full bg-brand opacity-0 shadow-[0_0_6px_currentColor] group-aria-[current=page]:opacity-100 transition-opacity" />
+            <Icon className="h-5 w-5" aria-hidden="true" />
+            <span className="text-[10px] font-medium leading-none">{t(tab.labelKey)}</span>
+          </Link>
+        );
+      })}
+      <button
+        type="button"
+        onClick={onMore}
+        className="flex flex-1 flex-col items-center justify-center gap-1 py-2 text-text-dim transition-colors active:bg-surface-hover/40"
+      >
+        <Menu className="h-5 w-5" aria-hidden="true" />
+        <span className="text-[10px] font-medium leading-none">{t("nav.more", { defaultValue: "More" })}</span>
+      </button>
+    </nav>
+  );
+}
+
 // Routes that must fill the remaining viewport height without scrolling.
 const FULL_HEIGHT_ROUTES = new Set(["/terminal"]);
 
@@ -1201,6 +1247,7 @@ export function App() {
             )}
           </AnimatePresence>
         </main>
+        <MobileBottomTabs onMore={() => setMobileMenuOpen(true)} />
       </div>
 
       {!isNoAuthRoute && <OfflineBanner />}

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -48,7 +48,9 @@
     "expand_sidebar": "Expand sidebar",
     "collapse_sidebar": "Collapse sidebar",
     "open_menu": "Open navigation menu",
-    "skip_to_content": "Skip to content"
+    "skip_to_content": "Skip to content",
+    "more": "More",
+    "mobile_tabs": "Bottom navigation"
   },
   "common": {
     "copied": "Copied",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -48,7 +48,9 @@
     "expand_sidebar": "展开侧边栏",
     "collapse_sidebar": "折叠侧边栏",
     "open_menu": "打开导航菜单",
-    "skip_to_content": "跳转到内容"
+    "skip_to_content": "跳转到内容",
+    "more": "更多",
+    "mobile_tabs": "底部导航"
   },
   "common": {
     "copied": "已复制",

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -739,10 +739,20 @@ export function AgentsPage() {
     ];
 
     return (
-      <Card padding="none" className="surface-lit overflow-hidden flex flex-col min-h-[640px]">
+      <Card padding="none" className="surface-lit overflow-hidden flex flex-col min-h-0 lg:min-h-[640px] h-full lg:h-auto">
         {/* Header */}
-        <div className="px-5 pt-4 pb-3 border-b border-border-subtle">
-          <div className="flex items-center gap-3">
+        <div className="px-3 sm:px-5 pt-3 sm:pt-4 pb-3 border-b border-border-subtle">
+          <div className="flex items-center gap-2 sm:gap-3">
+            {/* Mobile-only "back to list" affordance — closes the detail
+                overlay without deselecting state for lg+. */}
+            <button
+              type="button"
+              onClick={() => setDetailAgent(null)}
+              className="lg:hidden -ml-1 p-1.5 rounded-md text-text-dim hover:text-text-main hover:bg-main/40 shrink-0"
+              aria-label={t("common.back", { defaultValue: "Back" })}
+            >
+              <X className="w-4 h-4" />
+            </button>
             <div className="w-9 h-9 rounded-lg bg-brand/10 border border-brand/30 grid place-items-center text-brand shrink-0">
               <Bot className="w-[18px] h-[18px]" />
             </div>
@@ -765,26 +775,49 @@ export function AgentsPage() {
                 {(agent as AgentView).profile ? ` · ${(agent as AgentView).profile}` : ""}
               </p>
             </div>
-            <div className="flex items-center gap-1.5 shrink-0">
+            {/* Action cluster — labels collapse on mobile so the row keeps
+                three icon-buttons + back arrow on a 390px viewport. */}
+            <div className="flex items-center gap-1 sm:gap-1.5 shrink-0">
               {isSuspended ? (
-                <Button variant="ghost" size="sm" leftIcon={<Play className="w-3.5 h-3.5" />} onClick={async () => {
-                  try { await resumeMutation.mutateAsync(agent.id); } catch (e) {
-                    addToast(toastErr(e, t("agents.resume_failed", { defaultValue: "Failed to resume agent" })), "error");
-                  }
-                }}>
-                  {t("agents.resume", { defaultValue: "Resume" })}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  leftIcon={<Play className="w-3.5 h-3.5" />}
+                  aria-label={t("agents.resume", { defaultValue: "Resume" })}
+                  title={t("agents.resume", { defaultValue: "Resume" })}
+                  onClick={async () => {
+                    try { await resumeMutation.mutateAsync(agent.id); } catch (e) {
+                      addToast(toastErr(e, t("agents.resume_failed", { defaultValue: "Failed to resume agent" })), "error");
+                    }
+                  }}
+                >
+                  <span className="hidden sm:inline">{t("agents.resume", { defaultValue: "Resume" })}</span>
                 </Button>
               ) : (
-                <Button variant="ghost" size="sm" leftIcon={<Pause className="w-3.5 h-3.5" />} onClick={async () => {
-                  try { await suspendMutation.mutateAsync(agent.id); } catch (e) {
-                    addToast(toastErr(e, t("agents.suspend_failed", { defaultValue: "Failed to suspend agent" })), "error");
-                  }
-                }}>
-                  {t("agents.suspend", { defaultValue: "Pause" })}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  leftIcon={<Pause className="w-3.5 h-3.5" />}
+                  aria-label={t("agents.suspend", { defaultValue: "Pause" })}
+                  title={t("agents.suspend", { defaultValue: "Pause" })}
+                  onClick={async () => {
+                    try { await suspendMutation.mutateAsync(agent.id); } catch (e) {
+                      addToast(toastErr(e, t("agents.suspend_failed", { defaultValue: "Failed to suspend agent" })), "error");
+                    }
+                  }}
+                >
+                  <span className="hidden sm:inline">{t("agents.suspend", { defaultValue: "Pause" })}</span>
                 </Button>
               )}
-              <Button variant="secondary" size="sm" leftIcon={<MessageCircle className="w-3.5 h-3.5" />} onClick={() => navigate({ to: "/chat", search: { agentId: agent.id } })}>
-                {t("common.interact", { defaultValue: "Chat" })}
+              <Button
+                variant="secondary"
+                size="sm"
+                leftIcon={<MessageCircle className="w-3.5 h-3.5" />}
+                aria-label={t("common.interact", { defaultValue: "Chat" })}
+                title={t("common.interact", { defaultValue: "Chat" })}
+                onClick={() => navigate({ to: "/chat", search: { agentId: agent.id } })}
+              >
+                <span className="hidden sm:inline">{t("common.interact", { defaultValue: "Chat" })}</span>
               </Button>
               <Button
                 variant="ghost"
@@ -838,7 +871,7 @@ export function AgentsPage() {
         </div>
 
         {/* Tab content */}
-        <div className="flex-1 overflow-y-auto px-5 py-4">
+        <div className="flex-1 overflow-y-auto px-3 sm:px-5 py-3 sm:py-4">
           {renderTabContent(agent, isCrashed)}
         </div>
       </Card>
@@ -978,13 +1011,15 @@ export function AgentsPage() {
               return (
                 <div
                   key={r.id || `mem-${i}`}
-                  className="flex items-center gap-2.5 px-3 py-2 rounded-md border border-border-subtle bg-main/40"
+                  className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2.5 px-3 py-2 rounded-md border border-border-subtle bg-main/40"
                 >
-                  <span className="font-mono text-[12px] text-brand min-w-[180px] truncate shrink-0">{key}</span>
-                  <span className="font-mono text-[12px] text-text-dim flex-1 min-w-0 truncate">{valueText || "—"}</span>
-                  <span className="font-mono text-[10.5px] text-text-dim/70 shrink-0 tabular-nums">
-                    {r.created_at ? formatRelativeTime(r.created_at) : "—"}
-                  </span>
+                  <div className="flex items-center justify-between gap-2 sm:contents">
+                    <span className="font-mono text-[12px] text-brand sm:min-w-[180px] truncate sm:shrink-0 min-w-0">{key}</span>
+                    <span className="font-mono text-[10.5px] text-text-dim/70 sm:order-3 sm:shrink-0 tabular-nums shrink-0">
+                      {r.created_at ? formatRelativeTime(r.created_at) : "—"}
+                    </span>
+                  </div>
+                  <span className="font-mono text-[12px] text-text-dim sm:flex-1 min-w-0 truncate sm:order-2">{valueText || "—"}</span>
                 </div>
               );
             })}
@@ -1203,13 +1238,13 @@ export function AgentsPage() {
           </div>
         ) : (
           <div
-            className="rounded-md border border-border-subtle p-3 font-mono text-[11.5px] leading-[1.6] max-h-60 overflow-y-auto"
+            className="rounded-md border border-border-subtle p-3 font-mono text-[11.5px] leading-[1.6] max-h-60 overflow-auto -mx-3 sm:mx-0"
             style={{ background: "rgba(2,6,23,0.6)" }}
           >
             {filtered.map((row, i) => {
               const lv = levelOf(row);
               return (
-                <div key={i} className="flex gap-2.5">
+                <div key={i} className="flex gap-2.5 min-w-max sm:min-w-0">
                   <span className="text-text-dim/60 shrink-0">{fmtTime(row.timestamp)}</span>
                   <span className={`${levelColor(lv)} w-12 shrink-0`}>{lv}</span>
                   <span className="text-accent w-24 shrink-0 truncate">{row.action || "—"}</span>
@@ -1242,9 +1277,15 @@ export function AgentsPage() {
         </Button>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[360px_1fr] gap-4 min-h-[640px]">
-        {/* Left list panel — search + filter pills + sort + scroll body. */}
-        <Card padding="none" className="surface-lit overflow-hidden flex flex-col h-[calc(100vh-200px)] min-h-[480px]">
+      <div className="grid grid-cols-1 lg:grid-cols-[360px_1fr] gap-4 lg:min-h-[640px]">
+        {/* Left list panel — search + filter pills + sort + scroll body.
+            On mobile the list owns the viewport; the detail panel is
+            promoted to a full-screen overlay (see below) so we never
+            stack two scrollers on a 390px phone. */}
+        <Card
+          padding="none"
+          className={`surface-lit overflow-hidden flex flex-col h-[calc(100vh-200px)] min-h-[480px] ${detailAgent ? "hidden lg:flex" : "flex"}`}
+        >
           <div className="px-3 pt-3 pb-2.5 border-b border-border-subtle flex flex-col gap-2 flex-shrink-0">
             <Input
               value={search}
@@ -1339,11 +1380,20 @@ export function AgentsPage() {
           </div>
         </Card>
 
-        {/* Right detail panel — header + KPI tiles + 5 tabs. */}
+        {/* Right detail panel — header + KPI tiles + 5 tabs.
+            Mobile: rendered as a fixed full-viewport overlay above the
+            list (top inset 0, bottom inset 14 reserves the global tab
+            bar's ~56px so it never gets covered). lg+: collapses back
+            into the master-detail grid. */}
         {detailAgent ? (
-          renderDetailPanel(detailAgent)
+          <div className="fixed inset-x-0 top-0 bottom-14 z-30 bg-surface lg:static lg:inset-auto lg:bottom-auto lg:z-auto lg:bg-transparent overflow-hidden flex flex-col">
+            {renderDetailPanel(detailAgent)}
+          </div>
         ) : (
-          <Card padding="lg" className="surface-lit grid place-items-center text-center min-h-[480px]">
+          // Placeholder is desktop-only — on mobile the list fills the
+          // viewport when no agent is selected, so this empty-state would
+          // just be wasted vertical space.
+          <Card padding="lg" className="surface-lit hidden lg:grid place-items-center text-center min-h-[480px]">
             <div className="max-w-xs">
               <div className="w-12 h-12 mx-auto rounded-xl bg-brand/10 border border-brand/30 grid place-items-center text-brand mb-3">
                 <Bot className="w-6 h-6" />

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -1386,7 +1386,7 @@ export function AgentsPage() {
             bar's ~56px so it never gets covered). lg+: collapses back
             into the master-detail grid. */}
         {detailAgent ? (
-          <div className="fixed inset-x-0 top-0 bottom-14 z-30 bg-surface lg:static lg:inset-auto lg:bottom-auto lg:z-auto lg:bg-transparent overflow-hidden flex flex-col">
+          <div className="fixed inset-x-0 top-0 bottom-[calc(56px+env(safe-area-inset-bottom))] z-30 bg-surface lg:static lg:inset-auto lg:bottom-auto lg:z-auto lg:bg-transparent overflow-hidden flex flex-col">
             {renderDetailPanel(detailAgent)}
           </div>
         ) : (

--- a/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
@@ -36,7 +36,7 @@ type Tab = "pending" | "audit";
 type PendingTarget = { kind: "item"; id: string } | { kind: "batch" } | null;
 
 function tabClass(_tab: Tab, isActive: boolean) {
-  return `px-4 py-2 text-sm font-bold rounded-lg transition-colors ${
+  return `flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 px-4 py-2 text-sm font-bold rounded-lg transition-colors ${
     isActive
       ? "bg-brand/10 text-brand border border-brand/20"
       : "text-text-dim hover:text-text-main hover:bg-surface-hover border border-transparent"
@@ -132,13 +132,19 @@ function ModifyForm({
         rows={3}
         className="w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors resize-none"
       />
-      <div className="flex gap-2 justify-end">
-        <Button variant="ghost" size="sm" onClick={onDone}>
+      <div className="flex gap-2 lg:justify-end">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 justify-center"
+          onClick={onDone}
+        >
           {t("common.cancel", "Cancel")}
         </Button>
         <Button
           variant="primary"
           size="sm"
+          className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 justify-center"
           onClick={handleSubmit}
           disabled={modifyAndRetry.isPending || !feedback.trim()}
           isLoading={modifyAndRetry.isPending}
@@ -229,14 +235,15 @@ function AuditLogTab() {
       />
 
       {/* Pagination */}
-      <div className="flex items-center justify-between text-sm text-text-dim">
-        <span>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-sm text-text-dim">
+        <span className="text-center sm:text-left">
           {t("approvals.auditLog.showing", { from, to, total })}
         </span>
         <div className="flex gap-2">
           <Button
             variant="secondary"
             size="sm"
+            className="flex-1 sm:flex-initial min-h-[44px] sm:min-h-0"
             disabled={offset === 0}
             onClick={() => setOffset(Math.max(0, offset - AUDIT_PAGE_SIZE))}
             leftIcon={<ChevronLeft className="h-4 w-4" />}
@@ -246,6 +253,7 @@ function AuditLogTab() {
           <Button
             variant="secondary"
             size="sm"
+            className="flex-1 sm:flex-initial min-h-[44px] sm:min-h-0"
             disabled={offset + AUDIT_PAGE_SIZE >= total}
             onClick={() => setOffset(offset + AUDIT_PAGE_SIZE)}
             rightIcon={<ChevronRight className="h-4 w-4" />}
@@ -408,40 +416,51 @@ export function ApprovalsPage() {
         <div id="approvals-panel-pending" role="tabpanel" aria-labelledby="approvals-tab-pending">
           {/* Batch action bar */}
           {pendingApprovals.length > 0 && (
-            <div className="flex items-center gap-3 flex-wrap">
-              <label className="flex items-center gap-2 text-sm text-text-dim cursor-pointer select-none">
-                <input
-                  type="checkbox"
-                  checked={selected.size === pendingApprovals.length && pendingApprovals.length > 0}
-                  onChange={toggleSelectAll}
-                  className="h-4 w-4 rounded border-border-subtle text-brand focus:ring-brand/30 accent-[var(--color-brand)]"
-                />
-                {t("approvals.selectAll")}
-              </label>
-              {selected.size > 0 && (
-                <>
-                  <span className="text-xs text-text-dim">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:gap-3 lg:flex-wrap mb-4 lg:mb-0">
+              <div className="flex items-center justify-between gap-2">
+                <label className="flex items-center gap-2 text-sm text-text-dim cursor-pointer select-none min-h-[44px] lg:min-h-0">
+                  <input
+                    type="checkbox"
+                    checked={selected.size === pendingApprovals.length && pendingApprovals.length > 0}
+                    onChange={toggleSelectAll}
+                    className="h-5 w-5 lg:h-4 lg:w-4 rounded border-border-subtle text-brand focus:ring-brand/30 accent-[var(--color-brand)]"
+                  />
+                  {t("approvals.selectAll")}
+                </label>
+                {selected.size > 0 && (
+                  <span className="text-xs text-text-dim lg:hidden">
                     {t("approvals.selected", { count: selected.size })}
                   </span>
-                  <Button
-                    variant="success"
-                    size="sm"
-                    onClick={() => handleBatchAction("approve")}
-                    disabled={pendingTarget?.kind === "batch" || totpEnforced}
-                    isLoading={pendingTarget?.kind === "batch"}
-                    title={totpEnforced ? t("approvals.batch_disabled_totp") : undefined}
-                  >
-                    {t("approvals.approveSelected")}
-                  </Button>
-                  <Button
-                    variant="danger"
-                    size="sm"
-                    onClick={() => handleBatchAction("reject")}
-                    disabled={pendingTarget?.kind === "batch"}
-                    isLoading={pendingTarget?.kind === "batch"}
-                  >
-                    {t("approvals.rejectSelected")}
-                  </Button>
+                )}
+              </div>
+              {selected.size > 0 && (
+                <>
+                  <span className="hidden lg:inline text-xs text-text-dim">
+                    {t("approvals.selected", { count: selected.size })}
+                  </span>
+                  <div className="flex gap-2 lg:contents">
+                    <Button
+                      variant="success"
+                      size="sm"
+                      className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0"
+                      onClick={() => handleBatchAction("approve")}
+                      disabled={pendingTarget?.kind === "batch" || totpEnforced}
+                      isLoading={pendingTarget?.kind === "batch"}
+                      title={totpEnforced ? t("approvals.batch_disabled_totp") : undefined}
+                    >
+                      {t("approvals.approveSelected")}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0"
+                      onClick={() => handleBatchAction("reject")}
+                      disabled={pendingTarget?.kind === "batch"}
+                      isLoading={pendingTarget?.kind === "batch"}
+                    >
+                      {t("approvals.rejectSelected")}
+                    </Button>
+                  </div>
                 </>
               )}
             </div>
@@ -461,83 +480,103 @@ export function ApprovalsPage() {
               description={t("approvals.queue_clear_desc")}
             />
           ) : (
-            <div className="grid gap-4">
+            <div className="grid gap-3 lg:gap-4">
               {approvals.map((a) => {
                 const isPending = !a.status || a.status === "pending";
                 return (
-                  <Card key={a.id} hover padding="lg">
-                    <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
-                      <div className="min-w-0 flex-1 flex items-center gap-3">
+                  <Card key={a.id} hover padding="md">
+                    <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 lg:gap-6">
+                      <div className="min-w-0 flex-1 flex items-start lg:items-center gap-3">
                         {/* Checkbox for pending items */}
                         {isPending && (
                           <input
                             type="checkbox"
                             checked={selected.has(a.id)}
                             onChange={() => toggleSelect(a.id)}
-                            className="h-4 w-4 rounded border-border-subtle text-brand focus:ring-brand/30 shrink-0 accent-[var(--color-brand)]"
+                            className="h-5 w-5 lg:h-4 lg:w-4 mt-1 lg:mt-0 rounded border-border-subtle text-brand focus:ring-brand/30 shrink-0 accent-[var(--color-brand)]"
                           />
                         )}
                         <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${statusIconBg(a.status)}`}>
                           {statusIcon(a.status)}
                         </div>
-                        <div>
+                        <div className="min-w-0 flex-1">
                           {statusBadge(a.status, t)}
-                          <p className="mt-1 text-sm font-medium leading-relaxed">{a.action_summary || a.description || t("common.actions")}</p>
+                          <p className="mt-1 text-sm font-medium leading-relaxed break-words">{a.action_summary || a.description || t("common.actions")}</p>
                         </div>
                       </div>
                       {isPending ? (
-                        <div className="flex gap-2 shrink-0">
+                        <div className="grid grid-cols-2 gap-2 lg:flex lg:gap-2 lg:shrink-0">
                           <Button
                             variant="ghost"
                             size="sm"
+                            className="col-span-2 lg:col-auto min-h-[44px] lg:min-h-0 justify-center"
                             onClick={() => setModifyingId(modifyingId === a.id ? null : a.id)}
                             leftIcon={<MessageSquare className="h-3.5 w-3.5" />}
                           >
                             {t("approvals.modify")}
                           </Button>
-                          <Button variant="danger" size="sm" onClick={() => handleDecision(a.id, "reject")} disabled={pendingTarget?.kind === "item" && pendingTarget.id === a.id}>
+                          <Button
+                            variant="danger"
+                            size="sm"
+                            className="min-h-[44px] lg:min-h-0 justify-center"
+                            onClick={() => handleDecision(a.id, "reject")}
+                            disabled={pendingTarget?.kind === "item" && pendingTarget.id === a.id}
+                          >
                             {t("approvals.reject")}
                           </Button>
-                          <Button variant="success" size="sm" onClick={() => handleDecision(a.id, "approve")} disabled={pendingTarget?.kind === "item" && pendingTarget.id === a.id}>
+                          <Button
+                            variant="success"
+                            size="sm"
+                            className="min-h-[44px] lg:min-h-0 justify-center"
+                            onClick={() => handleDecision(a.id, "approve")}
+                            disabled={pendingTarget?.kind === "item" && pendingTarget.id === a.id}
+                          >
                             {t("approvals.approve")}
                           </Button>
                         </div>
                       ) : (
-                        <div className="text-sm text-text-dim shrink-0">
+                        <div className="text-sm text-text-dim lg:shrink-0">
                           {t(`approvals.status.${a.status}`)}
                         </div>
                       )}
                     </div>
                     {/* TOTP prompt */}
                     {totpPromptId === a.id && isPending && (
-                      <div className="mt-3 flex items-center gap-2">
-                        <input
-                          type="text"
-                          maxLength={9}
-                          value={totpInput}
-                          onChange={(e) => setTotpInput(e.target.value.replace(/[^0-9-]/g, "").slice(0, 9))}
-                          placeholder={t("approvals.totpPlaceholder", { defaultValue: "000000 / 0000-0000" })}
-                          className="w-40 rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono tracking-widest text-center focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors"
-                          autoFocus
-                          onKeyDown={(e) => e.key === "Enter" && handleTotpSubmit()}
-                        />
-                        <Button
-                          variant="success"
-                          size="sm"
-                          onClick={handleTotpSubmit}
-                          disabled={!isValidTotpOrRecovery(totpInput) || (pendingTarget?.kind === "item" && pendingTarget.id === a.id)}
-                          isLoading={pendingTarget?.kind === "item" && pendingTarget.id === a.id}
-                        >
-                          {t("approvals.approve")}
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => { setTotpPromptId(null); setTotpInput(""); }}
-                        >
-                          {t("common.cancel", "Cancel")}
-                        </Button>
-                        <span className="text-xs text-text-dim">{t("approvals.totpLabel", { defaultValue: "TOTP" })}</span>
+                      <div className="mt-3 flex flex-col lg:flex-row lg:items-center gap-2">
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="text"
+                            maxLength={9}
+                            value={totpInput}
+                            onChange={(e) => setTotpInput(e.target.value.replace(/[^0-9-]/g, "").slice(0, 9))}
+                            placeholder={t("approvals.totpPlaceholder", { defaultValue: "000000 / 0000-0000" })}
+                            className="flex-1 lg:flex-initial lg:w-40 min-h-[44px] lg:min-h-0 rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono tracking-widest text-center focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors"
+                            autoFocus
+                            onKeyDown={(e) => e.key === "Enter" && handleTotpSubmit()}
+                          />
+                          <span className="text-xs text-text-dim lg:hidden">{t("approvals.totpLabel", { defaultValue: "TOTP" })}</span>
+                        </div>
+                        <div className="flex gap-2">
+                          <Button
+                            variant="success"
+                            size="sm"
+                            className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 justify-center"
+                            onClick={handleTotpSubmit}
+                            disabled={!isValidTotpOrRecovery(totpInput) || (pendingTarget?.kind === "item" && pendingTarget.id === a.id)}
+                            isLoading={pendingTarget?.kind === "item" && pendingTarget.id === a.id}
+                          >
+                            {t("approvals.approve")}
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 justify-center"
+                            onClick={() => { setTotpPromptId(null); setTotpInput(""); }}
+                          >
+                            {t("common.cancel", "Cancel")}
+                          </Button>
+                        </div>
+                        <span className="hidden lg:inline text-xs text-text-dim">{t("approvals.totpLabel", { defaultValue: "TOTP" })}</span>
                       </div>
                     )}
                     {/* Modify form */}

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -21,7 +21,7 @@ import { agentKeys, approvalKeys } from "../lib/queries/keys";
 import { groupedPicker } from "../lib/chatPicker";
 import { normalizeToolOutput } from "../lib/chat";
 import { useTtsManager } from "../lib/tts";
-import { MessageCircle, Send, Square, Bot, User, RefreshCw, AlertCircle, Wifi, Sparkles, X, ArrowRight, ArrowLeft, Zap, ShieldAlert, CheckCircle, XCircle, Clock, Plus, Trash2, ChevronDown, Loader2, Copy, Volume2, Pause, Download, Brain, Eye, EyeOff, Mic, MicOff, Globe, Paperclip, FileText } from "lucide-react";
+import { MessageCircle, Send, Square, Bot, User, RefreshCw, AlertCircle, Wifi, Sparkles, X, ArrowRight, ArrowLeft, Zap, ShieldAlert, CheckCircle, XCircle, Clock, Plus, Trash2, ChevronDown, Loader2, Copy, Volume2, Pause, Download, Brain, Eye, EyeOff, Mic, MicOff, Globe, Paperclip, FileText, Menu } from "lucide-react";
 import { Badge } from "../components/ui/Badge";
 import { MarkdownContent } from "../components/ui/MarkdownContent";
 import { useUIStore } from "../lib/store";
@@ -1827,7 +1827,7 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
 }
 
 // Connection status bar with session dropdown
-function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, wsConnected, modelName, modelProvider, sessions, activeSessionId, onSwitchSession, onNewSession, onDeleteSession, agentId, isHand, onModelChange, webSearchAugmentation, onWebSearchChange, webSearchAvailable, onOpenConfig, attached, attachedEventCount }: {
+function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, wsConnected, modelName, modelProvider, sessions, activeSessionId, onSwitchSession, onNewSession, onDeleteSession, agentId, isHand, onModelChange, webSearchAugmentation, onWebSearchChange, webSearchAvailable, onOpenConfig, attached, attachedEventCount, onOpenMobileSheet }: {
   agentName: string; isLoading: boolean; messageCount: number; onClear: () => void; onExport: () => void; wsConnected?: boolean; modelName?: string; modelProvider?: string;
   sessions?: SessionListItem[]; activeSessionId?: string;
   onSwitchSession?: (sessionId: string) => void; onNewSession?: () => void; onDeleteSession?: (sessionId: string) => void;
@@ -1846,6 +1846,8 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
   attached?: boolean;
   /** Number of SSE events received on the attach stream (for operator visibility). */
   attachedEventCount?: number;
+  /** Mobile-only — opens the agent/session picker sheet. */
+  onOpenMobileSheet?: () => void;
 }) {
   const { t } = useTranslation();
   const [sessionOpen, setSessionOpen] = useState(false);
@@ -1975,11 +1977,21 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
   return (
     <div className="px-2 sm:px-4 py-2 sm:py-2.5 border-b border-border-subtle/50 bg-linear-to-r from-surface to-transparent flex items-center justify-between">
       <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
-        <div className="relative">
+        {onOpenMobileSheet && (
+          <button
+            type="button"
+            onClick={onOpenMobileSheet}
+            className="lg:hidden -ml-0.5 inline-flex h-8 w-8 items-center justify-center rounded-lg text-text-dim hover:text-brand hover:bg-surface-hover transition-colors shrink-0"
+            aria-label={t("chat.open_agent_picker", { defaultValue: "Open agent picker" })}
+          >
+            <Menu className="h-4 w-4" />
+          </button>
+        )}
+        <div className="relative hidden lg:block">
           <Wifi className="h-3.5 w-3.5 text-success" />
           <span className="absolute inset-0 rounded-full bg-success/30 animate-pulse" />
         </div>
-        <span className="text-xs font-semibold text-success uppercase tracking-wide hidden sm:inline">{t("chat.secure_link")}</span>
+        <span className="text-xs font-semibold text-success uppercase tracking-wide hidden lg:inline">{t("chat.secure_link")}</span>
         {wsConnected && (
           <Badge variant="brand" dot>
             <Zap className="h-2.5 w-2.5 mr-0.5" />
@@ -1995,8 +2007,8 @@ function ConnectionBar({ agentName, isLoading, messageCount, onClear, onExport, 
               : ""}
           </Badge>
         )}
-        <span className="text-text-dim/30 hidden sm:inline">&bull;</span>
-        <span className="text-xs font-medium text-text-dim truncate">{agentName}</span>
+        <span className="text-text-dim/30 hidden lg:inline">&bull;</span>
+        <span className="text-xs font-semibold text-text-main truncate">{agentName}</span>
         {isLoading && (
           <span className="ml-2 px-2 py-0.5 rounded-full bg-brand/10 text-brand text-[10px] font-medium animate-pulse">
             {wsConnected ? t("chat.ws_streaming") : t("chat.generating")}
@@ -2399,6 +2411,8 @@ export function ChatPage() {
   // Message windowing: render only the last N messages to avoid DOM bloat in
   // long sessions. The user can load earlier messages with the button above.
   const [visibleCount, setVisibleCount] = useState(50);
+  // Mobile-only: agent picker / session list slide-in sheet visibility.
+  const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
   const addToast = useUIStore((s) => s.addToast);
   const createSessionMutation = useCreateAgentSession();
   // NOTE: switch_agent_session is no longer called from ChatPage — see issue
@@ -2413,6 +2427,7 @@ export function ChatPage() {
   const selectAgent = useCallback((id: string) => {
     setSelectedAgentId(id);
     setVisibleCount(50);
+    setMobileSheetOpen(false);
     navigate({ to: "/chat", search: { agentId: id }, replace: true });
   }, [navigate]);
 
@@ -2761,27 +2776,28 @@ export function ChatPage() {
   );
 
   return (
-    <div className="flex h-[calc(100vh-100px)] sm:h-[calc(100vh-140px)] flex-col">
+    <div className="flex h-[calc(100dvh-180px)] lg:h-[calc(100vh-140px)] flex-col min-h-0">
       {/* Bug #3849: two separate aria-live regions so WS state changes and
           new-message announcements are each surfaced independently — a single
           region with `||` would silence msgAriaAnnouncement whenever the WS
           connection string is non-empty. */}
       <div key={ariaNonce} aria-live="polite" aria-atomic="true" className="sr-only">{ariaAnnouncement}</div>
       <div aria-live="polite" aria-atomic="true" className="sr-only">{msgAriaAnnouncement}</div>
-      {/* Header */}
-      <header className="pb-2 sm:pb-4">
+      {/* Header — hidden on mobile to maximize chat real estate above the BottomTabs */}
+      <header className="hidden lg:block pb-4">
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2 sm:gap-3">
-            <div className="relative hidden sm:block">
+          <div className="flex items-center gap-3">
+            <div className="relative">
               <Sparkles className="h-5 w-5 text-brand" />
               <span className="absolute inset-0 bg-brand/30 animate-pulse" />
             </div>
-            <span className="text-brand font-bold uppercase tracking-widest text-[10px] hidden sm:inline">{t("chat.neural_terminal")}</span>
-            <h1 className="text-xl sm:text-3xl font-extrabold tracking-tight">{t("chat.title")}</h1>
+            <span className="text-brand font-bold uppercase tracking-widest text-[10px]">{t("chat.neural_terminal")}</span>
+            <h1 className="text-3xl font-extrabold tracking-tight">{t("chat.title")}</h1>
           </div>
           <button
             onClick={() => void agentsQuery.refetch()}
-            className="p-2 sm:p-2.5 rounded-xl hover:bg-surface-hover text-text-dim hover:text-brand transition-colors"
+            className="p-2.5 rounded-xl hover:bg-surface-hover text-text-dim hover:text-brand transition-colors"
+            aria-label={t("common.refresh", { defaultValue: "Refresh" })}
           >
             <RefreshCw className={`h-4 w-4 ${agentsQuery.isFetching ? "animate-spin" : ""}`} />
           </button>
@@ -2789,9 +2805,9 @@ export function ChatPage() {
       </header>
 
       {/* Main content area */}
-      <div className="flex flex-1 overflow-hidden rounded-2xl border border-border-subtle bg-surface shadow-xl ring-1 ring-black/5 dark:ring-white/5">
-        {/* Left sidebar - Agent list */}
-        <aside className="hidden md:flex w-64 shrink-0 border-r border-border-subtle bg-main flex-col">
+      <div className="flex flex-1 min-h-0 overflow-hidden rounded-none lg:rounded-2xl border-y lg:border border-border-subtle bg-surface lg:shadow-xl lg:ring-1 lg:ring-black/5 dark:lg:ring-white/5">
+        {/* Left sidebar - Agent list (desktop only; mobile uses a sheet) */}
+        <aside className="hidden lg:flex w-64 shrink-0 border-r border-border-subtle bg-main flex-col">
           <div className="p-4 border-b border-border-subtle space-y-2">
             <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-text-dim/60">{t("nav.agents")}</h3>
             <button
@@ -2838,46 +2854,99 @@ export function ChatPage() {
         </aside>
 
         {/* Right side - Chat area */}
-        <main className="flex-1 flex flex-col overflow-hidden bg-main/10 relative">
+        <main className="flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden bg-main/10 relative">
           {/* Background decoration */}
           <div className="absolute inset-0 pointer-events-none opacity-30">
             <div className="absolute top-0 left-0 w-64 h-64 bg-brand/5 rounded-full blur-3xl" />
             <div className="absolute bottom-0 right-0 w-48 h-48 bg-accent/5 rounded-full blur-3xl" />
           </div>
 
-          {/* Mobile agent selector */}
-          <div className="md:hidden px-3 py-2 border-b border-border-subtle bg-surface/80">
-            <select
-              value={selectedAgentId}
-              onChange={(e) => selectAgent(e.target.value)}
-              className="w-full rounded-lg border border-border-subtle bg-main px-3 py-2 text-sm font-bold outline-none focus:border-brand"
-            >
-              <option value="">{t("chat.select_agent")}</option>
-              {picker.standalone.map((agent) => (
-                <option key={agent.id} value={agent.id}>
-                  {t(`agents.builtin.${agent.name}.name`, { defaultValue: agent.name })} ({agent.state || "unknown"})
-                </option>
-              ))}
-              {picker.handGroups.map((group) => (
-                <optgroup
-                  key={group.hand_id}
-                  label={`${group.hand_icon ?? ""} ${group.hand_name}`.trim()}
-                >
-                  {group.agents.map((agent) => (
-                    <option key={agent.id} value={agent.id}>
-                      {agent.role}
-                      {agent.isCoordinator
-                        ? ` (${t("chat.hand_coordinator", { defaultValue: "coordinator" })})`
-                        : ""}
-                    </option>
-                  ))}
-                </optgroup>
-              ))}
-            </select>
-          </div>
+          {/* Mobile agent picker — slide-in sheet from the left. The backing
+              <aside> is desktop-only (`hidden lg:flex`), so on mobile we mount
+              an absolutely-positioned drawer over the chat area instead of
+              consuming a fixed width. */}
+          {mobileSheetOpen && (
+            <div className="lg:hidden absolute inset-0 z-40">
+              <div
+                className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+                onClick={() => setMobileSheetOpen(false)}
+                aria-hidden="true"
+              />
+              <div
+                role="dialog"
+                aria-modal="true"
+                aria-label={t("nav.agents")}
+                className="absolute inset-y-0 left-0 w-[80%] max-w-xs bg-main border-r border-border-subtle flex flex-col shadow-xl"
+              >
+                <div className="p-3 border-b border-border-subtle flex items-center justify-between">
+                  <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-text-dim">{t("nav.agents")}</h3>
+                  <button
+                    type="button"
+                    onClick={() => setMobileSheetOpen(false)}
+                    className="h-8 w-8 rounded-lg flex items-center justify-center text-text-dim hover:text-brand hover:bg-surface-hover"
+                    aria-label={t("common.close", { defaultValue: "Close" })}
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+                <div className="px-3 pt-3">
+                  <button
+                    onClick={() => setShowHandAgents((value) => !value)}
+                    aria-pressed={showHandAgents}
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-bold transition-colors ${
+                      showHandAgents
+                        ? "border-brand/30 bg-brand/10 text-brand"
+                        : "border-border-subtle bg-surface text-text-dim hover:border-brand/20 hover:text-brand"
+                    }`}
+                  >
+                    <span>{t("agents.show_hand_agents", { defaultValue: "Show hand agents" })}</span>
+                  </button>
+                </div>
+                <div className="flex-1 overflow-y-auto p-3 space-y-2 scrollbar-thin">
+                  {picker.standalone.length === 0 && picker.handGroups.length === 0 ? (
+                    <div className="p-4 text-center text-text-dim text-sm">{t("common.no_data")}</div>
+                  ) : (
+                    <>
+                      {picker.standalone.length > 0 && (
+                        <div className="space-y-2">
+                          {picker.handGroups.length > 0 && (
+                            <h4 className="px-1 pt-1 text-[10px] font-black uppercase tracking-[0.2em] text-text-dim">
+                              {t("chat.group_standalone", { defaultValue: "Standalone" })}
+                            </h4>
+                          )}
+                          {picker.standalone.map((agent) => renderAgentButton(agent))}
+                        </div>
+                      )}
+                      {picker.handGroups.map((group) => (
+                        <div key={group.hand_id} className="space-y-2 pt-3">
+                          <h4 className="px-1 text-[10px] font-black uppercase tracking-[0.2em] text-text-dim flex items-center gap-1.5">
+                            {group.hand_icon && <span aria-hidden="true">{group.hand_icon}</span>}
+                            <span>{group.hand_name}</span>
+                          </h4>
+                          {group.agents.map((agent) =>
+                            renderAgentButton(agent, agent.role, agent.isCoordinator),
+                          )}
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </div>
+                <div className="p-3 border-t border-border-subtle">
+                  <button
+                    onClick={() => { void agentsQuery.refetch(); }}
+                    className="w-full inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-xs font-medium text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
+                  >
+                    <RefreshCw className={`h-3.5 w-3.5 ${agentsQuery.isFetching ? "animate-spin" : ""}`} />
+                    <span>{t("common.refresh", { defaultValue: "Refresh" })}</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
 
           {selectedAgentId && (
             <ConnectionBar
+              onOpenMobileSheet={() => setMobileSheetOpen(true)}
               agentName={selectedAgent?.name || ""}
               isLoading={isLoading}
               messageCount={messages.length}
@@ -2917,7 +2986,7 @@ export function ChatPage() {
           )}
 
           {/* Message area */}
-          <div className="flex-1 overflow-y-auto p-3 sm:p-6 scrollbar-thin">
+          <div className="flex-1 min-h-0 overflow-y-auto p-3 sm:p-6 scrollbar-thin">
             <div className="w-full space-y-4 sm:space-y-6">
             {!selectedAgentId ? (
               <div className="h-full flex flex-col items-center justify-center text-center relative">
@@ -2973,8 +3042,11 @@ export function ChatPage() {
             </div>
           </div>
 
-          {/* Input area */}
-          <div className={`pt-2 px-2 pb-safe-2 sm:pt-4 sm:px-4 sm:pb-safe-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
+          {/* Input area — sticks to the bottom of the chat column. The
+              app-shell's <main> already keeps this row above the
+              MobileBottomTabs (lg:hidden, ~56px + safe-area), so we don't
+              need a separate fixed bar here. */}
+          <div className={`shrink-0 pt-2 px-2 pb-2 sm:pt-4 sm:px-4 sm:pb-4 border-t border-border-subtle bg-surface transition-opacity ${!selectedAgentId ? "opacity-30 pointer-events-none" : ""}`}>
             <ChatInput
               agentId={selectedAgentId ?? ""}
               onSend={sendMessage}

--- a/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/OverviewPage.tsx
@@ -58,7 +58,7 @@ function CostChart({ data, height = 170 }: { data: number[]; height?: number }) 
   const markerX = markerIndex * stepX;
   const markerY = height - (data[markerIndex] / max) * (height - 16);
   return (
-    <svg viewBox={`0 0 ${w} ${height}`} preserveAspectRatio="none" className="block w-full" style={{ height }} aria-hidden="true">
+    <svg viewBox={`0 0 ${w} ${height}`} preserveAspectRatio="none" className="block w-full h-[130px] lg:h-[170px]" aria-hidden="true">
       <defs>
         <linearGradient id="cc-1" x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="#38bdf8" stopOpacity="0.3" />
@@ -464,16 +464,16 @@ export function OverviewPage() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-3 lg:gap-4 p-3 lg:p-6">
       {/* Hero strip */}
-      <header className="flex items-end justify-between gap-4 flex-wrap">
-        <div>
-          <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-text-dim flex items-center gap-1.5">
-            <span className="font-mono">{snapshot?.status?.hostname ?? versionInfo?.hostname ?? "node-01"}</span>
+      <header className="flex items-end justify-between gap-3 lg:gap-4 flex-wrap">
+        <div className="min-w-0 flex-1">
+          <div className="text-[10.5px] lg:text-[11px] font-semibold uppercase tracking-[0.08em] text-text-dim flex items-center gap-1.5">
+            <span className="font-mono truncate">{snapshot?.status?.hostname ?? versionInfo?.hostname ?? "node-01"}</span>
             <span>·</span>
-            <span>{new Date().toLocaleString(undefined, { day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit" })}</span>
+            <span className="truncate">{new Date().toLocaleString(undefined, { day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit" })}</span>
           </div>
-          <h1 className="mt-1.5 text-xl sm:text-2xl font-semibold tracking-[-0.02em] text-text-main flex items-center gap-2 flex-wrap">
+          <h1 className="mt-1.5 text-lg sm:text-xl lg:text-2xl font-semibold tracking-[-0.02em] text-text-main flex items-center gap-2 flex-wrap">
             {isLoading ? (
               <span className="text-text-dim font-normal">{t("overview.loading_runtime", { defaultValue: "Loading runtime…" })}</span>
             ) : agentsTotal === 0 ? (
@@ -520,6 +520,36 @@ export function OverviewPage() {
             {t("overview.new_agent", { defaultValue: "New agent" })}
           </Button>
         </div>
+        {/* Mobile action bar — compact icon-only buttons */}
+        <div className="flex sm:hidden items-center gap-1.5 shrink-0">
+          <button
+            type="button"
+            onClick={refresh}
+            aria-label={t("overview.refresh", { defaultValue: "Refresh" })}
+            className="w-9 h-9 rounded-md border border-border-subtle bg-surface text-text-dim hover:text-text-main hover:border-brand/30 grid place-items-center transition-colors"
+          >
+            <RefreshCw className={`w-4 h-4 ${snapshotQuery.isFetching ? "animate-spin" : ""}`} />
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const next: Range = range === "30d" ? "7d" : range === "7d" ? "90d" : "30d";
+              setRange(next);
+            }}
+            className="h-9 px-2.5 rounded-md border border-border-subtle bg-surface text-text-dim hover:text-text-main hover:border-brand/30 inline-flex items-center gap-1 text-[11px] font-mono transition-colors"
+          >
+            <Filter className="w-3.5 h-3.5" />
+            <span>{range}</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate({ to: "/agents" })}
+            aria-label={t("overview.new_agent", { defaultValue: "New agent" })}
+            className="w-9 h-9 rounded-md bg-brand/15 border border-brand/30 text-brand hover:bg-brand/25 grid place-items-center transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+        </div>
       </header>
 
       {/* Setup banner */}
@@ -551,7 +581,7 @@ export function OverviewPage() {
       ) : null}
 
       {/* KPI grid */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 lg:gap-3">
         <Kpi
           label={t("overview.kpi.active_agents", { defaultValue: "Active agents" })}
           value={agentsRunning}
@@ -595,26 +625,26 @@ export function OverviewPage() {
       {/* Cost trend chart + Health column */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
         <Card padding="none" className="surface-lit lg:col-span-2 overflow-hidden">
-          <div className="px-4 pt-3.5 pb-2 flex items-start justify-between">
-            <div>
+          <div className="px-3 lg:px-4 pt-3 lg:pt-3.5 pb-2 flex items-start justify-between gap-2">
+            <div className="min-w-0">
               <SectionLabel className="!mb-0.5">
                 {t("overview.cost.title", { defaultValue: "Cost" })} · {t(rangeData.labelKey, { defaultValue: range })}
               </SectionLabel>
-              <div className="flex items-baseline gap-2">
-                <span className="font-mono font-semibold text-[22px] tracking-[-0.02em] tabular-nums">${rangeData.cost.toFixed(2)}</span>
+              <div className="flex items-baseline gap-2 flex-wrap">
+                <span className="font-mono font-semibold text-lg lg:text-[22px] tracking-[-0.02em] tabular-nums">${rangeData.cost.toFixed(2)}</span>
                 <span className={`text-[11px] font-mono tabular-nums ${costTrendDir === "up" ? "text-rose-400" : "text-emerald-400"}`}>
                   {costTrendDir === "up" ? "+" : "−"}${Math.abs(costDelta).toFixed(0)} {t("overview.cost.vs_prior", { defaultValue: "vs prior" })}
                 </span>
               </div>
             </div>
-            <div className="flex gap-1.5">
+            <div className="flex gap-1 lg:gap-1.5 shrink-0">
               {(["7d", "30d", "90d"] as const).map((p) => {
                 const active = p === range;
                 return (
                   <button
                     key={p}
                     onClick={() => setRange(p)}
-                    className={`px-2.5 py-0.5 text-[11px] rounded-md font-mono cursor-pointer transition-colors ${
+                    className={`px-2 lg:px-2.5 py-0.5 text-[11px] rounded-md font-mono cursor-pointer transition-colors ${
                       active
                         ? "bg-brand/10 border border-brand/30 text-brand"
                         : "bg-transparent border border-border-subtle text-text-dim hover:border-brand/20"
@@ -629,7 +659,7 @@ export function OverviewPage() {
           <div className="px-2 pb-2">
             <CostChart data={rangeData.trend} height={170} />
           </div>
-          <div className="flex gap-4 px-4 pb-3 text-[11px] text-text-dim">
+          <div className="flex flex-wrap gap-x-3 gap-y-1 lg:gap-4 px-3 lg:px-4 pb-3 text-[10.5px] lg:text-[11px] text-text-dim">
             <span className="inline-flex items-center gap-1.5">
               <span className="w-2 h-0.5 bg-sky-400 rounded-sm" /> Anthropic · 64%
             </span>
@@ -645,7 +675,7 @@ export function OverviewPage() {
         {/* Alerts — derived from agents/MCP/approvals. Mirrors the design's
             sidebar Alerts panel; dismissible items, View all / Show less. */}
         <Card padding="none" className="surface-lit">
-          <div className="px-4 pt-3.5">
+          <div className="px-3 lg:px-4 pt-3 lg:pt-3.5">
             <SectionLabel
               action={
                 visibleAlerts.length > 3 ? (
@@ -710,7 +740,7 @@ export function OverviewPage() {
                     if (alert.page) navigate({ to: alert.page as never });
                     dismissAlert(alert.id);
                   }}
-                  className="px-4 py-2.5 flex items-start gap-2.5 border-t border-border-subtle bg-transparent text-left cursor-pointer hover:bg-main/30 transition-colors"
+                  className="px-3 lg:px-4 py-2.5 flex items-start gap-2.5 border-t border-border-subtle bg-transparent text-left cursor-pointer hover:bg-main/30 transition-colors"
                 >
                   <div
                     className="w-6 h-6 rounded-md grid place-items-center shrink-0"
@@ -743,14 +773,14 @@ export function OverviewPage() {
           recent-agents view when the daemon hasn't surfaced any sessions yet
           (e.g. fresh install) so the row never goes empty. */}
       <Card padding="none" className="surface-lit">
-        <div className="px-4 pt-3.5 pb-2 flex items-center justify-between">
+        <div className="px-3 lg:px-4 pt-3 lg:pt-3.5 pb-2 flex items-center justify-between gap-2">
           <SectionLabel className="!mb-0">
             {recentSessions.length > 0
               ? t("overview.recent_sessions", { defaultValue: "Recent sessions" })
               : t("overview.recent_agents", { defaultValue: "Recent agents" })}
           </SectionLabel>
-          <div className="flex items-center gap-3">
-            <span className="font-mono text-[11px] text-text-dim/80">
+          <div className="flex items-center gap-2 lg:gap-3 shrink-0">
+            <span className="font-mono text-[10.5px] lg:text-[11px] text-text-dim/80 hidden sm:inline">
               {t("overview.updated", { defaultValue: "updated" })} · {updatedAgo}
             </span>
             <button
@@ -763,7 +793,86 @@ export function OverviewPage() {
             </button>
           </div>
         </div>
-        <div className="overflow-hidden">
+
+        {/* Mobile card list (sessions) */}
+        {recentSessions.length > 0 ? (
+          <ul className="md:hidden flex flex-col">
+            {recentSessions.slice(0, 4).map((session) => {
+              const agentName = session.agent_id
+                ? agentNameById.get(session.agent_id) ?? session.agent_id
+                : "—";
+              const status = session.active ? "running" : "ok";
+              const tokens = sessionTokens(session);
+              return (
+                <li key={session.session_id}>
+                  <button
+                    onClick={() => navigate({ to: "/sessions" } as never)}
+                    className="w-full text-left px-3 py-2.5 border-t border-border-subtle hover:bg-main/30 transition-colors flex items-start gap-2.5"
+                  >
+                    <Pill kind={pillKindForSessionStatus(status)} dot size="sm">
+                      <span className="sr-only">{status}</span>
+                    </Pill>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-mono text-[12px] truncate">{agentName}</span>
+                        <span className="font-mono text-[10.5px] text-text-dim/80 shrink-0 tabular-nums">
+                          {session.created_at ? formatRelativeTime(session.created_at) : "-"}
+                        </span>
+                      </div>
+                      <div className="text-[12px] text-text-main mt-0.5 truncate">
+                        {session.label ? (
+                          session.label
+                        ) : (
+                          <span className="font-mono text-text-dim">#{session.session_id.slice(0, 8)}</span>
+                        )}
+                      </div>
+                      <div className="mt-1 flex items-center gap-3 text-[10.5px] text-text-dim font-mono tabular-nums">
+                        <span>{tokens == null ? "-" : `${formatCompact(tokens)} tok`}</span>
+                        <span>{typeof session.cost_usd === "number" ? formatCost(session.cost_usd) : "-"}</span>
+                        <span>{formatDuration(session.duration_ms)}</span>
+                      </div>
+                    </div>
+                    <ChevronRight className="w-3.5 h-3.5 mt-0.5 text-text-dim/60 shrink-0" />
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <ul className="md:hidden flex flex-col">
+            {recentAgents.length === 0 && !isLoading ? (
+              <li className="px-3 py-5 text-center text-text-dim text-xs border-t border-border-subtle">
+                {t("overview.no_active_agents", { defaultValue: "No agents yet" })}
+              </li>
+            ) : null}
+            {recentAgents.slice(0, 4).map((agent) => (
+              <li key={agent.id}>
+                <button
+                  onClick={() => navigate({ to: "/agents" })}
+                  className="w-full text-left px-3 py-2.5 border-t border-border-subtle hover:bg-main/30 transition-colors flex items-start gap-2.5"
+                >
+                  <Pill kind={pillKindForState(agent.state)} dot size="sm">
+                    <span className="sr-only">{agent.state}</span>
+                  </Pill>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-mono text-[12px] truncate">{agent.name}</span>
+                      <span className="font-mono text-[10.5px] text-text-dim/80 shrink-0 tabular-nums">
+                        {agent.last_active ? formatRelativeTime(agent.last_active) : "-"}
+                      </span>
+                    </div>
+                    <div className="font-mono text-[11px] text-text-dim mt-0.5 truncate">
+                      {agent.model_name ?? "-"}
+                    </div>
+                  </div>
+                  <ChevronRight className="w-3.5 h-3.5 mt-0.5 text-text-dim/60 shrink-0" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="overflow-hidden hidden md:block">
           {recentSessions.length > 0 ? (
             <table className="w-full border-collapse text-[12.5px]">
               <thead>


### PR DESCRIPTION
## Summary

Brings the dashboard to a usable shape on phone-sized viewports (`<lg`, 1024px). Mirrors the design canvas (`/dashboard/project/app/shell.jsx::BottomTabs` + each page's mobile artboard).

- **c95fe101** Mobile bottom-tab nav — five tabs (Overview / Agents / Chat / Approvals / More); More opens the existing sidebar drawer. Active state via TanStack Router `activeProps={"aria-current":"page"}` + Tailwind `group-aria-[current=page]:` rules; safe-area-inset-bottom keeps tabs above the iOS home indicator. Adds `nav.more` / `nav.mobile_tabs` to en/zh (parity preserved).
- **ff287ba7** Overview — KPI grid tightens, recent-sessions table converts to a stacked card list on mobile, hero strip scales typography, mobile-only 3-icon action bar replaces the desktop toolbar.
- **989bf0d9** Agents — master-detail collapses to single-pane on mobile (detail is a fixed `inset-x-0 top-0 bottom-14` overlay reserving the tab bar height), back button restores the list, action labels collapse to icons, log block horizontally scrolls instead of clipping.
- **3d27e8b9** Chat — single-pane on mobile; sessions list moves into a left slide-in sheet behind a hamburger; outer card chrome drops; height switches to `100dvh-180px` to reserve topbar + tabs + safe area; composer stays naturally pinned via flex (no `position:fixed`).
- **0784d9f1** Approvals — Pending/History tabs go full-width with 44px tap targets, batch-action bar and Approve/Reject stack vertically on mobile, approval cards shrink padding and put actions in a 2-column grid; TOTP and pagination rows also stack.

All changes use existing design-token classes (`bg-surface`, `border-border-subtle`, `text-text-dim`, `text-brand`, `text-warning`, `text-success`, `text-error`); no new dependencies, no ad-hoc CSS.

## Test plan
- [ ] Open dashboard on a 390px-wide phone viewport — bottom tabs visible, More opens nav drawer
- [ ] Tap each tab — active indicator + brand color tracks the route
- [ ] Overview / Agents / Chat / Approvals each render without horizontal overflow on 390×844
- [ ] Desktop layout unchanged at >=1024px