### PR TITLE
test(cli): cover launcher / init_wizard / desktop_install (#3582)

### DIFF
--- a/crates/librefang-cli/src/launcher.rs
+++ b/crates/librefang-cli/src/launcher.rs
@@ -792,3 +792,268 @@ pub fn launch_desktop_app() {
         desktop_install::launch(&installed);
     }
 }
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    //! #3582: `launcher.rs` previously had 0 tests. The file is largely
+    //! ratatui-based draw + event-loop code (untestable without spawning a
+    //! real terminal), but the menu structure, layout sizing, ANSI stripping,
+    //! and first-run detection are all pure helpers that drive user-visible
+    //! behaviour and *can* be locked down here.
+
+    use super::*;
+    use ratatui::layout::Rect;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    /// Tests in this file mutate process-global env vars (`LIBREFANG_HOME`,
+    /// `HOME`). Cargo runs tests within a single binary in parallel, so we
+    /// serialize anything that touches those vars through one mutex.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // ── strip_ansi ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn strip_ansi_passes_through_plain_text() {
+        assert_eq!(strip_ansi("hello world"), "hello world");
+    }
+
+    #[test]
+    fn strip_ansi_removes_color_codes() {
+        // \x1b[31mRED\x1b[0m — the SGR sequences must vanish, payload kept.
+        let input = "\x1b[31mRED\x1b[0m";
+        assert_eq!(strip_ansi(input), "RED");
+    }
+
+    #[test]
+    fn strip_ansi_handles_bold_and_reset() {
+        let input = "\x1b[1mbold\x1b[0m normal";
+        assert_eq!(strip_ansi(input), "bold normal");
+    }
+
+    #[test]
+    fn strip_ansi_handles_multiple_sequences() {
+        let input = "\x1b[31m\x1b[1mboth\x1b[0m";
+        assert_eq!(strip_ansi(input), "both");
+    }
+
+    // ── content_area ────────────────────────────────────────────────────────
+
+    #[test]
+    fn content_area_returns_full_area_when_terminal_too_small() {
+        // The function explicitly bails on tiny terminals to avoid clipping.
+        let tiny = Rect {
+            x: 0,
+            y: 0,
+            width: 5,
+            height: 3,
+        };
+        let out = content_area(tiny);
+        assert_eq!(out, tiny);
+    }
+
+    #[test]
+    fn content_area_caps_width_at_80_on_wide_terminal() {
+        let wide = Rect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 50,
+        };
+        let out = content_area(wide);
+        // Width is capped at 80 columns — content should never sprawl across
+        // the entire terminal on an ultrawide monitor.
+        assert_eq!(out.width, 80);
+        // Left margin is applied (MARGIN_LEFT = 3).
+        assert_eq!(out.x, MARGIN_LEFT);
+        // Y / height are unchanged (vertical layout is the caller's job).
+        assert_eq!(out.y, wide.y);
+        assert_eq!(out.height, wide.height);
+    }
+
+    #[test]
+    fn content_area_shrinks_margin_on_narrow_terminal() {
+        // Width 12: margin must shrink so it doesn't eat the readable area.
+        let narrow = Rect {
+            x: 0,
+            y: 0,
+            width: 12,
+            height: 20,
+        };
+        let out = content_area(narrow);
+        assert!(
+            out.x + out.width <= narrow.width,
+            "content area must fit inside the parent rect: x={} w={} parent_w={}",
+            out.x,
+            out.width,
+            narrow.width
+        );
+        // Must leave at least 10 visible columns (the function's reserved minimum).
+        assert!(out.width >= 10, "expected >=10 cols, got {}", out.width);
+    }
+
+    // ── Menu invariants (first-run vs returning) ────────────────────────────
+
+    #[test]
+    fn first_run_menu_starts_with_get_started() {
+        // First-run users land on "Get started" by design — regression here
+        // would silently demote onboarding behind less-relevant entries.
+        let first = MENU_FIRST_RUN
+            .first()
+            .expect("first-run menu must not be empty");
+        assert!(
+            matches!(first.choice, LauncherChoice::GetStarted),
+            "first entry must be GetStarted"
+        );
+    }
+
+    #[test]
+    fn returning_menu_starts_with_chat_not_setup() {
+        // Returning users shouldn't have to scroll past setup to chat.
+        let first = MENU_RETURNING
+            .first()
+            .expect("returning menu must not be empty");
+        assert!(
+            matches!(first.choice, LauncherChoice::Chat),
+            "first entry must be Chat"
+        );
+    }
+
+    #[test]
+    fn both_menus_offer_show_help_and_no_quit_entry() {
+        // ShowHelp must be reachable from both menus (it's the discoverability
+        // hatch). Quit is keyboard-only (`q`/`Esc`) — never a list item.
+        for menu in [MENU_FIRST_RUN, MENU_RETURNING] {
+            assert!(menu.iter().any(|m| m.choice == LauncherChoice::ShowHelp));
+            assert!(menu.iter().all(|m| m.choice != LauncherChoice::Quit));
+        }
+    }
+
+    #[test]
+    fn both_menus_fit_number_shortcuts() {
+        // The key handler binds digits 1-9 to the first nine entries; an
+        // overlong menu would silently lose entries to keyboard navigation.
+        assert!(
+            MENU_FIRST_RUN.len() <= 9,
+            "first-run menu has {} entries, exceeds 1-9 shortcut range",
+            MENU_FIRST_RUN.len()
+        );
+        assert!(
+            MENU_RETURNING.len() <= 9,
+            "returning menu has {} entries, exceeds 1-9 shortcut range",
+            MENU_RETURNING.len()
+        );
+    }
+
+    #[test]
+    fn both_menus_have_chat_and_dashboard() {
+        // Smoke test that the headline actions are present in both menus.
+        for menu in [MENU_FIRST_RUN, MENU_RETURNING] {
+            assert!(menu.iter().any(|m| m.choice == LauncherChoice::Chat));
+            assert!(menu.iter().any(|m| m.choice == LauncherChoice::Dashboard));
+            assert!(
+                menu.iter()
+                    .any(|m| m.choice == LauncherChoice::TerminalUI)
+            );
+        }
+    }
+
+    #[test]
+    fn launcher_state_menu_picks_first_run_variant() {
+        // Direct-construct so we don't have to mock env detection.
+        let mut list = ListState::default();
+        list.select(Some(0));
+        let s = LauncherState {
+            list,
+            daemon_url: None,
+            daemon_agents: 0,
+            detecting: false,
+            tick: 0,
+            first_run: true,
+            openclaw_detected: false,
+            openfang_detected: false,
+            screen: Screen::Menu,
+        };
+        // Same slice (compare by length+head choice — slices are 'static).
+        assert_eq!(s.menu().len(), MENU_FIRST_RUN.len());
+        assert!(
+            matches!(s.menu()[0].choice, LauncherChoice::GetStarted),
+            "first-run menu head must be GetStarted"
+        );
+    }
+
+    #[test]
+    fn launcher_state_menu_picks_returning_variant() {
+        let mut list = ListState::default();
+        list.select(Some(0));
+        let s = LauncherState {
+            list,
+            daemon_url: None,
+            daemon_agents: 0,
+            detecting: false,
+            tick: 0,
+            first_run: false,
+            openclaw_detected: false,
+            openfang_detected: false,
+            screen: Screen::Menu,
+        };
+        assert_eq!(s.menu().len(), MENU_RETURNING.len());
+        assert!(
+            matches!(s.menu()[0].choice, LauncherChoice::Chat),
+            "returning menu head must be Chat"
+        );
+    }
+
+    // ── is_first_run ────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_first_run_true_when_config_missing() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new().expect("tempdir");
+        let prev = std::env::var_os("LIBREFANG_HOME");
+
+        // SAFETY: env mutation is serialized through ENV_LOCK; restored in the
+        // same scope before the lock is released at end of test.
+        unsafe {
+            std::env::set_var("LIBREFANG_HOME", tmp.path());
+        }
+        let result = is_first_run();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("LIBREFANG_HOME", v),
+                None => std::env::remove_var("LIBREFANG_HOME"),
+            }
+        }
+
+        assert!(
+            result,
+            "empty LIBREFANG_HOME (no config.toml) must report first run"
+        );
+    }
+
+    #[test]
+    fn is_first_run_false_once_config_exists() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = TempDir::new().expect("tempdir");
+        std::fs::write(tmp.path().join("config.toml"), "# fake config\n").unwrap();
+        let prev = std::env::var_os("LIBREFANG_HOME");
+
+        unsafe {
+            std::env::set_var("LIBREFANG_HOME", tmp.path());
+        }
+        let result = is_first_run();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("LIBREFANG_HOME", v),
+                None => std::env::remove_var("LIBREFANG_HOME"),
+            }
+        }
+
+        assert!(
+            !result,
+            "presence of config.toml under LIBREFANG_HOME must clear first-run flag"
+        );
+    }
+}

--- a/crates/librefang-cli/src/tui/screens/init_wizard.rs
+++ b/crates/librefang-cli/src/tui/screens/init_wizard.rs
@@ -2680,4 +2680,175 @@ mod tests {
         assert_eq!(tier_label(ModelTier::Local), "local");
         assert_eq!(tier_label(ModelTier::Custom), "custom");
     }
+
+    // ── #3582: reducer-style coverage for handle_routing_key ────────────────
+    //
+    // The maintainer asked for an `Event → State → State` table-test on the
+    // wizard's reducer. `handle_routing_key` is the closest the codebase has
+    // to a pure reducer today (the migration handler has thread-spawning side
+    // effects, the api-key handler does file I/O). We exercise navigation
+    // arms only: `Enter` arms call `save_config`, which writes
+    // `~/.librefang/config.toml` and would touch the user's filesystem
+    // outside a tempdir, so they're deliberately out of scope here.
+
+    /// Construct a minimal `State` for routing-step navigation tests.
+    /// Pre-loads three fake model entries so `PickTier` arrow-key cycling
+    /// has something to wrap around.
+    fn routing_state_with_models(entries: usize) -> State {
+        let mut s = State::new();
+        s.step = Step::Routing;
+        s.routing_phase = RoutingPhase::Choice;
+        s.routing_choice_list.select(Some(0));
+        s.routing_tier_list.select(Some(0));
+        s.model_entries.clear();
+        for i in 0..entries {
+            s.model_entries.push(ModelEntry {
+                id: format!("model-{i}"),
+                display_name: format!("Model {i}"),
+                tier: "fast",
+                cost: String::new(),
+            });
+        }
+        s
+    }
+
+    #[test]
+    fn routing_choice_down_toggles_to_no() {
+        let mut s = routing_state_with_models(3);
+        // Selection starts at 0 (Yes); Down/j flips to 1 (No).
+        handle_routing_key(&mut s, KeyCode::Down);
+        assert_eq!(s.routing_choice_list.selected(), Some(1));
+    }
+
+    #[test]
+    fn routing_choice_up_toggles_back_to_yes() {
+        let mut s = routing_state_with_models(3);
+        s.routing_choice_list.select(Some(1));
+        handle_routing_key(&mut s, KeyCode::Up);
+        assert_eq!(s.routing_choice_list.selected(), Some(0));
+    }
+
+    #[test]
+    fn routing_choice_j_and_k_match_arrow_keys() {
+        // Vim-style bindings must mirror the arrow keys exactly — a regression
+        // here would create a confusing two-modes-of-input UX.
+        let mut s = routing_state_with_models(3);
+        s.routing_choice_list.select(Some(0));
+        handle_routing_key(&mut s, KeyCode::Char('j'));
+        assert_eq!(s.routing_choice_list.selected(), Some(1));
+        handle_routing_key(&mut s, KeyCode::Char('k'));
+        assert_eq!(s.routing_choice_list.selected(), Some(0));
+    }
+
+    #[test]
+    fn routing_choice_esc_returns_to_model_step() {
+        // Esc on the first routing screen should let the user back out into
+        // the model-picker step, not silently swallow the input.
+        let mut s = routing_state_with_models(3);
+        s.step = Step::Routing;
+        handle_routing_key(&mut s, KeyCode::Esc);
+        assert!(
+            matches!(s.step, Step::Model),
+            "Esc on routing/Choice must go back to Model step"
+        );
+    }
+
+    #[test]
+    fn routing_choice_ignores_unrelated_keys() {
+        // Random keys must NOT auto-advance or reset selection.
+        let mut s = routing_state_with_models(3);
+        s.routing_choice_list.select(Some(1));
+        handle_routing_key(&mut s, KeyCode::Char('z'));
+        handle_routing_key(&mut s, KeyCode::Tab);
+        assert_eq!(s.routing_choice_list.selected(), Some(1));
+        assert!(matches!(s.step, Step::Routing));
+        assert!(matches!(s.routing_phase, RoutingPhase::Choice));
+    }
+
+    #[test]
+    fn routing_pick_tier0_esc_returns_to_choice() {
+        // Esc on the first tier rolls all the way back to the Yes/No screen.
+        let mut s = routing_state_with_models(3);
+        s.routing_phase = RoutingPhase::PickTier(0);
+        handle_routing_key(&mut s, KeyCode::Esc);
+        assert!(matches!(s.routing_phase, RoutingPhase::Choice));
+    }
+
+    #[test]
+    fn routing_pick_tier1_esc_returns_to_tier0() {
+        let mut s = routing_state_with_models(3);
+        s.routing_phase = RoutingPhase::PickTier(1);
+        handle_routing_key(&mut s, KeyCode::Esc);
+        assert!(matches!(s.routing_phase, RoutingPhase::PickTier(0)));
+    }
+
+    #[test]
+    fn routing_pick_tier2_esc_returns_to_tier1() {
+        let mut s = routing_state_with_models(3);
+        s.routing_phase = RoutingPhase::PickTier(2);
+        handle_routing_key(&mut s, KeyCode::Esc);
+        assert!(matches!(s.routing_phase, RoutingPhase::PickTier(1)));
+    }
+
+    #[test]
+    fn routing_pick_tier_down_cycles_through_models() {
+        // Down/j must wrap from the last entry back to 0, otherwise users on
+        // small model lists get stuck at the bottom with no way around.
+        let mut s = routing_state_with_models(3);
+        s.routing_phase = RoutingPhase::PickTier(0);
+        s.routing_tier_list.select(Some(0));
+
+        handle_routing_key(&mut s, KeyCode::Down);
+        assert_eq!(s.routing_tier_list.selected(), Some(1));
+        handle_routing_key(&mut s, KeyCode::Down);
+        assert_eq!(s.routing_tier_list.selected(), Some(2));
+        handle_routing_key(&mut s, KeyCode::Down);
+        assert_eq!(s.routing_tier_list.selected(), Some(0), "must wrap");
+    }
+
+    #[test]
+    fn routing_pick_tier_up_wraps_from_zero_to_last() {
+        let mut s = routing_state_with_models(3);
+        s.routing_phase = RoutingPhase::PickTier(0);
+        s.routing_tier_list.select(Some(0));
+
+        handle_routing_key(&mut s, KeyCode::Up);
+        assert_eq!(
+            s.routing_tier_list.selected(),
+            Some(2),
+            "up at index 0 must wrap to the last entry"
+        );
+    }
+
+    // ── #3582: step_label / step_index lock-in ──────────────────────────────
+
+    #[test]
+    fn step_label_matches_step_index_progression() {
+        // The header shows "N of 7"; index and label must stay aligned. A
+        // mismatch means the user sees a wrong-step indicator without any
+        // compile-time signal.
+        let pairs: [(Step, &str, usize, &str); 7] = [
+            (Step::Welcome, "1 of 7", 0, "Welcome"),
+            (Step::Migration, "2 of 7", 1, "Migration"),
+            (Step::Provider, "3 of 7", 2, "Provider"),
+            (Step::ApiKey, "4 of 7", 3, "ApiKey"),
+            (Step::Model, "5 of 7", 4, "Model"),
+            (Step::Routing, "6 of 7", 5, "Routing"),
+            (Step::Complete, "7 of 7", 6, "Complete"),
+        ];
+        for (step, label, idx, name) in pairs {
+            let mut s = State::new();
+            s.step = step;
+            assert_eq!(s.step_label(), label, "label drift for {name}");
+            assert_eq!(s.step_index(), idx, "index drift for {name}");
+        }
+    }
+
+    #[test]
+    fn routing_tier_constants_are_three_wide() {
+        // The PickTier sub-state is indexed 0..=2; the parallel display
+        // arrays must match that or `draw_routing_pick` panics on indexing.
+        assert_eq!(ROUTING_TIER_NAMES.len(), 3);
+        assert_eq!(ROUTING_TIER_DESC.len(), 3);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #3582.

#3582 flagged `librefang-cli` (38k LOC) as having TUI/launcher screens with 0 tests. Maintainer's framing was "pick three highest-value surfaces, not 'add 100 tests'". This PR delivers two of those three; the third was already addressed by prior work (see "Coverage map" below).

## Coverage map vs the issue's three suggested surfaces

| Surface | Status | Notes |
|---------|--------|-------|
| `launcher.rs` (was 0 tests) | **NEW in this PR** | Pure helpers + menu invariants. The maintainer suggested `find_free_port` / daemon-detection — `launcher.rs` does not contain `find_free_port`; daemon detection lives in `main.rs::find_daemon_with_probe` and is **already covered** by 4 tests landed for #3582 in a prior commit. So the missing pieces here were `strip_ansi`, `content_area`, the menu invariants, `LauncherState::menu()`, and `is_first_run`. All added. |
| `init_wizard.rs` reducer | **NEW in this PR** | Reducer-style table tests on `handle_routing_key` (Choice + PickTier sub-states). Step-label/step-index lock-in. Took **Path A** (test the existing handler in place) — no production refactor. `Enter` arms call `save_config` which writes `~/.librefang/config.toml`; those arms are deliberately out of scope to avoid touching the user's filesystem outside a tempdir. Pure-helper coverage (`build_routing_section`, `build_api_key_line`, `render_init_wizard_config`, `default_model_for_provider`, `tier_label`, `KeyTestState::SaveFailed`) was already in place from earlier #3582 work. |
| `desktop_install.rs` (tempdir-rooted writes) | **already done** | 11 tests already cover `linux_install_path_in`, `install_linux_appimage_to`, `which_lookup`, `find_parent_app_bundle`, `desktop_binary_name`, `platform_asset_suffix` — all routed through `tempfile::TempDir`, no writes escape the tempdir. Verified during exploration; no PR changes needed. |

## What's in the diff

**`crates/librefang-cli/src/launcher.rs`** (+265 lines, mostly tests):
- `strip_ansi`: pass-through, color codes, bold, multi-sequence
- `content_area`: tiny-terminal bypass, 80-col cap on wide terminals, margin shrinkage on narrow terminals
- Menu invariants: first-run leads with `GetStarted`, returning leads with `Chat`, both menus expose `ShowHelp`, both fit the 1-9 number-shortcut range, no `Quit` entry
- `LauncherState::menu()` picks the right slice for the `first_run` flag (direct-construct, no env mocking)
- `is_first_run` reads `LIBREFANG_HOME` and toggles on `config.toml` presence (env mutations serialized through a `Mutex`, restored before the lock drops, matching the pattern already in `desktop_install.rs`)

**`crates/librefang-cli/src/tui/screens/init_wizard.rs`** (+171 lines, all tests):
- `handle_routing_key` Choice phase: `Up`/`Down`/`j`/`k` toggle Yes/No, `Esc` returns to `Step::Model`, unrelated keys ignored (no auto-advance)
- `handle_routing_key` PickTier phase: `Esc` walks back tier-by-tier (T2 -> T1 -> T0 -> Choice), `Down`/`Up` cycle and wrap through `model_entries`
- `step_label` / `step_index` lock-in across all 7 wizard steps
- `ROUTING_TIER_NAMES` / `ROUTING_TIER_DESC` width matches `PickTier(0..=2)` (catches a panic-on-index regression at compile-time-of-test)

Total diff: 436 insertions, 0 deletions, 0 production-code changes (tests only).

## Out of scope (per maintainer's "not 100 tests" framing)

- `agents.rs`, `event.rs`, `chat.rs`, `mod.rs`, `desktop_install.rs` install_macos_dmg/install_windows — would require either spawning real terminals, mocking subprocess execution, or invasive refactor. Captured as follow-up.
- `handle_routing_key` `Enter` arms — the `save_config` call writes to `~/.librefang/`. Routing those writes through a tempdir would need either a `&Path` parameter on `save_config` (production refactor) or `LIBREFANG_HOME` env override held across the whole save+daemon-spawn path. Skipped per "don't refactor in this PR" guidance.
- `handle_migration_key` — spawns a worker thread on the `Enter` "Yes" arm; the no-side-effect arms (`Up`/`Down` toggle, `Esc`) are similar shape to routing and lower marginal value.

## Verification

Local `cargo check` / `clippy` / `cargo test -p librefang-cli` could not be run because the toolchain is not installed on this build host. Relying on CI.

Tests are pure unit tests with no network, no daemon, no shared mutable file state outside per-test `tempfile::TempDir`s. Env-mutation tests serialize through a module-level `Mutex` to be safe under cargo's parallel test runner.

## Test plan

- [ ] CI: `cargo check --workspace --lib` passes
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] CI: `cargo test -p librefang-cli` passes
- [ ] All new tests appear in test output (grep for `routing_choice_`, `routing_pick_tier`, `strip_ansi_`, `content_area_`, `is_first_run_`, `step_label_matches`)
