### PR TITLE
fix(dashboard): unwrap audit entries on agents Logs tab

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -1175,7 +1175,7 @@ export function AgentsPage() {
 
   // ---------- Logs tab — terminal-style stderr tail per design canvas
   const renderLogsTab = (agent: AgentDetail) => {
-    const audit = (auditRecentQuery.data ?? []) as Array<{
+    const audit = (auditRecentQuery.data?.entries ?? []) as Array<{
       timestamp?: string;
       action?: string;
       agent_id?: string;


### PR DESCRIPTION
## Summary
`listAuditRecent` returns `{ entries, total, tip_hash }`, not a bare array. The Logs tab in `AgentsPage.tsx:1178` cast the whole response to `Array<...>` and crashed at runtime with `audit.filter is not a function`.

## Test plan
- [x] Logs tab on agent detail panel renders without throwing