### PR TITLE
refactor(api/channels): drop kernel dep for librefang_home() lookup (#3744)

### DIFF
--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -43,9 +43,24 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::types::ApiErrorResponse;
+
+/// Resolve the LibreFang home directory without depending on the kernel crate.
+///
+/// Mirrors `librefang_kernel::config::librefang_home`:
+/// `LIBREFANG_HOME` env var takes priority, otherwise `~/.librefang`
+/// (falling back to the system temp dir if no home directory is available).
+fn librefang_home() -> PathBuf {
+    if let Ok(home) = std::env::var("LIBREFANG_HOME") {
+        return PathBuf::from(home);
+    }
+    dirs::home_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join(".librefang")
+}
 // ---------------------------------------------------------------------------
 // Channel status endpoints — data-driven registry for all 40 adapters
 // ---------------------------------------------------------------------------
@@ -1380,7 +1395,7 @@ pub async fn configure_channel(
         None => return ApiErrorResponse::bad_request("Missing 'fields' object").into_json_tuple(),
     };
 
-    let home = librefang_kernel::config::librefang_home();
+    let home = librefang_home();
     let secrets_path = home.join("secrets.env");
     let config_path = home.join("config.toml");
     let mut config_fields: HashMap<String, (String, FieldType)> = HashMap::new();
@@ -1500,7 +1515,7 @@ pub async fn remove_channel(
         None => return ApiErrorResponse::not_found("Unknown channel").into_json_tuple(),
     };
 
-    let home = librefang_kernel::config::librefang_home();
+    let home = librefang_home();
     let secrets_path = home.join("secrets.env");
     let config_path = home.join("config.toml");
 


### PR DESCRIPTION
## Summary
9th narrow slice of #3744. Channels handler dropped a kernel-internal call.

Refs #3744