### PR TITLE
fix(api): make DELETE handlers idempotent and fix webhook_wake auth status (#3509)

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -2191,14 +2191,21 @@ pub async fn get_agent_session(
 }
 
 /// DELETE /api/agents/:id — Kill an agent.
+///
+/// Idempotent (RFC 9110 §9.2.2 / §9.3.5): deleting an agent that is already
+/// gone returns `200 OK` with `{"status": "already-deleted"}` instead of
+/// `404`. `404` is reserved for the malformed-UUID case alone, so retried
+/// or replayed DELETEs by clients (network blips, dashboard double-clicks)
+/// no longer surface a phantom error. Refs #3509.
 #[utoipa::path(
     delete,
     path = "/api/agents/{id}",
     tag = "agents",
     params(("id" = String, Path, description = "Agent ID")),
     responses(
-        (status = 200, description = "Agent killed"),
-        (status = 404, description = "Agent not found")
+        (status = 200, description = "Agent killed (or was already absent — idempotent)"),
+        (status = 400, description = "Malformed agent ID"),
+        (status = 409, description = "Agent is hand-owned and cannot be deleted directly")
     )
 )]
 pub async fn kill_agent(
@@ -2221,13 +2228,24 @@ pub async fn kill_agent(
     // can respawn or produce stale instance state — require callers to
     // deactivate or uninstall the owning hand instead. The dashboard hides
     // Delete for hand agents already; this closes the direct-API loophole.
-    if let Some(entry) = state.kernel.agent_registry().get(agent_id) {
-        if entry.is_hand {
+    match state.kernel.agent_registry().get(agent_id) {
+        Some(entry) if entry.is_hand => {
             return ApiErrorResponse::conflict(
                 "Cannot delete a hand-spawned agent directly; deactivate or uninstall the owning hand instead.",
             )
             .with_code("hand_agent_delete_denied")
             .into_response();
+        }
+        Some(_) => {}
+        None => {
+            // Idempotent DELETE: the agent is already gone (replayed request,
+            // double-click, race with another deleter). Treat as success per
+            // RFC 9110 §9.2.2 — DELETE is idempotent.
+            return (
+                StatusCode::OK,
+                Json(serde_json::json!({"status": "already-deleted", "agent_id": id})),
+            )
+                .into_response();
         }
     }
 
@@ -2238,9 +2256,25 @@ pub async fn kill_agent(
         )
             .into_response(),
         Err(e) => {
+            // The agent existed when we checked above but vanished mid-flight
+            // (concurrent delete). Still treat as idempotent success — the
+            // caller's intent ("agent {id} should be gone") is satisfied.
+            if matches!(
+                e,
+                librefang_kernel::error::KernelError::LibreFang(
+                    librefang_types::error::LibreFangError::AgentNotFound(_)
+                )
+            ) {
+                tracing::debug!("kill_agent: agent {id} vanished mid-flight; treating as already-deleted");
+                return (
+                    StatusCode::OK,
+                    Json(serde_json::json!({"status": "already-deleted", "agent_id": id})),
+                )
+                    .into_response();
+            }
             tracing::warn!("kill_agent failed for {id}: {e}");
-            ApiErrorResponse::not_found(t.t("api-error-agent-not-found-or-terminated"))
-                .with_code("agent_not_found")
+            ApiErrorResponse::internal(format!("Failed to kill agent {id}: {e}"))
+                .with_code("agent_kill_failed")
                 .into_response()
         }
     }

--- a/crates/librefang-api/src/routes/system.rs
+++ b/crates/librefang-api/src/routes/system.rs
@@ -2014,13 +2014,29 @@ pub async fn totp_revoke(
 ///
 /// Publishes a custom event through the kernel's event system, which can
 /// trigger proactive agents that subscribe to the event type.
-#[utoipa::path(post, path = "/api/hooks/wake", tag = "webhooks", request_body = crate::types::JsonObject, responses((status = 200, description = "Wake hook triggered", body = crate::types::JsonObject)))]
+///
+/// Auth (#3509): missing or invalid bearer token returns `401 Unauthorized`
+/// with a `WWW-Authenticate: Bearer realm="librefang-webhook"` header per
+/// RFC 9110 §11.6.1. The previous behaviour (400 Bad Request) confused
+/// clients that tried to retry with a fixed body instead of fixing the
+/// token.
+#[utoipa::path(
+    post,
+    path = "/api/hooks/wake",
+    tag = "webhooks",
+    request_body = crate::types::JsonObject,
+    responses(
+        (status = 200, description = "Wake hook triggered", body = crate::types::JsonObject),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 404, description = "Webhook triggers not enabled")
+    )
+)]
 pub async fn webhook_wake(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
     lang: Option<axum::Extension<RequestLanguage>>,
     Json(body): Json<librefang_types::webhook::WakePayload>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     let (err_webhook_not_enabled, err_invalid_token) = {
         let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
         (
@@ -2034,18 +2050,21 @@ pub async fn webhook_wake(
     let wh_config = match &cfg.webhook_triggers {
         Some(c) if c.enabled => c,
         _ => {
-            return ApiErrorResponse::not_found(err_webhook_not_enabled).into_json_tuple();
+            return ApiErrorResponse::not_found(err_webhook_not_enabled).into_response();
         }
     };
 
-    // Validate bearer token (constant-time comparison)
+    // Validate bearer token (constant-time comparison). Invalid token is
+    // an authentication failure, not a malformed request — return 401 with
+    // the standard `WWW-Authenticate` challenge per RFC 9110 §11.6.1
+    // (#3509).
     if !validate_webhook_token(&headers, &wh_config.token_env) {
-        return ApiErrorResponse::bad_request(err_invalid_token).into_json_tuple();
+        return webhook_unauthorized_response(err_invalid_token);
     }
 
     // Validate payload
     if let Err(e) = body.validate() {
-        return ApiErrorResponse::bad_request(e).into_json_tuple();
+        return ApiErrorResponse::bad_request(e).into_response();
     }
 
     // Publish through the kernel's publish_event (KernelHandle trait), which
@@ -2066,26 +2085,61 @@ pub async fn webhook_wake(
                 &[("error", &e.to_string())],
             )
         };
-        return ApiErrorResponse::internal(err_msg).into_json_tuple();
+        return ApiErrorResponse::internal(err_msg).into_response();
     }
 
     (
         StatusCode::OK,
         Json(serde_json::json!({"status": "accepted", "mode": body.mode})),
     )
+        .into_response()
+}
+
+/// Build a `401 Unauthorized` response with the standard
+/// `WWW-Authenticate: Bearer realm="librefang-webhook"` challenge header
+/// (RFC 9110 §11.6.1). Used by webhook trigger endpoints whose bearer-token
+/// check failed (#3509).
+fn webhook_unauthorized_response(message: String) -> axum::response::Response {
+    let body = ApiErrorResponse {
+        error: message,
+        code: Some("webhook_invalid_token".to_string()),
+        r#type: Some("webhook_invalid_token".to_string()),
+        details: None,
+        status: StatusCode::UNAUTHORIZED,
+    };
+    let mut resp = body.into_response();
+    resp.headers_mut().insert(
+        axum::http::header::WWW_AUTHENTICATE,
+        axum::http::HeaderValue::from_static("Bearer realm=\"librefang-webhook\""),
+    );
+    resp
 }
 
 /// POST /hooks/agent — Run an isolated agent turn via webhook.
 ///
 /// Sends a message directly to the specified agent and returns the response.
 /// This enables external systems (CI/CD, Slack, etc.) to trigger agent work.
-#[utoipa::path(post, path = "/api/hooks/agent", tag = "webhooks", request_body = crate::types::JsonObject, responses((status = 200, description = "Agent hook triggered", body = crate::types::JsonObject)))]
+///
+/// Auth (#3509): missing or invalid bearer token returns `401 Unauthorized`
+/// with a `WWW-Authenticate: Bearer realm="librefang-webhook"` header per
+/// RFC 9110 §11.6.1, mirroring the `/hooks/wake` fix.
+#[utoipa::path(
+    post,
+    path = "/api/hooks/agent",
+    tag = "webhooks",
+    request_body = crate::types::JsonObject,
+    responses(
+        (status = 200, description = "Agent hook triggered", body = crate::types::JsonObject),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 404, description = "Webhook triggers not enabled or agent not found")
+    )
+)]
 pub async fn webhook_agent(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
     lang: Option<axum::Extension<RequestLanguage>>,
     Json(body): Json<librefang_types::webhook::AgentHookPayload>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     let (err_webhook_not_enabled, err_invalid_token, err_no_agents) = {
         let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
         (
@@ -2100,18 +2154,18 @@ pub async fn webhook_agent(
     let wh_config = match &cfg2.webhook_triggers {
         Some(c) if c.enabled => c,
         _ => {
-            return ApiErrorResponse::not_found(err_webhook_not_enabled).into_json_tuple();
+            return ApiErrorResponse::not_found(err_webhook_not_enabled).into_response();
         }
     };
 
-    // Validate bearer token
+    // Validate bearer token (#3509: 401 + WWW-Authenticate, not 400).
     if !validate_webhook_token(&headers, &wh_config.token_env) {
-        return ApiErrorResponse::bad_request(err_invalid_token).into_json_tuple();
+        return webhook_unauthorized_response(err_invalid_token);
     }
 
     // Validate payload
     if let Err(e) = body.validate() {
-        return ApiErrorResponse::bad_request(e).into_json_tuple();
+        return ApiErrorResponse::bad_request(e).into_response();
     }
 
     // Resolve the agent by name or ID (if not specified, use the first running agent)
@@ -2127,7 +2181,7 @@ pub async fn webhook_agent(
                             let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
                             t.t_args("api-error-webhook-agent-not-found", &[("id", agent_ref)])
                         };
-                        return ApiErrorResponse::not_found(err_msg).into_json_tuple();
+                        return ApiErrorResponse::not_found(err_msg).into_response();
                     }
                 }
             }
@@ -2137,7 +2191,7 @@ pub async fn webhook_agent(
             match state.kernel.agent_registry().list().first() {
                 Some(entry) => entry.id,
                 None => {
-                    return ApiErrorResponse::not_found(err_no_agents).into_json_tuple();
+                    return ApiErrorResponse::not_found(err_no_agents).into_response();
                 }
             }
         }
@@ -2156,14 +2210,15 @@ pub async fn webhook_agent(
                     "output_tokens": result.total_usage.output_tokens,
                 },
             })),
-        ),
+        )
+            .into_response(),
         Err(e) => {
             let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
             let msg = t.t_args(
                 "api-error-webhook-agent-exec-failed",
                 &[("error", &e.to_string())],
             );
-            ApiErrorResponse::internal(msg).into_json_tuple()
+            ApiErrorResponse::internal(msg).into_response()
         }
     }
 }

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1203,7 +1203,20 @@ pub async fn get_trigger(
 }
 
 /// DELETE /api/triggers/:id — Remove a trigger.
-#[utoipa::path(delete, path = "/api/triggers/{id}", tag = "workflows", params(("id" = String, Path, description = "Trigger ID")), responses((status = 200, description = "Trigger deleted")))]
+///
+/// Idempotent (RFC 9110 §9.2.2): deleting a trigger that is already gone
+/// returns `200 OK` with `{"status": "already-deleted"}` instead of `404`.
+/// `400` is reserved for the malformed-UUID case alone. Refs #3509.
+#[utoipa::path(
+    delete,
+    path = "/api/triggers/{id}",
+    tag = "workflows",
+    params(("id" = String, Path, description = "Trigger ID")),
+    responses(
+        (status = 200, description = "Trigger deleted (or was already absent — idempotent)"),
+        (status = 400, description = "Malformed trigger ID")
+    )
+)]
 pub async fn delete_trigger(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1221,7 +1234,13 @@ pub async fn delete_trigger(
             Json(serde_json::json!({"status": "removed", "trigger_id": id})),
         )
     } else {
-        ApiErrorResponse::not_found("Trigger not found").into_json_tuple()
+        // Idempotent DELETE — replayed request, double-click, or already
+        // removed by another caller. Surface success so clients don't have
+        // to special-case 404 on a successful-state outcome.
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({"status": "already-deleted", "trigger_id": id})),
+        )
     }
 }
 
@@ -1942,34 +1961,54 @@ pub async fn create_cron_job(
 
 /// DELETE /api/cron/jobs/{id} — Delete a cron job.
 ///
-/// Returns 500 if the in-memory removal succeeds but persistence to disk
-/// fails — without persistence, the deletion would silently revert on
-/// daemon restart (issue #3515).
-#[utoipa::path(delete, path = "/api/cron/jobs/{id}", tag = "workflows", params(("id" = String, Path, description = "Cron job ID")), responses((status = 200, description = "Cron job deleted"), (status = 500, description = "Persist failed; change will not survive restart")))]
+/// Idempotent (RFC 9110 §9.2.2): deleting a cron job that is already gone
+/// returns `200 OK` with `{"status": "already-deleted"}` instead of `404`.
+/// `400` is reserved for the malformed-UUID case alone (Refs #3509). Returns
+/// `500` if the in-memory removal succeeds but persistence to disk fails —
+/// without persistence, the deletion would silently revert on daemon restart
+/// (issue #3515).
+#[utoipa::path(
+    delete,
+    path = "/api/cron/jobs/{id}",
+    tag = "workflows",
+    params(("id" = String, Path, description = "Cron job ID")),
+    responses(
+        (status = 200, description = "Cron job deleted (or was already absent — idempotent)"),
+        (status = 400, description = "Malformed cron job ID"),
+        (status = 500, description = "Persist failed; change will not survive restart")
+    )
+)]
 pub async fn delete_cron_job(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    match uuid::Uuid::parse_str(&id) {
-        Ok(uuid) => {
-            let job_id = librefang_types::scheduler::CronJobId(uuid);
-            match state.kernel.cron().remove_job(job_id) {
-                Ok(_) => {
-                    if let Err(e) = state.kernel.cron().persist() {
-                        tracing::error!(
-                            "Failed to persist cron scheduler state after delete: {e}"
-                        );
-                        return cron_persist_failed_response("delete", &e.to_string());
-                    }
-                    (
-                        StatusCode::OK,
-                        Json(serde_json::json!({"status": "deleted"})),
-                    )
-                }
-                Err(e) => ApiErrorResponse::not_found(format!("{e}")).into_json_tuple(),
+    let uuid = match uuid::Uuid::parse_str(&id) {
+        Ok(u) => u,
+        Err(_) => return ApiErrorResponse::bad_request("Invalid job ID").into_json_tuple(),
+    };
+    let job_id = librefang_types::scheduler::CronJobId(uuid);
+    match state.kernel.cron().remove_job(job_id) {
+        Ok(_) => {
+            if let Err(e) = state.kernel.cron().persist() {
+                tracing::error!(
+                    "Failed to persist cron scheduler state after delete: {e}"
+                );
+                return cron_persist_failed_response("delete", &e.to_string());
             }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"status": "deleted", "job_id": id})),
+            )
         }
-        Err(_) => ApiErrorResponse::bad_request("Invalid job ID").into_json_tuple(),
+        Err(_) => {
+            // Idempotent DELETE — the cron job is already gone (replayed
+            // request, double-click, or removed by another deleter). Treat
+            // as success so clients don't have to special-case 404.
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"status": "already-deleted", "job_id": id})),
+            )
+        }
     }
 }
 

--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -332,3 +332,77 @@ async fn test_patch_agent_without_token_returns_401_when_api_key_set() {
     .await;
     assert_eq!(status_ok, StatusCode::OK);
 }
+
+// ---------------------------------------------------------------------------
+// DELETE /api/agents/{id} — idempotency (#3509)
+// ---------------------------------------------------------------------------
+
+fn delete(path: &str, bearer: Option<&str>) -> Request<Body> {
+    let mut b = Request::builder().method(Method::DELETE).uri(path);
+    if let Some(token) = bearer {
+        b = b.header("authorization", format!("Bearer {}", token));
+    }
+    b.body(Body::empty()).unwrap()
+}
+
+/// Refs #3509: DELETE is idempotent (RFC 9110 §9.2.2). Killing the same
+/// agent twice MUST succeed both times — the second call returns
+/// `200 OK` with `status: already-deleted` instead of `404 Not Found`,
+/// so clients (dashboard double-clicks, CLI retries, network-recovery
+/// loops) never see a phantom error for an outcome that already matches
+/// their intent.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_agent_twice_both_succeed_idempotent() {
+    let h = boot(TEST_TOKEN).await;
+    let id = spawn_named(&h.state, "kill-target");
+
+    // First call — agent exists, normal kill path.
+    let (status1, body1) = send(
+        h.app.clone(),
+        delete(&format!("/api/agents/{}", id), Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status1, StatusCode::OK, "first DELETE should be 200; body={body1:?}");
+    assert_eq!(body1["status"], "killed", "first DELETE body={body1:?}");
+
+    // Second call — agent already gone. MUST still be 200, not 404.
+    let (status2, body2) = send(
+        h.app.clone(),
+        delete(&format!("/api/agents/{}", id), Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(
+        status2,
+        StatusCode::OK,
+        "second DELETE on a now-absent agent must be idempotent-200 (#3509); got {status2} body={body2:?}"
+    );
+    assert_eq!(body2["status"], "already-deleted", "second DELETE body={body2:?}");
+}
+
+/// Refs #3509: 400 stays reserved for malformed-id rejection. Only the
+/// `not-found` case relaxed to 200 idempotent. Without this the relaxation
+/// could mask genuine client bugs (typo'd id, wrong path).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_agent_invalid_id_still_returns_400() {
+    let h = boot(TEST_TOKEN).await;
+    let (status, body) = send(h.app.clone(), delete("/api/agents/not-a-uuid", Some(TEST_TOKEN))).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body={body:?}");
+    assert_eq!(body["code"], "invalid_agent_id");
+}
+
+/// Refs #3509: deleting an unknown-but-well-formed UUID is idempotent —
+/// no agent existed under that id, so the caller's intent ("agent {id}
+/// should be gone") is already satisfied. 200 with `already-deleted` lets
+/// idempotent clients (Terraform-style reconcilers) skip the dance.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_agent_unknown_uuid_is_idempotent_200() {
+    let h = boot(TEST_TOKEN).await;
+    let unknown = AgentId::new();
+    let (status, body) = send(
+        h.app.clone(),
+        delete(&format!("/api/agents/{}", unknown), Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body:?}");
+    assert_eq!(body["status"], "already-deleted", "body={body:?}");
+}

--- a/crates/librefang-api/tests/hooks_commands_routes_integration.rs
+++ b/crates/librefang-api/tests/hooks_commands_routes_integration.rs
@@ -71,6 +71,19 @@ async fn send(
     body: Option<serde_json::Value>,
     bearer: Option<&str>,
 ) -> (StatusCode, serde_json::Value) {
+    let (status, _headers, value) = send_full(h, method, path, body, bearer).await;
+    (status, value)
+}
+
+/// Variant that also returns the response headers so tests can assert on
+/// e.g. `WWW-Authenticate` (#3509).
+async fn send_full(
+    h: &Harness,
+    method: Method,
+    path: &str,
+    body: Option<serde_json::Value>,
+    bearer: Option<&str>,
+) -> (StatusCode, axum::http::HeaderMap, serde_json::Value) {
     let mut builder = Request::builder().method(method).uri(path);
     if let Some(tok) = bearer {
         builder = builder.header("authorization", format!("Bearer {tok}"));
@@ -85,6 +98,7 @@ async fn send(
     let req = builder.body(Body::from(body_bytes)).unwrap();
     let resp = h.app.clone().oneshot(req).await.unwrap();
     let status = resp.status();
+    let headers = resp.headers().clone();
     let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
         .await
         .unwrap();
@@ -93,7 +107,7 @@ async fn send(
     } else {
         serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
     };
-    (status, value)
+    (status, headers, value)
 }
 
 // ---------------------------------------------------------------------------
@@ -139,7 +153,10 @@ async fn hooks_wake_returns_404_when_webhook_triggers_disabled_explicitly() {
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
-/// Missing Authorization header against an enabled hook = 400.
+/// Missing Authorization header against an enabled hook = 401 with the
+/// standard `WWW-Authenticate: Bearer ...` challenge (#3509). Previously
+/// returned 400 (Bad Request), which mis-categorised an auth failure as a
+/// payload bug.
 #[tokio::test(flavor = "multi_thread")]
 async fn hooks_wake_rejects_missing_bearer() {
     let env_name = "LIBREFANG_TEST_WEBHOOK_TOKEN_WAKE_MISSING_3571";
@@ -149,7 +166,7 @@ async fn hooks_wake_rejects_missing_bearer() {
         std::env::set_var(env_name, "x".repeat(40));
     }
     let h = boot_enabled(env_name).await;
-    let (status, body) = send(
+    let (status, headers, body) = send_full(
         &h,
         Method::POST,
         "/api/hooks/wake",
@@ -160,10 +177,21 @@ async fn hooks_wake_rejects_missing_bearer() {
     unsafe {
         std::env::remove_var(env_name);
     }
-    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "#3509 {body:?}");
+    let challenge = headers
+        .get(axum::http::header::WWW_AUTHENTICATE)
+        .expect("#3509: 401 must carry WWW-Authenticate header")
+        .to_str()
+        .expect("WWW-Authenticate must be ASCII");
+    assert!(
+        challenge.starts_with("Bearer"),
+        "#3509: WWW-Authenticate must advertise Bearer scheme; got {challenge:?}"
+    );
 }
 
-/// Wrong bearer token against an enabled hook = 400 (constant-time mismatch).
+/// Wrong bearer token against an enabled hook = 401 + WWW-Authenticate
+/// (#3509). Constant-time mismatch path now correctly signals auth failure
+/// rather than payload failure.
 #[tokio::test(flavor = "multi_thread")]
 async fn hooks_wake_rejects_wrong_bearer() {
     let env_name = "LIBREFANG_TEST_WEBHOOK_TOKEN_WAKE_WRONG_3571";
@@ -172,7 +200,7 @@ async fn hooks_wake_rejects_wrong_bearer() {
         std::env::set_var(env_name, &real);
     }
     let h = boot_enabled(env_name).await;
-    let (status, _) = send(
+    let (status, headers, _body) = send_full(
         &h,
         Method::POST,
         "/api/hooks/wake",
@@ -183,11 +211,18 @@ async fn hooks_wake_rejects_wrong_bearer() {
     unsafe {
         std::env::remove_var(env_name);
     }
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "#3509");
+    assert!(
+        headers
+            .get(axum::http::header::WWW_AUTHENTICATE)
+            .is_some(),
+        "#3509: 401 must carry WWW-Authenticate"
+    );
 }
 
 /// A token shorter than 32 bytes is treated as "no token configured", so the
 /// auth gate fails closed even when the caller sends a matching string.
+/// #3509: still 401 (auth failure), just like wrong-token case.
 #[tokio::test(flavor = "multi_thread")]
 async fn hooks_wake_rejects_short_configured_token() {
     let env_name = "LIBREFANG_TEST_WEBHOOK_TOKEN_WAKE_SHORT_3571";
@@ -206,7 +241,7 @@ async fn hooks_wake_rejects_short_configured_token() {
     unsafe {
         std::env::remove_var(env_name);
     }
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "#3509");
 }
 
 /// Auth passes, payload validation fails — empty `text` is rejected with
@@ -287,6 +322,8 @@ async fn hooks_agent_returns_404_when_webhook_triggers_not_enabled() {
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
+/// #3509: same auth-status fix mirrored to `/hooks/agent` for consistency
+/// — missing bearer is 401 + WWW-Authenticate, not 400.
 #[tokio::test(flavor = "multi_thread")]
 async fn hooks_agent_rejects_missing_bearer() {
     let env_name = "LIBREFANG_TEST_WEBHOOK_TOKEN_AGENT_MISSING_3571";
@@ -294,7 +331,7 @@ async fn hooks_agent_rejects_missing_bearer() {
         std::env::set_var(env_name, "y".repeat(40));
     }
     let h = boot_enabled(env_name).await;
-    let (status, _) = send(
+    let (status, headers, _) = send_full(
         &h,
         Method::POST,
         "/api/hooks/agent",
@@ -305,7 +342,13 @@ async fn hooks_agent_rejects_missing_bearer() {
     unsafe {
         std::env::remove_var(env_name);
     }
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "#3509");
+    assert!(
+        headers
+            .get(axum::http::header::WWW_AUTHENTICATE)
+            .is_some(),
+        "#3509: 401 must carry WWW-Authenticate"
+    );
 }
 
 /// Auth passes, payload validation fails — empty `message`.

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -527,7 +527,10 @@ async fn cron_job_delete_invalid_id_returns_400() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn cron_job_delete_unknown_uuid_returns_404() {
+async fn cron_job_delete_unknown_uuid_is_idempotent_200() {
+    // Refs #3509: DELETE is idempotent (RFC 9110 §9.2.2). Deleting an
+    // already-absent cron job returns 200 with `status: already-deleted`,
+    // not 404 — clients can replay/retry without seeing a phantom error.
     let h = boot().await;
     let (status, body) = json_request(
         &h,
@@ -536,7 +539,51 @@ async fn cron_job_delete_unknown_uuid_returns_404() {
         None,
     )
     .await;
-    assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert_eq!(body["status"], "already-deleted", "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_delete_twice_both_succeed() {
+    // Refs #3509: idempotent DELETE — calling DELETE on the same id twice
+    // never surfaces an error on the second call. Tests the
+    // already-absent path explicitly (no created job needed; the path
+    // taken on the second call is identical to "never existed").
+    let h = boot().await;
+    let path = "/api/cron/jobs/11111111-1111-1111-1111-111111111111";
+    for attempt in 1..=2 {
+        let (status, body) = json_request(&h, Method::DELETE, path, None).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "attempt {attempt} should be 200; got {status} body={body:?}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trigger_delete_unknown_uuid_is_idempotent_200() {
+    // Refs #3509: same idempotency contract for triggers.
+    let h = boot().await;
+    let (status, body) = json_request(
+        &h,
+        Method::DELETE,
+        "/api/triggers/00000000-0000-0000-0000-000000000000",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert_eq!(body["status"], "already-deleted", "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trigger_delete_invalid_uuid_returns_400() {
+    // Refs #3509: 400 stays reserved for malformed-id rejection. Only the
+    // `not-found` case relaxed to 200.
+    let h = boot().await;
+    let (status, _body) =
+        json_request(&h, Method::DELETE, "/api/triggers/not-a-uuid", None).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Closes #3509.

## Summary

Four related HTTP-status-code bugs:

1. `DELETE /api/agents/{id}` returned `404` on the second call — now `200 OK` with `{"status": "already-deleted"}`. Idempotent per RFC 9110 §9.2.2.
2. `DELETE /api/triggers/{id}` — same fix.
3. `DELETE /api/cron/jobs/{id}` — same fix.
4. `POST /hooks/wake` and `POST /hooks/agent` (consistency) returned `400 Bad Request` for missing/invalid bearer token, mis-categorising an authentication failure as a payload bug. Now return `401 Unauthorized` with `WWW-Authenticate: Bearer realm="librefang-webhook"` per RFC 9110 §11.6.1.

`400` (DELETE handlers) and the malformed-payload `400` (webhook handlers) are intentionally preserved — they catch genuine client bugs that the relaxation would otherwise mask.

## Per-file detail

- `crates/librefang-api/src/routes/agents.rs::kill_agent` — `agent_registry().get(agent_id).is_none()` short-circuit returns 200 already-deleted; mid-flight `AgentNotFound` from `kill_agent()` (race with another deleter) is also collapsed to 200; other kernel errors are now honestly returned as 500 instead of being masked as 404 with a misleading "agent not found" message.
- `crates/librefang-api/src/routes/workflows.rs::delete_trigger` — `else` branch returns 200 already-deleted instead of 404.
- `crates/librefang-api/src/routes/workflows.rs::delete_cron_job` — `Err(_)` branch from `cron().remove_job()` returns 200 already-deleted instead of 404. (Cron's `remove_job` only fails on not-found, no other variants.)
- `crates/librefang-api/src/routes/system.rs::webhook_wake` / `webhook_agent` — function return type widened from `impl IntoResponse` (tuple form) to `axum::response::Response` so the new `webhook_unauthorized_response` helper can attach the `WWW-Authenticate` header. All other branches updated to `.into_response()` accordingly.
- All four `#[utoipa::path(...)]` attribute blocks updated so the auto-generated OpenAPI spec reflects the new status codes (200 idempotent / 401 unauthorized).

## Tests

Live integration tests via `tower::ServiceExt::oneshot` against the production router. No daemon, no LLM calls.

- `agents_routes_integration::test_delete_agent_twice_both_succeed_idempotent` — kill agent twice, both 200 (`status: killed` then `status: already-deleted`).
- `agents_routes_integration::test_delete_agent_unknown_uuid_is_idempotent_200` — well-formed-but-unknown UUID also gives 200 already-deleted.
- `agents_routes_integration::test_delete_agent_invalid_id_still_returns_400` — pins that the malformed-id path keeps returning 400.
- `workflows_routes_integration::cron_job_delete_unknown_uuid_is_idempotent_200` — was `cron_job_delete_unknown_uuid_returns_404`, behaviour intentionally flipped.
- `workflows_routes_integration::cron_job_delete_twice_both_succeed` — second-call idempotency.
- `workflows_routes_integration::trigger_delete_unknown_uuid_is_idempotent_200` — same for triggers.
- `workflows_routes_integration::trigger_delete_invalid_uuid_returns_400` — pins the malformed-id 400 path for triggers.
- `hooks_commands_routes_integration::hooks_wake_rejects_missing_bearer` / `hooks_wake_rejects_wrong_bearer` / `hooks_wake_rejects_short_configured_token` / `hooks_agent_rejects_missing_bearer` — all four flipped from asserting 400 to asserting 401, plus assert the `WWW-Authenticate: Bearer ...` challenge header is present (where it's the primary fix).

## Intentionally NOT done (potential follow-ups)

- **`POST /api/agents/bulk` delete branch (`bulk_delete_agents`)** — same kernel call, same per-item error-on-already-absent behaviour, but the response envelope is a `BulkActionResult { success: bool, error: Option<String> }` per item rather than a top-level status code. Different surface, different fix shape; out of scope for this issue's narrow target.
- **Other DELETE handlers in `routes/system.rs`** (e.g. `pairing_remove_device`, `task_queue_delete`, `delete_agent_kv_key`, `remove_binding`) — not flagged in #3509. `pairing_remove_device` already returns `204 No Content` for the success path but still 404s on missing; left untouched to keep this PR scoped.
- **`openapi.json` regeneration at the repo root** — auto-regenerated by `crates/librefang-api/tests/openapi_spec_test.rs::generate_openapi_json`, which CI runs on every push. The `#[utoipa::path(...)]` annotations *in this PR* are the source of truth; the generated file will pick up the new status codes when CI runs the openapi_spec test.
- **i18n: changing the `api-error-agent-not-found-or-terminated` key** — that string was previously emitted as a 404 body. The kernel-error 500 path now emits a plain `Failed to kill agent {id}: {e}` message instead so we don't leak a misleading "not found" string on a server error. The translation key is still used by other handlers and is left in place.

## Local verification

`cargo` and `rustup` are not installed on the build host (`which cargo` → not found). All compile / clippy / test verification is deferred to CI. Code reviewed by hand against existing patterns in the same files; uses only types + traits already in scope (no new dependencies).

## Test plan

- [ ] CI: `cargo check --workspace --lib`
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] CI: `cargo test -p librefang-api --test agents_routes_integration`
- [ ] CI: `cargo test -p librefang-api --test workflows_routes_integration`
- [ ] CI: `cargo test -p librefang-api --test hooks_commands_routes_integration`
- [ ] CI: `cargo test -p librefang-api --test openapi_spec_test` (regenerates `openapi.json`)
- [ ] Manual smoke (reviewer): `curl -X DELETE /api/agents/{real-id}` then again on the same id → both 200; second response body has `"status": "already-deleted"`.
- [ ] Manual smoke (reviewer): `curl -H 'Authorization: Bearer wrong-token-padded-to-32-chars-xx' /api/hooks/wake` → 401, `WWW-Authenticate: Bearer realm="librefang-webhook"` in response headers.
