### PR TITLE
refactor(api): add Path<AgentId> extractor and remove parsing boilerplate (#3603)

### DIFF
--- a/crates/librefang-api/src/extractors.rs
+++ b/crates/librefang-api/src/extractors.rs
@@ -1,0 +1,156 @@
+//! Axum extractors shared by the route handlers.
+//!
+//! At the moment this module only hosts the [`AgentIdPath`] path extractor,
+//! which collapses the parsing boilerplate that was duplicated across many
+//! handlers (see #3603). Add new extractors here whenever a parsing pattern
+//! starts to repeat between route modules.
+
+use axum::extract::{FromRequestParts, Path};
+use axum::http::request::Parts;
+use librefang_types::agent::AgentId;
+use librefang_types::i18n::{self, ErrorTranslator};
+
+use crate::middleware::RequestLanguage;
+use crate::types::ApiErrorResponse;
+
+/// Translation key used by handlers for "invalid agent id". Kept as a constant
+/// so the extractor and any remaining hand-rolled parse sites agree on the key.
+const INVALID_AGENT_ID_KEY: &str = "api-error-agent-invalid-id";
+
+/// Build the localized "invalid agent id" message using the resolved request
+/// language, falling back to the English bundle when the
+/// [`RequestLanguage`] extension is missing (e.g. in tests that bypass the
+/// `accept_language` middleware).
+fn invalid_agent_id_message(parts: &Parts) -> String {
+    let lang = parts
+        .extensions
+        .get::<RequestLanguage>()
+        .map(|rl| rl.0)
+        .unwrap_or(i18n::DEFAULT_LANGUAGE);
+    ErrorTranslator::new(lang).t(INVALID_AGENT_ID_KEY)
+}
+
+/// Newtype extractor that parses an [`AgentId`] from a single-segment path
+/// parameter.
+///
+/// Lets handlers replace the repeated
+///
+/// ```ignore
+/// let agent_id: AgentId = match id.parse() {
+///     Ok(aid) => aid,
+///     Err(_) => {
+///         return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
+///             .into_json_tuple();
+///     }
+/// };
+/// ```
+///
+/// boilerplate with a direct `AgentIdPath(agent_id): AgentIdPath` argument.
+///
+/// On a malformed path segment, returns a 400 [`ApiErrorResponse`] whose
+/// message is translated via the request's `Accept-Language` header just like
+/// the handlers used to do explicitly.
+///
+/// `Path` cannot be implemented for foreign types and the route modules also
+/// use `Path<(String, String)>` tuples (e.g. `/agents/:id/kv/:key`), so a
+/// newtype wrapper is preferable to overriding `Path<AgentId>` itself — it
+/// keeps the existing tuple extractors working without coercion.
+#[derive(Debug, Clone, Copy)]
+pub struct AgentIdPath(pub AgentId);
+
+impl AgentIdPath {
+    /// Consume the wrapper and return the inner [`AgentId`].
+    #[allow(dead_code)]
+    pub fn into_inner(self) -> AgentId {
+        self.0
+    }
+}
+
+impl std::ops::Deref for AgentIdPath {
+    type Target = AgentId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<S> FromRequestParts<S> for AgentIdPath
+where
+    S: Send + Sync,
+{
+    type Rejection = ApiErrorResponse;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Path(raw) = Path::<String>::from_request_parts(parts, state)
+            .await
+            .map_err(|_| ApiErrorResponse::bad_request(invalid_agent_id_message(parts)))?;
+        let id: AgentId = raw
+            .parse()
+            .map_err(|_| ApiErrorResponse::bad_request(invalid_agent_id_message(parts)))?;
+        Ok(AgentIdPath(id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+    use axum::Router;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    async fn echo(AgentIdPath(id): AgentIdPath) -> String {
+        id.to_string()
+    }
+
+    fn app() -> Router {
+        Router::new().route("/agents/{id}", get(echo))
+    }
+
+    #[tokio::test]
+    async fn extracts_valid_agent_id() {
+        let aid = AgentId::new();
+        let uri = format!("/agents/{aid}");
+        let response = app()
+            .oneshot(Request::builder().uri(&uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], aid.to_string().as_bytes());
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_agent_id_with_400_and_localized_message() {
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/not-a-uuid")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // Without the `accept_language` middleware the extractor falls back to
+        // the English bundle, which is what `ErrorTranslator::new("en")` returns
+        // for the well-known key. The test asserts on that exact text so a
+        // translation typo would surface here.
+        let expected = ErrorTranslator::new("en").t(INVALID_AGENT_ID_KEY);
+        assert_eq!(body["error"].as_str(), Some(expected.as_str()));
+    }
+
+    #[tokio::test]
+    async fn into_response_has_400_status() {
+        // Sanity-check that the rejection type renders as 400 outside of the
+        // routing layer, since `ApiErrorResponse::bad_request` is used in many
+        // other places too.
+        let resp = ApiErrorResponse::bad_request("invalid agent id").into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/librefang-api/src/lib.rs
+++ b/crates/librefang-api/src/lib.rs
@@ -107,6 +107,7 @@ pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::R
 }
 
 pub mod channel_bridge;
+pub mod extractors;
 pub mod mcp_oauth;
 pub mod middleware;
 pub mod oauth;

--- a/crates/librefang-api/src/routes/auto_dream.rs
+++ b/crates/librefang-api/src/routes/auto_dream.rs
@@ -12,14 +12,14 @@
 
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_types::agent::AgentId;
 use serde::Deserialize;
 
 use super::AppState;
+use crate::extractors::AgentIdPath;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
@@ -61,18 +61,8 @@ pub async fn auto_dream_status(State(state): State<Arc<AppState>>) -> impl IntoR
 )]
 pub async fn auto_dream_trigger(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
+    AgentIdPath(agent_id): AgentIdPath,
 ) -> impl IntoResponse {
-    let agent_id = match id.parse::<AgentId>() {
-        Ok(id) => id,
-        Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "invalid agent id"})),
-            )
-                .into_response();
-        }
-    };
     let outcome = Arc::clone(&state.kernel)
         .auto_dream_trigger_manual(agent_id)
         .await;
@@ -91,18 +81,8 @@ pub async fn auto_dream_trigger(
 )]
 pub async fn auto_dream_abort(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
+    AgentIdPath(agent_id): AgentIdPath,
 ) -> impl IntoResponse {
-    let agent_id = match id.parse::<AgentId>() {
-        Ok(id) => id,
-        Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "invalid agent id"})),
-            )
-                .into_response();
-        }
-    };
     let outcome = state.kernel.auto_dream_abort(agent_id).await;
     Json(outcome).into_response()
 }
@@ -125,19 +105,9 @@ pub struct SetEnabledRequest {
 )]
 pub async fn auto_dream_set_enabled(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
+    AgentIdPath(agent_id): AgentIdPath,
     Json(req): Json<SetEnabledRequest>,
 ) -> impl IntoResponse {
-    let agent_id = match id.parse::<AgentId>() {
-        Ok(id) => id,
-        Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "invalid agent id"})),
-            )
-                .into_response();
-        }
-    };
     match state.kernel.auto_dream_set_enabled(agent_id, req.enabled) {
         Ok(()) => Json(serde_json::json!({
             "agent_id": agent_id.to_string(),

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -32,12 +32,13 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
                 .delete(delete_user_budget),
         )
 }
+use crate::extractors::AgentIdPath;
 use crate::middleware::UserRole;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use librefang_types::agent::{AgentId, UserId};
+use librefang_types::agent::UserId;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -404,15 +405,8 @@ pub async fn update_budget(
 )]
 pub async fn agent_budget_status(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
+    AgentIdPath(agent_id): AgentIdPath,
 ) -> impl IntoResponse {
-    let agent_id: AgentId = match id.parse() {
-        Ok(id) => id,
-        Err(_) => {
-            return ApiErrorResponse::bad_request("Invalid agent ID").into_response();
-        }
-    };
-
     let entry = match state.kernel.agent_registry().get(agent_id) {
         Some(e) => e,
         None => {
@@ -520,17 +514,11 @@ pub async fn agent_budget_ranking(State(state): State<Arc<AppState>>) -> impl In
 )]
 pub async fn update_agent_budget(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
+    AgentIdPath(agent_id): AgentIdPath,
     api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let api_user_ref = api_user.as_ref().map(|e| &e.0);
-    let agent_id: AgentId = match id.parse() {
-        Ok(id) => id,
-        Err(_) => {
-            return ApiErrorResponse::bad_request("Invalid agent ID").into_response();
-        }
-    };
 
     let hourly = body["max_cost_per_hour_usd"].as_f64();
     let daily = body["max_cost_per_day_usd"].as_f64();

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -164,6 +164,7 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
         // Backup / restore (extracted to routes::backup, #3749)
         .merge(crate::routes::backup::router())
 }
+use crate::extractors::AgentIdPath;
 use crate::middleware::RequestLanguage;
 use crate::types::ApiErrorResponse;
 use axum::extract::{Path, Query, State};
@@ -200,18 +201,11 @@ pub(super) fn librefang_home() -> PathBuf {
 #[utoipa::path(get, path = "/api/memory/agents/{id}/kv", tag = "memory", params(("id" = String, Path, description = "Agent ID")), responses((status = 200, description = "Agent KV store", body = crate::types::JsonObject)))]
 pub async fn get_agent_kv(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
+    AgentIdPath(agent_id): AgentIdPath,
     lang: Option<axum::Extension<RequestLanguage>>,
     api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
-    let agent_id: AgentId = match id.parse() {
-        Ok(aid) => aid,
-        Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
-                .into_json_tuple();
-        }
-    };
     // Owner-scoping: non-admins can only read the KV store of agents
     // they authored. Without this, anyone authenticated could pull
     // user.preferences / oncall.contact / api.tokens out of any agent.
@@ -347,17 +341,10 @@ pub async fn delete_agent_kv_key(
 #[utoipa::path(get, path = "/api/agents/{id}/memory/export", tag = "memory", params(("id" = String, Path, description = "Agent ID")), responses((status = 200, description = "Exported memory", body = crate::types::JsonObject)))]
 pub async fn export_agent_memory(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
+    AgentIdPath(agent_id): AgentIdPath,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
-    let agent_id: AgentId = match id.parse() {
-        Ok(aid) => aid,
-        Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
-                .into_json_tuple();
-        }
-    };
 
     // Verify agent exists
     if state.kernel.agent_registry().get(agent_id).is_none() {
@@ -390,18 +377,11 @@ pub async fn export_agent_memory(
 #[utoipa::path(post, path = "/api/agents/{id}/memory/import", tag = "memory", params(("id" = String, Path, description = "Agent ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Memory imported", body = crate::types::JsonObject)))]
 pub async fn import_agent_memory(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
+    AgentIdPath(agent_id): AgentIdPath,
     lang: Option<axum::Extension<RequestLanguage>>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
-    let agent_id: AgentId = match id.parse() {
-        Ok(aid) => aid,
-        Err(_) => {
-            return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
-                .into_json_tuple();
-        }
-    };
 
     // Verify agent exists
     if state.kernel.agent_registry().get(agent_id).is_none() {


### PR DESCRIPTION
## Summary

Closes #3603.

Adds an Axum `FromRequestParts` extractor (`crate::extractors::AgentIdPath`)
that parses an `AgentId` from a single-segment path parameter and rejects
malformed input with a localized 400 `ApiErrorResponse`. Converts every
single-`Path<String>` agent-id call site that was repeating the boilerplate.

The extractor is a newtype rather than a direct `impl FromRequestParts for AgentId`
so that the existing `Path<(String, String)>` tuple extractors used by routes
like `/agents/{id}/kv/{key}` keep working unchanged. Handlers now write
`AgentIdPath(agent_id): AgentIdPath` and reference `agent_id: AgentId` as before.

### Sites converted (8 total)

- `crates/librefang-api/src/routes/system.rs` — `get_agent_kv`,
  `export_agent_memory`, `import_agent_memory`
- `crates/librefang-api/src/routes/budget.rs` — `agent_budget_status`,
  `update_agent_budget`
- `crates/librefang-api/src/routes/auto_dream.rs` — `auto_dream_trigger`,
  `auto_dream_abort`, `auto_dream_set_enabled`

### Sites intentionally skipped

The remaining `id.parse::<AgentId>()` sites in `system.rs` use the
multi-segment `Path<(String, String)>` extractor (`/agents/{id}/kv/{key}` —
`get_agent_kv_key`, `set_agent_kv_key`, `delete_agent_kv_key`). The issue's
suggested approach (`Path<AgentId>`) does not apply there, and reshaping the
tuple paths is out of scope for this refactor.

`routes/agents.rs` also has many similar parse sites, but most are entwined
with bulk-operation per-item validation (`BulkAgentIdsRequest.agent_ids:
Vec<String>`) or use the same `Path<(String, String)>` pattern, so they are
also out of scope here. They can be migrated incrementally in follow-ups.

### Behavior preservation

Error message localization is preserved end-to-end: the extractor reads the
`RequestLanguage` extension that the `accept_language` middleware inserts and
calls `ErrorTranslator::new(lang).t("api-error-agent-invalid-id")` — the same
key the handlers used to look up manually. When the extension is missing
(e.g. unit tests that bypass the middleware), it falls back to the English
bundle.

The three sites in `auto_dream.rs` previously returned a plain
`(StatusCode::BAD_REQUEST, Json({"error": "invalid agent id"}))` with a
hardcoded English string. After this PR they return the standard
`ApiErrorResponse::bad_request(...)` shape, which still serializes to the
same `{"error": "..."}` JSON contract on a 400 status code, but the message
is now localized via `Accept-Language`. The dashboard checks `error` as a
free-text string, so this is a benign improvement, not a breaking change.

### Tests

The extractor module ships three unit tests (`extractors.rs:tests`):
- `extracts_valid_agent_id` — round-trips a valid UUID via a oneshot router.
- `rejects_invalid_agent_id_with_400_and_localized_message` — confirms 400
  status and that the error body matches the English Fluent message exactly.
- `into_response_has_400_status` — sanity check on `ApiErrorResponse::bad_request`
  rendering (the extractor's rejection type).

## Build / verify

Local cargo toolchain absent on this build host; relying on CI for `cargo
check`, `clippy`, and `cargo test -p librefang-api`. The unit tests use only
already-available dev-deps (`http-body-util`, `tower`, `tokio` test runtime).

## Test plan

- [ ] CI: `cargo check --workspace --lib` passes.
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings` passes.
- [ ] CI: `cargo test -p librefang-api` passes (in particular the three new
      `extractors::tests` cases).
- [ ] Spot-check after merge: `GET /api/budget/agents/<bad-id>` returns 400
      with a localized error body matching prior behavior.
- [ ] Spot-check after merge: `POST /api/auto-dream/agents/<bad-id>/trigger`
      returns 400 with `{"error": "..."}` (now localized).
