### PR TITLE
refactor(kernel): preserve typed HandError at 7 remaining collapse sites (extends #4351)

### DIFF
--- a/crates/librefang-kernel/src/error.rs
+++ b/crates/librefang-kernel/src/error.rs
@@ -70,4 +70,29 @@ mod tests {
         let kerr: KernelError = HandError::NotFound("missing".to_string()).into();
         assert_eq!(format!("{kerr}"), "Hand not found: missing");
     }
+
+    /// Regression for #3711 (slice 1 follow-up): the additional collapse
+    /// sites migrated in `deactivate_hand`, `pause_hand`, `resume_hand`,
+    /// `set_agents`, `merge_agent_runtime_override`,
+    /// `clear_agent_runtime_override`, and `persist_hand_state_result`
+    /// most commonly surface `HandError::InstanceNotFound(Uuid)` when the
+    /// caller passes a stale id. Before the migration the boundary
+    /// rendered this as `LibreFangError::Internal("Hand instance not
+    /// found: <uuid>")` via `e.to_string()`. With `KernelError::Hand`
+    /// `#[error(transparent)]` the rendering must be byte-identical, and
+    /// the typed variant must survive so upstream can map it to 404.
+    #[test]
+    fn hand_error_instance_not_found_survives_and_displays_unchanged() {
+        let id = uuid::Uuid::nil();
+        let inner = HandError::InstanceNotFound(id);
+        let prev_collapsed_display = inner.to_string();
+        let kerr: KernelError = inner.into();
+        // Display preserved (matches the pre-refactor `e.to_string()`).
+        assert_eq!(format!("{kerr}"), prev_collapsed_display);
+        // Typed variant preserved across the boundary.
+        match kerr {
+            KernelError::Hand(HandError::InstanceNotFound(got)) => assert_eq!(got, id),
+            other => panic!("expected KernelError::Hand(InstanceNotFound), got {other:?}"),
+        }
+    }
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10876,7 +10876,9 @@ system_prompt = "You are a helpful assistant."
                 agent_ids_map.clone(),
                 coordinator_role.clone(),
             )
-            .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
+            // #3711: propagate typed HandError; Display preserved by
+            // `#[error(transparent)]` on `KernelError::Hand`.
+            .map_err(KernelError::from)?;
 
         let display_manifest_path = last_manifest_path
             .as_deref()
@@ -10906,7 +10908,8 @@ system_prompt = "You are a helpful assistant."
         let instance = self
             .hand_registry
             .deactivate(instance_id)
-            .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
+            // #3711: propagate typed HandError (Display preserved).
+            .map_err(KernelError::from)?;
 
         // Collect every hand-agent id touched by this instance so we can both
         // kill the live runtime and scrub the persisted SQLite rows below.
@@ -10984,7 +10987,8 @@ system_prompt = "You are a helpful assistant."
         let state_path = self.home_dir_boot.join("data").join("hand_state.json");
         self.hand_registry
             .persist_state(&state_path)
-            .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))
+            // #3711: propagate typed HandError (Display preserved).
+            .map_err(KernelError::from)
     }
 
     /// Per-instance serialization lock for runtime-override mutations.
@@ -11130,7 +11134,8 @@ system_prompt = "You are a helpful assistant."
         let merged = self
             .hand_registry
             .merge_agent_runtime_override(instance.instance_id, &role, override_config)
-            .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
+            // #3711: propagate typed HandError (Display preserved).
+            .map_err(KernelError::from)?;
         if let Err(err) = self.persist_hand_state_result() {
             let _ = self.hand_registry.restore_agent_runtime_override(
                 instance.instance_id,
@@ -11213,7 +11218,8 @@ system_prompt = "You are a helpful assistant."
         // returns Ok(None) — idempotent.
         self.hand_registry
             .clear_agent_runtime_override(instance.instance_id, &role)
-            .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
+            // #3711: propagate typed HandError (Display preserved).
+            .map_err(KernelError::from)?;
 
         // Step 2: persist before touching live state. If the disk write
         // fails, restore the in-memory entry and bail — the operator
@@ -11305,7 +11311,8 @@ system_prompt = "You are a helpful assistant."
         }
         self.hand_registry
             .pause(instance_id)
-            .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
+            // #3711: propagate typed HandError (Display preserved).
+            .map_err(KernelError::from)?;
         self.persist_hand_state();
         Ok(())
     }
@@ -11314,7 +11321,8 @@ system_prompt = "You are a helpful assistant."
     pub fn resume_hand(&self, instance_id: uuid::Uuid) -> KernelResult<()> {
         self.hand_registry
             .resume(instance_id)
-            .map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))?;
+            // #3711: propagate typed HandError (Display preserved).
+            .map_err(KernelError::from)?;
         // Resume the background loop for all of this hand's agents
         if let Some(instance) = self.hand_registry.get_instance(instance_id) {
             for &agent_id in instance.agent_ids.values() {


### PR DESCRIPTION
## Summary

Extends slice 1 of #3711 (PR #4351, now merged). PR #4351 restored the typed `HandError` at one collapse site in `activate_hand_with_id`. A follow-up sweep found 7 more identical collapse sites in the same file using `.map_err(|e| KernelError::LibreFang(LibreFangError::Internal(e.to_string())))`. This PR migrates all of them to `.map_err(KernelError::from)?`, routing through the `KernelError::Hand(#[from] HandError)` variant that PR #4351 added.

Sites migrated in `crates/librefang-kernel/src/kernel/mod.rs`:

- `set_agents` (post-activate link)
- `deactivate_hand`
- `persist_hand_state_result`
- `merge_agent_runtime_override`
- `clear_agent_runtime_override`
- `pause_hand`
- `resume_hand`

Display output is preserved by `#[error(transparent)]` on `KernelError::Hand`, so logs / UI strings are byte-identical.

## Test plan

- [x] `cargo check --workspace --lib` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-kernel --lib error::` (3 passed, including new `hand_error_instance_not_found_survives_and_displays_unchanged` regression pinning Display equivalence + typed-variant preservation for the variant most of these sites surface)
- [x] grep confirms zero remaining `LibreFangError::Internal(e.to_string())` collapse patterns in `kernel/mod.rs`

Refs #3711