### PR TITLE
refactor(api): re-export UserRole through middleware boundary

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -10,6 +10,11 @@
 use axum::body::Body;
 use axum::http::{Request, Response, StatusCode};
 use axum::middleware::Next;
+// Re-export `UserRole` through the api-layer auth boundary so that route
+// modules (and tests) don't need to reach into `librefang_kernel::auth`
+// directly. This keeps the `librefang-api` <-> `librefang-kernel` import
+// surface narrow per issue #3744 — the underlying type still lives in the
+// kernel; only the import path is centralized here.
 pub use librefang_kernel::auth::UserRole;
 use librefang_types::agent::UserId;
 use librefang_types::i18n;

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -865,7 +865,7 @@ pub async fn list_agents(
     // username automatically.
     if params.owner.is_none() {
         if let Some(ref user) = api_user {
-            use librefang_kernel::auth::UserRole;
+            use crate::middleware::UserRole;
             if user.0.role < UserRole::Admin {
                 params.owner = Some(user.0.name.clone());
             }
@@ -1068,7 +1068,7 @@ pub async fn get_agent_stats(
     // detail-panel rollup can't leak per-agent cost / latency to other
     // users on the same instance.
     if let Some(ref user) = api_user {
-        use librefang_kernel::auth::UserRole;
+        use crate::middleware::UserRole;
         if user.0.role < UserRole::Admin
             && !entry.manifest.author.eq_ignore_ascii_case(&user.0.name)
         {
@@ -1175,7 +1175,7 @@ pub async fn list_agent_events(
     // Mirror the owner-scoping on /stats and /sessions — turn-level
     // event data carries token counts and cost, so it shouldn't leak.
     if let Some(ref user) = api_user {
-        use librefang_kernel::auth::UserRole;
+        use crate::middleware::UserRole;
         if user.0.role < UserRole::Admin
             && !entry.manifest.author.eq_ignore_ascii_case(&user.0.name)
         {
@@ -2834,7 +2834,7 @@ pub async fn list_agent_sessions(
     // authored. Mirrors the filter on `list_agents` so per-agent
     // session metadata (cost, message count) doesn't leak.
     if let Some(ref user) = api_user {
-        use librefang_kernel::auth::UserRole;
+        use crate::middleware::UserRole;
         if user.0.role < UserRole::Admin {
             let entry = state.kernel.agent_registry().get(agent_id);
             let owned = entry
@@ -5823,7 +5823,7 @@ pub async fn serve_upload(
     // only by the uploader or by Admin/Owner callers; un-owned entries (pre-
     // #3361 uploads, generator output) stay readable for compatibility.
     if let Some(owner_id) = owner {
-        use librefang_kernel::auth::UserRole;
+        use crate::middleware::UserRole;
         let allowed = match api_user.as_ref().map(|u| &u.0) {
             Some(u) => u.user_id == owner_id || u.role >= UserRole::Admin,
             None => false,

--- a/crates/librefang-api/src/routes/audit.rs
+++ b/crates/librefang-api/src/routes/audit.rs
@@ -13,6 +13,7 @@
 
 use super::AppState;
 use crate::middleware::AuthenticatedApiUser;
+use crate::middleware::UserRole;
 use crate::types::ApiErrorResponse;
 use axum::body::Body;
 use axum::extract::{Query, State};
@@ -20,7 +21,6 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use chrono::{DateTime, Utc};
-use librefang_kernel::auth::UserRole;
 use librefang_runtime::audit::AuditEntry;
 use librefang_types::agent::UserId;
 use serde::Deserialize;

--- a/crates/librefang-api/src/routes/authz.rs
+++ b/crates/librefang-api/src/routes/authz.rs
@@ -23,11 +23,11 @@
 
 use super::AppState;
 use crate::middleware::AuthenticatedApiUser;
+use crate::middleware::UserRole;
 use crate::types::ApiErrorResponse;
 use axum::extract::{Path, Query, State};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use librefang_kernel::auth::UserRole;
 use librefang_types::agent::UserId;
 use librefang_types::user_policy::UserToolGate;
 use serde::{Deserialize, Serialize};

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -32,11 +32,11 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
                 .delete(delete_user_budget),
         )
 }
+use crate::middleware::UserRole;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use librefang_kernel::auth::UserRole;
 use librefang_types::agent::{AgentId, UserId};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -939,9 +939,9 @@ fn token_endpoint_host_matches(token_endpoint: &str, expected_host: &str) -> boo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::middleware::UserRole;
     use axum::body::to_bytes;
     use axum::http::{HeaderName, HeaderValue};
-    use librefang_kernel::auth::UserRole;
     use librefang_types::agent::UserId;
 
     #[test]

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1751,7 +1751,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn auth_denied_emits_audit_row_for_authenticated_user() {
         use crate::middleware::AuthenticatedApiUser;
-        use librefang_kernel::auth::UserRole;
+        use crate::middleware::UserRole;
         use librefang_types::agent::UserId;
 
         let (state, _tmp) = audit_test_app_state();

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -216,7 +216,7 @@ pub async fn get_agent_kv(
     // they authored. Without this, anyone authenticated could pull
     // user.preferences / oncall.contact / api.tokens out of any agent.
     if let Some(ref user) = api_user {
-        use librefang_kernel::auth::UserRole;
+        use crate::middleware::UserRole;
         if user.0.role < UserRole::Admin {
             let entry = state.kernel.agent_registry().get(agent_id);
             let owned = entry
@@ -2427,7 +2427,7 @@ pub async fn pairing_complete(
             let device_user_name = format!("device:{}", device.device_id);
             let auth = crate::middleware::ApiUserAuth {
                 name: device_user_name.clone(),
-                role: librefang_kernel::auth::UserRole::User,
+                role: crate::middleware::UserRole::User,
                 api_key_hash,
                 user_id: librefang_types::agent::UserId::from_name(&device_user_name),
             };

--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -23,11 +23,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::middleware::UserRole;
 use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_kernel::auth::UserRole;
 use librefang_types::agent::UserId;
 use librefang_types::config::UserConfig;
 use librefang_types::user_policy::{

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1143,7 +1143,7 @@ pub async fn list_triggers(
     //   1. With ?agent_id=... — verify the caller owns that agent.
     //   2. Without — post-filter the trigger list by author.
     let restrict_to: Option<String> = match api_user.as_ref() {
-        Some(u) if u.0.role < librefang_kernel::auth::UserRole::Admin => Some(u.0.name.clone()),
+        Some(u) if u.0.role < crate::middleware::UserRole::Admin => Some(u.0.name.clone()),
         _ => None,
     };
     if let (Some(user_name), Some(aid)) = (restrict_to.as_ref(), agent_filter) {


### PR DESCRIPTION
## Summary
- Centralize `UserRole` access via `crate::middleware::UserRole` (a `pub use` re-export of `librefang_kernel::auth::UserRole`).
- Migrate all 17 sites in `crates/librefang-api/src/` away from `use librefang_kernel::auth::UserRole;` / fully-qualified `librefang_kernel::auth::UserRole::*` paths.
- The kernel type itself is unchanged; only the api-side import path is narrowed so the api↔kernel boundary surface shrinks per issue.

Refs #3744 (UserRole hotspot — ~12-17 sites).

## Test plan
- [x] `cargo check -p librefang-api --lib` (clean)
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` (clean)
- [ ] CI green