### PR TITLE
fix(api/workflows): update returns Workflow entity (#3832)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1911,8 +1911,8 @@ export async function updateWorkflow(workflowId: string, payload: {
     timeout_secs?: number;
   }>;
   layout?: unknown;
-}): Promise<ApiActionResponse> {
-  return put<ApiActionResponse>(`/api/workflows/${encodeURIComponent(workflowId)}`, payload);
+}): Promise<WorkflowItem> {
+  return put<WorkflowItem>(`/api/workflows/${encodeURIComponent(workflowId)}`, payload);
 }
 
 export async function listWorkflowRuns(workflowId: string): Promise<WorkflowRunItem[]> {

--- a/crates/librefang-api/dashboard/src/lib/mutations/workflows.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/workflows.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../http/client", () => ({
   dryRunWorkflow: vi.fn().mockResolvedValue({ valid: true, steps: [] }),
   deleteWorkflow: vi.fn().mockResolvedValue({ status: "ok" }),
   createWorkflow: vi.fn().mockResolvedValue({ id: "wf-1" }),
-  updateWorkflow: vi.fn().mockResolvedValue({ status: "ok" }),
+  updateWorkflow: vi.fn().mockResolvedValue({ id: "wf-1", name: "Updated workflow", description: "" }),
   instantiateTemplate: vi.fn().mockResolvedValue({ workflow_id: "wf-1" }),
   saveWorkflowAsTemplate: vi.fn().mockResolvedValue({ status: "ok" }),
 }));

--- a/crates/librefang-api/dashboard/src/lib/mutations/workflows.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/workflows.ts
@@ -8,6 +8,7 @@ import {
   instantiateTemplate,
   saveWorkflowAsTemplate,
 } from "../http/client";
+import type { WorkflowItem } from "../../api";
 import { workflowKeys } from "../queries/keys";
 
 function invalidateWorkflowLists(qc: ReturnType<typeof useQueryClient>) {
@@ -84,10 +85,26 @@ export function useUpdateWorkflow() {
       workflowId: string;
       payload: Parameters<typeof updateWorkflow>[1];
     }) => updateWorkflow(workflowId, payload),
-    onSuccess: (_data, variables) => Promise.all([
-      invalidateWorkflowLists(qc),
-      invalidateWorkflowRecord(qc, variables.workflowId),
-    ]),
+    onSuccess: (data, variables) => {
+      // Patch the cached workflow detail in place using the post-mutation
+      // entity returned by the handler (#3832). Falls through to invalidate
+      // as a belt-and-suspenders guard, and to cover the narrow race where
+      // the handler returned a stale fallback body. List rows can preserve
+      // shared fields (name, description, last_run, success_rate); we still
+      // invalidate the lists for safety since they may include aggregates.
+      const hasEntity =
+        data && typeof data === "object" && "id" in data && (data as WorkflowItem).id;
+      if (hasEntity) {
+        qc.setQueryData<WorkflowItem>(
+          workflowKeys.detail(variables.workflowId),
+          data as WorkflowItem,
+        );
+      }
+      return Promise.all([
+        invalidateWorkflowLists(qc),
+        invalidateWorkflowRecord(qc, variables.workflowId),
+      ]);
+    },
   });
 }
 

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -111,6 +111,38 @@ use std::sync::Arc;
 use tracing::warn;
 
 use crate::types::ApiErrorResponse;
+
+/// Render a `Workflow` into the JSON shape used by the GET handler.
+///
+/// Centralized so that mutation handlers (PUT) can return the post-mutation
+/// entity in the same shape the dashboard already consumes for GET, letting
+/// the caller patch caches in place via `setQueryData` instead of a follow-up
+/// refetch (#3832).
+fn workflow_to_json(w: &Workflow) -> serde_json::Value {
+    serde_json::json!({
+        "id": w.id.to_string(),
+        "name": w.name,
+        "description": w.description,
+        "steps": w.steps.iter().map(|s| {
+            serde_json::json!({
+                "name": s.name,
+                "agent": match &s.agent {
+                    StepAgent::ById { id } => serde_json::json!({"agent_id": id}),
+                    StepAgent::ByName { name } => serde_json::json!({"agent_name": name}),
+                },
+                "prompt_template": s.prompt_template,
+                "mode": serde_json::to_value(&s.mode).unwrap_or_default(),
+                "timeout_secs": s.timeout_secs,
+                "error_mode": serde_json::to_value(&s.error_mode).unwrap_or_default(),
+                "output_var": s.output_var,
+                "depends_on": s.depends_on,
+            })
+        }).collect::<Vec<_>>(),
+        "created_at": w.created_at.to_rfc3339(),
+        "layout": w.layout,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Helpers – parse StepMode / ErrorMode from both flat-string and nested-object
 // formats so the frontend can send either:
@@ -497,31 +529,7 @@ pub async fn get_workflow(
         .get_workflow(workflow_id)
         .await
     {
-        Some(w) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "id": w.id.to_string(),
-                "name": w.name,
-                "description": w.description,
-                "steps": w.steps.iter().map(|s| {
-                    serde_json::json!({
-                        "name": s.name,
-                        "agent": match &s.agent {
-                            StepAgent::ById { id } => serde_json::json!({"agent_id": id}),
-                            StepAgent::ByName { name } => serde_json::json!({"agent_name": name}),
-                        },
-                        "prompt_template": s.prompt_template,
-                        "mode": serde_json::to_value(&s.mode).unwrap_or_default(),
-                        "timeout_secs": s.timeout_secs,
-                        "error_mode": serde_json::to_value(&s.error_mode).unwrap_or_default(),
-                        "output_var": s.output_var,
-                        "depends_on": s.depends_on,
-                    })
-                }).collect::<Vec<_>>(),
-                "created_at": w.created_at.to_rfc3339(),
-                "layout": w.layout,
-            })),
-        ),
+        Some(w) => (StatusCode::OK, Json(workflow_to_json(&w))),
         None => {
             ApiErrorResponse::not_found(format!("Workflow '{}' not found", id)).into_json_tuple()
         }
@@ -643,19 +651,28 @@ pub async fn update_workflow(
     if !state
         .kernel
         .workflow_engine()
-        .update_workflow(workflow_id, updated)
+        .update_workflow(workflow_id, updated.clone())
         .await
     {
         return ApiErrorResponse::not_found("Workflow not found").into_json_tuple();
     }
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({
-            "status": "updated",
-            "workflow_id": id,
-        })),
-    )
+    // Return the post-mutation entity in the same shape as GET so the
+    // dashboard can `setQueryData` instead of round-tripping a refetch
+    // (#3832). Read back from the engine in case the kernel normalized
+    // anything during persist; fall back to `updated` if the row vanished
+    // between write and read (narrow race — concurrent delete) so the
+    // mutation still appears successful.
+    let body = match state
+        .kernel
+        .workflow_engine()
+        .get_workflow(workflow_id)
+        .await
+    {
+        Some(persisted) => workflow_to_json(&persisted),
+        None => workflow_to_json(&updated),
+    };
+    (StatusCode::OK, Json(body))
 }
 
 /// DELETE /api/workflows/:id — Remove a workflow.

--- a/openapi.json
+++ b/openapi.json
@@ -8129,6 +8129,7 @@
           "budget"
         ],
         "summary": "GET /api/usage — Get per-agent usage statistics.",
+        "description": "Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`\nshape used by `/api/agents`, `/api/peers`, and `/api/goals` (#3842). The\nper-agent rollup is materialized from the in-memory agent registry and\nreturned in one page — `offset=0` and `limit=None` always.",
         "operationId": "usage_stats",
         "responses": {
           "200": {


### PR DESCRIPTION
## Summary
5th slice of #3832. Migrates `PUT /api/workflows/{id}` from `{status:"updated",workflow_id}` ack envelope to returning the post-mutation `Workflow` JSON in the GET shape. Earlier slices: #4356 goals, #4360 budget agents, #4364 experiments, #4365 prompts activate.

## Before / After
- Before: `200 OK {"status":"updated","workflow_id":"42"}`
- After: `200 OK <Workflow JSON>` (same shape as `GET /api/workflows/{id}`). Falls back to the in-memory updated copy if the row vanishes between write and read.

## Files
- `crates/librefang-api/src/routes/workflows.rs` — extract `workflow_to_json` helper; PUT reads back and returns it; GET reuses helper
- `crates/librefang-api/dashboard/src/api.ts` — `updateWorkflow` returns `WorkflowItem`
- `crates/librefang-api/dashboard/src/lib/mutations/workflows.ts` — `useUpdateWorkflow` does `setQueryData` on detail cache plus invalidate
- `crates/librefang-api/dashboard/src/lib/mutations/workflows.test.tsx` — mock returns entity shape
- `openapi.json` + SDKs — regen by pre-commit hook

## Verification
- `cargo check --workspace --lib`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p librefang-api --lib workflows`: 34 passed

Refs #3832