### PR TITLE
fix(kernel): thread parent_session_id through fork LoopOptions to fix TOCTOU race (#4291)

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1916,6 +1916,23 @@ impl LibreFangKernel {
             .map(|e| e.value().clone())
     }
 
+    /// First currently-active `(parent_session_id, parent_interrupt)` pair
+    /// for `agent_id`. Same DashMap-iteration-order semantics as
+    /// [`Self::any_session_interrupt_for_agent`], but also returns the
+    /// session key the interrupt was registered under so fork-spawn sites
+    /// can pin themselves to the parent turn's actual session — rather
+    /// than re-reading `entry.session_id`, which is a TOCTOU race against
+    /// `switch_agent_session` (#4291).
+    pub(crate) fn any_session_interrupt_with_id_for_agent(
+        &self,
+        agent_id: AgentId,
+    ) -> Option<(SessionId, librefang_runtime::interrupt::SessionInterrupt)> {
+        self.session_interrupts
+            .iter()
+            .find(|e| e.key().0 == agent_id)
+            .map(|e| (e.key().1, e.value().clone()))
+    }
+
     /// Per-agent decision traces.
     #[inline]
     pub fn traces(&self) -> &dashmap::DashMap<AgentId, Vec<librefang_types::tool::DecisionTrace>> {
@@ -5176,6 +5193,7 @@ system_prompt = "You are a helpful assistant."
                 max_iterations: self.config.load().agent_max_iterations,
                 max_history_messages: self.config.load().max_history_messages,
                 aux_client: Some(self.aux_client.load_full()),
+                parent_session_id: None,
             },
         )
         .await
@@ -6012,9 +6030,24 @@ system_prompt = "You are a helpful assistant."
         // shared Arc<AtomicBool> still work — `stop_agent_run(agent_id)`
         // fans out across all sessions, so no matter which entry we
         // borrowed from, the cascade reaches this fork.
-        let interrupt = self
-            .any_session_interrupt_for_agent(agent_id)
-            .unwrap_or_default();
+        //
+        // We also snapshot the parent session id from the same lookup so
+        // the kernel's session resolver can pin the fork to the parent
+        // turn's session for prompt-cache alignment, instead of
+        // re-reading `entry.session_id` later (which is mutable by
+        // `switch_agent_session`, producing a TOCTOU race — #4291). When
+        // no parent loop is in flight, fall back to the registry pointer
+        // — the only signal we have, and the fork will create/resume
+        // that session on its own.
+        let (parent_session_id, interrupt) = match self
+            .any_session_interrupt_with_id_for_agent(agent_id)
+        {
+            Some((sid, intr)) => (sid, intr),
+            None => (
+                entry.session_id,
+                librefang_runtime::interrupt::SessionInterrupt::default(),
+            ),
+        };
         let loop_opts = librefang_runtime::agent_loop::LoopOptions {
             is_fork: true,
             allowed_tools,
@@ -6022,6 +6055,7 @@ system_prompt = "You are a helpful assistant."
             max_iterations: self.config.load().agent_max_iterations,
             max_history_messages: self.config.load().max_history_messages,
             aux_client: Some(self.aux_client.load_full()),
+            parent_session_id: Some(parent_session_id),
         };
         // INVARIANT: forks must use the canonical session so the parent turn's
         // prompt-cache prefix is reused. Do NOT pass a `session_id_override`
@@ -6093,6 +6127,7 @@ system_prompt = "You are a helpful assistant."
             max_iterations: self.config.load().agent_max_iterations,
             max_history_messages: self.config.load().max_history_messages,
             aux_client: Some(self.aux_client.load_full()),
+            parent_session_id: None,
         };
         self.send_message_streaming_with_sender_and_opts(
             agent_id,
@@ -6252,20 +6287,36 @@ system_prompt = "You are a helpful assistant."
                     };
                     SessionId::for_channel(agent_id, &scope)
                 }
-                // Fork calls always target the agent's canonical session —
-                // the whole point of fork mode is to share the parent turn's
+                // Fork calls always target the parent turn's session — the
+                // whole point of fork mode is to share the parent's
                 // context (and therefore its prompt-cache prefix). An agent
                 // with `session_mode = "new"` would otherwise land on
                 // `SessionId::new()` here, producing a fresh empty session
                 // and breaking cache alignment. Force Persistent for forks
                 // regardless of manifest.
                 //
+                // We read the parent session id from `loop_opts`, NOT from
+                // `entry.session_id`. The registry pointer is mutable by
+                // `switch_agent_session` / `update_session_id` and can flip
+                // between parent loop start and fork spawn, sending the
+                // fork to the wrong session and polluting that session's
+                // history (#4291). The fork-spawn site
+                // (`run_forked_agent_streaming`) snapshots the parent
+                // session at fork-construction time and threads it through
+                // `LoopOptions::parent_session_id`.
+                //
                 // NOTE: an explicit `session_id_override` (above) wins over
                 // this branch — if you ever plumb an override through a fork
                 // caller, prompt-cache alignment WILL break. The current
                 // `run_forked_agent_streaming` deliberately passes `None` to
                 // preserve this invariant.
-                _ if loop_opts.is_fork => entry.session_id,
+                _ if loop_opts.is_fork => loop_opts.parent_session_id.ok_or_else(|| {
+                    KernelError::LibreFang(LibreFangError::Internal(
+                        "fork loop_opts missing parent_session_id (must be set by \
+                         run_forked_agent_streaming before reaching the session resolver)"
+                            .to_string(),
+                    ))
+                })?,
                 _ => match entry.manifest.session_mode {
                     librefang_types::agent::SessionMode::Persistent => entry.session_id,
                     librefang_types::agent::SessionMode::New => SessionId::new(),
@@ -8413,6 +8464,7 @@ system_prompt = "You are a helpful assistant."
             max_iterations: cfg.agent_max_iterations,
             max_history_messages: cfg.max_history_messages,
             aux_client: Some(self.aux_client.load_full()),
+            parent_session_id: None,
         };
 
         // Build a per-execution MCP pool that includes the agent workspace as

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -3907,6 +3907,176 @@ fn test_fork_does_not_overwrite_parent_registration() {
     kernel.shutdown();
 }
 
+/// Regression for #4291. The previous fork-spawn site read
+/// `entry.session_id` from the agent registry to decide which session
+/// the fork should land on — but `entry.session_id` is mutable by
+/// `switch_agent_session` (`POST /api/agents/{id}/sessions/{sid}/switch`),
+/// which any dashboard tab can call mid-turn. A fork emitted between
+/// the parent's `effective_session_id` resolution and the fork-spawn
+/// lookup would read the *new* registry pointer and pollute the wrong
+/// session's history, breaking prompt-cache alignment.
+///
+/// The fix snapshots the parent session id at fork construction time
+/// (from `session_interrupts`, which is keyed by the parent's actual
+/// `effective_session_id`) and threads it through
+/// `LoopOptions::parent_session_id`. The session resolver in
+/// `send_message_streaming_with_sender_and_opts` reads
+/// `loop_opts.parent_session_id` for forks and never re-touches
+/// `entry.session_id`.
+///
+/// This test exercises the snapshot primitive: register a parent
+/// interrupt for `(agent, X)`, mutate the registry to point at `Y`
+/// via `update_session_id`, then re-snapshot via
+/// `any_session_interrupt_with_id_for_agent`. The snapshot must still
+/// return `X` — the helper reads the in-flight interrupt map, not the
+/// registry pointer, so a concurrent `switch_agent_session` cannot
+/// drag the fork onto the wrong session.
+#[test]
+fn fork_session_snapshot_is_unaffected_by_registry_mutation_4291() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().join("librefang-fork-toctou-4291");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let kernel = LibreFangKernel::boot_with_config(KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    })
+    .expect("kernel should boot");
+
+    // Register a real agent so `update_session_id` can find it. The
+    // initial entry.session_id is `parent_session` — what the parent
+    // turn was actually invoked with.
+    let agent_id = AgentId::new();
+    let parent_session = SessionId::new();
+    let entry = librefang_types::agent::AgentEntry {
+        id: agent_id,
+        name: format!("toctou-agent-{}", agent_id),
+        manifest: librefang_types::agent::AgentManifest {
+            name: format!("toctou-agent-{}", agent_id),
+            description: "test".into(),
+            author: "test".into(),
+            module: "test".into(),
+            ..Default::default()
+        },
+        state: librefang_types::agent::AgentState::Running,
+        mode: librefang_types::agent::AgentMode::default(),
+        created_at: chrono::Utc::now(),
+        last_active: chrono::Utc::now(),
+        parent: None,
+        children: vec![],
+        session_id: parent_session,
+        tags: vec![],
+        identity: Default::default(),
+        onboarding_completed: false,
+        onboarding_completed_at: None,
+        source_toml_path: None,
+        is_hand: false,
+        ..Default::default()
+    };
+    kernel.registry.register(entry).expect("register agent");
+
+    // Simulate the parent loop being mid-turn: insert its interrupt
+    // under `(agent, parent_session)`, exactly as
+    // `send_message_streaming_with_sender_and_opts` does at the
+    // `if !loop_opts.is_fork` register block. This is what the fork-
+    // spawn site uses to discover which session to land on.
+    let parent_interrupt = librefang_runtime::interrupt::SessionInterrupt::new();
+    kernel
+        .session_interrupts
+        .insert((agent_id, parent_session), parent_interrupt.clone());
+
+    // Pre-mutation snapshot: helper must return the parent session.
+    let (snapshot_sid_before, _) = kernel
+        .any_session_interrupt_with_id_for_agent(agent_id)
+        .expect("parent loop must be discoverable via session_interrupts");
+    assert_eq!(
+        snapshot_sid_before, parent_session,
+        "fork-spawn snapshot must return the session the parent loop is actually \
+         running on, not whatever the registry currently points at"
+    );
+
+    // Now do exactly what the dashboard's Sessions-page Play button
+    // (or any other `switch_agent_session` caller) would do mid-turn:
+    // mutate the registry pointer to a *different* session.
+    let switched_session = SessionId::new();
+    assert_ne!(switched_session, parent_session);
+    kernel
+        .registry
+        .update_session_id(agent_id, switched_session)
+        .expect("update_session_id");
+
+    // Sanity: the registry pointer really did flip.
+    let entry_after = kernel
+        .registry
+        .get(agent_id)
+        .expect("agent still registered");
+    assert_eq!(
+        entry_after.session_id, switched_session,
+        "registry mutation must have taken effect — otherwise this test \
+         is not actually exercising the TOCTOU window"
+    );
+
+    // Critical assertion: the fork-spawn snapshot is UNCHANGED. The
+    // helper reads the in-flight interrupt map (parent's actual
+    // session), not the now-stale registry pointer. The fork plumbed
+    // through `LoopOptions::parent_session_id` would therefore land on
+    // `parent_session`, NOT `switched_session`.
+    let (snapshot_sid_after, _) = kernel
+        .any_session_interrupt_with_id_for_agent(agent_id)
+        .expect("parent loop must still be discoverable after registry mutation");
+    assert_eq!(
+        snapshot_sid_after, parent_session,
+        "fork-spawn snapshot must NOT follow registry mutations — that is the \
+         whole TOCTOU race in #4291. Got {:?}, expected {:?}",
+        snapshot_sid_after, parent_session
+    );
+
+    // Belt-and-braces: the canonical fork-time `LoopOptions` carries
+    // exactly this snapshot, so a fork constructed *after* the
+    // registry flip still targets the parent's session. Build the
+    // options the same way `run_forked_agent_streaming` does and
+    // assert.
+    let loop_opts = librefang_runtime::agent_loop::LoopOptions {
+        is_fork: true,
+        parent_session_id: Some(snapshot_sid_after),
+        ..Default::default()
+    };
+    assert_eq!(
+        loop_opts.parent_session_id,
+        Some(parent_session),
+        "fork LoopOptions must carry the parent's actual session id, \
+         not the post-mutation registry pointer"
+    );
+    assert_ne!(
+        loop_opts.parent_session_id,
+        Some(switched_session),
+        "fork LoopOptions must not have followed the registry switch"
+    );
+
+    kernel.shutdown();
+}
+
+/// Default `LoopOptions` must have `parent_session_id == None`, and
+/// non-fork construction sites that don't set it explicitly inherit
+/// the default. The session resolver MUST refuse to read this field
+/// when `is_fork = false` — that contract is asserted at the resolver
+/// arm. This test just pins the default value so a future refactor of
+/// `LoopOptions::Default` doesn't accidentally start sending forks to
+/// a stale id.
+#[test]
+fn loop_options_default_has_no_parent_session_id_4291() {
+    let opts = librefang_runtime::agent_loop::LoopOptions::default();
+    assert!(
+        opts.parent_session_id.is_none(),
+        "LoopOptions::default() must leave parent_session_id unset; \
+         only run_forked_agent_streaming should populate it"
+    );
+    assert!(
+        !opts.is_fork,
+        "LoopOptions::default() must be a non-fork main turn"
+    );
+}
+
 /// `agent_concurrency_for` resolves a `New`-mode manifest with
 /// `max_concurrent_invocations = 4` to a 4-permit semaphore — the
 /// happy path for parallel trigger fires.

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1761,6 +1761,20 @@ pub struct LoopOptions {
     /// Kernel populates this from the boot-time-built [`AuxClient`].
     /// Tests typically leave it as `None`.
     pub aux_client: Option<std::sync::Arc<crate::aux_client::AuxClient>>,
+    /// When `is_fork = true`, the session id the *parent* turn was actually
+    /// invoked on (i.e. the parent's resolved `effective_session_id`, NOT
+    /// the registry's mutable `entry.session_id` pointer). The kernel's
+    /// session resolver consumes this to land the fork on the parent's
+    /// session for prompt-cache alignment, regardless of whether the
+    /// agent registry pointer has since been re-pointed by
+    /// `switch_agent_session` / `update_session_id`.
+    ///
+    /// MUST be `Some(parent_session)` whenever `is_fork = true`. The
+    /// kernel surfaces a hard error if `is_fork && parent_session_id ==
+    /// None`, because reading `entry.session_id` at fork-spawn time is a
+    /// TOCTOU race against `switch_agent_session` (#4291). For
+    /// non-fork loops this field is ignored and should be left `None`.
+    pub parent_session_id: Option<librefang_types::agent::SessionId>,
 }
 
 /// Result of an agent loop execution.


### PR DESCRIPTION
## Summary

Forks previously read `entry.session_id` from the agent registry at fork-spawn time to decide which session to land on. That field is mutable by `switch_agent_session` (`POST /api/agents/{id}/sessions/{sid}/switch`), so a fork emitted between parent loop start and fork spawn could follow a concurrent registry mutation onto the wrong session, appending fork output into a session that was not the parent\047s and breaking Anthropic prompt-cache alignment.

## Fix

- Add `LoopOptions::parent_session_id: Option<SessionId>` (in `librefang-runtime/src/agent_loop.rs`).
- The session resolver in `send_message_streaming_with_sender_and_opts` now reads `loop_opts.parent_session_id` for `is_fork = true` (returning `Internal` if missing) and never re-touches `entry.session_id` for forks.
- `run_forked_agent_streaming` snapshots the parent session id from `session_interrupts` (keyed by the parent\047s actual `effective_session_id`) at fork construction time, so a later `switch_agent_session` cannot drag the fork onto a different session.
- New `any_session_interrupt_with_id_for_agent` helper returns `(parent_session_id, parent_interrupt)` from the same DashMap lookup that already produced just the interrupt — existing cascade behaviour unchanged.
- Updated all four `LoopOptions` construction sites in `kernel/mod.rs` to set the new field (only `run_forked_agent_streaming` populates it; the rest pass `None`).

## Test plan

- [x] Added regression test `fork_session_snapshot_is_unaffected_by_registry_mutation_4291` in `crates/librefang-kernel/src/kernel/tests.rs`. Steps: register a parent interrupt under `(agent, X)` (simulating the parent mid-turn), mutate the registry pointer to `Y` via `update_session_id`, then assert the snapshot helper still returns `X` and the constructed `LoopOptions::parent_session_id` carries `X` not `Y`.
- [x] Added `loop_options_default_has_no_parent_session_id_4291` to pin the `Default` value for the new field at `None`, so future `LoopOptions::Default` refactors can not silently start sending forks to a stale id.
- [ ] Live integration: spawn parent on session X, mutate registry mid-turn via the dashboard Sessions Play button, fork from parent (e.g. via auto-dream or `run_forked_agent_oneshot`), verify the fork persists into X (not Y).

## Notes

- Local cargo verification skipped — the rust toolchain is absent on this build host. Relying on CI for `cargo check --workspace --lib`, `cargo clippy --workspace --all-targets -- -D warnings`, and the new tests via `cargo test -p librefang-kernel`.
- Diff is minimal: 3 files, +242/-6. No public API change to `LoopOptions` consumers because the new field is `Option<SessionId>` with `Default = None`; existing `..Default::default()` callers (the agent_loop unit tests) remain compatible.
- The interrupt cascade and `running_tasks` registration semantics for forks are unchanged — the fork still skips both maps under the existing `if !loop_opts.is_fork` guards.

Closes #4291