### PR TITLE
fix(api): standardize /api/audit/* on PaginatedResponse envelope

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -621,8 +621,15 @@ export interface AuditEntry {
 }
 
 export interface AuditRecentResponse {
+  // Canonical `PaginatedResponse` field (#3842). Legacy daemons returned
+  // the same payload under `entries`; both are exposed here so the
+  // dashboard can read either during the transition.
+  items?: AuditEntry[];
+  /** @deprecated #3842 — use `items`. Populated by older daemons only. */
   entries?: AuditEntry[];
   total?: number;
+  offset?: number;
+  limit?: number;
   tip_hash?: string;
 }
 
@@ -2458,7 +2465,14 @@ export async function queryApprovalAudit(params: {
   offset?: number;
   agent_id?: string;
   tool_name?: string;
-}): Promise<{ entries: ApprovalAuditEntry[]; total: number }> {
+}): Promise<{
+  items?: ApprovalAuditEntry[];
+  /** @deprecated #3842 — older daemons populated this; prefer `items`. */
+  entries?: ApprovalAuditEntry[];
+  total: number;
+  offset?: number;
+  limit?: number;
+}> {
   const query = new URLSearchParams();
   if (params.limit != null) query.set("limit", String(params.limit));
   if (params.offset != null) query.set("offset", String(params.offset));

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -621,9 +621,6 @@ export interface AuditEntry {
 }
 
 export interface AuditRecentResponse {
-  // Canonical `PaginatedResponse` field (#3842). Legacy daemons returned
-  // the same payload under `entries`; both are exposed here so the
-  // dashboard can read either during the transition.
   items?: AuditEntry[];
   /** @deprecated #3842 — use `items`. Populated by older daemons only. */
   entries?: AuditEntry[];

--- a/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
@@ -283,7 +283,9 @@ function HistoryTab() {
   const { t } = useTranslation();
   const [offset, setOffset] = useState(0);
   const auditQuery = useApprovalAudit({ limit: HISTORY_PAGE_SIZE, offset });
-  const entries: ApprovalAuditEntry[] = auditQuery.data?.entries ?? [];
+  // #3842: prefer canonical `items`; fall back to legacy `entries` for older daemons.
+  const entries: ApprovalAuditEntry[] =
+    auditQuery.data?.items ?? auditQuery.data?.entries ?? [];
   const total = auditQuery.data?.total ?? 0;
   const from = total === 0 ? 0 : offset + 1;
   const to = Math.min(offset + HISTORY_PAGE_SIZE, total);

--- a/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ApprovalsPage.tsx
@@ -283,7 +283,6 @@ function HistoryTab() {
   const { t } = useTranslation();
   const [offset, setOffset] = useState(0);
   const auditQuery = useApprovalAudit({ limit: HISTORY_PAGE_SIZE, offset });
-  // #3842: prefer canonical `items`; fall back to legacy `entries` for older daemons.
   const entries: ApprovalAuditEntry[] =
     auditQuery.data?.items ?? auditQuery.data?.entries ?? [];
   const total = auditQuery.data?.total ?? 0;

--- a/crates/librefang-api/dashboard/src/pages/LogsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/LogsPage.tsx
@@ -31,7 +31,8 @@ export function LogsPage() {
     refetchInterval: REFRESH_MS, // Logs page polls faster so the live tail stays responsive.
   });
 
-  const logs = auditQuery.data?.entries ?? [];
+  // #3842: prefer canonical `items`; fall back to legacy `entries` for older daemons.
+  const logs = auditQuery.data?.items ?? auditQuery.data?.entries ?? [];
   const modules = useMemo(
     () => Array.from(new Set(logs.map(logModule).filter(Boolean))) as string[],
     [logs],

--- a/crates/librefang-api/dashboard/src/pages/LogsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/LogsPage.tsx
@@ -31,7 +31,6 @@ export function LogsPage() {
     refetchInterval: REFRESH_MS, // Logs page polls faster so the live tail stays responsive.
   });
 
-  // #3842: prefer canonical `items`; fall back to legacy `entries` for older daemons.
   const logs = auditQuery.data?.items ?? auditQuery.data?.entries ?? [];
   const modules = useMemo(
     () => Array.from(new Set(logs.map(logModule).filter(Boolean))) as string[],

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -151,7 +151,8 @@ export function RuntimePage() {
   const allHealthy = healthChecks.length > 0 && healthChecks.every((c: HealthCheck) => OK_STATUSES.has(c.status));
   const lanes = queue?.lanes ?? [];
   const queueConfig = queue?.config;
-  const auditEntries = auditQuery.data?.entries ?? [];
+  // #3842: prefer canonical `items`; fall back to legacy `entries` for older daemons.
+  const auditEntries = auditQuery.data?.items ?? auditQuery.data?.entries ?? [];
   const auditValid = auditVerifyQuery.data?.valid;
   const backups = backupsQuery.data?.backups ?? [];
   const taskStatus = taskStatusQuery.data;

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -151,7 +151,6 @@ export function RuntimePage() {
   const allHealthy = healthChecks.length > 0 && healthChecks.every((c: HealthCheck) => OK_STATUSES.has(c.status));
   const lanes = queue?.lanes ?? [];
   const queueConfig = queue?.config;
-  // #3842: prefer canonical `items`; fall back to legacy `entries` for older daemons.
   const auditEntries = auditQuery.data?.items ?? auditQuery.data?.entries ?? [];
   const auditValid = auditVerifyQuery.data?.valid;
   const backups = backupsQuery.data?.backups ?? [];

--- a/crates/librefang-api/src/routes/audit.rs
+++ b/crates/librefang-api/src/routes/audit.rs
@@ -270,9 +270,15 @@ pub async fn audit_query(
         })
         .collect();
 
+    // Canonical `PaginatedResponse{items,total,offset,limit}` envelope (#3842).
+    // The handler returns at most `limit` rows starting at the head of the
+    // filtered (newest-first) view, so `offset = 0`. `total = items.len()`
+    // mirrors the post-filter count exposed by the previous `count` field.
+    let total = items.len();
     Json(serde_json::json!({
-        "entries": items,
-        "count": items.len(),
+        "items": items,
+        "total": total,
+        "offset": 0,
         "limit": limit,
     }))
     .into_response()

--- a/crates/librefang-api/src/routes/audit.rs
+++ b/crates/librefang-api/src/routes/audit.rs
@@ -270,10 +270,6 @@ pub async fn audit_query(
         })
         .collect();
 
-    // Canonical `PaginatedResponse{items,total,offset,limit}` envelope (#3842).
-    // The handler returns at most `limit` rows starting at the head of the
-    // filtered (newest-first) view, so `offset = 0`. `total = items.len()`
-    // mirrors the post-filter count exposed by the previous `count` field.
     let total = items.len();
     Json(serde_json::json!({
         "items": items,

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -841,9 +841,16 @@ pub async fn audit_recent(
         })
         .collect();
 
+    // Canonical `PaginatedResponse{items,total,offset,limit}` envelope (#3842).
+    // The audit log is in-memory and `recent(n)` always returns the tail,
+    // so `offset = 0` and `limit = Some(n)`. `tip_hash` is preserved as an
+    // extra field so the dashboard's chain-integrity badge keeps working.
+    let total = state.kernel.audit().len();
     Json(serde_json::json!({
-        "entries": items,
-        "total": state.kernel.audit().len(),
+        "items": items,
+        "total": total,
+        "offset": 0,
+        "limit": n,
         "tip_hash": tip,
     }))
 }
@@ -2564,7 +2571,13 @@ pub async fn audit_log(
         .approvals()
         .audit_count(params.agent_id.as_deref(), params.tool_name.as_deref());
 
-    Json(serde_json::json!({"entries": entries, "total": total}))
+    // Canonical `PaginatedResponse{items,total,offset,limit}` envelope (#3842).
+    Json(serde_json::json!({
+        "items": entries,
+        "total": total,
+        "offset": params.offset,
+        "limit": limit,
+    }))
 }
 
 /// GET /api/approvals/count — Lightweight pending count for notification badges.

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -841,10 +841,6 @@ pub async fn audit_recent(
         })
         .collect();
 
-    // Canonical `PaginatedResponse{items,total,offset,limit}` envelope (#3842).
-    // The audit log is in-memory and `recent(n)` always returns the tail,
-    // so `offset = 0` and `limit = Some(n)`. `tip_hash` is preserved as an
-    // extra field so the dashboard's chain-integrity badge keeps working.
     let total = state.kernel.audit().len();
     Json(serde_json::json!({
         "items": items,
@@ -2571,7 +2567,6 @@ pub async fn audit_log(
         .approvals()
         .audit_count(params.agent_id.as_deref(), params.tool_name.as_deref());
 
-    // Canonical `PaginatedResponse{items,total,offset,limit}` envelope (#3842).
     Json(serde_json::json!({
         "items": entries,
         "total": total,

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2815,9 +2815,6 @@ async fn test_audit_query_rejects_viewer_admin_returns_200() {
         .unwrap();
     assert_eq!(admin.status(), 200, "Admin must be allowed");
     let body: serde_json::Value = admin.json().await.unwrap();
-    // #3842: canonical `PaginatedResponse{items,total,offset,limit}`
-    // envelope. All four fields are always present, even on an empty
-    // audit log.
     assert!(body["items"].is_array(), "response must carry items[]");
     assert!(body["total"].is_number(), "response must carry total");
     assert!(body["offset"].is_number(), "response must carry offset");
@@ -3687,7 +3684,6 @@ async fn test_user_budget_put_audit_records_old_new_diff_and_caller() {
         .json()
         .await
         .unwrap();
-    // #3842: canonical envelope is `items`.
     let entries = q["items"].as_array().expect("items[] present");
     assert!(
         !entries.is_empty(),

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2813,10 +2813,12 @@ async fn test_audit_query_rejects_viewer_admin_returns_200() {
         .unwrap();
     assert_eq!(admin.status(), 200, "Admin must be allowed");
     let body: serde_json::Value = admin.json().await.unwrap();
-    // Shape contract: `entries` array, `count`, `limit` fields all
-    // present even on an empty audit log.
-    assert!(body["entries"].is_array(), "response must carry entries[]");
-    assert!(body["count"].is_number(), "response must carry count");
+    // #3842: canonical `PaginatedResponse{items,total,offset,limit}`
+    // envelope. All four fields are always present, even on an empty
+    // audit log.
+    assert!(body["items"].is_array(), "response must carry items[]");
+    assert!(body["total"].is_number(), "response must carry total");
+    assert!(body["offset"].is_number(), "response must carry offset");
     assert!(body["limit"].is_number(), "response must carry limit");
 }
 
@@ -3683,7 +3685,8 @@ async fn test_user_budget_put_audit_records_old_new_diff_and_caller() {
         .json()
         .await
         .unwrap();
-    let entries = q["entries"].as_array().expect("entries[] present");
+    // #3842: canonical envelope is `items`.
+    let entries = q["items"].as_array().expect("items[] present");
     assert!(
         !entries.is_empty(),
         "ConfigChange audit row must be emitted by /api/budget/users/{{user}} PUT"

--- a/crates/librefang-api/tests/approvals_routes_integration.rs
+++ b/crates/librefang-api/tests/approvals_routes_integration.rs
@@ -428,7 +428,7 @@ async fn batch_oversize_is_bad_request() {
 // ---------------------------------------------------------------------------
 
 /// Audit endpoint returns the canonical `PaginatedResponse{items,total,offset,limit}`
-/// envelope (#3842) even when nothing has been resolved yet.
+/// envelope even when nothing has been resolved yet.
 #[tokio::test(flavor = "multi_thread")]
 async fn audit_empty_returns_envelope() {
     let h = boot();

--- a/crates/librefang-api/tests/approvals_routes_integration.rs
+++ b/crates/librefang-api/tests/approvals_routes_integration.rs
@@ -427,15 +427,17 @@ async fn batch_oversize_is_bad_request() {
 // GET /api/approvals/audit
 // ---------------------------------------------------------------------------
 
-/// Audit endpoint returns the canonical `{entries, total}` envelope even when
-/// nothing has been resolved yet.
+/// Audit endpoint returns the canonical `PaginatedResponse{items,total,offset,limit}`
+/// envelope (#3842) even when nothing has been resolved yet.
 #[tokio::test(flavor = "multi_thread")]
 async fn audit_empty_returns_envelope() {
     let h = boot();
     let (status, body) = get(&h, "/api/approvals/audit").await;
     assert_eq!(status, StatusCode::OK, "got: {body}");
-    assert!(body["entries"].is_array());
+    assert!(body["items"].is_array());
     assert!(body["total"].is_number());
+    assert!(body["offset"].is_number());
+    assert!(body["limit"].is_number());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/tests/audit_routes_integration.rs
+++ b/crates/librefang-api/tests/audit_routes_integration.rs
@@ -456,11 +456,7 @@ async fn audit_export_rejects_viewer() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn audit_recent_returns_documented_shape() {
-    // `/audit/recent` is gated by the dashboard-reads middleware tier and
-    // returns the canonical `PaginatedResponse{items,total,offset,limit}`
-    // envelope (#3842) plus a `tip_hash` extra field for the dashboard's
-    // chain-integrity badge. Pin the shape so a rename doesn't silently
-    // break the dashboard download flow.
+    // `/audit/recent` returns `PaginatedResponse{items,total,offset,limit}` plus `tip_hash`.
     let h = build_audit_harness("", vec![]);
     seed_audit_entries(&h.state);
 

--- a/crates/librefang-api/tests/audit_routes_integration.rs
+++ b/crates/librefang-api/tests/audit_routes_integration.rs
@@ -22,8 +22,9 @@
 //!   - `/audit/export?format=json` content shape (chunked array w/ `prev_hash`)
 //!   - `/audit/export?format=bogus` → 400
 //!   - `/audit/export` admin-gated (anon → 401, viewer → 403)
-//!   - `/audit/recent` returns `entries` / `total` / `tip_hash` shape and the
-//!     `?n=` cap (capped at 1000 by handler)
+//!   - `/audit/recent` returns the canonical `PaginatedResponse` shape
+//!     (`items`/`total`/`offset`/`limit`) plus `tip_hash`, and the `?n=` cap
+//!     (capped at 1000 by handler)
 //!   - `/audit/verify` returns `valid: true` on a fresh chain; `warning` field
 //!     surfaces when the chain is empty
 
@@ -202,7 +203,7 @@ async fn audit_query_filters_by_action_case_insensitive() {
     .await;
     assert_eq!(status, StatusCode::OK);
     let body = body_json(&bytes);
-    let entries = body["entries"].as_array().expect("entries[]");
+    let entries = body["items"].as_array().expect("items[]");
     assert!(
         !entries.is_empty(),
         "PermissionDenied filter must surface the seeded denial; got {body}"
@@ -228,7 +229,7 @@ async fn audit_query_filters_by_agent_and_channel() {
     .await;
     assert_eq!(status, StatusCode::OK);
     let body = body_json(&bytes);
-    let entries = body["entries"].as_array().expect("entries[]");
+    let entries = body["items"].as_array().expect("items[]");
     assert!(
         !entries.is_empty(),
         "agent+channel filter must match seeded beta entry"
@@ -255,7 +256,7 @@ async fn audit_query_filters_by_user_name_resolves_to_uuid() {
     .await;
     assert_eq!(status, StatusCode::OK);
     let body = body_json(&bytes);
-    let entries = body["entries"].as_array().expect("entries[]");
+    let entries = body["items"].as_array().expect("items[]");
     assert!(
         !entries.is_empty(),
         "?user=Bob must match the Bob-attributed entry"
@@ -323,7 +324,7 @@ async fn audit_query_clamps_zero_limit_up_to_one() {
     let body = body_json(&bytes);
     let limit = body["limit"].as_u64().expect("limit number");
     assert!(limit >= 1, "limit must be clamped up to >= 1; got {limit}");
-    let entries = body["entries"].as_array().expect("entries[]");
+    let entries = body["items"].as_array().expect("items[]");
     assert!(
         entries.len() <= limit as usize,
         "entries length ({}) must respect the reported limit ({})",
@@ -456,16 +457,20 @@ async fn audit_export_rejects_viewer() {
 #[tokio::test(flavor = "multi_thread")]
 async fn audit_recent_returns_documented_shape() {
     // `/audit/recent` is gated by the dashboard-reads middleware tier and
-    // returns `{entries, total, tip_hash}`. Pin the shape so the dashboard
-    // download flow doesn't break on a future field rename.
+    // returns the canonical `PaginatedResponse{items,total,offset,limit}`
+    // envelope (#3842) plus a `tip_hash` extra field for the dashboard's
+    // chain-integrity badge. Pin the shape so a rename doesn't silently
+    // break the dashboard download flow.
     let h = build_audit_harness("", vec![]);
     seed_audit_entries(&h.state);
 
     let (status, bytes) = send_get(h.app.clone(), "/api/audit/recent", None).await;
     assert_eq!(status, StatusCode::OK);
     let body = body_json(&bytes);
-    assert!(body["entries"].is_array(), "must carry entries[]");
+    assert!(body["items"].is_array(), "must carry items[]");
     assert!(body["total"].is_number(), "must carry total");
+    assert!(body["offset"].is_number(), "must carry offset");
+    assert!(body["limit"].is_number(), "must carry limit");
     assert!(
         body["tip_hash"].is_string(),
         "must carry tip_hash (chain-tip SHA-256)"
@@ -485,7 +490,7 @@ async fn audit_recent_caps_n_at_1000() {
     let (status, bytes) = send_get(h.app.clone(), "/api/audit/recent?n=999999", None).await;
     assert_eq!(status, StatusCode::OK);
     let body = body_json(&bytes);
-    let entries = body["entries"].as_array().expect("entries[]");
+    let entries = body["items"].as_array().expect("items[]");
     assert!(
         entries.len() <= 1000,
         "?n= must be capped at 1000; got {} entries",


### PR DESCRIPTION
## Summary
Refs #3842 (audit slice): migrate three list endpoints from bespoke envelopes to the canonical `PaginatedResponse{items,total,offset,limit}` shape.

- `GET /api/audit/recent`    (`system.rs`) — was `{entries,total,tip_hash}`
- `GET /api/audit/query`     (`audit.rs`)  — was `{entries,count,limit}`
- `GET /api/approvals/audit` (`system.rs`) — was `{entries,total}`

`tip_hash` is preserved on `/audit/recent` as an extra field so the dashboard's chain-integrity badge keeps working. Dashboard helpers (`api.ts`, `LogsPage`, `RuntimePage`, `ApprovalsPage`) read `items` first and fall back to legacy `entries` during the transition.

Integration tests in `audit_routes_integration.rs`, `approvals_routes_integration.rs`, and `api_integration_test.rs` are updated to pin the new envelope keys.

Remaining envelopes in `workflows.rs` / `goals.rs` / `skills.rs` / `budget.rs` still to be migrated in follow-up PRs.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy -p librefang-api --tests -- -D warnings`
- [x] `cargo test -p librefang-api --test audit_routes_integration --test approvals_routes_integration` (15+21 passing)
- [x] `cargo test -p librefang-api --test api_integration_test test_audit_query` (2 passing)