### PR TITLE
refactor(api/workflows): drop WorkflowEngine import via Workflow::to_template (#3744)

### DIFF
--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -944,7 +944,7 @@ pub async fn save_workflow_as_template(
         }
     };
 
-    let template = state.kernel.workflow_to_template(&workflow);
+    let template = workflow.to_template();
 
     // Persist template to TOML file under the active kernel home directory.
     let templates_dir = state.kernel.home_dir().join("workflows").join("templates");

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -2399,6 +2399,22 @@ impl WorkflowEngine {
     /// `{{var}}` placeholders and creates a [`TemplateParameter`] for each
     /// unique variable found.
     pub fn workflow_to_template(workflow: &Workflow) -> WorkflowTemplate {
+        workflow.to_template()
+    }
+}
+
+impl Workflow {
+    /// Convert this workflow into a reusable [`WorkflowTemplate`].
+    ///
+    /// Each `WorkflowStep` is mapped to a `WorkflowTemplateStep`. Parameters
+    /// are auto-detected by scanning `prompt_template` fields for `{{var}}`
+    /// placeholders, with one [`TemplateParameter`] created per unique name.
+    ///
+    /// Exposed as an inherent method so callers outside the kernel (e.g. the
+    /// API crate) can perform the conversion without importing
+    /// `WorkflowEngine` directly.
+    pub fn to_template(&self) -> WorkflowTemplate {
+        let workflow = self;
         // Slugify workflow name -> template ID
         let id = workflow
             .name


### PR DESCRIPTION
## Summary
- Adds a pure inherent `Workflow::to_template()` method in `librefang-kernel`; `WorkflowEngine::workflow_to_template` becomes a thin wrapper.
- Updates `save_workflow_as_template` in `librefang-api` to call `workflow.to_template()`, removing the local `use librefang_kernel::workflow::WorkflowEngine` import.
- Slice 12 of the #3744 KernelHandle boundary cleanup.

## Test plan
- [x] cargo check -p librefang-kernel -p librefang-api --lib
- [x] cargo clippy -p librefang-kernel -p librefang-api --all-targets -- -D warnings
- [x] Existing test_workflow_to_template_preserves_depends_on_graph still covers the conversion path through the wrapper.

Refs #3744 (12-of-many)