### PR TITLE
docs: merge dual [Unreleased] sections in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [Unreleased]
+
+### Added
+
+- Config-driven session mode for agent triggers (`session_mode = "new" | "persistent"`) — per-agent default with per-trigger override
+
+### Changed
+
+- Default `api_listen` flipped from `0.0.0.0:4545` to `127.0.0.1:4545` (loopback-only). New installs are local-only by default; set `api_listen = "0.0.0.0:4545"` to expose on LAN/remote. Affects `librefang init`, the dashboard's init endpoint, and `librefang.toml.example`. `librefang start` with an explicit `--config <path>` that doesn't exist now prints a clear `librefang init` hint instead of failing obscurely. (#2766)
+- **iOS minimum supported version raised from 14.0 to 16.0.** Required by the Tauri 2 mobile toolchain that the new mobile CI builds against. Devices on iOS 14 or 15 (iPhone 6s, original iPhone SE, iPad Air 2 and similar) will no longer be able to install the LibreFang mobile app once mobile bundles ship. Affects only the iOS app — the desktop and Android builds are unchanged. (#3970)
+
+### Security
+
+- **Channel webhook HMAC verification is now mandatory** for Messenger, LINE, Teams, Viber, and DingTalk. Previously, missing signature headers were silently bypassed; they now return `400 Bad Request`, and signature mismatches return `401 Unauthorized`. **Action required if you operate any of these channels:**
+  - **Messenger** — set `MESSENGER_APP_SECRET` to your Facebook App Secret (the new `app_secret_env` field in `[channels.messenger]` defaults to this). If unset, signatures are skipped with a startup warning and the endpoint stays unauthenticated — production should always set it.
+  - **Teams** — set `TEAMS_SECURITY_TOKEN` to the base64 outgoing-webhook security token from the Teams portal (the new `security_token_env` field in `[channels.teams]`). Same fallback semantics as Messenger.
+  - **LINE / Viber / DingTalk** — no new env vars, but probes that don't carry the platform's signature header (curl, monitoring health checks pointed at the webhook path) will now return 4xx instead of 200.
+- **Outbound `[channels.webhook] callback_url` is SSRF-guarded.** Adapters refuse to start if the URL resolves to a private (`10/8`, `172.16/12`, `192.168/16`), CGN (`100.64/10`), loopback (`127/8`, `::1`), link-local, multicast, or cloud-metadata range. Catches IPv6 short forms like `[::]`, IPv4-mapped (`[::ffff:127.0.0.1]`), NAT64, and trailing-dot FQDNs. **Action required**: local dev setups using `callback_url = "http://127.0.0.1/..."` must switch to a public tunnel (ngrok, cloudflared) or omit `callback_url`. (#3942)
+- **BREAKING**: `require_auth_for_reads` now defaults to *enabled* whenever any form of authentication is configured (`api_key`, `user_api_keys`, or dashboard credentials). Previously the flag had to be set explicitly, leaving read endpoints open even on instances with an `api_key`. Operators who deliberately want open reads on an authenticated instance (e.g. behind a trusted reverse proxy) must now set `require_auth_for_reads = false` in `config.toml`. A boot-time INFO log records when the flag is auto-enabled. (#2448)
+
 ## [2026.4.28] - 2026-04-28
 
 _67 PRs from 4 contributors since v2026.4.27-beta6._
@@ -530,21 +550,6 @@ _No notable changes._
 - Replace cloudflare/wrangler-action with direct npx wrangler calls (#2740) (@houko)
 
 
-## [Unreleased]
-
-### Changed
-
-- Default `api_listen` flipped from `0.0.0.0:4545` to `127.0.0.1:4545` (loopback-only). New installs are local-only by default; set `api_listen = "0.0.0.0:4545"` to expose on LAN/remote. Affects `librefang init`, the dashboard's init endpoint, and `librefang.toml.example`. `librefang start` with an explicit `--config <path>` that doesn't exist now prints a clear `librefang init` hint instead of failing obscurely. (#2766)
-- **iOS minimum supported version raised from 14.0 to 16.0.** Required by the Tauri 2 mobile toolchain that the new mobile CI builds against. Devices on iOS 14 or 15 (iPhone 6s, original iPhone SE, iPad Air 2 and similar) will no longer be able to install the LibreFang mobile app once mobile bundles ship. Affects only the iOS app — the desktop and Android builds are unchanged. (#3970)
-
-### Security
-
-- **Channel webhook HMAC verification is now mandatory** for Messenger, LINE, Teams, Viber, and DingTalk. Previously, missing signature headers were silently bypassed; they now return `400 Bad Request`, and signature mismatches return `401 Unauthorized`. **Action required if you operate any of these channels:**
-  - **Messenger** — set `MESSENGER_APP_SECRET` to your Facebook App Secret (the new `app_secret_env` field in `[channels.messenger]` defaults to this). If unset, signatures are skipped with a startup warning and the endpoint stays unauthenticated — production should always set it.
-  - **Teams** — set `TEAMS_SECURITY_TOKEN` to the base64 outgoing-webhook security token from the Teams portal (the new `security_token_env` field in `[channels.teams]`). Same fallback semantics as Messenger.
-  - **LINE / Viber / DingTalk** — no new env vars, but probes that don't carry the platform's signature header (curl, monitoring health checks pointed at the webhook path) will now return 4xx instead of 200.
-- **Outbound `[channels.webhook] callback_url` is SSRF-guarded.** Adapters refuse to start if the URL resolves to a private (`10/8`, `172.16/12`, `192.168/16`), CGN (`100.64/10`), loopback (`127/8`, `::1`), link-local, multicast, or cloud-metadata range. Catches IPv6 short forms like `[::]`, IPv4-mapped (`[::ffff:127.0.0.1]`), NAT64, and trailing-dot FQDNs. **Action required**: local dev setups using `callback_url = "http://127.0.0.1/..."` must switch to a public tunnel (ngrok, cloudflared) or omit `callback_url`. (#3942)
-
 ## [2026.4.18] - 2026-04-18
 
 ### Added
@@ -733,16 +738,6 @@ _No notable changes._
 - Skip security and install-smoke on unrelated PRs (#2377) (@houko)
 - Apply cargo fmt to runtime drivers (#2380) (@houko)
 
-
-## [Unreleased]
-
-### Added
-
-- Config-driven session mode for agent triggers (`session_mode = "new" | "persistent"`) — per-agent default with per-trigger override
-
-### Security
-
-- **BREAKING**: `require_auth_for_reads` now defaults to *enabled* whenever any form of authentication is configured (`api_key`, `user_api_keys`, or dashboard credentials). Previously the flag had to be set explicitly, leaving read endpoints open even on instances with an `api_key`. Operators who deliberately want open reads on an authenticated instance (e.g. behind a trusted reverse proxy) must now set `require_auth_for_reads = false` in `config.toml`. A boot-time INFO log records when the flag is auto-enabled. (#2448)
 
 ## [2026.4.11] - 2026-04-11
 

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -11,6 +11,19 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Guard against duplicate `## [Unreleased]` headings in CHANGELOG.md.
+# Release tooling (`.github/workflows/release.yml` awk extractor and
+# `xtask/src/changelog.rs`) silently picks the first match and drops any
+# subsequent block, so a duplicate quietly loses entries. See #3395.
+if git diff --cached --name-only | grep -qx "CHANGELOG.md"; then
+    UNRELEASED_COUNT=$(grep -c '^## \[Unreleased\]' CHANGELOG.md || true)
+    if [ "$UNRELEASED_COUNT" -gt 1 ]; then
+        echo "Error: CHANGELOG.md has $UNRELEASED_COUNT '## [Unreleased]' sections; expected exactly 1."
+        echo "Release tooling will silently drop entries from all but the first. Merge them into one block."
+        exit 1
+    fi
+fi
+
 # Regenerate openapi.json only when staged route changes can actually move
 # the spec. OpenAPI output is driven by utoipa attributes, derives, and
 # handler signatures — pure function-body edits never change openapi.json,


### PR DESCRIPTION
## Summary

Closes #3395.

`CHANGELOG.md` had two `## [Unreleased]` blocks buried mid-history (between `2026.4.19`/`4.18` and `2026.4.13`/`4.11`). Both the `release.yml` awk extractor and `xtask/src/changelog.rs` stop at the first `## [` they find after the version heading, so the second block was silently dropped from every release note and from any tooling that searches for `Unreleased`.

## Changes

- **`CHANGELOG.md`**: Folded both `[Unreleased]` blocks into a single canonical `## [Unreleased]` at the top of the version list (above `2026.4.28`), ordered Added / Changed / Security. No verbatim duplicates existed between the two blocks; every bullet is preserved (#2341/session_mode, #2766/api_listen, #3970/iOS 16, channel HMAC, #3942/SSRF, #2448/require_auth_for_reads).
- **`scripts/hooks/pre-commit`**: Added a one-line guard — when `CHANGELOG.md` is staged, fail the commit if `grep -c '^## \[Unreleased\]' CHANGELOG.md` is greater than 1. Fits naturally into the existing pre-commit hook (already enabled via `just setup` / `core.hooksPath = scripts/hooks`).

## Notes / Follow-ups

- Did **not** add a parallel CI check. The pre-commit hook only runs for contributors who ran `just setup`; a 3-line workflow step (or a step in `ci.yml`'s docs lane) would catch it for everyone else. Left out per the issue's "one-line guard that fits naturally" guidance — adding a new workflow step is non-trivial scaffolding here.
- The stale `[0.1.0]: https://...` reference link at the bottom of `CHANGELOG.md` (also flagged by the issue) is left untouched; the issue's explicit Fix scope only covers the `[Unreleased]` duplication.

## Test plan

- [x] `grep -c '^## \[Unreleased\]' CHANGELOG.md` returns `1`
- [x] All bullets from both original `[Unreleased]` blocks present in merged section
- [x] Pre-commit hook passes on the cleaned-up file
- [ ] Reviewer manually confirms no entry was dropped