### PR TITLE
test(cli): unit tests for templates module helpers (refs #3582)

### DIFF
--- a/crates/librefang-cli/src/templates.rs
+++ b/crates/librefang-cli/src/templates.rs
@@ -110,8 +110,224 @@ pub fn template_display_hint(t: &AgentTemplate) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use librefang_types::agent::AgentManifest;
     use librefang_types::config::DefaultModelConfig;
+
+    // -----------------------------------------------------------------------
+    // extract_description — TOML scanner without full parser dependency.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_description_finds_quoted_value() {
+        let toml = r#"
+name = "demo"
+description = "A demo agent"
+"#;
+        assert_eq!(extract_description(toml), "A demo agent");
+    }
+
+    #[test]
+    fn extract_description_returns_empty_when_missing() {
+        let toml = r#"
+name = "demo"
+"#;
+        assert_eq!(extract_description(toml), "");
+    }
+
+    #[test]
+    fn extract_description_handles_unquoted_value() {
+        // The scanner trims surrounding double-quotes; an unquoted value
+        // should still come through verbatim (with its surrounding whitespace
+        // trimmed).
+        let toml = "description = bare-value\n";
+        assert_eq!(extract_description(toml), "bare-value");
+    }
+
+    #[test]
+    fn extract_description_ignores_lines_with_description_substring() {
+        // Only lines whose first non-whitespace token is `description` count;
+        // a line like `# description of the agent` must not be picked up.
+        let toml = r#"
+# description of the agent
+name = "demo"
+description = "real one"
+"#;
+        assert_eq!(extract_description(toml), "real one");
+    }
+
+    #[test]
+    fn extract_description_first_match_wins() {
+        // Real TOML would not have two top-level `description` keys, but the
+        // scanner is line-based — pin the first-match behaviour so refactors
+        // don't silently flip it.
+        let toml = r#"
+description = "first"
+description = "second"
+"#;
+        assert_eq!(extract_description(toml), "first");
+    }
+
+    // -----------------------------------------------------------------------
+    // template_display_hint — UI hint formatter with 60-char ellipsis.
+    // -----------------------------------------------------------------------
+
+    fn make_template(description: &str) -> AgentTemplate {
+        AgentTemplate {
+            name: "t".to_string(),
+            description: description.to_string(),
+            content: String::new(),
+        }
+    }
+
+    #[test]
+    fn display_hint_passes_short_description_through() {
+        let t = make_template("short and sweet");
+        assert_eq!(template_display_hint(&t), "short and sweet");
+    }
+
+    #[test]
+    fn display_hint_returns_empty_for_no_description() {
+        let t = make_template("");
+        assert_eq!(template_display_hint(&t), "");
+    }
+
+    #[test]
+    fn display_hint_truncates_with_ellipsis_above_60_chars() {
+        // 70 'a's → must be truncated to 57 chars + "..." = 60 chars total.
+        let long = "a".repeat(70);
+        let t = make_template(&long);
+        let hint = template_display_hint(&t);
+        assert_eq!(hint.chars().count(), 60);
+        assert!(hint.ends_with("..."));
+        assert!(hint.starts_with(&"a".repeat(57)));
+    }
+
+    #[test]
+    fn display_hint_keeps_exactly_60_char_description_intact() {
+        // Boundary: cutoff is `> 60`, so exactly 60 chars must NOT be
+        // truncated.
+        let s = "a".repeat(60);
+        let t = make_template(&s);
+        assert_eq!(template_display_hint(&t), s);
+    }
+
+    #[test]
+    fn display_hint_counts_chars_not_bytes_for_unicode() {
+        // 70 multi-byte characters: must trigger truncation by char count
+        // (not by byte length) and must not panic on a non-char-boundary
+        // byte slice.
+        let s = "汉".repeat(70);
+        let t = make_template(&s);
+        let hint = template_display_hint(&t);
+        assert_eq!(hint.chars().count(), 60);
+        assert!(hint.ends_with("..."));
+    }
+
+    // -----------------------------------------------------------------------
+    // discover_template_dirs — env-var-driven path discovery.
+    //
+    // These tests mutate process-global env vars; group them in a single
+    // test (and serialize via a Mutex) so the cargo parallel harness can't
+    // race on LIBREFANG_HOME / LIBREFANG_AGENTS_DIR.
+    // -----------------------------------------------------------------------
+
+    /// Process-wide guard for the env-mutating tests in this module: cargo
+    /// runs `#[test]` fns in parallel, and `LIBREFANG_HOME`/`LIBREFANG_AGENTS_DIR`
+    /// are global state. Both tests must lock the same mutex.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        // If a previous test panicked while holding the guard, the mutex is
+        // poisoned but the data inside is still sound — recover and proceed.
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    #[test]
+    fn discover_template_dirs_picks_up_env_override() {
+        let _guard = env_lock();
+
+        let tmp = std::env::temp_dir().join("librefang-cli-templates-test-3582");
+        let _ = std::fs::create_dir_all(&tmp);
+
+        // Snapshot + override; restore on drop.
+        let prev_home = std::env::var("LIBREFANG_HOME").ok();
+        let prev_agents = std::env::var("LIBREFANG_AGENTS_DIR").ok();
+
+        // Point HOME at a definitely-empty location so the home branch
+        // contributes nothing, then point AGENTS_DIR at our tmp dir.
+        let empty_home = std::env::temp_dir().join("librefang-cli-templates-test-3582-empty-home");
+        let _ = std::fs::create_dir_all(&empty_home);
+        // SAFETY: tests in this module serialize on ENV_LOCK so no other
+        // thread in this process is reading these vars concurrently.
+        unsafe {
+            std::env::set_var("LIBREFANG_HOME", &empty_home);
+            std::env::set_var("LIBREFANG_AGENTS_DIR", &tmp);
+        }
+
+        let dirs = discover_template_dirs();
+        assert!(
+            dirs.contains(&tmp),
+            "AGENTS_DIR override not picked up: {dirs:?}"
+        );
+
+        // Restore.
+        // SAFETY: see above — still under ENV_LOCK.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("LIBREFANG_HOME", v),
+                None => std::env::remove_var("LIBREFANG_HOME"),
+            }
+            match prev_agents {
+                Some(v) => std::env::set_var("LIBREFANG_AGENTS_DIR", v),
+                None => std::env::remove_var("LIBREFANG_AGENTS_DIR"),
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&tmp);
+        let _ = std::fs::remove_dir_all(&empty_home);
+    }
+
+    #[test]
+    fn discover_template_dirs_skips_nonexistent_env_path() {
+        let _guard = env_lock();
+
+        let bogus = std::env::temp_dir().join("librefang-cli-templates-test-3582-does-not-exist");
+        let _ = std::fs::remove_dir_all(&bogus);
+
+        let prev_home = std::env::var("LIBREFANG_HOME").ok();
+        let prev_agents = std::env::var("LIBREFANG_AGENTS_DIR").ok();
+
+        let empty_home =
+            std::env::temp_dir().join("librefang-cli-templates-test-3582-empty-home-2");
+        let _ = std::fs::create_dir_all(&empty_home);
+        // SAFETY: ENV_LOCK serializes env mutation across this module's tests.
+        unsafe {
+            std::env::set_var("LIBREFANG_HOME", &empty_home);
+            std::env::set_var("LIBREFANG_AGENTS_DIR", &bogus);
+        }
+
+        let dirs = discover_template_dirs();
+        assert!(
+            !dirs.contains(&bogus),
+            "non-existent AGENTS_DIR must be filtered out: {dirs:?}"
+        );
+
+        // SAFETY: see above.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("LIBREFANG_HOME", v),
+                None => std::env::remove_var("LIBREFANG_HOME"),
+            }
+            match prev_agents {
+                Some(v) => std::env::set_var("LIBREFANG_AGENTS_DIR", v),
+                None => std::env::remove_var("LIBREFANG_AGENTS_DIR"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&empty_home);
+    }
 
     /// Mirror the kernel's spawn-time + execute-time default_model overlay so
     /// we can verify a manifest with empty/"default" provider+model resolves


### PR DESCRIPTION
## Summary
First scoped slice of tests for #3582 (librefang-cli has 0 tests on TUI/launcher surfaces). Picked the pure-function helpers in `crates/librefang-cli/src/templates.rs` since they run without a daemon, terminal, or network.

Adds 12 unit tests covering:
- `extract_description` — TOML line scanner: quoted/unquoted values, missing key, comment-line false positives, first-match semantics.
- `template_display_hint` — 60-char ellipsis: short pass-through, empty input, exact-60 boundary, >60 truncation, unicode (counts chars not bytes — guards against UTF-8 boundary panic).
- `discover_template_dirs` — `LIBREFANG_AGENTS_DIR` env override is picked up; non-existent paths are filtered out. Env-mutating tests serialize on a shared `OnceLock<Mutex>`.

## Coverage gap remaining
TUI screens (`init_wizard.rs` 2387 LOC, `chat.rs`, `event.rs`, `agents.rs`, `tui/mod.rs`), `launcher.rs` port detection, and `desktop_install.rs` filesystem writes still have 0 tests — issue #3582 stays open until those are addressed.

## Test plan
- [x] `cargo check -p librefang-cli --tests` clean
- [x] `cargo clippy -p librefang-cli --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-cli templates` — 12 new tests pass

Refs #3582