### PR TITLE
fix(api,dashboard/agents): typed /events schema + skills_disabled / type tidy

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1109,6 +1109,16 @@ export interface AgentDetail {
   system_prompt?: string;
   capabilities?: { tools?: boolean; network?: boolean };
   skills?: string[];
+  /** Skill assignment mode derived by the backend:
+   *  - 'all' — manifest doesn't pin an allowlist (the default).
+   *  - 'allowlist' — manifest pinned the list in `skills`.
+   *  - 'none' — skills_disabled = true. */
+  skills_mode?: "all" | "allowlist" | "none";
+  /** Human-readable schedule summary derived from manifest.schedule:
+   *  'manual' for reactive, the cron expression, 'proactive', or
+   *  'continuous · Ns'. Matches what `enrich_agent_json` puts on the
+   *  list endpoint. */
+  schedule?: string;
   tags?: string[];
   mode?: string;
   thinking?: { budget_tokens?: number; stream_thinking?: boolean };

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -1205,12 +1205,13 @@ export function AgentsPage() {
       : Array.isArray(view.capabilities?.skills)
         ? view.capabilities!.skills!
         : [];
-    // skills_mode: "all" means the manifest doesn't enumerate a skill
-    // allowlist — the agent uses every skill in the registry. The
-    // previous "0 installed" empty state was misleading: most agents
-    // ship with no allowlist precisely because they accept everything.
-    const skillsMode = (view as { skills_mode?: string }).skills_mode;
+    // skills_mode: 'none' (skills_disabled), 'all' (no allowlist — uses
+    // every skill in the registry, the default), or 'allowlist' (manifest
+    // pinned a list). Each needs a different empty-state copy; the
+    // previous code collapsed them all to "0 installed".
+    const skillsMode = (agent as AgentDetail).skills_mode;
     const usesAllSkills = skillsMode === "all" && skills.length === 0;
+    const skillsDisabled = skillsMode === "none";
     return (
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
@@ -1230,7 +1231,21 @@ export function AgentsPage() {
             {t("agents.detail.install_skill", { defaultValue: "Install" })}
           </Button>
         </div>
-        {usesAllSkills ? (
+        {skillsDisabled ? (
+          <div className="rounded-md border border-border-subtle bg-main/40 p-4 flex items-start gap-3">
+            <X className="w-4 h-4 text-text-dim shrink-0 mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <div className="font-mono text-[12.5px] font-medium text-text-main">
+                {t("agents.detail.skills_disabled_title", { defaultValue: "Skills disabled" })}
+              </div>
+              <div className="font-mono text-[10.5px] text-text-dim/80 mt-0.5">
+                {t("agents.detail.skills_disabled_desc", {
+                  defaultValue: "manifest pinned skills_disabled = true — the agent runs without skill dispatch",
+                })}
+              </div>
+            </div>
+          </div>
+        ) : usesAllSkills ? (
           <div
             onClick={() => navigate({ to: "/skills" })}
             className="rounded-md border border-border-subtle bg-main/40 p-4 flex items-start gap-3 cursor-pointer hover:border-brand/40 transition-colors"
@@ -1371,7 +1386,7 @@ export function AgentsPage() {
           // schedule mode (also returned by GET /api/agents on list, but
           // we re-derive from the detail response defensively).
           (() => {
-            const mode = (agent as { schedule?: string }).schedule;
+            const mode = (agent as AgentDetail).schedule;
             const isReactive = !mode || mode === "manual";
             return (
               <div className="rounded-md border border-border-subtle bg-main/40 p-4 flex items-start gap-3">

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -368,6 +368,8 @@ use crate::types;
         routes::auto_dream::SetEnabledRequest,
         routes::agents::AgentStats24hView,
         routes::agents::AgentStatsPrevView,
+        routes::agents::AgentEventRowView,
+        routes::agents::AgentEventsResponse,
         routes::users::UserView,
         routes::users::UserUpsert,
         routes::users::BulkImportRequest,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1095,6 +1095,42 @@ pub async fn get_agent_stats(
     }
 }
 
+/// Wire-shape for one row in [`list_agent_events`]. Mirrors
+/// [`librefang_memory::usage::AgentEventRow`] but defined here as a
+/// utoipa::ToSchema view so we can register it with the OpenAPI doc
+/// without forcing utoipa into the memory crate.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct AgentEventRowView {
+    pub timestamp: String,
+    pub model: String,
+    pub provider: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+    pub tool_calls: u64,
+    pub latency_ms: u64,
+}
+
+impl From<librefang_memory::usage::AgentEventRow> for AgentEventRowView {
+    fn from(r: librefang_memory::usage::AgentEventRow) -> Self {
+        Self {
+            timestamp: r.timestamp,
+            model: r.model,
+            provider: r.provider,
+            input_tokens: r.input_tokens,
+            output_tokens: r.output_tokens,
+            cost_usd: r.cost_usd,
+            tool_calls: r.tool_calls,
+            latency_ms: r.latency_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct AgentEventsResponse {
+    pub events: Vec<AgentEventRowView>,
+}
+
 /// GET /api/agents/{id}/events — Recent turn-level events for one agent.
 ///
 /// Backs the dashboard's agent-detail Logs tab. Returns rows sourced
@@ -1110,7 +1146,7 @@ pub async fn get_agent_stats(
         ("limit" = Option<u32>, Query, description = "Max rows (default 30, max 200)"),
     ),
     responses(
-        (status = 200, description = "Recent agent events", body = serde_json::Value),
+        (status = 200, description = "Recent agent events", body = AgentEventsResponse),
         (status = 404, description = "Agent not found")
     )
 )]
@@ -1166,7 +1202,12 @@ pub async fn list_agent_events(
         .usage()
         .list_agent_events_recent(agent_uuid, limit)
     {
-        Ok(events) => Json(serde_json::json!({ "events": events })).into_response(),
+        Ok(events) => {
+            let view = AgentEventsResponse {
+                events: events.into_iter().map(AgentEventRowView::from).collect(),
+            };
+            Json(view).into_response()
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": e.to_string() })),

--- a/openapi.json
+++ b/openapi.json
@@ -742,7 +742,9 @@
             "description": "Recent agent events",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/AgentEventsResponse"
+                }
               }
             }
           },
@@ -8225,6 +8227,69 @@
   },
   "components": {
     "schemas": {
+      "AgentEventRowView": {
+        "type": "object",
+        "description": "Wire-shape for one row in [`list_agent_events`]. Mirrors\n[`librefang_memory::usage::AgentEventRow`] but defined here as a\nutoipa::ToSchema view so we can register it with the OpenAPI doc\nwithout forcing utoipa into the memory crate.",
+        "required": [
+          "timestamp",
+          "model",
+          "provider",
+          "input_tokens",
+          "output_tokens",
+          "cost_usd",
+          "tool_calls",
+          "latency_ms"
+        ],
+        "properties": {
+          "cost_usd": {
+            "type": "number",
+            "format": "double"
+          },
+          "input_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "latency_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "provider": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "tool_calls": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
+      "AgentEventsResponse": {
+        "type": "object",
+        "required": [
+          "events"
+        ],
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentEventRowView"
+            }
+          }
+        }
+      },
       "AgentStats24hView": {
         "type": "object",
         "description": "24-hour KPI rollup view returned by `GET /api/agents/{id}/stats`.\nMirrors [`librefang_memory::session::AgentStats24h`] — defined here as a\nview so we can derive `utoipa::ToSchema` without forcing utoipa into the\nmemory crate. Generated SDKs and the OpenAPI spec pick up this shape.",


### PR DESCRIPTION
## Why

Self-review follow-up to #4275. Three real gaps surfaced on a critical re-read:

## Fixes

**1. Typed OpenAPI schema for `/events`**
The new \`GET /api/agents/{id}/events\` handler from #4275 declared \`body = serde_json::Value\` so generated SDKs and \`openapi.json\` consumers saw an empty object. Added \`AgentEventRowView\` / \`AgentEventsResponse\` view types with \`utoipa::ToSchema\`, registered them in the ApiDoc components, and switched the response. Wire payload unchanged — same as the \`/stats\` typing pass earlier in this branch line.

**2. Skills tab — distinguish \`skills_disabled\` from "no skills"**
The previous code collapsed \`skills_mode = "none"\` (manifest pinned \`skills_disabled = true\`) and \`skills_mode = "allowlist"\` with empty list into the same "No skills installed" empty-state. Now branches three ways:
- \`none\` → "Skills disabled — the agent runs without skill dispatch"
- \`all\` → "Using all available skills" (the default for most agents)
- \`allowlist\` with 0 items → existing "No skills installed"

**3. TS type tidy**
\`agent.skills_mode\` and \`agent.schedule\` were being read via \`(agent as { … })\` casts inline. Backend has been shipping both fields since the parent commits in this branch line; just declare them properly on \`AgentDetail\`.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`cargo check -p librefang-api --lib\`
- [ ] \`openapi.json\` regen surfaces \`AgentEventRowView\` + \`AgentEventsResponse\` schemas
- [ ] Hand agent (often \`skills_disabled = true\`) shows the "Skills disabled" card