### PR TITLE
test(cli): add launcher daemon-detection tests (refs #3582)

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -2304,25 +2304,49 @@ pub(crate) fn restrict_dir_permissions(path: &std::path::Path) {
 #[cfg(not(unix))]
 pub(crate) fn restrict_dir_permissions(_path: &std::path::Path) {}
 
-fn find_daemon_in_home(home_dir: &std::path::Path) -> Option<String> {
+/// Normalize a daemon listen address for client-side probing.
+///
+/// `0.0.0.0` (the default bind-all address) is replaced with `127.0.0.1`,
+/// which avoids DNS/connectivity hangs on macOS when probing locally.
+fn normalize_daemon_addr(listen_addr: &str) -> String {
+    listen_addr.replace("0.0.0.0", "127.0.0.1")
+}
+
+/// Core daemon-detection logic, parameterized over the health-probe.
+///
+/// Returns `Some(base_url)` iff `daemon.json` is readable AND `probe`
+/// reports the daemon's `/api/health` endpoint is up. Extracted so unit
+/// tests can inject a fake probe instead of binding real sockets.
+fn find_daemon_with_probe<F>(home_dir: &std::path::Path, probe: F) -> Option<String>
+where
+    F: FnOnce(&str) -> bool,
+{
     let info = read_daemon_info(home_dir)?;
-
-    // Normalize listen address: replace 0.0.0.0 with 127.0.0.1 to avoid
-    // DNS/connectivity issues on macOS where 0.0.0.0 can hang.
-    let addr = info.listen_addr.replace("0.0.0.0", "127.0.0.1");
-    let url = format!("http://{addr}/api/health");
-
-    let client = crate::http_client::client_builder()
-        .connect_timeout(std::time::Duration::from_secs(1))
-        .timeout(std::time::Duration::from_secs(2))
-        .build()
-        .ok()?;
-    let resp = client.get(&url).send().ok()?;
-    if resp.status().is_success() {
+    let addr = normalize_daemon_addr(&info.listen_addr);
+    let health_url = format!("http://{addr}/api/health");
+    if probe(&health_url) {
         Some(format!("http://{addr}"))
     } else {
         None
     }
+}
+
+fn find_daemon_in_home(home_dir: &std::path::Path) -> Option<String> {
+    find_daemon_with_probe(home_dir, |url| {
+        let client = match crate::http_client::client_builder()
+            .connect_timeout(std::time::Duration::from_secs(1))
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+        client
+            .get(url)
+            .send()
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    })
 }
 
 pub(crate) fn find_daemon() -> Option<String> {
@@ -12402,9 +12426,10 @@ fn remove_self_binary(exe_path: &std::path::Path) {
 mod tests {
     use super::{
         channel_test_request_body, compare_release_tag, daemon_log_path_for_config,
-        daemon_log_path_for_home, detached_daemon_args, normalize_release_tag, parse_toml_integer,
-        parse_version_core, resolve_device_auth_start, resolve_hand_instance, AuthCommands,
-        ChannelCommands, Cli, Commands, DeviceAuthNextStep, GatewayCommands, ReleaseComparison,
+        daemon_log_path_for_home, detached_daemon_args, find_daemon_with_probe,
+        normalize_daemon_addr, normalize_release_tag, parse_toml_integer, parse_version_core,
+        resolve_device_auth_start, resolve_hand_instance, AuthCommands, ChannelCommands, Cli,
+        Commands, DeviceAuthNextStep, GatewayCommands, ReleaseComparison,
     };
     use clap::Parser;
     use serde_json::json;
@@ -13190,5 +13215,121 @@ input_schema = { type = "object" }
             "expected lowercase hex, got {hex:?}"
         );
         assert_eq!(hex, "0123456789abcdef0123456789abcdef");
+    }
+
+    // --- Daemon detection / launcher port logic (#3582) ---
+    //
+    // These exercise the `find_daemon_with_probe` core, which was extracted
+    // from `find_daemon_in_home` so the HTTP probe can be faked in unit
+    // tests instead of binding sockets or making real requests.
+
+    fn write_daemon_json(home: &Path, listen_addr: &str) {
+        let body = json!({
+            "pid": 4242u32,
+            "listen_addr": listen_addr,
+            "started_at": "1970-01-01T00:00:00Z",
+            "version": "0.0.0-test",
+            "platform": "test",
+        });
+        fs::write(home.join("daemon.json"), body.to_string()).expect("write daemon.json");
+    }
+
+    #[test]
+    fn normalize_daemon_addr_rewrites_bind_all_to_loopback() {
+        // `0.0.0.0:4545` is the default bind-all address; on macOS, probing
+        // it directly can hang, so the launcher rewrites to 127.0.0.1.
+        assert_eq!(normalize_daemon_addr("0.0.0.0:4545"), "127.0.0.1:4545");
+    }
+
+    #[test]
+    fn normalize_daemon_addr_leaves_explicit_loopback_alone() {
+        assert_eq!(normalize_daemon_addr("127.0.0.1:4545"), "127.0.0.1:4545");
+    }
+
+    #[test]
+    fn normalize_daemon_addr_leaves_other_hosts_alone() {
+        // A user who explicitly bound to a LAN IP should keep it.
+        assert_eq!(
+            normalize_daemon_addr("192.168.1.10:4545"),
+            "192.168.1.10:4545"
+        );
+    }
+
+    #[test]
+    fn find_daemon_with_probe_returns_none_when_no_daemon_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // No daemon.json written. Probe must NOT be invoked.
+        let probe_called = std::cell::Cell::new(false);
+        let got = find_daemon_with_probe(tmp.path(), |_url| {
+            probe_called.set(true);
+            true
+        });
+        assert!(got.is_none());
+        assert!(
+            !probe_called.get(),
+            "probe must not run when daemon.json is absent — saves a network round-trip"
+        );
+    }
+
+    #[test]
+    fn find_daemon_with_probe_returns_none_on_unparseable_daemon_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join("daemon.json"), "not valid json {{{").unwrap();
+        let got = find_daemon_with_probe(tmp.path(), |_url| true);
+        assert!(
+            got.is_none(),
+            "corrupt daemon.json must not be treated as a live daemon"
+        );
+    }
+
+    #[test]
+    fn find_daemon_with_probe_returns_base_url_on_healthy_probe() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_daemon_json(tmp.path(), "127.0.0.1:4545");
+
+        let seen = std::cell::Cell::new(None);
+        let got = find_daemon_with_probe(tmp.path(), |url| {
+            seen.set(Some(url.to_string()));
+            true
+        });
+
+        // The probe receives the /api/health URL...
+        assert_eq!(
+            seen.into_inner().as_deref(),
+            Some("http://127.0.0.1:4545/api/health")
+        );
+        // ...and the caller gets back the *base* URL (no /api/health suffix).
+        assert_eq!(got.as_deref(), Some("http://127.0.0.1:4545"));
+    }
+
+    #[test]
+    fn find_daemon_with_probe_normalizes_bind_all_in_url() {
+        // Regression: ensure 0.0.0.0 in daemon.json is rewritten to 127.0.0.1
+        // BEFORE we hand the URL to the probe (and before we return it).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_daemon_json(tmp.path(), "0.0.0.0:4545");
+
+        let seen = std::cell::Cell::new(None);
+        let got = find_daemon_with_probe(tmp.path(), |url| {
+            seen.set(Some(url.to_string()));
+            true
+        });
+
+        assert_eq!(
+            seen.into_inner().as_deref(),
+            Some("http://127.0.0.1:4545/api/health"),
+            "probe must see normalized 127.0.0.1 URL, never 0.0.0.0"
+        );
+        assert_eq!(got.as_deref(), Some("http://127.0.0.1:4545"));
+    }
+
+    #[test]
+    fn find_daemon_with_probe_returns_none_on_failed_probe() {
+        // Stale daemon.json (process gone, port in use by something else, or
+        // returning 5xx) — probe returns false → caller gets None.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_daemon_json(tmp.path(), "127.0.0.1:4545");
+        let got = find_daemon_with_probe(tmp.path(), |_url| false);
+        assert!(got.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Extract `find_daemon_with_probe(home_dir, probe)` from `find_daemon_in_home` so the HTTP health probe is an injectable closure rather than a hard-wired `reqwest` call.
- Pull the listen-address fixup (`0.0.0.0` -> `127.0.0.1`) into a tiny pure helper `normalize_daemon_addr`.
- Add 7 unit tests covering: bind-all rewrite, loopback / LAN passthrough, missing `daemon.json`, corrupt `daemon.json`, healthy probe (URL shape + base-URL return), failed probe, and end-to-end normalization through to the probed URL.

No behavior change in the production code path: `find_daemon_in_home` still wires up the same reqwest client with the same 1s/2s timeouts.

Refs #3582 (partial — the launcher slice from the suggested-fix list). The `init_wizard.rs` reducer extraction and `desktop_install.rs` tempdir-sandbox slices remain as separate follow-ups; the `templates.rs` slice is already covered by #4350.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy -p librefang-cli --all-targets -- -D warnings`
- [x] `cargo test -p librefang-cli` — all 7 new tests pass alongside existing cases (12 matched the `daemon` filter, 0 failures)