### PR TITLE
refactor(api/inbox): wrap inbox_status behind kernel method (#3744)

### DIFF
--- a/crates/librefang-api/src/routes/inbox.rs
+++ b/crates/librefang-api/src/routes/inbox.rs
@@ -21,7 +21,6 @@ pub fn router() -> axum::Router<Arc<AppState>> {
     )
 )]
 pub async fn inbox_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let cfg = state.kernel.config_ref();
-    let status = librefang_kernel::inbox::inbox_status(&cfg.inbox, state.kernel.home_dir());
+    let status = state.kernel.inbox_status();
     Json(serde_json::json!(status))
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1060,6 +1060,15 @@ impl LibreFangKernel {
         &self.home_dir_boot
     }
 
+    /// Snapshot the inbox subsystem's status (config + on-disk file counts).
+    ///
+    /// Provided as a kernel-surface method so API callers do not need to reach
+    /// into the `librefang_kernel::inbox` module directly. See issue #3744.
+    pub fn inbox_status(&self) -> crate::inbox::InboxStatus {
+        let cfg = self.config_ref();
+        crate::inbox::inbox_status(&cfg.inbox, self.home_dir())
+    }
+
     /// Build the roots list for a specific MCP server config.
     ///
     /// Starts with the default roots (workspaces directory) and, for stdio


### PR DESCRIPTION
## Summary
Fifth scoped slice of #3744 — remove a direct `librefang_kernel::*` non-trait import from `librefang-api`.

- `crates/librefang-api/src/routes/inbox.rs` previously called `librefang_kernel::inbox::inbox_status(&cfg.inbox, state.kernel.home_dir())`, reaching into the kernel's `inbox` submodule.
- Added `LibreFangKernel::inbox_status()` which owns the config-ref + home-dir lookup and returns `inbox::InboxStatus`.
- Route handler now goes through that single kernel method, with no `librefang_kernel::inbox::*` reference left in the API crate.

## Verification
- `cargo check -p librefang-kernel -p librefang-api --lib` clean
- `cargo clippy -p librefang-kernel -p librefang-api --all-targets -- -D warnings` clean

Refs #3744 (5-of-many; follows #4386, #4390, #4391, #4394).