### PR TITLE
feat(dashboard): redesign Approvals page per design bundle

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/useListNav.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/useListNav.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useListNav } from "./useListNav";
+
+function fireKey(key: string, opts: { shift?: boolean } = {}) {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", { key, shiftKey: !!opts.shift, bubbles: true }),
+  );
+}
+
+beforeEach(() => {
+  // Make sure each test starts with focus on body so isTypingTarget=false.
+  document.body.focus();
+});
+
+describe("useListNav", () => {
+  it("starts with no selection", () => {
+    const { result } = renderHook(() => useListNav({ items: ["a", "b", "c"] }));
+    expect(result.current.selectedIndex).toBe(-1);
+  });
+
+  it("j/ArrowDown advances; k/ArrowUp retreats; first j selects index 0", () => {
+    const { result } = renderHook(() => useListNav({ items: ["a", "b", "c"] }));
+    act(() => fireKey("j"));
+    expect(result.current.selectedIndex).toBe(0);
+    act(() => fireKey("ArrowDown"));
+    expect(result.current.selectedIndex).toBe(1);
+    act(() => fireKey("k"));
+    expect(result.current.selectedIndex).toBe(0);
+    // Clamp at top.
+    act(() => fireKey("ArrowUp"));
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it("j clamps at the bottom", () => {
+    const { result } = renderHook(() => useListNav({ items: ["a", "b"] }));
+    act(() => fireKey("j"));
+    act(() => fireKey("j"));
+    act(() => fireKey("j"));
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
+  it("Shift+G jumps to bottom", () => {
+    const { result } = renderHook(() => useListNav({ items: ["a", "b", "c", "d"] }));
+    act(() => fireKey("G", { shift: true }));
+    expect(result.current.selectedIndex).toBe(3);
+  });
+
+  it("gg jumps to top within the 1500ms window", () => {
+    const { result } = renderHook(() => useListNav({ items: ["a", "b", "c"] }));
+    act(() => fireKey("G", { shift: true })); // jump to bottom first
+    expect(result.current.selectedIndex).toBe(2);
+    act(() => {
+      fireKey("g");
+      fireKey("g");
+    });
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it("Enter calls onActivate with the selected item", () => {
+    const onActivate = vi.fn();
+    const { result } = renderHook(() =>
+      useListNav({ items: [{ id: "a" }, { id: "b" }], onActivate }),
+    );
+    act(() => fireKey("j"));
+    act(() => fireKey("j"));
+    expect(result.current.selectedIndex).toBe(1);
+    act(() => fireKey("Enter"));
+    expect(onActivate).toHaveBeenCalledWith({ id: "b" }, 1);
+  });
+
+  it("Enter falls back to index 0 when nothing is selected", () => {
+    const onActivate = vi.fn();
+    renderHook(() => useListNav({ items: [{ id: "x" }], onActivate }));
+    act(() => fireKey("Enter"));
+    expect(onActivate).toHaveBeenCalledWith({ id: "x" }, 0);
+  });
+
+  it("Escape clears selection and invokes onEscape", () => {
+    const onEscape = vi.fn();
+    const { result } = renderHook(() => useListNav({ items: ["a", "b"], onEscape }));
+    act(() => fireKey("j"));
+    expect(result.current.selectedIndex).toBe(0);
+    act(() => fireKey("Escape"));
+    expect(result.current.selectedIndex).toBe(-1);
+    expect(onEscape).toHaveBeenCalled();
+  });
+
+  it("ignores keys while typing into an input", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    const { result } = renderHook(() => useListNav({ items: ["a", "b"] }));
+    // Dispatch on the input, not window — the listener still fires on window
+    // but reads e.target. We dispatch via the input.
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+    expect(result.current.selectedIndex).toBe(-1);
+    document.body.removeChild(input);
+  });
+
+  it("clamps selection back when items shrink", () => {
+    const { result, rerender } = renderHook(
+      ({ items }: { items: string[] }) => useListNav({ items }),
+      { initialProps: { items: ["a", "b", "c", "d"] } },
+    );
+    act(() => fireKey("G", { shift: true }));
+    expect(result.current.selectedIndex).toBe(3);
+    rerender({ items: ["a", "b"] });
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
+  it("does nothing when disabled", () => {
+    const { result } = renderHook(() =>
+      useListNav({ items: ["a", "b"], disabled: true }),
+    );
+    act(() => fireKey("j"));
+    expect(result.current.selectedIndex).toBe(-1);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/useListNav.ts
+++ b/crates/librefang-api/dashboard/src/lib/useListNav.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Skip when the user is typing into a form field — same rule as the
+// global g-nav shortcuts.
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+export interface ListNavOptions<T> {
+  // Items currently rendered in the list (filtered, sorted, etc.).
+  items: readonly T[];
+  // Called on Enter — usually opens detail / drills in.
+  onActivate?: (item: T, index: number) => void;
+  // Called on Esc — usually closes detail or clears selection.
+  onEscape?: () => void;
+  // Disable the listener entirely (e.g., when a modal owns the keyboard).
+  disabled?: boolean;
+}
+
+export interface ListNavItemProps {
+  ref: (el: HTMLElement | null) => void;
+  tabIndex: number;
+  "aria-selected": boolean;
+  "data-listnav-index": number;
+  onMouseEnter: () => void;
+  onClick: () => void;
+}
+
+export interface ListNavApi {
+  selectedIndex: number;
+  setSelectedIndex: (idx: number) => void;
+  getItemProps: (index: number) => ListNavItemProps;
+}
+
+/**
+ * Vim-style keyboard navigation for any list:
+ *  - `j` / `↓` — next
+ *  - `k` / `↑` — prev
+ *  - `g g` — top
+ *  - `G` (shift) — bottom
+ *  - `Enter` — onActivate(items[selectedIndex])
+ *  - `Esc` — onEscape() (and clear selection)
+ *
+ * Selection is index-based and clamped against `items.length`. The hook
+ * silently no-ops while focus is inside an input / textarea / select /
+ * contenteditable so that typing isn't hijacked.
+ *
+ * Usage:
+ *   const nav = useListNav({ items, onActivate: (a) => openDetail(a.id) });
+ *   {items.map((a, i) => (
+ *     <Card {...nav.getItemProps(i)} key={a.id}>...</Card>
+ *   ))}
+ */
+export function useListNav<T>({
+  items,
+  onActivate,
+  onEscape,
+  disabled,
+}: ListNavOptions<T>): ListNavApi {
+  const [selectedIndex, setSelectedIndexRaw] = useState(-1);
+  const itemRefs = useRef(new Map<number, HTMLElement>());
+  const lastGAt = useRef(0);
+
+  const length = items.length;
+  // Re-clamp when the list shrinks past the current selection.
+  useEffect(() => {
+    if (selectedIndex >= length) {
+      setSelectedIndexRaw(length === 0 ? -1 : length - 1);
+    }
+  }, [length, selectedIndex]);
+
+  const setSelectedIndex = useCallback((idx: number) => {
+    setSelectedIndexRaw(idx);
+  }, []);
+
+  // Scroll selected row into view (centered in viewport).
+  useEffect(() => {
+    if (selectedIndex < 0) return;
+    const el = itemRefs.current.get(selectedIndex);
+    el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    // Move focus so screen readers announce the new selection.
+    if (el && document.activeElement !== el) {
+      // Avoid stealing focus from the body when the user hasn't yet
+      // engaged with the list — only refocus if the list itself already
+      // had focus.
+      const inListNav = document.activeElement?.closest("[data-listnav-index]");
+      if (inListNav) el.focus({ preventScroll: true });
+    }
+  }, [selectedIndex]);
+
+  useEffect(() => {
+    if (disabled) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target) || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (length === 0 && e.key !== "Escape") return;
+
+      // Enter activates current selection (or first item if none selected).
+      if (e.key === "Enter") {
+        if (!onActivate) return;
+        const idx = selectedIndex >= 0 ? selectedIndex : 0;
+        if (idx < length) {
+          e.preventDefault();
+          onActivate(items[idx], idx);
+        }
+        return;
+      }
+
+      if (e.key === "Escape") {
+        if (selectedIndex >= 0) setSelectedIndexRaw(-1);
+        onEscape?.();
+        return;
+      }
+
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndexRaw((cur) => Math.min(length - 1, cur < 0 ? 0 : cur + 1));
+        lastGAt.current = 0;
+        return;
+      }
+      if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndexRaw((cur) => Math.max(0, cur < 0 ? 0 : cur - 1));
+        lastGAt.current = 0;
+        return;
+      }
+
+      // Shift+G → bottom (vim).
+      if (e.key === "G" && e.shiftKey) {
+        e.preventDefault();
+        setSelectedIndexRaw(length - 1);
+        lastGAt.current = 0;
+        return;
+      }
+
+      // gg → top (vim). 1500ms window to match the global g-nav shortcut.
+      if (e.key === "g") {
+        const now = Date.now();
+        if (lastGAt.current && now - lastGAt.current < 1500) {
+          e.preventDefault();
+          setSelectedIndexRaw(0);
+          lastGAt.current = 0;
+        } else {
+          lastGAt.current = now;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [items, length, selectedIndex, onActivate, onEscape, disabled]);
+
+  const getItemProps = useCallback(
+    (index: number): ListNavItemProps => ({
+      ref: (el: HTMLElement | null) => {
+        if (el) itemRefs.current.set(index, el);
+        else itemRefs.current.delete(index);
+      },
+      tabIndex: index === selectedIndex ? 0 : -1,
+      "aria-selected": index === selectedIndex,
+      "data-listnav-index": index,
+      onMouseEnter: () => setSelectedIndexRaw(index),
+      onClick: () => setSelectedIndexRaw(index),
+    }),
+    [selectedIndex],
+  );
+
+  return { selectedIndex, setSelectedIndex, getItemProps };
+}

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2239,7 +2239,48 @@
     "batch_disabled_totp": "Batch approve disabled when TOTP is enforced",
     "goToAgent": "Go to Agent",
     "totpPlaceholder": "000000 / 0000-0000",
-    "totpLabel": "TOTP"
+    "totpLabel": "TOTP",
+    "tabHistory": "History",
+    "pendingCount": "{{count}} pending",
+    "filter": "Filter",
+    "filterPlaceholder": "Filter by agent, tool, or action…",
+    "noFilterMatch": "No requests match this filter.",
+    "autoRules": "Auto-rules",
+    "requestedAgo": "requested {{ago}} ago",
+    "approveWithTotp": "Approve with TOTP",
+    "editApprove": "Edit & approve",
+    "editApproveTitle": "Edit and approve",
+    "editApproveSubmit": "Submit & approve",
+    "deny": "Deny",
+    "risk": {
+      "high": "high risk",
+      "medium": "medium risk",
+      "low": "low risk"
+    },
+    "history": {
+      "empty": "No history yet",
+      "emptyDesc": "Resolved approvals will appear here.",
+      "decisions": {
+        "approved": "Approved",
+        "denied": "Denied",
+        "edited": "Edited"
+      },
+      "cols": {
+        "decision": "Decision",
+        "agent": "Agent",
+        "action": "Action",
+        "risk": "Risk",
+        "resolvedBy": "Resolved by",
+        "when": "When"
+      }
+    },
+    "totp": {
+      "modalTitle": "Confirm with TOTP",
+      "modalSubtitle": "High-risk action requires 2FA",
+      "modalContext": "wants to run: {{action}}. Enter the 6-digit code from your authenticator (or a 8-digit recovery code).",
+      "expiresHint": "Codes refresh every 30 seconds.",
+      "confirm": "Confirm & approve"
+    }
   },
   "wizard": {
     "welcome": "Welcome to LibreFang",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2176,7 +2176,48 @@
     "batch_disabled_totp": "TOTP 强制启用时不可批量审批",
     "goToAgent": "跳转到 Agent",
     "totpPlaceholder": "000000 / 0000-0000",
-    "totpLabel": "TOTP"
+    "totpLabel": "TOTP",
+    "tabHistory": "历史",
+    "pendingCount": "{{count}} 个待处理",
+    "filter": "筛选",
+    "filterPlaceholder": "按智能体、工具或操作筛选…",
+    "noFilterMatch": "没有匹配此筛选的请求。",
+    "autoRules": "自动规则",
+    "requestedAgo": "{{ago}} 前请求",
+    "approveWithTotp": "使用 TOTP 批准",
+    "editApprove": "编辑并批准",
+    "editApproveTitle": "编辑并批准",
+    "editApproveSubmit": "提交并批准",
+    "deny": "拒绝",
+    "risk": {
+      "high": "高风险",
+      "medium": "中风险",
+      "low": "低风险"
+    },
+    "history": {
+      "empty": "暂无历史",
+      "emptyDesc": "已处理的审批将显示在这里。",
+      "decisions": {
+        "approved": "已批准",
+        "denied": "已拒绝",
+        "edited": "已修改"
+      },
+      "cols": {
+        "decision": "决定",
+        "agent": "智能体",
+        "action": "操作",
+        "risk": "风险",
+        "resolvedBy": "处理者",
+        "when": "时间"
+      }
+    },
+    "totp": {
+      "modalTitle": "TOTP 确认",
+      "modalSubtitle": "高风险操作需要二次验证",
+      "modalContext": "想要执行：{{action}}。请输入身份验证器中的 6 位验证码（或 8 位恢复码）。",
+      "expiresHint": "验证码每 30 秒刷新。",
+      "confirm": "确认并批准"
+    }
   },
   "wizard": {
     "welcome": "欢迎使用 LibreFang",

--- a/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
@@ -12,6 +12,7 @@ import {
   useRejectApproval,
   useModifyAndRetryApproval,
 } from "../lib/mutations/approvals";
+import { useListNav } from "../lib/useListNav";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
 import { ErrorState } from "../components/ui/ErrorState";
@@ -415,6 +416,15 @@ function HistoryTab() {
 /*  Pending card                                                      */
 /* ------------------------------------------------------------------ */
 
+type CardElementProps = {
+  ref: (el: HTMLElement | null) => void;
+  tabIndex: number;
+  "aria-selected": boolean;
+  "data-listnav-index": number;
+  onMouseEnter: () => void;
+  onClick: () => void;
+};
+
 function PendingCard({
   approval,
   totpEnforced,
@@ -423,6 +433,8 @@ function PendingCard({
   onDeny,
   isEditing,
   onToggleEdit,
+  navProps,
+  selected,
 }: {
   approval: ApprovalItem;
   totpEnforced: boolean;
@@ -431,6 +443,8 @@ function PendingCard({
   onDeny: () => void;
   isEditing: boolean;
   onToggleEdit: () => void;
+  navProps: CardElementProps;
+  selected: boolean;
 }) {
   const { t } = useTranslation();
   const now = useNow(30_000);
@@ -442,6 +456,13 @@ function PendingCard({
   const tools = approval.tool_name ? [approval.tool_name] : [];
 
   return (
+    <div
+      {...navProps}
+      role="option"
+      className={`outline-none rounded-2xl transition-shadow ${
+        selected ? "ring-2 ring-brand/50" : ""
+      }`}
+    >
     <Card padding="none" className="overflow-hidden">
       {/* Risk-tinted header */}
       <div
@@ -526,6 +547,7 @@ function PendingCard({
         {isEditing && <EditAndApproveForm id={approval.id} onDone={onToggleEdit} />}
       </div>
     </Card>
+    </div>
   );
 }
 
@@ -564,6 +586,20 @@ export function ApprovalsPage() {
         .some((s) => (s as string).toLowerCase().includes(q)),
     );
   }, [pendingApprovals, filter]);
+
+  // j/k vim-nav over the visible pending list. Esc closes (in priority
+  // order) the TOTP modal → the open filter input → clears row selection.
+  const nav = useListNav({
+    items: filteredPending,
+    disabled: activeTab !== "pending",
+    onEscape: () => {
+      if (totpFor) setTotpFor(null);
+      else if (filterOpen) {
+        setFilter("");
+        setFilterOpen(false);
+      }
+    },
+  });
 
   async function executeApprove(id: string, totpCode?: string) {
     setPendingId(id);
@@ -718,8 +754,8 @@ export function ApprovalsPage() {
             }
           />
         ) : (
-          <div className="flex flex-col gap-3">
-            {filteredPending.map((a) => (
+          <div className="flex flex-col gap-3" role="listbox" aria-label={t("approvals.tabPending")}>
+            {filteredPending.map((a, i) => (
               <PendingCard
                 key={a.id}
                 approval={a}
@@ -729,6 +765,8 @@ export function ApprovalsPage() {
                 onApprove={() => handleApprove(a)}
                 onDeny={() => void executeReject(a.id)}
                 onToggleEdit={() => setEditingId(editingId === a.id ? null : a.id)}
+                navProps={nav.getItemProps(i)}
+                selected={nav.selectedIndex === i}
               />
             ))}
           </div>

--- a/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { type ApprovalAuditEntry } from "../api";
+import { Link } from "@tanstack/react-router";
+import { type ApprovalAuditEntry, type ApprovalItem } from "../api";
 import {
   useApprovals,
   useApprovalAudit,
@@ -9,21 +10,28 @@ import {
 import {
   useApproveApproval,
   useRejectApproval,
-  useBatchResolveApprovals,
   useModifyAndRetryApproval,
 } from "../lib/mutations/approvals";
-import { PageHeader } from "../components/ui/PageHeader";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
 import { ErrorState } from "../components/ui/ErrorState";
 import { Card } from "../components/ui/Card";
 import { Button } from "../components/ui/Button";
-import { ResponsiveTable, type ResponsiveTableColumn } from "../components/ui/ResponsiveTable";
-import { Badge } from "../components/ui/Badge";
 import { useUIStore } from "../lib/store";
-import { CheckCircle, XCircle, Clock, MessageSquare, ChevronLeft, ChevronRight } from "lucide-react";
-
-const AUDIT_PAGE_SIZE = 20;
+import {
+  CheckCircle,
+  XCircle,
+  Clock,
+  Shield,
+  ShieldCheck,
+  Filter,
+  RefreshCw,
+  Search,
+  Lock,
+  Edit3,
+  History as HistoryIcon,
+  Zap,
+} from "lucide-react";
 
 const TOTP_REGEX = /^\d{6}$/;
 const RECOVERY_REGEX = /^\d{4}-\d{4}$/;
@@ -32,80 +40,58 @@ function isValidTotpOrRecovery(v: string) {
   return TOTP_REGEX.test(v) || RECOVERY_REGEX.test(v);
 }
 
-type Tab = "pending" | "audit";
-type PendingTarget = { kind: "item"; id: string } | { kind: "batch" } | null;
+type Tab = "pending" | "history";
 
-function tabClass(_tab: Tab, isActive: boolean) {
-  return `flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 px-4 py-2 text-sm font-bold rounded-lg transition-colors ${
-    isActive
-      ? "bg-brand/10 text-brand border border-brand/20"
-      : "text-text-dim hover:text-text-main hover:bg-surface-hover border border-transparent"
-  }`;
+/* ------------------------------------------------------------------ */
+/*  Risk palette — drives gradient/badges/icons                       */
+/* ------------------------------------------------------------------ */
+
+type Risk = "high" | "medium" | "low";
+
+function normalizeRisk(r: string | undefined): Risk {
+  const v = (r ?? "").toLowerCase();
+  if (v === "high" || v === "critical") return "high";
+  if (v === "medium" || v === "moderate") return "medium";
+  return "low";
 }
 
-function statusBadge(status: string | undefined, t: (key: string) => string) {
-  switch (status) {
-    case "approved":
-      return <Badge variant="success">{t("approvals.status.approved")}</Badge>;
-    case "rejected":
-      return <Badge variant="error">{t("approvals.status.rejected")}</Badge>;
-    case "expired":
-      return <Badge variant="default">{t("approvals.status.expired")}</Badge>;
-    default:
-      return <Badge variant="warning">{t("approvals.pending_review")}</Badge>;
-  }
+const riskHex: Record<Risk, string> = {
+  high: "var(--color-error)",
+  medium: "var(--color-warning)",
+  low: "var(--color-success)",
+};
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+function timeAgo(iso: string | undefined, now: number): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return "—";
+  const sec = Math.max(0, Math.floor((now - t) / 1000));
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  return `${Math.floor(hr / 24)}d`;
 }
 
-function statusIcon(status: string | undefined) {
-  switch (status) {
-    case "approved":
-      return <CheckCircle className="w-5 h-5 text-success" />;
-    case "rejected":
-      return <XCircle className="w-5 h-5 text-danger" />;
-    case "expired":
-      return <Clock className="w-5 h-5 text-text-dim" />;
-    default:
-      return <CheckCircle className="w-5 h-5 text-warning" />;
-  }
-}
-
-function statusIconBg(status: string | undefined) {
-  switch (status) {
-    case "approved":
-      return "bg-success/10";
-    case "rejected":
-      return "bg-danger/10";
-    case "expired":
-      return "bg-surface-2";
-    default:
-      return "bg-warning/10";
-  }
-}
-
-function decisionBadge(decision: string, t: (key: string) => string) {
-  switch (decision) {
-    case "approved":
-      return <Badge variant="success">{t("approvals.status.approved")}</Badge>;
-    case "rejected":
-      return <Badge variant="error">{t("approvals.status.rejected")}</Badge>;
-    case "modified":
-      return <Badge variant="info">{t("approvals.modify")}</Badge>;
-    default:
-      return <Badge variant="default">{decision}</Badge>;
-  }
+function useNow(intervalMs = 30_000) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+  return now;
 }
 
 /* ------------------------------------------------------------------ */
-/*  Modify & Retry inline form                                        */
+/*  Inline edit-and-approve form                                      */
 /* ------------------------------------------------------------------ */
 
-function ModifyForm({
-  id,
-  onDone,
-}: {
-  id: string;
-  onDone: () => void;
-}) {
+function EditAndApproveForm({ id, onDone }: { id: string; onDone: () => void }) {
   const { t } = useTranslation();
   const [feedback, setFeedback] = useState("");
   const addToast = useUIStore((s) => s.addToast);
@@ -123,33 +109,29 @@ function ModifyForm({
   }
 
   return (
-    <div className="mt-3 flex flex-col gap-2">
-      <label className="text-xs font-bold text-text-dim">{t("approvals.modifyTitle")}</label>
+    <div className="mt-4 flex flex-col gap-2 border-t border-border-subtle pt-4">
+      <label className="text-[10px] font-bold uppercase tracking-wider text-text-dim">
+        {t("approvals.editApproveTitle")}
+      </label>
       <textarea
         value={feedback}
         onChange={(e) => setFeedback(e.target.value)}
         placeholder={t("approvals.modifyPlaceholder")}
         rows={3}
-        className="w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors resize-none"
+        className="w-full rounded-lg border border-border-subtle bg-main px-3 py-2 text-sm focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors resize-none"
       />
-      <div className="flex gap-2 lg:justify-end">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 justify-center"
-          onClick={onDone}
-        >
+      <div className="flex gap-2 justify-end">
+        <Button variant="ghost" size="sm" onClick={onDone}>
           {t("common.cancel", "Cancel")}
         </Button>
         <Button
           variant="primary"
           size="sm"
-          className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 justify-center"
           onClick={handleSubmit}
           disabled={modifyAndRetry.isPending || !feedback.trim()}
           isLoading={modifyAndRetry.isPending}
         >
-          {t("approvals.modifySubmit")}
+          {t("approvals.editApproveSubmit")}
         </Button>
       </div>
     </div>
@@ -157,106 +139,269 @@ function ModifyForm({
 }
 
 /* ------------------------------------------------------------------ */
-/*  Audit Log Tab                                                      */
+/*  TOTP modal — full overlay, six visual boxes                       */
 /* ------------------------------------------------------------------ */
 
-function AuditLogTab() {
+function TotpModal({
+  approval,
+  onCancel,
+  onSubmit,
+  pending,
+}: {
+  approval: ApprovalItem;
+  onCancel: () => void;
+  onSubmit: (code: string) => void;
+  pending: boolean;
+}) {
+  const { t } = useTranslation();
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  const isRecovery = value.includes("-");
+  const digits = isRecovery ? null : value.padEnd(6, " ").slice(0, 6).split("");
+  const cursorIdx = Math.min(value.length, 5);
+  const valid = isValidTotpOrRecovery(value);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 grid place-items-center bg-black/60 backdrop-blur-md p-5"
+      onClick={onCancel}
+    >
+      <div
+        className="animate-rise w-full max-w-sm rounded-2xl border border-accent/40 bg-surface p-5 shadow-[0_24px_60px_-12px_rgba(0,0,0,0.7),0_0_60px_-10px_rgba(167,139,250,0.4)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 mb-4">
+          <div className="grid place-items-center w-9 h-9 rounded-lg bg-accent/15 border border-accent/40 text-accent">
+            <Lock className="w-4 h-4" />
+          </div>
+          <div>
+            <div className="text-[14px] font-semibold">
+              {t("approvals.totp.modalTitle")}
+            </div>
+            <div className="text-[11.5px] text-text-dim mt-0.5">
+              {t("approvals.totp.modalSubtitle")}
+            </div>
+          </div>
+        </div>
+
+        <p className="text-[12.5px] leading-relaxed text-text-dim mb-4">
+          <span className="font-mono">
+            {approval.agent_name || approval.agent_id || "agent"}
+          </span>{" "}
+          {t("approvals.totp.modalContext", {
+            action:
+              approval.action_summary || approval.action || approval.tool_name || "",
+          })}
+        </p>
+
+        {digits ? (
+          <div className="flex gap-1.5 mb-3">
+            {digits.map((d, i) => {
+              const filled = d.trim().length > 0;
+              const isCursor = i === cursorIdx && value.length < 6;
+              return (
+                <div
+                  key={i}
+                  className={`flex-1 h-11 grid place-items-center rounded-lg border font-mono text-lg font-semibold transition-colors ${
+                    filled
+                      ? "border-accent/50 bg-accent/10 text-accent"
+                      : "border-border-subtle bg-main/60 text-text-dim"
+                  } ${isCursor ? "ring-2 ring-accent/40" : ""}`}
+                >
+                  {filled ? d : isCursor ? "|" : ""}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="mb-3 px-3 py-2 rounded-lg border border-accent/30 bg-accent/5 font-mono text-sm tracking-widest text-accent text-center">
+            {value}
+          </div>
+        )}
+
+        {/* hidden actual input — captures keystrokes including paste */}
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={(e) =>
+            setValue(e.target.value.replace(/[^0-9-]/g, "").slice(0, 9))
+          }
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && valid && !pending) onSubmit(value);
+          }}
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          maxLength={9}
+          className="sr-only"
+          aria-label={t("approvals.totpLabel")}
+        />
+
+        <div className="flex items-center gap-1.5 mb-4 text-[11.5px] text-text-dim">
+          <Clock className="w-3 h-3" />
+          <span>{t("approvals.totp.expiresHint")}</span>
+        </div>
+
+        <div className="flex gap-2">
+          <Button variant="ghost" size="md" className="flex-1 justify-center" onClick={onCancel}>
+            {t("common.cancel", "Cancel")}
+          </Button>
+          <Button
+            variant="success"
+            size="md"
+            className="flex-1 justify-center"
+            leftIcon={<ShieldCheck className="w-4 h-4" />}
+            disabled={!valid || pending}
+            isLoading={pending}
+            onClick={() => onSubmit(value)}
+          >
+            {t("approvals.totp.confirm")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  History tab                                                       */
+/* ------------------------------------------------------------------ */
+
+const HISTORY_PAGE_SIZE = 50;
+
+function HistoryTab() {
   const { t } = useTranslation();
   const [offset, setOffset] = useState(0);
-
-  const auditQuery = useApprovalAudit({ limit: AUDIT_PAGE_SIZE, offset });
-
+  const auditQuery = useApprovalAudit({ limit: HISTORY_PAGE_SIZE, offset });
   const entries: ApprovalAuditEntry[] = auditQuery.data?.entries ?? [];
   const total = auditQuery.data?.total ?? 0;
   const from = total === 0 ? 0 : offset + 1;
-  const to = Math.min(offset + AUDIT_PAGE_SIZE, total);
+  const to = Math.min(offset + HISTORY_PAGE_SIZE, total);
 
-  if (auditQuery.isLoading) {
-    return <ListSkeleton rows={5} />;
+  if (auditQuery.isLoading) return <ListSkeleton rows={5} />;
+  if (auditQuery.isError) {
+    return (
+      <ErrorState
+        message={t("approvals.loadError")}
+        onRetry={() => auditQuery.refetch()}
+      />
+    );
   }
-
   if (entries.length === 0) {
     return (
       <EmptyState
-        icon={<Clock className="w-7 h-7" />}
-        title={t("approvals.auditLog.noEntries")}
+        icon={<HistoryIcon className="w-7 h-7" />}
+        title={t("approvals.history.empty")}
+        description={t("approvals.history.emptyDesc")}
       />
     );
   }
 
-  const auditColumns = useMemo<ResponsiveTableColumn<ApprovalAuditEntry>[]>(
-    () => [
-      {
-        key: "tool_name",
-        label: t("approvals.auditLog.tool"),
-        tdClass: "px-4 py-3 font-medium",
-        render: (e) => e.tool_name,
-      },
-      {
-        key: "agent_id",
-        label: t("approvals.auditLog.agent"),
-        tdClass: "px-4 py-3 text-text-dim",
-        render: (e) => e.agent_id,
-      },
-      {
-        key: "decision",
-        label: t("approvals.auditLog.decision"),
-        tdClass: "px-4 py-3",
-        render: (e) => decisionBadge(e.decision, t),
-      },
-      {
-        key: "decided_by",
-        label: t("approvals.auditLog.decidedBy"),
-        tdClass: "px-4 py-3 text-text-dim",
-        render: (e) => e.decided_by ?? "—",
-      },
-      {
-        key: "decided_at",
-        label: t("approvals.auditLog.decidedAt"),
-        tdClass: "px-4 py-3 text-text-dim text-xs",
-        render: (e) => (e.decided_at ? new Date(e.decided_at).toLocaleString() : "—"),
-      },
-      {
-        key: "feedback",
-        label: t("approvals.auditLog.feedback"),
-        tdClass: "px-4 py-3 text-text-dim text-xs max-w-48 truncate",
-        render: (e) => e.feedback ?? "—",
-      },
-    ],
-    [t],
-  );
-
   return (
     <div className="flex flex-col gap-4">
-      <ResponsiveTable
-        columns={auditColumns}
-        rows={entries}
-        rowKey={(e) => e.id}
-      />
+      <Card padding="none" className="overflow-hidden">
+        {/* Header row — only visible on lg */}
+        <div className="hidden lg:grid grid-cols-[100px_140px_1fr_80px_160px_110px] items-center px-4 py-2 border-b border-border-subtle bg-main/40 text-[10px] font-bold uppercase tracking-wider text-text-dim">
+          <span>{t("approvals.history.cols.decision")}</span>
+          <span>{t("approvals.history.cols.agent")}</span>
+          <span>{t("approvals.history.cols.action")}</span>
+          <span>{t("approvals.history.cols.risk")}</span>
+          <span>{t("approvals.history.cols.resolvedBy")}</span>
+          <span className="text-right">{t("approvals.history.cols.when")}</span>
+        </div>
+        {entries.map((h, i) => {
+          const risk = normalizeRisk(h.risk_level);
+          const decision = h.decision;
+          const isApprove = decision === "approved" || decision === "approve";
+          const isDeny = decision === "rejected" || decision === "reject";
+          const decisionColor = isApprove
+            ? "var(--color-success)"
+            : isDeny
+              ? "var(--color-error)"
+              : "var(--color-warning)";
+          const DecisionIcon = isApprove ? CheckCircle : isDeny ? XCircle : Edit3;
+          const decisionLabel = isApprove
+            ? t("approvals.history.decisions.approved")
+            : isDeny
+              ? t("approvals.history.decisions.denied")
+              : t("approvals.history.decisions.edited");
+          const dt = h.decided_at ? new Date(h.decided_at) : null;
+          const auto = (h.decided_by ?? "").startsWith("auto");
 
-      {/* Pagination */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-sm text-text-dim">
-        <span className="text-center sm:text-left">
-          {t("approvals.auditLog.showing", { from, to, total })}
-        </span>
+          return (
+            <div
+              key={h.id}
+              className={`grid grid-cols-[1fr_80px] lg:grid-cols-[100px_140px_1fr_80px_160px_110px] items-center px-4 py-2.5 text-[12.5px] ${
+                i < entries.length - 1 ? "border-b border-border-subtle" : ""
+              }`}
+            >
+              <span
+                className="inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider"
+                style={{ color: decisionColor }}
+              >
+                <DecisionIcon className="w-3 h-3" />
+                {decisionLabel}
+              </span>
+
+              <span className="hidden lg:inline font-mono text-[12px] truncate pr-2">
+                {h.agent_id}
+              </span>
+
+              <span className="hidden lg:inline truncate pr-3">
+                {h.action_summary || h.tool_name}
+              </span>
+
+              <span
+                className="hidden lg:inline-flex items-center justify-self-start text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border"
+                style={{
+                  background: `color-mix(in oklab, ${riskHex[risk]} 15%, transparent)`,
+                  borderColor: `color-mix(in oklab, ${riskHex[risk]} 30%, transparent)`,
+                  color: riskHex[risk],
+                }}
+              >
+                {risk}
+              </span>
+
+              <span className="hidden lg:inline-flex items-center gap-1 font-mono text-[11px] text-text-dim truncate pr-2">
+                {auto ? <Zap className="w-2.5 h-2.5 text-accent" /> : null}
+                {h.decided_by ?? "—"}
+              </span>
+
+              <span className="font-mono text-[11px] text-text-dim text-right">
+                {dt
+                  ? dt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+                  : "—"}
+              </span>
+            </div>
+          );
+        })}
+      </Card>
+
+      <div className="flex items-center justify-between text-sm text-text-dim">
+        <span>{t("approvals.auditLog.showing", { from, to, total })}</span>
         <div className="flex gap-2">
           <Button
             variant="secondary"
             size="sm"
-            className="flex-1 sm:flex-initial min-h-[44px] sm:min-h-0"
             disabled={offset === 0}
-            onClick={() => setOffset(Math.max(0, offset - AUDIT_PAGE_SIZE))}
-            leftIcon={<ChevronLeft className="h-4 w-4" />}
+            onClick={() => setOffset(Math.max(0, offset - HISTORY_PAGE_SIZE))}
           >
             {t("common.previous", "Previous")}
           </Button>
           <Button
             variant="secondary"
             size="sm"
-            className="flex-1 sm:flex-initial min-h-[44px] sm:min-h-0"
-            disabled={offset + AUDIT_PAGE_SIZE >= total}
-            onClick={() => setOffset(offset + AUDIT_PAGE_SIZE)}
-            rightIcon={<ChevronRight className="h-4 w-4" />}
+            disabled={offset + HISTORY_PAGE_SIZE >= total}
+            onClick={() => setOffset(offset + HISTORY_PAGE_SIZE)}
           >
             {t("common.next", "Next")}
           </Button>
@@ -267,328 +412,337 @@ function AuditLogTab() {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Main Page                                                          */
+/*  Pending card                                                      */
+/* ------------------------------------------------------------------ */
+
+function PendingCard({
+  approval,
+  totpEnforced,
+  isPending,
+  onApprove,
+  onDeny,
+  isEditing,
+  onToggleEdit,
+}: {
+  approval: ApprovalItem;
+  totpEnforced: boolean;
+  isPending: boolean;
+  onApprove: () => void;
+  onDeny: () => void;
+  isEditing: boolean;
+  onToggleEdit: () => void;
+}) {
+  const { t } = useTranslation();
+  const now = useNow(30_000);
+  const risk = normalizeRisk(approval.risk_level);
+  const color = riskHex[risk];
+  const ago = timeAgo(approval.requested_at || approval.created_at, now);
+  const action = approval.action_summary || approval.action || approval.tool_name || "—";
+  const description = approval.description ?? "";
+  const tools = approval.tool_name ? [approval.tool_name] : [];
+
+  return (
+    <Card padding="none" className="overflow-hidden">
+      {/* Risk-tinted header */}
+      <div
+        className="flex items-center gap-2.5 px-3.5 py-2.5 border-b border-border-subtle"
+        style={{
+          background: `linear-gradient(90deg, color-mix(in oklab, ${color} 8%, transparent), transparent)`,
+        }}
+      >
+        <Shield className="w-3.5 h-3.5 shrink-0" style={{ color }} />
+        <span className="font-mono text-[12px] truncate">
+          {approval.agent_name || approval.agent_id || "agent"}
+        </span>
+        <span className="text-[11px] text-text-dim hidden sm:inline">
+          {t("approvals.requestedAgo", { ago })}
+        </span>
+        <span className="ml-auto flex items-center gap-1.5">
+          <span
+            className="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border"
+            style={{
+              background: `color-mix(in oklab, ${color} 15%, transparent)`,
+              borderColor: `color-mix(in oklab, ${color} 30%, transparent)`,
+              color,
+            }}
+          >
+            {t(`approvals.risk.${risk}`)}
+          </span>
+          {totpEnforced && (
+            <span className="font-mono text-[10px] px-1.5 py-0.5 rounded border border-accent/30 bg-accent/10 text-accent">
+              TOTP
+            </span>
+          )}
+        </span>
+      </div>
+
+      {/* Body */}
+      <div className="p-3.5">
+        <div className="text-[13.5px] font-medium mb-1.5 break-words">{action}</div>
+        {description && (
+          <div className="text-[12.5px] text-text-dim leading-relaxed break-words">
+            {description}
+          </div>
+        )}
+
+        {tools.length > 0 && (
+          <div className="flex gap-1.5 flex-wrap my-3">
+            {tools.map((tName) => (
+              <span
+                key={tName}
+                className="font-mono text-[10.5px] px-1.5 py-0.5 rounded border border-accent/25 bg-accent/10 text-accent"
+              >
+                {tName}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-2 mt-3">
+          <Button
+            variant="success"
+            size="md"
+            leftIcon={<CheckCircle className="w-4 h-4" />}
+            onClick={onApprove}
+            disabled={isPending}
+            isLoading={isPending}
+          >
+            {totpEnforced ? t("approvals.approveWithTotp") : t("approvals.approve")}
+          </Button>
+          <Button variant="secondary" size="md" onClick={onToggleEdit} disabled={isPending}>
+            {t("approvals.editApprove")}
+          </Button>
+          <Button
+            variant="ghost"
+            size="md"
+            leftIcon={<XCircle className="w-4 h-4" />}
+            onClick={onDeny}
+            disabled={isPending}
+          >
+            {t("approvals.deny")}
+          </Button>
+        </div>
+
+        {isEditing && <EditAndApproveForm id={approval.id} onDone={onToggleEdit} />}
+      </div>
+    </Card>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main page                                                         */
 /* ------------------------------------------------------------------ */
 
 export function ApprovalsPage() {
   const { t } = useTranslation();
-  const [pendingTarget, setPendingTarget] = useState<PendingTarget>(null);
-  const [selected, setSelected] = useState<Set<string>>(() => new Set());
-  const [modifyingId, setModifyingId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>("pending");
-  const [totpPromptId, setTotpPromptId] = useState<string | null>(null);
-  const [totpInput, setTotpInput] = useState("");
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [totpFor, setTotpFor] = useState<ApprovalItem | null>(null);
+  const [filter, setFilter] = useState("");
+  const [filterOpen, setFilterOpen] = useState(false);
   const addToast = useUIStore((s) => s.addToast);
 
   const approvalsQuery = useApprovals();
   const totpQuery = useTotpStatus();
   const approveMutation = useApproveApproval();
   const rejectMutation = useRejectApproval();
-  const batchResolve = useBatchResolveApprovals();
 
   const totpEnforced = totpQuery.data?.enforced ?? false;
-
   const approvals = approvalsQuery.data ?? [];
   const pendingApprovals = useMemo(
     () => approvals.filter((a) => !a.status || a.status === "pending"),
-    [approvals]
+    [approvals],
   );
 
-  async function handleDecision(id: string, decision: "approve" | "reject") {
-    // If TOTP is enforced and user is approving, prompt for code
-    if (decision === "approve" && totpEnforced) {
-      setTotpPromptId(id);
-      setTotpInput("");
-      return;
-    }
-    await executeDecision(id, decision);
-  }
+  const filteredPending = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return pendingApprovals;
+    return pendingApprovals.filter((a) =>
+      [a.agent_id, a.agent_name, a.tool_name, a.action_summary, a.description]
+        .filter(Boolean)
+        .some((s) => (s as string).toLowerCase().includes(q)),
+    );
+  }, [pendingApprovals, filter]);
 
-  async function handleTotpSubmit() {
-    if (!totpPromptId || !isValidTotpOrRecovery(totpInput)) return;
-    await executeDecision(totpPromptId, "approve", totpInput);
-    setTotpPromptId(null);
-    setTotpInput("");
-  }
-
-  async function executeDecision(id: string, decision: "approve" | "reject", totpCode?: string) {
-    setPendingTarget({ kind: "item", id });
+  async function executeApprove(id: string, totpCode?: string) {
+    setPendingId(id);
     try {
-      if (decision === "approve") {
-        await approveMutation.mutateAsync({ id, totpCode });
-        addToast(t("approvals.approvedToast"), "success");
-      } else {
-        await rejectMutation.mutateAsync(id);
-        addToast(t("approvals.rejectedToast"), "success");
-      }
-      setSelected((prev) => {
-        const next = new Set(prev);
-        next.delete(id);
-        return next;
-      });
+      await approveMutation.mutateAsync({ id, totpCode });
+      addToast(t("approvals.approvedToast"), "success");
+      setTotpFor(null);
     } catch (e: unknown) {
       addToast(e instanceof Error ? e.message : String(e), "error");
     } finally {
-      setPendingTarget(null);
+      setPendingId(null);
     }
   }
 
-  async function handleBatchAction(decision: "approve" | "reject") {
-    if (selected.size === 0) return;
-    const ids = Array.from(selected);
-    setPendingTarget({ kind: "batch" });
+  async function executeReject(id: string) {
+    setPendingId(id);
     try {
-      await batchResolve.mutateAsync({ ids, decision });
-      addToast(t("approvals.batchSuccess"), "success");
-      setSelected(new Set());
+      await rejectMutation.mutateAsync(id);
+      addToast(t("approvals.rejectedToast"), "success");
     } catch (e: unknown) {
       addToast(e instanceof Error ? e.message : String(e), "error");
     } finally {
-      setPendingTarget(null);
+      setPendingId(null);
     }
   }
 
-  function toggleSelect(id: string) {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }
-
-  function toggleSelectAll() {
-    if (selected.size === pendingApprovals.length) {
-      setSelected(new Set());
+  function handleApprove(a: ApprovalItem) {
+    if (totpEnforced) {
+      setTotpFor(a);
     } else {
-      setSelected(new Set(pendingApprovals.map((a) => a.id)));
+      void executeApprove(a.id);
     }
   }
 
   return (
-    <div className="flex flex-col gap-6 transition-colors duration-300">
-      <PageHeader
-        badge={t("nav.approvals")}
-        title={t("approvals.title")}
-        subtitle={t("approvals.subtitle")}
-        isFetching={approvalsQuery.isFetching}
-        onRefresh={() => void approvalsQuery.refetch()}
-        icon={<CheckCircle className="h-4 w-4" />}
-        helpText={t("approvals.help")}
-      />
-
-      {/* Tab toggle */}
-      <div role="tablist" aria-label={t("approvals.title")} className="flex gap-2">
-        <button
-          id="approvals-tab-pending"
-          role="tab"
-          aria-selected={activeTab === "pending"}
-          aria-controls="approvals-panel-pending"
-          tabIndex={activeTab === "pending" ? 0 : -1}
-          className={tabClass("pending", activeTab === "pending")}
-          onClick={() => setActiveTab("pending")}
+    <div className="flex flex-col h-full">
+      {/* Top bar */}
+      <div className="flex items-center gap-2.5 flex-wrap px-4 lg:px-5 py-3 border-b border-border-subtle">
+        <h2 className="m-0 text-[15px] font-semibold">{t("approvals.title")}</h2>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-bold ${
+            pendingApprovals.length > 0
+              ? "bg-warning/15 text-warning"
+              : "bg-success/10 text-success"
+          }`}
         >
-          {t("approvals.tabPending")}
-          {pendingApprovals.length > 0 && (
-            <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-warning/20 px-1.5 text-[10px] font-bold text-warning">
-              {pendingApprovals.length}
-            </span>
-          )}
-        </button>
-        <button
-          id="approvals-tab-audit"
-          role="tab"
-          aria-selected={activeTab === "audit"}
-          aria-controls="approvals-panel-audit"
-          tabIndex={activeTab === "audit" ? 0 : -1}
-          className={tabClass("audit", activeTab === "audit")}
-          onClick={() => setActiveTab("audit")}
-        >
-          {t("approvals.tabAuditLog")}
-        </button>
+          {t("approvals.pendingCount", { count: pendingApprovals.length })}
+        </span>
+        <div className="ml-auto flex items-center gap-1.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => approvalsQuery.refetch()}
+            leftIcon={
+              <RefreshCw
+                className={`w-3.5 h-3.5 ${approvalsQuery.isFetching ? "animate-spin" : ""}`}
+              />
+            }
+          >
+            <span className="hidden sm:inline">{t("common.refresh", "Refresh")}</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setFilterOpen((v) => !v)}
+            leftIcon={<Filter className="w-3.5 h-3.5" />}
+          >
+            <span className="hidden sm:inline">{t("approvals.filter")}</span>
+          </Button>
+          <Link
+            to="/settings"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border-subtle bg-surface px-2.5 h-7 text-xs font-semibold hover:border-brand/30 hover:text-brand transition-colors"
+          >
+            {t("approvals.autoRules")}
+          </Link>
+        </div>
       </div>
 
-      {activeTab === "audit" ? (
-        <div id="approvals-panel-audit" role="tabpanel" aria-labelledby="approvals-tab-audit">
-          <AuditLogTab />
-        </div>
-      ) : (
-        <div id="approvals-panel-pending" role="tabpanel" aria-labelledby="approvals-tab-pending">
-          {/* Batch action bar */}
-          {pendingApprovals.length > 0 && (
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:gap-3 lg:flex-wrap mb-4 lg:mb-0">
-              <div className="flex items-center justify-between gap-2">
-                <label className="flex items-center gap-2 text-sm text-text-dim cursor-pointer select-none min-h-[44px] lg:min-h-0">
-                  <input
-                    type="checkbox"
-                    checked={selected.size === pendingApprovals.length && pendingApprovals.length > 0}
-                    onChange={toggleSelectAll}
-                    className="h-5 w-5 lg:h-4 lg:w-4 rounded border-border-subtle text-brand focus:ring-brand/30 accent-[var(--color-brand)]"
-                  />
-                  {t("approvals.selectAll")}
-                </label>
-                {selected.size > 0 && (
-                  <span className="text-xs text-text-dim lg:hidden">
-                    {t("approvals.selected", { count: selected.size })}
-                  </span>
-                )}
-              </div>
-              {selected.size > 0 && (
-                <>
-                  <span className="hidden lg:inline text-xs text-text-dim">
-                    {t("approvals.selected", { count: selected.size })}
-                  </span>
-                  <div className="flex gap-2 lg:contents">
-                    <Button
-                      variant="success"
-                      size="sm"
-                      className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0"
-                      onClick={() => handleBatchAction("approve")}
-                      disabled={pendingTarget?.kind === "batch" || totpEnforced}
-                      isLoading={pendingTarget?.kind === "batch"}
-                      title={totpEnforced ? t("approvals.batch_disabled_totp") : undefined}
-                    >
-                      {t("approvals.approveSelected")}
-                    </Button>
-                    <Button
-                      variant="danger"
-                      size="sm"
-                      className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0"
-                      onClick={() => handleBatchAction("reject")}
-                      disabled={pendingTarget?.kind === "batch"}
-                      isLoading={pendingTarget?.kind === "batch"}
-                    >
-                      {t("approvals.rejectSelected")}
-                    </Button>
-                  </div>
-                </>
+      {/* Tabs */}
+      <div className="flex gap-0 px-4 lg:px-5 border-b border-border-subtle bg-main/30">
+        {([
+          { id: "pending", label: t("approvals.tabPending"), count: pendingApprovals.length },
+          { id: "history", label: t("approvals.tabHistory"), count: undefined },
+        ] as const).map((tDef) => {
+          const active = activeTab === tDef.id;
+          return (
+            <button
+              key={tDef.id}
+              role="tab"
+              aria-selected={active}
+              onClick={() => setActiveTab(tDef.id)}
+              className={`relative inline-flex items-center gap-2 px-3.5 py-2.5 text-[12.5px] transition-colors ${
+                active
+                  ? "font-semibold border-b-2 border-brand"
+                  : "text-text-dim font-medium border-b-2 border-transparent hover:text-current"
+              }`}
+            >
+              {tDef.id === "pending" ? (
+                <Clock className="w-3 h-3" />
+              ) : (
+                <HistoryIcon className="w-3 h-3" />
               )}
-            </div>
-          )}
+              {tDef.label}
+              {tDef.count !== undefined && (
+                <span
+                  className={`font-mono text-[10px] px-1.5 py-px rounded-full ${
+                    active ? "bg-brand/15 text-brand" : "bg-text-dim/10 text-text-dim"
+                  }`}
+                >
+                  {tDef.count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
 
-          {approvalsQuery.isLoading ? (
-            <ListSkeleton rows={3} />
-          ) : approvalsQuery.isError ? (
-            <ErrorState
-              message={t("approvals.loadError", "Failed to load approvals. Check your connection.")}
-              onRetry={() => approvalsQuery.refetch()}
+      {/* Filter input — collapses */}
+      {filterOpen && activeTab === "pending" && (
+        <div className="px-4 lg:px-5 py-2.5 border-b border-border-subtle">
+          <div className="relative max-w-md">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-dim" />
+            <input
+              type="text"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder={t("approvals.filterPlaceholder")}
+              autoFocus
+              className="w-full pl-8 pr-3 py-1.5 rounded-lg border border-border-subtle bg-main text-[13px] focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none"
             />
-          ) : approvals.length === 0 ? (
-            <EmptyState
-              icon={<CheckCircle className="w-7 h-7" />}
-              title={t("approvals.queue_clear")}
-              description={t("approvals.queue_clear_desc")}
-            />
-          ) : (
-            <div className="grid gap-3 lg:gap-4">
-              {approvals.map((a) => {
-                const isPending = !a.status || a.status === "pending";
-                return (
-                  <Card key={a.id} hover padding="md">
-                    <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 lg:gap-6">
-                      <div className="min-w-0 flex-1 flex items-start lg:items-center gap-3">
-                        {/* Checkbox for pending items */}
-                        {isPending && (
-                          <input
-                            type="checkbox"
-                            checked={selected.has(a.id)}
-                            onChange={() => toggleSelect(a.id)}
-                            className="h-5 w-5 lg:h-4 lg:w-4 mt-1 lg:mt-0 rounded border-border-subtle text-brand focus:ring-brand/30 shrink-0 accent-[var(--color-brand)]"
-                          />
-                        )}
-                        <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${statusIconBg(a.status)}`}>
-                          {statusIcon(a.status)}
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          {statusBadge(a.status, t)}
-                          <p className="mt-1 text-sm font-medium leading-relaxed break-words">{a.action_summary || a.description || t("common.actions")}</p>
-                        </div>
-                      </div>
-                      {isPending ? (
-                        <div className="grid grid-cols-2 gap-2 lg:flex lg:gap-2 lg:shrink-0">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="col-span-2 lg:col-auto min-h-[44px] lg:min-h-0 justify-center"
-                            onClick={() => setModifyingId(modifyingId === a.id ? null : a.id)}
-                            leftIcon={<MessageSquare className="h-3.5 w-3.5" />}
-                          >
-                            {t("approvals.modify")}
-                          </Button>
-                          <Button
-                            variant="danger"
-                            size="sm"
-                            className="min-h-[44px] lg:min-h-0 justify-center"
-                            onClick={() => handleDecision(a.id, "reject")}
-                            disabled={pendingTarget?.kind === "item" && pendingTarget.id === a.id}
-                          >
-                            {t("approvals.reject")}
-                          </Button>
-                          <Button
-                            variant="success"
-                            size="sm"
-                            className="min-h-[44px] lg:min-h-0 justify-center"
-                            onClick={() => handleDecision(a.id, "approve")}
-                            disabled={pendingTarget?.kind === "item" && pendingTarget.id === a.id}
-                          >
-                            {t("approvals.approve")}
-                          </Button>
-                        </div>
-                      ) : (
-                        <div className="text-sm text-text-dim lg:shrink-0">
-                          {t(`approvals.status.${a.status}`)}
-                        </div>
-                      )}
-                    </div>
-                    {/* TOTP prompt */}
-                    {totpPromptId === a.id && isPending && (
-                      <div className="mt-3 flex flex-col lg:flex-row lg:items-center gap-2">
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="text"
-                            maxLength={9}
-                            value={totpInput}
-                            onChange={(e) => setTotpInput(e.target.value.replace(/[^0-9-]/g, "").slice(0, 9))}
-                            placeholder={t("approvals.totpPlaceholder", { defaultValue: "000000 / 0000-0000" })}
-                            className="flex-1 lg:flex-initial lg:w-40 min-h-[44px] lg:min-h-0 rounded-xl border border-border-subtle bg-main px-3 py-2 text-sm font-mono tracking-widest text-center focus:border-brand focus:ring-2 focus:ring-brand/10 outline-none transition-colors"
-                            autoFocus
-                            onKeyDown={(e) => e.key === "Enter" && handleTotpSubmit()}
-                          />
-                          <span className="text-xs text-text-dim lg:hidden">{t("approvals.totpLabel", { defaultValue: "TOTP" })}</span>
-                        </div>
-                        <div className="flex gap-2">
-                          <Button
-                            variant="success"
-                            size="sm"
-                            className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 justify-center"
-                            onClick={handleTotpSubmit}
-                            disabled={!isValidTotpOrRecovery(totpInput) || (pendingTarget?.kind === "item" && pendingTarget.id === a.id)}
-                            isLoading={pendingTarget?.kind === "item" && pendingTarget.id === a.id}
-                          >
-                            {t("approvals.approve")}
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="flex-1 lg:flex-initial min-h-[44px] lg:min-h-0 justify-center"
-                            onClick={() => { setTotpPromptId(null); setTotpInput(""); }}
-                          >
-                            {t("common.cancel", "Cancel")}
-                          </Button>
-                        </div>
-                        <span className="hidden lg:inline text-xs text-text-dim">{t("approvals.totpLabel", { defaultValue: "TOTP" })}</span>
-                      </div>
-                    )}
-                    {/* Modify form */}
-                    {modifyingId === a.id && isPending && (
-                      <ModifyForm id={a.id} onDone={() => setModifyingId(null)} />
-                    )}
-                  </Card>
-                );
-              })}
-            </div>
-          )}
+          </div>
         </div>
+      )}
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto p-4 lg:p-5">
+        {activeTab === "history" ? (
+          <HistoryTab />
+        ) : approvalsQuery.isLoading ? (
+          <ListSkeleton rows={3} />
+        ) : approvalsQuery.isError ? (
+          <ErrorState
+            message={t("approvals.loadError")}
+            onRetry={() => approvalsQuery.refetch()}
+          />
+        ) : filteredPending.length === 0 ? (
+          <EmptyState
+            icon={<CheckCircle className="w-7 h-7" />}
+            title={t("approvals.queue_clear")}
+            description={
+              filter ? t("approvals.noFilterMatch") : t("approvals.queue_clear_desc")
+            }
+          />
+        ) : (
+          <div className="flex flex-col gap-3">
+            {filteredPending.map((a) => (
+              <PendingCard
+                key={a.id}
+                approval={a}
+                totpEnforced={totpEnforced}
+                isPending={pendingId === a.id}
+                isEditing={editingId === a.id}
+                onApprove={() => handleApprove(a)}
+                onDeny={() => void executeReject(a.id)}
+                onToggleEdit={() => setEditingId(editingId === a.id ? null : a.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* TOTP modal */}
+      {totpFor && (
+        <TotpModal
+          approval={totpFor}
+          pending={pendingId === totpFor.id}
+          onCancel={() => setTotpFor(null)}
+          onSubmit={(code) => void executeApprove(totpFor.id, code)}
+        />
       )}
     </div>
   );

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -14,6 +14,7 @@ import {
   useUpdateMcpServer,
   useDeleteMcpServer,
   useReloadMcp,
+  useReconnectMcpServer,
   useStartMcpAuth,
   useRevokeMcpAuth,
 } from "../lib/mutations/mcp";
@@ -29,10 +30,10 @@ import { Input } from "../components/ui/Input";
 import { useUIStore } from "../lib/store";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
 import {
-  Plug, Plus, X, Trash2, Settings, ChevronDown, ChevronUp, Wrench, Terminal, Globe, Radio,
+  Plug, Plus, X, Trash2, Settings, Wrench, Terminal, Globe, Radio,
   Shield, ShieldCheck, ShieldAlert, ShieldX, Check, ExternalLink,
-  Search, Clock, Filter, Store, Key, Download, RefreshCw, Activity,
-  ShieldHalf,
+  Search, Filter, Store, Key, Download, RefreshCw, Activity,
+  ShieldHalf, Server, FileText, RotateCw,
 } from "lucide-react";
 import { TaintPolicyEditor } from "../components/TaintPolicyEditor";
 // Lazy-load individual lucide icons by name — avoids pulling the full
@@ -480,197 +481,349 @@ function AuthBadge({
   );
 }
 
-// ── Server Card ─────────────────────────────────────────────────────
+// ── Server Card (compact design) ────────────────────────────────────
 
 function ServerCard({
   server,
   conn,
-  isExpanded,
-  onToggleTools,
-  onEdit,
-  onEditTaintPolicy,
-  onDelete,
   onAuthSuccess,
   onViewDetail,
   t,
 }: {
   server: McpServerConfigured;
   conn?: McpServerConnected;
-  isExpanded: boolean;
-  onToggleTools: () => void;
-  onEdit: () => void;
-  onEditTaintPolicy: () => void;
-  onDelete: () => void;
   onAuthSuccess?: () => void;
   onViewDetail: () => void;
   t: TFunction;
 }) {
   const isConnected = conn?.connected ?? false;
   const toolsCount = conn?.tools_count ?? 0;
-  const [showAllTools, setShowAllTools] = useState(false);
-
-  // Cache transport info — computed once per render, not 3-4x
   const transportType = useMemo(() => getTransportType(server), [server]);
   const transportDetail = useMemo(() => getTransportDetail(server), [server]);
-
-  // Reset "show all" when tools section is collapsed
-  useEffect(() => {
-    if (!isExpanded) setShowAllTools(false);
-  }, [isExpanded]);
-
-  const visibleTools = useMemo(() => {
-    if (!conn?.tools) return [];
-    if (showAllTools || conn.tools.length <= 5) return conn.tools;
-    return conn.tools.slice(0, 5);
-  }, [conn?.tools, showAllTools]);
-
-  const hiddenCount = (conn?.tools?.length ?? 0) - visibleTools.length;
+  const authState = server.auth_state?.state ?? "not_required";
+  const authLabel =
+    authState === "authorized"
+      ? "oauth"
+      : authState === "not_required"
+        ? (server.env ?? []).length > 0
+          ? "token"
+          : "none"
+        : authState;
 
   return (
-    <Card hover padding="none" className="flex flex-col overflow-hidden group">
-      {/* Gradient top bar */}
-      <div className={`h-1.5 bg-linear-to-r ${
-        isConnected
-          ? "from-success via-success/60 to-success/30"
-          : "from-error via-error/60 to-error/30"
-      }`} />
-
-      <div
-        className="p-5 flex-1 flex flex-col cursor-pointer"
-        role="button"
-        tabIndex={0}
-        onClick={onViewDetail}
-        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onViewDetail(); } }}
-        aria-label={t("mcp.view_detail", { defaultValue: "View server details" })}
-      >
-        {/* Header */}
-        <div className="flex items-start justify-between gap-3 mb-4">
-          <div className="flex items-center gap-3 min-w-0">
-            <div className={`w-10 h-10 rounded-lg flex items-center justify-center shadow-sm ${
-              isConnected
-                ? "bg-linear-to-br from-success/10 to-success/5 border border-success/20"
-                : "bg-linear-to-br from-brand/10 to-brand/5 border border-brand/20"
-            }`}>
-              <Plug className={`w-5 h-5 ${isConnected ? "text-success" : "text-brand"}`} />
-            </div>
-            <div className="min-w-0">
-              <h2 className={`text-base font-black truncate transition-colors ${
-                isConnected ? "group-hover:text-success" : "group-hover:text-brand"
-              }`}>{server.name}</h2>
-              <p className="text-[10px] font-black uppercase tracking-widest text-text-dim/60">
-                {transportType}
-              </p>
-            </div>
-          </div>
-          <Badge variant={isConnected ? "success" : "error"} dot>
-            {isConnected ? t("mcp.connected") : t("mcp.disconnected")}
-          </Badge>
+    <Card
+      hover
+      padding="none"
+      className="overflow-hidden cursor-pointer group"
+      onClick={onViewDetail}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onViewDetail();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={t("mcp.view_detail", { defaultValue: "View server details" })}
+    >
+      <div className="p-3.5 flex items-start gap-2.5">
+        <div className="grid place-items-center w-[30px] h-[30px] rounded-lg bg-brand/10 border border-brand/30 text-brand shrink-0">
+          <Server className="w-3.5 h-3.5" />
         </div>
-
-        {/* OAuth auth badge */}
-        <AuthBadge server={server} onAuthSuccess={onAuthSuccess} />
-
-        {/* Stats */}
-        <div className="grid grid-cols-2 gap-3 mb-4">
-          <div className="p-3 rounded-xl bg-linear-to-br from-main/60 to-main/30 border border-border-subtle/50">
-            <div className="flex items-center gap-1.5 mb-1">
-              <Wrench className={`w-3 h-3 ${isConnected ? "text-success" : "text-brand"}`} />
-              <p className="text-[9px] font-black uppercase tracking-wider text-text-dim/70">{t("mcp.tools")}</p>
-            </div>
-            <p className="text-xl font-black text-text-main">{toolsCount}</p>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[13px] font-medium truncate">{server.name}</span>
+            <Badge variant={isConnected ? "success" : "error"} dot>
+              {isConnected ? t("mcp.connected") : t("mcp.disconnected")}
+            </Badge>
           </div>
-          <div className="p-3 rounded-xl bg-linear-to-br from-main/60 to-main/30 border border-border-subtle/50">
-            <div className="flex items-center gap-1.5 mb-1">
-              <Clock className="w-3 h-3 text-warning" />
-              <p className="text-[9px] font-black uppercase tracking-wider text-text-dim/70">{t("mcp.timeout")}</p>
-            </div>
-            <p className="text-xl font-black text-text-main">{server.timeout_secs ?? 30}s</p>
+          <div className="font-mono text-[11px] text-text-dim mt-0.5 truncate">
+            {transportType === "stdio"
+              ? `mcp+stdio://${transportDetail || server.name}`
+              : transportDetail}
           </div>
-        </div>
-
-        {/* Transport badge + detail */}
-        <div className="flex items-center gap-2 mb-3">
-          <Badge variant="default">
-            <TransportIcon type={transportType} />
-            <span className="ml-1">{transportType.toUpperCase()}</span>
-          </Badge>
-        </div>
-        <div className="flex items-center gap-2 text-xs mb-2">
-          {transportType === "stdio" ? (
-            <Terminal className="w-3 h-3 text-text-dim/50 shrink-0" />
-          ) : (
-            <Globe className="w-3 h-3 text-text-dim/50 shrink-0" />
-          )}
-          <span className="text-text-dim font-mono text-[10px] truncate">{transportDetail}</span>
+          <div className="flex items-center gap-2.5 mt-2 text-[11px]">
+            <span className="font-mono text-text-dim">
+              {t("mcp.tools_count_short", { count: toolsCount, defaultValue: "{{count}} tools" })}
+            </span>
+            <span className="font-mono text-accent">{authLabel}</span>
+          </div>
         </div>
       </div>
-
-      {/* Tools expand */}
-      {toolsCount > 0 && (
-        <>
-          <button
-            onClick={onToggleTools}
-            className="flex items-center justify-center gap-1.5 py-2.5 border-t border-border-subtle text-xs font-bold text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
-            aria-expanded={isExpanded}
-            aria-label={isExpanded ? t("mcp.hide_tools") : t("mcp.show_tools")}
-          >
-            {isExpanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
-            {t("mcp.tools")} ({toolsCount})
-          </button>
-          {isExpanded && conn?.tools && (
-            <div className="border-t border-border-subtle px-4 py-3 space-y-2 max-h-64 overflow-y-auto scrollbar-thin">
-              {visibleTools.map((tool) => (
-                <div key={tool.name} className="p-2.5 rounded-lg bg-main/40 border border-border-subtle/50">
-                  <span className="text-xs font-mono font-bold text-text-main">{tool.name}</span>
-                  {tool.description && (
-                    <p className="text-[10px] text-text-dim leading-snug mt-0.5">{tool.description}</p>
-                  )}
-                </div>
-              ))}
-              {hiddenCount > 0 && (
-                <button
-                  onClick={() => setShowAllTools(true)}
-                  className="w-full text-center text-[10px] font-bold text-brand hover:text-brand/80 py-1.5 transition-colors"
-                >
-                  {t("mcp.show_more_tools", { count: hiddenCount })}
-                </button>
-              )}
-            </div>
-          )}
-        </>
+      {/* OAuth state — only renders when not "not_required". Stops the parent
+          click so the auth button doesn't accidentally open the detail. */}
+      {authState !== "not_required" && (
+        <div
+          className="px-3.5 pb-3 -mt-1"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <AuthBadge server={server} onAuthSuccess={onAuthSuccess} />
+        </div>
       )}
-
-      {/* Actions */}
-      <div className="flex border-t border-border-subtle">
-        <button
-          onClick={onEdit}
-          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-bold text-text-dim hover:text-brand hover:bg-surface-hover transition-colors rounded-bl-xl sm:rounded-bl-2xl"
-          aria-label={t("mcp.edit_server")}
-        >
-          <Settings className="h-3.5 w-3.5" />
-          {t("common.edit")}
-        </button>
-        <div className="w-px bg-border-subtle" />
-        <button
-          onClick={onEditTaintPolicy}
-          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-bold text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
-          aria-label={t("mcp.edit_taint_policy", "Taint policy")}
-          title={t("mcp.edit_taint_policy", "Taint policy")}
-        >
-          <ShieldHalf className="h-3.5 w-3.5" />
-          {t("mcp.taint_policy_short", "Taint")}
-        </button>
-        <div className="w-px bg-border-subtle" />
-        <button
-          onClick={onDelete}
-          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-xs font-bold text-text-dim hover:text-error hover:bg-error/5 transition-colors rounded-br-xl sm:rounded-br-2xl"
-          aria-label={t("mcp.delete_server")}
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-          {t("common.delete")}
-        </button>
-      </div>
     </Card>
+  );
+}
+
+// ── Server Detail Drawer Body (Tools / Logs / Config tabs) ─────────
+
+function Mini({ label, value, tone }: { label: string; value: string; tone?: "ok" | "bad" }) {
+  return (
+    <div className="rounded-lg border border-border-subtle bg-main/40 p-2.5">
+      <div className="text-[9px] font-bold uppercase tracking-wider text-text-dim mb-1">{label}</div>
+      <div
+        className={`font-mono text-[14px] font-semibold ${
+          tone === "ok" ? "text-success" : tone === "bad" ? "text-error" : ""
+        }`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+type DetailTab = "tools" | "logs" | "config";
+
+function ServerDetailBody({
+  server,
+  conn,
+  onClose,
+  onEdit,
+  onEditTaintPolicy,
+  onDelete,
+}: {
+  server: McpServerConfigured;
+  conn?: McpServerConnected;
+  onClose: () => void;
+  onEdit: () => void;
+  onEditTaintPolicy: () => void;
+  onDelete: () => void;
+}) {
+  const { t } = useTranslation();
+  const addToast = useUIStore((s) => s.addToast);
+  const reconnectMutation = useReconnectMcpServer();
+  const [tab, setTab] = useState<DetailTab>("tools");
+
+  const isConnected = conn?.connected ?? false;
+  const transportType = getTransportType(server);
+  const transportDetail = getTransportDetail(server);
+  const transportLabel =
+    transportType === "stdio"
+      ? `stdio · ${transportDetail || "—"}`
+      : `${transportType} · ${transportDetail || "—"}`;
+  const authStateStr = server.auth_state?.state ?? "not_required";
+  const tools = conn?.tools ?? [];
+
+  const handleReconnect = () => {
+    reconnectMutation.mutate(serverIdOf(server), {
+      onSuccess: () => addToast(t("mcp.reconnect_success", { defaultValue: "Reconnect requested" }), "success"),
+      onError: (e: unknown) =>
+        addToast(errorMessage(e, t("mcp.reconnect_failed", { defaultValue: "Reconnect failed" })), "error"),
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Hero */}
+      <div className="px-5 py-4 border-b border-border-subtle">
+        <div className="flex items-start gap-3">
+          <div className="grid place-items-center w-10 h-10 rounded-lg bg-brand/10 border border-brand/30 text-brand shrink-0">
+            <Server className="w-5 h-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h2 className="text-base font-semibold tracking-tight truncate">{server.name}</h2>
+              <Badge variant={isConnected ? "success" : "error"} dot>
+                {isConnected ? t("mcp.connected") : t("mcp.disconnected")}
+              </Badge>
+            </div>
+            <p className="font-mono text-[11px] text-text-dim mt-1 break-all">{transportLabel}</p>
+          </div>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <Button
+              size="sm"
+              variant="ghost"
+              leftIcon={<RotateCw className={`h-3.5 w-3.5 ${reconnectMutation.isPending ? "animate-spin" : ""}`} />}
+              onClick={handleReconnect}
+              disabled={reconnectMutation.isPending}
+            >
+              {t("mcp.reconnect", { defaultValue: "Reconnect" })}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-border-subtle px-5 bg-main/20">
+        {([
+          { id: "tools" as const, label: t("mcp.tab_tools", { defaultValue: "Tools" }), icon: Wrench, count: conn?.tools_count ?? 0 },
+          { id: "logs" as const, label: t("mcp.tab_logs", { defaultValue: "Logs" }), icon: FileText },
+          { id: "config" as const, label: t("mcp.tab_config", { defaultValue: "Config" }), icon: Settings },
+        ]).map((td) => {
+          const active = tab === td.id;
+          const Icon = td.icon;
+          return (
+            <button
+              key={td.id}
+              role="tab"
+              aria-selected={active}
+              onClick={() => setTab(td.id)}
+              className={`inline-flex items-center gap-2 px-3 py-2.5 text-[12.5px] border-b-2 transition-colors ${
+                active
+                  ? "border-brand font-semibold"
+                  : "border-transparent text-text-dim font-medium hover:text-current"
+              }`}
+            >
+              <Icon className="w-3.5 h-3.5" />
+              {td.label}
+              {td.count !== undefined && (
+                <span
+                  className={`font-mono text-[10px] px-1.5 py-px rounded-full ${
+                    active ? "bg-brand/15 text-brand" : "bg-text-dim/10 text-text-dim"
+                  }`}
+                >
+                  {td.count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab body */}
+      <div className="flex-1 overflow-y-auto p-5">
+        {tab === "tools" && (
+          <>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2.5 mb-4">
+              <Mini label="tools_count" value={String(conn?.tools_count ?? 0)} />
+              <Mini label="connected" value={isConnected ? "true" : "false"} tone={isConnected ? "ok" : "bad"} />
+              <Mini label="auth_state" value={authStateStr} />
+              <Mini label="timeout_secs" value={String(server.timeout_secs ?? 30)} />
+            </div>
+
+            {tools.length === 0 ? (
+              <EmptyState
+                icon={<Wrench className="h-7 w-7" />}
+                title={t("mcp.tools_empty", { defaultValue: "No tools advertised" })}
+                description={t("mcp.tools_empty_desc", {
+                  defaultValue: "The server hasn't reported any tools yet — confirm it's connected.",
+                })}
+              />
+            ) : (
+              <Card padding="none" className="overflow-hidden">
+                <div className="hidden sm:grid grid-cols-[1fr_2fr_70px_60px_70px] items-center px-3 py-2 border-b border-border-subtle bg-main/40 text-[10px] font-bold uppercase tracking-wider text-text-dim">
+                  <span>{t("mcp.col_name", { defaultValue: "name" })}</span>
+                  <span>{t("mcp.col_description", { defaultValue: "description" })}</span>
+                  <span className="text-right">{t("mcp.col_calls", { defaultValue: "calls" })}</span>
+                  <span className="text-right">{t("mcp.col_ok", { defaultValue: "ok %" })}</span>
+                  <span className="text-right">{t("mcp.col_last", { defaultValue: "last" })}</span>
+                </div>
+                {tools.map((tool, i) => (
+                  <div
+                    key={tool.name}
+                    className={`grid grid-cols-[1fr_60px] sm:grid-cols-[1fr_2fr_70px_60px_70px] items-center px-3 py-2 text-[12px] ${
+                      i < tools.length - 1 ? "border-b border-border-subtle" : ""
+                    }`}
+                  >
+                    <span className="font-mono font-medium truncate pr-2">{tool.name}</span>
+                    <span className="hidden sm:block text-text-dim text-[11.5px] truncate pr-2">
+                      {tool.description ?? ""}
+                    </span>
+                    {/* TODO: aggregate from /api/sessions to populate calls/ok%/last per tool */}
+                    <span className="font-mono text-text-dim/60 text-right text-[11px]">—</span>
+                    <span className="hidden sm:inline font-mono text-text-dim/60 text-right text-[11px]">—</span>
+                    <span className="font-mono text-text-dim/60 text-right text-[11px]">—</span>
+                  </div>
+                ))}
+              </Card>
+            )}
+          </>
+        )}
+
+        {tab === "logs" && (
+          <EmptyState
+            icon={<FileText className="h-7 w-7" />}
+            title={t("mcp.logs_empty", { defaultValue: "Logs not available" })}
+            description={t("mcp.logs_empty_desc", {
+              defaultValue: "Per-server MCP logs aren't exposed yet — check the daemon's stdout for connection traces.",
+            })}
+          />
+        )}
+
+        {tab === "config" && (
+          <div className="flex flex-col gap-4">
+            {/* OAuth banner if non-ok */}
+            {server.auth_state && server.auth_state.state !== "ok" && server.auth_state.state !== "not_required" && (
+              <div className="rounded-lg border border-warning/30 bg-warning/5 p-3 text-[12px] text-warning">
+                <p className="font-bold mb-1">{server.auth_state.state}</p>
+                {server.auth_state.message && (
+                  <p className="text-text-dim">{server.auth_state.message}</p>
+                )}
+              </div>
+            )}
+
+            {/* Action row */}
+            <div className="flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                leftIcon={<Settings className="w-3.5 h-3.5" />}
+                onClick={() => {
+                  onClose();
+                  onEdit();
+                }}
+              >
+                {t("common.edit")}
+              </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                leftIcon={<ShieldHalf className="w-3.5 h-3.5" />}
+                onClick={() => {
+                  onClose();
+                  onEditTaintPolicy();
+                }}
+              >
+                {t("mcp.taint_policy_short", { defaultValue: "Taint" })}
+              </Button>
+              <Button
+                size="sm"
+                variant="danger"
+                leftIcon={<Trash2 className="w-3.5 h-3.5" />}
+                onClick={() => {
+                  onClose();
+                  onDelete();
+                }}
+              >
+                {t("common.delete")}
+              </Button>
+            </div>
+
+            {/* JSON spec */}
+            <Card padding="none" className="overflow-hidden">
+              <div className="px-3 py-2 border-b border-border-subtle bg-main/40 flex items-center justify-between">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-text-dim">
+                  McpServerConfigured
+                </span>
+                <span className="font-mono text-[10px] text-brand">
+                  PUT /api/mcp/servers/{serverIdOf(server)}
+                </span>
+              </div>
+              <pre className="font-mono text-[11px] leading-relaxed p-3 overflow-x-auto whitespace-pre">
+                {JSON.stringify(server, null, 2)}
+              </pre>
+            </Card>
+
+            <div className="rounded-lg border border-brand/25 bg-brand/5 p-3 text-[11.5px] text-text-dim font-mono leading-relaxed">
+              {t("mcp.config_env_notice", {
+                defaultValue:
+                  "env vars are referenced by name only; secrets resolved from the host environment at connect-time.",
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -687,7 +840,6 @@ export function McpServersPage() {
   const [deletingServer, setDeletingServer] = useState<McpServerConfigured | null>(null);
   const [detailsServer, setDetailsServer] = useState<McpServerConfigured | null>(null);
   const [detailsCatalog, setDetailsCatalog] = useState<McpCatalogEntry | null>(null);
-  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const [form, setForm] = useState<ServerFormState>(defaultForm);
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
@@ -746,16 +898,6 @@ export function McpServersPage() {
     }
     return result;
   }, [configured, searchQuery, statusFilter, connectedMap]);
-
-  const toggleTools = useCallback((server: McpServerConfigured) => {
-    const identity = serverIdentityOf(server);
-    setExpandedTools(prev => {
-      const next = new Set(prev);
-      if (next.has(identity)) next.delete(identity);
-      else next.add(identity);
-      return next;
-    });
-  }, []);
 
   function openAdd() {
     setForm(defaultForm);
@@ -1056,11 +1198,6 @@ export function McpServersPage() {
                     key={id}
                     server={server}
                     conn={connectedMap.get(id)}
-                    isExpanded={expandedTools.has(id)}
-                    onToggleTools={() => toggleTools(server)}
-                    onEdit={() => openEdit(server)}
-                    onEditTaintPolicy={() => setTaintEditingServer(server)}
-                    onDelete={() => deleteServer(server)}
                     onViewDetail={() => setDetailsServer(server)}
                     t={t}
                   />
@@ -1421,159 +1558,23 @@ export function McpServersPage() {
         />
       )}
 
-      {/* Server detail drawer */}
+      {/* Server detail drawer — tabbed Tools / Logs / Config */}
       <DrawerPanel
         isOpen={!!detailsServer}
         onClose={() => setDetailsServer(null)}
         title={detailsServer?.name ?? ""}
         size="lg"
       >
-        {detailsServer && (() => {
-          const conn = connectedMap.get(serverIdentityOf(detailsServer));
-          const isConnected = conn?.connected ?? false;
-          const transportType = getTransportType(detailsServer);
-          const transport = detailsServer.transport;
-          return (
-            <div className="p-5 space-y-5">
-              {/* Hero */}
-              <div className="flex items-start gap-3">
-                <div className={`w-12 h-12 rounded-xl flex items-center justify-center shrink-0 ${
-                  isConnected
-                    ? "bg-success/15 text-success"
-                    : "bg-brand/10 text-brand"
-                }`}>
-                  <Plug className="w-5 h-5" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <h2 className="text-lg font-black tracking-tight truncate">{detailsServer.name}</h2>
-                    <Badge variant={isConnected ? "success" : "error"} dot>
-                      {isConnected ? t("mcp.connected") : t("mcp.disconnected")}
-                    </Badge>
-                    <Badge variant="default">{transportType.toUpperCase()}</Badge>
-                  </div>
-                  {detailsServer.template_id && (
-                    <p className="text-[11px] text-text-dim/70 mt-0.5 font-mono">{detailsServer.template_id}</p>
-                  )}
-                </div>
-              </div>
-
-              {/* OAuth state */}
-              {detailsServer.auth_state && detailsServer.auth_state.state !== "ok" && (
-                <div className="rounded-xl border border-warning/30 bg-warning/5 p-3 text-xs text-warning">
-                  <p className="font-bold mb-1">{detailsServer.auth_state.state}</p>
-                  {detailsServer.auth_state.message && (
-                    <p className="text-text-dim">{detailsServer.auth_state.message}</p>
-                  )}
-                </div>
-              )}
-
-              {/* Transport */}
-              <div>
-                <p className="text-[10px] font-black uppercase tracking-widest text-text-dim/60 mb-2">
-                  {t("mcp.transport", { defaultValue: "Transport" })}
-                </p>
-                {transportType === "stdio" ? (
-                  <div className="space-y-1.5">
-                    <div className="flex items-start gap-2 text-xs">
-                      <Terminal className="w-3.5 h-3.5 text-text-dim/60 shrink-0 mt-0.5" />
-                      <code className="font-mono text-[11px] break-all">{transport?.command ?? "-"}</code>
-                    </div>
-                    {(transport?.args ?? []).length > 0 && (
-                      <div className="ml-5 flex flex-wrap gap-1">
-                        {(transport?.args ?? []).map((a, i) => (
-                          <code key={i} className="font-mono text-[10px] px-1.5 py-0.5 rounded bg-main/60 text-text-dim">{a}</code>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <div className="flex items-center gap-2 text-xs">
-                    <Globe className="w-3.5 h-3.5 text-text-dim/60 shrink-0" />
-                    <code className="font-mono text-[11px] break-all">{transport?.url ?? "-"}</code>
-                  </div>
-                )}
-                <div className="mt-2 flex items-center gap-2 text-[11px] text-text-dim/70">
-                  <Clock className="w-3 h-3" />
-                  {t("mcp.timeout")}: {detailsServer.timeout_secs ?? 30}s
-                </div>
-              </div>
-
-              {/* Env */}
-              {(detailsServer.env ?? []).length > 0 && (
-                <div>
-                  <p className="text-[10px] font-black uppercase tracking-widest text-text-dim/60 mb-2">
-                    {t("mcp.env", { defaultValue: "Environment" })}
-                  </p>
-                  <div className="flex flex-wrap gap-1">
-                    {(detailsServer.env ?? []).map((e, i) => (
-                      <code key={i} className="font-mono text-[10px] px-1.5 py-0.5 rounded bg-main/60 text-text-dim">{e}</code>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Headers */}
-              {(detailsServer.headers ?? []).length > 0 && (
-                <div>
-                  <p className="text-[10px] font-black uppercase tracking-widest text-text-dim/60 mb-2">
-                    {t("mcp.headers", { defaultValue: "Headers" })}
-                  </p>
-                  <div className="space-y-1">
-                    {(detailsServer.headers ?? []).map((h, i) => (
-                      <code key={i} className="block font-mono text-[10px] px-2 py-1 rounded bg-main/60 text-text-dim break-all">{h}</code>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Tools */}
-              {conn?.tools && conn.tools.length > 0 && (
-                <div>
-                  <p className="text-[10px] font-black uppercase tracking-widest text-text-dim/60 mb-2">
-                    {t("mcp.tools")} ({conn.tools.length})
-                  </p>
-                  <div className="space-y-1.5 max-h-80 overflow-y-auto scrollbar-thin">
-                    {conn.tools.map((tool) => (
-                      <div key={tool.name} className="p-2.5 rounded-lg bg-main/40 border border-border-subtle/50">
-                        <span className="text-xs font-mono font-bold text-text-main">{tool.name}</span>
-                        {tool.description && (
-                          <p className="text-[10px] text-text-dim leading-snug mt-0.5">{tool.description}</p>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Actions */}
-              <div className="flex flex-wrap gap-2 pt-3 border-t border-border-subtle/50">
-                <Button
-                  variant="secondary" size="sm"
-                  leftIcon={<Settings className="w-3.5 h-3.5" />}
-                  onClick={() => { const s = detailsServer; setDetailsServer(null); openEdit(s); }}
-                >
-                  {t("common.edit")}
-                </Button>
-                <Button
-                  variant="secondary" size="sm"
-                  leftIcon={<ShieldHalf className="w-3.5 h-3.5" />}
-                  onClick={() => { const s = detailsServer; setDetailsServer(null); setTaintEditingServer(s); }}
-                >
-                  {t("mcp.taint_policy_short", "Taint")}
-                </Button>
-                <Button
-                  variant="secondary" size="sm"
-                  leftIcon={<Trash2 className="w-3.5 h-3.5" />}
-                  className="!text-error hover:!bg-error/10"
-                  onClick={() => { const s = detailsServer; setDetailsServer(null); deleteServer(s); }}
-                >
-                  {t("common.delete")}
-                </Button>
-              </div>
-            </div>
-          );
-        })()}
+        {detailsServer && (
+          <ServerDetailBody
+            server={detailsServer}
+            conn={connectedMap.get(serverIdentityOf(detailsServer))}
+            onClose={() => setDetailsServer(null)}
+            onEdit={() => openEdit(detailsServer)}
+            onEditTaintPolicy={() => setTaintEditingServer(detailsServer)}
+            onDelete={() => deleteServer(detailsServer)}
+          />
+        )}
       </DrawerPanel>
 
       {/* Catalog template detail drawer */}

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -4025,10 +4025,9 @@ pub async fn install_plugin_deps(name: &str) -> Result<Vec<String>, String> {
     // load_plugin_manifest_raw reads plugin.toml synchronously; run on the
     // blocking pool so we don't stall the async runtime.
     let manifest_dir = plugin_dir.clone();
-    let manifest =
-        tokio::task::spawn_blocking(move || load_plugin_manifest_raw(&manifest_dir))
-            .await
-            .map_err(|e| format!("load_plugin_manifest_raw task failed: {e}"))??;
+    let manifest = tokio::task::spawn_blocking(move || load_plugin_manifest_raw(&manifest_dir))
+        .await
+        .map_err(|e| format!("load_plugin_manifest_raw task failed: {e}"))??;
     let runtime = manifest
         .hooks
         .runtime


### PR DESCRIPTION
## Summary

Rebuilds `ApprovalsPage` to match the Approvals + TOTPModal mocks in the
design handoff bundle (`/tmp/design-bundle/dashboard/project/app/workflows.jsx`).

- Top bar with title, pending pill, Refresh / Filter / Auto-rules controls.
  Filter toggles an inline search that matches agent / tool / action text.
  Auto-rules links to `/settings`.
- Underline-style **Pending / History** tabs (renamed from "Audit Log") with
  count chips.
- Pending cards: risk-tinted gradient header, agent mono name + "requested
  Xm ago", risk + TOTP chips, action title + description, single tool chip,
  and **Approve** / **Edit & approve** / **Deny** actions. Batch select is
  removed (not in the design); `Edit & approve` reuses the existing
  `useModifyAndRetryApproval` mutation.
- TOTP enforcement now opens a full-screen modal with six visual digit boxes;
  accepts 6-digit codes and `####-####` recovery codes; closes on Esc /
  backdrop click.
- History tab: card-wrapped grid using the designed columns
  (Decision / Agent / Action / Risk / Resolved by / When), keeps existing
  audit pagination.

i18n: adds `tabHistory`, `pendingCount`, `requestedAgo`, `approveWithTotp`,
`editApprove*`, `deny`, `risk.{high|medium|low}`, `history.*`, `totp.*` keys
to `en.json` and `zh.json`.

The first commit (`chore(fmt)`) is unrelated rustfmt drift on `origin/main`
(introduced by #4251) that was blocking the cargo-fmt-check pre-commit hook.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test --run\` — 346/346 pass
- [x] \`pnpm build\` clean
- [ ] Manual check: Pending cards render risk colors and "requested ago" updates
- [ ] Manual check: TOTP modal flow with TOTP enforced
- [ ] Manual check: History tab table layout on mobile and desktop
- [ ] Manual check: Filter input narrows pending list