### PR TITLE
feat(kernel): vault startup sentinel + rotate-key + audit on crypto failure (#3651)

### DIFF
--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -334,10 +334,25 @@ pub async fn auth_start(
             {
                 Ok(cid) => {
                     tracing::info!(client_id = %cid, "Dynamic Client Registration succeeded");
-                    let _ = provider.vault_set(
-                        &KernelOAuthProvider::vault_key(&server_url, "client_id"),
-                        &cid,
-                    );
+                    // #3651: replaced `let _ = vault_set(...)` so a vault
+                    // crypto failure here is no longer silently swallowed.
+                    // Behavior is intentionally unchanged on the happy path
+                    // (continue with the freshly-registered client_id even
+                    // if persistence failed — the OAuth flow can still
+                    // complete in-memory) but the audit trail now records
+                    // every failure so operators can detect a
+                    // wrong-`LIBREFANG_VAULT_KEY` boot from the logs.
+                    let vault_key =
+                        KernelOAuthProvider::vault_key(&server_url, "client_id");
+                    if let Err(e) = provider.vault_set(&vault_key, &cid) {
+                        tracing::error!(
+                            target: "audit",
+                            op = "vault_set",
+                            key = %vault_key,
+                            error = %e,
+                            "vault op failed during MCP Dynamic Client Registration persistence"
+                        );
+                    }
                     client_id = Some(cid);
                 }
                 Err(e) => {
@@ -811,6 +826,13 @@ pub async fn auth_callback(
     }
 
     // Clean up one-time PKCE values from vault (per-flow key — #3727).
+    //
+    // #3651: replaced `let _ = vault_remove(...)` so vault crypto failures
+    // during PKCE cleanup are no longer silently dropped. Behavior is
+    // intentionally unchanged on success (one-time cleanup, errors don't
+    // abort the OAuth callback path), but every failure now produces an
+    // `audit` log line so operators can correlate stale PKCE entries with
+    // a misconfigured `LIBREFANG_VAULT_KEY`.
     for field in &[
         "pkce_verifier",
         "pkce_state",
@@ -818,7 +840,16 @@ pub async fn auth_callback(
         "token_endpoint",
         "client_id",
     ] {
-        let _ = provider.vault_remove(&KernelOAuthProvider::vault_key(&flow_key_prefix, field));
+        let vault_key = KernelOAuthProvider::vault_key(&flow_key_prefix, field);
+        if let Err(e) = provider.vault_remove(&vault_key) {
+            tracing::error!(
+                target: "audit",
+                op = "vault_remove",
+                key = %vault_key,
+                error = %e,
+                "vault op failed during PKCE cleanup"
+            );
+        }
     }
 
     // Retry the MCP connection now that we have tokens.

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -4152,7 +4152,15 @@ pub async fn delete_mcp_server(
     }
     drop(t);
 
-    // Clean up OAuth vault tokens, auth state, and live connections
+    // Clean up OAuth vault tokens, auth state, and live connections.
+    //
+    // #3651: replaced `let _ = vault_remove(...)` so vault crypto failures
+    // during MCP server uninstall are no longer silently dropped. Behavior
+    // is intentionally unchanged on success (uninstall continues even if a
+    // few vault entries can't be wiped — the auth state is reset
+    // unconditionally below) but each failure now produces an `audit` log
+    // line so operators can detect leftover credentials after a wrong-key
+    // boot.
     if let Some(ref url) = server_url {
         let provider = KernelOAuthProvider::new(state.kernel.home_dir().to_path_buf());
         for field in &[
@@ -4165,7 +4173,16 @@ pub async fn delete_mcp_server(
             "pkce_state",
             "redirect_uri",
         ] {
-            let _ = provider.vault_remove(&KernelOAuthProvider::vault_key(url, field));
+            let vault_key = KernelOAuthProvider::vault_key(url, field);
+            if let Err(e) = provider.vault_remove(&vault_key) {
+                tracing::error!(
+                    target: "audit",
+                    op = "vault_remove",
+                    key = %vault_key,
+                    error = %e,
+                    "vault op failed during MCP server uninstall"
+                );
+            }
         }
     }
     state

--- a/crates/librefang-cli/locales/en/main.ftl
+++ b/crates/librefang-cli/locales/en/main.ftl
@@ -271,6 +271,19 @@ vault-store-failed = Failed to store: { $error }
 vault-removed = Removed '{ $key }' from vault.
 vault-key-not-found = Key '{ $key }' not found in vault.
 vault-remove-failed = Failed to remove: { $error }
+vault-rotate-no-vault = No vault file found. Run `librefang vault init` first.
+vault-rotate-old-key-missing = LIBREFANG_VAULT_KEY_OLD not set. Provide the current master key (base64 of 32 bytes) before rotating.
+vault-rotate-new-key-missing = LIBREFANG_VAULT_KEY_NEW not set. Provide the new master key (base64 of 32 bytes), or pass --from-stdin to read it from stdin.
+vault-rotate-stdin-read-failed = Failed to read new key from stdin: { $error }
+vault-rotate-stdin-empty = New key read from stdin was empty.
+vault-rotate-same-key = LIBREFANG_VAULT_KEY_OLD and the new key are identical — refusing to rotate to the same key.
+vault-rotate-old-key-invalid = LIBREFANG_VAULT_KEY_OLD is not a valid 32-byte base64 key: { $error }
+vault-rotate-new-key-invalid = New key is not a valid 32-byte base64 key: { $error }
+vault-rotate-unlock-failed = Failed to unlock vault with the OLD key: { $error }. Check LIBREFANG_VAULT_KEY_OLD matches the key the vault was originally encrypted with.
+vault-rotate-sentinel-failed = Vault sentinel verification failed under the OLD key: { $error }
+vault-rotate-rewrap-failed = Failed to re-encrypt vault under the new key: { $error }. The original vault file is unchanged.
+vault-rotate-success = Vault re-encrypted under the new master key ({ $count } user entries preserved).
+vault-rotate-next-step = Next: set LIBREFANG_VAULT_KEY to the new value before restarting the daemon.
 
 # --- Cron ---
 cron-created = Cron job created: { $id }

--- a/crates/librefang-cli/locales/zh-CN/main.ftl
+++ b/crates/librefang-cli/locales/zh-CN/main.ftl
@@ -271,6 +271,19 @@ vault-store-failed = 存储失败：{ $error }
 vault-removed = 已从保险库中移除 '{ $key }'。
 vault-key-not-found = 在保险库中未找到密钥 '{ $key }'。
 vault-remove-failed = 移除失败：{ $error }
+vault-rotate-no-vault = 未找到保险库文件。请先运行 `librefang vault init`。
+vault-rotate-old-key-missing = 未设置 LIBREFANG_VAULT_KEY_OLD。请在轮换前提供当前主密钥（32 字节的 base64）。
+vault-rotate-new-key-missing = 未设置 LIBREFANG_VAULT_KEY_NEW。请提供新的主密钥（32 字节的 base64），或使用 --from-stdin 从标准输入读取。
+vault-rotate-stdin-read-failed = 从标准输入读取新密钥失败：{ $error }
+vault-rotate-stdin-empty = 从标准输入读取的新密钥为空。
+vault-rotate-same-key = LIBREFANG_VAULT_KEY_OLD 与新密钥相同 — 拒绝轮换到相同的密钥。
+vault-rotate-old-key-invalid = LIBREFANG_VAULT_KEY_OLD 不是有效的 32 字节 base64 密钥：{ $error }
+vault-rotate-new-key-invalid = 新密钥不是有效的 32 字节 base64 密钥：{ $error }
+vault-rotate-unlock-failed = 使用旧密钥解锁保险库失败：{ $error }。请检查 LIBREFANG_VAULT_KEY_OLD 是否与最初加密保险库时使用的密钥一致。
+vault-rotate-sentinel-failed = 使用旧密钥验证保险库哨兵值失败：{ $error }
+vault-rotate-rewrap-failed = 使用新密钥重新加密保险库失败：{ $error }。原始保险库文件未被修改。
+vault-rotate-success = 已使用新主密钥重新加密保险库（保留了 { $count } 条用户条目）。
+vault-rotate-next-step = 下一步：在重启守护进程前，将 LIBREFANG_VAULT_KEY 设置为新值。
 
 # --- Cron ---
 cron-created = 定时任务已创建：{ $id }

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -540,6 +540,27 @@ enum VaultCommands {
         /// Credential key.
         key: String,
     },
+    /// Rotate the vault master key (re-encrypt every entry with a new key).
+    ///
+    /// Recovery / hygiene workflow shipped for #3651. By default reads the
+    /// old key from `LIBREFANG_VAULT_KEY_OLD` and the new key from
+    /// `LIBREFANG_VAULT_KEY_NEW`; pass `--from-stdin` to read the new key
+    /// from stdin instead (useful when the new key cannot safely live in
+    /// the shell history). Both keys must be valid base64 of exactly
+    /// 32 bytes (`openssl rand -base64 32`).
+    ///
+    /// The vault is re-encrypted to a temp file, fsync'd, then atomically
+    /// renamed over the original — no half-rotated state on disk if the
+    /// process is killed mid-way. The startup sentinel is preserved so the
+    /// daemon will boot cleanly under the new key.
+    #[command(
+        long_about = "Rotate the vault master key (re-encrypt every entry with a new key).\n\nReads the old key from LIBREFANG_VAULT_KEY_OLD and the new key from LIBREFANG_VAULT_KEY_NEW (or from stdin with --from-stdin). Both must be base64 of exactly 32 bytes (openssl rand -base64 32).\n\nAfter a successful rotation, restart the daemon with the new LIBREFANG_VAULT_KEY set to the new value. Until you do, the daemon will refuse to boot — the startup sentinel verifies the key matches the rotated vault.\n\nExamples:\n  LIBREFANG_VAULT_KEY_OLD=$(cat .key.old) \\\n  LIBREFANG_VAULT_KEY_NEW=$(cat .key.new) \\\n    librefang vault rotate-key\n\n  echo $NEW_KEY | LIBREFANG_VAULT_KEY_OLD=$OLD_KEY librefang vault rotate-key --from-stdin"
+    )]
+    RotateKey {
+        /// Read the new key from stdin instead of `LIBREFANG_VAULT_KEY_NEW`.
+        #[arg(long)]
+        from_stdin: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2185,6 +2206,7 @@ fn main() {
             VaultCommands::Set { key } => cmd_vault_set(&key),
             VaultCommands::List => cmd_vault_list(),
             VaultCommands::Remove { key } => cmd_vault_remove(&key),
+            VaultCommands::RotateKey { from_stdin } => cmd_vault_rotate_key(from_stdin),
         },
         Some(Commands::New { kind }) => cmd_scaffold(kind),
         // ── New commands ────────────────────────────────────────────────
@@ -9714,6 +9736,150 @@ fn cmd_vault_remove(key: &str) {
             std::process::exit(1);
         }
     }
+}
+
+/// Rotate the vault master key by re-encrypting every entry under a fresh
+/// 32-byte key. Issue #3651.
+///
+/// Source of the keys (in order):
+///   - OLD: env var `LIBREFANG_VAULT_KEY_OLD` (REQUIRED)
+///   - NEW: env var `LIBREFANG_VAULT_KEY_NEW` unless `--from-stdin` is set,
+///          in which case stdin is read until EOF and trimmed.
+///
+/// Both must be base64 of exactly 32 raw bytes (`openssl rand -base64 32`,
+/// matches `LIBREFANG_VAULT_KEY` in production). Any other length is
+/// rejected up-front before any vault state is touched.
+///
+/// On success the vault file is atomically replaced (vault.rs's `save()`
+/// already writes to `<path>.tmp` and `rename`s — re-using it gives us the
+/// atomic-swap-on-disk guarantee for free) and prints the new key fingerprint
+/// so the operator has a non-secret confirmation that the rotation took.
+fn cmd_vault_rotate_key(from_stdin: bool) {
+    use std::io::Read as _;
+    use zeroize::Zeroizing;
+
+    let home = librefang_home();
+    let vault_path = home.join("vault.enc");
+
+    // Pre-flight: vault must already exist. Refuse on missing file rather
+    // than silently `init()` — rotating a vault that was never created is
+    // a no-op masking an operator error.
+    if !vault_path.exists() {
+        ui::error(&i18n::t("vault-rotate-no-vault"));
+        std::process::exit(1);
+    }
+
+    // Read OLD key from env. Always required.
+    let old_key_b64 = match std::env::var("LIBREFANG_VAULT_KEY_OLD") {
+        Ok(s) if !s.is_empty() => Zeroizing::new(s),
+        _ => {
+            ui::error(&i18n::t("vault-rotate-old-key-missing"));
+            std::process::exit(1);
+        }
+    };
+
+    // Read NEW key from stdin or env, depending on the flag. stdin wins
+    // when `--from-stdin` is set so a key in env can't accidentally
+    // override an explicit stdin pipe.
+    let new_key_b64 = if from_stdin {
+        let mut buf = String::new();
+        if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+            ui::error(&i18n::t_args(
+                "vault-rotate-stdin-read-failed",
+                &[("error", &e.to_string())],
+            ));
+            std::process::exit(1);
+        }
+        let trimmed = buf.trim().to_string();
+        if trimmed.is_empty() {
+            ui::error(&i18n::t("vault-rotate-stdin-empty"));
+            std::process::exit(1);
+        }
+        Zeroizing::new(trimmed)
+    } else {
+        match std::env::var("LIBREFANG_VAULT_KEY_NEW") {
+            Ok(s) if !s.is_empty() => Zeroizing::new(s),
+            _ => {
+                ui::error(&i18n::t("vault-rotate-new-key-missing"));
+                std::process::exit(1);
+            }
+        }
+    };
+
+    // Reject identical OLD/NEW up-front — silently no-op rotations are a
+    // footgun. (`Zeroizing<String>` derefs to `&str` so direct comparison
+    // is safe and constant-time on equal-length strings is unnecessary
+    // here: this is a configuration check, not a credential check.)
+    if old_key_b64.as_str() == new_key_b64.as_str() {
+        ui::error(&i18n::t("vault-rotate-same-key"));
+        std::process::exit(1);
+    }
+
+    // Decode both keys via the same parser the production daemon uses so
+    // any rejection here matches what the daemon will reject at boot.
+    let old_key_bytes = match librefang_extensions::vault::decode_master_key(&old_key_b64) {
+        Ok(k) => k,
+        Err(e) => {
+            ui::error(&i18n::t_args(
+                "vault-rotate-old-key-invalid",
+                &[("error", &e.to_string())],
+            ));
+            std::process::exit(1);
+        }
+    };
+    let new_key_bytes = match librefang_extensions::vault::decode_master_key(&new_key_b64) {
+        Ok(k) => k,
+        Err(e) => {
+            ui::error(&i18n::t_args(
+                "vault-rotate-new-key-invalid",
+                &[("error", &e.to_string())],
+            ));
+            std::process::exit(1);
+        }
+    };
+
+    // Open + unlock with OLD key. Use `unlock_with_key` so the rotation
+    // doesn't accidentally pick up a stale env / keyring value — we want
+    // the rotation to fail loudly if `LIBREFANG_VAULT_KEY_OLD` doesn't
+    // match the on-disk vault.
+    let mut vault = librefang_extensions::vault::CredentialVault::new(vault_path.clone());
+    if let Err(e) = vault.unlock_with_key(old_key_bytes) {
+        ui::error(&i18n::t_args(
+            "vault-rotate-unlock-failed",
+            &[("error", &e.to_string())],
+        ));
+        std::process::exit(1);
+    }
+
+    // Verify (or backfill) the sentinel under the OLD key BEFORE rotating.
+    // This catches "OLD key decrypted noise" and ensures legacy vaults
+    // gain a sentinel during rotation rather than after.
+    if let Err(e) = vault.verify_or_install_sentinel() {
+        ui::error(&i18n::t_args(
+            "vault-rotate-sentinel-failed",
+            &[("error", &e.to_string())],
+        ));
+        std::process::exit(1);
+    }
+
+    let entry_count = vault.list_keys().len();
+
+    // Re-encrypt the entire vault under the NEW key. `rewrap_with_new_key`
+    // re-uses the proven atomic save path inside vault.rs (write to
+    // `<path>.tmp`, fsync, rename) — no separate code path to maintain.
+    if let Err(e) = vault.rewrap_with_new_key(new_key_bytes) {
+        ui::error(&i18n::t_args(
+            "vault-rotate-rewrap-failed",
+            &[("error", &e.to_string())],
+        ));
+        std::process::exit(1);
+    }
+
+    ui::success(&i18n::t_args(
+        "vault-rotate-success",
+        &[("count", &entry_count.to_string())],
+    ));
+    println!("{}", i18n::t("vault-rotate-next-step"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-cli/tests/vault_rotate_key.rs
+++ b/crates/librefang-cli/tests/vault_rotate_key.rs
@@ -1,0 +1,174 @@
+//! Integration test for the `librefang vault rotate-key` workflow (#3651).
+//!
+//! The CLI subcommand wraps `CredentialVault::unlock_with_key`,
+//! `verify_or_install_sentinel`, and `rewrap_with_new_key` — all from
+//! `librefang-extensions`. This test exercises the same code path the CLI
+//! drives so a regression in any of those building blocks (or in the
+//! sentinel preservation contract) trips the test the CLI would have
+//! caught at runtime.
+//!
+//! Spawning the CLI binary is intentionally avoided: `cmd_vault_rotate_key`
+//! calls `std::process::exit` on every error path and reads
+//! `LIBREFANG_VAULT_KEY_OLD` / `LIBREFANG_VAULT_KEY_NEW` from the global
+//! process env, which makes parallel `cargo test` runs flaky. Driving the
+//! library API directly is deterministic AND covers the actual rotation
+//! invariants (vault re-encrypted under new key, old key rejected, sentinel
+//! survives).
+
+use librefang_extensions::vault::{CredentialVault, SENTINEL_KEY, SENTINEL_VALUE};
+use zeroize::Zeroizing;
+
+/// Build a 32-byte key whose every byte is `b`. Deterministic so test
+/// failures are reproducible without `OsRng` noise.
+fn key_filled(b: u8) -> Zeroizing<[u8; 32]> {
+    Zeroizing::new([b; 32])
+}
+
+/// End-to-end: create vault with key A → store entries → rotate to key B →
+/// reads work with B → reads fail with A → sentinel survives and verifies.
+#[test]
+fn rotate_key_end_to_end_replaces_master_key_and_preserves_entries() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.enc");
+
+    let key_a = key_filled(0x11);
+    let key_b = key_filled(0x22);
+    assert_ne!(key_a.as_ref(), key_b.as_ref());
+
+    // ── Phase 1: create vault under KEY A and populate it. ──────────────
+    {
+        let mut vault = CredentialVault::new(vault_path.clone());
+        vault
+            .init_with_key(key_a.clone())
+            .expect("init under key A");
+        vault
+            .set(
+                "API_KEY".to_string(),
+                Zeroizing::new("groq-key-aaa".to_string()),
+            )
+            .expect("set API_KEY");
+        vault
+            .set(
+                "REFRESH_TOKEN".to_string(),
+                Zeroizing::new("rt-bbb".to_string()),
+            )
+            .expect("set REFRESH_TOKEN");
+        // sanity: sentinel was pre-written by init_with_key (#3651).
+        vault
+            .verify_or_install_sentinel()
+            .expect("sentinel present after init");
+    }
+
+    // ── Phase 2: rotate from KEY A → KEY B (matches what cmd_vault_rotate_key does). ──
+    {
+        let mut vault = CredentialVault::new(vault_path.clone());
+        vault
+            .unlock_with_key(key_a.clone())
+            .expect("unlock under OLD key A");
+        vault
+            .verify_or_install_sentinel()
+            .expect("sentinel verifies under OLD key");
+        // Confirm we see exactly the two user entries (sentinel is hidden).
+        let mut user_keys = vault.list_keys();
+        user_keys.sort();
+        assert_eq!(user_keys, vec!["API_KEY", "REFRESH_TOKEN"]);
+        // Re-wrap under KEY B — atomic save + sentinel preserved.
+        vault
+            .rewrap_with_new_key(key_b.clone())
+            .expect("rewrap with NEW key B");
+    }
+
+    // ── Phase 3: NEW key reads succeed and recover the original plaintext. ──
+    {
+        let mut vault = CredentialVault::new(vault_path.clone());
+        vault
+            .unlock_with_key(key_b.clone())
+            .expect("unlock under NEW key B");
+        assert_eq!(
+            vault.get("API_KEY").expect("API_KEY present").as_str(),
+            "groq-key-aaa"
+        );
+        assert_eq!(
+            vault
+                .get("REFRESH_TOKEN")
+                .expect("REFRESH_TOKEN present")
+                .as_str(),
+            "rt-bbb"
+        );
+        // Sentinel survived rotation and verifies cleanly.
+        vault
+            .verify_or_install_sentinel()
+            .expect("sentinel verifies under NEW key");
+        // Sentinel is invisible to user-facing list_keys.
+        let mut user_keys = vault.list_keys();
+        user_keys.sort();
+        assert_eq!(user_keys, vec!["API_KEY", "REFRESH_TOKEN"]);
+    }
+
+    // ── Phase 4: OLD key MUST now be rejected — that's the whole point. ──
+    {
+        let mut vault = CredentialVault::new(vault_path.clone());
+        let result = vault.unlock_with_key(key_a);
+        assert!(
+            result.is_err(),
+            "rotated vault must reject the OLD key A; got {result:?}"
+        );
+    }
+}
+
+/// Rotating to the SAME master key would be a no-op masking an operator
+/// error. The CLI rejects it up-front; verify the underlying invariant
+/// here too (the rewrap itself does succeed at the library layer because
+/// it's just a re-encrypt-with-same-key, but the CLI guard prevents the
+/// footgun before we get there).
+#[test]
+fn rewrap_with_identical_key_still_decrypts() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.enc");
+    let key = key_filled(0x42);
+
+    let mut vault = CredentialVault::new(vault_path.clone());
+    vault.init_with_key(key.clone()).unwrap();
+    vault
+        .set("K".to_string(), Zeroizing::new("v".to_string()))
+        .unwrap();
+    // Library-level rewrap with the same key is allowed (idempotent re-encrypt
+    // under fresh AES-GCM nonce/salt). The CLI layer is where the same-key
+    // guard lives, intentionally — see `vault-rotate-same-key` in main.ftl.
+    vault.rewrap_with_new_key(key.clone()).unwrap();
+
+    // Re-open and confirm everything still works under the same key.
+    let mut v2 = CredentialVault::new(vault_path);
+    v2.unlock_with_key(key).unwrap();
+    assert_eq!(v2.get("K").unwrap().as_str(), "v");
+    v2.verify_or_install_sentinel().unwrap();
+}
+
+/// Rotation must preserve every reserved internal slot (only the sentinel
+/// today, but future internal keys would benefit from the same guard).
+/// Without `iter_all_entries` / sentinel-aware rewrap, the post-rotation
+/// vault would be missing the sentinel and the boot path would refuse to
+/// start under the new key.
+#[test]
+fn sentinel_round_trips_through_rotation() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.enc");
+    let key_old = key_filled(0xAA);
+    let key_new = key_filled(0xBB);
+
+    let mut vault = CredentialVault::new(vault_path.clone());
+    vault.init_with_key(key_old.clone()).unwrap();
+    vault.rewrap_with_new_key(key_new.clone()).unwrap();
+    drop(vault);
+
+    let mut vault2 = CredentialVault::new(vault_path);
+    vault2.unlock_with_key(key_new).unwrap();
+    // Use iter_all_entries (which includes reserved keys) to inspect the
+    // sentinel directly; verify_or_install_sentinel is also exercised.
+    let sentinel_pair = vault2
+        .iter_all_entries()
+        .find(|(k, _)| *k == SENTINEL_KEY);
+    let (_, sv) = sentinel_pair.expect("sentinel must survive rotation");
+    assert_eq!(sv, SENTINEL_VALUE, "sentinel value must round-trip exactly");
+    vault2.verify_or_install_sentinel().unwrap();
+}

--- a/crates/librefang-extensions/src/lib.rs
+++ b/crates/librefang-extensions/src/lib.rs
@@ -44,6 +44,18 @@ pub enum ExtensionError {
     Vault(String),
     #[error("Vault locked — unlock with vault key or LIBREFANG_VAULT_KEY env var")]
     VaultLocked,
+    /// The vault was opened with a key that does not match the key it was
+    /// encrypted with. Surfaced from #3651: pre-fix the daemon would silently
+    /// boot, then every subsequent vault read would error with a generic
+    /// "Decryption failed" log line — the operator never learned the root
+    /// cause was a mismatched `LIBREFANG_VAULT_KEY`.
+    ///
+    /// `hint` carries the recovery instruction for the operator (typically
+    /// "restore the original env var, or rebuild from backup"). The
+    /// boot-path translates this into a `KernelError::BootFailed` so the
+    /// daemon refuses to start instead of corrupting downstream state.
+    #[error("Vault key mismatch: {hint}")]
+    VaultKeyMismatch { hint: String },
     #[error("OAuth error: {0}")]
     OAuth(String),
     #[error("TOML parse error: {0}")]

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -28,6 +28,26 @@ use zeroize::Zeroizing;
 /// Env var fallback for vault key.
 const VAULT_KEY_ENV: &str = "LIBREFANG_VAULT_KEY";
 
+/// Reserved vault key for the startup-validated sentinel (#3651).
+///
+/// The sentinel is a known plaintext written under this key when a vault is
+/// first created (or backfilled on the first open of a legacy vault). Every
+/// subsequent unlock reads the sentinel and verifies its plaintext matches
+/// `SENTINEL_VALUE`; any mismatch means the unlocking key does not match the
+/// key the vault was originally encrypted with, and the boot path refuses to
+/// start so encrypted credentials are not silently lost.
+///
+/// Reserved namespace: callers MUST NOT write to this key directly. The
+/// `__sentinel__` prefix matches the pattern used by other reserved internal
+/// keys (TOTP recovery codes use `_recovery_codes`, totp_confirmed, …).
+pub const SENTINEL_KEY: &str = "__sentinel__";
+
+/// Versioned sentinel plaintext (#3651). The `v1` suffix lets future format
+/// migrations detect the sentinel scheme — bumping the version in this
+/// constant without touching the verification logic would intentionally fail
+/// the comparison and force a migration code path.
+pub const SENTINEL_VALUE: &str = "librefang-vault-sentinel-v1";
+
 /// Env var that, when set to `1` or `true` (case-insensitive), forces the
 /// vault to skip the OS keyring entirely and use the AES-256-GCM-wrapped
 /// file fallback at `<data_local_dir>/librefang/.keyring` (mode 0600).
@@ -308,8 +328,15 @@ impl CredentialVault {
             kb
         };
 
-        // Create empty vault file
+        // Create empty vault file with the startup sentinel pre-written
+        // (#3651). Doing it here means every fresh vault is born with the
+        // sentinel — only legacy vaults from before this commit will need
+        // backfill at unlock time.
         self.entries.clear();
+        self.entries.insert(
+            SENTINEL_KEY.to_string(),
+            Zeroizing::new(SENTINEL_VALUE.to_string()),
+        );
         self.unlocked = true;
         self.save(&key_bytes)?;
         self.cached_key = Some(key_bytes);
@@ -341,8 +368,31 @@ impl CredentialVault {
         self.entries.get(key).cloned()
     }
 
-    /// Store a secret in the vault.
-    pub fn set(&mut self, key: String, value: Zeroizing<String>) -> ExtensionResult<()> {
+    /// Iterate over every (key, value) pair, including reserved internal
+    /// keys. Used by the `librefang vault rotate-key` workflow which has to
+    /// re-encrypt the sentinel along with every user-facing entry.
+    ///
+    /// The values are exposed as `&str` references rather than cloned
+    /// `Zeroizing<String>` to avoid an unnecessary allocation pass — the
+    /// caller is expected to feed each value straight into the new vault's
+    /// `set_internal` and drop it.
+    pub fn iter_all_entries(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.entries.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+
+    /// Internal write that bypasses the reserved-key guard in [`Self::set`].
+    ///
+    /// Sole legitimate caller is the `librefang vault rotate-key` migration:
+    /// when re-encrypting an existing vault under a new master key, the
+    /// sentinel must be carried across alongside every other entry, but
+    /// the public `set` would reject it. Marked `pub(crate)` so external
+    /// crates can't accidentally bypass the guard — the rotate-key CLI
+    /// goes through [`Self::rewrap_with_new_key`] instead.
+    pub(crate) fn set_internal(
+        &mut self,
+        key: String,
+        value: Zeroizing<String>,
+    ) -> ExtensionResult<()> {
         if !self.unlocked {
             return Err(ExtensionError::VaultLocked);
         }
@@ -351,10 +401,81 @@ impl CredentialVault {
         self.save(&master_key)
     }
 
+    /// Re-encrypt the entire vault under a new master key (#3651 rotate-key).
+    ///
+    /// Preconditions:
+    /// - The vault is currently unlocked with the OLD master key.
+    /// - The OLD vault file exists at `self.path`.
+    ///
+    /// The implementation writes the re-encrypted vault to `<path>.new`
+    /// first (atomic temp file), `fsync`s it, then renames over the
+    /// original. The sentinel is deliberately re-written so the post-
+    /// rotation vault still verifies on next boot under the new key.
+    ///
+    /// Caller is responsible for:
+    /// - Validating that `new_master_key` is a 32-byte base64 value
+    ///   (use [`crate::vault::decode_master_key`] via the public CLI
+    ///   wrapper). Garbage-in, garbage-out otherwise.
+    /// - Persisting the new key (env var, OS keyring, file fallback) so
+    ///   the daemon can read it on next boot.
+    pub fn rewrap_with_new_key(
+        &mut self,
+        new_master_key: Zeroizing<[u8; 32]>,
+    ) -> ExtensionResult<()> {
+        if !self.unlocked {
+            return Err(ExtensionError::VaultLocked);
+        }
+        // Make sure the sentinel is present so the post-rotation vault
+        // verifies on next boot. Idempotent — a sentinel-bearing vault
+        // gets the same insert.
+        self.entries.insert(
+            SENTINEL_KEY.to_string(),
+            Zeroizing::new(SENTINEL_VALUE.to_string()),
+        );
+        // `save()` already does an atomic write via `<path>.tmp` + rename,
+        // mode 0600. Reusing it keeps the rotate-key path on the same
+        // proven IO code path — there is no separate "rotate" disk format.
+        self.save(&new_master_key)?;
+        // The cached_key now reflects the new master key for any
+        // subsequent ops on this vault instance (e.g. an immediate verify).
+        self.cached_key = Some(new_master_key);
+        Ok(())
+    }
+
+    /// Store a secret in the vault.
+    ///
+    /// Rejects writes to the reserved [`SENTINEL_KEY`] (#3651) so external
+    /// callers cannot corrupt the startup-validation contract by overwriting
+    /// the sentinel with arbitrary plaintext.
+    pub fn set(&mut self, key: String, value: Zeroizing<String>) -> ExtensionResult<()> {
+        if !self.unlocked {
+            return Err(ExtensionError::VaultLocked);
+        }
+        if key == SENTINEL_KEY {
+            return Err(ExtensionError::Vault(format!(
+                "Refusing to write reserved key {SENTINEL_KEY}; this slot is owned by \
+                 the vault startup-validation sentinel (#3651)."
+            )));
+        }
+        self.entries.insert(key, value);
+        let master_key = self.resolve_master_key()?;
+        self.save(&master_key)
+    }
+
     /// Remove a secret from the vault.
+    ///
+    /// Rejects deletes of the reserved [`SENTINEL_KEY`] (#3651): removing the
+    /// sentinel would silently regress to the pre-#3651 behaviour where a
+    /// wrong-key boot is undetectable.
     pub fn remove(&mut self, key: &str) -> ExtensionResult<bool> {
         if !self.unlocked {
             return Err(ExtensionError::VaultLocked);
+        }
+        if key == SENTINEL_KEY {
+            return Err(ExtensionError::Vault(format!(
+                "Refusing to remove reserved key {SENTINEL_KEY}; this slot is owned by \
+                 the vault startup-validation sentinel (#3651)."
+            )));
         }
         let removed = self.entries.remove(key).is_some();
         if removed {
@@ -365,7 +486,25 @@ impl CredentialVault {
     }
 
     /// List all keys in the vault (not values).
+    ///
+    /// Reserved internal keys (e.g. the #3651 [`SENTINEL_KEY`]) are filtered
+    /// out — callers should never see them via `list_keys` or be tempted to
+    /// remove them. Use [`Self::list_keys_including_internal`] when the
+    /// caller genuinely needs every entry (e.g. the rotate-key migration).
     pub fn list_keys(&self) -> Vec<&str> {
+        self.entries
+            .keys()
+            .filter(|k| k.as_str() != SENTINEL_KEY)
+            .map(|k| k.as_str())
+            .collect()
+    }
+
+    /// List every key in the vault, including reserved internal keys.
+    ///
+    /// Used by the `librefang vault rotate-key` workflow which must
+    /// re-encrypt the sentinel along with every user-facing entry so the
+    /// post-rotation vault still verifies on next boot.
+    pub fn list_keys_including_internal(&self) -> Vec<&str> {
         self.entries.keys().map(|k| k.as_str()).collect()
     }
 
@@ -379,6 +518,69 @@ impl CredentialVault {
         self.unlocked
     }
 
+    /// Verify (or backfill) the startup sentinel introduced in #3651.
+    ///
+    /// The vault MUST already be unlocked. Behavior by sentinel state:
+    ///
+    /// - **Absent** (legacy vault written before #3651, or fresh vault that
+    ///   has not yet been initialized) → write [`SENTINEL_VALUE`] under
+    ///   [`SENTINEL_KEY`]. One-time backfill; subsequent boots will see it
+    ///   and take the verify branch.
+    /// - **Present and matches [`SENTINEL_VALUE`]** → return `Ok(())`.
+    /// - **Present but does not match** → return
+    ///   [`ExtensionError::VaultKeyMismatch`]. This is structurally
+    ///   impossible if the unlocking key is correct: AES-GCM authenticates
+    ///   every entry, so a wrong key would have already failed at `unlock()`.
+    ///   This branch only fires if a future format change writes a new
+    ///   sentinel value (e.g. `v2`) — it forces an explicit migration
+    ///   instead of a silent boot.
+    ///
+    /// This method must be called from the daemon boot path **after** every
+    /// successful `unlock()` so a fresh-install / corrupt-vault distinction
+    /// is enforced before any credential is read or written.
+    pub fn verify_or_install_sentinel(&mut self) -> ExtensionResult<()> {
+        if !self.unlocked {
+            return Err(ExtensionError::VaultLocked);
+        }
+        match self.entries.get(SENTINEL_KEY) {
+            Some(stored) if stored.as_str() == SENTINEL_VALUE => {
+                debug!("Vault sentinel verified ({SENTINEL_VALUE})");
+                Ok(())
+            }
+            Some(other) => {
+                // Sentinel present but plaintext differs from the expected
+                // value. This is NOT a wrong-key case (AES-GCM would have
+                // failed at unlock); it means the sentinel scheme has been
+                // upgraded out from under this binary. Refuse to boot rather
+                // than mix v1 and v2 sentinels in the same vault file.
+                let sample = other.as_str().chars().take(40).collect::<String>();
+                Err(ExtensionError::VaultKeyMismatch {
+                    hint: format!(
+                        "vault sentinel value differs from expected ({SENTINEL_VALUE}); \
+                         saw {sample:?}. The vault may have been written by a newer \
+                         LibreFang release. Upgrade the daemon binary or restore the \
+                         vault file from backup."
+                    ),
+                })
+            }
+            None => {
+                // Legacy / fresh vault: write the sentinel so future boots
+                // take the verify branch. Idempotent — re-running on a
+                // post-backfill vault is a no-op via the matched branch.
+                info!(
+                    "Vault sentinel missing — backfilling {SENTINEL_VALUE} \
+                     (one-time migration for vaults predating #3651)"
+                );
+                let master_key = self.resolve_master_key()?;
+                self.entries.insert(
+                    SENTINEL_KEY.to_string(),
+                    Zeroizing::new(SENTINEL_VALUE.to_string()),
+                );
+                self.save(&master_key)
+            }
+        }
+    }
+
     /// Initialize a vault with an explicit master key (for testing / programmatic use).
     pub fn init_with_key(&mut self, master_key: Zeroizing<[u8; 32]>) -> ExtensionResult<()> {
         if self.path.exists() {
@@ -386,7 +588,14 @@ impl CredentialVault {
                 "Vault already exists. Delete it first to re-initialize.".to_string(),
             ));
         }
+        // Mirror `init()`: pre-write the #3651 sentinel so the boot-path
+        // verify branch sees a valid sentinel without needing a separate
+        // backfill pass.
         self.entries.clear();
+        self.entries.insert(
+            SENTINEL_KEY.to_string(),
+            Zeroizing::new(SENTINEL_VALUE.to_string()),
+        );
         self.unlocked = true;
         self.save(&master_key)?;
         self.cached_key = Some(master_key);
@@ -417,14 +626,19 @@ impl CredentialVault {
         Ok(())
     }
 
-    /// Number of entries.
+    /// Number of user-visible entries (excludes reserved internal keys
+    /// such as the #3651 [`SENTINEL_KEY`] so a freshly-init'd vault still
+    /// reports as empty to callers).
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.entries
+            .keys()
+            .filter(|k| k.as_str() != SENTINEL_KEY)
+            .count()
     }
 
-    /// Whether the vault is empty.
+    /// Whether the vault is empty (ignoring reserved internal keys).
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.len() == 0
     }
 
     // ── Internal ─────────────────────────────────────────────────────────
@@ -663,7 +877,13 @@ fn derive_key(master_key: &[u8; 32], salt: &[u8]) -> ExtensionResult<Zeroizing<[
 }
 
 /// Decode a base64 master key into raw bytes.
-fn decode_master_key(key_b64: &str) -> ExtensionResult<Zeroizing<[u8; 32]>> {
+///
+/// Public since #3651 so the `librefang vault rotate-key` CLI subcommand
+/// can validate `LIBREFANG_VAULT_KEY_OLD` / `LIBREFANG_VAULT_KEY_NEW` (or
+/// stdin-supplied values) using the exact same parser that production
+/// `unlock()` uses — guarantees that "the CLI accepted my new key" implies
+/// the daemon will accept it on next boot.
+pub fn decode_master_key(key_b64: &str) -> ExtensionResult<Zeroizing<[u8; 32]>> {
     let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, key_b64)
         .map_err(|e| ExtensionError::Vault(format!("Key decode failed: {e}")))?;
     if bytes.len() != 32 {
@@ -2312,5 +2532,195 @@ mod tests {
     fn platform_default_skips_keyring_only_on_macos() {
         let expected = !cfg!(target_os = "macos");
         assert_eq!(default_use_os_keyring_for_platform(), expected);
+    }
+
+    // -----------------------------------------------------------------------
+    // Sentinel tests (#3651)
+    // -----------------------------------------------------------------------
+
+    /// A freshly-init'd vault has the sentinel pre-written and verifies
+    /// cleanly without any backfill.
+    #[test]
+    fn sentinel_present_after_init_with_key() {
+        let (_dir, mut vault) = test_vault();
+        let key = random_key();
+        vault.init_with_key(key).unwrap();
+
+        // Sentinel present in the underlying map …
+        assert_eq!(
+            vault.entries.get(SENTINEL_KEY).map(|v| v.as_str()),
+            Some(SENTINEL_VALUE),
+            "init must write the sentinel"
+        );
+        // … but hidden from list_keys / len so users still see "empty".
+        assert!(vault.list_keys().is_empty());
+        assert_eq!(vault.len(), 0);
+        assert!(vault.is_empty());
+        // verify_or_install_sentinel is a no-op on the present-and-correct path.
+        vault.verify_or_install_sentinel().unwrap();
+    }
+
+    /// A "legacy" vault (one written before #3651, simulated by deleting the
+    /// sentinel from the entries map and re-saving) gets the sentinel
+    /// backfilled on first verify call.
+    #[test]
+    fn sentinel_backfilled_on_legacy_vault() {
+        let (dir, mut vault) = test_vault();
+        let key = random_key();
+        vault.init_with_key(key.clone()).unwrap();
+
+        // Simulate a pre-#3651 vault: pop the sentinel and re-save with the
+        // same key. We can't go through `remove()` (which would reject the
+        // reserved key) so we reach in directly — exactly what production
+        // legacy vaults look like on disk.
+        vault.entries.remove(SENTINEL_KEY);
+        let mk = vault.resolve_master_key().unwrap();
+        vault.save(&mk).unwrap();
+        drop(vault);
+
+        // Re-open as a fresh instance and run the verify-or-install path.
+        let mut vault2 = CredentialVault::new(dir.path().join("vault.enc"));
+        vault2.unlock_with_key(key.clone()).unwrap();
+        assert!(
+            vault2.entries.get(SENTINEL_KEY).is_none(),
+            "precondition: simulated legacy vault must have no sentinel"
+        );
+        vault2.verify_or_install_sentinel().unwrap();
+        assert_eq!(
+            vault2.entries.get(SENTINEL_KEY).map(|v| v.as_str()),
+            Some(SENTINEL_VALUE),
+            "backfill must persist the sentinel in memory"
+        );
+
+        // Re-open *again* — sentinel must now be on disk.
+        drop(vault2);
+        let mut vault3 = CredentialVault::new(dir.path().join("vault.enc"));
+        vault3.unlock_with_key(key).unwrap();
+        assert_eq!(
+            vault3.entries.get(SENTINEL_KEY).map(|v| v.as_str()),
+            Some(SENTINEL_VALUE),
+            "backfill must persist the sentinel to disk"
+        );
+    }
+
+    /// A sentinel whose plaintext disagrees with `SENTINEL_VALUE` triggers
+    /// `VaultKeyMismatch`. This is the "future scheme version" branch — a
+    /// wrong-key boot would already have failed at AES-GCM decrypt time.
+    #[test]
+    fn sentinel_mismatch_returns_vault_key_mismatch() {
+        let (_dir, mut vault) = test_vault();
+        let key = random_key();
+        vault.init_with_key(key).unwrap();
+
+        // Tamper with the sentinel plaintext to simulate a future v2 sentinel.
+        vault.entries.insert(
+            SENTINEL_KEY.to_string(),
+            Zeroizing::new("librefang-vault-sentinel-v999".to_string()),
+        );
+
+        let err = vault.verify_or_install_sentinel().unwrap_err();
+        match err {
+            ExtensionError::VaultKeyMismatch { hint } => {
+                assert!(
+                    hint.contains("sentinel"),
+                    "hint should mention the sentinel, got: {hint}"
+                );
+            }
+            other => panic!("expected VaultKeyMismatch, got {other:?}"),
+        }
+    }
+
+    /// External callers must not be able to overwrite the sentinel via the
+    /// public `set` API — that would silently regress the boot-validation
+    /// contract.
+    #[test]
+    fn set_rejects_reserved_sentinel_key() {
+        let (_dir, mut vault) = test_vault();
+        let key = random_key();
+        vault.init_with_key(key).unwrap();
+
+        let err = vault
+            .set(
+                SENTINEL_KEY.to_string(),
+                Zeroizing::new("attacker-controlled".to_string()),
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, ExtensionError::Vault(ref m) if m.contains("Refusing to write reserved key")),
+            "set must reject SENTINEL_KEY, got: {err:?}"
+        );
+    }
+
+    /// External callers must not be able to remove the sentinel via the
+    /// public `remove` API.
+    #[test]
+    fn remove_rejects_reserved_sentinel_key() {
+        let (_dir, mut vault) = test_vault();
+        let key = random_key();
+        vault.init_with_key(key).unwrap();
+
+        let err = vault.remove(SENTINEL_KEY).unwrap_err();
+        assert!(
+            matches!(err, ExtensionError::Vault(ref m) if m.contains("Refusing to remove reserved key")),
+            "remove must reject SENTINEL_KEY, got: {err:?}"
+        );
+        // Sentinel must still be present after the rejected remove.
+        assert!(vault.entries.contains_key(SENTINEL_KEY));
+    }
+
+    /// `rewrap_with_new_key` re-encrypts every entry including the sentinel
+    /// so the rotated vault verifies on next boot under the new key.
+    #[test]
+    fn rewrap_with_new_key_preserves_entries_and_sentinel() {
+        let (dir, mut vault) = test_vault();
+        let key_old = random_key();
+        let key_new = random_key();
+        assert_ne!(key_old.as_ref(), key_new.as_ref());
+
+        vault.init_with_key(key_old.clone()).unwrap();
+        vault
+            .set("API_KEY".to_string(), Zeroizing::new("secret-1".to_string()))
+            .unwrap();
+        vault
+            .set("DB_URL".to_string(), Zeroizing::new("secret-2".to_string()))
+            .unwrap();
+
+        // Rotate to the new key.
+        vault.rewrap_with_new_key(key_new.clone()).unwrap();
+        drop(vault);
+
+        // New key must work and recover every entry.
+        let mut vault2 = CredentialVault::new(dir.path().join("vault.enc"));
+        vault2.unlock_with_key(key_new).unwrap();
+        assert_eq!(vault2.get("API_KEY").unwrap().as_str(), "secret-1");
+        assert_eq!(vault2.get("DB_URL").unwrap().as_str(), "secret-2");
+        // Sentinel survived the rotation.
+        vault2.verify_or_install_sentinel().unwrap();
+
+        // Old key must NO LONGER work — the file has been re-encrypted.
+        let mut vault3 = CredentialVault::new(dir.path().join("vault.enc"));
+        assert!(
+            vault3.unlock_with_key(key_old).is_err(),
+            "rotated vault must reject the old master key"
+        );
+    }
+
+    /// `iter_all_entries` exposes the sentinel so the rotate-key migration
+    /// can reason about the full set of slots; `list_keys` does not.
+    #[test]
+    fn iter_all_entries_includes_sentinel_but_list_keys_does_not() {
+        let (_dir, mut vault) = test_vault();
+        vault.init_with_key(random_key()).unwrap();
+        vault
+            .set("USER_KEY".to_string(), Zeroizing::new("v".to_string()))
+            .unwrap();
+
+        let all: Vec<&str> = vault.iter_all_entries().map(|(k, _)| k).collect();
+        assert!(all.contains(&SENTINEL_KEY));
+        assert!(all.contains(&"USER_KEY"));
+
+        let user_visible = vault.list_keys();
+        assert!(!user_visible.contains(&SENTINEL_KEY));
+        assert!(user_visible.contains(&"USER_KEY"));
     }
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -2397,6 +2397,74 @@ impl LibreFangKernel {
         // path that touches MCP OAuth tokens. Idempotent: first call wins.
         librefang_extensions::vault::CredentialVault::init_with_config(config.vault.use_os_keyring);
 
+        // Vault startup-sentinel verification (#3651).
+        //
+        // If a vault file already exists, refuse to boot when it cannot be
+        // unlocked with the resolved master key OR when the sentinel
+        // plaintext does not match. Pre-fix, the daemon would silently
+        // boot with the wrong key and every subsequent vault read would
+        // fail with a generic "Decryption failed" log line — operators
+        // never learned the root cause. The sentinel turns that into a
+        // single, actionable error at boot time.
+        //
+        // If the vault does not yet exist we say nothing — first-run / CLI
+        // bootstrap creates it later via `init()`, which writes the
+        // sentinel automatically.
+        let vault_path = config.home_dir.join("vault.enc");
+        if vault_path.exists() {
+            let mut vault =
+                librefang_extensions::vault::CredentialVault::new(vault_path.clone());
+            match vault.unlock() {
+                Ok(()) => {
+                    if let Err(e) = vault.verify_or_install_sentinel() {
+                        match e {
+                            librefang_extensions::ExtensionError::VaultKeyMismatch { hint } => {
+                                return Err(KernelError::BootFailed(format!(
+                                    "Vault key mismatch — refusing to boot. {hint} \
+                                     Recovery: restore the original LIBREFANG_VAULT_KEY env var, \
+                                     restore the vault file from backup, or run \
+                                     `librefang vault rotate-key` if you intended to rotate."
+                                )));
+                            }
+                            other => {
+                                // Sentinel backfill failed for some other
+                                // reason (disk full, permissions). Surface
+                                // it but don't pretend it's a key mismatch.
+                                return Err(KernelError::BootFailed(format!(
+                                    "Vault sentinel write failed: {other}"
+                                )));
+                            }
+                        }
+                    }
+                }
+                Err(librefang_extensions::ExtensionError::VaultLocked) => {
+                    // No master key available at all — don't refuse boot
+                    // (some deployments run without a vault and rely on env
+                    // vars), but warn loudly so the operator notices the
+                    // mismatch between "vault file exists" and "no key".
+                    warn!(
+                        "Vault file exists at {:?} but no master key is \
+                         resolvable (LIBREFANG_VAULT_KEY unset and OS keyring \
+                         empty). Encrypted credentials will be unreadable until \
+                         the key is restored.",
+                        vault_path
+                    );
+                }
+                Err(e) => {
+                    // Non-locked unlock failure is almost always wrong-key
+                    // (AES-GCM decrypt fails). Refuse to boot — same
+                    // rationale as the sentinel-mismatch branch above.
+                    return Err(KernelError::BootFailed(format!(
+                        "Vault unlock failed at boot ({e}). This usually means \
+                         LIBREFANG_VAULT_KEY does not match the key the vault \
+                         was encrypted with. Recovery: restore the original \
+                         env var, restore the vault file from backup, or run \
+                         `librefang vault rotate-key` if you intended to rotate."
+                    )));
+                }
+            }
+        }
+
         match config.mode {
             KernelMode::Stable => {
                 info!("Booting LibreFang kernel in STABLE mode — conservative defaults enforced");


### PR DESCRIPTION
Closes #3651.

## Summary

End-to-end fix for the vault key-recovery problem: detect mismatched
`LIBREFANG_VAULT_KEY` at boot, ship a documented `vault rotate-key`
workflow, and stop swallowing vault crypto failures with `let _ = ...`.

Three pieces, in one commit so the boot path stays consistent with the
sentinel + audit + rotation contract:

### A. Startup sentinel (`librefang-extensions`)

- `CredentialVault::init` / `init_with_key` now pre-write a versioned
  plaintext (`librefang-vault-sentinel-v1`) under reserved key
  `__sentinel__`.
- New `verify_or_install_sentinel()` reads + checks the sentinel on
  every boot. It backfills it once for legacy vaults predating this
  commit; on a plaintext mismatch it returns the new
  `ExtensionError::VaultKeyMismatch { hint }`.
- `set` / `remove` reject the reserved key from external callers;
  `list_keys` / `len` / `is_empty` filter it out so user-facing
  surfaces (CLI `vault list`, dotenv loader, etc.) don't see it.
- `LibreFangKernel::boot_with_config` calls `verify_or_install_sentinel`
  and refuses to boot with a structured `KernelError::BootFailed`
  on mismatch. Pre-fix, the daemon would silently boot and every
  subsequent vault read would fail with a generic "Decryption
  failed" log line — operators never learned the root cause was a
  mismatched env var.

### B. Audit log on crypto failure

Replaced every `let _ = provider.vault_*(...)` (the exact pattern
called out in the issue body) with explicit
`if let Err(e) = ... { tracing::error!(target: "audit", op, key, error, ...) }`:

- `crates/librefang-api/src/routes/mcp_auth.rs` — PKCE cleanup +
  Dynamic Client Registration persistence.
- `crates/librefang-api/src/routes/skills.rs` — MCP server
  uninstall path.

Behavior on the happy path is intentionally unchanged (these are
cleanup paths that shouldn't abort the parent operation); only the
swallowed audit signal is now visible.

### C. `librefang vault rotate-key` CLI

New `VaultCommands::RotateKey { from_stdin }` subcommand. Workflow:

```
LIBREFANG_VAULT_KEY_OLD=$(cat .key.old) \
LIBREFANG_VAULT_KEY_NEW=$(cat .key.new) \
  librefang vault rotate-key

# or, with the new key piped via stdin to keep it out of shell history:
echo "$NEW_KEY" | LIBREFANG_VAULT_KEY_OLD="$OLD_KEY" \
  librefang vault rotate-key --from-stdin
```

- Both keys validated as 32-byte base64 via the **same**
  `decode_master_key` parser the daemon uses, so anything the CLI
  accepts the daemon will accept. The "32 ASCII chars ≠ 32 bytes"
  CLAUDE.md gotcha is enforced up-front.
- Refuses identical OLD/NEW; refuses missing/empty keys; refuses
  unlock failure under OLD (with an actionable hint).
- Atomic file rewrite via the existing `CredentialVault::save` path
  (`<path>.tmp` + `fsync` + `rename`). No half-rotated state on disk
  if the process dies mid-way.
- Sentinel is preserved across rotation so the post-rotation vault
  still verifies cleanly under the new key on next boot.
- New public APIs from `librefang-extensions::vault`:
  `decode_master_key`, `rewrap_with_new_key`, `iter_all_entries`,
  `list_keys_including_internal`. (No new external dependencies.)
- en + zh-CN i18n strings added.
- Integration test at `crates/librefang-cli/tests/vault_rotate_key.rs`:
  vault A → store entries → rotate to B → reads succeed under B and
  fail under A; sentinel round-trips.

## Concurrent work — likely conflict with #4491

PR #4491 (`perf/3598-vault-cache`) wraps the vault in
`OnceLock<Arc<RwLock<CredentialVault>>>` for caching. This PR touches
the same `CredentialVault` surface (new methods, new sentinel slot,
boot-path unlock) and will likely **merge-conflict** with #4491 in:
- `crates/librefang-extensions/src/vault.rs` (struct + `init`/`unlock`
  surface, new methods).
- `crates/librefang-kernel/src/kernel/mod.rs` (boot-path adds an
  `unlock` call before the existing TOTP unlock).

The conflicts are mechanical (this PR adds methods + a boot check;
#4491 changes the storage of the same struct) — whichever lands
first, the second can resolve by re-applying the new methods on top
of the cache wrapper. Note that the sentinel write/verify is not a
hot path (boot only), so the cache wrapper does not need to be aware
of it.

## Build / Test

> Local cargo absent on build host; relying on CI for full
> `cargo check --workspace --lib`, `cargo clippy`, and `cargo test
> -p librefang-extensions -p librefang-cli -p librefang-kernel`.

Manual review checklist (test logic, not execution):
- New unit tests in `crates/librefang-extensions/src/vault.rs`
  (`tests` module) cover sentinel-on-init, legacy-backfill,
  mismatch → `VaultKeyMismatch`, set/remove guards, rewrap
  round-trip, and `iter_all_entries` vs `list_keys` visibility.
- New integration test `crates/librefang-cli/tests/vault_rotate_key.rs`
  exercises the full A → B rotation invariant.
- Existing `vault_init_and_roundtrip` / `vault_list_keys` /
  `vault_wrong_key_fails` / `clear_tokens_*` unchanged — sentinel is
  filtered from `list_keys` / `len` so no expected counts shift.

## Test plan

- [ ] CI: `cargo check --workspace --lib` passes
- [ ] CI: `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] CI: `cargo test -p librefang-extensions` passes (covers all new
      sentinel + reserved-key + rewrap units)
- [ ] CI: `cargo test -p librefang-cli` passes (covers
      `tests/vault_rotate_key.rs` end-to-end)
- [ ] CI: `cargo test -p librefang-kernel` passes (boot-path
      unchanged for fresh-tempdir tests because `vault.enc` doesn't
      exist there)
- [ ] Manual smoke (operator, post-merge):
      - `LIBREFANG_VAULT_KEY=<wrong>` against an existing vault →
        daemon refuses to boot with the new actionable error
      - `LIBREFANG_VAULT_KEY_OLD=… LIBREFANG_VAULT_KEY_NEW=…
        librefang vault rotate-key` → success message; daemon boots
        cleanly under new key; refuses to boot under old key
