### PR TITLE
fix(api): goals list returns PaginatedResponse (#3842)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2832,8 +2832,14 @@ export async function getHandInstanceStatus(instanceId: string): Promise<HandIns
 }
 
 export async function listGoals(): Promise<GoalItem[]> {
-  const data = await get<{ goals?: GoalItem[]; total?: number }>("/api/goals");
-  return data.goals ?? [];
+  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
+  // legacy `{goals}` shape during the transition so older daemons keep working.
+  const data = await get<{
+    items?: GoalItem[];
+    goals?: GoalItem[];
+    total?: number;
+  }>("/api/goals");
+  return data.items ?? data.goals ?? [];
 }
 
 export interface GoalTemplate {

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -43,23 +43,32 @@ fn goals_shared_agent_id() -> AgentId {
 }
 
 /// GET /api/goals — List all goals.
+///
+/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+/// shape used by `/api/agents` and `/api/peers` (#3842). Goals are stored as
+/// a single JSON array in shared KV memory and returned in one page —
+/// `offset=0` and `limit=None` always.
 pub async fn list_goals(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let agent_id = goals_shared_agent_id();
-    match state
+    let items: Vec<serde_json::Value> = match state
         .kernel
         .memory_substrate()
         .structured_get(agent_id, GOALS_KEY)
     {
-        Ok(Some(serde_json::Value::Array(arr))) => {
-            let total = arr.len();
-            Json(serde_json::json!({"goals": arr, "total": total}))
-        }
-        Ok(_) => Json(serde_json::json!({"goals": [], "total": 0})),
+        Ok(Some(serde_json::Value::Array(arr))) => arr,
+        Ok(_) => Vec::new(),
         Err(e) => {
             tracing::warn!("Failed to load goals: {e}");
-            Json(serde_json::json!({"goals": [], "total": 0, "error": format!("{e}")}))
+            Vec::new()
         }
-    }
+    };
+    let total = items.len();
+    Json(crate::types::PaginatedResponse {
+        items,
+        total,
+        offset: 0,
+        limit: None,
+    })
 }
 
 /// GET /api/goals/{id} — Get a specific goal by ID.

--- a/crates/librefang-api/tests/goals_routes_integration.rs
+++ b/crates/librefang-api/tests/goals_routes_integration.rs
@@ -80,7 +80,8 @@ async fn goals_list_starts_empty() {
     let (status, body) = json_request(&h, Method::GET, "/api/goals", None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["total"], 0);
-    assert_eq!(body["goals"], serde_json::json!([]));
+    assert_eq!(body["items"], serde_json::json!([]));
+    assert_eq!(body["offset"], 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -92,7 +93,7 @@ async fn goals_list_reflects_created_goals() {
     let (status, body) = json_request(&h, Method::GET, "/api/goals", None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["total"], 2);
-    assert_eq!(body["goals"].as_array().unwrap().len(), 2);
+    assert_eq!(body["items"].as_array().unwrap().len(), 2);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second slice of #3842 (envelope standardization; #4355 migrated peers).
Migrates `GET /api/goals` from bespoke `{goals,total}` to the canonical
`PaginatedResponse{items,total,offset,limit}` shape used by `/api/agents`
and `/api/peers`.

## Before / After

Before:
```json
{ "goals": [...], "total": 7 }
```

After:
```json
{ "items": [...], "total": 7, "offset": 0, "limit": null }
```

Goals are stored as a single JSON array in shared KV memory and returned
in one page, so `offset=0` and `limit=None` always.

## Callers / tests updated

- `crates/librefang-api/src/routes/goals.rs` — `list_goals` now returns
  `PaginatedResponse<serde_json::Value>`.
- `crates/librefang-api/dashboard/src/api.ts` — `listGoals()` reads
  `items`, falls back to legacy `goals` during transition (so older
  daemons keep working).
- `crates/librefang-api/tests/goals_routes_integration.rs` — asserts the
  new `items` / `offset` fields; `total` assertions unchanged.

No `utoipa` annotation on `list_goals`, so no `openapi.json` regen.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo test -p librefang-api --test goals_routes_integration` — 23/23 pass.
- `cargo clippy -p librefang-api --tests -- -D warnings` — clean.

Refs #3842