### PR TITLE
fix(api): migrate /api/workflows list to PaginatedResponse envelope

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1864,8 +1864,13 @@ export async function instantiateTemplate(id: string, params: Record<string, unk
 }
 
 export async function listWorkflows(): Promise<WorkflowItem[]> {
-  const data = await get<{ workflows?: WorkflowItem[] }>("/api/workflows");
-  return data.workflows ?? [];
+  // Canonical envelope is `PaginatedResponse{items,...}` (#3842). Older
+  // daemons returned `{workflows: [...]}` — fall back so a stale dashboard
+  // bundle keeps working against either shape during rollout.
+  const data = await get<{ items?: WorkflowItem[]; workflows?: WorkflowItem[] }>(
+    "/api/workflows",
+  );
+  return data.items ?? data.workflows ?? [];
 }
 
 export async function createWorkflow(payload: {

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -365,7 +365,7 @@ pub async fn create_workflow(
     path = "/api/workflows",
     tag = "workflows",
     responses(
-        (status = 200, description = "List workflows", body = Vec<serde_json::Value>)
+        (status = 200, description = "List workflows (PaginatedResponse envelope)", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_workflows(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -466,7 +466,16 @@ pub async fn list_workflows(State(state): State<Arc<AppState>>) -> impl IntoResp
             })
         })
         .collect();
-    Json(serde_json::json!({ "workflows": list }))
+    // Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+    // shape (#3842). All workflows are returned in a single page — the engine
+    // holds them in memory — so `offset=0` and `limit=None` always.
+    let total = list.len();
+    Json(serde_json::json!({
+        "items": list,
+        "total": total,
+        "offset": 0,
+        "limit": serde_json::Value::Null,
+    }))
 }
 
 /// GET /api/workflows/:id — Get a single workflow by ID.

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -1078,7 +1078,7 @@ async fn test_workflow_crud() {
         .unwrap();
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
-    let workflows = body["workflows"].as_array().unwrap();
+    let workflows = body["items"].as_array().unwrap();
     assert_eq!(workflows.len(), 1);
     assert_eq!(workflows[0]["name"], "test-workflow");
     assert_eq!(workflows[0]["steps"], 1);

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -482,10 +482,7 @@ async fn load_workflow_operations() {
         .json()
         .await
         .unwrap();
-    let wf_count = workflows["workflows"]
-        .as_array()
-        .map(|a| a.len())
-        .unwrap_or(0);
+    let wf_count = workflows["items"].as_array().map(|a| a.len()).unwrap_or(0);
     eprintln!(
         "  [LOAD] Listed {wf_count} workflows in {:.1}ms",
         start.elapsed().as_secs_f64() * 1000.0

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -128,11 +128,14 @@ async fn workflows_list_starts_empty() {
     let h = boot().await;
     let (status, body) = get(&h, "/api/workflows").await;
     assert_eq!(status, StatusCode::OK, "{body:?}");
-    let arr = body["workflows"].as_array().expect("workflows array");
+    let arr = body["items"].as_array().expect("items array");
     assert!(
         arr.is_empty(),
         "fresh kernel must have no workflows: {body:?}"
     );
+    assert_eq!(body["total"], 0, "{body:?}");
+    assert_eq!(body["offset"], 0, "{body:?}");
+    assert!(body["limit"].is_null(), "{body:?}");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -188,8 +191,9 @@ async fn workflow_create_then_list_then_get_round_trips() {
     // list now contains it
     let (status, body) = get(&h, "/api/workflows").await;
     assert_eq!(status, StatusCode::OK);
-    let arr = body["workflows"].as_array().expect("array");
+    let arr = body["items"].as_array().expect("array");
     assert_eq!(arr.len(), 1);
+    assert_eq!(body["total"], 1, "{body:?}");
     assert_eq!(arr[0]["id"], wf_id);
     assert_eq!(arr[0]["name"], "demo");
     assert_eq!(arr[0]["steps"], 1);


### PR DESCRIPTION
## Summary
- `GET /api/workflows` previously returned `{workflows: [...]}` — one of the divergent envelope shapes called out in #3842 that blocks a generic typed SDK.
- Switch the handler to the canonical `PaginatedResponse{items,total,offset,limit}` envelope, matching the `/api/agents` and `/api/peers` slices already merged.
- Dashboard `listWorkflows()` reads `items` first and falls back to the legacy `workflows` key so a stale bundle keeps working against either daemon during rollout.

## Before / After
Before: `{ "workflows": [ ... ] }`
After:  `{ "items": [ ... ], "total": N, "offset": 0, "limit": null }`

## Callers touched
- `crates/librefang-api/src/routes/workflows.rs` — handler + utoipa response schema
- `crates/librefang-api/dashboard/src/api.ts` — `listWorkflows()` reader with fallback
- `crates/librefang-api/tests/workflows_routes_integration.rs` — assertions
- `crates/librefang-api/tests/api_integration_test.rs` — assertions
- `crates/librefang-api/tests/load_test.rs` — assertion

## Test plan
- [x] `cargo check -p librefang-api --lib`
- [x] `cargo clippy -p librefang-api --tests -- -D warnings`
- [x] `cargo test -p librefang-api --test workflows_routes_integration` (35/35 pass)
- [x] `cargo test -p librefang-api --test api_integration_test workflow` (1/1 pass)

Refs #3842