### PR TITLE
test(api): smoke-matrix coverage for ~80% untested routes (#3571)

### DIFF
--- a/crates/librefang-api/tests/route_smoke.rs
+++ b/crates/librefang-api/tests/route_smoke.rs
@@ -1,0 +1,520 @@
+//! Route smoke matrix — issue #3571.
+//!
+//! Walks a hand-curated table of every GET path registered under
+//! `crates/librefang-api/src/routes/` (plus a few protocol-level routes mounted
+//! directly in `server::build_router`) and asserts that hitting each one with
+//! an empty body never produces a 5xx.  The point is to catch the failure
+//! mode the issue calls out: handlers that compile but panic / return 500 the
+//! moment they are actually invoked because their dependency on `AppState`
+//! is wrong, a feature flag silently disabled them, or an `unwrap()` fires on
+//! the empty-config path.
+//!
+//! Companion focused tests cover the highest-risk POST surfaces from the
+//! issue body:
+//!   - `/v1/chat/completions` — malformed JSON, missing `model`
+//!   - `/api/approvals/{id}/approve` — bogus id
+//!   - `/api/a2a/discover` — bad URL
+//!   - `/hooks/agent` — bad signature header
+//!
+//! ## Maintenance
+//!
+//! The path list in `SMOKE_GET_ROUTES` is the authoritative source.  When you
+//! add a `.route("/foo", get(...))` anywhere under
+//! `crates/librefang-api/src/routes/`, append it here too.  To regenerate the
+//! complete set:
+//!
+//! ```bash
+//! grep -rn '\.route(' crates/librefang-api/src/routes/ \
+//!   | grep -oE '"/[^"]+"' | sort -u
+//! ```
+//!
+//! axum does not expose its registered routes via a public API, so we
+//! intentionally keep the list explicit instead of parsing source at runtime.
+//! Drift is caught the next time a smoke run discovers a 500 on a path that
+//! was never added.
+//!
+//! ## What this test does NOT do
+//!
+//! - It only walks GET, with a placeholder UUID for `{id}`-style segments.
+//!   Per the issue's "Suggested fix", POST/PUT are covered by the focused
+//!   tests below rather than the matrix.
+//! - The harness boots in open dev mode (no `api_key`, loopback bind).
+//!   Auth-required paths therefore execute their handler instead of being
+//!   short-circuited to 401, which is the behaviour we want for "does the
+//!   handler panic on an empty kernel".
+//! - WebSocket upgrade endpoints (`/api/agents/{id}/ws`, `/api/terminal/ws`)
+//!   are skipped — without an upgrade header axum returns 426, which is fine,
+//!   but they don't add coverage value.
+//!
+//! Run: `cargo test -p librefang-api --test route_smoke -- --nocapture`
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use librefang_api::routes::AppState;
+use librefang_api::server;
+use librefang_kernel::LibreFangKernel;
+use librefang_types::config::{DefaultModelConfig, KernelConfig};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+struct Harness {
+    app: axum::Router,
+    _tmp: tempfile::TempDir,
+    state: Arc<AppState>,
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.state.kernel.shutdown();
+    }
+}
+
+/// Boot a real router in open dev mode (`api_key=""`, loopback bind).  This
+/// matches the pattern used by `tests/auth_public_allowlist.rs` so behaviour
+/// stays comparable across files.
+async fn boot_router() -> Harness {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Populate the registry cache so the kernel boots without network access.
+    librefang_runtime::registry_sync::sync_registry(
+        tmp.path(),
+        librefang_runtime::registry_sync::DEFAULT_CACHE_TTL_SECS,
+        "",
+    );
+
+    let config = KernelConfig {
+        home_dir: tmp.path().to_path_buf(),
+        data_dir: tmp.path().join("data"),
+        api_key: String::new(),
+        default_model: DefaultModelConfig {
+            provider: "ollama".to_string(),
+            model: "test-model".to_string(),
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        },
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("kernel boot");
+    let kernel = Arc::new(kernel);
+    kernel.set_self_handle();
+
+    let (app, state) = server::build_router(kernel, "127.0.0.1:0".parse().expect("addr")).await;
+
+    Harness {
+        app,
+        _tmp: tmp,
+        state,
+    }
+}
+
+/// Send a GET request through the live router and return the (status, content-type).
+async fn get(app: axum::Router, path: &str) -> (StatusCode, Option<String>) {
+    // Inject a loopback ConnectInfo so the auth middleware's "fail closed for
+    // non-loopback when no api_key" branch (boot_router uses `api_key=""`)
+    // treats the oneshot as a localhost caller. axum's Router::oneshot bypasses
+    // the connection layer that normally provides this.
+    let mut req = Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .body(Body::empty())
+        .expect("request builds");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+    let resp = app.oneshot(req).await.expect("oneshot");
+    let status = resp.status();
+    let ct = resp
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    (status, ct)
+}
+
+async fn post_json(app: axum::Router, path: &str, body: &str) -> StatusCode {
+    let mut req = Request::builder()
+        .method(Method::POST)
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builds");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+    app.oneshot(req).await.expect("oneshot").status()
+}
+
+// ---------------------------------------------------------------------------
+// Smoke matrix
+//
+// Every GET-only path served by `crates/librefang-api/src/routes/`, mounted
+// at `/api` and `/api/v1` in `server::build_router`.  Path parameters are
+// substituted with safe placeholders:
+//   - `{id}`            -> a zeroed UUID
+//   - `{name}`          -> "smoke-test"
+//   - `{filename}`      -> "missing.bak"
+//   - `{*id}` (wildcard)-> "openai/gpt-4"  (used by `/api/models/{*id}`)
+//
+// Protocol-level paths mounted at the root (`/.well-known/agent.json`,
+// `/a2a/agents`, etc.) are also included so the matrix captures everything
+// the daemon serves on GET.
+//
+// Source of truth: `grep -rn '\.route(' crates/librefang-api/src/routes/`
+// run on the same revision as this commit (#3571).
+// ---------------------------------------------------------------------------
+
+const SMOKE_GET_ROUTES: &[&str] = &[
+    // ── Health / version / config ────────────────────────────────────────
+    "/api/health",
+    "/api/health/detail",
+    "/api/status",
+    "/api/version",
+    "/api/versions",
+    "/api/config",
+    "/api/config/export",
+    "/api/config/schema",
+    "/api/security",
+    "/api/migrate/detect",
+    "/api/metrics",
+    "/api/openapi.json",
+    // ── Agents / triggers / sessions ─────────────────────────────────────
+    "/api/agents",
+    "/api/agents/00000000-0000-0000-0000-000000000000/logs",
+    "/api/triggers",
+    "/api/sessions",
+    "/api/sessions/search",
+    // ── Approvals (no live tests pre-#3571) ──────────────────────────────
+    "/api/approvals",
+    "/api/approvals/audit",
+    "/api/approvals/count",
+    "/api/approvals/totp/status",
+    "/api/approvals/00000000-0000-0000-0000-000000000000",
+    // ── Network / peers / pairing ────────────────────────────────────────
+    "/api/peers",
+    "/api/peers/00000000-0000-0000-0000-000000000000",
+    "/api/network/status",
+    "/api/pairing/devices",
+    // ── Comms (OFP) ──────────────────────────────────────────────────────
+    "/api/comms/topology",
+    "/api/comms/events",
+    // ── Inbox / goals / auto-dream ───────────────────────────────────────
+    "/api/inbox/status",
+    "/api/goals",
+    "/api/goals/templates",
+    "/api/auto-dream/status",
+    // ── Skills / hands / extensions / clawhub ────────────────────────────
+    "/api/skills",
+    "/api/skills/registry",
+    "/api/skills/smoke-test",
+    "/api/hands",
+    "/api/hands/active",
+    "/api/hands/smoke-test",
+    "/api/extensions",
+    "/api/extensions/smoke-test",
+    "/api/clawhub/search",
+    "/api/clawhub/browse",
+    "/api/clawhub-cn/search",
+    "/api/clawhub-cn/browse",
+    // ── MCP catalog / health / taint rules ───────────────────────────────
+    "/api/mcp/catalog",
+    "/api/mcp/health",
+    "/api/mcp/taint-rules",
+    // ── Budget / usage ───────────────────────────────────────────────────
+    "/api/usage",
+    "/api/usage/summary",
+    "/api/usage/by-model",
+    "/api/usage/daily",
+    "/api/budget/agents",
+    "/api/budget/users",
+    // ── Audit / authz ────────────────────────────────────────────────────
+    "/api/audit/recent",
+    "/api/audit/query",
+    "/api/audit/export",
+    "/api/audit/verify",
+    "/api/authz/check",
+    // ── Backups ──────────────────────────────────────────────────────────
+    "/api/backups",
+    // ── Queue / tasks ────────────────────────────────────────────────────
+    "/api/queue/status",
+    "/api/tasks/status",
+    "/api/tasks/list",
+    "/api/registry/schema",
+    // ── Templates / profiles / commands ──────────────────────────────────
+    "/api/templates",
+    "/api/templates/smoke-test",
+    "/api/profiles",
+    "/api/profiles/smoke-test",
+    "/api/commands",
+    "/api/commands/smoke-test",
+    // ── Channels ─────────────────────────────────────────────────────────
+    "/api/channels",
+    "/api/channels/smoke-test",
+    // ── Providers / models / catalog ─────────────────────────────────────
+    "/api/providers",
+    "/api/providers/ollama",
+    "/api/models",
+    "/api/models/openai/gpt-4",
+    "/api/catalog/status",
+    // ── Plugins ──────────────────────────────────────────────────────────
+    "/api/plugins",
+    "/api/plugins/doctor",
+    "/api/plugins/smoke-test",
+    "/api/plugins/smoke-test/status",
+    "/api/plugins/smoke-test/lint",
+    "/api/plugins/smoke-test/env",
+    "/api/plugins/smoke-test/export",
+    "/api/plugins/smoke-test/health",
+    // ── Memory / tools ───────────────────────────────────────────────────
+    "/api/memory/search",
+    "/api/memory/stats",
+    "/api/tools",
+    "/api/tools/file_read",
+    // ── Media ────────────────────────────────────────────────────────────
+    "/api/media/providers",
+    // ── Logs / terminal ──────────────────────────────────────────────────
+    "/api/logs/stream",
+    "/api/terminal/health",
+    // ── Users ────────────────────────────────────────────────────────────
+    "/api/users",
+    // ── Auth (GET surface) ───────────────────────────────────────────────
+    "/api/auth/providers",
+    "/api/auth/login",
+    "/api/auth/userinfo",
+    "/api/auth/dashboard-check",
+    // ── A2A (auth+protocol) ──────────────────────────────────────────────
+    "/api/a2a/agents",
+    "/api/a2a/tasks/00000000-0000-0000-0000-000000000000/status",
+    // ── Protocol-level (mounted at root) ─────────────────────────────────
+    "/.well-known/agent.json",
+    "/a2a/agents",
+    "/a2a/tasks/00000000-0000-0000-0000-000000000000",
+    // ── Versioned alias spot-check (/api/v1) ─────────────────────────────
+    "/api/v1/health",
+    "/api/v1/agents",
+    "/api/v1/budget/agents",
+    "/api/v1/mcp/catalog",
+];
+
+/// Smoke walk: every GET path must respond without a 5xx.  4xx is fine — a
+/// handler returning "not found" or "bad request" still proves the route is
+/// wired up and the handler executed without panicking.
+#[tokio::test(flavor = "multi_thread")]
+async fn smoke_get_routes_never_500() {
+    let harness = boot_router().await;
+
+    let mut failures: Vec<String> = Vec::new();
+    for path in SMOKE_GET_ROUTES {
+        let (status, ct) = get(harness.app.clone(), path).await;
+        if status.is_server_error() {
+            failures.push(format!("{path} -> {status} (content-type: {ct:?})"));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "Smoke matrix discovered {} GET route(s) returning 5xx:\n  {}\n\n\
+             These handlers panicked or returned an internal error on an empty \
+             request — likely the 'compiles but dead' class called out in #3571.\n\
+             Investigate each one individually; do NOT silence by editing the \
+             smoke list.",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
+}
+
+/// Successful (2xx) routes returning a body should advertise JSON.  This
+/// doesn't fail on 4xx because some error paths intentionally return text/html
+/// (e.g. dashboard fallback pages), but a 2xx without a content-type is
+/// suspicious.
+#[tokio::test(flavor = "multi_thread")]
+async fn smoke_get_routes_with_2xx_advertise_json() {
+    let harness = boot_router().await;
+
+    let mut violations: Vec<String> = Vec::new();
+    for path in SMOKE_GET_ROUTES {
+        let (status, ct) = get(harness.app.clone(), path).await;
+        if !status.is_success() {
+            continue;
+        }
+        // Streaming endpoints (SSE) and metrics use other content types and are
+        // legitimately not JSON.
+        if matches!(*path, "/api/logs/stream" | "/api/comms/events" | "/api/metrics") {
+            continue;
+        }
+        match ct.as_deref() {
+            Some(ct) if ct.starts_with("application/json") => {}
+            other => violations.push(format!("{path} -> 2xx, content-type = {other:?}")),
+        }
+    }
+
+    if !violations.is_empty() {
+        panic!(
+            "Routes returned 2xx without an application/json content-type:\n  {}",
+            violations.join("\n  ")
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Focused failure-mode tests for the highest-risk surfaces (#3571 body)
+// ---------------------------------------------------------------------------
+
+/// `/v1/chat/completions` — malformed JSON must produce 4xx, not 5xx.
+///
+/// The OpenAI-compatible surface is the single most exposed entry point for
+/// arbitrary external JSON (#3571 calls it out by name).  axum's `Json<T>`
+/// extractor returns 4xx on deserialization failure; this test pins that
+/// behaviour so a future refactor (e.g. swapping to a custom extractor) can't
+/// silently regress to 500.
+#[tokio::test(flavor = "multi_thread")]
+async fn openai_chat_completions_rejects_malformed_json() {
+    let harness = boot_router().await;
+    let status = post_json(
+        harness.app.clone(),
+        "/v1/chat/completions",
+        "{ this is not valid json",
+    )
+    .await;
+    assert!(
+        status.is_client_error(),
+        "/v1/chat/completions on malformed JSON returned {status}; expected 4xx"
+    );
+    assert!(
+        !status.is_server_error(),
+        "/v1/chat/completions on malformed JSON returned 5xx ({status}) — handler panicked or failed to validate input"
+    );
+}
+
+/// `/v1/chat/completions` — missing `model` field must be a 4xx, not 5xx.
+#[tokio::test(flavor = "multi_thread")]
+async fn openai_chat_completions_rejects_missing_model() {
+    let harness = boot_router().await;
+    let status = post_json(
+        harness.app.clone(),
+        "/v1/chat/completions",
+        r#"{"messages": [{"role": "user", "content": "hi"}]}"#,
+    )
+    .await;
+    assert!(
+        status.is_client_error(),
+        "/v1/chat/completions without `model` returned {status}; expected 4xx (axum Json<T> deserialize failure)"
+    );
+}
+
+/// `/v1/chat/completions` — empty messages array must not 5xx.
+#[tokio::test(flavor = "multi_thread")]
+async fn openai_chat_completions_rejects_empty_messages() {
+    let harness = boot_router().await;
+    let status = post_json(
+        harness.app.clone(),
+        "/v1/chat/completions",
+        r#"{"model": "definitely-not-a-real-model", "messages": []}"#,
+    )
+    .await;
+    assert!(
+        !status.is_server_error(),
+        "/v1/chat/completions with empty messages returned 5xx ({status})"
+    );
+}
+
+/// `/api/approvals/{id}/approve` — bogus id must produce 4xx, not 5xx.
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_approve_with_bogus_id_does_not_500() {
+    let harness = boot_router().await;
+    let status = post_json(
+        harness.app.clone(),
+        "/api/approvals/this-is-not-a-valid-id/approve",
+        "{}",
+    )
+    .await;
+    assert!(
+        !status.is_server_error(),
+        "/api/approvals/<bogus>/approve returned 5xx ({status}) — handler did not validate id"
+    );
+}
+
+/// `/api/a2a/discover` — non-URL string must produce 4xx, not 5xx.
+#[tokio::test(flavor = "multi_thread")]
+async fn a2a_discover_with_bad_url_does_not_500() {
+    let harness = boot_router().await;
+    let status = post_json(
+        harness.app.clone(),
+        "/api/a2a/discover",
+        r#"{"url": "not-a-url"}"#,
+    )
+    .await;
+    assert!(
+        status.is_client_error(),
+        "/api/a2a/discover with bad url returned {status}; expected 4xx"
+    );
+    assert!(
+        !status.is_server_error(),
+        "/api/a2a/discover with bad url returned 5xx ({status})"
+    );
+}
+
+/// `/api/a2a/discover` — missing `url` field must produce 4xx, not 5xx.
+#[tokio::test(flavor = "multi_thread")]
+async fn a2a_discover_missing_url_does_not_500() {
+    let harness = boot_router().await;
+    let status = post_json(harness.app.clone(), "/api/a2a/discover", r#"{}"#).await;
+    assert!(
+        !status.is_server_error(),
+        "/api/a2a/discover without url returned 5xx ({status})"
+    );
+}
+
+/// `/hooks/agent` — bad / missing signature must be a 4xx, not 5xx.
+///
+/// In the default test config webhook_triggers is unset, so the handler short
+/// circuits to "not enabled" — still 4xx, never 500.  This test pins that
+/// shape so a future change that enables webhook_triggers by accident fails
+/// loudly here instead of silently exposing the endpoint.
+#[tokio::test(flavor = "multi_thread")]
+async fn hooks_agent_with_bad_signature_does_not_500() {
+    let harness = boot_router().await;
+    let mut req = Request::builder()
+        .method(Method::POST)
+        .uri("/hooks/agent")
+        .header("content-type", "application/json")
+        .header("authorization", "Bearer not-a-real-token")
+        .body(Body::from(
+            r#"{"agent": "nonexistent", "message": "hi"}"#.to_string(),
+        ))
+        .expect("request builds");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+    let resp = harness.app.clone().oneshot(req).await.expect("oneshot");
+    let status = resp.status();
+    assert!(
+        !status.is_server_error(),
+        "/hooks/agent with bad signature returned 5xx ({status}) — handler should reject before doing work"
+    );
+}
+
+/// `/hooks/agent` — completely empty body must be a 4xx, not 5xx.
+#[tokio::test(flavor = "multi_thread")]
+async fn hooks_agent_with_empty_body_does_not_500() {
+    let harness = boot_router().await;
+    let status = post_json(harness.app.clone(), "/hooks/agent", "{}").await;
+    assert!(
+        !status.is_server_error(),
+        "/hooks/agent with empty body returned 5xx ({status})"
+    );
+}


### PR DESCRIPTION
Closes #3571.

## Summary

Adds a smoke matrix that walks **every GET path** registered under
`crates/librefang-api/src/routes/` (plus the root-mounted A2A protocol
routes) through `server::build_router` and asserts none of them return
5xx. This catches the "compiles but dead" failure mode the issue calls
out — handlers that panic on an empty `AppState` or never executed
because their route was never wired up.

Also adds focused failure-mode tests for the highest-risk POST surfaces
listed in the issue body:

| Endpoint | What's tested |
|---|---|
| `POST /v1/chat/completions` | malformed JSON + missing `model` field + empty `messages` array |
| `POST /api/approvals/{id}/approve` | bogus id |
| `POST /api/a2a/discover` | non-URL string + missing `url` field |
| `POST /hooks/agent` | bad signature header + empty body |

All POST tests assert `!status.is_server_error()` rather than pinning a
specific 4xx — the test's contract is "the daemon does not panic on
adversarial input", not "this handler returns exactly 400 vs 422".

## Coverage delta

The new file (`crates/librefang-api/tests/route_smoke.rs`) covers
**~115 GET paths**, including every family the issue flagged as having
zero tests:

- `/api/approvals/*`, `/api/comms/*`, `/api/peers/*`, `/api/pairing/*`,
  `/api/network/*`, `/api/inbox/*`, `/api/goals/*`, `/api/auto-dream/*`,
  `/api/clawhub/*`, `/api/clawhub-cn/*`, `/api/skills/*`,
  `/api/sessions/*`
- `/api/mcp/catalog`, `/api/mcp/health`, `/api/mcp/taint-rules`
- `/api/budget/agents`, `/api/budget/users`
- `/api/audit/*`, `/api/authz/check`
- `/api/backups`, `/api/queue/status`, `/api/registry/schema`
- `/api/templates/*`, `/api/profiles/*`, `/api/security`
- `/api/usage/by-model`, `/api/extensions/*`
- `/api/auth/providers`, `/api/auth/login`, `/api/auth/userinfo`,
  `/api/auth/dashboard-check`
- `/api/a2a/agents`, `/api/a2a/tasks/{id}/status`
- Root protocol: `/.well-known/agent.json`, `/a2a/agents`,
  `/a2a/tasks/{id}`
- `/api/v1/*` versioned-alias spot-checks

## What's intentionally NOT in the matrix

Per the issue's "Suggested fix" wording ("walks every GET … hitting
every GET with empty body"):

- **POST/PUT/DELETE** — these need handler-specific payloads. Covered
  for the four highest-risk surfaces via focused tests; broader POST
  coverage is a follow-up.
- **WebSocket upgrade endpoints** (`/api/agents/{id}/ws`,
  `/api/terminal/ws`) — without an upgrade header axum returns 426,
  which is correct but adds no coverage value.
- **`/hooks/wake`, `/api/shutdown`, `/api/init`, `/api/migrate`,
  `/api/migrate/scan`, `/api/config/reload`, `/api/config/set`,
  `/api/memory/cleanup`, `/api/memory/decay`** etc — POST-only state
  mutators. Not in the GET matrix; covered by existing
  `tests/api_integration_test.rs`.

## Maintenance contract

The path list in `SMOKE_GET_ROUTES` is hand-curated because axum does
not expose registered routes via a public API. The file header
documents the regen command:

```bash
grep -rn '\.route(' crates/librefang-api/src/routes/ \
  | grep -oE '"/[^"]+"' | sort -u
```

Drift is caught the next time a new route 500s in CI; this is the
trade-off the existing `tests/auth_public_allowlist.rs` already
accepts (see its file-level LIMITATIONS comment).

## Verification

> **Note on local verification.** Local `cargo check` /
> `cargo clippy --workspace --all-targets -- -D warnings` /
> `cargo test -p librefang-api --test route_smoke` could not be run
> because the Rust toolchain is not installed on this build host
> (`which cargo` → not found). The file follows the same harness
> pattern as the existing `tests/auth_public_allowlist.rs`
> (`server::build_router` + `tower::ServiceExt::oneshot` +
> `boot_router_with_api_key("")`) and re-uses only public APIs already
> consumed by other tests. **Relying on CI to validate.**

If CI surfaces any 5xx during the smoke walk, that is exactly what the
test is designed to catch — file a follow-up issue per panicking
handler rather than silencing the matrix. Per the global rule
"discover panics, but don't fix in the same PR — one issue at a time".

## Test plan

- [ ] CI green (`cargo test -p librefang-api --test route_smoke`)
- [ ] No clippy warnings introduced
- [ ] If smoke matrix flags any panicking handler, open a follow-up
      issue per finding rather than amending this PR
