### PR TITLE
fix(ci): align Arc<Event> receiver and Arc<Vec<Message>> in tests

### DIFF
--- a/crates/librefang-kernel/src/event_bus.rs
+++ b/crates/librefang-kernel/src/event_bus.rs
@@ -262,10 +262,10 @@ impl Default for EventBus {
 /// burst into a permanent miss; callers that ignore `Lagged` lose triggers
 /// silently (issue #3630).
 pub async fn recv_event_skipping_lag(
-    rx: &mut broadcast::Receiver<Event>,
+    rx: &mut broadcast::Receiver<Arc<Event>>,
     bus: &EventBus,
     context: &'static str,
-) -> Option<Event> {
+) -> Option<Arc<Event>> {
     loop {
         match rx.recv().await {
             Ok(event) => return Some(event),

--- a/crates/librefang-llm-drivers/tests/common/mod.rs
+++ b/crates/librefang-llm-drivers/tests/common/mod.rs
@@ -63,7 +63,7 @@ pub fn mock_gemini_driver(server: &MockServer) -> GeminiDriver {
 pub fn simple_request(model: &str) -> CompletionRequest {
     CompletionRequest {
         model: model.to_string(),
-        messages: vec![Message::user("hello")],
+        messages: std::sync::Arc::new(vec![Message::user("hello")]),
         tools: Vec::new(),
         max_tokens: 16,
         temperature: 0.0,
@@ -81,7 +81,7 @@ pub fn simple_request(model: &str) -> CompletionRequest {
 pub fn request_with_tools(model: &str) -> CompletionRequest {
     CompletionRequest {
         model: model.to_string(),
-        messages: vec![Message::user("use a tool")],
+        messages: std::sync::Arc::new(vec![Message::user("use a tool")]),
         tools: vec![ToolDefinition {
             name: "get_weather".to_string(),
             description: "Get current weather".to_string(),
@@ -109,7 +109,7 @@ pub fn request_with_tools(model: &str) -> CompletionRequest {
 pub fn request_with_temperature(model: &str, temp: f32) -> CompletionRequest {
     CompletionRequest {
         model: model.to_string(),
-        messages: vec![Message::user("hello")],
+        messages: std::sync::Arc::new(vec![Message::user("hello")]),
         tools: Vec::new(),
         max_tokens: 16,
         temperature: temp,
@@ -127,7 +127,7 @@ pub fn request_with_temperature(model: &str, temp: f32) -> CompletionRequest {
 pub fn o_series_request() -> CompletionRequest {
     CompletionRequest {
         model: "o3-mini".to_string(),
-        messages: vec![Message::user("solve this")],
+        messages: std::sync::Arc::new(vec![Message::user("solve this")]),
         tools: Vec::new(),
         max_tokens: 1000,
         temperature: 1.0,


### PR DESCRIPTION
## Summary
Main is red since 7d381f8f. Two compile errors blocked Quality + Test on all three OS runners.

- `recv_event_skipping_lag` in `librefang-kernel::event_bus` was declared as `broadcast::Receiver<Event> -> Option<Event>`, but `EventBus` broadcasts `Arc<Event>`. The only caller (`librefang-desktop::forward_kernel_events`) was already passing `Receiver<Arc<Event>>`, so the helper signature is updated to match.
- `LlmRequest.messages` was migrated to `Arc<Vec<Message>>`, but the four fixtures in `crates/librefang-llm-drivers/tests/common/mod.rs` still constructed bare `Vec<Message>`. Wrapped each in `Arc::new(...)`.

Verified locally with `cargo check -p librefang-kernel -p librefang-desktop -p librefang-llm-drivers --tests`.

## Test plan
- [x] `cargo check -p librefang-llm-drivers --tests`
- [x] `cargo check -p librefang-desktop -p librefang-kernel`
- [ ] CI green on Ubuntu / Windows / macOS