### PR TITLE
fix(api): skills/hands lists return PaginatedResponse (#3842)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -165,14 +165,12 @@ export interface SkillItem {
 }
 
 export interface SkillsResponse {
-  // Canonical PaginatedResponse envelope (#3842).
   items?: SkillItem[];
   total?: number;
   offset?: number;
   limit?: number | null;
   categories?: string[];
-  // Legacy `skills` field — kept for transition; remove once all callers
-  // upgrade.
+  // Legacy fallback — remove once all callers adopt the #3842 envelope.
   skills?: SkillItem[];
 }
 

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -165,9 +165,15 @@ export interface SkillItem {
 }
 
 export interface SkillsResponse {
-  skills?: SkillItem[];
+  // Canonical PaginatedResponse envelope (#3842).
+  items?: SkillItem[];
   total?: number;
+  offset?: number;
+  limit?: number | null;
   categories?: string[];
+  // Legacy `skills` field — kept for transition; remove once all callers
+  // upgrade.
+  skills?: SkillItem[];
 }
 
 // Skill evolution types
@@ -1608,7 +1614,9 @@ export async function whatsappQrStatus(qrCode: string): Promise<QrStatusResponse
 
 export async function listSkills(): Promise<SkillItem[]> {
   const data = await get<SkillsResponse>("/api/skills");
-  return data.skills ?? [];
+  // Canonical envelope (#3842) ships `items`; fall back to legacy `skills`
+  // during the transition window.
+  return data.items ?? data.skills ?? [];
 }
 
 export async function listTools(): Promise<ToolDefinition[]> {
@@ -2690,8 +2698,13 @@ export async function postCommsTask(payload: {
 }
 
 export async function listHands(): Promise<HandDefinitionItem[]> {
-  const data = await get<{ hands?: HandDefinitionItem[]; total?: number }>("/api/hands");
-  return data.hands ?? [];
+  const data = await get<{
+    items?: HandDefinitionItem[];
+    hands?: HandDefinitionItem[];
+    total?: number;
+  }>("/api/hands");
+  // Canonical envelope (#3842) ships `items`; fall back to legacy `hands`.
+  return data.items ?? data.hands ?? [];
 }
 
 export async function getHandManifestToml(handId: string): Promise<string> {
@@ -2703,8 +2716,13 @@ export async function getRawConfigToml(): Promise<string> {
 }
 
 export async function listActiveHands(): Promise<HandInstanceItem[]> {
-  const data = await get<{ instances?: HandInstanceItem[]; total?: number }>("/api/hands/active");
-  return data.instances ?? [];
+  const data = await get<{
+    items?: HandInstanceItem[];
+    instances?: HandInstanceItem[];
+    total?: number;
+  }>("/api/hands/active");
+  // Canonical envelope (#3842) ships `items`; fall back to legacy `instances`.
+  return data.items ?? data.instances ?? [];
 }
 
 export async function activateHand(

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -230,12 +230,20 @@ use std::time::Instant;
 // ---------------------------------------------------------------------------
 
 /// GET /api/skills — List installed skills.
+///
+/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+/// shape used by `/api/agents` / `/api/peers` / `/api/goals` (#3842). Skills
+/// are loaded from the kernel registry into a single in-memory list, so
+/// `offset=0` and `limit=None` always. The list is not paginated server-side.
+/// The bespoke `categories` sibling is preserved for the dashboard's
+/// sibling-tab UI — it intentionally reflects all skills, not just the
+/// `?category=` filtered subset.
 #[utoipa::path(
     get,
     path = "/api/skills",
     tag = "skills",
     responses(
-        (status = 200, description = "List installed skills", body = Vec<serde_json::Value>)
+        (status = 200, description = "List installed skills", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_skills(
@@ -310,9 +318,16 @@ pub async fn list_skills(
         .collect();
 
     let categories_vec: Vec<String> = categories.into_iter().collect();
+    let total = skills.len();
+    // Canonical PaginatedResponse envelope (#3842) with `categories` kept as
+    // a sibling field for the dashboard's category tabs. We hand-build the
+    // JSON so we can flatten the envelope and add the extra without a new
+    // bespoke struct.
     Json(serde_json::json!({
-        "skills": skills,
-        "total": skills.len(),
+        "items": skills,
+        "total": total,
+        "offset": 0,
+        "limit": serde_json::Value::Null,
         "categories": categories_vec,
     }))
 }
@@ -1745,6 +1760,10 @@ fn server_platform() -> &'static str {
 }
 
 /// GET /api/hands — List all hand definitions (marketplace).
+///
+/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+/// shape (#3842). Hand definitions come from the kernel registry as a single
+/// list — `offset=0`, `limit=None`.
 #[utoipa::path(
     get,
     path = "/api/hands",
@@ -1833,10 +1852,19 @@ pub async fn list_hands(
         })
         .collect();
 
-    Json(serde_json::json!({ "hands": hands, "total": hands.len() }))
+    let total = hands.len();
+    Json(crate::types::PaginatedResponse {
+        items: hands,
+        total,
+        offset: 0,
+        limit: None,
+    })
 }
 
 /// GET /api/hands/active — List active hand instances.
+///
+/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+/// shape (#3842). Active instances are returned in a single page.
 #[utoipa::path(
     get,
     path = "/api/hands/active",
@@ -1898,7 +1926,13 @@ pub async fn list_active_hands(
         })
         .collect();
 
-    Json(serde_json::json!({ "instances": items, "total": items.len() }))
+    let total = items.len();
+    Json(crate::types::PaginatedResponse {
+        items,
+        total,
+        offset: 0,
+        limit: None,
+    })
 }
 
 /// GET /api/hands/{hand_id} — Get a single hand definition with requirements check.

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -231,13 +231,7 @@ use std::time::Instant;
 
 /// GET /api/skills — List installed skills.
 ///
-/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
-/// shape used by `/api/agents` / `/api/peers` / `/api/goals` (#3842). Skills
-/// are loaded from the kernel registry into a single in-memory list, so
-/// `offset=0` and `limit=None` always. The list is not paginated server-side.
-/// The bespoke `categories` sibling is preserved for the dashboard's
-/// sibling-tab UI — it intentionally reflects all skills, not just the
-/// `?category=` filtered subset.
+/// `categories` always reflects all skills regardless of the `?category=` filter.
 #[utoipa::path(
     get,
     path = "/api/skills",
@@ -319,10 +313,7 @@ pub async fn list_skills(
 
     let categories_vec: Vec<String> = categories.into_iter().collect();
     let total = skills.len();
-    // Canonical PaginatedResponse envelope (#3842) with `categories` kept as
-    // a sibling field for the dashboard's category tabs. We hand-build the
-    // JSON so we can flatten the envelope and add the extra without a new
-    // bespoke struct.
+    // Untyped JSON so `categories` can be added alongside PaginatedResponse fields without a new struct.
     Json(serde_json::json!({
         "items": skills,
         "total": total,
@@ -1760,10 +1751,6 @@ fn server_platform() -> &'static str {
 }
 
 /// GET /api/hands — List all hand definitions (marketplace).
-///
-/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
-/// shape (#3842). Hand definitions come from the kernel registry as a single
-/// list — `offset=0`, `limit=None`.
 #[utoipa::path(
     get,
     path = "/api/hands",
@@ -1862,9 +1849,6 @@ pub async fn list_hands(
 }
 
 /// GET /api/hands/active — List active hand instances.
-///
-/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
-/// shape (#3842). Active instances are returned in a single page.
 #[utoipa::path(
     get,
     path = "/api/hands/active",

--- a/crates/librefang-api/tests/hands_routes_integration.rs
+++ b/crates/librefang-api/tests/hands_routes_integration.rs
@@ -181,18 +181,23 @@ async fn list_hands_returns_envelope_with_total_and_array() {
         "/api/hands must return a JSON object envelope, got: {body}"
     );
     assert!(
-        body.get("hands").map(|v| v.is_array()).unwrap_or(false),
-        "missing/non-array `hands` field: {body}"
+        body.get("items").map(|v| v.is_array()).unwrap_or(false),
+        "missing/non-array `items` field (canonical PaginatedResponse #3842): {body}"
     );
     assert!(
         body.get("total").map(|v| v.is_u64()).unwrap_or(false),
         "missing/non-numeric `total` field: {body}"
     );
-    let arr_len = body["hands"].as_array().unwrap().len();
+    assert_eq!(
+        body.get("offset").and_then(|v| v.as_u64()),
+        Some(0),
+        "canonical envelope must include `offset`: {body}"
+    );
+    let arr_len = body["items"].as_array().unwrap().len();
     assert_eq!(
         body["total"].as_u64().unwrap(),
         arr_len as u64,
-        "`total` must equal `hands.len()`: {body}"
+        "`total` must equal `items.len()`: {body}"
     );
 }
 
@@ -228,9 +233,14 @@ async fn list_active_hands_starts_empty() {
         "fresh kernel must have no active hands: {body}"
     );
     assert_eq!(
-        body["instances"].as_array().map(|a| a.len()),
+        body["items"].as_array().map(|a| a.len()),
         Some(0),
         "fresh kernel must have no active hand instances: {body}"
+    );
+    assert_eq!(
+        body.get("offset").and_then(|v| v.as_u64()),
+        Some(0),
+        "canonical envelope must include `offset` (#3842): {body}"
     );
 }
 

--- a/crates/librefang-api/tests/skills_routes_test.rs
+++ b/crates/librefang-api/tests/skills_routes_test.rs
@@ -126,7 +126,8 @@ async fn skills_list_starts_empty() {
     let (status, body) = json_request(&h, Method::GET, "/api/skills", None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["total"], 0);
-    assert_eq!(body["skills"], serde_json::json!([]));
+    assert_eq!(body["offset"], 0);
+    assert_eq!(body["items"], serde_json::json!([]));
     assert_eq!(body["categories"], serde_json::json!([]));
 }
 
@@ -141,7 +142,7 @@ async fn skills_list_returns_installed_skill_metadata() {
     assert_eq!(status, StatusCode::OK, "{body:?}");
     assert_eq!(body["total"], 2, "{body:?}");
 
-    let names: Vec<&str> = body["skills"]
+    let names: Vec<&str> = body["items"]
         .as_array()
         .unwrap()
         .iter()
@@ -151,7 +152,7 @@ async fn skills_list_returns_installed_skill_metadata() {
     assert!(names.contains(&"beta"));
 
     // Each entry exposes the dashboard-visible flags.
-    for s in body["skills"].as_array().unwrap() {
+    for s in body["items"].as_array().unwrap() {
         assert_eq!(s["enabled"], true);
         assert_eq!(s["tools_count"], 1);
         assert!(s["source"]["type"].is_string());
@@ -218,7 +219,8 @@ async fn skills_list_unknown_category_returns_zero() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["total"], 0);
-    assert_eq!(body["skills"], serde_json::json!([]));
+    assert_eq!(body["offset"], 0);
+    assert_eq!(body["items"], serde_json::json!([]));
 }
 
 // ---------------------------------------------------------------------------
@@ -352,7 +354,7 @@ async fn skills_reload_picks_up_filesystem_drops() {
 
     let (_, after) = json_request(&h, Method::GET, "/api/skills", None).await;
     assert_eq!(after["total"], 1);
-    assert_eq!(after["skills"][0]["name"], "dropped");
+    assert_eq!(after["items"][0]["name"], "dropped");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Migrates `GET /api/skills`, `GET /api/hands`, and `GET /api/hands/active` from bespoke envelopes (`{skills,total,categories}`, `{hands,total}`, `{instances,total}`) to the canonical `PaginatedResponse{items,total,offset,limit}` shape used by `/api/agents`, `/api/peers`, `/api/goals`.
- `/api/skills` keeps `categories` as a sibling field so the dashboard's category-tab UI continues to render the unfiltered category set across filtered queries.
- Dashboard `listSkills`, `listHands`, and `listActiveHands` now read `items` with a legacy fallback (`skills` / `hands` / `instances`) during the transition window.

Refs #3842 (6-of-N envelope standardization slice; previous: peers #4355, goals #4358, usage #4362, workflows #4363, audit #4368).

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy -p librefang-api --tests -- -D warnings`
- [x] `cargo test -p librefang-api --test skills_routes_test --test hands_routes_integration` (33 passed)
- [ ] Live: `curl /api/skills` returns `{items,total,offset,limit,categories}`
- [ ] Live: `curl /api/hands` and `curl /api/hands/active` return `{items,total,offset,limit}`