### PR TITLE
i18n(dashboard/channels): add zh + en entries for #4279 strings

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -100,6 +100,8 @@
     "resume": "Resume",
     "close": "Close",
     "clear_search": "Clear search",
+    "select": "Select",
+    "deselect": "Deselect",
     "yes": "Yes",
     "no": "No",
     "details": "Details",
@@ -775,7 +777,14 @@
     "qr_failed": "Failed to get QR code",
     "login_success": "Login successful! Saving configuration...",
     "config_failed": "Configuration failed",
-    "config_success": "Configuration saved"
+    "config_success": "Configuration saved",
+    "add": "Add",
+    "all_configured": "All channels configured",
+    "msgs_24h": "msgs/24h",
+    "empty_title": "No channels yet",
+    "empty_body": "Connect Slack, Discord, email, SMS, or any of the bundled bridges so agents can post and receive messages.",
+    "connect_first": "Connect a channel",
+    "picker_title": "Add channel"
   },
   "skills": {
     "title": "Skills",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -100,6 +100,8 @@
     "resume": "恢复",
     "close": "关闭",
     "clear_search": "清除搜索",
+    "select": "选择",
+    "deselect": "取消选择",
     "yes": "是",
     "no": "否",
     "details": "详情",
@@ -774,7 +776,14 @@
     "qr_failed": "获取二维码失败",
     "login_success": "登录成功！正在保存配置...",
     "config_failed": "配置失败",
-    "config_success": "配置已保存"
+    "config_success": "配置已保存",
+    "add": "添加",
+    "all_configured": "已配置全部 channel",
+    "msgs_24h": "条/24h",
+    "empty_title": "尚未配置 channel",
+    "empty_body": "接入 Slack、Discord、邮件、短信或其他自带桥接，让 agent 可以收发消息。",
+    "connect_first": "添加一个 channel",
+    "picker_title": "添加 channel"
   },
   "skills": {
     "title": "技能",


### PR DESCRIPTION
## Why

#4279 introduced new strings with \`defaultValue\` fallbacks but never added them to \`en.json\` / \`zh.json\`, so Chinese sessions rendered the English literals (Add / No channels yet / Connect a channel / …).

## Keys added

Under \`channels\`:
- \`add\`
- \`all_configured\`
- \`msgs_24h\`
- \`empty_title\`
- \`empty_body\`
- \`connect_first\`
- \`picker_title\`

Under \`common\`:
- \`select\`
- \`deselect\`

English values match the defaults already in \`ChannelsPage.tsx\`; zh translations land in the same idiom as the rest of \`zh.json\` (\`添加\`, \`尚未配置 channel\`, …).

## Test plan
- [x] \`pnpm typecheck\`
- [x] JSON validates
- [ ] Switch UI to zh → empty-state CTA, Add button, picker drawer all in Chinese