### PR TITLE
refactor(api/server): route UserRole through middleware re-export (#3744)

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -10,7 +10,11 @@
 use axum::body::Body;
 use axum::http::{Request, Response, StatusCode};
 use axum::middleware::Next;
-use librefang_kernel::auth::UserRole;
+// Re-export so other modules in this crate can refer to the auth role type
+// via `crate::middleware::UserRole` instead of reaching into
+// `librefang_kernel::auth` directly. Keeps the kernel↔api touchpoint for
+// `UserRole` localized to this module (see #3744).
+pub use librefang_kernel::auth::UserRole;
 use librefang_types::agent::UserId;
 use librefang_types::i18n;
 use std::collections::HashMap;

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -209,7 +209,7 @@ pub(crate) fn configured_user_api_keys(kernel: &LibreFangKernel) -> Vec<middlewa
             }
             Some(middleware::ApiUserAuth {
                 name: user.name.clone(),
-                role: librefang_kernel::auth::UserRole::from_str_role(&user.role),
+                role: middleware::UserRole::from_str_role(&user.role),
                 api_key_hash: api_key_hash.to_string(),
                 user_id: librefang_types::agent::UserId::from_name(&user.name),
             })
@@ -231,7 +231,7 @@ pub(crate) fn paired_device_user_keys(kernel: &LibreFangKernel) -> Vec<middlewar
             let name = format!("device:{device_id}");
             middleware::ApiUserAuth {
                 user_id: librefang_types::agent::UserId::from_name(&name),
-                role: librefang_kernel::auth::UserRole::User,
+                role: middleware::UserRole::User,
                 api_key_hash,
                 name,
             }


### PR DESCRIPTION
## Summary

- ws.rs already migrated `classify_streaming_error` to `&dyn Display` (PR #4386, intact on main).
- This PR picks the alternate scope from #3744: server.rs's two direct `librefang_kernel::auth::UserRole::\*` references.
- middleware.rs now `pub use`s `UserRole`; server.rs uses `middleware::UserRole` instead. Localizes the api↔kernel touchpoint for the auth role enum to a single module.

Refs #3744.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings`
- [ ] CI workspace build/test