### PR TITLE
fix(api/budget): return updated ResourceQuota from PUT /api/budget/agents/{id}

### DIFF
--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -508,7 +508,7 @@ pub async fn agent_budget_ranking(State(state): State<Arc<AppState>>) -> impl In
     path = "/api/budget/agents/{id}",
     tag = "budget",
     params(("id" = String, Path, description = "Agent ID")),
-    responses((status = 200, description = "Updated agent budget", body = crate::types::JsonObject))
+    responses((status = 200, description = "Updated agent ResourceQuota (max_cost_per_hour_usd, max_cost_per_day_usd, max_cost_per_month_usd, max_llm_tokens_per_hour, …)", body = crate::types::JsonObject))
 )]
 pub async fn update_agent_budget(
     State(state): State<Arc<AppState>>,
@@ -577,11 +577,22 @@ pub async fn update_agent_budget(
                 api_user_ref.map(|u| u.user_id),
                 Some("api".to_string()),
             );
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({"status": "ok", "message": "Agent budget updated"})),
-            )
-                .into_response()
+            // Return the post-mutation ResourceQuota so callers can
+            // setQueryData / hydrate caches without an extra GET.
+            // If the agent vanished between update and snapshot (race),
+            // fall back to a minimal ack so the call still appears to
+            // have succeeded — `update_resources` already returned Ok.
+            match new_resources {
+                Some(resources) => (StatusCode::OK, Json(resources)).into_response(),
+                None => (
+                    StatusCode::OK,
+                    Json(serde_json::json!({
+                        "status": "ok",
+                        "message": "Agent budget updated"
+                    })),
+                )
+                    .into_response(),
+            }
         }
         Err(e) => ApiErrorResponse::not_found(format!("{e}")).into_response(),
     }

--- a/openapi.json
+++ b/openapi.json
@@ -3361,7 +3361,7 @@
         },
         "responses": {
           "200": {
-            "description": "Updated agent budget",
+            "description": "Updated agent ResourceQuota (max_cost_per_hour_usd, max_cost_per_day_usd, max_cost_per_month_usd, max_llm_tokens_per_hour, …)",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary
Second slice of #3832 (mutation handlers returning ack envelopes instead of the canonical mutated entity). Migrates `PUT /api/budget/agents/{id}`.

- Before: `200 OK { \"status\": \"ok\", \"message\": \"Agent budget updated\" }`
- After: `200 OK <ResourceQuota>` (`max_cost_per_hour_usd`, `max_cost_per_day_usd`, `max_cost_per_month_usd`, `max_llm_tokens_per_hour`, plus the full quota struct already returned by `manifest.resources`).

The handler already snapshots `new_resources` for the audit-log diff — this slice just surfaces it in the response body too, so a caller doesn't need an extra `GET /api/budget/agents/{id}` round-trip to hydrate cache after a write. If the agent vanished between `update_resources()` and the snapshot read (narrow race), we fall back to the old ack envelope so the call still appears successful.

## Changes
- `crates/librefang-api/src/routes/budget.rs` — `update_agent_budget` returns `Json(resources)` on the success path, falling back to the ack envelope only if the post-mutation snapshot is `None`. Also tightens the utoipa response description.
- `openapi.json` — text-only description bump for the same response. No schema shape change (`ResourceQuota` doesn't derive `ToSchema`; introducing that derive would touch unrelated tooling and is out of scope for this slice — same compromise other budget endpoints make).

No dashboard mutation hook exists for this endpoint yet (verified via `grep -rn \"updateAgentBudget\\|/budget/agents/\" crates/librefang-api/dashboard/src/`), so no React-Query hook update is needed in this slice. SDK call signatures (go / js / python / rust) already return the raw JSON body, so the regenerated SDKs are byte-identical.

Out of scope: agents, prompts, workflows handlers — listed in #3832 as follow-up slices.

Refs #3832 (2-of-N)

## Test plan
- [x] `cargo check -p librefang-api --lib` clean
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-api --lib` — 575 passed
- [ ] live integration (human run): `curl -X PUT http://127.0.0.1:4545/api/budget/agents/<id> -H 'content-type: application/json' -d '{\"max_cost_per_hour_usd\": 1.5}'` should now return the full `ResourceQuota` body, not the `{status:\"ok\"}` ack