### PR TITLE
fix(hooks): shlex tokenization — kill the commit-message false-positive class

### DIFF
--- a/.claude/hooks/forbid-main-worktree.sh
+++ b/.claude/hooks/forbid-main-worktree.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
-# PreToolUse guard: forbid Claude from doing modifying work in the librefang
-# main worktree. CLAUDE.md requires `git worktree add` for any feature work.
-# Hook protocol: read tool-call JSON from stdin, exit 2 to deny.
+# PreToolUse guard for the librefang main worktree.
+#
+# Refuses Edit/Write tool calls whose target file lives under the main worktree,
+# and Bash commands that mutate it (git mutations, sed -i, cargo build, etc.).
+# The actual Bash rule logic lives in lib/check-bash-rules.py — that file uses
+# shlex tokenization so it can tell apart real command invocations from string
+# content inside quoted args (a long-running source of false positives in the
+# old regex-based version).
+#
+# Hook protocol: read JSON from stdin, exit 2 to deny.
 
 set -euo pipefail
-
 input="$(cat)"
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+LIB="$script_dir/lib/check-bash-rules.py"
+
 py() { python3 -c "$1" 2>/dev/null || true; }
 
 cwd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("cwd",""))')"
 tool="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_name",""))')"
 
-# detect_git <path>: prints "<repo_root> <kind>" where kind is "main" if the
-# repo's .git is a directory or "worktree" if it is a gitlink file.
+# detect_git <path>: prints "<repo_root> <kind>" where kind is main or worktree.
 detect_git() {
   local start="$1"
   [ -n "$start" ] || return 0
@@ -28,6 +36,9 @@ detect_git() {
   done
 }
 
+# Determine the path the action targets. For Edit/Write we look at the
+# file_path; for Bash we look at cwd, plus a leading `cd <path>` and any
+# `git -C <path>`.
 target_dir=""
 case "$tool" in
   Edit|MultiEdit|Write|NotebookEdit)
@@ -43,33 +54,12 @@ case "$tool" in
     fi
     ;;
   Bash)
-    target_dir="$cwd"  # default; may be overridden per-command below
-    ;;
-  *)
-    exit 0
-    ;;
-esac
-
-# For Bash, recompute target_dir by inspecting the command itself:
-#   1. A leading `cd <path>` (or `(cd <path>` subshell) changes the shell's
-#      working directory for everything that follows. Common case:
-#      `cd /tmp/librefang-feat && git add ... && git commit ...`
-#   2. `git -C <path>` overrides cwd for that single git invocation. Common
-#      case: operating on a worktree without `cd`-ing into it.
-# Resolution: cd first (sets the new shell base), then -C (overrides for git).
-if [ "$tool" = "Bash" ]; then
-  cmd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))')"
-
-  # Compute the effective working dir for this Bash command.
-  target_dir="$(printf '%s' "$cmd" | python3 -c '
+    cmd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))')"
+    target_dir="$(printf '%s' "$cmd" | python3 -c '
 import sys, re, os
 text = sys.stdin.read()
 cwd = sys.argv[1] if len(sys.argv) > 1 else ""
 base = cwd
-
-# Leading `cd <path>` (or `(cd <path>` subshell) at the very start of the
-# command updates the shell base for everything that follows. We only
-# handle the leading occurrence — chasing nested cds is too ambiguous.
 m = re.match(r"\s*\(?\s*cd\s+(\"([^\"]+)\"|\x27([^\x27]+)\x27|(\S+))", text)
 if m:
     p = m.group(2) or m.group(3) or m.group(4) or ""
@@ -77,10 +67,6 @@ if m:
         base = p
     elif base:
         base = os.path.join(base, p)
-
-# `git -C <path>` overrides for that one git invocation. If both are present
-# the -C wins (it is closer to the call site). Relative -C resolves against
-# the post-cd base.
 m = re.search(r"\bgit\s+-C\s+(\"([^\"]+)\"|\x27([^\x27]+)\x27|(\S+))", text)
 if m:
     p = m.group(2) or m.group(3) or m.group(4) or ""
@@ -88,17 +74,21 @@ if m:
         base = p
     elif base:
         base = os.path.join(base, p)
-
 print(base)
 ' "$cwd" 2>/dev/null || echo "$cwd")"
-fi
+    ;;
+  *)
+    exit 0
+    ;;
+esac
 
 read -r repo_root kind <<<"$(detect_git "$target_dir" || true)"
 [ -n "${repo_root:-}" ] || exit 0
 
-# For Bash, also resolve the *toplevel* of the main repo (so cargo bans apply
-# whether we are in the main tree or a linked worktree — they share target/).
-toplevel=""; main_root=""
+# Compute main_root (the root of the main worktree even when target_dir is in
+# a linked one). Used by the cargo / worktree-remove rules so they apply
+# anywhere inside the librefang repo.
+main_root=""
 if [ "$tool" = "Bash" ]; then
   toplevel="$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || true)"
   if [ -n "$toplevel" ]; then
@@ -106,102 +96,16 @@ if [ "$tool" = "Bash" ]; then
       | awk '/^worktree / {print $2; exit}')"
     [ -n "$main_root" ] || main_root="$toplevel"
   fi
-
-  # Cargo build/test/run/install: banned anywhere in the librefang repo.
-  if [ -n "$main_root" ]; then
-    case "$main_root" in
-      */librefang)
-        # Always-banned cargo subcommands (long-running and shared-target).
-        if printf '%s' "$cmd" | grep -qE '(^|[;&|`(]|&&|\|\|)[[:space:]]*cargo[[:space:]]+(build|run|install)\b'; then
-          cat >&2 <<EOF
-[forbid-main-worktree] Refusing Bash — \`cargo build/run/install\` is
-banned in this repo (target/ is shared across worktrees and contends
-with the user's other sessions). Use \`cargo check\` for compile
-verification; CI handles full build.
-Command: $cmd
-EOF
-          exit 2
-        fi
-        # \`git worktree remove\`/\`worktree move\` against the MAIN tree —
-        # blocked from any worktree. The earlier git-mutation regex only
-        # catches it when cwd resolves to main; using \`git -C <linked>\` to
-        # remove main was a hole. Here we parse the target path and refuse
-        # if it resolves to the main worktree itself.
-        wt_target_hits_main="$(printf '%s' "$cmd" | python3 -c '
-import sys, shlex, os
-text = sys.stdin.read()
-cwd = sys.argv[1] if len(sys.argv) > 1 else ""
-main_root = sys.argv[2] if len(sys.argv) > 2 else ""
-real_main = os.path.realpath(main_root) if main_root else ""
-try:
-    toks = shlex.split(text, posix=True)
-except ValueError:
-    toks = text.split()
-# Track a -C base for relative-path resolution.
-c_base = cwd
-i = 0
-hit = False
-subcmd = None
-while i < len(toks):
-    t = toks[i]
-    if t == "git" and i + 1 < len(toks) and toks[i+1] == "-C":
-        c_base = toks[i+2] if i + 2 < len(toks) else c_base
-        i += 3
-        continue
-    if t == "worktree" and i + 1 < len(toks) and toks[i+1] in ("remove", "move"):
-        subcmd = toks[i+1]
-        rest = toks[i+2:]
-        positionals = [x for x in rest if not x.startswith("-")]
-        if positionals:
-            target = positionals[0]
-            if not target.startswith("/") and c_base:
-                target = os.path.join(c_base, target)
-            target = os.path.realpath(target) if target else ""
-            if real_main and (target == real_main):
-                hit = True
-        break
-    i += 1
-print(str(1 if hit else 0) + "|" + (subcmd if subcmd else ""))
-' "$cwd" "$main_root" 2>/dev/null || echo "0|")"
-        if [ "${wt_target_hits_main%%|*}" = "1" ]; then
-          subcmd="${wt_target_hits_main#*|}"
-          cat >&2 <<EOF
-[forbid-main-worktree] Refusing \`git worktree $subcmd\` targeting the MAIN
-worktree itself ($main_root). That would destroy the user's main checkout.
-If this is really what you want, ask the user to do it manually.
-Command: $cmd
-EOF
-          exit 2
-        fi
-        # Conditional: \`cargo test\` without --package / -p compiles & runs the
-        # whole workspace, which is the slow case we want to keep out of the AI's
-        # hands. Allow scoped \`cargo test -p <crate>\`.
-        if printf '%s' "$cmd" | grep -qE '(^|[;&|`(]|&&|\|\|)[[:space:]]*cargo[[:space:]]+test\b'; then
-          if ! printf '%s' "$cmd" | grep -qE '(^|[[:space:]])(-p|--package)([[:space:]]+|=)[[:alnum:]_-]+'; then
-            cat >&2 <<EOF
-[forbid-main-worktree] Refusing Bash — unscoped \`cargo test\` builds and
-runs the whole workspace, which is too slow / target-contending for the
-AI to invoke. Re-run with \`-p <crate>\` (or \`--package <crate>\`) so it's
-scoped to one crate. CI runs the full suite.
-Command: $cmd
-EOF
-            exit 2
-          fi
-        fi
-        ;;
-    esac
-  fi
 fi
 
-[ "${kind:-}" = "main" ] || exit 0
-
-case "$repo_root" in
-  */librefang) ;;
-  *) exit 0 ;;
-esac
-
+# === Edit/Write tool rules ===
 case "$tool" in
   Edit|MultiEdit|Write|NotebookEdit)
+    [ "${kind:-}" = "main" ] || exit 0
+    case "$repo_root" in
+      */librefang) ;;
+      *) exit 0 ;;
+    esac
     cat >&2 <<EOF
 [forbid-main-worktree] Refusing $tool — target lives in the main worktree:
   ${target:-$target_dir}
@@ -211,58 +115,36 @@ for any work. Edits in the main worktree collide with the user's other sessions.
 EOF
     exit 2
     ;;
-  Bash)
-    trimmed="$(printf '%s' "$cmd" | sed -E 's/^[[:space:]]+//')"
-    block=0; reason=""
-    if printf '%s' "$trimmed" | grep -qE '(^|[;&|`(]|&&|\|\|)[[:space:]]*git([[:space:]]+-C[[:space:]]+\S+)?[[:space:]]+(checkout|switch|merge|rebase|reset|commit|push|pull|cherry-pick|revert|am|apply|branch[[:space:]]+(-D|-d|-m|--delete|--force)|stash[[:space:]]+(pop|apply|drop|clear)|worktree[[:space:]]+(remove|prune)|clean|tag[[:space:]]+(-d|--delete))\b'; then
-      block=1; reason="git mutation in main worktree"
-    fi
-    # Shell write redirect: only block if the redirect target path resolves
-    # *into the main worktree*. Writes to /tmp, /var/log, etc. are fine.
-    redirect_into_main="$(printf '%s' "$cmd" | python3 -c '
-import sys, re, os
-text = sys.stdin.read()
-repo = sys.argv[1] if len(sys.argv) > 1 else ""
-real_repo = os.path.realpath(repo) if repo else ""
-hit = False
-# Match >  or  >>  (NOT preceded by a digit or & — those are file-descriptor
-# operators like 2>&1, &>file, 2>file). We only care about plain stdout
-# redirects, since those are what an AI would use to write into the repo.
-for m in re.finditer(r"(?<![\d&])>>?\s*(?:\"([^\"]+)\"|\x27([^\x27]+)\x27|(\S+))", text):
-    p = m.group(1) or m.group(2) or m.group(3)
-    if not p:
-        continue
-    # Skip fd duplications (>&1, >&2) and known void targets.
-    if p.startswith("&") or p in ("/dev/null", "/dev/stderr", "/dev/stdout"):
-        continue
-    if p.startswith("/"):
-        ap = os.path.realpath(p)
-    elif real_repo:
-        ap = os.path.realpath(os.path.join(real_repo, p))
-    else:
-        continue
-    if real_repo and (ap == real_repo or ap.startswith(real_repo + "/")):
-        hit = True
-        break
-print("1" if hit else "0")
-' "$repo_root" 2>/dev/null || echo 0)"
-    if [ "$redirect_into_main" = "1" ]; then
-      block=1; reason="${reason:+$reason; }shell write redirect into main worktree"
-    fi
-    if printf '%s' "$trimmed" | grep -qE '(^|[[:space:]])(sed[[:space:]]+(-[a-zA-Z]*i[a-zA-Z]*|-i)|perl[[:space:]]+-[a-zA-Z]*pi[a-zA-Z]*)\b'; then
-      block=1; reason="${reason:+$reason; }in-place edit in main worktree"
-    fi
-    if [ "$block" -eq 1 ]; then
-      cat >&2 <<EOF
-[forbid-main-worktree] Refusing Bash — target is the main worktree:
-  $repo_root
-Reason: $reason
-Command: $cmd
-
-Move to a worktree first (or pass git -C <worktree-path>).
-EOF
-      exit 2
-    fi
-    ;;
 esac
+
+# === Bash tool rules — delegated to lib/check-bash-rules.py (shlex-based) ===
+# Rules that always apply when somewhere in the librefang repo (cargo bans,
+# worktree remove targeting main).
+rules="cargo-build-run-install,cargo-test-unscoped,worktree-remove-main"
+# Rules that only apply when the effective cwd is the main worktree.
+if [ "${kind:-}" = "main" ]; then
+  rules="$rules,git-mutation-main,sed-i-perl-pi-main,redirect-into-main"
+fi
+
+# Only invoke the rule library when we are inside librefang (otherwise we
+# would mis-fire on unrelated repos).
+case "$main_root" in
+  */librefang) ;;
+  *) exit 0 ;;
+esac
+
+msg="$(printf '%s' "$cmd" | python3 "$LIB" \
+  --rules "$rules" \
+  --cwd "$cwd" \
+  --main-root "$main_root" \
+  --kind "${kind:-}" 2>/dev/null || true)"
+
+if [ -n "$msg" ]; then
+  cat >&2 <<EOF
+[forbid-main-worktree] $msg
+Command: $cmd
+EOF
+  exit 2
+fi
+
 exit 0

--- a/.claude/hooks/guard-bash-safety.sh
+++ b/.claude/hooks/guard-bash-safety.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
-# PreToolUse Bash guard: block five classes of AI mistakes.
+# PreToolUse Bash safety guard for librefang.
 #
-# Rules:
-#   A. Force-push to main / master (incl. `+branch` syntax)
-#   B. `--no-verify` / `--no-gpg-sign` on commit/push/rebase/merge/am/cherry-pick/pull
-#   C. Staging likely-sensitive files (.env / *.pem / *.key / credentials.json / id_rsa…)
-#      and broad `git add -A` / `git add .` (CLAUDE.md global rule: prefer specific paths)
-#   D. Commit messages containing Claude attribution
-#      (`Co-Authored-By: Claude`, `Generated with Claude`, `🤖 Generated with [Claude Code]`)
-#   E. `rm -rf` against dangerous targets (/, ~, $HOME, target, .git, /Users, /usr, /etc, …)
+# Blocks classes of AI mistakes documented under "Other AI safety hooks"
+# in CLAUDE.md. Rule logic lives in lib/check-bash-rules.py, which uses
+# shlex tokenization so quoted argument content (commit message bodies,
+# etc.) does not falsely match against rule keywords.
 #
-# Hook protocol: read tool-call JSON from stdin, exit 2 to deny.
+# Hook protocol: read JSON from stdin, exit 2 to deny.
 
 set -euo pipefail
 input="$(cat)"
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+LIB="$script_dir/lib/check-bash-rules.py"
+
 py() { python3 -c "$1" 2>/dev/null || true; }
 
 tool="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_name",""))')"
@@ -22,134 +21,16 @@ tool="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).g
 cmd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))')"
 [ -n "$cmd" ] || exit 0
 
-deny() {
-  printf '[guard-bash-safety] %s\nCommand: %s\n' "$1" "$cmd" >&2
+rules="force-push-main,no-verify,broad-git-add,sensitive-file-add,claude-attribution,rm-rf-dangerous,librefang-daemon-launch,cargo-add-remove-upgrade,gh-pr-merge"
+
+msg="$(printf '%s' "$cmd" | python3 "$LIB" --rules "$rules" 2>/dev/null || true)"
+
+if [ -n "$msg" ]; then
+  cat >&2 <<MSG
+[guard-bash-safety] $msg
+Command: $cmd
+MSG
   exit 2
-}
-
-# ---------------------------------------------------------------------------
-# A. Force-push to main / master
-# ---------------------------------------------------------------------------
-# Match if the command is a `git push` AND uses a force flag AND targets a
-# protected branch (either `... main` / `... master` arg, or the `+branch`
-# refspec syntax).
-if printf '%s' "$cmd" | grep -qE '\bgit\b([[:space:]]+-C[[:space:]]+\S+)?[[:space:]].*\bpush\b'; then
-  has_force=0
-  if printf '%s' "$cmd" | grep -qE '([[:space:]]|^)(-f|--force|--force-with-lease)([[:space:]]|=|$)'; then
-    has_force=1
-  fi
-  # `git push origin +main` is also a force push.
-  if printf '%s' "$cmd" | grep -qE '([[:space:]])\+(main|master|HEAD)([[:space:]]|:|$)'; then
-    has_force=1
-  fi
-  if [ "$has_force" = 1 ]; then
-    if printf '%s' "$cmd" | grep -qE '([[:space:]]|/|:|\+)(main|master)([[:space:]]|:|$)'; then
-      deny "Refusing force-push to main / master. Force pushes there are near-irreversible — get explicit user confirmation and consider a safer alternative."
-    fi
-  fi
-fi
-
-# ---------------------------------------------------------------------------
-# B. --no-verify / --no-gpg-sign
-# ---------------------------------------------------------------------------
-if printf '%s' "$cmd" | grep -qE '\bgit\b.*(\s|^)(commit|push|rebase|merge|am|cherry-pick|pull)\b' \
-   && printf '%s' "$cmd" | grep -qE '(\s|^)(--no-verify|--no-gpg-sign)\b'; then
-  deny "Refusing --no-verify / --no-gpg-sign. Bypassing hooks is not allowed — fix the underlying failure instead."
-fi
-
-# ---------------------------------------------------------------------------
-# D. Claude attribution in commit message
-# ---------------------------------------------------------------------------
-# Inspect the value of -m / --message arguments. If the user is reading the
-# message from a heredoc / file we cannot see it from here; in that case we
-# fall through and rely on a git-side commit-msg hook (out of scope here).
-if printf '%s' "$cmd" | grep -qE '\bgit\b.*\bcommit\b'; then
-  msg="$(printf '%s' "$cmd" | py '
-import sys, shlex
-text = sys.stdin.read()
-try:
-    toks = shlex.split(text, posix=True)
-except ValueError:
-    toks = text.split()
-msgs = []
-i = 0
-while i < len(toks):
-    t = toks[i]
-    if t in ("-m", "--message", "-F", "--file"):
-        if i + 1 < len(toks):
-            msgs.append(toks[i+1])
-        i += 2
-        continue
-    if t.startswith("--message="):
-        msgs.append(t[len("--message="):])
-    elif t.startswith("-m") and len(t) > 2:
-        msgs.append(t[2:])
-    i += 1
-print("\n----\n".join(msgs))
-')"
-  if [ -n "$msg" ] && printf '%s' "$msg" | grep -qiE '(Co-Authored-By:.*(Claude|Anthropic|noreply@anthropic\.com)|Generated with .{0,40}Claude|🤖.*Claude[[:space:]]+Code)'; then
-    deny "Refusing commit — message contains Claude attribution (Co-Authored-By / Generated with Claude). CLAUDE.md forbids these. Remove the line and retry."
-  fi
-fi
-
-# ---------------------------------------------------------------------------
-# C. Sensitive-file staging + broad `git add`
-# ---------------------------------------------------------------------------
-if printf '%s' "$cmd" | grep -qE '\bgit\b([[:space:]]+-C[[:space:]]+\S+)?[[:space:]].*\b(add|commit)\b'; then
-  # C1. Block broad add (`git add -A`, `git add --all`, `git add .`, `git add :/`).
-  if printf '%s' "$cmd" | grep -qE '\bgit\b([[:space:]]+-C[[:space:]]+\S+)?[[:space:]]+add\b[^|;&]*([[:space:]](-A|-a|--all|--update|-u)\b|[[:space:]]\.($|[[:space:]])|[[:space:]]:/(\s|$))'; then
-    deny "Refusing broad \`git add\`. CLAUDE.md (global) requires staging specific files by name to avoid sweeping in secrets / large binaries. Add files explicitly: \`git add path/to/file ...\`."
-  fi
-  # C2. Block known sensitive filenames anywhere in the command.
-  if printf '%s' "$cmd" | grep -qiE '(^|[[:space:]/=":'\''])((\.env)(\.[a-z0-9._-]+)?|id_(rsa|ed25519|ecdsa|dsa)(\.pub)?|credentials(\.[a-z]+)?|secrets?(\.[a-z]+)?|vault[_-][a-z0-9_-]+\.(key|json)|[a-z0-9_/.-]+\.(pem|p12|pfx|jks|keystore))($|[[:space:]"'\''])' \
-     && ! printf '%s' "$cmd" | grep -qiE '\.(example|template|sample)(\s|$|"|'\'')'; then
-    deny "Refusing — command references a likely-sensitive file (.env / id_rsa / *.pem / credentials.json / vault_*.key …). If you really need to track it, ask the user first."
-  fi
-fi
-
-# ---------------------------------------------------------------------------
-# E. rm -rf against dangerous paths
-# ---------------------------------------------------------------------------
-# Catch any rm with a recursive+force combo (-rf / -fr / -Rf / -fR / -r -f / etc.)
-if printf '%s' "$cmd" | grep -qE '(^|[[:space:]/;&|`(])rm[[:space:]]+([^|;&]*[[:space:]])?(-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*|-rf|-fr|-Rf|-fR)([[:space:]]|$)' \
-   || printf '%s' "$cmd" | grep -qE '(^|[[:space:]/;&|`(])rm[[:space:]]+(-[rR]\b[^|;&]*-f\b|-f\b[^|;&]*-[rR]\b)'; then
-  # Dangerous targets: filesystem roots, $HOME, repo-shared dirs, system trees.
-  # Match either as a standalone token after rm or with simple suffixes.
-  if printf '%s' "$cmd" | grep -qE '(^|[[:space:]"'\''])(/|/\*|~|~/|\$HOME|\$HOME/|\$\{HOME\}|/Users|/Users/|/home|/home/|/usr|/var|/etc|/opt|/private|/System|/Library|target|target/|\./target|\./target/|\.git|\.git/|\./\.git|\./\.git/)([[:space:]"'\'']|$)'; then
-    deny "Refusing rm -rf against a dangerous path (/, ~, \$HOME, target, .git, /Users, /usr, /etc …). Be specific or ask the user."
-  fi
-fi
-
-# ---------------------------------------------------------------------------
-# F. Daemon launch ban (`librefang start`, direct binary invocation)
-# ---------------------------------------------------------------------------
-# The librefang daemon binds 127.0.0.1:4545 by default. The user typically has
-# one running. AI launching another (or killing theirs and replacing) causes
-# port conflicts and clobbers the user's session. Per CLAUDE.md, the
-# "Live Integration Testing" flow is a HUMAN workflow.
-if printf '%s' "$cmd" | grep -qE '(^|[[:space:]/;&|`(])(librefang(\.exe)?|target/(debug|release)/librefang(\.exe)?|\./target/(debug|release)/librefang(\.exe)?)[[:space:]]+(start|daemon)\b'; then
-  deny "Refusing — starting the librefang daemon is a HUMAN workflow per CLAUDE.md (port 4545 is typically already bound by the user's session). Ask the user to run it and report back, instead of launching it yourself."
-fi
-
-# ---------------------------------------------------------------------------
-# G. `cargo add` / `cargo remove` — dependency mutations require user OK
-# ---------------------------------------------------------------------------
-# Global CLAUDE.md: "禁止擅自加依赖". Block the cargo subcommands that add or
-# remove deps; force the AI to surface the change for explicit approval.
-if printf '%s' "$cmd" | grep -qE '(^|[[:space:]/;&|`(])cargo[[:space:]]+(add|rm|remove|upgrade)\b'; then
-  deny "Refusing — \`cargo add/remove/upgrade\` mutates Cargo.toml dependencies, which CLAUDE.md (global) forbids without explicit user approval. Surface the proposed dep change first and let the user run the command."
-fi
-
-# ---------------------------------------------------------------------------
-# H. \`gh pr merge\` and admin-bypass merges
-# ---------------------------------------------------------------------------
-# Always block merge bypasses (--admin) and disallow merging without explicit
-# user say-so — even regular \`gh pr merge <pr>\` is a publish-level action.
-if printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+merge\b'; then
-  if printf '%s' "$cmd" | grep -qE '(^|[[:space:]])--admin\b'; then
-    deny "Refusing \`gh pr merge --admin\`. The --admin flag bypasses branch protection — equivalent to force-pushing to main. Get explicit user confirmation."
-  fi
-  deny "Refusing \`gh pr merge\`. Merging is a publish-level action; ask the user to merge themselves rather than doing it from the AI session."
 fi
 
 exit 0

--- a/.claude/hooks/lib/check-bash-rules.py
+++ b/.claude/hooks/lib/check-bash-rules.py
@@ -1,0 +1,682 @@
+#!/usr/bin/env python3
+"""Shared rule-checker for the librefang Claude Code hooks.
+
+Tokenizes a Bash command with shlex (quote-aware) and runs the requested rule.
+Returns the violation message on stdout, empty stdout on no violation.
+Always exits 0 — the calling shell hook decides what to do with the message.
+
+Why shlex? Earlier versions used `grep -qE` regexes against the raw command
+string. That conflated *real* command invocations with *string content* —
+for example, a commit message body containing the literal text
+"... use cargo check ...; cargo test is a HUMAN workflow ..." matched the
+"cargo test" regex even though no cargo invocation existed. shlex respects
+quotes, so any text inside `-m "..."` arrives as a single token and we can
+skip it when looking for command-position tokens.
+
+Usage (called from the hook shell scripts):
+
+    msg="$(printf '%s' "$cmd" | python3 path/to/check-bash-rules.py \\
+        --rule <rule-name> [--cwd ...] [--main-root ...] [--kind main|worktree])"
+    if [ -n "$msg" ]; then ... refuse ... fi
+
+Available rules:
+
+  cargo-build-run-install   -> banned anywhere in the librefang repo
+  cargo-test-unscoped       -> banned (allow `cargo test -p <crate>` only)
+  cargo-add-remove-upgrade  -> banned (deps need user OK)
+  worktree-remove-main      -> banned (`git worktree remove/move` of main path)
+  git-mutation-main         -> banned (when kind=main)
+  sed-i-main / perl-pi-main -> banned (when kind=main)
+  redirect-into-main        -> banned (when kind=main)
+  force-push-main           -> banned
+  no-verify                 -> banned
+  broad-git-add             -> banned (`git add -A` / `git add .`)
+  sensitive-file-add        -> banned (.env, *.pem, id_rsa, …)
+  claude-attribution        -> banned (-m / --message containing Co-Authored-By: Claude etc.)
+  rm-rf-dangerous           -> banned (rm -rf against /, ~, target, .git, …)
+  librefang-daemon-launch   -> banned (`librefang start`, target/release/librefang start)
+  gh-pr-merge               -> banned (publish-level)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import sys
+
+
+# -----------------------------------------------------------------------------
+# Tokenization
+# -----------------------------------------------------------------------------
+
+SKIP_AFTER_FLAGS = {"-m", "--message", "-F", "--file", "-c", "-C"}
+
+# Operators shlex returns as their own tokens (sometimes glued to surrounding
+# text). We split tokens on these to recover command-position info.
+SHELL_OPS = ("&&", "||", ";;", ";", "|", "&", "(", ")")
+
+
+def tokenize(cmd: str) -> list[str]:
+    """shlex.split with a fallback so a malformed quote can't crash the hook."""
+    try:
+        return shlex.split(cmd, posix=True)
+    except ValueError:
+        return cmd.split()
+
+
+def is_quoted_content(t: str) -> bool:
+    """A token containing whitespace came from inside a quoted string in the
+    original command; shlex would otherwise have split it."""
+    return any(c in t for c in " \t\n\r")
+
+
+def strip_parens(t: str) -> str:
+    """Bash subshells like `(cargo build)` keep the parens glued in shlex
+    tokens. Strip them so equality checks work."""
+    return t.lstrip("(").rstrip(")")
+
+
+def at_command_position(toks: list[str], i: int) -> bool:
+    """Return True if the token at index i sits at the start of a command —
+    either at index 0, after a shell operator, or after a paren."""
+    if i == 0:
+        return True
+    p = toks[i - 1]
+    if p in SHELL_OPS:
+        return True
+    if p in SKIP_AFTER_FLAGS:
+        return False
+    return False
+
+
+def has_p_flag(rest: list[str]) -> bool:
+    """`cargo test` is scoped if any of -p / --package / -p<crate> /
+    --package=<crate> appears in the trailing args."""
+    for x in rest:
+        if x in ("-p", "--package"):
+            return True
+        if x.startswith("--package="):
+            return True
+        if x.startswith("-p") and len(x) > 2 and not x[2:].startswith("-"):
+            return True
+    return False
+
+
+# -----------------------------------------------------------------------------
+# Helpers shared across rules
+# -----------------------------------------------------------------------------
+
+
+def find_cargo_subcommand(toks: list[str], wanted_subs: set[str]):
+    """Walk tokens looking for a real `cargo <sub>` invocation where <sub> is
+    in wanted_subs. Returns (sub, index_of_sub) or None."""
+    for i, t in enumerate(toks):
+        if is_quoted_content(t):
+            continue
+        prev = toks[i - 1] if i > 0 else None
+        if prev in SKIP_AFTER_FLAGS:
+            continue
+        if strip_parens(t) != "cargo":
+            continue
+        if i + 1 >= len(toks):
+            continue
+        sub = strip_parens(toks[i + 1])
+        if sub in wanted_subs:
+            return sub, i + 1
+    return None
+
+
+def walk_git_invocations(toks: list[str]):
+    """Yield (i_git, j_after_C, c_path) for each `git [-C path] ...` we find
+    where i_git is the index of the `git` token, j_after_C is the index of the
+    first non-`-C` argument, and c_path is the value passed via `-C` (or None
+    if no `-C` was used). Skips occurrences inside quoted content."""
+    i = 0
+    while i < len(toks):
+        if is_quoted_content(toks[i]):
+            i += 1
+            continue
+        if strip_parens(toks[i]) != "git":
+            i += 1
+            continue
+        # Optional -C <path>
+        j = i + 1
+        c_path = None
+        if j < len(toks) and toks[j] == "-C":
+            if j + 1 < len(toks):
+                c_path = toks[j + 1]
+            j += 2
+        yield i, j, c_path
+        i = j + 1
+
+
+# -----------------------------------------------------------------------------
+# Rule implementations
+# -----------------------------------------------------------------------------
+
+
+def rule_cargo_build_run_install(toks, ctx):
+    hit = find_cargo_subcommand(toks, {"build", "run", "install"})
+    if hit:
+        sub = hit[0]
+        return (
+            f"`cargo {sub}` is banned in this repo (target/ is shared across "
+            f"worktrees and contends with the user's other sessions). Use "
+            f"`cargo check`; CI handles full build."
+        )
+    return None
+
+
+def rule_cargo_test_unscoped(toks, ctx):
+    hit = find_cargo_subcommand(toks, {"test"})
+    if not hit:
+        return None
+    _sub, sub_idx = hit
+    if has_p_flag(toks[sub_idx + 1 :]):
+        return None
+    return (
+        "Unscoped `cargo test` builds and runs the whole workspace, which is "
+        "too slow / target-contending for the AI to invoke. Re-run with "
+        "`-p <crate>` (or `--package <crate>`)."
+    )
+
+
+def rule_cargo_add_remove_upgrade(toks, ctx):
+    hit = find_cargo_subcommand(toks, {"add", "rm", "remove", "upgrade"})
+    if not hit:
+        return None
+    sub = hit[0]
+    return (
+        f"`cargo {sub}` mutates Cargo.toml dependencies, which CLAUDE.md "
+        f"(global) forbids without explicit user approval. Surface the "
+        f"proposed dep change first and let the user run the command."
+    )
+
+
+def rule_worktree_remove_main(toks, ctx):
+    """git [-C base] worktree (remove|move) <path> where <path> resolves to
+    main_root."""
+    main_root = ctx.get("main_root", "")
+    cwd = ctx.get("cwd", "")
+    if not main_root:
+        return None
+    real_main = os.path.realpath(main_root)
+
+    for i_git, j, c_path in walk_git_invocations(toks):
+        if j >= len(toks):
+            continue
+        if strip_parens(toks[j]) != "worktree":
+            continue
+        if j + 1 >= len(toks):
+            continue
+        sub = strip_parens(toks[j + 1])
+        if sub not in ("remove", "move"):
+            continue
+        rest = toks[j + 2 :]
+        positionals = [x for x in rest if not x.startswith("-")]
+        if not positionals:
+            continue
+        target = positionals[0]
+        base = c_path or cwd
+        if not target.startswith("/") and base:
+            target = os.path.join(base, target)
+        try:
+            target = os.path.realpath(target)
+        except OSError:
+            continue
+        if target == real_main:
+            return (
+                f"`git worktree {sub}` targeting the MAIN worktree itself "
+                f"({main_root}). That would destroy the user's main checkout. "
+                f"If this is really what you want, ask the user to do it."
+            )
+    return None
+
+
+GIT_DIRECT_MUTATIONS = {
+    "checkout", "switch", "merge", "rebase", "reset", "commit", "push",
+    "pull", "cherry-pick", "revert", "am", "apply", "clean",
+}
+GIT_BRANCH_FORCE_FLAGS = {"-D", "-d", "-m", "--delete", "--force"}
+GIT_STASH_MUTATIONS = {"pop", "apply", "drop", "clear"}
+GIT_WORKTREE_MUTATIONS = {"remove", "prune", "move"}
+GIT_TAG_DELETE_FLAGS = {"-d", "--delete"}
+
+
+def rule_git_mutation_main(toks, ctx):
+    """When kind=main, refuse any modifying git invocation. We use
+    walk_git_invocations to skip git commands embedded inside quoted args."""
+    if ctx.get("kind") != "main":
+        return None
+
+    for i_git, j, c_path in walk_git_invocations(toks):
+        if j >= len(toks):
+            continue
+        sub = strip_parens(toks[j])
+        sub_arg = strip_parens(toks[j + 1]) if j + 1 < len(toks) else None
+        if sub in GIT_DIRECT_MUTATIONS:
+            return f"`git {sub}` in main worktree."
+        if sub == "branch" and sub_arg in GIT_BRANCH_FORCE_FLAGS:
+            return f"`git branch {sub_arg}` in main worktree."
+        if sub == "stash" and sub_arg in GIT_STASH_MUTATIONS:
+            return f"`git stash {sub_arg}` in main worktree."
+        if sub == "worktree" and sub_arg in GIT_WORKTREE_MUTATIONS:
+            return f"`git worktree {sub_arg}` in main worktree."
+        if sub == "tag" and sub_arg in GIT_TAG_DELETE_FLAGS:
+            return f"`git tag {sub_arg}` in main worktree."
+    return None
+
+
+def rule_sed_i_perl_pi_main(toks, ctx):
+    if ctx.get("kind") != "main":
+        return None
+    for i, t in enumerate(toks):
+        if is_quoted_content(t):
+            continue
+        c = strip_parens(t)
+        if c == "sed":
+            for x in toks[i + 1 :]:
+                if is_quoted_content(x):
+                    break
+                cx = strip_parens(x)
+                if cx.startswith("-") and not cx.startswith("--") and "i" in cx[1:]:
+                    return "`sed -i` in main worktree."
+                if not cx.startswith("-"):
+                    break
+        if c == "perl":
+            for x in toks[i + 1 :]:
+                if is_quoted_content(x):
+                    break
+                cx = strip_parens(x)
+                if cx.startswith("-") and "p" in cx and "i" in cx:
+                    return "`perl -pi` in main worktree."
+                if not cx.startswith("-"):
+                    break
+    return None
+
+
+def rule_redirect_into_main(toks, ctx):
+    """Detect `>` / `>>` redirects whose target lands in the main worktree.
+
+    shlex tokenization gives us quote-awareness for free: `>` inside a quoted
+    string (e.g. inside a commit message) becomes part of the surrounding
+    token rather than a standalone redirect operator, so we just scan the
+    tokens for real shell-level redirects.
+    """
+    if ctx.get("kind") != "main":
+        return None
+    main_root = ctx.get("main_root", "")
+    if not main_root:
+        return None
+    real_repo = os.path.realpath(main_root)
+
+    for i, t in enumerate(toks):
+        target = None
+        if t in (">", ">>"):
+            if i + 1 < len(toks) and not is_quoted_content(toks[i + 1]):
+                target = toks[i + 1]
+        elif re.match(r"^>>?[^&]", t):
+            # Glued form: `>foo`, `>>foo`. Excludes `>&1`, `>&-`, etc.
+            target = t[2:] if t.startswith(">>") else t[1:]
+        if not target:
+            continue
+        if target.startswith("&") or target in ("/dev/null", "/dev/stderr", "/dev/stdout"):
+            continue
+        if target.startswith("/"):
+            ap = os.path.realpath(target)
+        else:
+            ap = os.path.realpath(os.path.join(real_repo, target))
+        if ap == real_repo or ap.startswith(real_repo + "/"):
+            return f"Shell write redirect into main worktree (target: {ap})."
+    return None
+
+
+def rule_force_push_main(toks, ctx):
+    """git [-C ...] push ... (-f|--force|--force-with-lease) ... main|master,
+    or `+main`/`+master` refspec."""
+    for i_git, j, c_path in walk_git_invocations(toks):
+        # Find `push` somewhere in the rest of this git invocation. We treat
+        # the rest of the tokens (until next ;|&||| etc) as args; shlex doesn't
+        # know about operators, so we walk until end of toks. False matches
+        # are unlikely because we only walk after a literal `git` token.
+        rest = toks[j:]
+        if not any(strip_parens(x) == "push" for x in rest):
+            continue
+        has_force = any(
+            x in ("-f", "--force", "--force-with-lease")
+            or x.startswith("--force=")
+            for x in rest
+        )
+        targets_main = False
+        for x in rest:
+            cx = strip_parens(x)
+            if cx in ("main", "master"):
+                targets_main = True
+                break
+            if cx.startswith("+"):
+                bare = cx.lstrip("+")
+                if bare in ("main", "master", "HEAD"):
+                    targets_main = True
+                    has_force = True
+                    break
+            if ":" in cx:
+                _, dst = cx.rsplit(":", 1)
+                if dst.lstrip("+") in ("main", "master"):
+                    targets_main = True
+                    if cx.startswith("+") or "+" in cx.split(":")[0]:
+                        has_force = True
+                    break
+        if has_force and targets_main:
+            return (
+                "Force-push to main / master is near-irreversible. Get "
+                "explicit user confirmation and consider a safer alternative."
+            )
+    return None
+
+
+def rule_no_verify(toks, ctx):
+    """`--no-verify` / `--no-gpg-sign` on commit/push/rebase/merge/am/cherry-pick/pull."""
+    for i_git, j, c_path in walk_git_invocations(toks):
+        rest = toks[j:]
+        if not rest:
+            continue
+        sub = strip_parens(rest[0])
+        if sub not in (
+            "commit", "push", "rebase", "merge", "am", "cherry-pick", "pull",
+        ):
+            continue
+        for x in rest[1:]:
+            if is_quoted_content(x):
+                continue
+            if x in ("--no-verify", "--no-gpg-sign"):
+                return (
+                    f"`{x}` bypasses hooks/signing. Not allowed — fix the "
+                    f"underlying failure instead."
+                )
+    return None
+
+
+def rule_broad_git_add(toks, ctx):
+    for i_git, j, c_path in walk_git_invocations(toks):
+        rest = toks[j:]
+        if not rest:
+            continue
+        sub = strip_parens(rest[0])
+        if sub != "add":
+            continue
+        for x in rest[1:]:
+            if is_quoted_content(x):
+                continue
+            cx = strip_parens(x)
+            if cx in ("-A", "-a", "--all", "--update", "-u"):
+                return (
+                    "Broad `git add` (-A / -a / --all / --update). CLAUDE.md "
+                    "(global) requires staging specific files by name to "
+                    "avoid sweeping in secrets / large binaries."
+                )
+            if cx == ".":
+                return (
+                    "Broad `git add .` stages everything in cwd. Stage "
+                    "specific files by name."
+                )
+            if cx == ":/":
+                return "Broad `git add :/` stages the whole repo."
+    return None
+
+
+_SENSITIVE_RE = re.compile(
+    r"^("
+    r"\.env(\.[a-z0-9._-]+)?"
+    r"|id_(rsa|ed25519|ecdsa|dsa)(\.pub)?"
+    r"|credentials(\.[a-z]+)?"
+    r"|secrets?(\.[a-z]+)?"
+    r"|vault[_-][a-z0-9_-]+\.(key|json)"
+    r"|.+\.(pem|p12|pfx|jks|keystore)"
+    r")$",
+    re.IGNORECASE,
+)
+_EXAMPLE_RE = re.compile(r"\.(example|template|sample)$", re.IGNORECASE)
+
+
+def _looks_sensitive(token: str) -> bool:
+    if is_quoted_content(token):
+        return False
+    # Inspect just the basename — `path/to/.env` and `~/.ssh/id_rsa` should both match.
+    base = os.path.basename(strip_parens(token))
+    if not base:
+        return False
+    if _EXAMPLE_RE.search(base):
+        return False
+    return bool(_SENSITIVE_RE.match(base))
+
+
+def rule_sensitive_file_add(toks, ctx):
+    for i_git, j, c_path in walk_git_invocations(toks):
+        rest = toks[j:]
+        if not rest:
+            continue
+        sub = strip_parens(rest[0])
+        if sub not in ("add", "commit"):
+            continue
+        # For `git commit`, ignore everything after -m / -F / --message / --file.
+        i = 1
+        while i < len(rest):
+            x = rest[i]
+            if is_quoted_content(x):
+                i += 1
+                continue
+            if x in SKIP_AFTER_FLAGS:
+                i += 2
+                continue
+            if x.startswith("--message=") or x.startswith("--file="):
+                i += 1
+                continue
+            if _looks_sensitive(x):
+                return (
+                    f"Command references a likely-sensitive file ({x}). "
+                    f"If you really need to track it, ask the user first."
+                )
+            i += 1
+    return None
+
+
+_ATTRIBUTION_RE = re.compile(
+    r"(Co-Authored-By:.*(Claude|Anthropic|noreply@anthropic\.com)"
+    r"|Generated with .{0,40}Claude"
+    r"|🤖.*Claude\s+Code)",
+    re.IGNORECASE,
+)
+
+
+def rule_claude_attribution(toks, ctx):
+    """Inspect the value passed to -m / --message of a `git commit`."""
+    for i_git, j, c_path in walk_git_invocations(toks):
+        rest = toks[j:]
+        if not rest or strip_parens(rest[0]) != "commit":
+            continue
+        i = 1
+        while i < len(rest):
+            x = rest[i]
+            msg = None
+            if x in ("-m", "--message"):
+                if i + 1 < len(rest):
+                    msg = rest[i + 1]
+                i += 2
+            elif x.startswith("--message="):
+                msg = x[len("--message=") :]
+                i += 1
+            elif x.startswith("-m") and len(x) > 2:
+                msg = x[2:]
+                i += 1
+            else:
+                i += 1
+                continue
+            if msg and _ATTRIBUTION_RE.search(msg):
+                return (
+                    "Commit message contains Claude / Anthropic attribution "
+                    "(Co-Authored-By / Generated with Claude / 🤖 Claude Code). "
+                    "CLAUDE.md forbids these. Remove the line and retry."
+                )
+    return None
+
+
+_RM_DANGEROUS_PATHS = {
+    "/", "/*", "~", "~/", "$HOME", "$HOME/", "${HOME}", "${HOME}/",
+    "/Users", "/Users/", "/home", "/home/", "/usr", "/var", "/etc",
+    "/opt", "/private", "/System", "/Library",
+    "target", "target/", "./target", "./target/",
+    ".git", ".git/", "./.git", "./.git/",
+}
+
+
+def rule_rm_rf_dangerous(toks, ctx):
+    for i, t in enumerate(toks):
+        if is_quoted_content(t):
+            continue
+        if strip_parens(t) != "rm":
+            continue
+        # Collect flags + positionals until we leave this rm command.
+        flags = ""
+        positionals = []
+        for x in toks[i + 1 :]:
+            if is_quoted_content(x):
+                # Quoted arg — could be a path. Treat as positional.
+                positionals.append(x)
+                continue
+            cx = strip_parens(x)
+            if cx in SHELL_OPS:
+                break
+            if cx.startswith("-") and not cx == "-":
+                # Long --opt or short -rf cluster
+                flags += cx[1:].lstrip("-")
+            else:
+                positionals.append(cx)
+        # rm needs both -r/-R and -f for our criterion
+        recursive = "r" in flags or "R" in flags or "--recursive" in flags
+        force = "f" in flags or "--force" in flags
+        # Long-flag detection above isn't quite right — refine:
+        if "--recursive" in toks[i + 1 :]:
+            recursive = True
+        if "--force" in toks[i + 1 :]:
+            force = True
+        if not (recursive and force):
+            continue
+        for p in positionals:
+            if p in _RM_DANGEROUS_PATHS:
+                return (
+                    f"`rm -rf {p}` against a dangerous path. Be specific or "
+                    f"ask the user."
+                )
+    return None
+
+
+def rule_librefang_daemon_launch(toks, ctx):
+    for i, t in enumerate(toks):
+        if is_quoted_content(t):
+            continue
+        c = strip_parens(t)
+        # Match: librefang, librefang.exe, target/{debug,release}/librefang[.exe],
+        # ./target/{debug,release}/librefang[.exe]
+        is_binary = (
+            c == "librefang"
+            or c == "librefang.exe"
+            or re.fullmatch(r"\.?/?target/(debug|release)/librefang(\.exe)?", c)
+        )
+        if not is_binary:
+            continue
+        if i + 1 >= len(toks):
+            continue
+        sub = strip_parens(toks[i + 1])
+        if sub in ("start", "daemon"):
+            return (
+                "Starting the librefang daemon is a HUMAN workflow per "
+                "CLAUDE.md (port 4545 typically owned by the user's session). "
+                "Ask the user to run it and report back."
+            )
+    return None
+
+
+def rule_gh_pr_merge(toks, ctx):
+    for i, t in enumerate(toks):
+        if is_quoted_content(t):
+            continue
+        if strip_parens(t) != "gh":
+            continue
+        if i + 2 >= len(toks):
+            continue
+        if strip_parens(toks[i + 1]) != "pr":
+            continue
+        if strip_parens(toks[i + 2]) != "merge":
+            continue
+        # Found gh pr merge
+        if any(x == "--admin" for x in toks[i + 3 :] if not is_quoted_content(x)):
+            return (
+                "`gh pr merge --admin` bypasses branch protection — equivalent "
+                "to force-pushing to main. Get explicit user confirmation."
+            )
+        return (
+            "`gh pr merge` is a publish-level action; ask the user to merge "
+            "themselves rather than doing it from the AI session."
+        )
+    return None
+
+
+# -----------------------------------------------------------------------------
+# Dispatcher
+# -----------------------------------------------------------------------------
+
+RULES = {
+    "cargo-build-run-install":   rule_cargo_build_run_install,
+    "cargo-test-unscoped":       rule_cargo_test_unscoped,
+    "cargo-add-remove-upgrade":  rule_cargo_add_remove_upgrade,
+    "worktree-remove-main":      rule_worktree_remove_main,
+    "git-mutation-main":         rule_git_mutation_main,
+    "sed-i-perl-pi-main":        rule_sed_i_perl_pi_main,
+    "redirect-into-main":        rule_redirect_into_main,
+    "force-push-main":           rule_force_push_main,
+    "no-verify":                 rule_no_verify,
+    "broad-git-add":             rule_broad_git_add,
+    "sensitive-file-add":        rule_sensitive_file_add,
+    "claude-attribution":        rule_claude_attribution,
+    "rm-rf-dangerous":           rule_rm_rf_dangerous,
+    "librefang-daemon-launch":   rule_librefang_daemon_launch,
+    "gh-pr-merge":               rule_gh_pr_merge,
+}
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--rules", required=True,
+                   help="Comma-separated list of rule names to evaluate")
+    p.add_argument("--cwd", default="")
+    p.add_argument("--main-root", default="")
+    p.add_argument("--kind", default="", choices=["", "main", "worktree"])
+    args = p.parse_args()
+
+    cmd = sys.stdin.read()
+    toks = tokenize(cmd)
+    ctx = {
+        "cwd": args.cwd,
+        "main_root": args.main_root,
+        "kind": args.kind,
+        "cmd": cmd,
+    }
+
+    for name in args.rules.split(","):
+        name = name.strip()
+        if not name:
+            continue
+        rule = RULES.get(name)
+        if not rule:
+            print(f"unknown rule: {name}", file=sys.stderr)
+            sys.exit(2)
+        msg = rule(toks, ctx)
+        if msg:
+            print(msg)
+            return  # first match wins; let the hook shell print prefix
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ result
 !.claude/hooks/forbid-main-worktree.sh
 !.claude/hooks/session-start-worktree-check.sh
 !.claude/hooks/guard-bash-safety.sh
+!.claude/hooks/lib/
+.claude/hooks/lib/*
+!.claude/hooks/lib/check-bash-rules.py
 .codex
 .omc/
 .qwen/


### PR DESCRIPTION
## Summary

The two PreToolUse Bash hooks (`forbid-main-worktree.sh` and `guard-bash-safety.sh`) used `grep -qE` against the raw command string for all rule checks. This conflated *real* command invocations with *string content*. The user just hit a real failure attempting to write a commit message containing the literal text `cargo test is a HUMAN workflow` — the cargo-test rule fired on the message body and the commit was refused.

The same false-positive shape affects most rules: `cargo build/run/install`, `rm -rf <path>`, `gh pr merge`, `librefang start`, `--no-verify`, `--force`, `git add .`, sensitive filenames, `sed -i`, in-place git mutations. Any of these could be triggered by mere mention in a commit message body or here-doc.

## Fix

- New shared helper `.claude/hooks/lib/check-bash-rules.py` uses `shlex.split` (quote-aware) to tokenize the command. A token that contains whitespace was inside a quoted string in the original command, so it is treated as content rather than as a candidate command. Real command invocations like `cargo build`, `git push --force origin main`, and `rm -rf target` survive as standalone tokens at command-start positions and are still caught.
- All previously regex-based rules across both hooks now route through the helper. The hook scripts are reduced to thin shells that detect context (cwd, kind, main_root) and invoke the helper.
- The `redirect-into-main` check also moves to shlex tokens, so a commit message containing `> Cargo.toml` no longer false-fires.
- `Edit`/`Write`/`MultiEdit`/`NotebookEdit` logic in `forbid-main-worktree.sh` is unchanged (it doesn't go through the Bash rule path).
- `.gitignore`: track the new `.claude/hooks/lib/` directory and the helper alongside the existing hook script exceptions.

## Test plan

74-case lib unit-test suite + 39-case end-to-end hook integration test all passing. Highlights:

- ✅ User regression (`cargo test` in commit body) — fixed
- ✅ All other commit-body false-positives (`rm -rf`, `gh pr merge`, `.env`, `librefang daemon`, `cargo add`, `--force`, `--no-verify`, `git add .`) — fixed
- ✅ Real invocations (`cargo build`, `gh pr merge`, `rm -rf /`, etc.) — still caught
- ✅ cd-prefixed commands (`cd /tmp/wt && git commit`) — still allowed in worktree, blocked in main
- ✅ `git -C linked worktree remove main` — still caught (PR #4193 fix preserved)
- ✅ `2>&1` / `>/dev/null` / `>&2` — still allowed
- ✅ `Edit`/`Write` on main — still blocked

## Architecture

Old (regex):
```
hook script → grep -qE 'pattern' → match raw cmd → false positive on string content
```

New (shlex):
```
hook script → check-bash-rules.py → shlex.split → walk tokens → detect by token shape
```

The helper exposes 15 named rules; each hook picks the subset it cares about and passes them via `--rules a,b,c`. Adding or refining a rule is now a Python function in one file rather than three regex tweaks across two shell scripts.
