### PR TITLE
feat(wire): X25519 ephemeral KEX for OFP session keys (closes #4269)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1853,7 +1853,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2175,7 +2175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2735,8 +2735,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -3145,6 +3145,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -4725,6 +4734,7 @@ dependencies = [
  "dashmap",
  "ed25519-dalek",
  "hex",
+ "hkdf",
  "hmac",
  "librefang-types",
  "rand_core 0.6.4",
@@ -4737,6 +4747,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -5263,7 +5274,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5734,7 +5745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6485,7 +6496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6629,7 +6640,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7270,7 +7281,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7353,7 +7364,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8819,7 +8830,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10613,7 +10624,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11358,6 +11369,18 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,8 @@ hex = "0.4"
 k256 = { version = "0.13", features = ["schnorr"] }
 subtle = "2"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+hkdf = "0.12"
 rsa = "0.9.6"
 rand = "0.10"
 zeroize = { version = "1", features = ["derive"] }

--- a/crates/librefang-wire/Cargo.toml
+++ b/crates/librefang-wire/Cargo.toml
@@ -21,6 +21,8 @@ hex = { workspace = true }
 subtle = { workspace = true }
 dashmap = { workspace = true }
 ed25519-dalek = { workspace = true }
+x25519-dalek = { workspace = true }
+hkdf = { workspace = true }
 base64 = { workspace = true }
 rand_core = { version = "0.6", features = ["getrandom"] }
 

--- a/crates/librefang-wire/src/kex.rs
+++ b/crates/librefang-wire/src/kex.rs
@@ -1,0 +1,222 @@
+//! Ephemeral X25519 key exchange for OFP per-message session keys (#4269).
+//!
+//! Background: prior to this module the per-message HMAC `session_key`
+//! derived from `shared_secret + handshake_nonces`. An attacker holding
+//! `shared_secret` and able to passively observe a connection's
+//! handshake nonces could recompute the same key and forge in-flight
+//! messages. The Ed25519 identity layer from #3873 prevents node_id
+//! impersonation but does not, on its own, give per-session forward
+//! secrecy of the symmetric channel.
+//!
+//! This module adds an ephemeral X25519 keypair generated **per
+//! handshake**. Both peers exchange the public halves inside the
+//! Handshake/HandshakeAck messages (covered by the Ed25519 identity
+//! signature so an active MITM cannot substitute their own pubkey),
+//! then ECDH the local secret with the remote pubkey to obtain a
+//! shared point. HKDF-SHA256 over that point yields the session key.
+//!
+//! Resulting properties:
+//! - **Forward secrecy** — the ephemeral private keys are dropped at
+//!   the end of the handshake, so a future leak of `shared_secret` or
+//!   even of either node's static Ed25519 private key cannot decrypt
+//!   recorded past traffic.
+//! - **`shared_secret` leak no longer breaks message integrity** — the
+//!   symmetric session key is independent of `shared_secret`. Stealing
+//!   it still bypasses the network admission gate, but cannot be used
+//!   to forge in-flight HMACs on a session the attacker did not also
+//!   actively MITM during its handshake.
+//!
+//! Backward compatibility: `ephemeral_pubkey` is `Option<String>` on
+//! the wire. When either side omits it, the kernel falls back to the
+//! legacy `derive_session_key(shared_secret, nonces)` path so existing
+//! peers keep interoperating during a federation rollout.
+
+use base64::Engine as _;
+use hkdf::Hkdf;
+use rand_core::{OsRng, RngCore};
+use sha2::Sha256;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+use crate::keys::KeyError;
+
+const B64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::STANDARD;
+
+/// HKDF info string. Bumping this string is the protocol-versioning
+/// hook: change it on a breaking session-key derivation change so an
+/// old client and a new server cannot accidentally agree on a key.
+const HKDF_INFO: &[u8] = b"librefang-ofp/v1/session-key";
+
+/// One side of an ephemeral KEX. The secret is held until the handshake
+/// completes, at which point [`derive_session_key`] is called and the
+/// caller drops the [`EphemeralKex`] — taking the private bytes with
+/// it (`StaticSecret` zeroizes on drop).
+pub struct EphemeralKex {
+    secret: StaticSecret,
+    public_b64: String,
+}
+
+impl EphemeralKex {
+    /// Generate a fresh per-handshake X25519 keypair.
+    pub fn generate() -> Result<Self, KeyError> {
+        let mut bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut bytes);
+        let secret = StaticSecret::from(bytes);
+        let public = PublicKey::from(&secret);
+        Ok(Self {
+            secret,
+            public_b64: B64.encode(public.as_bytes()),
+        })
+    }
+
+    /// This side's X25519 public key, base64. Goes on the wire in the
+    /// handshake's `ephemeral_pubkey` field. Intentionally returns
+    /// `&str` so the caller can clone into the message struct.
+    pub fn public_b64(&self) -> &str {
+        &self.public_b64
+    }
+
+    /// Combine the local ephemeral secret with the remote ephemeral
+    /// public to produce a 32-byte HKDF-derived session key, hex-encoded
+    /// for compatibility with the existing string-based per-message
+    /// HMAC API.
+    ///
+    /// `transcript` is mixed into the HKDF salt so two peers that
+    /// happened to pick the same ephemeral pair on the same wire (e.g.
+    /// retransmits, parallel sessions) cannot end up with the same
+    /// session key. Caller is expected to pass the concatenation of
+    /// the two handshake nonces in a stable order.
+    pub fn derive_session_key(
+        self,
+        remote_pubkey_b64: &str,
+        transcript: &[u8],
+    ) -> Result<String, KeyError> {
+        let pk_bytes = B64
+            .decode(remote_pubkey_b64)
+            .map_err(|_| KeyError::InvalidFormat)?;
+        if pk_bytes.len() != 32 {
+            return Err(KeyError::InvalidFormat);
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&pk_bytes);
+        let remote = PublicKey::from(arr);
+
+        let shared = self.secret.diffie_hellman(&remote);
+        // SECURITY (#4269): per the X25519 spec the all-zero shared
+        // secret is the unique known weak output (occurs when one side
+        // contributes a low-order public key). RustCrypto's
+        // `x25519_dalek` does NOT reject these by default; we do.
+        if shared.as_bytes().iter().all(|b| *b == 0) {
+            return Err(KeyError::BadSignature);
+        }
+
+        let hk = Hkdf::<Sha256>::new(Some(transcript), shared.as_bytes());
+        let mut okm = [0u8; 32];
+        hk.expand(HKDF_INFO, &mut okm)
+            .map_err(|_| KeyError::InvalidFormat)?;
+        Ok(hex::encode(okm))
+    }
+}
+
+/// Build the HKDF salt bound to a given handshake. Both sides MUST
+/// produce the same byte string for the derivation to agree, so the
+/// nonces are concatenated in a fixed order: client first, server
+/// second, regardless of which side is calling.
+pub fn handshake_transcript(client_nonce: &str, server_nonce: &str) -> Vec<u8> {
+    let mut t = Vec::with_capacity(client_nonce.len() + 1 + server_nonce.len());
+    t.extend_from_slice(client_nonce.as_bytes());
+    t.push(b'|');
+    t.extend_from_slice(server_nonce.as_bytes());
+    t
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The point of the whole module: two peers each generate an
+    /// ephemeral keypair, exchange pubkeys, and arrive at the same
+    /// session key — without `shared_secret` ever entering the
+    /// derivation.
+    #[test]
+    fn issue_4269_two_ephemerals_agree_on_session_key() {
+        let alice = EphemeralKex::generate().unwrap();
+        let bob = EphemeralKex::generate().unwrap();
+        let alice_pub = alice.public_b64().to_string();
+        let bob_pub = bob.public_b64().to_string();
+        let transcript = handshake_transcript("client-nonce", "server-nonce");
+
+        let k_a = alice.derive_session_key(&bob_pub, &transcript).unwrap();
+        let k_b = bob.derive_session_key(&alice_pub, &transcript).unwrap();
+        assert_eq!(k_a, k_b);
+        assert_eq!(k_a.len(), 64); // 32 bytes hex-encoded
+    }
+
+    /// A passive observer with `shared_secret` cannot reproduce the
+    /// session key because the derivation contains zero bits of
+    /// `shared_secret`. The test makes that explicit by using ONLY
+    /// public material to derive a different key and asserting it
+    /// disagrees.
+    #[test]
+    fn issue_4269_session_key_is_independent_of_any_shared_secret() {
+        let alice = EphemeralKex::generate().unwrap();
+        let bob = EphemeralKex::generate().unwrap();
+        let alice_pub = alice.public_b64().to_string();
+        let bob_pub = bob.public_b64().to_string();
+        let transcript = handshake_transcript("c", "s");
+
+        let real_key = alice.derive_session_key(&bob_pub, &transcript).unwrap();
+
+        // Re-run an HKDF using the *handshake-public* parts only — the
+        // best an off-path attacker with `shared_secret` and nonces
+        // could do without the ephemeral private keys.
+        let public_only = format!("{alice_pub}|{bob_pub}|cluster-secret");
+        let hk = Hkdf::<Sha256>::new(Some(&transcript), public_only.as_bytes());
+        let mut okm = [0u8; 32];
+        hk.expand(HKDF_INFO, &mut okm).unwrap();
+        let attacker_key = hex::encode(okm);
+
+        assert_ne!(
+            real_key, attacker_key,
+            "session key must not be reproducible from public material + shared_secret"
+        );
+    }
+
+    /// Different transcripts (e.g. different handshake nonces) MUST
+    /// yield different session keys even when the same ephemeral pair
+    /// is reused. Pin the property so a future refactor can't silently
+    /// drop the salt and reintroduce reuse.
+    #[test]
+    fn issue_4269_transcript_is_part_of_derivation() {
+        let alice = EphemeralKex::generate().unwrap();
+        let bob = EphemeralKex::generate().unwrap();
+        let alice_pub = alice.public_b64().to_string();
+        let bob_pub = bob.public_b64().to_string();
+
+        let alice2 = EphemeralKex {
+            secret: alice.secret.clone(),
+            public_b64: alice.public_b64.clone(),
+        };
+        let bob2 = EphemeralKex {
+            secret: bob.secret.clone(),
+            public_b64: bob.public_b64.clone(),
+        };
+
+        let k1 = alice
+            .derive_session_key(&bob_pub, &handshake_transcript("n1", "n2"))
+            .unwrap();
+        let k2 = bob2
+            .derive_session_key(&alice_pub, &handshake_transcript("n1", "different"))
+            .unwrap();
+        // alice2 not used in this test; just satisfies clone semantic.
+        let _ = alice2;
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn invalid_remote_pubkey_is_rejected() {
+        let alice = EphemeralKex::generate().unwrap();
+        let res = alice.derive_session_key("not-base64!", &[]);
+        assert!(matches!(res, Err(KeyError::InvalidFormat)));
+    }
+}

--- a/crates/librefang-wire/src/lib.rs
+++ b/crates/librefang-wire/src/lib.rs
@@ -51,6 +51,7 @@
 //! threats. Re-implementing TLS on top of that adds maintenance burden
 //! without changing the supported deployment model.
 
+pub mod kex;
 pub mod keys;
 pub mod message;
 pub mod peer;

--- a/crates/librefang-wire/src/message.rs
+++ b/crates/librefang-wire/src/message.rs
@@ -71,6 +71,14 @@ pub enum WireRequest {
         /// `public_key` is also absent.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         identity_signature: Option<String>,
+        /// SECURITY (#4269): Per-handshake X25519 ephemeral public key
+        /// (base64, 32 bytes). When both peers send one, the per-message
+        /// HMAC `session_key` is derived via X25519 ECDH + HKDF instead
+        /// of from `shared_secret + nonces`, decoupling session integrity
+        /// from `shared_secret` and gaining forward secrecy. Optional
+        /// for backward compatibility with peers that omit it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ephemeral_pubkey: Option<String>,
     },
     /// Discover agents matching a query on the remote peer.
     #[serde(rename = "discover")]
@@ -119,6 +127,9 @@ pub enum WireResponse {
         /// SECURITY (#3873): See `WireRequest::Handshake::identity_signature`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         identity_signature: Option<String>,
+        /// SECURITY (#4269): See `WireRequest::Handshake::ephemeral_pubkey`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ephemeral_pubkey: Option<String>,
     },
     /// Discovery results.
     #[serde(rename = "discover_result")]
@@ -244,6 +255,7 @@ mod tests {
                 auth_hmac: "test-hmac".to_string(),
                 public_key: None,
                 identity_signature: None,
+                ephemeral_pubkey: None,
             }),
         };
         let json = serde_json::to_string_pretty(&msg).unwrap();

--- a/crates/librefang-wire/src/peer.rs
+++ b/crates/librefang-wire/src/peer.rs
@@ -251,6 +251,27 @@ fn hmac_verify(secret: &str, data: &[u8], signature: &str) -> bool {
     subtle::ConstantTimeEq::ct_eq(expected.as_bytes(), signature.as_bytes()).into()
 }
 
+/// SECURITY (#4269): Build the byte string the Ed25519 identity
+/// signature covers. When an ephemeral X25519 pubkey is included in
+/// the handshake, it is appended to `auth_data` so the static-identity
+/// signature also binds the ephemeral — closing an active MITM that
+/// would otherwise swap in its own ephemeral. With no ephemeral
+/// (legacy PR-2..5 peers) the scope reduces to `auth_data`, keeping
+/// signature compatibility with already-pinned peers from those
+/// releases.
+fn identity_signing_scope(auth_data: &[u8], ephemeral_pubkey: Option<&str>) -> Vec<u8> {
+    match ephemeral_pubkey {
+        Some(eph) => {
+            let mut buf = Vec::with_capacity(auth_data.len() + 1 + eph.len());
+            buf.extend_from_slice(auth_data);
+            buf.push(b'|');
+            buf.extend_from_slice(eph.as_bytes());
+            buf
+        }
+        None => auth_data.to_vec(),
+    }
+}
+
 /// Errors from the wire protocol layer.
 #[derive(Debug, Error)]
 pub enum WireError {
@@ -551,13 +572,22 @@ impl PeerNode {
         out
     }
 
-    /// SECURITY (#3873): If this node has an Ed25519 identity, return
-    /// `(Some(public_key_b64), Some(signature_b64))` over `auth_data`. With
-    /// no identity configured returns `(None, None)` and the recipient gets
-    /// only HMAC authentication.
-    fn sign_identity(&self, auth_data: &[u8]) -> (Option<String>, Option<String>) {
+    /// SECURITY (#3873, #4269): If this node has an Ed25519 identity,
+    /// return `(Some(public_key_b64), Some(signature_b64))`. The signed
+    /// scope is `auth_data | "|" | ephemeral_pubkey` when an ephemeral
+    /// X25519 pubkey is being sent (#4269), or just `auth_data` when not
+    /// — binding the per-handshake KEX pubkey to the static identity so
+    /// an active MITM cannot substitute a pubkey it controls.
+    fn sign_identity(
+        &self,
+        auth_data: &[u8],
+        ephemeral_pubkey: Option<&str>,
+    ) -> (Option<String>, Option<String>) {
         match &self.keypair {
-            Some(kp) => (Some(kp.public_key().to_string()), Some(kp.sign(auth_data))),
+            Some(kp) => {
+                let scope = identity_signing_scope(auth_data, ephemeral_pubkey);
+                (Some(kp.public_key().to_string()), Some(kp.sign(&scope)))
+            }
             None => (None, None),
         }
     }
@@ -580,10 +610,12 @@ impl PeerNode {
         public_key: &Option<String>,
         signature: &Option<String>,
         auth_data: &[u8],
+        ephemeral_pubkey: Option<&str>,
     ) -> Result<(), WireError> {
         match (public_key, signature) {
             (Some(pk), Some(sig)) => {
-                verify_signature(pk, auth_data, sig).map_err(|e| {
+                let scope = identity_signing_scope(auth_data, ephemeral_pubkey);
+                verify_signature(pk, &scope, sig).map_err(|e| {
                     WireError::HandshakeFailed(format!(
                         "Ed25519 identity signature invalid for node {peer_node_id}: {e}"
                     ))
@@ -707,7 +739,13 @@ impl PeerNode {
             our_nonce, self.config.node_id, recipient_node_id
         );
         let auth_hmac = hmac_sign(&self.config.shared_secret, auth_data.as_bytes());
-        let (our_pubkey, our_identity_sig) = self.sign_identity(auth_data.as_bytes());
+        // SECURITY (#4269): Generate per-handshake X25519 ephemeral so the
+        // resulting session_key derives from ECDH instead of shared_secret.
+        let our_kex = crate::kex::EphemeralKex::generate()
+            .map_err(|e| WireError::HandshakeFailed(format!("X25519 keygen failed: {e}")))?;
+        let our_eph = our_kex.public_b64().to_string();
+        let (our_pubkey, our_identity_sig) =
+            self.sign_identity(auth_data.as_bytes(), Some(&our_eph));
 
         let handshake = WireMessage {
             id: uuid::Uuid::new_v4().to_string(),
@@ -720,6 +758,7 @@ impl PeerNode {
                 auth_hmac,
                 public_key: our_pubkey,
                 identity_signature: our_identity_sig,
+                ephemeral_pubkey: Some(our_eph.clone()),
             }),
         };
         write_message(&mut writer, &handshake).await?;
@@ -736,6 +775,7 @@ impl PeerNode {
                 auth_hmac: ack_hmac,
                 public_key: ack_pubkey,
                 identity_signature: ack_identity_sig,
+                ephemeral_pubkey: ack_eph,
             }) => {
                 if *protocol_version != PROTOCOL_VERSION {
                     return Err(WireError::VersionMismatch {
@@ -761,12 +801,14 @@ impl PeerNode {
                 }
 
                 // SECURITY (#3873): Verify Ed25519 identity signature (if
-                // present) over the same auth_data and TOFU-pin the pubkey.
+                // present) over auth_data + ephemeral_pubkey (#4269) and
+                // TOFU-pin the pubkey.
                 self.verify_and_pin_identity(
                     node_id,
                     ack_pubkey,
                     ack_identity_sig,
                     expected_ack_data.as_bytes(),
+                    ack_eph.as_deref(),
                 )?;
 
                 // SECURITY (#3880): Record nonce AFTER successful HMAC
@@ -777,8 +819,21 @@ impl PeerNode {
                     return Err(WireError::HandshakeFailed(replay_err));
                 }
 
-                // SECURITY: Derive per-session key for authenticated messages
-                let key = derive_session_key(&self.config.shared_secret, &our_nonce, ack_nonce);
+                // SECURITY (#4269): Prefer ECDH-derived session_key when
+                // both sides provided an ephemeral pubkey. Falls back to
+                // the legacy shared_secret derivation for peers from
+                // PR-2..5 that don't yet send one.
+                let key = match ack_eph {
+                    Some(remote_eph) => {
+                        let transcript = crate::kex::handshake_transcript(&our_nonce, ack_nonce);
+                        our_kex
+                            .derive_session_key(remote_eph, &transcript)
+                            .map_err(|e| {
+                                WireError::HandshakeFailed(format!("X25519 ECDH failed: {e}"))
+                            })?
+                    }
+                    None => derive_session_key(&self.config.shared_secret, &our_nonce, ack_nonce),
+                };
 
                 info!(
                     "OFP: handshake complete with {} ({}) — {} agents",
@@ -866,7 +921,12 @@ impl PeerNode {
         let our_nonce = uuid::Uuid::new_v4().to_string();
         let auth_data = format!("{}|{}|{}", our_nonce, self.config.node_id, node_id);
         let auth_hmac = hmac_sign(&self.config.shared_secret, auth_data.as_bytes());
-        let (our_pubkey, our_identity_sig) = self.sign_identity(auth_data.as_bytes());
+        // SECURITY (#4269): per-handshake X25519 ephemeral.
+        let our_kex = crate::kex::EphemeralKex::generate()
+            .map_err(|e| WireError::HandshakeFailed(format!("X25519 keygen failed: {e}")))?;
+        let our_eph = our_kex.public_b64().to_string();
+        let (our_pubkey, our_identity_sig) =
+            self.sign_identity(auth_data.as_bytes(), Some(&our_eph));
 
         let handshake = WireMessage {
             id: uuid::Uuid::new_v4().to_string(),
@@ -879,6 +939,7 @@ impl PeerNode {
                 auth_hmac,
                 public_key: our_pubkey,
                 identity_signature: our_identity_sig,
+                ephemeral_pubkey: Some(our_eph.clone()),
             }),
         };
         write_message(&mut writer, &handshake).await?;
@@ -893,6 +954,7 @@ impl PeerNode {
                 protocol_version,
                 public_key: ack_pubkey,
                 identity_signature: ack_identity_sig,
+                ephemeral_pubkey: ack_eph,
                 ..
             }) => {
                 if *protocol_version != PROTOCOL_VERSION {
@@ -914,19 +976,32 @@ impl PeerNode {
                         "HMAC verification failed on HandshakeAck".into(),
                     ));
                 }
-                // SECURITY (#3873): Verify Ed25519 identity + TOFU pin.
+                // SECURITY (#3873): Verify Ed25519 identity + TOFU pin
+                // (#4269: scope also covers the server's ephemeral pubkey).
                 self.verify_and_pin_identity(
                     ack_node_id,
                     ack_pubkey,
                     ack_identity_sig,
                     expected_ack_data.as_bytes(),
+                    ack_eph.as_deref(),
                 )?;
                 // SECURITY (#3880): Record nonce AFTER HMAC verification.
                 if let Err(replay_err) = self.nonce_tracker.check_and_record(ack_nonce) {
                     return Err(WireError::HandshakeFailed(replay_err));
                 }
-                // SECURITY: Derive per-session key for authenticated post-handshake I/O
-                derive_session_key(&self.config.shared_secret, &our_nonce, ack_nonce)
+                // SECURITY (#4269): ECDH-derived session_key when both
+                // peers brought an ephemeral; legacy fallback otherwise.
+                match ack_eph {
+                    Some(remote_eph) => {
+                        let transcript = crate::kex::handshake_transcript(&our_nonce, ack_nonce);
+                        our_kex
+                            .derive_session_key(remote_eph, &transcript)
+                            .map_err(|e| {
+                                WireError::HandshakeFailed(format!("X25519 ECDH failed: {e}"))
+                            })?
+                    }
+                    None => derive_session_key(&self.config.shared_secret, &our_nonce, ack_nonce),
+                }
             }
             WireMessageKind::Response(WireResponse::Error { code, message }) => {
                 return Err(WireError::HandshakeFailed(format!(
@@ -1015,6 +1090,7 @@ impl PeerNode {
                 auth_hmac,
                 public_key: peer_pubkey,
                 identity_signature: peer_identity_sig,
+                ephemeral_pubkey: peer_eph,
             }) => {
                 if *protocol_version != PROTOCOL_VERSION {
                     let err_resp = WireMessage {
@@ -1073,6 +1149,7 @@ impl PeerNode {
                     peer_pubkey,
                     peer_identity_sig,
                     expected_data.as_bytes(),
+                    peer_eph.as_deref(),
                 ) {
                     let err_resp = WireMessage {
                         id: msg.id.clone(),
@@ -1105,7 +1182,21 @@ impl PeerNode {
                 let ack_nonce = uuid::Uuid::new_v4().to_string();
                 let ack_auth_data = format!("{}|{}|{}", ack_nonce, node.config.node_id, node_id);
                 let ack_hmac = hmac_sign(&node.config.shared_secret, ack_auth_data.as_bytes());
-                let (our_pubkey, our_identity_sig) = node.sign_identity(ack_auth_data.as_bytes());
+
+                // SECURITY (#4269): Server-side ephemeral X25519. Generated
+                // only when the client also brought one — otherwise we keep
+                // legacy session_key derivation for compatibility with
+                // PR-2..5 peers that have not yet adopted KEX.
+                let our_kex = if peer_eph.is_some() {
+                    Some(crate::kex::EphemeralKex::generate().map_err(|e| {
+                        WireError::HandshakeFailed(format!("X25519 keygen failed: {e}"))
+                    })?)
+                } else {
+                    None
+                };
+                let our_eph = our_kex.as_ref().map(|k| k.public_b64().to_string());
+                let (our_pubkey, our_identity_sig) =
+                    node.sign_identity(ack_auth_data.as_bytes(), our_eph.as_deref());
 
                 let ack = WireMessage {
                     id: msg.id.clone(),
@@ -1118,16 +1209,23 @@ impl PeerNode {
                         auth_hmac: ack_hmac,
                         public_key: our_pubkey,
                         identity_signature: our_identity_sig,
+                        ephemeral_pubkey: our_eph,
                     }),
                 };
                 write_message(&mut writer, &ack).await?;
 
-                // SECURITY: Derive per-session key (server side: their nonce first, our nonce second)
-                let session_key = derive_session_key(
-                    &node.config.shared_secret,
-                    nonce,      // client's nonce
-                    &ack_nonce, // our nonce
-                );
+                // SECURITY (#4269): Prefer ECDH-derived session_key when the
+                // KEX was completed on both sides; legacy fallback otherwise.
+                let session_key = match (our_kex, peer_eph.as_deref()) {
+                    (Some(kex), Some(remote_eph)) => {
+                        let transcript = crate::kex::handshake_transcript(nonce, &ack_nonce);
+                        kex.derive_session_key(remote_eph, &transcript)
+                            .map_err(|e| {
+                                WireError::HandshakeFailed(format!("X25519 ECDH failed: {e}"))
+                            })?
+                    }
+                    _ => derive_session_key(&node.config.shared_secret, nonce, &ack_nonce),
+                };
 
                 info!(
                     "OFP: handshake with {} ({}) from {} — {} agents",
@@ -2408,6 +2506,60 @@ mod tests {
             Err(other) => panic!("expected HandshakeFailed, got: {other}"),
             Ok(_) => panic!("corrupt trust file MUST not produce a running PeerNode"),
         }
+    }
+
+    /// PR-6 / #4269: a successful handshake between two identity-bearing
+    /// peers carries `ephemeral_pubkey` on both legs and the resulting
+    /// post-handshake message exchange round-trips correctly. The
+    /// existing per-message HMAC test (`test_handshake_and_message_loop`)
+    /// already exercises the message loop, but did so under the legacy
+    /// session-key derivation. This test re-runs the same end-to-end
+    /// flow under the KEX path to catch any regression where the
+    /// derivation diverges between the two sides — which would surface
+    /// as the message-loop test passing but the agent_message HMAC
+    /// rejecting.
+    #[tokio::test]
+    async fn issue_4269_kex_session_key_round_trips_a_message() {
+        let kp1 = Ed25519KeyPair::generate().unwrap();
+        let kp2 = Ed25519KeyPair::generate().unwrap();
+
+        let r1 = PeerRegistry::new();
+        let h1 = Arc::new(TestHandle::new());
+        let (n1, _t1) = PeerNode::start_with_identity(
+            test_config("kex-A", "A"),
+            r1.clone(),
+            h1.clone(),
+            Some(kp1),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let r2 = PeerRegistry::new();
+        let h2 = Arc::new(TestHandle::new());
+        let (n2, _t2) = PeerNode::start_with_identity(
+            test_config("kex-B", "B"),
+            r2.clone(),
+            h2.clone(),
+            Some(kp2),
+            None,
+        )
+        .await
+        .unwrap();
+
+        n2.connect_to_peer_with_id(n1.local_addr(), h2.clone(), "kex-A")
+            .await
+            .expect("KEX-bearing handshake must complete");
+
+        // Exercise the post-handshake message channel — this signs each
+        // frame with the session_key both sides derived. If KEX outputs
+        // diverged silently, the receiver's HMAC verify would reject and
+        // send_to_peer would error here.
+        let resp = n2
+            .send_to_peer("kex-A", "echo", "ping over KEX session", None, h2)
+            .await
+            .expect("authenticated message round-trip must succeed under KEX");
+        assert!(resp.contains("ping over KEX session"));
     }
 
     /// PR-5: `list_pinned_peers` is the input the admin endpoint at


### PR DESCRIPTION
## Summary

Closes the per-message HMAC session-key coupling tracked by #4269 by adding a forward-secret X25519 ECDH exchange. After this PR, a leaked \`shared_secret\` no longer lets an on-path attacker forge in-flight OFP messages.

## Threat model after this PR

| Threat | Before | After |
|--------|--------|-------|
| Impersonate a pinned \`node_id\` with leaked \`shared_secret\` | Blocked (#3873) | Blocked |
| Forge in-flight messages on an existing connection given \`shared_secret\` + nonce sniff | **Possible** | **Blocked** |
| Decrypt recorded past traffic given later compromise of \`shared_secret\` or static Ed25519 keys | (no encryption) | Forward secret per session |

## Design

- **kex.rs** — new module. \`EphemeralKex::generate\` produces a per-handshake X25519 keypair (OsRng). \`derive_session_key\` does ECDH + HKDF-SHA256 with the two handshake nonces as salt; emits a 32-byte hex key compatible with the existing HMAC-string API. Rejects the all-zero ECDH output (low-order point attack — \`x25519_dalek\` doesn't by default). HKDF info string \`librefang-ofp/v1/session-key\` is the protocol-versioning hook.
- **message.rs** — \`Handshake\` and \`HandshakeAck\` gain optional \`ephemeral_pubkey: Option<String>\` (serde default + skip_serializing_if).
- **peer.rs**:
  - The Ed25519 identity signature scope is extended to \`auth_data | '|' | ephemeral_pubkey\` when an ephemeral is present, so the static identity binds the per-handshake KEX pubkey (blocks an active MITM swapping their own ephemeral). Legacy peers with no ephemeral reduce to the PR-2..5 scope, keeping signatures pinned by existing peers valid.
  - All three handshake sites generate / accept an ephemeral and prefer the ECDH-derived session key. Fall back to \`derive_session_key(shared_secret, ...)\` only when **either** side omits the ephemeral — so a PR-2..5 peer interoperates without breakage during a federation rollout.

## Backward compatibility

Pure-additive on the wire. PR-2..5 peers that don't send \`ephemeral_pubkey\` keep working through the legacy fallback. New peers communicating with each other upgrade automatically with no config change.

## Tests

- \`kex::tests\` — agreement, independence from any \`shared_secret\`-shaped input, transcript binding, malformed pubkey rejection (4 unit tests).
- \`peer::tests::issue_4269_kex_session_key_round_trips_a_message\` — full handshake + message exchange under KEX. The implicit per-message HMAC verify acts as the agreement assertion: divergent session keys would fail the message round-trip.

\`cargo test -p librefang-wire\` → 57/57 (52 prior + 4 + 1).
\`cargo clippy -p librefang-wire -p librefang-kernel -p librefang-api --all-targets --all-features -- -D warnings\` → clean.

## Dependencies added

- \`x25519-dalek = \"2\"\` with \`static_secrets\` (zeroizes on drop)
- \`hkdf = \"0.12\"\` (RustCrypto, integrates with existing \`sha2\`)

Both are core to the KEX and have no equivalent already in tree.

Closes #4269.