### PR TITLE
refactor(api/channel_bridge): drop ApprovalManager static calls in TOTP verify (#3744)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -7,7 +7,6 @@ use librefang_channels::bridge::{BridgeManager, ChannelBridgeHandle};
 use librefang_channels::router::AgentRouter;
 use librefang_channels::sidecar::SidecarAdapter;
 use librefang_channels::types::{ChannelAdapter, SenderContext};
-use librefang_kernel::approval::ApprovalManager;
 
 /// Sanitize LLM/driver errors into user-friendly messages for channel delivery.
 ///
@@ -1521,7 +1520,9 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                         return "Too many failed TOTP attempts. Try again later.".into();
                     }
                     match totp_code {
-                        Some(code) if ApprovalManager::is_recovery_code_format(code) => {
+                        Some(code)
+                            if self.kernel.approvals().recovery_code_format_matches(code) =>
+                        {
                             // Atomic redeem: read + verify + consume under
                             // the kernel's recovery-code mutex.  The
                             // earlier vault_get → verify → vault_set
@@ -1568,7 +1569,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                                 None => return "TOTP not configured. Set up TOTP first.".into(),
                             };
                             let totp_issuer = self.kernel.approvals().policy().totp_issuer.clone();
-                            match librefang_kernel::approval::ApprovalManager::verify_totp_code_with_issuer(
+                            match self.kernel.approvals().verify_totp_with_issuer(
                                 &secret,
                                 code,
                                 &totp_issuer,

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -1032,6 +1032,22 @@ impl ApprovalManager {
         Ok(totp.check_current(code).unwrap_or(false))
     }
 
+    /// Instance wrapper around [`Self::verify_totp_code_with_issuer`].
+    ///
+    /// Lets callers go through `kernel.approvals().verify_totp_with_issuer(...)`
+    /// instead of importing `librefang_kernel::approval::ApprovalManager`
+    /// directly (see #3744 — the API crate should not reach into kernel
+    /// internals). The static helper is retained for back-compat with
+    /// existing in-kernel callers.
+    pub fn verify_totp_with_issuer(
+        &self,
+        secret_base32: &str,
+        code: &str,
+        issuer: &str,
+    ) -> Result<bool, String> {
+        Self::verify_totp_code_with_issuer(secret_base32, code, issuer)
+    }
+
     /// Instance-method wrapper around the static `generate_totp_secret`.
     ///
     /// Lets API-layer callers go through `kernel.approvals().new_totp_secret(...)`
@@ -3549,5 +3565,31 @@ mod tests {
                 "instance wrapper must mirror static helper for input {c:?}",
             );
         }
+    }
+
+    /// `verify_totp_with_issuer` instance wrapper must agree with the static
+    /// `verify_totp_code_with_issuer` helper for valid + invalid codes and
+    /// for malformed secrets. Lets `librefang-api::channel_bridge` go through
+    /// `kernel.approvals()` instead of importing `ApprovalManager` (#3744).
+    #[test]
+    fn verify_totp_with_issuer_matches_static_helper() {
+        let (secret, _uri, _qr) =
+            ApprovalManager::generate_totp_secret("LibreFang", "test@example.com")
+                .expect("secret generation");
+        let mgr = ApprovalManager::new(ApprovalPolicy::default());
+
+        // Wrong code: both forms must return Ok(false).
+        let static_res =
+            ApprovalManager::verify_totp_code_with_issuer(&secret, "000000", "LibreFang");
+        let instance_res = mgr.verify_totp_with_issuer(&secret, "000000", "LibreFang");
+        assert_eq!(static_res, instance_res);
+        assert_eq!(instance_res, Ok(false));
+
+        // Malformed secret: both forms must return the same Err.
+        let static_err =
+            ApprovalManager::verify_totp_code_with_issuer("not-base32!!", "123456", "LibreFang");
+        let instance_err = mgr.verify_totp_with_issuer("not-base32!!", "123456", "LibreFang");
+        assert!(static_err.is_err());
+        assert_eq!(static_err, instance_err);
     }
 }


### PR DESCRIPTION
## Summary
- Channel-bridge approval handling in `crates/librefang-api/src/channel_bridge.rs` imports `librefang_kernel::approval::ApprovalManager` and reaches into kernel internals via `ApprovalManager::is_recovery_code_format` and `ApprovalManager::verify_totp_code_with_issuer` for the channel-message TOTP path. This slice migrates both call sites to thin instance wrappers on the existing kernel handle, matching the pattern from #4391 / #4394 / #4404.
- Adds `ApprovalManager::verify_totp_with_issuer` instance method (delegating to the existing static helper) plus a regression test asserting parity for invalid codes and malformed secrets.
- `recovery_code_format_matches` already landed in #4404 and is reused here.

Refs #3744 (11-of-many).

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy -p librefang-kernel -p librefang-api --all-targets -- -D warnings`
- [ ] CI runs full workspace build / test