### PR TITLE
feat(desktop,dashboard,api): bundle dashboard into mobile release builds

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/bundleMode.ts
+++ b/crates/librefang-api/dashboard/src/lib/bundleMode.ts
@@ -1,0 +1,125 @@
+// Bundle-mode bootstrap for the mobile Tauri shell.
+//
+// On mobile release builds, the Tauri shell loads the dashboard from the
+// embedded `tauri://localhost/index.html` (set via `frontendDist` in
+// `tauri.{ios,android}.conf.json`) instead of the remote daemon's HTTP
+// origin. The dashboard JS still issues relative API requests like
+// `fetch("/api/agents")` and `new WebSocket("/api/agents/.../events")`,
+// which would resolve against `tauri://localhost` and fail.
+//
+// The shell encodes the daemon URL into the navigation target's hash
+// (`tauri://localhost/index.html#api=<encoded>`); this module pulls it out,
+// persists it to localStorage so reloads keep working, and patches
+// `window.fetch` + `window.WebSocket` to rewrite same-origin paths onto
+// the configured daemon base. CORS on the daemon must allow
+// `tauri://localhost` for the rewritten requests to succeed.
+//
+// In thin-client mode (debug builds, desktop, or any non-Tauri page) this
+// is a no-op — the bootstrap detects `window.location.protocol !== "tauri:"`
+// or an unset base and bails out before touching globals.
+
+const BASE_KEY = "librefang-api-base";
+
+const SAME_ORIGIN_PREFIXES = [
+  "/api/",
+  "/dashboard/",
+  "/locales/",
+  "/.well-known/",
+  "/a2a/",
+  "/connect",
+];
+
+function isApiPath(path: string): boolean {
+  if (path === "/") return true;
+  return SAME_ORIGIN_PREFIXES.some((p) => path.startsWith(p));
+}
+
+function rewritePath(httpBase: string, path: string): string {
+  return httpBase + path;
+}
+
+function maybeStripTauriOrigin(url: string): string | null {
+  if (url.startsWith("tauri://localhost")) {
+    return url.slice("tauri://localhost".length) || "/";
+  }
+  return null;
+}
+
+export function setupBundleMode(): void {
+  if (typeof window === "undefined") return;
+  if (window.location.protocol !== "tauri:") return;
+
+  // Pull the daemon URL out of the hash injected by the mobile shell, store
+  // it locally, and strip the hash so React Router doesn't try to interpret
+  // it as a route.
+  const hash = window.location.hash;
+  if (hash.startsWith("#api=")) {
+    const encoded = hash.slice("#api=".length);
+    try {
+      const decoded = decodeURIComponent(encoded);
+      if (decoded) {
+        localStorage.setItem(BASE_KEY, decoded);
+      }
+    } catch {
+      // Malformed hash — ignore, fall back to whatever localStorage has.
+    }
+    history.replaceState(null, "", window.location.pathname + window.location.search);
+  }
+
+  const stored = (localStorage.getItem(BASE_KEY) || "").replace(/\/$/, "");
+  if (!stored) return;
+
+  const httpBase = stored;
+  const wsBase = httpBase.replace(/^http(s?):\/\//i, (_m, s) => `ws${s}://`);
+
+  const ORIG_FETCH = window.fetch.bind(window);
+  window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    let url: string | undefined;
+    if (typeof input === "string") {
+      url = input;
+    } else if (input instanceof URL) {
+      url = input.href;
+    } else if (input instanceof Request) {
+      url = input.url;
+    }
+    if (url) {
+      if (url.startsWith("/") && isApiPath(url)) {
+        return ORIG_FETCH(rewritePath(httpBase, url), init);
+      }
+      const stripped = maybeStripTauriOrigin(url);
+      if (stripped && isApiPath(stripped)) {
+        return ORIG_FETCH(rewritePath(httpBase, stripped), init);
+      }
+    }
+    return ORIG_FETCH(input as RequestInfo, init);
+  }) as typeof window.fetch;
+
+  const ORIG_WS = window.WebSocket;
+  // Replace the global constructor with a wrapper that rewrites relative or
+  // tauri://localhost-bound URLs onto the daemon's ws/wss base. Constants
+  // (CONNECTING/OPEN/...) and the prototype chain are forwarded so existing
+  // `instanceof WebSocket` and static-property reads keep working.
+  function PatchedWS(
+    this: WebSocket,
+    url: string | URL,
+    protocols?: string | string[],
+  ): WebSocket {
+    let u = typeof url === "string" ? url : url.href;
+    if (u.startsWith("/") && isApiPath(u)) {
+      u = wsBase + u;
+    } else if (u.startsWith("ws://localhost") || u.startsWith("wss://localhost")) {
+      const path = u.replace(/^wss?:\/\/localhost/, "");
+      if (isApiPath(path)) u = wsBase + path;
+    } else {
+      const stripped = maybeStripTauriOrigin(u);
+      if (stripped && isApiPath(stripped)) {
+        u = wsBase + stripped;
+      }
+    }
+    return new ORIG_WS(u, protocols);
+  }
+  PatchedWS.prototype = ORIG_WS.prototype;
+  Object.assign(PatchedWS, ORIG_WS);
+  // @ts-expect-error — replacing the global is the whole point.
+  window.WebSocket = PatchedWS;
+}

--- a/crates/librefang-api/dashboard/src/lib/bundleMode.ts
+++ b/crates/librefang-api/dashboard/src/lib/bundleMode.ts
@@ -17,6 +17,16 @@
 // In thin-client mode (debug builds, desktop, or any non-Tauri page) this
 // is a no-op — the bootstrap detects `window.location.protocol !== "tauri:"`
 // or an unset base and bails out before touching globals.
+//
+// IMPORTANT: `setupBundleMode()` runs in `main.tsx` after the imports
+// but before `createRoot().render()`. ESM evaluates module bodies in
+// textual import order, so any module imported by `main.tsx` (or
+// transitively) that issues a fetch / opens a WebSocket *during its own
+// module evaluation* would beat the patch. Today none do
+// (`react-i18next`, `@tanstack/react-query`, `@tanstack/react-router`,
+// `i18next` w/ bundled JSON resources). Adding a backend-loaded i18n
+// (`i18next-http-backend`) or any other eager-fetching module here will
+// silently regress bundled mobile — keep the rule.
 
 const BASE_KEY = "librefang-api-base";
 
@@ -27,6 +37,8 @@ const SAME_ORIGIN_PREFIXES = [
   "/.well-known/",
   "/a2a/",
   "/connect",
+  "/hooks/",
+  "/mcp",
 ];
 
 function isApiPath(path: string): boolean {
@@ -95,31 +107,29 @@ export function setupBundleMode(): void {
   }) as typeof window.fetch;
 
   const ORIG_WS = window.WebSocket;
-  // Replace the global constructor with a wrapper that rewrites relative or
-  // tauri://localhost-bound URLs onto the daemon's ws/wss base. Constants
-  // (CONNECTING/OPEN/...) and the prototype chain are forwarded so existing
-  // `instanceof WebSocket` and static-property reads keep working.
-  function PatchedWS(
-    this: WebSocket,
-    url: string | URL,
-    protocols?: string | string[],
-  ): WebSocket {
-    let u = typeof url === "string" ? url : url.href;
-    if (u.startsWith("/") && isApiPath(u)) {
-      u = wsBase + u;
-    } else if (u.startsWith("ws://localhost") || u.startsWith("wss://localhost")) {
-      const path = u.replace(/^wss?:\/\/localhost/, "");
-      if (isApiPath(path)) u = wsBase + path;
-    } else {
-      const stripped = maybeStripTauriOrigin(u);
-      if (stripped && isApiPath(stripped)) {
-        u = wsBase + stripped;
+  // Replace the global with a subclass that rewrites relative /
+  // `tauri://localhost`-bound URLs onto the daemon's ws/wss base before
+  // delegating to the real constructor. `extends ORIG_WS` automatically
+  // forwards the static constants (`OPEN` / `CONNECTING` / `CLOSING` /
+  // `CLOSED`) that the dashboard reads as `WebSocket.OPEN` (TerminalPage,
+  // ChatPage retry logic), and gives `instanceof WebSocket` for free —
+  // both broken if we used a function constructor with `Object.assign`.
+  class PatchedWS extends ORIG_WS {
+    constructor(url: string | URL, protocols?: string | string[]) {
+      let u = typeof url === "string" ? url : url.href;
+      if (u.startsWith("/") && isApiPath(u)) {
+        u = wsBase + u;
+      } else if (u.startsWith("ws://localhost") || u.startsWith("wss://localhost")) {
+        const path = u.replace(/^wss?:\/\/localhost/, "");
+        if (isApiPath(path)) u = wsBase + path;
+      } else {
+        const stripped = maybeStripTauriOrigin(u);
+        if (stripped && isApiPath(stripped)) {
+          u = wsBase + stripped;
+        }
       }
+      super(u, protocols);
     }
-    return new ORIG_WS(u, protocols);
   }
-  PatchedWS.prototype = ORIG_WS.prototype;
-  Object.assign(PatchedWS, ORIG_WS);
-  // @ts-expect-error — replacing the global is the whole point.
-  window.WebSocket = PatchedWS;
+  window.WebSocket = PatchedWS as unknown as typeof WebSocket;
 }

--- a/crates/librefang-api/dashboard/src/main.tsx
+++ b/crates/librefang-api/dashboard/src/main.tsx
@@ -1,3 +1,11 @@
+import { setupBundleMode } from "./lib/bundleMode";
+// Patch `window.fetch` and `window.WebSocket` BEFORE any module that
+// might issue a request — React Query, Router, i18n loaders all run
+// during their own imports below. No-op on non-Tauri origins and on
+// debug builds, where the dashboard is served same-origin from the
+// daemon.
+setupBundleMode();
+
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -925,6 +925,14 @@ pub async fn build_router(
             format!("http://{listen_addr}").parse().unwrap(),
             format!("http://localhost:{port}").parse().unwrap(),
             format!("http://127.0.0.1:{port}").parse().unwrap(),
+            // Tauri 2 mobile bundled webview origins. iOS WKWebView
+            // exposes the embedded dashboard via the `tauri://localhost`
+            // custom scheme; Android serves it through
+            // WebViewAssetLoader at `https://tauri.localhost`. Both have
+            // to clear the CORS check so `bundleMode.ts`'s rewritten
+            // `/api/*` requests against this daemon succeed.
+            "tauri://localhost".parse().unwrap(),
+            "https://tauri.localhost".parse().unwrap(),
         ];
         // Also allow common dev ports
         for p in [3000u16, 8080] {

--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -81,6 +81,14 @@ pub async fn test_connection(url: String) -> Result<serde_json::Value, String> {
 /// requests onto the daemon (CORS on the daemon must allow
 /// `tauri://localhost`). In every other case — mobile dev, desktop — we
 /// stay in thin-client mode and navigate directly to the daemon URL.
+///
+/// The cfg gate is `not(debug_assertions)`, so any release-profile mobile
+/// build picks the bundled branch — including `cargo tauri ios dev
+/// --release`. If you run that without a fresh `pnpm build` for the
+/// dashboard the App will load whichever stale bundle is still in
+/// `crates/librefang-api/static/react/`. Either rebuild the dashboard
+/// first or stick with the default `cargo tauri ios dev` (debug
+/// profile, thin-client).
 #[cfg(all(any(target_os = "ios", target_os = "android"), not(debug_assertions)))]
 pub(crate) fn navigation_target(daemon_url: &str) -> String {
     let mut bundled =

--- a/crates/librefang-desktop/src/connection.rs
+++ b/crates/librefang-desktop/src/connection.rs
@@ -73,6 +73,27 @@ pub async fn test_connection(url: String) -> Result<serde_json::Value, String> {
         .map_err(|e| format!("Invalid response: {e}"))
 }
 
+/// Build the URL the WebView should navigate to once a daemon URL is
+/// known. On mobile release builds the dashboard ships embedded (see
+/// `tauri.{ios,android}.conf.json::build.frontendDist`); we navigate to
+/// `tauri://localhost/index.html#api=<percent-encoded daemon URL>` and
+/// let the dashboard's `bundleMode` bootstrap fence relative API/WS
+/// requests onto the daemon (CORS on the daemon must allow
+/// `tauri://localhost`). In every other case — mobile dev, desktop — we
+/// stay in thin-client mode and navigate directly to the daemon URL.
+#[cfg(all(any(target_os = "ios", target_os = "android"), not(debug_assertions)))]
+pub(crate) fn navigation_target(daemon_url: &str) -> String {
+    let mut bundled =
+        tauri::Url::parse("tauri://localhost/index.html").expect("static bundled URL must parse");
+    bundled.set_fragment(Some(&format!("api={daemon_url}")));
+    bundled.to_string()
+}
+
+#[cfg(not(all(any(target_os = "ios", target_os = "android"), not(debug_assertions))))]
+pub(crate) fn navigation_target(daemon_url: &str) -> String {
+    daemon_url.to_string()
+}
+
 /// Connect to a remote LibreFang server. Validates the URL, verifies the
 /// server is reachable, optionally saves the preference, and navigates the
 /// WebView to the remote dashboard.
@@ -126,10 +147,13 @@ pub async fn connect_remote(
 
     info!("Connecting to remote server: {url}");
 
-    // Navigate WebView to the remote dashboard
+    // Navigate WebView. On mobile release builds the target points at the
+    // embedded dashboard with the daemon URL hash-encoded; on every other
+    // build it is the daemon URL directly. See `navigation_target`.
+    let target = navigation_target(&url);
     let js = format!(
         "window.location.href = {};",
-        serde_json::to_string(&url).unwrap_or_default()
+        serde_json::to_string(&target).unwrap_or_default()
     );
     window
         .eval(&js)

--- a/crates/librefang-desktop/src/lib.rs
+++ b/crates/librefang-desktop/src/lib.rs
@@ -467,7 +467,15 @@ pub fn run(server_url: Option<String>, force_local: bool) {
             {
                 if !show_connection_screen && !initial_url.is_empty() {
                     if let Some(window) = app.get_webview_window("main") {
-                        let url: tauri::Url = initial_url.parse().expect("Invalid server URL");
+                        // Release builds use the embedded dashboard with
+                        // the daemon URL hash-encoded; debug stays
+                        // thin-client. Both branches resolve through
+                        // `connection::navigation_target` so the rule
+                        // lives in one place.
+                        let target = connection::navigation_target(&initial_url);
+                        let url: tauri::Url = target
+                            .parse()
+                            .expect("navigation_target must return parsable URL");
                         window.navigate(url)?;
                     } else {
                         warn!("Mobile main window not found at setup time");

--- a/crates/librefang-desktop/tauri.android.conf.json
+++ b/crates/librefang-desktop/tauri.android.conf.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "identifier": "ai.librefang.app",
+  "build": {
+    "frontendDist": "../librefang-api/static/react"
+  },
   "app": {
     "windows": [
       {

--- a/crates/librefang-desktop/tauri.ios.conf.json
+++ b/crates/librefang-desktop/tauri.ios.conf.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "identifier": "ai.librefang.app",
+  "build": {
+    "frontendDist": "../librefang-api/static/react"
+  },
   "app": {
     "windows": [
       {


### PR DESCRIPTION
## Summary

Mobile release flips from thin-client (webview navigates to the daemon URL and serves the dashboard same-origin) to bundled (dashboard ships embedded inside the App; only `/api/*` round-trips to the daemon).

**Goals**: instant launch, offline-tolerant first paint, no white screen during a daemon restart.

**Scope**: only mobile release. Debug builds and desktop stay thin-client (verified via `cfg(all(any(target_os = ios, target_os = android), not(debug_assertions)))`).

## How it composes

1. **Embed the dashboard.** `tauri.{ios,android}.conf.json` set `build.frontendDist` to `../librefang-api/static/react`, the dashboard's existing vite `outDir`.
2. **Hand the daemon URL to the dashboard.** New `connection::navigation_target(daemon_url)` returns `tauri://localhost/index.html#api=<percent-encoded url>` on mobile release, daemon URL untouched everywhere else. Used by both `connect_remote` (Tauri command) and `setup()`'s mobile branch.
3. **Rewrite same-origin requests.** New `dashboard/src/lib/bundleMode.ts` runs as the very first thing in `main.tsx`. No-op on non-`tauri:` origins. On bundled mobile: pulls the URL out of `#api=...`, persists to localStorage, patches `window.fetch` + `window.WebSocket` to rewrite `/api/*`, `/dashboard/*`, `/locales/*`, `/.well-known/*`, `/a2a/*`, `/connect`, and `/` onto the configured base. The 200+ relative `fetch("/api/...")` call sites in `api.ts` keep working unchanged.
4. **Let the rewritten requests through CORS.** `server.rs` adds `tauri://localhost` and `https://tauri.localhost` to the default CORS allow list — the only two origins Tauri 2 mobile bundled webviews ever surface (iOS WKWebView custom scheme, Android WebViewAssetLoader). Auth keeps working: dashboard already sends `Authorization: Bearer <token>` from sessionStorage/localStorage and the daemon already accepts that header.

## Test plan
- [ ] iOS Simulator (debug): connection screen still shows, navigates to daemon URL after `Connect` (thin-client path)
- [ ] iOS device (release): `cargo tauri ios build`, install via Xcode, launch. After entering daemon URL: dashboard renders from `tauri://localhost/`, all `/api/*` calls land on the daemon (look for them in daemon logs)
- [ ] Daemon restart while bundled App is open: dashboard does not white-screen, just gets `fetch` errors and recovers
- [ ] Desktop (`cargo tauri dev`): unchanged — thin-client to local daemon