### PR TITLE
perf(kernel): cache unlocked vault to avoid per-call Argon2id KDF (#3598)

### DIFF
--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -835,6 +835,29 @@ pub struct LibreFangKernel {
     /// first request has written the updated list can redeem the same code
     /// twice.
     vault_recovery_codes_mutex: std::sync::Mutex<()>,
+    /// Process-lifetime cache of the unlocked credential vault (#3598).
+    ///
+    /// Without this cache, every `vault_get` / `vault_set` rebuilt a fresh
+    /// `CredentialVault`, re-read `vault.enc` from disk, and re-ran the
+    /// Argon2id KDF inside `unlock()` — which is intentionally slow.
+    /// `dashboard_login` reads two keys (`dashboard_user`, `dashboard_password`)
+    /// per request and so paid two full KDF runs every login attempt.
+    ///
+    /// Lazy-initialised on first `vault_handle()` call so kernels that never
+    /// touch the vault do no I/O. Subsequent reads hit the in-memory
+    /// `HashMap<String, Zeroizing<String>>` directly. Writes still call
+    /// `CredentialVault::set` which re-derives a fresh per-write KDF inside
+    /// `save()` (that path is unchanged — at-rest security is not
+    /// regressed). The vault's `Drop` impl still zeroises entries when the
+    /// kernel is dropped.
+    ///
+    /// `OnceLock<Arc<RwLock<…>>>` because:
+    /// - lazy init must be one-shot and race-safe (`OnceLock`),
+    /// - the cached vault is shared by &-borrowing kernel methods (`Arc`),
+    /// - reads dominate writes (`RwLock`).
+    vault_cache: std::sync::OnceLock<
+        std::sync::Arc<std::sync::RwLock<librefang_extensions::vault::CredentialVault>>,
+    >,
 }
 
 /// Bounded in-memory delivery receipt tracker.
@@ -1689,36 +1712,92 @@ impl LibreFangKernel {
         &self.approval_manager
     }
 
-    /// Read a secret from the encrypted vault.
+    /// Lazily open and unlock the credential vault, caching the result for
+    /// the lifetime of this kernel (#3598).
     ///
-    /// Opens and unlocks the vault on each call (stateless). Returns `None` if
-    /// the vault does not exist, cannot be unlocked, or the key is missing.
-    pub fn vault_get(&self, key: &str) -> Option<String> {
-        let vault_path = self.home_dir_boot.join("vault.enc");
-        let mut vault = librefang_extensions::vault::CredentialVault::new(vault_path);
-        if vault.unlock().is_err() {
-            return None;
+    /// The first call pays a single Argon2id KDF (inside `unlock()`) and
+    /// reads `vault.enc` from disk; every subsequent call returns the cached
+    /// `Arc<RwLock<…>>` with no I/O and no KDF. `vault_set` writes through
+    /// the same handle and persists via `CredentialVault::set` →
+    /// `save()` (that path still re-derives a per-write key — at-rest
+    /// security is unchanged).
+    ///
+    /// Returns `Err(_)` only when the vault file exists but cannot be
+    /// unlocked (bad master key, corrupt file, missing keyring entry).
+    /// A missing vault file is **not** an error: the cache is populated
+    /// with an unopened vault and the first `set()` call will `init()` it.
+    fn vault_handle(
+        &self,
+    ) -> Result<
+        std::sync::Arc<std::sync::RwLock<librefang_extensions::vault::CredentialVault>>,
+        String,
+    > {
+        // Fast path: cache already populated.
+        if let Some(handle) = self.vault_cache.get() {
+            return Ok(std::sync::Arc::clone(handle));
         }
-        vault.get(key).map(|s| s.to_string())
-    }
 
-    /// Write a secret to the encrypted vault.
-    ///
-    /// Opens and unlocks the vault on each call (stateless). Creates the vault
-    /// if it does not exist.
-    pub fn vault_set(&self, key: &str, value: &str) -> Result<(), String> {
+        // Slow path: build the vault, unlock if it exists, install once.
+        // OnceLock::set() losing a race is fine — both racers built an
+        // equivalent unlocked vault; we just discard ours and use the
+        // installed one. Argon2id runs at most a small bounded number of
+        // times during the brief race window (in practice ≤ 2).
         let vault_path = self.home_dir_boot.join("vault.enc");
         let mut vault = librefang_extensions::vault::CredentialVault::new(vault_path);
-        if !vault.exists() {
-            vault
-                .init()
-                .map_err(|e| format!("Vault init failed: {e}"))?;
-        } else {
+        if vault.exists() {
             vault
                 .unlock()
                 .map_err(|e| format!("Vault unlock failed: {e}"))?;
         }
-        vault
+        let handle = std::sync::Arc::new(std::sync::RwLock::new(vault));
+        match self.vault_cache.set(std::sync::Arc::clone(&handle)) {
+            Ok(()) => Ok(handle),
+            Err(_) => Ok(std::sync::Arc::clone(self.vault_cache.get().expect(
+                "OnceLock::set() returned Err; another thread must have installed a value",
+            ))),
+        }
+    }
+
+    /// Read a secret from the encrypted vault.
+    ///
+    /// First call lazily unlocks the vault (one Argon2id KDF + one disk
+    /// read) and caches the result on the kernel; subsequent calls — for
+    /// any key — are pure in-memory `HashMap` lookups. See `vault_handle`
+    /// and #3598.
+    ///
+    /// Returns `None` if the vault does not exist, cannot be unlocked, or
+    /// the key is missing.
+    pub fn vault_get(&self, key: &str) -> Option<String> {
+        let handle = match self.vault_handle() {
+            Ok(h) => h,
+            Err(_) => return None,
+        };
+        let guard = handle.read().unwrap_or_else(|e| e.into_inner());
+        if !guard.is_unlocked() {
+            // Vault file did not exist when the cache was populated and no
+            // `set()` has initialised it yet — nothing to read.
+            return None;
+        }
+        guard.get(key).map(|s| s.to_string())
+    }
+
+    /// Write a secret to the encrypted vault.
+    ///
+    /// Uses the cached, already-unlocked vault when available (#3598) so
+    /// the unlock-time Argon2id KDF runs at most once per kernel lifetime
+    /// instead of once per call. The save-time KDF inside
+    /// `CredentialVault::set` still runs on every write — at-rest
+    /// security is unchanged. Creates the vault if it does not exist.
+    pub fn vault_set(&self, key: &str, value: &str) -> Result<(), String> {
+        let handle = self.vault_handle()?;
+        let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
+        if !guard.is_unlocked() {
+            // Vault did not exist at cache-population time; create it now.
+            guard
+                .init()
+                .map_err(|e| format!("Vault init failed: {e}"))?;
+        }
+        guard
             .set(key.to_string(), zeroize::Zeroizing::new(value.to_string()))
             .map_err(|e| format!("Vault write failed: {e}"))
     }
@@ -3542,6 +3621,7 @@ impl LibreFangKernel {
             taint_rules_swap: initial_taint_rules,
             log_reloader: OnceLock::new(),
             vault_recovery_codes_mutex: std::sync::Mutex::new(()),
+            vault_cache: std::sync::OnceLock::new(),
         };
 
         // Initialize proactive memory system (mem0-style) from config.

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -5990,3 +5990,97 @@ async fn config_reload_lock_not_held_across_long_await_3564() {
     long_reader.await.unwrap();
     kernel.shutdown();
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// vault cache (#3598)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Regression test for #3598: `vault_handle()` must reuse the same
+/// `Arc<RwLock<CredentialVault>>` across calls so we run Argon2id at most
+/// once per kernel lifetime instead of once per `vault_get` / `vault_set`.
+///
+/// Direct CPU-time / Argon2-call-count assertions would be flaky on shared
+/// CI runners; instead we assert the structural invariant that produces the
+/// perf win:
+///
+///   1. The cached `Arc` returned by two consecutive `vault_handle()`
+///      calls is the same allocation (`Arc::ptr_eq`), proving we're
+///      reading from the in-memory cache rather than rebuilding a fresh
+///      `CredentialVault` and re-running KDF inside `unlock()`.
+///   2. Round-tripping a value (`vault_set` → `vault_get` → `vault_get`)
+///      returns the written value on every read, proving the cache stays
+///      coherent across writes that go through the same handle.
+///
+/// Serialised because `LIBREFANG_VAULT_KEY` and `LIBREFANG_VAULT_NO_KEYRING`
+/// are process-global; `mcp_oauth_provider` tests in this same crate also
+/// poke `LIBREFANG_VAULT_KEY` without serialisation, so we use the
+/// unnamed `serial` group to gate against any concurrent env-var mutation.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn vault_cache_reuses_unlocked_handle_across_calls() {
+    // 44-char standard base64 of 32 deterministic bytes — produced offline
+    // so this test does not pull a new `base64` dev-dep just to construct
+    // a key. CLAUDE.md gotcha: `LIBREFANG_VAULT_KEY` must base64-decode to
+    // exactly 32 bytes (44 base64 chars). Decoded value is irrelevant; we
+    // just need a stable valid key for the duration of this test.
+    const TEST_VAULT_KEY_B64: &str =
+        "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
+    let _vault_key = set_test_env("LIBREFANG_VAULT_KEY", TEST_VAULT_KEY_B64);
+    // Force the file-based keyring backend off too — we don't want the
+    // unlock path probing the keyring during this test.
+    let _no_keyring = set_test_env("LIBREFANG_VAULT_NO_KEYRING", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+
+    // First write — initialises vault (init() runs KDF once) and populates
+    // the cache. Subsequent reads/writes must hit the cached handle.
+    kernel
+        .vault_set("dashboard_user", "alice")
+        .expect("first vault_set should succeed");
+
+    // Two reads back-to-back — the perf win we're protecting.
+    let first = kernel.vault_get("dashboard_user");
+    let second = kernel.vault_get("dashboard_user");
+    assert_eq!(first.as_deref(), Some("alice"));
+    assert_eq!(second.as_deref(), Some("alice"));
+
+    // Structural invariant: the cache slot is shared, not rebuilt per call.
+    let h1 = kernel
+        .vault_handle()
+        .expect("vault_handle should not error after a successful set");
+    let h2 = kernel
+        .vault_handle()
+        .expect("vault_handle should not error on repeat call");
+    assert!(
+        std::sync::Arc::ptr_eq(&h1, &h2),
+        "vault_handle must return the SAME Arc on repeat calls — \
+         otherwise we'd rebuild CredentialVault and re-run Argon2id KDF \
+         on every vault_get / vault_set (#3598)",
+    );
+
+    // Cache coherence across a write through the handle: read-back sees
+    // the new value with no re-unlock.
+    kernel
+        .vault_set("dashboard_password", "s3cret")
+        .expect("second vault_set should succeed via cached handle");
+    assert_eq!(
+        kernel.vault_get("dashboard_password").as_deref(),
+        Some("s3cret"),
+    );
+    assert_eq!(
+        kernel.vault_get("dashboard_user").as_deref(),
+        Some("alice"),
+        "earlier-written keys must still be readable after a subsequent set",
+    );
+
+    kernel.shutdown();
+}


### PR DESCRIPTION
Closes #3598.

## Problem

`LibreFangKernel::vault_get` / `vault_set` rebuilt a fresh
`CredentialVault` on every call:

1. `CredentialVault::new(path)`
2. read & decrypt `vault.enc`
3. **run Argon2id KDF inside `unlock()`** (intentionally slow)
4. return one value

Flows that need multiple keys (e.g. `dashboard_login` reads both
`dashboard_user` and `dashboard_password`) paid one full Argon2id KDF
per key.

## Strategy

Add a kernel-lifetime cache of the unlocked vault:

```rust
vault_cache: OnceLock<Arc<RwLock<CredentialVault>>>
```

- `OnceLock` — race-safe one-shot lazy init; kernels that never touch
  the vault do no I/O.
- `Arc<RwLock<…>>` — shared by `&self` kernel methods; reads dominate
  writes.

`vault_handle()` (new private helper) populates the cache on first call:
opens the vault, runs `unlock()` (one Argon2id KDF), and installs the
`Arc`. Every subsequent call returns the cached handle with no I/O and
no KDF.

`vault_get` is now a `HashMap` lookup behind a read guard.

`vault_set` writes through the cached, already-unlocked vault. The
save-time KDF inside `CredentialVault::set → save()` is unchanged
(still derives a fresh per-write key) — at-rest security is **not**
regressed.

## Why this strategy over the issue's `DashMap<String, Zeroizing<String>>` sketch

The sketch loses semantics: re-encryption on `set`, on-disk
persistence, and the existing `init`/`unlock`/`save` lifecycle.
Wrapping the existing `CredentialVault` in `Arc<RwLock<…>>` keeps every
on-disk and security guarantee while still eliminating the unlock-time
KDF cost.

## Security notes

- `CredentialVault::Drop` still zeroises entries (per-value
  `Zeroizing<String>`) when the kernel is dropped.
- Save-path KDF unchanged → ciphertext rotation per write preserved.
- AAD binding (path + schema version) unchanged.
- No change to keyring / env-var key resolution.
- No new dependencies introduced.

## Scope notes

- The issue is narrowly scoped to the kernel's `vault_get`/`vault_set`.
  Other call sites that build their own `CredentialVault` directly
  (`channel_bridge.rs`, `routes/mcp_auth.rs`, `routes/skills.rs`,
  `mcp_oauth_provider.rs`, `server.rs`) are out of scope here — they
  have their own constructors and could be migrated to go through the
  kernel cache in a follow-up.
- No `rotate_vault_key` exists at the kernel surface, so no
  cache-invalidation hook was needed. If one is added later, it must
  call into the cached vault (it owns the cache) rather than reinstate
  the old "fresh CredentialVault per call" pattern.

## Test plan

- [x] Added `vault_cache_reuses_unlocked_handle_across_calls` in
      `crates/librefang-kernel/src/kernel/tests.rs`. It:
  - asserts `Arc::ptr_eq` across two `vault_handle()` calls (the
    structural invariant that produces the perf win — direct
    KDF-counting would be flaky on shared CI runners), and
  - round-trips `vault_set` → `vault_get` → `vault_set` →
    `vault_get` to prove cache coherence across writes.
  - is `#[serial_test::serial]` because `LIBREFANG_VAULT_KEY` /
    `LIBREFANG_VAULT_NO_KEYRING` are process-global.
- [ ] CI: `cargo check --workspace --lib`
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] CI: `cargo test -p librefang-kernel
      vault_cache_reuses_unlocked_handle_across_calls`

> Local cargo toolchain absent on this build host (`which cargo` →
> not found, no `~/.cargo/bin`); relying on CI for `cargo
> check`/`clippy`/`test`.
