### PR TITLE
refactor(api/system): drop ApprovalManager static calls in TOTP setup (#3744)

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -2733,20 +2733,20 @@ pub async fn totp_setup(
         );
     }
 
-    let (secret_base32, otpauth_uri, qr_base64) =
-        match librefang_kernel::approval::ApprovalManager::generate_totp_secret(
-            &totp_issuer,
-            "admin",
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                return ApiErrorResponse::internal(e).into_json_tuple();
-            }
-        };
+    let (secret_base32, otpauth_uri, qr_base64) = match state
+        .kernel
+        .approvals()
+        .new_totp_secret(&totp_issuer, "admin")
+    {
+        Ok(v) => v,
+        Err(e) => {
+            return ApiErrorResponse::internal(e).into_json_tuple();
+        }
+    };
     let qr_data_uri = format!("data:image/png;base64,{qr_base64}");
 
     // Generate recovery codes
-    let recovery_codes = librefang_kernel::approval::ApprovalManager::generate_recovery_codes();
+    let recovery_codes = state.kernel.approvals().new_recovery_codes();
     let recovery_json = serde_json::to_string(&recovery_codes).unwrap_or_default();
 
     // Store secret and recovery codes in vault (not yet active — totp_confirmed = false)

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -1017,6 +1017,28 @@ impl ApprovalManager {
         Ok(totp.check_current(code).unwrap_or(false))
     }
 
+    /// Instance-method wrapper around the static `generate_totp_secret`.
+    ///
+    /// Lets API-layer callers go through `kernel.approvals().new_totp_secret(...)`
+    /// without importing `librefang_kernel::approval::ApprovalManager` directly
+    /// (see #3744 — the API crate should not reach into kernel-internal types).
+    /// The static method is retained for callers that already have it imported
+    /// and for symmetry with `verify_totp_code_with_issuer`.
+    pub fn new_totp_secret(
+        &self,
+        issuer: &str,
+        account: &str,
+    ) -> Result<(String, String, String), String> {
+        Self::generate_totp_secret(issuer, account)
+    }
+
+    /// Instance-method wrapper around the static `generate_recovery_codes`.
+    ///
+    /// See `new_totp_secret` for the rationale (#3744).
+    pub fn new_recovery_codes(&self) -> Vec<String> {
+        Self::generate_recovery_codes()
+    }
+
     /// Generate a new TOTP secret and return (base32_secret, otpauth_uri, qr_base64_png).
     pub fn generate_totp_secret(
         issuer: &str,
@@ -2655,6 +2677,29 @@ mod tests {
     fn test_verify_totp_code_invalid_secret() {
         let result = ApprovalManager::verify_totp_code("not-valid-base32!!!", "123456");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_instance_totp_wrappers_match_static_helpers() {
+        // The instance-method wrappers added for #3744 must produce shapes
+        // equivalent to the static helpers so the API layer can switch over
+        // without behavior changes. Secrets are random so we compare shape,
+        // not bytes.
+        let mgr = make_manager_with_db();
+        let (secret, uri, qr) = mgr.new_totp_secret("LibreFang", "admin").unwrap();
+        assert!(!secret.is_empty());
+        assert!(uri.starts_with("otpauth://totp/"));
+        assert!(uri.contains("LibreFang"));
+        assert!(!qr.is_empty());
+
+        let codes = mgr.new_recovery_codes();
+        let static_codes = ApprovalManager::generate_recovery_codes();
+        assert_eq!(codes.len(), static_codes.len());
+        for c in &codes {
+            // Same XXXX-XXXX-XXXX-XXXX hex shape as the static helper.
+            assert_eq!(c.len(), 19);
+            assert_eq!(c.matches('-').count(), 3);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Refs #3744 (4-of-many).

`crates/librefang-api/src/routes/system.rs` reaches into kernel internals via `librefang_kernel::approval::ApprovalManager::generate_totp_secret` and `::generate_recovery_codes` inside the TOTP setup handler. This PR migrates those two static call sites to instance-method wrappers on `ApprovalManager` accessed through the kernel handle (`state.kernel.approvals().new_totp_secret(...)` / `.new_recovery_codes()`), matching the pattern established in #4391 for `verify_totp`.

- `crates/librefang-kernel/src/approval.rs` — adds two thin instance wrappers (`new_totp_secret`, `new_recovery_codes`) that delegate to the existing static helpers. Static helpers retained for back-compat.
- `crates/librefang-api/src/routes/system.rs` — totp_setup handler now goes through `state.kernel.approvals()` instead of the `librefang_kernel::approval` module path.
- Regression test `test_instance_totp_wrappers_match_static_helpers` asserts shape parity.

Other `librefang_kernel::approval::ApprovalManager::*` static calls in `system.rs` (verify_totp, is_recovery_code_format) remain — slated for follow-up slices.

## Test plan
- [x] `cargo check -p librefang-api --lib` clean
- [x] `cargo clippy -p librefang-kernel -p librefang-api --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-kernel --lib approval::tests::test_instance_totp_wrappers_match_static_helpers` passes
- [ ] Live integration: human verifies `POST /api/approvals/totp/setup` still returns secret + qr_data_uri + recovery codes