### PR TITLE
perf(kernel-handle): switch send_channel_file_data to bytes::Bytes (#3553)

### DIFF
--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -99,7 +99,7 @@ async fn create_prompt_version(
     let mut hasher = Sha256::new();
     hasher.update(version.system_prompt.as_bytes());
     version.content_hash = format!("{:x}", hasher.finalize());
-    match state.kernel.create_prompt_version(version.clone()) {
+    match state.kernel.create_prompt_version(&version) {
         Ok(_) => Json(version).into_response(),
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()
@@ -208,7 +208,7 @@ async fn create_experiment(
     for variant in &mut experiment.variants {
         variant.id = uuid::Uuid::new_v4();
     }
-    match state.kernel.create_experiment(experiment.clone()) {
+    match state.kernel.create_experiment(&experiment) {
         Ok(_) => Json(experiment).into_response(),
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()

--- a/crates/librefang-kernel-handle/Cargo.toml
+++ b/crates/librefang-kernel-handle/Cargo.toml
@@ -8,6 +8,7 @@ description = "KernelHandle trait for in-process callers into the LibreFang kern
 [dependencies]
 librefang-types = { path = "../librefang-types" }
 async-trait = { workspace = true }
+bytes = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -131,15 +131,25 @@ pub trait KernelHandle: Send + Sync {
     ) -> Result<(), String>;
 
     /// Add an entity to the knowledge graph.
+    ///
+    /// Takes `entity` by reference so callers that already hold an owned
+    /// value (e.g. proactive memory extractors that may retry the call)
+    /// avoid forced moves and downstream `.clone()` chains. The kernel
+    /// implementation clones into the underlying store when it actually
+    /// needs ownership; total clone count is unchanged but the choice
+    /// moves from caller to callee. See issue #3553.
     async fn knowledge_add_entity(
         &self,
-        entity: librefang_types::memory::Entity,
+        entity: &librefang_types::memory::Entity,
     ) -> Result<String, String>;
 
     /// Add a relation to the knowledge graph.
+    ///
+    /// Takes `relation` by reference for the same reason as
+    /// [`knowledge_add_entity`](Self::knowledge_add_entity). See #3553.
     async fn knowledge_add_relation(
         &self,
-        relation: librefang_types::memory::Relation,
+        relation: &librefang_types::memory::Relation,
     ) -> Result<String, String>;
 
     /// Query the knowledge graph with a pattern.
@@ -393,12 +403,18 @@ pub trait KernelHandle: Send + Sync {
     /// Used by the `channel_send` tool when `file_path` is provided.
     /// When `thread_id` is provided, the file is sent as a thread reply.
     /// When `account_id` is provided, routes through the specific configured bot with that ID.
+    ///
+    /// `data` is a `bytes::Bytes` so wrapping layers (metering, retry,
+    /// fan-out to multiple adapters) can `clone()` it for free instead
+    /// of cloning the underlying buffer. With the 10 MiB upload bump
+    /// (#3514) this avoids per-send buffer copies in every wrapping
+    /// layer. See issue #3553.
     #[allow(clippy::too_many_arguments)]
     async fn send_channel_file_data(
         &self,
         channel: &str,
         recipient: &str,
-        data: Vec<u8>,
+        data: bytes::Bytes,
         filename: &str,
         mime_type: &str,
         thread_id: Option<&str>,
@@ -493,9 +509,13 @@ pub trait KernelHandle: Send + Sync {
     }
 
     /// Create a new prompt version. Default: error.
+    ///
+    /// Takes `version` by reference; the kernel clones into the
+    /// underlying store. Lets API handlers keep a copy for the response
+    /// JSON without forcing two clones. See #3553.
     fn create_prompt_version(
         &self,
-        _version: librefang_types::agent::PromptVersion,
+        _version: &librefang_types::agent::PromptVersion,
     ) -> Result<(), String> {
         Err("Prompt store not available".to_string())
     }
@@ -519,9 +539,12 @@ pub trait KernelHandle: Send + Sync {
     }
 
     /// Create a new experiment. Default: error.
+    ///
+    /// Takes `experiment` by reference for the same reason as
+    /// [`create_prompt_version`](Self::create_prompt_version). See #3553.
     fn create_experiment(
         &self,
-        _experiment: librefang_types::agent::PromptExperiment,
+        _experiment: &librefang_types::agent::PromptExperiment,
     ) -> Result<(), String> {
         Err("Prompt store not available".to_string())
     }

--- a/crates/librefang-kernel-handle/tests/defaults_approval.rs
+++ b/crates/librefang-kernel-handle/tests/defaults_approval.rs
@@ -103,11 +103,11 @@ impl KernelHandle for NoopKernelHandle {
         Err("not implemented".into())
     }
 
-    async fn knowledge_add_entity(&self, _entity: Entity) -> Result<String, String> {
+    async fn knowledge_add_entity(&self, _entity: &Entity) -> Result<String, String> {
         Err("not implemented".into())
     }
 
-    async fn knowledge_add_relation(&self, _relation: Relation) -> Result<String, String> {
+    async fn knowledge_add_relation(&self, _relation: &Relation) -> Result<String, String> {
         Err("not implemented".into())
     }
 

--- a/crates/librefang-kernel-handle/tests/defaults_delegation.rs
+++ b/crates/librefang-kernel-handle/tests/defaults_delegation.rs
@@ -112,14 +112,14 @@ impl KernelHandle for TrackingSendHandle {
 
     async fn knowledge_add_entity(
         &self,
-        _entity: librefang_types::memory::Entity,
+        _entity: &librefang_types::memory::Entity,
     ) -> Result<String, String> {
         Ok("entity".into())
     }
 
     async fn knowledge_add_relation(
         &self,
-        _relation: librefang_types::memory::Relation,
+        _relation: &librefang_types::memory::Relation,
     ) -> Result<String, String> {
         Ok("relation".into())
     }
@@ -253,14 +253,14 @@ impl KernelHandle for TrackingSpawnHandle {
 
     async fn knowledge_add_entity(
         &self,
-        _entity: librefang_types::memory::Entity,
+        _entity: &librefang_types::memory::Entity,
     ) -> Result<String, String> {
         Ok("entity".into())
     }
 
     async fn knowledge_add_relation(
         &self,
-        _relation: librefang_types::memory::Relation,
+        _relation: &librefang_types::memory::Relation,
     ) -> Result<String, String> {
         Ok("relation".into())
     }
@@ -393,14 +393,14 @@ impl KernelHandle for TrackingApprovalHandle {
 
     async fn knowledge_add_entity(
         &self,
-        _entity: librefang_types::memory::Entity,
+        _entity: &librefang_types::memory::Entity,
     ) -> Result<String, String> {
         Ok("entity".into())
     }
 
     async fn knowledge_add_relation(
         &self,
-        _relation: librefang_types::memory::Relation,
+        _relation: &librefang_types::memory::Relation,
     ) -> Result<String, String> {
         Ok("relation".into())
     }

--- a/crates/librefang-kernel-handle/tests/defaults_returns.rs
+++ b/crates/librefang-kernel-handle/tests/defaults_returns.rs
@@ -103,11 +103,11 @@ impl KernelHandle for NoopKernelHandle {
         Err("noop".into())
     }
 
-    async fn knowledge_add_entity(&self, _entity: Entity) -> Result<String, String> {
+    async fn knowledge_add_entity(&self, _entity: &Entity) -> Result<String, String> {
         Err("noop".into())
     }
 
-    async fn knowledge_add_relation(&self, _relation: Relation) -> Result<String, String> {
+    async fn knowledge_add_relation(&self, _relation: &Relation) -> Result<String, String> {
         Err("noop".into())
     }
 

--- a/crates/librefang-kernel-handle/tests/send_channel_file_data_zero_copy.rs
+++ b/crates/librefang-kernel-handle/tests/send_channel_file_data_zero_copy.rs
@@ -1,0 +1,241 @@
+//! Regression test for issue #3553.
+//!
+//! `KernelHandle::send_channel_file_data` now takes `bytes::Bytes` instead
+//! of `Vec<u8>`. The structural win is that wrapping layers (channel
+//! adapters that retry, metering, fan-out) can `.clone()` the buffer for
+//! free instead of copying it. This test pins that property: cloning a
+//! `Bytes` returned from `Bytes::from(Vec<u8>)` must NOT allocate a fresh
+//! buffer — clones share the underlying allocation.
+//!
+//! It also exercises the trait method through a stub implementor so any
+//! future signature drift breaks compilation here, not silently inside
+//! `librefang-kernel`.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use librefang_kernel_handle::{AgentInfo, KernelHandle};
+use librefang_types::memory::{Entity, GraphMatch, GraphPattern, Relation};
+use std::sync::Mutex;
+
+struct CapturingFileKernel {
+    // Store the buffer address as `usize` rather than `*const u8` so the
+    // struct stays auto-`Send + Sync` without an `unsafe impl`. We only
+    // compare addresses, never deref.
+    last_seen_addr: Mutex<Option<usize>>,
+    last_seen_len: Mutex<usize>,
+}
+
+impl CapturingFileKernel {
+    fn new() -> Self {
+        Self {
+            last_seen_addr: Mutex::new(None),
+            last_seen_len: Mutex::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl KernelHandle for CapturingFileKernel {
+    async fn spawn_agent(
+        &self,
+        _manifest_toml: &str,
+        _parent_id: Option<&str>,
+    ) -> Result<(String, String), String> {
+        Err("not used".into())
+    }
+
+    async fn send_to_agent(&self, _agent_id: &str, _message: &str) -> Result<String, String> {
+        Err("not used".into())
+    }
+
+    fn list_agents(&self) -> Vec<AgentInfo> {
+        vec![]
+    }
+
+    fn kill_agent(&self, _agent_id: &str) -> Result<(), String> {
+        Err("not used".into())
+    }
+
+    fn memory_store(
+        &self,
+        _key: &str,
+        _value: serde_json::Value,
+        _peer_id: Option<&str>,
+    ) -> Result<(), String> {
+        Err("not used".into())
+    }
+
+    fn memory_recall(
+        &self,
+        _key: &str,
+        _peer_id: Option<&str>,
+    ) -> Result<Option<serde_json::Value>, String> {
+        Err("not used".into())
+    }
+
+    fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
+        Err("not used".into())
+    }
+
+    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+
+    async fn task_post(
+        &self,
+        _title: &str,
+        _description: &str,
+        _assigned_to: Option<&str>,
+        _created_by: Option<&str>,
+    ) -> Result<String, String> {
+        Err("not used".into())
+    }
+
+    async fn task_claim(&self, _agent_id: &str) -> Result<Option<serde_json::Value>, String> {
+        Err("not used".into())
+    }
+
+    async fn task_complete(
+        &self,
+        _agent_id: &str,
+        _task_id: &str,
+        _result: &str,
+    ) -> Result<(), String> {
+        Err("not used".into())
+    }
+
+    async fn task_list(&self, _status: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+        Err("not used".into())
+    }
+
+    async fn task_delete(&self, _task_id: &str) -> Result<bool, String> {
+        Err("not used".into())
+    }
+
+    async fn task_retry(&self, _task_id: &str) -> Result<bool, String> {
+        Err("not used".into())
+    }
+
+    async fn task_get(&self, _task_id: &str) -> Result<Option<serde_json::Value>, String> {
+        Err("not used".into())
+    }
+
+    async fn task_update_status(&self, _task_id: &str, _new_status: &str) -> Result<bool, String> {
+        Err("not used".into())
+    }
+
+    async fn publish_event(
+        &self,
+        _event_type: &str,
+        _payload: serde_json::Value,
+    ) -> Result<(), String> {
+        Err("not used".into())
+    }
+
+    async fn knowledge_add_entity(&self, _entity: &Entity) -> Result<String, String> {
+        Err("not used".into())
+    }
+
+    async fn knowledge_add_relation(&self, _relation: &Relation) -> Result<String, String> {
+        Err("not used".into())
+    }
+
+    async fn knowledge_query(
+        &self,
+        _pattern: GraphPattern,
+    ) -> Result<Vec<GraphMatch>, String> {
+        Err("not used".into())
+    }
+
+    // The method under test. Records the underlying pointer + length so
+    // the test can assert the kernel observed the same allocation as the
+    // caller's Bytes — i.e. the trait did not silently copy the buffer.
+    async fn send_channel_file_data(
+        &self,
+        _channel: &str,
+        _recipient: &str,
+        data: Bytes,
+        _filename: &str,
+        _mime_type: &str,
+        _thread_id: Option<&str>,
+        _account_id: Option<&str>,
+    ) -> Result<String, String> {
+        *self.last_seen_addr.lock().unwrap() = Some(data.as_ptr() as usize);
+        *self.last_seen_len.lock().unwrap() = data.len();
+        Ok("captured".into())
+    }
+}
+
+#[test]
+fn cloning_bytes_shares_underlying_allocation() {
+    // A 10 MiB payload — the size that motivated #3553 (paired with #3514).
+    let payload: Vec<u8> = vec![0xAB; 10 * 1024 * 1024];
+    let original = Bytes::from(payload);
+    let original_addr = original.as_ptr() as usize;
+
+    // Each clone is a refcount bump; the underlying buffer is unchanged.
+    let clone_a = original.clone();
+    let clone_b = original.clone();
+    let clone_c = clone_b.clone();
+
+    assert_eq!(original_addr, clone_a.as_ptr() as usize);
+    assert_eq!(original_addr, clone_b.as_ptr() as usize);
+    assert_eq!(original_addr, clone_c.as_ptr() as usize);
+    assert_eq!(original.len(), clone_c.len());
+}
+
+#[tokio::test]
+async fn send_channel_file_data_does_not_copy_buffer() {
+    let kernel = CapturingFileKernel::new();
+    let payload: Vec<u8> = vec![0x42; 4096];
+    let original = Bytes::from(payload);
+    let expected_addr = original.as_ptr() as usize;
+    let expected_len = original.len();
+
+    // Cloning at the call site simulates the metering / retry wrappers
+    // the issue describes. The kernel must see the same allocation.
+    kernel
+        .send_channel_file_data(
+            "telegram",
+            "user@example",
+            original.clone(),
+            "test.bin",
+            "application/octet-stream",
+            None,
+            None,
+        )
+        .await
+        .expect("capture call should succeed");
+
+    let seen_addr = kernel
+        .last_seen_addr
+        .lock()
+        .unwrap()
+        .expect("kernel observed Bytes");
+    let seen_len = *kernel.last_seen_len.lock().unwrap();
+
+    assert_eq!(
+        seen_addr, expected_addr,
+        "Bytes clone must share its allocation with the caller — \
+         a different address means the trait copied the buffer"
+    );
+    assert_eq!(seen_len, expected_len);
+}
+
+#[test]
+fn vec_to_bytes_round_trip_is_zero_copy_for_unique_bytes() {
+    // The kernel impl converts back to Vec<u8> at the
+    // `ChannelContent::FileData` boundary. `Vec::from(Bytes)` is
+    // documented O(1) when the Bytes uniquely owns its allocation
+    // (bytes 1.x via the vtable's `into_vec`). Pin that here so a
+    // future bytes-crate change is caught.
+    let original_vec: Vec<u8> = vec![0xCD; 8192];
+    let original_addr = original_vec.as_ptr() as usize;
+
+    let bytes = Bytes::from(original_vec);
+    assert_eq!(bytes.as_ptr() as usize, original_addr);
+
+    let round_tripped: Vec<u8> = Vec::from(bytes);
+    assert_eq!(round_tripped.as_ptr() as usize, original_addr);
+    assert_eq!(round_tripped.len(), 8192);
+}

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -17773,20 +17773,23 @@ impl KernelHandle for LibreFangKernel {
 
     async fn knowledge_add_entity(
         &self,
-        entity: librefang_types::memory::Entity,
+        entity: &librefang_types::memory::Entity,
     ) -> Result<String, String> {
+        // The substrate owns the value (it moves into spawn_blocking).
+        // Clone here so the trait can take `&Entity` and avoid forcing
+        // every caller to give up ownership. See #3553.
         self.memory
-            .add_entity(entity)
+            .add_entity(entity.clone())
             .await
             .map_err(|e| format!("Knowledge add entity failed: {e}"))
     }
 
     async fn knowledge_add_relation(
         &self,
-        relation: librefang_types::memory::Relation,
+        relation: &librefang_types::memory::Relation,
     ) -> Result<String, String> {
         self.memory
-            .add_relation(relation)
+            .add_relation(relation.clone())
             .await
             .map_err(|e| format!("Knowledge add relation failed: {e}"))
     }
@@ -18614,7 +18617,7 @@ impl KernelHandle for LibreFangKernel {
         &self,
         channel: &str,
         recipient: &str,
-        data: Vec<u8>,
+        data: bytes::Bytes,
         filename: &str,
         mime_type: &str,
         thread_id: Option<&str>,
@@ -18652,8 +18655,14 @@ impl KernelHandle for LibreFangKernel {
             librefang_user: None,
         };
 
+        // `ChannelContent::FileData` still carries `Vec<u8>` (changing it
+        // is out of scope for #3553 — that's a follow-up that touches
+        // every channel adapter). `Vec::from(Bytes)` is O(1) when the
+        // Bytes uniquely owns its allocation, which is the common case
+        // here (caller built it via `Bytes::from(vec)` straight from
+        // `tokio::fs::read`).
         let content = librefang_channels::types::ChannelContent::FileData {
-            data,
+            data: Vec::from(data),
             filename: filename.to_string(),
             mime_type: mime_type.to_string(),
         };
@@ -18823,7 +18832,7 @@ impl KernelHandle for LibreFangKernel {
 
     fn create_prompt_version(
         &self,
-        version: librefang_types::agent::PromptVersion,
+        version: &librefang_types::agent::PromptVersion,
     ) -> Result<(), String> {
         let cfg = self.config.load();
         let store = self
@@ -18831,8 +18840,10 @@ impl KernelHandle for LibreFangKernel {
             .get()
             .ok_or("Prompt store not initialized")?;
         let agent_id = version.agent_id;
+        // Clone here — the store owns the value. Trade-off accepted by
+        // #3553: callers (API handlers) no longer have to clone first.
         store
-            .create_version(version)
+            .create_version(version.clone())
             .map_err(|e| format!("Failed to create version: {e}"))?;
         // Prune old versions if over the configured limit
         let max = cfg.prompt_intelligence.max_versions_per_agent;
@@ -18884,14 +18895,15 @@ impl KernelHandle for LibreFangKernel {
 
     fn create_experiment(
         &self,
-        experiment: librefang_types::agent::PromptExperiment,
+        experiment: &librefang_types::agent::PromptExperiment,
     ) -> Result<(), String> {
         let store = self
             .prompt_store
             .get()
             .ok_or("Prompt store not initialized")?;
+        // Clone here — the store owns the value. See #3553.
         store
-            .create_experiment(experiment)
+            .create_experiment(experiment.clone())
             .map_err(|e| format!("Failed to create experiment: {e}"))
     }
 

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -1302,13 +1302,13 @@ mod tests {
         }
         async fn knowledge_add_entity(
             &self,
-            _: librefang_types::memory::Entity,
+            _: &librefang_types::memory::Entity,
         ) -> Result<String, String> {
             Err("not implemented".to_string())
         }
         async fn knowledge_add_relation(
             &self,
-            _: librefang_types::memory::Relation,
+            _: &librefang_types::memory::Relation,
         ) -> Result<String, String> {
             Err("not implemented".to_string())
         }

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -3636,7 +3636,7 @@ async fn tool_knowledge_add_entity(
         updated_at: chrono::Utc::now(),
     };
 
-    let id = kh.knowledge_add_entity(entity).await?;
+    let id = kh.knowledge_add_entity(&entity).await?;
     Ok(format!("Entity '{name}' added with ID: {id}"))
 }
 
@@ -3670,7 +3670,7 @@ async fn tool_knowledge_add_relation(
         created_at: chrono::Utc::now(),
     };
 
-    let id = kh.knowledge_add_relation(relation).await?;
+    let id = kh.knowledge_add_relation(&relation).await?;
     Ok(format!(
         "Relation '{source}' --[{relation_str}]--> '{target}' added with ID: {id}"
     ))
@@ -4184,9 +4184,18 @@ async fn tool_channel_send(
             _ => "application/octet-stream",
         };
 
+        // `Bytes::from(Vec<u8>)` is O(1) — it takes ownership of the
+        // Vec's allocation without copying. Subsequent clones (retry,
+        // metering wrappers, fan-out) become refcount bumps. See #3553.
         return kh
             .send_channel_file_data(
-                &channel, recipient, data, &filename, mime_type, thread_id, account_id,
+                &channel,
+                recipient,
+                bytes::Bytes::from(data),
+                &filename,
+                mime_type,
+                thread_id,
+                account_id,
             )
             .await;
     }
@@ -6590,14 +6599,14 @@ mod tests {
 
         async fn knowledge_add_entity(
             &self,
-            _entity: librefang_types::memory::Entity,
+            _entity: &librefang_types::memory::Entity,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
 
         async fn knowledge_add_relation(
             &self,
-            _relation: librefang_types::memory::Relation,
+            _relation: &librefang_types::memory::Relation,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
@@ -6737,13 +6746,13 @@ mod tests {
         }
         async fn knowledge_add_entity(
             &self,
-            _entity: librefang_types::memory::Entity,
+            _entity: &librefang_types::memory::Entity,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
         async fn knowledge_add_relation(
             &self,
-            _relation: librefang_types::memory::Relation,
+            _relation: &librefang_types::memory::Relation,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
@@ -7248,13 +7257,13 @@ mod tests {
         }
         async fn knowledge_add_entity(
             &self,
-            _entity: librefang_types::memory::Entity,
+            _entity: &librefang_types::memory::Entity,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
         async fn knowledge_add_relation(
             &self,
-            _relation: librefang_types::memory::Relation,
+            _relation: &librefang_types::memory::Relation,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
@@ -9881,14 +9890,14 @@ mod tests {
 
         async fn knowledge_add_entity(
             &self,
-            _entity: librefang_types::memory::Entity,
+            _entity: &librefang_types::memory::Entity,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
 
         async fn knowledge_add_relation(
             &self,
-            _relation: librefang_types::memory::Relation,
+            _relation: &librefang_types::memory::Relation,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }

--- a/crates/librefang-runtime/tests/tool_runner_forwarding.rs
+++ b/crates/librefang-runtime/tests/tool_runner_forwarding.rs
@@ -121,13 +121,13 @@ impl KernelHandle for CapturingKernel {
     }
     async fn knowledge_add_entity(
         &self,
-        _: librefang_types::memory::Entity,
+        _: &librefang_types::memory::Entity,
     ) -> Result<String, String> {
         Err("not implemented".into())
     }
     async fn knowledge_add_relation(
         &self,
-        _: librefang_types::memory::Relation,
+        _: &librefang_types::memory::Relation,
     ) -> Result<String, String> {
         Err("not implemented".into())
     }

--- a/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
+++ b/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
@@ -100,13 +100,13 @@ impl KernelHandle for CapturingKernel {
     }
     async fn knowledge_add_entity(
         &self,
-        _: librefang_types::memory::Entity,
+        _: &librefang_types::memory::Entity,
     ) -> Result<String, String> {
         Err("not implemented".into())
     }
     async fn knowledge_add_relation(
         &self,
-        _: librefang_types::memory::Relation,
+        _: &librefang_types::memory::Relation,
     ) -> Result<String, String> {
         Err("not implemented".into())
     }


### PR DESCRIPTION
## Summary

Closes #3553.

`KernelHandle::send_channel_file_data` previously took `data: Vec<u8>` by value. With the 10 MiB upload bump in #3514, every retry / metering / fan-out wrapper that wanted to keep the buffer was forced into a 10 MiB allocation copy. This PR switches it to `bytes::Bytes`, where `clone()` is a refcount bump and the underlying allocation is shared.

It also flips four "kernel only reads it" methods to take `&T` (per the issue body) so callers that already hold an owned value no longer have to give it up:

- `knowledge_add_entity(&Entity)`
- `knowledge_add_relation(&Relation)`
- `create_prompt_version(&PromptVersion)`
- `create_experiment(&PromptExperiment)`

The kernel impl clones into the underlying store. Total clone count is unchanged but the choice now lives with the kernel rather than every caller — and the API handlers in `routes/prompts.rs` no longer need their explicit `version.clone()` / `experiment.clone()` step.

## Files touched

| File | Change |
|---|---|
| `crates/librefang-kernel-handle/Cargo.toml` | Add `bytes = { workspace = true }` (workspace dep already present at root). |
| `crates/librefang-kernel-handle/src/lib.rs` | Trait: `send_channel_file_data` takes `bytes::Bytes`; the four CRUD methods take `&T`. |
| `crates/librefang-kernel-handle/tests/send_channel_file_data_zero_copy.rs` | New regression test: clones share allocation; trait method does not copy buffer; `Bytes` ↔ `Vec<u8>` round-trip is O(1). |
| `crates/librefang-kernel-handle/tests/defaults_approval.rs` | Stub impl signature update. |
| `crates/librefang-kernel-handle/tests/defaults_delegation.rs` | Stub impl signature update (3 implementors). |
| `crates/librefang-kernel-handle/tests/defaults_returns.rs` | Stub impl signature update. |
| `crates/librefang-kernel/src/kernel/mod.rs` | Real impls: convert `Bytes` → `Vec<u8>` at `ChannelContent::FileData` boundary (still O(1) via `Vec::from(Bytes)`); clone `&Entity` / `&Relation` / `&PromptVersion` / `&PromptExperiment` into the store. |
| `crates/librefang-runtime/src/tool_runner.rs` | Caller wraps disk read in `bytes::Bytes::from(data)`; `knowledge_add_*` calls pass `&entity` / `&relation`; 4 nested-mod stub impls updated. |
| `crates/librefang-runtime/tests/tool_runner_forwarding.rs` | Stub impl signature update. |
| `crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs` | Stub impl signature update. |
| `crates/librefang-runtime-wasm/src/host_functions.rs` | Stub impl signature update. |
| `crates/librefang-api/src/routes/prompts.rs` | Drop `.clone()` at `create_prompt_version` / `create_experiment` callsites. |

## Out of scope

- `ChannelContent::FileData::data` still carries `Vec<u8>` — pushing `Bytes` deeper would touch every channel adapter (telegram, signal, bridge, …) and is a separate follow-up. The kernel converts `Bytes::from` → `Vec::from` at the boundary; that conversion is O(1) for uniquely-owned Bytes (the common case here, since the caller built it via `Bytes::from(tokio::fs::read(...))`), pinned by `vec_to_bytes_round_trip_is_zero_copy_for_unique_bytes`.
- The `#[must_use]` migration that the issue mentions is deferred per its own caveat ("(skip — separate issue)").

## Test plan

- [ ] CI green on `perf/3553-channel-file-bytes` (workspace `cargo check`, `cargo clippy -D warnings`, `cargo test`).
- [ ] New regression tests pass: `cargo test -p librefang-kernel-handle --test send_channel_file_data_zero_copy`.
- [ ] Existing default-impl tests still pass: `cargo test -p librefang-kernel-handle`.
- [ ] Runtime trait-forwarding tests still pass: `cargo test -p librefang-runtime --test tool_runner_forwarding --test tool_runner_forwarding_task_cron`.
- [ ] Prompt routes integration tests still pass: `cargo test -p librefang-api --test prompts_routes_integration`.

## Build host note

Local `cargo` and `rustup` are absent on the build host that prepared this PR; verification has been done by reading the source. CI is the gate.
