### PR TITLE
fix(api): standardize /api/usage on PaginatedResponse envelope

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2603,8 +2603,14 @@ export async function decayMemories(): Promise<ApiActionResponse> {
 }
 
 export async function listUsageByAgent(): Promise<UsageByAgentItem[]> {
-  const data = await get<{ agents?: UsageByAgentItem[] }>("/api/usage");
-  return data.agents ?? [];
+  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
+  // legacy `{agents}` shape during the transition so older daemons keep working.
+  const data = await get<{
+    items?: UsageByAgentItem[];
+    agents?: UsageByAgentItem[];
+    total?: number;
+  }>("/api/usage");
+  return data.items ?? data.agents ?? [];
 }
 
 export async function getUsageSummary(): Promise<UsageSummaryResponse> {

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -128,6 +128,11 @@ fn fmt_global_budget_diff(
 // ---------------------------------------------------------------------------
 
 /// GET /api/usage — Get per-agent usage statistics.
+///
+/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+/// shape used by `/api/agents`, `/api/peers`, and `/api/goals` (#3842). The
+/// per-agent rollup is materialized from the in-memory agent registry and
+/// returned in one page — `offset=0` and `limit=None` always.
 #[utoipa::path(
     get,
     path = "/api/usage",
@@ -136,7 +141,7 @@ fn fmt_global_budget_diff(
 )]
 pub async fn usage_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let usage_store = state.kernel.memory_substrate().usage();
-    let agents: Vec<serde_json::Value> = state
+    let items: Vec<serde_json::Value> = state
         .kernel
         .agent_registry()
         .list()
@@ -158,8 +163,13 @@ pub async fn usage_stats(State(state): State<Arc<AppState>>) -> impl IntoRespons
             })
         })
         .collect();
-
-    Json(serde_json::json!({"agents": agents}))
+    let total = items.len();
+    Json(crate::types::PaginatedResponse {
+        items,
+        total,
+        offset: 0,
+        limit: None,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/tests/budget_routes_test.rs
+++ b/crates/librefang-api/tests/budget_routes_test.rs
@@ -418,12 +418,15 @@ async fn usage_stats_lists_each_registered_agent() {
 
     let (status, body) = request(&h, Method::GET, "/api/usage", None).await;
     assert_eq!(status, StatusCode::OK);
-    let agents = body["agents"].as_array().unwrap();
+    // #3842: canonical envelope is `{items,total,offset,limit}`.
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(body["offset"], 0);
+    assert_eq!(body["total"].as_u64().unwrap() as usize, items.len());
     // The kernel may auto-register internal agents (system hands etc.) so we
     // locate our scribe by id rather than asserting the total count — what
     // we're verifying here is that recorded usage is rolled up onto the row
     // for the registered agent, not the size of the registry.
-    let row = agents
+    let row = items
         .iter()
         .find(|r| r["agent_id"] == id.to_string())
         .unwrap_or_else(|| panic!("scribe row missing from /api/usage: {body:?}"));


### PR DESCRIPTION
## Summary

3-of-N slice of #3842 (envelope standardization; #4355 migrated peers,
#4358 migrated goals). Migrates `GET /api/usage` from the bespoke
`{agents}` envelope to the canonical
`PaginatedResponse{items,total,offset,limit}` shape used by
`/api/agents`, `/api/peers`, and `/api/goals`.

The per-agent rollup is materialized from the in-memory agent registry
and returned in one page, so `offset=0` and `limit=None` always.

## Before / After

Before:
```json
{ "agents": [...] }
```

After:
```json
{ "items": [...], "total": N, "offset": 0, "limit": null }
```

## Callers / tests updated

- `crates/librefang-api/src/routes/budget.rs` — `usage_stats` now
  returns `PaginatedResponse<serde_json::Value>`.
- `crates/librefang-api/dashboard/src/api.ts` — `listUsageByAgent()`
  reads `items`, falls back to legacy `agents` during the transition.
- `crates/librefang-api/tests/budget_routes_test.rs` — asserts the new
  `items` / `offset` fields and `total == items.len()`.

The handler's utoipa response body is `JsonObject` (loose), so no
`openapi.json` / SDK regen is needed.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean.
- `cargo test -p librefang-api --test budget_routes_test usage_stats` —
  1/1 pass.

Refs #3842