### PR TITLE
fix(api,kernel): emit `active` on /api/sessions rows (#4290)

### DIFF
--- a/crates/librefang-api/src/routes/tools_sessions.rs
+++ b/crates/librefang-api/src/routes/tools_sessions.rs
@@ -357,18 +357,47 @@ pub async fn list_sessions(
     let substrate = state.kernel.memory_substrate();
     // Push pagination into SQLite so we don't deserialize every session blob (#3485).
     let total = substrate.count_sessions().unwrap_or(0);
+    // Snapshot of in-flight session IDs from the kernel runtime — the
+    // SQLite substrate has no view into liveness, so we merge it in here
+    // (#4290). Taken once per request before the SQL call so every row
+    // sees a consistent view.
+    let running = state.kernel.running_session_ids();
     // Canonical paginated envelope (#3842): {items,total,offset,limit}.
-    let (items, total, offset_out, limit_out) =
+    let (mut items, total, offset_out, limit_out) =
         match substrate.list_sessions_paginated(Some(limit), offset) {
             Ok(items) => (items, total, offset, limit),
             Err(_) => (Vec::new(), 0, 0, PaginationParams::DEFAULT_LIMIT),
         };
+    annotate_sessions_active(&mut items, &running);
     Json(crate::types::PaginatedResponse {
         items,
         total,
         offset: offset_out,
         limit: Some(limit_out),
     })
+}
+
+/// Inject an `"active": bool` field into each session JSON row by looking
+/// up its `session_id` in the running-tasks snapshot. Rows whose
+/// `session_id` doesn't parse as a UUID get `active: false` (a corrupt
+/// row can't possibly be in the live registry keyed by `SessionId`).
+/// Used by `/api/sessions` and `/api/sessions/search` (#4290).
+fn annotate_sessions_active(
+    items: &mut [serde_json::Value],
+    running: &std::collections::HashSet<librefang_types::agent::SessionId>,
+) {
+    for item in items.iter_mut() {
+        let active = item
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| uuid::Uuid::parse_str(s).ok())
+            .map(librefang_types::agent::SessionId)
+            .map(|id| running.contains(&id))
+            .unwrap_or(false);
+        if let Some(obj) = item.as_object_mut() {
+            obj.insert("active".to_string(), serde_json::Value::Bool(active));
+        }
+    }
 }
 
 /// GET /api/sessions/:id — Get a single session by ID.
@@ -392,18 +421,25 @@ pub async fn get_session(
         .memory_substrate()
         .get_session_with_created_at(session_id)
     {
-        Ok(Some((session, created_at))) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "session_id": session.id.0.to_string(),
-                "agent_id": session.agent_id.0.to_string(),
-                "message_count": session.messages.len(),
-                "messages": session.messages,
-                "context_window_tokens": session.context_window_tokens,
-                "label": session.label,
-                "created_at": created_at,
-            })),
-        ),
+        Ok(Some((session, created_at))) => {
+            // Mirror the list endpoint and surface the kernel runtime's
+            // liveness bit (#4290) so single-session fetches don't lie
+            // about idle state either.
+            let active = state.kernel.running_session_ids().contains(&session.id);
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "session_id": session.id.0.to_string(),
+                    "agent_id": session.agent_id.0.to_string(),
+                    "message_count": session.messages.len(),
+                    "messages": session.messages,
+                    "context_window_tokens": session.context_window_tokens,
+                    "label": session.label,
+                    "created_at": created_at,
+                    "active": active,
+                })),
+            )
+        }
         Ok(None) => {
             ApiErrorResponse::not_found(t.t("api-error-session-not-found")).into_json_tuple()
         }
@@ -656,11 +692,20 @@ pub async fn search_sessions(
             } else {
                 offset + results.len() + 1
             };
+            // Project SessionSearchResult into untyped JSON so we can merge
+            // the kernel runtime's `active` bit per row (#4290) — same
+            // contract as /api/sessions.
+            let mut items: Vec<serde_json::Value> = results
+                .into_iter()
+                .map(|r| serde_json::to_value(r).unwrap_or(serde_json::Value::Null))
+                .collect();
+            let running = state.kernel.running_session_ids();
+            annotate_sessions_active(&mut items, &running);
             (
                 StatusCode::OK,
                 Json(
                     serde_json::to_value(crate::types::PaginatedResponse {
-                        items: results,
+                        items,
                         total,
                         offset,
                         limit: Some(limit),

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -10160,6 +10160,16 @@ system_prompt = "You are a helpful assistant."
         self.running_tasks.iter().any(|e| e.key().0 == agent_id)
     }
 
+    /// Snapshot of every `SessionId` whose agent loop is currently in flight,
+    /// kernel-wide. Used by `/api/sessions` (and friends) to populate the
+    /// `active` field on each session row so the dashboard can distinguish
+    /// running vs idle. DashMap iteration is unordered; the caller treats
+    /// the result as a set lookup, never as a list. Cheap: one
+    /// `(AgentId, SessionId)` clone per running task.
+    pub fn running_session_ids(&self) -> std::collections::HashSet<SessionId> {
+        self.running_tasks.iter().map(|e| e.key().1).collect()
+    }
+
     /// Suspend an agent — sets state to Suspended, persists enabled=false to TOML.
     pub fn suspend_agent(&self, agent_id: AgentId) -> KernelResult<()> {
         use librefang_types::agent::AgentState;

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -3726,6 +3726,71 @@ fn test_running_tasks_two_concurrent_sessions_for_same_agent() {
     kernel.shutdown();
 }
 
+/// `/api/sessions` joins the SQLite session list with this snapshot to set
+/// the per-row `active` flag (#4290). Verify it surfaces every running
+/// session across agents and shrinks back to empty after stops.
+#[test]
+fn test_running_session_ids_reflects_live_tasks() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().join("librefang-running-ids-test");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let kernel = LibreFangKernel::boot_with_config(KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    })
+    .expect("kernel should boot");
+
+    // Empty kernel: snapshot must be empty.
+    assert!(kernel.running_session_ids().is_empty());
+
+    let agent_a = AgentId(uuid::Uuid::new_v4());
+    let agent_b = AgentId(uuid::Uuid::new_v4());
+    let s1 = SessionId::new();
+    let s2 = SessionId::new();
+    let s3 = SessionId::new();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mk_handle = || {
+        rt.spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        })
+        .abort_handle()
+    };
+
+    for (a, s) in [(agent_a, s1), (agent_a, s2), (agent_b, s3)] {
+        kernel.running_tasks.insert(
+            (a, s),
+            RunningTask {
+                abort: mk_handle(),
+                started_at: chrono::Utc::now(),
+                task_id: uuid::Uuid::new_v4(),
+            },
+        );
+    }
+
+    let ids = kernel.running_session_ids();
+    assert_eq!(ids.len(), 3, "all three live sessions must be present");
+    assert!(ids.contains(&s1));
+    assert!(ids.contains(&s2));
+    assert!(ids.contains(&s3));
+
+    // Stop one — snapshot must drop exactly that one.
+    assert!(kernel.stop_session_run(agent_a, s1).unwrap());
+    let ids = kernel.running_session_ids();
+    assert_eq!(ids.len(), 2);
+    assert!(!ids.contains(&s1));
+    assert!(ids.contains(&s2));
+    assert!(ids.contains(&s3));
+
+    let _ = kernel.stop_session_run(agent_a, s2);
+    let _ = kernel.stop_session_run(agent_b, s3);
+    assert!(kernel.running_session_ids().is_empty());
+
+    drop(rt);
+    kernel.shutdown();
+}
+
 #[test]
 fn test_stop_agent_run_fans_out_across_sessions() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Closes #4290