### PR TITLE
fix(ci): unbreak main — Arc<Event> helper, openapi drift, test fallout

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -2202,7 +2202,7 @@ fn is_writable_config_path(path: &str) -> bool {
         "approval.auto_approve",
         "approval.totp_grace_period_secs",
     ];
-    if EXACT.iter().any(|p| *p == path) {
+    if EXACT.contains(&path) {
         return true;
     }
 

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -2777,6 +2777,28 @@ mod tests {
         assert!(mgr.is_totp_code_used("987654"));
     }
 
+    /// `record_totp_code_used_for` MUST surface a DB write failure as `Err`,
+    /// not swallow it as `Ok`. The doc on the function spells out why: a
+    /// silent failure leaves the code out of the replay-detection table,
+    /// letting an attacker reuse the same code immediately. This test
+    /// simulates the failure by dropping the underlying table out from under
+    /// the manager (e.g. corrupted or mis-migrated audit DB).
+    #[test]
+    fn record_totp_code_used_for_surfaces_db_failure() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        librefang_memory::migration::run_migrations(&conn).unwrap();
+        let conn = Arc::new(StdMutex::new(conn));
+        let mgr = ApprovalManager::new_with_db(ApprovalPolicy::default(), conn.clone());
+
+        conn.lock()
+            .unwrap()
+            .execute("DROP TABLE totp_used_codes", [])
+            .unwrap();
+
+        mgr.record_totp_code_used_for("999111", Some("approval:abc"))
+            .expect_err("DB write must surface as Err so the caller can return 500");
+    }
+
     // -----------------------------------------------------------------------
     // Per-session queue methods (Hermes-Agent parity)
     // -----------------------------------------------------------------------

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -2769,7 +2769,8 @@ mod tests {
         mgr.record_totp_code_used_for(
             "987654",
             Some("approval:11111111-1111-1111-1111-111111111111"),
-        );
+        )
+        .expect("record TOTP code");
         // Same code claimed for a different approval — must still be flagged
         // as used. Without this an attacker rewriting the path could replay
         // a captured TOTP request to authorize a higher-impact approval.

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -261,6 +261,11 @@ impl Default for EventBus {
 /// Without this helper, callers that exit on `Lagged` turn a transient
 /// burst into a permanent miss; callers that ignore `Lagged` lose triggers
 /// silently (issue #3630).
+///
+/// The payload is `Arc<Event>` because the broadcast bus shares one
+/// allocation across all subscribers (cheap fan-out). Read fields through
+/// the deref (`&event.payload`); never assume exclusive ownership — other
+/// listeners hold the same `Arc` concurrently.
 pub async fn recv_event_skipping_lag(
     rx: &mut broadcast::Receiver<Arc<Event>>,
     bus: &EventBus,

--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -262,10 +262,10 @@ impl Default for EventBus {
 /// burst into a permanent miss; callers that ignore `Lagged` lose triggers
 /// silently (issue #3630).
 pub async fn recv_event_skipping_lag(
-    rx: &mut broadcast::Receiver<Event>,
+    rx: &mut broadcast::Receiver<Arc<Event>>,
     bus: &EventBus,
     context: &'static str,
-) -> Option<Event> {
+) -> Option<Arc<Event>> {
     loop {
         match rx.recv().await {
             Ok(event) => return Some(event),

--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -793,7 +793,7 @@ mod tests {
         drop(rx);
         let request = CompletionRequest {
             model: "test".to_string(),
-            messages: vec![],
+            messages: std::sync::Arc::new(vec![]),
             tools: vec![],
             max_tokens: 1,
             temperature: 0.0,

--- a/crates/librefang-llm-drivers/tests/common/mod.rs
+++ b/crates/librefang-llm-drivers/tests/common/mod.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use librefang_llm_driver::{CompletionRequest, LlmDriver, LlmError, StreamEvent};
@@ -63,7 +64,7 @@ pub fn mock_gemini_driver(server: &MockServer) -> GeminiDriver {
 pub fn simple_request(model: &str) -> CompletionRequest {
     CompletionRequest {
         model: model.to_string(),
-        messages: vec![Message::user("hello")],
+        messages: Arc::new(vec![Message::user("hello")]),
         tools: Vec::new(),
         max_tokens: 16,
         temperature: 0.0,
@@ -81,7 +82,7 @@ pub fn simple_request(model: &str) -> CompletionRequest {
 pub fn request_with_tools(model: &str) -> CompletionRequest {
     CompletionRequest {
         model: model.to_string(),
-        messages: vec![Message::user("use a tool")],
+        messages: Arc::new(vec![Message::user("use a tool")]),
         tools: vec![ToolDefinition {
             name: "get_weather".to_string(),
             description: "Get current weather".to_string(),
@@ -109,7 +110,7 @@ pub fn request_with_tools(model: &str) -> CompletionRequest {
 pub fn request_with_temperature(model: &str, temp: f32) -> CompletionRequest {
     CompletionRequest {
         model: model.to_string(),
-        messages: vec![Message::user("hello")],
+        messages: Arc::new(vec![Message::user("hello")]),
         tools: Vec::new(),
         max_tokens: 16,
         temperature: temp,
@@ -127,7 +128,7 @@ pub fn request_with_temperature(model: &str, temp: f32) -> CompletionRequest {
 pub fn o_series_request() -> CompletionRequest {
     CompletionRequest {
         model: "o3-mini".to_string(),
-        messages: vec![Message::user("solve this")],
+        messages: Arc::new(vec![Message::user("solve this")]),
         tools: Vec::new(),
         max_tokens: 1000,
         temperature: 1.0,

--- a/openapi.json
+++ b/openapi.json
@@ -2173,7 +2173,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Max items (default 100, max 500)",
+            "description": "Max items (default 50, max 500)",
             "required": false,
             "schema": {
               "type": "integer",
@@ -6875,7 +6875,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Max items (default 100, max 500)",
+            "description": "Max items (default 50, max 500)",
             "required": false,
             "schema": {
               "type": "integer",


### PR DESCRIPTION
## Summary

Three CI failures stacked on `main` from concurrent merges:

- **Quality / Test (Ubuntu, Windows, macOS)** — `librefang-desktop` failed to compile because `recv_event_skipping_lag` still expected `Receiver<Event>` after the broadcast bus moved to `Arc<Event>`. Helper signature bumped to `Receiver<Arc<Event>>` / `Option<Arc<Event>>`. The only call site (the desktop notification listener) was already passing an `Arc<Event>` receiver and uses `&event.payload`, which keeps working through `Arc` deref.
- **OpenAPI Drift** — `openapi.json` regenerated so the `limit` query parameter on agent-list and similar routes matches the route doc-comment (`default 50, max 500`); it had drifted to `default 100`.
- **Test / lint fallout** from other in-flight refactors:
  - `approval.rs` replay test: `record_totp_code_used_for` now returns `Result`, add `.expect(...)`.
  - `librefang-llm-driver` test + `librefang-llm-drivers/tests/common`: `CompletionRequest.messages` is `Arc<Vec<Message>>`, wrap fixtures with `Arc::new`.
  - `routes/config.rs`: clippy `manual_iter_contains` — use `EXACT.contains(&path)` over `iter().any`.

Failing run for reference: https://github.com/librefang/librefang/actions/runs/25198729822

## Test plan

- [x] `cargo check -p librefang-desktop -p librefang-kernel --lib`
- [x] `cargo check -p librefang-llm-drivers --tests -p librefang-llm-driver --lib`
- [x] `cargo check -p librefang-api --lib`
- [x] `RUSTFLAGS="-D warnings" cargo clippy -p librefang-desktop -p librefang-kernel -p librefang-llm-driver -p librefang-llm-drivers -p librefang-api --all-targets`
- [ ] CI on the PR runs the full Quality / Test / OpenAPI Drift matrix