### PR TITLE
fix(channels): give ChannelsConfig a non-zero file_download_max default

### DIFF
--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -5271,7 +5271,7 @@ impl std::fmt::Debug for NetworkConfig {
 ///
 /// Each field uses `OneOrMany<T>` to support both single-instance (`[channels.telegram]`)
 /// and multi-instance (`[[channels.telegram]]`) TOML syntax for multi-bot routing.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub struct ChannelsConfig {
     /// Telegram bot configuration(s).
@@ -5380,6 +5380,66 @@ pub struct ChannelsConfig {
 /// Default max file download size: 50 MB.
 fn default_file_download_max_bytes() -> u64 {
     50 * 1024 * 1024
+}
+
+impl Default for ChannelsConfig {
+    // Manual impl so `file_download_max_bytes` matches the
+    // `#[serde(default = "default_file_download_max_bytes")]` value (50 MiB)
+    // instead of `u64::default() == 0`. Without this, code paths that build
+    // a `ChannelsConfig` programmatically (e.g. `KernelConfig::default()`,
+    // tests, configs without a `[channels]` section) would silently set
+    // `file_download_max_bytes = 0`, causing the bridge to reject every
+    // channel attachment as oversized. See issue #4436.
+    fn default() -> Self {
+        Self {
+            telegram: OneOrMany::default(),
+            discord: OneOrMany::default(),
+            slack: OneOrMany::default(),
+            whatsapp: OneOrMany::default(),
+            signal: OneOrMany::default(),
+            matrix: OneOrMany::default(),
+            email: OneOrMany::default(),
+            teams: OneOrMany::default(),
+            mattermost: OneOrMany::default(),
+            irc: OneOrMany::default(),
+            google_chat: OneOrMany::default(),
+            twitch: OneOrMany::default(),
+            rocketchat: OneOrMany::default(),
+            zulip: OneOrMany::default(),
+            xmpp: OneOrMany::default(),
+            line: OneOrMany::default(),
+            viber: OneOrMany::default(),
+            messenger: OneOrMany::default(),
+            reddit: OneOrMany::default(),
+            mastodon: OneOrMany::default(),
+            bluesky: OneOrMany::default(),
+            feishu: OneOrMany::default(),
+            revolt: OneOrMany::default(),
+            nextcloud: OneOrMany::default(),
+            guilded: OneOrMany::default(),
+            keybase: OneOrMany::default(),
+            threema: OneOrMany::default(),
+            nostr: OneOrMany::default(),
+            webex: OneOrMany::default(),
+            pumble: OneOrMany::default(),
+            flock: OneOrMany::default(),
+            twist: OneOrMany::default(),
+            mumble: OneOrMany::default(),
+            dingtalk: OneOrMany::default(),
+            qq: OneOrMany::default(),
+            discourse: OneOrMany::default(),
+            gitter: OneOrMany::default(),
+            ntfy: OneOrMany::default(),
+            gotify: OneOrMany::default(),
+            webhook: OneOrMany::default(),
+            voice: OneOrMany::default(),
+            linkedin: OneOrMany::default(),
+            wechat: OneOrMany::default(),
+            wecom: OneOrMany::default(),
+            file_download_max_bytes: default_file_download_max_bytes(),
+            file_download_dir: None,
+        }
+    }
 }
 
 /// Telegram channel adapter configuration.

--- a/crates/librefang-types/tests/config_default_roundtrip.rs
+++ b/crates/librefang-types/tests/config_default_roundtrip.rs
@@ -376,24 +376,30 @@ fn agent_manifest_default_roundtrips_through_toml() {
 
 #[test]
 fn channels_config_default_roundtrips_through_toml() {
-    // Known #3462 Default-drift, flagged for separate triage:
-    //   `ChannelsConfig` uses `#[derive(Default)]`, so
-    //   `file_download_max_bytes` defaults to `u64::default() == 0`, but the
-    //   field is annotated `#[serde(default = "default_file_download_max_bytes")]`
-    //   which returns 50 MiB. Empty-TOML deserialization therefore yields
-    //   52_428_800 while the in-memory `Default::default()` yields 0.
-    //
-    // Per the task brief, this test does NOT silently fix the type — the
-    // discrepancy is normalized only on the divergent field so that drift in
-    // every OTHER field is still caught. The underlying type bug should be
-    // fixed by either replacing `#[derive(Default)]` with a manual impl that
-    // calls `default_file_download_max_bytes()`, or by aligning the serde
-    // helper with the derived zero value, depending on which value is
-    // intended at runtime.
-    let canonical_max_bytes = ChannelsConfig::default().file_download_max_bytes;
-    assert_default_roundtrip_with::<ChannelsConfig>("ChannelsConfig", move |c| {
-        c.file_download_max_bytes = canonical_max_bytes;
-    });
+    // Regression test for #4436: `ChannelsConfig` previously used
+    // `#[derive(Default)]`, so `file_download_max_bytes` defaulted to
+    // `u64::default() == 0` while `#[serde(default = "...")]` returned
+    // 50 MiB. The bridge then silently rejected every attachment as
+    // oversized whenever `ChannelsConfig` was constructed programmatically
+    // (e.g. `KernelConfig::default()`, tests, configs without a
+    // `[channels]` section). The fix is a manual `Default` impl that
+    // calls `default_file_download_max_bytes()`; this test now exercises
+    // the full roundtrip with no field-specific normalization.
+    assert_default_roundtrip::<ChannelsConfig>("ChannelsConfig");
+}
+
+/// Pinned-value regression test for #4436. Independent of the roundtrip
+/// test so a future change that silently zeroes `Default` AND the serde
+/// helper (keeping them consistent) still trips CI.
+#[test]
+fn channels_config_default_has_50mb_max() {
+    assert_eq!(
+        ChannelsConfig::default().file_download_max_bytes,
+        50 * 1024 * 1024,
+        "ChannelsConfig::default().file_download_max_bytes must be 50 MiB; \
+         see issue #4436 — anything less means the channel bridge will \
+         reject attachments whenever the config is built programmatically."
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `ChannelsConfig` derived `Default`, so `file_download_max_bytes` was `u64::default() == 0`, while `#[serde(default = "default_file_download_max_bytes")]` returned 50 MiB. Any path that built the struct programmatically (`KernelConfig::default()`, tests, configs without a `[channels]` section) silently set a 0-byte cap and the bridge rejected every channel attachment.
- Replace `#[derive(Default)]` with a manual `Default` impl that calls `default_file_download_max_bytes()`, matching the pattern used elsewhere in `KernelConfig`'s nested structs.
- Drop the field-specific normalization in the existing `channels_config_default_roundtrips_through_toml` test (it was masking exactly this bug, see PR #4308 thread) and add a new pinned-value test `channels_config_default_has_50mb_max` so any future regression to `derive(Default)` + serde-only default trips CI.

## Test plan
- [x] `cargo check -p librefang-types --lib`
- [x] `cargo clippy -p librefang-types --all-targets -- -D warnings`
- [x] `cargo test -p librefang-types --test config_default_roundtrip channels_config` — both tests pass

Closes #4436