### PR TITLE
feat(kernel): trace session_mode resolution to expose channel/cron overrides (#3692)

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -6250,7 +6250,40 @@ system_prompt = "You are a helpful assistant."
                         Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
                         _ => ctx.channel.clone(),
                     };
-                    SessionId::for_channel(agent_id, &scope)
+                    let derived = SessionId::for_channel(agent_id, &scope);
+                    // #3692: surface when the channel branch silently
+                    // overrides a non-default manifest `session_mode`.
+                    // Operators previously had no way to tell from logs
+                    // why their `session_mode = "new"` declaration was
+                    // not producing per-fire isolation for channel /
+                    // cron traffic. Demoted to `trace!` when the
+                    // manifest is on the default (Persistent) so the
+                    // override is observationally a no-op.
+                    let requested_mode = entry.manifest.session_mode;
+                    if matches!(
+                        requested_mode,
+                        librefang_types::agent::SessionMode::New
+                    ) {
+                        debug!(
+                            agent_id = %agent_id,
+                            effective_session_id = %derived,
+                            resolution_source = "channel-derived",
+                            requested_session_mode = ?requested_mode,
+                            channel = %ctx.channel,
+                            chat_id = ctx.chat_id.as_deref().unwrap_or(""),
+                            "session_mode override ignored: channel branch derives a deterministic SessionId::for_channel(agent, channel:chat)"
+                        );
+                    } else {
+                        tracing::trace!(
+                            agent_id = %agent_id,
+                            effective_session_id = %derived,
+                            resolution_source = "channel-derived",
+                            requested_session_mode = ?requested_mode,
+                            channel = %ctx.channel,
+                            "session resolved via channel branch"
+                        );
+                    }
+                    derived
                 }
                 // Fork calls always target the agent's canonical session —
                 // the whole point of fork mode is to share the parent turn's
@@ -7851,7 +7884,43 @@ system_prompt = "You are a helpful assistant."
                         Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
                         _ => ctx.channel.clone(),
                     };
-                    SessionId::for_channel(agent_id, &scope)
+                    let derived = SessionId::for_channel(agent_id, &scope);
+                    // #3692: surface when the channel branch silently
+                    // overrides a non-default manifest `session_mode`.
+                    // The `execute_llm_agent` path is reached by
+                    // channel bridges (always) and by the cron
+                    // dispatcher (synthetic `SenderContext{channel:
+                    // "cron"}`), so this is the canonical place where
+                    // the manifest declaration gets dropped on the
+                    // floor. Logged at `debug!` when the manifest /
+                    // per-trigger override actually disagrees with the
+                    // channel-derived id; `trace!` otherwise.
+                    let requested_mode =
+                        session_mode_override.unwrap_or(entry.manifest.session_mode);
+                    if matches!(
+                        requested_mode,
+                        librefang_types::agent::SessionMode::New
+                    ) {
+                        debug!(
+                            agent_id = %agent_id,
+                            effective_session_id = %derived,
+                            resolution_source = "channel-derived",
+                            requested_session_mode = ?requested_mode,
+                            channel = %ctx.channel,
+                            chat_id = ctx.chat_id.as_deref().unwrap_or(""),
+                            "session_mode override ignored: channel branch derives a deterministic SessionId::for_channel(agent, channel:chat)"
+                        );
+                    } else {
+                        tracing::trace!(
+                            agent_id = %agent_id,
+                            effective_session_id = %derived,
+                            resolution_source = "channel-derived",
+                            requested_session_mode = ?requested_mode,
+                            channel = %ctx.channel,
+                            "session resolved via channel branch"
+                        );
+                    }
+                    derived
                 }
                 _ => {
                     let mode = session_mode_override.unwrap_or(entry.manifest.session_mode);
@@ -13606,14 +13675,43 @@ system_prompt = "You are a helpful assistant."
                                 // `session_mode` so that agents with
                                 // `session_mode = "new"` in agent.toml get
                                 // per-fire isolation for cron jobs as well.
-                                let effective_session_mode = job.session_mode.or_else(|| {
-                                    kernel
-                                        .registry
-                                        .get(agent_id)
-                                        .map(|entry| entry.manifest.session_mode)
-                                });
+                                // Snapshot the manifest's declared session_mode
+                                // separately so the trace below can show what
+                                // the agent.toml actually asked for, in
+                                // addition to the per-job override.
+                                let manifest_session_mode = kernel
+                                    .registry
+                                    .get(agent_id)
+                                    .map(|entry| entry.manifest.session_mode);
+                                let effective_session_mode = job
+                                    .session_mode
+                                    .or(manifest_session_mode);
                                 let wants_new_session = effective_session_mode
                                     == Some(librefang_types::agent::SessionMode::New);
+                                // #3692: emit a structured event recording how
+                                // the cron fire's session id was resolved, so
+                                // operators can grep logs to confirm whether
+                                // their `session_mode = "new"` (per-job or
+                                // manifest) was honored — or silently ignored
+                                // because neither path set it.
+                                let resolution_source = if job.session_mode.is_some() {
+                                    "cron-job-override"
+                                } else if manifest_session_mode
+                                    == Some(librefang_types::agent::SessionMode::New)
+                                {
+                                    "cron-manifest-fallback"
+                                } else {
+                                    "cron-default-persistent"
+                                };
+                                debug!(
+                                    agent_id = %agent_id,
+                                    job = %job_name,
+                                    resolution_source = resolution_source,
+                                    job_session_mode = ?job.session_mode,
+                                    manifest_session_mode = ?manifest_session_mode,
+                                    effective_session_mode = ?effective_session_mode,
+                                    "cron session_mode resolved"
+                                );
                                 let cron_sender = SenderContext {
                                     channel: SYSTEM_CHANNEL_CRON.to_string(),
                                     user_id: job.peer_id.clone().unwrap_or_default(),

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -743,6 +743,36 @@ pub struct AgentManifest {
     /// Session mode for automated (non-channel) invocations.
     /// Controls whether background ticks, triggers, and `agent_send` calls
     /// reuse the agent's persistent session or create a fresh one.
+    ///
+    /// Resolved session id precedence (highest first):
+    /// 1. Explicit `session_id_override` from the dispatch caller (HTTP /
+    ///    multi-tab UIs, fork plumbing) — always wins.
+    /// 2. Per-trigger override (`Trigger.session_mode`) — honored for
+    ///    event triggers and `agent_send`.
+    /// 3. Channel branch — ALWAYS uses
+    ///    `SessionId::for_channel(agent, "channel:chat")`, overriding both
+    ///    per-trigger and manifest values whenever a non-empty
+    ///    `SenderContext.channel` is present (and `use_canonical_session`
+    ///    is false).
+    /// 4. Cron — synthesizes `SenderContext{channel:"cron"}` and takes
+    ///    the channel branch, so all cron fires for an agent share one
+    ///    `(agent, "cron")` session unless the per-job `session_mode` is
+    ///    set to `New`. The cron dispatcher sidesteps the channel branch
+    ///    by passing an explicit `session_id_override` derived from the
+    ///    job id and fire timestamp; manifest-level `session_mode = "new"`
+    ///    is also consulted as a fallback when the per-job override is
+    ///    unset.
+    /// 5. Manifest `session_mode` — final fallback; honored by event
+    ///    triggers and `agent_send` when no higher-priority signal
+    ///    applies.
+    ///
+    /// Diagnostic: when the channel branch or the cron path overrides a
+    /// non-default manifest setting, the kernel emits a
+    /// `tracing::debug!` event with `resolution_source` set to
+    /// `"channel-derived"`, `"cron-job-override"`, or
+    /// `"cron-manifest-fallback"` so operators can grep logs to confirm
+    /// why a `session_mode = "new"` declaration is or is not being
+    /// honored.
     #[serde(default)]
     pub session_mode: SessionMode,
     /// LLM model configuration.


### PR DESCRIPTION
## Summary

Closes #3692. `session_mode` declared in `agent.toml` is silently ignored on
two of the most common dispatch paths (channel bridges and cron jobs), and
operators had no log signal explaining why their `session_mode = "new"`
declaration was not producing per-fire isolation. This change adds structured
tracing at the resolution sites so the divergence is now observable.

## What changed

* **`send_message_streaming_with_sender_and_opts`** (`crates/librefang-kernel/src/kernel/mod.rs`):
  emit `tracing::debug!` when the channel branch derives
  `SessionId::for_channel(agent, channel:chat)` while the manifest is
  declaring `session_mode = "new"`. Falls back to `tracing::trace!` when the
  manifest is on the default Persistent (override is a no-op observationally).
  Fields: `agent_id`, `effective_session_id`, `resolution_source =
  "channel-derived"`, `requested_session_mode`, `channel`, `chat_id`.

* **`execute_llm_agent`** (same file): identical instrumentation, since this
  is the canonical site reached by channel bridges (always) and the cron
  dispatcher (synthetic `SenderContext{channel:"cron"}`). The cron path also
  flows through here, but the cron-specific dispatch site below records the
  per-job vs. manifest-fallback decision before this point.

* **Cron dispatch loop** (~line 13680 in `kernel/mod.rs`): added a
  `tracing::debug!` event with `resolution_source` set to one of
  `cron-job-override`, `cron-manifest-fallback`, or
  `cron-default-persistent`, plus a snapshot of `job_session_mode` and
  `manifest_session_mode`. Operators can `grep "cron session_mode resolved"`
  to confirm which path won for any given job.

* **`AgentManifest.session_mode` doc comment** (`crates/librefang-types/src/agent.rs`):
  added the precedence matrix from the issue (cross-checked against the
  existing CLAUDE.md note, which is the more recent ground truth) so the
  resolution order is documented at the type definition.

## Intentionally out of scope

* The `SessionSemantics` enum refactor in `SenderContext` proposed as item 3
  in the issue is left for a follow-up. This change is observability-only and
  behavior-preserving — no resolution logic moves.

## Tests

No new unit test was added: there is no logger-capturing harness in the
workspace (no `tracing-test`, no helper in `librefang-testing`) and the
issue-supplied scope explicitly forbids adding a new dev dep for this. The
existing `cron::tests::fire_session_override_*` tests in
`crates/librefang-kernel/src/cron.rs` and the
`resolve_dispatch_session_id_*` tests in `kernel/tests.rs` continue to
exercise the resolution helpers; the events fire at the call sites, which are
covered by the wider integration suite when CI runs.

## Verification note

The local build host for this change does not have `cargo` / `rustup`
installed, so `cargo check`, `cargo clippy`, and `cargo test` could not be run
locally. CI is the authoritative gate.

## Test plan

- [ ] CI: `cargo check --workspace --lib`
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] CI: `cargo test -p librefang-kernel`
- [ ] Manual (operator): start daemon at `RUST_LOG=librefang_kernel=debug`,
      send a Telegram message to an agent with `session_mode = "new"` in
      `agent.toml`, confirm a log line `session_mode override ignored:
      channel branch derives a deterministic SessionId::for_channel(...)`.
- [ ] Manual (operator): create a cron job without per-job `session_mode`
      against an agent with manifest `session_mode = "new"`, confirm
      `cron session_mode resolved` log with
      `resolution_source = "cron-manifest-fallback"`.
