### PR TITLE
fix(api/workflows): list returns PaginatedResponse (#3842)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1864,8 +1864,15 @@ export async function instantiateTemplate(id: string, params: Record<string, unk
 }
 
 export async function listWorkflows(): Promise<WorkflowItem[]> {
-  const data = await get<{ workflows?: WorkflowItem[] }>("/api/workflows");
-  return data.workflows ?? [];
+  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
+  // legacy `{workflows}` shape during the transition so older daemons keep
+  // working.
+  const data = await get<{
+    items?: WorkflowItem[];
+    workflows?: WorkflowItem[];
+    total?: number;
+  }>("/api/workflows");
+  return data.items ?? data.workflows ?? [];
 }
 
 export async function createWorkflow(payload: {

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -418,7 +418,7 @@ pub async fn list_workflows(State(state): State<Arc<AppState>>) -> impl IntoResp
     // Load cron jobs to find workflow-bound schedules
     let all_cron_jobs = state.kernel.cron().list_all_jobs();
 
-    let list: Vec<serde_json::Value> = workflows
+    let items: Vec<serde_json::Value> = workflows
         .iter()
         .map(|w| {
             let wid = w.id.to_string();
@@ -466,7 +466,16 @@ pub async fn list_workflows(State(state): State<Arc<AppState>>) -> impl IntoResp
             })
         })
         .collect();
-    Json(serde_json::json!({ "workflows": list }))
+    // #3842: canonical `PaginatedResponse{items,total,offset,limit}` envelope.
+    // Workflows are loaded from the engine in a single page, so offset=0 /
+    // limit=None.
+    let total = items.len();
+    Json(crate::types::PaginatedResponse {
+        items,
+        total,
+        offset: 0,
+        limit: None,
+    })
 }
 
 /// GET /api/workflows/:id — Get a single workflow by ID.

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -1078,8 +1078,10 @@ async fn test_workflow_crud() {
         .unwrap();
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
-    let workflows = body["workflows"].as_array().unwrap();
+    // #3842: canonical PaginatedResponse envelope.
+    let workflows = body["items"].as_array().unwrap();
     assert_eq!(workflows.len(), 1);
+    assert_eq!(body["total"].as_u64().unwrap(), 1);
     assert_eq!(workflows[0]["name"], "test-workflow");
     assert_eq!(workflows[0]["steps"], 1);
 

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -482,10 +482,8 @@ async fn load_workflow_operations() {
         .json()
         .await
         .unwrap();
-    let wf_count = workflows["workflows"]
-        .as_array()
-        .map(|a| a.len())
-        .unwrap_or(0);
+    // #3842: canonical PaginatedResponse envelope (`items`).
+    let wf_count = workflows["items"].as_array().map(|a| a.len()).unwrap_or(0);
     eprintln!(
         "  [LOAD] Listed {wf_count} workflows in {:.1}ms",
         start.elapsed().as_secs_f64() * 1000.0

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -128,11 +128,14 @@ async fn workflows_list_starts_empty() {
     let h = boot().await;
     let (status, body) = get(&h, "/api/workflows").await;
     assert_eq!(status, StatusCode::OK, "{body:?}");
-    let arr = body["workflows"].as_array().expect("workflows array");
+    // #3842: canonical PaginatedResponse envelope.
+    let arr = body["items"].as_array().expect("items array");
     assert!(
         arr.is_empty(),
         "fresh kernel must have no workflows: {body:?}"
     );
+    assert_eq!(body["total"].as_u64().unwrap(), 0);
+    assert_eq!(body["offset"].as_u64().unwrap(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -188,8 +191,10 @@ async fn workflow_create_then_list_then_get_round_trips() {
     // list now contains it
     let (status, body) = get(&h, "/api/workflows").await;
     assert_eq!(status, StatusCode::OK);
-    let arr = body["workflows"].as_array().expect("array");
+    // #3842: canonical PaginatedResponse envelope.
+    let arr = body["items"].as_array().expect("array");
     assert_eq!(arr.len(), 1);
+    assert_eq!(body["total"].as_u64().unwrap(), 1);
     assert_eq!(arr[0]["id"], wf_id);
     assert_eq!(arr[0]["name"], "demo");
     assert_eq!(arr[0]["steps"], 1);


### PR DESCRIPTION
## Summary
Migrates `GET /api/workflows` from non-canonical `{"workflows":[...]}` envelope to canonical `PaginatedResponse{items,total,offset,limit}`.

5th slice of #3842. Earlier: #4355 peers, #4358 goals, #4361/#4362 usage_stats.

## Files
- `crates/librefang-api/src/routes/workflows.rs` — `list_workflows` handler
- `crates/librefang-api/dashboard/src/api.ts` — `listWorkflows` reads `items` with legacy `workflows` fallback
- `crates/librefang-api/tests/workflows_routes_integration.rs` + `api_integration_test.rs` + `load_test.rs` — assert new shape

## Verification
- `cargo check --workspace --lib` ✓
- `cargo test -p librefang-api --test workflows_routes_integration` ✓

Refs #3842