### PR TITLE
fix(dashboard): normalize MCP server name when stripping tool prefix

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -201,17 +201,28 @@ function getTransportDetail(server: McpServerConfigured): string {
   return server.transport.url ?? "\u2014";
 }
 
-// Kernel-side names tools as `mcp_<server>_<tool>` and prepends
-// `[MCP:<server>] ` to descriptions so the LLM can disambiguate
+// Kernel-side names tools as `mcp_<normalized-server>_<normalized-tool>` and
+// prepends `[MCP:<server>] ` to descriptions so the LLM can disambiguate
 // across servers. Both prefixes are noise once we already show the
 // server's name as the page header \u2014 strip them for display, keep
 // the full names in `title=` for copy/inspect.
+//
+// `normalize_name` in crates/librefang-runtime-mcp/src/lib.rs does
+// `to_lowercase().replace('-', "_")`, so a server named `test-filesystem`
+// gets tool prefix `mcp_test_filesystem_`. Mirror that here or strip
+// silently fails for hyphenated names.
+function normalizeMcpName(name: string): string {
+  return name.toLowerCase().replace(/-/g, "_");
+}
+
 function stripMcpToolPrefix(toolName: string, serverName: string): string {
-  const prefix = `mcp_${serverName}_`;
+  const prefix = `mcp_${normalizeMcpName(serverName)}_`;
   return toolName.startsWith(prefix) ? toolName.slice(prefix.length) : toolName;
 }
 
 function stripMcpDescPrefix(description: string, serverName: string): string {
+  // The description prefix uses the raw server name, not the normalized one
+  // (kernel writes it as `[MCP:{server.name}]`). Match that exactly.
   const prefix = `[MCP:${serverName}] `;
   return description.startsWith(prefix) ? description.slice(prefix.length) : description;
 }


### PR DESCRIPTION
Follow-up to #4281. Live verification on a server named \`test-filesystem\`
showed tool names still rendered as \`mcp_test_filesystem_r…\` despite the
new strip — the description strip worked but the tool-name strip didn't.

Root cause: \`stripMcpToolPrefix\` built the prefix from the raw
\`server.name\`, but the kernel runs every server name through
\`normalize_name\` (\`to_lowercase().replace('-', \"_\")\`, in
\`crates/librefang-runtime-mcp/src/lib.rs::normalize_name\`) before
composing the tool name. So the dashboard was looking for
\`mcp_test-filesystem_\` while the actual prefix on the wire is
\`mcp_test_filesystem_\` — never matched, silent no-op.

Mirror the same normalization in JS. The description prefix stays
matched against the raw name, since the kernel writes that one as
\`[MCP:{server.name}]\`.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test --run\` — 357/357 pass
- [ ] Manual: open the test-filesystem MCP detail drawer, verify the Tools tab shows \`read_text_file\` etc. instead of \`mcp_test_filesystem_read_t…\`