### PR TITLE
fix(channels,runtime): finish #3630 lag-counter migration

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -4402,4 +4402,19 @@ mod tests {
             "expected safety-filter msg, got: {msg}"
         );
     }
+
+    /// `KernelBridgeAdapter::record_consumer_lag` must forward to
+    /// `EventBus::record_consumer_lag`, which increments `dropped_count`.
+    /// This test exercises the EventBus path directly (constructing a full
+    /// kernel in a unit test would be prohibitively expensive) and mirrors
+    /// the assertion in `event_bus::tests::record_consumer_lag_increments_dropped_count`.
+    #[test]
+    fn test_event_bus_record_consumer_lag_increments_dropped_count() {
+        let bus = librefang_kernel::event_bus::EventBus::new();
+        assert_eq!(bus.dropped_count(), 0);
+        bus.record_consumer_lag(5, "test-context");
+        assert_eq!(bus.dropped_count(), 5);
+        bus.record_consumer_lag(3, "test-context");
+        assert_eq!(bus.dropped_count(), 8);
+    }
 }

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1633,6 +1633,10 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         Some(self.kernel.event_bus_ref().subscribe_all())
     }
 
+    fn record_consumer_lag(&self, n: u64, context: &'static str) {
+        self.kernel.event_bus_ref().record_consumer_lag(n, context);
+    }
+
     async fn reset_session(&self, agent_id: AgentId) -> Result<String, String> {
         self.kernel
             .reset_session(agent_id)

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -368,6 +368,15 @@ pub trait ChannelBridgeHandle: Send + Sync {
         None
     }
 
+    /// Record that the consumer side dropped `n` events due to broadcast
+    /// lag. Called by listeners that receive from [`subscribe_events`] when
+    /// they observe `RecvError::Lagged(n)`. The production impl forwards
+    /// to `EventBus::record_consumer_lag` so lag drops show up in the
+    /// kernel's `dropped_count` metric and trigger a rate-limited
+    /// `error!` log (issue #3630). Default is a no-op so test mocks
+    /// without an event bus don't need to thread one in.
+    fn record_consumer_lag(&self, _n: u64, _context: &'static str) {}
+
     // ── Budget, Network, A2A ──
 
     /// Show global budget status (limits, spend, % used).
@@ -1308,7 +1317,13 @@ impl BridgeManager {
                                 }
                             }
                             Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                                warn!("Approval event listener lagged by {n} events");
+                                // Route through the kernel's lag counter so
+                                // approval-event misses contribute to
+                                // EventBus::dropped_count and surface as a
+                                // rate-limited error! log (#3630). Default
+                                // impl is a no-op for test mocks without an
+                                // event bus.
+                                handle.record_consumer_lag(n, "channel_approval_listener");
                             }
                             Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                                 info!("Event bus closed — stopping approval listener");

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -373,8 +373,14 @@ pub trait ChannelBridgeHandle: Send + Sync {
     /// they observe `RecvError::Lagged(n)`. The production impl forwards
     /// to `EventBus::record_consumer_lag` so lag drops show up in the
     /// kernel's `dropped_count` metric and trigger a rate-limited
-    /// `error!` log (issue #3630). Default is a no-op so test mocks
-    /// without an event bus don't need to thread one in.
+    /// `error!` log (issue #3630).
+    ///
+    /// **Production implementations MUST override this.** The default is
+    /// a no-op convenience for test mocks that do not have an event bus
+    /// to forward to; a production handle that inherits the default would
+    /// silently swallow lag drops, defeating #3630. There is no compiler
+    /// signal for this — please remember to override when adding a new
+    /// non-test impl.
     fn record_consumer_lag(&self, _n: u64, _context: &'static str) {}
 
     // ── Budget, Network, A2A ──

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -49,12 +49,18 @@ impl EventBus {
         // above 1 024 events between scheduler ticks, causing RecvError::Lagged
         // and silently dropping trigger-driving events (issue #3630).
         let (sender, _) = broadcast::channel(4096);
+        // Backdate the rate-limit timestamp so the FIRST lag burst after
+        // process start is always logged. Initialising to `Instant::now()`
+        // would silence the first 10 s of lag — a fresh process that
+        // immediately sees backlog would only bump dropped_count and stay
+        // quiet, defeating the "make lag visible" goal of #3630.
+        let warmup = std::time::Instant::now() - std::time::Duration::from_secs(11);
         Self {
             sender,
             agent_channels: DashMap::new(),
             history: Arc::new(RwLock::new(VecDeque::with_capacity(HISTORY_SIZE))),
             dropped_count: AtomicU64::new(0),
-            last_drop_warn: std::sync::Mutex::new(std::time::Instant::now()),
+            last_drop_warn: std::sync::Mutex::new(warmup),
         }
     }
 

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -138,8 +138,10 @@ pub struct PluginEvent {
 }
 
 /// Rate-limit window between consecutive `error!` logs from
-/// [`PluginEventBus::record_consumer_lag`]. Mirrors the kernel
-/// `EventBus`'s 10 s cadence so the two buses behave the same.
+/// [`PluginEventBus::record_consumer_lag`]. Must stay in sync with the
+/// hardcoded `10` in `librefang_kernel::event_bus::EventBus::record_consumer_lag`
+/// (search for `from_secs(10)` in `crates/librefang-kernel/src/event_bus.rs`)
+/// so the two buses behave identically.
 const LAG_WARN_INTERVAL_SECS: u64 = 10;
 
 /// A simple in-process event bus for plugin events.

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -143,12 +143,22 @@ pub struct PluginEvent {
 /// receive the same event without coordination.
 pub struct PluginEventBus {
     tx: tokio::sync::broadcast::Sender<PluginEvent>,
+    /// Total events dropped by consumers due to broadcast lag. Mirrors
+    /// the kernel `EventBus` counter so plugin-side `on_event` misses
+    /// stop being silently swallowed (issue #3630).
+    dropped_count: std::sync::atomic::AtomicU64,
+    /// Rate-limit timestamp for the lag warning log.
+    last_drop_warn: std::sync::Mutex<std::time::Instant>,
 }
 
 impl PluginEventBus {
     pub fn new(capacity: usize) -> Self {
         let (tx, _) = tokio::sync::broadcast::channel(capacity);
-        Self { tx }
+        Self {
+            tx,
+            dropped_count: std::sync::atomic::AtomicU64::new(0),
+            last_drop_warn: std::sync::Mutex::new(std::time::Instant::now()),
+        }
     }
 
     /// Publish an event to all subscribers.
@@ -159,6 +169,34 @@ impl PluginEventBus {
     /// Subscribe to the event stream.
     pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<PluginEvent> {
         self.tx.subscribe()
+    }
+
+    /// Total events that consumers dropped due to broadcast lag.
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped_count
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Record that a consumer lagged and dropped `n` events. Bumps
+    /// `dropped_count` and emits a rate-limited `error!` log. Mirrors
+    /// `librefang_kernel::event_bus::EventBus::record_consumer_lag`.
+    pub fn record_consumer_lag(&self, n: u64, context: &'static str) {
+        let total = self
+            .dropped_count
+            .fetch_add(n, std::sync::atomic::Ordering::Relaxed)
+            + n;
+        if let Ok(mut last) = self.last_drop_warn.lock() {
+            if last.elapsed() >= std::time::Duration::from_secs(10) {
+                tracing::error!(
+                    lagged = n,
+                    total_dropped = total,
+                    context = context,
+                    "Plugin event bus: consumer lagged behind broadcast queue, events dropped — \
+                     receiver should be drained faster or buffer increased",
+                );
+                *last = std::time::Instant::now();
+            }
+        }
     }
 }
 
@@ -1244,7 +1282,12 @@ impl ScriptableContextEngine {
                             });
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            warn!(plugin = %plugin_name, skipped = n, "on_event: broadcast lagged, some events skipped");
+                            // Route through the bus's lag counter so plugin
+                            // on_event misses are observable in
+                            // `dropped_count()` and emit a rate-limited
+                            // error! log (#3630). The previous per-listener
+                            // warn! was silent in aggregate metrics.
+                            bus.record_consumer_lag(n, "plugin.on_event");
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     }

--- a/crates/librefang-runtime/src/context_engine.rs
+++ b/crates/librefang-runtime/src/context_engine.rs
@@ -137,6 +137,11 @@ pub struct PluginEvent {
     pub source_plugin: String,
 }
 
+/// Rate-limit window between consecutive `error!` logs from
+/// [`PluginEventBus::record_consumer_lag`]. Mirrors the kernel
+/// `EventBus`'s 10 s cadence so the two buses behave the same.
+const LAG_WARN_INTERVAL_SECS: u64 = 10;
+
 /// A simple in-process event bus for plugin events.
 ///
 /// Backed by a `tokio::sync::broadcast` channel so multiple engines can
@@ -154,10 +159,17 @@ pub struct PluginEventBus {
 impl PluginEventBus {
     pub fn new(capacity: usize) -> Self {
         let (tx, _) = tokio::sync::broadcast::channel(capacity);
+        // Initialise the rate-limit timestamp far enough in the past that
+        // the FIRST lag burst after startup is always logged. Without this,
+        // a fresh process that immediately sees lag would only bump the
+        // counter and stay silent for the first 10 s — defeating the
+        // "make lag visible" goal of #3630.
+        let warmup =
+            std::time::Instant::now() - std::time::Duration::from_secs(LAG_WARN_INTERVAL_SECS + 1);
         Self {
             tx,
             dropped_count: std::sync::atomic::AtomicU64::new(0),
-            last_drop_warn: std::sync::Mutex::new(std::time::Instant::now()),
+            last_drop_warn: std::sync::Mutex::new(warmup),
         }
     }
 
@@ -186,7 +198,7 @@ impl PluginEventBus {
             .fetch_add(n, std::sync::atomic::Ordering::Relaxed)
             + n;
         if let Ok(mut last) = self.last_drop_warn.lock() {
-            if last.elapsed() >= std::time::Duration::from_secs(10) {
+            if last.elapsed() >= std::time::Duration::from_secs(LAG_WARN_INTERVAL_SECS) {
                 tracing::error!(
                     lagged = n,
                     total_dropped = total,
@@ -4602,6 +4614,20 @@ mod tests {
         let config = ContextEngineConfig::default();
         let engine = DefaultContextEngine::new(config.clone(), make_memory(), None);
         assert!(engine.bootstrap(&config).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn plugin_bus_record_consumer_lag_increments_dropped_count() {
+        // Mirrors `EventBus::record_consumer_lag_increments_dropped_count`
+        // from librefang-kernel — the two impls drift apart silently
+        // unless both are tested. Counter accounting only; the rate-
+        // limited error! log is exercised but not asserted on.
+        let bus = PluginEventBus::new(8);
+        assert_eq!(bus.dropped_count(), 0);
+        bus.record_consumer_lag(7, "test");
+        assert_eq!(bus.dropped_count(), 7);
+        bus.record_consumer_lag(3, "test");
+        assert_eq!(bus.dropped_count(), 10);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #4104. That PR added `EventBus::record_consumer_lag` and the `recv_event_skipping_lag` helper but only migrated the desktop notification listener; the other two sensible call sites still swallowed `RecvError::Lagged` into per-listener `warn!` lines that never reached `EventBus::dropped_count` or the rate-limited error log #3630 was supposed to surface.

This PR finishes the migration:

- **`ChannelBridgeHandle`** gets a default-no-op `record_consumer_lag(n, context)`. `KernelBridgeAdapter` overrides it to forward to `EventBus::record_consumer_lag`. `bridge.rs` approval listener now records lag through it instead of `warn!`. The default is a no-op so all existing test impls (5+ `MockHandle`s in tests) inherit it without code changes.
- **`PluginEventBus`** grows its own `dropped_count` + `record_consumer_lag`, mirroring `EventBus`'s design. `context_engine.rs` `on_event` hook routes `Lagged(n)` through the bus instead of a per-listener `warn!`. Plugin-side lag is now observable via `PluginEventBus::dropped_count()`.

Intentionally **not** migrated:

- `agents.rs:2485` SSE attach uses `StreamEvent` from `SessionStreamHub`, which is documented as intentionally lossy. Routing those drops to `error!` would over-log normal SSE backpressure for slow clients.

## Test plan

- [x] `cargo build --lib -p librefang-channels -p librefang-api -p librefang-runtime` — green
- [x] `cargo clippy --lib -p librefang-channels -p librefang-api -p librefang-runtime -- -D warnings` — green
- [x] `cargo test --lib -p librefang-channels -p librefang-runtime` — only failures are pre-existing env-dependent `aux_client::tests::*` (test code itself says "in a clean test env"); unrelated to changes here
- [ ] Verify `EventBus::dropped_count()` increments under load (manual / integration)