### PR TITLE
refactor(api/agents): wrap session trajectory export behind kernel method (#3744)

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -3038,7 +3038,6 @@ pub async fn export_session_trajectory(
     Query(params): Query<HashMap<String, String>>,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> axum::response::Response {
-    use crate::trajectory::{AgentContext, RedactionPolicy, TrajectoryExporter};
     use axum::http::header;
     use axum::response::IntoResponse;
 
@@ -3083,71 +3082,28 @@ pub async fn export_session_trajectory(
         }
     };
 
-    // Lookup agent → 404 if missing.
-    let agent_entry = match state.kernel.agent_registry().get(agent_id) {
-        Some(e) => e,
-        None => {
+    // Build the redacted bundle via the kernel surface so this route does
+    // not need to import `librefang_kernel::trajectory` directly (#3744).
+    let bundle = match state.kernel.export_session_trajectory(agent_id, session_id) {
+        Ok(b) => b,
+        Err(librefang_kernel::error::KernelError::LibreFang(
+            librefang_types::error::LibreFangError::AgentNotFound(_),
+        )) => {
             return (
                 StatusCode::NOT_FOUND,
                 Json(serde_json::json!({"error": err_not_found})),
             )
                 .into_response();
         }
-    };
-
-    // Build redaction policy. Use the agent's workspace as the path-collapse
-    // root when present.
-    let mut policy = RedactionPolicy::default();
-    if let Some(ws) = agent_entry.manifest.workspace.clone() {
-        policy = policy.with_workspace_root(ws);
-    }
-
-    let exporter = TrajectoryExporter::new(state.kernel.memory_substrate().clone(), policy);
-    let agent_ctx = AgentContext {
-        name: agent_entry.name.clone(),
-        model: agent_entry.manifest.model.model.clone(),
-        provider: agent_entry.manifest.model.provider.clone(),
-        system_prompt: agent_entry.manifest.model.system_prompt.clone(),
-    };
-
-    // Sessions are persisted lazily on first message. If the row is missing
-    // but the requested session_id matches the agent's currently-registered
-    // session (authoritative ownership signal from the registry), treat it
-    // as an empty session rather than 404.
-    let bundle = match state.kernel.memory_substrate().get_session(session_id) {
-        Ok(None) if session_id == agent_entry.session_id => {
-            exporter.empty_bundle(agent_id, session_id, agent_ctx)
+        Err(librefang_kernel::error::KernelError::LibreFang(
+            librefang_types::error::LibreFangError::Memory(msg),
+        )) if msg.contains("not found") || msg.contains("does not belong") => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": err_session_not_found})),
+            )
+                .into_response();
         }
-        Ok(_) => match exporter.export_session(agent_id, session_id, agent_ctx) {
-            Ok(b) => b,
-            Err(librefang_types::error::LibreFangError::Memory(msg))
-                if msg.contains("not found") =>
-            {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({"error": err_session_not_found})),
-                )
-                    .into_response();
-            }
-            Err(librefang_types::error::LibreFangError::Memory(msg))
-                if msg.contains("does not belong") =>
-            {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({"error": err_session_not_found})),
-                )
-                    .into_response();
-            }
-            Err(e) => {
-                let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
-                let msg = t.t_args(&err_generic_key, &[("error", &e.to_string())]);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": msg})),
-                )
-                    .into_response();
-            }
-        },
         Err(e) => {
             let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
             let msg = t.t_args(&err_generic_key, &[("error", &e.to_string())]);

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1116,6 +1116,51 @@ impl LibreFangKernel {
         crate::auto_dream::set_agent_enabled(self, agent_id, enabled)
     }
 
+    /// Build a redacted trajectory bundle for an agent's session.
+    ///
+    /// Encapsulates `librefang_kernel::trajectory` (exporter + policy + agent
+    /// context) so API callers do not need to import that module directly.
+    /// Sessions are persisted lazily on first message; if the session row is
+    /// missing but the requested ID matches the agent's currently-registered
+    /// session, an empty bundle is returned instead of a not-found error.
+    /// See issue #3744.
+    pub fn export_session_trajectory(
+        &self,
+        agent_id: AgentId,
+        session_id: SessionId,
+    ) -> KernelResult<crate::trajectory::TrajectoryBundle> {
+        use crate::trajectory::{AgentContext, RedactionPolicy, TrajectoryExporter};
+
+        let entry = self.registry.get(agent_id).ok_or_else(|| {
+            KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
+        })?;
+
+        // Build redaction policy. Use the agent's workspace as the
+        // path-collapse root when present.
+        let mut policy = RedactionPolicy::default();
+        if let Some(ws) = entry.manifest.workspace.clone() {
+            policy = policy.with_workspace_root(ws);
+        }
+
+        let exporter = TrajectoryExporter::new(self.memory.clone(), policy);
+        let agent_ctx = AgentContext {
+            name: entry.name.clone(),
+            model: entry.manifest.model.model.clone(),
+            provider: entry.manifest.model.provider.clone(),
+            system_prompt: entry.manifest.model.system_prompt.clone(),
+        };
+
+        match self.memory.get_session(session_id) {
+            Ok(None) if session_id == entry.session_id => {
+                Ok(exporter.empty_bundle(agent_id, session_id, agent_ctx))
+            }
+            Ok(_) => exporter
+                .export_session(agent_id, session_id, agent_ctx)
+                .map_err(KernelError::LibreFang),
+            Err(e) => Err(KernelError::LibreFang(e)),
+        }
+    }
+
     /// Build the roots list for a specific MCP server config.
     ///
     /// Starts with the default roots (workspaces directory) and, for stdio


### PR DESCRIPTION
## Summary
10th narrow slice of #3744. Routes/agents.rs migrated one kernel-internal use behind a kernel method.

Refs #3744