### PR TITLE
feat(kernel): persist OFP identity, wire start_with_identity (refs #3873, 3/5)

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -47,7 +47,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock, Weak};
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 /// Synthetic `SenderContext.channel` value the cron dispatcher uses for
 /// `[[cron_jobs]]` fires. Matched in [`KernelHandle::resolve_user_tool_decision`]
@@ -13777,7 +13777,35 @@ system_prompt = "You are a helpful assistant."
                 .unwrap_or_else(|_| "0.0.0.0:9090".parse().unwrap())
         };
 
-        let node_id = uuid::Uuid::new_v4().to_string();
+        // SECURITY (#3873): Load (or generate + persist) this node's
+        // Ed25519 keypair AND a stable node_id from the data directory.
+        // Both are bundled in `peer_keypair.json` so a daemon restart
+        // resumes under the same OFP identity. Falling back to a fresh
+        // `Uuid::new_v4()` per restart — the prior behavior — silently
+        // defeated TOFU pinning, since legitimate peers always presented
+        // a "new" node_id and the mismatch-detection branch never fired.
+        let mut key_mgr = librefang_wire::keys::PeerKeyManager::new(self.data_dir_boot.clone());
+        let (keypair, node_id) = match key_mgr.load_or_generate() {
+            Ok(kp) => {
+                let kp = kp.clone();
+                let id = key_mgr
+                    .node_id()
+                    .expect("node_id is Some after successful load_or_generate")
+                    .to_string();
+                (Some(kp), id)
+            }
+            Err(e) => {
+                // Identity load failed — refuse to start OFP rather than
+                // silently degrading to ephemeral identity, which would
+                // lose TOFU continuity without operator awareness.
+                error!(
+                    error = %e,
+                    data_dir = %self.data_dir_boot.display(),
+                    "OFP: failed to load or generate peer identity; OFP networking will not start",
+                );
+                return;
+            }
+        };
         let node_name = gethostname().unwrap_or_else(|| "librefang-node".to_string());
 
         let peer_config = PeerConfig {
@@ -13793,7 +13821,9 @@ system_prompt = "You are a helpful assistant."
 
         let handle: Arc<dyn librefang_wire::peer::PeerHandle> = self.self_arc();
 
-        match PeerNode::start(peer_config, registry.clone(), handle.clone()).await {
+        match PeerNode::start_with_identity(peer_config, registry.clone(), handle.clone(), keypair)
+            .await
+        {
             Ok((node, _accept_task)) => {
                 let addr = node.local_addr();
                 info!(

--- a/crates/librefang-wire/src/keys.rs
+++ b/crates/librefang-wire/src/keys.rs
@@ -35,10 +35,16 @@ pub enum KeyError {
 
 /// Persisted shape on disk. Both halves are base64-encoded; the file MUST be
 /// kept readable only by the daemon user (caller's responsibility).
+///
+/// `node_id` was added in PR-3 of #3873. Files written by PR-1 are missing
+/// the field — `load_or_generate` materializes a UUID and rewrites the file
+/// in that case so subsequent restarts see a stable identity.
 #[derive(Serialize, Deserialize)]
 struct PersistedKeyPair {
     public_key: String,
     private_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    node_id: Option<String>,
 }
 
 /// An Ed25519 keypair owned by this node.
@@ -139,11 +145,15 @@ pub fn fingerprint_of_pubkey(public_key: &str) -> String {
 }
 
 /// Loads `<data_dir>/peer_keypair.json` if present, otherwise generates a
-/// fresh keypair and persists it. The file stores both public and private
-/// halves base64-encoded.
+/// fresh keypair + node_id and persists them. The file stores the keypair
+/// (both halves base64) **and** the node_id together so a daemon restart
+/// resumes under the same OFP identity — without this, every restart
+/// minted a new `Uuid::new_v4()` for the node_id and the TOFU pin map
+/// from #3873 had no stable key to bind against.
 pub struct PeerKeyManager {
     key_path: PathBuf,
     keypair: Option<Ed25519KeyPair>,
+    node_id: Option<String>,
 }
 
 impl PeerKeyManager {
@@ -151,14 +161,20 @@ impl PeerKeyManager {
         Self {
             key_path: data_dir.join("peer_keypair.json"),
             keypair: None,
+            node_id: None,
         }
     }
 
+    /// Load the persisted identity if present, otherwise generate a fresh
+    /// one and write it to disk. After this returns successfully, both
+    /// [`PeerKeyManager::keypair`] and [`PeerKeyManager::node_id`] are
+    /// guaranteed to be `Some`.
     pub fn load_or_generate(&mut self) -> Result<&Ed25519KeyPair, KeyError> {
         if let Some(ref kp) = self.keypair {
             return Ok(kp);
         }
-        let kp = if self.key_path.exists() {
+
+        let (kp, node_id, needs_rewrite) = if self.key_path.exists() {
             let raw = std::fs::read_to_string(&self.key_path)?;
             let persisted: PersistedKeyPair = serde_json::from_str(&raw)?;
             let priv_bytes = B64
@@ -174,18 +190,34 @@ impl PeerKeyManager {
             if derived_pub != persisted.public_key {
                 return Err(KeyError::InvalidFormat);
             }
-            Ed25519KeyPair {
-                public_key: persisted.public_key,
-                private_key_bytes: seed,
-            }
+            // Migrate PR-1 files (no node_id field) by minting one and
+            // marking the file for rewrite.
+            let (node_id, rewrite) = match persisted.node_id {
+                Some(id) if !id.is_empty() => (id, false),
+                _ => (uuid::Uuid::new_v4().to_string(), true),
+            };
+            (
+                Ed25519KeyPair {
+                    public_key: persisted.public_key,
+                    private_key_bytes: seed,
+                },
+                node_id,
+                rewrite,
+            )
         } else {
             let kp = Ed25519KeyPair::generate()?;
+            let node_id = uuid::Uuid::new_v4().to_string();
+            (kp, node_id, true)
+        };
+
+        if needs_rewrite {
             if let Some(parent) = self.key_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
             let persisted = PersistedKeyPair {
                 public_key: kp.public_key.clone(),
                 private_key: B64.encode(kp.private_key_bytes),
+                node_id: Some(node_id.clone()),
             };
             let serialized = serde_json::to_string_pretty(&persisted)?;
             std::fs::write(&self.key_path, serialized)?;
@@ -200,8 +232,9 @@ impl PeerKeyManager {
                     let _ = std::fs::set_permissions(&self.key_path, perms);
                 }
             }
-            kp
-        };
+        }
+
+        self.node_id = Some(node_id);
         Ok(self.keypair.insert(kp))
     }
 
@@ -211,6 +244,12 @@ impl PeerKeyManager {
 
     pub fn public_key(&self) -> Option<&str> {
         self.keypair.as_ref().map(|kp| kp.public_key())
+    }
+
+    /// Stable node_id persisted alongside the keypair. `Some` after a
+    /// successful [`load_or_generate`].
+    pub fn node_id(&self) -> Option<&str> {
+        self.node_id.as_deref()
     }
 }
 
@@ -300,5 +339,49 @@ mod tests {
         assert_eq!(kp.fingerprint(), fingerprint_of_pubkey(kp.public_key()));
         let other = Ed25519KeyPair::generate().unwrap();
         assert_ne!(kp.fingerprint(), other.fingerprint());
+    }
+
+    /// PR-3: node_id MUST persist across restarts. Without this the kernel
+    /// fell back to `Uuid::new_v4()` per startup and TOFU pinning had no
+    /// stable key to bind against.
+    #[test]
+    fn manager_persists_node_id_across_restarts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr_a = PeerKeyManager::new(tmp.path().to_path_buf());
+        let _ = mgr_a.load_or_generate().unwrap();
+        let id_a = mgr_a.node_id().unwrap().to_string();
+        assert!(!id_a.is_empty());
+
+        let mut mgr_b = PeerKeyManager::new(tmp.path().to_path_buf());
+        let _ = mgr_b.load_or_generate().unwrap();
+        assert_eq!(mgr_b.node_id(), Some(id_a.as_str()));
+    }
+
+    /// PR-3 backward compat: a PR-1-format file (no `node_id` field) must
+    /// still load successfully. The manager mints a fresh node_id and
+    /// rewrites the file so subsequent restarts see a stable identity.
+    #[test]
+    fn manager_migrates_legacy_file_without_node_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("peer_keypair.json");
+        // Hand-craft a PR-1-shaped file (only public_key + private_key).
+        let kp = Ed25519KeyPair::generate().unwrap();
+        let legacy = serde_json::json!({
+            "public_key": kp.public_key(),
+            "private_key": B64.encode(kp.private_key_bytes),
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&legacy).unwrap()).unwrap();
+
+        let mut mgr = PeerKeyManager::new(tmp.path().to_path_buf());
+        let loaded = mgr.load_or_generate().unwrap();
+        assert_eq!(loaded.public_key(), kp.public_key());
+        let migrated_id = mgr.node_id().unwrap().to_string();
+        assert!(!migrated_id.is_empty());
+
+        // File must have been rewritten with the new field — a second mgr
+        // sees the same node_id without minting a fresh one.
+        let mut mgr2 = PeerKeyManager::new(tmp.path().to_path_buf());
+        let _ = mgr2.load_or_generate().unwrap();
+        assert_eq!(mgr2.node_id(), Some(migrated_id.as_str()));
     }
 }


### PR DESCRIPTION
## Summary

Part 3 of the #3873 fix. Activates the per-peer Ed25519 identity defense in production by persisting \`(node_id, keypair)\` together and switching kernel to \`start_with_identity\`.

Without this PR, the defense from PR-2 was effectively dormant in real deployments because:
1. Kernel called the legacy \`PeerNode::start\` (no keypair sent on the wire), and
2. \`node_id\` was \`Uuid::new_v4()\` per startup, so even with a keypair every restart looked like first-contact and the mismatch-detection branch never fired across restarts.

## Changes

### \`librefang-wire/src/keys.rs\`
- \`PersistedKeyPair\` on disk gains optional \`node_id\` field (\`skip_serializing_if\` keeps the field absent when cleanly handled).
- \`PeerKeyManager::load_or_generate\` materializes \`(keypair, node_id)\` together. PR-1-format files (no \`node_id\`) are migrated in-place: a UUID is minted and the file is rewritten so subsequent restarts see a stable identity.
- New accessor: \`PeerKeyManager::node_id() -> Option<&str>\`.

### \`librefang-kernel/src/kernel/mod.rs\` (\`start_ofp_node\`)
- Loads \`PeerKeyManager\` from \`data_dir_boot\` and uses its persisted \`node_id\` instead of \`Uuid::new_v4()\`.
- Calls \`PeerNode::start_with_identity\` with the loaded keypair so every outbound handshake carries pubkey + Ed25519 signature.
- Identity load failure aborts OFP startup with an \`error!\` log rather than silently degrading to ephemeral identity.

## Tests
- \`manager_persists_node_id_across_restarts\` — second \`PeerKeyManager\` returns the same \`node_id\`.
- \`manager_migrates_legacy_file_without_node_id\` — PR-1-shaped file loads, gets a fresh \`node_id\`, file is rewritten so a third load sees the same id.

\`cargo test -p librefang-wire\` → 49/49 (47 prior + 2 new).
\`cargo clippy -p librefang-kernel -p librefang-wire --all-targets --all-features -- -D warnings\` → clean.

## Net security posture after this PR

- **Within daemon lifetime**: PR-2 already prevented impersonation via shared_secret leak.
- **Across restarts**: now also protected, because identity is stable. A peer that has previously seen \`node-X\` retains nothing across restart (pin map is in-memory) — but \`node-X\` itself comes back with the same pubkey, so when its peers reconnect, **their** newly-built pin matches.
- **First contact after either side restarts**: still TOFU; PR-4 will persist the pin map so even the first contact after a restart can be enforced against a pre-existing pin.

## Plan
| PR | Status | Scope |
|----|--------|-------|
| 1 (#4245) | merged | Ed25519 keypair primitive + persistence |
| 2 (#4253) | merged | Handshake fields + verification + in-memory TOFU |
| **3 (this)** | **open** | Kernel persists node_id + keypair, wires start_with_identity |
| 4 | next | Persist pin map (\`trusted_peers.rs\`) + admin/dashboard pairing UI |
| 5 | | Demote shared_secret to admission gate only |

Refs #3873.