### PR TITLE
refactor(api/skills): wrap invalidate_hand_route_cache behind kernel method (#3744)

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2509,7 +2509,7 @@ pub async fn uninstall_hand(
     let home_dir = state.kernel.home_dir().to_path_buf();
     match state.kernel.hands().uninstall_hand(&home_dir, &hand_id) {
         Ok(()) => {
-            librefang_kernel::router::invalidate_hand_route_cache();
+            state.kernel.invalidate_hand_route_cache();
             state.kernel.persist_hand_state();
             (
                 StatusCode::OK,
@@ -2560,7 +2560,7 @@ pub async fn install_hand(
         skill_content,
     ) {
         Ok(def) => {
-            librefang_kernel::router::invalidate_hand_route_cache();
+            state.kernel.invalidate_hand_route_cache();
             // Return the full canonical `HandDefinition` so dashboard /
             // SDK callers can `setQueryData` on the hands list directly
             // instead of doing a follow-up GET. The previous {id, name,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1116,6 +1116,17 @@ impl LibreFangKernel {
         crate::auto_dream::set_agent_enabled(self, agent_id, enabled)
     }
 
+    /// Drop the cached hand-route resolver so the next dispatch rebuilds it
+    /// from the current registry. Call after any hand install / uninstall
+    /// that mutates the routing surface.
+    ///
+    /// Provided as a kernel-surface method so API callers do not need to
+    /// reach into the `librefang_kernel::router` module directly. See
+    /// issue #3744.
+    pub fn invalidate_hand_route_cache(&self) {
+        crate::router::invalidate_hand_route_cache();
+    }
+
     /// Build the roots list for a specific MCP server config.
     ///
     /// Starts with the default roots (workspaces directory) and, for stdio


### PR DESCRIPTION
## Summary
Sixth scoped slice of #3744 — remove a direct `librefang_kernel::*` non-trait import from `librefang-api`.

- `crates/librefang-api/src/routes/skills.rs` previously called `librefang_kernel::router::invalidate_hand_route_cache()` from `install_hand` and `uninstall_hand`, reaching into the kernel's `router` submodule.
- Added `LibreFangKernel::invalidate_hand_route_cache()` which delegates to the existing free function.
- Both route handlers now go through the kernel-surface method; no `librefang_kernel::router::*` reference left in the API crate.

## Verification
- `cargo check -p librefang-kernel -p librefang-api --lib` clean
- `cargo clippy -p librefang-kernel -p librefang-api --all-targets -- -D warnings` clean

Refs #3744 (6-of-many; follows #4386, #4390, #4391, #4394, #4395, #4406).