### PR TITLE
refactor(api): switch prometheus_handle to OnceLock (#3747)

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -6879,8 +6879,6 @@ mod monitoring_tests {
                 home_dir.join("data").join("webhooks.json"),
             ),
             active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
-            #[cfg(feature = "telemetry")]
-            prometheus_handle: None,
             media_drivers: librefang_runtime::media::MediaDriverCache::new(),
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -634,7 +634,7 @@ pub async fn prometheus_metrics(State(state): State<Arc<AppState>>) -> impl Into
     // LibreFang metrics above with standard `metrics` crate counters/histograms
     // (e.g. HTTP request metrics from the telemetry middleware).
     #[cfg(feature = "telemetry")]
-    if let Some(handle) = &state.prometheus_handle {
+    if let Some(handle) = crate::telemetry::prometheus_handle() {
         out.push_str("# --- metrics-exporter-prometheus output ---\n");
         out.push_str(&handle.render());
     }

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1640,8 +1640,6 @@ mod tests {
                 home_dir.join("data").join("webhooks.json"),
             ),
             active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
-            #[cfg(feature = "telemetry")]
-            prometheus_handle: None,
             media_drivers: librefang_runtime::media::MediaDriverCache::new(),
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -157,7 +157,4 @@ pub struct AppState {
     /// task can call `retain_recent()` to evict stale per-IP entries and prevent
     /// the DashMap from growing unbounded over a long-running daemon. See #3668.
     pub gcra_limiter: Arc<KeyedRateLimiter>,
-    /// Prometheus metrics handle (only set when `telemetry` feature + config enabled).
-    #[cfg(feature = "telemetry")]
-    pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
 }

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -982,14 +982,15 @@ pub async fn build_router(
         channel_bridge::start_channel_bridge(kernel.clone()).await;
 
     // Initialize Prometheus metrics recorder if telemetry feature is enabled
-    // and the config has prometheus_enabled = true.
+    // and the config has prometheus_enabled = true. The handle is parked in a
+    // module-local `OnceLock` inside `crate::telemetry`; the `/api/metrics`
+    // route fetches it via `crate::telemetry::prometheus_handle()` rather than
+    // carrying a redundant copy on `AppState`.
     #[cfg(feature = "telemetry")]
-    let prom_handle = if kernel.config_ref().telemetry.prometheus_enabled {
+    if kernel.config_ref().telemetry.prometheus_enabled {
         info!("Initializing Prometheus metrics recorder");
-        Some(crate::telemetry::init_prometheus())
-    } else {
-        None
-    };
+        let _ = crate::telemetry::init_prometheus();
+    }
 
     let channels_config = kernel.config_ref().channels.clone();
     let persisted_sessions = load_sessions(kernel.home_dir());
@@ -1042,8 +1043,6 @@ pub async fn build_router(
         pending_a2a_agents: dashmap::DashMap::new(),
         auth_login_limiter: auth_login_limiter.clone(),
         gcra_limiter: gcra_limiter_arc.clone(),
-        #[cfg(feature = "telemetry")]
-        prometheus_handle: prom_handle,
     });
 
     // CORS: allow localhost origins by default, plus any configured in cors_origin.

--- a/crates/librefang-testing/src/test_app.rs
+++ b/crates/librefang-testing/src/test_app.rs
@@ -205,7 +205,6 @@ impl TestAppState {
             active_sessions: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
             api_key_lock: Arc::new(tokio::sync::RwLock::new(String::new())),
             user_api_keys: Arc::new(tokio::sync::RwLock::new(Vec::new())),
-            prometheus_handle: None,
             media_drivers: librefang_runtime::media::MediaDriverCache::new(),
             webhook_router: Arc::new(tokio::sync::RwLock::new(Arc::new(axum::Router::new()))),
             config_write_lock: tokio::sync::Mutex::new(()),


### PR DESCRIPTION
## Summary
Removes the redundant `Option<PrometheusHandle>` field on `AppState` in favor of reading the handle directly from the module-local `OnceLock` already maintained by `crate::telemetry`.

`Refs #3747` — prometheus_handle slice. `bridge_manager` remains for a follow-up; `peer_registry` was handled by #4306.

## Before / After

Before:
```rust
// routes/mod.rs
pub struct AppState {
    // ...
    #[cfg(feature = "telemetry")]
    pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
}

// server.rs
let prom_handle = if kernel.config_ref().telemetry.prometheus_enabled {
    Some(crate::telemetry::init_prometheus())
} else {
    None
};
// ... AppState { prometheus_handle: prom_handle, ... }

// routes/config.rs
if let Some(handle) = &state.prometheus_handle { ... }
```

After:
```rust
// routes/mod.rs — field removed entirely

// server.rs
if kernel.config_ref().telemetry.prometheus_enabled {
    let _ = crate::telemetry::init_prometheus();
}

// routes/config.rs
if let Some(handle) = crate::telemetry::prometheus_handle() { ... }
```

`init_prometheus()` already parks the handle in a `static OnceLock<PrometheusHandle>` inside `crate::telemetry`, and the public accessor `prometheus_handle() -> Option<&'static PrometheusHandle>` was already exposed — `AppState` was duplicating that storage.

## Files touched
- `crates/librefang-api/src/server.rs` — drop `prom_handle` local + `AppState` field assignment.
- `crates/librefang-api/src/routes/mod.rs` — remove `prometheus_handle` field.
- `crates/librefang-api/src/routes/config.rs` — read from `telemetry::prometheus_handle()`.
- `crates/librefang-api/src/routes/agents.rs` — drop field from test `AppState` fixture.
- `crates/librefang-api/src/routes/memory.rs` — drop field from test `AppState` fixture.
- `crates/librefang-testing/src/test_app.rs` — drop field from shared test fixture.

## Verification
- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean (no new warnings).
- `cargo test -p librefang-api --lib` — `test result: ok. 575 passed; 0 failed`.

## Test plan
- [x] Workspace lib check passes.
- [x] `librefang-api` clippy clean with `-D warnings`.
- [x] `librefang-api` lib tests all pass.
- [ ] Live: with `telemetry.prometheus_enabled = true`, `GET /api/metrics` still emits the `metrics-exporter-prometheus` block.