### PR TITLE
refactor(kernel): preserve typed HandError across kernel boundary (1-of-21 slice of #3711)

### DIFF
--- a/crates/librefang-kernel/src/error.rs
+++ b/crates/librefang-kernel/src/error.rs
@@ -1,5 +1,6 @@
 //! Kernel-specific error types.
 
+use librefang_hands::HandError;
 use librefang_types::error::LibreFangError;
 use thiserror::Error;
 
@@ -9,6 +10,17 @@ pub enum KernelError {
     /// A wrapped LibreFangError.
     #[error(transparent)]
     LibreFang(#[from] LibreFangError),
+
+    /// A structured Hands-registry error.
+    ///
+    /// Restored as part of issue #3711 (1-of-21 slice): previously every
+    /// `HandError` was stringified into `LibreFangError::Internal(String)`
+    /// at the kernel boundary, losing the typed kind (`AlreadyActive`,
+    /// `NotFound`, `BuiltinHand`, …). Carrying the typed variant lets
+    /// upstream callers branch on it (e.g. surface 409 Conflict for
+    /// `AlreadyActive` vs 500 for `Io`).
+    #[error(transparent)]
+    Hand(#[from] HandError),
 
     /// The kernel failed to boot.
     #[error("Boot failed: {0}")]
@@ -24,3 +36,38 @@ pub enum KernelError {
 
 /// Alias for kernel results.
 pub type KernelResult<T> = Result<T, KernelError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for #3711 (1-of-21 slice): a `HandError::AlreadyActive`
+    /// surfaced through the kernel boundary must keep its typed kind, not
+    /// be flattened to `LibreFangError::Internal(String)`. Upstream
+    /// callers rely on this to differentiate 409 Conflict from a generic
+    /// 500 Internal.
+    #[test]
+    fn hand_error_kind_survives_kernel_boundary() {
+        let inner = HandError::AlreadyActive("clip".to_string());
+        let kerr: KernelError = inner.into();
+        match kerr {
+            KernelError::Hand(HandError::AlreadyActive(id)) => assert_eq!(id, "clip"),
+            other => panic!("expected KernelError::Hand(AlreadyActive), got {other:?}"),
+        }
+    }
+
+    /// Regression for #3711: human-readable `Display` output must remain
+    /// identical to the previous `LibreFangError::Internal(format!(...))`
+    /// rendering so logs / UI surfaces don't shift. `#[error(transparent)]`
+    /// on `KernelError::Hand` delegates to `HandError`'s own Display, which
+    /// already produces "Hand already active: {id}" — the exact string the
+    /// pre-refactor code constructed by hand.
+    #[test]
+    fn hand_error_display_is_unchanged() {
+        let kerr: KernelError = HandError::AlreadyActive("clip".to_string()).into();
+        assert_eq!(format!("{kerr}"), "Hand already active: clip");
+
+        let kerr: KernelError = HandError::NotFound("missing".to_string()).into();
+        assert_eq!(format!("{kerr}"), "Hand not found: missing");
+    }
+}

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10399,7 +10399,6 @@ system_prompt = "You are a helpful assistant."
         timestamps: Option<(chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>)>,
     ) -> KernelResult<librefang_hands::HandInstance> {
         let cfg = self.config.load();
-        use librefang_hands::HandError;
 
         let def = self
             .hand_registry
@@ -10449,12 +10448,13 @@ system_prompt = "You are a helpful assistant."
                 instance_id,
                 timestamps,
             )
-            .map_err(|e| match e {
-                HandError::AlreadyActive(id) => KernelError::LibreFang(LibreFangError::Internal(
-                    format!("Hand already active: {id}"),
-                )),
-                other => KernelError::LibreFang(LibreFangError::Internal(other.to_string())),
-            })?;
+            // #3711: propagate the typed `HandError` instead of collapsing
+            // it to `LibreFangError::Internal(String)`. Display output is
+            // preserved by `#[error(transparent)]` on `KernelError::Hand`,
+            // so existing log/UI strings remain identical while upstream
+            // callers gain the ability to match on the typed variant
+            // (e.g., `AlreadyActive` → 409 Conflict).
+            .map_err(KernelError::from)?;
 
         // Pre-compute shared overrides from hand definition. The system-prompt
         // tail is materialized later (after per-role manifest cloning) via


### PR DESCRIPTION
## Summary

- Adds `KernelError::Hand(#[from] HandError)` with `#[error(transparent)]` so the typed Hands-registry error survives the kernel trait boundary instead of being flattened to `LibreFangError::Internal(String)`.
- Replaces the manual `match` in `kernel::activate_hand_with_id` with `.map_err(KernelError::from)?`, preserving the existing Display output byte-for-byte while letting upstream callers branch on the typed variant (e.g. `HandError::AlreadyActive` -> 409 Conflict).
- Adds two regression tests in `librefang-kernel::error::tests` pinning both properties: (1) typed kind survives the boundary, (2) human-readable Display string is unchanged.

This is a **1-of-21 slice** of #3711. The remaining typed enums (`LlmError`, `MemoryError`, `SkillError`, `MediaError`, ...) each need the same treatment but have their own boundary considerations and call-site fan-out, so they will ship as separate PRs.

Refs #3711

## Test plan

- [x] `cargo check --workspace --lib` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-kernel --lib error::` (2 passed, 0 failed) — covers both typed-kind survival and Display stability