### PR TITLE
fix(api/prompts): list endpoints return PaginatedResponse (#3842)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3254,7 +3254,12 @@ export interface ExperimentVariantMetrics {
 }
 
 export async function listPromptVersions(agentId: string): Promise<PromptVersion[]> {
-  return get<PromptVersion[]>(`/api/agents/${encodeURIComponent(agentId)}/prompts/versions`);
+  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
+  // legacy bare-array shape during the transition so older daemons keep working.
+  const data = await get<PaginatedResponse<PromptVersion> | PromptVersion[]>(
+    `/api/agents/${encodeURIComponent(agentId)}/prompts/versions`,
+  );
+  return Array.isArray(data) ? data : (data.items ?? []);
 }
 
 export async function createPromptVersion(agentId: string, version: Omit<PromptVersion, "id" | "agent_id" | "created_at" | "is_active">): Promise<PromptVersion> {
@@ -3270,7 +3275,12 @@ export async function activatePromptVersion(versionId: string, agentId: string):
 }
 
 export async function listExperiments(agentId: string): Promise<PromptExperiment[]> {
-  return get<PromptExperiment[]>(`/api/agents/${encodeURIComponent(agentId)}/prompts/experiments`);
+  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
+  // legacy bare-array shape during the transition so older daemons keep working.
+  const data = await get<PaginatedResponse<PromptExperiment> | PromptExperiment[]>(
+    `/api/agents/${encodeURIComponent(agentId)}/prompts/experiments`,
+  );
+  return Array.isArray(data) ? data : (data.items ?? []);
 }
 
 export async function createExperiment(agentId: string, experiment: Omit<PromptExperiment, "id" | "agent_id" | "created_at">): Promise<PromptExperiment> {

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -62,9 +62,6 @@ async fn list_prompt_versions(
                 .into_response()
         }
     };
-    // Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
-    // shape (#3842). Versions are returned in a single page — `offset=0` and
-    // `limit=None` always.
     match state.kernel.list_prompt_versions(agent_id) {
         Ok(versions) => {
             let total = versions.len();
@@ -167,8 +164,6 @@ async fn list_experiments(
                 .into_response()
         }
     };
-    // Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
-    // shape (#3842). Experiments are returned in a single page.
     match state.kernel.list_experiments(agent_id) {
         Ok(experiments) => {
             let total = experiments.len();

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -62,8 +62,20 @@ async fn list_prompt_versions(
                 .into_response()
         }
     };
+    // Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+    // shape (#3842). Versions are returned in a single page — `offset=0` and
+    // `limit=None` always.
     match state.kernel.list_prompt_versions(agent_id) {
-        Ok(versions) => Json(versions).into_response(),
+        Ok(versions) => {
+            let total = versions.len();
+            Json(crate::types::PaginatedResponse {
+                items: versions,
+                total,
+                offset: 0,
+                limit: None,
+            })
+            .into_response()
+        }
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()
             .into_response(),
@@ -155,8 +167,19 @@ async fn list_experiments(
                 .into_response()
         }
     };
+    // Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
+    // shape (#3842). Experiments are returned in a single page.
     match state.kernel.list_experiments(agent_id) {
-        Ok(experiments) => Json(experiments).into_response(),
+        Ok(experiments) => {
+            let total = experiments.len();
+            Json(crate::types::PaginatedResponse {
+                items: experiments,
+                total,
+                offset: 0,
+                limit: None,
+            })
+            .into_response()
+        }
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()
             .into_response(),

--- a/crates/librefang-api/tests/prompts_routes_integration.rs
+++ b/crates/librefang-api/tests/prompts_routes_integration.rs
@@ -74,7 +74,11 @@ async fn list_prompt_versions_empty_for_unknown_agent() {
     let path = format!("/api/agents/{AGENT_UUID}/prompts/versions");
     let (status, body) = json_request(&h, Method::GET, &path, None).await;
     assert_eq!(status, StatusCode::OK, "body={body:?}");
-    assert_eq!(body, serde_json::json!([]));
+    // #3842 canonical envelope.
+    assert_eq!(body["items"], serde_json::json!([]));
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["offset"], 0);
+    assert!(body.get("limit").is_some(), "limit field present: {body:?}");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -118,14 +122,15 @@ async fn create_prompt_version_round_trips_through_get_and_list() {
     let new_id = body["id"].as_str().expect("id string").to_string();
     assert_ne!(new_id, "00000000-0000-0000-0000-000000000000");
 
-    // List should now contain it.
+    // List should now contain it. #3842 canonical envelope.
     let (status, listed) = json_request(&h, Method::GET, &path, None).await;
     assert_eq!(status, StatusCode::OK);
-    let arr = listed.as_array().expect("list is array");
+    let arr = listed["items"].as_array().expect("items is array");
     assert!(
         arr.iter().any(|v| v["id"] == new_id),
         "expected new version in list: {listed:?}"
     );
+    assert_eq!(listed["total"], arr.len());
 
     // GET single should return the same record.
     let (status, fetched) = json_request(
@@ -221,7 +226,11 @@ async fn list_experiments_empty_for_unknown_agent() {
     let path = format!("/api/agents/{AGENT_UUID}/prompts/experiments");
     let (status, body) = json_request(&h, Method::GET, &path, None).await;
     assert_eq!(status, StatusCode::OK, "body={body:?}");
-    assert_eq!(body, serde_json::json!([]));
+    // #3842 canonical envelope.
+    assert_eq!(body["items"], serde_json::json!([]));
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["offset"], 0);
+    assert!(body.get("limit").is_some(), "limit field present: {body:?}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/librefang-api/tests/prompts_routes_integration.rs
+++ b/crates/librefang-api/tests/prompts_routes_integration.rs
@@ -74,7 +74,6 @@ async fn list_prompt_versions_empty_for_unknown_agent() {
     let path = format!("/api/agents/{AGENT_UUID}/prompts/versions");
     let (status, body) = json_request(&h, Method::GET, &path, None).await;
     assert_eq!(status, StatusCode::OK, "body={body:?}");
-    // #3842 canonical envelope.
     assert_eq!(body["items"], serde_json::json!([]));
     assert_eq!(body["total"], 0);
     assert_eq!(body["offset"], 0);
@@ -122,7 +121,7 @@ async fn create_prompt_version_round_trips_through_get_and_list() {
     let new_id = body["id"].as_str().expect("id string").to_string();
     assert_ne!(new_id, "00000000-0000-0000-0000-000000000000");
 
-    // List should now contain it. #3842 canonical envelope.
+    // List should now contain it.
     let (status, listed) = json_request(&h, Method::GET, &path, None).await;
     assert_eq!(status, StatusCode::OK);
     let arr = listed["items"].as_array().expect("items is array");
@@ -226,7 +225,6 @@ async fn list_experiments_empty_for_unknown_agent() {
     let path = format!("/api/agents/{AGENT_UUID}/prompts/experiments");
     let (status, body) = json_request(&h, Method::GET, &path, None).await;
     assert_eq!(status, StatusCode::OK, "body={body:?}");
-    // #3842 canonical envelope.
     assert_eq!(body["items"], serde_json::json!([]));
     assert_eq!(body["total"], 0);
     assert_eq!(body["offset"], 0);


### PR DESCRIPTION
## Summary
Migrates GET /api/agents/{id}/prompts/versions and /experiments to canonical `PaginatedResponse{items,total,offset,limit}` envelope.

Refs #3842