### PR TITLE
fix(kernel,extensions): unbreak workspace build

### DIFF
--- a/crates/librefang-extensions/src/lib.rs
+++ b/crates/librefang-extensions/src/lib.rs
@@ -18,7 +18,7 @@ pub mod catalog;
 pub mod credentials;
 pub mod dotenv;
 pub mod health;
-pub(crate) mod http_client;
+pub mod http_client;
 pub mod installer;
 pub mod oauth;
 pub mod vault;

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -94,7 +94,7 @@ pub(crate) fn resolve_cron_max_messages(raw: Option<usize>) -> Option<usize> {
 /// - `None`    → no cap
 /// - `Some(0)` → disable (treat as no cap)
 /// - `Some(n)` otherwise → use as-is
-pub(crate) fn resolve_cron_max_tokens(raw: Option<u32>) -> Option<u32> {
+pub(crate) fn resolve_cron_max_tokens(raw: Option<u64>) -> Option<u64> {
     match raw {
         Some(0) => None,
         other => other,


### PR DESCRIPTION
## Summary
- \`resolve_cron_max_tokens\` widened from \`Option<u32>\` to \`Option<u64>\` to match \`KernelConfig::cron_session_max_tokens\` (the call site at \`kernel/mod.rs:13335\` was already passing \`Option<u64>\`, the workspace stopped compiling).
- \`librefang-extensions::http_client\` promoted from \`pub(crate)\` to \`pub\` — \`librefang-kernel::mcp_oauth_provider\` calls \`librefang_extensions::http_client::new_client()\` across crates, which the \`pub(crate)\` visibility silently rejected.

Both regressions slipped in via independent merges that didn't compile against each other; main is currently red and every dependabot PR (#4167, #4172, …) inherits the failure.

## Test plan
- [ ] \`cargo build --workspace --lib\` (CI)
- [ ] \`cargo test --workspace\` (CI)
- [ ] CI passes on dependabot PRs that were red on the same errors