### PR TITLE
fix(api/plugins): list returns PaginatedResponse (#3842)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3166,8 +3166,16 @@ export interface RegistryEntry {
   plugins: RegistryPluginListing[];
 }
 
-export async function listPlugins(): Promise<{ plugins: PluginItem[]; total: number; plugins_dir: string }> {
-  return get<{ plugins: PluginItem[]; total: number; plugins_dir: string }>("/api/plugins");
+export async function listPlugins(): Promise<PluginItem[]> {
+  // #3842: canonical envelope is `{items,total,offset,limit}`. Tolerate the
+  // legacy `{plugins,total,plugins_dir}` shape during the transition so older
+  // daemons keep working.
+  const data = await get<{
+    items?: PluginItem[];
+    plugins?: PluginItem[];
+    total?: number;
+  }>("/api/plugins");
+  return data.items ?? data.plugins ?? [];
 }
 
 export async function getPlugin(name: string): Promise<PluginItem> {

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -75,7 +75,7 @@ export function PluginsPage() {
   const scaffoldMutation = useScaffoldPlugin();
   const depsMutation = useInstallPluginDeps();
 
-  const plugins = pluginsQuery.data?.plugins ?? EMPTY_PLUGINS;
+  const plugins = pluginsQuery.data ?? EMPTY_PLUGINS;
 
   // First-time visitors with nothing installed land on the marketplace
   // tab — installing from the registry is the obvious next step. Fires

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -243,11 +243,19 @@ pub async fn list_plugins(
         })
         .collect();
 
-    Json(serde_json::json!({
-        "plugins": items,
-        "total": items.len(),
-        "plugins_dir": librefang_runtime::plugin_manager::plugins_dir().display().to_string(),
-    }))
+    // #3842: canonical `PaginatedResponse{items,total,offset,limit}` envelope.
+    // Plugin list is materialized in one shot from the on-disk plugin manager,
+    // so offset=0 / limit=None. The previous shape carried a `plugins_dir`
+    // field — no caller in the dashboard or SDK reads it, and it doesn't
+    // belong on a list envelope. If a UI ever needs the plugins directory
+    // path, expose it via a separate config/info endpoint.
+    let total = items.len();
+    Json(crate::types::PaginatedResponse {
+        items,
+        total,
+        offset: 0,
+        limit: None,
+    })
 }
 
 /// GET /api/plugins/:name — Get details of a specific plugin.

--- a/crates/librefang-api/tests/plugins_routes_integration.rs
+++ b/crates/librefang-api/tests/plugins_routes_integration.rs
@@ -291,17 +291,18 @@ async fn context_engine_get_trace_by_id_rejects_malformed_id() {
 // /api/plugins read endpoints — 404 for unknown plugin names
 // ---------------------------------------------------------------------------
 
-/// `/api/plugins` always responds with a JSON envelope (`plugins`, `total`,
-/// `plugins_dir`). Even if the developer happens to have plugins on disk,
-/// the shape must match.
+/// `/api/plugins` always responds with the canonical
+/// `PaginatedResponse{items,total,offset,limit}` envelope (#3842). Even if
+/// the developer happens to have plugins on disk, the shape must match.
 #[tokio::test(flavor = "multi_thread")]
 async fn list_plugins_returns_envelope_shape() {
     let h = boot();
     let (status, body) = json_request(&h, Method::GET, "/api/plugins", None).await;
     assert_eq!(status, StatusCode::OK, "{body:?}");
-    assert!(body["plugins"].is_array(), "{body:?}");
+    assert!(body["items"].is_array(), "{body:?}");
     assert!(body["total"].is_number(), "{body:?}");
-    assert!(body["plugins_dir"].is_string(), "{body:?}");
+    assert_eq!(body["offset"], 0, "{body:?}");
+    assert!(body.get("limit").is_some(), "{body:?}");
 }
 
 /// `/api/plugins/{name}` returns 404 for an unknown plugin.


### PR DESCRIPTION
## Summary
- Migrate `GET /api/plugins` from non-canonical `{plugins, total, plugins_dir}` to canonical `PaginatedResponse{items, total, offset, limit}` (offset=0, limit=None — list is loaded in one shot from the on-disk plugin manager).
- Drop `plugins_dir` from the list envelope. No caller in the dashboard or SDK reads it, and it doesn't belong on a list response. If a UI needs the plugins directory path, expose it via a dedicated config/info endpoint.
- Update dashboard `listPlugins` to return the bare `PluginItem[]` (mirrors `listWorkflows` from #4363), tolerating the legacy `{plugins}` shape during the transition so older daemons keep working.
- Update `PluginsPage` consumer (was `pluginsQuery.data?.plugins`, now `pluginsQuery.data`).
- Update integration test `list_plugins_returns_envelope_shape` to assert the new envelope.

Before:
```
{ "plugins": [...], "total": N, "plugins_dir": "/path" }
```
After:
```
{ "items": [...], "total": N, "offset": 0, "limit": null }
```

Refs #3842

## Test plan
- [x] `cargo check -p librefang-api --lib`
- [x] `cargo clippy -p librefang-api --lib --tests -- -D warnings` (clean)
- [ ] CI runs `cargo test -p librefang-api --test plugins_routes_integration` — local run blocked by disk-full on the worktree's `target/`; the test now matches the migrated shape.