### PR TITLE
docs(mcp-oauth): align parser test + SECURITY note with userinfo fix

### DIFF
--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -163,17 +163,23 @@ pub fn extract_metadata_url(params: &HashMap<String, String>, server_url: &str) 
     Some(url_str.clone())
 }
 
-/// Return `true` when the given host string resolves to a network range that
-/// must not be reachable via OAuth metadata fetches (SSRF defence-in-depth).
+/// Return `true` when the given host string is a literal IP address or
+/// known internal hostname that must not be reachable via OAuth metadata
+/// fetches (SSRF defence-in-depth).  No DNS resolution is performed —
+/// only the literal value is matched.  A public hostname that DNS-rebinds
+/// to an internal IP at fetch time is out of scope; mitigate at the
+/// network layer.
 ///
-/// Blocked ranges:
-/// * Exact hostnames: `localhost`, `metadata.google.internal`
+/// Blocked values:
+/// * Exact hostnames:   `localhost`, `metadata.google.internal`
 /// * IPv4 loopback      127.0.0.0/8
 /// * IPv4 private       10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-/// * IPv4 link-local    169.254.0.0/16
+/// * IPv4 link-local    169.254.0.0/16 (covers IMDS 169.254.169.254)
 /// * IPv6 loopback      ::1
 /// * IPv6 unique-local  fc00::/7
 /// * IPv6 link-local    fe80::/10
+/// * IPv4-mapped IPv6   `::ffff:x.x.x.x` when the embedded v4 is private
+/// * NAT64              `64:ff9b::x.x.x.x` when the embedded v4 is private
 fn is_ssrf_blocked_host(host: &str) -> bool {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -297,8 +303,9 @@ pub fn is_ssrf_blocked_url(url_str: &str) -> Result<(), String> {
 /// Construct the `.well-known/oauth-authorization-server` URL for a given server URL.
 ///
 /// Parses the URL, extracts the origin, and appends the well-known path.
-/// Returns `None` if the origin resolves to a private/loopback/link-local
-/// host (SSRF guard — see `is_ssrf_blocked_host`).
+/// Returns `None` when the origin's host is a literal private / loopback /
+/// link-local address or a known internal hostname (SSRF guard — see
+/// `is_ssrf_blocked_host`).  No DNS resolution is performed.
 pub fn well_known_url(server_url: &str) -> Option<String> {
     let parsed = Url::parse(server_url).ok()?;
     // Block SSRF before constructing the well-known URL.

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -465,10 +465,12 @@ struct AuthorizationServerMetadata {
 ///
 /// SECURITY (#3623): All discovered endpoint URLs are validated through the
 /// SSRF guard (`is_ssrf_blocked_url`) before being returned.  This rejects
-/// non-http/https schemes, URLs with a userinfo component, and any host
-/// that resolves into a loopback, link-local, RFC 1918, or other reserved
-/// range — a malicious MCP server could otherwise point any of these
-/// endpoints at internal services or smuggle credentials through userinfo.
+/// non-http/https schemes, URLs with a userinfo component, and any literal
+/// IP or known internal hostname (loopback, link-local, RFC 1918, IMDS,
+/// IPv4-mapped IPv6, NAT64, …) — a malicious MCP server could otherwise
+/// point an endpoint at an internal service or attach userinfo that leaks
+/// into logs and reqwest's connection-pool key.  DNS resolution is out
+/// of scope; mitigate rebinding at the network layer.
 pub fn parse_authorization_server_metadata(
     body: &str,
     server_url: &str,

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -464,10 +464,11 @@ struct AuthorizationServerMetadata {
 /// (RFC 8414). Extracts the required endpoints and converts to our internal type.
 ///
 /// SECURITY (#3623): All discovered endpoint URLs are validated through the
-/// SSRF guard (`is_ssrf_blocked_host`) before being returned.  A malicious
-/// MCP server could otherwise point any of these endpoints at loopback,
-/// link-local, or RFC 1918 addresses to trigger server-side requests to
-/// internal services.
+/// SSRF guard (`is_ssrf_blocked_url`) before being returned.  This rejects
+/// non-http/https schemes, URLs with a userinfo component, and any host
+/// that resolves into a loopback, link-local, RFC 1918, or other reserved
+/// range — a malicious MCP server could otherwise point any of these
+/// endpoints at internal services or smuggle credentials through userinfo.
 pub fn parse_authorization_server_metadata(
     body: &str,
     server_url: &str,
@@ -1154,9 +1155,14 @@ mod tests {
 
     #[test]
     fn parse_authorization_server_metadata_rejects_userinfo_endpoint() {
-        // Rogue MCP server tries to smuggle userinfo to bypass the host check.
+        // Userinfo on OAuth metadata is anomalous (RFC 6749 doesn't
+        // sanction it).  The post-`@` host here is public — `host_str()`
+        // returns "auth.example.com" and the host check passes — so this
+        // test fails ONLY if the userinfo guard is removed.  Pairs with
+        // `is_ssrf_blocked_url_rejects_userinfo` to lock the parser-level
+        // wiring at the same isolated regression point.
         let body = r#"{
-            "authorization_endpoint": "https://allowed.com@127.0.0.1/authorize",
+            "authorization_endpoint": "https://user@auth.example.com/authorize",
             "token_endpoint": "https://auth.example.com/token"
         }"#;
         let result = parse_authorization_server_metadata(body, "https://server.com/mcp");


### PR DESCRIPTION
## Summary

Followup to #4110.  That PR's first round of comment cleanup landed,
but two stragglers in `crates/librefang-runtime-mcp/src/mcp_oauth.rs`
kept the older (and incorrect) explanation of why the userinfo guard
in `is_ssrf_blocked_url` exists.

* The `SECURITY (#3623)` note on `parse_authorization_server_metadata`
  still pointed at `is_ssrf_blocked_host` — but the parser was already
  refactored to go through `is_ssrf_blocked_url` (which adds scheme +
  userinfo checks on top).  Also re-worded to make explicit that the
  guard does **not** do DNS resolution (only literal IP / hostname
  matching), so the contract lines up with the rest of the file.
* `parse_authorization_server_metadata_rejects_userinfo_endpoint`
  used `https://allowed.com@127.0.0.1/authorize`, which `host_str()`
  reduces to `127.0.0.1` — the **host** check rejects it before the
  userinfo guard ever runs.  Removing the userinfo guard would not
  actually fail the test.  Switched to
  `https://user@auth.example.com/authorize` (post-`@` host is public)
  so the assertion fires *only* via the userinfo path, matching the
  regression-isolation shape already used by
  `is_ssrf_blocked_url_rejects_userinfo`.

No behaviour change.  Comments + one test URL only.

## Test plan

- [x] `cargo test -p librefang-runtime-mcp --lib mcp_oauth::` — 53/53 pass locally
- [x] `cargo clippy -p librefang-runtime-mcp --all-targets -- -D warnings` — clean