### PR TITLE
fix(api/agents): return live tools config from PUT /api/agents/{id}/tools (#3832)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.test.ts
+++ b/crates/librefang-api/dashboard/src/api.test.ts
@@ -202,15 +202,30 @@ describe("dashboard auth helpers", () => {
   it("updateAgentTools sends both allowlist and blocklist", async () => {
     setApiKey("secret-token");
     fetchMock.mockResolvedValue(
-      new Response(JSON.stringify({ status: "ok" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+      new Response(
+        JSON.stringify({
+          capabilities_tools: ["bash"],
+          tool_allowlist: ["bash", "webfetch"],
+          tool_blocklist: ["rm"],
+          disabled: false,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
     );
 
-    await updateAgentTools("agent-123", {
+    await expect(
+      updateAgentTools("agent-123", {
+        tool_allowlist: ["bash", "webfetch"],
+        tool_blocklist: ["rm"],
+      }),
+    ).resolves.toEqual({
+      capabilities_tools: ["bash"],
       tool_allowlist: ["bash", "webfetch"],
       tool_blocklist: ["rm"],
+      disabled: false,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1313,8 +1313,8 @@ export async function getAgentTools(agentId: string): Promise<AgentToolsResponse
   return get<AgentToolsResponse>(`/api/agents/${encodeURIComponent(agentId)}/tools`);
 }
 
-export async function updateAgentTools(agentId: string, payload: { capabilities_tools?: string[]; tool_allowlist?: string[]; tool_blocklist?: string[] }): Promise<ApiActionResponse> {
-  return put<ApiActionResponse>(`/api/agents/${encodeURIComponent(agentId)}/tools`, payload);
+export async function updateAgentTools(agentId: string, payload: { capabilities_tools?: string[]; tool_allowlist?: string[]; tool_blocklist?: string[] }): Promise<AgentToolsResponse> {
+  return put<AgentToolsResponse>(`/api/agents/${encodeURIComponent(agentId)}/tools`, payload);
 }
 
 export async function listAgents(

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -3792,7 +3792,23 @@ pub async fn set_agent_tools(
         body.tool_allowlist,
         body.tool_blocklist,
     ) {
-        Ok(()) => (StatusCode::OK, Json(serde_json::json!({"status": "ok"}))),
+        // Read the agent back so the dashboard can `setQueryData` directly
+        // instead of refetching. Returns the same shape as `GET /api/agents/{id}/tools`.
+        // If the registry entry vanished between the write and read (extremely
+        // unlikely — would mean the agent was deleted mid-PUT) fall back to a
+        // 200 ack so existing clients don't crash on the missing body.
+        Ok(()) => match state.kernel.agent_registry().get(agent_id) {
+            Some(entry) => (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "capabilities_tools": entry.manifest.capabilities.tools,
+                    "tool_allowlist": entry.manifest.tool_allowlist,
+                    "tool_blocklist": entry.manifest.tool_blocklist,
+                    "disabled": entry.manifest.tools_disabled,
+                })),
+            ),
+            None => (StatusCode::OK, Json(serde_json::json!({"status": "ok"}))),
+        },
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(


### PR DESCRIPTION
## Summary
7th slice of #3832. Migrates the agent tools update mutation from ack envelope to returning live tools config.

Refs #3832