### PR TITLE
refactor(web): consolidate fmtNum, harden marketplace stats a11y/CLS

### DIFF
--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -146,8 +146,9 @@ export interface Translation {
     lastUpdated: string
     copyLink: string
     trending: string
-    sort?: { label: string; popular: string; nameAsc: string; nameDesc: string; trending: string; downloads?: string }
+    sort?: { label: string; popular: string; nameAsc: string; nameDesc: string; trending: string; downloads?: string; weekly?: string }
     downloads?: string
+    stars?: string
     thisWeek?: string
     onThisPage: string
     previous: string
@@ -430,8 +431,9 @@ export const translations: Record<string, Translation> = {
       copyLink: 'Skopiuj link do tej sekcji',
       trending: 'Na czasie',
       downloads: 'pobrań',
+      stars: 'gwiazdek',
       thisWeek: 'w tym tygodniu',
-      sort: { label: 'Sortuj', popular: 'Popularne', nameAsc: 'Nazwa A–Z', nameDesc: 'Nazwa Z–A', trending: 'Najczęściej klikane', downloads: 'Najczęściej pobierane' },
+      sort: { label: 'Sortuj', popular: 'Popularne', nameAsc: 'Nazwa A–Z', nameDesc: 'Nazwa Z–A', trending: 'Najczęściej klikane', downloads: 'Najczęściej pobierane', weekly: 'Trendy w tym tygodniu' },
       onThisPage: 'Na tej stronie',
       previous: 'Poprzednia',
       next: 'Następna',
@@ -703,8 +705,9 @@ export const translations: Record<string, Translation> = {
       copyLink: 'Copy link to this section',
       trending: 'Trending',
       downloads: 'downloads',
+      stars: 'stars',
       thisWeek: 'this week',
-      sort: { label: 'Sort', popular: 'Popular', nameAsc: 'Name A–Z', nameDesc: 'Name Z–A', trending: 'Most clicked', downloads: 'Most downloaded' },
+      sort: { label: 'Sort', popular: 'Popular', nameAsc: 'Name A–Z', nameDesc: 'Name Z–A', trending: 'Most clicked', downloads: 'Most downloaded', weekly: 'Trending this week' },
       onThisPage: 'On this page',
       previous: 'Previous',
       next: 'Next',
@@ -951,8 +954,9 @@ export const translations: Record<string, Translation> = {
       copyLink: '复制此段链接',
       trending: '热门',
       downloads: '次下载',
+      stars: '颗星',
       thisWeek: '本周新增',
-      sort: { label: '排序', popular: '热门优先', nameAsc: '名称 A–Z', nameDesc: '名称 Z–A', trending: '点击量', downloads: '下载量最多' },
+      sort: { label: '排序', popular: '热门优先', nameAsc: '名称 A–Z', nameDesc: '名称 Z–A', trending: '点击量', downloads: '下载量最多', weekly: '本周热门' },
       onThisPage: '本页导航',
       previous: '上一个',
       next: '下一个',
@@ -1199,8 +1203,9 @@ export const translations: Record<string, Translation> = {
       copyLink: '複製此段連結',
       trending: '熱門',
       downloads: '次下載',
+      stars: '顆星',
       thisWeek: '本週新增',
-      sort: { label: '排序', popular: '熱門優先', nameAsc: '名稱 A–Z', nameDesc: '名稱 Z–A', trending: '點擊量', downloads: '下載量最多' },
+      sort: { label: '排序', popular: '熱門優先', nameAsc: '名稱 A–Z', nameDesc: '名稱 Z–A', trending: '點擊量', downloads: '下載量最多', weekly: '本週熱門' },
       onThisPage: '本頁導覽',
       previous: '上一個',
       next: '下一個',
@@ -1447,8 +1452,9 @@ export const translations: Record<string, Translation> = {
       copyLink: 'このセクションのリンクをコピー',
       trending: '人気',
       downloads: 'ダウンロード',
+      stars: 'スター',
       thisWeek: '今週',
-      sort: { label: '並び替え', popular: '人気順', nameAsc: '名前 A–Z', nameDesc: '名前 Z–A', trending: 'クリック数', downloads: 'ダウンロード数順' },
+      sort: { label: '並び替え', popular: '人気順', nameAsc: '名前 A–Z', nameDesc: '名前 Z–A', trending: 'クリック数', downloads: 'ダウンロード数順', weekly: '今週のトレンド' },
       onThisPage: 'このページ',
       previous: '前へ',
       next: '次へ',
@@ -1695,8 +1701,9 @@ export const translations: Record<string, Translation> = {
       copyLink: '이 섹션 링크 복사',
       trending: '인기',
       downloads: '다운로드',
+      stars: '스타',
       thisWeek: '이번 주',
-      sort: { label: '정렬', popular: '인기순', nameAsc: '이름 A–Z', nameDesc: '이름 Z–A', trending: '클릭수', downloads: '다운로드 많은 순' },
+      sort: { label: '정렬', popular: '인기순', nameAsc: '이름 A–Z', nameDesc: '이름 Z–A', trending: '클릭수', downloads: '다운로드 많은 순', weekly: '이번 주 인기' },
       onThisPage: '이 페이지',
       previous: '이전',
       next: '다음',
@@ -1943,8 +1950,9 @@ export const translations: Record<string, Translation> = {
       copyLink: 'Link zu diesem Abschnitt kopieren',
       trending: 'Beliebt',
       downloads: 'Downloads',
+      stars: 'Sterne',
       thisWeek: 'diese Woche',
-      sort: { label: 'Sortieren', popular: 'Beliebt', nameAsc: 'Name A–Z', nameDesc: 'Name Z–A', trending: 'Meistgeklickt', downloads: 'Meistgeladen' },
+      sort: { label: 'Sortieren', popular: 'Beliebt', nameAsc: 'Name A–Z', nameDesc: 'Name Z–A', trending: 'Meistgeklickt', downloads: 'Meistgeladen', weekly: 'Trends diese Woche' },
       onThisPage: 'Auf dieser Seite',
       previous: 'Zurück',
       next: 'Weiter',
@@ -2191,8 +2199,9 @@ export const translations: Record<string, Translation> = {
       copyLink: 'Copiar enlace a esta sección',
       trending: 'Tendencia',
       downloads: 'descargas',
+      stars: 'estrellas',
       thisWeek: 'esta semana',
-      sort: { label: 'Ordenar', popular: 'Populares', nameAsc: 'Nombre A–Z', nameDesc: 'Nombre Z–A', trending: 'Más clics', downloads: 'Más descargados' },
+      sort: { label: 'Ordenar', popular: 'Populares', nameAsc: 'Nombre A–Z', nameDesc: 'Nombre Z–A', trending: 'Más clics', downloads: 'Más descargados', weekly: 'Tendencia esta semana' },
       onThisPage: 'En esta página',
       previous: 'Anterior',
       next: 'Siguiente',

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { fmtNum } from './format'
+
+describe('fmtNum', () => {
+  it('renders raw digits below 1k', () => {
+    expect(fmtNum(0)).toBe('0')
+    expect(fmtNum(1)).toBe('1')
+    expect(fmtNum(999)).toBe('999')
+  })
+
+  it('renders thousands with one decimal place', () => {
+    expect(fmtNum(1_000)).toBe('1.0k')
+    expect(fmtNum(1_234)).toBe('1.2k')
+    expect(fmtNum(12_345)).toBe('12.3k')
+    expect(fmtNum(999_000)).toBe('999.0k')
+  })
+
+  it('cascades to m when k rounds to 1000', () => {
+    expect(fmtNum(999_950)).toBe('1.0m')
+    expect(fmtNum(999_999)).toBe('1.0m')
+    expect(fmtNum(1_000_000)).toBe('1.0m')
+    expect(fmtNum(2_345_678)).toBe('2.3m')
+  })
+
+  it('cascades to b when m rounds to 1000', () => {
+    expect(fmtNum(999_950_000)).toBe('1.0b')
+    expect(fmtNum(1_500_000_000)).toBe('1.5b')
+  })
+
+  it('clamps invalid input to 0', () => {
+    expect(fmtNum(-1)).toBe('0')
+    expect(fmtNum(NaN)).toBe('0')
+    expect(fmtNum(Infinity)).toBe('0')
+  })
+
+  it('truncates fractional input below 1k', () => {
+    expect(fmtNum(42.7)).toBe('42')
+  })
+})

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,12 @@
+// Compact number formatting for marketplace stats. Mirrors the threshold
+// behavior commonly seen on package registries: keep raw digits below 1k,
+// switch to k/m above. One decimal place matches GitHub's stargazer pill
+// and npm's download counters. Cascades up a unit instead of rendering
+// "1000.0k" / "1000.0m" at the upper edge of each band.
+export function fmtNum(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return '0'
+  if (n < 1000) return String(Math.trunc(n))
+  if (n < 999_950) return `${(n / 1_000).toFixed(1)}k`
+  if (n < 999_950_000) return `${(n / 1_000_000).toFixed(1)}m`
+  return `${(n / 1_000_000_000).toFixed(1)}b`
+}

--- a/web/src/pages/RegistryDetailPage.tsx
+++ b/web/src/pages/RegistryDetailPage.tsx
@@ -14,6 +14,7 @@ import Breadcrumbs from '../components/Breadcrumbs'
 import RegistryIcon from '../components/RegistryIcon'
 import { fetchRegistryRaw, pathCandidatesFor, fetchFirstAvailable } from '../lib/registry-raw'
 import { useMarketplace } from '../lib/useMarketplace'
+import { fmtNum } from '../lib/format'
 
 interface RegistryDetailPageProps {
   category: RegistryCategory
@@ -302,30 +303,54 @@ export default function RegistryDetailPage({ category, id, onOpenSearch }: Regis
             </div>
           )}
           {mktPkg && (mktPkg.total_downloads > 0 || mktPkg.stars > 0 || mktPkg.latest_version) && (
-            <div className="flex flex-wrap items-center gap-3 mb-4 p-3 bg-black/3 dark:bg-white/3 border border-black/8 dark:border-white/8 rounded">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mb-4 pt-3 border-t border-black/8 dark:border-white/8">
               {mktPkg.latest_version && (
-                <span className="flex items-center gap-1.5 text-xs font-mono font-semibold text-cyan-600 dark:text-cyan-400 bg-cyan-500/10 px-2 py-1 rounded">
+                <span
+                  className="flex items-center gap-1.5 text-xs font-mono font-semibold text-cyan-600 dark:text-cyan-400 bg-cyan-500/10 px-2 py-1 rounded tabular-nums"
+                  aria-label={`Latest version v${mktPkg.latest_version}`}
+                >
                   v{mktPkg.latest_version}
                 </span>
               )}
               {mktPkg.total_downloads > 0 && (
-                <span className="flex items-center gap-1.5 text-xs font-mono text-gray-600 dark:text-gray-300">
-                  <Download className="w-3.5 h-3.5 text-cyan-500/70" />
-                  <strong>{mktPkg.total_downloads >= 1000 ? `${(mktPkg.total_downloads / 1000).toFixed(1)}k` : mktPkg.total_downloads}</strong>
+                <span
+                  className="flex items-center gap-1.5 text-xs font-mono text-gray-600 dark:text-gray-300 tabular-nums"
+                  aria-label={`${mktPkg.total_downloads.toLocaleString()} ${t.registry?.downloads || 'downloads'}`}
+                  title={mktPkg.total_downloads.toLocaleString()}
+                >
+                  <Download className="w-3.5 h-3.5 text-cyan-500/70" aria-hidden="true" />
+                  <strong>{fmtNum(mktPkg.total_downloads)}</strong>
                   <span className="text-gray-400">{t.registry?.downloads || 'downloads'}</span>
                 </span>
               )}
-              {mktPkg.weekly_downloads > 0 && (
-                <span className="flex items-center gap-1.5 text-xs font-mono text-green-600 dark:text-green-400">
-                  <TrendingUp className="w-3.5 h-3.5" />
-                  <strong>{mktPkg.weekly_downloads >= 1000 ? `${(mktPkg.weekly_downloads / 1000).toFixed(1)}k` : mktPkg.weekly_downloads}</strong>
+              {/* Render weekly even when zero (when total_downloads > 0) so
+                  visitors can see the metric exists rather than wondering
+                  whether the data simply failed to load. */}
+              {mktPkg.total_downloads > 0 && (
+                <span
+                  className={cn(
+                    'flex items-center gap-1.5 text-xs font-mono tabular-nums',
+                    mktPkg.weekly_downloads > 0
+                      ? 'text-green-600 dark:text-green-400'
+                      : 'text-gray-400 dark:text-gray-600'
+                  )}
+                  aria-label={`${mktPkg.weekly_downloads.toLocaleString()} ${t.registry?.thisWeek || 'this week'}`}
+                  title={mktPkg.weekly_downloads.toLocaleString()}
+                >
+                  <TrendingUp className="w-3.5 h-3.5" aria-hidden="true" />
+                  <strong>{fmtNum(mktPkg.weekly_downloads)}</strong>
                   <span className="text-gray-400">{t.registry?.thisWeek || 'this week'}</span>
                 </span>
               )}
               {mktPkg.stars > 0 && (
-                <span className="flex items-center gap-1.5 text-xs font-mono text-amber-500">
-                  <Star className="w-3.5 h-3.5" fill="currentColor" />
-                  <strong>{mktPkg.stars}</strong>
+                <span
+                  className="flex items-center gap-1.5 text-xs font-mono text-amber-500 tabular-nums"
+                  aria-label={`${mktPkg.stars.toLocaleString()} ${t.registry?.stars || 'stars'}`}
+                  title={mktPkg.stars.toLocaleString()}
+                >
+                  <Star className="w-3.5 h-3.5" fill="currentColor" aria-hidden="true" />
+                  <strong>{fmtNum(mktPkg.stars)}</strong>
+                  <span className="text-gray-400">{t.registry?.stars || 'stars'}</span>
                 </span>
               )}
             </div>

--- a/web/src/pages/RegistryPage.tsx
+++ b/web/src/pages/RegistryPage.tsx
@@ -13,6 +13,7 @@ import Breadcrumbs from '../components/Breadcrumbs'
 import RegistryIcon from '../components/RegistryIcon'
 import { useFavorites } from '../lib/useFavorites'
 import { useMarketplace, type MarketplacePkg } from '../lib/useMarketplace'
+import { fmtNum } from '../lib/format'
 // Fixed top header needs content to start below its 64px band.
 
 interface RegistryPageProps {
@@ -48,7 +49,9 @@ function isPopular(item: Detail) {
   return item.tags?.includes('popular') ?? false
 }
 
-type SortKey = 'popular' | 'nameAsc' | 'nameDesc' | 'trending' | 'downloads'
+type SortKey = 'popular' | 'nameAsc' | 'nameDesc' | 'trending' | 'downloads' | 'weekly'
+
+const SORT_KEYS: SortKey[] = ['popular', 'nameAsc', 'nameDesc', 'trending', 'downloads', 'weekly']
 
 function sortItems(items: Detail[], key: SortKey, trendingIds: Map<string, number>, marketplace: Map<string, MarketplacePkg>): Detail[] {
   const arr = [...items]
@@ -66,6 +69,8 @@ function sortItems(items: Detail[], key: SortKey, trendingIds: Map<string, numbe
       })
     case 'downloads':
       return arr.sort((a, b) => (marketplace.get(b.id)?.total_downloads ?? 0) - (marketplace.get(a.id)?.total_downloads ?? 0))
+    case 'weekly':
+      return arr.sort((a, b) => (marketplace.get(b.id)?.weekly_downloads ?? 0) - (marketplace.get(a.id)?.weekly_downloads ?? 0))
     case 'popular':
     default:
       return arr.sort((a, b) => {
@@ -75,12 +80,6 @@ function sortItems(items: Detail[], key: SortKey, trendingIds: Map<string, numbe
         return a.name.localeCompare(b.name)
       })
   }
-}
-
-function fmtNum(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}m`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
-  return String(n)
 }
 
 const TRENDING_API = 'https://stats.librefang.ai/api/registry/trending'
@@ -110,7 +109,7 @@ export default function RegistryPage({ category, onOpenSearch }: RegistryPagePro
   const [sortBy, setSortBy] = useState<SortKey>(() => {
     if (typeof window === 'undefined') return 'popular'
     const raw = new URLSearchParams(window.location.search).get('sort')
-    return (['popular', 'nameAsc', 'nameDesc', 'trending', 'downloads'] as SortKey[]).includes(raw as SortKey)
+    return SORT_KEYS.includes(raw as SortKey)
       ? (raw as SortKey)
       : 'popular'
   })
@@ -147,6 +146,13 @@ export default function RegistryPage({ category, onOpenSearch }: RegistryPagePro
     for (const row of trendingQuery.data?.top ?? []) m.set(row.id, row.clicks)
     return m
   }, [trendingQuery.data])
+
+  // Enable the "Trending this week" sort only when at least one package has a
+  // non-zero weekly count — otherwise the option would just re-order by id.
+  const hasWeeklyData = useMemo(() => {
+    for (const pkg of marketplace.values()) if (pkg.weekly_downloads > 0) return true
+    return false
+  }, [marketplace])
 
   const filtered = useMemo(() => {
     const sorted = sortItems(items, sortBy, trendingIds, marketplace)
@@ -234,6 +240,9 @@ export default function RegistryPage({ category, onOpenSearch }: RegistryPagePro
               </option>
               <option value="downloads" disabled={marketplace.size === 0}>
                 {t.registry?.sort?.downloads || 'Most downloaded'}
+              </option>
+              <option value="weekly" disabled={!hasWeeklyData}>
+                {t.registry?.sort?.weekly || 'Trending this week'}
               </option>
             </select>
           </label>
@@ -432,28 +441,24 @@ export default function RegistryPage({ category, onOpenSearch }: RegistryPagePro
                     <ArrowRight className="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 group-hover:text-cyan-500 transition-colors shrink-0 mt-1" />
                   </div>
 
-                  {/* Meta row: category · version · popular badge */}
-                  <div className="flex items-center gap-2 mb-2.5 flex-wrap">
+                  {/* Meta row: category, version, popular — flex gap handles
+                      spacing so chips wrap cleanly on narrow viewports without
+                      orphaned separator dots. */}
+                  <div className="flex items-center gap-x-3 gap-y-1 mb-2.5 flex-wrap">
                     {item.category && (
                       <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 uppercase tracking-wider">
                         {item.category}
                       </span>
                     )}
                     {mktPkg?.latest_version && (
-                      <>
-                        {item.category && <span className="text-gray-300 dark:text-gray-700 text-[10px]">·</span>}
-                        <span className="text-[10px] font-mono text-cyan-600 dark:text-cyan-500">
-                          v{mktPkg.latest_version}
-                        </span>
-                      </>
+                      <span className="text-[10px] font-mono text-cyan-600 dark:text-cyan-500 tabular-nums">
+                        v{mktPkg.latest_version}
+                      </span>
                     )}
                     {popular && (
-                      <>
-                        <span className="text-gray-300 dark:text-gray-700 text-[10px]">·</span>
-                        <span className="flex items-center gap-0.5 text-[10px] font-mono text-amber-500">
-                          <Sparkles className="w-2.5 h-2.5" /> popular
-                        </span>
-                      </>
+                      <span className="flex items-center gap-0.5 text-[10px] font-mono text-amber-500">
+                        <Sparkles className="w-2.5 h-2.5" /> popular
+                      </span>
                     )}
                   </div>
 
@@ -474,29 +479,46 @@ export default function RegistryPage({ category, onOpenSearch }: RegistryPagePro
                     </div>
                   )}
 
-                  {/* Stats row */}
-                  {mktPkg && (mktPkg.total_downloads > 0 || mktPkg.stars > 0) && (
+                  {/* Stats row. While marketplace data is still loading
+                      (`marketplace.size === 0`) we render an invisible
+                      placeholder of the same height so the card doesn't
+                      reflow when stats stream in. */}
+                  {marketplace.size === 0 ? (
+                    <div className="h-[28px]" aria-hidden="true" />
+                  ) : mktPkg && (mktPkg.total_downloads > 0 || mktPkg.stars > 0 || mktPkg.weekly_downloads > 0) ? (
                     <div className="flex items-center gap-3 pt-2.5 border-t border-black/8 dark:border-white/8">
                       {mktPkg.total_downloads > 0 && (
-                        <span className="flex items-center gap-1 text-[11px] font-mono text-gray-500 dark:text-gray-400">
-                          <Download className="w-3 h-3 text-cyan-500/70" />
+                        <span
+                          className="flex items-center gap-1 text-[11px] font-mono text-gray-500 dark:text-gray-400 tabular-nums"
+                          aria-label={`${mktPkg.total_downloads.toLocaleString()} ${t.registry?.downloads || 'downloads'}`}
+                          title={`${mktPkg.total_downloads.toLocaleString()} ${t.registry?.downloads || 'downloads'}`}
+                        >
+                          <Download className="w-3 h-3 text-cyan-500/70" aria-hidden="true" />
                           {fmtNum(mktPkg.total_downloads)}
                         </span>
                       )}
                       {mktPkg.weekly_downloads > 0 && (
-                        <span className="flex items-center gap-1 text-[11px] font-mono text-green-600 dark:text-green-500">
-                          <TrendingUp className="w-3 h-3" />
+                        <span
+                          className="flex items-center gap-1 text-[11px] font-mono text-green-600 dark:text-green-500 tabular-nums"
+                          aria-label={`${mktPkg.weekly_downloads.toLocaleString()} ${t.registry?.thisWeek || 'this week'}`}
+                          title={`${mktPkg.weekly_downloads.toLocaleString()} ${t.registry?.thisWeek || 'this week'}`}
+                        >
+                          <TrendingUp className="w-3 h-3" aria-hidden="true" />
                           {fmtNum(mktPkg.weekly_downloads)}
                         </span>
                       )}
                       {mktPkg.stars > 0 && (
-                        <span className="flex items-center gap-1 text-[11px] font-mono text-amber-500/80">
-                          <Star className="w-3 h-3" />
+                        <span
+                          className="flex items-center gap-1 text-[11px] font-mono text-amber-500/80 tabular-nums"
+                          aria-label={`${mktPkg.stars.toLocaleString()} ${t.registry?.stars || 'stars'}`}
+                          title={`${mktPkg.stars.toLocaleString()} ${t.registry?.stars || 'stars'}`}
+                        >
+                          <Star className="w-3 h-3" aria-hidden="true" />
                           {fmtNum(mktPkg.stars)}
                         </span>
                       )}
                     </div>
-                  )}
+                  ) : null}
                 </a>
               )
             })}


### PR DESCRIPTION
## Summary

Follow-up polish on the marketplace stats UI shipped in #4185. Ten small improvements rolled into one PR:

- **Shared `fmtNum`** — extracted the compact-number formatter from `RegistryPage` into `web/src/lib/format.ts`, replaced the inline `>= 1000 ? '${...}k' : N` ternary on the detail page. New version cascades to `m`/`b` at the upper edge of each band (so 999_999 → `1.0m`, not the previous `1000.0k`). Vitest covers the boundaries.
- **Tabular numerals** — `tabular-nums` on every stat counter so digits don't reflow as values change.
- **A11y** — each stat chip now has an `aria-label` + `title` carrying the raw localized number (e.g. `"12,345 downloads"`); decorative icons marked `aria-hidden`.
- **CLS** — registry cards reserve a 28px placeholder row while marketplace data is loading, so cards don't reflow when stats stream in.
- **Discoverable weekly metric** — detail page now shows `0 this week` (gray) when total > 0 but weekly is 0, instead of hiding the row entirely.
- **Stars label** — detail page now reads `12 stars` rather than just `12`. New `t.registry.stars` key wired across all 8 supported languages.
- **`Trending this week` sort** — new SortKey on the list page; auto-disabled in the dropdown when no item has weekly_downloads > 0. URL param validation includes the new key.
- **Detail stats visual weight** — dropped the boxed `bg-black/3 + rounded` container in favor of `border-top + gap`, aligning with surrounding sections.
- **Card meta row** — removed `·` separator `<span>`s in favor of pure flex `gap-x-3`, so chips wrap cleanly on narrow viewports without orphaned dots.
- **i18n** — `stars` label + `sort.weekly` translations added for pl, en, zh-cn, zh-tw, ja, ko, de, es.

## Test plan

- [x] `pnpm lint` (tsc --noEmit) — clean
- [x] `pnpm test` — 35/35 pass (incl. 6 new `fmtNum` cases)
- [x] `pnpm build` — clean, `format` chunk emitted
- [ ] Visual: registry list page on a populated category, hover stats chips → verify tooltip shows the precise count
- [ ] Visual: detail page for a popular package → verify no boxed bg, weekly-zero shows gray
- [ ] Visual: pick `Trending this week` from the sort dropdown → list reorders by weekly desc
- [ ] Visual: throttle network and reload list page → cards keep their height while marketplace data streams