### PR TITLE
fix(kernel): clear clippy::let_unit_value in TOTP test (fixes #4232)

### DIFF
--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -2879,12 +2879,11 @@ mod tests {
     #[test]
     fn issue_3360_totp_code_single_use_across_actions() {
         let mgr = make_manager_with_db();
-        let _ = mgr
-            .record_totp_code_used_for(
-                "987654",
-                Some("approval:11111111-1111-1111-1111-111111111111"),
-            )
-            .expect("record TOTP code");
+        mgr.record_totp_code_used_for(
+            "987654",
+            Some("approval:11111111-1111-1111-1111-111111111111"),
+        )
+        .expect("record TOTP code");
         // Same code claimed for a different approval — must still be flagged
         // as used. Without this an attacker rewriting the path could replay
         // a captured TOTP request to authorize a higher-impact approval.


### PR DESCRIPTION
## Summary
- Main CI broke on a62eb5b: `clippy::let_unit_value` in `approval.rs:2882` (`let _ = mgr.record_totp_code_used_for(...).expect(...)` — `expect` on `Result<(), _>` produces `()`).
- Drop the redundant `let _ =` binding so the workspace clippy run passes under `-D warnings`.

## Test plan
- [x] `cargo clippy -p librefang-kernel --all-targets --all-features -- -D warnings`

Fixes #4232.