### PR TITLE
fix(api): surface cron persist failures with 500 instead of silent revert (#3515)

### DIFF
--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1941,7 +1941,11 @@ pub async fn create_cron_job(
 }
 
 /// DELETE /api/cron/jobs/{id} — Delete a cron job.
-#[utoipa::path(delete, path = "/api/cron/jobs/{id}", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), responses((status = 200, description = "Cron job deleted")))]
+///
+/// Returns 500 if the in-memory removal succeeds but persistence to disk
+/// fails — without persistence, the deletion would silently revert on
+/// daemon restart (issue #3515).
+#[utoipa::path(delete, path = "/api/cron/jobs/{id}", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), responses((status = 200, description = "Cron job deleted"), (status = 500, description = "Persist failed; change will not survive restart")))]
 pub async fn delete_cron_job(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1952,7 +1956,10 @@ pub async fn delete_cron_job(
             match state.kernel.cron().remove_job(job_id) {
                 Ok(_) => {
                     if let Err(e) = state.kernel.cron().persist() {
-                        tracing::warn!("Failed to persist cron scheduler state: {e}");
+                        tracing::error!(
+                            "Failed to persist cron scheduler state after delete: {e}"
+                        );
+                        return cron_persist_failed_response("delete", &e.to_string());
                     }
                     (
                         StatusCode::OK,
@@ -1967,7 +1974,11 @@ pub async fn delete_cron_job(
 }
 
 /// PUT /api/cron/jobs/{id} — Update a cron job's configuration.
-#[utoipa::path(put, path = "/api/cron/jobs/{id}", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Cron job updated", body = crate::types::JsonObject)))]
+///
+/// Returns 500 if the in-memory update succeeds but persistence to disk
+/// fails — without persistence, the new schedule runs in-memory until the
+/// next restart, then silently reverts to the old schedule (issue #3515).
+#[utoipa::path(put, path = "/api/cron/jobs/{id}", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Cron job updated", body = crate::types::JsonObject), (status = 500, description = "Persist failed; change will not survive restart")))]
 pub async fn update_cron_job(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1978,7 +1989,12 @@ pub async fn update_cron_job(
             let job_id = librefang_types::scheduler::CronJobId(uuid);
             match state.kernel.cron().update_job(job_id, &body) {
                 Ok(job) => {
-                    let _ = state.kernel.cron().persist();
+                    if let Err(e) = state.kernel.cron().persist() {
+                        tracing::error!(
+                            "Failed to persist cron scheduler state after update: {e}"
+                        );
+                        return cron_persist_failed_response("update", &e.to_string());
+                    }
                     (
                         StatusCode::OK,
                         Json(serde_json::to_value(&job).unwrap_or_default()),
@@ -1992,7 +2008,11 @@ pub async fn update_cron_job(
 }
 
 /// PUT /api/cron/jobs/{id}/enable — Enable or disable a cron job.
-#[utoipa::path(put, path = "/api/cron/jobs/{id}/enable", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Cron job toggled", body = crate::types::JsonObject)))]
+///
+/// Returns 500 if the in-memory toggle succeeds but persistence to disk
+/// fails — without persistence, the new enabled state would silently
+/// revert on daemon restart (issue #3515).
+#[utoipa::path(put, path = "/api/cron/jobs/{id}/enable", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), request_body = crate::types::JsonObject, responses((status = 200, description = "Cron job toggled", body = crate::types::JsonObject), (status = 500, description = "Persist failed; change will not survive restart")))]
 pub async fn toggle_cron_job(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -2005,7 +2025,10 @@ pub async fn toggle_cron_job(
             match state.kernel.cron().set_enabled(job_id, enabled) {
                 Ok(()) => {
                     if let Err(e) = state.kernel.cron().persist() {
-                        tracing::warn!("Failed to persist cron scheduler state: {e}");
+                        tracing::error!(
+                            "Failed to persist cron scheduler state after toggle: {e}"
+                        );
+                        return cron_persist_failed_response("toggle", &e.to_string());
                     }
                     (
                         StatusCode::OK,
@@ -2017,6 +2040,31 @@ pub async fn toggle_cron_job(
         }
         Err(_) => ApiErrorResponse::bad_request("Invalid job ID").into_json_tuple(),
     }
+}
+
+/// Build a 500 response for cron persist failures.
+///
+/// The in-memory scheduler change has already been applied at this point,
+/// so the response signals two things: (a) the change is live in-memory
+/// right now, but (b) it will silently revert on daemon restart unless
+/// the persist failure is resolved. Clients should surface this clearly
+/// (it is *not* a routine 500).
+fn cron_persist_failed_response(
+    operation: &str,
+    detail: &str,
+) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({
+            "error": "Failed to persist cron job change",
+            "code": "cron_persist_failed",
+            "type": "cron_persist_failed",
+            "operation": operation,
+            "in_memory_applied": true,
+            "will_survive_restart": false,
+            "detail": detail,
+        })),
+    )
 }
 
 /// GET /api/cron/jobs/{id} — Get a single cron job by ID.

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -1906,6 +1906,72 @@ mod tests {
         );
     }
 
+    /// Regression for #3515: when the persist destination is not writable
+    /// (here: `data/` exists as a regular file instead of a directory so
+    /// `create_dir_all` fails), `persist()` MUST surface the I/O error
+    /// rather than swallow it. The route layer relies on this `Err` to
+    /// translate into a 500 response, otherwise UI-driven cron updates
+    /// silently revert on the next daemon restart.
+    #[test]
+    fn persist_returns_error_when_data_dir_unwritable() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Pre-create `data` as a regular file so `create_dir_all` fails on
+        // the persist path's parent. This is portable across platforms
+        // (no need for chmod/permission tricks that don't work on
+        // Windows or as root in CI).
+        std::fs::write(tmp.path().join("data"), b"not a directory").unwrap();
+
+        let sched = CronScheduler::new(tmp.path(), 100);
+        let agent = AgentId::new();
+        sched.add_job(make_job(agent), false).unwrap();
+
+        let result = sched.persist();
+        assert!(
+            result.is_err(),
+            "persist() must surface I/O failure (got Ok). Without this signal \
+             the API layer cannot return 500 and silently reverts schedules \
+             on restart (#3515)."
+        );
+    }
+
+    /// Regression for #3515: an `update_job` that successfully patches the
+    /// in-memory state must not mask a subsequent `persist()` failure.
+    /// The two operations are independent — `update_job` returns Ok, then
+    /// `persist()` returns Err on a non-writable path — and the route
+    /// handler must observe both results separately.
+    #[test]
+    fn update_job_then_persist_failure_is_observable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sched = CronScheduler::new(tmp.path(), 100);
+        let agent = AgentId::new();
+        let id = sched.add_job(make_job(agent), false).unwrap();
+
+        // First persist succeeds (data/ does not yet exist as a file).
+        sched.persist().unwrap();
+
+        // Now sabotage the parent dir so future persists fail. We replace
+        // the existing data/ directory with a regular file of the same
+        // name. `create_dir_all` on the parent will then fail because
+        // a non-directory already occupies that path.
+        let data_dir = tmp.path().join("data");
+        std::fs::remove_dir_all(&data_dir).unwrap();
+        std::fs::write(&data_dir, b"sabotage").unwrap();
+
+        // In-memory update still succeeds (it doesn't touch disk).
+        let updates = serde_json::json!({ "name": "renamed-after-sabotage" });
+        let updated = sched.update_job(id, &updates).expect("update_job must succeed in-memory");
+        assert_eq!(updated.name, "renamed-after-sabotage");
+
+        // But persist now fails — and the route handler must see this Err
+        // so it can return 500 instead of pretending the change was saved.
+        let persist_result = sched.persist();
+        assert!(
+            persist_result.is_err(),
+            "persist() after in-memory update must fail loudly when disk \
+             write is impossible (#3515)"
+        );
+    }
+
     #[test]
     fn delivery_targets_persist_across_reload() {
         use librefang_types::scheduler::CronDeliveryTarget;


### PR DESCRIPTION
## Summary

Fixes #3515. `PUT /api/cron/jobs/{id}` previously dropped `cron().persist()` errors with `let _ = ...` and returned `200 OK` regardless. The in-memory scheduler ran the new schedule until the next daemon restart, at which point the OLD schedule was reloaded from disk — a silent schedule reversion with no log line and no signal to the UI.

The sibling `DELETE /api/cron/jobs/{id}` and `PUT /api/cron/jobs/{id}/enable` handlers had the same shape at lower probability — they logged the persist failure at `WARN` but still returned 200, so any cron CRUD on a degraded disk silently lied about success.

## Contract change

| Endpoint | Before | After |
|---|---|---|
| `PUT  /api/cron/jobs/{id}` | persist error swallowed; 200 OK with stale-on-restart job | 500 with `code: cron_persist_failed`, `tracing::error!` |
| `DELETE /api/cron/jobs/{id}` | persist error WARN-logged; 200 OK | 500 with `code: cron_persist_failed`, `tracing::error!` |
| `PUT /api/cron/jobs/{id}/enable` | persist error WARN-logged; 200 OK | 500 with `code: cron_persist_failed`, `tracing::error!` |

The 500 response body distinguishes "live in-memory now" from "will survive restart" so clients don't have to guess:

```json
{
  "error": "Failed to persist cron job change",
  "code": "cron_persist_failed",
  "type": "cron_persist_failed",
  "operation": "update",        // or "delete" / "toggle"
  "in_memory_applied": true,
  "will_survive_restart": false,
  "detail": "<underlying I/O error>"
}
```

This is the issue's recommended "Better" path applied consistently across all three handlers. The `WARN` -> `ERROR` log level bump matches the new severity (silent on-disk divergence is data loss, not a warning).

## Regression tests

Two new tests in `crates/librefang-kernel/src/cron.rs`:

- `persist_returns_error_when_data_dir_unwritable` — fault-injects an unwritable persist destination (replaces `data/` with a regular file so `create_dir_all` fails) and asserts `persist()` returns `Err`. The route handlers rely on this `Err` propagating.
- `update_job_then_persist_failure_is_observable` — proves the exact sequence used by `update_cron_job`: `update_job(...)` returns Ok (in-memory patch), then `persist()` returns Err (disk write impossible). The two outcomes must be independently observable so the handler can return 500 instead of pretending the change was saved.

Fault-injection is portable: replacing the directory with a regular file makes `create_dir_all` fail on Linux / macOS / Windows / CI-as-root without chmod tricks.

A pure route-level integration test would require standing up the full `AppState` (kernel + memory + auth middleware + etc.), so the seam is asserted at the kernel-handle boundary instead. The route handler itself is a thin `match` over the same `Result` shape — its branches are covered by reading the diff.

## Files changed

- `crates/librefang-api/src/routes/workflows.rs` — three handlers + new `cron_persist_failed_response` helper, updated `#[utoipa::path]` to document the 500 response.
- `crates/librefang-kernel/src/cron.rs` — two regression tests in the existing `tests` module.

No new dependencies. No migration needed.

## Test plan

- [ ] CI green (clippy --all-targets -D warnings, full test suite)
- [ ] OpenAPI regen captures the new `500` response on all three routes
- [ ] Manual: with a read-only `~/.librefang/data/`, `PUT /api/cron/jobs/{id}` returns 500 with the documented body and the daemon log contains `tracing::error!` for `Failed to persist cron scheduler state after update`
- [ ] Manual: dashboard SchedulerPage surfaces the failure (follow-up if it currently swallows non-2xx — out of scope for this PR)

## Build host note

`cargo` and `rustup` are not installed on the build host this PR was authored from, so local `cargo check` / `clippy` / `test` could not be run. Relying on CI as the gate. The diff is mechanical — three matched edits and a new helper in one file, plus two unit tests next to existing tests using the same `make_job` / `tempdir` pattern.
