### PR TITLE
fix(api/prompts): return updated PromptExperiment from start/pause/complete

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3225,16 +3225,18 @@ export async function createExperiment(agentId: string, experiment: Omit<PromptE
   return post<PromptExperiment>(`/api/agents/${encodeURIComponent(agentId)}/prompts/experiments`, experiment);
 }
 
-export async function startExperiment(experimentId: string): Promise<ApiActionResponse> {
-  return post<ApiActionResponse>(`/api/prompts/experiments/${encodeURIComponent(experimentId)}/start`, {});
+// Status-transition endpoints now return the post-mutation `PromptExperiment`
+// so callers can `setQueryData` directly without a follow-up GET. See #3832.
+export async function startExperiment(experimentId: string): Promise<PromptExperiment> {
+  return post<PromptExperiment>(`/api/prompts/experiments/${encodeURIComponent(experimentId)}/start`, {});
 }
 
-export async function pauseExperiment(experimentId: string): Promise<ApiActionResponse> {
-  return post<ApiActionResponse>(`/api/prompts/experiments/${encodeURIComponent(experimentId)}/pause`, {});
+export async function pauseExperiment(experimentId: string): Promise<PromptExperiment> {
+  return post<PromptExperiment>(`/api/prompts/experiments/${encodeURIComponent(experimentId)}/pause`, {});
 }
 
-export async function completeExperiment(experimentId: string): Promise<ApiActionResponse> {
-  return post<ApiActionResponse>(`/api/prompts/experiments/${encodeURIComponent(experimentId)}/complete`, {});
+export async function completeExperiment(experimentId: string): Promise<PromptExperiment> {
+  return post<PromptExperiment>(`/api/prompts/experiments/${encodeURIComponent(experimentId)}/complete`, {});
 }
 
 export async function getExperimentMetrics(experimentId: string): Promise<ExperimentVariantMetrics[]> {

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
@@ -24,7 +24,7 @@ import {
   uploadAgentFile,
   sendAgentMessage,
 } from "../http/client";
-import type { SendAgentMessageOptions } from "../../api";
+import type { PromptExperiment, SendAgentMessageOptions } from "../../api";
 import { agentKeys, approvalKeys, handKeys, overviewKeys, sessionKeys } from "../queries/keys";
 
 /**
@@ -338,14 +338,29 @@ export function useCreateExperiment() {
   });
 }
 
+// After #3832, the start/pause/complete endpoints return the post-mutation
+// `PromptExperiment`, so we patch the experiments-list cache for `agentId`
+// directly via `setQueryData` (eliminates a stale-read window before the
+// invalidate-driven refetch lands). The `invalidateQueries` calls remain as
+// a belt-and-suspenders guard for any concurrent server-side mutation.
+function patchExperimentInCache(
+  qc: ReturnType<typeof useQueryClient>,
+  agentId: string,
+  updated: PromptExperiment,
+) {
+  qc.setQueryData<PromptExperiment[] | undefined>(
+    agentKeys.experiments(agentId),
+    (prev) => prev?.map((e) => (e.id === updated.id ? updated : e)),
+  );
+}
+
 export function useStartExperiment() {
   const qc = useQueryClient();
   return useMutation({
-    // agentId aliased to _agentId so it's available as variables.agentId in
-    // onSuccess for targeted invalidation, but not passed to the API call.
     mutationFn: ({ experimentId, agentId: _agentId }: { experimentId: string; agentId: string }) =>
       startExperiment(experimentId),
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables) => {
+      patchExperimentInCache(qc, variables.agentId, data);
       qc.invalidateQueries({ queryKey: agentKeys.experiments(variables.agentId) });
       qc.invalidateQueries({ queryKey: agentKeys.experimentMetrics(variables.experimentId) });
     },
@@ -355,11 +370,10 @@ export function useStartExperiment() {
 export function usePauseExperiment() {
   const qc = useQueryClient();
   return useMutation({
-    // agentId aliased to _agentId so it's available as variables.agentId in
-    // onSuccess for targeted invalidation, but not passed to the API call.
     mutationFn: ({ experimentId, agentId: _agentId }: { experimentId: string; agentId: string }) =>
       pauseExperiment(experimentId),
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables) => {
+      patchExperimentInCache(qc, variables.agentId, data);
       qc.invalidateQueries({ queryKey: agentKeys.experiments(variables.agentId) });
       qc.invalidateQueries({ queryKey: agentKeys.experimentMetrics(variables.experimentId) });
     },
@@ -369,11 +383,10 @@ export function usePauseExperiment() {
 export function useCompleteExperiment() {
   const qc = useQueryClient();
   return useMutation({
-    // agentId aliased to _agentId so it's available as variables.agentId in
-    // onSuccess for targeted invalidation, but not passed to the API call.
     mutationFn: ({ experimentId, agentId: _agentId }: { experimentId: string; agentId: string }) =>
       completeExperiment(experimentId),
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables) => {
+      patchExperimentInCache(qc, variables.agentId, data);
       qc.invalidateQueries({ queryKey: agentKeys.experiments(variables.agentId) });
       qc.invalidateQueries({ queryKey: agentKeys.experimentMetrics(variables.experimentId) });
     },

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -203,49 +203,65 @@ async fn get_experiment(
     }
 }
 
-async fn start_experiment(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-) -> impl IntoResponse {
-    match state
-        .kernel
-        .update_experiment_status(&id, librefang_types::agent::ExperimentStatus::Running)
-    {
-        Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
+// Apply a status transition and return the post-mutation `PromptExperiment` so
+// callers (dashboard React Query hooks, SDK consumers) can `setQueryData`
+// directly instead of doing a follow-up GET. If the experiment vanished
+// between the status write and the snapshot read (narrow race — e.g. a
+// concurrent delete), fall back to the legacy `{"success": true}` ack so the
+// call still appears successful. Refs #3832.
+async fn transition_experiment(
+    state: &AppState,
+    id: &str,
+    status: librefang_types::agent::ExperimentStatus,
+) -> axum::response::Response {
+    if let Err(e) = state.kernel.update_experiment_status(id, status) {
+        return ApiErrorResponse::internal(e)
+            .into_json_tuple()
+            .into_response();
+    }
+    match state.kernel.get_experiment(id) {
+        Ok(Some(experiment)) => Json(experiment).into_response(),
+        Ok(None) => Json(serde_json::json!({"success": true})).into_response(),
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()
             .into_response(),
     }
+}
+
+async fn start_experiment(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    transition_experiment(
+        &state,
+        &id,
+        librefang_types::agent::ExperimentStatus::Running,
+    )
+    .await
 }
 
 async fn pause_experiment(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match state
-        .kernel
-        .update_experiment_status(&id, librefang_types::agent::ExperimentStatus::Paused)
-    {
-        Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
-        Err(e) => ApiErrorResponse::internal(e)
-            .into_json_tuple()
-            .into_response(),
-    }
+    transition_experiment(
+        &state,
+        &id,
+        librefang_types::agent::ExperimentStatus::Paused,
+    )
+    .await
 }
 
 async fn complete_experiment(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match state
-        .kernel
-        .update_experiment_status(&id, librefang_types::agent::ExperimentStatus::Completed)
-    {
-        Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
-        Err(e) => ApiErrorResponse::internal(e)
-            .into_json_tuple()
-            .into_response(),
-    }
+    transition_experiment(
+        &state,
+        &id,
+        librefang_types::agent::ExperimentStatus::Completed,
+    )
+    .await
 }
 
 async fn get_experiment_metrics(


### PR DESCRIPTION
## Summary
Third slice of #3832 (mutation handlers returning ack envelopes instead of the canonical mutated entity). Migrates the three experiment status transitions in `crates/librefang-api/src/routes/prompts.rs`:

- `POST /api/prompts/experiments/{id}/start`
- `POST /api/prompts/experiments/{id}/pause`
- `POST /api/prompts/experiments/{id}/complete`

Before: `200 OK {"success": true}`
After: `200 OK <PromptExperiment>`

A new `transition_experiment` helper applies the status write and then snapshots the post-mutation experiment via the existing `get_experiment` kernel method. If the experiment vanished between the status write and the snapshot read (narrow race — e.g. concurrent delete), we fall back to the legacy ack envelope so the call still appears successful — same compromise the budget slice (#4360) made.

## Changes
- `crates/librefang-api/src/routes/prompts.rs` — `start_experiment`, `pause_experiment`, `complete_experiment` now delegate to `transition_experiment` which returns the updated entity.
- `crates/librefang-api/dashboard/src/api.ts` — `startExperiment` / `pauseExperiment` / `completeExperiment` return type `ApiActionResponse` -> `PromptExperiment`.
- `crates/librefang-api/dashboard/src/lib/mutations/agents.ts` — `useStartExperiment` / `usePauseExperiment` / `useCompleteExperiment` now call `setQueryData(agentKeys.experiments(agentId), prev => prev?.map(...))` to patch the cached list in place, then still invalidate as a belt-and-suspenders guard.

No `utoipa` annotations on these endpoints and no entries in `openapi.json` (verified) — no SDK regen needed. Existing `agents-experiments.test.tsx` tests still pass: they spy on `invalidateQueries`, which is still called.

Out of scope: agents, workflows, channels handlers — listed in #3832 as follow-up slices.

Refs #3832 (3-of-N)

## Test plan
- [x] `cargo check -p librefang-api --lib` clean
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-api --lib` — 575 passed
- [x] dashboard `tsc --noEmit` clean
- [x] dashboard `vitest run` — 380 passed (38 files)
- [ ] live integration (human run): `curl -X POST http://127.0.0.1:4545/api/prompts/experiments/<id>/start` should now return the full `PromptExperiment` body, not `{success:true}`