### PR TITLE
fix(api/goals): return mutated GoalItem from PUT /api/goals/{id}

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2870,8 +2870,10 @@ export async function updateGoal(
     parent_id?: string | null;
     agent_id?: string | null;
   }
-): Promise<ApiActionResponse> {
-  return put<ApiActionResponse>(`/api/goals/${encodeURIComponent(goalId)}`, payload);
+): Promise<GoalItem> {
+  // Issue #3832: handler now returns the mutated GoalItem instead of an ack
+  // envelope, so callers can `setQueryData` directly without a follow-up GET.
+  return put<GoalItem>(`/api/goals/${encodeURIComponent(goalId)}`, payload);
 }
 
 export async function deleteGoal(goalId: string): Promise<ApiActionResponse> {

--- a/crates/librefang-api/dashboard/src/lib/mutations/goals.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/goals.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createGoal, updateGoal, deleteGoal } from "../http/client";
+import type { GoalItem } from "../../api";
 import { goalKeys } from "../queries/keys";
 
 export function useCreateGoal() {
@@ -15,7 +16,15 @@ export function useUpdateGoal() {
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: Parameters<typeof updateGoal>[1] }) =>
       updateGoal(id, data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: goalKeys.lists() }),
+    // Issue #3832: handler now returns the mutated GoalItem, so we can patch the
+    // cached list immediately for an instant UI update, then invalidate as a
+    // belt-and-suspenders guard against drift.
+    onSuccess: (updated: GoalItem) => {
+      qc.setQueryData<GoalItem[]>(goalKeys.lists(), (prev) =>
+        prev ? prev.map((g) => (g.id === updated.id ? updated : g)) : prev,
+      );
+      qc.invalidateQueries({ queryKey: goalKeys.lists() });
+    },
   });
 }
 

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -300,10 +300,9 @@ pub async fn update_goal_by_id(
 
     // --- Apply mutations ---
 
-    let mut found = false;
+    let mut updated: Option<serde_json::Value> = None;
     for g in goals.iter_mut() {
         if g["id"].as_str() == Some(&id) {
-            found = true;
             if let Some(title) = req.get("title").and_then(|v| v.as_str()) {
                 g["title"] = serde_json::Value::String(title.to_string());
             }
@@ -331,13 +330,14 @@ pub async fn update_goal_by_id(
                 }
             }
             g["updated_at"] = serde_json::Value::String(chrono::Utc::now().to_rfc3339());
+            updated = Some(g.clone());
             break;
         }
     }
 
-    if !found {
+    let Some(entity) = updated else {
         return ApiErrorResponse::not_found("Goal not found").into_json_tuple();
-    }
+    };
 
     if let Err(e) = state.kernel.memory_substrate().structured_set(
         shared_id,
@@ -347,10 +347,9 @@ pub async fn update_goal_by_id(
         return ApiErrorResponse::internal(format!("Failed to update goal: {e}")).into_json_tuple();
     }
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({"status": "updated", "goal_id": id})),
-    )
+    // Issue #3832: return the mutated entity so the dashboard can `setQueryData`
+    // without an extra round-trip GET. Aligns with `create_goal`'s response shape.
+    (StatusCode::OK, Json(entity))
 }
 
 /// DELETE /api/goals/{id} — Delete a goal and all its descendants.


### PR DESCRIPTION
## Summary
First slice of #3832 (mutation handlers returning ack envelopes instead of mutated entities). Migrates `PUT /api/goals/{id}`.

- Before: `200 OK { "status": "updated", "goal_id": "<id>" }`
- After: `200 OK <GoalItem>` (same shape returned by `POST /api/goals`)

This lets the dashboard `useUpdateGoal` hook `setQueryData` directly instead of always invalidating + refetching, eliminating a stale-read window and an extra round-trip.

## Changes
- `crates/librefang-api/src/routes/goals.rs` — handler clones the post-mutation goal and returns it as the JSON body; control flow switched from `found: bool` to `Option<Value>` so the return value is the source of truth.
- `crates/librefang-api/dashboard/src/api.ts` — `updateGoal` return type `ApiActionResponse` -> `GoalItem`.
- `crates/librefang-api/dashboard/src/lib/mutations/goals.ts` — `useUpdateGoal.onSuccess` now patches `goalKeys.lists()` cache via `setQueryData(prev => prev.map(...))`, then still invalidates as a belt-and-suspenders guard.

No OpenAPI / SDK regen needed: `update_goal_by_id` has no `utoipa` annotation and isn't surfaced in `openapi.json` or the TS SDK under `sdk/`.

Out of scope: budget, agents, prompts, workflows handlers — listed in #3832 as follow-up slices.

Refs #3832

## Test plan
- [x] `cargo check -p librefang-api --lib` clean
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-api --lib` — 575 passed
- [x] dashboard `npm run typecheck` clean
- [x] dashboard `npm test` — 357 passed
- [ ] live integration: human run — `curl -X PUT http://127.0.0.1:4545/api/goals/<id> -d '{"status":"completed","progress":100}'` should return the full `GoalItem` body, not `{status:"updated"}`