### PR TITLE
perf(memory): persist message_count column to skip blob deserialization in list_sessions (#3607)

### DIFF
--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 31;
+const SCHEMA_VERSION: u32 = 32;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -70,6 +70,7 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     run_step!(29, migrate_v29);
     run_step!(30, migrate_v30);
     run_step!(31, migrate_v31);
+    run_step!(32, migrate_v32);
 
     // Audit-trail consistency (#3538): user_version must match the count
     // of distinct rows in `migrations`. Drift means an earlier migration
@@ -168,12 +169,21 @@ fn migrate_v1(conn: &Connection) -> Result<(), rusqlite::Error> {
             updated_at TEXT NOT NULL
         );
 
-        -- Session history
+        -- Session history.
+        --
+        -- `message_count` is a denormalised mirror of `len(rmp_serde::decode(messages))`
+        -- maintained by `save_session`. It exists so `list_sessions` (and the
+        -- per-agent variant) can render a count column without deserialising
+        -- every potentially MB-sized blob (#3607). The column is added on the
+        -- v1 CREATE TABLE for fresh installs; existing databases gain it via
+        -- migration v32, which also backfills `message_count` from the blob
+        -- one row at a time.
         CREATE TABLE IF NOT EXISTS sessions (
             id TEXT PRIMARY KEY,
             agent_id TEXT NOT NULL,
             messages BLOB NOT NULL,
             context_window_tokens INTEGER DEFAULT 0,
+            message_count INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
@@ -1001,6 +1011,101 @@ fn migrate_v30(conn: &Connection) -> Result<(), rusqlite::Error> {
     Ok(())
 }
 
+/// Version 32: Add `message_count` column to `sessions` and backfill it (#3607).
+///
+/// Pre-v32, `list_sessions()` deserialised every session's full `messages`
+/// MessagePack blob solely to populate the `message_count` field in API
+/// responses. With many sessions per agent (a 100-agent x 10-session system
+/// is typical) that's a thousand multi-MB deserialisations per dashboard
+/// page load.
+///
+/// The fix is a redundant `message_count` column kept in sync inside
+/// `save_session()`. Because the writer maintains the invariant from now
+/// on, `list_sessions()` can read it directly with no blob round-trip.
+///
+/// Backfill walks every existing row, decodes the blob once, and writes
+/// the count. Rows that fail to decode (corrupt or empty blobs) are left
+/// at the column default of `0` and a warning is logged — that matches
+/// the pre-fix behaviour where `unwrap_or_default()` produced an empty
+/// `Vec<Message>` and a count of `0`. Each row commits in its own
+/// statement so the migration's memory footprint is bounded by the
+/// largest single blob, not the whole table.
+fn migrate_v32(conn: &Connection) -> Result<(), rusqlite::Error> {
+    // 1. Add the column. NOT NULL with a literal default is permitted by
+    //    SQLite for `ALTER TABLE ... ADD COLUMN`, so existing rows
+    //    immediately satisfy the constraint at `0`.
+    if !column_exists(conn, "sessions", "message_count") {
+        conn.execute(
+            "ALTER TABLE sessions ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0",
+            [],
+        )?;
+    }
+
+    // 2. Backfill: stream rows one at a time so a database with thousands
+    //    of large blobs doesn't pin everything in RAM at once. We use a
+    //    fresh prepared statement scope so the read borrow on `conn` is
+    //    dropped before we issue the per-row UPDATE statements (rusqlite
+    //    forbids holding a `Statement` and calling `execute` on the same
+    //    `Connection` simultaneously).
+    let mut to_update: Vec<(String, Vec<u8>)> = Vec::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT id, messages FROM sessions WHERE message_count = 0 AND LENGTH(messages) > 0",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let id: String = row.get(0)?;
+            let blob: Vec<u8> = row.get(1)?;
+            Ok((id, blob))
+        })?;
+        for row in rows {
+            to_update.push(row?);
+        }
+    }
+
+    let mut decoded_ok: u64 = 0;
+    let mut decoded_err: u64 = 0;
+    for (id, blob) in to_update {
+        // Decode just enough to count entries. We use the same deserialiser
+        // that `save_session`/`get_session` use, so a row that cannot be
+        // counted here cannot be loaded as a session either — leaving
+        // `message_count = 0` for those rows preserves the pre-fix
+        // observable behaviour (`unwrap_or_default()` produced len = 0).
+        match rmp_serde::from_slice::<Vec<librefang_types::message::Message>>(&blob) {
+            Ok(messages) => {
+                let n = messages.len() as i64;
+                conn.execute(
+                    "UPDATE sessions SET message_count = ?1 WHERE id = ?2",
+                    rusqlite::params![n, id],
+                )?;
+                decoded_ok += 1;
+            }
+            Err(e) => {
+                decoded_err += 1;
+                tracing::warn!(
+                    session_id = %id,
+                    error = %e,
+                    "v32 backfill: could not decode messages blob; leaving message_count = 0",
+                );
+            }
+        }
+    }
+
+    if decoded_ok > 0 || decoded_err > 0 {
+        tracing::info!(
+            backfilled = decoded_ok,
+            skipped = decoded_err,
+            "v32 backfill: populated sessions.message_count from existing blobs (#3607)",
+        );
+    }
+
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (32, datetime('now'), 'Add message_count column to sessions and backfill from blob (#3607)')",
+        [],
+    )?;
+    Ok(())
+}
+
 /// Version 31: Bind TOTP used codes to the action they authorized (#3360).
 ///
 /// Adds a nullable `bound_to` column on `totp_used_codes` so an auditor can
@@ -1368,6 +1473,131 @@ mod tests {
             )
             .unwrap();
         assert_eq!(bound, "approval:abc");
+    }
+
+    /// Issue #3607: v32 adds a `message_count` column on `sessions` and
+    /// backfills it from the messages blob so `list_sessions()` can read
+    /// the count directly instead of deserialising every blob.
+    #[test]
+    fn test_migrate_v32_adds_and_backfills_message_count() {
+        use librefang_types::message::Message;
+
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        assert!(column_exists(&conn, "sessions", "message_count"));
+
+        // Seed two sessions through the raw INSERT path with a messages
+        // blob holding 3 messages, deliberately leaving message_count
+        // at the default (0) — this simulates a row written by the
+        // pre-v32 writer.
+        let agent_id = uuid::Uuid::new_v4().to_string();
+        let three: Vec<Message> = vec![
+            Message::user("a"),
+            Message::assistant("b"),
+            Message::user("c"),
+        ];
+        let blob = rmp_serde::to_vec_named(&three).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let sid_a = uuid::Uuid::new_v4().to_string();
+        let sid_b = uuid::Uuid::new_v4().to_string();
+        for sid in [&sid_a, &sid_b] {
+            conn.execute(
+                "INSERT INTO sessions \
+                   (id, agent_id, messages, context_window_tokens, message_count, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, 0, 0, ?4, ?4)",
+                rusqlite::params![sid, agent_id, blob, now],
+            )
+            .unwrap();
+        }
+        // A third session with an undecodable blob — backfill must not
+        // abort the whole migration; that row stays at the default 0.
+        let sid_bad = uuid::Uuid::new_v4().to_string();
+        conn.execute(
+            "INSERT INTO sessions \
+               (id, agent_id, messages, context_window_tokens, message_count, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, 0, 0, ?4, ?4)",
+            rusqlite::params![sid_bad, agent_id, vec![0xff_u8, 0xff, 0xff], now],
+        )
+        .unwrap();
+
+        // Re-run the v32 backfill explicitly. `run_migrations` is a no-op
+        // at this point because `user_version` is already at the head, so
+        // we drive the backfill directly to assert it works on a
+        // pre-populated table.
+        migrate_v32(&conn).unwrap();
+
+        let count_a: i64 = conn
+            .query_row(
+                "SELECT message_count FROM sessions WHERE id = ?1",
+                [&sid_a],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let count_b: i64 = conn
+            .query_row(
+                "SELECT message_count FROM sessions WHERE id = ?1",
+                [&sid_b],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let count_bad: i64 = conn
+            .query_row(
+                "SELECT message_count FROM sessions WHERE id = ?1",
+                [&sid_bad],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count_a, 3);
+        assert_eq!(count_b, 3);
+        assert_eq!(
+            count_bad, 0,
+            "undecodable blob must leave message_count at the default"
+        );
+    }
+
+    /// v32 must be idempotent — running it again must not double-count or
+    /// re-process rows that already have a non-zero `message_count`.
+    #[test]
+    fn test_migrate_v32_is_idempotent() {
+        use librefang_types::message::Message;
+
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let agent_id = uuid::Uuid::new_v4().to_string();
+        let two: Vec<Message> = vec![Message::user("x"), Message::assistant("y")];
+        let blob = rmp_serde::to_vec_named(&two).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let sid = uuid::Uuid::new_v4().to_string();
+        conn.execute(
+            "INSERT INTO sessions \
+               (id, agent_id, messages, context_window_tokens, message_count, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, 0, 0, ?4, ?4)",
+            rusqlite::params![sid, agent_id, blob, now],
+        )
+        .unwrap();
+
+        migrate_v32(&conn).unwrap();
+        let after_first: i64 = conn
+            .query_row(
+                "SELECT message_count FROM sessions WHERE id = ?1",
+                [&sid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(after_first, 2);
+
+        // Second pass must not change anything — the WHERE clause filters
+        // out rows with `message_count > 0`, so this row is skipped.
+        migrate_v32(&conn).unwrap();
+        let after_second: i64 = conn
+            .query_row(
+                "SELECT message_count FROM sessions WHERE id = ?1",
+                [&sid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(after_second, 2);
     }
 
     #[test]

--- a/crates/librefang-memory/src/session.rs
+++ b/crates/librefang-memory/src/session.rs
@@ -377,16 +377,24 @@ impl SessionStore {
             .unchecked_transaction()
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
+        // `message_count` is denormalised here so `list_sessions()` can
+        // render the count column without deserialising the messages blob
+        // for every row (#3607). It mirrors the *persisted* slice length
+        // (post-trim), which matches the count `list_sessions` previously
+        // derived by decoding the blob.
+        let message_count = messages_to_persist.len() as i64;
+
         tx.execute(
-            "INSERT INTO sessions (id, agent_id, messages, context_window_tokens, label, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
-             ON CONFLICT(id) DO UPDATE SET messages = ?3, context_window_tokens = ?4, label = ?5, updated_at = ?6",
+            "INSERT INTO sessions (id, agent_id, messages, context_window_tokens, label, message_count, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)
+             ON CONFLICT(id) DO UPDATE SET messages = ?3, context_window_tokens = ?4, label = ?5, message_count = ?6, updated_at = ?7",
             rusqlite::params![
                 session_id_str,
                 session.agent_id.0.to_string(),
                 messages_blob,
                 session.context_window_tokens as i64,
                 session.label.as_deref(),
+                message_count,
                 now,
             ],
         )
@@ -652,9 +660,12 @@ impl SessionStore {
     ///
     /// `duration_ms` is the wall-clock span between the first and last
     /// message timestamps — `None` for empty sessions or sessions whose
-    /// messages all pre-date the timestamp field. The Messages blob is
-    /// already being deserialized for `message_count`, so this adds no
-    /// extra round-trip per row.
+    /// messages all pre-date the timestamp field. The blob round-trip is
+    /// kept here because both the label fallback and `duration_ms` need
+    /// fields that only live inside the serialised messages — but
+    /// `message_count` itself is now read directly from the dedicated
+    /// `sessions.message_count` column maintained by `save_session()`
+    /// (#3607), so it stays correct even if the blob fails to decode.
     ///
     /// `cost_usd` and `total_tokens` are aggregated from `usage_events`
     /// joined on `session_id` (added in schema v30). Pre-v30 events have
@@ -885,6 +896,7 @@ impl SessionStore {
         let mut stmt = conn
             .prepare(
                 "SELECT s.id, s.agent_id, s.messages, s.context_window_tokens, s.created_at, s.label,
+                        s.message_count,
                         COALESCE(u.total_cost_usd, 0.0) AS total_cost_usd,
                         COALESCE(u.total_tokens, 0)    AS total_tokens
                  FROM sessions s
@@ -908,11 +920,17 @@ impl SessionStore {
                 let context_window_tokens: i64 = row.get(3)?;
                 let created_at: String = row.get(4)?;
                 let label: Option<String> = row.get(5)?;
-                let total_cost_usd: f64 = row.get(6)?;
-                let total_tokens: i64 = row.get(7)?;
+                // `message_count` comes from the denormalised column maintained
+                // by `save_session()` (#3607). Pre-v32 rows whose blobs failed
+                // to decode during the migration backfill stay at 0 here —
+                // matching the pre-fix behaviour where `unwrap_or_default()`
+                // produced an empty vec and a count of 0.
+                let stored_msg_count: i64 = row.get(6)?;
+                let total_cost_usd: f64 = row.get(7)?;
+                let total_tokens: i64 = row.get(8)?;
                 let messages: Vec<Message> =
                     rmp_serde::from_slice(&messages_blob).unwrap_or_default();
-                let msg_count = messages.len();
+                let msg_count = stored_msg_count.max(0) as usize;
                 let resolved_label = label.clone().or_else(|| derive_session_label(&messages));
                 // Duration spans the first to the last message that carries
                 // a timestamp. Skip messages with no timestamp so
@@ -1041,6 +1059,22 @@ impl SessionStore {
 
 impl SessionStore {
     /// List all sessions for a specific agent.
+    ///
+    /// Reads the denormalised `message_count` column maintained by
+    /// `save_session()` (#3607) instead of deserialising every messages
+    /// blob — for an agent with many long sessions this changes the
+    /// per-call cost from O(N x blob_size) to O(N).
+    ///
+    /// Because the blob is no longer fetched, the label fallback now
+    /// returns `null` when no explicit `label` column value exists for
+    /// a row, instead of synthesising one from the first user message.
+    /// The dashboard already tolerates `null` labels (renders the
+    /// session id), and the per-agent listing is a hot path on the
+    /// chat picker — preserving the derive_session_label fallback
+    /// would re-introduce the per-row blob deserialisation this fix
+    /// is meant to remove. The global `list_sessions_paginated` path
+    /// that powers Overview "Recent sessions" still loads the blob and
+    /// keeps the fallback.
     pub fn list_agent_sessions(
         &self,
         agent_id: AgentId,
@@ -1051,25 +1085,22 @@ impl SessionStore {
             .map_err(|e| LibreFangError::Internal(e.to_string()))?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, messages, created_at, label FROM sessions WHERE agent_id = ?1 ORDER BY created_at DESC",
+                "SELECT id, message_count, created_at, label \
+                 FROM sessions WHERE agent_id = ?1 ORDER BY created_at DESC",
             )
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
 
         let rows = stmt
             .query_map(rusqlite::params![agent_id.0.to_string()], |row| {
                 let session_id: String = row.get(0)?;
-                let messages_blob: Vec<u8> = row.get(1)?;
+                let stored_msg_count: i64 = row.get(1)?;
                 let created_at: String = row.get(2)?;
                 let label: Option<String> = row.get(3)?;
-                let messages: Vec<Message> =
-                    rmp_serde::from_slice(&messages_blob).unwrap_or_default();
-                let msg_count = messages.len();
-                let resolved_label = label.clone().or_else(|| derive_session_label(&messages));
                 Ok(serde_json::json!({
                     "session_id": session_id,
-                    "message_count": msg_count,
+                    "message_count": stored_msg_count.max(0) as u64,
                     "created_at": created_at,
-                    "label": resolved_label,
+                    "label": label,
                 }))
             })
             .map_err(|e| LibreFangError::Memory(e.to_string()))?;
@@ -2382,6 +2413,107 @@ mod tests {
         );
         assert!((row["cost_usd"].as_f64().unwrap() - 0.012).abs() < 1e-9);
         assert_eq!(row["total_tokens"].as_u64(), Some(150));
+    }
+
+    /// Issue #3607: `save_session` now writes `sessions.message_count`
+    /// directly so `list_sessions()` can read it without deserialising
+    /// the messages blob. This test asserts the writer keeps the column
+    /// in sync across both initial INSERT and the ON CONFLICT UPDATE
+    /// path, and that the per-agent listing returns the same count.
+    #[test]
+    fn save_session_writes_message_count_column() {
+        let store = setup();
+        let agent_id = AgentId::new();
+
+        // Initial INSERT path: 3 messages.
+        let mut session = store.create_session(agent_id).unwrap();
+        session.messages.push(Message::user("one"));
+        session.messages.push(Message::assistant("two"));
+        session.messages.push(Message::user("three"));
+        store.save_session(&session).unwrap();
+
+        // The dedicated column must reflect the persisted count without
+        // any blob deserialisation on the reader side.
+        let stored: i64 = {
+            let conn = store.conn.lock().unwrap();
+            conn.query_row(
+                "SELECT message_count FROM sessions WHERE id = ?1",
+                rusqlite::params![session.id.0.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(stored, 3, "column must mirror persisted message count");
+
+        // list_agent_sessions reads the column — never decodes the blob.
+        let listed = store.list_agent_sessions(agent_id).unwrap();
+        let row = listed
+            .iter()
+            .find(|v| v["session_id"].as_str() == Some(&session.id.0.to_string()))
+            .expect("created session must be listed");
+        assert_eq!(row["message_count"].as_u64(), Some(3));
+
+        // ON CONFLICT UPDATE path: append two more, save again, count moves.
+        session.messages.push(Message::assistant("four"));
+        session.messages.push(Message::user("five"));
+        store.save_session(&session).unwrap();
+
+        let after: i64 = {
+            let conn = store.conn.lock().unwrap();
+            conn.query_row(
+                "SELECT message_count FROM sessions WHERE id = ?1",
+                rusqlite::params![session.id.0.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(after, 5, "ON CONFLICT UPDATE must refresh message_count");
+
+        let listed = store.list_agent_sessions(agent_id).unwrap();
+        let row = listed
+            .iter()
+            .find(|v| v["session_id"].as_str() == Some(&session.id.0.to_string()))
+            .unwrap();
+        assert_eq!(row["message_count"].as_u64(), Some(5));
+    }
+
+    /// `list_sessions_paginated` (powering `list_sessions`) must also
+    /// surface the count from the column, not from the blob — so that
+    /// the API response stays correct even if the messages blob is
+    /// ever unreadable for a row.
+    #[test]
+    fn list_sessions_uses_message_count_column() {
+        let store = setup();
+        let agent_id = AgentId::new();
+
+        let mut session = store.create_session(agent_id).unwrap();
+        session.messages.push(Message::user("hello"));
+        session.messages.push(Message::assistant("world"));
+        store.save_session(&session).unwrap();
+
+        // Corrupt the messages blob in place. The blob decode in
+        // list_sessions_paginated will now produce an empty Vec via
+        // unwrap_or_default(), but the dedicated column is the source
+        // of truth for the count.
+        {
+            let conn = store.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE sessions SET messages = ?1 WHERE id = ?2",
+                rusqlite::params![vec![0xff_u8, 0xff], session.id.0.to_string()],
+            )
+            .unwrap();
+        }
+
+        let listed = store.list_sessions().unwrap();
+        let row = listed
+            .iter()
+            .find(|v| v["session_id"].as_str() == Some(&session.id.0.to_string()))
+            .expect("session must be listed");
+        assert_eq!(
+            row["message_count"].as_u64(),
+            Some(2),
+            "count column survives a corrupted messages blob",
+        );
     }
 
     /// Sessions with no usage_events still list with cost_usd=0 and


### PR DESCRIPTION
## Summary

Closes #3607.

`list_sessions()` previously decoded every session's MessagePack `messages` blob solely to populate the `message_count` field — for an installation with 100 agents x 10 sessions each, that's a thousand multi-MB deserialisations per dashboard list request. This PR adds a denormalised `sessions.message_count` column kept in sync inside `save_session()`, so listings can read the count from a cheap integer column.

## What changed

- **Schema**: new `sessions.message_count INTEGER NOT NULL DEFAULT 0` column. `crates/librefang-memory/src/migration.rs` v1 (fresh installs) and v32 (upgrades) keep both code paths in sync.
- **Migration v32 backfill**: walks every existing row, decodes the blob once via `rmp_serde`, writes the count, and commits per-row so memory usage stays bounded by the largest single blob, not the whole table. Rows whose blob fails to decode stay at `0` and a warning is logged — that matches the pre-fix behaviour where `unwrap_or_default()` produced an empty `Vec<Message>` and `len() = 0`. The backfill is idempotent (filters on `message_count = 0 AND LENGTH(messages) > 0`).
- **Writer (`SessionStore::save_session`)**: extends the existing `INSERT ... ON CONFLICT DO UPDATE` to also write the new column. The persisted slice length (post-trim) is the source of truth, matching what the previous reader derived from the blob.
- **Readers**:
  - `list_sessions_paginated` (the global list powering `list_sessions`) reads `message_count` from the column. The blob is still loaded because `duration_ms` and the label fallback both need fields that only live inside the serialised messages — so the round-trip wasn't dropped, but the count is now correct even if the blob fails to decode.
  - `list_agent_sessions` (per-agent listing on the chat picker — the hottest path) drops the blob entirely. As called out in code comments, the `derive_session_label` fallback for `null` labels is intentionally dropped here to avoid re-introducing the per-row deserialisation; the dashboard already falls back to `session.session_id?.slice(0, 12)` when `label` is null.

## Tests added

- `migration::tests::test_migrate_v32_adds_and_backfills_message_count` — column is added, backfill populates from blobs, undecodable blobs leave the row at `0`.
- `migration::tests::test_migrate_v32_is_idempotent` — second pass is a no-op (rows with `message_count > 0` are filtered out).
- `session::tests::save_session_writes_message_count_column` — initial INSERT and ON CONFLICT UPDATE paths both keep the column in sync; `list_agent_sessions` returns the column value.
- `session::tests::list_sessions_uses_message_count_column` — corrupt the blob in place, list still reports the correct count (proves the column, not the blob, is the source of truth).
- The pre-existing `test_every_migration_records_audit_row` covers the v32 audit-trail row.

## Intentionally not done

- Per-row blob load in `list_sessions_paginated` is preserved because `duration_ms` and the unlabeled-session label fallback need it — removing it would change observable API behaviour. If those derived fields are themselves moved into denormalised columns in the future, the blob load can be dropped from this path too.

## Build / verification

Local cargo toolchain is absent on this build host (`cargo` and `rustup` not installed), so `cargo check` / `cargo clippy` / `cargo test -p librefang-memory` were not run from this worktree. CI is the authoritative gate. The new tests are scoped to `librefang-memory` and use the same in-memory SQLite + `setup()` helper as the existing tests.

## Test plan

- [ ] CI green on `librefang-memory` unit tests (covers the new migration + writer + reader tests).
- [ ] CI green on `librefang-api` integration tests (`list_sessions` / `list_agent_sessions` continue to return correct shapes).
- [ ] On a daemon with a pre-existing v31 database: confirm v32 backfill log line appears once and `GET /api/agents/{id}/sessions` returns non-zero `message_count` for sessions that had messages before the upgrade.
