### PR TITLE
fix(runtime/a2a): drain client request before responding in redirect test

### DIFF
--- a/crates/librefang-runtime/src/a2a.rs
+++ b/crates/librefang-runtime/src/a2a.rs
@@ -1764,7 +1764,7 @@ mod tests {
     /// rebind window.
     #[tokio::test]
     async fn discover_rejects_redirect_response() {
-        use tokio::io::AsyncWriteExt;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1772,6 +1772,15 @@ mod tests {
 
         let server = tokio::spawn(async move {
             if let Ok((mut stream, _)) = listener.accept().await {
+                // Drain the client's request before responding. On Windows,
+                // writing + shutting down without first reading causes the
+                // peer to surface a connection error (RST) instead of the
+                // 302, which masks what we're actually testing here. Linux
+                // and macOS buffer the response across the close so they
+                // don't need this. The other A2A redirect test on line ~1626
+                // already follows this pattern for the same reason.
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf).await;
                 // Reply with a 302 to a benign-looking external URL. The
                 // target is irrelevant — `Policy::none` plus the explicit
                 // `is_redirection()` check must reject before any second


### PR DESCRIPTION
## Summary

- `a2a::tests::discover_rejects_redirect_response` has been failing on the **Windows** runner of every CI run on `main` for the past 4+ pushes (Linux + macOS pass).
- Root cause: the bare `TcpListener` test server `accept()`s and immediately `write_all` + `shutdown` the 302 response without reading the client's HTTP request first. On Windows the kernel surfaces this as a connection RST to reqwest, so `discover()` never enters the `is_redirection()` branch — it returns \"error sending request\" instead of the expected \"redirect not followed\".
- Fix: read the client's request before responding. This mirrors the working SSRF redirect test on the same file (~line 1626) which has always passed on all three OSes for exactly this reason. Linux/macOS buffer the response across `close` so they didn't catch the race.

## Why this isn't a SSRF guarantee weakening

Production code is untouched. The test still:
- Uses `Policy::none` redirect setup.
- Sends a real 302 from a TCP listener.
- Asserts `err.contains("redirect not followed")` — i.e. the explicit `is_redirection()` branch must fire.

## Test plan

- [ ] CI Windows job for `a2a::tests::discover_rejects_redirect_response` turns green.
- [ ] CI Linux + macOS still pass (no behavioral change for them).