### PR TITLE
fix(api): register 12 missing endpoints in openapi.json

### DIFF
--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -93,6 +93,13 @@ use crate::types;
         routes::upload_file,
         routes::serve_upload,
         routes::get_agent_deliveries,
+        routes::inject_message,
+        routes::push_message,
+        routes::reload_agent_manifest,
+        routes::suspend_agent,
+        routes::resume_agent,
+        routes::agent_metrics,
+        routes::agent_logs,
 
         // ── Bulk Operations ──
         routes::bulk_create_agents,
@@ -341,6 +348,13 @@ use crate::types;
         oauth::auth_callback_post,
         oauth::auth_userinfo,
         oauth::auth_introspect,
+        oauth::auth_refresh,
+
+        // ── Dashboard auth (credential login / logout / password change) ──
+        crate::server::dashboard_login,
+        crate::server::dashboard_auth_check,
+        crate::server::dashboard_logout,
+        crate::server::change_password,
 
         // ── OpenAI-Compatible API ──
         openai_compat::chat_completions,
@@ -367,6 +381,10 @@ use crate::types;
         types::BulkActionResult,
         types::ExtensionInstallRequest,
         types::ExtensionUninstallRequest,
+        types::InjectMessageRequest,
+        types::InjectMessageResponse,
+        types::PushMessageRequest,
+        crate::server::ChangePasswordRequest,
         routes::auto_dream::SetEnabledRequest,
         routes::agents::AgentStats24hView,
         routes::agents::AgentStatsPrevView,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -6069,6 +6069,19 @@ pub async fn inject_message(
 /// The agent must exist, but the message is sent directly through the channel
 /// adapter without going through the agent loop. This is the REST API
 /// counterpart of the built-in `channel_send` tool that agents can self-invoke.
+#[utoipa::path(
+    post,
+    path = "/api/agents/{id}/push",
+    tag = "agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    request_body = crate::types::PushMessageRequest,
+    responses(
+        (status = 200, description = "Message pushed to channel", body = serde_json::Value),
+        (status = 400, description = "Invalid agent ID or missing required fields"),
+        (status = 404, description = "Agent not found"),
+        (status = 502, description = "Channel adapter rejected the message")
+    )
+)]
 pub async fn push_message(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -6645,6 +6658,17 @@ mod tests {
 ///
 /// Includes message count, token usage, tool execution count, error count,
 /// average response time (estimated), and cost data.
+#[utoipa::path(
+    get,
+    path = "/api/agents/{id}/metrics",
+    tag = "agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    responses(
+        (status = 200, description = "Aggregated agent metrics", body = serde_json::Value),
+        (status = 400, description = "Invalid agent ID"),
+        (status = 404, description = "Agent not found")
+    )
+)]
 pub async fn agent_metrics(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -6762,6 +6786,22 @@ pub async fn agent_metrics(
 /// - `n`: max number of log entries (default 100, max 1000)
 /// - `level`: filter by outcome (e.g. "error", "ok")
 /// - `offset`: number of matching entries to skip for pagination (default 0)
+#[utoipa::path(
+    get,
+    path = "/api/agents/{id}/logs",
+    tag = "agents",
+    params(
+        ("id" = String, Path, description = "Agent ID"),
+        ("n" = Option<usize>, Query, description = "Max entries to return (default 100, max 1000)"),
+        ("level" = Option<String>, Query, description = "Filter by audit outcome (e.g. \"error\", \"ok\")"),
+        ("offset" = Option<usize>, Query, description = "Pagination offset over filtered entries")
+    ),
+    responses(
+        (status = 200, description = "Recent agent execution log entries", body = serde_json::Value),
+        (status = 400, description = "Invalid agent ID"),
+        (status = 404, description = "Agent not found")
+    )
+)]
 pub async fn agent_logs(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -369,7 +369,17 @@ fn session_cookie_attrs(headers: &axum::http::HeaderMap) -> &'static str {
 /// Dashboard credential login — validates username/password using Argon2id
 /// (with transparent fallback from legacy plaintext passwords) and returns
 /// a randomly generated session token with expiration metadata.
-async fn dashboard_login(
+#[utoipa::path(
+    post,
+    path = "/api/auth/dashboard-login",
+    tag = "auth",
+    request_body = serde_json::Value,
+    responses(
+        (status = 200, description = "Login outcome — returns session token on success or `requires_totp` when 2FA is needed", body = serde_json::Value),
+        (status = 401, description = "Invalid username, password, or TOTP code")
+    )
+)]
+pub(crate) async fn dashboard_login(
     axum::extract::State(state): axum::extract::State<Arc<routes::AppState>>,
     headers: axum::http::HeaderMap,
     axum::Json(body): axum::Json<serde_json::Value>,
@@ -540,7 +550,15 @@ async fn dashboard_login(
 }
 
 /// Check what auth mode the dashboard needs.
-async fn dashboard_auth_check(
+#[utoipa::path(
+    get,
+    path = "/api/auth/dashboard-check",
+    tag = "auth",
+    responses(
+        (status = 200, description = "Auth mode for the dashboard SPA — one of `none`, `api_key`, `credentials`, or `hybrid`", body = serde_json::Value)
+    )
+)]
+pub(crate) async fn dashboard_auth_check(
     axum::extract::State(state): axum::extract::State<Arc<routes::AppState>>,
 ) -> axum::response::Json<serde_json::Value> {
     let cfg = state.kernel.config_ref();
@@ -589,7 +607,15 @@ async fn dashboard_auth_check(
 /// Accepts the token via the `librefang_session` cookie, `Authorization:
 /// Bearer ...`, or `X-API-Key`. Always clears the cookie client-side so a
 /// caller who already lost their token can still wipe it locally.
-async fn dashboard_logout(
+#[utoipa::path(
+    post,
+    path = "/api/auth/logout",
+    tag = "auth",
+    responses(
+        (status = 200, description = "Session invalidated and cookie cleared", body = serde_json::Value)
+    )
+)]
+pub(crate) async fn dashboard_logout(
     axum::extract::State(state): axum::extract::State<Arc<routes::AppState>>,
     headers: axum::http::HeaderMap,
 ) -> axum::response::Response {
@@ -645,13 +671,13 @@ async fn dashboard_logout(
 }
 
 /// Request body for POST /api/auth/change-password.
-#[derive(serde::Deserialize)]
-struct ChangePasswordRequest {
-    current_password: String,
+#[derive(serde::Deserialize, utoipa::ToSchema)]
+pub(crate) struct ChangePasswordRequest {
+    pub current_password: String,
     /// New password — optional, omit to keep the current password.
-    new_password: Option<String>,
+    pub new_password: Option<String>,
     /// New username — optional, omit to keep the current username.
-    new_username: Option<String>,
+    pub new_username: Option<String>,
 }
 
 /// Change the dashboard password and/or username.
@@ -659,7 +685,18 @@ struct ChangePasswordRequest {
 /// Verifies the current password, then updates whichever credentials are
 /// provided in the request body. At least one of `new_password` or
 /// `new_username` must be non-empty. All existing sessions are invalidated on success.
-async fn change_password(
+#[utoipa::path(
+    post,
+    path = "/api/auth/change-password",
+    tag = "auth",
+    request_body = ChangePasswordRequest,
+    responses(
+        (status = 200, description = "Credentials updated and existing sessions invalidated", body = serde_json::Value),
+        (status = 400, description = "Missing required fields or password too short"),
+        (status = 401, description = "Current password is incorrect")
+    )
+)]
+pub(crate) async fn change_password(
     axum::extract::State(state): axum::extract::State<Arc<routes::AppState>>,
     axum::Json(body): axum::Json<ChangePasswordRequest>,
 ) -> axum::response::Response {

--- a/openapi.json
+++ b/openapi.json
@@ -1192,6 +1192,127 @@
         }
       }
     },
+    "/api/agents/{id}/inject": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "POST /api/agents/:id/inject — Inject a message into a running agent's tool loop.",
+        "description": "If the agent is currently executing tools (mid-turn), the injected message\nwill be processed between tool calls, interrupting the remaining sequence.\nReturns `{\"injected\": true}` if accepted, `{\"injected\": false}` if no\nactive tool loop is running for this agent.",
+        "operationId": "inject_message",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InjectMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Injection result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InjectMessageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent ID"
+          },
+          "404": {
+            "description": "Agent not found"
+          },
+          "413": {
+            "description": "Message too large"
+          },
+          "503": {
+            "description": "All injection channels for the agent are full; retry shortly (#3575)"
+          }
+        }
+      }
+    },
+    "/api/agents/{id}/logs": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "GET /api/agents/{id}/logs — Returns structured execution logs for an agent.",
+        "description": "Supports optional query parameters:\n- `n`: max number of log entries (default 100, max 1000)\n- `level`: filter by outcome (e.g. \"error\", \"ok\")\n- `offset`: number of matching entries to skip for pagination (default 0)",
+        "operationId": "agent_logs",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "n",
+            "in": "query",
+            "description": "Max entries to return (default 100, max 1000)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "description": "Filter by audit outcome (e.g. \"error\", \"ok\")",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Pagination offset over filtered entries",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recent agent execution log entries",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent ID"
+          },
+          "404": {
+            "description": "Agent not found"
+          }
+        }
+      }
+    },
     "/api/agents/{id}/mcp_servers": {
       "get": {
         "tags": [
@@ -1418,6 +1539,43 @@
         }
       }
     },
+    "/api/agents/{id}/metrics": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "GET /api/agents/{id}/metrics — Returns aggregated metrics for an agent.",
+        "description": "Includes message count, token usage, tool execution count, error count,\naverage response time (estimated), and cost data.",
+        "operationId": "agent_metrics",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Aggregated agent metrics",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent ID"
+          },
+          "404": {
+            "description": "Agent not found"
+          }
+        }
+      }
+    },
     "/api/agents/{id}/mode": {
       "put": {
         "tags": [
@@ -1497,6 +1655,114 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/agents/{id}/push": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "`POST /api/agents/:id/push` — push a proactive outbound message from an\nagent to a channel recipient (e.g., Telegram chat, Slack channel, email).",
+        "description": "The agent must exist, but the message is sent directly through the channel\nadapter without going through the agent loop. This is the REST API\ncounterpart of the built-in `channel_send` tool that agents can self-invoke.",
+        "operationId": "push_message",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PushMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Message pushed to channel",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent ID or missing required fields"
+          },
+          "404": {
+            "description": "Agent not found"
+          },
+          "502": {
+            "description": "Channel adapter rejected the message"
+          }
+        }
+      }
+    },
+    "/api/agents/{id}/reload": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "POST /api/agents/{id}/reload — Re-read the agent's agent.toml from disk.",
+        "description": "Picks up manual edits to fields like `skills`, `mcp_servers`, `tools`,\nor `system_prompt` without restarting the daemon. Runtime-only fields\n(workspace path, tags) are preserved.",
+        "operationId": "reload_agent_manifest",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent manifest reloaded from agent.toml",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agents/{id}/resume": {
+      "put": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "PUT /api/agents/:id/resume — Resume a suspended agent.",
+        "operationId": "resume_agent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent resumed"
           }
         }
       }
@@ -2184,6 +2450,31 @@
         }
       }
     },
+    "/api/agents/{id}/suspend": {
+      "put": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "PUT /api/agents/:id/suspend — Suspend an agent (stops cron, keeps in registry).",
+        "operationId": "suspend_agent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent suspended"
+          }
+        }
+      }
+    },
     "/api/agents/{id}/tools": {
       "get": {
         "tags": [
@@ -2833,6 +3124,91 @@
         }
       }
     },
+    "/api/auth/change-password": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Change the dashboard password and/or username.",
+        "description": "Verifies the current password, then updates whichever credentials are\nprovided in the request body. At least one of `new_password` or\n`new_username` must be non-empty. All existing sessions are invalidated on success.",
+        "operationId": "change_password",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Credentials updated and existing sessions invalidated",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required fields or password too short"
+          },
+          "401": {
+            "description": "Current password is incorrect"
+          }
+        }
+      }
+    },
+    "/api/auth/dashboard-check": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Check what auth mode the dashboard needs.",
+        "operationId": "dashboard_auth_check",
+        "responses": {
+          "200": {
+            "description": "Auth mode for the dashboard SPA — one of `none`, `api_key`, `credentials`, or `hybrid`",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/dashboard-login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Dashboard credential login — validates username/password using Argon2id\n(with transparent fallback from legacy plaintext passwords) and returns\na randomly generated session token with expiration metadata.",
+        "operationId": "dashboard_login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Login outcome — returns session token on success or `requires_totp` when 2FA is needed",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid username, password, or TOTP code"
+          }
+        }
+      }
+    },
     "/api/auth/introspect": {
       "post": {
         "tags": [
@@ -2904,6 +3280,26 @@
         }
       }
     },
+    "/api/auth/logout": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Invalidate the caller's dashboard session and clear the browser cookie.",
+        "description": "Accepts the token via the `librefang_session` cookie, `Authorization:\nBearer ...`, or `X-API-Key`. Always clears the cookie client-side so a\ncaller who already lost their token can still wipe it locally.",
+        "operationId": "dashboard_logout",
+        "responses": {
+          "200": {
+            "description": "Session invalidated and cookie cleared",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/providers": {
       "get": {
         "tags": [
@@ -2921,6 +3317,44 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/auth/refresh": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "POST /api/auth/refresh — Exchange a refresh token for a new access token.",
+        "description": "When the access token expires, clients can call this endpoint with the\nrefresh token received during login instead of forcing a full re-authorization.\nIf the request body omits `refresh_token`, the server looks up the token store\nfor a previously stored refresh token (from the OAuth callback).",
+        "operationId": "auth_refresh",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "New access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid refresh token"
+          },
+          "502": {
+            "description": "Token refresh failed"
           }
         }
       }
@@ -8129,6 +8563,7 @@
           "budget"
         ],
         "summary": "GET /api/usage — Get per-agent usage statistics.",
+        "description": "Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`\nshape used by `/api/agents`, `/api/peers`, and `/api/goals` (#3842). The\nper-agent rollup is materialized from the in-memory agent registry and\nreturned in one page — `offset=0` and `limit=None` always.",
         "operationId": "usage_stats",
         "responses": {
           "200": {
@@ -9143,6 +9578,32 @@
           }
         }
       },
+      "ChangePasswordRequest": {
+        "type": "object",
+        "description": "Request body for POST /api/auth/change-password.",
+        "required": [
+          "current_password"
+        ],
+        "properties": {
+          "current_password": {
+            "type": "string"
+          },
+          "new_password": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "New password — optional, omit to keep the current password."
+          },
+          "new_username": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "New username — optional, omit to keep the current username."
+          }
+        }
+      },
       "ClawHubInstallRequest": {
         "type": "object",
         "description": "Request to install a skill from ClawHub.",
@@ -9206,6 +9667,39 @@
           "name": {
             "type": "string",
             "description": "Extension/integration ID to remove."
+          }
+        }
+      },
+      "InjectMessageRequest": {
+        "type": "object",
+        "description": "Request to inject a message into a running agent's tool-execution loop (#956).",
+        "required": [
+          "message"
+        ],
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "The message to inject between tool calls."
+          },
+          "session_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional session id; when omitted the message broadcasts to all live sessions for the agent."
+          }
+        }
+      },
+      "InjectMessageResponse": {
+        "type": "object",
+        "description": "Response from a mid-turn message injection.",
+        "required": [
+          "injected"
+        ],
+        "properties": {
+          "injected": {
+            "type": "boolean",
+            "description": "Whether the message was accepted (true = injected, false = no active loop)."
           }
         }
       },
@@ -9543,6 +10037,56 @@
               "null"
             ],
             "description": "Web search augmentation mode: \"off\", \"auto\", or \"always\"."
+          }
+        }
+      },
+      "PushMessageRequest": {
+        "type": "object",
+        "description": "Request to push a proactive outbound message from an agent to a channel.",
+        "required": [
+          "channel",
+          "recipient",
+          "message"
+        ],
+        "properties": {
+          "channel": {
+            "type": "string",
+            "description": "Channel adapter name (e.g., \"telegram\", \"slack\", \"discord\")."
+          },
+          "message": {
+            "type": "string",
+            "description": "The message text to send."
+          },
+          "recipient": {
+            "type": "string",
+            "description": "Recipient identifier (platform-specific: chat_id, username, email, etc.)."
+          },
+          "thread_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional thread/topic ID for threaded replies (platform-specific)."
+          }
+        }
+      },
+      "RefreshRequest": {
+        "type": "object",
+        "description": "Request body for the refresh token endpoint.",
+        "properties": {
+          "provider": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional provider hint (if the user logged in with a specific provider)."
+          },
+          "refresh_token": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The refresh token obtained from the initial login callback.\nIf omitted, the server looks up a stored refresh token from the token store."
           }
         }
       },

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -354,6 +354,14 @@ func (r *AgentsResource) UpdateAgentIdentity(id string, data map[string]interfac
 	return r.client.request("PATCH", fmt.Sprintf("/api/agents/%s/identity", id), data, nil)
 }
 
+func (r *AgentsResource) InjectMessage(id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/agents/%s/inject", id), data, nil)
+}
+
+func (r *AgentsResource) AgentLogs(id string, query map[string]string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/logs", id), nil, query)
+}
+
 func (r *AgentsResource) GetAgentMcpServers(id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/mcp_servers", id), nil, nil)
 }
@@ -370,12 +378,28 @@ func (r *AgentsResource) SendMessageStream(id string, data map[string]interface{
 	return r.client.stream("POST", fmt.Sprintf("/api/agents/%s/message/stream", id), data, nil)
 }
 
+func (r *AgentsResource) AgentMetrics(id string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/metrics", id), nil, nil)
+}
+
 func (r *AgentsResource) SetAgentMode(id string, data map[string]interface{}) (interface{}, error) {
 	return r.client.request("PUT", fmt.Sprintf("/api/agents/%s/mode", id), data, nil)
 }
 
 func (r *AgentsResource) SetModel(id string, data map[string]interface{}) (interface{}, error) {
 	return r.client.request("PUT", fmt.Sprintf("/api/agents/%s/model", id), data, nil)
+}
+
+func (r *AgentsResource) PushMessage(id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/agents/%s/push", id), data, nil)
+}
+
+func (r *AgentsResource) ReloadAgentManifest(id string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/agents/%s/reload", id), nil, nil)
+}
+
+func (r *AgentsResource) ResumeAgent(id string) (interface{}, error) {
+	return r.client.request("PUT", fmt.Sprintf("/api/agents/%s/resume", id), nil, nil)
 }
 
 func (r *AgentsResource) ListAgentRuntime(id string) (interface{}, error) {
@@ -446,6 +470,10 @@ func (r *AgentsResource) StopAgent(id string) (interface{}, error) {
 	return r.client.request("POST", fmt.Sprintf("/api/agents/%s/stop", id), nil, nil)
 }
 
+func (r *AgentsResource) SuspendAgent(id string) (interface{}, error) {
+	return r.client.request("PUT", fmt.Sprintf("/api/agents/%s/suspend", id), nil, nil)
+}
+
 func (r *AgentsResource) GetAgentTools(id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/agents/%s/tools", id), nil, nil)
 }
@@ -506,6 +534,18 @@ func (r *AuthResource) AuthCallbackPost(data map[string]interface{}) (interface{
 	return r.client.request("POST", "/api/auth/callback", data, nil)
 }
 
+func (r *AuthResource) ChangePassword(data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", "/api/auth/change-password", data, nil)
+}
+
+func (r *AuthResource) DashboardAuthCheck() (interface{}, error) {
+	return r.client.request("GET", "/api/auth/dashboard-check", nil, nil)
+}
+
+func (r *AuthResource) DashboardLogin(data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", "/api/auth/dashboard-login", data, nil)
+}
+
 func (r *AuthResource) AuthIntrospect(data map[string]interface{}) (interface{}, error) {
 	return r.client.request("POST", "/api/auth/introspect", data, nil)
 }
@@ -518,8 +558,16 @@ func (r *AuthResource) AuthLoginProvider(provider string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/auth/login/%s", provider), nil, nil)
 }
 
+func (r *AuthResource) DashboardLogout() (interface{}, error) {
+	return r.client.request("POST", "/api/auth/logout", nil, nil)
+}
+
 func (r *AuthResource) AuthProviders() (interface{}, error) {
 	return r.client.request("GET", "/api/auth/providers", nil, nil)
+}
+
+func (r *AuthResource) AuthRefresh(data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", "/api/auth/refresh", data, nil)
 }
 
 func (r *AuthResource) AuthUserinfo() (interface{}, error) {

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -221,6 +221,14 @@ class AgentsResource {
     return this._c._request("PATCH", `/api/agents/${id}/identity`, data, undefined);
   }
 
+  async injectMessage(id, data) {
+    return this._c._request("POST", `/api/agents/${id}/inject`, data, undefined);
+  }
+
+  async agentLogs(id, query) {
+    return this._c._request("GET", `/api/agents/${id}/logs`, undefined, query);
+  }
+
   async getAgentMcpServers(id) {
     return this._c._request("GET", `/api/agents/${id}/mcp_servers`);
   }
@@ -237,12 +245,28 @@ class AgentsResource {
     yield* this._c._stream("POST", `/api/agents/${id}/message/stream`, data, undefined);
   }
 
+  async agentMetrics(id) {
+    return this._c._request("GET", `/api/agents/${id}/metrics`);
+  }
+
   async setAgentMode(id, data) {
     return this._c._request("PUT", `/api/agents/${id}/mode`, data, undefined);
   }
 
   async setModel(id, data) {
     return this._c._request("PUT", `/api/agents/${id}/model`, data, undefined);
+  }
+
+  async pushMessage(id, data) {
+    return this._c._request("POST", `/api/agents/${id}/push`, data, undefined);
+  }
+
+  async reloadAgentManifest(id) {
+    return this._c._request("POST", `/api/agents/${id}/reload`);
+  }
+
+  async resumeAgent(id) {
+    return this._c._request("PUT", `/api/agents/${id}/resume`);
   }
 
   async listAgentRuntime(id) {
@@ -313,6 +337,10 @@ class AgentsResource {
     return this._c._request("POST", `/api/agents/${id}/stop`);
   }
 
+  async suspendAgent(id) {
+    return this._c._request("PUT", `/api/agents/${id}/suspend`);
+  }
+
   async getAgentTools(id) {
     return this._c._request("GET", `/api/agents/${id}/tools`);
   }
@@ -377,6 +405,18 @@ class AuthResource {
     return this._c._request("POST", "/api/auth/callback", data, undefined);
   }
 
+  async changePassword(data) {
+    return this._c._request("POST", "/api/auth/change-password", data, undefined);
+  }
+
+  async dashboardAuthCheck() {
+    return this._c._request("GET", "/api/auth/dashboard-check");
+  }
+
+  async dashboardLogin(data) {
+    return this._c._request("POST", "/api/auth/dashboard-login", data, undefined);
+  }
+
   async authIntrospect(data) {
     return this._c._request("POST", "/api/auth/introspect", data, undefined);
   }
@@ -389,8 +429,16 @@ class AuthResource {
     return this._c._request("GET", `/api/auth/login/${provider}`);
   }
 
+  async dashboardLogout() {
+    return this._c._request("POST", "/api/auth/logout");
+  }
+
   async authProviders() {
     return this._c._request("GET", "/api/auth/providers");
+  }
+
+  async authRefresh(data) {
+    return this._c._request("POST", "/api/auth/refresh", data, undefined);
   }
 
   async authUserinfo() {

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -208,6 +208,12 @@ class _AgentsResource(_Resource):
     def update_agent_identity(self, id: str, **data):
         return self._c._request("PATCH", f"/api/agents/{id}/identity", data)
 
+    def inject_message(self, id: str, **data):
+        return self._c._request("POST", f"/api/agents/{id}/inject", data)
+
+    def agent_logs(self, id: str, n: Any = None, level: Any = None, offset: Any = None):
+        return self._c._request("GET", f"/api/agents/{id}/logs", None, query={"n": n, "level": level, "offset": offset})
+
     def get_agent_mcp_servers(self, id: str):
         return self._c._request("GET", f"/api/agents/{id}/mcp_servers")
 
@@ -220,11 +226,23 @@ class _AgentsResource(_Resource):
     def send_message_stream(self, id: str, **data) -> Generator[Dict, None, None]:
         return self._c._stream("POST", f"/api/agents/{id}/message/stream", data)
 
+    def agent_metrics(self, id: str):
+        return self._c._request("GET", f"/api/agents/{id}/metrics")
+
     def set_agent_mode(self, id: str, **data):
         return self._c._request("PUT", f"/api/agents/{id}/mode", data)
 
     def set_model(self, id: str, **data):
         return self._c._request("PUT", f"/api/agents/{id}/model", data)
+
+    def push_message(self, id: str, **data):
+        return self._c._request("POST", f"/api/agents/{id}/push", data)
+
+    def reload_agent_manifest(self, id: str):
+        return self._c._request("POST", f"/api/agents/{id}/reload")
+
+    def resume_agent(self, id: str):
+        return self._c._request("PUT", f"/api/agents/{id}/resume")
 
     def list_agent_runtime(self, id: str):
         return self._c._request("GET", f"/api/agents/{id}/runtime")
@@ -277,6 +295,9 @@ class _AgentsResource(_Resource):
     def stop_agent(self, id: str):
         return self._c._request("POST", f"/api/agents/{id}/stop")
 
+    def suspend_agent(self, id: str):
+        return self._c._request("PUT", f"/api/agents/{id}/suspend")
+
     def get_agent_tools(self, id: str):
         return self._c._request("GET", f"/api/agents/{id}/tools")
 
@@ -326,6 +347,15 @@ class _AuthResource(_Resource):
     def auth_callback_post(self, **data):
         return self._c._request("POST", "/api/auth/callback", data)
 
+    def change_password(self, **data):
+        return self._c._request("POST", "/api/auth/change-password", data)
+
+    def dashboard_auth_check(self):
+        return self._c._request("GET", "/api/auth/dashboard-check")
+
+    def dashboard_login(self, **data):
+        return self._c._request("POST", "/api/auth/dashboard-login", data)
+
     def auth_introspect(self, **data):
         return self._c._request("POST", "/api/auth/introspect", data)
 
@@ -335,8 +365,14 @@ class _AuthResource(_Resource):
     def auth_login_provider(self, provider: str):
         return self._c._request("GET", f"/api/auth/login/{provider}")
 
+    def dashboard_logout(self):
+        return self._c._request("POST", "/api/auth/logout")
+
     def auth_providers(self):
         return self._c._request("GET", "/api/auth/providers")
+
+    def auth_refresh(self, **data):
+        return self._c._request("POST", "/api/auth/refresh", data)
 
     def auth_userinfo(self):
         return self._c._request("GET", "/api/auth/userinfo")

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -330,6 +330,14 @@ impl AgentsResource {
         do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/agents/{}/identity", id), Some(data), &[]).await
     }
 
+    pub async fn inject_message(&self, id: &str, data: Value) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/inject", id), Some(data), &[]).await
+    }
+
+    pub async fn agent_logs(&self, id: &str, n: Option<&str>, level: Option<&str>, offset: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/logs", id), None, &[("n", n), ("level", level), ("offset", offset)]).await
+    }
+
     pub async fn get_agent_mcp_servers(&self, id: &str) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/mcp_servers", id), None, &[]).await
     }
@@ -346,12 +354,28 @@ impl AgentsResource {
         do_stream(self.client.clone(), self.base_url.clone(), format!("/api/agents/{}/message/stream", id), reqwest::Method::POST, Some(data), Vec::new())
     }
 
+    pub async fn agent_metrics(&self, id: &str) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/metrics", id), None, &[]).await
+    }
+
     pub async fn set_agent_mode(&self, id: &str, data: Value) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/mode", id), Some(data), &[]).await
     }
 
     pub async fn set_model(&self, id: &str, data: Value) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/model", id), Some(data), &[]).await
+    }
+
+    pub async fn push_message(&self, id: &str, data: Value) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/push", id), Some(data), &[]).await
+    }
+
+    pub async fn reload_agent_manifest(&self, id: &str) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/reload", id), None, &[]).await
+    }
+
+    pub async fn resume_agent(&self, id: &str) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/resume", id), None, &[]).await
     }
 
     pub async fn list_agent_runtime(&self, id: &str) -> Result<Value> {
@@ -420,6 +444,10 @@ impl AgentsResource {
 
     pub async fn stop_agent(&self, id: &str) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/stop", id), None, &[]).await
+    }
+
+    pub async fn suspend_agent(&self, id: &str) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/suspend", id), None, &[]).await
     }
 
     pub async fn get_agent_tools(&self, id: &str) -> Result<Value> {
@@ -502,6 +530,18 @@ impl AuthResource {
         do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/callback".to_string(), Some(data), &[]).await
     }
 
+    pub async fn change_password(&self, data: Value) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/change-password".to_string(), Some(data), &[]).await
+    }
+
+    pub async fn dashboard_auth_check(&self) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/dashboard-check".to_string(), None, &[]).await
+    }
+
+    pub async fn dashboard_login(&self, data: Value) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/dashboard-login".to_string(), Some(data), &[]).await
+    }
+
     pub async fn auth_introspect(&self, data: Value) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/introspect".to_string(), Some(data), &[]).await
     }
@@ -514,8 +554,16 @@ impl AuthResource {
         do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/auth/login/{}", provider), None, &[]).await
     }
 
+    pub async fn dashboard_logout(&self) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/logout".to_string(), None, &[]).await
+    }
+
     pub async fn auth_providers(&self) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/providers".to_string(), None, &[]).await
+    }
+
+    pub async fn auth_refresh(&self, data: Value) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/refresh".to_string(), Some(data), &[]).await
     }
 
     pub async fn auth_userinfo(&self) -> Result<Value> {


### PR DESCRIPTION
## Summary
Twelve registered, reachable routes were absent from the published `openapi.json`, so SDK generators silently skipped them and third-party integrators had to hand-write call sites for the entire dashboard auth lifecycle, mid-turn injection, push messaging, and per-agent metrics/logs.

## Endpoints added
- `POST   /api/agents/{id}/inject`
- `POST   /api/agents/{id}/push`
- `POST   /api/agents/{id}/reload`
- `PUT    /api/agents/{id}/suspend`
- `PUT    /api/agents/{id}/resume`
- `GET    /api/agents/{id}/metrics`
- `GET    /api/agents/{id}/logs`
- `POST   /api/auth/dashboard-login`
- `GET    /api/auth/dashboard-check`
- `POST   /api/auth/logout`
- `POST   /api/auth/change-password`
- `POST   /api/auth/refresh`

## Mechanism
Project uses `utoipa` derives — `crates/librefang-api/src/openapi.rs` collects annotated handlers into `ApiDoc::paths(...)`. `inject`, `reload`, `suspend`, `resume`, `auth_refresh` already carried `#[utoipa::path]` macros but were never listed in `paths(...)`. `push_message`, `agent_metrics`, `agent_logs`, and the four `server.rs` dashboard-auth handlers had no macro at all — added the attribute and bumped the four `server.rs` handlers from private to `pub(crate)` so the `OpenApi` derive can reach them.

Schemas registered: `InjectMessageRequest`, `InjectMessageResponse`, `PushMessageRequest`, `ChangePasswordRequest` (the last needed `utoipa::ToSchema` and `pub(crate)` visibility added).

Regeneration: `cargo xtask codegen --openapi` (driven by the existing `scripts/hooks/pre-commit` heuristic). Spec went from 229 → 241 paths. SDKs regenerated by the same hook via `scripts/codegen-sdks.py`.

## Out of scope
- Issue #3396 — empty `{}` schema bodies on existing paths.
- CI drift check that diffs registered axum routes against `openapi.json` (mentioned in #3487 as a follow-up — left for a separate PR).
- `/api/agents/{id}/ws` — websocket upgrade route, not REST; OpenAPI 3.1 has no clean way to express it.

## Test plan
- [x] `cargo check --workspace --lib` clean
- [x] `cargo xtask codegen --openapi` regenerated spec deterministically
- [x] All 12 expected paths present in `openapi.json` after regeneration
- [x] `python3 scripts/codegen-sdks.py` regenerated all four SDKs without errors
- [ ] CI clippy / build / openapi-drift jobs

Fixes #3487