### PR TITLE
docs: correct stale crate, driver, and channel counts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Build your own: define a `HAND.toml` + system prompt + `SKILL.md`. [Guide](https
 
 ```
 librefang-kernel            Orchestration, workflows, metering, RBAC, scheduler, budget
-librefang-runtime           Agent loop, 3 LLM drivers, 53 tools, WASM sandbox, MCP, A2A
+librefang-runtime           Agent loop, tool execution, WASM sandbox, MCP, A2A
 librefang-api               140+ REST/WS/SSE endpoints, OpenAI-compatible API, dashboard
-librefang-channels          40 messaging adapters with rate limiting, DM/group policies
+librefang-channels          45 messaging adapters with rate limiting, DM/group policies
 librefang-memory            SQLite persistence, vector embeddings, sessions, compaction
 librefang-types             Core types, taint tracking, Ed25519 signing, model catalog
 librefang-skills            60 bundled skills, SKILL.md parser, FangHub marketplace

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -110,9 +110,9 @@ Eigene Hands erstellen: `HAND.toml` + System-Prompt + `SKILL.md` definieren. [An
 
 ```
 librefang-kernel            Orchestrierung, Workflows, Metering, RBAC, Scheduler, Budget
-librefang-runtime           Agenten-Loop, 3 LLM-Treiber, 53 Tools, WASM-Sandbox, MCP, A2A
+librefang-runtime           Agenten-Loop, Tool-Ausführung, WASM-Sandbox, MCP, A2A
 librefang-api               140+ REST/WS/SSE-Endpunkte, OpenAI-kompatible API, Dashboard
-librefang-channels          40 Messaging-Adapter, Rate Limiting, DM/Gruppen-Policies
+librefang-channels          45 Messaging-Adapter, Rate Limiting, DM/Gruppen-Policies
 librefang-memory            SQLite-Persistenz, Vektor-Embeddings, Sessions, Komprimierung
 librefang-types             Kerntypen, Taint-Tracking, Ed25519-Signierung, Modellkatalog
 librefang-skills            60 gebündelte Skills, SKILL.md-Parser, FangHub-Marktplatz

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -6,7 +6,7 @@
 <h3 align="center">Sistema Operativo de Agentes Libre — Libre como en Libertad</h3>
 
 <p align="center">
-  Agent OS de código abierto construido en Rust. 14 crates. 2,100+ tests. Cero advertencias de clippy.
+  Agent OS de código abierto construido en Rust. 24 crates. 2,100+ tests. Cero advertencias de clippy.
 </p>
 
 <p align="center">
@@ -111,9 +111,9 @@ Crea el tuyo: define un `HAND.toml` + prompt de sistema + `SKILL.md`. [Guía](ht
 
 ```bash
 librefang-kernel            Orquestación, workflows, medición, RBAC, planificador, presupuesto
-librefang-runtime           Bucle de agente, 3 drivers LLM, 53 herramientas, sandbox WASM, MCP, A2A
+librefang-runtime           Bucle de agente, ejecución de herramientas, sandbox WASM, MCP, A2A
 librefang-api               140+ endpoints REST/WS/SSE, API compatible con OpenAI, dashboard
-librefang-channels          40 adaptadores de mensajería, limitación de tasa, políticas DM/grupo
+librefang-channels          45 adaptadores de mensajería, limitación de tasa, políticas DM/grupo
 librefang-memory            Persistencia SQLite, embeddings vectoriales, sesiones, compactación
 librefang-types             Tipos core, seguimiento de taint, firma Ed25519, catálogo de modelos
 librefang-skills            60 skills incluidos, parser SKILL.md, marketplace FangHub

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -111,9 +111,9 @@ librefang hand list                  # 全 Hands を表示
 
 ```
 librefang-kernel            オーケストレーション、ワークフロー、計量、RBAC、スケジューラ、予算
-librefang-runtime           エージェントループ、3 LLM ドライバ、53 ツール、WASM サンドボックス、MCP、A2A
+librefang-runtime           エージェントループ、ツール実行、WASM サンドボックス、MCP、A2A
 librefang-api               140+ REST/WS/SSE エンドポイント、OpenAI 互換 API、ダッシュボード
-librefang-channels          40 メッセージングアダプター、レート制限、DM/グループポリシー
+librefang-channels          45 メッセージングアダプター、レート制限、DM/グループポリシー
 librefang-memory            SQLite 永続化、ベクトル埋め込み、セッション、圧縮
 librefang-types             コア型、テイント追跡、Ed25519 署名、モデルカタログ
 librefang-skills            60 バンドルスキル、SKILL.md パーサー、FangHub マーケットプレイス

--- a/i18n/README.ko.md
+++ b/i18n/README.ko.md
@@ -111,9 +111,9 @@ librefang hand list                  # 모든 Hands 보기
 
 ```
 librefang-kernel            오케스트레이션, 워크플로, 미터링, RBAC, 스케줄러, 예산
-librefang-runtime           에이전트 루프, 3 LLM 드라이버, 53 도구, WASM 샌드박스, MCP, A2A
+librefang-runtime           에이전트 루프, 도구 실행, WASM 샌드박스, MCP, A2A
 librefang-api               140+ REST/WS/SSE 엔드포인트, OpenAI 호환 API, 대시보드
-librefang-channels          40 메시징 어댑터, 레이트 리미팅, DM/그룹 정책
+librefang-channels          45 메시징 어댑터, 레이트 리미팅, DM/그룹 정책
 librefang-memory            SQLite 영속화, 벡터 임베딩, 세션, 압축
 librefang-types             코어 타입, 테인트 추적, Ed25519 서명, 모델 카탈로그
 librefang-skills            60 번들 스킬, SKILL.md 파서, FangHub 마켓플레이스

--- a/i18n/README.pl.md
+++ b/i18n/README.pl.md
@@ -111,9 +111,9 @@ Zbuduj własnego: zdefiniuj `HAND.toml` + prompt systemowy + `SKILL.md`. [Przewo
 
 ```
 librefang-kernel            Orkiestracja, przepływy pracy, opomiarowanie, RBAC, scheduler, budżet
-librefang-runtime           Pętla agenta, 3 sterowniki LLM, 53 narzędzia, piaskownica WASM, MCP, A2A
+librefang-runtime           Pętla agenta, wykonywanie narzędzi, piaskownica WASM, MCP, A2A
 librefang-api               140+ endpointów REST/WS/SSE, API kompatybilne z OpenAI, dashboard
-librefang-channels          40 adapterów komunikacyjnych z limitowaniem liczby żądań, polityki DM/grupowe
+librefang-channels          45 adapterów komunikacyjnych z limitowaniem liczby żądań, polityki DM/grupowe
 librefang-memory            Persystencja SQLite, osadzenia wektorowe, sesje, kompakcja
 librefang-types             Typy podstawowe, taint tracking, podpisywanie Ed25519, katalog modeli
 librefang-skills            60 wbudowanych umiejętności, parser SKILL.md, marketplace FangHub

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -111,9 +111,9 @@ librefang hand list                  # 查看所有 Hands
 
 ```
 librefang-kernel            编排、工作流、计量、RBAC、调度、预算
-librefang-runtime           智能体循环、3 个 LLM 驱动器、53 个工具、WASM 沙箱、MCP、A2A
+librefang-runtime           智能体循环、工具执行、WASM 沙箱、MCP、A2A
 librefang-api               140+ REST/WS/SSE 端点、OpenAI 兼容 API、控制台
-librefang-channels          40 个消息适配器，速率限制、DM/群组策略
+librefang-channels          45 个消息适配器，速率限制、DM/群组策略
 librefang-memory            SQLite 持久化、向量嵌入、会话、压缩
 librefang-types             核心类型、污点追踪、Ed25519 签名、模型目录
 librefang-skills            60 个内置技能、SKILL.md 解析器、FangHub 市场


### PR DESCRIPTION
## Summary

Re-derives the numeric claims in README from `origin/main` HEAD and fixes the stale ones across `README.md` plus all 6 i18n translations.

## Re-derivation (provenance)

| Number | Method | Result |
|---|---|---|
| Crates | `ls crates/` (each is a `Cargo.toml` subdir) | **24** |
| Channel adapters | `grep -c '^#\[cfg(feature = "channel-' crates/librefang-channels/src/lib.rs` (feature-gated `pub mod` registrations) | **45** |
| LLM drivers in `librefang-runtime` | N/A — drivers live in `librefang-llm-drivers`, not `librefang-runtime`. The "3 LLM drivers" line was misattributed. Provider driver files: `ls crates/librefang-llm-drivers/src/drivers/` minus 4 infra files (`mod`, `fallback`, `fallback_chain`, `token_rotation`) = **12** | claim removed |

## Changes

- `librefang-runtime` row: drop "3 LLM drivers, 53 tools" (misattributed to runtime; drivers live in `librefang-llm-drivers`).
- `librefang-channels` row: `40` -> `45` (matches existing "45 Channel Adapters" line in Key Features).
- `i18n/README.es.md` header: `14 crates` -> `24 crates` (already corrected in EN and other translations).
- Same two architecture-table fixes propagated to de/es/ja/ko/pl/zh.

Skipped: "53 tools", "60 bundled skills", "28 LLM Providers", "16 Security Layers" — no clear single-source-of-truth in the codebase to re-derive from. Per the issue's "Fix" guidance, did not invent numbers.

Closes #3394

## Test plan

- [x] `git diff --stat` confirms only the 7 README files touched
- [x] No residual `14 crates` / `3 LLM drivers` / `40 messaging adapters` strings (in any of the 7 translations)
- [x] Markdown structure preserved (table column alignment intact)