### PR TITLE
fix(cli): add wildcard arms for non_exhaustive enums

### DIFF
--- a/crates/librefang-cli/src/tui/chat_runner.rs
+++ b/crates/librefang-cli/src/tui/chat_runner.rs
@@ -164,6 +164,7 @@ impl StandaloneChat {
                 let preview: String = text.chars().take(80).collect();
                 self.chat.status_msg = Some(format!("[owner_notice] {preview}"));
             }
+            _ => {}
         }
     }
 

--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -1259,6 +1259,7 @@ impl App {
                 let preview: String = text.chars().take(80).collect();
                 self.chat.status_msg = Some(format!("[owner_notice] {preview}"));
             }
+            _ => {}
         }
     }
 

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -535,6 +535,7 @@ impl State {
                         frontier = Some(&m.id);
                     }
                 }
+                _ => {}
             }
         }
 
@@ -565,6 +566,7 @@ fn tier_label(tier: ModelTier) -> &'static str {
         ModelTier::Fast => "fast",
         ModelTier::Local => "local",
         ModelTier::Custom => "custom",
+        _ => "unknown",
     }
 }
 


### PR DESCRIPTION
## Summary
- \`StreamEvent\` (librefang-llm-driver) and \`ModelTier\` (librefang-types) are both \`#[non_exhaustive]\`. Three TUI match sites in \`librefang-cli\` lacked wildcard arms, breaking the build when new variants land upstream.
- Adds \`_ => {}\` / \`_ => \"unknown\"\` fallbacks at:
  - \`tui/chat_runner.rs:112\` (StreamEvent)
  - \`tui/mod.rs:1208\` (StreamEvent)
  - \`tui/screens/init_wizard.rs:513\` and \`:561\` (ModelTier)

## Test plan
- [x] \`cargo check -p librefang-cli\`