### PR TITLE
ci: scope -D warnings to first-party via workspace lints (#3554)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,14 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-D warnings"
+  # NOTE: `RUSTFLAGS: "-D warnings"` is intentionally NOT set here.
+  # Setting it workflow-wide propagates to dependency compilation, which
+  # makes every CI lane break whenever any transitive crate introduces a
+  # new lint warning. First-party warnings are still gated:
+  #   - `cargo clippy ... -- -D warnings` in the `quality` job below
+  #   - `[workspace.lints.rust] warnings = "deny"` in the root Cargo.toml
+  #     (applied to first-party crates via `lints.workspace = true`)
+  # See issue #3554.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,3 +246,11 @@ opt-level = "s"
 inherits = "release"
 lto = "thin"
 codegen-units = 4
+
+# Workspace-wide build lint policy. Applies ONLY to first-party crates
+# that opt in via `[lints] workspace = true` in their own Cargo.toml.
+# Replaces the previous workflow-wide `RUSTFLAGS=-D warnings` (#3554)
+# which leaked into dependency compilation and broke CI on transitive
+# lint regressions.
+[workspace.lints.rust]
+warnings = "deny"

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -193,3 +193,6 @@ uuid = { workspace = true }
 http-body-util = "0.1"
 librefang-testing = { path = "../librefang-testing" }
 totp-rs = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -167,3 +167,6 @@ tempfile = { workspace = true }
 [[bench]]
 name = "dispatch"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -74,3 +74,6 @@ tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-desktop/Cargo.toml
+++ b/crates/librefang-desktop/Cargo.toml
@@ -100,3 +100,6 @@ path = "src/main.rs"
 # the manifest layer, so we accept the cost.
 [lib]
 crate-type = ["staticlib", "cdylib", "lib"]
+
+[lints]
+workspace = true

--- a/crates/librefang-extensions/Cargo.toml
+++ b/crates/librefang-extensions/Cargo.toml
@@ -45,3 +45,6 @@ keyring = { workspace = true }
 tempfile = { workspace = true }
 serial_test = "3"
 librefang-runtime = { path = "../librefang-runtime" }
+
+[lints]
+workspace = true

--- a/crates/librefang-hands/Cargo.toml
+++ b/crates/librefang-hands/Cargo.toml
@@ -20,3 +20,6 @@ dashmap = { workspace = true }
 tempfile = { workspace = true }
 librefang-runtime = { path = "../librefang-runtime" }
 serial_test = "3"
+
+[lints]
+workspace = true

--- a/crates/librefang-http/Cargo.toml
+++ b/crates/librefang-http/Cargo.toml
@@ -12,3 +12,6 @@ rustls = { workspace = true }
 webpki-roots = { workspace = true }
 rustls-native-certs = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-kernel-handle/Cargo.toml
+++ b/crates/librefang-kernel-handle/Cargo.toml
@@ -14,3 +14,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/crates/librefang-kernel-metering/Cargo.toml
+++ b/crates/librefang-kernel-metering/Cargo.toml
@@ -10,3 +10,6 @@ librefang-types = { path = "../librefang-types" }
 librefang-memory = { path = "../librefang-memory" }
 librefang-runtime = { path = "../librefang-runtime" }
 serde = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-kernel-router/Cargo.toml
+++ b/crates/librefang-kernel-router/Cargo.toml
@@ -17,3 +17,6 @@ toml = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 librefang-runtime = { path = "../librefang-runtime" }
+
+[lints]
+workspace = true

--- a/crates/librefang-kernel/Cargo.toml
+++ b/crates/librefang-kernel/Cargo.toml
@@ -57,3 +57,6 @@ tempfile = { workspace = true }
 serial_test = "3"
 librefang-testing = { path = "../librefang-testing" }
 librefang-kernel-handle = { path = "../librefang-kernel-handle" }
+
+[lints]
+workspace = true

--- a/crates/librefang-llm-driver/Cargo.toml
+++ b/crates/librefang-llm-driver/Cargo.toml
@@ -12,3 +12,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-llm-drivers/Cargo.toml
+++ b/crates/librefang-llm-drivers/Cargo.toml
@@ -30,3 +30,6 @@ rand = { workspace = true }
 serial_test = "3"
 tempfile = { workspace = true }
 wiremock = "0.6"
+
+[lints]
+workspace = true

--- a/crates/librefang-memory/Cargo.toml
+++ b/crates/librefang-memory/Cargo.toml
@@ -22,3 +22,6 @@ reqwest = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-migrate/Cargo.toml
+++ b/crates/librefang-migrate/Cargo.toml
@@ -20,3 +20,6 @@ dirs = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-runtime-mcp/Cargo.toml
+++ b/crates/librefang-runtime-mcp/Cargo.toml
@@ -22,3 +22,6 @@ sha2 = { workspace = true }
 url = { workspace = true }
 rand = { workspace = true }
 arc-swap = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-runtime-oauth/Cargo.toml
+++ b/crates/librefang-runtime-oauth/Cargo.toml
@@ -19,3 +19,6 @@ sha2 = { workspace = true }
 zeroize = { workspace = true }
 rand = { workspace = true }
 hex = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-runtime-wasm/Cargo.toml
+++ b/crates/librefang-runtime-wasm/Cargo.toml
@@ -19,3 +19,6 @@ anyhow = { workspace = true }
 [dev-dependencies]
 async-trait = { workspace = true }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-runtime/Cargo.toml
+++ b/crates/librefang-runtime/Cargo.toml
@@ -62,3 +62,6 @@ serial_test = "3"
 landlock-sandbox = ["dep:landlock"]
 seccomp-sandbox = ["dep:seccompiler"]
 
+
+[lints]
+workspace = true

--- a/crates/librefang-skills/Cargo.toml
+++ b/crates/librefang-skills/Cargo.toml
@@ -30,3 +30,6 @@ fs2 = "0.4"
 [dev-dependencies]
 tempfile = { workspace = true }
 serial_test = "3"
+
+[lints]
+workspace = true

--- a/crates/librefang-telemetry/Cargo.toml
+++ b/crates/librefang-telemetry/Cargo.toml
@@ -9,3 +9,6 @@ description = "OpenTelemetry + Prometheus metrics instrumentation for LibreFang"
 metrics = { workspace = true }
 librefang-types = { path = "../librefang-types" }
 
+
+[lints]
+workspace = true

--- a/crates/librefang-testing/Cargo.toml
+++ b/crates/librefang-testing/Cargo.toml
@@ -21,3 +21,6 @@ tempfile = { workspace = true }
 toml = { workspace = true }
 uuid = { workspace = true }
 http-body-util = "0.1"
+
+[lints]
+workspace = true

--- a/crates/librefang-types/Cargo.toml
+++ b/crates/librefang-types/Cargo.toml
@@ -27,3 +27,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 rmp-serde = { workspace = true }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/librefang-wire/Cargo.toml
+++ b/crates/librefang-wire/Cargo.toml
@@ -28,3 +28,6 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,3 +14,6 @@ chrono = "0.4"
 base64 = { workspace = true }
 sha2 = { workspace = true }
 librefang-migrate = { path = "../crates/librefang-migrate" }
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary

Fixes #3554 — workflow-wide `RUSTFLAGS: "-D warnings"` propagated into dependency compilation, breaking every CI lane any time a transitive crate introduced a new lint warning. Replace it with a first-party-only ratchet:

- Drop `RUSTFLAGS: "-D warnings"` from `.github/workflows/ci.yml` env (kept a `NOTE` comment so it isn't re-added).
- Add `[workspace.lints.rust] warnings = "deny"` to root `Cargo.toml`.
- Opt every workspace member (24 crates + `xtask`) in via `[lints] workspace = true`.

## Trade-off

**Before**: `RUSTFLAGS=-D warnings` set process-wide → applied to first-party AND every dependency build → CI broke whenever any transitive crate produced a new warning (e.g. on a Rust toolchain bump).

**After**: First-party warnings still gated end-to-end:
- `cargo clippy ... -- -D warnings` in the `quality` job (unchanged at line ~192).
- `[workspace.lints.rust]` denies build-time warnings via cargo's own lint pipeline, applied **only** to crates that opt in via `[lints] workspace = true`. Dependency builds are no longer affected.

Net: same first-party strictness, no false alarms from upstream crates.

## Rust version requirement

`[workspace.lints]` requires Rust 1.74+ (stabilized 2023-11). Workspace MSRV in `Cargo.toml` is `rust-version = "1.94.1"` and `rust-toolchain.toml` pins `channel = "stable"`, so this is well within bounds.

## Test plan

- [ ] CI `quality` job still fails on first-party warnings (clippy `-D warnings` unchanged + cargo build now sees `[workspace.lints]`).
- [ ] CI `test-ubuntu` / `test-windows` / `test-macos` no longer break on transitive dep warnings (the original bug).
- [ ] No new dependencies added (verify `Cargo.lock` is unchanged).

> **Local cargo unavailable on the author's machine; relying on CI for verification.**

Closes #3554.
