### PR TITLE
fix(openapi): typed placeholders for free-form JSON responses (refs #3396)

### DIFF
--- a/crates/librefang-api/src/oauth.rs
+++ b/crates/librefang-api/src/oauth.rs
@@ -412,7 +412,7 @@ impl TokenStore {
 // ── Route: GET /api/auth/providers ──────────────────────────────────────
 
 /// GET /api/auth/providers — List available authentication providers.
-#[utoipa::path(get, path = "/api/auth/providers", tag = "auth", responses((status = 200, description = "List configured OAuth/OIDC providers", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/auth/providers", tag = "auth", responses((status = 200, description = "List configured OAuth/OIDC providers", body = crate::types::JsonObject)))]
 pub async fn auth_providers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let cfg = state.kernel.config_snapshot();
     let ext_auth = &cfg.external_auth;
@@ -601,7 +601,7 @@ struct CallbackUser {
 }
 
 /// GET /api/auth/callback — Handle the OAuth2 authorization code callback (browser redirect).
-#[utoipa::path(get, path = "/api/auth/callback", tag = "auth", responses((status = 200, description = "OAuth callback — completes login flow", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/auth/callback", tag = "auth", responses((status = 200, description = "OAuth callback — completes login flow", body = crate::types::JsonObject)))]
 pub async fn auth_callback(
     State(state): State<Arc<AppState>>,
     Query(query): Query<CallbackQuery>,
@@ -672,7 +672,7 @@ pub async fn auth_callback(
 }
 
 /// POST /api/auth/callback — Handle the OAuth2 callback (programmatic clients).
-#[utoipa::path(post, path = "/api/auth/callback", tag = "auth", responses((status = 200, description = "OAuth callback (POST) — completes login flow", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/auth/callback", tag = "auth", responses((status = 200, description = "OAuth callback (POST) — completes login flow", body = crate::types::JsonObject)))]
 pub async fn auth_callback_post(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CallbackBody>,
@@ -1080,7 +1080,7 @@ async fn handle_code_exchange(
 ///
 /// If a valid JWT is in the Authorization header and JWKS validation succeeds,
 /// returns the decoded claims. Otherwise falls back to provider userinfo endpoint.
-#[utoipa::path(get, path = "/api/auth/userinfo", tag = "auth", responses((status = 200, description = "Get authenticated user info", body = serde_json::Value), (status = 401, description = "Not authenticated")))]
+#[utoipa::path(get, path = "/api/auth/userinfo", tag = "auth", responses((status = 200, description = "Get authenticated user info", body = crate::types::JsonObject), (status = 401, description = "Not authenticated")))]
 pub async fn auth_userinfo(
     State(state): State<Arc<AppState>>,
     request: axum::http::Request<axum::body::Body>,
@@ -1172,7 +1172,7 @@ pub struct IntrospectRequest {
 /// POST /api/auth/introspect — Validate a token and return its claims.
 ///
 /// Follows RFC 7662 conventions: returns `{"active": true/false, ...}`.
-#[utoipa::path(post, path = "/api/auth/introspect", tag = "auth", request_body = serde_json::Value, responses((status = 200, description = "Token introspection result", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/auth/introspect", tag = "auth", request_body = crate::types::JsonObject, responses((status = 200, description = "Token introspection result", body = crate::types::JsonObject)))]
 pub async fn auth_introspect(
     State(state): State<Arc<AppState>>,
     Json(req): Json<IntrospectRequest>,
@@ -1260,7 +1260,7 @@ struct RefreshResponse {
 /// refresh token received during login instead of forcing a full re-authorization.
 /// If the request body omits `refresh_token`, the server looks up the token store
 /// for a previously stored refresh token (from the OAuth callback).
-#[utoipa::path(post, path = "/api/auth/refresh", tag = "auth", request_body = RefreshRequest, responses((status = 200, description = "New access token", body = serde_json::Value), (status = 400, description = "Missing or invalid refresh token"), (status = 502, description = "Token refresh failed")))]
+#[utoipa::path(post, path = "/api/auth/refresh", tag = "auth", request_body = RefreshRequest, responses((status = 200, description = "New access token", body = crate::types::JsonObject), (status = 400, description = "Missing or invalid refresh token"), (status = 502, description = "Token refresh failed")))]
 pub async fn auth_refresh(
     State(state): State<Arc<AppState>>,
     Json(req): Json<RefreshRequest>,

--- a/crates/librefang-api/src/openai_compat.rs
+++ b/crates/librefang-api/src/openai_compat.rs
@@ -251,7 +251,7 @@ fn convert_messages(oai_messages: &[OaiMessage]) -> Vec<Message> {
 // ── Handlers ────────────────────────────────────────────────────────────────
 
 /// POST /v1/chat/completions
-#[utoipa::path(post, path = "/v1/chat/completions", tag = "openai", request_body = serde_json::Value, responses((status = 200, description = "OpenAI-compatible chat completion", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/v1/chat/completions", tag = "openai", request_body = crate::types::JsonObject, responses((status = 200, description = "OpenAI-compatible chat completion", body = crate::types::JsonObject)))]
 #[allow(private_interfaces)]
 pub async fn chat_completions(
     State(state): State<Arc<AppState>>,
@@ -547,7 +547,7 @@ async fn stream_response(
 }
 
 /// GET /v1/models — List available agents as OpenAI model objects.
-#[utoipa::path(get, path = "/v1/models", tag = "openai", operation_id = "list_openai_models", responses((status = 200, description = "OpenAI-compatible model list", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/v1/models", tag = "openai", operation_id = "list_openai_models", responses((status = 200, description = "OpenAI-compatible model list", body = crate::types::JsonObject)))]
 pub async fn list_models(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let agents = state.kernel.agent_registry().list();
     let created = std::time::SystemTime::now()

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -347,6 +347,8 @@ use crate::types;
         openai_compat::list_models,
     ),
     components(schemas(
+        types::JsonObject,
+        types::JsonArray,
         types::SpawnRequest,
         types::SpawnResponse,
         types::AttachmentRef,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -3471,7 +3471,7 @@ pub async fn stop_agent(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "List of in-flight sessions for the agent", body = crate::types::JsonObject)
+        (status = 200, description = "List of in-flight sessions for the agent", body = crate::types::JsonArray)
     )
 )]
 pub async fn list_agent_runtime(

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -437,7 +437,7 @@ fn validate_bulk_size(
     tag = "agents",
     request_body(content = BulkCreateRequest, description = "Array of agent spawn requests"),
     responses(
-        (status = 200, description = "Create multiple agents at once", body = serde_json::Value)
+        (status = 200, description = "Create multiple agents at once", body = crate::types::JsonObject)
     )
 )]
 pub async fn bulk_create_agents(
@@ -514,7 +514,7 @@ pub async fn bulk_create_agents(
     tag = "agents",
     request_body(content = BulkAgentIdsRequest, description = "Array of agent IDs to delete"),
     responses(
-        (status = 200, description = "Delete multiple agents at once", body = serde_json::Value)
+        (status = 200, description = "Delete multiple agents at once", body = crate::types::JsonObject)
     )
 )]
 pub async fn bulk_delete_agents(
@@ -599,7 +599,7 @@ pub async fn bulk_delete_agents(
     tag = "agents",
     request_body(content = BulkAgentIdsRequest, description = "Array of agent IDs to start"),
     responses(
-        (status = 200, description = "Start multiple agents (set to Full mode)", body = serde_json::Value)
+        (status = 200, description = "Start multiple agents (set to Full mode)", body = crate::types::JsonObject)
     )
 )]
 pub async fn bulk_start_agents(
@@ -675,7 +675,7 @@ pub async fn bulk_start_agents(
     tag = "agents",
     request_body(content = BulkAgentIdsRequest, description = "Array of agent IDs to stop"),
     responses(
-        (status = 200, description = "Stop multiple agents' current runs", body = serde_json::Value)
+        (status = 200, description = "Stop multiple agents' current runs", body = crate::types::JsonObject)
     )
 )]
 pub async fn bulk_stop_agents(
@@ -1935,7 +1935,7 @@ pub struct GetAgentSessionQuery {
         ("session_id" = Option<String>, Query, description = "Optional session id to load instead of the canonical active session"),
     ),
     responses(
-        (status = 200, description = "Get agent conversation session history", body = serde_json::Value)
+        (status = 200, description = "Get agent conversation session history", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_agent_session(
@@ -2310,7 +2310,7 @@ pub async fn resume_agent(
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = SetModeRequest, description = "New agent mode"),
     responses(
-        (status = 200, description = "Change an agent's operational mode", body = serde_json::Value)
+        (status = 200, description = "Change an agent's operational mode", body = crate::types::JsonObject)
     )
 )]
 pub async fn set_agent_mode(
@@ -2356,7 +2356,7 @@ pub async fn set_agent_mode(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Agent details", body = serde_json::Value),
+        (status = 200, description = "Agent details", body = crate::types::JsonObject),
         (status = 404, description = "Agent not found")
     )
 )]
@@ -2815,7 +2815,7 @@ pub async fn attach_session_stream(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "List all sessions for an agent", body = serde_json::Value)
+        (status = 200, description = "List all sessions for an agent", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_agent_sessions(
@@ -2875,7 +2875,7 @@ pub async fn list_agent_sessions(
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = serde_json::Value, description = "Optional label for the new session"),
     responses(
-        (status = 200, description = "Create a new session for an agent", body = serde_json::Value)
+        (status = 200, description = "Create a new session for an agent", body = crate::types::JsonObject)
     )
 )]
 pub async fn create_agent_session(
@@ -2916,7 +2916,7 @@ pub async fn create_agent_session(
         ("session_id" = String, Path, description = "Session ID to switch to"),
     ),
     responses(
-        (status = 200, description = "Switch to an existing session", body = serde_json::Value)
+        (status = 200, description = "Switch to an existing session", body = crate::types::JsonObject)
     )
 )]
 pub async fn switch_agent_session(
@@ -2969,7 +2969,7 @@ pub async fn switch_agent_session(
         ("session_id" = String, Path, description = "Session ID to export"),
     ),
     responses(
-        (status = 200, description = "Exported session data", body = serde_json::Value)
+        (status = 200, description = "Exported session data", body = crate::types::JsonObject)
     )
 )]
 pub async fn export_session(
@@ -3031,7 +3031,7 @@ pub async fn export_session(
         ("format" = Option<String>, Query, description = "Response format: 'json' (default) or 'jsonl'"),
     ),
     responses(
-        (status = 200, description = "Redacted trajectory bundle", body = serde_json::Value),
+        (status = 200, description = "Redacted trajectory bundle", body = crate::types::JsonObject),
         (status = 400, description = "Invalid agent or session ID"),
         (status = 404, description = "Agent or session not found"),
     )
@@ -3199,7 +3199,7 @@ pub async fn export_session_trajectory(
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = serde_json::Value, description = "Exported session JSON"),
     responses(
-        (status = 200, description = "Session imported successfully", body = serde_json::Value)
+        (status = 200, description = "Session imported successfully", body = crate::types::JsonObject)
     )
 )]
 pub async fn import_session(
@@ -3254,7 +3254,7 @@ pub async fn import_session(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Reset an agent's current session", body = serde_json::Value)
+        (status = 200, description = "Reset an agent's current session", body = crate::types::JsonObject)
     )
 )]
 pub async fn reset_session(
@@ -3293,7 +3293,7 @@ pub async fn reset_session(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Hard-reboot an agent's session without saving summary", body = serde_json::Value)
+        (status = 200, description = "Hard-reboot an agent's session without saving summary", body = crate::types::JsonObject)
     )
 )]
 pub async fn reboot_session(
@@ -3334,7 +3334,7 @@ pub async fn reboot_session(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Clear all conversation history for an agent", body = serde_json::Value)
+        (status = 200, description = "Clear all conversation history for an agent", body = crate::types::JsonObject)
     )
 )]
 pub async fn clear_agent_history(
@@ -3379,7 +3379,7 @@ pub async fn clear_agent_history(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Trigger LLM session compaction", body = serde_json::Value)
+        (status = 200, description = "Trigger LLM session compaction", body = crate::types::JsonObject)
     )
 )]
 pub async fn compact_session(
@@ -3425,7 +3425,7 @@ pub async fn compact_session(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Cancel an agent's current LLM run", body = serde_json::Value)
+        (status = 200, description = "Cancel an agent's current LLM run", body = crate::types::JsonObject)
     )
 )]
 pub async fn stop_agent(
@@ -3471,7 +3471,7 @@ pub async fn stop_agent(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "List of in-flight sessions for the agent", body = serde_json::Value)
+        (status = 200, description = "List of in-flight sessions for the agent", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_agent_runtime(
@@ -3509,7 +3509,7 @@ pub async fn list_agent_runtime(
         ("session_id" = String, Path, description = "Session ID"),
     ),
     responses(
-        (status = 200, description = "Cancel a single (agent, session) loop", body = serde_json::Value)
+        (status = 200, description = "Cancel a single (agent, session) loop", body = crate::types::JsonObject)
     )
 )]
 pub async fn stop_session(
@@ -3557,7 +3557,7 @@ pub async fn stop_session(
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = serde_json::Value, description = "Model name and optional provider"),
     responses(
-        (status = 200, description = "Change an agent's LLM model", body = serde_json::Value)
+        (status = 200, description = "Change an agent's LLM model", body = crate::types::JsonObject)
     )
 )]
 pub async fn set_model(
@@ -3640,7 +3640,7 @@ pub async fn set_model(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Get decision traces from the agent's most recent message", body = serde_json::Value)
+        (status = 200, description = "Get decision traces from the agent's most recent message", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_agent_traces(
@@ -3687,7 +3687,7 @@ pub async fn get_agent_traces(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Get an agent's tool allowlist and blocklist", body = serde_json::Value)
+        (status = 200, description = "Get an agent's tool allowlist and blocklist", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_agent_tools(
@@ -3746,7 +3746,7 @@ pub struct SetAgentToolsRequest {
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = SetAgentToolsRequest, description = "Tool configuration fields"),
     responses(
-        (status = 200, description = "Update an agent's tool allowlist and blocklist", body = serde_json::Value)
+        (status = 200, description = "Update an agent's tool allowlist and blocklist", body = crate::types::JsonObject)
     )
 )]
 pub async fn set_agent_tools(
@@ -3811,7 +3811,7 @@ pub async fn set_agent_tools(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Get an agent's skill assignment info", body = serde_json::Value)
+        (status = 200, description = "Get an agent's skill assignment info", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_agent_skills(
@@ -3863,7 +3863,7 @@ pub async fn get_agent_skills(
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = serde_json::Value, description = "Array of skill names"),
     responses(
-        (status = 200, description = "Update an agent's skill allowlist", body = serde_json::Value)
+        (status = 200, description = "Update an agent's skill allowlist", body = crate::types::JsonObject)
     )
 )]
 pub async fn set_agent_skills(
@@ -3911,7 +3911,7 @@ pub async fn set_agent_skills(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Get an agent's MCP server assignment info", body = serde_json::Value)
+        (status = 200, description = "Get an agent's MCP server assignment info", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_agent_mcp_servers(
@@ -3982,7 +3982,7 @@ pub async fn get_agent_mcp_servers(
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = serde_json::Value, description = "Array of MCP server names"),
     responses(
-        (status = 200, description = "Update an agent's MCP server allowlist", body = serde_json::Value)
+        (status = 200, description = "Update an agent's MCP server allowlist", body = crate::types::JsonObject)
     )
 )]
 pub async fn set_agent_mcp_servers(
@@ -4038,7 +4038,7 @@ pub async fn set_agent_mcp_servers(
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = AgentUpdateRequest, description = "New agent manifest TOML"),
     responses(
-        (status = 200, description = "Update an agent's manifest", body = serde_json::Value)
+        (status = 200, description = "Update an agent's manifest", body = crate::types::JsonObject)
     )
 )]
 pub async fn update_agent(
@@ -4107,7 +4107,7 @@ pub async fn update_agent(
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = serde_json::Value, description = "Partial agent fields to update"),
     responses(
-        (status = 200, description = "Partially update an agent (name, description, model, system prompt)", body = serde_json::Value)
+        (status = 200, description = "Partially update an agent (name, description, model, system prompt)", body = crate::types::JsonObject)
     )
 )]
 pub async fn patch_agent(
@@ -4285,7 +4285,7 @@ pub(crate) struct UpdateIdentityRequest {
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = UpdateIdentityRequest, description = "Identity fields to update"),
     responses(
-        (status = 200, description = "Update an agent's visual identity", body = serde_json::Value)
+        (status = 200, description = "Update an agent's visual identity", body = crate::types::JsonObject)
     )
 )]
 #[allow(private_interfaces)]
@@ -4403,7 +4403,7 @@ pub struct PatchAgentConfigRequest {
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = PatchAgentConfigRequest, description = "Agent config fields to update"),
     responses(
-        (status = 200, description = "Hot-update agent name, description, system prompt, identity, and model", body = serde_json::Value)
+        (status = 200, description = "Hot-update agent name, description, system prompt, identity, and model", body = crate::types::JsonObject)
     )
 )]
 #[allow(private_interfaces)]
@@ -4743,11 +4743,11 @@ fn map_hand_runtime_override_err(
         description = "Runtime override fields. Whitespace is trimmed on all string fields. For `model` and `provider` an empty (or whitespace-only) string is ignored ('leave unchanged'); for the nullable secrets `api_key_env` and `base_url` an empty (or whitespace-only) string clears the override."
     ),
     responses(
-        (status = 200, description = "Runtime override applied to the live manifest and persisted to hand_state.json", body = serde_json::Value),
-        (status = 400, description = "Invalid agent id or target agent is not managed by a hand", body = serde_json::Value),
-        (status = 404, description = "Agent not found", body = serde_json::Value),
-        (status = 409, description = "Hand role not found for the agent (hand registry inconsistency)", body = serde_json::Value),
-        (status = 500, description = "Internal kernel error", body = serde_json::Value),
+        (status = 200, description = "Runtime override applied to the live manifest and persisted to hand_state.json", body = crate::types::JsonObject),
+        (status = 400, description = "Invalid agent id or target agent is not managed by a hand", body = crate::types::JsonObject),
+        (status = 404, description = "Agent not found", body = crate::types::JsonObject),
+        (status = 409, description = "Hand role not found for the agent (hand registry inconsistency)", body = crate::types::JsonObject),
+        (status = 500, description = "Internal kernel error", body = crate::types::JsonObject),
     )
 )]
 pub async fn patch_hand_agent_runtime_config(
@@ -4835,10 +4835,10 @@ pub async fn patch_hand_agent_runtime_config(
     params(("id" = String, Path, description = "Hand agent ID")),
     responses(
         (status = 204, description = "Runtime overrides cleared; manifest restored to HAND.toml defaults"),
-        (status = 400, description = "Invalid agent id or target agent is not managed by a hand", body = serde_json::Value),
-        (status = 404, description = "Agent not found", body = serde_json::Value),
-        (status = 409, description = "Hand role not found for the agent (hand registry inconsistency)", body = serde_json::Value),
-        (status = 500, description = "Internal kernel error", body = serde_json::Value),
+        (status = 400, description = "Invalid agent id or target agent is not managed by a hand", body = crate::types::JsonObject),
+        (status = 404, description = "Agent not found", body = crate::types::JsonObject),
+        (status = 409, description = "Hand role not found for the agent (hand registry inconsistency)", body = crate::types::JsonObject),
+        (status = 500, description = "Internal kernel error", body = crate::types::JsonObject),
     )
 )]
 pub async fn delete_hand_agent_runtime_config(
@@ -4953,7 +4953,7 @@ fn format_schedule_mode(schedule: &librefang_types::agent::ScheduleMode) -> Stri
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = CloneAgentRequest, description = "New name for the cloned agent"),
     responses(
-        (status = 200, description = "Clone an agent with its workspace files", body = serde_json::Value)
+        (status = 200, description = "Clone an agent with its workspace files", body = crate::types::JsonObject)
     )
 )]
 #[allow(private_interfaces)]
@@ -5079,7 +5079,7 @@ pub async fn clone_agent(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Agent manifest reloaded from agent.toml", body = serde_json::Value)
+        (status = 200, description = "Agent manifest reloaded from agent.toml", body = crate::types::JsonObject)
     )
 )]
 pub async fn reload_agent_manifest(
@@ -5134,7 +5134,7 @@ const KNOWN_IDENTITY_FILES: &[&str] = &[
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "List workspace identity files for an agent", body = serde_json::Value)
+        (status = 200, description = "List workspace identity files for an agent", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_agent_files(
@@ -5208,7 +5208,7 @@ pub async fn list_agent_files(
         ("filename" = String, Path, description = "Identity file name"),
     ),
     responses(
-        (status = 200, description = "Read a workspace identity file", body = serde_json::Value)
+        (status = 200, description = "Read a workspace identity file", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_agent_file(
@@ -5328,7 +5328,7 @@ pub(crate) struct SetAgentFileRequest {
     ),
     request_body(content = SetAgentFileRequest, description = "File content to write"),
     responses(
-        (status = 200, description = "Write a workspace identity file", body = serde_json::Value)
+        (status = 200, description = "Write a workspace identity file", body = crate::types::JsonObject)
     )
 )]
 #[allow(private_interfaces)]
@@ -5464,8 +5464,8 @@ pub async fn set_agent_file(
         ("filename" = String, Path, description = "Identity file name"),
     ),
     responses(
-        (status = 200, description = "File deleted successfully", body = serde_json::Value),
-        (status = 404, description = "File not found", body = serde_json::Value)
+        (status = 200, description = "File deleted successfully", body = crate::types::JsonObject),
+        (status = 404, description = "File not found", body = crate::types::JsonObject)
     )
 )]
 pub async fn delete_agent_file(
@@ -5684,7 +5684,7 @@ fn is_allowed_content_type(ct: &str) -> bool {
     params(("id" = String, Path, description = "Agent ID")),
     request_body(content = String, content_type = "application/octet-stream"),
     responses(
-        (status = 200, description = "Upload a file attachment for an agent", body = serde_json::Value)
+        (status = 200, description = "Upload a file attachment for an agent", body = crate::types::JsonObject)
     )
 )]
 pub async fn upload_file(
@@ -5836,7 +5836,7 @@ pub async fn upload_file(
     tag = "agents",
     params(("file_id" = String, Path, description = "Upload file ID (UUID)")),
     responses(
-        (status = 200, description = "Serve an uploaded file by ID", body = serde_json::Value)
+        (status = 200, description = "Serve an uploaded file by ID", body = crate::types::JsonObject)
     )
 )]
 pub async fn serve_upload(
@@ -5935,7 +5935,7 @@ pub async fn serve_upload(
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "List recent delivery receipts for an agent", body = serde_json::Value)
+        (status = 200, description = "List recent delivery receipts for an agent", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_agent_deliveries(

--- a/crates/librefang-api/src/routes/audit.rs
+++ b/crates/librefang-api/src/routes/audit.rs
@@ -216,7 +216,7 @@ fn user_matches_loose(query: &str, recorded_uuid: &str) -> bool {
         ("to" = Option<String>, Query, description = "ISO-8601 upper bound (inclusive)"),
         ("limit" = Option<u32>, Query, description = "Max rows (default 200, hard cap 5000)"),
     ),
-    responses((status = 200, description = "Filtered audit log entries", body = serde_json::Value))
+    responses((status = 200, description = "Filtered audit log entries", body = crate::types::JsonObject))
 )]
 pub async fn audit_query(
     State(state): State<Arc<AppState>>,

--- a/crates/librefang-api/src/routes/authz.rs
+++ b/crates/librefang-api/src/routes/authz.rs
@@ -105,7 +105,7 @@ fn require_admin(state: &AppState, api_user: Option<&AuthenticatedApiUser>) -> O
     tag = "system",
     params(("user_id" = String, Path, description = "User UUID or configured name")),
     responses(
-        (status = 200, description = "Effective permissions snapshot", body = serde_json::Value),
+        (status = 200, description = "Effective permissions snapshot", body = crate::types::JsonObject),
         (status = 404, description = "Unknown user"),
     )
 )]

--- a/crates/librefang-api/src/routes/auto_dream.rs
+++ b/crates/librefang-api/src/routes/auto_dream.rs
@@ -42,7 +42,7 @@ pub fn router() -> axum::Router<Arc<AppState>> {
     get,
     path = "/api/auto-dream/status",
     tag = "auto_dream",
-    responses((status = 200, description = "Auto-dream status", body = serde_json::Value))
+    responses((status = 200, description = "Auto-dream status", body = crate::types::JsonObject))
 )]
 pub async fn auto_dream_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let status = librefang_kernel::auto_dream::current_status(&state.kernel).await;
@@ -55,7 +55,7 @@ pub async fn auto_dream_status(State(state): State<Arc<AppState>>) -> impl IntoR
     tag = "auto_dream",
     params(("id" = String, Path, description = "Agent UUID")),
     responses(
-        (status = 200, description = "Trigger outcome", body = serde_json::Value),
+        (status = 200, description = "Trigger outcome", body = crate::types::JsonObject),
         (status = 400, description = "Invalid agent id"),
     )
 )]
@@ -84,7 +84,7 @@ pub async fn auto_dream_trigger(
     tag = "auto_dream",
     params(("id" = String, Path, description = "Agent UUID")),
     responses(
-        (status = 200, description = "Abort outcome", body = serde_json::Value),
+        (status = 200, description = "Abort outcome", body = crate::types::JsonObject),
         (status = 400, description = "Invalid agent id"),
     )
 )]
@@ -117,7 +117,7 @@ pub struct SetEnabledRequest {
     tag = "auto_dream",
     params(("id" = String, Path, description = "Agent UUID")),
     responses(
-        (status = 200, description = "Opt-in toggled", body = serde_json::Value),
+        (status = 200, description = "Opt-in toggled", body = crate::types::JsonObject),
         (status = 400, description = "Invalid agent id"),
         (status = 404, description = "Agent not found"),
     )

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -132,7 +132,7 @@ fn fmt_global_budget_diff(
     get,
     path = "/api/usage",
     tag = "budget",
-    responses((status = 200, description = "Per-agent usage statistics", body = serde_json::Value))
+    responses((status = 200, description = "Per-agent usage statistics", body = crate::types::JsonObject))
 )]
 pub async fn usage_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let usage_store = state.kernel.memory_substrate().usage();
@@ -171,7 +171,7 @@ pub async fn usage_stats(State(state): State<Arc<AppState>>) -> impl IntoRespons
     get,
     path = "/api/usage/summary",
     tag = "budget",
-    responses((status = 200, description = "Overall usage summary", body = serde_json::Value))
+    responses((status = 200, description = "Overall usage summary", body = crate::types::JsonObject))
 )]
 pub async fn usage_summary(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     match state.kernel.memory_substrate().usage().query_summary(None) {
@@ -197,7 +197,7 @@ pub async fn usage_summary(State(state): State<Arc<AppState>>) -> impl IntoRespo
     get,
     path = "/api/usage/by-model",
     tag = "budget",
-    responses((status = 200, description = "Usage grouped by model", body = serde_json::Value))
+    responses((status = 200, description = "Usage grouped by model", body = crate::types::JsonObject))
 )]
 pub async fn usage_by_model(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     match state.kernel.memory_substrate().usage().query_by_model() {
@@ -225,7 +225,7 @@ pub async fn usage_by_model(State(state): State<Arc<AppState>>) -> impl IntoResp
     get,
     path = "/api/usage/by-model/performance",
     tag = "budget",
-    responses((status = 200, description = "Model performance metrics", body = serde_json::Value))
+    responses((status = 200, description = "Model performance metrics", body = crate::types::JsonObject))
 )]
 pub async fn usage_by_model_performance(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     match state
@@ -263,7 +263,7 @@ pub async fn usage_by_model_performance(State(state): State<Arc<AppState>>) -> i
     get,
     path = "/api/usage/daily",
     tag = "budget",
-    responses((status = 200, description = "Daily usage breakdown", body = serde_json::Value))
+    responses((status = 200, description = "Daily usage breakdown", body = crate::types::JsonObject))
 )]
 pub async fn usage_daily(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let days = state
@@ -310,7 +310,7 @@ pub async fn usage_daily(State(state): State<Arc<AppState>>) -> impl IntoRespons
     path = "/api/budget",
     tag = "budget",
     responses(
-        (status = 200, description = "Global budget status", body = serde_json::Value)
+        (status = 200, description = "Global budget status", body = crate::types::JsonObject)
     )
 )]
 pub async fn budget_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -326,7 +326,7 @@ pub async fn budget_status(State(state): State<Arc<AppState>>) -> impl IntoRespo
     put,
     path = "/api/budget",
     tag = "budget",
-    responses((status = 200, description = "Updated global budget status", body = serde_json::Value))
+    responses((status = 200, description = "Updated global budget status", body = crate::types::JsonObject))
 )]
 pub async fn update_budget(
     State(state): State<Arc<AppState>>,
@@ -392,7 +392,7 @@ pub async fn update_budget(
     path = "/api/budget/agents/{id}",
     tag = "budget",
     params(("id" = String, Path, description = "Agent ID")),
-    responses((status = 200, description = "Per-agent budget and quota status", body = serde_json::Value))
+    responses((status = 200, description = "Per-agent budget and quota status", body = crate::types::JsonObject))
 )]
 pub async fn agent_budget_status(
     State(state): State<Arc<AppState>>,
@@ -508,7 +508,7 @@ pub async fn agent_budget_ranking(State(state): State<Arc<AppState>>) -> impl In
     path = "/api/budget/agents/{id}",
     tag = "budget",
     params(("id" = String, Path, description = "Agent ID")),
-    responses((status = 200, description = "Updated agent budget", body = serde_json::Value))
+    responses((status = 200, description = "Updated agent budget", body = crate::types::JsonObject))
 )]
 pub async fn update_agent_budget(
     State(state): State<Arc<AppState>>,
@@ -651,7 +651,7 @@ fn require_admin_for_user_budget(
     path = "/api/budget/users",
     tag = "budget",
     params(("limit" = Option<u32>, Query, description = "Top N users (default 25, cap 1000)")),
-    responses((status = 200, description = "Per-user cost ranking", body = serde_json::Value))
+    responses((status = 200, description = "Per-user cost ranking", body = crate::types::JsonObject))
 )]
 pub async fn user_budget_ranking(
     State(state): State<Arc<AppState>>,
@@ -735,7 +735,7 @@ pub async fn user_budget_ranking(
     path = "/api/budget/users/{user_id}",
     tag = "budget",
     params(("user_id" = String, Path, description = "User UUID or configured name")),
-    responses((status = 200, description = "Single user budget detail", body = serde_json::Value))
+    responses((status = 200, description = "Single user budget detail", body = crate::types::JsonObject))
 )]
 pub async fn user_budget_detail(
     State(state): State<Arc<AppState>>,
@@ -848,7 +848,7 @@ pub async fn user_budget_detail(
     tag = "budget",
     params(("user_id" = String, Path, description = "User UUID or configured name")),
     responses(
-        (status = 200, description = "Budget written and reloaded", body = serde_json::Value),
+        (status = 200, description = "Budget written and reloaded", body = crate::types::JsonObject),
         (status = 400, description = "Invalid or partial budget payload"),
         (status = 403, description = "Caller is not an admin"),
         (status = 404, description = "No user matches the given id/name"),

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1278,8 +1278,8 @@ pub(crate) async fn channels_snapshot(state: &Arc<AppState>) -> Vec<serde_json::
         ("name" = String, Path, description = "Channel adapter name (e.g. telegram, discord)")
     ),
     responses(
-        (status = 200, description = "Channel details", body = serde_json::Value),
-        (status = 404, description = "Unknown channel", body = serde_json::Value)
+        (status = 200, description = "Channel details", body = crate::types::JsonObject),
+        (status = 404, description = "Unknown channel", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_channel(
@@ -1345,11 +1345,11 @@ pub async fn get_channel(
     params(
         ("name" = String, Path, description = "Channel name")
     ),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Channel configured successfully", body = serde_json::Value),
-        (status = 400, description = "Bad request", body = serde_json::Value),
-        (status = 404, description = "Unknown channel", body = serde_json::Value)
+        (status = 200, description = "Channel configured successfully", body = crate::types::JsonObject),
+        (status = 400, description = "Bad request", body = crate::types::JsonObject),
+        (status = 404, description = "Unknown channel", body = crate::types::JsonObject)
     )
 )]
 /// POST /api/channels/{name}/configure — Save channel secrets + config fields.
@@ -1473,9 +1473,9 @@ pub async fn configure_channel(
         ("name" = String, Path, description = "Channel name")
     ),
     responses(
-        (status = 200, description = "Channel removed successfully", body = serde_json::Value),
-        (status = 404, description = "Unknown channel", body = serde_json::Value),
-        (status = 500, description = "Internal server error", body = serde_json::Value)
+        (status = 200, description = "Channel removed successfully", body = crate::types::JsonObject),
+        (status = 404, description = "Unknown channel", body = crate::types::JsonObject),
+        (status = 500, description = "Internal server error", body = crate::types::JsonObject)
     )
 )]
 /// DELETE /api/channels/{name}/configure — Remove channel secrets + config section.
@@ -1533,8 +1533,8 @@ pub async fn remove_channel(
     ),
     request_body(content = Option<serde_json::Value>, content_type = "application/json"),
     responses(
-        (status = 200, description = "Channel test result", body = serde_json::Value),
-        (status = 404, description = "Unknown channel", body = serde_json::Value)
+        (status = 200, description = "Channel test result", body = crate::types::JsonObject),
+        (status = 404, description = "Unknown channel", body = crate::types::JsonObject)
     )
 )]
 /// POST /api/channels/{name}/test — Connectivity check + optional live test message.
@@ -1688,8 +1688,8 @@ async fn send_channel_test_message(channel_name: &str, target_id: &str) -> Resul
     path = "/api/channels/reload",
     tag = "channels",
     responses(
-        (status = 200, description = "Channels reloaded successfully", body = serde_json::Value),
-        (status = 500, description = "Reload failed", body = serde_json::Value)
+        (status = 200, description = "Channels reloaded successfully", body = crate::types::JsonObject),
+        (status = 500, description = "Reload failed", body = crate::types::JsonObject)
     )
 )]
 /// POST /api/channels/reload — Manually trigger a channel hot-reload from disk config.
@@ -1720,7 +1720,7 @@ pub async fn reload_channels(State(state): State<Arc<AppState>>) -> impl IntoRes
     path = "/api/channels/whatsapp/qr/start",
     tag = "channels",
     responses(
-        (status = 200, description = "WhatsApp QR session started", body = serde_json::Value)
+        (status = 200, description = "WhatsApp QR session started", body = crate::types::JsonObject)
     )
 )]
 /// POST /api/channels/whatsapp/qr/start — Start a WhatsApp Web QR login session.
@@ -1784,7 +1784,7 @@ pub async fn whatsapp_qr_start() -> impl IntoResponse {
         ("session_id" = Option<String>, Query, description = "WhatsApp login session ID")
     ),
     responses(
-        (status = 200, description = "WhatsApp QR scan status", body = serde_json::Value)
+        (status = 200, description = "WhatsApp QR scan status", body = crate::types::JsonObject)
     )
 )]
 /// GET /api/channels/whatsapp/qr/status — Poll for QR scan completion.
@@ -1938,7 +1938,7 @@ const WECHAT_ILINK_BASE: &str = "https://ilinkai.weixin.qq.com";
     path = "/api/channels/wechat/qr/start",
     tag = "channels",
     responses(
-        (status = 200, description = "WeChat QR login initiated", body = serde_json::Value)
+        (status = 200, description = "WeChat QR login initiated", body = crate::types::JsonObject)
     )
 )]
 /// POST /api/channels/wechat/qr/start — Request a QR code from iLink for WeChat login.
@@ -2003,7 +2003,7 @@ pub async fn wechat_qr_start() -> impl IntoResponse {
         ("qr_code" = String, Query, description = "QR code value from /qr/start")
     ),
     responses(
-        (status = 200, description = "WeChat QR scan status", body = serde_json::Value)
+        (status = 200, description = "WeChat QR scan status", body = crate::types::JsonObject)
     )
 )]
 /// GET /api/channels/wechat/qr/status — Poll iLink for QR scan confirmation.

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -196,7 +196,7 @@ fn redacted_web(web: &librefang_types::config::WebConfig) -> serde_json::Value {
     path = "/api/status",
     tag = "system",
     responses(
-        (status = 200, description = "Daemon status", body = serde_json::Value)
+        (status = 200, description = "Daemon status", body = crate::types::JsonObject)
     )
 )]
 pub async fn status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -267,7 +267,7 @@ pub async fn status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     path = "/api/init",
     tag = "system",
     responses(
-        (status = 200, description = "Quick init result", body = serde_json::Value)
+        (status = 200, description = "Quick init result", body = crate::types::JsonObject)
     )
 )]
 pub async fn quick_init(State(state): State<Arc<AppState>>) -> axum::response::Response {
@@ -356,7 +356,7 @@ api_key_env = "{api_key_env}"
     path = "/api/shutdown",
     tag = "system",
     responses(
-        (status = 200, description = "Graceful daemon shutdown", body = serde_json::Value)
+        (status = 200, description = "Graceful daemon shutdown", body = crate::types::JsonObject)
     )
 )]
 pub async fn shutdown(
@@ -391,7 +391,7 @@ pub async fn shutdown(
     path = "/api/version",
     tag = "system",
     responses(
-        (status = 200, description = "Version information", body = serde_json::Value)
+        (status = 200, description = "Version information", body = crate::types::JsonObject)
     )
 )]
 pub async fn version() -> impl IntoResponse {
@@ -425,7 +425,7 @@ pub async fn version() -> impl IntoResponse {
     path = "/api/health",
     tag = "system",
     responses(
-        (status = 200, description = "Health check", body = serde_json::Value)
+        (status = 200, description = "Health check", body = crate::types::JsonObject)
     )
 )]
 pub async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -460,7 +460,7 @@ pub async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     path = "/api/health/detail",
     tag = "system",
     responses(
-        (status = 200, description = "Detailed health diagnostics", body = serde_json::Value)
+        (status = 200, description = "Detailed health diagnostics", body = crate::types::JsonObject)
     )
 )]
 pub async fn health_detail(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -526,7 +526,7 @@ pub async fn health_detail(State(state): State<Arc<AppState>>) -> impl IntoRespo
     path = "/api/metrics",
     tag = "system",
     responses(
-        (status = 200, description = "Prometheus text-format metrics", body = serde_json::Value)
+        (status = 200, description = "Prometheus text-format metrics", body = crate::types::JsonObject)
     )
 )]
 pub async fn prometheus_metrics(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -659,7 +659,7 @@ pub async fn prometheus_metrics(State(state): State<Arc<AppState>>) -> impl Into
     path = "/api/config",
     tag = "system",
     responses(
-        (status = 200, description = "Get kernel configuration (secrets redacted)", body = serde_json::Value)
+        (status = 200, description = "Get kernel configuration (secrets redacted)", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -1265,7 +1265,7 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> impl IntoResponse
     path = "/api/security",
     tag = "system",
     responses(
-        (status = 200, description = "Security feature status", body = serde_json::Value)
+        (status = 200, description = "Security feature status", body = crate::types::JsonObject)
     )
 )]
 pub async fn security_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -1345,7 +1345,7 @@ pub async fn security_status(State(state): State<Arc<AppState>>) -> impl IntoRes
     path = "/api/migrate/detect",
     tag = "system",
     responses(
-        (status = 200, description = "Detect migratable framework installation", body = serde_json::Value)
+        (status = 200, description = "Detect migratable framework installation", body = crate::types::JsonObject)
     )
 )]
 pub async fn migrate_detect() -> impl IntoResponse {
@@ -1396,7 +1396,7 @@ pub async fn migrate_detect() -> impl IntoResponse {
     path = "/api/migrate/scan",
     tag = "system",
     responses(
-        (status = 200, description = "Scan directory for migratable workspace", body = serde_json::Value)
+        (status = 200, description = "Scan directory for migratable workspace", body = crate::types::JsonObject)
     )
 )]
 pub async fn migrate_scan(Json(req): Json<MigrateScanRequest>) -> impl IntoResponse {
@@ -1414,7 +1414,7 @@ pub async fn migrate_scan(Json(req): Json<MigrateScanRequest>) -> impl IntoRespo
     path = "/api/migrate",
     tag = "system",
     responses(
-        (status = 200, description = "Run migration from another agent framework", body = serde_json::Value)
+        (status = 200, description = "Run migration from another agent framework", body = crate::types::JsonObject)
     )
 )]
 pub async fn run_migrate(
@@ -1515,7 +1515,7 @@ pub async fn run_migrate(
     path = "/api/config/reload",
     tag = "system",
     responses(
-        (status = 200, description = "Reload configuration from disk", body = serde_json::Value)
+        (status = 200, description = "Reload configuration from disk", body = crate::types::JsonObject)
     )
 )]
 pub async fn config_reload(
@@ -1659,7 +1659,7 @@ pub async fn export_config(State(state): State<Arc<AppState>>) -> impl IntoRespo
     path = "/api/config/schema",
     tag = "system",
     responses(
-        (status = 200, description = "Get config structure schema", body = serde_json::Value)
+        (status = 200, description = "Get config structure schema", body = crate::types::JsonObject)
     )
 )]
 pub async fn config_schema(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -1868,7 +1868,7 @@ pub fn ui_options_overlay(
     path = "/api/config/set",
     tag = "system",
     responses(
-        (status = 200, description = "Set a single config value and persist", body = serde_json::Value)
+        (status = 200, description = "Set a single config value and persist", body = crate::types::JsonObject)
     )
 )]
 pub async fn config_set(

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -414,7 +414,7 @@ pub async fn delete_goal(
     path = "/api/goals/templates",
     tag = "goals",
     responses(
-        (status = 200, description = "Goal templates", body = serde_json::Value)
+        (status = 200, description = "Goal templates", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_goal_templates() -> impl IntoResponse {

--- a/crates/librefang-api/src/routes/inbox.rs
+++ b/crates/librefang-api/src/routes/inbox.rs
@@ -17,7 +17,7 @@ pub fn router() -> axum::Router<Arc<AppState>> {
     path = "/api/inbox/status",
     tag = "inbox",
     responses(
-        (status = 200, description = "Inbox status", body = serde_json::Value)
+        (status = 200, description = "Inbox status", body = crate::types::JsonObject)
     )
 )]
 pub async fn inbox_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -60,7 +60,7 @@ fn auth_failed(detail: impl std::fmt::Display) -> Response {
         ("name" = String, Path, description = "MCP server name"),
     ),
     responses(
-        (status = 200, description = "Auth status for the MCP server", body = serde_json::Value),
+        (status = 200, description = "Auth status for the MCP server", body = crate::types::JsonObject),
         (status = 404, description = "MCP server not found")
     )
 )]
@@ -256,7 +256,7 @@ fn percent_encode_param(s: &str) -> String {
         ("name" = String, Path, description = "MCP server name"),
     ),
     responses(
-        (status = 200, description = "Auth flow started — returns auth URL", body = serde_json::Value),
+        (status = 200, description = "Auth flow started — returns auth URL", body = crate::types::JsonObject),
         (status = 400, description = "Server has no HTTP transport or discovery failed"),
         (status = 404, description = "MCP server not found")
     )
@@ -843,7 +843,7 @@ pub async fn auth_callback(
         ("name" = String, Path, description = "MCP server name"),
     ),
     responses(
-        (status = 200, description = "Auth revoked", body = serde_json::Value),
+        (status = 200, description = "Auth revoked", body = crate::types::JsonObject),
         (status = 404, description = "MCP server not found")
     )
 )]

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -382,7 +382,7 @@ fn auth_denied(
         ("q" = String, Query, description = "Search query"),
         ("limit" = usize, Query, description = "Max results (default 10)"),
     ),
-    responses((status = 200, description = "Search results", body = serde_json::Value))
+    responses((status = 200, description = "Search results", body = crate::types::JsonObject))
 )]
 pub async fn memory_search(
     State(state): State<Arc<AppState>>,
@@ -427,7 +427,7 @@ pub async fn memory_search(
         ("offset" = Option<usize>, Query, description = "Pagination offset (default 0)"),
         ("limit" = Option<usize>, Query, description = "Page size (default 10, max 100)"),
     ),
-    responses((status = 200, description = "Paginated memory list", body = serde_json::Value))
+    responses((status = 200, description = "Paginated memory list", body = crate::types::JsonObject))
 )]
 pub async fn memory_list(
     State(state): State<Arc<AppState>>,
@@ -488,7 +488,7 @@ pub async fn memory_list(
     path = "/api/memory/user/{user_id}",
     tag = "proactive-memory",
     params(("user_id" = String, Path, description = "User ID")),
-    responses((status = 200, description = "User memories", body = serde_json::Value))
+    responses((status = 200, description = "User memories", body = crate::types::JsonObject))
 )]
 pub async fn memory_get_user(
     State(state): State<Arc<AppState>>,
@@ -522,8 +522,8 @@ pub async fn memory_get_user(
     post,
     path = "/api/memory",
     tag = "proactive-memory",
-    request_body = serde_json::Value,
-    responses((status = 201, description = "Memories added", body = serde_json::Value))
+    request_body = crate::types::JsonObject,
+    responses((status = 201, description = "Memories added", body = crate::types::JsonObject))
 )]
 pub async fn memory_add(
     State(state): State<Arc<AppState>>,
@@ -560,8 +560,8 @@ pub async fn memory_add(
     path = "/api/memory/items/{memory_id}",
     tag = "proactive-memory",
     params(("memory_id" = String, Path, description = "Memory ID")),
-    request_body = serde_json::Value,
-    responses((status = 200, description = "Memory updated", body = serde_json::Value))
+    request_body = crate::types::JsonObject,
+    responses((status = 200, description = "Memory updated", body = crate::types::JsonObject))
 )]
 pub async fn memory_update(
     State(state): State<Arc<AppState>>,
@@ -611,7 +611,7 @@ pub async fn memory_update(
     path = "/api/memory/items/{memory_id}",
     tag = "proactive-memory",
     params(("memory_id" = String, Path, description = "Memory ID")),
-    responses((status = 200, description = "Memory deleted", body = serde_json::Value))
+    responses((status = 200, description = "Memory deleted", body = crate::types::JsonObject))
 )]
 pub async fn memory_delete(
     State(state): State<Arc<AppState>>,
@@ -649,8 +649,8 @@ pub async fn memory_delete(
     post,
     path = "/api/memory/bulk-delete",
     tag = "proactive-memory",
-    request_body = serde_json::Value,
-    responses((status = 200, description = "Bulk delete results", body = serde_json::Value))
+    request_body = crate::types::JsonObject,
+    responses((status = 200, description = "Bulk delete results", body = crate::types::JsonObject))
 )]
 pub async fn memory_bulk_delete(
     State(state): State<Arc<AppState>>,
@@ -709,7 +709,7 @@ pub async fn memory_bulk_delete(
     get,
     path = "/api/memory/stats",
     tag = "proactive-memory",
-    responses((status = 200, description = "Memory statistics", body = serde_json::Value))
+    responses((status = 200, description = "Memory statistics", body = crate::types::JsonObject))
 )]
 pub async fn memory_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     // Graceful degradation: proactive memory disabled → null stats, not 500.
@@ -751,7 +751,7 @@ pub async fn memory_stats(State(state): State<Arc<AppState>>) -> impl IntoRespon
     path = "/api/memory/agents/{id}",
     tag = "proactive-memory",
     params(("id" = String, Path, description = "Agent ID")),
-    responses((status = 200, description = "Memories reset", body = serde_json::Value))
+    responses((status = 200, description = "Memories reset", body = crate::types::JsonObject))
 )]
 pub async fn memory_reset_agent(
     State(state): State<Arc<AppState>>,
@@ -781,7 +781,7 @@ pub async fn memory_reset_agent(
         ("id" = String, Path, description = "Agent ID"),
         ("level" = String, Path, description = "Memory level: user, session, or agent"),
     ),
-    responses((status = 200, description = "Memories cleared at level", body = serde_json::Value))
+    responses((status = 200, description = "Memories cleared at level", body = crate::types::JsonObject))
 )]
 pub async fn memory_clear_level(
     State(state): State<Arc<AppState>>,
@@ -832,7 +832,7 @@ pub async fn memory_clear_level(
         ("offset" = Option<usize>, Query, description = "Pagination offset (default 0)"),
         ("limit" = Option<usize>, Query, description = "Page size (default 10, max 100)"),
     ),
-    responses((status = 200, description = "Paginated agent memory list", body = serde_json::Value))
+    responses((status = 200, description = "Paginated agent memory list", body = crate::types::JsonObject))
 )]
 pub async fn memory_list_agent(
     State(state): State<Arc<AppState>>,
@@ -887,7 +887,7 @@ pub async fn memory_list_agent(
         ("q" = String, Query, description = "Search query"),
         ("limit" = usize, Query, description = "Max results (default 10)"),
     ),
-    responses((status = 200, description = "Search results", body = serde_json::Value))
+    responses((status = 200, description = "Search results", body = crate::types::JsonObject))
 )]
 pub async fn memory_search_agent(
     State(state): State<Arc<AppState>>,
@@ -927,7 +927,7 @@ pub async fn memory_search_agent(
     path = "/api/memory/agents/{id}/stats",
     tag = "proactive-memory",
     params(("id" = String, Path, description = "Agent ID")),
-    responses((status = 200, description = "Agent memory statistics", body = serde_json::Value))
+    responses((status = 200, description = "Agent memory statistics", body = crate::types::JsonObject))
 )]
 pub async fn memory_stats_agent(
     State(state): State<Arc<AppState>>,
@@ -954,7 +954,7 @@ pub async fn memory_stats_agent(
     path = "/api/memory/agents/{id}/duplicates",
     tag = "proactive-memory",
     params(("id" = String, Path, description = "Agent ID")),
-    responses((status = 200, description = "Duplicate memory groups", body = serde_json::Value))
+    responses((status = 200, description = "Duplicate memory groups", body = crate::types::JsonObject))
 )]
 pub async fn memory_duplicates(
     State(state): State<Arc<AppState>>,
@@ -987,7 +987,7 @@ pub async fn memory_duplicates(
     path = "/api/memory/items/{memory_id}/history",
     tag = "proactive-memory",
     params(("memory_id" = String, Path, description = "Memory ID")),
-    responses((status = 200, description = "Memory version history", body = serde_json::Value))
+    responses((status = 200, description = "Memory version history", body = crate::types::JsonObject))
 )]
 pub async fn memory_history(
     State(state): State<Arc<AppState>>,
@@ -1024,7 +1024,7 @@ pub async fn memory_history(
     path = "/api/memory/agents/{id}/consolidate",
     tag = "proactive-memory",
     params(("id" = String, Path, description = "Agent ID")),
-    responses((status = 200, description = "Consolidation result", body = serde_json::Value))
+    responses((status = 200, description = "Consolidation result", body = crate::types::JsonObject))
 )]
 pub async fn memory_consolidate(
     State(state): State<Arc<AppState>>,
@@ -1059,7 +1059,7 @@ pub async fn memory_consolidate(
     post,
     path = "/api/memory/cleanup",
     tag = "proactive-memory",
-    responses((status = 200, description = "Cleanup result", body = serde_json::Value))
+    responses((status = 200, description = "Cleanup result", body = crate::types::JsonObject))
 )]
 pub async fn memory_cleanup(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let store = match get_pm_store(&state) {
@@ -1090,7 +1090,7 @@ pub async fn memory_cleanup(State(state): State<Arc<AppState>>) -> impl IntoResp
     path = "/api/memory/agents/{id}/export",
     tag = "proactive-memory",
     params(("id" = String, Path, description = "Agent ID")),
-    responses((status = 200, description = "Exported memories", body = serde_json::Value))
+    responses((status = 200, description = "Exported memories", body = crate::types::JsonObject))
 )]
 pub async fn memory_export_agent(
     State(state): State<Arc<AppState>>,
@@ -1124,8 +1124,8 @@ pub async fn memory_export_agent(
     path = "/api/memory/agents/{id}/import",
     tag = "proactive-memory",
     params(("id" = String, Path, description = "Agent ID")),
-    request_body = serde_json::Value,
-    responses((status = 200, description = "Import result", body = serde_json::Value))
+    request_body = crate::types::JsonObject,
+    responses((status = 200, description = "Import result", body = crate::types::JsonObject))
 )]
 pub async fn memory_import_agent(
     State(state): State<Arc<AppState>>,
@@ -1163,7 +1163,7 @@ pub async fn memory_import_agent(
     post,
     path = "/api/memory/decay",
     tag = "proactive-memory",
-    responses((status = 200, description = "Decay result", body = serde_json::Value))
+    responses((status = 200, description = "Decay result", body = crate::types::JsonObject))
 )]
 pub async fn memory_decay(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let store = match get_pm_store(&state) {
@@ -1201,7 +1201,7 @@ pub struct MemoryCountQuery {
         ("id" = String, Path, description = "Agent ID"),
         ("level" = Option<String>, Query, description = "Memory level filter (user, session, agent)"),
     ),
-    responses((status = 200, description = "Memory count", body = serde_json::Value))
+    responses((status = 200, description = "Memory count", body = crate::types::JsonObject))
 )]
 pub async fn memory_count_agent(
     State(state): State<Arc<AppState>>,
@@ -1246,8 +1246,8 @@ pub async fn memory_count_agent(
     path = "/api/memory/agents/{id}/relations",
     tag = "proactive-memory",
     params(("id" = String, Path, description = "Agent ID")),
-    request_body = serde_json::Value,
-    responses((status = 200, description = "Relations stored", body = serde_json::Value))
+    request_body = crate::types::JsonObject,
+    responses((status = 200, description = "Relations stored", body = crate::types::JsonObject))
 )]
 pub async fn memory_store_relations(
     State(state): State<Arc<AppState>>,
@@ -1296,7 +1296,7 @@ pub struct RelationQueryParams {
         ("relation" = Option<String>, Query, description = "Relation type"),
         ("target" = Option<String>, Query, description = "Target entity name or ID"),
     ),
-    responses((status = 200, description = "Matching relations", body = serde_json::Value))
+    responses((status = 200, description = "Matching relations", body = crate::types::JsonObject))
 )]
 pub async fn memory_query_relations(
     State(state): State<Arc<AppState>>,
@@ -1359,7 +1359,7 @@ pub async fn memory_query_relations(
 // GET /api/memory/config — Get memory configuration
 // ---------------------------------------------------------------------------
 
-#[utoipa::path(get, path = "/api/memory/config", tag = "memory", responses((status = 200, description = "Memory configuration", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/memory/config", tag = "memory", responses((status = 200, description = "Memory configuration", body = crate::types::JsonObject)))]
 pub async fn memory_config_get(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let config = state.kernel.config_ref();
     Json(serde_json::json!({
@@ -1381,7 +1381,7 @@ pub async fn memory_config_get(State(state): State<Arc<AppState>>) -> impl IntoR
 // PATCH /api/memory/config — Update memory configuration (writes config.toml)
 // ---------------------------------------------------------------------------
 
-#[utoipa::path(patch, path = "/api/memory/config", tag = "memory", request_body = serde_json::Value, responses((status = 200, description = "Memory configuration updated", body = serde_json::Value)))]
+#[utoipa::path(patch, path = "/api/memory/config", tag = "memory", request_body = crate::types::JsonObject, responses((status = 200, description = "Memory configuration updated", body = crate::types::JsonObject)))]
 pub async fn memory_config_patch(
     State(state): State<Arc<AppState>>,
     Json(req): Json<serde_json::Value>,

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -1714,7 +1714,7 @@ fn audit_to_comms_event(
         ("limit" = Option<usize>, Query, description = "Maximum number of results"),
     ),
     responses(
-        (status = 200, description = "Recent inter-agent communication events", body = crate::types::JsonObject)
+        (status = 200, description = "Recent inter-agent communication events", body = crate::types::JsonArray)
     )
 )]
 pub async fn comms_events(

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -83,7 +83,7 @@ use crate::types::ApiErrorResponse;
     path = "/api/peers",
     tag = "network",
     responses(
-        (status = 200, description = "List known OFP peers", body = serde_json::Value)
+        (status = 200, description = "List known OFP peers", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_peers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -122,7 +122,7 @@ pub async fn list_peers(State(state): State<Arc<AppState>>) -> impl IntoResponse
     tag = "network",
     params(("id" = String, Path, description = "Peer node ID")),
     responses(
-        (status = 200, description = "Peer details", body = serde_json::Value),
+        (status = 200, description = "Peer details", body = crate::types::JsonObject),
         (status = 404, description = "Peer not found")
     )
 )]
@@ -163,7 +163,7 @@ pub async fn get_peer(
     path = "/api/network/status",
     tag = "network",
     responses(
-        (status = 200, description = "OFP network status summary", body = serde_json::Value)
+        (status = 200, description = "OFP network status summary", body = crate::types::JsonObject)
     )
 )]
 pub async fn network_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -212,7 +212,7 @@ pub async fn network_status(State(state): State<Arc<AppState>>) -> impl IntoResp
     path = "/api/network/trusted-peers",
     tag = "network",
     responses(
-        (status = 200, description = "List TOFU-pinned peers", body = serde_json::Value)
+        (status = 200, description = "List TOFU-pinned peers", body = crate::types::JsonObject)
     )
 )]
 pub async fn network_trusted_peers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -238,7 +238,7 @@ pub async fn network_trusted_peers(State(state): State<Arc<AppState>>) -> impl I
     path = "/.well-known/agent.json",
     tag = "a2a",
     responses(
-        (status = 200, description = "Get the A2A agent card", body = serde_json::Value)
+        (status = 200, description = "Get the A2A agent card", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_agent_card(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -294,7 +294,7 @@ pub async fn a2a_agent_card(State(state): State<Arc<AppState>>) -> impl IntoResp
     path = "/a2a/agents",
     tag = "a2a",
     responses(
-        (status = 200, description = "List all A2A agent cards", body = serde_json::Value)
+        (status = 200, description = "List all A2A agent cards", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_list_agents(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -324,9 +324,9 @@ pub async fn a2a_list_agents(State(state): State<Arc<AppState>>) -> impl IntoRes
     post,
     path = "/a2a/tasks/send",
     tag = "a2a",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Submit a task to an agent via A2A", body = serde_json::Value)
+        (status = 200, description = "Submit a task to an agent via A2A", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_send_task(
@@ -476,7 +476,7 @@ pub async fn a2a_send_task(
         ("id" = String, Path, description = "Id"),
     ),
     responses(
-        (status = 200, description = "Get A2A task status", body = serde_json::Value)
+        (status = 200, description = "Get A2A task status", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_get_task(
@@ -503,7 +503,7 @@ pub async fn a2a_get_task(
         ("id" = String, Path, description = "Id"),
     ),
     responses(
-        (status = 200, description = "Cancel a tracked A2A task", body = serde_json::Value)
+        (status = 200, description = "Cancel a tracked A2A task", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_cancel_task(
@@ -536,7 +536,7 @@ pub async fn a2a_cancel_task(
     path = "/api/a2a/agents",
     tag = "a2a",
     responses(
-        (status = 200, description = "List discovered external A2A agents", body = serde_json::Value)
+        (status = 200, description = "List discovered external A2A agents", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_list_external_agents(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -765,7 +765,7 @@ fn is_private_ip(ip: &IpAddr) -> bool {
         ("id" = String, Path, description = "Id"),
     ),
     responses(
-        (status = 200, description = "Get a specific external A2A agent", body = serde_json::Value)
+        (status = 200, description = "Get a specific external A2A agent", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_get_external_agent(
@@ -813,9 +813,9 @@ pub async fn a2a_get_external_agent(
     post,
     path = "/api/a2a/discover",
     tag = "a2a",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Discover an external A2A agent by URL", body = serde_json::Value)
+        (status = 200, description = "Discover an external A2A agent by URL", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_discover_external(
@@ -969,9 +969,9 @@ pub async fn a2a_discover_external(
     post,
     path = "/api/a2a/send",
     tag = "a2a",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Send a task to an external A2A agent", body = serde_json::Value)
+        (status = 200, description = "Send a task to an external A2A agent", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_send_external(
@@ -1063,7 +1063,7 @@ pub async fn a2a_send_external(
         ("url" = String, Query, description = "URL of the external A2A agent"),
     ),
     responses(
-        (status = 200, description = "Get external A2A task status", body = serde_json::Value)
+        (status = 200, description = "Get external A2A task status", body = crate::types::JsonObject)
     )
 )]
 pub async fn a2a_external_task_status(
@@ -1149,7 +1149,7 @@ pub async fn a2a_external_task_status(
         ("id" = String, Path, description = "Discovery URL of the pending agent (URL-encoded)"),
     ),
     responses(
-        (status = 200, description = "Agent approved and promoted to trusted list", body = serde_json::Value),
+        (status = 200, description = "Agent approved and promoted to trusted list", body = crate::types::JsonObject),
         (status = 404, description = "No pending agent found for the given URL")
     )
 )]
@@ -1246,9 +1246,9 @@ pub async fn a2a_approve_external(
     post,
     path = "/mcp",
     tag = "mcp",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Handle MCP JSON-RPC requests over HTTP", body = serde_json::Value)
+        (status = 200, description = "Handle MCP JSON-RPC requests over HTTP", body = crate::types::JsonObject)
     )
 )]
 pub async fn mcp_http(
@@ -1430,7 +1430,7 @@ pub async fn mcp_http(
     path = "/api/comms/topology",
     tag = "network",
     responses(
-        (status = 200, description = "Build agent topology graph", body = serde_json::Value)
+        (status = 200, description = "Build agent topology graph", body = crate::types::JsonObject)
     )
 )]
 pub async fn comms_topology(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -1714,7 +1714,7 @@ fn audit_to_comms_event(
         ("limit" = Option<usize>, Query, description = "Maximum number of results"),
     ),
     responses(
-        (status = 200, description = "Recent inter-agent communication events", body = serde_json::Value)
+        (status = 200, description = "Recent inter-agent communication events", body = crate::types::JsonObject)
     )
 )]
 pub async fn comms_events(
@@ -1764,7 +1764,7 @@ pub async fn comms_events(
     path = "/api/comms/events/stream",
     tag = "network",
     responses(
-        (status = 200, description = "SSE stream of inter-agent events", body = serde_json::Value)
+        (status = 200, description = "SSE stream of inter-agent events", body = crate::types::JsonObject)
     )
 )]
 pub async fn comms_events_stream(State(state): State<Arc<AppState>>) -> axum::response::Response {
@@ -1819,9 +1819,9 @@ pub async fn comms_events_stream(State(state): State<Arc<AppState>>) -> axum::re
     post,
     path = "/api/comms/send",
     tag = "network",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Send a message between agents", body = serde_json::Value)
+        (status = 200, description = "Send a message between agents", body = crate::types::JsonObject)
     )
 )]
 pub async fn comms_send(
@@ -1900,9 +1900,9 @@ pub async fn comms_send(
     post,
     path = "/api/comms/task",
     tag = "network",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Post a task to the agent task queue", body = serde_json::Value)
+        (status = 200, description = "Post a task to the agent task queue", body = crate::types::JsonObject)
     )
 )]
 pub async fn comms_task(

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -193,7 +193,7 @@ pub struct ListPluginsQuery {
     path = "/api/plugins",
     tag = "plugins",
     responses(
-        (status = 200, description = "List installed plugins", body = serde_json::Value)
+        (status = 200, description = "List installed plugins", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_plugins(
@@ -257,7 +257,7 @@ pub async fn list_plugins(
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
     responses(
-        (status = 200, description = "Plugin details", body = serde_json::Value),
+        (status = 200, description = "Plugin details", body = crate::types::JsonObject),
         (status = 404, description = "Plugin not found")
     )
 )]
@@ -311,9 +311,9 @@ pub async fn get_plugin(
     post,
     path = "/api/plugins/install",
     tag = "plugins",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 201, description = "Plugin installed", body = serde_json::Value),
+        (status = 201, description = "Plugin installed", body = crate::types::JsonObject),
         (status = 400, description = "Invalid request"),
         (status = 409, description = "Plugin already installed")
     )
@@ -395,7 +395,7 @@ pub async fn install_plugin(Json(body): Json<serde_json::Value>) -> impl IntoRes
     post,
     path = "/api/plugins/uninstall",
     tag = "plugins",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
         (status = 200, description = "Plugin removed"),
         (status = 404, description = "Plugin not found")
@@ -437,7 +437,7 @@ pub async fn uninstall_plugin(Json(body): Json<serde_json::Value>) -> impl IntoR
     post,
     path = "/api/plugins/scaffold",
     tag = "plugins",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
         (status = 201, description = "Plugin scaffolded"),
         (status = 409, description = "Plugin already exists")
@@ -485,7 +485,7 @@ pub async fn scaffold_plugin(Json(body): Json<serde_json::Value>) -> impl IntoRe
     path = "/api/plugins/doctor",
     tag = "plugins",
     responses(
-        (status = 200, description = "Runtime availability + per-plugin diagnostics", body = serde_json::Value)
+        (status = 200, description = "Runtime availability + per-plugin diagnostics", body = crate::types::JsonObject)
     )
 )]
 pub async fn plugin_doctor() -> impl IntoResponse {
@@ -535,7 +535,7 @@ pub async fn install_plugin_deps(Path(name): Path<String>) -> impl IntoResponse 
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
     responses(
-        (status = 200, description = "Manifest reloaded", body = serde_json::Value),
+        (status = 200, description = "Manifest reloaded", body = crate::types::JsonObject),
         (status = 400, description = "Reload failed (invalid name or bad manifest)")
     )
 )]
@@ -568,7 +568,7 @@ pub async fn reload_plugin(Path(name): Path<String>) -> impl IntoResponse {
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
     responses(
-        (status = 200, description = "Plugin status", body = serde_json::Value),
+        (status = 200, description = "Plugin status", body = crate::types::JsonObject),
         (status = 400, description = "Plugin not found or invalid name")
     )
 )]
@@ -622,7 +622,7 @@ pub async fn plugin_status(
     path = "/api/context-engine/metrics",
     tag = "plugins",
     responses(
-        (status = 200, description = "Hook metrics snapshot", body = serde_json::Value),
+        (status = 200, description = "Hook metrics snapshot", body = crate::types::JsonObject),
         (status = 204, description = "No metrics available (no plugin engine active)")
     )
 )]
@@ -647,7 +647,7 @@ pub async fn context_engine_metrics(State(state): State<Arc<AppState>>) -> impl 
     path = "/api/plugins/registries",
     tag = "plugins",
     responses(
-        (status = 200, description = "Configured registries with available plugins", body = serde_json::Value)
+        (status = 200, description = "Configured registries with available plugins", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_plugin_registries(
@@ -741,7 +741,7 @@ pub async fn list_plugin_registries(
     path = "/api/context-engine/traces",
     tag = "plugins",
     responses(
-        (status = 200, description = "Hook invocation traces", body = serde_json::Value),
+        (status = 200, description = "Hook invocation traces", body = crate::types::JsonObject),
         (status = 204, description = "No plugin engine active")
     )
 )]
@@ -837,7 +837,7 @@ pub async fn disable_plugin(Path(name): Path<String>) -> impl IntoResponse {
     path = "/api/plugins/{name}/upgrade",
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
         (status = 200, description = "Plugin upgraded"),
         (status = 400, description = "Plugin not installed or upgrade failed")
@@ -935,7 +935,7 @@ pub async fn upgrade_plugin(
     path = "/api/plugins/{name}/test-hook",
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
         (status = 200, description = "Hook output"),
         (status = 400, description = "Hook not declared or invocation failed")
@@ -1066,7 +1066,7 @@ pub async fn test_plugin_hook(
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
     responses(
-        (status = 200, description = "Hashes written to plugin.toml", body = serde_json::Value),
+        (status = 200, description = "Hashes written to plugin.toml", body = crate::types::JsonObject),
         (status = 400, description = "Plugin not found or no hooks declared")
     )
 )]
@@ -1097,7 +1097,7 @@ pub async fn sign_plugin(Path(name): Path<String>) -> impl IntoResponse {
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
     responses(
-        (status = 200, description = "Lint report", body = serde_json::Value),
+        (status = 200, description = "Lint report", body = crate::types::JsonObject),
         (status = 400, description = "Plugin not found")
     )
 )]
@@ -1205,7 +1205,7 @@ pub async fn context_engine_health(State(state): State<Arc<AppState>>) -> impl I
     path = "/api/context-engine/chain",
     tag = "plugins",
     responses(
-        (status = 200, description = "Engine chain topology", body = serde_json::Value)
+        (status = 200, description = "Engine chain topology", body = crate::types::JsonObject)
     )
 )]
 pub async fn context_engine_chain(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -2057,7 +2057,7 @@ pub async fn context_engine_metrics_summary(
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
     responses(
-        (status = 200, description = "Advanced hook configuration", body = serde_json::Value),
+        (status = 200, description = "Advanced hook configuration", body = crate::types::JsonObject),
         (status = 404, description = "Plugin not found")
     )
 )]
@@ -2108,7 +2108,7 @@ pub async fn plugin_advanced_config(Path(name): Path<String>) -> impl IntoRespon
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
     responses(
-        (status = 200, description = "Plugin environment configuration", body = serde_json::Value),
+        (status = 200, description = "Plugin environment configuration", body = crate::types::JsonObject),
         (status = 404, description = "Plugin not found")
     )
 )]
@@ -2185,7 +2185,7 @@ pub async fn plugin_env(Path(name): Path<String>) -> impl IntoResponse {
     path = "/api/context-engine/config",
     tag = "plugins",
     responses(
-        (status = 200, description = "Context engine configuration", body = serde_json::Value)
+        (status = 200, description = "Context engine configuration", body = crate::types::JsonObject)
     )
 )]
 pub async fn context_engine_config(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -2258,7 +2258,7 @@ pub async fn context_engine_config(State(state): State<Arc<AppState>>) -> impl I
     tag = "plugins",
     params(("name" = String, Path, description = "Plugin name")),
     responses(
-        (status = 200, description = "Prewarm result", body = serde_json::Value),
+        (status = 200, description = "Prewarm result", body = crate::types::JsonObject),
         (status = 404, description = "Plugin not found")
     )
 )]
@@ -2302,7 +2302,7 @@ pub async fn prewarm_plugin(Path(name): Path<String>) -> impl IntoResponse {
     path = "/api/context-engine/sandbox-policy",
     tag = "plugins",
     responses(
-        (status = 200, description = "Sandbox policy for active plugins", body = serde_json::Value),
+        (status = 200, description = "Sandbox policy for active plugins", body = crate::types::JsonObject),
         (status = 204, description = "No plugin engine configured")
     )
 )]

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -208,7 +208,7 @@ pub async fn list_models(
     )
 }
 
-#[utoipa::path(get, path = "/api/models/aliases", tag = "models", responses((status = 200, description = "List model aliases", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/models/aliases", tag = "models", responses((status = 200, description = "List model aliases", body = crate::types::JsonObject)))]
 pub async fn list_aliases(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let aliases = state
         .kernel
@@ -239,7 +239,7 @@ pub async fn list_aliases(State(state): State<Arc<AppState>>) -> impl IntoRespon
 /// POST /api/models/aliases — Create a new alias mapping.
 ///
 /// Body: `{ "alias": "my-alias", "model_id": "gpt-4o" }`
-#[utoipa::path(post, path = "/api/models/aliases", tag = "models", request_body = serde_json::Value, responses((status = 200, description = "Alias created", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/models/aliases", tag = "models", request_body = crate::types::JsonObject, responses((status = 200, description = "Alias created", body = crate::types::JsonObject)))]
 pub async fn create_alias(
     State(state): State<Arc<AppState>>,
     Json(body): Json<serde_json::Value>,
@@ -303,7 +303,7 @@ pub async fn delete_alias(
     (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
 }
 
-#[utoipa::path(get, path = "/api/models/{id}", tag = "models", params(("id" = String, Path, description = "Model ID")), responses((status = 200, description = "Model details", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/models/{id}", tag = "models", params(("id" = String, Path, description = "Model ID")), responses((status = 200, description = "Model details", body = crate::types::JsonObject)))]
 pub async fn get_model(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -705,7 +705,7 @@ pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json:
     tag = "models",
     params(("name" = String, Path, description = "Provider identifier")),
     responses(
-        (status = 200, description = "Provider details", body = serde_json::Value),
+        (status = 200, description = "Provider details", body = crate::types::JsonObject),
         (status = 404, description = "Provider not found")
     )
 )]
@@ -806,7 +806,7 @@ pub async fn get_provider(
 ///
 /// Persists to `~/.librefang/custom_models.json` and makes the model immediately
 /// available in the catalog.
-#[utoipa::path(post, path = "/api/models/custom", tag = "models", request_body = serde_json::Value, responses((status = 200, description = "Custom model added", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/models/custom", tag = "models", request_body = crate::types::JsonObject, responses((status = 200, description = "Custom model added", body = crate::types::JsonObject)))]
 pub async fn add_custom_model(
     State(state): State<Arc<AppState>>,
     Json(body): Json<serde_json::Value>,
@@ -973,7 +973,7 @@ pub async fn remove_custom_model(
 
 // ── A2A (Agent-to-Agent) Protocol Endpoints ─────────────────────────
 
-#[utoipa::path(post, path = "/api/providers/{name}/key", tag = "models", params(("name" = String, Path, description = "Provider name")), request_body = serde_json::Value, responses((status = 200, description = "API key set", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/providers/{name}/key", tag = "models", params(("name" = String, Path, description = "Provider name")), request_body = crate::types::JsonObject, responses((status = 200, description = "API key set", body = crate::types::JsonObject)))]
 pub async fn set_provider_key(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -1245,7 +1245,7 @@ pub async fn delete_provider_key(
 }
 
 /// POST /api/providers/{name}/test — Test a provider's connectivity.
-#[utoipa::path(post, path = "/api/providers/{name}/test", tag = "models", params(("name" = String, Path, description = "Provider name")), responses((status = 200, description = "Provider test result", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/providers/{name}/test", tag = "models", params(("name" = String, Path, description = "Provider name")), responses((status = 200, description = "Provider test result", body = crate::types::JsonObject)))]
 pub async fn test_provider(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -1503,7 +1503,7 @@ pub async fn test_provider(
 }
 
 /// PUT /api/providers/{name}/url — Set a custom base URL for a provider.
-#[utoipa::path(put, path = "/api/providers/{name}/url", tag = "models", params(("name" = String, Path, description = "Provider name")), request_body = serde_json::Value, responses((status = 200, description = "Provider URL set", body = serde_json::Value)))]
+#[utoipa::path(put, path = "/api/providers/{name}/url", tag = "models", params(("name" = String, Path, description = "Provider name")), request_body = crate::types::JsonObject, responses((status = 200, description = "Provider URL set", body = crate::types::JsonObject)))]
 pub async fn set_provider_url(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -1652,7 +1652,7 @@ pub async fn set_provider_url(
     tag = "models",
     params(("name" = String, Path, description = "Provider identifier")),
     responses(
-        (status = 200, description = "Default provider updated", body = serde_json::Value),
+        (status = 200, description = "Default provider updated", body = crate::types::JsonObject),
         (status = 400, description = "No model found for provider"),
         (status = 404, description = "Provider not found")
     )
@@ -1990,7 +1990,7 @@ static COPILOT_FLOWS: LazyLock<DashMap<String, CopilotFlowState>> = LazyLock::ne
 ///
 /// Initiates a GitHub device flow for Copilot authentication.
 /// Returns a user code and verification URI that the user visits in their browser.
-#[utoipa::path(post, path = "/api/providers/github-copilot/oauth/start", tag = "models", responses((status = 200, description = "OAuth flow started", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/providers/github-copilot/oauth/start", tag = "models", responses((status = 200, description = "OAuth flow started", body = crate::types::JsonObject)))]
 pub async fn copilot_oauth_start() -> impl IntoResponse {
     // Clean up expired flows first
     COPILOT_FLOWS.retain(|_, state| state.expires_at > Instant::now());
@@ -2031,7 +2031,7 @@ pub async fn copilot_oauth_start() -> impl IntoResponse {
 /// Poll the status of a GitHub device flow.
 /// Returns `pending`, `complete`, `expired`, `denied`, or `error`.
 /// On `complete`, saves the token to secrets.env and sets GITHUB_TOKEN.
-#[utoipa::path(get, path = "/api/providers/github-copilot/oauth/poll/{poll_id}", tag = "models", params(("poll_id" = String, Path, description = "Poll ID")), responses((status = 200, description = "OAuth poll result", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/providers/github-copilot/oauth/poll/{poll_id}", tag = "models", params(("poll_id" = String, Path, description = "Poll ID")), responses((status = 200, description = "OAuth poll result", body = crate::types::JsonObject)))]
 pub async fn copilot_oauth_poll(
     State(state): State<Arc<AppState>>,
     Path(poll_id): Path<String>,
@@ -2142,7 +2142,7 @@ pub async fn copilot_oauth_poll(
 ///
 /// Downloads the latest catalog TOML files from GitHub and caches them locally.
 /// After syncing, the kernel's in-memory catalog is refreshed.
-#[utoipa::path(post, path = "/api/catalog/update", tag = "models", responses((status = 200, description = "Catalog updated", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/catalog/update", tag = "models", responses((status = 200, description = "Catalog updated", body = crate::types::JsonObject)))]
 pub async fn catalog_update(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let cfg = state.kernel.config_ref();
     let mirror = &cfg.registry.registry_mirror;
@@ -2191,7 +2191,7 @@ pub async fn catalog_update(State(state): State<Arc<AppState>>) -> impl IntoResp
 }
 
 /// GET /api/catalog/status — Check last catalog sync time.
-#[utoipa::path(get, path = "/api/catalog/status", tag = "models", responses((status = 200, description = "Catalog sync status", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/catalog/status", tag = "models", responses((status = 200, description = "Catalog sync status", body = crate::types::JsonObject)))]
 pub async fn catalog_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let last_sync = librefang_runtime::catalog_sync::last_sync_time_for(state.kernel.home_dir());
     Json(serde_json::json!({

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -3460,7 +3460,7 @@ fn serialize_mcp_transport(
     path = "/api/mcp/taint-rules",
     tag = "mcp",
     responses(
-        (status = 200, description = "List configured named taint rule sets", body = crate::types::JsonObject)
+        (status = 200, description = "List configured named taint rule sets", body = crate::types::JsonArray)
     )
 )]
 pub async fn list_mcp_taint_rules(State(state): State<Arc<AppState>>) -> impl IntoResponse {

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -322,9 +322,9 @@ pub async fn list_skills(
     post,
     path = "/api/skills/install",
     tag = "skills",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Install a skill from FangHub", body = serde_json::Value)
+        (status = 200, description = "Install a skill from FangHub", body = crate::types::JsonObject)
     )
 )]
 pub async fn install_skill(
@@ -399,9 +399,9 @@ pub async fn install_skill(
     post,
     path = "/api/skills/uninstall",
     tag = "skills",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Uninstall a skill", body = serde_json::Value)
+        (status = 200, description = "Uninstall a skill", body = crate::types::JsonObject)
     )
 )]
 pub async fn uninstall_skill(
@@ -438,7 +438,7 @@ pub async fn uninstall_skill(
     path = "/api/skills/reload",
     tag = "skills",
     responses(
-        (status = 200, description = "Rescan the skills directory from disk", body = serde_json::Value)
+        (status = 200, description = "Rescan the skills directory from disk", body = crate::types::JsonObject)
     )
 )]
 pub async fn reload_skills(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -461,7 +461,7 @@ pub async fn reload_skills(State(state): State<Arc<AppState>>) -> impl IntoRespo
     path = "/api/skills/registry",
     tag = "skills",
     responses(
-        (status = 200, description = "Official skills available in the FangHub registry", body = serde_json::Value)
+        (status = 200, description = "Official skills available in the FangHub registry", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_skill_registry(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -610,7 +610,7 @@ fn parse_skill_md_frontmatter(content: &str) -> Option<SkillMdFrontmatter> {
         ("q" = Option<String>, Query, description = "Search query"),
     ),
     responses(
-        (status = 200, description = "Search the FangHub marketplace", body = serde_json::Value)
+        (status = 200, description = "Search the FangHub marketplace", body = crate::types::JsonObject)
     )
 )]
 pub async fn marketplace_search(
@@ -672,7 +672,7 @@ pub async fn marketplace_search(
         ("q" = Option<String>, Query, description = "Search query"),
     ),
     responses(
-        (status = 200, description = "Search ClawHub skills", body = serde_json::Value)
+        (status = 200, description = "Search ClawHub skills", body = crate::types::JsonObject)
     )
 )]
 pub async fn clawhub_search(
@@ -758,7 +758,7 @@ pub async fn clawhub_search(
         ("q" = Option<String>, Query, description = "Search query"),
     ),
     responses(
-        (status = 200, description = "Browse ClawHub skills by sort order", body = serde_json::Value)
+        (status = 200, description = "Browse ClawHub skills by sort order", body = crate::types::JsonObject)
     )
 )]
 pub async fn clawhub_browse(
@@ -832,7 +832,7 @@ pub async fn clawhub_browse(
         ("slug" = String, Path, description = "Skill slug"),
     ),
     responses(
-        (status = 200, description = "Get detailed info about a ClawHub skill", body = serde_json::Value)
+        (status = 200, description = "Get detailed info about a ClawHub skill", body = crate::types::JsonObject)
     )
 )]
 pub async fn clawhub_skill_detail(
@@ -908,7 +908,7 @@ pub async fn clawhub_skill_detail(
         ("slug" = String, Path, description = "Skill slug"),
     ),
     responses(
-        (status = 200, description = "Fetch source code of a ClawHub skill", body = serde_json::Value)
+        (status = 200, description = "Fetch source code of a ClawHub skill", body = crate::types::JsonObject)
     )
 )]
 pub async fn clawhub_skill_code(
@@ -956,9 +956,9 @@ pub async fn clawhub_skill_code(
     post,
     path = "/api/clawhub/install",
     tag = "skills",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Install a skill from ClawHub", body = serde_json::Value)
+        (status = 200, description = "Install a skill from ClawHub", body = crate::types::JsonObject)
     )
 )]
 pub async fn clawhub_install(
@@ -1750,7 +1750,7 @@ fn server_platform() -> &'static str {
     path = "/api/hands",
     tag = "hands",
     responses(
-        (status = 200, description = "List all hand definitions", body = serde_json::Value)
+        (status = 200, description = "List all hand definitions", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_hands(
@@ -1842,7 +1842,7 @@ pub async fn list_hands(
     path = "/api/hands/active",
     tag = "hands",
     responses(
-        (status = 200, description = "List active hand instances", body = serde_json::Value)
+        (status = 200, description = "List active hand instances", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_active_hands(
@@ -1910,7 +1910,7 @@ pub async fn list_active_hands(
         ("hand_id" = String, Path, description = "Hand ID"),
     ),
     responses(
-        (status = 200, description = "Get a single hand definition with requirements", body = serde_json::Value)
+        (status = 200, description = "Get a single hand definition with requirements", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_hand(
@@ -2135,7 +2135,7 @@ pub async fn get_hand_manifest(
         ("hand_id" = String, Path, description = "Hand ID"),
     ),
     responses(
-        (status = 200, description = "Re-check dependency status for a hand", body = serde_json::Value)
+        (status = 200, description = "Re-check dependency status for a hand", body = crate::types::JsonObject)
     )
 )]
 pub async fn check_hand_deps(
@@ -2197,7 +2197,7 @@ pub async fn check_hand_deps(
         ("hand_id" = String, Path, description = "Hand ID"),
     ),
     responses(
-        (status = 200, description = "Auto-install missing dependencies for a hand", body = serde_json::Value)
+        (status = 200, description = "Auto-install missing dependencies for a hand", body = crate::types::JsonObject)
     )
 )]
 pub async fn install_hand_deps(
@@ -2479,7 +2479,7 @@ pub async fn install_hand_deps(
         ("hand_id" = String, Path, description = "Hand ID"),
     ),
     responses(
-        (status = 200, description = "Hand uninstalled", body = serde_json::Value),
+        (status = 200, description = "Hand uninstalled", body = crate::types::JsonObject),
         (status = 404, description = "Hand not found or is a built-in"),
         (status = 409, description = "Hand is still active — deactivate first"),
     )
@@ -2520,9 +2520,9 @@ pub async fn uninstall_hand(
     post,
     path = "/api/hands/install",
     tag = "hands",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Install a hand from TOML content", body = serde_json::Value)
+        (status = 200, description = "Install a hand from TOML content", body = crate::types::JsonObject)
     )
 )]
 pub async fn install_hand(
@@ -2565,9 +2565,9 @@ pub async fn install_hand(
     params(
         ("hand_id" = String, Path, description = "Hand ID"),
     ),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Activate a hand (spawns agent)", body = serde_json::Value)
+        (status = 200, description = "Activate a hand (spawns agent)", body = crate::types::JsonObject)
     )
 )]
 pub async fn activate_hand(
@@ -2626,7 +2626,7 @@ pub async fn activate_hand(
         ("id" = String, Path, description = "Instance ID"),
     ),
     responses(
-        (status = 200, description = "Pause a hand instance", body = serde_json::Value)
+        (status = 200, description = "Pause a hand instance", body = crate::types::JsonObject)
     )
 )]
 pub async fn pause_hand(
@@ -2651,7 +2651,7 @@ pub async fn pause_hand(
         ("id" = String, Path, description = "Instance ID"),
     ),
     responses(
-        (status = 200, description = "Resume a paused hand instance", body = serde_json::Value)
+        (status = 200, description = "Resume a paused hand instance", body = crate::types::JsonObject)
     )
 )]
 pub async fn resume_hand(
@@ -2676,7 +2676,7 @@ pub async fn resume_hand(
         ("id" = String, Path, description = "Instance ID"),
     ),
     responses(
-        (status = 200, description = "Deactivate a hand (kills agent)", body = serde_json::Value)
+        (status = 200, description = "Deactivate a hand (kills agent)", body = crate::types::JsonObject)
     )
 )]
 pub async fn deactivate_hand(
@@ -2698,8 +2698,8 @@ pub async fn deactivate_hand(
     path = "/api/hands/{hand_id}/secret",
     tag = "hands",
     params(("hand_id" = String, Path, description = "Hand ID")),
-    request_body = serde_json::Value,
-    responses((status = 200, description = "Secret saved", body = serde_json::Value))
+    request_body = crate::types::JsonObject,
+    responses((status = 200, description = "Secret saved", body = crate::types::JsonObject))
 )]
 pub async fn set_hand_secret(
     State(state): State<Arc<AppState>>,
@@ -2777,7 +2777,7 @@ pub async fn set_hand_secret(
         ("hand_id" = String, Path, description = "Hand ID"),
     ),
     responses(
-        (status = 200, description = "Get settings schema and current values", body = serde_json::Value)
+        (status = 200, description = "Get settings schema and current values", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_hand_settings(
@@ -2830,9 +2830,9 @@ pub async fn get_hand_settings(
     params(
         ("hand_id" = String, Path, description = "Hand ID"),
     ),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Update settings for a hand instance", body = serde_json::Value)
+        (status = 200, description = "Update settings for a hand instance", body = crate::types::JsonObject)
     )
 )]
 pub async fn update_hand_settings(
@@ -2878,7 +2878,7 @@ pub async fn update_hand_settings(
     path = "/api/hands/reload",
     tag = "hands",
     responses(
-        (status = 200, description = "Reload hand definitions from disk", body = serde_json::Value)
+        (status = 200, description = "Reload hand definitions from disk", body = crate::types::JsonObject)
     )
 )]
 pub async fn reload_hands(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -2904,7 +2904,7 @@ pub async fn reload_hands(State(state): State<Arc<AppState>>) -> impl IntoRespon
         ("id" = String, Path, description = "Instance ID"),
     ),
     responses(
-        (status = 200, description = "Get dashboard stats for a hand instance", body = serde_json::Value)
+        (status = 200, description = "Get dashboard stats for a hand instance", body = crate::types::JsonObject)
     )
 )]
 pub async fn hand_stats(
@@ -2979,7 +2979,7 @@ pub async fn hand_stats(
         ("id" = String, Path, description = "Instance ID"),
     ),
     responses(
-        (status = 200, description = "Get live browser state for a hand instance", body = serde_json::Value)
+        (status = 200, description = "Get live browser state for a hand instance", body = crate::types::JsonObject)
     )
 )]
 pub async fn hand_instance_browser(
@@ -3460,7 +3460,7 @@ fn serialize_mcp_transport(
     path = "/api/mcp/taint-rules",
     tag = "mcp",
     responses(
-        (status = 200, description = "List configured named taint rule sets", body = serde_json::Value)
+        (status = 200, description = "List configured named taint rule sets", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_mcp_taint_rules(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -3486,7 +3486,7 @@ pub async fn list_mcp_taint_rules(State(state): State<Arc<AppState>>) -> impl In
     path = "/api/mcp/servers",
     tag = "mcp",
     responses(
-        (status = 200, description = "List configured MCP servers and their tools", body = serde_json::Value)
+        (status = 200, description = "List configured MCP servers and their tools", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_mcp_servers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -3593,7 +3593,7 @@ pub async fn list_mcp_servers(State(state): State<Arc<AppState>>) -> impl IntoRe
         ("name" = String, Path, description = "Server name"),
     ),
     responses(
-        (status = 200, description = "MCP server details", body = serde_json::Value),
+        (status = 200, description = "MCP server details", body = crate::types::JsonObject),
         (status = 404, description = "MCP server not found")
     )
 )]
@@ -3660,9 +3660,9 @@ pub async fn get_mcp_server(
     post,
     path = "/api/mcp/servers",
     tag = "mcp",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Add a new MCP server configuration", body = serde_json::Value)
+        (status = 200, description = "Add a new MCP server configuration", body = crate::types::JsonObject)
     )
 )]
 pub async fn add_mcp_server(
@@ -3847,9 +3847,9 @@ pub async fn add_mcp_server(
     params(
         ("name" = String, Path, description = "Server name"),
     ),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Update an existing MCP server configuration", body = serde_json::Value)
+        (status = 200, description = "Update an existing MCP server configuration", body = crate::types::JsonObject)
     )
 )]
 pub async fn update_mcp_server(
@@ -3968,10 +3968,10 @@ pub(crate) struct PatchMcpTaintRequest {
     path = "/api/mcp/servers/{name}/taint",
     tag = "mcp",
     params(("name" = String, Path, description = "Server name")),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Taint settings updated", body = serde_json::Value),
-        (status = 404, description = "Server not found", body = serde_json::Value),
+        (status = 200, description = "Taint settings updated", body = crate::types::JsonObject),
+        (status = 404, description = "Server not found", body = crate::types::JsonObject),
     )
 )]
 #[allow(private_interfaces)]
@@ -4066,7 +4066,7 @@ pub async fn patch_mcp_server_taint(
         ("name" = String, Path, description = "Server name"),
     ),
     responses(
-        (status = 200, description = "Remove an MCP server configuration", body = serde_json::Value)
+        (status = 200, description = "Remove an MCP server configuration", body = crate::types::JsonObject)
     )
 )]
 pub async fn delete_mcp_server(
@@ -4275,9 +4275,9 @@ fn validate_static_file_path(
     post,
     path = "/api/skills/create",
     tag = "skills",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Create a new prompt-only skill", body = serde_json::Value)
+        (status = 200, description = "Create a new prompt-only skill", body = crate::types::JsonObject)
     )
 )]
 pub async fn create_skill(
@@ -4352,7 +4352,7 @@ pub async fn create_skill(
     tag = "skills",
     params(("name" = String, Path, description = "Skill name")),
     responses(
-        (status = 200, description = "Skill detail with evolution history", body = serde_json::Value),
+        (status = 200, description = "Skill detail with evolution history", body = crate::types::JsonObject),
         (status = 404, description = "Skill not found")
     )
 )]
@@ -4530,7 +4530,7 @@ fn evolution_ok_response(
         ("path" = String, Query, description = "Relative file path inside the skill directory")
     ),
     responses(
-        (status = 200, description = "File contents", body = serde_json::Value),
+        (status = 200, description = "File contents", body = crate::types::JsonObject),
         (status = 400, description = "Invalid path"),
         (status = 404, description = "Skill or file not found")
     )
@@ -4636,9 +4636,9 @@ fn audit_evolve(state: &Arc<AppState>, action: &str, skill_name: &str, detail: &
     path = "/api/skills/{name}/evolve/update",
     tag = "skills",
     params(("name" = String, Path, description = "Skill name")),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Skill updated", body = serde_json::Value),
+        (status = 200, description = "Skill updated", body = crate::types::JsonObject),
         (status = 400, description = "Invalid request / security-blocked content"),
         (status = 404, description = "Skill not found")
     )
@@ -4683,9 +4683,9 @@ pub async fn evolve_update_skill(
     path = "/api/skills/{name}/evolve/patch",
     tag = "skills",
     params(("name" = String, Path, description = "Skill name")),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Skill patched", body = serde_json::Value),
+        (status = 200, description = "Skill patched", body = crate::types::JsonObject),
         (status = 400, description = "Invalid request / fuzzy match failed"),
         (status = 404, description = "Skill not found")
     )
@@ -4737,7 +4737,7 @@ pub async fn evolve_patch_skill(
     tag = "skills",
     params(("name" = String, Path, description = "Skill name")),
     responses(
-        (status = 200, description = "Skill rolled back", body = serde_json::Value),
+        (status = 200, description = "Skill rolled back", body = crate::types::JsonObject),
         (status = 404, description = "Skill or snapshot not found")
     )
 )]
@@ -4774,7 +4774,7 @@ pub async fn evolve_rollback_skill(
     tag = "skills",
     params(("name" = String, Path, description = "Skill name")),
     responses(
-        (status = 200, description = "Skill deleted", body = serde_json::Value),
+        (status = 200, description = "Skill deleted", body = crate::types::JsonObject),
         (status = 400, description = "Non-local skill — deletion refused"),
         (status = 404, description = "Skill not found")
     )
@@ -4803,9 +4803,9 @@ pub async fn evolve_delete_skill(
     path = "/api/skills/{name}/evolve/file",
     tag = "skills",
     params(("name" = String, Path, description = "Skill name")),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "File written", body = serde_json::Value),
+        (status = 200, description = "File written", body = crate::types::JsonObject),
         (status = 400, description = "Invalid path / over size limit"),
         (status = 404, description = "Skill not found")
     )
@@ -4850,7 +4850,7 @@ pub async fn evolve_write_file(
         ("path" = String, Query, description = "Relative path of the file to remove")
     ),
     responses(
-        (status = 200, description = "File removed", body = serde_json::Value),
+        (status = 200, description = "File removed", body = crate::types::JsonObject),
         (status = 400, description = "Missing 'path' parameter"),
         (status = 404, description = "Skill or file not found")
     )
@@ -5222,7 +5222,7 @@ fn render_catalog_entry(
     path = "/api/mcp/catalog",
     tag = "mcp",
     responses(
-        (status = 200, description = "MCP catalog entries", body = serde_json::Value)
+        (status = 200, description = "MCP catalog entries", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_mcp_catalog(
@@ -5255,8 +5255,8 @@ pub async fn list_mcp_catalog(
     tag = "mcp",
     params(("id" = String, Path, description = "Catalog entry id")),
     responses(
-        (status = 200, description = "Catalog entry detail", body = serde_json::Value),
-        (status = 404, description = "Catalog entry not found", body = serde_json::Value),
+        (status = 200, description = "Catalog entry detail", body = crate::types::JsonObject),
+        (status = 404, description = "Catalog entry not found", body = crate::types::JsonObject),
     )
 )]
 pub async fn get_mcp_catalog_entry(
@@ -5289,8 +5289,8 @@ pub async fn get_mcp_catalog_entry(
     tag = "mcp",
     params(("name" = String, Path, description = "Server name")),
     responses(
-        (status = 200, description = "Reconnect an MCP server", body = serde_json::Value),
-        (status = 404, description = "MCP server not configured", body = serde_json::Value),
+        (status = 200, description = "Reconnect an MCP server", body = crate::types::JsonObject),
+        (status = 404, description = "MCP server not configured", body = crate::types::JsonObject),
     )
 )]
 pub async fn reconnect_mcp_server_handler(
@@ -5334,7 +5334,7 @@ pub async fn reconnect_mcp_server_handler(
     path = "/api/mcp/health",
     tag = "mcp",
     responses(
-        (status = 200, description = "Health snapshot for all configured MCP servers", body = serde_json::Value)
+        (status = 200, description = "Health snapshot for all configured MCP servers", body = crate::types::JsonObject)
     )
 )]
 pub async fn mcp_health_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -5368,7 +5368,7 @@ pub async fn mcp_health_handler(State(state): State<Arc<AppState>>) -> impl Into
     path = "/api/mcp/reload",
     tag = "mcp",
     responses(
-        (status = 200, description = "Reload catalog and reconnect MCP servers", body = serde_json::Value)
+        (status = 200, description = "Reload catalog and reconnect MCP servers", body = crate::types::JsonObject)
     )
 )]
 pub async fn reload_mcp_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -5435,7 +5435,7 @@ fn status_str_for_catalog(
     path = "/api/extensions",
     tag = "extensions",
     responses(
-        (status = 200, description = "List catalog entries with install/health status", body = serde_json::Value)
+        (status = 200, description = "List catalog entries with install/health status", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_extensions(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -5486,7 +5486,7 @@ pub async fn list_extensions(State(state): State<Arc<AppState>>) -> impl IntoRes
         ("name" = String, Path, description = "Catalog entry id"),
     ),
     responses(
-        (status = 200, description = "Catalog entry detail + install status", body = serde_json::Value)
+        (status = 200, description = "Catalog entry detail + install status", body = crate::types::JsonObject)
     )
 )]
 pub async fn get_extension(
@@ -5554,9 +5554,9 @@ pub async fn get_extension(
     post,
     path = "/api/extensions/install",
     tag = "extensions",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Install a catalog entry", body = serde_json::Value)
+        (status = 200, description = "Install a catalog entry", body = crate::types::JsonObject)
     )
 )]
 pub async fn install_extension(
@@ -5656,9 +5656,9 @@ pub async fn install_extension(
     post,
     path = "/api/extensions/uninstall",
     tag = "extensions",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Uninstall a catalog-backed MCP server", body = serde_json::Value)
+        (status = 200, description = "Uninstall a catalog-backed MCP server", body = crate::types::JsonObject)
     )
 )]
 pub async fn uninstall_extension(

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -274,7 +274,7 @@ pub async fn list_profiles() -> impl IntoResponse {
 }
 
 /// GET /api/profiles/:name — Get a single profile by name.
-#[utoipa::path(get, path = "/api/profiles/{name}", tag = "system", params(("name" = String, Path, description = "Profile name")), responses((status = 200, description = "Profile details", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/profiles/{name}", tag = "system", params(("name" = String, Path, description = "Profile name")), responses((status = 200, description = "Profile details", body = crate::types::JsonObject)))]
 pub async fn get_profile(
     Path(name): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
@@ -414,7 +414,7 @@ pub async fn list_agent_templates() -> impl IntoResponse {
 }
 
 /// GET /api/templates/:name — Get template details.
-#[utoipa::path(get, path = "/api/templates/{name}", tag = "system", operation_id = "get_agent_template", params(("name" = String, Path, description = "Template name")), responses((status = 200, description = "Template details", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/templates/{name}", tag = "system", operation_id = "get_agent_template", params(("name" = String, Path, description = "Template name")), responses((status = 200, description = "Template details", body = crate::types::JsonObject)))]
 pub async fn get_agent_template(
     Path(name): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
@@ -524,7 +524,7 @@ pub async fn get_agent_template_toml(
 // ---------------------------------------------------------------------------
 
 /// GET /api/memory/agents/:id/kv — List KV pairs for an agent.
-#[utoipa::path(get, path = "/api/memory/agents/{id}/kv", tag = "memory", params(("id" = String, Path, description = "Agent ID")), responses((status = 200, description = "Agent KV store", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/memory/agents/{id}/kv", tag = "memory", params(("id" = String, Path, description = "Agent ID")), responses((status = 200, description = "Agent KV store", body = crate::types::JsonObject)))]
 pub async fn get_agent_kv(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -572,7 +572,7 @@ pub async fn get_agent_kv(
 }
 
 /// GET /api/memory/agents/:id/kv/:key — Get a specific KV value.
-#[utoipa::path(get, path = "/api/memory/agents/{id}/kv/{key}", tag = "memory", params(("id" = String, Path, description = "Agent ID"), ("key" = String, Path, description = "Key name")), responses((status = 200, description = "KV value", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/memory/agents/{id}/kv/{key}", tag = "memory", params(("id" = String, Path, description = "Agent ID"), ("key" = String, Path, description = "Key name")), responses((status = 200, description = "KV value", body = crate::types::JsonObject)))]
 pub async fn get_agent_kv_key(
     State(state): State<Arc<AppState>>,
     Path((id, key)): Path<(String, String)>,
@@ -606,7 +606,7 @@ pub async fn get_agent_kv_key(
 }
 
 /// PUT /api/memory/agents/:id/kv/:key — Set a KV value.
-#[utoipa::path(put, path = "/api/memory/agents/{id}/kv/{key}", tag = "memory", params(("id" = String, Path, description = "Agent ID"), ("key" = String, Path, description = "Key name")), request_body = serde_json::Value, responses((status = 200, description = "KV value set", body = serde_json::Value)))]
+#[utoipa::path(put, path = "/api/memory/agents/{id}/kv/{key}", tag = "memory", params(("id" = String, Path, description = "Agent ID"), ("key" = String, Path, description = "Key name")), request_body = crate::types::JsonObject, responses((status = 200, description = "KV value set", body = crate::types::JsonObject)))]
 pub async fn set_agent_kv_key(
     State(state): State<Arc<AppState>>,
     Path((id, key)): Path<(String, String)>,
@@ -671,7 +671,7 @@ pub async fn delete_agent_kv_key(
 }
 
 /// GET /api/agents/:id/memory/export — Export all KV memory for an agent as JSON.
-#[utoipa::path(get, path = "/api/agents/{id}/memory/export", tag = "memory", params(("id" = String, Path, description = "Agent ID")), responses((status = 200, description = "Exported memory", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/agents/{id}/memory/export", tag = "memory", params(("id" = String, Path, description = "Agent ID")), responses((status = 200, description = "Exported memory", body = crate::types::JsonObject)))]
 pub async fn export_agent_memory(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -714,7 +714,7 @@ pub async fn export_agent_memory(
 ///
 /// Accepts a JSON body with a `kv` object mapping string keys to JSON values.
 /// Optionally accepts `clear_existing: true` to wipe existing memory before import.
-#[utoipa::path(post, path = "/api/agents/{id}/memory/import", tag = "memory", params(("id" = String, Path, description = "Agent ID")), request_body = serde_json::Value, responses((status = 200, description = "Memory imported", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/agents/{id}/memory/import", tag = "memory", params(("id" = String, Path, description = "Agent ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Memory imported", body = crate::types::JsonObject)))]
 pub async fn import_agent_memory(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -849,7 +849,7 @@ pub async fn audit_recent(
 }
 
 /// GET /api/audit/verify — Verify the audit chain integrity.
-#[utoipa::path(get, path = "/api/audit/verify", tag = "system", responses((status = 200, description = "Audit verification result", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/audit/verify", tag = "system", responses((status = 200, description = "Audit verification result", body = crate::types::JsonObject)))]
 pub async fn audit_verify(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let entry_count = state.kernel.audit().len();
     match state.kernel.audit().verify_integrity() {
@@ -1029,7 +1029,7 @@ pub async fn list_tools(State(state): State<Arc<AppState>>) -> impl IntoResponse
 }
 
 /// GET /api/tools/:name — Get a single tool definition by name.
-#[utoipa::path(get, path = "/api/tools/{name}", tag = "skills", params(("name" = String, Path, description = "Tool name")), responses((status = 200, description = "Tool details", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/tools/{name}", tag = "skills", params(("name" = String, Path, description = "Tool name")), responses((status = 200, description = "Tool details", body = crate::types::JsonObject)))]
 pub async fn get_tool(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -1088,9 +1088,9 @@ pub async fn get_tool(
         ("name" = String, Path, description = "Tool name"),
         ("agent_id" = Option<String>, Query, description = "Caller agent UUID (required for approval-gated tools)")
     ),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Tool execution result", body = serde_json::Value),
+        (status = 200, description = "Tool execution result", body = crate::types::JsonObject),
         (status = 400, description = "Tool invocation failed or requires an agent context"),
         (status = 403, description = "Endpoint disabled or tool not in allowlist"),
         (status = 404, description = "Tool not found")
@@ -1285,7 +1285,7 @@ impl PaginationParams {
         ("offset" = Option<usize>, Query, description = "Items to skip"),
     ),
     responses(
-        (status = 200, description = "Paginated list of sessions", body = serde_json::Value)
+        (status = 200, description = "Paginated list of sessions", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_sessions(
@@ -1314,7 +1314,7 @@ pub async fn list_sessions(
 }
 
 /// GET /api/sessions/:id — Get a single session by ID.
-#[utoipa::path(get, path = "/api/sessions/{id}", tag = "sessions", params(("id" = String, Path, description = "Session ID")), responses((status = 200, description = "Session found", body = serde_json::Value), (status = 404, description = "Session not found")))]
+#[utoipa::path(get, path = "/api/sessions/{id}", tag = "sessions", params(("id" = String, Path, description = "Session ID")), responses((status = 200, description = "Session found", body = crate::types::JsonObject), (status = 404, description = "Session not found")))]
 pub async fn get_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1384,7 +1384,7 @@ pub async fn delete_session(
 }
 
 /// PUT /api/sessions/:id/label — Set a session label.
-#[utoipa::path(put, path = "/api/sessions/{id}/label", tag = "sessions", params(("id" = String, Path, description = "Session ID")), request_body = serde_json::Value, responses((status = 200, description = "Label set", body = serde_json::Value)))]
+#[utoipa::path(put, path = "/api/sessions/{id}/label", tag = "sessions", params(("id" = String, Path, description = "Session ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Label set", body = crate::types::JsonObject)))]
 pub async fn set_session_label(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1433,7 +1433,7 @@ pub async fn set_session_label(
 }
 
 /// GET /api/sessions/by-label/:label — Find session by label (scoped to agent).
-#[utoipa::path(get, path = "/api/agents/{id}/sessions/by-label/{label}", tag = "sessions", params(("id" = String, Path, description = "Agent ID"), ("label" = String, Path, description = "Session label")), responses((status = 200, description = "Session found", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/agents/{id}/sessions/by-label/{label}", tag = "sessions", params(("id" = String, Path, description = "Agent ID"), ("label" = String, Path, description = "Session label")), responses((status = 200, description = "Session found", body = crate::types::JsonObject)))]
 pub async fn find_session_by_label(
     State(state): State<Arc<AppState>>,
     Path((agent_id_str, label)): Path<(String, String)>,
@@ -1486,7 +1486,7 @@ pub async fn find_session_by_label(
 ///
 /// Runs both expired-session and excess-session cleanup using the configured
 /// `[session]` policy. Returns `{"sessions_deleted": N}`.
-#[utoipa::path(post, path = "/api/sessions/cleanup", tag = "sessions", responses((status = 200, description = "Cleanup result", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/sessions/cleanup", tag = "sessions", responses((status = 200, description = "Cleanup result", body = crate::types::JsonObject)))]
 pub async fn session_cleanup(
     State(state): State<Arc<AppState>>,
     lang: Option<axum::Extension<RequestLanguage>>,
@@ -1548,7 +1548,7 @@ pub async fn session_cleanup(
         ("offset" = Option<usize>, Query, description = "Items to skip"),
     ),
     responses(
-        (status = 200, description = "Search results", body = serde_json::Value),
+        (status = 200, description = "Search results", body = crate::types::JsonObject),
         (status = 400, description = "Missing query parameter"),
     )
 )]
@@ -1652,7 +1652,7 @@ fn approval_to_json(
         ("limit" = Option<usize>, Query, description = "Max items (default 50, max 500)"),
         ("offset" = Option<usize>, Query, description = "Items to skip"),
     ),
-    responses((status = 200, description = "Paginated list of pending and recent approvals", body = serde_json::Value))
+    responses((status = 200, description = "Paginated list of pending and recent approvals", body = crate::types::JsonObject))
 )]
 pub async fn list_approvals(
     State(state): State<Arc<AppState>>,
@@ -1735,7 +1735,7 @@ pub async fn list_approvals(
 }
 
 /// GET /api/approvals/{id} — Get a single approval request by ID.
-#[utoipa::path(get, path = "/api/approvals/{id}", tag = "approvals", params(("id" = String, Path, description = "Approval ID")), responses((status = 200, description = "Single approval request", body = serde_json::Value), (status = 404, description = "Approval not found")))]
+#[utoipa::path(get, path = "/api/approvals/{id}", tag = "approvals", params(("id" = String, Path, description = "Approval ID")), responses((status = 200, description = "Single approval request", body = crate::types::JsonObject), (status = 404, description = "Approval not found")))]
 pub async fn get_approval(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1781,7 +1781,7 @@ pub(crate) struct CreateApprovalRequest {
     pub session_id: Option<String>,
 }
 
-#[utoipa::path(post, path = "/api/approvals", tag = "approvals", request_body = serde_json::Value, responses((status = 200, description = "Approval created", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/approvals", tag = "approvals", request_body = crate::types::JsonObject, responses((status = 200, description = "Approval created", body = crate::types::JsonObject)))]
 #[allow(private_interfaces)]
 pub async fn create_approval(
     State(state): State<Arc<AppState>>,
@@ -1836,7 +1836,7 @@ pub(crate) struct ApproveRequestBody {
     totp_code: Option<String>,
 }
 
-#[utoipa::path(post, path = "/api/approvals/{id}/approve", tag = "approvals", params(("id" = String, Path, description = "Approval ID")), request_body = serde_json::Value, responses((status = 200, description = "Request approved", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/approvals/{id}/approve", tag = "approvals", params(("id" = String, Path, description = "Approval ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Request approved", body = crate::types::JsonObject)))]
 #[allow(private_interfaces)]
 pub async fn approve_request(
     State(state): State<Arc<AppState>>,
@@ -2062,7 +2062,7 @@ pub async fn approve_request(
 }
 
 /// POST /api/approvals/{id}/reject — Reject a pending request.
-#[utoipa::path(post, path = "/api/approvals/{id}/reject", tag = "approvals", params(("id" = String, Path, description = "Approval ID")), responses((status = 200, description = "Request rejected", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/approvals/{id}/reject", tag = "approvals", params(("id" = String, Path, description = "Approval ID")), responses((status = 200, description = "Request rejected", body = crate::types::JsonObject)))]
 pub async fn reject_request(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -2111,7 +2111,7 @@ pub(crate) struct ModifyRequestBody {
     feedback: String,
 }
 
-#[utoipa::path(post, path = "/api/approvals/{id}/modify", tag = "approvals", params(("id" = String, Path, description = "Approval ID")), request_body = serde_json::Value, responses((status = 200, description = "Request modified", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/approvals/{id}/modify", tag = "approvals", params(("id" = String, Path, description = "Approval ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Request modified", body = crate::types::JsonObject)))]
 #[allow(private_interfaces)]
 pub async fn modify_request(
     State(state): State<Arc<AppState>>,
@@ -2164,7 +2164,7 @@ pub(crate) struct BatchResolveRequest {
     decision: String,
 }
 
-#[utoipa::path(post, path = "/api/approvals/batch", tag = "approvals", request_body = serde_json::Value, responses((status = 200, description = "Batch resolve results", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/approvals/batch", tag = "approvals", request_body = crate::types::JsonObject, responses((status = 200, description = "Batch resolve results", body = crate::types::JsonObject)))]
 #[allow(private_interfaces)]
 pub async fn batch_resolve(
     State(state): State<Arc<AppState>>,
@@ -2272,7 +2272,7 @@ pub async fn batch_resolve(
     tag = "approvals",
     params(("session_id" = String, Path, description = "Session ID")),
     responses(
-        (status = 200, description = "Pending approvals for session", body = serde_json::Value)
+        (status = 200, description = "Pending approvals for session", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_approvals_for_session(
@@ -2346,9 +2346,9 @@ pub(crate) struct ApproveAllForSessionRequest {
     params(("session_id" = String, Path, description = "Session ID")),
     request_body = ApproveAllForSessionRequest,
     responses(
-        (status = 200, description = "All pending session approvals approved", body = serde_json::Value),
-        (status = 400, description = "TOTP required for one or more items", body = serde_json::Value),
-        (status = 409, description = "Pending set changed since request was issued", body = serde_json::Value),
+        (status = 200, description = "All pending session approvals approved", body = crate::types::JsonObject),
+        (status = 400, description = "TOTP required for one or more items", body = crate::types::JsonObject),
+        (status = 409, description = "Pending set changed since request was issued", body = crate::types::JsonObject),
     )
 )]
 #[allow(private_interfaces)]
@@ -2475,7 +2475,7 @@ pub async fn approve_all_for_session(
     tag = "approvals",
     params(("session_id" = String, Path, description = "Session ID")),
     responses(
-        (status = 200, description = "All pending session approvals rejected", body = serde_json::Value)
+        (status = 200, description = "All pending session approvals rejected", body = crate::types::JsonObject)
     )
 )]
 pub async fn reject_all_for_session(
@@ -2546,7 +2546,7 @@ fn default_audit_limit() -> usize {
     50
 }
 
-#[utoipa::path(get, path = "/api/approvals/audit", tag = "approvals", params(("limit" = Option<usize>, Query, description = "Max entries"), ("offset" = Option<usize>, Query, description = "Offset"), ("agent_id" = Option<String>, Query, description = "Filter by agent"), ("tool_name" = Option<String>, Query, description = "Filter by tool")), responses((status = 200, description = "Audit log entries", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/approvals/audit", tag = "approvals", params(("limit" = Option<usize>, Query, description = "Max entries"), ("offset" = Option<usize>, Query, description = "Offset"), ("agent_id" = Option<String>, Query, description = "Filter by agent"), ("tool_name" = Option<String>, Query, description = "Filter by tool")), responses((status = 200, description = "Audit log entries", body = crate::types::JsonObject)))]
 pub async fn audit_log(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AuditQueryParams>,
@@ -2568,7 +2568,7 @@ pub async fn audit_log(
 }
 
 /// GET /api/approvals/count — Lightweight pending count for notification badges.
-#[utoipa::path(get, path = "/api/approvals/count", tag = "approvals", responses((status = 200, description = "Pending approval count", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/approvals/count", tag = "approvals", responses((status = 200, description = "Pending approval count", body = crate::types::JsonObject)))]
 pub async fn approval_count(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let pending = state.kernel.approvals().pending_count();
     Json(serde_json::json!({"pending": pending}))
@@ -3030,7 +3030,7 @@ pub async fn totp_revoke(
 ///
 /// Publishes a custom event through the kernel's event system, which can
 /// trigger proactive agents that subscribe to the event type.
-#[utoipa::path(post, path = "/api/hooks/wake", tag = "webhooks", request_body = serde_json::Value, responses((status = 200, description = "Wake hook triggered", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/hooks/wake", tag = "webhooks", request_body = crate::types::JsonObject, responses((status = 200, description = "Wake hook triggered", body = crate::types::JsonObject)))]
 pub async fn webhook_wake(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
@@ -3095,7 +3095,7 @@ pub async fn webhook_wake(
 ///
 /// Sends a message directly to the specified agent and returns the response.
 /// This enables external systems (CI/CD, Slack, etc.) to trigger agent work.
-#[utoipa::path(post, path = "/api/hooks/agent", tag = "webhooks", request_body = serde_json::Value, responses((status = 200, description = "Agent hook triggered", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/hooks/agent", tag = "webhooks", request_body = crate::types::JsonObject, responses((status = 200, description = "Agent hook triggered", body = crate::types::JsonObject)))]
 pub async fn webhook_agent(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
@@ -3197,7 +3197,7 @@ pub async fn list_bindings(State(state): State<Arc<AppState>>) -> impl IntoRespo
 }
 
 /// POST /api/bindings — Add a new agent binding.
-#[utoipa::path(post, path = "/api/bindings", tag = "system", request_body = serde_json::Value, responses((status = 200, description = "Binding added", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/bindings", tag = "system", request_body = crate::types::JsonObject, responses((status = 200, description = "Binding added", body = crate::types::JsonObject)))]
 pub async fn add_binding(
     State(state): State<Arc<AppState>>,
     Json(binding): Json<librefang_types::config::AgentBinding>,
@@ -3284,7 +3284,7 @@ fn resolve_pairing_base_url(
 }
 
 /// POST /api/pairing/request — Create a new pairing request (returns token + QR URI).
-#[utoipa::path(post, path = "/api/pairing/request", tag = "pairing", responses((status = 200, description = "Pairing request created", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/pairing/request", tag = "pairing", responses((status = 200, description = "Pairing request created", body = crate::types::JsonObject)))]
 pub async fn pairing_request(
     State(state): State<Arc<AppState>>,
     lang: Option<axum::Extension<RequestLanguage>>,
@@ -3372,7 +3372,7 @@ fn default_unknown() -> String {
 }
 
 /// POST /api/pairing/complete — Complete pairing with token + device info.
-#[utoipa::path(post, path = "/api/pairing/complete", tag = "pairing", request_body = serde_json::Value, responses((status = 200, description = "Pairing completed", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/pairing/complete", tag = "pairing", request_body = crate::types::JsonObject, responses((status = 200, description = "Pairing completed", body = crate::types::JsonObject)))]
 pub async fn pairing_complete(
     State(state): State<Arc<AppState>>,
     lang: Option<axum::Extension<RequestLanguage>>,
@@ -3549,7 +3549,7 @@ pub async fn pairing_remove_device(
 }
 
 /// POST /api/pairing/notify — Push a notification to all paired devices.
-#[utoipa::path(post, path = "/api/pairing/notify", tag = "pairing", request_body = serde_json::Value, responses((status = 200, description = "Notification sent", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/pairing/notify", tag = "pairing", request_body = crate::types::JsonObject, responses((status = 200, description = "Notification sent", body = crate::types::JsonObject)))]
 pub async fn pairing_notify(
     State(state): State<Arc<AppState>>,
     lang: Option<axum::Extension<RequestLanguage>>,
@@ -3623,7 +3623,7 @@ pub async fn list_commands(State(state): State<Arc<AppState>>) -> impl IntoRespo
 }
 
 /// GET /api/commands/{name} — Lookup a single command by name.
-#[utoipa::path(get, path = "/api/commands/{name}", tag = "system", params(("name" = String, Path, description = "Command name")), responses((status = 200, description = "Command details", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/commands/{name}", tag = "system", params(("name" = String, Path, description = "Command name")), responses((status = 200, description = "Command details", body = crate::types::JsonObject)))]
 pub async fn get_command(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -3717,7 +3717,7 @@ struct BackupManifest {
 ///
 /// Returns the backup metadata including the filename. The archive is stored
 /// in `<home_dir>/backups/` with a timestamped filename.
-#[utoipa::path(post, path = "/api/backup", tag = "system", responses((status = 200, description = "Backup created", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/backup", tag = "system", responses((status = 200, description = "Backup created", body = crate::types::JsonObject)))]
 pub async fn create_backup(
     State(state): State<Arc<AppState>>,
     lang: Option<axum::Extension<RequestLanguage>>,
@@ -4078,7 +4078,7 @@ pub async fn delete_backup(
 ///
 /// **Warning**: This overwrites existing state files. The daemon should be
 /// restarted after a restore for all changes to take effect.
-#[utoipa::path(post, path = "/api/restore", tag = "system", request_body = serde_json::Value, responses((status = 200, description = "Backup restored", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/restore", tag = "system", request_body = crate::types::JsonObject, responses((status = 200, description = "Backup restored", body = crate::types::JsonObject)))]
 pub async fn restore_backup(
     State(state): State<Arc<AppState>>,
     lang: Option<axum::Extension<RequestLanguage>>,
@@ -4252,7 +4252,7 @@ fn read_backup_manifest(path: &std::path::Path) -> Option<BackupManifest> {
 }
 
 /// GET /api/queue/status — Command queue status and occupancy.
-#[utoipa::path(get, path = "/api/queue/status", tag = "system", responses((status = 200, description = "Queue status", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/queue/status", tag = "system", responses((status = 200, description = "Queue status", body = crate::types::JsonObject)))]
 pub async fn queue_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let occupancy = state.kernel.command_queue_ref().occupancy();
     let lanes: Vec<serde_json::Value> = occupancy
@@ -4330,7 +4330,7 @@ fn validate_webhook_token(headers: &axum::http::HeaderMap, token_env: &str) -> b
     path = "/api/versions",
     tag = "system",
     responses(
-        (status = 200, description = "API version info", body = serde_json::Value)
+        (status = 200, description = "API version info", body = crate::types::JsonObject)
     )
 )]
 pub async fn api_versions() -> impl IntoResponse {

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -1224,7 +1224,7 @@ fn decode_field<T: serde::de::DeserializeOwned>(
     tag = "users",
     params(("name" = String, Path, description = "User name (case-sensitive)")),
     responses(
-        (status = 200, description = "Per-user policy slice", body = serde_json::Value),
+        (status = 200, description = "Per-user policy slice", body = crate::types::JsonObject),
         (status = 404, description = "Not found"),
     )
 )]
@@ -1270,9 +1270,9 @@ pub async fn get_user_policy(
     path = "/api/users/{name}/policy",
     tag = "users",
     params(("name" = String, Path, description = "User name (case-sensitive)")),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Updated user policy slice", body = serde_json::Value),
+        (status = 200, description = "Updated user policy slice", body = crate::types::JsonObject),
         (status = 400, description = "Validation error"),
         (status = 404, description = "Not found"),
     )

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -279,9 +279,9 @@ fn parse_error_mode(val: &serde_json::Value, step: &serde_json::Value) -> ErrorM
     post,
     path = "/api/workflows",
     tag = "workflows",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Workflow created", body = serde_json::Value),
+        (status = 200, description = "Workflow created", body = crate::types::JsonObject),
         (status = 400, description = "Invalid workflow definition")
     )
 )]
@@ -476,7 +476,7 @@ pub async fn list_workflows(State(state): State<Arc<AppState>>) -> impl IntoResp
     tag = "workflows",
     params(("id" = String, Path, description = "Workflow ID")),
     responses(
-        (status = 200, description = "Workflow details", body = serde_json::Value),
+        (status = 200, description = "Workflow details", body = crate::types::JsonObject),
         (status = 404, description = "Workflow not found")
     )
 )]
@@ -534,9 +534,9 @@ pub async fn get_workflow(
     path = "/api/workflows/{id}",
     tag = "workflows",
     params(("id" = String, Path, description = "Workflow ID")),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Workflow updated", body = serde_json::Value),
+        (status = 200, description = "Workflow updated", body = crate::types::JsonObject),
         (status = 400, description = "Invalid workflow definition"),
         (status = 404, description = "Workflow not found")
     )
@@ -696,7 +696,7 @@ pub async fn delete_workflow(
 }
 
 /// POST /api/workflows/:id/run — Execute a workflow.
-#[utoipa::path(post, path = "/api/workflows/{id}/run", tag = "workflows", params(("id" = String, Path, description = "Workflow ID")), responses((status = 200, description = "Workflow run started", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/workflows/{id}/run", tag = "workflows", params(("id" = String, Path, description = "Workflow ID")), responses((status = 200, description = "Workflow run started", body = crate::types::JsonObject)))]
 pub async fn run_workflow(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -762,9 +762,9 @@ pub async fn run_workflow(
     path = "/api/workflows/{id}/dry-run",
     tag = "workflows",
     params(("id" = String, Path, description = "Workflow ID")),
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Dry-run preview", body = serde_json::Value),
+        (status = 200, description = "Dry-run preview", body = crate::types::JsonObject),
         (status = 404, description = "Workflow not found")
     )
 )]
@@ -814,7 +814,7 @@ pub async fn dry_run_workflow(
     tag = "workflows",
     params(("run_id" = String, Path, description = "Workflow run ID")),
     responses(
-        (status = 200, description = "Workflow run details", body = serde_json::Value),
+        (status = 200, description = "Workflow run details", body = crate::types::JsonObject),
         (status = 404, description = "Run not found")
     )
 )]
@@ -892,7 +892,7 @@ pub async fn list_workflow_runs(
     tag = "workflows",
     params(("id" = String, Path, description = "Workflow ID")),
     responses(
-        (status = 200, description = "Template created", body = serde_json::Value),
+        (status = 200, description = "Template created", body = crate::types::JsonObject),
         (status = 404, description = "Workflow not found")
     )
 )]
@@ -966,9 +966,9 @@ pub async fn save_workflow_as_template(
     post,
     path = "/api/triggers",
     tag = "workflows",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Trigger created", body = serde_json::Value),
+        (status = 200, description = "Trigger created", body = crate::types::JsonObject),
         (status = 400, description = "Invalid trigger definition")
     )
 )]
@@ -1083,7 +1083,7 @@ pub async fn create_trigger(
     path = "/api/triggers",
     tag = "workflows",
     responses(
-        (status = 200, description = "List triggers", body = serde_json::Value)
+        (status = 200, description = "List triggers", body = crate::types::JsonObject)
     )
 )]
 /// Serialize a `Trigger` to a JSON value (shared by list and get endpoints).
@@ -1106,7 +1106,7 @@ fn trigger_to_json(t: &Trigger) -> serde_json::Value {
     v
 }
 
-#[utoipa::path(get, path = "/api/triggers", tag = "workflows", params(("agent_id" = Option<String>, Query, description = "Filter by agent ID")), responses((status = 200, description = "List triggers", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/triggers", tag = "workflows", params(("agent_id" = Option<String>, Query, description = "Filter by agent ID")), responses((status = 200, description = "List triggers", body = crate::types::JsonObject)))]
 pub async fn list_triggers(
     State(state): State<Arc<AppState>>,
     api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
@@ -1164,7 +1164,7 @@ pub async fn list_triggers(
     Json(serde_json::json!({"triggers": list, "total": total})).into_response()
 }
 
-#[utoipa::path(get, path = "/api/triggers/{id}", tag = "workflows", params(("id" = String, Path, description = "Trigger ID")), responses((status = 200, description = "Trigger detail", body = serde_json::Value), (status = 404, description = "Not found")))]
+#[utoipa::path(get, path = "/api/triggers/{id}", tag = "workflows", params(("id" = String, Path, description = "Trigger ID")), responses((status = 200, description = "Trigger detail", body = crate::types::JsonObject), (status = 404, description = "Not found")))]
 /// GET /api/triggers/:id — Fetch a single trigger by ID.
 pub async fn get_trigger(
     State(state): State<Arc<AppState>>,
@@ -1207,7 +1207,7 @@ pub async fn delete_trigger(
 // Trigger update endpoint
 // ---------------------------------------------------------------------------
 
-#[utoipa::path(patch, path = "/api/triggers/{id}", tag = "workflows", params(("id" = String, Path, description = "Trigger ID")), responses((status = 200, description = "Updated trigger", body = serde_json::Value), (status = 404, description = "Not found")))]
+#[utoipa::path(patch, path = "/api/triggers/{id}", tag = "workflows", params(("id" = String, Path, description = "Trigger ID")), responses((status = 200, description = "Updated trigger", body = crate::types::JsonObject), (status = 404, description = "Not found")))]
 /// PATCH /api/triggers/:id — Partially update a trigger.
 ///
 /// All body fields are optional. Only provided fields are changed.
@@ -1412,7 +1412,7 @@ pub async fn list_schedules(State(state): State<Arc<AppState>>) -> impl IntoResp
 }
 
 /// GET /api/schedules/{id} — Get a specific schedule by ID.
-#[utoipa::path(get, path = "/api/schedules/{id}", tag = "workflows", params(("id" = String, Path, description = "Schedule ID")), responses((status = 200, description = "Schedule details", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/schedules/{id}", tag = "workflows", params(("id" = String, Path, description = "Schedule ID")), responses((status = 200, description = "Schedule details", body = crate::types::JsonObject)))]
 pub async fn get_schedule(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1432,9 +1432,9 @@ pub async fn get_schedule(
     post,
     path = "/api/schedules",
     tag = "workflows",
-    request_body = serde_json::Value,
+    request_body = crate::types::JsonObject,
     responses(
-        (status = 200, description = "Schedule created", body = serde_json::Value),
+        (status = 200, description = "Schedule created", body = crate::types::JsonObject),
         (status = 400, description = "Invalid schedule definition")
     )
 )]
@@ -1614,7 +1614,7 @@ pub async fn create_schedule(
 }
 
 /// PUT /api/schedules/:id — Update a scheduled job (toggle enabled, edit fields).
-#[utoipa::path(put, path = "/api/schedules/{id}", tag = "workflows", params(("id" = String, Path, description = "Schedule ID")), request_body = serde_json::Value, responses((status = 200, description = "Schedule updated", body = serde_json::Value)))]
+#[utoipa::path(put, path = "/api/schedules/{id}", tag = "workflows", params(("id" = String, Path, description = "Schedule ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Schedule updated", body = crate::types::JsonObject)))]
 pub async fn update_schedule(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1754,7 +1754,7 @@ pub async fn delete_schedule(
 }
 
 /// POST /api/schedules/:id/run — Manually trigger a scheduled job now.
-#[utoipa::path(post, path = "/api/schedules/{id}/run", tag = "workflows", params(("id" = String, Path, description = "Schedule ID")), responses((status = 200, description = "Schedule triggered", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/schedules/{id}/run", tag = "workflows", params(("id" = String, Path, description = "Schedule ID")), responses((status = 200, description = "Schedule triggered", body = crate::types::JsonObject)))]
 pub async fn run_schedule(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1890,7 +1890,7 @@ pub async fn list_cron_jobs(
 }
 
 /// POST /api/cron/jobs — Create a new cron job.
-#[utoipa::path(post, path = "/api/cron/jobs", tag = "workflows", request_body = serde_json::Value, responses((status = 200, description = "Cron job created", body = serde_json::Value)))]
+#[utoipa::path(post, path = "/api/cron/jobs", tag = "workflows", request_body = crate::types::JsonObject, responses((status = 200, description = "Cron job created", body = crate::types::JsonObject)))]
 pub async fn create_cron_job(
     State(state): State<Arc<AppState>>,
     Json(body): Json<serde_json::Value>,
@@ -1935,7 +1935,7 @@ pub async fn delete_cron_job(
 }
 
 /// PUT /api/cron/jobs/{id} — Update a cron job's configuration.
-#[utoipa::path(put, path = "/api/cron/jobs/{id}", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), request_body = serde_json::Value, responses((status = 200, description = "Cron job updated", body = serde_json::Value)))]
+#[utoipa::path(put, path = "/api/cron/jobs/{id}", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Cron job updated", body = crate::types::JsonObject)))]
 pub async fn update_cron_job(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1960,7 +1960,7 @@ pub async fn update_cron_job(
 }
 
 /// PUT /api/cron/jobs/{id}/enable — Enable or disable a cron job.
-#[utoipa::path(put, path = "/api/cron/jobs/{id}/enable", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), request_body = serde_json::Value, responses((status = 200, description = "Cron job toggled", body = serde_json::Value)))]
+#[utoipa::path(put, path = "/api/cron/jobs/{id}/enable", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Cron job toggled", body = crate::types::JsonObject)))]
 pub async fn toggle_cron_job(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1988,7 +1988,7 @@ pub async fn toggle_cron_job(
 }
 
 /// GET /api/cron/jobs/{id} — Get a single cron job by ID.
-#[utoipa::path(get, path = "/api/cron/jobs/{id}", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), responses((status = 200, description = "Cron job details", body = serde_json::Value), (status = 404, description = "Job not found")))]
+#[utoipa::path(get, path = "/api/cron/jobs/{id}", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), responses((status = 200, description = "Cron job details", body = crate::types::JsonObject), (status = 404, description = "Job not found")))]
 pub async fn get_cron_job(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -2009,7 +2009,7 @@ pub async fn get_cron_job(
 }
 
 /// GET /api/cron/jobs/{id}/status — Get status of a specific cron job.
-#[utoipa::path(get, path = "/api/cron/jobs/{id}/status", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), responses((status = 200, description = "Cron job status", body = serde_json::Value)))]
+#[utoipa::path(get, path = "/api/cron/jobs/{id}/status", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), responses((status = 200, description = "Cron job status", body = crate::types::JsonObject)))]
 pub async fn cron_job_status(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -2103,7 +2103,7 @@ pub async fn list_workflow_templates(
     tag = "workflows",
     params(("id" = String, Path, description = "Template ID")),
     responses(
-        (status = 200, description = "Template details", body = serde_json::Value),
+        (status = 200, description = "Template details", body = crate::types::JsonObject),
         (status = 404, description = "Template not found")
     )
 )]
@@ -2130,7 +2130,7 @@ pub async fn get_workflow_template(
     params(("id" = String, Path, description = "Template ID")),
     request_body = HashMap<String, serde_json::Value>,
     responses(
-        (status = 201, description = "Workflow created from template", body = serde_json::Value),
+        (status = 201, description = "Workflow created from template", body = crate::types::JsonObject),
         (status = 400, description = "Invalid parameters"),
         (status = 404, description = "Template not found")
     )

--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -6,6 +6,37 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
+// Generic JSON wrappers — used as `body = JsonObject` / `body = JsonArray`
+// in `#[utoipa::path]` attributes for handlers that return free-form JSON
+// (heterogeneous shapes that are not worth a dedicated struct, or shapes
+// that are still in flux). They emit `{ "type": "object" }` / `{ "type":
+// "array" }` instead of the empty `{}` blob that `serde_json::Value`
+// produces, so downstream SDK generators see a real schema.
+// ---------------------------------------------------------------------------
+
+/// OpenAPI placeholder for an arbitrary JSON object response/request.
+///
+/// Use `body = JsonObject` (qualified as `crate::types::JsonObject` from
+/// route modules) when the underlying handler returns
+/// `axum::Json<serde_json::Value>` and the shape is dynamic. The schema
+/// renders as `{ "type": "object", "additionalProperties": true }`,
+/// which is honest about the contract (any JSON object) without leaving
+/// SDK generators with `{}` to ignore.
+#[derive(Serialize, Deserialize, utoipa::ToSchema)]
+#[schema(value_type = Object, description = "Arbitrary JSON object")]
+#[allow(dead_code)]
+pub struct JsonObject(pub serde_json::Value);
+
+/// OpenAPI placeholder for an arbitrary JSON array response/request.
+///
+/// Counterpart to [`JsonObject`] for handlers that return a top-level
+/// JSON array of heterogeneous items.
+#[derive(Serialize, Deserialize, utoipa::ToSchema)]
+#[schema(value_type = Vec<Object>, description = "Arbitrary JSON array")]
+#[allow(dead_code)]
+pub struct JsonArray(pub Vec<serde_json::Value>);
+
+// ---------------------------------------------------------------------------
 // Unified API error response
 // ---------------------------------------------------------------------------
 

--- a/openapi.json
+++ b/openapi.json
@@ -1526,7 +1526,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonObject"
+                  "$ref": "#/components/schemas/JsonArray"
                 }
               }
             }
@@ -4049,7 +4049,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonObject"
+                  "$ref": "#/components/schemas/JsonArray"
                 }
               }
             }
@@ -5519,7 +5519,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JsonObject"
+                  "$ref": "#/components/schemas/JsonArray"
                 }
               }
             }

--- a/openapi.json
+++ b/openapi.json
@@ -21,7 +21,9 @@
             "description": "Get the A2A agent card",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -40,7 +42,9 @@
             "description": "List all A2A agent cards",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -57,7 +61,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -67,7 +73,9 @@
             "description": "Submit a task to an agent via A2A",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -97,7 +105,9 @@
             "description": "Get A2A task status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -127,7 +137,9 @@
             "description": "Cancel a tracked A2A task",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -147,7 +159,9 @@
             "description": "List discovered external A2A agents",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -177,7 +191,9 @@
             "description": "Get a specific external A2A agent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -194,7 +210,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -204,7 +222,9 @@
             "description": "Discover an external A2A agent by URL",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -221,7 +241,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -231,7 +253,9 @@
             "description": "Send a task to an external A2A agent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -270,7 +294,9 @@
             "description": "Get external A2A task status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -405,7 +431,9 @@
             "description": "Create multiple agents at once",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -433,7 +461,9 @@
             "description": "Delete multiple agents at once",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -463,7 +493,9 @@
             "description": "Start multiple agents (set to Full mode)",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -493,7 +525,9 @@
             "description": "Stop multiple agents' current runs",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -523,7 +557,9 @@
             "description": "Agent details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -588,7 +624,9 @@
             "description": "Partially update an agent (name, description, model, system prompt)",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -629,7 +667,9 @@
             "description": "Clone an agent with its workspace files",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -670,7 +710,9 @@
             "description": "Hot-update agent name, description, system prompt, identity, and model",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -700,7 +742,9 @@
             "description": "List recent delivery receipts for an agent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -777,7 +821,9 @@
             "description": "List workspace identity files for an agent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -816,7 +862,9 @@
             "description": "Read a workspace identity file",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -864,7 +912,9 @@
             "description": "Write a workspace identity file",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -901,7 +951,9 @@
             "description": "File deleted successfully",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -909,7 +961,9 @@
             "description": "File not found",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -943,7 +997,9 @@
             "description": "Invalid agent id or target agent is not managed by a hand",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -951,7 +1007,9 @@
             "description": "Agent not found",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -959,7 +1017,9 @@
             "description": "Hand role not found for the agent (hand registry inconsistency)",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -967,7 +1027,9 @@
             "description": "Internal kernel error",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1006,7 +1068,9 @@
             "description": "Runtime override applied to the live manifest and persisted to hand_state.json",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -1014,7 +1078,9 @@
             "description": "Invalid agent id or target agent is not managed by a hand",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -1022,7 +1088,9 @@
             "description": "Agent not found",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -1030,7 +1098,9 @@
             "description": "Hand role not found for the agent (hand registry inconsistency)",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -1038,7 +1108,9 @@
             "description": "Internal kernel error",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1068,7 +1140,9 @@
             "description": "Clear all conversation history for an agent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1109,7 +1183,9 @@
             "description": "Update an agent's visual identity",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1139,7 +1215,9 @@
             "description": "Get an agent's MCP server assignment info",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1176,7 +1254,9 @@
             "description": "Update an agent's MCP server allowlist",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1206,7 +1286,9 @@
             "description": "Exported memory",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1235,7 +1317,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -1245,7 +1329,9 @@
             "description": "Memory imported",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1366,7 +1452,9 @@
             "description": "Change an agent's operational mode",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1404,7 +1492,9 @@
             "description": "Change an agent's LLM model",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1435,7 +1525,9 @@
             "description": "List of in-flight sessions for the agent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1474,7 +1566,9 @@
             "description": "Get agent conversation session history",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1504,7 +1598,9 @@
             "description": "Trigger LLM session compaction",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1534,7 +1630,9 @@
             "description": "Hard-reboot an agent's session without saving summary",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1564,7 +1662,9 @@
             "description": "Reset an agent's current session",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1593,7 +1693,9 @@
             "description": "List all sessions for an agent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1630,7 +1732,9 @@
             "description": "Create a new session for an agent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1669,7 +1773,9 @@
             "description": "Session found",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1708,7 +1814,9 @@
             "description": "Session imported successfully",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1747,7 +1855,9 @@
             "description": "Exported session data",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1787,7 +1897,9 @@
             "description": "Cancel a single (agent, session) loop",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1867,7 +1979,9 @@
             "description": "Switch to an existing session",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1916,7 +2030,9 @@
             "description": "Redacted trajectory bundle",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -1952,7 +2068,9 @@
             "description": "Get an agent's skill assignment info",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -1989,7 +2107,9 @@
             "description": "Update an agent's skill allowlist",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2055,7 +2175,9 @@
             "description": "Cancel an agent's current LLM run",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2085,7 +2207,9 @@
             "description": "Get an agent's tool allowlist and blocklist",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2124,7 +2248,9 @@
             "description": "Update an agent's tool allowlist and blocklist",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2155,7 +2281,9 @@
             "description": "Get decision traces from the agent's most recent message",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2196,7 +2324,9 @@
             "description": "Update an agent's manifest",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2237,7 +2367,9 @@
             "description": "Upload a file attachment for an agent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2279,7 +2411,9 @@
             "description": "Paginated list of pending and recent approvals",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2293,7 +2427,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -2303,7 +2439,9 @@
             "description": "Approval created",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2333,7 +2471,9 @@
             "description": "Single approval request",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -2363,7 +2503,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -2373,7 +2515,9 @@
             "description": "Request approved",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2403,7 +2547,9 @@
             "description": "Request rejected",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2585,7 +2731,9 @@
             "description": "Filtered audit log entries",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2626,7 +2774,9 @@
             "description": "Audit verification result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2645,7 +2795,9 @@
             "description": "OAuth callback — completes login flow",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2672,7 +2824,9 @@
             "description": "OAuth callback (POST) — completes login flow",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2690,7 +2844,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -2700,7 +2856,9 @@
             "description": "Token introspection result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2758,7 +2916,9 @@
             "description": "List configured OAuth/OIDC providers",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2778,7 +2938,9 @@
             "description": "Get authenticated user info",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -2810,7 +2972,9 @@
             "description": "Abort outcome",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -2852,7 +3016,9 @@
             "description": "Opt-in toggled",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -2887,7 +3053,9 @@
             "description": "Trigger outcome",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -2908,7 +3076,9 @@
             "description": "Auto-dream status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -2928,7 +3098,9 @@
             "description": "Backup created",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3012,7 +3184,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -3022,7 +3196,9 @@
             "description": "Binding added",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3068,7 +3244,9 @@
             "description": "Global budget status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3093,7 +3271,9 @@
             "description": "Updated global budget status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3146,7 +3326,9 @@
             "description": "Per-agent budget and quota status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3182,7 +3364,9 @@
             "description": "Updated agent budget",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3215,7 +3399,9 @@
             "description": "Per-user cost ranking",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3246,7 +3432,9 @@
             "description": "Single user budget detail",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3265,7 +3453,9 @@
             "description": "Catalog sync status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3285,7 +3475,9 @@
             "description": "Catalog updated",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3326,7 +3518,9 @@
             "description": "Channels reloaded successfully",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -3334,7 +3528,9 @@
             "description": "Reload failed",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3353,7 +3549,9 @@
             "description": "WeChat QR login initiated",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3383,7 +3581,9 @@
             "description": "WeChat QR scan status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3403,7 +3603,9 @@
             "description": "WhatsApp QR session started",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3434,7 +3636,9 @@
             "description": "WhatsApp QR scan status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3462,7 +3666,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -3472,7 +3678,9 @@
             "description": "Channel configured successfully",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -3480,7 +3688,9 @@
             "description": "Bad request",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -3488,7 +3698,9 @@
             "description": "Unknown channel",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3516,7 +3728,9 @@
             "description": "Channel removed successfully",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -3524,7 +3738,9 @@
             "description": "Unknown channel",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -3532,7 +3748,9 @@
             "description": "Internal server error",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3570,7 +3788,9 @@
             "description": "Channel test result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -3578,7 +3798,9 @@
             "description": "Unknown channel",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3609,7 +3831,9 @@
             "description": "Browse ClawHub skills by sort order",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3627,7 +3851,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -3637,7 +3863,9 @@
             "description": "Install a skill from ClawHub",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3668,7 +3896,9 @@
             "description": "Search ClawHub skills",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3698,7 +3928,9 @@
             "description": "Get detailed info about a ClawHub skill",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3728,7 +3960,9 @@
             "description": "Fetch source code of a ClawHub skill",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3780,7 +4014,9 @@
             "description": "Command details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3812,7 +4048,9 @@
             "description": "Recent inter-agent communication events",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3832,7 +4070,9 @@
             "description": "SSE stream of inter-agent events",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3849,7 +4089,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -3859,7 +4101,9 @@
             "description": "Send a message between agents",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3876,7 +4120,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -3886,7 +4132,9 @@
             "description": "Post a task to the agent task queue",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3905,7 +4153,9 @@
             "description": "Build agent topology graph",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3924,7 +4174,9 @@
             "description": "Get kernel configuration (secrets redacted)",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3944,7 +4196,9 @@
             "description": "Reload configuration from disk",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3963,7 +4217,9 @@
             "description": "Get config structure schema",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -3991,7 +4247,9 @@
             "description": "Set a single config value and persist",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4028,7 +4286,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4038,7 +4298,9 @@
             "description": "Cron job created",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4066,7 +4328,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4076,7 +4340,9 @@
             "description": "Cron job updated",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4127,7 +4393,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4137,7 +4405,9 @@
             "description": "Cron job toggled",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4167,7 +4437,9 @@
             "description": "Cron job status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4186,7 +4458,9 @@
             "description": "List catalog entries with install/health status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4203,7 +4477,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4213,7 +4489,9 @@
             "description": "Install a catalog entry",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4230,7 +4508,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4240,7 +4520,9 @@
             "description": "Uninstall a catalog-backed MCP server",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4270,7 +4552,9 @@
             "description": "Catalog entry detail + install status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4289,7 +4573,9 @@
             "description": "List all hand definitions",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4308,7 +4594,9 @@
             "description": "List active hand instances",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4325,7 +4613,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4335,7 +4625,9 @@
             "description": "Install a hand from TOML content",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4365,7 +4657,9 @@
             "description": "Deactivate a hand (kills agent)",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4395,7 +4689,9 @@
             "description": "Get live browser state for a hand instance",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4425,7 +4721,9 @@
             "description": "Pause a hand instance",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4455,7 +4753,9 @@
             "description": "Resume a paused hand instance",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4485,7 +4785,9 @@
             "description": "Get dashboard stats for a hand instance",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4504,7 +4806,9 @@
             "description": "Reload hand definitions from disk",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4534,7 +4838,9 @@
             "description": "Get a single hand definition with requirements",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4562,7 +4868,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4572,7 +4880,9 @@
             "description": "Activate a hand (spawns agent)",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4602,7 +4912,9 @@
             "description": "Re-check dependency status for a hand",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4632,7 +4944,9 @@
             "description": "Auto-install missing dependencies for a hand",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4662,7 +4976,9 @@
             "description": "Get settings schema and current values",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4688,7 +5004,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4698,7 +5016,9 @@
             "description": "Update settings for a hand instance",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4717,7 +5037,9 @@
             "description": "Health check",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4736,7 +5058,9 @@
             "description": "Detailed health diagnostics",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4754,7 +5078,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4764,7 +5090,9 @@
             "description": "Agent hook triggered",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4782,7 +5110,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4792,7 +5122,9 @@
             "description": "Wake hook triggered",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4812,7 +5144,9 @@
             "description": "Quick init result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4857,7 +5191,9 @@
             "description": "Search the FangHub marketplace",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4876,7 +5212,9 @@
             "description": "MCP catalog entries",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4906,7 +5244,9 @@
             "description": "Catalog entry detail",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -4914,7 +5254,9 @@
             "description": "Catalog entry not found",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4933,7 +5275,9 @@
             "description": "Health snapshot for all configured MCP servers",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4952,7 +5296,9 @@
             "description": "Reload catalog and reconnect MCP servers",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4971,7 +5317,9 @@
             "description": "List configured MCP servers and their tools",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -4987,7 +5335,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -4997,7 +5347,9 @@
             "description": "Add a new MCP server configuration",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5028,7 +5380,9 @@
             "description": "MCP server details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -5058,7 +5412,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -5068,7 +5424,9 @@
             "description": "Update an existing MCP server configuration",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5096,7 +5454,9 @@
             "description": "Remove an MCP server configuration",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5126,7 +5486,9 @@
             "description": "Reconnect an MCP server",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -5134,7 +5496,9 @@
             "description": "MCP server not configured",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5154,7 +5518,9 @@
             "description": "List configured named taint rule sets",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5205,7 +5571,9 @@
             "description": "Paginated memory list",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5220,7 +5588,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -5230,7 +5600,9 @@
             "description": "Memories added",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5289,7 +5661,9 @@
             "description": "Paginated agent memory list",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5317,7 +5691,9 @@
             "description": "Memories reset",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5347,7 +5723,9 @@
             "description": "Consolidation result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5377,7 +5755,9 @@
             "description": "Duplicate memory groups",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5407,7 +5787,9 @@
             "description": "Exported memories",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5435,7 +5817,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -5445,7 +5829,9 @@
             "description": "Import result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5475,7 +5861,9 @@
             "description": "Agent KV store",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5514,7 +5902,9 @@
             "description": "KV value",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5549,7 +5939,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -5559,7 +5951,9 @@
             "description": "KV value set",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5630,7 +6024,9 @@
             "description": "Memories cleared at level",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5679,7 +6075,9 @@
             "description": "Search results",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5709,7 +6107,9 @@
             "description": "Agent memory statistics",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5729,7 +6129,9 @@
             "description": "Cleanup result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5757,7 +6159,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -5767,7 +6171,9 @@
             "description": "Memory updated",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5795,7 +6201,9 @@
             "description": "Memory deleted",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5825,7 +6233,9 @@
             "description": "Memory version history",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5865,7 +6275,9 @@
             "description": "Search results",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5885,7 +6297,9 @@
             "description": "Memory statistics",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5915,7 +6329,9 @@
             "description": "User memories",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5935,7 +6351,9 @@
             "description": "Prometheus text-format metrics",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5964,7 +6382,9 @@
             "description": "Run migration from another agent framework",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -5982,7 +6402,9 @@
             "description": "Detect migratable framework installation",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6011,7 +6433,9 @@
             "description": "Scan directory for migratable workspace",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6050,7 +6474,9 @@
             "description": "List model aliases",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6066,7 +6492,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -6076,7 +6504,9 @@
             "description": "Alias created",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6119,7 +6549,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -6129,7 +6561,9 @@
             "description": "Custom model added",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6183,7 +6617,9 @@
             "description": "Model details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6202,7 +6638,9 @@
             "description": "OFP network status summary",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6219,7 +6657,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -6229,7 +6669,9 @@
             "description": "Pairing completed",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6293,7 +6735,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -6303,7 +6747,9 @@
             "description": "Notification sent",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6322,7 +6768,9 @@
             "description": "Pairing request created",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6341,7 +6789,9 @@
             "description": "List known OFP peers",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6371,7 +6821,9 @@
             "description": "Peer details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -6426,7 +6878,9 @@
             "description": "Profile details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6480,7 +6934,9 @@
             "description": "OAuth poll result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6500,7 +6956,9 @@
             "description": "OAuth flow started",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6530,7 +6988,9 @@
             "description": "Provider details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -6571,7 +7031,9 @@
             "description": "Default provider updated",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -6604,7 +7066,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -6614,7 +7078,9 @@
             "description": "API key set",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6667,7 +7133,9 @@
             "description": "Provider test result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6695,7 +7163,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -6705,7 +7175,9 @@
             "description": "Provider URL set",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6724,7 +7196,9 @@
             "description": "Queue status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6742,7 +7216,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -6752,7 +7228,9 @@
             "description": "Backup restored",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6789,7 +7267,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -6799,7 +7279,9 @@
             "description": "Schedule created",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -6832,7 +7314,9 @@
             "description": "Schedule details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6858,7 +7342,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -6868,7 +7354,9 @@
             "description": "Schedule updated",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6921,7 +7409,9 @@
             "description": "Schedule triggered",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6940,7 +7430,9 @@
             "description": "Security feature status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -6981,7 +7473,9 @@
             "description": "Paginated list of sessions",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7001,7 +7495,9 @@
             "description": "Cleanup result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7031,7 +7527,9 @@
             "description": "Session found",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -7085,7 +7583,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -7095,7 +7595,9 @@
             "description": "Label set",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7114,7 +7616,9 @@
             "description": "Graceful daemon shutdown",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7152,7 +7656,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -7162,7 +7668,9 @@
             "description": "Create a new prompt-only skill",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7179,7 +7687,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -7189,7 +7699,9 @@
             "description": "Install a skill from FangHub",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7206,7 +7718,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -7216,7 +7730,9 @@
             "description": "Uninstall a skill",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7234,7 +7750,9 @@
             "description": "Daemon status",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7286,7 +7804,9 @@
             "description": "Template details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7338,7 +7858,9 @@
             "description": "Tool details",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7376,7 +7898,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -7386,7 +7910,9 @@
             "description": "Tool execution result",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -7424,7 +7950,9 @@
             "description": "List triggers",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7439,7 +7967,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -7449,7 +7979,9 @@
             "description": "Trigger created",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -7482,7 +8014,9 @@
             "description": "Trigger detail",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -7545,7 +8079,9 @@
             "description": "Updated trigger",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -7578,7 +8114,9 @@
             "description": "Serve an uploaded file by ID",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7597,7 +8135,9 @@
             "description": "Per-agent usage statistics",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7616,7 +8156,9 @@
             "description": "Usage grouped by model",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7635,7 +8177,9 @@
             "description": "Daily usage breakdown",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7654,7 +8198,9 @@
             "description": "Overall usage summary",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7900,7 +8446,9 @@
             "description": "Version information",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7919,7 +8467,9 @@
             "description": "API version info",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -7956,7 +8506,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -7966,7 +8518,9 @@
             "description": "Workflow created",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -7997,7 +8551,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -8007,7 +8563,9 @@
             "description": "Workflow updated",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -8077,7 +8635,9 @@
             "description": "Workflow run started",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -8140,7 +8700,9 @@
             "description": "Template created",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           },
@@ -8161,7 +8723,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -8171,7 +8735,9 @@
             "description": "Handle MCP JSON-RPC requests over HTTP",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -8188,7 +8754,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {}
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
             }
           },
           "required": true
@@ -8198,7 +8766,9 @@
             "description": "OpenAI-compatible chat completion",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -8217,7 +8787,9 @@
             "description": "OpenAI-compatible model list",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
               }
             }
           }
@@ -8636,6 +9208,17 @@
             "description": "Extension/integration ID to remove."
           }
         }
+      },
+      "JsonArray": {
+        "type": "array",
+        "items": {
+          "type": "object"
+        },
+        "description": "Arbitrary JSON array"
+      },
+      "JsonObject": {
+        "type": "object",
+        "description": "Arbitrary JSON object"
       },
       "MessageRequest": {
         "type": "object",


### PR DESCRIPTION
## Summary

Empty inline schemas in `openapi.json` drop from **299 → 13** (~96% reduction).

`utoipa` cannot derive `ToSchema` for `serde_json::Value`, so handlers using `body = serde_json::Value` were emitting opaque `{}` schemas — invisible to SDK generators and external consumers (issue #3396).

## Scope picked

Introduce two typed placeholder structs in `crates/librefang-api/src/types.rs`:

- `JsonObject` — `{"type": "object", "additionalProperties": true}`
- `JsonArray`  — `{"type": "array", "items": {"type": "object"}}`

Both registered in `openapi.rs` `components(schemas(...))`. Then mechanically replace `body = serde_json::Value` with `body = crate::types::JsonObject` / `JsonArray` across all route modules where the handler genuinely returns dynamic JSON.

## Files touched (23)

- `crates/librefang-api/src/types.rs` (+ new placeholder structs)
- `crates/librefang-api/src/openapi.rs` (register schemas)
- `crates/librefang-api/src/oauth.rs`, `openai_compat.rs`
- 18 route modules under `crates/librefang-api/src/routes/`
- `openapi.json` (regenerated)

## Empty-schema audit

| Metric | Before | After |
|---|---|---|
| `.schema == {}` (inline params/bodies) | 299 | 13 |
| Total empty `{}` objects in spec | 319 | 33 |
| `.components.schemas` named entries | 36 | 38 |

Remaining 13 inline empties are intentionally dynamic shapes (config blobs, etc.) deserving dedicated structs in follow-up work — hence `Refs #3396` rather than `Closes`.

## Verification

- `cargo check --workspace --lib` — clean
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — only pre-existing `needless_borrow` error in `routes/workflows.rs:1127` (present on `origin/main`, unrelated)
- `cargo xtask codegen --openapi` — regenerated cleanly via pre-commit hook
- `python3 scripts/codegen-sdks.py` — Python/JS/Go/Rust SDKs regenerated

## Test plan

- [ ] CI green
- [ ] Spot-check a few routes in openapi.json: confirm `JsonObject` ref where previously `{}`
- [ ] Generated SDKs compile / type-check downstream

Refs #3396