### PR TITLE
fix(hooks): allow worktree-cleanup commands from main worktree

### DIFF
--- a/.claude/hooks/lib/check-bash-rules.py
+++ b/.claude/hooks/lib/check-bash-rules.py
@@ -246,8 +246,13 @@ GIT_TAG_DELETE_FLAGS = {"-d", "--delete"}
 
 
 def rule_git_mutation_main(toks, ctx):
-    """When kind=main, refuse any modifying git invocation. We use
-    walk_git_invocations to skip git commands embedded inside quoted args."""
+    """When kind=main, refuse any modifying git invocation that would touch
+    the main worktree's tree, HEAD, or stash. Worktree-cleanup commands
+    (`git worktree remove|prune|move` against linked trees, `git branch
+    -D <feature>` for spent branches) are allowed: removing a linked
+    worktree doesn't affect main, and git itself refuses to delete a
+    checked-out branch. The dangerous case (removing main itself) is
+    caught by `rule_worktree_remove_main`."""
     if ctx.get("kind") != "main":
         return None
 
@@ -258,12 +263,8 @@ def rule_git_mutation_main(toks, ctx):
         sub_arg = strip_parens(toks[j + 1]) if j + 1 < len(toks) else None
         if sub in GIT_DIRECT_MUTATIONS:
             return f"`git {sub}` in main worktree."
-        if sub == "branch" and sub_arg in GIT_BRANCH_FORCE_FLAGS:
-            return f"`git branch {sub_arg}` in main worktree."
         if sub == "stash" and sub_arg in GIT_STASH_MUTATIONS:
             return f"`git stash {sub_arg}` in main worktree."
-        if sub == "worktree" and sub_arg in GIT_WORKTREE_MUTATIONS:
-            return f"`git worktree {sub_arg}` in main worktree."
         if sub == "tag" and sub_arg in GIT_TAG_DELETE_FLAGS:
             return f"`git tag {sub_arg}` in main worktree."
     return None


### PR DESCRIPTION
## Summary

`rule_git_mutation_main` in `.claude/hooks/lib/check-bash-rules.py` was blocking two safe cleanup actions when invoked from the main worktree:

- `git worktree remove /tmp/librefang-<feature>` — removing a linked worktree doesn't touch main's content
- `git branch -D <feature>` — git itself refuses to delete a branch that's currently checked out anywhere

So the standard end-of-task cleanup pattern (`git worktree remove ... && git branch -D ...`) couldn't be run by the agent and got punted to the user.

The genuinely dangerous case — `git worktree remove` whose target resolves to the main worktree itself — is already caught specifically by `rule_worktree_remove_main`, which is independent of this rule.

## Smoke test

```
git worktree remove /tmp/librefang-foo --force     -> ALLOW
git branch -D some-feature                         -> ALLOW
git worktree prune                                 -> ALLOW
git checkout main                                  -> blocked
git reset --hard                                   -> blocked
git stash drop                                     -> blocked
git worktree remove /home/xiaomo/workspace/librefang -> blocked (rule_worktree_remove_main)
```

## Test plan

- [x] Run check-bash-rules.py against allowed/blocked sample commands above
- [ ] Verify `git worktree remove /tmp/librefang-...` from main tree no longer trips the hook in a real session