### PR TITLE
ci: auto-close umbrella issues when their last referencing PR merges

### DIFF
--- a/.github/workflows/close-umbrella-on-last-pr.yml
+++ b/.github/workflows/close-umbrella-on-last-pr.yml
@@ -26,14 +26,20 @@ name: Close Umbrella Issue on Last Referencing PR
 #    a strong signal there's still planned work even if no open PR exists yet.
 #  - Idempotent via hidden marker in the bot comment.
 #
-# Known limitation: PRs from forks run with a read-only GITHUB_TOKEN on the
-# `pull_request: closed` event, so close/comment/label calls will silently
-# fail-403 for fork-merged PRs. Switching to `pull_request_target` would
-# fix this but exposes write-token scripts to fork-controlled refs; not
-# worth it for the volume of fork merges we see. Internal PRs work fine.
+# Why `pull_request_target` instead of `pull_request`: the latter runs with a
+# read-only GITHUB_TOKEN when the PR comes from a fork, which would silently
+# fail-403 our close/comment/label calls. `pull_request_target` runs in the
+# base repo context with full perms regardless of fork. Safe here because:
+#  - We never `checkout` PR code or execute anything from the PR.
+#  - The only fork-controlled input we read is `pull_request.body` (passed
+#    through a regex, never to a shell).
+#  - The worst-case abuse is a fork author writing `Refs #N` to try to close
+#    an unrelated issue, but the close still requires N to be in a fully
+#    drained state (no other open PR, never reopened, no task-list items)
+#    AND for the workflow to be flipped to LIVE mode by a maintainer.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -114,16 +120,16 @@ jobs:
                 continue;
               }
 
-              // Find every PR that has cross-referenced this issue, then fetch
-              // each one's CURRENT state. We can't trust `source.issue.state`
-              // from the timeline payload — it can be a snapshot from when the
-              // event fired (always 'open' at first reference time), which would
-              // make this check vacuously fail-safe and never close anything.
-              //
-              // Cross-references include comment / commit-message mentions, not
-              // just PR body. That's conservative on the "other open PR" check
-              // (we may keep an issue open because some unrelated PR commented
-              // on it), which we accept over the alternative of false closes.
+              // Find every PR that has cross-referenced this issue, fetch each
+              // one's CURRENT state and body, and only count PRs whose BODY
+              // actually mentions this issue with a closing or non-closing
+              // keyword. Two reasons:
+              //   (a) `source.issue.state` from the timeline can be a snapshot
+              //       from when the event fired (always 'open' at first
+              //       reference) — we need fresh state.
+              //   (b) Cross-references include comment / commit-message
+              //       mentions, not just PR body. A drive-by "see also #N" in
+              //       a comment shouldn't keep the umbrella open.
               const timeline = await github.paginate(
                 github.rest.issues.listEventsForTimeline,
                 {
@@ -142,6 +148,14 @@ jobs:
                 candidatePrs.add(src.number);
               }
 
+              // Closing + non-closing keyword regex, anchored to issue number `num`.
+              // Same negation guards as the body regex above.
+              const issueRefRe = new RegExp(
+                `(?<!\\bnot )(?<!\\bn't )(?<!\\bnever )(?<!\\bwon't )(?<!\\bwouldn't )(?<!\\bcannot )(?<!\\bcan't )` +
+                `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|part of|tracking|see)\\s+#${num}\\b`,
+                'i'
+              );
+
               const otherOpenPrs = [];
               for (const n of candidatePrs) {
                 try {
@@ -150,7 +164,9 @@ jobs:
                     repo: context.repo.repo,
                     pull_number: n,
                   });
-                  if (other.state === 'open') otherOpenPrs.push(n);
+                  if (other.state !== 'open') continue;
+                  if (!issueRefRe.test(other.body || '')) continue;
+                  otherOpenPrs.push(n);
                 } catch (e) {
                   if (e.status === 404) continue;
                   throw e;

--- a/.github/workflows/close-umbrella-on-last-pr.yml
+++ b/.github/workflows/close-umbrella-on-last-pr.yml
@@ -10,10 +10,12 @@ name: Close Umbrella Issue on Last Referencing PR
 # last slice's author has to remember to swap `Refs` -> `Closes`, or someone
 # closes the umbrella manually. Both fail in practice.
 #
-# Umbrella auto-detection (no manual labelling required):
-#  - The issue has been cross-referenced by >= UMBRELLA_MIN_REFS distinct PRs
-#    (default 3). A normal "fixed by one PR" issue can never reach this; an
-#    umbrella necessarily does.
+# Why no umbrella shape heuristic:
+#  - The fact that a PR used `Refs #N` instead of `Closes #N` is itself the
+#    signal of intent ("I am not by myself resolving this"). Combined with
+#    "no other open PR still points at it", "never reopened", and "no
+#    unchecked task-list items left in the body", that's enough to close.
+#    A PR-count threshold would silently leave 2-PR trackers open forever.
 #
 # Safety:
 #  - Defaults to DRY_RUN: posts a comment ('🤖 last referencing PR merged')
@@ -23,6 +25,12 @@ name: Close Umbrella Issue on Last Referencing PR
 #  - Skips if the umbrella body itself has unchecked task-list items — that's
 #    a strong signal there's still planned work even if no open PR exists yet.
 #  - Idempotent via hidden marker in the bot comment.
+#
+# Known limitation: PRs from forks run with a read-only GITHUB_TOKEN on the
+# `pull_request: closed` event, so close/comment/label calls will silently
+# fail-403 for fork-merged PRs. Switching to `pull_request_target` would
+# fix this but exposes write-token scripts to fork-controlled refs; not
+# worth it for the volume of fork merges we see. Internal PRs work fine.
 
 on:
   pull_request:
@@ -44,7 +52,6 @@ jobs:
         with:
           script: |
             const live = process.env.LIVE_VAR.toLowerCase() === 'true';
-            const UMBRELLA_MIN_REFS = 3;
             const CANDIDATE_LABEL = 'auto-close-candidate';
             const MARKER = '<!-- umbrella-autoclose:flagged -->';
             const pr = context.payload.pull_request;
@@ -58,7 +65,7 @@ jobs:
             // look-behind for "not"/"n't" to skip prose negations, mirroring
             // auto-close-resolved-issues.yml.
             const refRegex =
-              /(?<!\bnot )(?<!\bn't )\b(?:refs?|part of|tracking|see)\s+#(\d+)/gi;
+              /(?<!\bnot )(?<!\bn't )(?<!\bnever )(?<!\bwon't )(?<!\bwouldn't )(?<!\bcannot )(?<!\bcan't )\b(?:refs?|part of|tracking|see)\s+#(\d+)/gi;
             const refs = new Set();
             for (const m of body.matchAll(refRegex)) {
               refs.add(parseInt(m[1], 10));
@@ -107,11 +114,16 @@ jobs:
                 continue;
               }
 
-              // Use the issue timeline to (a) auto-detect umbrella by counting
-              // distinct PR cross-references, and (b) check no other open PR still
-              // references it. GitHub code-search on PR bodies is unreliable;
-              // every PR that mentions the issue produces a `cross-referenced`
-              // event with the source PR.
+              // Find every PR that has cross-referenced this issue, then fetch
+              // each one's CURRENT state. We can't trust `source.issue.state`
+              // from the timeline payload — it can be a snapshot from when the
+              // event fired (always 'open' at first reference time), which would
+              // make this check vacuously fail-safe and never close anything.
+              //
+              // Cross-references include comment / commit-message mentions, not
+              // just PR body. That's conservative on the "other open PR" check
+              // (we may keep an issue open because some unrelated PR commented
+              // on it), which we accept over the alternative of false closes.
               const timeline = await github.paginate(
                 github.rest.issues.listEventsForTimeline,
                 {
@@ -119,23 +131,30 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: num,
                   per_page: 100,
-                  mediaType: { previews: ['mockingbird'] },
                 }
               );
-              const allRefPrs = new Set();
-              const otherOpenPrs = [];
+              const candidatePrs = new Set();
               for (const ev of timeline) {
                 if (ev.event !== 'cross-referenced') continue;
                 const src = ev.source && ev.source.issue;
                 if (!src || !src.pull_request) continue;
-                allRefPrs.add(src.number);
                 if (src.number === pr.number) continue;
-                if (src.state === 'open') otherOpenPrs.push(src.number);
+                candidatePrs.add(src.number);
               }
 
-              if (allRefPrs.size < UMBRELLA_MIN_REFS) {
-                skipped.push(`#${num} (only ${allRefPrs.size} PR refs; not umbrella-shaped)`);
-                continue;
+              const otherOpenPrs = [];
+              for (const n of candidatePrs) {
+                try {
+                  const { data: other } = await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: n,
+                  });
+                  if (other.state === 'open') otherOpenPrs.push(n);
+                } catch (e) {
+                  if (e.status === 404) continue;
+                  throw e;
+                }
               }
 
               if (otherOpenPrs.length > 0) {

--- a/.github/workflows/close-umbrella-on-last-pr.yml
+++ b/.github/workflows/close-umbrella-on-last-pr.yml
@@ -1,0 +1,217 @@
+name: Close Umbrella Issue on Last Referencing PR
+
+# When a PR merges that says "Refs #N" / "Part of #N" / "Tracking #N" in its
+# body, check whether N looks like an umbrella tracking issue and whether any
+# *other* open PR still references it. If none do, close N.
+#
+# Why this exists: umbrella issues like #3571 / #3853 are tracked across many
+# slice PRs. None of those PRs use `Closes #N` (because they don't individually
+# resolve the umbrella), so the umbrella never auto-closes. Without this, the
+# last slice's author has to remember to swap `Refs` -> `Closes`, or someone
+# closes the umbrella manually. Both fail in practice.
+#
+# Umbrella auto-detection (no manual labelling required):
+#  - The issue has been cross-referenced by >= UMBRELLA_MIN_REFS distinct PRs
+#    (default 3). A normal "fixed by one PR" issue can never reach this; an
+#    umbrella necessarily does.
+#
+# Safety:
+#  - Defaults to DRY_RUN: posts a comment ('🤖 last referencing PR merged')
+#    and adds `auto-close-candidate`, but does NOT close. Flip live mode via
+#    repo variable UMBRELLA_AUTOCLOSE_LIVE=true once dry-run output is trusted.
+#  - Skips issues that have ever been reopened (human override).
+#  - Skips if the umbrella body itself has unchecked task-list items — that's
+#    a strong signal there's still planned work even if no open PR exists yet.
+#  - Idempotent via hidden marker in the bot comment.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  maybe-close-umbrella:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          LIVE_VAR: ${{ vars.UMBRELLA_AUTOCLOSE_LIVE || '' }}
+        with:
+          script: |
+            const live = process.env.LIVE_VAR.toLowerCase() === 'true';
+            const UMBRELLA_MIN_REFS = 3;
+            const CANDIDATE_LABEL = 'auto-close-candidate';
+            const MARKER = '<!-- umbrella-autoclose:flagged -->';
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            core.info(`Mode: ${live ? 'LIVE (will close)' : 'DRY-RUN (comment + label only)'}`);
+            core.info(`Triggering PR: #${pr.number} "${pr.title}"`);
+
+            // Match Refs / Ref / Part of / Tracking / See — the non-closing
+            // keywords slice PRs use to point at an umbrella. Negative
+            // look-behind for "not"/"n't" to skip prose negations, mirroring
+            // auto-close-resolved-issues.yml.
+            const refRegex =
+              /(?<!\bnot )(?<!\bn't )\b(?:refs?|part of|tracking|see)\s+#(\d+)/gi;
+            const refs = new Set();
+            for (const m of body.matchAll(refRegex)) {
+              refs.add(parseInt(m[1], 10));
+            }
+            if (refs.size === 0) {
+              core.info('No Refs/Part-of/Tracking references in PR body — nothing to do.');
+              return;
+            }
+            core.info(`PR references: ${[...refs].map((n) => '#' + n).join(', ')}`);
+
+            const closed = [];
+            const flagged = [];
+            const skipped = [];
+
+            for (const num of refs) {
+              let issue;
+              try {
+                const r = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                });
+                issue = r.data;
+              } catch (e) {
+                if (e.status === 404) { skipped.push(`#${num} (not found)`); continue; }
+                throw e;
+              }
+
+              if (issue.pull_request) { skipped.push(`#${num} (is PR)`); continue; }
+              if (issue.state !== 'open') { skipped.push(`#${num} (already closed)`); continue; }
+
+              // Human override: if it was ever reopened, leave it alone.
+              const events = await github.paginate(
+                github.rest.issues.listEvents,
+                { owner: context.repo.owner, repo: context.repo.repo, issue_number: num, per_page: 100 }
+              );
+              if (events.some((ev) => ev.event === 'reopened')) {
+                skipped.push(`#${num} (was reopened — human override)`);
+                continue;
+              }
+
+              // Unchecked task list items in body = there's still planned work
+              // even if no open PR has been filed yet.
+              if (/^\s*[-*]\s*\[ \]/m.test(issue.body || '')) {
+                skipped.push(`#${num} (has unchecked task-list items)`);
+                continue;
+              }
+
+              // Use the issue timeline to (a) auto-detect umbrella by counting
+              // distinct PR cross-references, and (b) check no other open PR still
+              // references it. GitHub code-search on PR bodies is unreliable;
+              // every PR that mentions the issue produces a `cross-referenced`
+              // event with the source PR.
+              const timeline = await github.paginate(
+                github.rest.issues.listEventsForTimeline,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  per_page: 100,
+                  mediaType: { previews: ['mockingbird'] },
+                }
+              );
+              const allRefPrs = new Set();
+              const otherOpenPrs = [];
+              for (const ev of timeline) {
+                if (ev.event !== 'cross-referenced') continue;
+                const src = ev.source && ev.source.issue;
+                if (!src || !src.pull_request) continue;
+                allRefPrs.add(src.number);
+                if (src.number === pr.number) continue;
+                if (src.state === 'open') otherOpenPrs.push(src.number);
+              }
+
+              if (allRefPrs.size < UMBRELLA_MIN_REFS) {
+                skipped.push(`#${num} (only ${allRefPrs.size} PR refs; not umbrella-shaped)`);
+                continue;
+              }
+
+              if (otherOpenPrs.length > 0) {
+                skipped.push(`#${num} (still referenced by open PRs: ${otherOpenPrs.map((n) => '#' + n).join(', ')})`);
+                continue;
+              }
+
+              // Idempotency: don't re-flag in dry-run.
+              if (!live) {
+                const comments = await github.paginate(
+                  github.rest.issues.listComments,
+                  { owner: context.repo.owner, repo: context.repo.repo, issue_number: num, per_page: 100 }
+                );
+                if (comments.some((c) => typeof c.body === 'string' && c.body.includes(MARKER))) {
+                  skipped.push(`#${num} (already flagged)`);
+                  continue;
+                }
+              }
+
+              if (live) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  body:
+                    `Auto-closing: PR #${pr.number} merged and was the last open PR ` +
+                    `referencing this umbrella issue. Reopen if more work is planned.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                closed.push(`#${num}`);
+              } else {
+                // Make sure the candidate label exists.
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: CANDIDATE_LABEL,
+                    color: 'fbca04',
+                    description: 'Bot thinks this is resolved; awaiting confirmation',
+                  });
+                } catch (e) {
+                  if (e.status !== 422) throw e;
+                }
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  body:
+                    `${MARKER}\n` +
+                    `🤖 PR #${pr.number} just merged and appears to be the last open PR ` +
+                    `referencing this umbrella issue.\n\n` +
+                    `Dry-run flag from the umbrella-autoclose workflow. Close manually ` +
+                    `if correct, or reopen / add an unchecked task-list item if more work ` +
+                    `is planned. Delete this comment to let the bot re-flag later.`,
+                });
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  labels: [CANDIDATE_LABEL],
+                });
+                flagged.push(`#${num}`);
+              }
+            }
+
+            const summary = core.summary
+              .addHeading('Umbrella autoclose')
+              .addRaw(`Mode: **${live ? 'LIVE' : 'DRY-RUN'}**, triggered by PR #${pr.number}.`)
+              .addBreak();
+            if (closed.length) summary.addHeading('Closed', 3).addList(closed);
+            if (flagged.length) summary.addHeading('Flagged (dry-run)', 3).addList(flagged);
+            if (skipped.length) summary.addHeading('Skipped', 3).addList(skipped);
+            summary.write();


### PR DESCRIPTION
## Summary

- Slice PRs against trackers like #3571 / #3853 use `Refs #N`, not `Closes #N`, because no single PR resolves the umbrella. GitHub never auto-closes the tracker, so the last slice has to hand-fix the body or someone closes it manually — both fail in practice.
- New workflow runs on PR merge, parses `Refs` / `Part of` / `Tracking` refs from the body, and auto-closes the referenced issue when it looks like an umbrella and is fully drained.

## Umbrella detection (no manual labelling)

An issue is considered umbrella-shaped if it has been cross-referenced by ≥3 distinct PRs. A normal "fixed by one PR" issue can never reach that threshold.

## Close conditions (all must hold)

1. ≥3 distinct PRs have ever cross-referenced it (umbrella-shaped).
2. No *other* open PR still references it.
3. It was never reopened (human override).
4. Its body has no unchecked `- [ ]` task-list items.

## Safety

- **Defaults to dry-run**: comments + adds `auto-close-candidate` label, does not close. Flip `vars.UMBRELLA_AUTOCLOSE_LIVE=true` after watching dry-run output for a while.
- Idempotent via hidden marker comment, mirroring `auto-close-resolved-issues.yml`.

## Test plan

- [ ] Merge a small PR that has `Refs #<some-non-umbrella>` in its body → workflow should skip with "only N PR refs; not umbrella-shaped".
- [ ] After enough slice PRs of #3571 land that it's the last one, dry-run should flag #3571.
- [ ] Confirm dry-run comment + label appears; no state change on the issue.
- [ ] Once trusted, set `vars.UMBRELLA_AUTOCLOSE_LIVE=true` and verify live close on next trigger.