### PR TITLE
fix(tests): align with PaginatedResponse + return-entity envelope changes

### DIFF
--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -2082,7 +2082,7 @@ mod tests {
             json["total"], 1,
             "expected post-boot peer to appear, got {json}"
         );
-        assert_eq!(json["peers"][0]["node_id"], "node-abc");
+        assert_eq!(json["items"][0]["node_id"], "node-abc");
     }
 
     #[test]

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -1889,7 +1889,7 @@ metrics = []
         .await
         .expect("read body");
     let json: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
-    let instances = json["instances"].as_array().expect("instances array");
+    let instances = json["items"].as_array().expect("items array");
     let hand = instances
         .iter()
         .find(|i| i["hand_id"] == "test-grouping-hand")

--- a/crates/librefang-api/tests/prompts_routes_integration.rs
+++ b/crates/librefang-api/tests/prompts_routes_integration.rs
@@ -214,7 +214,8 @@ async fn activate_prompt_version_with_agent_id_in_body_succeeds() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "body={body:?}");
-    assert_eq!(body["success"], true);
+    // #4365: activate now returns the full PromptVersion entity, not an ack envelope.
+    assert_eq!(body["id"], VERSION_ID, "body={body:?}");
 }
 
 // ----- experiments -----


### PR DESCRIPTION
## Summary

Main has been red since #4306, #4365, and #4371 merged — three inline test assertions weren't updated to reflect the new response shapes their parent PRs introduced. This patches the assertions:

| Test | Was checking | Now should check | Caused by |
|---|---|---|---|
| `routes::network::tests::list_peers_reflects_peers_added_after_appstate_boot` | `json["peers"][0]` | `json["items"][0]` | #4306 + #4355 |
| `list_active_hands_includes_definition_metadata` | `json["instances"]` | `json["items"]` | #4371 |
| `activate_prompt_version_with_agent_id_in_body_succeeds` | `body["success"] == true` | `body["id"] == VERSION_ID` | #4365 |

All three production contracts already shipped on main; only the assertions lagged.

## Test plan

- [ ] CI green on this PR (was failing across Ubuntu/macOS/Windows for those three names).
- [ ] Once merged, the cascade of "all open PRs show 3 fails" should clear.