### PR TITLE
feat(api,dashboard/agents): unblank Skills/Schedule/Logs tabs

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1143,6 +1143,29 @@ export async function getAgentStats(agentId: string): Promise<AgentStats24h> {
   return get<AgentStats24h>(`/api/agents/${encodeURIComponent(agentId)}/stats`);
 }
 
+/** Per-agent turn-level events row from `usage_events`, surfaced via
+ *  `GET /api/agents/{id}/events`. Powers the agent-detail Logs tab. */
+export interface AgentEventRow {
+  timestamp: string;
+  model: string;
+  provider: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+  tool_calls: number;
+  latency_ms: number;
+}
+
+export async function listAgentEvents(
+  agentId: string,
+  limit = 30,
+): Promise<AgentEventRow[]> {
+  const data = await get<{ events?: AgentEventRow[] }>(
+    `/api/agents/${encodeURIComponent(agentId)}/events?limit=${limit}`,
+  );
+  return data.events ?? [];
+}
+
 export async function patchAgentConfig(
   agentId: string,
   config: {

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -21,6 +21,7 @@ export {
   listAgents,
   getAgentDetail,
   getAgentStats,
+  listAgentEvents,
   listAgentSessions,
   listAgentTemplates,
   listPromptVersions,

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.ts
@@ -3,6 +3,7 @@ import {
   listAgents,
   getAgentDetail,
   getAgentStats,
+  listAgentEvents,
   listAgentSessions,
   listAgentTemplates,
   listPromptVersions,
@@ -44,6 +45,14 @@ export const agentQueries = {
       enabled: !!agentId,
       staleTime: 15_000,
       refetchInterval: 30_000,
+    }),
+  events: (agentId: string, limit = 30) =>
+    queryOptions({
+      queryKey: agentKeys.events(agentId, limit),
+      queryFn: () => listAgentEvents(agentId, limit),
+      enabled: !!agentId,
+      staleTime: 10_000,
+      refetchInterval: 15_000,
     }),
   templates: () =>
     queryOptions({
@@ -87,6 +96,14 @@ export function useAgentSessions(agentId: string, options: QueryOverrides = {}) 
 
 export function useAgentStats(agentId: string, options: QueryOverrides = {}) {
   return useQuery(withOverrides(agentQueries.stats(agentId), options));
+}
+
+export function useAgentEvents(
+  agentId: string,
+  limit = 30,
+  options: QueryOverrides = {},
+) {
+  return useQuery(withOverrides(agentQueries.events(agentId, limit), options));
 }
 
 export function useAgentTemplates(options: QueryOverrides = {}) {

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -26,6 +26,8 @@ export const agentKeys = {
     [...agentKeys.all, "sessions", agentId] as const,
   stats: (agentId: string) =>
     [...agentKeys.all, "stats", agentId] as const,
+  events: (agentId: string, limit: number) =>
+    [...agentKeys.all, "events", agentId, limit] as const,
   promptVersions: (agentId: string) =>
     [...agentKeys.all, "promptVersions", agentId] as const,
   experiments: (agentId: string) =>

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -42,7 +42,7 @@ import { getStatusVariant } from "../lib/status";
 import { useDashboardSnapshot } from "../lib/queries/overview";
 import { useSessions, useSessionDetails } from "../lib/queries/sessions";
 import { useAgentKvMemory } from "../lib/queries/memory";
-import { useAuditRecent, useCronJobs } from "../lib/queries/runtime";
+import { useCronJobs } from "../lib/queries/runtime";
 import { useAgentTriggers } from "../lib/queries/schedules";
 import { useProviders } from "../lib/queries/providers";
 import { useModels } from "../lib/queries/models";
@@ -59,6 +59,7 @@ import {
 import { generateManifestMarkdown } from "../lib/agentManifestMarkdown";
 import {
   agentQueries,
+  useAgentEvents,
   useAgentSessions,
   useAgentStats,
   useAgentTemplates,
@@ -494,7 +495,6 @@ export function AgentsPage() {
   // memory, which is empty unless [proactive_memory] is enabled — so the
   // tab read empty even when the agent had KV pairs.
   const agentKvMemoryQuery = useAgentKvMemory(detailAgent?.id ?? "");
-  const auditRecentQuery = useAuditRecent(120);
   const cronJobsQuery = useCronJobs(detailAgent?.id);
   // Per-agent KPI rollup (#4246) — replaces a global /api/sessions scan
   // that was capped by pagination and missed agents whose sessions
@@ -504,6 +504,12 @@ export function AgentsPage() {
   // tab's event-trigger cards don't depend on agent detail embedding
   // them (which it currently doesn't).
   const agentTriggersQuery = useAgentTriggers(detailAgent?.id ?? "");
+  // Per-agent recent turn events — backs the Logs tab. usage_events is
+  // turn-level (model dispatch, latency, tokens, cost) — exactly what
+  // the design's stderr-style log feed wants. The previous source
+  // (global audit) only had admin lifecycle entries, leaving the tab
+  // blank for almost every agent.
+  const agentEventsQuery = useAgentEvents(detailAgent?.id ?? "", 30);
   // Per-agent session list — Conversation tab uses this directly. The
   // global /api/sessions used previously was paginated to 50, so the
   // agent's latest session was often not in the page.
@@ -1199,11 +1205,21 @@ export function AgentsPage() {
       : Array.isArray(view.capabilities?.skills)
         ? view.capabilities!.skills!
         : [];
+    // skills_mode: "all" means the manifest doesn't enumerate a skill
+    // allowlist — the agent uses every skill in the registry. The
+    // previous "0 installed" empty state was misleading: most agents
+    // ship with no allowlist precisely because they accept everything.
+    const skillsMode = (view as { skills_mode?: string }).skills_mode;
+    const usesAllSkills = skillsMode === "all" && skills.length === 0;
     return (
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <div className="text-[11px] uppercase font-semibold tracking-[0.08em] text-text-dim">
-            {t("agents.detail.installed_skills", { defaultValue: "Installed skills" })} · {skills.length}
+            {t("agents.detail.installed_skills", { defaultValue: "Installed skills" })}
+            {" · "}
+            {usesAllSkills
+              ? t("agents.detail.skills_all", { defaultValue: "all" })
+              : skills.length}
           </div>
           <Button
             variant="ghost"
@@ -1214,7 +1230,24 @@ export function AgentsPage() {
             {t("agents.detail.install_skill", { defaultValue: "Install" })}
           </Button>
         </div>
-        {skills.length === 0 ? (
+        {usesAllSkills ? (
+          <div
+            onClick={() => navigate({ to: "/skills" })}
+            className="rounded-md border border-border-subtle bg-main/40 p-4 flex items-start gap-3 cursor-pointer hover:border-brand/40 transition-colors"
+          >
+            <Sparkles className="w-4 h-4 text-brand/80 shrink-0 mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <div className="font-mono text-[12.5px] font-medium text-text-main">
+                {t("agents.detail.skills_all_title", { defaultValue: "Using all available skills" })}
+              </div>
+              <div className="font-mono text-[10.5px] text-text-dim/80 mt-0.5">
+                {t("agents.detail.skills_all_desc", {
+                  defaultValue: "manifest doesn't pin an allowlist — every skill in the registry is available",
+                })}
+              </div>
+            </div>
+          </div>
+        ) : skills.length === 0 ? (
           <div className="rounded-md border border-border-subtle bg-main/40 p-4 text-[12px] text-text-dim italic">
             {t("agents.detail.no_skills", { defaultValue: "No skills installed for this agent." })}
           </div>
@@ -1332,9 +1365,36 @@ export function AgentsPage() {
             ))}
           </>
         ) : (
-          <div className="rounded-md border border-border-subtle bg-main/40 p-4 text-[12px] text-text-dim italic">
-            {t("agents.detail.no_schedule", { defaultValue: "Manual — no triggers or cron jobs configured." })}
-          </div>
+          // Honest empty state — most agents are reactive (no cron, no
+          // triggers) and the panel was previously rendering "Manual" as
+          // if it were a misconfiguration. Surface the manifest's actual
+          // schedule mode (also returned by GET /api/agents on list, but
+          // we re-derive from the detail response defensively).
+          (() => {
+            const mode = (agent as { schedule?: string }).schedule;
+            const isReactive = !mode || mode === "manual";
+            return (
+              <div className="rounded-md border border-border-subtle bg-main/40 p-4 flex items-start gap-3">
+                <Zap className="w-4 h-4 text-brand/80 shrink-0 mt-0.5" />
+                <div className="min-w-0 flex-1">
+                  <div className="font-mono text-[12.5px] font-medium text-text-main">
+                    {isReactive
+                      ? t("agents.detail.schedule_reactive_title", { defaultValue: "Reactive" })
+                      : mode}
+                  </div>
+                  <div className="font-mono text-[10.5px] text-text-dim/80 mt-0.5">
+                    {isReactive
+                      ? t("agents.detail.schedule_reactive_desc", {
+                          defaultValue: "wakes on incoming messages and events — no cron or trigger pinned",
+                        })
+                      : t("agents.detail.schedule_no_triggers", {
+                          defaultValue: "schedule mode set but no cron jobs or event triggers configured",
+                        })}
+                  </div>
+                </div>
+              </div>
+            );
+          })()
         )}
 
         <div className="text-[11px] uppercase font-semibold tracking-[0.08em] text-text-dim mt-2">
@@ -1361,17 +1421,12 @@ export function AgentsPage() {
     );
   };
 
-  // ---------- Logs tab — terminal-style stderr tail per design canvas
-  const renderLogsTab = (agent: AgentDetail) => {
-    const audit = (auditRecentQuery.data?.entries ?? []) as Array<{
-      timestamp?: string;
-      action?: string;
-      agent_id?: string;
-      detail?: string;
-      target?: string;
-      level?: string;
-    }>;
-    const filtered = audit.filter((row) => !row.agent_id || row.agent_id === agent.id).slice(0, 12);
+  // ---------- Logs tab — terminal-style turn feed per design canvas
+  // Sourced from /api/agents/{id}/events (usage_events) so each row is
+  // a real LLM turn — model / latency / tokens / cost — instead of the
+  // global audit ledger, which is mostly admin lifecycle entries.
+  const renderLogsTab = (_agent: AgentDetail) => {
+    const events = agentEventsQuery.data ?? [];
     const fmtTime = (s?: string): string => {
       if (!s) return "—";
       try {
@@ -1385,31 +1440,24 @@ export function AgentsPage() {
         return s;
       }
     };
-    const levelOf = (row: { level?: string; action?: string }): "INFO" | "WARN" | "DEBUG" | "ERROR" => {
-      const lv = (row.level || "").toUpperCase();
-      if (lv === "WARN" || lv === "ERROR" || lv === "DEBUG" || lv === "INFO") return lv as never;
-      const action = (row.action || "").toLowerCase();
-      if (action.includes("fail") || action.includes("error") || action.includes("denied")) return "ERROR";
-      if (action.includes("warn") || action.includes("budget")) return "WARN";
-      return "INFO";
-    };
-    const levelColor = (lv: string) =>
-      lv === "WARN" ? "text-warning" :
-      lv === "ERROR" ? "text-error" :
-      lv === "DEBUG" ? "text-text-dim/60" : "text-success";
+    // Token shorthand (1.2k tok) — keeps the line fitting the design.
+    const fmtTokens = (n: number): string =>
+      n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+    const formatLine = (e: typeof events[number]): string =>
+      `turn · ${e.model} · in=${fmtTokens(e.input_tokens)} out=${fmtTokens(e.output_tokens)} · ${e.latency_ms}ms · $${e.cost_usd.toFixed(4)}`;
     return (
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <div className="text-[11px] uppercase font-semibold tracking-[0.08em] text-text-dim">
-            {t("agents.detail.stderr_tail", { defaultValue: "stderr · tail" })}
+            {t("agents.detail.events_tail", { defaultValue: "events · tail" })} · {events.length}
           </div>
           <Button
             variant="ghost"
             size="sm"
             leftIcon={<Copy className="h-3.5 w-3.5" />}
             onClick={() => {
-              const text = filtered
-                .map((r) => `${fmtTime(r.timestamp)} ${levelOf(r)} ${r.action ?? ""} ${r.detail ?? ""}`)
+              const text = events
+                .map((e) => `${fmtTime(e.timestamp)} INFO ${e.provider || "—"} ${formatLine(e)}`)
                 .join("\n");
               void navigator.clipboard?.writeText(text);
               addToast(t("common.copied", { defaultValue: "Copied" }), "success");
@@ -1418,28 +1466,27 @@ export function AgentsPage() {
             {t("common.copy", { defaultValue: "Copy" })}
           </Button>
         </div>
-        {auditRecentQuery.isLoading ? (
+        {agentEventsQuery.isLoading ? (
           <div className="text-[12px] text-text-dim italic">{t("common.loading", { defaultValue: "Loading…" })}</div>
-        ) : filtered.length === 0 ? (
+        ) : events.length === 0 ? (
           <div className="rounded-md border border-border-subtle bg-main/40 p-4 text-[12px] text-text-dim italic">
-            {t("agents.detail.no_logs", { defaultValue: "No recent log entries for this agent." })}
+            {t("agents.detail.no_logs", { defaultValue: "No turns recorded yet for this agent." })}
           </div>
         ) : (
           <div
             className="rounded-md border border-border-subtle p-3 font-mono text-[11.5px] leading-[1.6] max-h-60 overflow-auto -mx-3 sm:mx-0"
             style={{ background: "rgba(2,6,23,0.6)" }}
           >
-            {filtered.map((row, i) => {
-              const lv = levelOf(row);
-              return (
-                <div key={i} className="flex gap-2.5 min-w-max sm:min-w-0">
-                  <span className="text-text-dim/60 shrink-0">{fmtTime(row.timestamp)}</span>
-                  <span className={`${levelColor(lv)} w-12 shrink-0`}>{lv}</span>
-                  <span className="text-accent w-24 shrink-0 truncate">{row.action || "—"}</span>
-                  <span className="text-text-dim min-w-0 truncate">{row.detail || row.target || ""}</span>
-                </div>
-              );
-            })}
+            {events.map((e, i) => (
+              <div key={`${e.timestamp}-${i}`} className="flex gap-2.5 min-w-max sm:min-w-0">
+                <span className="text-text-dim/60 shrink-0">{fmtTime(e.timestamp)}</span>
+                <span className="text-success w-12 shrink-0">INFO</span>
+                <span className="text-accent w-24 shrink-0 truncate">{e.provider || "agent"}</span>
+                <span className="text-text-dim min-w-0 truncate" title={formatLine(e)}>
+                  {formatLine(e)}
+                </span>
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -49,6 +49,7 @@ use crate::types;
         // ── Agents ──
         routes::list_agents,
         routes::get_agent_stats,
+        routes::list_agent_events,
         routes::spawn_agent,
         routes::get_agent,
         routes::kill_agent,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -33,6 +33,10 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             axum::routing::get(get_agent_stats),
         )
         .route(
+            "/agents/{id}/events",
+            axum::routing::get(list_agent_events),
+        )
+        .route(
             "/agents/{id}/mode",
             axum::routing::put(set_agent_mode),
         )
@@ -779,17 +783,7 @@ pub(crate) fn enrich_agent_json(
     let ready =
         matches!(e.state, librefang_types::agent::AgentState::Running) && auth_status != "missing";
 
-    use librefang_types::agent::ScheduleMode;
-    let schedule = match &e.manifest.schedule {
-        ScheduleMode::Reactive => "manual".to_string(),
-        ScheduleMode::Periodic { cron } => cron.clone(),
-        ScheduleMode::Proactive { .. } => "proactive".to_string(),
-        ScheduleMode::Continuous {
-            check_interval_secs,
-        } => {
-            format!("continuous · {check_interval_secs}s")
-        }
-    };
+    let schedule = format_schedule_mode(&e.manifest.schedule);
 
     let (sessions_24h, cost_24h) = bulk_stats
         .and_then(|m| m.get(&e.id.to_string()).copied())
@@ -1093,6 +1087,86 @@ pub async fn get_agent_stats(
     let substrate = state.kernel.memory_substrate();
     match substrate.agent_stats_24h(&id) {
         Ok(stats) => Json(AgentStats24hView::from(stats)).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// GET /api/agents/{id}/events — Recent turn-level events for one agent.
+///
+/// Backs the dashboard's agent-detail Logs tab. Returns rows sourced
+/// from `usage_events` (newest first) so the panel shows real
+/// operational data — model dispatch, latency, tokens, cost — instead
+/// of the audit ledger, which is mostly admin lifecycle entries.
+#[utoipa::path(
+    get,
+    path = "/api/agents/{id}/events",
+    tag = "agents",
+    params(
+        ("id" = String, Path, description = "Agent ID"),
+        ("limit" = Option<u32>, Query, description = "Max rows (default 30, max 200)"),
+    ),
+    responses(
+        (status = 200, description = "Recent agent events", body = serde_json::Value),
+        (status = 404, description = "Agent not found")
+    )
+)]
+pub async fn list_agent_events(
+    State(state): State<Arc<AppState>>,
+    api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
+    Path(id): Path<String>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let agent_uuid = match uuid::Uuid::parse_str(&id) {
+        Ok(u) => librefang_types::agent::AgentId(u),
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "invalid agent id" })),
+            )
+                .into_response();
+        }
+    };
+    let entry = match state.kernel.agent_registry().get(agent_uuid) {
+        Some(e) => e,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "agent not found" })),
+            )
+                .into_response();
+        }
+    };
+    // Mirror the owner-scoping on /stats and /sessions — turn-level
+    // event data carries token counts and cost, so it shouldn't leak.
+    if let Some(ref user) = api_user {
+        use librefang_kernel::auth::UserRole;
+        if user.0.role < UserRole::Admin
+            && !entry.manifest.author.eq_ignore_ascii_case(&user.0.name)
+        {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "agent not found" })),
+            )
+                .into_response();
+        }
+    }
+
+    let limit = params
+        .get("limit")
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(30)
+        .min(200);
+
+    let substrate = state.kernel.memory_substrate();
+    match substrate
+        .usage()
+        .list_agent_events_recent(agent_uuid, limit)
+    {
+        Ok(events) => Json(serde_json::json!({ "events": events })).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": e.to_string() })),
@@ -2325,6 +2399,7 @@ pub async fn get_agent(
             },
             "skills": entry.manifest.skills,
             "skills_mode": skill_assignment_mode(&entry.manifest),
+            "schedule": format_schedule_mode(&entry.manifest.schedule),
             "skills_disabled": entry.manifest.skills_disabled,
             "tools_disabled": entry.manifest.tools_disabled,
             "mcp_servers": entry.manifest.mcp_servers,
@@ -4810,6 +4885,22 @@ fn skill_assignment_mode(manifest: &librefang_types::agent::AgentManifest) -> &'
         "all"
     } else {
         "allowlist"
+    }
+}
+
+/// Render a ScheduleMode as the short string the dashboard's Schedule
+/// tab displays (and what `enrich_agent_json` already exposes on the
+/// agent list). Both endpoints go through this helper so they can't
+/// drift apart.
+fn format_schedule_mode(schedule: &librefang_types::agent::ScheduleMode) -> String {
+    use librefang_types::agent::ScheduleMode;
+    match schedule {
+        ScheduleMode::Reactive => "manual".to_string(),
+        ScheduleMode::Periodic { cron } => cron.clone(),
+        ScheduleMode::Proactive { .. } => "proactive".to_string(),
+        ScheduleMode::Continuous {
+            check_interval_secs,
+        } => format!("continuous · {check_interval_secs}s"),
     }
 }
 

--- a/crates/librefang-memory/src/usage.rs
+++ b/crates/librefang-memory/src/usage.rs
@@ -98,6 +98,21 @@ pub struct UsageSummary {
     pub total_tool_calls: u64,
 }
 
+/// One row of a per-agent recent-events feed. Mirrors the columns on
+/// `usage_events` that operators care about when looking at a single
+/// agent's tail (model / latency / tokens / cost).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentEventRow {
+    pub timestamp: String,
+    pub model: String,
+    pub provider: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+    pub tool_calls: u64,
+    pub latency_ms: u64,
+}
+
 /// Usage grouped by model.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelUsage {
@@ -1219,6 +1234,53 @@ impl UsageStore {
             }
         }
         Ok(results)
+    }
+
+    /// Recent usage events for one agent — backs the dashboard's
+    /// agent-detail Logs tab so it shows turn-level operational data
+    /// (model / latency / tokens / cost) instead of the audit ledger,
+    /// which is mostly admin lifecycle entries. Newest first.
+    pub fn list_agent_events_recent(
+        &self,
+        agent_id: AgentId,
+        limit: u32,
+    ) -> LibreFangResult<Vec<AgentEventRow>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| LibreFangError::Internal(e.to_string()))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT timestamp, model, provider, input_tokens, output_tokens,
+                        cost_usd, tool_calls, latency_ms
+                 FROM usage_events
+                 WHERE agent_id = ?1
+                 ORDER BY timestamp DESC
+                 LIMIT ?2",
+            )
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![agent_id.0.to_string(), limit as i64],
+                |row| {
+                    Ok(AgentEventRow {
+                        timestamp: row.get(0)?,
+                        model: row.get(1)?,
+                        provider: row.get(2)?,
+                        input_tokens: row.get::<_, i64>(3)?.max(0) as u64,
+                        output_tokens: row.get::<_, i64>(4)?.max(0) as u64,
+                        cost_usd: row.get(5)?,
+                        tool_calls: row.get::<_, i64>(6)?.max(0) as u64,
+                        latency_ms: row.get::<_, i64>(7)?.max(0) as u64,
+                    })
+                },
+            )
+            .map_err(|e| LibreFangError::Memory(e.to_string()))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| LibreFangError::Memory(e.to_string()))?);
+        }
+        Ok(out)
     }
 
     /// Delete usage events older than the given number of days.

--- a/openapi.json
+++ b/openapi.json
@@ -707,6 +707,51 @@
         }
       }
     },
+    "/api/agents/{id}/events": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "GET /api/agents/{id}/events — Recent turn-level events for one agent.",
+        "description": "Backs the dashboard's agent-detail Logs tab. Returns rows sourced\nfrom `usage_events` (newest first) so the panel shows real\noperational data — model dispatch, latency, tokens, cost — instead\nof the audit ledger, which is mostly admin lifecycle entries.",
+        "operationId": "list_agent_events",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max rows (default 30, max 200)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recent agent events",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Agent not found"
+          }
+        }
+      }
+    },
     "/api/agents/{id}/files": {
       "get": {
         "tags": [

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -318,6 +318,10 @@ func (r *AgentsResource) GetAgentDeliveries(id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/deliveries", id), nil, nil)
 }
 
+func (r *AgentsResource) ListAgentEvents(id string, query map[string]string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/events", id), nil, query)
+}
+
 func (r *AgentsResource) ListAgentFiles(id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/files", id), nil, nil)
 }

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -185,6 +185,10 @@ class AgentsResource {
     return this._c._request("GET", `/api/agents/${id}/deliveries`);
   }
 
+  async listAgentEvents(id, query) {
+    return this._c._request("GET", `/api/agents/${id}/events`, undefined, query);
+  }
+
   async listAgentFiles(id) {
     return this._c._request("GET", `/api/agents/${id}/files`);
   }

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -181,6 +181,9 @@ class _AgentsResource(_Resource):
     def get_agent_deliveries(self, id: str):
         return self._c._request("GET", f"/api/agents/{id}/deliveries")
 
+    def list_agent_events(self, id: str, limit: Any = None):
+        return self._c._request("GET", f"/api/agents/{id}/events", None, query={"limit": limit})
+
     def list_agent_files(self, id: str):
         return self._c._request("GET", f"/api/agents/{id}/files")
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -294,6 +294,10 @@ impl AgentsResource {
         do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/deliveries", id), None, &[]).await
     }
 
+    pub async fn list_agent_events(&self, id: &str, limit: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/events", id), None, &[("limit", limit)]).await
+    }
+
     pub async fn list_agent_files(&self, id: &str) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/files", id), None, &[]).await
     }


### PR DESCRIPTION
## Why

Follow-up to #4272. After fixing the wiring of detail-panel tabs to per-agent endpoints, three tabs still rendered empty for normal agents because the dashboard was reading the wrong shape:

| Tab | Why it was blank | Fix |
| --- | --- | --- |
| **Skills** | \`skills_mode = "all"\` (the default — manifest declares no allowlist) was shown as \`0 installed\`. An empty allowlist means the agent uses every skill in the registry. | Detect \`skills_mode === "all"\` on the detail response and render "Using all available skills" instead of the empty-state. |
| **Schedule** | \`GET /api/agents/{id}\` didn't include \`schedule\` (only \`list_agents\` did). With cron + triggers both empty, the panel showed "Manual — no triggers configured" as if it were a misconfiguration. | \`get_agent\` now ships \`schedule\` via a shared \`format_schedule_mode\` helper. Empty state surfaces "Reactive — wakes on incoming messages and events" for the common reactive case. |
| **Logs** | Wired to the global audit ledger (mostly admin lifecycle entries), so it was blank for almost every agent. | New \`GET /api/agents/{id}/events\` backed by \`usage_events\` — turn-level data (model, latency, tokens, cost) that matches the design's stderr-style feed. Owner-scoped like \`/stats\` and \`/sessions\`. |

## Backend

- \`UsageStore::list_agent_events_recent\` + \`AgentEventRow\` struct.
- \`routes::list_agent_events\` handler — registered in OpenAPI, owner-scoped.
- \`format_schedule_mode\` helper shared between \`get_agent\` and \`enrich_agent_json\` so the two endpoints can't drift on the schedule string.
- \`get_agent\` adds the \`schedule\` field (was previously only on the list endpoint).

## Dashboard

- \`useAgentEvents(agentId, limit)\` hook + \`listAgentEvents\` client.
- Logs tab renders \`{ts} INFO {provider} turn · {model} · in=X out=Y · Nms · \$Z\` per row, copy button preserved.
- Skills tab branches on \`skills_mode === "all"\` to render the descriptive card.
- Schedule tab empty-state branches on \`schedule\` mode and renders the right human-readable description (\`Reactive\` / cron / proactive / continuous).

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`cargo check -p librefang-api --lib\`
- [ ] Open an agent that ran any LLM turn → Logs tab shows turn rows
- [ ] Open a default agent (no skills allowlist) → Skills tab shows "Using all available skills"
- [ ] Open a reactive agent (no cron / triggers) → Schedule tab shows "Reactive" card