### PR TITLE
refactor(api/users): route config_reload validate through Kernel method (#3744)

### DIFF
--- a/crates/librefang-api/src/routes/users.rs
+++ b/crates/librefang-api/src/routes/users.rs
@@ -971,7 +971,7 @@ where
     let mut parsed: librefang_types::config::KernelConfig = toml::from_str(&new_toml)
         .map_err(|e| PersistError::Internal(format!("invalid config after edit: {e}")))?;
     parsed.clamp_bounds();
-    if let Err(errors) = librefang_kernel::config_reload::validate_config_for_reload(&parsed) {
+    if let Err(errors) = state.kernel.validate_config_for_reload(&parsed) {
         return Err(PersistError::BadRequest(format!(
             "invalid config: {}",
             errors.join("; ")

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1161,6 +1161,18 @@ impl LibreFangKernel {
         }
     }
 
+    /// Validate a `KernelConfig` candidate for hot-reload eligibility.
+    ///
+    /// Provided as a kernel-surface method so API callers do not need to
+    /// reach into the `librefang_kernel::config_reload` module directly.
+    /// See issue #3744.
+    pub fn validate_config_for_reload(
+        &self,
+        config: &librefang_types::config::KernelConfig,
+    ) -> Result<(), Vec<String>> {
+        crate::config_reload::validate_config_for_reload(config)
+    }
+
     /// Build the roots list for a specific MCP server config.
     ///
     /// Starts with the default roots (workspaces directory) and, for stdio


### PR DESCRIPTION
## Summary
- Adds `Kernel::validate_config_for_reload` as a thin wrapper over the free `librefang_kernel::config_reload::validate_config_for_reload`.
- Switches `routes/users.rs::persist_users` to call it via `state.kernel`, removing one more direct `librefang_kernel::*` reach-in from the API crate (issue #3744).

Note: the two `librefang_kernel::config::librefang_home()` sites originally listed in channels.rs were already migrated to a local wrapper by the time this branch was cut; per the task scope, this slice picks up `users.rs:974` instead.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy -p librefang-kernel -p librefang-api --all-targets -- -D warnings`
- [ ] Live: PUT /api/users/{name} with an invalid policy, confirm 400 with the same validation error message as before.