### PR TITLE
fix(extensions/vault,testing): pin test vault key + align resolve precedence

### DIFF
--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -436,14 +436,20 @@ impl CredentialVault {
             return Ok(cached.clone());
         }
 
-        // Try OS keyring first
-        if let Ok(key_b64) = load_keyring_key() {
+        // Env var wins over the keyring — matches `init()`'s precedence
+        // (line ~279) so an explicit `LIBREFANG_VAULT_KEY` survives across
+        // re-opens of the same vault. Without this, `init()` would honor
+        // the env key but a subsequent `unlock()` on a fresh instance
+        // would silently switch to whatever the (process-shared) keyring
+        // file currently holds — which races between parallel tests
+        // (#TOTP flake) and surprises CI/headless deployments that set
+        // the env var as the source of truth.
+        if let Ok(key_b64) = std::env::var(VAULT_KEY_ENV) {
+            let key_b64 = Zeroizing::new(key_b64);
             return decode_master_key(&key_b64);
         }
 
-        // Fallback to env var
-        if let Ok(key_b64) = std::env::var(VAULT_KEY_ENV) {
-            let key_b64 = Zeroizing::new(key_b64);
+        if let Ok(key_b64) = load_keyring_key() {
             return decode_master_key(&key_b64);
         }
 

--- a/crates/librefang-testing/src/mock_kernel.rs
+++ b/crates/librefang-testing/src/mock_kernel.rs
@@ -6,7 +6,33 @@
 
 use librefang_kernel::LibreFangKernel;
 use librefang_types::config::KernelConfig;
+use std::sync::Once;
 use tempfile::TempDir;
+
+/// Pin a deterministic vault master key for the test process the first
+/// time a mock kernel is built. Without this, parallel integration tests
+/// race on the process-shared `<data_local_dir>/librefang/.keyring` file
+/// (or OS keyring entry): one test's `init()` overwrites another's master
+/// key, and the loser's later `vault_get`/`vault_set` calls open a fresh
+/// `CredentialVault` whose `resolve_master_key` then loads the wrong key
+/// and fails to decrypt its own vault file (TOTP test flake on CI).
+///
+/// 32 zero bytes, base64-encoded — value is irrelevant, only stability is.
+static VAULT_KEY_INIT: Once = Once::new();
+const TEST_VAULT_KEY_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+fn ensure_test_vault_key() {
+    VAULT_KEY_INIT.call_once(|| {
+        if std::env::var_os("LIBREFANG_VAULT_KEY").is_none() {
+            // SAFETY: only runs once, before any kernel is booted in this
+            // process — no other thread can be reading the env at this point
+            // because all paths into the vault go through MockKernelBuilder
+            // (or `LibreFangKernel::boot_with_config`, which the builder
+            // owns the entry to).
+            std::env::set_var("LIBREFANG_VAULT_KEY", TEST_VAULT_KEY_B64);
+        }
+    });
+}
 
 /// Test kernel builder.
 ///
@@ -61,6 +87,7 @@ impl MockKernelBuilder {
     /// Returns `(LibreFangKernel, TempDir)` — the caller must hold onto `TempDir`,
     /// otherwise the temp directory will be deleted on drop, invalidating kernel file paths.
     pub fn build(mut self) -> (LibreFangKernel, TempDir) {
+        ensure_test_vault_key();
         let tmp = tempfile::tempdir().expect("failed to create temp directory");
         let home_dir = tmp.path().to_path_buf();
         let data_dir = home_dir.join("data");


### PR DESCRIPTION
## Summary
- Reorder `CredentialVault::resolve_master_key` to check `LIBREFANG_VAULT_KEY` **before** the keyring, matching `init()`'s existing precedence.
- `MockKernelBuilder::build` now pins `LIBREFANG_VAULT_KEY` to a deterministic value once per process so parallel mock kernels share one master key while keeping isolated per-tempdir vault files.

## Why
Several recent CI runs on `main` failed on Ubuntu/macOS with intermittent panics in `crates/librefang-api/tests/totp_flow_test.rs:111` (`expect(\"totp_secret in vault\")`). Windows always passed. Root cause: the kernel's `vault_get` / `vault_set` open a fresh `CredentialVault` on each call. `init()` honored the env key, but `resolve_master_key()` checked the keyring first — and the file-based keyring at `<data_local_dir>/librefang/.keyring` is process-global. Under nextest's parallel runs, sibling tests' `init()` calls overwrote it, so a later `unlock()` in test A loaded the wrong key and silently failed to decrypt its own vault file.

## Test plan
- [x] `cargo test -p librefang-api --test totp_flow_test` (10/10 pass locally)
- [x] `cargo test -p librefang-extensions vault` (26/26 pass)
- [x] `cargo check -p librefang-extensions -p librefang-testing --tests`
- [ ] CI green on Ubuntu/macOS/Windows