### PR TITLE
fix(api): standardize /api/peers on PaginatedResponse envelope

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2916,8 +2916,12 @@ export async function getNetworkStatus(): Promise<NetworkStatusResponse> {
 }
 
 export async function listPeers(): Promise<PeerItem[]> {
-  const data = await get<{ peers?: PeerItem[] }>("/api/peers");
-  return data.peers ?? [];
+  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
+  // legacy `{peers}` shape during the transition so older daemons keep working.
+  const data = await get<{ items?: PeerItem[]; peers?: PeerItem[] }>(
+    "/api/peers",
+  );
+  return data.items ?? data.peers ?? [];
 }
 
 export async function listTrustedPeers(): Promise<TrustedPeerItem[]> {

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -90,8 +90,13 @@ pub async fn list_peers(State(state): State<Arc<AppState>>) -> impl IntoResponse
     // Peers are tracked in the wire module's PeerRegistry.
     // The kernel doesn't directly hold a PeerRegistry, so we return an empty list
     // unless one is available. The API server can be extended to inject a registry.
-    if let Some(ref peer_registry) = state.peer_registry {
-        let peers: Vec<serde_json::Value> = peer_registry
+    //
+    // Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+    // shape used by `/api/agents` (#3842). All peers are returned in a single
+    // page — the registry is in-memory and small — so `offset=0` and
+    // `limit=None` always.
+    let items: Vec<serde_json::Value> = if let Some(ref peer_registry) = state.peer_registry {
+        peer_registry
             .all_peers()
             .iter()
             .map(|p| {
@@ -108,11 +113,17 @@ pub async fn list_peers(State(state): State<Arc<AppState>>) -> impl IntoResponse
                     "protocol_version": p.protocol_version,
                 })
             })
-            .collect();
-        Json(serde_json::json!({"peers": peers, "total": peers.len()}))
+            .collect()
     } else {
-        Json(serde_json::json!({"peers": [], "total": 0}))
-    }
+        Vec::new()
+    };
+    let total = items.len();
+    Json(crate::types::PaginatedResponse {
+        items,
+        total,
+        offset: 0,
+        limit: None,
+    })
 }
 
 /// GET /api/peers/{id} — Get a single peer by node ID.


### PR DESCRIPTION
## Summary
- 1-of-N slice of #3842. Migrates `GET /api/peers` from the bespoke `{peers, total}` envelope to the canonical `PaginatedResponse{items, total, offset, limit}` shape already used by `/api/agents`.
- Dashboard `listPeers()` tolerates both shapes during the transition so older daemons keep working.
- Peer registry is in-memory and small, so all peers ship in a single page (`offset=0`, `limit=None`).

Refs #3842. Remaining envelopes in `workflows.rs` / `goals.rs` / `skills.rs` / `system.rs` (audit) / `budget.rs` / `routes/budget.rs::usage_stats` to be migrated in follow-up PRs — kept tight here so the diff stays reviewable and breakage is bounded.

Note: `crates/librefang-cli/src/tui/event.rs::spawn_fetch_peers` already mis-parses the response (it calls `as_array()` on what has always been a JSON object), so it returned an empty list under the old envelope and continues to return an empty list under the new one. That pre-existing bug is filed separately, not in scope.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p librefang-api --lib` (575 passed, 0 failed)
- [ ] Live: `curl /api/peers` returns `{items, total, offset:0, limit:null}`
- [ ] Live: dashboard Network page still lists peers

## Before / After
Before:
```json
{ "peers": [...], "total": N }
```
After:
```json
{ "items": [...], "total": N, "offset": 0, "limit": null }
```