### PR TITLE
fix(approval,api): surface TOTP DB write errors and resync openapi.json

### DIFF
--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -2769,11 +2769,33 @@ mod tests {
         mgr.record_totp_code_used_for(
             "987654",
             Some("approval:11111111-1111-1111-1111-111111111111"),
-        );
+        )
+        .expect("record TOTP code");
         // Same code claimed for a different approval — must still be flagged
         // as used. Without this an attacker rewriting the path could replay
         // a captured TOTP request to authorize a higher-impact approval.
         assert!(mgr.is_totp_code_used("987654"));
+    }
+
+    /// `record_totp_code_used_for` MUST surface a DB write failure as `Err`,
+    /// not swallow it as `Ok`. A silent failure leaves the code out of the
+    /// replay-detection table, letting an attacker reuse the same code
+    /// immediately. Simulate the failure by dropping the underlying table
+    /// out from under the manager (e.g. a corrupted/mis-migrated audit DB).
+    #[test]
+    fn record_totp_code_used_for_surfaces_db_failure() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        librefang_memory::migration::run_migrations(&conn).unwrap();
+        let conn = Arc::new(StdMutex::new(conn));
+        let mgr = ApprovalManager::new_with_db(ApprovalPolicy::default(), conn.clone());
+
+        conn.lock()
+            .unwrap()
+            .execute("DROP TABLE totp_used_codes", [])
+            .unwrap();
+
+        mgr.record_totp_code_used_for("999111", Some("approval:abc"))
+            .expect_err("DB write must surface as Err so the caller can return 500");
     }
 
     // -----------------------------------------------------------------------

--- a/openapi.json
+++ b/openapi.json
@@ -2173,7 +2173,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Max items (default 100, max 500)",
+            "description": "Max items (default 50, max 500)",
             "required": false,
             "schema": {
               "type": "integer",
@@ -6875,7 +6875,7 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "Max items (default 100, max 500)",
+            "description": "Max items (default 50, max 500)",
             "required": false,
             "schema": {
               "type": "integer",


### PR DESCRIPTION
## Summary
Two small follow-ups split out of closed #4200 (the rest of #4200 was either landed in #4207 or is covered by #4205 / #4204).

- `record_totp_code_used_for` now returns `Result`. The `issue_3360_totp_code_single_use_across_actions` test was calling it as an expression statement, swallowing real DB write failures. Use `.expect(...)` at the call site and add a regression test (`record_totp_code_used_for_surfaces_db_failure`) that drops `totp_used_codes` out from under the manager and asserts the call returns `Err` — silent failure would let an attacker reuse a captured code.
- `openapi.json` had drifted to `default 100, max 500` on the `limit` query for `list_approvals` and `list_audit`. The source doc-comments in `crates/librefang-api/src/routes/system.rs` say `default 50`. Resync the spec to match the code.

## Test plan
- [x] `cargo check -p librefang-kernel --tests` — clean (the unused-`Result` warn from main is gone)
- [x] `record_totp_code_used_for_surfaces_db_failure` compiles via `ApprovalManager::new_with_db`
- [ ] CI: OpenAPI Drift check goes green