### PR TITLE
refactor(api/system): drop ApprovalManager static is_recovery_code_format calls (#3744)

### DIFF
--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -230,12 +230,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
-// TOTP helpers
-// ---------------------------------------------------------------------------
-
-use librefang_kernel::approval::ApprovalManager;
-
-// ---------------------------------------------------------------------------
 // Profile + Mode endpoints
 // ---------------------------------------------------------------------------
 
@@ -1889,7 +1883,7 @@ pub async fn approve_request(
         }
         match body.totp_code.as_deref() {
             Some(code) => {
-                if ApprovalManager::is_recovery_code_format(code) {
+                if state.kernel.approvals().recovery_code_format_matches(code) {
                     // Atomically redeem the recovery code (fixes TOCTOU #3560
                     // and vault_set-failure bypass #3633).
                     match state.kernel.vault_redeem_recovery_code(code) {
@@ -2638,7 +2632,7 @@ pub async fn totp_setup(
                 .into_json_tuple();
             }
             Some(code) => {
-                let verified = if ApprovalManager::is_recovery_code_format(code) {
+                let verified = if state.kernel.approvals().recovery_code_format_matches(code) {
                     // Atomically redeem the recovery code (fixes TOCTOU #3560 / #3633).
                     match state.kernel.vault_redeem_recovery_code(code) {
                         Ok(matched) => matched,
@@ -2927,7 +2921,11 @@ pub async fn totp_revoke(
     // Verify the provided code (recovery codes are consumed on use).
     // For recovery codes, use the atomic vault_redeem_recovery_code path
     // (fixes TOCTOU #3560 and vault_set-failure bypass #3633).
-    let verified = if ApprovalManager::is_recovery_code_format(&body.code) {
+    let verified = if state
+        .kernel
+        .approvals()
+        .recovery_code_format_matches(&body.code)
+    {
         match state.kernel.vault_redeem_recovery_code(&body.code) {
             Ok(matched) => matched,
             Err(e) => {

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -1066,6 +1066,16 @@ impl ApprovalManager {
             .collect()
     }
 
+    /// Instance wrapper around [`Self::is_recovery_code_format`].
+    ///
+    /// Lets callers go through `state.kernel.approvals().recovery_code_format_matches(code)`
+    /// instead of importing `librefang_kernel::approval::ApprovalManager` directly,
+    /// preserving the `KernelHandle`-style boundary tracked in #3744. The static
+    /// helper is retained for back-compat with existing in-kernel callers.
+    pub fn recovery_code_format_matches(&self, code: &str) -> bool {
+        Self::is_recovery_code_format(code)
+    }
+
     /// Check if a string matches any supported recovery code format.
     ///
     /// Accepts both:
@@ -3438,5 +3448,31 @@ mod tests {
             s, TOTP_MAX_FAILURES,
             "exactly {TOTP_MAX_FAILURES} calls should succeed before lockout, got {s}"
         );
+    }
+
+    /// `recovery_code_format_matches` instance wrapper must agree with the
+    /// static `is_recovery_code_format` helper across new + old + invalid
+    /// formats. Lets `librefang-api` route handlers go through
+    /// `state.kernel.approvals()` instead of importing
+    /// `librefang_kernel::approval::ApprovalManager` directly (#3744).
+    #[test]
+    fn recovery_code_format_matches_agrees_with_static_helper() {
+        let m = ApprovalManager::new(ApprovalPolicy::default());
+        let cases = [
+            "abcd-ef01-2345-6789", // new format, valid hex
+            "ABCD-EF01-2345-6789", // new format, uppercase hex
+            "1234-5678",           // old format, valid digits
+            "abcd-efgh-2345-6789", // new format, invalid (g/h not hex)
+            "12345-6789",          // wrong dash position
+            "",                    // empty
+            "not-a-code",          // garbage
+        ];
+        for c in cases {
+            assert_eq!(
+                m.recovery_code_format_matches(c),
+                ApprovalManager::is_recovery_code_format(c),
+                "instance wrapper must mirror static helper for input {c:?}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
Refs #3744 (7-of-many).

`crates/librefang-api/src/routes/system.rs` reaches into kernel internals via `librefang_kernel::approval::ApprovalManager::is_recovery_code_format` at three TOTP-verification handler call sites. This PR migrates them to an instance-method wrapper accessed through the existing kernel handle (`state.kernel.approvals().recovery_code_format_matches(code)`), matching the pattern established in #4391 (verify_totp) and #4394 (TOTP setup). The now-unused top-level `use librefang_kernel::approval::ApprovalManager` import is removed.

- `crates/librefang-kernel/src/approval.rs` — adds `recovery_code_format_matches(&self, code: &str) -> bool` delegating to the existing static helper. Static helper is retained for in-kernel callers.
- `crates/librefang-api/src/routes/system.rs` — rewrites the three call sites in `request_approval`, `totp_enroll`, and `totp_confirm` flows.
- Regression test `approval::tests::recovery_code_format_matches_agrees_with_static_helper` asserts shape parity across new-format hex, old-format digits, and invalid inputs.

Other `librefang_kernel::approval::ApprovalManager::*` calls in `system.rs` (`verify_totp_code_with_issuer`, `generate_totp_secret`, `generate_recovery_codes`) are tracked by sibling PRs / follow-up slices.

## Test plan
- [x] `cargo check -p librefang-kernel -p librefang-api --lib` clean
- [x] `cargo clippy -p librefang-kernel -p librefang-api --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-kernel --lib approval::tests::recovery_code_format_matches_agrees_with_static_helper` passes
- [ ] Live integration: human verifies `POST /api/approvals/{id}/approve` with a recovery code still redeems and unblocks the approval