### PR TITLE
perf(api): event-drive agents WS instead of per-client 5s polling (#3513)

### DIFF
--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -584,15 +584,36 @@ async fn handle_agent_ws(
     )
     .await;
 
-    // Spawn background task: periodic agent list updates with change detection
+    // Spawn background task: event-driven agent list updates (#3513).
+    //
+    // Replaces the previous per-client 5s polling loop, which rebuilt and
+    // hashed the entire agent list for every connected dashboard tab on
+    // every tick (50 agents x 10 tabs = 500 manifest reads + serializations
+    // every 5s, even when nothing changed). We now subscribe to a single
+    // shared broadcast on `AgentRegistry` and only rebuild the snapshot when
+    // a real mutation fires. A 200ms debounce coalesces bursts (one user
+    // action can trigger several mutations in rapid succession), and a
+    // `last_hash` comparison preserves the existing belt-and-suspenders
+    // suppression for no-op mutations.
+    //
+    // Initial snapshot is sent once on connect so a freshly opened tab
+    // doesn't have to wait for the next mutation to populate the agent list.
     let sender_clone = Arc::clone(&sender);
     let state_clone = Arc::clone(&state);
     let update_handle = tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(5));
+        use tokio::sync::broadcast::error::RecvError;
+
+        let mut rx = state_clone.kernel.agent_registry().subscribe_changes();
         let mut last_hash: u64 = 0;
-        loop {
-            interval.tick().await;
-            let agents: Vec<serde_json::Value> = state_clone
+
+        // Helper closure: snapshot, hash, and send on change.
+        // Returns Err(()) when the websocket peer is gone (terminate task).
+        async fn snapshot_and_send(
+            state: &Arc<AppState>,
+            sender: &Arc<Mutex<SplitSink<WebSocket, Message>>>,
+            last_hash: &mut u64,
+        ) -> Result<(), ()> {
+            let agents: Vec<serde_json::Value> = state
                 .kernel
                 .agent_registry()
                 .list()
@@ -608,7 +629,9 @@ async fn handle_agent_ws(
                 })
                 .collect();
 
-            // Change detection: hash the agent list and only send on change
+            // Belt-and-suspenders: even though broadcasts only fire on real
+            // mutations, a no-op mutation (e.g. update_skills with the same
+            // list) still publishes — suppress those at the send boundary.
             let mut hasher = DefaultHasher::new();
             for a in &agents {
                 serde_json::to_string(a)
@@ -616,13 +639,13 @@ async fn handle_agent_ws(
                     .hash(&mut hasher);
             }
             let new_hash = hasher.finish();
-            if new_hash == last_hash {
-                continue; // No change — skip broadcast
+            if new_hash == *last_hash {
+                return Ok(());
             }
-            last_hash = new_hash;
+            *last_hash = new_hash;
 
             if send_json(
-                &sender_clone,
+                sender,
                 &serde_json::json!({
                     "type": "agents_updated",
                     "agents": agents,
@@ -630,6 +653,52 @@ async fn handle_agent_ws(
             )
             .await
             .is_err()
+            {
+                return Err(());
+            }
+            Ok(())
+        }
+
+        // 1) Initial snapshot — guarantees a freshly connected dashboard tab
+        //    sees the current agent list without waiting for a mutation.
+        if snapshot_and_send(&state_clone, &sender_clone, &mut last_hash)
+            .await
+            .is_err()
+        {
+            return;
+        }
+
+        // 2) Event loop: wait for a registry change, debounce, then snapshot.
+        const DEBOUNCE: Duration = Duration::from_millis(200);
+        loop {
+            // Block until something happens.
+            match rx.recv().await {
+                Ok(()) => {}
+                // Lagged means the channel buffer overflowed before we got
+                // to drain it — perfectly fine, just snapshot the current
+                // state and keep listening (we don't care about individual
+                // events, only that "something changed").
+                Err(RecvError::Lagged(_)) => {}
+                // Sender dropped (kernel teardown) — exit cleanly.
+                Err(RecvError::Closed) => break,
+            }
+
+            // 3) Debounce: drain further events that arrive within the
+            //    debounce window so a burst of N mutations only produces
+            //    one snapshot+send instead of N.
+            let deadline = tokio::time::Instant::now() + DEBOUNCE;
+            loop {
+                match tokio::time::timeout_at(deadline, rx.recv()).await {
+                    Ok(Ok(())) => continue,
+                    Ok(Err(RecvError::Lagged(_))) => continue,
+                    Ok(Err(RecvError::Closed)) => return,
+                    Err(_) => break, // debounce window elapsed
+                }
+            }
+
+            if snapshot_and_send(&state_clone, &sender_clone, &mut last_hash)
+                .await
+                .is_err()
             {
                 break; // Client disconnected
             }

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -5,6 +5,14 @@ use dashmap::DashMap;
 use librefang_types::agent::{AgentEntry, AgentId, AgentMode, AgentState};
 use librefang_types::error::{LibreFangError, LibreFangResult};
 use std::sync::Arc;
+use tokio::sync::broadcast;
+
+/// Capacity of the registry-change broadcast channel (#3513).
+///
+/// Subscribers only need to learn "something changed" — not what changed —
+/// so the buffer can be small. A lagging receiver is treated as a signal
+/// to re-fetch the full state, which is exactly what we want.
+const CHANGE_CHANNEL_CAPACITY: usize = 16;
 
 /// Registry of all agents in the kernel.
 pub struct AgentRegistry {
@@ -14,16 +22,46 @@ pub struct AgentRegistry {
     name_index: DashMap<String, AgentId>,
     /// Tag index: tag → list of agent IDs.
     tag_index: DashMap<String, Vec<AgentId>>,
+    /// Broadcast that fires after every successful registry mutation (#3513).
+    ///
+    /// Replaces the per-WS-client 5s polling loop in `librefang-api/src/ws.rs`
+    /// with an event-driven push: every dashboard tab subscribes once and only
+    /// rebuilds the agent snapshot when an actual mutation occurred.
+    /// Capacity is intentionally small — losing a tick is benign because
+    /// receivers re-snapshot from the registry on every signal anyway, and
+    /// `RecvError::Lagged` is treated as "send a fresh snapshot".
+    changed_tx: broadcast::Sender<()>,
 }
 
 impl AgentRegistry {
     /// Create a new empty registry.
     pub fn new() -> Self {
+        let (changed_tx, _) = broadcast::channel(CHANGE_CHANNEL_CAPACITY);
         Self {
             agents: DashMap::new(),
             name_index: DashMap::new(),
             tag_index: DashMap::new(),
+            changed_tx,
         }
+    }
+
+    /// Subscribe to registry-change events (#3513).
+    ///
+    /// Each successful mutator (`register`, `remove`, `set_state`, `set_mode`,
+    /// `update_*`, `mark_*`, `schedule_session_wipe`, `add_child`, `touch`,
+    /// `mark_processed_message`) publishes one `()` after the mutation
+    /// completes. Subscribers should re-snapshot the registry on each recv,
+    /// and treat `RecvError::Lagged` the same way (snapshot, then keep
+    /// listening).
+    pub fn subscribe_changes(&self) -> broadcast::Receiver<()> {
+        self.changed_tx.subscribe()
+    }
+
+    /// Publish a "registry changed" event. Ignores send failures: when no
+    /// receivers are connected `send` returns `Err`, which is the expected
+    /// state for headless operation (no dashboard, no WS).
+    fn notify_changed(&self) {
+        let _ = self.changed_tx.send(());
     }
 
     /// Register a new agent.
@@ -58,6 +96,7 @@ impl AgentRegistry {
                 vacant.insert(id);
             }
         }
+        self.notify_changed();
         Ok(())
     }
 
@@ -97,23 +136,29 @@ impl AgentRegistry {
 
     /// Update agent state.
     pub fn set_state(&self, id: AgentId, state: AgentState) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.state = state;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.state = state;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
     /// Update agent operational mode.
     pub fn set_mode(&self, id: AgentId, mode: AgentMode) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.mode = mode;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.mode = mode;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -151,6 +196,7 @@ impl AgentRegistry {
                 ids.retain(|&agent_id| agent_id != id);
             }
         }
+        self.notify_changed();
         Ok(entry)
     }
 
@@ -198,8 +244,16 @@ impl AgentRegistry {
 
     /// Add a child agent ID to a parent's children list.
     pub fn add_child(&self, parent_id: AgentId, child_id: AgentId) {
-        if let Some(mut entry) = self.agents.get_mut(&parent_id) {
-            entry.children.push(child_id);
+        let mutated = {
+            if let Some(mut entry) = self.agents.get_mut(&parent_id) {
+                entry.children.push(child_id);
+                true
+            } else {
+                false
+            }
+        };
+        if mutated {
+            self.notify_changed();
         }
     }
 
@@ -214,12 +268,15 @@ impl AgentRegistry {
         id: AgentId,
         new_session_id: librefang_types::agent::SessionId,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.session_id = new_session_id;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.session_id = new_session_id;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -229,12 +286,15 @@ impl AgentRegistry {
         id: AgentId,
         workspace: Option<std::path::PathBuf>,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.workspace = workspace;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.workspace = workspace;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -244,12 +304,15 @@ impl AgentRegistry {
         id: AgentId,
         source_toml_path: Option<std::path::PathBuf>,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.source_toml_path = source_toml_path;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.source_toml_path = source_toml_path;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -261,12 +324,15 @@ impl AgentRegistry {
         id: AgentId,
         manifest: librefang_types::agent::AgentManifest,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest = manifest;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest = manifest;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -276,23 +342,29 @@ impl AgentRegistry {
         id: AgentId,
         identity: librefang_types::agent::AgentIdentity,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.identity = identity;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.identity = identity;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
     /// Update an agent's model configuration.
     pub fn update_model(&self, id: AgentId, new_model: String) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.model.model = new_model;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.model.model = new_model;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -303,13 +375,16 @@ impl AgentRegistry {
         new_model: String,
         new_provider: String,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.model.model = new_model;
-        entry.manifest.model.provider = new_provider;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.model.model = new_model;
+            entry.manifest.model.provider = new_provider;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -322,37 +397,46 @@ impl AgentRegistry {
         api_key_env: Option<String>,
         base_url: Option<String>,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.model.model = new_model;
-        entry.manifest.model.provider = new_provider;
-        entry.manifest.model.api_key_env = api_key_env;
-        entry.manifest.model.base_url = base_url;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.model.model = new_model;
+            entry.manifest.model.provider = new_provider;
+            entry.manifest.model.api_key_env = api_key_env;
+            entry.manifest.model.base_url = base_url;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
     /// Update an agent's max_tokens (response length limit).
     pub fn update_max_tokens(&self, id: AgentId, max_tokens: u32) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.model.max_tokens = max_tokens;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.model.max_tokens = max_tokens;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
     /// Update an agent's sampling temperature.
     pub fn update_temperature(&self, id: AgentId, temperature: f32) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.model.temperature = temperature;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.model.temperature = temperature;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -362,12 +446,15 @@ impl AgentRegistry {
         id: AgentId,
         mode: librefang_types::agent::WebSearchAugmentationMode,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.web_search_augmentation = mode;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.web_search_augmentation = mode;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -377,35 +464,44 @@ impl AgentRegistry {
         id: AgentId,
         fallback_models: Vec<librefang_types::agent::FallbackModel>,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.fallback_models = fallback_models;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.fallback_models = fallback_models;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
     /// Update an agent's skill allowlist.
     pub fn update_skills(&self, id: AgentId, skills: Vec<String>) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.skills = skills;
-        entry.manifest.skills_disabled = false;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.skills = skills;
+            entry.manifest.skills_disabled = false;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
     /// Update an agent's MCP server allowlist.
     pub fn update_mcp_servers(&self, id: AgentId, servers: Vec<String>) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.mcp_servers = servers;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.mcp_servers = servers;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -418,21 +514,24 @@ impl AgentRegistry {
         allowlist: Option<Vec<String>>,
         blocklist: Option<Vec<String>>,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        if let Some(ct) = capabilities_tools {
-            entry.manifest.capabilities.tools = ct;
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            if let Some(ct) = capabilities_tools {
+                entry.manifest.capabilities.tools = ct;
+            }
+            if let Some(al) = allowlist {
+                entry.manifest.tool_allowlist = al;
+            }
+            if let Some(bl) = blocklist {
+                entry.manifest.tool_blocklist = bl;
+            }
+            entry.manifest.tools_disabled = false;
+            entry.last_active = chrono::Utc::now();
         }
-        if let Some(al) = allowlist {
-            entry.manifest.tool_allowlist = al;
-        }
-        if let Some(bl) = blocklist {
-            entry.manifest.tool_blocklist = bl;
-        }
-        entry.manifest.tools_disabled = false;
-        entry.last_active = chrono::Utc::now();
+        self.notify_changed();
         Ok(())
     }
 
@@ -447,13 +546,16 @@ impl AgentRegistry {
         skills: Vec<String>,
         skills_disabled: bool,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.skills = skills;
-        entry.manifest.skills_disabled = skills_disabled;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.skills = skills;
+            entry.manifest.skills_disabled = skills_disabled;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -469,26 +571,32 @@ impl AgentRegistry {
         blocklist: Vec<String>,
         tools_disabled: bool,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.capabilities.tools = capabilities_tools;
-        entry.manifest.tool_allowlist = allowlist;
-        entry.manifest.tool_blocklist = blocklist;
-        entry.manifest.tools_disabled = tools_disabled;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.capabilities.tools = capabilities_tools;
+            entry.manifest.tool_allowlist = allowlist;
+            entry.manifest.tool_blocklist = blocklist;
+            entry.manifest.tools_disabled = tools_disabled;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
     /// Update an agent's system prompt (hot-swap, takes effect on next message).
     pub fn update_system_prompt(&self, id: AgentId, new_prompt: String) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.model.system_prompt = new_prompt;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.model.system_prompt = new_prompt;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -514,17 +622,21 @@ impl AgentRegistry {
         entry.last_active = chrono::Utc::now();
         drop(entry);
         self.name_index.remove(&old_name);
+        self.notify_changed();
         Ok(())
     }
 
     /// Update an agent's description.
     pub fn update_description(&self, id: AgentId, new_desc: String) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.description = new_desc;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.description = new_desc;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -533,12 +645,15 @@ impl AgentRegistry {
     /// In-memory only — persisting to the agent manifest file is a separate
     /// concern (matches the pattern of `update_system_prompt`).
     pub fn update_auto_dream_enabled(&self, id: AgentId, enabled: bool) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.manifest.auto_dream_enabled = enabled;
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.manifest.auto_dream_enabled = enabled;
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -564,35 +679,41 @@ impl AgentRegistry {
         monthly: Option<f64>,
         tokens_per_hour: Option<u64>,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        if let Some(v) = hourly {
-            entry.manifest.resources.max_cost_per_hour_usd = v;
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            if let Some(v) = hourly {
+                entry.manifest.resources.max_cost_per_hour_usd = v;
+            }
+            if let Some(v) = daily {
+                entry.manifest.resources.max_cost_per_day_usd = v;
+            }
+            if let Some(v) = monthly {
+                entry.manifest.resources.max_cost_per_month_usd = v;
+            }
+            if let Some(v) = tokens_per_hour {
+                entry.manifest.resources.max_llm_tokens_per_hour = Some(v);
+            }
+            entry.last_active = chrono::Utc::now();
         }
-        if let Some(v) = daily {
-            entry.manifest.resources.max_cost_per_day_usd = v;
-        }
-        if let Some(v) = monthly {
-            entry.manifest.resources.max_cost_per_month_usd = v;
-        }
-        if let Some(v) = tokens_per_hour {
-            entry.manifest.resources.max_llm_tokens_per_hour = Some(v);
-        }
-        entry.last_active = chrono::Utc::now();
+        self.notify_changed();
         Ok(())
     }
 
     /// Mark an agent's onboarding as complete.
     pub fn mark_onboarding_complete(&self, id: AgentId) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.onboarding_completed = true;
-        entry.onboarding_completed_at = Some(chrono::Utc::now());
-        entry.last_active = chrono::Utc::now();
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.onboarding_completed = true;
+            entry.onboarding_completed_at = Some(chrono::Utc::now());
+            entry.last_active = chrono::Utc::now();
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -609,13 +730,16 @@ impl AgentRegistry {
         id: AgentId,
         reason: librefang_types::config::SessionResetReason,
     ) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.force_session_wipe = false;
-        entry.resume_pending = false;
-        entry.reset_reason = Some(reason);
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.force_session_wipe = false;
+            entry.resume_pending = false;
+            entry.reset_reason = Some(reason);
+        }
+        self.notify_changed();
         Ok(())
     }
 
@@ -626,23 +750,34 @@ impl AgentRegistry {
     /// Named `schedule_session_wipe` to avoid confusion with
     /// `suspend_agent()` / `AgentState::Suspended`.
     pub fn schedule_session_wipe(&self, id: AgentId) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        entry.force_session_wipe = true;
+        {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            entry.force_session_wipe = true;
+        }
+        self.notify_changed();
         Ok(())
     }
 
     /// Mark an agent's session as `resume_pending` after an interrupted
     /// restart.  Ignored when `force_session_wipe` is already set (hard-wipe wins).
     pub fn mark_resume_pending(&self, id: AgentId) -> LibreFangResult<()> {
-        let mut entry = self
-            .agents
-            .get_mut(&id)
-            .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
-        if !entry.force_session_wipe {
-            entry.resume_pending = true;
+        let mutated = {
+            let mut entry = self
+                .agents
+                .get_mut(&id)
+                .ok_or_else(|| LibreFangError::AgentNotFound(id.to_string()))?;
+            if !entry.force_session_wipe {
+                entry.resume_pending = true;
+                true
+            } else {
+                false
+            }
+        };
+        if mutated {
+            self.notify_changed();
         }
         Ok(())
     }
@@ -955,5 +1090,108 @@ mod tests {
             result,
             Err(librefang_types::error::LibreFangError::AgentNotFound(_))
         ));
+    }
+
+    /// #3513: every successful mutation must publish a change event so
+    /// dashboard WebSockets can re-snapshot without polling. Verifies the
+    /// broadcast channel fires on `register` (and that the receiver wakes up).
+    #[tokio::test]
+    async fn change_broadcast_fires_on_register() {
+        let registry = AgentRegistry::new();
+        let mut rx = registry.subscribe_changes();
+
+        registry.register(test_entry("first")).unwrap();
+
+        // The receiver must wake up promptly; bound the wait so a missed
+        // broadcast surfaces as a test failure rather than a hang.
+        let recv = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await;
+        assert!(matches!(recv, Ok(Ok(()))), "expected change event, got {recv:?}");
+    }
+
+    /// #3513: a burst of mutations must all be observable by a subscriber.
+    /// `Lagged` is acceptable — subscribers handle it by re-snapshotting —
+    /// what is not acceptable is a silent miss with no signal at all.
+    #[tokio::test]
+    async fn change_broadcast_handles_burst_of_mutations() {
+        let registry = AgentRegistry::new();
+        let mut rx = registry.subscribe_changes();
+
+        // Fire 5 in rapid succession.
+        for i in 0..5 {
+            registry.register(test_entry(&format!("burst-{i}"))).unwrap();
+        }
+
+        // Drain — we must observe at least one event (Ok or Lagged), and
+        // total events seen plus any lag must cover all 5 mutations or
+        // signal lag explicitly.
+        let mut got_ok = 0usize;
+        let mut got_lagged = false;
+        loop {
+            match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await {
+                Ok(Ok(())) => got_ok += 1,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {
+                    got_lagged = true;
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
+                Err(_) => break, // timeout — channel quiesced
+            }
+        }
+
+        assert!(
+            got_ok > 0 || got_lagged,
+            "subscriber received no signal at all from a burst of 5 mutations"
+        );
+        if !got_lagged {
+            assert_eq!(
+                got_ok, 5,
+                "expected 5 change events without lag, got {got_ok}"
+            );
+        }
+    }
+
+    /// #3513: subscribe_changes() must hand out independent receivers so
+    /// multiple WS clients can all listen.
+    #[tokio::test]
+    async fn change_broadcast_supports_multiple_subscribers() {
+        let registry = AgentRegistry::new();
+        let mut rx_a = registry.subscribe_changes();
+        let mut rx_b = registry.subscribe_changes();
+
+        registry.register(test_entry("multi")).unwrap();
+
+        let a = tokio::time::timeout(std::time::Duration::from_secs(1), rx_a.recv()).await;
+        let b = tokio::time::timeout(std::time::Duration::from_secs(1), rx_b.recv()).await;
+        assert!(matches!(a, Ok(Ok(()))), "rx_a expected event, got {a:?}");
+        assert!(matches!(b, Ok(Ok(()))), "rx_b expected event, got {b:?}");
+    }
+
+    /// #3513: mutators other than register must also publish — otherwise a
+    /// dashboard tab opened after agent creation would never observe model
+    /// changes, state transitions, etc.
+    #[tokio::test]
+    async fn change_broadcast_fires_on_state_and_model_updates() {
+        let registry = AgentRegistry::new();
+        let entry = test_entry("mutable");
+        let id = entry.id;
+        registry.register(entry).unwrap();
+
+        // Subscribe AFTER register so we observe only post-subscribe mutations.
+        let mut rx = registry.subscribe_changes();
+
+        registry
+            .set_state(id, AgentState::Running)
+            .expect("set_state");
+        let s1 = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await;
+        assert!(matches!(s1, Ok(Ok(()))), "set_state should fire event");
+
+        registry
+            .update_model(id, "claude-sonnet-4-7".to_string())
+            .expect("update_model");
+        let s2 = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await;
+        assert!(matches!(s2, Ok(Ok(()))), "update_model should fire event");
+
+        registry.remove(id).expect("remove");
+        let s3 = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await;
+        assert!(matches!(s3, Ok(Ok(()))), "remove should fire event");
     }
 }


### PR DESCRIPTION
Closes #3513.

## Problem

Every connected dashboard WebSocket spawned an `update_handle` that ticked
every 5 s, called `agent_registry().list()`, built a `Vec<serde_json::Value>`
for **all** agents, JSON-serialized each, hashed via `DefaultHasher`, and
**only then** suppressed the send if the hash matched. The list-build,
JSON serialize, and hash all happened unconditionally per client.

50 agents x 10 dashboard tabs = 500 manifest reads + 500 JSON serializations
+ 500 hashes every 5 s, even when nothing had changed. Pure CPU burn.

## Fix

Replace the per-client poll with a single shared
`tokio::sync::broadcast::Sender<()>` on `AgentRegistry`. Mutators publish
one event after each successful mutation; WS clients subscribe once and
only re-snapshot when something actually changes.

### `AgentRegistry` (`crates/librefang-kernel/src/registry.rs`)

- New `changed_tx: broadcast::Sender<()>` field, capacity 16.
- `pub fn subscribe_changes(&self) -> broadcast::Receiver<()>`.
- Private `notify_changed()` helper; `send` errors are ignored
  (they only mean "no listeners" — the headless / no-dashboard case).

### Mutators instrumented (31 sites)

`register`, `set_state`, `set_mode`, `remove`, `add_child` (only when
the parent existed), `update_session_id`, `update_workspace`,
`update_source_toml_path`, `replace_manifest`, `update_identity`,
`update_model`, `update_model_and_provider`, `update_model_provider_config`,
`update_max_tokens`, `update_temperature`, `update_web_search_augmentation`,
`update_fallback_models`, `update_skills`, `update_mcp_servers`,
`update_tool_config`, `restore_skills_state`, `restore_tool_state`,
`update_system_prompt`, `update_name`, `update_description`,
`update_auto_dream_enabled`, `update_resources`, `mark_onboarding_complete`,
`update_session_reset_state`, `schedule_session_wipe`,
`mark_resume_pending` (only when the flag actually flipped).

### Deliberately NOT instrumented

`touch()` and `mark_processed_message()` — they fire on every LLM turn /
heartbeat. Publishing on those would convert one mutation per turn into a
broadcast → snapshot rebuild and defeat the entire perf gain. The visible
WS payload (`id`, `name`, `state`, `model_provider`, `model_name`) does
**not** include `last_active`, so skipping them changes nothing the
dashboard renders.

### `ws.rs` (`crates/librefang-api/src/ws.rs`)

- 5 s `interval` poll loop replaced with `broadcast::Receiver<()>`.
- **Initial snapshot** sent once on connect so a freshly opened tab does
  not have to wait for the next mutation.
- `RecvError::Lagged(_)` is treated as "snapshot now and keep listening"
  — we only care that *something* changed, not what.
- `RecvError::Closed` (kernel teardown) ends the task cleanly.
- **200 ms debounce** after a recv: subsequent events within the window
  are drained so a burst of N mutations from one user action produces
  one payload, not N.
- `last_hash` belt-and-suspenders preserved at the send boundary to
  suppress no-op mutations (e.g. `update_skills` with an unchanged list).
- `update_handle.abort()` cleanup path unchanged.

## Complexity

| | Before | After |
|---|---|---|
| Per-tick work | O(N_clients × N_agents) every 5 s | 0 |
| Per-mutation work | 0 | O(1) broadcast send + per-listener O(N_agents) snapshot |
| Burst of M mutations in <200 ms | M × O(N_clients × N_agents) | 1 × O(N_listeners × N_agents) |

For an idle dashboard with 50 agents and 10 tabs, the 5 s tick cost goes
from 500 manifest reads / serialize / hash → **zero**.

## Tests

Added four `#[tokio::test]`s on `AgentRegistry`:

- `change_broadcast_fires_on_register` — single mutation reaches receiver.
- `change_broadcast_handles_burst_of_mutations` — 5 rapid registers all
  observed (or `Lagged` returned, which is acceptable).
- `change_broadcast_supports_multiple_subscribers` — independent receivers.
- `change_broadcast_fires_on_state_and_model_updates` — `set_state`,
  `update_model`, `remove` all publish post-register.

Integration with `ws.rs` skipped — would require a full HTTP harness;
the broadcast contract on the registry is the load-bearing piece.

## Build verification

Local cargo absent on this build host; relying on CI for
`cargo check --workspace --lib`, `cargo clippy --workspace --all-targets
-- -D warnings`, and the new `librefang-kernel` tests.
