### PR TITLE
feat(api): expose existing budget/LLM metrics on /api/health/detail (#3776)

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -454,6 +454,76 @@ pub async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     }))
 }
 
+// ---------------------------------------------------------------------------
+// Health-detail derived-metrics cache (#3776)
+//
+// `query_model_performance()` runs a `GROUP BY model` over `usage_events`,
+// which can grow unbounded. The health endpoint is often probed every few
+// seconds by external monitors (Prometheus blackbox, k8s readiness, etc.) so
+// we memoize the derived snapshot for `HEALTH_METRICS_TTL` to keep the probe
+// cheap. The TTL is short enough that operators still see fresh data.
+// ---------------------------------------------------------------------------
+
+const HEALTH_METRICS_TTL: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[derive(Clone)]
+struct LlmHealthSnapshot {
+    /// Total LLM calls aggregated across every model in `usage_events`.
+    total_calls: u64,
+    /// Call-count-weighted mean latency in milliseconds across all models.
+    avg_latency_ms: f64,
+    /// Highest single-call latency observed across all models.
+    max_latency_ms: u64,
+    /// Number of distinct models seen.
+    model_count: usize,
+}
+
+static LLM_HEALTH_CACHE: std::sync::OnceLock<
+    std::sync::Mutex<Option<(std::time::Instant, LlmHealthSnapshot)>>,
+> = std::sync::OnceLock::new();
+
+fn llm_health_snapshot(state: &AppState) -> LlmHealthSnapshot {
+    let cell = LLM_HEALTH_CACHE.get_or_init(|| std::sync::Mutex::new(None));
+    if let Ok(guard) = cell.lock() {
+        if let Some((ts, snap)) = guard.as_ref() {
+            if ts.elapsed() < HEALTH_METRICS_TTL {
+                return snap.clone();
+            }
+        }
+    }
+
+    let perf = state
+        .kernel
+        .memory_substrate()
+        .usage()
+        .query_model_performance()
+        .unwrap_or_default();
+
+    let total_calls: u64 = perf.iter().map(|m| m.call_count).sum();
+    let weighted_sum: f64 = perf
+        .iter()
+        .map(|m| m.avg_latency_ms * m.call_count as f64)
+        .sum();
+    let avg_latency_ms = if total_calls > 0 {
+        weighted_sum / total_calls as f64
+    } else {
+        0.0
+    };
+    let max_latency_ms = perf.iter().map(|m| m.max_latency_ms).max().unwrap_or(0);
+
+    let snap = LlmHealthSnapshot {
+        total_calls,
+        avg_latency_ms,
+        max_latency_ms,
+        model_count: perf.len(),
+    };
+
+    if let Ok(mut guard) = cell.lock() {
+        *guard = Some((std::time::Instant::now(), snap.clone()));
+    }
+    snap
+}
+
 /// GET /api/health/detail — Full health diagnostics (requires auth).
 #[utoipa::path(
     get,
@@ -479,6 +549,35 @@ pub async fn health_detail(State(state): State<Arc<AppState>>) -> impl IntoRespo
     let config_warnings = hcfg.validate();
     let status = if db_ok { "ok" } else { "degraded" };
 
+    // Budget snapshot — already aggregated by MeteringEngine (single-row SQL
+    // queries, all indexed). `daily_spend_percent` is `None` when no daily
+    // cap is configured so monitors don't false-fire on undefined ratios.
+    let budget_status = state
+        .kernel
+        .metering_ref()
+        .budget_status(&state.kernel.budget_config());
+    let daily_spend_percent = if budget_status.daily_limit > 0.0 {
+        Some(budget_status.daily_pct * 100.0)
+    } else {
+        None
+    };
+    let hourly_spend_percent = if budget_status.hourly_limit > 0.0 {
+        Some(budget_status.hourly_pct * 100.0)
+    } else {
+        None
+    };
+    let monthly_spend_percent = if budget_status.monthly_limit > 0.0 {
+        Some(budget_status.monthly_pct * 100.0)
+    } else {
+        None
+    };
+
+    // LLM call latency snapshot — cached for HEALTH_METRICS_TTL to avoid
+    // re-running the GROUP BY on every probe scrape. Only `count` and
+    // mean / max latency are surfaced; P50/P95 percentiles would require a
+    // histogram which the kernel does not currently maintain (see PR notes).
+    let llm = llm_health_snapshot(&state);
+
     Json(serde_json::json!({
         "status": status,
         "version": env!("CARGO_PKG_VERSION"),
@@ -497,6 +596,24 @@ pub async fn health_detail(State(state): State<Arc<AppState>>) -> impl IntoRespo
         "config_warnings": config_warnings,
         "event_bus": {
             "dropped_events": state.kernel.event_bus_ref().dropped_count(),
+        },
+        "budget": {
+            "hourly_spend_usd": budget_status.hourly_spend,
+            "hourly_limit_usd": budget_status.hourly_limit,
+            "hourly_spend_percent": hourly_spend_percent,
+            "daily_spend_usd": budget_status.daily_spend,
+            "daily_limit_usd": budget_status.daily_limit,
+            "daily_spend_percent": daily_spend_percent,
+            "monthly_spend_usd": budget_status.monthly_spend,
+            "monthly_limit_usd": budget_status.monthly_limit,
+            "monthly_spend_percent": monthly_spend_percent,
+            "alert_threshold": budget_status.alert_threshold,
+        },
+        "llm": {
+            "total_calls": llm.total_calls,
+            "avg_latency_ms": llm.avg_latency_ms,
+            "max_latency_ms": llm.max_latency_ms,
+            "model_count": llm.model_count,
         },
     }))
 }

--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -384,3 +384,132 @@ async fn config_reload_requires_auth_when_key_set() {
     let (status, _) = send(h.app.clone(), req).await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
+
+// ---------------------------------------------------------------------------
+// GET /api/health/detail (#3776)
+//
+// Validates that the new operational metric sections (`budget`, `llm`) are
+// wired into the response and serialize with the documented shape so that
+// monitoring systems (Prometheus blackbox exporter, alerting rules) can rely
+// on the field names.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn health_detail_includes_budget_and_llm_sections() {
+    let h = boot_router_with_api_key(API_KEY).await;
+    let (status, body) = send(h.app.clone(), auth_get("/api/health/detail")).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "body: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
+
+    // Pre-existing fields must remain (regression guard).
+    for key in [
+        "status",
+        "version",
+        "uptime_seconds",
+        "panic_count",
+        "restart_count",
+        "agent_count",
+        "database",
+        "memory",
+        "config_warnings",
+        "event_bus",
+    ] {
+        assert!(
+            json.get(key).is_some(),
+            "missing pre-existing field '{key}' in /api/health/detail: {json}"
+        );
+    }
+
+    // New `budget` block — exposes already-collected MeteringEngine spend.
+    let budget = json
+        .get("budget")
+        .expect("missing 'budget' section in /api/health/detail");
+    for key in [
+        "hourly_spend_usd",
+        "hourly_limit_usd",
+        "hourly_spend_percent",
+        "daily_spend_usd",
+        "daily_limit_usd",
+        "daily_spend_percent",
+        "monthly_spend_usd",
+        "monthly_limit_usd",
+        "monthly_spend_percent",
+        "alert_threshold",
+    ] {
+        assert!(
+            budget.get(key).is_some(),
+            "missing budget.{key} in /api/health/detail: {budget}"
+        );
+    }
+    // With no budget cap configured in the test kernel, the *_percent fields
+    // must serialize as JSON null (operators distinguish "no cap" from "0%").
+    for key in [
+        "daily_spend_percent",
+        "hourly_spend_percent",
+        "monthly_spend_percent",
+    ] {
+        assert!(
+            budget.get(key).expect("present").is_null(),
+            "{key} must be null when no cap is configured: {budget}"
+        );
+    }
+
+    // New `llm` block — sourced from query_model_performance() snapshot.
+    let llm = json
+        .get("llm")
+        .expect("missing 'llm' section in /api/health/detail");
+    for key in ["total_calls", "avg_latency_ms", "max_latency_ms", "model_count"] {
+        assert!(
+            llm.get(key).is_some(),
+            "missing llm.{key} in /api/health/detail: {llm}"
+        );
+    }
+    // No LLM calls have been recorded in this fresh kernel.
+    assert_eq!(llm["total_calls"].as_u64(), Some(0));
+    assert_eq!(llm["max_latency_ms"].as_u64(), Some(0));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn health_detail_daily_spend_percent_reflects_configured_cap() {
+    use librefang_types::config::BudgetConfig;
+
+    let h = boot_router_with_api_key(API_KEY).await;
+
+    // Set a non-zero daily cap so the *_percent fields become defined (0.0
+    // for an empty kernel rather than null).
+    h.state
+        .kernel
+        .update_budget_config(|b: &mut BudgetConfig| {
+            b.max_daily_usd = 25.0;
+            b.max_hourly_usd = 5.0;
+        });
+
+    let (status, body) = send(h.app.clone(), auth_get("/api/health/detail")).await;
+    assert_eq!(status, StatusCode::OK);
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
+    let budget = &json["budget"];
+
+    assert_eq!(budget["daily_limit_usd"].as_f64(), Some(25.0));
+    assert_eq!(budget["hourly_limit_usd"].as_f64(), Some(5.0));
+    assert_eq!(
+        budget["daily_spend_percent"].as_f64(),
+        Some(0.0),
+        "daily_spend_percent must be 0.0 (not null) once a cap is set: {budget}"
+    );
+    assert_eq!(
+        budget["hourly_spend_percent"].as_f64(),
+        Some(0.0),
+        "hourly_spend_percent must be 0.0 (not null) once a cap is set: {budget}"
+    );
+    // No monthly cap was set — must remain null.
+    assert!(
+        budget["monthly_spend_percent"].is_null(),
+        "monthly_spend_percent must stay null when no monthly cap is set: {budget}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #3776.

Surfaces operational metrics that the kernel **already collects** but
that `/api/health/detail` did not expose. Monitoring systems
(Prometheus blackbox exporter, k8s readiness, alert rules) can now
trigger on budget exhaustion and aggregate LLM latency without having
to scrape `/api/budget` and `/api/usage/models` separately.

## Fields added to `/api/health/detail`

| Section  | Field                  | Source                                                |
|----------|------------------------|-------------------------------------------------------|
| `budget` | `hourly_spend_usd`     | `MeteringEngine::budget_status().hourly_spend`        |
| `budget` | `hourly_limit_usd`     | `BudgetConfig::max_hourly_usd`                        |
| `budget` | `hourly_spend_percent` | derived (null when no cap configured)                 |
| `budget` | `daily_spend_usd`      | `MeteringEngine::budget_status().daily_spend`         |
| `budget` | `daily_limit_usd`      | `BudgetConfig::max_daily_usd`                         |
| `budget` | `daily_spend_percent`  | derived (null when no cap configured)                 |
| `budget` | `monthly_spend_usd`    | `MeteringEngine::budget_status().monthly_spend`       |
| `budget` | `monthly_limit_usd`    | `BudgetConfig::max_monthly_usd`                       |
| `budget` | `monthly_spend_percent`| derived (null when no cap configured)                 |
| `budget` | `alert_threshold`      | `BudgetConfig::alert_threshold`                       |
| `llm`    | `total_calls`          | `UsageStore::query_model_performance()` aggregate     |
| `llm`    | `avg_latency_ms`       | call-count-weighted mean across all models            |
| `llm`    | `max_latency_ms`       | max across all models                                 |
| `llm`    | `model_count`          | distinct models seen in `usage_events`                |

`*_spend_percent` deliberately serializes as JSON `null` when no cap is
configured, so monitors can distinguish "no cap" from "0% used"
without false-firing on undefined ratios.

## Metrics from the issue table that were SKIPPED (and why)

The issue invited several metrics that have **no existing collector**
in the kernel today. Per the scope-discipline note in the task brief,
this PR does not build new collection infrastructure for them; each is
called out below so a follow-up issue can decide whether to do that
work explicitly.

- **LLM error rate** — `usage_events` only stores *successful* LLM
  calls (no `success` / `error_category` column, no separate failure
  counter on the kernel surface). Computing an error rate would
  require a schema change to `usage_events` and changes to every
  `agent_loop.rs` failure path that currently just logs and returns
  the error to the caller. The closest existing signal is per-driver
  `consecutive_errors` inside `librefang-llm-drivers/.../fallback.rs`,
  but those atomics are not exposed past the driver boundary today.

- **LLM latency P50 / P95** — only mean / min / max are stored
  (`AVG/MIN/MAX(latency_ms)` in `query_model_performance`). True
  percentiles need a histogram (e.g. `metrics::histogram!`) wired
  through the LLM call path, which the kernel does not currently
  maintain.

- **Database connection wait-queue length** — `librefang-memory`
  uses raw `rusqlite::Connection` behind a `std::sync::Mutex`, not
  `r2d2` / `deadpool`. There is no pool object that exposes a queued
  / idle / in-flight count.

- **Per-agent memory usage (RSS)** — would require OS-level process /
  thread sampling (procfs on Linux, mach_task_info on macOS, etc.).
  Nothing in the workspace samples per-agent RSS today, and per-agent
  attribution is not even well-defined since most agents share the
  daemon process.

## Production-risk guardrails

- The added budget block reads from `MeteringEngine::budget_status()`,
  which is already a single-row indexed query the dashboard scrapes
  via `/api/budget`.
- The LLM block calls `query_model_performance()`, which does a
  `GROUP BY model` over `usage_events`. To keep the probe cheap when
  monitors poll on a tight interval, the derived snapshot is
  memoized for 5 seconds in a process-local cache.
- No new sensitive data is exposed (no API keys, no agent prompts);
  cost figures already flow through the auth-gated `/api/budget`.

## Tests

Two new tests in `crates/librefang-api/tests/config_routes_integration.rs`:

- `health_detail_includes_budget_and_llm_sections` — asserts every
  pre-existing field is still present (regression guard) and that
  the new `budget` / `llm` sections expose the documented field set,
  with `*_spend_percent == null` on a fresh kernel that has no caps
  configured.
- `health_detail_daily_spend_percent_reflects_configured_cap` — flips
  the in-memory `BudgetConfig` daily / hourly caps via
  `kernel.update_budget_config(...)` and asserts the percent fields
  switch from `null` to `0.0`, while an unset monthly cap keeps its
  field as `null`.

## Build verification

Local cargo toolchain absent on this build host (no `cargo` / `rustup`
on PATH); relying on CI for `cargo check / clippy / test`.

## Test plan

- [ ] CI: `cargo check --workspace --lib` green
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings` green
- [ ] CI: `cargo test -p librefang-api` green (covers the new integration tests)
- [ ] Manual smoke (operator): `curl -s -H "Authorization: Bearer $LIBREFANG_API_KEY" http://127.0.0.1:4545/api/health/detail | jq .budget,.llm` returns the documented shape
