### PR TITLE
perf(llm-driver): make LlmError::TimedOut.partial_text Arc-shared (#3552)

### DIFF
--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -3,6 +3,7 @@
 //! Abstracts over multiple LLM providers (Anthropic, OpenAI, Ollama, etc.).
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use librefang_types::config::{AzureOpenAiConfig, ResponseFormat, VertexAiConfig};
@@ -61,10 +62,19 @@ pub enum LlmError {
     #[error("Model not found: {0}")]
     ModelNotFound(String),
     /// Subprocess timed out due to inactivity, but partial output was captured.
+    ///
+    /// `partial_text` is wrapped in `Option<Arc<str>>` so cloning the error
+    /// (e.g. when stringifying through `LibreFangError::LlmDriver(e.to_string())`,
+    /// matching for failover decisions, etc.) is an O(1) refcount bump rather
+    /// than copying potentially-megabyte payloads. Most consumers only ever
+    /// read `partial_text_len` (which is what `Display` references) and never
+    /// touch the body; CLI driver callers that DO want to forward the partial
+    /// to the user can still pattern-match the variant and clone cheaply. See
+    /// #3552.
     #[error("Timed out after {inactivity_secs}s of inactivity (last: {last_activity}, {partial_text_len} chars partial output)")]
     TimedOut {
         inactivity_secs: u64,
-        partial_text: String,
+        partial_text: Option<Arc<str>>,
         partial_text_len: usize,
         /// Last known activity before the process stalled.
         last_activity: String,
@@ -533,6 +543,56 @@ impl std::fmt::Debug for DriverConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #3552: `LlmError::TimedOut.partial_text` is `Option<Arc<str>>` so that
+    // cloning the variant (or the whole error) is an O(1) refcount bump.
+    // Display still interpolates `partial_text_len` only — the body is opaque
+    // to most consumers — and pattern-matching the variant must keep working
+    // for the CLI-driver callers that DO want to forward the partial.
+    #[test]
+    fn test_timed_out_partial_text_is_arc_shared_and_display_unchanged() {
+        let body: Arc<str> = Arc::from("hello world partial output");
+        let err = LlmError::TimedOut {
+            inactivity_secs: 30,
+            partial_text: Some(Arc::clone(&body)),
+            partial_text_len: body.len(),
+            last_activity: "tool_use".to_string(),
+        };
+
+        // Display references only `inactivity_secs`, `last_activity`, and
+        // `partial_text_len` — the body is intentionally not interpolated.
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "Timed out after 30s of inactivity (last: tool_use, {} chars partial output)",
+                body.len()
+            )
+        );
+
+        // Pattern-match still exposes the partial for CLI callers that want it.
+        match &err {
+            LlmError::TimedOut { partial_text, .. } => {
+                assert_eq!(partial_text.as_deref(), Some(body.as_ref()));
+            }
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+
+        // The `None` shape is also valid for callers that don't have a partial.
+        let empty = LlmError::TimedOut {
+            inactivity_secs: 5,
+            partial_text: None,
+            partial_text_len: 0,
+            last_activity: "init".to_string(),
+        };
+        assert_eq!(
+            empty.to_string(),
+            "Timed out after 5s of inactivity (last: init, 0 chars partial output)"
+        );
+
+        // Failover classification is unaffected by the field-shape change.
+        assert_eq!(err.failover_reason(), FailoverReason::Timeout);
+        assert_eq!(empty.failover_reason(), FailoverReason::Timeout);
+    }
 
     #[test]
     fn test_completion_response_text() {

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -1091,10 +1091,17 @@ impl LlmDriver for ClaudeCodeDriver {
                             "Claude CLI streaming timed out due to inactivity, killing process"
                         );
                         let _ = child.kill().await;
+                        let partial_body: std::sync::Arc<str> =
+                            std::sync::Arc::from(std::mem::take(&mut full_text));
                         break Some(LlmError::TimedOut {
                             inactivity_secs: kill_secs,
                             partial_text_len: partial_len,
-                            partial_text: std::mem::take(&mut full_text),
+                            // #3552: Arc-shared so error clone / stringify is O(1).
+                            partial_text: if partial_body.is_empty() {
+                                None
+                            } else {
+                                Some(partial_body)
+                            },
                             last_activity: last_activity.clone(),
                         });
                     }

--- a/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
@@ -608,7 +608,7 @@ mod tests {
     fn failover_reason_timed_out_variant() {
         let e = LlmError::TimedOut {
             inactivity_secs: 30,
-            partial_text: String::new(),
+            partial_text: None,
             partial_text_len: 0,
             last_activity: "none".to_string(),
         };

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -4449,8 +4449,20 @@ async fn stream_with_retry(
                     inactivity_secs,
                     partial_text_len, last_activity, "LLM stream timed out with partial output"
                 );
-                if !partial_text.is_empty() {
-                    let _ = tx.send(StreamEvent::TextDelta { text: partial_text }).await;
+                // #3552: `partial_text` is `Option<Arc<str>>` — copy the body
+                // into the owned `String` that `TextDelta` requires only when
+                // we actually have one to forward. Most consumers (failover
+                // classification, log lines, error stringification through
+                // `LibreFangError::LlmDriver(e.to_string())`) only ever read
+                // `partial_text_len` and pay nothing for the body.
+                if let Some(body) = partial_text.as_deref() {
+                    if !body.is_empty() {
+                        let _ = tx
+                            .send(StreamEvent::TextDelta {
+                                text: body.to_string(),
+                            })
+                            .await;
+                    }
                 }
                 return Err(LibreFangError::LlmDriver(format!(
                     "Task timed out after {inactivity_secs}s of inactivity \


### PR DESCRIPTION
## Summary

Closes #3552.

`LlmError::TimedOut` carried `partial_text: String` by value, so every clone of the error allocated and copied the full body — even though `Display` only references `partial_text_len` and the most common consumer path (`LibreFangError::LlmDriver(e.to_string())`) drops the body entirely. With the Claude Code CLI driver this can be megabytes that 95% of consumers never read.

This PR takes the conservative fix from the issue: change the field to `Option<Arc<str>>`. Cloning the variant (or the whole error) becomes an O(1) refcount bump, but the variant shape, pattern-matching ergonomics, and `Display` output stay identical.

## Changes

- `crates/librefang-llm-driver/src/lib.rs`: `partial_text: String` -> `partial_text: Option<Arc<str>>`. `partial_text_len: usize` stays so `Display` and log lines keep rendering the same string without unwrapping the `Arc`. Adds `use std::sync::Arc;`.
- `crates/librefang-llm-drivers/src/drivers/claude_code.rs` (the only real construction site): drains the streaming buffer with `std::mem::take`, wraps in `Arc::from(...)`, collapses empty bodies to `None` so consumers don't have to disambiguate "no partial" from "empty partial".
- `crates/librefang-llm-drivers/src/drivers/fallback_chain.rs` (test fixture): `String::new()` -> `None`.
- `crates/librefang-runtime/src/agent_loop.rs` (the only real read site): pattern-binds `partial_text` as `Option<Arc<str>>` and only allocates a `String` for `StreamEvent::TextDelta` when a non-empty body is actually present.

## Test

Adds `test_timed_out_partial_text_is_arc_shared_and_display_unchanged` in `librefang-llm-driver/src/lib.rs`, asserting:
- `Display` output is byte-identical to the pre-change behaviour for both `Some(Arc<str>)` and `None` shapes (`partial_text_len` is what's interpolated, not the body).
- Pattern matching on the variant still exposes the partial body via `partial_text.as_deref()` for CLI callers that want to forward it.
- `failover_reason()` remains `FailoverReason::Timeout`.

The clone-cost claim ("Arc clone is O(1) refcount bump") is design-self-evident from the type change and not asserted by the test — the test guards against behaviour regression instead.

## Conservative-vs-better tradeoff

The issue suggested two paths:

1. **Conservative** (this PR): swap `String` for `Option<Arc<str>>`. Same variant, same `Display`, same pattern-match ergonomics; existing call sites keep compiling with one-line wraps. Memory savings are the immediate win.
2. **Better**: side-channel the partial via a new `StreamEvent::PartialOutputCheckpoint` and slim `LlmError::TimedOut` down to `{ inactivity_secs, last_activity }`. Strictly cleaner, but it's a streaming-protocol redesign that touches every consumer of the event stream and forces all CLI drivers to emit checkpoints during the run rather than at timeout.

I went with (1) here because it captures the entire memory win with a tiny diff and zero protocol churn. Followup work to migrate to the side-channel design is tracked as future work; the right time to do it is alongside another stream-event change so consumers only re-handshake once.

## Verification

Local cargo absent on build host; relying on CI for `cargo check --workspace --lib`, `cargo clippy --workspace --all-targets -- -D warnings`, and the per-crate test runs that cover the new test in `librefang-llm-driver`.
