### PR TITLE
refactor(api/server): route UserRole through middleware re-export (#3744)

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -10,7 +10,7 @@
 use axum::body::Body;
 use axum::http::{Request, Response, StatusCode};
 use axum::middleware::Next;
-use librefang_kernel::auth::UserRole;
+pub use librefang_kernel::auth::UserRole;
 use librefang_types::agent::UserId;
 use librefang_types::i18n;
 use std::collections::HashMap;

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -209,7 +209,7 @@ pub(crate) fn configured_user_api_keys(kernel: &LibreFangKernel) -> Vec<middlewa
             }
             Some(middleware::ApiUserAuth {
                 name: user.name.clone(),
-                role: librefang_kernel::auth::UserRole::from_str_role(&user.role),
+                role: middleware::UserRole::from_str_role(&user.role),
                 api_key_hash: api_key_hash.to_string(),
                 user_id: librefang_types::agent::UserId::from_name(&user.name),
             })
@@ -231,7 +231,7 @@ pub(crate) fn paired_device_user_keys(kernel: &LibreFangKernel) -> Vec<middlewar
             let name = format!("device:{device_id}");
             middleware::ApiUserAuth {
                 user_id: librefang_types::agent::UserId::from_name(&name),
-                role: librefang_kernel::auth::UserRole::User,
+                role: middleware::UserRole::User,
                 api_key_hash,
                 name,
             }


### PR DESCRIPTION
## Summary
- Slice of #3744: removes the two `librefang_kernel::auth::UserRole::*` direct references in `crates/librefang-api/src/server.rs` (lines 212, 234).
- Promotes the existing `use librefang_kernel::auth::UserRole;` in `middleware.rs` to `pub use`, giving the api crate a single re-export to depend on.
- Call sites now reference `middleware::UserRole::{from_str_role, User}`, narrowing the kernel-internal surface api leans on.

## Test plan
- [x] `cargo check -p librefang-api --lib`
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings`