### PR TITLE
fix(api): channels list returns PaginatedResponse (#3842)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -238,9 +238,14 @@ export interface ProvidersResponse {
 }
 
 export interface ChannelsResponse {
-  channels?: ChannelItem[];
+  // Canonical PaginatedResponse envelope (#3842).
+  items?: ChannelItem[];
   total?: number;
+  offset?: number;
+  limit?: number | null;
   configured_count?: number;
+  // Legacy field kept for transition window — pre-#3842 daemons.
+  channels?: ChannelItem[];
 }
 
 export interface DashboardSnapshot {
@@ -1561,7 +1566,8 @@ export async function generateMusic(req: { prompt?: string; lyrics?: string; pro
 
 export async function listChannels(): Promise<ChannelItem[]> {
   const data = await get<ChannelsResponse>("/api/channels");
-  return data.channels ?? [];
+  // Prefer canonical `items` (#3842); fall back to legacy `channels` field.
+  return data.items ?? data.channels ?? [];
 }
 
 export async function testChannel(channelName: string): Promise<ApiActionResponse> {

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1142,12 +1142,18 @@ fn channel_config_values(
 }
 
 /// GET /api/channels — List all 40 channel adapters with status and field metadata.
+///
+/// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+/// shape used by `/api/agents`, `/api/peers`, `/api/skills`, etc. (#3842).
+/// The full channel registry is materialized in-memory, so this is a single
+/// page — `offset=0`, `limit=None`. The bespoke `configured_count` sibling
+/// is preserved for the dashboard's "X of Y configured" sub-line.
 #[utoipa::path(
     get,
     path = "/api/channels",
     tag = "channels",
     responses(
-        (status = 200, description = "List configured channels", body = Vec<serde_json::Value>)
+        (status = 200, description = "List configured channels", body = crate::types::JsonObject)
     )
 )]
 pub async fn list_channels(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -1214,9 +1220,15 @@ pub async fn list_channels(State(state): State<Arc<AppState>>) -> impl IntoRespo
         channels.push(channel_json);
     }
 
+    let total = channels.len();
+    // Canonical PaginatedResponse envelope (#3842) hand-built so the bespoke
+    // `configured_count` sibling can ride alongside `items`/`total`/`offset`/
+    // `limit` without a new struct.
     Json(serde_json::json!({
-        "channels": channels,
-        "total": channels.len(),
+        "items": channels,
+        "total": total,
+        "offset": 0,
+        "limit": serde_json::Value::Null,
         "configured_count": configured_count,
     }))
 }

--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -97,9 +97,12 @@ async fn channels_list_returns_full_registry_with_zero_configured() {
     assert_eq!(status, StatusCode::OK);
 
     let total = body["total"].as_u64().expect("total must be a number");
-    let arr = body["channels"].as_array().expect("channels must be array");
-    assert_eq!(total as usize, arr.len(), "total must match channels.len()");
+    let arr = body["items"].as_array().expect("items must be array");
+    assert_eq!(total as usize, arr.len(), "total must match items.len()");
     assert!(total > 0, "registry must be non-empty");
+    // Canonical PaginatedResponse envelope (#3842).
+    assert_eq!(body["offset"], 0, "offset must be 0: {body}");
+    assert!(body["limit"].is_null(), "limit must be null: {body}");
     assert_eq!(
         body["configured_count"], 0,
         "no channels seeded, configured_count must be 0: {body}"
@@ -140,7 +143,7 @@ async fn channels_list_flips_configured_flag_when_seeded() {
         "exactly one channel was seeded: {body}"
     );
 
-    let arr = body["channels"].as_array().expect("array");
+    let arr = body["items"].as_array().expect("array");
     let telegram = arr
         .iter()
         .find(|r| r["name"] == "telegram")


### PR DESCRIPTION
## Summary
- Migrates `GET /api/channels` from `{channels, total, configured_count}` to canonical `PaginatedResponse{items, total, offset, limit}` (single in-memory page: `offset=0`, `limit=null`).
- Preserves `configured_count` as a sibling for the dashboard's "X of Y configured" sub-line.
- `/api/channels/registry` returns a bare array (not an envelope) — out of scope for this slice.
- Dashboard `listChannels` reads `items` with a legacy `channels` fallback for the transition window.

## Before / after
Before: `{ "channels": [...], "total": N, "configured_count": K }`
After:  `{ "items": [...], "total": N, "offset": 0, "limit": null, "configured_count": K }`

## Callers / tests touched
- `crates/librefang-api/src/routes/channels.rs` — `list_channels` envelope + utoipa response type.
- `crates/librefang-api/dashboard/src/api.ts` — `ChannelsResponse` shape + `listChannels` reader.
- `crates/librefang-api/tests/channels_routes_test.rs` — canonical assertions on `items` / `offset` / `limit`.

## Verification
- `cargo check --workspace --lib` — green.
- `cargo clippy -p librefang-api --tests -- -D warnings` — green.
- `cargo test -p librefang-api --test channels_routes_test` — 10/10 passed.

Refs #3842