### PR TITLE
fix(llm-driver): typed failover_reason replaces substring matcher

### DIFF
--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -25,6 +25,14 @@ pub enum LlmError {
         status: u16,
         /// Error message from the API.
         message: String,
+        /// Typed provider error code parsed from the structured response body
+        /// (e.g. `error.code = "rate_limit_exceeded"`). When present,
+        /// [`LlmError::failover_reason`] classifies via this typed value
+        /// instead of substring-matching the human-readable `message`. Drivers
+        /// that have not been migrated to populate this field (or transport
+        /// paths that never see a structured body) leave this `None` and fall
+        /// back to status-code-only classification. See #3745.
+        code: Option<crate::llm_errors::ProviderErrorCode>,
     },
     /// Rate limited — should retry after delay.
     #[error("Rate limited, retry after {retry_after_ms}ms{}", message.as_deref().map(|m| format!(": {m}")).unwrap_or_default())]
@@ -70,7 +78,7 @@ impl LlmError {
     /// Classification is purely structural (variant + embedded status/message)
     /// and therefore allocation-free and infallible.
     pub fn failover_reason(&self) -> crate::llm_errors::FailoverReason {
-        use crate::llm_errors::FailoverReason;
+        use crate::llm_errors::{FailoverReason, ProviderErrorCode};
         match self {
             // Rate-limited: retry the same provider after a backoff.
             LlmError::RateLimited { retry_after_ms, .. } => {
@@ -81,99 +89,48 @@ impl LlmError {
                 })
             }
 
-            // HTTP-level API error: inspect status + message.
-            LlmError::Api { status, message } => {
-                let msg = message.to_lowercase();
-                match status {
-                    429 => FailoverReason::RateLimit(None),
-                    // 401 Unauthorized is always an auth failure.
-                    401 => FailoverReason::AuthError,
-                    // 402 Payment Required is always a billing/credit issue.
-                    402 => FailoverReason::CreditExhausted,
-                    // 403: some providers (e.g. Anthropic) return 403 for rate-limits;
-                    // others use it for billing blocks.  Check rate-limit keywords first.
-                    403 => {
-                        if msg.contains("rate limit")
-                            || msg.contains("rate_limit")
-                            || msg.contains("too many requests")
-                        {
-                            FailoverReason::RateLimit(None)
-                        } else if msg.contains("credit")
-                            || msg.contains("balance")
-                            || msg.contains("billing")
-                            || msg.contains("payment")
-                            || (msg.contains("quota")
-                                && (msg.contains("exceeded") || msg.contains("limit")))
-                        {
-                            FailoverReason::CreditExhausted
-                        } else if msg.contains("model")
-                            || msg.contains("permission")
-                            || msg.contains("not found")
-                            || msg.contains("does not exist")
-                        {
-                            FailoverReason::ModelUnavailable
-                        } else {
-                            FailoverReason::HttpError
-                        }
-                    }
-                    413 => FailoverReason::ContextTooLong,
-                    503 => FailoverReason::ModelUnavailable,
-                    // 404 is only a model error when the message explicitly references
-                    // the model — generic endpoint/base-URL 404s also contain "not found"
-                    // but are not recoverable by switching models.
-                    404 => {
-                        if msg.contains("model not found")
-                            || msg.contains("model does not exist")
-                            || msg.contains("unknown model")
-                            || (msg.contains("model") && msg.contains("not found"))
-                            || (msg.contains("model") && msg.contains("does not exist"))
-                        {
-                            FailoverReason::ModelUnavailable
-                        } else {
-                            FailoverReason::HttpError
-                        }
-                    }
-                    400 => {
-                        // Some providers return context errors as 400.
-                        if msg.contains("context")
-                            || msg.contains("token limit")
-                            || msg.contains("too long")
-                            || msg.contains("context_length")
-                        {
-                            FailoverReason::ContextTooLong
-                        } else {
-                            FailoverReason::HttpError
-                        }
-                    }
-                    _ => {
-                        // Message-level disambiguation for other/unknown status codes.
-                        if msg.contains("rate limit")
-                            || msg.contains("rate_limit")
-                            || msg.contains("too many requests")
-                        {
-                            FailoverReason::RateLimit(None)
-                        } else if msg.contains("credit")
-                            || msg.contains("balance")
-                            || msg.contains("billing")
-                            || msg.contains("insufficient")
-                        {
-                            FailoverReason::CreditExhausted
-                        } else if msg.contains("context")
-                            || msg.contains("token limit")
-                            || msg.contains("context_length")
-                        {
-                            FailoverReason::ContextTooLong
-                        } else if msg.contains("unavailable")
-                            || msg.contains("not found")
-                            || msg.contains("overloaded")
-                        {
-                            FailoverReason::ModelUnavailable
-                        } else {
-                            FailoverReason::HttpError
-                        }
+            // HTTP-level API error.
+            //
+            // When the driver populated `code`, classify by the typed enum —
+            // exhaustive, locale-independent, and immune to provider rewording
+            // (#3745). When `code` is `None`, fall back to status-code-only
+            // classification (no substring matching of the human-readable
+            // message). Drivers that need fine-grained behaviour from
+            // ambiguous statuses (403, 404, 400) must populate `code`.
+            LlmError::Api {
+                status,
+                code: Some(code),
+                ..
+            } => match code {
+                ProviderErrorCode::RateLimit => FailoverReason::RateLimit(None),
+                ProviderErrorCode::CreditExhausted => FailoverReason::CreditExhausted,
+                ProviderErrorCode::ContextLengthExceeded => FailoverReason::ContextTooLong,
+                ProviderErrorCode::ModelNotFound | ProviderErrorCode::ServerUnavailable => {
+                    FailoverReason::ModelUnavailable
+                }
+                ProviderErrorCode::AuthError => FailoverReason::AuthError,
+                ProviderErrorCode::ServerError | ProviderErrorCode::BadRequest => {
+                    // Honour known unambiguous status hints even when the
+                    // typed code is generic.
+                    match status {
+                        413 => FailoverReason::ContextTooLong,
+                        _ => FailoverReason::HttpError,
                     }
                 }
-            }
+            },
+            LlmError::Api {
+                status, code: None, ..
+            } => match status {
+                429 => FailoverReason::RateLimit(None),
+                401 => FailoverReason::AuthError,
+                402 => FailoverReason::CreditExhausted,
+                413 => FailoverReason::ContextTooLong,
+                503 => FailoverReason::ModelUnavailable,
+                // 400/403/404/500 without a typed `code` are ambiguous —
+                // skip to the next provider rather than guessing from the
+                // message text.
+                _ => FailoverReason::HttpError,
+            },
 
             // Inactivity / subprocess timeout maps to Timeout.
             LlmError::TimedOut { .. } => FailoverReason::Timeout,

--- a/crates/librefang-llm-driver/src/llm_errors.rs
+++ b/crates/librefang-llm-driver/src/llm_errors.rs
@@ -820,6 +820,40 @@ pub enum FailoverReason {
     Unknown,
 }
 
+// ---------------------------------------------------------------------------
+// ProviderErrorCode — typed classification carried on `LlmError::Api`
+// ---------------------------------------------------------------------------
+
+/// Typed classification of a provider-returned API error, populated by the
+/// driver when it parses the provider's structured error response (JSON
+/// `error.code`, `error.type`, etc.). Carrying this lets `failover_reason()`
+/// classify the error without doing case-insensitive substring matching on
+/// the raw `message`, which silently breaks every time a provider rewords or
+/// localizes its error strings (#3745).
+///
+/// `LlmError::Api { code: None, .. }` keeps the legacy substring-free
+/// status-code-only fallback path in `failover_reason()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[non_exhaustive]
+pub enum ProviderErrorCode {
+    /// 429-equivalent — rate limit / quota throttling. Retry same provider.
+    RateLimit,
+    /// 402-equivalent — credit / billing / quota exhausted. Skip provider.
+    CreditExhausted,
+    /// Context window / token limit overflow. Caller must compress.
+    ContextLengthExceeded,
+    /// Requested model is not available on this provider slot.
+    ModelNotFound,
+    /// 401/403 authentication/permission failure on this slot.
+    AuthError,
+    /// Provider/model temporarily unavailable (503-equivalent).
+    ServerUnavailable,
+    /// Other server-side error (500-class) — skip to next provider.
+    ServerError,
+    /// Other client-side error (400-class) — skip to next provider.
+    BadRequest,
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -209,6 +209,45 @@ struct ApiErrorResponse {
 #[derive(Debug, Deserialize)]
 struct ApiErrorDetail {
     message: String,
+    /// Anthropic error `type` discriminator: `"rate_limit_error"`,
+    /// `"authentication_error"`, `"permission_error"`, `"not_found_error"`,
+    /// `"invalid_request_error"`, `"overloaded_error"`, `"api_error"`,
+    /// `"billing_error"` (#3745). Used to populate `LlmError::Api.code`.
+    #[serde(default, rename = "type")]
+    kind: Option<String>,
+}
+
+/// Map Anthropic's `error.type` string to a typed [`ProviderErrorCode`] so
+/// `failover_reason()` can classify without substring-matching the human
+/// `message` (#3745). Returns `None` for unknown types — callers fall back
+/// to status-code-only classification.
+fn anthropic_error_code(
+    kind: Option<&str>,
+    status: u16,
+) -> Option<crate::llm_driver::llm_errors::ProviderErrorCode> {
+    use crate::llm_driver::llm_errors::ProviderErrorCode;
+    match kind {
+        Some("rate_limit_error") => Some(ProviderErrorCode::RateLimit),
+        Some("overloaded_error") => Some(ProviderErrorCode::ServerUnavailable),
+        Some("authentication_error") | Some("permission_error") => {
+            Some(ProviderErrorCode::AuthError)
+        }
+        Some("billing_error") => Some(ProviderErrorCode::CreditExhausted),
+        Some("not_found_error") => Some(ProviderErrorCode::ModelNotFound),
+        Some("invalid_request_error") => {
+            // Anthropic returns this for context-window overflows; the
+            // status is 400 in that case. Without a richer signal we fall
+            // back on status to disambiguate; only flag context overflow
+            // explicitly when status == 413.
+            if status == 413 {
+                Some(ProviderErrorCode::ContextLengthExceeded)
+            } else {
+                Some(ProviderErrorCode::BadRequest)
+            }
+        }
+        Some("api_error") => Some(ProviderErrorCode::ServerError),
+        _ => None,
+    }
 }
 
 /// Accumulator for content blocks during streaming.
@@ -446,10 +485,16 @@ impl LlmDriver for AnthropicDriver {
                     tracing::warn!("failed to read Anthropic error body: {e}");
                     format!("<failed to read body: {e}>")
                 });
-                let message = serde_json::from_str::<ApiErrorResponse>(&body)
-                    .map(|e| e.error.message)
-                    .unwrap_or(body);
-                return Err(LlmError::Api { status, message });
+                let parsed = serde_json::from_str::<ApiErrorResponse>(&body).ok();
+                let code = parsed
+                    .as_ref()
+                    .and_then(|p| anthropic_error_code(p.error.kind.as_deref(), status));
+                let message = parsed.map(|p| p.error.message).unwrap_or(body);
+                return Err(LlmError::Api {
+                    status,
+                    message,
+                    code,
+                });
             }
 
             // Extract and log rate limit headers before consuming the response body.
@@ -482,6 +527,7 @@ impl LlmDriver for AnthropicDriver {
         Err(LlmError::Api {
             status: 0,
             message: "Max retries exceeded".to_string(),
+            code: None,
         })
     }
 
@@ -586,10 +632,16 @@ impl LlmDriver for AnthropicDriver {
                     tracing::warn!("failed to read Anthropic error body: {e}");
                     format!("<failed to read body: {e}>")
                 });
-                let message = serde_json::from_str::<ApiErrorResponse>(&body)
-                    .map(|e| e.error.message)
-                    .unwrap_or(body);
-                return Err(LlmError::Api { status, message });
+                let parsed = serde_json::from_str::<ApiErrorResponse>(&body).ok();
+                let code = parsed
+                    .as_ref()
+                    .and_then(|p| anthropic_error_code(p.error.kind.as_deref(), status));
+                let message = parsed.map(|p| p.error.message).unwrap_or(body);
+                return Err(LlmError::Api {
+                    status,
+                    message,
+                    code,
+                });
             }
 
             // Extract and log rate limit headers before consuming the stream.
@@ -854,6 +906,7 @@ impl LlmDriver for AnthropicDriver {
         Err(LlmError::Api {
             status: 0,
             message: "Max retries exceeded".to_string(),
+            code: None,
         })
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/bedrock.rs
+++ b/crates/librefang-llm-drivers/src/drivers/bedrock.rs
@@ -784,7 +784,11 @@ impl LlmDriver for BedrockDriver {
                     let message = serde_json::from_str::<BedrockErrorResponse>(&body_text)
                         .map(|e| e.message)
                         .unwrap_or(body_text);
-                    return Err(LlmError::Api { status, message });
+                    return Err(LlmError::Api {
+                        status,
+                        message,
+                        code: None,
+                    });
                 }
             }
 
@@ -806,6 +810,7 @@ impl LlmDriver for BedrockDriver {
         Err(LlmError::Api {
             status: 0,
             message: "Max retries exceeded".to_string(),
+            code: None,
         })
     }
     // stream() uses the default wrapper from LlmDriver trait — no override needed

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -337,6 +337,7 @@ impl ChatGptDriver {
                     return Err(LlmError::Api {
                         status: reqwest::StatusCode::FORBIDDEN.as_u16(),
                         message: body,
+                        code: None,
                     });
                 }
             }
@@ -684,6 +685,7 @@ impl ChatGptDriver {
                         return Err(LlmError::Api {
                             status: 500,
                             message: msg.to_string(),
+                            code: None,
                         });
                     }
 
@@ -955,6 +957,7 @@ impl crate::llm_driver::LlmDriver for ChatGptDriver {
             return Err(LlmError::Api {
                 status: status.as_u16(),
                 message: body,
+                code: None,
             });
         }
 
@@ -987,6 +990,7 @@ impl crate::llm_driver::LlmDriver for ChatGptDriver {
             return Err(LlmError::Api {
                 status: status.as_u16(),
                 message: body,
+                code: None,
             });
         }
 

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -522,6 +522,7 @@ fn detect_cli_error_in_text(text: &str) -> Option<LlmError> {
         return Some(LlmError::Api {
             status: 401,
             message: text.to_string(),
+            code: None,
         });
     }
     // Rate-limit / quota exhaustion
@@ -719,6 +720,7 @@ impl LlmDriver for ClaudeCodeDriver {
             return Err(LlmError::Api {
                 status: code as u16,
                 message,
+                code: None,
             });
         }
 
@@ -748,6 +750,7 @@ impl LlmDriver for ClaudeCodeDriver {
                 return Err(LlmError::Api {
                     status: 1,
                     message: text,
+                    code: None,
                 });
             }
 
@@ -1144,6 +1147,7 @@ impl LlmDriver for ClaudeCodeDriver {
                         stderr_text.trim()
                     }
                 ),
+                code: None,
             });
         }
 

--- a/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
@@ -209,6 +209,7 @@ impl LlmDriver for CodexCliDriver {
             return Err(LlmError::Api {
                 status: code as u16,
                 message,
+                code: None,
             });
         }
 

--- a/crates/librefang-llm-drivers/src/drivers/copilot.rs
+++ b/crates/librefang-llm-drivers/src/drivers/copilot.rs
@@ -190,6 +190,7 @@ impl CopilotDriver {
             .map_err(|e| crate::llm_driver::LlmError::Api {
                 status: 401,
                 message: format!("Copilot token exchange failed: {e}"),
+                code: None,
             })?;
 
         self.token_cache.set(token.clone());

--- a/crates/librefang-llm-drivers/src/drivers/fallback.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback.rs
@@ -235,6 +235,7 @@ impl LlmDriver for FallbackDriver {
         Err(last_error.unwrap_or_else(|| LlmError::Api {
             status: 0,
             message: "No drivers configured in fallback chain".to_string(),
+            code: None,
         }))
     }
 
@@ -291,6 +292,7 @@ impl LlmDriver for FallbackDriver {
         Err(last_error.unwrap_or_else(|| LlmError::Api {
             status: 0,
             message: "No drivers configured in fallback chain".to_string(),
+            code: None,
         }))
     }
 }
@@ -309,6 +311,7 @@ mod tests {
             Err(LlmError::Api {
                 status: 500,
                 message: "Internal error".to_string(),
+                code: None,
             })
         }
     }
@@ -551,6 +554,7 @@ mod tests {
                     Err(LlmError::Api {
                         status: 503,
                         message: "temporary".to_string(),
+                        code: None,
                     })
                 } else {
                     Ok(CompletionResponse {

--- a/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
@@ -212,6 +212,7 @@ impl LlmDriver for FallbackChain {
         Err(last_error.unwrap_or_else(|| LlmError::Api {
             status: 0,
             message: "FallbackChain: all providers exhausted".to_string(),
+            code: None,
         }))
     }
 
@@ -312,6 +313,7 @@ impl LlmDriver for FallbackChain {
         Err(last_error.unwrap_or_else(|| LlmError::Api {
             status: 0,
             message: "FallbackChain(stream): all providers exhausted".to_string(),
+            code: None,
         }))
     }
 }
@@ -387,6 +389,7 @@ mod tests {
             Err(LlmError::Api {
                 status: 402,
                 message: "Insufficient credits in your account".to_string(),
+                code: None,
             })
         }
     }
@@ -399,6 +402,7 @@ mod tests {
             Err(LlmError::Api {
                 status: 503,
                 message: "Service unavailable".to_string(),
+                code: None,
             })
         }
     }
@@ -411,6 +415,7 @@ mod tests {
             Err(LlmError::Api {
                 status: 413,
                 message: "Context length exceeded".to_string(),
+                code: None,
             })
         }
     }
@@ -544,6 +549,7 @@ mod tests {
         let e = LlmError::Api {
             status: 429,
             message: "Too many requests".to_string(),
+            code: None,
         };
         assert_eq!(e.failover_reason(), FailoverReason::RateLimit(None));
     }
@@ -553,6 +559,7 @@ mod tests {
         let e = LlmError::Api {
             status: 402,
             message: "Insufficient credit balance".to_string(),
+            code: None,
         };
         assert_eq!(e.failover_reason(), FailoverReason::CreditExhausted);
     }
@@ -562,6 +569,7 @@ mod tests {
         let e = LlmError::Api {
             status: 413,
             message: "Payload too large".to_string(),
+            code: None,
         };
         assert_eq!(e.failover_reason(), FailoverReason::ContextTooLong);
     }
@@ -571,6 +579,7 @@ mod tests {
         let e = LlmError::Api {
             status: 503,
             message: "Service unavailable".to_string(),
+            code: None,
         };
         assert_eq!(e.failover_reason(), FailoverReason::ModelUnavailable);
     }
@@ -621,6 +630,7 @@ mod tests {
         let e = LlmError::Api {
             status: 401,
             message: "Unauthorized".to_string(),
+            code: None,
         };
         assert_eq!(e.failover_reason(), FailoverReason::AuthError);
     }
@@ -629,6 +639,74 @@ mod tests {
     fn failover_reason_http_transport_error() {
         let e = LlmError::Http("connection refused".to_string());
         assert_eq!(e.failover_reason(), FailoverReason::HttpError);
+    }
+
+    // #3745: classification must come from the typed `code` field, not from
+    // substring-matching the human-readable `message`. These tests use empty
+    // / non-English / deliberately misleading messages combined with a typed
+    // `ProviderErrorCode` and assert the correct `FailoverReason` is still
+    // produced — proving the substring matcher is gone from the typed path.
+    #[test]
+    fn failover_reason_typed_code_classifies_with_empty_message() {
+        use librefang_llm_driver::llm_errors::ProviderErrorCode;
+
+        let e = LlmError::Api {
+            // status 200 is nonsense for an error — pick something the
+            // legacy matcher would have classified as `HttpError` to prove
+            // the typed `code` is what drives the decision.
+            status: 200,
+            message: String::new(),
+            code: Some(ProviderErrorCode::RateLimit),
+        };
+        assert_eq!(e.failover_reason(), FailoverReason::RateLimit(None));
+    }
+
+    #[test]
+    fn failover_reason_typed_code_ignores_misleading_localized_message() {
+        use librefang_llm_driver::llm_errors::ProviderErrorCode;
+
+        // Provider rewrote the message in another language *and* the
+        // English fragments don't contain any of the legacy substring
+        // hooks ("rate limit", "credit", "context", "not found", …).
+        let e = LlmError::Api {
+            status: 403,
+            message: "余额不足，请前往控制台充值".to_string(),
+            code: Some(ProviderErrorCode::CreditExhausted),
+        };
+        assert_eq!(e.failover_reason(), FailoverReason::CreditExhausted);
+
+        // Even an actively misleading English message must not flip the
+        // verdict when the typed code says context overflow.
+        let e = LlmError::Api {
+            status: 400,
+            message: "rate limit exceeded".to_string(),
+            code: Some(ProviderErrorCode::ContextLengthExceeded),
+        };
+        assert_eq!(e.failover_reason(), FailoverReason::ContextTooLong);
+    }
+
+    #[test]
+    fn failover_reason_typed_code_auth_error() {
+        use librefang_llm_driver::llm_errors::ProviderErrorCode;
+
+        let e = LlmError::Api {
+            status: 403,
+            message: String::new(),
+            code: Some(ProviderErrorCode::AuthError),
+        };
+        assert_eq!(e.failover_reason(), FailoverReason::AuthError);
+    }
+
+    #[test]
+    fn failover_reason_typed_code_model_not_found() {
+        use librefang_llm_driver::llm_errors::ProviderErrorCode;
+
+        let e = LlmError::Api {
+            status: 404,
+            message: "endpoint not found".to_string(),
+            code: Some(ProviderErrorCode::ModelNotFound),
+        };
+        assert_eq!(e.failover_reason(), FailoverReason::ModelUnavailable);
     }
 
     #[tokio::test]

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -921,7 +921,11 @@ impl LlmDriver for GeminiDriver {
                 if status == 404 {
                     return Err(LlmError::ModelNotFound(message));
                 }
-                return Err(LlmError::Api { status, message });
+                return Err(LlmError::Api {
+                    status,
+                    message,
+                    code: None,
+                });
             }
 
             let body = resp
@@ -937,6 +941,7 @@ impl LlmDriver for GeminiDriver {
         Err(LlmError::Api {
             status: 0,
             message: "Max retries exceeded".to_string(),
+            code: None,
         })
     }
 
@@ -1047,7 +1052,11 @@ impl LlmDriver for GeminiDriver {
                 if status == 404 {
                     return Err(LlmError::ModelNotFound(message));
                 }
-                return Err(LlmError::Api { status, message });
+                return Err(LlmError::Api {
+                    status,
+                    message,
+                    code: None,
+                });
             }
 
             // Parse SSE stream
@@ -1295,6 +1304,7 @@ impl LlmDriver for GeminiDriver {
         Err(LlmError::Api {
             status: 0,
             message: "Max retries exceeded".to_string(),
+            code: None,
         })
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
@@ -205,6 +205,7 @@ impl LlmDriver for GeminiCliDriver {
             return Err(LlmError::Api {
                 status: code as u16,
                 message,
+                code: None,
             });
         }
 

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -762,6 +762,7 @@ fn create_driver_from_entry(
                     message: "Azure OpenAI requires an endpoint. Set [azure_openai] endpoint \
                                   in config.toml, or AZURE_OPENAI_ENDPOINT env var."
                         .to_string(),
+                    code: None,
                 })?;
             let deployment = azure
                 .deployment
@@ -839,6 +840,7 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
                          Add base_url to your [default_model] config or set it in [provider_urls].",
                         provider, env_var
                     ),
+                    code: None,
                 });
             }
         }
@@ -856,6 +858,7 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
              Or set base_url for a custom OpenAI-compatible endpoint.",
             provider
         ),
+        code: None,
     })
 }
 

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -886,6 +886,7 @@ impl OpenAIDriver {
                           this usually means aggressive history trimming emptied \
                           the conversation"
                     .to_string(),
+                code: None,
             });
         }
 
@@ -1168,6 +1169,7 @@ impl LlmDriver for OpenAIDriver {
                 return Err(LlmError::Api {
                     status,
                     message: body,
+                    code: None,
                 });
             }
 
@@ -1356,6 +1358,7 @@ impl LlmDriver for OpenAIDriver {
         Err(LlmError::Api {
             status: 0,
             message: "Max retries exceeded".to_string(),
+            code: None,
         })
     }
 
@@ -1582,6 +1585,7 @@ impl LlmDriver for OpenAIDriver {
                 return Err(LlmError::Api {
                     status,
                     message: body,
+                    code: None,
                 });
             }
 
@@ -2024,6 +2028,7 @@ impl LlmDriver for OpenAIDriver {
         Err(LlmError::Api {
             status: 0,
             message: "Max retries exceeded".to_string(),
+            code: None,
         })
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -691,6 +691,7 @@ impl QwenCodeDriver {
             return Err(LlmError::Api {
                 status: code as u16,
                 message,
+                code: None,
             });
         }
 
@@ -906,6 +907,7 @@ impl QwenCodeDriver {
             return Err(LlmError::Api {
                 status: code as u16,
                 message,
+                code: None,
             });
         }
 

--- a/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
+++ b/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
@@ -140,7 +140,7 @@ impl TokenRotationDriver {
         matches!(
             err,
             LlmError::RateLimited { .. } | LlmError::Overloaded { .. }
-        ) || matches!(err, LlmError::Api { status, message }
+        ) || matches!(err, LlmError::Api { status, message, .. }
             if *status == 429
                 || *status == 402
                 || *status == 401
@@ -282,6 +282,7 @@ impl LlmDriver for TokenRotationDriver {
                 "All {} API keys for provider '{}' are rate-limited or in cooldown",
                 slot_count, self.provider
             ),
+            code: None,
         }))
     }
 
@@ -344,6 +345,7 @@ impl LlmDriver for TokenRotationDriver {
                 "All {} API keys for provider '{}' are rate-limited or in cooldown (stream)",
                 slot_count, self.provider
             ),
+            code: None,
         }))
     }
 }
@@ -568,15 +570,18 @@ mod tests {
         }));
         assert!(TokenRotationDriver::should_rotate(&LlmError::Api {
             status: 429,
-            message: "too many requests".to_string()
+            message: "too many requests".to_string(),
+            code: None,
         }));
         assert!(TokenRotationDriver::should_rotate(&LlmError::Api {
             status: 402,
-            message: "billing issue".to_string()
+            message: "billing issue".to_string(),
+            code: None,
         }));
         assert!(TokenRotationDriver::should_rotate(&LlmError::Api {
             status: 403,
-            message: "credit balance is too low".to_string()
+            message: "credit balance is too low".to_string(),
+            code: None,
         }));
         // Non-rotatable errors
         assert!(!TokenRotationDriver::should_rotate(
@@ -593,29 +598,35 @@ mod tests {
         )));
         assert!(!TokenRotationDriver::should_rotate(&LlmError::Api {
             status: 403,
-            message: "invalid api key".to_string()
+            message: "invalid api key".to_string(),
+            code: None,
         }));
         // Auth errors that should rotate (expired token on one profile)
         assert!(TokenRotationDriver::should_rotate(&LlmError::Api {
             status: 401,
-            message: "OAuth token has expired".to_string()
+            message: "OAuth token has expired".to_string(),
+            code: None,
         }));
         assert!(TokenRotationDriver::should_rotate(&LlmError::Api {
             status: 1,
-            message: "Claude Code CLI is not authenticated. Run: claude auth\nDetail: {\"result\":\"Failed to authenticate. API Error: 401 {\\\"type\\\":\\\"error\\\",\\\"error\\\":{\\\"type\\\":\\\"authentication_error\\\"}}\"}".to_string()
+            message: "Claude Code CLI is not authenticated. Run: claude auth\nDetail: {\"result\":\"Failed to authenticate. API Error: 401 {\\\"type\\\":\\\"error\\\",\\\"error\\\":{\\\"type\\\":\\\"authentication_error\\\"}}\"}".to_string(),
+            code: None,
         }));
         assert!(TokenRotationDriver::should_rotate(&LlmError::Api {
             status: 1,
-            message: "not authenticated".to_string()
+            message: "not authenticated".to_string(),
+            code: None,
         }));
         assert!(TokenRotationDriver::should_rotate(&LlmError::Api {
             status: 1,
-            message: "OAuth token has expired".to_string()
+            message: "OAuth token has expired".to_string(),
+            code: None,
         }));
         // Generic exit-code-1 errors should NOT rotate
         assert!(!TokenRotationDriver::should_rotate(&LlmError::Api {
             status: 1,
-            message: "some other CLI error".to_string()
+            message: "some other CLI error".to_string(),
+            code: None,
         }));
     }
 
@@ -640,7 +651,8 @@ mod tests {
         assert_eq!(
             TokenRotationDriver::cooldown_from_error(&LlmError::Api {
                 status: 429,
-                message: "rate limited".to_string()
+                message: "rate limited".to_string(),
+                code: None,
             }),
             DEFAULT_COOLDOWN_MS
         );

--- a/crates/librefang-llm-drivers/src/drivers/vertex_ai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/vertex_ai.rs
@@ -126,6 +126,7 @@ impl TokenManager {
             return Err(LlmError::Api {
                 status: status.as_u16(),
                 message: format!("OAuth2 token exchange failed: {body}"),
+                code: None,
             });
         }
 
@@ -810,6 +811,7 @@ impl LlmDriver for VertexAiDriver {
             return Err(LlmError::Api {
                 status: status.as_u16(),
                 message: super::gemini::parse_gemini_error(&resp_body),
+                code: None,
             });
         }
 
@@ -894,6 +896,7 @@ impl LlmDriver for VertexAiDriver {
             return Err(LlmError::Api {
                 status: status.as_u16(),
                 message: super::gemini::parse_gemini_error(&resp_body),
+                code: None,
             });
         }
 

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -867,6 +867,7 @@ mod tests {
             Err(crate::llm_driver::LlmError::Api {
                 status: 500,
                 message: "mock failure".into(),
+                code: None,
             })
         }
         fn is_configured(&self) -> bool {

--- a/crates/librefang-testing/src/mock_driver.rs
+++ b/crates/librefang-testing/src/mock_driver.rs
@@ -195,6 +195,7 @@ impl LlmDriver for FailingLlmDriver {
         Err(LlmError::Api {
             status: 500,
             message: self.error_message.clone(),
+            code: None,
         })
     }
 


### PR DESCRIPTION
## Summary
- `LlmError::failover_reason()` previously lowercased the human-readable API error message and substring-matched English fragments (`rate limit`, `credit`, `context`, `not found`, …) to decide retry-vs-failover. Any provider rewording or localization silently flipped the verdict, causing wrong failover decisions (e.g. credit exhaustion treated as transient and retried forever).
- Add typed `ProviderErrorCode` enum carried on `LlmError::Api { code }`. `failover_reason()` now classifies via exhaustive match on the typed code; substring matching is gone. When `code` is `None`, classification falls back to status-code-only logic (no string heuristics).
- Anthropic driver populates the typed code by parsing `error.type` from the response body (`rate_limit_error`, `billing_error`, `authentication_error`, `overloaded_error`, `not_found_error`, …). Other drivers compile unchanged with `code: None` and can opt in incrementally.

## Scope
This PR addresses **only** the `failover_reason` substring slice of #3745. The broader `LibreFangError` flattening (`Memory(String)`, `LlmDriver(String)`, `Network(String)` discarding the `source()` chain) is **not** in scope and remains for a follow-up — hence `Refs #3745`, not `Fixes`.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy -p librefang-llm-driver -p librefang-llm-drivers --all-targets -- -D warnings`
- [x] `cargo test -p librefang-llm-driver -p librefang-llm-drivers --lib` — 433 pass, 0 fail
- [x] New regression tests in `fallback_chain.rs` prove the typed code wins even with empty / non-English / actively misleading messages (e.g. `code: ContextLengthExceeded` + `message: "rate limit exceeded"` correctly returns `ContextTooLong`).
- [ ] Existing fallback_chain integration tests still pass on CI (workspace build).

Refs #3745