### PR TITLE
fix(cli): add wildcard arms for non_exhaustive StreamEvent and ModelTier matches

### DIFF
--- a/crates/librefang-cli/src/tui/chat_runner.rs
+++ b/crates/librefang-cli/src/tui/chat_runner.rs
@@ -164,6 +164,9 @@ impl StandaloneChat {
                 let preview: String = text.chars().take(80).collect();
                 self.chat.status_msg = Some(format!("[owner_notice] {preview}"));
             }
+            // `StreamEvent` is `#[non_exhaustive]`; future variants are ignored
+            // here until we deliberately wire UI behavior for them.
+            _ => {}
         }
     }
 

--- a/crates/librefang-cli/src/tui/mod.rs
+++ b/crates/librefang-cli/src/tui/mod.rs
@@ -1259,6 +1259,9 @@ impl App {
                 let preview: String = text.chars().take(80).collect();
                 self.chat.status_msg = Some(format!("[owner_notice] {preview}"));
             }
+            // `StreamEvent` is `#[non_exhaustive]`; future variants are ignored
+            // here until we deliberately wire UI behavior for them.
+            _ => {}
         }
     }
 

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -535,6 +535,9 @@ impl State {
                         frontier = Some(&m.id);
                     }
                 }
+                // `ModelTier` is `#[non_exhaustive]`; unknown future tiers are
+                // skipped here rather than misclassified into a known bucket.
+                _ => {}
             }
         }
 
@@ -565,6 +568,9 @@ fn tier_label(tier: ModelTier) -> &'static str {
         ModelTier::Fast => "fast",
         ModelTier::Local => "local",
         ModelTier::Custom => "custom",
+        // `ModelTier` is `#[non_exhaustive]`; render unknown future tiers
+        // generically rather than panicking.
+        _ => "unknown",
     }
 }
 


### PR DESCRIPTION
## Summary

Build is broken on `main` for `librefang-cli`:

```
error[E0004]: non-exhaustive patterns: \`_\` not covered
   --> crates/librefang-cli/src/tui/chat_runner.rs:112:15
   --> crates/librefang-cli/src/tui/mod.rs:1208:15
   --> crates/librefang-cli/src/tui/screens/init_wizard.rs:513:19
   --> crates/librefang-cli/src/tui/screens/init_wizard.rs:561:11
error: could not compile \`librefang-cli\` (bin \"librefang\") due to 4 previous errors
```

Commit 26971c18 (`chore: mark public error/state enums as #[non_exhaustive] (#3660, #3542) (#4196)`) added `#[non_exhaustive]` to `StreamEvent` (in `librefang-llm-driver`) and `ModelTier` (in `librefang-types`). For external crates, that attribute requires a wildcard arm even when every current variant is matched, so four `match` sites in the TUI failed to compile.

This PR adds a conservative wildcard arm to each:

- `tui/mod.rs` `handle_stream` and `tui/chat_runner.rs` `handle_stream`: `_ => {}` — future variants don't drive UI state until they're explicitly wired.
- `tui/screens/init_wizard.rs` routing-tier classifier (line 513): `_ => {}` — unknown future tiers are skipped rather than misclassified into fast/balanced/frontier.
- `tui/screens/init_wizard.rs` `tier_label` (line 561): `_ => "unknown"` — generic label so the wizard renders instead of panicking.

No behavior change for any current variant.

## Test plan

- [x] `cargo check -p librefang-cli` passes
- [x] `cargo clippy -p librefang-cli --all-targets -- -D warnings` passes