### PR TITLE
fix(api/prompts): activate version returns PromptVersion entity (#3832)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3265,8 +3265,8 @@ export async function deletePromptVersion(versionId: string): Promise<ApiActionR
   return del<ApiActionResponse>(`/api/prompts/versions/${encodeURIComponent(versionId)}`);
 }
 
-export async function activatePromptVersion(versionId: string, agentId: string): Promise<ApiActionResponse> {
-  return post<ApiActionResponse>(`/api/prompts/versions/${encodeURIComponent(versionId)}/activate`, { agent_id: agentId });
+export async function activatePromptVersion(versionId: string, agentId: string): Promise<PromptVersion> {
+  return post<PromptVersion>(`/api/prompts/versions/${encodeURIComponent(versionId)}/activate`, { agent_id: agentId });
 }
 
 export async function listExperiments(agentId: string): Promise<PromptExperiment[]> {

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
@@ -24,7 +24,7 @@ import {
   uploadAgentFile,
   sendAgentMessage,
 } from "../http/client";
-import type { PromptExperiment, SendAgentMessageOptions } from "../../api";
+import type { PromptExperiment, PromptVersion, SendAgentMessageOptions } from "../../api";
 import { agentKeys, approvalKeys, handKeys, overviewKeys, sessionKeys } from "../queries/keys";
 
 /**
@@ -298,7 +298,25 @@ export function useActivatePromptVersion() {
   return useMutation({
     mutationFn: ({ versionId, agentId }: { versionId: string; agentId: string }) =>
       activatePromptVersion(versionId, agentId),
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables) => {
+      // Patch the cached version list in place: flip is_active for the
+      // activated version and clear it on every other version of the same
+      // agent. Falls through to invalidate as a belt-and-suspenders guard
+      // (and to cover the narrow race where the kernel returned a fallback
+      // ack envelope without the entity body).
+      const hasEntity =
+        data && typeof data === "object" && "id" in data && (data as PromptVersion).id;
+      if (hasEntity) {
+        qc.setQueryData<PromptVersion[]>(
+          agentKeys.promptVersions(variables.agentId),
+          (prev) =>
+            prev?.map((v) =>
+              v.id === variables.versionId
+                ? { ...(data as PromptVersion) }
+                : { ...v, is_active: false },
+            ),
+        );
+      }
       qc.invalidateQueries({ queryKey: agentKeys.promptVersions(variables.agentId) });
       // Active version may be surfaced on the agent detail view.
       qc.invalidateQueries({ queryKey: agentKeys.detail(variables.agentId) });

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -135,11 +135,18 @@ async fn activate_prompt_version(
                 .into_response()
         }
     };
-    match state.kernel.set_active_prompt_version(&id, agent_id) {
-        Ok(_) => Json(serde_json::json!({"success": true})).into_response(),
-        Err(e) => ApiErrorResponse::internal(e)
+    if let Err(e) = state.kernel.set_active_prompt_version(&id, agent_id) {
+        return ApiErrorResponse::internal(e)
             .into_json_tuple()
-            .into_response(),
+            .into_response();
+    }
+    // Read back the activated version so the caller can patch caches in place
+    // without an extra round-trip. If the version vanished between write and
+    // read (narrow race — concurrent delete), fall back to the legacy ack
+    // envelope so the activation still appears successful.
+    match state.kernel.get_prompt_version(&id) {
+        Ok(version) => Json(version).into_response(),
+        Err(_) => Json(serde_json::json!({"success": true})).into_response(),
     }
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -3924,6 +3924,7 @@
           "channels"
         ],
         "summary": "GET /api/channels — List all 40 channel adapters with status and field metadata.",
+        "description": "Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`\nshape used by `/api/agents`, `/api/peers`, `/api/skills`, etc. (#3842).\nThe full channel registry is materialized in-memory, so this is a single\npage — `offset=0`, `limit=None`. The bespoke `configured_count` sibling\nis preserved for the dashboard's \"X of Y configured\" sub-line.",
         "operationId": "list_channels",
         "responses": {
           "200": {
@@ -3931,8 +3932,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {}
+                  "$ref": "#/components/schemas/JsonObject"
                 }
               }
             }
@@ -8065,6 +8065,7 @@
           "skills"
         ],
         "summary": "GET /api/skills — List installed skills.",
+        "description": "`categories` always reflects all skills regardless of the `?category=` filter.",
         "operationId": "list_skills",
         "responses": {
           "200": {
@@ -8072,8 +8073,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {}
+                  "$ref": "#/components/schemas/JsonObject"
                 }
               }
             }


### PR DESCRIPTION
## Summary
4th slice of #3832. Migrates POST `/api/prompts/versions/{id}/activate` from `{success:true}` ack envelope to returning the activated `PromptVersion` entity. Earlier slices: #4356 goals, #4360 budget agents, #4364 experiments.

## Before / After
- Before: `200 OK {"success":true}`
- After: `200 OK <PromptVersion>` (race fallback to ack if version vanishes between write+read).

## Files
- `crates/librefang-api/src/routes/prompts.rs` — activate handler
- `crates/librefang-api/dashboard/src/api.ts` — return type
- `crates/librefang-api/dashboard/src/lib/mutations/agents.ts` — `useActivatePromptVersion` does `setQueryData` plus invalidate

## Verification
- `cargo check --workspace --lib` ✓

Refs #3832