### PR TITLE
fix(api/budget): usage_stats returns PaginatedResponse (#3842)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2603,8 +2603,14 @@ export async function decayMemories(): Promise<ApiActionResponse> {
 }
 
 export async function listUsageByAgent(): Promise<UsageByAgentItem[]> {
-  const data = await get<{ agents?: UsageByAgentItem[] }>("/api/usage");
-  return data.agents ?? [];
+  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
+  // legacy `{agents}` shape during the transition so older daemons keep working.
+  const data = await get<{
+    items?: UsageByAgentItem[];
+    agents?: UsageByAgentItem[];
+    total?: number;
+  }>("/api/usage");
+  return data.items ?? data.agents ?? [];
 }
 
 export async function getUsageSummary(): Promise<UsageSummaryResponse> {

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -136,7 +136,7 @@ fn fmt_global_budget_diff(
 )]
 pub async fn usage_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let usage_store = state.kernel.memory_substrate().usage();
-    let agents: Vec<serde_json::Value> = state
+    let items: Vec<serde_json::Value> = state
         .kernel
         .agent_registry()
         .list()
@@ -159,7 +159,16 @@ pub async fn usage_stats(State(state): State<Arc<AppState>>) -> impl IntoRespons
         })
         .collect();
 
-    Json(serde_json::json!({"agents": agents}))
+    // #3842: canonical `PaginatedResponse{items,total,offset,limit}` envelope.
+    // Per-agent usage is materialized from the in-memory agent registry in a
+    // single page, so offset=0 / limit=None.
+    let total = items.len();
+    Json(crate::types::PaginatedResponse {
+        items,
+        total,
+        offset: 0,
+        limit: None,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/tests/budget_routes_test.rs
+++ b/crates/librefang-api/tests/budget_routes_test.rs
@@ -418,7 +418,10 @@ async fn usage_stats_lists_each_registered_agent() {
 
     let (status, body) = request(&h, Method::GET, "/api/usage", None).await;
     assert_eq!(status, StatusCode::OK);
-    let agents = body["agents"].as_array().unwrap();
+    // #3842: canonical PaginatedResponse envelope.
+    let agents = body["items"].as_array().unwrap();
+    assert_eq!(body["offset"], 0);
+    assert_eq!(body["total"].as_u64().unwrap() as usize, agents.len());
     // The kernel may auto-register internal agents (system hands etc.) so we
     // locate our scribe by id rather than asserting the total count — what
     // we're verifying here is that recorded usage is rolled up onto the row


### PR DESCRIPTION
## Summary
Migrates `GET /api/budget/agents` (`usage_stats` handler) from non-canonical `{"agents":[...]}` envelope to canonical `PaginatedResponse{items,total,offset,limit}`.

This is the 4th slice of #3842 after #4355 (peers), #4358 (goals).

## Before / After
- Before: `{"agents":[...]}`
- After: `{"items":[...], "total":N, "offset":0, "limit":null}`

Per-agent usage materializes from the in-memory `agent_registry` in a single page, so `offset=0`/`limit=None` is correct.

## Files
- `crates/librefang-api/src/routes/budget.rs` — handler change
- `crates/librefang-api/dashboard/src/api.ts` — `listAgentBudgets` reads `items`, falls back to legacy `agents` for staged rollout
- `crates/librefang-api/tests/budget_routes_test.rs` — integration tests pin new shape

## Verification
- `cargo check --workspace --lib` ✓
- `cargo test -p librefang-api --test budget_routes_test` ✓

Refs #3842