### PR TITLE
fix(channels): honor file_download_dir across all upload sites

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -1289,11 +1289,16 @@ fn is_text_like_attachment(content_type: &str, filename: &str) -> bool {
 ///     truncated at 200K chars.
 ///   - everything else → skipped with a warn log.
 pub fn resolve_attachments(
+    state: &AppState,
     attachments: &[AttachmentRef],
 ) -> Vec<librefang_types::message::ContentBlock> {
     use base64::Engine;
 
-    let upload_dir = std::env::temp_dir().join("librefang_uploads");
+    let upload_dir = state
+        .kernel
+        .config_ref()
+        .channels
+        .effective_file_download_dir();
     let mut blocks = Vec::new();
 
     for att in attachments {
@@ -1720,7 +1725,7 @@ pub async fn send_message(
 
     // Resolve file attachments into image content blocks
     if !req.attachments.is_empty() {
-        let image_blocks = resolve_attachments(&req.attachments);
+        let image_blocks = resolve_attachments(&state, &req.attachments);
         if !image_blocks.is_empty() {
             inject_attachments_into_session(&state.kernel, agent_id, image_blocks);
         }
@@ -2020,7 +2025,11 @@ pub async fn get_agent_session(
                                     // Persist image to upload dir so it can be
                                     // served back when loading session history.
                                     let file_id = uuid::Uuid::new_v4().to_string();
-                                    let upload_dir = std::env::temp_dir().join("librefang_uploads");
+                                    let upload_dir = state
+                                        .kernel
+                                        .config_ref()
+                                        .channels
+                                        .effective_file_download_dir();
                                     if let Err(e) = std::fs::create_dir_all(&upload_dir) {
                                         tracing::warn!("Failed to create upload directory: {e}");
                                     }
@@ -2505,7 +2514,7 @@ pub async fn send_message_stream(
 
     // Resolve file attachments into image content blocks (same as non-streaming)
     if !req.attachments.is_empty() {
-        let image_blocks = resolve_attachments(&req.attachments);
+        let image_blocks = resolve_attachments(&state, &req.attachments);
         if !image_blocks.is_empty() {
             inject_attachments_into_session(&state.kernel, agent_id, image_blocks);
         }
@@ -5702,7 +5711,11 @@ pub async fn upload_file(
 
     // Generate file ID and save
     let file_id = uuid::Uuid::new_v4().to_string();
-    let upload_dir = std::env::temp_dir().join("librefang_uploads");
+    let upload_dir = state
+        .kernel
+        .config_ref()
+        .channels
+        .effective_file_download_dir();
     if let Err(e) = std::fs::create_dir_all(&upload_dir) {
         tracing::warn!("Failed to create upload dir: {e}");
         return (
@@ -5778,6 +5791,7 @@ pub async fn upload_file(
     )
 )]
 pub async fn serve_upload(
+    State(state): State<Arc<AppState>>,
     Path(file_id): Path<String>,
     api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
 ) -> impl IntoResponse {
@@ -5793,8 +5807,11 @@ pub async fn serve_upload(
         );
     }
 
-    let file_path = std::env::temp_dir()
-        .join("librefang_uploads")
+    let file_path = state
+        .kernel
+        .config_ref()
+        .channels
+        .effective_file_download_dir()
         .join(&file_id);
 
     // Look up metadata from registry; fall back to disk probe for generated images

--- a/crates/librefang-api/src/routes/media.rs
+++ b/crates/librefang-api/src/routes/media.rs
@@ -77,9 +77,18 @@ fn resolve_driver(
 ///
 /// The file is registered in the shared `UPLOAD_REGISTRY` so the existing
 /// `serve_upload` handler returns the correct `Content-Type`.
-fn save_upload(data: &[u8], filename: &str, content_type: &str) -> Result<String, String> {
+fn save_upload(
+    state: &AppState,
+    data: &[u8],
+    filename: &str,
+    content_type: &str,
+) -> Result<String, String> {
     let file_id = uuid::Uuid::new_v4().to_string();
-    let upload_dir = std::env::temp_dir().join("librefang_uploads");
+    let upload_dir = state
+        .kernel
+        .config_ref()
+        .channels
+        .effective_file_download_dir();
     std::fs::create_dir_all(&upload_dir)
         .map_err(|e| format!("Failed to create upload directory: {e}"))?;
     std::fs::write(upload_dir.join(&file_id), data)
@@ -145,7 +154,7 @@ pub async fn generate_image(
         };
 
         let filename = format!("image_{i}.png");
-        match save_upload(&bytes, &filename, "image/png") {
+        match save_upload(&state, &bytes, &filename, "image/png") {
             Ok(url) => {
                 image_urls.push(serde_json::json!({
                     "url": url,
@@ -207,7 +216,7 @@ pub async fn synthesize_speech(
     };
     let filename = format!("speech.{}", result.format);
 
-    match save_upload(&result.audio_data, &filename, content_type) {
+    match save_upload(&state, &result.audio_data, &filename, content_type) {
         Ok(url) => Json(serde_json::json!({
             "url": url,
             "format": result.format,
@@ -350,7 +359,7 @@ pub async fn generate_music(
     };
     let filename = format!("music.{}", result.format);
 
-    match save_upload(&result.audio_data, &filename, content_type) {
+    match save_upload(&state, &result.audio_data, &filename, content_type) {
         Ok(url) => Json(serde_json::json!({
             "url": url,
             "format": result.format,
@@ -405,7 +414,11 @@ pub async fn transcribe_audio(
     }
 
     // Save to temp file so MediaEngine can read it
-    let upload_dir = std::env::temp_dir().join("librefang_uploads");
+    let upload_dir = state
+        .kernel
+        .config_ref()
+        .channels
+        .effective_file_download_dir();
     if let Err(e) = std::fs::create_dir_all(&upload_dir) {
         return ApiErrorResponse::internal(format!("Failed to create upload dir: {e}"))
             .into_response();

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -3170,7 +3170,7 @@ pub async fn hand_send_message(
 
     // Resolve file attachments
     if !req.attachments.is_empty() {
-        let image_blocks = super::agents::resolve_attachments(&req.attachments);
+        let image_blocks = super::agents::resolve_attachments(&state, &req.attachments);
         if !image_blocks.is_empty() {
             super::agents::inject_attachments_into_session(&state.kernel, agent_id, image_blocks);
         }

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -880,7 +880,7 @@ async fn handle_text_message(
                     .filter_map(|a| serde_json::from_value(a.clone()).ok())
                     .collect();
                 if !refs.is_empty() {
-                    let image_blocks = crate::routes::resolve_attachments(&refs);
+                    let image_blocks = crate::routes::resolve_attachments(state, &refs);
                     if !image_blocks.is_empty() {
                         has_images = true;
                         crate::routes::inject_attachments_into_session(

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -504,6 +504,14 @@ pub trait ChannelBridgeHandle: Send + Sync {
         None
     }
 
+    /// Return the effective file download directory: configured value or
+    /// the legacy `<temp>/librefang_uploads` default. Use this everywhere
+    /// instead of re-deriving the fallback inline (see issue #4435).
+    fn effective_channels_download_dir(&self) -> std::path::PathBuf {
+        self.channels_download_dir()
+            .unwrap_or_else(|| std::env::temp_dir().join("librefang_uploads"))
+    }
+
     /// Return the configured max file download size in bytes, if set.
     fn channels_download_max_bytes(&self) -> Option<u64> {
         None
@@ -1137,10 +1145,7 @@ impl BridgeManager {
         // redundant cleanup sweeps.
         {
             static CLEANUP_ONCE: std::sync::Once = std::sync::Once::new();
-            let dir = self
-                .handle
-                .channels_download_dir()
-                .unwrap_or_else(|| std::env::temp_dir().join("librefang_uploads"));
+            let dir = self.handle.effective_channels_download_dir();
             CLEANUP_ONCE.call_once(|| {
                 tokio::spawn(async move { cleanup_old_uploads(&dir).await });
             });
@@ -1189,6 +1194,7 @@ impl BridgeManager {
             .unwrap_or(64);
 
         let semaphore = Arc::new(tokio::sync::Semaphore::new(32));
+        let upload_dir = handle.effective_channels_download_dir();
 
         if debounce_ms == 0 {
             // Fast path: no debouncing (current behavior)
@@ -1264,7 +1270,7 @@ impl BridgeManager {
                                     let image_blocks = if let ChannelContent::Image {
                                         ref url, ref caption, ref mime_type
                                     } = message.content {
-                                        match download_image_to_blocks(url, caption.as_deref(), mime_type.as_deref()).await {
+                                        match download_image_to_blocks(url, caption.as_deref(), mime_type.as_deref(), &upload_dir).await {
                                             blocks if blocks.iter().any(|b| matches!(b, ContentBlock::Image { .. } | ContentBlock::ImageFile { .. })) => Some(blocks),
                                             _ => None,
                                         }
@@ -2721,7 +2727,10 @@ async fn dispatch_message(
         ref mime_type,
     } = message.content
     {
-        let blocks = download_image_to_blocks(url, caption.as_deref(), mime_type.as_deref()).await;
+        let upload_dir = handle.effective_channels_download_dir();
+        let blocks =
+            download_image_to_blocks(url, caption.as_deref(), mime_type.as_deref(), &upload_dir)
+                .await;
         if blocks.iter().any(|b| {
             matches!(
                 b,
@@ -2754,9 +2763,7 @@ async fn dispatch_message(
         ref filename,
     } = message.content
     {
-        let download_dir = handle
-            .channels_download_dir()
-            .unwrap_or_else(|| std::env::temp_dir().join("librefang_uploads"));
+        let download_dir = handle.effective_channels_download_dir();
         let max_bytes = handle
             .channels_download_max_bytes()
             .unwrap_or(CHANNEL_FILE_DOWNLOAD_MAX_BYTES);
@@ -2789,9 +2796,7 @@ async fn dispatch_message(
         duration_seconds,
     } = message.content
     {
-        let download_dir = handle
-            .channels_download_dir()
-            .unwrap_or_else(|| std::env::temp_dir().join("librefang_uploads"));
+        let download_dir = handle.effective_channels_download_dir();
         let max_bytes = handle
             .channels_download_max_bytes()
             .unwrap_or(CHANNEL_FILE_DOWNLOAD_MAX_BYTES);
@@ -2844,9 +2849,7 @@ async fn dispatch_message(
         ref performer,
     } = message.content
     {
-        let download_dir = handle
-            .channels_download_dir()
-            .unwrap_or_else(|| std::env::temp_dir().join("librefang_uploads"));
+        let download_dir = handle.effective_channels_download_dir();
         let max_bytes = handle
             .channels_download_max_bytes()
             .unwrap_or(CHANNEL_FILE_DOWNLOAD_MAX_BYTES);
@@ -2904,9 +2907,7 @@ async fn dispatch_message(
         ref filename,
     } = message.content
     {
-        let download_dir = handle
-            .channels_download_dir()
-            .unwrap_or_else(|| std::env::temp_dir().join("librefang_uploads"));
+        let download_dir = handle.effective_channels_download_dir();
         let max_bytes = handle
             .channels_download_max_bytes()
             .unwrap_or(CHANNEL_FILE_DOWNLOAD_MAX_BYTES);
@@ -4208,6 +4209,7 @@ async fn download_image_to_blocks(
     url: &str,
     caption: Option<&str>,
     mime_type_hint: Option<&str>,
+    upload_dir: &std::path::Path,
 ) -> Vec<ContentBlock> {
     use base64::Engine;
 
@@ -4369,8 +4371,6 @@ async fn download_image_to_blocks(
 
     // Save image to disk instead of base64-encoding into the session.
     // A 3 MB photo becomes ~100 KB on disk with only a short path in the session.
-    let upload_dir = std::env::temp_dir().join("librefang_uploads");
-
     let ext = match final_media_type.as_str() {
         "image/jpeg" => "jpg",
         "image/png" => "png",

--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -719,4 +719,12 @@ pub trait KernelHandle: Send + Sync {
     fn channel_file_download_dir(&self) -> Option<std::path::PathBuf> {
         None
     }
+
+    /// Return the effective directory for storing runtime-generated uploads
+    /// (image_generate, browser_screenshot, etc.). Honors operator-configured
+    /// `[channels].file_download_dir` when set, otherwise falls back to the
+    /// legacy `<temp>/librefang_uploads`. See issue #4435.
+    fn effective_upload_dir(&self) -> std::path::PathBuf {
+        std::env::temp_dir().join("librefang_uploads")
+    }
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -13340,7 +13340,7 @@ system_prompt = "You are a helpful assistant."
                     if kernel.supervisor.is_shutting_down() {
                         break;
                     }
-                    let upload_dir = std::env::temp_dir().join("librefang_uploads");
+                    let upload_dir = kernel.config_ref().channels.effective_file_download_dir();
                     if let Ok(mut entries) = tokio::fs::read_dir(&upload_dir).await {
                         let cutoff = std::time::SystemTime::now()
                             - std::time::Duration::from_secs(24 * 3600);
@@ -17365,6 +17365,10 @@ impl LibreFangKernel {
 
 #[async_trait]
 impl KernelHandle for LibreFangKernel {
+    fn effective_upload_dir(&self) -> std::path::PathBuf {
+        self.config_ref().channels.effective_file_download_dir()
+    }
+
     async fn spawn_agent(
         &self,
         manifest_toml: &str,

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -1112,6 +1112,7 @@ pub async fn tool_browser_screenshot(
     _input: &serde_json::Value,
     mgr: &BrowserManager,
     agent_id: &str,
+    upload_dir: &std::path::Path,
 ) -> Result<String, String> {
     let resp = mgr
         .send_command(agent_id, BrowserCommand::Screenshot)
@@ -1129,8 +1130,7 @@ pub async fn tool_browser_screenshot(
     let mut image_urls: Vec<String> = Vec::new();
     if !b64.is_empty() {
         use base64::Engine;
-        let upload_dir = std::env::temp_dir().join("librefang_uploads");
-        let _ = std::fs::create_dir_all(&upload_dir);
+        let _ = std::fs::create_dir_all(upload_dir);
         let file_id = uuid::Uuid::new_v4().to_string();
         if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(b64) {
             let path = upload_dir.join(&file_id);

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -858,7 +858,12 @@ pub async fn execute_tool_raw(
         }
 
         // Media generation tools (MediaDriver-based)
-        "image_generate" => tool_image_generate(input, *media_drivers, *workspace_root).await,
+        "image_generate" => {
+            let upload_dir = kernel
+                .map(|k| k.effective_upload_dir())
+                .unwrap_or_else(|| std::env::temp_dir().join("librefang_uploads"));
+            tool_image_generate(input, *media_drivers, *workspace_root, &upload_dir).await
+        }
         "video_generate" => tool_video_generate(input, *media_drivers).await,
         "video_status" => tool_video_status(input, *media_drivers).await,
         "music_generate" => tool_music_generate(input, *media_drivers, *workspace_root).await,
@@ -988,7 +993,10 @@ pub async fn execute_tool_raw(
         "browser_screenshot" => match browser_ctx {
             Some(mgr) => {
                 let aid = caller_agent_id.unwrap_or("default");
-                crate::browser::tool_browser_screenshot(input, mgr, aid).await
+                let upload_dir = kernel
+                    .map(|k| k.effective_upload_dir())
+                    .unwrap_or_else(|| std::env::temp_dir().join("librefang_uploads"));
+                crate::browser::tool_browser_screenshot(input, mgr, aid, &upload_dir).await
             }
             None => {
                 Err("Browser tools not available. Ensure Chrome/Chromium is installed.".to_string())
@@ -4836,6 +4844,7 @@ async fn tool_image_generate(
     input: &serde_json::Value,
     media_drivers: Option<&crate::media::MediaDriverCache>,
     workspace_root: Option<&Path>,
+    upload_dir: &Path,
 ) -> Result<String, String> {
     let prompt = input["prompt"]
         .as_str()
@@ -4879,7 +4888,7 @@ async fn tool_image_generate(
 
         // Save images to workspace and uploads dir
         let saved_paths = save_media_images_to_workspace(&result.images, workspace_root);
-        let image_urls = save_media_images_to_uploads(&result.images);
+        let image_urls = save_media_images_to_uploads(&result.images, upload_dir);
 
         let response = serde_json::json!({
             "model": result.model,
@@ -4936,8 +4945,7 @@ async fn tool_image_generate(
     let mut image_urls: Vec<String> = Vec::new();
     {
         use base64::Engine;
-        let upload_dir = std::env::temp_dir().join("librefang_uploads");
-        let _ = std::fs::create_dir_all(&upload_dir);
+        let _ = std::fs::create_dir_all(upload_dir);
         for img in &result.images {
             let file_id = uuid::Uuid::new_v4().to_string();
             if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(&img.data_base64)
@@ -4989,10 +4997,12 @@ fn save_media_images_to_workspace(
 }
 
 /// Save MediaImageResult images to uploads temp dir, returning /api/uploads/... URLs.
-fn save_media_images_to_uploads(images: &[librefang_types::media::GeneratedImage]) -> Vec<String> {
+fn save_media_images_to_uploads(
+    images: &[librefang_types::media::GeneratedImage],
+    upload_dir: &Path,
+) -> Vec<String> {
     use base64::Engine;
-    let upload_dir = std::env::temp_dir().join("librefang_uploads");
-    let _ = std::fs::create_dir_all(&upload_dir);
+    let _ = std::fs::create_dir_all(upload_dir);
     let mut urls = Vec::new();
     for img in images {
         // If provider returned a URL directly, use it as-is

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -5451,13 +5451,17 @@ impl Default for ChannelsConfig {
 }
 
 impl ChannelsConfig {
-    /// Resolve the effective directory channel bridges write downloaded
-    /// attachments to. Returns the operator-configured `file_download_dir`
-    /// when set, or `std::env::temp_dir()/librefang_uploads` otherwise.
+    /// Resolve the effective directory for storing downloaded channel
+    /// attachments (and any other code path that historically wrote into
+    /// `<temp>/librefang_uploads`). Returns the operator-configured
+    /// `[channels].file_download_dir` when set, otherwise the legacy
+    /// `std::env::temp_dir()/librefang_uploads` default.
     ///
-    /// Centralizing the fallback here lets the kernel hand the same path
-    /// to the file-read sandbox so agents can actually open the files the
-    /// bridge tells them about (issue #4434).
+    /// This helper is the single source of truth — no other site in the
+    /// codebase should hardcode the literal `"librefang_uploads"` so the
+    /// kernel can hand the same path to the file-read sandbox and agents
+    /// can actually open the files the bridge tells them about. See
+    /// issues #4434 and #4435.
     pub fn effective_file_download_dir(&self) -> std::path::PathBuf {
         self.file_download_dir
             .as_ref()


### PR DESCRIPTION
## Summary
- Adds `ChannelsConfig::effective_file_download_dir()` (single source of truth in `librefang-types`), plus `KernelHandle::effective_upload_dir()` and `ChannelHandle::effective_channels_download_dir()` convenience helpers.
- Migrates every previously-hardcoded `std::env::temp_dir().join("librefang_uploads")` call site (bridge cleanup, kernel periodic GC, API upload/serve/attachments/media routes, runtime `image_generate` and `browser_screenshot`) to use the helpers.
- Operator-configured `[channels].file_download_dir` is now respected end-to-end — fixing the silent split where the bridge wrote to the configured dir while UI uploads, generated images, screenshots, attachment resolution, and the cleanup sweep all hit `/tmp/librefang_uploads`.

Closes #4435

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Live integration: set `[channels].file_download_dir = "/data/uploads"`, send a Telegram photo, generate an image via `image_generate`, take a `browser_screenshot`, and `POST /api/uploads` — confirm all artifacts land in `/data/uploads` and `GET /api/uploads/{id}` serves them.