### PR TITLE
test(types): Default round-trip coverage for AgentManifest, ChannelsConfig, BroadcastConfig

### DIFF
--- a/crates/librefang-types/tests/config_default_roundtrip.rs
+++ b/crates/librefang-types/tests/config_default_roundtrip.rs
@@ -29,14 +29,16 @@
 //! the canonical value over before comparison. The test will still assert
 //! that every other field matches exactly.
 
+use librefang_types::agent::AgentManifest;
 use librefang_types::config::{
-    AuditConfig, AutoDreamConfig, AutoReplyConfig, BraveSearchConfig, BrowserConfig, BudgetConfig,
-    CanvasConfig, ChunkConfig, CompactionTomlConfig, ContextEngineTomlConfig, DockerSandboxConfig,
-    ExtensionsConfig, ExternalAuthConfig, HealthCheckConfig, HeartbeatTomlConfig, InboxConfig,
-    JinaSearchConfig, KernelConfig, LinkedInConfig, MemoryConfig, MemoryDecayConfig, NetworkConfig,
-    PairingConfig, ParallelToolsConfig, PerplexitySearchConfig, PrivacyConfig,
-    PromptIntelligenceConfig, QueueConcurrencyConfig, QueueConfig, RateLimitConfig, RegistryConfig,
-    ReloadConfig, SanitizeConfig, SessionConfig, SkillsConfig, TaskBoardConfig, TavilySearchConfig,
+    AuditConfig, AutoDreamConfig, AutoReplyConfig, BraveSearchConfig, BroadcastConfig,
+    BrowserConfig, BudgetConfig, CanvasConfig, ChannelsConfig, ChunkConfig, CompactionTomlConfig,
+    ContextEngineTomlConfig, DockerSandboxConfig, ExtensionsConfig, ExternalAuthConfig,
+    HealthCheckConfig, HeartbeatTomlConfig, InboxConfig, JinaSearchConfig, KernelConfig,
+    LinkedInConfig, MemoryConfig, MemoryDecayConfig, NetworkConfig, PairingConfig,
+    ParallelToolsConfig, PerplexitySearchConfig, PrivacyConfig, PromptIntelligenceConfig,
+    QueueConcurrencyConfig, QueueConfig, RateLimitConfig, RegistryConfig, ReloadConfig,
+    SanitizeConfig, SessionConfig, SkillsConfig, TaskBoardConfig, TavilySearchConfig,
     TelemetryConfig, TerminalConfig, ThinkingConfig, TriggersConfig, TtsConfig, VaultConfig,
     VoiceConfig, WebConfig, WebFetchConfig, WebhookTriggerConfig,
 };
@@ -359,4 +361,42 @@ fn voice_config_default_roundtrips_through_toml() {
 #[test]
 fn linked_in_config_default_roundtrips_through_toml() {
     assert_default_roundtrip::<LinkedInConfig>("LinkedInConfig");
+}
+
+// Issue #3462 — extend the round-trip property to nested config types
+// referenced from agent manifests and channel wiring. These three are the
+// load-bearing structs called out in the issue (`AgentManifest`,
+// `ChannelsConfig` — the closest match for the issue's "ChannelConfig" name —
+// and `BroadcastConfig`). `BudgetConfig` is already covered above.
+
+#[test]
+fn agent_manifest_default_roundtrips_through_toml() {
+    assert_default_roundtrip::<AgentManifest>("AgentManifest");
+}
+
+#[test]
+fn channels_config_default_roundtrips_through_toml() {
+    // Known #3462 Default-drift, flagged for separate triage:
+    //   `ChannelsConfig` uses `#[derive(Default)]`, so
+    //   `file_download_max_bytes` defaults to `u64::default() == 0`, but the
+    //   field is annotated `#[serde(default = "default_file_download_max_bytes")]`
+    //   which returns 50 MiB. Empty-TOML deserialization therefore yields
+    //   52_428_800 while the in-memory `Default::default()` yields 0.
+    //
+    // Per the task brief, this test does NOT silently fix the type — the
+    // discrepancy is normalized only on the divergent field so that drift in
+    // every OTHER field is still caught. The underlying type bug should be
+    // fixed by either replacing `#[derive(Default)]` with a manual impl that
+    // calls `default_file_download_max_bytes()`, or by aligning the serde
+    // helper with the derived zero value, depending on which value is
+    // intended at runtime.
+    let canonical_max_bytes = ChannelsConfig::default().file_download_max_bytes;
+    assert_default_roundtrip_with::<ChannelsConfig>("ChannelsConfig", move |c| {
+        c.file_download_max_bytes = canonical_max_bytes;
+    });
+}
+
+#[test]
+fn broadcast_config_default_roundtrips_through_toml() {
+    assert_default_roundtrip::<BroadcastConfig>("BroadcastConfig");
 }


### PR DESCRIPTION
## Summary
Extends the #3404 round-trip property to nested config types referenced from agent manifests and channel wiring, closing the gap called out in #3462.

For each new type `T`, asserts that `T::default()` and `toml::from_str::<T>("")?` agree, and that `T::default()` round-trips losslessly through TOML. This catches the bug class where a `#[serde(default)]` field (or a field-level `#[serde(default = "fn")]`) drifts from the manual / derived `Default` impl.

Types covered by this PR (issue #3462 list):
- `AgentManifest` — passes; struct-level `#[serde(default)]` makes empty-TOML fall back to the same manual `Default`.
- `BroadcastConfig` — passes; `#[derive(Default)]` + struct-level `#[serde(default)]` agree.
- `ChannelsConfig` — passes only after normalizing one field (see below). `BudgetConfig` was already covered by an earlier test.

## Default drift discovered (flag for separate triage)

`ChannelsConfig::file_download_max_bytes`:
- `Default::default()` returns `0` (derived `u64::default()`).
- `toml::from_str::<ChannelsConfig>("")` returns `52_428_800` (50 MiB) via `#[serde(default = "default_file_download_max_bytes")]`.

Per the task brief I did NOT silently fix the type — the test normalizes only that single field, so drift in every other field is still asserted. The fix should be either replacing `#[derive(Default)]` with a manual impl that calls `default_file_download_max_bytes()`, or aligning the serde helper with the derived zero, depending on which value is intended at runtime. Comment in the test points to this.

## Test plan
- [x] `cargo test -p librefang-types --test config_default_roundtrip` — 50 passed, 0 failed
- [x] `cargo check --workspace --lib` — clean
- [x] `cargo clippy -p librefang-types --all-targets -- -D warnings` — clean

Closes #3462