### PR TITLE
fix(dashboard): route ChatPage and ProvidersPage through queries/mutations layer

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -91,6 +91,7 @@ export {
   // sessions
   listSessions,
   getSessionDetails,
+  loadAgentSession,
   // skills (local + hubs)
   listSkills,
   getSkillDetail,
@@ -189,6 +190,10 @@ export {
   postCommsTask,
   // attachments
   uploadAgentFile,
+  // chat — imperative (HTTP) send, fallback when WS unavailable
+  sendAgentMessage,
+  // registry — generic content creation (provider, hand, etc.)
+  createRegistryContent,
   // media
   generateImage,
   synthesizeSpeech,

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
@@ -22,7 +22,9 @@ import {
   completeExperiment,
   resolveApproval,
   uploadAgentFile,
+  sendAgentMessage,
 } from "../http/client";
+import type { SendAgentMessageOptions } from "../../api";
 import { agentKeys, approvalKeys, handKeys, overviewKeys, sessionKeys } from "../queries/keys";
 
 /**
@@ -392,6 +394,43 @@ export function useUploadAgentFile() {
   return useMutation({
     mutationFn: ({ agentId, file }: { agentId: string; file: File }) =>
       uploadAgentFile(agentId, file),
+  });
+}
+
+/**
+ * POST /agents/{id}/message — imperative HTTP send used by ChatPage as the
+ * fallback when WebSocket streaming is unavailable. Invalidates the cached
+ * session snapshot so a re-mount/re-load reads the persisted history that
+ * now includes the just-completed turn; also invalidates per-agent stats
+ * (token counts / costs are surfaced there) and the global usage budget so
+ * the topbar reflects spend without waiting for the next poll.
+ *
+ * The agent list itself is intentionally NOT invalidated — sending a chat
+ * message doesn't change list-row projections, and refetching the list on
+ * every send would be noisy.
+ */
+export function useSendAgentMessage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      agentId,
+      message,
+      options,
+    }: {
+      agentId: string;
+      message: string;
+      options?: SendAgentMessageOptions;
+    }) => sendAgentMessage(agentId, message, options),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({
+        queryKey: agentKeys.session(
+          variables.agentId,
+          variables.options?.session_id ?? null,
+        ),
+      });
+      qc.invalidateQueries({ queryKey: agentKeys.sessions(variables.agentId) });
+      qc.invalidateQueries({ queryKey: agentKeys.stats(variables.agentId) });
+    },
   });
 }
 

--- a/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
@@ -5,6 +5,7 @@ import {
   deleteProviderKey,
   setProviderUrl,
   setDefaultProvider,
+  createRegistryContent,
 } from "../http/client";
 import { modelKeys, providerKeys, runtimeKeys } from "../queries/keys";
 
@@ -61,6 +62,35 @@ export function useSetProviderUrl() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: providerKeys.all });
       qc.invalidateQueries({ queryKey: modelKeys.lists() });
+    },
+  });
+}
+
+/**
+ * POST /registry/content/{contentType} — generic registry content creation.
+ *
+ * Today the only call site is the "Add provider" wizard on ProvidersPage,
+ * which writes a `provider` content entry. We invalidate `providerKeys.all`
+ * (list refresh) and `modelKeys.lists()` (a new provider may surface new
+ * models on the next list fetch) for that case. Other content types are
+ * accepted but currently invalidate the same scoped slices because no other
+ * caller exists yet — extend here when a non-provider call site lands.
+ */
+export function useCreateRegistryContent() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      contentType,
+      values,
+    }: {
+      contentType: string;
+      values: Record<string, unknown>;
+    }) => createRegistryContent(contentType, values),
+    onSuccess: (_data, variables) => {
+      if (variables.contentType === "provider") {
+        qc.invalidateQueries({ queryKey: providerKeys.all });
+        qc.invalidateQueries({ queryKey: modelKeys.lists() });
+      }
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.ts
@@ -9,6 +9,7 @@ import {
   listPromptVersions,
   listExperiments,
   getExperimentMetrics,
+  loadAgentSession,
 } from "../http/client";
 import { agentKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
@@ -76,6 +77,19 @@ export const agentQueries = {
       queryKey: agentKeys.experimentMetrics(experimentId),
       queryFn: () => getExperimentMetrics(experimentId),
       enabled: !!experimentId,
+    }),
+  // Snapshot of the (agent, session) chat history. ChatPage hydrates from
+  // this on first navigation and on session switch; subsequent turns are
+  // applied locally rather than refetched. Cache survives back/forward
+  // navigation so returning to a previously viewed agent is instant — the
+  // long staleTime keeps that cached payload from being refetched on focus.
+  session: (agentId: string, sessionId?: string | null) =>
+    queryOptions({
+      queryKey: agentKeys.session(agentId, sessionId ?? null),
+      queryFn: () => loadAgentSession(agentId, sessionId ?? null),
+      enabled: !!agentId,
+      staleTime: 5 * 60_000,
+      refetchOnWindowFocus: false,
     }),
 };
 

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
@@ -58,6 +58,18 @@ describe("query key factories", () => {
         "sessions",
         "abc",
       ]);
+      expect(agentKeys.session("abc")).toEqual([
+        "agents",
+        "session",
+        "abc",
+        null,
+      ]);
+      expect(agentKeys.session("abc", "sess-1")).toEqual([
+        "agents",
+        "session",
+        "abc",
+        "sess-1",
+      ]);
     });
 
     it("detail is nested under details", () => {
@@ -237,6 +249,10 @@ describe("query key factories", () => {
       expect(agentKeys.details().slice(0, prefix.length)).toEqual(prefix);
       expect(agentKeys.templates().slice(0, prefix.length)).toEqual(prefix);
       expect(agentKeys.sessions("x").slice(0, prefix.length)).toEqual(
+        prefix,
+      );
+      expect(agentKeys.session("x").slice(0, prefix.length)).toEqual(prefix);
+      expect(agentKeys.session("x", "s1").slice(0, prefix.length)).toEqual(
         prefix,
       );
     });

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -24,6 +24,11 @@ export const agentKeys = {
   templates: () => [...agentKeys.all, "templates"] as const,
   sessions: (agentId: string) =>
     [...agentKeys.all, "sessions", agentId] as const,
+  // History snapshot for a single (agent, session) pair — hydrates ChatPage
+  // when the user navigates to an agent or switches sessions. `sessionId`
+  // omitted/null means "the agent's current active session".
+  session: (agentId: string, sessionId?: string | null) =>
+    [...agentKeys.all, "session", agentId, sessionId ?? null] as const,
   stats: (agentId: string) =>
     [...agentKeys.all, "stats", agentId] as const,
   events: (agentId: string, limit: number) =>

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { motion } from "motion/react";
 import { messageIn, fadeInUp } from "../lib/motion";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { buildAuthenticatedWebSocket, sendAgentMessage, loadAgentSession } from "../api";
+import { buildAuthenticatedWebSocket } from "../api";
 import { useQueryClient } from "@tanstack/react-query";
 import type { ApprovalItem, SessionListItem, ModelItem, AgentTool, AgentItem } from "../api";
 import { clearAgentHistory } from "../lib/http/client";
@@ -14,7 +14,7 @@ import { useFullConfig } from "../lib/queries/config";
 import { useMediaProviders } from "../lib/queries/media";
 import { useModels } from "../lib/queries/models";
 import { usePendingApprovals } from "../lib/queries/approvals";
-import { useAgents, useAgentSessions } from "../lib/queries/agents";
+import { agentQueries, useAgents, useAgentSessions } from "../lib/queries/agents";
 import { useSessionStream } from "../lib/queries/sessions";
 import { useActiveHandsWhen } from "../lib/queries/hands";
 import { agentKeys, approvalKeys } from "../lib/queries/keys";
@@ -36,6 +36,7 @@ import {
   usePatchAgentConfig,
   usePatchHandAgentRuntimeConfig,
   useResolveApproval,
+  useSendAgentMessage,
   useStopAgent,
   useUploadAgentFile,
 } from "../lib/mutations/agents";
@@ -331,6 +332,12 @@ const sessionCache = new Map<string, ChatMessage[]>();
 function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessionVersion = 0, onModelSwitch?: () => void, onClearError?: (message: string) => void, sessionId: string | null = null, onNewSession?: (sessionId: string) => void) {
   const { t } = useTranslation();
   const stopAgentMutation = useStopAgent();
+  const sendAgentMessageMutation = useSendAgentMessage();
+  // Used to fetch the agent's session snapshot through the queries layer so
+  // hits get TanStack Query caching, dedup, and back/forward instant-load
+  // (see agentQueries.session). Imperative fetchQuery rather than useQuery
+  // because the load is gated on `sessionVersion` and `sessionCache`.
+  const queryClient = useQueryClient();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   // Per-agent loading state. A single shared `isLoading` would freeze the
   // ChatInput on every agent while one of them is streaming (#2322). Keyed
@@ -482,7 +489,8 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
     setMessages([]);
     const loadId = agentId;
     setAgentLoading(loadId, true);
-    loadAgentSession(loadId, sessionId)
+    queryClient
+      .fetchQuery(agentQueries.session(loadId, sessionId))
       .then(session => {
         if (session.messages?.length) {
           const historical: ChatMessage[] = session.messages.flatMap((msg, idx) => {
@@ -677,11 +685,15 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
     // Helper: send via HTTP (used as primary fallback and WS drop recovery)
     const sendViaHttp = async () => {
       try {
-        const response = await sendAgentMessage(sendAgentId, trimmed, {
-          thinking: deepThinking,
-          show_thinking: showThinkingProcess,
-          session_id: sessionId,
-          attachments: hasAttachments ? attachments : undefined,
+        const response = await sendAgentMessageMutation.mutateAsync({
+          agentId: sendAgentId,
+          message: trimmed,
+          options: {
+            thinking: deepThinking,
+            show_thinking: showThinkingProcess,
+            session_id: sessionId,
+            attachments: hasAttachments ? attachments : undefined,
+          },
         });
         const fullContent = response.response || "";
         updateAgentMessages(sendAgentId, prev => prev.map(m =>

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -5,12 +5,11 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { AnimatePresence, motion } from "motion/react";
 import { tabContent } from "../lib/motion";
-import { createRegistryContent } from "../api";
 import type { ApiActionResponse, ProviderItem } from "../api";
 import { isProviderAvailable } from "../lib/status";
 import { useProviders, useProviderStatus } from "../lib/queries/providers";
 import { useModels } from "../lib/queries/models";
-import { useTestProvider, useSetProviderKey, useDeleteProviderKey, useSetProviderUrl, useSetDefaultProvider } from "../lib/mutations/providers";
+import { useTestProvider, useSetProviderKey, useDeleteProviderKey, useSetProviderUrl, useSetDefaultProvider, useCreateRegistryContent } from "../lib/mutations/providers";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
@@ -1074,6 +1073,7 @@ export function ProvidersPage() {
   const deleteKeyMutation = useDeleteProviderKey();
   const setUrlMutation = useSetProviderUrl();
   const defaultProviderMutation = useSetDefaultProvider();
+  const createRegistryContentMutation = useCreateRegistryContent();
 
   const config = useProviderConfig(
     testMutation,
@@ -1477,10 +1477,15 @@ export function ProvidersPage() {
       <DrawerPanel isOpen={showCreateForm} onClose={() => setShowCreateForm(false)} title={t("providers.add")} size="xl" hideCloseButton>
         <CreateProviderWizard
           onSubmit={async (values) => {
-            await createRegistryContent("provider", values);
+            // Hook invalidates providerKeys.all + modelKeys.lists() on
+            // success, so the configured tab refetches without an explicit
+            // refetch() call here.
+            await createRegistryContentMutation.mutateAsync({
+              contentType: "provider",
+              values,
+            });
             setShowCreateForm(false);
             setActiveTab("configured");
-            void providersQuery.refetch();
           }}
           onCancel={() => setShowCreateForm(false)}
         />


### PR DESCRIPTION
## Summary
- ChatPage and ProvidersPage no longer call `api.*` directly — `loadAgentSession`, `sendAgentMessage`, and `createRegistryContent` now go through the queries/mutations layer with proper cache invalidation.
- Adds `agentKeys.session(agentId, sessionId?)`, `agentQueries.session`, `useSendAgentMessage`, and `useCreateRegistryContent` hooks. ChatPage hydrates history through `queryClient.fetchQuery(agentQueries.session(...))` so back/forward navigation is cached (per the issue's `queryOptions` recommendation).
- Drops the manual `providersQuery.refetch()` on Add-Provider success — the new hook invalidates `providerKeys.all` + `modelKeys.lists()` itself, so other pages that share those keys also stay fresh.

## Scope note
The issue cites CanvasPage lines 1180/1236/1733/2282 as well, but on `origin/main` those line numbers no longer reference direct `api.*` calls (CanvasPage already uses `useCreateSchedule`, and the only mention of `listWorkflows` is a comment). The remaining concrete violations were the three migrated here. If a fresh audit surfaces more, follow-up PRs can extend with the same pattern.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test --run` — 357 / 357 pass (includes new `agentKeys.session` anchoring assertions in `keys.test.ts`)
- [x] `pnpm build` — clean
- [ ] Manual: send a chat message, confirm session list / per-agent stats refresh without page reload
- [ ] Manual: add a custom provider via the wizard, confirm "Configured" tab updates without manual refresh

Refs #3386