### PR TITLE
fix(dashboard): PageHeader CJK wrap + strip MCP tool prefix

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/PageHeader.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/PageHeader.tsx
@@ -118,18 +118,22 @@ export function PageHeader({ icon, title, subtitle, badge, actions, isFetching, 
   return (
     <>
       <header className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
           <div className="p-1.5 rounded-lg bg-brand/10 text-brand shrink-0">{icon}</div>
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <h1 className="text-base font-extrabold tracking-tight">{title}</h1>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 min-w-0">
+              {/* truncate + min-w-0 prevents per-character CJK wrap when a
+                  push-drawer squeezes the main column (#mcp drawer). */}
+              <h1 className="text-base font-extrabold tracking-tight truncate min-w-0">
+                {title}
+              </h1>
               {badge && (
-                <span className="inline-flex items-center rounded-md border border-border-subtle bg-main/40 px-1.5 py-0.5 text-[10px] font-semibold text-text-dim">
+                <span className="inline-flex items-center rounded-md border border-border-subtle bg-main/40 px-1.5 py-0.5 text-[10px] font-semibold text-text-dim shrink-0">
                   {badge}
                 </span>
               )}
             </div>
-            {subtitle && <p className="text-[11px] text-text-dim hidden sm:block">{subtitle}</p>}
+            {subtitle && <p className="text-[11px] text-text-dim hidden sm:block truncate">{subtitle}</p>}
           </div>
         </div>
         <div className="flex items-center gap-2 shrink-0 flex-wrap justify-end">

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -201,6 +201,21 @@ function getTransportDetail(server: McpServerConfigured): string {
   return server.transport.url ?? "\u2014";
 }
 
+// Kernel-side names tools as `mcp_<server>_<tool>` and prepends
+// `[MCP:<server>] ` to descriptions so the LLM can disambiguate
+// across servers. Both prefixes are noise once we already show the
+// server's name as the page header \u2014 strip them for display, keep
+// the full names in `title=` for copy/inspect.
+function stripMcpToolPrefix(toolName: string, serverName: string): string {
+  const prefix = `mcp_${serverName}_`;
+  return toolName.startsWith(prefix) ? toolName.slice(prefix.length) : toolName;
+}
+
+function stripMcpDescPrefix(description: string, serverName: string): string {
+  const prefix = `[MCP:${serverName}] `;
+  return description.startsWith(prefix) ? description.slice(prefix.length) : description;
+}
+
 // ── ArgsEditor ──────────────────────────────────────────────────────
 
 function ArgsEditor({ items, onChange }: { items: LabeledItem[]; onChange: (items: LabeledItem[]) => void }) {
@@ -711,30 +726,42 @@ function ServerDetailBody({
               />
             ) : (
               <Card padding="none" className="overflow-hidden">
-                <div className="hidden sm:grid grid-cols-[1fr_2fr_70px_60px_70px] items-center px-3 py-2 border-b border-border-subtle bg-main/40 text-[10px] font-bold uppercase tracking-wider text-text-dim">
+                <div className="hidden sm:grid grid-cols-[minmax(160px,1.4fr)_2fr_60px_50px_60px] items-center gap-2 px-3 py-2 border-b border-border-subtle bg-main/40 text-[10px] font-bold uppercase tracking-wider text-text-dim">
                   <span>{t("mcp.col_name", { defaultValue: "name" })}</span>
                   <span>{t("mcp.col_description", { defaultValue: "description" })}</span>
                   <span className="text-right">{t("mcp.col_calls", { defaultValue: "calls" })}</span>
                   <span className="text-right">{t("mcp.col_ok", { defaultValue: "ok %" })}</span>
                   <span className="text-right">{t("mcp.col_last", { defaultValue: "last" })}</span>
                 </div>
-                {tools.map((tool, i) => (
-                  <div
-                    key={tool.name}
-                    className={`grid grid-cols-[1fr_60px] sm:grid-cols-[1fr_2fr_70px_60px_70px] items-center px-3 py-2 text-[12px] ${
-                      i < tools.length - 1 ? "border-b border-border-subtle" : ""
-                    }`}
-                  >
-                    <span className="font-mono font-medium truncate pr-2">{tool.name}</span>
-                    <span className="hidden sm:block text-text-dim text-[11.5px] truncate pr-2">
-                      {tool.description ?? ""}
-                    </span>
-                    {/* TODO: aggregate from /api/sessions to populate calls/ok%/last per tool */}
-                    <span className="font-mono text-text-dim/60 text-right text-[11px]">—</span>
-                    <span className="hidden sm:inline font-mono text-text-dim/60 text-right text-[11px]">—</span>
-                    <span className="font-mono text-text-dim/60 text-right text-[11px]">—</span>
-                  </div>
-                ))}
+                {tools.map((tool, i) => {
+                  const displayName = stripMcpToolPrefix(tool.name, server.name);
+                  const displayDesc = stripMcpDescPrefix(tool.description ?? "", server.name);
+                  return (
+                    <div
+                      key={tool.name}
+                      className={`grid grid-cols-[1fr_60px] sm:grid-cols-[minmax(160px,1.4fr)_2fr_60px_50px_60px] items-center gap-2 px-3 py-2 text-[12px] ${
+                        i < tools.length - 1 ? "border-b border-border-subtle" : ""
+                      }`}
+                    >
+                      <span
+                        className="font-mono font-medium truncate min-w-0"
+                        title={tool.name}
+                      >
+                        {displayName}
+                      </span>
+                      <span
+                        className="hidden sm:block text-text-dim text-[11.5px] truncate min-w-0"
+                        title={tool.description ?? ""}
+                      >
+                        {displayDesc}
+                      </span>
+                      {/* TODO: aggregate from /api/sessions to populate calls/ok%/last per tool */}
+                      <span className="font-mono text-text-dim/60 text-right text-[11px]">—</span>
+                      <span className="hidden sm:inline font-mono text-text-dim/60 text-right text-[11px]">—</span>
+                      <span className="font-mono text-text-dim/60 text-right text-[11px]">—</span>
+                    </div>
+                  );
+                })}
               </Card>
             )}
           </>


### PR DESCRIPTION
Two issues spotted in live testing on the MCP detail drawer:

## 1. PageHeader title wraps per-character when squeezed

The \`<h1>\` had no \`truncate\` / \`min-w-0\`, so when the push-drawer (e.g.
the MCP detail drawer at \`size=lg\`) shrank the main column, CJK titles
like \"MCP 服务器\" broke at every character — one Chinese glyph per line —
turning the header into vertical noise. Adding \`truncate\` + \`min-w-0\`
(and \`shrink-0\` on the badge so it doesn't get pushed below the title)
clips the title with an ellipsis instead.

**Affects every page that uses PageHeader, not just MCP.**

## 2. MCP tool table shows kernel-side disambiguation prefixes

The kernel registers MCP tools as \`mcp_<server>_<tool>\` and prepends
\`[MCP:<server>] \` to descriptions so the LLM can route across multiple
servers. In the dashboard's per-server detail table both prefixes are
pure noise — the server name is already the page title — and they steal
column width that the actual tool name needs (\`mcp_test_filesystem_read_file\`
truncated to \`mcp_test_filesy...\`).

Strip both at the display layer (full names kept in \`title=\` for hover /
copy) and widen the name column to \`minmax(160px, 1.4fr)\` with explicit
gap so the table reads cleanly inside the squeezed drawer.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test --run\` — 357/357 pass
- [x] \`pnpm build\` clean
- [ ] Manual: open MCP detail drawer, verify the page header shows \"MCP 服务器…\" with ellipsis instead of vertical glyphs
- [ ] Manual: tool names in the Tools tab show the suffix only, hover shows the full kernel name