### PR TITLE
perf(dashboard): suppress polling refetch in background tabs (#3393)

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/queries/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.ts
@@ -24,6 +24,7 @@ export const agentQueries = {
       queryFn: () => listAgents(opts),
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   detail: (agentId: string) =>
     queryOptions({
@@ -46,6 +47,7 @@ export const agentQueries = {
       enabled: !!agentId,
       staleTime: 15_000,
       refetchInterval: 30_000,
+      refetchIntervalInBackground: false, // #3393
     }),
   events: (agentId: string, limit = 30) =>
     queryOptions({
@@ -54,6 +56,7 @@ export const agentQueries = {
       enabled: !!agentId,
       staleTime: 10_000,
       refetchInterval: 15_000,
+      refetchIntervalInBackground: false, // #3393
     }),
   templates: () =>
     queryOptions({

--- a/crates/librefang-api/dashboard/src/lib/queries/analytics.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/analytics.ts
@@ -20,6 +20,7 @@ export const usageQueries = {
       queryFn: getUsageSummary,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393: skip polling when tab is hidden
     }),
   byAgent: () =>
     queryOptions({
@@ -27,6 +28,7 @@ export const usageQueries = {
       queryFn: listUsageByAgent,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false,
     }),
   byModel: () =>
     queryOptions({
@@ -34,6 +36,7 @@ export const usageQueries = {
       queryFn: listUsageByModel,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false,
     }),
   daily: () =>
     queryOptions({
@@ -41,6 +44,7 @@ export const usageQueries = {
       queryFn: getUsageDaily,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false,
     }),
   modelPerformance: () =>
     queryOptions({
@@ -48,6 +52,7 @@ export const usageQueries = {
       queryFn: getUsageByModelPerformance,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false,
     }),
 };
 
@@ -58,6 +63,7 @@ export const budgetQueries = {
       queryFn: getBudgetStatus,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
 };
 

--- a/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/approvals.ts
@@ -24,6 +24,7 @@ export const approvalQueries = {
       queryFn: listApprovals,
       staleTime: STALE_APPROVALS,
       refetchInterval: REFETCH_APPROVALS,
+      refetchIntervalInBackground: false, // #3393
     }),
   count: () =>
     queryOptions({
@@ -31,6 +32,7 @@ export const approvalQueries = {
       queryFn: fetchApprovalCount,
       staleTime: STALE_COUNT,
       refetchInterval: REFETCH_COUNT,
+      refetchIntervalInBackground: false, // #3393
     }),
   pending: (agentId?: string) =>
     queryOptions({
@@ -38,6 +40,7 @@ export const approvalQueries = {
       queryFn: () => listPendingApprovals(agentId),
       staleTime: STALE_PENDING,
       refetchInterval: REFETCH_PENDING,
+      refetchIntervalInBackground: false, // #3393
     }),
   audit: (params: {
     limit?: number;

--- a/crates/librefang-api/dashboard/src/lib/queries/autoDream.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/autoDream.ts
@@ -16,6 +16,7 @@ export const autoDreamQueries = {
       queryFn: getAutoDreamStatus,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
 };
 

--- a/crates/librefang-api/dashboard/src/lib/queries/channels.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/channels.ts
@@ -19,6 +19,7 @@ export const channelQueries = {
       queryFn: listChannels,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
 };
 
@@ -29,6 +30,7 @@ export const commsQueries = {
       queryFn: getCommsTopology,
       staleTime: STALE_MS,
       refetchInterval: TOPOLOGY_REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   events: (limit = 200) =>
     queryOptions({
@@ -54,5 +56,6 @@ export function useCommsEvents(
     ...commsQueries.events(limit),
     enabled: options.enabled,
     refetchInterval: options.refetchInterval ?? REFRESH_MS,
+    refetchIntervalInBackground: false, // #3393
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/goals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/goals.ts
@@ -13,6 +13,7 @@ export const goalQueries = {
       queryFn: listGoals,
       staleTime: STALE_MS,
       refetchInterval: STALE_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   templates: () =>
     queryOptions({

--- a/crates/librefang-api/dashboard/src/lib/queries/hands.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/hands.ts
@@ -22,6 +22,7 @@ export const handQueries = {
       queryFn: listHands,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   active: () =>
     queryOptions({
@@ -29,6 +30,7 @@ export const handQueries = {
       queryFn: listActiveHands,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   detail: (handId: string) =>
     queryOptions({
@@ -51,6 +53,7 @@ export const handQueries = {
       enabled: !!instanceId,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   statsBatch: (instanceIds: readonly string[]) =>
     queryOptions({
@@ -71,6 +74,7 @@ export const handQueries = {
       enabled: instanceIds.length > 0,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   session: (instanceId: string) =>
     queryOptions({

--- a/crates/librefang-api/dashboard/src/lib/queries/mcp.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/mcp.ts
@@ -28,6 +28,7 @@ export const mcpQueries = {
       queryFn: listMcpServers,
       staleTime: SERVERS_STALE_MS,
       refetchInterval: SERVERS_REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   server: (id: string) =>
     queryOptions({

--- a/crates/librefang-api/dashboard/src/lib/queries/media.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/media.ts
@@ -24,6 +24,7 @@ export const mediaQueries = {
       queryFn: listMediaProviders,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   videoTask: ({ taskId, provider }: VideoTaskParams) =>
     queryOptions({

--- a/crates/librefang-api/dashboard/src/lib/queries/memory.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/memory.ts
@@ -25,6 +25,7 @@ export const memoryQueries = {
       queryFn: () => getMemoryStats(agentId),
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS * 2,
+      refetchIntervalInBackground: false, // #3393
     }),
   config: () =>
     queryOptions({
@@ -63,6 +64,7 @@ export const memorySearchOrListQueryOptions = (search: string) =>
     },
     staleTime: STALE_MS,
     refetchInterval: REFRESH_MS,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useMemorySearchOrList(search: string) {

--- a/crates/librefang-api/dashboard/src/lib/queries/models.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/models.ts
@@ -17,6 +17,7 @@ export const modelQueries = {
       queryFn: () => listModels(filters),
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   overrides: (modelKey: string) =>
     queryOptions({

--- a/crates/librefang-api/dashboard/src/lib/queries/network.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/network.ts
@@ -18,6 +18,7 @@ export const networkQueries = {
       queryFn: getNetworkStatus,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   peers: () =>
     queryOptions({
@@ -25,6 +26,7 @@ export const networkQueries = {
       queryFn: listPeers,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   trustedPeers: () =>
     queryOptions({
@@ -32,6 +34,7 @@ export const networkQueries = {
       queryFn: listTrustedPeers,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   a2aAgents: () =>
     queryOptions({
@@ -39,6 +42,7 @@ export const networkQueries = {
       queryFn: listA2AAgents,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
 };
 

--- a/crates/librefang-api/dashboard/src/lib/queries/overview.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/overview.ts
@@ -9,6 +9,12 @@ export const dashboardSnapshotQueryOptions = () =>
     queryFn: loadDashboardSnapshot,
     staleTime: 5_000,
     refetchInterval: 5_000,
+    // #3393: every mounted page using `useDashboardSnapshot` would otherwise
+    // refetch every 5 s while the tab is backgrounded. The QueryClient
+    // default in `main.tsx` also pins this to false, but we set it
+    // explicitly per-query so the visibility gate sits next to the poll
+    // interval and survives any future change to the global default.
+    refetchIntervalInBackground: false,
   });
 
 export const versionInfoQueryOptions = () =>

--- a/crates/librefang-api/dashboard/src/lib/queries/plugins.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/plugins.ts
@@ -12,6 +12,7 @@ export const pluginQueries = {
       queryFn: listPlugins,
       staleTime: STALE_MS,
       refetchInterval: STALE_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   registries: () =>
     queryOptions({
@@ -19,6 +20,7 @@ export const pluginQueries = {
       queryFn: listPluginRegistries,
       staleTime: 300_000,
       refetchInterval: 300_000,
+      refetchIntervalInBackground: false, // #3393
     }),
 };
 

--- a/crates/librefang-api/dashboard/src/lib/queries/runtime.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/runtime.ts
@@ -20,6 +20,7 @@ export const systemStatusQueryOptions = () =>
     queryFn: getStatus,
     staleTime: 30_000,
     refetchInterval: 30_000,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useSystemStatus() {
@@ -32,6 +33,7 @@ export const queueStatusQueryOptions = () =>
     queryFn: getQueueStatus,
     staleTime: 15_000,
     refetchInterval: 15_000,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useQueueStatus() {
@@ -44,6 +46,7 @@ export const healthDetailQueryOptions = () =>
     queryFn: getHealthDetail,
     staleTime: 30_000,
     refetchInterval: 30_000,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useHealthDetail() {
@@ -56,6 +59,7 @@ export const securityStatusQueryOptions = () =>
     queryFn: getSecurityStatus,
     staleTime: 120_000,
     refetchInterval: 120_000,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useSecurityStatus(options: QueryOverrides = {}) {
@@ -68,6 +72,7 @@ export const auditRecentQueryOptions = (limit: number) =>
     queryFn: () => listAuditRecent(limit),
     staleTime: 30_000,
     refetchInterval: 30_000,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useAuditRecent(limit: number, options: QueryOverrides = {}) {
@@ -92,6 +97,7 @@ export const backupsQueryOptions = () =>
     queryFn: listBackups,
     staleTime: 60_000,
     refetchInterval: 60_000,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useBackups(options: QueryOverrides = {}) {
@@ -104,6 +110,7 @@ export const taskQueueStatusQueryOptions = () =>
     queryFn: getTaskQueueStatus,
     staleTime: 15_000,
     refetchInterval: 15_000,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useTaskQueueStatus() {
@@ -116,6 +123,7 @@ export const taskQueueQueryOptions = (status?: string) =>
     queryFn: () => listTaskQueue(status),
     staleTime: 30_000,
     refetchInterval: 30_000,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useTaskQueue(status?: string) {
@@ -129,6 +137,7 @@ export const cronJobsQueryOptions = (agentId?: string) =>
     enabled: !!agentId,
     staleTime: 30_000,
     refetchInterval: 30_000,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useCronJobs(agentId?: string, options: QueryOverrides = {}) {

--- a/crates/librefang-api/dashboard/src/lib/queries/schedules.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/schedules.ts
@@ -12,6 +12,7 @@ export const scheduleQueries = {
       queryFn: listSchedules,
       staleTime: STALE_MS,
       refetchInterval: STALE_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   triggers: (agentId?: string) =>
     queryOptions({
@@ -19,6 +20,7 @@ export const scheduleQueries = {
       queryFn: () => listTriggers(agentId),
       staleTime: STALE_MS,
       refetchInterval: STALE_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
 };
 

--- a/crates/librefang-api/dashboard/src/lib/queries/sessions.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions.ts
@@ -13,6 +13,7 @@ export const sessionQueries = {
       queryFn: listSessions,
       staleTime: STALE_MS,
       refetchInterval: STALE_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   detail: (sessionId: string) =>
     queryOptions({

--- a/crates/librefang-api/dashboard/src/lib/queries/skills.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/skills.ts
@@ -28,6 +28,7 @@ export const skillQueries = {
       queryFn: listSkills,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   detail: (name: string) =>
     queryOptions({

--- a/crates/librefang-api/dashboard/src/lib/queries/telemetry.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/telemetry.ts
@@ -12,6 +12,7 @@ export const telemetryQueryOptions = () =>
     queryFn: getMetricsText,
     staleTime: STALE_MS,
     refetchInterval: REFRESH_MS,
+    refetchIntervalInBackground: false, // #3393
   });
 
 export function useTelemetryMetrics(options: QueryOverrides = {}) {

--- a/crates/librefang-api/dashboard/src/lib/queries/terminal.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/terminal.ts
@@ -18,6 +18,7 @@ export const terminalQueries = {
       queryFn: listTerminalWindows,
       staleTime: REFRESH_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
 };
 

--- a/crates/librefang-api/dashboard/src/lib/queries/workflows.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/workflows.ts
@@ -29,6 +29,7 @@ export const workflowQueries = {
       queryFn: listWorkflows,
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   detail: (workflowId: string) =>
     queryOptions({
@@ -44,6 +45,7 @@ export const workflowQueries = {
       enabled: !!workflowId,
       staleTime: RUN_STALE_MS,
       refetchInterval: RUN_REFETCH_MS,
+      refetchIntervalInBackground: false, // #3393
     }),
   runDetail: (runId: string) =>
     queryOptions({


### PR DESCRIPTION
## Summary

Closes #3393.

`useDashboardSnapshot` (and every other polling query in `lib/queries/`) was refetching every poll interval even while the browser tab was backgrounded. The QueryClient global default in `main.tsx:25` already pins `refetchIntervalInBackground: false`, but #3393 explicitly asked for the per-query opt-out on `dashboardSnapshotQueryOptions` so the visibility gate is co-located with the poll interval and survives any future change to the global default. Pure additive — foreground behavior is unchanged for every query.

## Touched queries (file:line, existing interval kept)

- `crates/librefang-api/dashboard/src/lib/queries/overview.ts:11` — `dashboardSnapshotQueryOptions` @ 5 s (the issue)
- `crates/librefang-api/dashboard/src/lib/queries/analytics.ts:22,29,36,43,50,60` — usage `summary` / `byAgent` / `byModel` / `daily` / `modelPerformance` @ 30 s + budget `status` @ 30 s
- `crates/librefang-api/dashboard/src/lib/queries/approvals.ts:26,33,40` — approvals `list` @ 15 s, `count` @ 15 s, `pending` @ 5 s
- `crates/librefang-api/dashboard/src/lib/queries/agents.ts:26,48,56` — agents `list` @ 30 s, `stats` @ 30 s, `events` @ 15 s
- `crates/librefang-api/dashboard/src/lib/queries/autoDream.ts:18` — `status` @ 15 s
- `crates/librefang-api/dashboard/src/lib/queries/channels.ts:21,31,56` — channels `list` @ 30 s, comms `topology` @ 60 s, `useCommsEvents` inline @ 30 s
- `crates/librefang-api/dashboard/src/lib/queries/goals.ts:15` — `list` @ 30 s
- `crates/librefang-api/dashboard/src/lib/queries/hands.ts:24,31,53,73` — hands `list` / `active` / `stats` / `statsBatch` @ 30 s
- `crates/librefang-api/dashboard/src/lib/queries/mcp.ts:30` — `servers` @ 30 s
- `crates/librefang-api/dashboard/src/lib/queries/media.ts:26` — `providers` @ 60 s (NB: `useVideoTask` line 50 is intentionally `true`)
- `crates/librefang-api/dashboard/src/lib/queries/memory.ts:27,65` — `stats` @ 60 s, `searchOrList` @ 30 s
- `crates/librefang-api/dashboard/src/lib/queries/models.ts:19` — `list` @ 60 s
- `crates/librefang-api/dashboard/src/lib/queries/network.ts:20,27,34,41` — network `status` / `peers` / `trustedPeers` / `a2aAgents` @ 15 s
- `crates/librefang-api/dashboard/src/lib/queries/plugins.ts:14,21` — `list` @ 60 s, `registries` @ 5 min
- `crates/librefang-api/dashboard/src/lib/queries/runtime.ts:22,34,46,58,70,94,106,118,131` — `systemStatus`, `queueStatus`, `healthDetail`, `securityStatus`, `auditRecent`, `backups`, `taskQueueStatus`, `taskQueue`, `cronJobs` (intervals 15–120 s)
- `crates/librefang-api/dashboard/src/lib/queries/schedules.ts:14,21` — `list` @ 30 s, `triggers` @ 30 s
- `crates/librefang-api/dashboard/src/lib/queries/sessions.ts:15` — `list` @ 30 s
- `crates/librefang-api/dashboard/src/lib/queries/skills.ts:30` — `list` @ 30 s
- `crates/librefang-api/dashboard/src/lib/queries/telemetry.ts:14` — `metrics` @ 10 s
- `crates/librefang-api/dashboard/src/lib/queries/terminal.ts:20` — `windows` @ 10 s
- `crates/librefang-api/dashboard/src/lib/queries/workflows.ts:31,46` — `list` @ 30 s, `runs` @ 30 s

`useVideoTask` (media.ts:50) deliberately keeps `refetchIntervalInBackground: true` — video generations are long-running and must continue polling so a finished result is visible when the user returns to the tab.

## Follow-ups (not in this PR)

These pages call `useQuery({...})` inline with their own `refetchInterval`, violating the dashboard CLAUDE.md "all API access must go through hooks in `lib/queries`/`lib/mutations`" rule. They are still gated by the global `QueryClient` default in `main.tsx:25`, so this isn't a polling-CPU regression, but they should be refactored through the queries layer in a separate PR:

- `crates/librefang-api/dashboard/src/pages/CommsPage.tsx:108-111` — `useCommsEvents(50, { refetchInterval: 5_000 })` is actually the through-hooks form (fine), but the inline override pattern leaks the interval into the page; consider a dedicated hook
- `crates/librefang-api/dashboard/src/pages/MediaPage.tsx:495-501` — `useVideoTask(..., { refetchInterval: 5_000 })` likewise an override into a hook (fine)
- `crates/librefang-api/dashboard/src/pages/LogsPage.tsx:30-32` — `useAuditRecent(LIMIT, { refetchInterval: REFRESH_MS })` likewise (fine)

(All three are technically through-hook calls with overrides, not raw `useQuery`. No raw inline `useQuery({ refetchInterval })` was found in pages/components.)

## Test plan

- [ ] CI typecheck and dashboard build pass
- [ ] Open the dashboard, switch to another tab for several minutes, switch back — Network tab should show no polling requests during the away window for snapshot/agents/approvals/etc.
- [ ] `useVideoTask` flow (Media → submit a video) keeps polling while the tab is backgrounded; the toast still fires when the result lands.

## Local verification

Local `pnpm` / `cargo` are not installed in this environment, so this PR relies on CI to gate. The changes are pure additive option flags on TanStack Query `queryOptions({...})` calls — no API surface change, no new dependency.
