### PR TITLE
ci(release): inject APPLE_DEVELOPMENT_TEAM into iOS init + build steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1779,6 +1779,13 @@ jobs:
 
       - name: Initialise iOS project
         working-directory: crates/librefang-desktop
+        # cargo-mobile2 reads APPLE_DEVELOPMENT_TEAM at init time and bakes
+        # it into the generated xcodeproj's DEVELOPMENT_TEAM build setting.
+        # Without it, xcodebuild later fails with "Signing for ... requires a
+        # development team". Reuses the same secret as the macOS notarize
+        # step — same Apple Developer account.
+        env:
+          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
         run: cargo tauri ios init
 
       # Mirror of the Android version-derivation logic. Both jobs run in
@@ -1879,6 +1886,7 @@ jobs:
         working-directory: crates/librefang-desktop
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
         # `-f mobile-no-email -- --no-default-features`: see android build
         # above for why `--no-default-features` goes after `--`. We keep iOS
         # on the same channel flavor as Android so mobile binaries are


### PR DESCRIPTION
## Why

The v2026.5.2-beta8 release (run [25238202566](https://github.com/librefang/librefang/actions/runs/25238202566/job/74009007203)) failed on the `Mobile / iOS (ipa)` job with:

> Signing for "librefang-desktop_iOS" requires a development team. Select a development team in the Signing & Capabilities editor.

This was the **first** release where the iOS job actually ran end-to-end — every prior release short-circuited at the `Import distribution certificate` step (`steps.keychain.outputs.signed != 'true'`) because the Apple secrets weren't all configured yet. Now that they are, the underlying workflow gap is exposed.

## Root cause

`cargo tauri ios init` (run via cargo-mobile2) reads **`APPLE_DEVELOPMENT_TEAM`** at project-generation time and bakes it into the generated xcodeproj's `DEVELOPMENT_TEAM` build setting. The workflow only exports `APPLE_TEAM_ID` (which Tauri uses for **macOS** notarization, not iOS signing), so the generated project has an empty team and xcodebuild rejects the manual signing config.

## Fix

Inject `APPLE_DEVELOPMENT_TEAM` into both:
- `Initialise iOS project` — so the generated xcodeproj gets the team baked in.
- `Build signed .ipa` — defensive, in case any later cargo-mobile2 release also reads it at build time.

Reuses the existing `APPLE_TEAM_ID` repo secret (same Apple Developer account as macOS notarization). No new secret required.

## Verification

Cannot fully verify locally (requires macOS + Xcode + the real signing secrets). The next release tag will exercise the path; if it still fails on signing, the next thing to try is adding `bundle.iOS.developmentTeam` to `tauri.ios.conf.json` as a config-side fallback.