### PR TITLE
test(api): un-ignore load_concurrent_agent_spawns and load_spawn_kill_cycle

### DIFF
--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -126,9 +126,6 @@ memory_write = ["self.*"]
 
 /// Test: Concurrent agent spawns — verify kernel handles parallel agent creation.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Flaky: concurrent spawn race in AgentRegistry — registry lock contention causes \
-            intermittent 409/500 under load. Root cause: #3817 (concurrent agent lifecycle \
-            races). Un-ignore after registry spawn serialization is fixed."]
 async fn load_concurrent_agent_spawns() {
     let server = start_test_server().await;
     let client = librefang_runtime::http_client::new_client();
@@ -493,10 +490,6 @@ async fn load_workflow_operations() {
 
 /// Test: Agent spawn + kill cycle — stress the registry.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Flaky: spawn/kill race in AgentRegistry — kill sometimes races with post-spawn \
-            initialization leaving dangling registry entries that fail the final count assert. \
-            Root cause: #3817 (concurrent agent lifecycle races). Un-ignore after kill-during-init \
-            guard is implemented."]
 async fn load_spawn_kill_cycle() {
     let server = start_test_server().await;
     let client = librefang_runtime::http_client::new_client();


### PR DESCRIPTION
## Summary

Stacked on top of #4393. Removes the two `#[ignore]` markers in
`crates/librefang-api/tests/load_test.rs` (lines 128 and 495). After
#4393's `AgentRegistry` publish-order fix, both tests pass
deterministically — the SQLite write-contention concern called out in
#4393's scope note did not materialize at this load level.

## Findings

- 5/5 isolated runs of just the two tests: green (~1.8s each).
- Full `load_test.rs` suite (7 tests, multi-threaded): green.
- Concurrent spawn: 20/20 succeed in ~10ms. Spawn+kill: 10 cycles in ~31ms.
- No lock timeout, no `database is locked`, no count-assert failures observed.

The architectural SQLite rewrite tracked in #3378 is therefore not a
prerequisite for closing #3338's "un-ignore both tests" acceptance
criterion. If contention does emerge at higher concurrency (>20) it
should be tracked under #3378 with its own reproducer.

## Test plan
- [x] `cargo test -p librefang-api --test load_test -- load_concurrent_agent_spawns load_spawn_kill_cycle` — 5/5 stable.
- [x] `cargo test -p librefang-api --test load_test` — all 7 pass.
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean.
- [ ] CI on PR.

Closes #3338 (combined with #4393).