### PR TITLE
chore(workflow): forbid main-worktree edits + ban local cargo build/test

### DIFF
--- a/.claude/hooks/forbid-main-worktree.sh
+++ b/.claude/hooks/forbid-main-worktree.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# PreToolUse guard: forbid Claude from doing modifying work in the librefang
+# main worktree. CLAUDE.md requires `git worktree add` for any feature work.
+# Hook protocol: read tool-call JSON from stdin, exit 2 to deny.
+
+set -euo pipefail
+
+input="$(cat)"
+py() { python3 -c "$1" 2>/dev/null || true; }
+
+cwd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("cwd",""))')"
+tool="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_name",""))')"
+
+# detect_git <path>: prints "<repo_root> <kind>" where kind is "main" if the
+# repo's .git is a directory or "worktree" if it is a gitlink file.
+detect_git() {
+  local start="$1"
+  [ -n "$start" ] || return 0
+  local dir
+  dir="$(cd "$start" 2>/dev/null && pwd -P || true)"
+  [ -n "$dir" ] || return 0
+  while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+    if [ -e "$dir/.git" ]; then
+      if [ -d "$dir/.git" ]; then echo "$dir main"; else echo "$dir worktree"; fi
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+}
+
+target_dir=""
+case "$tool" in
+  Edit|MultiEdit|Write|NotebookEdit)
+    fp="$(printf '%s' "$input" | py 'import sys,json; t=json.load(sys.stdin).get("tool_input",{}); print(t.get("file_path") or t.get("notebook_path") or "")')"
+    if [ -n "$fp" ]; then
+      case "$fp" in
+        /*) target="$fp" ;;
+        *)  target="$cwd/$fp" ;;
+      esac
+      target_dir="$(dirname "$target")"
+    else
+      target_dir="$cwd"
+    fi
+    ;;
+  Bash)
+    target_dir="$cwd"  # default; may be overridden per-command below
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# For Bash, prefer the path passed via `git -C <path>` if present, since the
+# user often operates on a worktree from a different cwd.
+if [ "$tool" = "Bash" ]; then
+  cmd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))')"
+  c_path="$(printf '%s' "$cmd" | py 'import sys,re
+cmd=sys.stdin.read()
+m=re.search(r"\bgit\s+-C\s+(\"([^\"]+)\"|'\''([^'\'']+)'\''|(\S+))", cmd)
+if m:
+    print(m.group(2) or m.group(3) or m.group(4) or "")')"
+  if [ -n "$c_path" ]; then
+    case "$c_path" in
+      /*) target_dir="$c_path" ;;
+      *)  target_dir="$cwd/$c_path" ;;
+    esac
+  fi
+fi
+
+read -r repo_root kind <<<"$(detect_git "$target_dir" || true)"
+[ -n "${repo_root:-}" ] || exit 0
+[ "${kind:-}" = "main" ] || exit 0
+
+case "$repo_root" in
+  */librefang) ;;
+  *) exit 0 ;;
+esac
+
+case "$tool" in
+  Edit|MultiEdit|Write|NotebookEdit)
+    cat >&2 <<EOF
+[forbid-main-worktree] Refusing $tool — target lives in the main worktree:
+  ${target:-$target_dir}
+
+CLAUDE.md rule: \`git worktree add\` on an external disk (or /tmp/librefang-<feature>)
+for any work. Edits in the main worktree collide with the user's other sessions.
+EOF
+    exit 2
+    ;;
+  Bash)
+    trimmed="$(printf '%s' "$cmd" | sed -E 's/^[[:space:]]+//')"
+    block=0; reason=""
+    if printf '%s' "$trimmed" | grep -qE '(^|[;&|`(]|&&|\|\|)[[:space:]]*git([[:space:]]+-C[[:space:]]+\S+)?[[:space:]]+(checkout|switch|merge|rebase|reset|commit|push|pull|cherry-pick|revert|am|apply|branch[[:space:]]+(-D|-d|-m|--delete|--force)|stash[[:space:]]+(pop|apply|drop|clear)|worktree[[:space:]]+(remove|prune)|clean|tag[[:space:]]+(-d|--delete))\b'; then
+      block=1; reason="git mutation in main worktree"
+    fi
+    if printf '%s' "$trimmed" | grep -qE '(^|[[:space:]])(cat|tee|printf|echo)[[:space:]].*[[:space:]]>[>]?[[:space:]]'; then
+      block=1; reason="${reason:+$reason; }shell write redirect in main worktree"
+    fi
+    if printf '%s' "$trimmed" | grep -qE '(^|[[:space:]])(sed[[:space:]]+(-[a-zA-Z]*i[a-zA-Z]*|-i)|perl[[:space:]]+-[a-zA-Z]*pi[a-zA-Z]*)\b'; then
+      block=1; reason="${reason:+$reason; }in-place edit in main worktree"
+    fi
+    if [ "$block" -eq 1 ]; then
+      cat >&2 <<EOF
+[forbid-main-worktree] Refusing Bash — target is the main worktree:
+  $repo_root
+Reason: $reason
+Command: $cmd
+
+Move to a worktree first (or pass git -C <worktree-path>).
+EOF
+      exit 2
+    fi
+    ;;
+esac
+exit 0

--- a/.claude/hooks/forbid-main-worktree.sh
+++ b/.claude/hooks/forbid-main-worktree.sh
@@ -85,15 +85,31 @@ if [ "$tool" = "Bash" ]; then
   if [ -n "$main_root" ]; then
     case "$main_root" in
       */librefang)
-        if printf '%s' "$cmd" | grep -qE '(^|[;&|`(]|&&|\|\|)[[:space:]]*cargo[[:space:]]+(build|test|run|install)\b'; then
+        # Always-banned cargo subcommands (long-running and shared-target).
+        if printf '%s' "$cmd" | grep -qE '(^|[;&|`(]|&&|\|\|)[[:space:]]*cargo[[:space:]]+(build|run|install)\b'; then
           cat >&2 <<EOF
-[forbid-main-worktree] Refusing Bash — \`cargo build/test/run/install\` is
-banned in this repo (target/ is shared across worktrees and contends with
-the user's other sessions). Use \`cargo check\` for compile verification;
-CI handles full build / test.
+[forbid-main-worktree] Refusing Bash — \`cargo build/run/install\` is
+banned in this repo (target/ is shared across worktrees and contends
+with the user's other sessions). Use \`cargo check\` for compile
+verification; CI handles full build.
 Command: $cmd
 EOF
           exit 2
+        fi
+        # Conditional: \`cargo test\` without --package / -p compiles & runs the
+        # whole workspace, which is the slow case we want to keep out of the AI's
+        # hands. Allow scoped \`cargo test -p <crate>\`.
+        if printf '%s' "$cmd" | grep -qE '(^|[;&|`(]|&&|\|\|)[[:space:]]*cargo[[:space:]]+test\b'; then
+          if ! printf '%s' "$cmd" | grep -qE '(^|[[:space:]])(-p|--package)([[:space:]]+|=)[[:alnum:]_-]+'; then
+            cat >&2 <<EOF
+[forbid-main-worktree] Refusing Bash — unscoped \`cargo test\` builds and
+runs the whole workspace, which is too slow / target-contending for the
+AI to invoke. Re-run with \`-p <crate>\` (or \`--package <crate>\`) so it's
+scoped to one crate. CI runs the full suite.
+Command: $cmd
+EOF
+            exit 2
+          fi
         fi
         ;;
     esac

--- a/.claude/hooks/forbid-main-worktree.sh
+++ b/.claude/hooks/forbid-main-worktree.sh
@@ -69,6 +69,37 @@ fi
 
 read -r repo_root kind <<<"$(detect_git "$target_dir" || true)"
 [ -n "${repo_root:-}" ] || exit 0
+
+# For Bash, also resolve the *toplevel* of the main repo (so cargo bans apply
+# whether we are in the main tree or a linked worktree — they share target/).
+toplevel=""; main_root=""
+if [ "$tool" = "Bash" ]; then
+  toplevel="$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [ -n "$toplevel" ]; then
+    main_root="$(git -C "$toplevel" worktree list --porcelain 2>/dev/null \
+      | awk '/^worktree / {print $2; exit}')"
+    [ -n "$main_root" ] || main_root="$toplevel"
+  fi
+
+  # Cargo build/test/run/install: banned anywhere in the librefang repo.
+  if [ -n "$main_root" ]; then
+    case "$main_root" in
+      */librefang)
+        if printf '%s' "$cmd" | grep -qE '(^|[;&|`(]|&&|\|\|)[[:space:]]*cargo[[:space:]]+(build|test|run|install)\b'; then
+          cat >&2 <<EOF
+[forbid-main-worktree] Refusing Bash — \`cargo build/test/run/install\` is
+banned in this repo (target/ is shared across worktrees and contends with
+the user's other sessions). Use \`cargo check\` for compile verification;
+CI handles full build / test.
+Command: $cmd
+EOF
+          exit 2
+        fi
+        ;;
+    esac
+  fi
+fi
+
 [ "${kind:-}" = "main" ] || exit 0
 
 case "$repo_root" in

--- a/.claude/hooks/forbid-main-worktree.sh
+++ b/.claude/hooks/forbid-main-worktree.sh
@@ -140,8 +140,32 @@ EOF
     if printf '%s' "$trimmed" | grep -qE '(^|[;&|`(]|&&|\|\|)[[:space:]]*git([[:space:]]+-C[[:space:]]+\S+)?[[:space:]]+(checkout|switch|merge|rebase|reset|commit|push|pull|cherry-pick|revert|am|apply|branch[[:space:]]+(-D|-d|-m|--delete|--force)|stash[[:space:]]+(pop|apply|drop|clear)|worktree[[:space:]]+(remove|prune)|clean|tag[[:space:]]+(-d|--delete))\b'; then
       block=1; reason="git mutation in main worktree"
     fi
-    if printf '%s' "$trimmed" | grep -qE '(^|[[:space:]])(cat|tee|printf|echo)[[:space:]].*[[:space:]]>[>]?[[:space:]]'; then
-      block=1; reason="${reason:+$reason; }shell write redirect in main worktree"
+    # Shell write redirect: only block if the redirect target path resolves
+    # *into the main worktree*. Writes to /tmp, /var/log, etc. are fine.
+    redirect_into_main="$(printf '%s' "$cmd" | python3 -c '
+import sys, re, os
+text = sys.stdin.read()
+repo = sys.argv[1] if len(sys.argv) > 1 else ""
+real_repo = os.path.realpath(repo) if repo else ""
+hit = False
+# Match >  or  >> followed by an unquoted or quoted path token.
+for m in re.finditer(r">>?\s*(?:\"([^\"]+)\"|\x27([^\x27]+)\x27|(\S+))", text):
+    p = m.group(1) or m.group(2) or m.group(3)
+    if not p:
+        continue
+    if p.startswith("/"):
+        ap = os.path.realpath(p)
+    elif real_repo:
+        ap = os.path.realpath(os.path.join(real_repo, p))
+    else:
+        continue
+    if real_repo and (ap == real_repo or ap.startswith(real_repo + "/")):
+        hit = True
+        break
+print("1" if hit else "0")
+' "$repo_root" 2>/dev/null || echo 0)"
+    if [ "$redirect_into_main" = "1" ]; then
+      block=1; reason="${reason:+$reason; }shell write redirect into main worktree"
     fi
     if printf '%s' "$trimmed" | grep -qE '(^|[[:space:]])(sed[[:space:]]+(-[a-zA-Z]*i[a-zA-Z]*|-i)|perl[[:space:]]+-[a-zA-Z]*pi[a-zA-Z]*)\b'; then
       block=1; reason="${reason:+$reason; }in-place edit in main worktree"

--- a/.claude/hooks/guard-bash-safety.sh
+++ b/.claude/hooks/guard-bash-safety.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# PreToolUse Bash guard: block five classes of AI mistakes.
+#
+# Rules:
+#   A. Force-push to main / master (incl. `+branch` syntax)
+#   B. `--no-verify` / `--no-gpg-sign` on commit/push/rebase/merge/am/cherry-pick/pull
+#   C. Staging likely-sensitive files (.env / *.pem / *.key / credentials.json / id_rsa…)
+#      and broad `git add -A` / `git add .` (CLAUDE.md global rule: prefer specific paths)
+#   D. Commit messages containing Claude attribution
+#      (`Co-Authored-By: Claude`, `Generated with Claude`, `🤖 Generated with [Claude Code]`)
+#   E. `rm -rf` against dangerous targets (/, ~, $HOME, target, .git, /Users, /usr, /etc, …)
+#
+# Hook protocol: read tool-call JSON from stdin, exit 2 to deny.
+
+set -euo pipefail
+input="$(cat)"
+py() { python3 -c "$1" 2>/dev/null || true; }
+
+tool="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_name",""))')"
+[ "$tool" = "Bash" ] || exit 0
+
+cmd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))')"
+[ -n "$cmd" ] || exit 0
+
+deny() {
+  printf '[guard-bash-safety] %s\nCommand: %s\n' "$1" "$cmd" >&2
+  exit 2
+}
+
+# ---------------------------------------------------------------------------
+# A. Force-push to main / master
+# ---------------------------------------------------------------------------
+# Match if the command is a `git push` AND uses a force flag AND targets a
+# protected branch (either `... main` / `... master` arg, or the `+branch`
+# refspec syntax).
+if printf '%s' "$cmd" | grep -qE '\bgit\b([[:space:]]+-C[[:space:]]+\S+)?[[:space:]].*\bpush\b'; then
+  has_force=0
+  if printf '%s' "$cmd" | grep -qE '([[:space:]]|^)(-f|--force|--force-with-lease)([[:space:]]|=|$)'; then
+    has_force=1
+  fi
+  # `git push origin +main` is also a force push.
+  if printf '%s' "$cmd" | grep -qE '([[:space:]])\+(main|master|HEAD)([[:space:]]|:|$)'; then
+    has_force=1
+  fi
+  if [ "$has_force" = 1 ]; then
+    if printf '%s' "$cmd" | grep -qE '([[:space:]]|/|:|\+)(main|master)([[:space:]]|:|$)'; then
+      deny "Refusing force-push to main / master. Force pushes there are near-irreversible — get explicit user confirmation and consider a safer alternative."
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# B. --no-verify / --no-gpg-sign
+# ---------------------------------------------------------------------------
+if printf '%s' "$cmd" | grep -qE '\bgit\b.*(\s|^)(commit|push|rebase|merge|am|cherry-pick|pull)\b' \
+   && printf '%s' "$cmd" | grep -qE '(\s|^)(--no-verify|--no-gpg-sign)\b'; then
+  deny "Refusing --no-verify / --no-gpg-sign. Bypassing hooks is not allowed — fix the underlying failure instead."
+fi
+
+# ---------------------------------------------------------------------------
+# D. Claude attribution in commit message
+# ---------------------------------------------------------------------------
+# Inspect the value of -m / --message arguments. If the user is reading the
+# message from a heredoc / file we cannot see it from here; in that case we
+# fall through and rely on a git-side commit-msg hook (out of scope here).
+if printf '%s' "$cmd" | grep -qE '\bgit\b.*\bcommit\b'; then
+  msg="$(printf '%s' "$cmd" | py '
+import sys, shlex
+text = sys.stdin.read()
+try:
+    toks = shlex.split(text, posix=True)
+except ValueError:
+    toks = text.split()
+msgs = []
+i = 0
+while i < len(toks):
+    t = toks[i]
+    if t in ("-m", "--message", "-F", "--file"):
+        if i + 1 < len(toks):
+            msgs.append(toks[i+1])
+        i += 2
+        continue
+    if t.startswith("--message="):
+        msgs.append(t[len("--message="):])
+    elif t.startswith("-m") and len(t) > 2:
+        msgs.append(t[2:])
+    i += 1
+print("\n----\n".join(msgs))
+')"
+  if [ -n "$msg" ] && printf '%s' "$msg" | grep -qiE '(Co-Authored-By:.*(Claude|Anthropic|noreply@anthropic\.com)|Generated with .{0,40}Claude|🤖.*Claude[[:space:]]+Code)'; then
+    deny "Refusing commit — message contains Claude attribution (Co-Authored-By / Generated with Claude). CLAUDE.md forbids these. Remove the line and retry."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# C. Sensitive-file staging + broad `git add`
+# ---------------------------------------------------------------------------
+if printf '%s' "$cmd" | grep -qE '\bgit\b([[:space:]]+-C[[:space:]]+\S+)?[[:space:]].*\b(add|commit)\b'; then
+  # C1. Block broad add (`git add -A`, `git add --all`, `git add .`, `git add :/`).
+  if printf '%s' "$cmd" | grep -qE '\bgit\b([[:space:]]+-C[[:space:]]+\S+)?[[:space:]]+add\b[^|;&]*([[:space:]](-A|-a|--all|--update|-u)\b|[[:space:]]\.($|[[:space:]])|[[:space:]]:/(\s|$))'; then
+    deny "Refusing broad \`git add\`. CLAUDE.md (global) requires staging specific files by name to avoid sweeping in secrets / large binaries. Add files explicitly: \`git add path/to/file ...\`."
+  fi
+  # C2. Block known sensitive filenames anywhere in the command.
+  if printf '%s' "$cmd" | grep -qiE '(^|[[:space:]/=":'\''])((\.env)(\.[a-z0-9._-]+)?|id_(rsa|ed25519|ecdsa|dsa)(\.pub)?|credentials(\.[a-z]+)?|secrets?(\.[a-z]+)?|vault[_-][a-z0-9_-]+\.(key|json)|[a-z0-9_/.-]+\.(pem|p12|pfx|jks|keystore))($|[[:space:]"'\''])' \
+     && ! printf '%s' "$cmd" | grep -qiE '\.(example|template|sample)(\s|$|"|'\'')'; then
+    deny "Refusing — command references a likely-sensitive file (.env / id_rsa / *.pem / credentials.json / vault_*.key …). If you really need to track it, ask the user first."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# E. rm -rf against dangerous paths
+# ---------------------------------------------------------------------------
+# Catch any rm with a recursive+force combo (-rf / -fr / -Rf / -fR / -r -f / etc.)
+if printf '%s' "$cmd" | grep -qE '(^|[[:space:]/;&|`(])rm[[:space:]]+([^|;&]*[[:space:]])?(-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*|-rf|-fr|-Rf|-fR)([[:space:]]|$)' \
+   || printf '%s' "$cmd" | grep -qE '(^|[[:space:]/;&|`(])rm[[:space:]]+(-[rR]\b[^|;&]*-f\b|-f\b[^|;&]*-[rR]\b)'; then
+  # Dangerous targets: filesystem roots, $HOME, repo-shared dirs, system trees.
+  # Match either as a standalone token after rm or with simple suffixes.
+  if printf '%s' "$cmd" | grep -qE '(^|[[:space:]"'\''])(/|/\*|~|~/|\$HOME|\$HOME/|\$\{HOME\}|/Users|/Users/|/home|/home/|/usr|/var|/etc|/opt|/private|/System|/Library|target|target/|\./target|\./target/|\.git|\.git/|\./\.git|\./\.git/)([[:space:]"'\'']|$)'; then
+    deny "Refusing rm -rf against a dangerous path (/, ~, \$HOME, target, .git, /Users, /usr, /etc …). Be specific or ask the user."
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/guard-bash-safety.sh
+++ b/.claude/hooks/guard-bash-safety.sh
@@ -120,4 +120,36 @@ if printf '%s' "$cmd" | grep -qE '(^|[[:space:]/;&|`(])rm[[:space:]]+([^|;&]*[[:
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# F. Daemon launch ban (`librefang start`, direct binary invocation)
+# ---------------------------------------------------------------------------
+# The librefang daemon binds 127.0.0.1:4545 by default. The user typically has
+# one running. AI launching another (or killing theirs and replacing) causes
+# port conflicts and clobbers the user's session. Per CLAUDE.md, the
+# "Live Integration Testing" flow is a HUMAN workflow.
+if printf '%s' "$cmd" | grep -qE '(^|[[:space:]/;&|`(])(librefang(\.exe)?|target/(debug|release)/librefang(\.exe)?|\./target/(debug|release)/librefang(\.exe)?)[[:space:]]+(start|daemon)\b'; then
+  deny "Refusing — starting the librefang daemon is a HUMAN workflow per CLAUDE.md (port 4545 is typically already bound by the user's session). Ask the user to run it and report back, instead of launching it yourself."
+fi
+
+# ---------------------------------------------------------------------------
+# G. `cargo add` / `cargo remove` — dependency mutations require user OK
+# ---------------------------------------------------------------------------
+# Global CLAUDE.md: "禁止擅自加依赖". Block the cargo subcommands that add or
+# remove deps; force the AI to surface the change for explicit approval.
+if printf '%s' "$cmd" | grep -qE '(^|[[:space:]/;&|`(])cargo[[:space:]]+(add|rm|remove|upgrade)\b'; then
+  deny "Refusing — \`cargo add/remove/upgrade\` mutates Cargo.toml dependencies, which CLAUDE.md (global) forbids without explicit user approval. Surface the proposed dep change first and let the user run the command."
+fi
+
+# ---------------------------------------------------------------------------
+# H. \`gh pr merge\` and admin-bypass merges
+# ---------------------------------------------------------------------------
+# Always block merge bypasses (--admin) and disallow merging without explicit
+# user say-so — even regular \`gh pr merge <pr>\` is a publish-level action.
+if printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+merge\b'; then
+  if printf '%s' "$cmd" | grep -qE '(^|[[:space:]])--admin\b'; then
+    deny "Refusing \`gh pr merge --admin\`. The --admin flag bypasses branch protection — equivalent to force-pushing to main. Get explicit user confirmation."
+  fi
+  deny "Refusing \`gh pr merge\`. Merging is a publish-level action; ask the user to merge themselves rather than doing it from the AI session."
+fi
+
 exit 0

--- a/.claude/hooks/session-start-worktree-check.sh
+++ b/.claude/hooks/session-start-worktree-check.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SessionStart hook: emit a banner into the model's context noting whether the
+# session is starting in the librefang main worktree (where edits will be
+# blocked by forbid-main-worktree.sh) or in a linked worktree.
+#
+# Hook protocol: read JSON from stdin, write `additionalContext` text to
+# stdout via {"hookSpecificOutput":{"hookEventName":"SessionStart",...}}.
+
+set -euo pipefail
+
+input="$(cat)"
+cwd="$(printf '%s' "$input" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("cwd",""))' 2>/dev/null || true)"
+[ -n "$cwd" ] || { echo '{}'; exit 0; }
+
+real_cwd="$(cd "$cwd" 2>/dev/null && pwd -P || true)"
+[ -n "$real_cwd" ] || { echo '{}'; exit 0; }
+
+dir="$real_cwd"
+git_kind=""; repo_root=""
+while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+  if [ -e "$dir/.git" ]; then
+    repo_root="$dir"
+    if [ -d "$dir/.git" ]; then git_kind="main"; else git_kind="worktree"; fi
+    break
+  fi
+  dir="$(dirname "$dir")"
+done
+[ -n "$repo_root" ] || { echo '{}'; exit 0; }
+
+# Find the *main* worktree path (first entry of `git worktree list`) so we can
+# tell whether this session is inside the librefang repo regardless of whether
+# we are in the main tree or a linked one.
+main_root="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null \
+  | awk '/^worktree / {print $2; exit}')"
+[ -n "$main_root" ] || main_root="$repo_root"
+
+case "$main_root" in
+  */librefang) ;;
+  *) echo '{}'; exit 0 ;;
+esac
+
+if [ "$git_kind" = "main" ]; then
+  msg="⚠️  Session starting in the librefang MAIN WORKTREE ($repo_root). Edits and mutating git commands here are blocked by .claude/hooks/forbid-main-worktree.sh. For any task that will modify files, FIRST run: git worktree add /tmp/librefang-<feature> -b <branch> origin/main, then continue from that path."
+else
+  msg="✅ Session starting in a librefang LINKED WORKTREE ($repo_root). Edits permitted; cargo build/test still forbidden — only cargo check / cargo clippy."
+fi
+
+python3 - "$msg" <<'PY'
+import json, sys
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": sys.argv[1],
+    }
+}))
+PY

--- a/.claude/hooks/session-start-worktree-check.sh
+++ b/.claude/hooks/session-start-worktree-check.sh
@@ -42,7 +42,16 @@ esac
 if [ "$git_kind" = "main" ]; then
   msg="⚠️  Session starting in the librefang MAIN WORKTREE ($repo_root). Edits and mutating git commands here are blocked by .claude/hooks/forbid-main-worktree.sh. For any task that will modify files, FIRST run: git worktree add /tmp/librefang-<feature> -b <branch> origin/main, then continue from that path."
 else
-  msg="✅ Session starting in a librefang LINKED WORKTREE ($repo_root). Edits permitted; cargo build/test still forbidden — only cargo check / cargo clippy."
+  msg="✅ Session starting in a librefang LINKED WORKTREE ($repo_root). Edits permitted; cargo build/run/install still forbidden, cargo test only with -p <crate>."
+fi
+
+# Warn if .githooks/ is checked into the tree but not yet activated.
+# (commit-msg + pre-commit live there; user runs scripts/install-githooks.sh once.)
+hooks_path="$(git -C "$main_root" config --get core.hooksPath 2>/dev/null || true)"
+if [ -d "$main_root/.githooks" ] && [ "$hooks_path" != ".githooks" ]; then
+  msg="$msg
+
+🔧 git core.hooksPath is not pointing at .githooks/ yet — the version-controlled commit-msg / pre-commit hooks are inactive in this clone. Run once: \`bash scripts/install-githooks.sh\` (from the main worktree)."
 fi
 
 python3 - "$msg" <<'PY'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/forbid-main-worktree.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,6 +65,15 @@
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/forbid-main-worktree.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-bash-safety.sh"
+          }
+        ]
       }
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,60 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(pwd)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(file:*)",
+      "Bash(stat:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote:*)",
+      "Bash(git config --get:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git worktree list:*)",
+      "Bash(git worktree add:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git blame:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo clippy:*)",
+      "Bash(cargo fmt:*)",
+      "Bash(cargo metadata:*)",
+      "Bash(cargo tree:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh api:*)"
+    ],
+    "deny": [
+      "Bash(cargo build:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo run:*)",
+      "Bash(cargo install:*)"
+    ]
+  },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-worktree-check.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,8 @@
       "Bash(cargo fmt:*)",
       "Bash(cargo metadata:*)",
       "Bash(cargo tree:*)",
+      "Bash(cargo test -p:*)",
+      "Bash(cargo test --package:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr diff:*)",
@@ -39,7 +41,6 @@
     ],
     "deny": [
       "Bash(cargo build:*)",
-      "Bash(cargo test:*)",
       "Bash(cargo run:*)",
       "Bash(cargo install:*)"
     ]

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# git commit-msg hook: reject commit messages containing Claude / Anthropic
+# attribution. CLAUDE.md (global + project) forbids these in this repo.
+#
+# This is the second layer behind .claude/hooks/guard-bash-safety.sh — that
+# hook can only see -m / --message values on the command line. Heredoc-based
+# messages (`git commit -F-`) and editor-driven messages bypass it. This
+# git-side hook catches them all.
+#
+# To enable: from repo root, run once
+#     git config core.hooksPath .githooks
+# (or run scripts/install-githooks.sh)
+
+set -eu
+
+msg_file="$1"
+if grep -qiE '(Co-Authored-By:.*(Claude|Anthropic|noreply@anthropic\.com)|Generated with .{0,40}Claude|🤖.*Claude[[:space:]]+Code)' "$msg_file"; then
+  cat >&2 <<'EOF'
+[commit-msg] Refusing commit — message contains Claude / Anthropic
+attribution (Co-Authored-By / "Generated with Claude" / 🤖 Claude Code).
+CLAUDE.md (global + project) forbids these. Edit the message and retry.
+EOF
+  exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Pre-commit hook: run cargo fmt check on staged Rust files.
+# Mirrors the previous personal .git/hooks/pre-commit so behavior is unchanged
+# after switching to `core.hooksPath = .githooks`.
+
+if git diff --cached --name-only | grep -q '\.rs$'; then
+    cargo fmt -- --check 2>/dev/null
+    if [ $? -ne 0 ]; then
+        echo "Running cargo fmt..."
+        cargo fmt
+        echo "Formatted. Please re-stage and commit again."
+        exit 1
+    fi
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ result
 .claude/hooks/*
 !.claude/hooks/forbid-main-worktree.sh
 !.claude/hooks/session-start-worktree-check.sh
+!.claude/hooks/guard-bash-safety.sh
 .codex
 .omc/
 .qwen/

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ result
 !.claude/hooks/
 .claude/hooks/*
 !.claude/hooks/forbid-main-worktree.sh
+!.claude/hooks/session-start-worktree-check.sh
 .codex
 .omc/
 .qwen/

--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,11 @@ result
 # IDE & tools
 .idea/
 .vscode/
-.claude/
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/hooks/*
+!.claude/hooks/forbid-main-worktree.sh
 .codex
 .omc/
 .qwen/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,17 @@ LibreFang is an open-source Agent Operating System written in Rust (24 crates in
 - **Extensibility**: `librefang-skills`, `librefang-hands`, `librefang-extensions`, `librefang-channels`
 
 ## Build & Verify Workflow
-**Do NOT run `cargo build` or `cargo test` locally.** Use `cargo check` for
-compile verification. Full build / test runs in CI — local invocations are
-slow, use lots of disk, and contend with other sessions on the same target dir.
-After every change, only run:
+**Do NOT run `cargo build`, `cargo run`, or `cargo install` locally.**
+**`cargo test` is allowed only when scoped with `-p <crate>` / `--package <crate>`** —
+the unscoped, workspace-wide form is blocked because it contends with the user's
+other sessions on the shared `target/` directory. Full workspace build / test
+runs in CI.
+
+After every change, run:
 ```bash
 cargo check --workspace --lib                          # Compile-check only
 cargo clippy --workspace --all-targets -- -D warnings  # Zero warnings
+cargo test -p <crate>                                  # Only when verifying behavior in one crate
 ```
 
 ## MANDATORY: Live Integration Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,22 @@ and continue all work from that path. The `forbid-main-worktree` hook
 commands targeted at the main tree if you forget — but the hook is a safety
 net, not your plan.
 
+### Other AI safety hooks (`.claude/hooks/`)
+
+`guard-bash-safety.sh` (PreToolUse on Bash) blocks:
+- Force-push to `main` / `master` (incl. `+main` refspec) — get explicit user OK first
+- `--no-verify` / `--no-gpg-sign` on commit/push/rebase/merge/am/cherry-pick/pull
+- Staging known-sensitive files (`.env*`, `*.pem`, `*.p12`, `id_rsa`, `id_ed25519`,
+  `credentials*`, `secrets*`, `vault_*.key`); also broad `git add -A` / `git add .`
+  (CLAUDE.md global rule: stage specific paths)
+- Commit messages containing Claude attribution (`Co-Authored-By: Claude`,
+  `🤖 Generated with [Claude Code]`, etc.)
+- `rm -rf` against dangerous targets (`/`, `~`, `$HOME`, `target`, `.git`,
+  `/Users`, `/usr`, `/etc`, `/var`, `/opt`, …)
+
+`session-start-worktree-check.sh` (SessionStart) emits a banner telling
+the model whether the session started in the main tree or a linked worktree.
+
 ## Project Overview
 LibreFang is an open-source Agent Operating System written in Rust (24 crates in `crates/`, plus `xtask/`).
 - Config: `~/.librefang/config.toml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,22 @@
 # LibreFang — Agent Instructions
 
+## ⚠️ Before any work: verify you are in a worktree, not the main tree
+
+The very first action in any task that will edit files **must** be:
+```bash
+pwd && git rev-parse --git-dir
+```
+If `pwd` ends in `/Workspace/libre/librefang` (or wherever the user keeps the
+main clone) **and** `git rev-parse --git-dir` prints `.git` (a directory, not
+a `gitdir: ...` file), you are in the main worktree. **Stop.** Run:
+```bash
+git worktree add /tmp/librefang-<feature> -b <feature-branch> origin/main
+```
+and continue all work from that path. The `forbid-main-worktree` hook
+(`.claude/hooks/forbid-main-worktree.sh`) will block edits and mutating git
+commands targeted at the main tree if you forget — but the hook is a safety
+net, not your plan.
+
 ## Project Overview
 LibreFang is an open-source Agent Operating System written in Rust (24 crates in `crates/`, plus `xtask/`).
 - Config: `~/.librefang/config.toml`
@@ -26,7 +43,13 @@ cargo clippy --workspace --all-targets -- -D warnings  # Zero warnings
 ```
 
 ## MANDATORY: Live Integration Testing
-**After implementing any new endpoint, feature, or wiring change, you MUST run live integration tests.** Unit tests alone are not enough — they can pass while the feature is actually dead code. Live tests catch:
+**This section is a HUMAN workflow.** Claude must NOT execute these steps —
+they require `cargo build` and starting a long-lived daemon, both forbidden
+to the AI per the rules above. Claude's role is to prepare exact commands /
+payloads and ask the user to run them, then read the user's pasted output.
+Do not auto-spawn the daemon or `cargo build --release` yourself.
+
+**After implementing any new endpoint, feature, or wiring change, the user MUST run live integration tests.** Unit tests alone are not enough — they can pass while the feature is actually dead code. Live tests catch:
 - Missing route registrations in server.rs
 - Config fields not being deserialized from TOML
 - Type mismatches between kernel and API layers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,32 @@ net, not your plan.
   `🤖 Generated with [Claude Code]`, etc.)
 - `rm -rf` against dangerous targets (`/`, `~`, `$HOME`, `target`, `.git`,
   `/Users`, `/usr`, `/etc`, `/var`, `/opt`, …)
+- Daemon launches: `librefang start`, `target/{debug,release}/librefang start|daemon`
+  (port 4545 contention with the user's session — Live Integration Testing is human-only)
+- `cargo add` / `cargo remove` / `cargo upgrade` (deps need explicit user OK)
+- `gh pr merge` and `gh pr merge --admin` (publish-level + branch-protection bypass)
 
 `session-start-worktree-check.sh` (SessionStart) emits a banner telling
-the model whether the session started in the main tree or a linked worktree.
+the model whether the session started in the main tree or a linked worktree,
+and warns if `core.hooksPath` hasn't been pointed at `.githooks/`.
+
+### Version-controlled git-side hooks (`.githooks/`)
+
+These run inside `git` itself (regardless of which tool invoked the commit),
+giving defense in depth on top of the Claude Code PreToolUse layer.
+
+- `pre-commit` — runs `cargo fmt -- --check` on staged Rust files; auto-formats
+  and asks you to re-stage if anything was off.
+- `commit-msg` — rejects commit messages containing Claude / Anthropic
+  attribution (catches heredocs and `git commit -F file` that the PreToolUse
+  Bash hook cannot see).
+
+**Enable once per clone:**
+```bash
+bash scripts/install-githooks.sh   # sets git config core.hooksPath .githooks
+```
+The `session-start-worktree-check.sh` banner will remind you if this is
+not yet configured.
 
 ## Project Overview
 LibreFang is an open-source Agent Operating System written in Rust (24 crates in `crates/`, plus `xtask/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,12 @@ LibreFang is an open-source Agent Operating System written in Rust (24 crates in
 - **Extensibility**: `librefang-skills`, `librefang-hands`, `librefang-extensions`, `librefang-channels`
 
 ## Build & Verify Workflow
-After every feature implementation, run ALL THREE checks:
+**Do NOT run `cargo build` or `cargo test` locally.** Use `cargo check` for
+compile verification. Full build / test runs in CI — local invocations are
+slow, use lots of disk, and contend with other sessions on the same target dir.
+After every change, only run:
 ```bash
-cargo build --workspace --lib          # Must compile (use --lib if exe is locked)
-cargo test --workspace                 # All tests must pass (currently 2100+)
+cargo check --workspace --lib                          # Compile-check only
 cargo clippy --workspace --all-targets -- -D warnings  # Zero warnings
 ```
 

--- a/scripts/install-githooks.sh
+++ b/scripts/install-githooks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# One-shot installer: point this clone's git at the version-controlled hooks.
+# After running this once, every future commit / push uses .githooks/* and
+# inherits the rules in CLAUDE.md.
+#
+# Idempotent — running it again just re-confirms the setting.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+
+echo "✓ core.hooksPath set to .githooks"
+echo "  Active hooks:"
+ls -1 .githooks | sed 's/^/    /'


### PR DESCRIPTION
## Summary

- Add a PreToolUse hook (`.claude/hooks/forbid-main-worktree.sh`) that blocks Claude Code from editing files inside the main worktree or running mutating git/shell commands there. Worktrees created via `git worktree add` are detected (`.git` is a file, not a directory) and allowed; other repos are unaffected.
- Rewrite `CLAUDE.md` Build & Verify Workflow to ban local `cargo build` / `cargo test` — only `cargo check` + `cargo clippy` are permitted. CI runs the full suite.
- Track `.claude/settings.json` and the new hook script via a `.gitignore` exception so every contributor gets the guardrail without manual setup.

## Why

A recent session edited files in the main worktree while another session was mid-merge on the same tree. Branches flip-flopped between `fix/totp-entropy-toctou` and `fix/3606-keyring-fallback-kdf`, and a partial merge ended up with 100+ unrelated files staged. The CLAUDE.md text rule ("Never develop on the main worktree") existed already but was easy to skim past. This makes the rule mechanical.

## What the hook blocks

| Tool | Trigger | Action |
|------|---------|--------|
| Edit / Write / MultiEdit / NotebookEdit | `file_path` resolves under the main worktree | exit 2 (deny) |
| Bash | `cwd` or `git -C <path>` resolves to the main worktree, AND command is `git checkout/switch/merge/rebase/reset/commit/push/pull/cherry-pick/revert/am/apply/branch -d/-D/-m/--delete/--force/stash pop|apply|drop|clear/worktree remove|prune/clean/tag -d`, OR `sed -i` / `perl -pi`, OR a shell write redirect (`cat >`, `tee`, etc.) | exit 2 (deny) |
| Bash (read-only) | `git status`, `ls`, etc. | allowed |
| Anywhere outside `*/librefang` | — | allowed |

Detection of "main worktree" vs "linked worktree": walk up to find `.git`; if it is a directory the location is a main worktree, if it is a file (`gitlink`) it is a worktree from `git worktree add`.

## Test plan

- [x] Hook blocks `Edit` against `/Users/.../librefang/CLAUDE.md`
- [x] Hook allows `Edit` against `/tmp/librefang-worktree-guard/CLAUDE.md`
- [x] Hook blocks plain `git commit` when cwd is main worktree
- [x] Hook allows `git -C /tmp/librefang-worktree-guard commit` from main worktree cwd
- [x] Hook allows read-only `git status` in main worktree
- [x] Hook is a no-op outside `*/librefang`
- [ ] Reviewer: try to edit a file in the main worktree from a fresh Claude Code session — should be denied