### PR TITLE
fix(memory): satisfy clippy doc_lazy_continuation and needless_borrows in session tests

### DIFF
--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -2194,6 +2194,7 @@ mod tests {
     ///   - skip exactly OFFSET rows,
     ///   - produce a contiguous, non-overlapping window across pages, and
     ///   - return all rows (>50) when limit = None.
+    ///
     /// These guarantees are what makes #3691's network-side cap meaningful;
     /// without them the SQL bind indices could silently drift and the
     /// paginated route would still pass the existing FTS smoke test.
@@ -2209,7 +2210,7 @@ mod tests {
             let mut session = store.create_session(agent_id).unwrap();
             session
                 .messages
-                .push(Message::user(&format!("needle session number {i}")));
+                .push(Message::user(format!("needle session number {i}")));
             store.save_session(&session).unwrap();
         }
 


### PR DESCRIPTION
Main CI was red on clippy from `crates/librefang-memory/src/session.rs`:

- `doc_lazy_continuation` on the `test_fts_search_sessions_paginated` doc comment — added a blank line so the trailing prose isn't treated as a continuation of the bullet list.
- `needless_borrows_for_generic_args` on `Message::user(&format!(...))` — dropped the `&`.

Verified locally with `cargo clippy -p librefang-memory --all-targets -- -D warnings`.