### PR TITLE
refactor(api): remove rotting issue-number refs from PaginatedResponse comments

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1886,9 +1886,7 @@ export async function instantiateTemplate(id: string, params: Record<string, unk
 }
 
 export async function listWorkflows(): Promise<WorkflowItem[]> {
-  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
-  // legacy `{workflows}` shape during the transition so older daemons keep
-  // working.
+  // Daemons may return legacy `{workflows}` — fall back for version skew.
   const data = await get<{
     items?: WorkflowItem[];
     workflows?: WorkflowItem[];
@@ -2658,8 +2656,7 @@ export async function decayMemories(): Promise<ApiActionResponse> {
 }
 
 export async function listUsageByAgent(): Promise<UsageByAgentItem[]> {
-  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
-  // legacy `{agents}` shape during the transition so older daemons keep working.
+  // Daemons may return legacy `{agents}` — fall back for version skew.
   const data = await get<{
     items?: UsageByAgentItem[];
     agents?: UsageByAgentItem[];
@@ -2911,8 +2908,7 @@ export async function getHandInstanceStatus(instanceId: string): Promise<HandIns
 }
 
 export async function listGoals(): Promise<GoalItem[]> {
-  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
-  // legacy `{goals}` shape during the transition so older daemons keep working.
+  // Daemons may return legacy `{goals}` — fall back for version skew.
   const data = await get<{
     items?: GoalItem[];
     goals?: GoalItem[];
@@ -3003,8 +2999,7 @@ export async function getNetworkStatus(): Promise<NetworkStatusResponse> {
 }
 
 export async function listPeers(): Promise<PeerItem[]> {
-  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
-  // legacy `{peers}` shape during the transition so older daemons keep working.
+  // Daemons may return legacy `{peers}` — fall back for version skew.
   const data = await get<{ items?: PeerItem[]; peers?: PeerItem[] }>(
     "/api/peers",
   );

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -129,10 +129,8 @@ fn fmt_global_budget_diff(
 
 /// GET /api/usage — Get per-agent usage statistics.
 ///
-/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
-/// shape used by `/api/agents`, `/api/peers`, and `/api/goals` (#3842). The
-/// per-agent rollup is materialized from the in-memory agent registry and
-/// returned in one page — `offset=0` and `limit=None` always.
+/// The per-agent rollup is materialized from the in-memory agent registry
+/// and returned in one page — `offset=0` and `limit=None` always.
 #[utoipa::path(
     get,
     path = "/api/usage",

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -44,10 +44,8 @@ fn goals_shared_agent_id() -> AgentId {
 
 /// GET /api/goals — List all goals.
 ///
-/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
-/// shape used by `/api/agents` and `/api/peers` (#3842). Goals are stored as
-/// a single JSON array in shared KV memory and returned in one page —
-/// `offset=0` and `limit=None` always.
+/// Goals are stored as a single JSON array in shared KV memory and returned
+/// in one page — `offset=0` and `limit=None` always.
 pub async fn list_goals(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let agent_id = goals_shared_agent_id();
     let items: Vec<serde_json::Value> = match state

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -92,10 +92,8 @@ pub async fn list_peers(State(state): State<Arc<AppState>>) -> impl IntoResponse
     // request — caching at boot would return a stale (or empty) snapshot if the
     // OFP node initialized after AppState was constructed (#3644).
     //
-    // Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
-    // shape used by `/api/agents` (#3842). All peers are returned in a single
-    // page — the registry is in-memory and small — so `offset=0` and
-    // `limit=None` always.
+    // All peers are returned in a single page — the registry is in-memory
+    // and small — so `offset=0` and `limit=None` always.
     let items: Vec<serde_json::Value> =
         if let Some(peer_registry) = state.kernel.peer_registry_ref() {
             peer_registry

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -498,9 +498,7 @@ pub async fn list_workflows(State(state): State<Arc<AppState>>) -> impl IntoResp
             })
         })
         .collect();
-    // #3842: canonical `PaginatedResponse{items,total,offset,limit}` envelope.
-    // Workflows are loaded from the engine in a single page, so offset=0 /
-    // limit=None.
+    // Workflows load from the engine in a single page (in-memory), so offset=0 / limit=None.
     let total = items.len();
     Json(crate::types::PaginatedResponse {
         items,

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -1078,7 +1078,6 @@ async fn test_workflow_crud() {
         .unwrap();
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
-    // #3842: canonical PaginatedResponse envelope.
     let workflows = body["items"].as_array().unwrap();
     assert_eq!(workflows.len(), 1);
     assert_eq!(body["total"].as_u64().unwrap(), 1);

--- a/crates/librefang-api/tests/budget_routes_test.rs
+++ b/crates/librefang-api/tests/budget_routes_test.rs
@@ -418,7 +418,6 @@ async fn usage_stats_lists_each_registered_agent() {
 
     let (status, body) = request(&h, Method::GET, "/api/usage", None).await;
     assert_eq!(status, StatusCode::OK);
-    // #3842: canonical envelope is `{items,total,offset,limit}`.
     let items = body["items"].as_array().unwrap();
     assert_eq!(body["offset"], 0);
     assert_eq!(body["total"].as_u64().unwrap() as usize, items.len());

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -479,7 +479,6 @@ async fn load_workflow_operations() {
         .json()
         .await
         .unwrap();
-    // #3842: canonical PaginatedResponse envelope (`items`).
     let wf_count = workflows["items"].as_array().map(|a| a.len()).unwrap_or(0);
     eprintln!(
         "  [LOAD] Listed {wf_count} workflows in {:.1}ms",

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -128,7 +128,6 @@ async fn workflows_list_starts_empty() {
     let h = boot().await;
     let (status, body) = get(&h, "/api/workflows").await;
     assert_eq!(status, StatusCode::OK, "{body:?}");
-    // #3842: canonical PaginatedResponse envelope.
     let arr = body["items"].as_array().expect("items array");
     assert!(
         arr.is_empty(),
@@ -191,7 +190,6 @@ async fn workflow_create_then_list_then_get_round_trips() {
     // list now contains it
     let (status, body) = get(&h, "/api/workflows").await;
     assert_eq!(status, StatusCode::OK);
-    // #3842: canonical PaginatedResponse envelope.
     let arr = body["items"].as_array().expect("array");
     assert_eq!(arr.len(), 1);
     assert_eq!(body["total"].as_u64().unwrap(), 1);

--- a/openapi.json
+++ b/openapi.json
@@ -8518,7 +8518,7 @@
           "budget"
         ],
         "summary": "GET /api/usage — Get per-agent usage statistics.",
-        "description": "Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`\nshape used by `/api/agents`, `/api/peers`, and `/api/goals` (#3842). The\nper-agent rollup is materialized from the in-memory agent registry and\nreturned in one page — `offset=0` and `limit=None` always.",
+        "description": "The per-agent rollup is materialized from the in-memory agent registry\nand returned in one page — `offset=0` and `limit=None` always.",
         "operationId": "usage_stats",
         "responses": {
           "200": {


### PR DESCRIPTION
## Summary

- Strip `// #3842:` prefixes from code comments across 9 files in `librefang-api`
- Informative WHY content (version-skew fallback rationale, single-page constraint) is preserved; only the issue-number reference and temporal language ("during the transition") are removed
- Zero-value test annotations that only named the envelope shape are dropped entirely

## Background

PR #4363 migrated list endpoints to the canonical `PaginatedResponse{items,total,offset,limit}` envelope. In doing so it left `// #3842:` prefixes on comments and doc-strings. Per CLAUDE.md: *"Don't reference the current task, fix, or callers in code comments — those belong in the PR description and rot as the codebase evolves."* Now that #4363 is merged and #3842 is closed, those refs are dead weight.

## Files changed

| File | Change |
|------|--------|
| `src/routes/budget.rs` | Strip `#3842:` prefix from doc comment |
| `src/routes/goals.rs` | Strip `#3842:` prefix + temporal language from doc comment |
| `src/routes/network.rs` | Strip `#3842:` prefix + cross-references from inline comment |
| `src/routes/workflows.rs` | Strip `#3842:` prefix from inline comment |
| `dashboard/src/api.ts` | Strip `#3842:` prefix from 4 fallback comments |
| `tests/api_integration_test.rs` | Remove zero-value envelope annotation |
| `tests/budget_routes_test.rs` | Remove zero-value envelope annotation |
| `tests/load_test.rs` | Remove zero-value envelope annotation |
| `tests/workflows_routes_integration.rs` | Remove 2 zero-value envelope annotations |

## Test plan

- [ ] `cargo check --workspace --lib` — compile-check passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — no new warnings
- [ ] `cargo test -p librefang-api` — existing tests pass unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_011dS2DJGiEPZL6tVN5vmkhP)_