### PR TITLE
fix(runtime): route plugin-installer through librefang-http (refs #3577)

### DIFF
--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -4115,8 +4115,10 @@ pub async fn install_plugin_with_deps(
     validate_plugin_name(name)?;
 
     // Fetch the registry index to resolve the dependency graph.
+    // Routed through librefang-http so the registry fetch honors [proxy] and
+    // the workspace TLS roots (#3577).
     let repo = github_repo.unwrap_or("librefang/librefang-registry");
-    let client = reqwest::Client::builder()
+    let client = librefang_http::proxied_client_builder()
         .user_agent("librefang-plugin-installer/1.0")
         .timeout(std::time::Duration::from_secs(30))
         .build()


### PR DESCRIPTION
## Summary

Follow-up to #4242 — that PR cleans up four `reqwest::Client::*` sites that bypass `[proxy]` config / centralized TLS roots, but missed one more in the same family:

- `crates/librefang-runtime/src/plugin_manager.rs:4119` — `install_plugin_with_deps()` fetches the registry index when resolving plugin dependency graphs. Same `[proxy]` blindness as the `plugin_update_check` / `plugin_registry_search` sites #4242 already fixes.

This switches it to `librefang_http::proxied_client_builder()`, preserving the existing user-agent (`librefang-plugin-installer/1.0`) and 30s timeout. `librefang-http` is already a path dep of `librefang-runtime`, so no Cargo manifest change.

## Why a separate PR

Independent of #4242 — uses the public `librefang_http::proxied_client_builder()` directly rather than the `crate::http_client::` re-export #4242 introduces, so this can land before, after, or alongside it.

## Out-of-scope (verified)

While auditing for the same family I confirmed:
- `runtime-mcp/lib.rs:1748,1811` — `reqwest::Client::new()` used as a `std::mem::replace` sentinel inside `close()` / `Drop`. The client never sends a request — it's a placeholder before the variant is matched out. No fix needed.
- `runtime-mcp/lib.rs:3990,4010` — inside `#[tokio::test]` blocks pointing at a 127.0.0.1 test server. Test fixtures, no proxy concern.
- The deferred set called out in #4242's notes (`desktop/{updater,connection}.rs`, `kernel/cron_delivery.rs`) is left untouched here for the same reasons stated there.

## Test plan

- [x] `cargo check -p librefang-runtime --lib`
- [x] `cargo clippy -p librefang-runtime --all-targets -- -D warnings`
- [ ] Live verification with a configured `[proxy]` block: trigger `install_plugin_with_deps` (e.g. via plugin install CLI / API) and confirm the GitHub registry fetch flows through the proxy.