### PR TITLE
fix(api/workflows): drop needless ref binding in restrict_to match

### DIFF
--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1124,7 +1124,7 @@ pub async fn list_triggers(
         Some(u) if u.0.role < librefang_kernel::auth::UserRole::Admin => Some(u.0.name.clone()),
         _ => None,
     };
-    if let (Some(ref user_name), Some(aid)) = (restrict_to.as_ref(), agent_filter) {
+    if let (Some(user_name), Some(aid)) = (restrict_to.as_ref(), agent_filter) {
         let owns = state
             .kernel
             .agent_registry()


### PR DESCRIPTION
## Summary
- Rust 1.95 clippy promoted `needless_borrow` and flagged `Some(ref user_name)` in `workflows.rs:1127`, breaking the `Quality / Build + clippy` job on main.
- Replace with plain `Some(user_name)` since `restrict_to.as_ref()` already yields `Option<&String>`.

## Test plan
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings`