### PR TITLE
fix(cli,kernel): wire init wizard Smart Router into config (#4466)

### DIFF
--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -589,20 +589,26 @@ fn default_model_for_provider(provider: &str, model_catalog: &ModelCatalog) -> S
         .unwrap_or_else(|| "local-model".to_string())
 }
 
-/// Build the `[routing]` TOML section emitted into `config.toml`.
+/// Build the `[default_routing]` TOML section emitted into `config.toml`.
 ///
 /// Pure helper extracted from `save_config` (#3582) so the formatting can be
 /// unit-tested without touching the filesystem or the wizard `State`. When
 /// `enabled` is `false`, the wizard writes no routing section at all and we
 /// must return an empty string (callers concat this directly into the
 /// rendered template).
+///
+/// Issue #4466: this previously emitted `[routing]`, which is not a known
+/// `KernelConfig` field — strict-config mode warned and the kernel silently
+/// ignored the user's Smart Router selection. The kernel now reads
+/// `[default_routing]` as a fallback for any agent without its own per-agent
+/// `routing` block, so the wizard emits that exact key here.
 fn build_routing_section(enabled: bool, models: &[String; 3]) -> String {
     if !enabled {
         return String::new();
     }
     format!(
         r#"
-[routing]
+[default_routing]
 simple_model = "{fast}"
 medium_model = "{balanced}"
 complex_model = "{frontier}"
@@ -2554,9 +2560,26 @@ mod tests {
     #[test]
     fn routing_section_disabled_is_empty() {
         // When the user picks "No" in the routing prompt the wizard must emit
-        // no `[routing]` block at all — an empty section, not a stub.
+        // no `[default_routing]` block at all — an empty section, not a stub.
         let out = build_routing_section(false, &models("a", "b", "c"));
         assert!(out.is_empty(), "expected empty section, got {out:?}");
+    }
+
+    #[test]
+    fn routing_section_uses_default_routing_key_not_legacy_routing() {
+        // Regression for issue #4466: the wizard previously emitted `[routing]`
+        // which is NOT a recognised KernelConfig field, so the user's Smart
+        // Router selection was silently ignored. The kernel reads
+        // `[default_routing]` as the agent-fallback Smart Router config.
+        let out = build_routing_section(true, &models("a", "b", "c"));
+        assert!(
+            out.contains("[default_routing]"),
+            "expected `[default_routing]` header, got {out:?}"
+        );
+        assert!(
+            !out.contains("[routing]"),
+            "wizard must not emit the dead `[routing]` key, got {out:?}"
+        );
     }
 
     #[test]
@@ -2630,7 +2653,7 @@ mod tests {
             &build_api_key_line("ANTHROPIC_API_KEY"),
             &build_routing_section(true, &models("haiku", "sonnet", "opus")),
         );
-        assert!(rendered.contains("[routing]"));
+        assert!(rendered.contains("[default_routing]"));
         assert!(rendered.contains("simple_model = \"haiku\""));
         assert!(rendered.contains("complex_model = \"opus\""));
     }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -4254,6 +4254,21 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
+        // Validate kernel-wide default_routing (issue #4466) so the init
+        // wizard's Smart Router selection surfaces alias / unknown-model
+        // warnings at boot, not silently at first dispatch.
+        if let Some(ref routing_config) = kernel.config.load().default_routing {
+            let router = ModelRouter::new(routing_config.clone());
+            for warning in router.validate_models(
+                &kernel
+                    .model_catalog
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner()),
+            ) {
+                warn!(target: "librefang_kernel::default_routing", "{warning}");
+            }
+        }
+
         info!("LibreFang kernel booted successfully");
         Ok(kernel)
     }
@@ -8172,7 +8187,9 @@ system_prompt = "You are a helpful assistant."
                 );
                 manifest.model.model = pinned.clone();
             }
-        } else if let Some(ref routing_config) = manifest.routing {
+        } else if let Some(routing_config) =
+            manifest.routing.as_ref().or(cfg.default_routing.as_ref())
+        {
             let mut router = ModelRouter::new(routing_config.clone());
             // Resolve aliases (e.g. "sonnet" -> "claude-sonnet-4-20250514") before scoring
             router.resolve_aliases(&self.model_catalog.read().unwrap_or_else(|e| e.into_inner()));

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -63,7 +63,7 @@ impl std::str::FromStr for UserId {
 }
 
 /// Model routing configuration — auto-selects cheap/mid/expensive models by complexity.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub struct ModelRoutingConfig {
     /// Model to use for simple queries.

--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -1205,6 +1205,53 @@ admin_role = "admin"
     }
 
     #[test]
+    fn default_routing_section_parses_and_is_known_top_level() {
+        // Regression for issue #4466: the init wizard writes Smart Router
+        // selections under `[default_routing]`. The field must
+        // (a) deserialise into KernelConfig and (b) be on the strict-mode
+        // allowlist so users running `strict_config = true` don't see a
+        // bogus unknown-field warning for their own wizard output.
+        let raw: toml::Value = toml::from_str(
+            r#"
+            [default_routing]
+            simple_model = "haiku"
+            medium_model = "sonnet"
+            complex_model = "opus"
+            simple_threshold = 100
+            complex_threshold = 500
+        "#,
+        )
+        .unwrap();
+
+        let unknown = KernelConfig::detect_unknown_fields(&raw);
+        assert!(
+            unknown.is_empty(),
+            "default_routing must be allowlisted: {unknown:?}"
+        );
+
+        let cfg: KernelConfig = toml::from_str(
+            r#"
+            [default_routing]
+            simple_model = "haiku"
+            medium_model = "sonnet"
+            complex_model = "opus"
+            simple_threshold = 100
+            complex_threshold = 500
+        "#,
+        )
+        .unwrap();
+        let r = cfg
+            .default_routing
+            .as_ref()
+            .expect("default_routing must deserialise");
+        assert_eq!(r.simple_model, "haiku");
+        assert_eq!(r.medium_model, "sonnet");
+        assert_eq!(r.complex_model, "opus");
+        assert_eq!(r.simple_threshold, 100);
+        assert_eq!(r.complex_threshold, 500);
+    }
+
+    #[test]
     fn test_known_fields_cover_real_kernelconfig_fields() {
         // Regression test for strict_config rejecting valid fields whose names
         // were never added to the hand-maintained allowlists.

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2560,6 +2560,13 @@ pub struct KernelConfig {
     /// at runtime with a warning log.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_history_messages: Option<usize>,
+    /// Kernel-wide Smart Model Router defaults applied to any agent whose
+    /// `agent.toml` does not set its own `[routing]` block. The `init` wizard
+    /// writes user-selected tier models here under `[default_routing]` so the
+    /// chosen routing actually reaches the kernel — see issue #4466. Per-agent
+    /// `routing` always wins when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_routing: Option<crate::agent::ModelRoutingConfig>,
     /// Default LLM provider configuration.
     pub default_model: DefaultModelConfig,
     /// Memory substrate configuration.
@@ -4745,6 +4752,7 @@ impl Default for KernelConfig {
             network_enabled: false,
             agent_max_iterations: None,
             max_history_messages: None,
+            default_routing: None,
             default_model: DefaultModelConfig::default(),
             memory: MemoryConfig::default(),
             network: NetworkConfig::default(),

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -100,6 +100,7 @@ impl KernelConfig {
             "task_board",
             "auto_dream",
             "max_history_messages",
+            "default_routing",
         ]
     }
 


### PR DESCRIPTION
## Summary
- The init wizard's Smart Model Router prompt wrote `[routing]` to `config.toml`, but `KernelConfig` has no such field — strict mode flagged it as unknown and the kernel only ever read per-agent `routing` from `agent.toml`. The user's selection was silently discarded.
- Add `default_routing: Option<ModelRoutingConfig>` to `KernelConfig` (allowlisted for strict mode), have the kernel fall back to it when an agent manifest has no `routing`, and validate it against the model catalog at boot.
- Wizard now emits `[default_routing]` instead of the dead `[routing]` key.

## Test plan
- [x] `cargo check --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p librefang-types --lib default_routing` — new allowlist + deserialise test passes
- [x] `cargo test -p librefang-cli init_wizard` — 12 tests including new `routing_section_uses_default_routing_key_not_legacy_routing` regression
- [ ] Live: run `librefang init`, pick Smart Router, confirm `[default_routing]` lands in `~/.librefang/config.toml` and that an agent without its own `routing` block routes through the configured tiers

Closes #4466