### PR TITLE
fix(api,kernel): align /api/agents/{id}/sessions `active` with running-loop semantics

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -9346,15 +9346,22 @@ system_prompt = "You are a helpful assistant."
             .list_agent_sessions(agent_id)
             .map_err(KernelError::LibreFang)?;
 
-        // Mark the active session
+        // `active` means "an agent loop is currently running against this
+        // session" — matching `/api/sessions` (#4290) and the dashboard's
+        // green-dot/pulse rendering. The legacy "is registry pointer"
+        // meaning is preserved as `is_canonical`, which forks /
+        // `agent_send` defaults still rely on. See #4293.
+        let running = self.running_session_ids();
+        let canonical_sid = entry.session_id.0.to_string();
         for s in &mut sessions {
             if let Some(obj) = s.as_object_mut() {
-                let is_active = obj
-                    .get("session_id")
-                    .and_then(|v| v.as_str())
-                    .map(|sid| sid == entry.session_id.0.to_string())
+                let sid_str = obj.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
+                let is_active = uuid::Uuid::parse_str(sid_str)
+                    .map(|u| running.contains(&SessionId(u)))
                     .unwrap_or(false);
+                let is_canonical = sid_str == canonical_sid;
                 obj.insert("active".to_string(), serde_json::json!(is_active));
+                obj.insert("is_canonical".to_string(), serde_json::json!(is_canonical));
             }
         }
 
@@ -10442,11 +10449,12 @@ system_prompt = "You are a helpful assistant."
     }
 
     /// Snapshot of every `SessionId` whose agent loop is currently in flight,
-    /// kernel-wide. Used by `/api/sessions` (and friends) to populate the
-    /// `active` field on each session row so the dashboard can distinguish
-    /// running vs idle. DashMap iteration is unordered; the caller treats
-    /// the result as a set lookup, never as a list. Cheap: one
-    /// `(AgentId, SessionId)` clone per running task.
+    /// kernel-wide. Used by `/api/sessions` and per-agent session-listing
+    /// endpoints to populate the `active` field with "loop is currently
+    /// running" semantics — matching the dashboard's green-dot/pulse
+    /// rendering (see #4290, #4293). DashMap iteration is unordered; the
+    /// caller treats the result as a set lookup, never as a list. Cheap:
+    /// one `(AgentId, SessionId)` clone per running task.
     pub fn running_session_ids(&self) -> std::collections::HashSet<SessionId> {
         self.running_tasks.iter().map(|e| e.key().1).collect()
     }

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6319,3 +6319,166 @@ async fn vault_cache_reuses_unlocked_handle_across_calls() {
 
     kernel.shutdown();
 }
+
+// ── /api/agents/{id}/sessions `active` semantics (#4293) ────────────────────
+//
+// `list_agent_sessions` historically marked `active = (sid == registry pointer)`.
+// That disagrees with the dashboard's "loop is running" rendering and with
+// /api/sessions (#4290). These tests pin the new contract: `active` reflects
+// `running_session_ids()` membership; the registry-pointer answer is preserved
+// as `is_canonical`.
+
+#[test]
+fn list_agent_sessions_active_reflects_running_tasks_not_registry_pointer() {
+    let kernel = boot_kernel_for_display_tests();
+    let agent_id = register_test_agent(&kernel, "busy");
+
+    // Seed three persisted sessions for this agent.
+    let s1 = kernel
+        .memory
+        .create_session_with_label(agent_id, Some("one"))
+        .unwrap();
+    let s2 = kernel
+        .memory
+        .create_session_with_label(agent_id, Some("two"))
+        .unwrap();
+    let s3 = kernel
+        .memory
+        .create_session_with_label(agent_id, Some("three"))
+        .unwrap();
+
+    // Point the registry pointer at s2 — the legacy "active" answer.
+    kernel.registry.update_session_id(agent_id, s2.id).unwrap();
+
+    // Mark s1 and s3 as in-flight via running_tasks (not s2).
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let h1 = rt.spawn(async {
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+    });
+    let h3 = rt.spawn(async {
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+    });
+    kernel.running_tasks.insert(
+        (agent_id, s1.id),
+        RunningTask {
+            abort: h1.abort_handle(),
+            started_at: chrono::Utc::now(),
+            task_id: uuid::Uuid::new_v4(),
+        },
+    );
+    kernel.running_tasks.insert(
+        (agent_id, s3.id),
+        RunningTask {
+            abort: h3.abort_handle(),
+            started_at: chrono::Utc::now(),
+            task_id: uuid::Uuid::new_v4(),
+        },
+    );
+
+    let listed = kernel.list_agent_sessions(agent_id).expect("list ok");
+    assert_eq!(listed.len(), 3);
+
+    let by_id: std::collections::HashMap<String, &serde_json::Value> = listed
+        .iter()
+        .map(|v| {
+            (
+                v.get("session_id")
+                    .and_then(|s| s.as_str())
+                    .unwrap()
+                    .to_string(),
+                v,
+            )
+        })
+        .collect();
+
+    let row1 = by_id.get(&s1.id.0.to_string()).unwrap();
+    let row2 = by_id.get(&s2.id.0.to_string()).unwrap();
+    let row3 = by_id.get(&s3.id.0.to_string()).unwrap();
+
+    // active == running_session_ids membership
+    assert_eq!(row1.get("active").and_then(|v| v.as_bool()), Some(true));
+    assert_eq!(row2.get("active").and_then(|v| v.as_bool()), Some(false));
+    assert_eq!(row3.get("active").and_then(|v| v.as_bool()), Some(true));
+
+    // is_canonical == registry pointer
+    assert_eq!(
+        row1.get("is_canonical").and_then(|v| v.as_bool()),
+        Some(false)
+    );
+    assert_eq!(
+        row2.get("is_canonical").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        row3.get("is_canonical").and_then(|v| v.as_bool()),
+        Some(false)
+    );
+
+    // Cleanup.
+    let _ = kernel.stop_session_run(agent_id, s1.id);
+    let _ = kernel.stop_session_run(agent_id, s3.id);
+    drop(rt);
+    kernel.shutdown();
+}
+
+#[test]
+fn list_agent_sessions_idle_agent_marks_all_inactive() {
+    let kernel = boot_kernel_for_display_tests();
+    let agent_id = register_test_agent(&kernel, "idle");
+
+    for label in ["a", "b", "c", "d", "e"] {
+        kernel
+            .memory
+            .create_session_with_label(agent_id, Some(label))
+            .unwrap();
+    }
+
+    let listed = kernel.list_agent_sessions(agent_id).expect("list ok");
+    assert_eq!(listed.len(), 5);
+    for row in &listed {
+        assert_eq!(
+            row.get("active").and_then(|v| v.as_bool()),
+            Some(false),
+            "no running tasks → every row inactive; row = {row}"
+        );
+    }
+    kernel.shutdown();
+}
+
+#[test]
+fn list_agent_sessions_canonical_and_active_can_coexist_on_same_row() {
+    let kernel = boot_kernel_for_display_tests();
+    let agent_id = register_test_agent(&kernel, "both");
+
+    let s = kernel
+        .memory
+        .create_session_with_label(agent_id, Some("only"))
+        .unwrap();
+    kernel.registry.update_session_id(agent_id, s.id).unwrap();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let h = rt.spawn(async {
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+    });
+    kernel.running_tasks.insert(
+        (agent_id, s.id),
+        RunningTask {
+            abort: h.abort_handle(),
+            started_at: chrono::Utc::now(),
+            task_id: uuid::Uuid::new_v4(),
+        },
+    );
+
+    let listed = kernel.list_agent_sessions(agent_id).expect("list ok");
+    assert_eq!(listed.len(), 1);
+    let row = &listed[0];
+    assert_eq!(row.get("active").and_then(|v| v.as_bool()), Some(true));
+    assert_eq!(
+        row.get("is_canonical").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+
+    let _ = kernel.stop_session_run(agent_id, s.id);
+    drop(rt);
+    kernel.shutdown();
+}


### PR DESCRIPTION
## Summary
- `kernel::list_agent_sessions` previously set `active = (sid == entry.session_id)`. That meaning disagreed with /api/sessions (#4290), with the dashboard's green-dot/pulse rendering, and with what users mean. By construction it marked at most one row active per agent, and a busy agent with several concurrent loops could show zero active rows whenever the registry pointer landed on a not-yet-listed session.
- Add `Kernel::running_session_ids() -> HashSet<SessionId>` over `running_tasks` and switch `active` to mean "an agent loop is currently in flight against this session", matching the proposed kernel-side liveness flag in #4290 / #4293.
- Preserve the legacy "registry pointer" answer as a separate `is_canonical: bool` field so forks (#4291) and `agent_send` defaults still have an honest place to read it.

## Test plan
- [x] `cargo check -p librefang-kernel --lib --tests`
- [x] `cargo clippy -p librefang-kernel --all-targets -- -D warnings`
- [x] `cargo test -p librefang-kernel --lib list_agent_sessions` — three new regressions pass:
  - busy agent, 3 sessions, 2 in flight (registry pointer on the idle one) → exactly the 2 in-flight rows are `active: true`; only the registry-pointer row is `is_canonical: true`
  - idle agent, 5 sessions, no running tasks → every row `active: false`
  - single session that is both canonical and running → `active: true` AND `is_canonical: true`

Closes #4293
Refs #4290 #3172