### PR TITLE
test(api): HTTP integration coverage for TOTP & MCP OAuth flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,6 +4158,7 @@ dependencies = [
  "tokio-stream",
  "toml 1.1.2+spec-1.1.0",
  "toml_edit 0.25.11+spec-1.1.0",
+ "totp-rs",
  "tower",
  "tower-http",
  "tracing",

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -191,3 +191,4 @@ tempfile = { workspace = true }
 uuid = { workspace = true }
 http-body-util = "0.1"
 librefang-testing = { path = "../librefang-testing" }
+totp-rs = { workspace = true }

--- a/crates/librefang-api/tests/mcp_oauth_flow_test.rs
+++ b/crates/librefang-api/tests/mcp_oauth_flow_test.rs
@@ -1,0 +1,268 @@
+//! Integration tests for the MCP OAuth callback / status / revoke endpoints.
+//!
+//! Targets the route handlers in `routes::mcp_auth`. Issue references:
+//! #3402, #3403.
+//!
+//! Scope notes:
+//! - `auth_start` is intentionally NOT exercised here — it requires a live
+//!   `.well-known` discovery against the configured MCP server URL, which
+//!   would either need a mock HTTP server stood up per test or would race
+//!   on outbound network. The other four endpoints (`status`, `callback`,
+//!   `revoke`) cover the security-critical state transitions.
+//! - The skills router is mounted directly under `/api`, mirroring the
+//!   pairing tests — this skips the global auth middleware so the tests
+//!   focus on handler behaviour.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use axum::Router;
+use librefang_api::routes::{self, AppState};
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+struct Harness {
+    app: Router,
+    state: Arc<AppState>,
+    _test: TestAppState,
+}
+
+fn boot_with_mcp_server(name: &str, url: &str) -> Harness {
+    let name = name.to_string();
+    let url = url.to_string();
+    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(move |cfg| {
+        cfg.mcp_servers
+            .push(librefang_types::config::McpServerConfigEntry {
+                name: name.clone(),
+                template_id: None,
+                transport: Some(librefang_types::config::McpTransportEntry::Http {
+                    url: url.clone(),
+                }),
+                timeout_secs: 30,
+                env: Vec::new(),
+                headers: Vec::new(),
+                oauth: None,
+                taint_scanning: true,
+                taint_policy: None,
+            });
+    }));
+    let state = test.state.clone();
+    let app = Router::new()
+        .nest("/api", routes::skills::router())
+        .with_state(state.clone());
+    Harness {
+        app,
+        state,
+        _test: test,
+    }
+}
+
+fn boot_no_servers() -> Harness {
+    let test = TestAppState::with_builder(MockKernelBuilder::new());
+    let state = test.state.clone();
+    let app = Router::new()
+        .nest("/api", routes::skills::router())
+        .with_state(state.clone());
+    Harness {
+        app,
+        state,
+        _test: test,
+    }
+}
+
+async fn get(h: &Harness, path: &str) -> (StatusCode, String) {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .body(Body::empty())
+        .unwrap();
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let body = String::from_utf8_lossy(&bytes).into_owned();
+    (status, body)
+}
+
+async fn get_json(h: &Harness, path: &str) -> (StatusCode, serde_json::Value) {
+    let (status, body) = get(h, path).await;
+    let value = if body.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_str(&body).unwrap_or(serde_json::Value::Null)
+    };
+    (status, value)
+}
+
+async fn delete(h: &Harness, path: &str) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method(Method::DELETE)
+        .uri(path)
+        .body(Body::empty())
+        .unwrap();
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let value: serde_json::Value = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, value)
+}
+
+// ---------------------------------------------------------------------------
+// auth_status
+// ---------------------------------------------------------------------------
+
+/// Status for an unknown MCP server name must 404 — the dashboard infers
+/// "server not yet installed" from this response, and a default-200 with a
+/// fake state would mask wiring bugs.
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_status_unknown_server_is_404() {
+    let h = boot_no_servers();
+    let (status, body) = get_json(&h, "/api/mcp/servers/does-not-exist/auth/status").await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "got body: {body:?}");
+}
+
+/// For a configured but never-connected server with no recorded auth state,
+/// the handler reports `state = "unknown"` (not `"not_required"` — that
+/// label is reserved for servers known to be reachable without OAuth).
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_status_known_server_with_no_state_is_unknown() {
+    let h = boot_with_mcp_server("test-srv", "https://example.invalid/mcp");
+    let (status, body) = get_json(&h, "/api/mcp/servers/test-srv/auth/status").await;
+    assert_eq!(status, StatusCode::OK, "got body: {body:?}");
+    assert_eq!(body["server"], "test-srv");
+    assert_eq!(
+        body["auth"]["state"], "unknown",
+        "no in-memory state and no live connection => 'unknown', got {body:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// auth_callback
+// ---------------------------------------------------------------------------
+
+/// Callback without a `state` query parameter must be rejected — the state
+/// param is the only proof that this callback was initiated by a flow on
+/// this daemon. A missing-state path that progressed any further would be
+/// a CSRF foothold (#3730).
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_callback_missing_state_is_rejected() {
+    let h = boot_with_mcp_server("test-srv", "https://example.invalid/mcp");
+    let (status, body) = get(&h, "/api/mcp/servers/test-srv/auth/callback?code=abc").await;
+    // The handler responds 200 with text/plain "Authorization Failed" — a
+    // browser-friendly response rather than a JSON error. The security
+    // contract is that no auth state was mutated.
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("Authorization Failed"),
+        "expected failure text, got: {body}"
+    );
+    assert!(
+        body.to_lowercase().contains("missing state"),
+        "expected explanatory message, got: {body}"
+    );
+
+    // No auth state should have been recorded — a missing-state probe must
+    // not be able to write to the auth_states map.
+    let states = h.state.kernel.mcp_auth_states_ref().lock().await;
+    assert!(
+        !states.contains_key("test-srv"),
+        "auth state must not be created from a missing-state callback, got {states:?}"
+    );
+}
+
+/// Callback with a state value that lacks the `{flow_id}.{nonce}` separator
+/// must be rejected before any vault lookup — the malformed state proves
+/// the call did not originate from `auth_start` on this daemon.
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_callback_malformed_state_is_rejected() {
+    let h = boot_with_mcp_server("test-srv", "https://example.invalid/mcp");
+    let (status, body) = get(
+        &h,
+        "/api/mcp/servers/test-srv/auth/callback?code=abc&state=no-dot-here",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("Authorization Failed"),
+        "expected failure text, got: {body}"
+    );
+    assert!(
+        body.contains("Malformed state") || body.contains("flow ID"),
+        "expected malformed-state error, got: {body}"
+    );
+}
+
+/// Callback for an unknown server name must fail — the path-level lookup
+/// is the first gate, so a callback hitting a non-existent server can't
+/// poison auth state for any real one.
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_callback_unknown_server_fails() {
+    let h = boot_no_servers();
+    let (status, body) = get(
+        &h,
+        "/api/mcp/servers/ghost/auth/callback?code=abc&state=flow.nonce",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("Authorization Failed"),
+        "expected failure text, got: {body}"
+    );
+    assert!(
+        body.contains("not found"),
+        "expected 'not found' detail, got: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// auth_revoke
+// ---------------------------------------------------------------------------
+
+/// Revoke for a known server must return 200 and reset the in-memory auth
+/// state to `NeedsAuth`. The dashboard relies on this transition to
+/// surface the "Sign in" CTA after the user clicks "Sign out".
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_revoke_known_server_resets_state_to_needs_auth() {
+    let h = boot_with_mcp_server("test-srv", "https://example.invalid/mcp");
+
+    // Seed an "authorized" state so we can observe the transition.
+    {
+        let mut states = h.state.kernel.mcp_auth_states_ref().lock().await;
+        states.insert(
+            "test-srv".to_string(),
+            librefang_runtime::mcp_oauth::McpAuthState::Authorized {
+                expires_at: None,
+                tokens: None,
+            },
+        );
+    }
+
+    let (status, body) = delete(&h, "/api/mcp/servers/test-srv/auth/revoke").await;
+    assert_eq!(status, StatusCode::OK, "got body: {body:?}");
+    assert_eq!(body["server"], "test-srv");
+
+    let states = h.state.kernel.mcp_auth_states_ref().lock().await;
+    let s = states.get("test-srv").expect("state retained after revoke");
+    let serialized = serde_json::to_value(s).unwrap();
+    assert_eq!(
+        serialized["state"], "needs_auth",
+        "revoke must transition to needs_auth, got {serialized:?}"
+    );
+}
+
+/// Revoke against an unknown server must 404 — silently 200'ing here would
+/// hide config typos and let the UI think it just signed out a server that
+/// was never installed.
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_revoke_unknown_server_is_404() {
+    let h = boot_no_servers();
+    let (status, body) = delete(&h, "/api/mcp/servers/does-not-exist/auth/revoke").await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "got body: {body:?}");
+}

--- a/crates/librefang-api/tests/totp_flow_test.rs
+++ b/crates/librefang-api/tests/totp_flow_test.rs
@@ -1,0 +1,457 @@
+//! Integration tests for the TOTP enrollment / confirm / status / revoke flow.
+//!
+//! Exercises `POST /api/approvals/totp/{setup,confirm,revoke}` and
+//! `GET /api/approvals/totp/status` end-to-end against a freshly-booted
+//! mock kernel. Issue references: #3402, #3403.
+//!
+//! Notes:
+//! - The system router is mounted directly under `/api`, mirroring the
+//!   pairing tests — this skips the global auth middleware so each test
+//!   focuses on the handler's own logic, not the auth gate.
+//! - Generating a "current" TOTP code in tests requires reproducing the
+//!   exact (algo, digits, step, secret, issuer) tuple that `ApprovalManager`
+//!   uses. That contract is asserted by reading the secret out of the vault
+//!   right after setup and feeding it through `totp-rs` with the same
+//!   parameters as `ApprovalManager::generate_totp_secret`.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use axum::Router;
+use librefang_api::routes::{self, AppState};
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+struct Harness {
+    app: Router,
+    state: Arc<AppState>,
+    _test: TestAppState,
+}
+
+fn boot() -> Harness {
+    let test = TestAppState::with_builder(MockKernelBuilder::new());
+    let state = test.state.clone();
+    let app = Router::new()
+        .nest("/api", routes::system::router())
+        .with_state(state.clone());
+    Harness {
+        app,
+        state,
+        _test: test,
+    }
+}
+
+async fn json_post(
+    h: &Harness,
+    path: &str,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let value: serde_json::Value = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, value)
+}
+
+async fn get(h: &Harness, path: &str) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .body(Body::empty())
+        .unwrap();
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let value: serde_json::Value = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, value)
+}
+
+/// Build a `TOTP` client that exactly mirrors `ApprovalManager::generate_totp_secret`
+/// so `generate_current()` produces a code the kernel will accept.
+fn totp_for(secret_base32: &str, issuer: &str) -> totp_rs::TOTP {
+    use totp_rs::{Algorithm, Secret, TOTP};
+    let raw = Secret::Encoded(secret_base32.to_string())
+        .to_bytes()
+        .expect("decode base32 secret");
+    TOTP::new(
+        Algorithm::SHA1,
+        6,
+        1,
+        30,
+        raw,
+        Some(issuer.to_string()),
+        String::new(),
+    )
+    .expect("totp init")
+}
+
+fn current_code(h: &Harness) -> String {
+    let secret = h
+        .state
+        .kernel
+        .vault_get("totp_secret")
+        .expect("totp_secret in vault");
+    let issuer = h.state.kernel.approvals().policy().totp_issuer.clone();
+    totp_for(&secret, &issuer)
+        .generate_current()
+        .expect("generate current code")
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+/// Status before any enrollment must report an empty, unconfirmed, unenforced
+/// state — the dashboard relies on these defaults to decide whether to surface
+/// the "Set up 2FA" CTA.
+#[tokio::test(flavor = "multi_thread")]
+async fn status_initial_state_is_empty() {
+    let h = boot();
+    let (status, body) = get(&h, "/api/approvals/totp/status").await;
+    assert_eq!(status, StatusCode::OK, "got body: {body:?}");
+    assert_eq!(body["enrolled"], false);
+    assert_eq!(body["confirmed"], false);
+    assert_eq!(body["enforced"], false);
+    assert_eq!(body["remaining_recovery_codes"], 0);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+/// First-time setup must mint a base32 secret, an otpauth URI, a data:image
+/// QR payload, and a fresh batch of recovery codes — and persist the secret
+/// in the vault as "pending" (`totp_confirmed = "false"`).
+#[tokio::test(flavor = "multi_thread")]
+async fn setup_returns_secret_uri_qr_and_recovery_codes() {
+    let h = boot();
+    let (status, body) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+    assert_eq!(status, StatusCode::OK, "got body: {body:?}");
+
+    let secret = body["secret"].as_str().expect("secret string");
+    assert!(!secret.is_empty(), "secret must not be empty");
+
+    let uri = body["otpauth_uri"].as_str().expect("otpauth_uri string");
+    assert!(uri.starts_with("otpauth://totp/"), "got {uri}");
+
+    let qr = body["qr_code"].as_str().expect("qr_code string");
+    assert!(
+        qr.starts_with("data:image/png;base64,"),
+        "qr_code must be a data: URI, got prefix {:?}",
+        &qr.chars().take(30).collect::<String>()
+    );
+
+    let codes = body["recovery_codes"].as_array().expect("recovery_codes");
+    assert_eq!(codes.len(), 8, "expected 8 recovery codes");
+
+    // Vault state: pending confirmation.
+    assert_eq!(
+        h.state.kernel.vault_get("totp_secret").as_deref(),
+        Some(secret)
+    );
+    assert_eq!(
+        h.state.kernel.vault_get("totp_confirmed").as_deref(),
+        Some("false"),
+        "secret must be present but unconfirmed after setup"
+    );
+
+    // Status now reports enrolled-but-unconfirmed.
+    let (_, st) = get(&h, "/api/approvals/totp/status").await;
+    assert_eq!(st["enrolled"], true);
+    assert_eq!(st["confirmed"], false);
+    assert_eq!(st["remaining_recovery_codes"], 8);
+}
+
+/// Calling `setup` a second time while the first enrollment is still pending
+/// must NOT silently overwrite the original secret — that would invalidate
+/// the QR already scanned into a user's authenticator app without any
+/// indication. Expect 409 CONFLICT.
+#[tokio::test(flavor = "multi_thread")]
+async fn setup_pending_enrollment_is_conflict_not_overwrite() {
+    let h = boot();
+    let (s1, b1) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+    assert_eq!(s1, StatusCode::OK, "first setup must succeed: {b1:?}");
+    let original_secret = b1["secret"].as_str().unwrap().to_string();
+
+    let (s2, b2) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+    assert_eq!(s2, StatusCode::CONFLICT, "got body: {b2:?}");
+    assert_eq!(b2["status"], "pending_confirmation");
+
+    // Vault secret must still be the first one.
+    assert_eq!(
+        h.state.kernel.vault_get("totp_secret").as_deref(),
+        Some(original_secret.as_str()),
+        "second setup must not clobber pending secret"
+    );
+}
+
+/// Once an enrollment is confirmed, `setup` MUST require the caller to
+/// authenticate with the existing TOTP/recovery code before issuing a new
+/// secret. Calling without `current_code` is a 400 — anything else would
+/// allow a session-hijacked attacker to silently rotate 2FA off the victim.
+#[tokio::test(flavor = "multi_thread")]
+async fn setup_when_already_confirmed_requires_current_code() {
+    let h = boot();
+    // First setup + confirm.
+    let (_, b1) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+    assert!(b1["secret"].is_string());
+    let code = current_code(&h);
+    let (sc, _) = json_post(
+        &h,
+        "/api/approvals/totp/confirm",
+        serde_json::json!({ "code": code }),
+    )
+    .await;
+    assert_eq!(sc, StatusCode::OK);
+    assert_eq!(
+        h.state.kernel.vault_get("totp_confirmed").as_deref(),
+        Some("true")
+    );
+
+    // Bare setup call must now refuse.
+    let (s2, b2) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+    assert_eq!(s2, StatusCode::BAD_REQUEST, "got body: {b2:?}");
+    let err = b2["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("current_code"),
+        "error must mention current_code, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Confirm
+// ---------------------------------------------------------------------------
+
+/// Confirming with a fresh, valid current code must flip `totp_confirmed`
+/// to `"true"` and report `confirmed=true` on the next status fetch.
+#[tokio::test(flavor = "multi_thread")]
+async fn confirm_with_valid_code_activates_enrollment() {
+    let h = boot();
+    let (_, _) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+    let code = current_code(&h);
+
+    let (status, body) = json_post(
+        &h,
+        "/api/approvals/totp/confirm",
+        serde_json::json!({ "code": code }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got body: {body:?}");
+    assert_eq!(body["status"], "confirmed");
+
+    let (_, st) = get(&h, "/api/approvals/totp/status").await;
+    assert_eq!(st["enrolled"], true);
+    assert_eq!(st["confirmed"], true);
+}
+
+/// Confirming with a wrong code must not flip `totp_confirmed`; the secret
+/// remains pending and a follow-up status call still shows `confirmed=false`.
+#[tokio::test(flavor = "multi_thread")]
+async fn confirm_with_invalid_code_keeps_pending() {
+    let h = boot();
+    let (_, _) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+
+    let (status, body) = json_post(
+        &h,
+        "/api/approvals/totp/confirm",
+        serde_json::json!({ "code": "000000" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got body: {body:?}");
+
+    assert_eq!(
+        h.state.kernel.vault_get("totp_confirmed").as_deref(),
+        Some("false"),
+        "confirmed flag must stay false after a bad code"
+    );
+    let (_, st) = get(&h, "/api/approvals/totp/status").await;
+    assert_eq!(st["confirmed"], false);
+}
+
+/// Replaying the same TOTP code twice (even one that just successfully
+/// confirmed) must be rejected — the replay-prevention bucket
+/// (`is_totp_code_used`) is the only line of defense between an attacker
+/// who shoulder-surfed a single 30-second window and full 2FA bypass.
+#[tokio::test(flavor = "multi_thread")]
+async fn confirm_rejects_replayed_code() {
+    let h = boot();
+    let (_, _) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+    let code = current_code(&h);
+
+    let (s1, _) = json_post(
+        &h,
+        "/api/approvals/totp/confirm",
+        serde_json::json!({ "code": code.clone() }),
+    )
+    .await;
+    assert_eq!(s1, StatusCode::OK);
+
+    // Setup another enrollment so we have a fresh secret in the vault for
+    // confirm to look at — without this, the second call would short-circuit
+    // on the "already confirmed" path. We need a path that actually hits the
+    // replay check with the same code as before.
+    //
+    // Simpler approach: directly re-issue confirm without going through
+    // setup. The handler reads the same secret + checks is_totp_code_used
+    // first, so the replayed code gets blocked. After the first OK, the
+    // confirmed flag is "true", but `totp_confirm` does not check that flag —
+    // it just verifies the code. So a second call with the same code should
+    // hit the replay bucket and 400.
+    let (s2, b2) = json_post(
+        &h,
+        "/api/approvals/totp/confirm",
+        serde_json::json!({ "code": code }),
+    )
+    .await;
+    assert_eq!(s2, StatusCode::BAD_REQUEST, "got body: {b2:?}");
+    let err = b2["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("already been used"),
+        "expected replay error, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Revoke
+// ---------------------------------------------------------------------------
+
+/// Revoke must refuse before any enrollment exists — returning 200 here
+/// would let an unauthenticated probe of this endpoint clear arbitrary
+/// vault keys (or report misleading success). Expect 400.
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_before_enrollment_is_bad_request() {
+    let h = boot();
+    let (status, body) = json_post(
+        &h,
+        "/api/approvals/totp/revoke",
+        serde_json::json!({ "code": "000000" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got body: {body:?}");
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("not enrolled"),
+        "expected 'not enrolled' error, got: {err}"
+    );
+}
+
+/// Revoke with a valid current TOTP code must wipe both the secret and the
+/// confirmation flag — the login gate keys off `totp_confirmed`, so leaving
+/// it `true` would silently keep 2FA active even after a "successful"
+/// revoke (the precise regression that motivated the rewrite at line ~2933).
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_with_valid_code_clears_enrollment() {
+    let h = boot();
+    let (_, _) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+    let confirm_code = current_code(&h);
+    let (sc, _) = json_post(
+        &h,
+        "/api/approvals/totp/confirm",
+        serde_json::json!({ "code": confirm_code }),
+    )
+    .await;
+    assert_eq!(sc, StatusCode::OK);
+
+    // Wait one TOTP step boundary so we don't try to reuse the confirm code
+    // (which is now in the replay bucket). 31s is too long for a unit test —
+    // instead, use a recovery code.
+    // Look up the recovery codes from the setup response by re-invoking
+    // setup-confirm fresh; simpler: store the ones from the very first
+    // setup. We'll redo this test using a recovery code path to avoid the
+    // 30-second TOTP-window dependency.
+    //
+    // (Re-running setup-confirm here would consume another code; just use
+    // the recovery list saved in the vault.)
+    let recovery_json = h
+        .state
+        .kernel
+        .vault_get("totp_recovery_codes")
+        .expect("recovery codes in vault");
+    let recovery: Vec<String> = serde_json::from_str(&recovery_json).expect("decode recovery");
+    let one_code = recovery
+        .first()
+        .expect("at least one recovery code")
+        .clone();
+
+    let (status, body) = json_post(
+        &h,
+        "/api/approvals/totp/revoke",
+        serde_json::json!({ "code": one_code }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "got body: {body:?}");
+
+    // After revoke, confirmed flag must be cleared (the login gate's check),
+    // and the secret should also be gone so the verify path is dead.
+    assert_ne!(
+        h.state.kernel.vault_get("totp_confirmed").as_deref(),
+        Some("true"),
+        "totp_confirmed must not remain 'true' after revoke"
+    );
+    // The handler 'wipes' by writing the empty string (it doesn't remove the
+    // vault entry outright); the status handler treats empty == missing, so the
+    // verify path is dead either way. Accept both shapes.
+    let secret_after = h.state.kernel.vault_get("totp_secret").unwrap_or_default();
+    assert!(
+        secret_after.is_empty(),
+        "totp_secret must be empty/absent after revoke, got: {secret_after:?}"
+    );
+
+    let (_, st) = get(&h, "/api/approvals/totp/status").await;
+    assert_eq!(st["enrolled"], false);
+    assert_eq!(st["confirmed"], false);
+}
+
+/// Revoke with a wrong code must NOT clear enrollment. This guards the
+/// most damaging single-step bypass: a hostile call that lands a 200 here
+/// would disable 2FA outright.
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_with_invalid_code_does_not_clear() {
+    let h = boot();
+    let (_, _) = json_post(&h, "/api/approvals/totp/setup", serde_json::json!({})).await;
+    let confirm_code = current_code(&h);
+    let (sc, _) = json_post(
+        &h,
+        "/api/approvals/totp/confirm",
+        serde_json::json!({ "code": confirm_code }),
+    )
+    .await;
+    assert_eq!(sc, StatusCode::OK);
+
+    let (status, body) = json_post(
+        &h,
+        "/api/approvals/totp/revoke",
+        serde_json::json!({ "code": "000000" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got body: {body:?}");
+
+    // Enrollment must survive intact.
+    assert_eq!(
+        h.state.kernel.vault_get("totp_confirmed").as_deref(),
+        Some("true"),
+        "confirmed flag must NOT be cleared by a failed revoke"
+    );
+    assert!(
+        h.state.kernel.vault_get("totp_secret").is_some(),
+        "secret must NOT be wiped by a failed revoke"
+    );
+}

--- a/crates/librefang-api/tests/totp_flow_test.rs
+++ b/crates/librefang-api/tests/totp_flow_test.rs
@@ -304,17 +304,8 @@ async fn confirm_rejects_replayed_code() {
     .await;
     assert_eq!(s1, StatusCode::OK);
 
-    // Setup another enrollment so we have a fresh secret in the vault for
-    // confirm to look at — without this, the second call would short-circuit
-    // on the "already confirmed" path. We need a path that actually hits the
-    // replay check with the same code as before.
-    //
-    // Simpler approach: directly re-issue confirm without going through
-    // setup. The handler reads the same secret + checks is_totp_code_used
-    // first, so the replayed code gets blocked. After the first OK, the
-    // confirmed flag is "true", but `totp_confirm` does not check that flag —
-    // it just verifies the code. So a second call with the same code should
-    // hit the replay bucket and 400.
+    // Re-issue the same code: the replay bucket (`is_totp_code_used`)
+    // must reject it, even though the first call already succeeded.
     let (s2, b2) = json_post(
         &h,
         "/api/approvals/totp/confirm",
@@ -370,16 +361,9 @@ async fn revoke_with_valid_code_clears_enrollment() {
     .await;
     assert_eq!(sc, StatusCode::OK);
 
-    // Wait one TOTP step boundary so we don't try to reuse the confirm code
-    // (which is now in the replay bucket). 31s is too long for a unit test —
-    // instead, use a recovery code.
-    // Look up the recovery codes from the setup response by re-invoking
-    // setup-confirm fresh; simpler: store the ones from the very first
-    // setup. We'll redo this test using a recovery code path to avoid the
-    // 30-second TOTP-window dependency.
-    //
-    // (Re-running setup-confirm here would consume another code; just use
-    // the recovery list saved in the vault.)
+    // Use a recovery code (not the just-consumed TOTP code, which is now in
+    // the replay bucket — and waiting out the 30s step boundary would slow
+    // the test).
     let recovery_json = h
         .state
         .kernel


### PR DESCRIPTION
## Summary

Adds two new integration test suites under `crates/librefang-api/tests/` that exercise the approval-TOTP enrollment lifecycle and the MCP OAuth callback / status / revoke handlers end-to-end against an in-process kernel and mounted axum routers — addressing #3402 and #3403.

Both surfaces previously had only unit-level coverage that could not catch wiring or state-transition regressions (e.g. a revoke handler that 200s while leaving `totp_confirmed=true`, or a callback that mutates auth state on a missing-state probe).

### What ships

**`totp_flow_test.rs` — 10 cases against `/api/approvals/totp/*`:**
- `status_initial_state_is_empty`
- `setup_returns_secret_uri_qr_and_recovery_codes`
- `setup_pending_enrollment_is_conflict_not_overwrite` (409 — anti-clobber)
- `setup_when_already_confirmed_requires_current_code` (anti-hijack)
- `confirm_with_valid_code_activates_enrollment`
- `confirm_with_invalid_code_keeps_pending`
- `confirm_rejects_replayed_code` (replay-bucket guard)
- `revoke_before_enrollment_is_bad_request`
- `revoke_with_valid_code_clears_enrollment` (uses recovery code path so the test doesn't depend on TOTP-window timing)
- `revoke_with_invalid_code_does_not_clear` (single-step bypass guard)

**`mcp_oauth_flow_test.rs` — 7 cases against `/api/mcp/servers/{name}/auth/*`:**
- `auth_status_unknown_server_is_404`
- `auth_status_known_server_with_no_state_is_unknown`
- `auth_callback_missing_state_is_rejected` (CSRF guard, #3730)
- `auth_callback_malformed_state_is_rejected`
- `auth_callback_unknown_server_fails`
- `auth_revoke_known_server_resets_state_to_needs_auth`
- `auth_revoke_unknown_server_is_404`

Generating a "current" valid TOTP code in tests requires reproducing the exact `(algo, digits, step, secret, issuer)` tuple `ApprovalManager::generate_totp_secret` uses; the test reads the secret straight out of the vault and feeds it through `totp-rs` with the same parameters. `totp-rs` is added to `librefang-api`'s `[dev-dependencies]` (already a workspace dep — only the placement is new).

`auth_start` is intentionally NOT covered: it would require either a live `.well-known` discovery against the configured MCP server URL or a per-test mock HTTP server. The other four endpoints already cover the security-critical state transitions.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` (workspace-wide clippy fails on **pre-existing** issues in `librefang-cli` and `librefang-kernel` unrelated to this PR — confirmed by stashing the patch and re-running)
- [x] `cargo test -p librefang-api` — all 569 + 72 + 27 + … tests pass, including the 17 new ones
- [x] Tests pass deterministically across multiple runs (no clock-window flakiness — recovery code path used for revoke)

Refs #3402, #3403.