### PR TITLE
feat(network): expose OFP identity fingerprint, refresh docs (closes #3873, 5/5)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2797,7 +2797,18 @@ export interface NetworkStatusResponse {
   protocol_version?: string;
   listen_addr?: string;
   peer_count?: number;
+  // SECURITY (#3873): null when this node has no Ed25519 identity
+  // (HMAC-only legacy mode); operators should treat that as "new defense
+  // is dormant" and investigate.
+  identity_fingerprint?: string | null;
+  pinned_peers?: number;
   [key: string]: unknown;
+}
+
+export interface TrustedPeerItem {
+  node_id: string;
+  public_key: string;
+  fingerprint: string;
 }
 
 export interface PeerItem {
@@ -2817,6 +2828,13 @@ export async function getNetworkStatus(): Promise<NetworkStatusResponse> {
 
 export async function listPeers(): Promise<PeerItem[]> {
   const data = await get<{ peers?: PeerItem[] }>("/api/peers");
+  return data.peers ?? [];
+}
+
+export async function listTrustedPeers(): Promise<TrustedPeerItem[]> {
+  const data = await get<{ peers?: TrustedPeerItem[] }>(
+    "/api/network/trusted-peers",
+  );
   return data.peers ?? [];
 }
 

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -77,6 +77,7 @@ export {
   // network / peers / a2a
   getNetworkStatus,
   listPeers,
+  listTrustedPeers,
   listA2AAgents,
   getA2ATaskStatus,
   // plugins

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -233,6 +233,7 @@ export const goalKeys = {
 export const networkKeys = {
   all: ["network"] as const,
   status: () => [...networkKeys.all, "status"] as const,
+  trustedPeers: () => [...networkKeys.all, "trusted-peers"] as const,
 };
 
 export const peerKeys = {

--- a/crates/librefang-api/dashboard/src/lib/queries/network.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/network.ts
@@ -2,6 +2,7 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import {
   getNetworkStatus,
   listPeers,
+  listTrustedPeers,
   listA2AAgents,
 } from "../http/client";
 import { networkKeys, peerKeys, a2aKeys } from "./keys";
@@ -25,6 +26,13 @@ export const networkQueries = {
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
     }),
+  trustedPeers: () =>
+    queryOptions({
+      queryKey: networkKeys.trustedPeers(),
+      queryFn: listTrustedPeers,
+      staleTime: STALE_MS,
+      refetchInterval: REFRESH_MS,
+    }),
   a2aAgents: () =>
     queryOptions({
       queryKey: a2aKeys.agents(),
@@ -40,6 +48,10 @@ export function useNetworkStatus(options: QueryOverrides = {}) {
 
 export function usePeers(options: QueryOverrides = {}) {
   return useQuery(withOverrides(networkQueries.peers(), options));
+}
+
+export function useTrustedPeers(options: QueryOverrides = {}) {
+  return useQuery(withOverrides(networkQueries.trustedPeers(), options));
 }
 
 export function useA2AAgents(options: QueryOverrides = {}) {

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2467,6 +2467,14 @@
     "connected": "connected",
     "no_peers": "No peers connected",
     "no_peers_desc": "No OFP peers are currently connected to this node.",
+    "identity_fingerprint": "Identity fingerprint",
+    "identity_fingerprint_hint": "Compare with the remote operator out-of-band before pinning.",
+    "identity_missing": "No Ed25519 identity loaded. OFP is running in HMAC-only legacy mode; per-peer impersonation defense (#3873) is dormant.",
+    "pinned_peers_count_one": "{{count}} TOFU-pinned peer",
+    "pinned_peers_count_other": "{{count}} TOFU-pinned peers",
+    "trusted_peers": "Trusted peers",
+    "trusted_peers_pinned": "{{count}} pinned",
+    "trusted_peer_fingerprint_hint": "SHA-256 fingerprint of the pinned Ed25519 public key. Compare OOB.",
     "help": "Network shows this instance's status in the Open Federation Protocol (OFP) — peer LibreFang nodes you've discovered or been discovered by, your own node identity, and the OFP version in use. OFP is the layer below A2A: it's how nodes find each other; A2A is what they say once connected.\n\nHow to use this page:\n\n1. Identity. The node-id and protocol version identify this LibreFang instance to the federation.\n\n2. Peers. Shows every connected peer with online / offline status. Empty list means you're not federating with anyone yet.\n\n3. Status. Online means OFP is reachable and your node is announcing itself.\n\nWhen to use it (vs. A2A):\n\n  · Network — node-level federation: who's out there, who's connected.\n  · A2A — agent-level talk: what agents on those nodes can do for each other.\n\nTypical scenarios:\n\n  · Confirming two LibreFang instances actually see each other before debugging A2A.\n  · Reading off your node-id to share with a peer for direct connection.\n\nThings to know:\n\n  · Federation is opt-in and config-gated. If \"no peers\" looks empty by default, that's expected unless you've configured peers.\n  · Network status is a live read — refresh polls, no caching."
   },
   "a2a": {

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2393,6 +2393,14 @@
     "connected": "已连接",
     "no_peers": "暂无连接节点",
     "no_peers_desc": "当前没有 OFP 节点连接到此实例。",
+    "identity_fingerprint": "身份指纹",
+    "identity_fingerprint_hint": "在 pin 之前先和远端运维做带外（OOB）比对。",
+    "identity_missing": "未加载 Ed25519 身份。OFP 正在以 HMAC-only 兼容模式运行；针对节点冒充的防御 (#3873) 暂未激活。",
+    "pinned_peers_count_one": "{{count}} 个 TOFU 已固定节点",
+    "pinned_peers_count_other": "{{count}} 个 TOFU 已固定节点",
+    "trusted_peers": "已信任节点",
+    "trusted_peers_pinned": "已 pin {{count}} 个",
+    "trusted_peer_fingerprint_hint": "已 pin 的 Ed25519 公钥 SHA-256 指纹。请带外比对确认。",
     "help": "Network 显示本实例在开放联邦协议（OFP）中的状态——已发现或被发现的对等 LibreFang 节点、本节点身份、使用的 OFP 版本。OFP 是 A2A 之下那一层：节点互相找到对方靠 OFP；连上之后说什么靠 A2A。\n\n使用步骤：\n\n1. 身份。node-id 和协议版本是本 LibreFang 实例对联邦的标识。\n\n2. 节点。显示每个已连接的对等节点和 online / offline 状态。空列表说明你还没在和任何人联邦。\n\n3. 状态。Online 表示 OFP 可达，本节点正在向外宣告自己。\n\n跟 A2A 的区别：\n\n  · Network —— 节点级联邦：外面有谁、连上了谁。\n  · A2A —— agent 级对话：那些节点上的 agent 能为彼此做什么。\n\n典型场景：\n\n  · 调试 A2A 前先确认两个 LibreFang 实例确实互相能看到。\n  · 读 node-id 发给对端做直连。\n\n注意事项：\n\n  · 联邦是可选且配置控制的。默认 \"no peers\" 是预期，除非你已配 peers。\n  · 网络状态是实时读，刷新即重新拉，无缓存。"
   },
   "a2a": {

--- a/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
@@ -1,28 +1,47 @@
 import { useCallback } from "react";
 import { formatDateTime } from "../lib/datetime";
 import { useTranslation } from "react-i18next";
-import { useNetworkStatus, usePeers } from "../lib/queries/network";
+import {
+  useNetworkStatus,
+  usePeers,
+  useTrustedPeers,
+} from "../lib/queries/network";
 import { PageHeader } from "../components/ui/PageHeader";
 import { Card } from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
 import { EmptyState } from "../components/ui/EmptyState";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { StaggerList } from "../components/ui/StaggerList";
-import { Network, Globe, Server, Wifi, WifiOff, Hash, Clock } from "lucide-react";
+import {
+  Network,
+  Globe,
+  Server,
+  Wifi,
+  WifiOff,
+  Hash,
+  Clock,
+  ShieldCheck,
+} from "lucide-react";
 
 export function NetworkPage() {
   const { t } = useTranslation();
 
   const statusQuery = useNetworkStatus();
   const peersQuery = usePeers();
+  const trustedQuery = useTrustedPeers();
 
   const status = statusQuery.data;
   const peers = peersQuery.data ?? [];
+  const trustedPeers = trustedQuery.data ?? [];
   const isLoading = statusQuery.isPending || peersQuery.isPending;
 
   const handleRefresh = useCallback(() => {
-    void Promise.all([statusQuery.refetch(), peersQuery.refetch()]);
-  }, [statusQuery, peersQuery]);
+    void Promise.all([
+      statusQuery.refetch(),
+      peersQuery.refetch(),
+      trustedQuery.refetch(),
+    ]);
+  }, [statusQuery, peersQuery, trustedQuery]);
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -95,6 +114,85 @@ export function NetworkPage() {
               ) : null}
             </Card>
           </StaggerList>
+
+          {/* SECURITY (#3873): Identity card. Operators verify the
+              fingerprint is non-null (else this node is HMAC-only and the
+              new defense is dormant) and OOB-share it with remote peers
+              before federating. */}
+          <Card padding="md">
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] font-black uppercase tracking-widest text-text-dim/60">
+                Identity fingerprint
+              </span>
+              <div
+                className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+                  status?.identity_fingerprint ? "bg-success/10" : "bg-warning/10"
+                }`}
+              >
+                <ShieldCheck
+                  className={`w-4 h-4 ${
+                    status?.identity_fingerprint ? "text-success" : "text-warning"
+                  }`}
+                />
+              </div>
+            </div>
+            {status?.identity_fingerprint ? (
+              <p
+                className="text-xs font-mono mt-2 break-all"
+                title="Compare with the remote operator out-of-band before pinning."
+              >
+                {status.identity_fingerprint}
+              </p>
+            ) : (
+              <p className="text-xs text-warning mt-2">
+                No Ed25519 identity loaded. OFP is running in HMAC-only legacy
+                mode; per-peer impersonation defense (#3873) is dormant.
+              </p>
+            )}
+            <p className="text-[10px] text-text-dim mt-2">
+              {status?.pinned_peers ?? 0} TOFU-pinned peer
+              {(status?.pinned_peers ?? 0) === 1 ? "" : "s"}
+            </p>
+          </Card>
+
+          {/* SECURITY (#3873): Trusted peers list. Each entry is a
+              (node_id, fingerprint) the local kernel will accept on
+              future handshakes. Mismatches are rejected. */}
+          {trustedPeers.length > 0 ? (
+            <div>
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-black tracking-tight">
+                  Trusted peers
+                </h2>
+                <Badge variant="brand">{trustedPeers.length} pinned</Badge>
+              </div>
+              <StaggerList className="grid gap-2 sm:gap-3 md:grid-cols-2">
+                {trustedPeers.map((tp) => (
+                  <Card key={tp.node_id} padding="md">
+                    <div className="flex items-start gap-3">
+                      <div className="w-10 h-10 rounded-xl bg-success/10 flex items-center justify-center shrink-0">
+                        <ShieldCheck className="w-5 h-5 text-success" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p
+                          className="text-sm font-bold font-mono truncate"
+                          title={tp.node_id}
+                        >
+                          {tp.node_id}
+                        </p>
+                        <p
+                          className="text-[10px] text-text-dim font-mono mt-1 break-all"
+                          title="SHA-256 fingerprint of the pinned Ed25519 public key. Compare OOB."
+                        >
+                          {tp.fingerprint}
+                        </p>
+                      </div>
+                    </div>
+                  </Card>
+                ))}
+              </StaggerList>
+            </div>
+          ) : null}
 
           {/* Peers list */}
           <div>

--- a/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
@@ -122,7 +122,7 @@ export function NetworkPage() {
           <Card padding="md">
             <div className="flex items-center justify-between">
               <span className="text-[10px] font-black uppercase tracking-widest text-text-dim/60">
-                Identity fingerprint
+                {t("network.identity_fingerprint")}
               </span>
               <div
                 className={`w-8 h-8 rounded-lg flex items-center justify-center ${
@@ -139,19 +139,19 @@ export function NetworkPage() {
             {status?.identity_fingerprint ? (
               <p
                 className="text-xs font-mono mt-2 break-all"
-                title="Compare with the remote operator out-of-band before pinning."
+                title={t("network.identity_fingerprint_hint")}
               >
                 {status.identity_fingerprint}
               </p>
             ) : (
               <p className="text-xs text-warning mt-2">
-                No Ed25519 identity loaded. OFP is running in HMAC-only legacy
-                mode; per-peer impersonation defense (#3873) is dormant.
+                {t("network.identity_missing")}
               </p>
             )}
             <p className="text-[10px] text-text-dim mt-2">
-              {status?.pinned_peers ?? 0} TOFU-pinned peer
-              {(status?.pinned_peers ?? 0) === 1 ? "" : "s"}
+              {t("network.pinned_peers_count", {
+                count: status?.pinned_peers ?? 0,
+              })}
             </p>
           </Card>
 
@@ -162,9 +162,13 @@ export function NetworkPage() {
             <div>
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-lg font-black tracking-tight">
-                  Trusted peers
+                  {t("network.trusted_peers")}
                 </h2>
-                <Badge variant="brand">{trustedPeers.length} pinned</Badge>
+                <Badge variant="brand">
+                  {t("network.trusted_peers_pinned", {
+                    count: trustedPeers.length,
+                  })}
+                </Badge>
               </div>
               <StaggerList className="grid gap-2 sm:gap-3 md:grid-cols-2">
                 {trustedPeers.map((tp) => (
@@ -182,7 +186,7 @@ export function NetworkPage() {
                         </p>
                         <p
                           className="text-[10px] text-text-dim font-mono mt-1 break-all"
-                          title="SHA-256 fingerprint of the pinned Ed25519 public key. Compare OOB."
+                          title={t("network.trusted_peer_fingerprint_hint")}
                         >
                           {tp.fingerprint}
                         </p>

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -167,7 +167,7 @@ pub async fn network_status(State(state): State<Arc<AppState>>) -> impl IntoResp
     let enabled = cfg.network_enabled && !cfg.network.shared_secret.is_empty();
     drop(cfg);
 
-    let (node_id, listen_address, connected_peers, total_peers) =
+    let (node_id, listen_address, connected_peers, total_peers, identity_fingerprint, pinned_peers) =
         if let Some(peer_node) = state.kernel.peer_node_ref() {
             let registry = peer_node.registry();
             (
@@ -175,17 +175,27 @@ pub async fn network_status(State(state): State<Arc<AppState>>) -> impl IntoResp
                 peer_node.local_addr().to_string(),
                 registry.connected_count(),
                 registry.total_count(),
+                peer_node.identity_fingerprint(),
+                peer_node.pinned_peer_count(),
             )
         } else {
-            (String::new(), String::new(), 0, 0)
+            (String::new(), String::new(), 0, 0, None, 0)
         };
 
+    // SECURITY (#3873): Surface this node's Ed25519 identity fingerprint
+    // and the count of TOFU-pinned peers so operators can verify their
+    // own identity is loaded (not silently HMAC-only) and watch the pin
+    // map populate as peers are encountered. The fingerprint is the
+    // out-of-band-comparable value — share it on a side channel so a
+    // remote operator can check the value their kernel pinned.
     Json(serde_json::json!({
         "enabled": enabled,
         "node_id": node_id,
         "listen_address": listen_address,
         "connected_peers": connected_peers,
         "total_peers": total_peers,
+        "identity_fingerprint": identity_fingerprint,
+        "pinned_peers": pinned_peers,
     }))
 }
 

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -8,6 +8,10 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
         .route("/peers", axum::routing::get(list_peers))
         .route("/peers/{id}", axum::routing::get(get_peer))
         .route("/network/status", axum::routing::get(network_status))
+        .route(
+            "/network/trusted-peers",
+            axum::routing::get(network_trusted_peers),
+        )
         .route("/comms/topology", axum::routing::get(comms_topology))
         .route("/comms/events", axum::routing::get(comms_events))
         .route(
@@ -197,6 +201,36 @@ pub async fn network_status(State(state): State<Arc<AppState>>) -> impl IntoResp
         "identity_fingerprint": identity_fingerprint,
         "pinned_peers": pinned_peers,
     }))
+}
+
+/// SECURITY (#3873): GET /api/network/trusted-peers — list every TOFU-pinned
+/// peer this node will accept under each `node_id`. Operators read this to
+/// verify what their daemon trusts and out-of-band-compare fingerprints
+/// with remote operators before federating.
+#[utoipa::path(
+    get,
+    path = "/api/network/trusted-peers",
+    tag = "network",
+    responses(
+        (status = 200, description = "List TOFU-pinned peers", body = serde_json::Value)
+    )
+)]
+pub async fn network_trusted_peers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let entries: Vec<serde_json::Value> = match state.kernel.peer_node_ref() {
+        Some(peer_node) => peer_node
+            .list_pinned_peers()
+            .into_iter()
+            .map(|(node_id, public_key, fingerprint)| {
+                serde_json::json!({
+                    "node_id": node_id,
+                    "public_key": public_key,
+                    "fingerprint": fingerprint,
+                })
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+    Json(serde_json::json!({ "peers": entries }))
 }
 
 #[utoipa::path(

--- a/crates/librefang-wire/src/lib.rs
+++ b/crates/librefang-wire/src/lib.rs
@@ -10,19 +10,46 @@
 //! - **WireMessage**: JSON-framed protocol messages
 //! - **PeerHandle**: Trait for routing remote messages through the kernel
 //!
+//! ## Authentication model
+//!
+//! Two layers, both required for a successful handshake:
+//!
+//! 1. **Network admission** — HMAC-SHA256 over `nonce | sender_node_id |
+//!    recipient_node_id` using `shared_secret`. Coarse "do you have the
+//!    cluster password" gate, bound to a specific `(sender, recipient)`
+//!    pair so a captured packet cannot be replayed against a different
+//!    mesh node (#3875).
+//! 2. **Per-peer identity** (#3873) — every node persists an Ed25519
+//!    keypair in `<data_dir>/peer_keypair.json`. The handshake also
+//!    carries the sender's pubkey plus an Ed25519 signature over the
+//!    same auth-data string the HMAC covers. Recipients verify the
+//!    signature and TOFU-pin the pubkey to the sender's `node_id`.
+//!    Subsequent handshakes claiming the same `node_id` MUST present
+//!    the same pubkey or are rejected. Pins persist across restarts in
+//!    `<data_dir>/trusted_peers.json`.
+//!
+//! Net effect: a leaked `shared_secret` no longer lets an attacker
+//! impersonate a previously-pinned peer — they would also need that
+//! node's private key. They can still open a connection under a fresh
+//! `node_id` (admission gate is symmetric) but cannot pretend to be an
+//! existing identity. Operators verify the local fingerprint via
+//! `GET /api/network/status` (`identity_fingerprint`) and compare it
+//! out-of-band with the peer they intend to federate with.
+//!
 //! ## Wire confidentiality
 //!
-//! OFP frames are **plaintext** on the wire. Authentication, integrity, and
-//! replay protection are provided by an HMAC-SHA256 handshake plus per-message
-//! HMAC; confidentiality is **not** provided here and must come from the
-//! deployment (WireGuard / Tailscale / SSH tunnel / service-mesh mTLS).
+//! OFP frames are **plaintext** on the wire. Authentication, integrity,
+//! and replay protection are provided in this crate; confidentiality is
+//! **not**, and must come from the deployment (WireGuard / Tailscale /
+//! SSH tunnel / service-mesh mTLS).
 //!
-//! Do not add TLS termination inside this crate without first re-evaluating
-//! the decision documented at <https://docs.librefang.ai/architecture/ofp-wire>
-//! (closed issue #3874, closed PR #4001). The HMAC framing intentionally
-//! covers active-attacker threats; overlays cover passive-observer threats.
-//! Re-implementing TLS on top of that adds maintenance burden without
-//! changing the supported deployment model.
+//! Do not add TLS termination inside this crate without first
+//! re-evaluating the decision documented at
+//! <https://docs.librefang.ai/architecture/ofp-wire> (closed issue
+//! #3874, closed PR #4001). The HMAC + Ed25519 framing intentionally
+//! covers active-attacker threats; overlays cover passive-observer
+//! threats. Re-implementing TLS on top of that adds maintenance burden
+//! without changing the supported deployment model.
 
 pub mod keys;
 pub mod message;

--- a/crates/librefang-wire/src/peer.rs
+++ b/crates/librefang-wire/src/peer.rs
@@ -2409,4 +2409,61 @@ mod tests {
             Ok(_) => panic!("corrupt trust file MUST not produce a running PeerNode"),
         }
     }
+
+    /// PR-5: `list_pinned_peers` is the input the admin endpoint at
+    /// `GET /api/network/trusted-peers` rebuilds for operators. It MUST
+    /// emit `(node_id, public_key, fingerprint)` triples sorted by
+    /// `node_id` so the dashboard doesn't reshuffle on every refresh,
+    /// and the fingerprint MUST match what `fingerprint_of_pubkey`
+    /// computes for the corresponding public key (else operators
+    /// OOB-comparing fingerprints would be misled).
+    #[tokio::test]
+    async fn issue_3873_list_pinned_peers_is_sorted_and_consistent() {
+        // Hand-craft a trust file with three peers in non-sorted order
+        // so the hydration step alone doesn't accidentally produce a
+        // sorted output.
+        let tmp = tempfile::tempdir().unwrap();
+        let kp_a = Ed25519KeyPair::generate().unwrap();
+        let kp_b = Ed25519KeyPair::generate().unwrap();
+        let kp_c = Ed25519KeyPair::generate().unwrap();
+        {
+            let mut store = crate::trusted_peers::TrustedPeers::new(tmp.path().to_path_buf());
+            store
+                .trust_peer("zeta".into(), kp_c.public_key().to_string(), None, None)
+                .unwrap();
+            store
+                .trust_peer("alpha".into(), kp_a.public_key().to_string(), None, None)
+                .unwrap();
+            store
+                .trust_peer("mike".into(), kp_b.public_key().to_string(), None, None)
+                .unwrap();
+        }
+
+        let (node, _t) = PeerNode::start_with_identity(
+            test_config("server", "S"),
+            PeerRegistry::new(),
+            Arc::new(TestHandle::new()),
+            None,
+            Some(tmp.path().to_path_buf()),
+        )
+        .await
+        .unwrap();
+
+        let listed = node.list_pinned_peers();
+        let ids: Vec<&str> = listed.iter().map(|(id, _, _)| id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["alpha", "mike", "zeta"],
+            "must be sorted by node_id"
+        );
+        for (id, pk, fp) in &listed {
+            assert_eq!(
+                fp,
+                &crate::keys::fingerprint_of_pubkey(pk),
+                "fingerprint for {id} must equal fingerprint_of_pubkey(public_key)"
+            );
+        }
+        assert_eq!(listed.len(), 3);
+        assert_eq!(node.pinned_peer_count(), 3);
+    }
 }

--- a/crates/librefang-wire/src/peer.rs
+++ b/crates/librefang-wire/src/peer.rs
@@ -526,6 +526,31 @@ impl PeerNode {
         self.pinned_pubkeys.lock().map(|g| g.len()).unwrap_or(0)
     }
 
+    /// SECURITY (#3873): Snapshot of every TOFU-pinned `(node_id,
+    /// public_key, fingerprint)` triple, sorted by `node_id` for stable
+    /// rendering. Used by `GET /api/network/trusted-peers` so an operator
+    /// can verify exactly which identities this node will accept under
+    /// each `node_id`. Fingerprint is the value to compare out-of-band
+    /// with the remote operator before treating the pin as trustworthy.
+    pub fn list_pinned_peers(&self) -> Vec<(String, String, String)> {
+        let pins = match self.pinned_pubkeys.lock() {
+            Ok(g) => g,
+            Err(_) => return Vec::new(),
+        };
+        let mut out: Vec<_> = pins
+            .iter()
+            .map(|(id, pk)| {
+                (
+                    id.clone(),
+                    pk.clone(),
+                    crate::keys::fingerprint_of_pubkey(pk),
+                )
+            })
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
     /// SECURITY (#3873): If this node has an Ed25519 identity, return
     /// `(Some(public_key_b64), Some(signature_b64))` over `auth_data`. With
     /// no identity configured returns `(None, None)` and the recipient gets

--- a/crates/librefang-wire/src/peer.rs
+++ b/crates/librefang-wire/src/peer.rs
@@ -508,6 +508,24 @@ impl PeerNode {
         &self.registry
     }
 
+    /// SECURITY (#3873): Stable hex SHA-256 fingerprint of this node's
+    /// Ed25519 public key. `None` when this node was started without an
+    /// identity (HMAC-only legacy mode). The fingerprint is the value an
+    /// operator compares out-of-band with a remote peer to verify the
+    /// pubkey before TOFU pins it.
+    pub fn identity_fingerprint(&self) -> Option<String> {
+        self.keypair.as_ref().map(|kp| kp.fingerprint())
+    }
+
+    /// SECURITY (#3873): Number of remote nodes this PeerNode currently
+    /// has Ed25519 pubkeys pinned for. Includes pins hydrated from the
+    /// persistent trust store at startup plus any added during this
+    /// daemon's lifetime. Surfaced via `/api/network/status` so operators
+    /// can see at a glance whether TOFU pinning is actually populating.
+    pub fn pinned_peer_count(&self) -> usize {
+        self.pinned_pubkeys.lock().map(|g| g.len()).unwrap_or(0)
+    }
+
     /// SECURITY (#3873): If this node has an Ed25519 identity, return
     /// `(Some(public_key_b64), Some(signature_b64))` over `auth_data`. With
     /// no identity configured returns `(None, None)` and the recipient gets

--- a/docs/src/app/architecture/ofp-wire/page.mdx
+++ b/docs/src/app/architecture/ofp-wire/page.mdx
@@ -14,18 +14,33 @@ networks safely.
 - **OFP frames are plaintext on the wire.** A passive observer between two
   kernels can read system prompts, user inputs, LLM outputs, and tool
   results.
-- **HMAC framing covers active attackers** (forgery, tampering, replay,
-  cross-peer replay). It does **not** cover confidentiality.
+- **HMAC framing + Ed25519 identity covers active attackers** (forgery,
+  tampering, replay, cross-peer replay, **and** node-id impersonation
+  via leaked `shared_secret`). It does **not** cover confidentiality.
 - **Confidentiality is delegated to the deployment layer.** For
   cross-network federation, run OFP behind WireGuard, Tailscale, an SSH
   tunnel, or a service-mesh mTLS layer.
 - We **don't** ship in-tree TLS in `librefang-wire` and don't plan to —
   see the rationale below.
 
-## What HMAC framing already covers
+## What the framing already covers
 
-OFP requires a pre-shared `shared_secret` before any traffic flows.
-Authentication runs on every frame:
+OFP authenticates every connection in two layers:
+
+1. **HMAC admission** — `shared_secret` HMAC-SHA256 over
+   `nonce | sender_node_id | recipient_node_id`. A coarse "do you have
+   the cluster password" gate, bound to a specific (sender, recipient)
+   pair.
+2. **Per-peer Ed25519 identity** ([#3873](https://github.com/librefang/librefang/issues/3873)) —
+   each kernel persists an Ed25519 keypair in
+   `<data_dir>/peer_keypair.json` and signs the same auth-data string
+   the HMAC covers. Recipients verify the signature and TOFU-pin the
+   pubkey to the sender's `node_id`. Subsequent handshakes claiming the
+   same `node_id` MUST present the same pubkey or are rejected. Pins
+   persist in `<data_dir>/trusted_peers.json` so the defense is durable
+   across daemon restarts. Operators view the local fingerprint and the
+   pin set via `GET /api/network/status` and
+   `GET /api/network/trusted-peers`.
 
 | Attack | Blocked? | Mechanism |
 |--------|----------|-----------|
@@ -33,9 +48,12 @@ Authentication runs on every frame:
 | Modifying frame contents in transit | Yes | Per-message HMAC over the JSON body |
 | Replaying a captured handshake | Yes | Time-windowed nonce tracker ([#3880](https://github.com/librefang/librefang/issues/3880)), HMAC-verify-before-record ordering |
 | Replaying a captured handshake against a *different* peer that shares the secret | Yes | HMAC binds `nonce \| sender_node_id \| recipient_node_id` ([#3875](https://github.com/librefang/librefang/issues/3875)) |
+| **Impersonating a previously-pinned `node_id` after stealing `shared_secret`** | **Yes** | **Per-peer Ed25519 identity + TOFU pin ([#3873](https://github.com/librefang/librefang/issues/3873)). Attacker would also need the victim's `peer_keypair.json` private key.** |
+| Downgrading from Ed25519 identity back to HMAC-only on a pinned node_id | Yes | Pinned node_ids reject (None, None) identity fields ([#3873](https://github.com/librefang/librefang/issues/3873)) |
 | Oversized `AgentMessage` draining the receiver's LLM budget | Yes | `MAX_PEER_MESSAGE_BYTES = 64 KiB` ([#3876](https://github.com/librefang/librefang/issues/3876)) |
 | Timing side-channel on HMAC verification | Yes | `subtle::ConstantTimeEq` |
 | **Reading frame contents on the wire** | **No** | Use a deployment-layer overlay |
+| **Forging in-flight messages of an existing connection given `shared_secret` + nonce sniff** | **Partial — open follow-up** | Per-message HMAC currently derives `session_key` from `shared_secret` + handshake nonces; a passive observer who has both can recompute it. Closing this requires an Ed25519/X25519 ephemeral key exchange and is filed for a separate protocol PR. |
 
 In other words: an attacker on the path can sniff your federation traffic,
 but cannot impersonate a peer, mutate a message, or get oversized payloads

--- a/docs/src/app/configuration/core/page.mdx
+++ b/docs/src/app/configuration/core/page.mdx
@@ -145,7 +145,7 @@ The status endpoint returns the resolved `effective_min_hours` / `effective_min_
 
 ### `[network]`
 
-Configures the OFP (LibreFang Protocol) peer-to-peer networking layer with HMAC-SHA256 mutual authentication.
+Configures the OFP (LibreFang Protocol) peer-to-peer networking layer. Authentication has two layers: a `shared_secret` HMAC admission gate plus per-node Ed25519 identity with TOFU pinning (#3873). The Ed25519 keypair and trust pins live in `<data_dir>/peer_keypair.json` and `<data_dir>/trusted_peers.json`.
 
 ```toml
 [network]
@@ -162,7 +162,7 @@ shared_secret = "my-cluster-secret"
 | `bootstrap_peers` | list of strings | `[]` | Multiaddresses of bootstrap peers for DHT discovery. |
 | `mdns_enabled` | bool | `true` | Enable mDNS for automatic local network peer discovery. |
 | `max_peers` | u32 | `50` | Maximum number of simultaneously connected peers. |
-| `shared_secret` | string | `""` (empty) | Pre-shared secret for OFP HMAC-SHA256 mutual authentication. **Required** when `network_enabled = true`. Both sides must use the same secret. Redacted in logs. |
+| `shared_secret` | string | `""` (empty) | Pre-shared admission secret for OFP HMAC-SHA256. **Required** when `network_enabled = true`. Both sides must use the same value. Acts as a coarse "cluster password" gate; per-node identity is provided separately by the Ed25519 keypair persisted in the data dir, so a leaked `shared_secret` cannot impersonate a previously-pinned peer. Redacted in logs. |
 
 ---
 

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -608,7 +608,7 @@ Per-agent opt-in can be toggled at runtime via `PUT /api/auto-dream/agents/{id}/
 
 ### `[network]`
 
-Configures the OFP (LibreFang Protocol) peer-to-peer networking layer with HMAC-SHA256 mutual authentication.
+Configures the OFP (LibreFang Protocol) peer-to-peer networking layer. Authentication has two layers: a `shared_secret` HMAC admission gate plus per-node Ed25519 identity with TOFU pinning (#3873). The Ed25519 keypair and trust pins live in `<data_dir>/peer_keypair.json` and `<data_dir>/trusted_peers.json`.
 
 ```toml
 [network]
@@ -625,7 +625,7 @@ shared_secret = "my-cluster-secret"
 | `bootstrap_peers` | list of strings | `[]` | Multiaddresses of bootstrap peers for DHT discovery. |
 | `mdns_enabled` | bool | `true` | Enable mDNS for automatic local network peer discovery. |
 | `max_peers` | u32 | `50` | Maximum number of simultaneously connected peers. |
-| `shared_secret` | string | `""` (empty) | Pre-shared secret for OFP HMAC-SHA256 mutual authentication. **Required** when `network_enabled = true`. Both sides must use the same secret. Redacted in logs. |
+| `shared_secret` | string | `""` (empty) | Pre-shared admission secret for OFP HMAC-SHA256. **Required** when `network_enabled = true`. Both sides must use the same value. Acts as a coarse "cluster password" gate; per-node identity is provided separately by the Ed25519 keypair persisted in the data dir, so a leaked `shared_secret` cannot impersonate a previously-pinned peer. Redacted in logs. |
 
 ---
 

--- a/docs/src/app/operations/troubleshooting/page.mdx
+++ b/docs/src/app/operations/troubleshooting/page.mdx
@@ -559,7 +559,7 @@ Yes. Agents can use the `agent_send`, `agent_spawn`, `agent_find`, and `agent_li
 
 ### Is my data sent to the cloud?
 
-Only LLM API calls go to the provider's servers. All agent data, memory, sessions, and configuration are stored locally in SQLite (`~/.librefang/data/librefang.db`). The OFP wire protocol uses HMAC-SHA256 mutual authentication for P2P communication.
+Only LLM API calls go to the provider's servers. All agent data, memory, sessions, and configuration are stored locally in SQLite (`~/.librefang/data/librefang.db`). The OFP wire protocol authenticates P2P traffic with two layers: a `shared_secret` HMAC admission gate plus per-node Ed25519 identity with TOFU pinning (`peer_keypair.json` + `trusted_peers.json` in the data dir). See `/api/network/status` for the local fingerprint.
 
 ### How do I back up my data?
 

--- a/docs/src/app/security/network-api/page.mdx
+++ b/docs/src/app/security/network-api/page.mdx
@@ -110,8 +110,20 @@ http://example.com              ->  example.com:80
 
 **Source:** `librefang-wire/src/peer.rs`
 
-The LibreFang Wire Protocol (OFP) uses HMAC-SHA256 with nonce-based mutual
-authentication over TCP connections.
+The LibreFang Wire Protocol (OFP) authenticates every TCP connection in
+two layers:
+
+1. **HMAC admission** (`shared_secret`) — coarse cluster-password gate.
+2. **Per-peer Ed25519 identity** ([#3873](https://github.com/librefang/librefang/issues/3873)) — each
+   kernel persists its own Ed25519 keypair in
+   `<data_dir>/peer_keypair.json` and signs the handshake. Recipients
+   TOFU-pin the pubkey to the sender's `node_id` (persisted in
+   `<data_dir>/trusted_peers.json`) and reject any future handshake
+   that claims the same `node_id` with a different pubkey.
+
+A leaked `shared_secret` therefore no longer lets an attacker
+impersonate a previously-pinned peer — they would also need that
+peer's private key file.
 
 ### Pre-Shared Key Requirement
 
@@ -148,39 +160,70 @@ timing side-channel attacks.
 
 ### Handshake Protocol
 
+The same `auth_data` byte string is bound by **both** the HMAC and the
+Ed25519 signature, so identity verification piggybacks on the existing
+replay protection without protocol-level race windows.
+
+```
+auth_data = nonce | sender_node_id | recipient_node_id    // #3875
+```
+
 **Initiator (client):**
 
 1. Generate a random UUID nonce.
-2. Compute `auth_data = nonce + node_id`.
+2. Compute `auth_data` (above) using the expected `recipient_node_id`.
 3. Compute `auth_hmac = hmac_sign(shared_secret, auth_data)`.
-4. Send `Handshake { node_id, node_name, protocol_version, agents, nonce, auth_hmac }`.
+4. If this kernel has an Ed25519 identity loaded:
+   `identity_signature = ed25519_sign(private_key, auth_data)` and
+   include `public_key` (base64) plus `identity_signature` (base64) in
+   the handshake message.
+5. Send `Handshake { node_id, node_name, protocol_version, agents, nonce, auth_hmac, public_key?, identity_signature? }`.
 
 **Responder (server):**
 
 1. Receive the `Handshake` message.
-2. Verify the incoming HMAC: `hmac_verify(shared_secret, nonce + node_id, auth_hmac)`.
-3. If verification fails, return error code 403.
-4. Generate a new UUID nonce for the ack.
-5. Compute `ack_auth_data = ack_nonce + self.node_id`.
-6. Compute `ack_hmac = hmac_sign(shared_secret, ack_auth_data)`.
-7. Send `HandshakeAck { node_id, node_name, protocol_version, agents, nonce: ack_nonce, auth_hmac: ack_hmac }`.
+2. Verify the incoming HMAC over `auth_data`. Fail → 403.
+3. Verify the Ed25519 identity (#3873):
+   - **(public_key, identity_signature) both present:**
+     `ed25519_verify(public_key, auth_data, identity_signature)` MUST
+     succeed. Then enforce TOFU pinning:
+     - If `node_id` is already pinned to a different pubkey → reject.
+     - If new → pin pubkey to `node_id` (in memory + persistent
+       `trusted_peers.json`).
+   - **Both absent (legacy peer):** allowed only if no pin exists for
+     this `node_id`; if a pin exists, the dropped identity is treated
+     as a downgrade attack and rejected.
+   - **Mixed presence:** rejected (malformed).
+4. Record nonce in the replay tracker (HMAC- and identity-verified
+   first; ordering fix for [#3880](https://github.com/librefang/librefang/issues/3880)).
+5. Generate a new UUID `ack_nonce` and `ack_auth_data = ack_nonce | self.node_id | sender.node_id`.
+6. `ack_hmac = hmac_sign(shared_secret, ack_auth_data)`.
+7. If this kernel has an Ed25519 identity loaded, sign `ack_auth_data`
+   the same way and include `public_key` + `identity_signature`.
+8. Send `HandshakeAck { ..., nonce: ack_nonce, auth_hmac: ack_hmac, public_key?, identity_signature? }`.
 
 **Initiator (verification):**
 
 1. Receive `HandshakeAck`.
-2. Verify: `hmac_verify(shared_secret, ack_nonce + node_id, ack_hmac)`.
-3. If verification fails, return `WireError::HandshakeFailed`.
+2. Verify the ack HMAC over the corresponding `ack_auth_data`.
+3. Verify the ack's Ed25519 identity using the same TOFU rules as the
+   responder above.
+4. Both checks must pass before any subsequent message is processed.
 
 ### Security Properties
 
 | Property | How It Is Achieved |
 |----------|-------------------|
-| **Mutual authentication** | Both sides prove knowledge of the shared secret |
-| **Replay protection** | Random UUID nonces per handshake |
-| **Timing-attack resistance** | `subtle::ConstantTimeEq` for HMAC comparison |
+| **Mutual admission** | Both sides prove knowledge of `shared_secret` |
+| **Per-peer identity** ([#3873](https://github.com/librefang/librefang/issues/3873)) | Ed25519 sign-on-handshake + TOFU pin in `trusted_peers.json` |
+| **Cross-peer replay protection** ([#3875](https://github.com/librefang/librefang/issues/3875)) | `auth_data` binds `recipient_node_id` |
+| **Replay protection** | Random UUID nonces per handshake, time-windowed tracker |
+| **Timing-attack resistance** | `subtle::ConstantTimeEq` for HMAC comparison; constant-time Ed25519 verify |
 | **Mandatory secret** | OFP refuses to start with an empty `shared_secret` |
 | **Message size limit** | `MAX_MESSAGE_SIZE = 16 MB` prevents memory DoS |
 | **Protocol version check** | `PROTOCOL_VERSION` mismatch returns `WireError::VersionMismatch` |
+| **Pin map DoS bound** | `MAX_PIN_ENTRIES = 100_000`; hydration also capped |
+| **Trust file confidentiality** | `peer_keypair.json` and `trusted_peers.json` written with `0600` on Unix |
 
 ---
 


### PR DESCRIPTION
## Summary

Final part of the #3873 fix. PR-1..4 closed the impersonation hole at the protocol level; this PR makes the new model **visible to operators** and removes the now-misleading 'HMAC-SHA256 mutual authentication' claims from user-facing docs.

## Changes

### API

\`GET /api/network/status\` now includes:
\`\`\`json
{
  ...
  "identity_fingerprint": "9f3a2c…",  // hex SHA-256 of own pubkey, or null
  "pinned_peers": 3                    // count of TOFU-pinned remote pubkeys
}
\`\`\`
Operators verify \`identity_fingerprint\` is non-null (else this node is still HMAC-only and the new defense is dormant) and watch \`pinned_peers\` grow as the federation populates. The fingerprint is the value to compare out-of-band when bootstrapping a new peer.

### PeerNode accessors
- \`identity_fingerprint() -> Option<String>\`
- \`pinned_peer_count() -> usize\`

### Docs
- \`librefang-wire/src/lib.rs\` module docs rewritten to describe the two-layer auth model (HMAC admission + Ed25519 identity + TOFU pinning).
- \`docs/configuration/core/page.mdx\` and \`docs/configuration/page.mdx\` \`[network]\` sections updated. \`shared_secret\` is now described as an admission gate; per-peer identity is called out as a separate layer that survives \`shared_secret\` leaks (the attack #3873 raised).
- \`docs/operations/troubleshooting/page.mdx\` 'is data sent to cloud?' FAQ no longer says 'HMAC-SHA256 mutual authentication' verbatim; points operators at \`/api/network/status\`.

## Out of scope (follow-ups)

These were in the original 5-part plan but are best filed as separate issues:

1. **Per-message HMAC session-key coupling** — \`session_key = derive_session_key(shared_secret, nonce_a, nonce_b)\` still folds in \`shared_secret\`. Closing this requires an Ed25519/X25519 ephemeral key exchange and is a substantial protocol change. Independent of #3873's impersonation hole.
2. **Dashboard UI** for pin inspection / manual unpin / OOB pairing UX.
3. **Deep protocol docs** (\`architecture/ofp-wire\`, \`security/network-api\`) describe the wire format field-by-field; they need a careful rewrite that this PR doesn't attempt.

## Test plan
- [x] \`cargo test -p librefang-wire\` → 51/51
- [x] \`cargo clippy -p librefang-wire -p librefang-api --all-targets --all-features -- -D warnings\` → clean

## #3873 series wrap-up

| PR | Status | Scope |
|----|--------|-------|
| 1 (#4245) | merged | Ed25519 keypair primitive + persistence |
| 2 (#4253) | merged | Handshake fields + verification + in-memory TOFU |
| 3 (#4259) | merged | Kernel persists node_id + keypair, wires start_with_identity |
| 4 (#4263) | merged | Pin persistence via TrustedPeers store + 0600 perms + cap on hydration |
| **5 (this)** | **open** | API surface for fingerprint/pin count + doc refresh |

Closes #3873.