### PR TITLE
fix(dashboard/agents): wire detail-panel tabs to per-agent endpoints

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1980,8 +1980,11 @@ export async function runSchedule(scheduleId: string): Promise<ApiActionResponse
   return post<ApiActionResponse>(`/api/schedules/${encodeURIComponent(scheduleId)}/run`, {});
 }
 
-export async function listTriggers(): Promise<TriggerItem[]> {
-  const data = await get<{ triggers?: TriggerItem[] }>("/api/triggers");
+export async function listTriggers(agentId?: string): Promise<TriggerItem[]> {
+  const url = agentId
+    ? `/api/triggers?agent_id=${encodeURIComponent(agentId)}`
+    : "/api/triggers";
+  const data = await get<{ triggers?: TriggerItem[] }>(url);
   return data.triggers ?? [];
 }
 

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2442,10 +2442,15 @@ export async function createAgentSession(
 }
 
 export async function listSessions(): Promise<SessionListItem[]> {
-  // Bump past the server's default page size (50) so list-row aggregates
+  // Bumped past the server's default page size (50) so list-row aggregates
   // (sessions/cost in the agent row) don't silently clip when an agent's
-  // sessions aren't in the latest 50 globally. The detail-panel KPI uses
-  // GET /api/agents/{id}/stats which is unaffected by this.
+  // sessions aren't in the latest 50 globally. Modern backends embed
+  // `sessions_24h` / `cost_24h` directly on each AgentItem (see
+  // `enrich_agent_json`), so this scan is now only the *fallback* path
+  // for older daemons; the detail-panel KPI tile reads from
+  // `GET /api/agents/{id}/stats` and never touches this list.
+  // TODO: drop the fallback (and this whole call from AgentsPage) once
+  // the minimum supported daemon version is past the embed change.
   const data = await get<{ sessions?: SessionListItem[] }>("/api/sessions?limit=500");
   return data.sessions ?? [];
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/schedules.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/schedules.ts
@@ -13,10 +13,10 @@ export const scheduleQueries = {
       staleTime: STALE_MS,
       refetchInterval: STALE_MS,
     }),
-  triggers: () =>
+  triggers: (agentId?: string) =>
     queryOptions({
-      queryKey: triggerKeys.lists(),
-      queryFn: listTriggers,
+      queryKey: triggerKeys.list(agentId),
+      queryFn: () => listTriggers(agentId),
       staleTime: STALE_MS,
       refetchInterval: STALE_MS,
     }),
@@ -28,4 +28,15 @@ export function useSchedules(options: QueryOverrides = {}) {
 
 export function useTriggers(options: QueryOverrides = {}) {
   return useQuery(withOverrides(scheduleQueries.triggers(), options));
+}
+
+/** Per-agent triggers — uses GET /api/triggers?agent_id=… so the agent
+ *  detail panel doesn't need to load every trigger and filter clientside. */
+export function useAgentTriggers(agentId: string, options: QueryOverrides = {}) {
+  return useQuery(
+    withOverrides(
+      { ...scheduleQueries.triggers(agentId), enabled: !!agentId },
+      options,
+    ),
+  );
 }

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -317,6 +317,15 @@
     "create_failed": "Failed to create agent",
     "manifest_toml": "Agent Manifest (TOML)",
     "thinking_toml_hint": "Add a [thinking] section in TOML to enable extended thinking",
+    "schedule_manual": "manual",
+    "kpi": {
+      "sessions": "Sessions · 24h",
+      "sessions_idle": "idle",
+      "cost": "Cost · 24h",
+      "p95": "P95 latency",
+      "samples": "{{count}} samples",
+      "tools": "Tools"
+    },
     "form": {
       "basics": "Basics",
       "model": "Model",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -316,6 +316,15 @@
     "create_failed": "创建智能体失败",
     "manifest_toml": "智能体清单 (TOML)",
     "thinking_toml_hint": "在 TOML 中添加 [thinking] 段可启用扩展思考",
+    "schedule_manual": "手动触发",
+    "kpi": {
+      "sessions": "会话数 · 24h",
+      "sessions_idle": "空闲",
+      "cost": "费用 · 24h",
+      "p95": "P95 延迟",
+      "samples": "{{count}} 次采样",
+      "tools": "工具"
+    },
     "form": {
       "basics": "基本信息",
       "model": "模型配置",

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -40,8 +40,9 @@ import { truncateId } from "../lib/string";
 import { getStatusVariant } from "../lib/status";
 import { useDashboardSnapshot } from "../lib/queries/overview";
 import { useSessions, useSessionDetails } from "../lib/queries/sessions";
-import { useMemorySearchOrList } from "../lib/queries/memory";
+import { useAgentKvMemory } from "../lib/queries/memory";
 import { useAuditRecent, useCronJobs } from "../lib/queries/runtime";
+import { useAgentTriggers } from "../lib/queries/schedules";
 import { useProviders } from "../lib/queries/providers";
 import { useModels } from "../lib/queries/models";
 import { AgentManifestForm } from "../components/AgentManifestForm";
@@ -57,6 +58,7 @@ import {
 import { generateManifestMarkdown } from "../lib/agentManifestMarkdown";
 import {
   agentQueries,
+  useAgentSessions,
   useAgentStats,
   useAgentTemplates,
   useExperimentMetrics,
@@ -486,25 +488,35 @@ export function AgentsPage() {
   // `enabled` flag gates the network request on `detailAgent?.id`).
   // TanStack Query dedupes / caches across pages so revisiting an agent
   // is free.
-  const memoryListQuery = useMemorySearchOrList("");
+  // Per-agent KV memory (matches the design canvas's key/value/age rows).
+  // The previous useMemorySearchOrList(\"\") query returned global proactive
+  // memory, which is empty unless [proactive_memory] is enabled — so the
+  // tab read empty even when the agent had KV pairs.
+  const agentKvMemoryQuery = useAgentKvMemory(detailAgent?.id ?? "");
   const auditRecentQuery = useAuditRecent(120);
   const cronJobsQuery = useCronJobs(detailAgent?.id);
-  // Per-agent KPI rollup. Replaces a global /api/sessions scan that was
-  // capped by pagination and missed agents whose sessions weren't in
-  // the latest N rows.
+  // Per-agent KPI rollup (#4246) — replaces a global /api/sessions scan
+  // that was capped by pagination and missed agents whose sessions
+  // weren't in the latest N rows.
   const agentStatsQuery = useAgentStats(detailAgent?.id ?? "");
-  // Pick the latest session for the selected agent so the Conversation
-  // tab can stream in its messages without a separate per-agent route.
+  // Per-agent triggers — GET /api/triggers?agent_id=… so the Schedule
+  // tab's event-trigger cards don't depend on agent detail embedding
+  // them (which it currently doesn't).
+  const agentTriggersQuery = useAgentTriggers(detailAgent?.id ?? "");
+  // Per-agent session list — Conversation tab uses this directly. The
+  // global /api/sessions used previously was paginated to 50, so the
+  // agent's latest session was often not in the page.
+  const agentSessionsQuery = useAgentSessions(detailAgent?.id ?? "");
   const latestSessionForAgent = useMemo(() => {
-    if (!detailAgent?.id) return undefined;
+    const list = agentSessionsQuery.data ?? [];
+    if (list.length === 0) return undefined;
     let best: { session_id: string; ts: number } | undefined;
-    for (const s of sessionsQuery.data ?? []) {
-      if (s.agent_id !== detailAgent.id) continue;
+    for (const s of list) {
       const ts = s.created_at ? Date.parse(s.created_at) : 0;
       if (!best || ts > best.ts) best = { session_id: s.session_id, ts };
     }
     return best?.session_id;
-  }, [sessionsQuery.data, detailAgent?.id]);
+  }, [agentSessionsQuery.data]);
   const sessionDetailQuery = useSessionDetails(latestSessionForAgent ?? "");
   // Row-level aggregate only — detail-panel KPI reads from the per-agent
   // /stats endpoint (useAgentStats) which doesn't suffer from the global
@@ -1081,22 +1093,24 @@ export function AgentsPage() {
     );
   };
 
-  // ---------- Memory tab — KV row layout per design canvas
+  // ---------- Memory tab — per-agent KV row layout per design canvas
   const renderMemoryTab = (agent: AgentDetail) => {
-    const allItems = (memoryListQuery.data?.memories ?? []) as Array<{
-      id?: string;
-      content?: string;
-      category?: string | null;
-      created_at?: string;
-      agent_id?: string;
-    }>;
-    const scoped = allItems.filter((m) => !m.agent_id || m.agent_id === agent.id);
-    const rows = scoped.slice(0, 5);
+    const kv = agentKvMemoryQuery.data ?? [];
+    const rows = kv.slice(0, 8);
+    const formatValue = (v: unknown): string => {
+      if (typeof v === "string") return v;
+      if (v == null) return "—";
+      try {
+        return JSON.stringify(v);
+      } catch {
+        return String(v);
+      }
+    };
     return (
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <div className="text-[11px] uppercase font-semibold tracking-[0.08em] text-text-dim">
-            {t("agents.detail.memory_label", { defaultValue: "Memory · sqlite" })} · {scoped.length}
+            {t("agents.detail.memory_label", { defaultValue: "Memory · sqlite" })} · {kv.length}
           </div>
           <Button
             variant="ghost"
@@ -1107,7 +1121,7 @@ export function AgentsPage() {
             {t("agents.detail.open_memory", { defaultValue: "Open" })}
           </Button>
         </div>
-        {memoryListQuery.isLoading ? (
+        {agentKvMemoryQuery.isLoading ? (
           <div className="text-[12px] text-text-dim italic">{t("common.loading", { defaultValue: "Loading…" })}</div>
         ) : rows.length === 0 ? (
           <div className="rounded-md border border-border-subtle bg-main/40 p-4 text-[12px] text-text-dim italic">
@@ -1115,24 +1129,22 @@ export function AgentsPage() {
           </div>
         ) : (
           <div className="flex flex-col gap-1.5">
-            {rows.map((r, i) => {
-              const key = r.category || r.id || `row-${i}`;
-              const valueText = (r.content || "").replace(/\s+/g, " ").trim();
-              return (
-                <div
-                  key={r.id || `mem-${i}`}
-                  className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2.5 px-3 py-2 rounded-md border border-border-subtle bg-main/40"
-                >
-                  <div className="flex items-center justify-between gap-2 sm:contents">
-                    <span className="font-mono text-[12px] text-brand sm:min-w-[180px] truncate sm:shrink-0 min-w-0">{key}</span>
-                    <span className="font-mono text-[10.5px] text-text-dim/70 sm:order-3 sm:shrink-0 tabular-nums shrink-0">
-                      {r.created_at ? formatRelativeTime(r.created_at) : "—"}
-                    </span>
-                  </div>
-                  <span className="font-mono text-[12px] text-text-dim sm:flex-1 min-w-0 truncate sm:order-2">{valueText || "—"}</span>
+            {rows.map((r, i) => (
+              <div
+                key={`${r.key}-${i}`}
+                className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2.5 px-3 py-2 rounded-md border border-border-subtle bg-main/40"
+              >
+                <div className="flex items-center justify-between gap-2 sm:contents">
+                  <span className="font-mono text-[12px] text-brand sm:min-w-[180px] truncate sm:shrink-0 min-w-0">{r.key}</span>
+                  <span className="font-mono text-[10.5px] text-text-dim/70 sm:order-3 sm:shrink-0 tabular-nums shrink-0">
+                    {r.created_at ? formatRelativeTime(r.created_at) : "—"}
+                  </span>
                 </div>
-              );
-            })}
+                <span className="font-mono text-[12px] text-text-dim sm:flex-1 min-w-0 truncate sm:order-2">
+                  {formatValue(r.value)}
+                </span>
+              </div>
+            ))}
           </div>
         )}
       </div>
@@ -1192,9 +1204,42 @@ export function AgentsPage() {
   // ---------- Schedule tab — trigger card + 14-run bar chart per design canvas
   const renderScheduleTab = (agent: AgentDetail) => {
     const cron = cronJobsQuery.data ?? [];
-    const triggers: AgentTriggerSummary[] = Array.isArray((agent as AgentView).triggers)
+    // GET /api/agents/{id} doesn't embed triggers, so we hit the
+    // dedicated /api/triggers?agent_id=... endpoint here. Falling back
+    // to the (legacy) embedded-on-detail field if a future backend
+    // version ships it.
+    const liveTriggers = (agentTriggersQuery.data ?? []) as Array<{
+      id?: string;
+      pattern?: unknown;
+      prompt_template?: string;
+      enabled?: boolean;
+    }>;
+    const embeddedTriggers: AgentTriggerSummary[] = Array.isArray(
+      (agent as AgentView).triggers,
+    )
       ? ((agent as AgentView).triggers as AgentTriggerSummary[])
       : [];
+    const triggers: AgentTriggerSummary[] = liveTriggers.length > 0
+      ? liveTriggers.map((t) => {
+          // Render the trigger pattern compactly. The full TriggerPattern
+          // shape is rich (event filters / regex / etc.); for the panel
+          // we only need a one-liner.
+          const patternStr = (() => {
+            if (!t.pattern) return undefined;
+            if (typeof t.pattern === "string") return t.pattern;
+            try {
+              return JSON.stringify(t.pattern);
+            } catch {
+              return undefined;
+            }
+          })();
+          return {
+            event_pattern: patternStr,
+            name: t.id,
+            description: t.prompt_template,
+          };
+        })
+      : embeddedTriggers;
     // Synthetic "last 14 runs" — backend doesn't expose per-fire history
     // through a single agent-scoped endpoint yet, so we visualise an
     // agent-id-seeded waveform as a placeholder. Wire up real run

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -1214,32 +1214,25 @@ export function AgentsPage() {
       prompt_template?: string;
       enabled?: boolean;
     }>;
-    const embeddedTriggers: AgentTriggerSummary[] = Array.isArray(
-      (agent as AgentView).triggers,
-    )
-      ? ((agent as AgentView).triggers as AgentTriggerSummary[])
-      : [];
-    const triggers: AgentTriggerSummary[] = liveTriggers.length > 0
-      ? liveTriggers.map((t) => {
-          // Render the trigger pattern compactly. The full TriggerPattern
-          // shape is rich (event filters / regex / etc.); for the panel
-          // we only need a one-liner.
-          const patternStr = (() => {
-            if (!t.pattern) return undefined;
-            if (typeof t.pattern === "string") return t.pattern;
-            try {
-              return JSON.stringify(t.pattern);
-            } catch {
-              return undefined;
-            }
-          })();
-          return {
-            event_pattern: patternStr,
-            name: t.id,
-            description: t.prompt_template,
-          };
-        })
-      : embeddedTriggers;
+    const triggers: AgentTriggerSummary[] = liveTriggers.map((tr) => {
+      // Render the trigger pattern compactly. The full TriggerPattern shape
+      // is rich (event filters / regex / etc.); the detail panel only
+      // needs a one-liner — full pattern lives on the dedicated page.
+      const patternStr = (() => {
+        if (!tr.pattern) return undefined;
+        if (typeof tr.pattern === "string") return tr.pattern;
+        try {
+          return JSON.stringify(tr.pattern);
+        } catch {
+          return undefined;
+        }
+      })();
+      return {
+        event_pattern: patternStr,
+        name: tr.id,
+        description: tr.prompt_template,
+      };
+    });
     // Synthetic "last 14 runs" — backend doesn't expose per-fire history
     // through a single agent-scoped endpoint yet, so we visualise an
     // agent-id-seeded waveform as a placeholder. Wire up real run

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -365,6 +365,8 @@ use crate::types;
         types::ExtensionInstallRequest,
         types::ExtensionUninstallRequest,
         routes::auto_dream::SetEnabledRequest,
+        routes::agents::AgentStats24hView,
+        routes::agents::AgentStatsPrevView,
         routes::users::UserView,
         routes::users::UserUpsert,
         routes::users::BulkImportRequest,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -992,6 +992,45 @@ pub async fn list_agents(
     .into_response()
 }
 
+/// 24-hour KPI rollup view returned by `GET /api/agents/{id}/stats`.
+/// Mirrors [`librefang_memory::session::AgentStats24h`] — defined here as a
+/// view so we can derive `utoipa::ToSchema` without forcing utoipa into the
+/// memory crate. Generated SDKs and the OpenAPI spec pick up this shape.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct AgentStats24hView {
+    pub sessions_24h: u64,
+    pub cost_24h: f64,
+    pub p95_latency_ms: u64,
+    pub active_now: u64,
+    pub samples: u64,
+    pub prev: AgentStatsPrevView,
+}
+
+/// Prior 24-48h window scoped fields backing the KPI tile trend deltas.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct AgentStatsPrevView {
+    pub sessions_24h: u64,
+    pub cost_24h: f64,
+    pub p95_latency_ms: u64,
+}
+
+impl From<librefang_memory::session::AgentStats24h> for AgentStats24hView {
+    fn from(s: librefang_memory::session::AgentStats24h) -> Self {
+        Self {
+            sessions_24h: s.sessions_24h,
+            cost_24h: s.cost_24h,
+            p95_latency_ms: s.p95_latency_ms,
+            active_now: s.active_now,
+            samples: s.samples,
+            prev: AgentStatsPrevView {
+                sessions_24h: s.prev.sessions_24h,
+                cost_24h: s.prev.cost_24h,
+                p95_latency_ms: s.prev.p95_latency_ms,
+            },
+        }
+    }
+}
+
 /// GET /api/agents/{id}/stats — 24-hour KPI rollup for one agent.
 ///
 /// Returns sessions/cost/P95-latency/active-now in a single round trip so
@@ -1004,7 +1043,7 @@ pub async fn list_agents(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "24-hour stats rollup", body = serde_json::Value),
+        (status = 200, description = "24-hour stats rollup", body = AgentStats24hView),
         (status = 404, description = "Agent not found")
     )
 )]
@@ -1053,7 +1092,7 @@ pub async fn get_agent_stats(
 
     let substrate = state.kernel.memory_substrate();
     match substrate.agent_stats_24h(&id) {
-        Ok(stats) => Json(stats).into_response(),
+        Ok(stats) => Json(AgentStats24hView::from(stats)).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": e.to_string() })),

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -2704,6 +2704,7 @@ pub async fn list_agent_sessions(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
+    api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     let agent_id: AgentId = match id.parse() {
@@ -2715,6 +2716,25 @@ pub async fn list_agent_sessions(
             )
         }
     };
+    // Owner-scoping: non-admins can only list sessions for agents they
+    // authored. Mirrors the filter on `list_agents` so per-agent
+    // session metadata (cost, message count) doesn't leak.
+    if let Some(ref user) = api_user {
+        use librefang_kernel::auth::UserRole;
+        if user.0.role < UserRole::Admin {
+            let entry = state.kernel.agent_registry().get(agent_id);
+            let owned = entry
+                .as_ref()
+                .map(|e| e.manifest.author.eq_ignore_ascii_case(&user.0.name))
+                .unwrap_or(false);
+            if !owned {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
+                );
+            }
+        }
+    }
     match state.kernel.list_agent_sessions(agent_id) {
         Ok(sessions) => (
             StatusCode::OK,

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -529,6 +529,7 @@ pub async fn get_agent_kv(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
+    api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     let agent_id: AgentId = match id.parse() {
@@ -538,6 +539,23 @@ pub async fn get_agent_kv(
                 .into_json_tuple();
         }
     };
+    // Owner-scoping: non-admins can only read the KV store of agents
+    // they authored. Without this, anyone authenticated could pull
+    // user.preferences / oncall.contact / api.tokens out of any agent.
+    if let Some(ref user) = api_user {
+        use librefang_kernel::auth::UserRole;
+        if user.0.role < UserRole::Admin {
+            let entry = state.kernel.agent_registry().get(agent_id);
+            let owned = entry
+                .as_ref()
+                .map(|e| e.manifest.author.eq_ignore_ascii_case(&user.0.name))
+                .unwrap_or(false);
+            if !owned {
+                return ApiErrorResponse::not_found(t.t("api-error-agent-not-found"))
+                    .into_json_tuple();
+            }
+        }
+    }
     match state.kernel.memory_substrate().list_kv(agent_id) {
         Ok(pairs) => {
             let kv: Vec<serde_json::Value> = pairs

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1055,16 +1055,59 @@ fn trigger_to_json(t: &Trigger) -> serde_json::Value {
 #[utoipa::path(get, path = "/api/triggers", tag = "workflows", params(("agent_id" = Option<String>, Query, description = "Filter by agent ID")), responses((status = 200, description = "List triggers", body = serde_json::Value)))]
 pub async fn list_triggers(
     State(state): State<Arc<AppState>>,
+    api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
     Query(params): Query<HashMap<String, String>>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     let agent_filter = params
         .get("agent_id")
         .and_then(|id| id.parse::<AgentId>().ok());
 
+    // Owner-scoping: non-admins can't see triggers for agents they don't
+    // author. Two enforcement points:
+    //   1. With ?agent_id=... — verify the caller owns that agent.
+    //   2. Without — post-filter the trigger list by author.
+    let restrict_to: Option<String> = match api_user.as_ref() {
+        Some(u) if u.0.role < librefang_kernel::auth::UserRole::Admin => Some(u.0.name.clone()),
+        _ => None,
+    };
+    if let (Some(ref user_name), Some(aid)) = (restrict_to.as_ref(), agent_filter) {
+        let owns = state
+            .kernel
+            .agent_registry()
+            .get(aid)
+            .as_ref()
+            .map(|e| e.manifest.author.eq_ignore_ascii_case(user_name))
+            .unwrap_or(false);
+        if !owns {
+            return (
+                StatusCode::OK,
+                Json(serde_json::json!({"triggers": [], "total": 0})),
+            )
+                .into_response();
+        }
+    }
+
     let triggers = state.kernel.list_triggers(agent_filter);
-    let list: Vec<serde_json::Value> = triggers.iter().map(trigger_to_json).collect();
+    let list: Vec<serde_json::Value> = if let Some(ref user_name) = restrict_to {
+        // No explicit agent_id — fall back to per-trigger owner check.
+        let owned_ids: std::collections::HashSet<librefang_types::agent::AgentId> = state
+            .kernel
+            .agent_registry()
+            .list()
+            .iter()
+            .filter(|e| e.manifest.author.eq_ignore_ascii_case(user_name))
+            .map(|e| e.id)
+            .collect();
+        triggers
+            .iter()
+            .filter(|tr| owned_ids.contains(&tr.agent_id))
+            .map(trigger_to_json)
+            .collect()
+    } else {
+        triggers.iter().map(trigger_to_json).collect()
+    };
     let total = list.len();
-    Json(serde_json::json!({"triggers": list, "total": total}))
+    Json(serde_json::json!({"triggers": list, "total": total})).into_response()
 }
 
 #[utoipa::path(get, path = "/api/triggers/{id}", tag = "workflows", params(("id" = String, Path, description = "Trigger ID")), responses((status = 200, description = "Trigger detail", body = serde_json::Value), (status = 404, description = "Not found")))]

--- a/openapi.json
+++ b/openapi.json
@@ -1973,7 +1973,9 @@
             "description": "24-hour stats rollup",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/AgentStats24hView"
+                }
               }
             }
           },
@@ -8178,6 +8180,72 @@
   },
   "components": {
     "schemas": {
+      "AgentStats24hView": {
+        "type": "object",
+        "description": "24-hour KPI rollup view returned by `GET /api/agents/{id}/stats`.\nMirrors [`librefang_memory::session::AgentStats24h`] — defined here as a\nview so we can derive `utoipa::ToSchema` without forcing utoipa into the\nmemory crate. Generated SDKs and the OpenAPI spec pick up this shape.",
+        "required": [
+          "sessions_24h",
+          "cost_24h",
+          "p95_latency_ms",
+          "active_now",
+          "samples",
+          "prev"
+        ],
+        "properties": {
+          "active_now": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "cost_24h": {
+            "type": "number",
+            "format": "double"
+          },
+          "p95_latency_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "prev": {
+            "$ref": "#/components/schemas/AgentStatsPrevView"
+          },
+          "samples": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "sessions_24h": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
+      "AgentStatsPrevView": {
+        "type": "object",
+        "description": "Prior 24-48h window scoped fields backing the KPI tile trend deltas.",
+        "required": [
+          "sessions_24h",
+          "cost_24h",
+          "p95_latency_ms"
+        ],
+        "properties": {
+          "cost_24h": {
+            "type": "number",
+            "format": "double"
+          },
+          "p95_latency_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "sessions_24h": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
       "AgentUpdateRequest": {
         "type": "object",
         "description": "Request to update an agent's manifest.",


### PR DESCRIPTION
## Summary

PR 4246 was merged with two trailing commits left on the branch (typed `/stats` schema + i18n parity, and a Conversation tab fix). This PR brings them back, plus the Memory + Schedule tab fixes, plus owner-scoping for the per-agent endpoints the dashboard now hits.

## Detail-panel tabs that were silently empty

| Tab | Root cause | Fix |
| --- | --- | --- |
| **Conversation** | Filtered global `/api/sessions` for "latest session for this agent". `/api/sessions` defaults to a 50-row page; if the agent's latest session wasn't in the top-N globally, the tab rendered "No conversation yet". | `useAgentSessions(agent.id)` (`GET /api/agents/{id}/sessions`). |
| **Memory** | `useMemorySearchOrList("")` — global proactive memory, filtered clientside by `agent_id`. Empty unless `[proactive_memory]` is enabled. The design's key/value/age rows are the per-agent KV store. | `useAgentKvMemory(agent.id)` (`GET /api/memory/agents/{id}/kv`); render `kv_pairs` directly. |
| **Schedule** | Reading `agent.triggers` from the agent-detail response, which doesn't include the field. Cron half worked. | Added `agentId`-scoped `listTriggers` + `useAgentTriggers` hook → `GET /api/triggers?agent_id=…`. |

## Owner-scoping for the per-agent endpoints

Extending the dashboard to call these per-agent endpoints widened the attack surface — `get_agent_stats` already enforced owner-scoping in #4246; the rest didn't. Fixed in this PR:

- `list_agent_sessions` (`GET /api/agents/{id}/sessions`)
- `get_agent_kv` (`GET /api/memory/agents/{id}/kv`)
- `list_triggers` (`GET /api/triggers` and `?agent_id=…`)

Without these, anyone authenticated could enumerate any agent's session metadata (cost, message counts), read its KV memory (`user.preferences`, `oncall.contact`, …), and list its triggers. Non-admin callers now get an empty list / 404 for agents they don't author.

## Carried over from #4246's tail

- **Typed OpenAPI schema for `/stats`**: `AgentStats24hView` / `AgentStatsPrevView` registered with `utoipa::ToSchema`; handler declares `body = AgentStats24hView` instead of `serde_json::Value`. SDKs / openapi.json consumers get the real shape.
- **i18n parity**: `agents.kpi.{sessions,sessions_idle,cost,p95,samples,tools}` and `agents.schedule_manual` were rendered via `defaultValue` only — Chinese sessions fell back to English literals. Added matching entries to `en.json` and `zh.json`.
- **`listSessions` comment**: clarified that `?limit=500` is now only a fallback path since `enrich_agent_json` embeds `sessions_24h` / `cost_24h` per row.

## Not in this PR

- **Skills** and **Logs** were already wired correctly. Empty render means the agent has no skills / no audit entries.

## Test plan
- [x] `pnpm typecheck`
- [x] `cargo check -p librefang-api --lib`
- [ ] Open an agent that has KV memory writes → Memory tab shows rows
- [ ] Open an agent with at least one trigger → Schedule tab shows event-trigger card
- [ ] Open an agent on a busy instance → Conversation tab loads
- [ ] Switch to Chinese locale → KPI tile labels in Chinese
- [ ] Non-admin user querying another author's agent → 404 / empty