### PR TITLE
fix: clear baseline main-red blocking 24h merged PR queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,6 +4377,7 @@ version = "2026.5.2-beta8"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "bytes",
  "chrono",
  "chrono-tz",
  "cron",
@@ -4425,6 +4426,7 @@ name = "librefang-kernel-handle"
 version = "2026.5.2-beta8"
 dependencies = [
  "async-trait",
+ "bytes",
  "librefang-types",
  "serde_json",
  "tokio",
@@ -4541,6 +4543,7 @@ version = "2026.5.2-beta8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "dashmap",
  "dirs 6.0.0",

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -151,11 +151,13 @@ async fn activate_prompt_version(
     }
     // Read back the activated version so the caller can patch caches in place
     // without an extra round-trip. If the version vanished between write and
-    // read (narrow race — concurrent delete), fall back to the legacy ack
+    // read (narrow race — concurrent delete) or the kernel implementation
+    // doesn't expose it (e.g. mock kernels in tests, or stores that accept
+    // activate without persisting versions), fall back to the legacy ack
     // envelope so the activation still appears successful.
     match state.kernel.get_prompt_version(&id) {
-        Ok(version) => Json(version).into_response(),
-        Err(_) => Json(serde_json::json!({"success": true})).into_response(),
+        Ok(Some(version)) => Json(version).into_response(),
+        Ok(None) | Err(_) => Json(serde_json::json!({"success": true})).into_response(),
     }
 }
 

--- a/crates/librefang-api/tests/prompts_routes_integration.rs
+++ b/crates/librefang-api/tests/prompts_routes_integration.rs
@@ -214,15 +214,14 @@ async fn activate_prompt_version_with_agent_id_in_body_succeeds() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "body={body:?}");
-    // #4365: activate returns the full PromptVersion entity when one exists.
-    // This test exercises the activate path against a non-persisted VERSION_ID
-    // (the in-memory store accepts the activate UPDATE without error even
-    // though the row doesn't exist), so the read-back yields `Ok(None)` and
-    // the handler falls back to the legacy ack envelope. Either response
-    // shape is acceptable — both indicate the activation succeeded.
-    assert!(
-        body["id"] == VERSION_ID || body["success"] == true,
-        "expected PromptVersion entity or ack envelope, got body={body:?}"
+    // The mock kernel has no real PromptStore, so activate writes succeed but
+    // the subsequent read-back returns Ok(None). The handler falls back to the
+    // legacy ack envelope. Assert the ack shape explicitly — the entity-return
+    // path from #4365 requires a real PromptStore-backed fixture to verify.
+    assert_eq!(
+        body["success"],
+        serde_json::json!(true),
+        "expected ack envelope {{success:true}}, got body={body:?}"
     );
 }
 

--- a/crates/librefang-api/tests/prompts_routes_integration.rs
+++ b/crates/librefang-api/tests/prompts_routes_integration.rs
@@ -214,8 +214,16 @@ async fn activate_prompt_version_with_agent_id_in_body_succeeds() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "body={body:?}");
-    // #4365: activate now returns the full PromptVersion entity, not an ack envelope.
-    assert_eq!(body["id"], VERSION_ID, "body={body:?}");
+    // #4365: activate returns the full PromptVersion entity when one exists.
+    // This test exercises the activate path against a non-persisted VERSION_ID
+    // (the in-memory store accepts the activate UPDATE without error even
+    // though the row doesn't exist), so the read-back yields `Ok(None)` and
+    // the handler falls back to the legacy ack envelope. Either response
+    // shape is acceptable — both indicate the activation succeeded.
+    assert!(
+        body["id"] == VERSION_ID || body["success"] == true,
+        "expected PromptVersion entity or ack envelope, got body={body:?}"
+    );
 }
 
 // ----- experiments -----

--- a/crates/librefang-api/tests/skills_routes_test.rs
+++ b/crates/librefang-api/tests/skills_routes_test.rs
@@ -135,7 +135,12 @@ async fn skills_list_starts_empty() {
 async fn skills_list_returns_installed_skill_metadata() {
     let h = boot().await;
     install_skill(h.home(), "alpha", &["data"]);
-    install_skill(h.home(), "beta", &["linux", "writing"]);
+    // Use only non-platform tags. `librefang_skills::registry::skill_matches_platform`
+    // (`registry.rs:68`) filters out skills whose tags include a platform hint
+    // (`"macos"` / `"linux"` / `"windows"`) when running on a different OS, so
+    // a tag set like `["linux", "writing"]` would silently drop "beta" on
+    // macOS and Windows runners and the test would observe `total = 1`.
+    install_skill(h.home(), "beta", &["writing"]);
     h._state.kernel.reload_skills();
 
     let (status, body) = json_request(&h, Method::GET, "/api/skills", None).await;
@@ -242,12 +247,16 @@ async fn skills_detail_returns_full_manifest() {
     assert_eq!(tools.len(), 1);
     assert_eq!(tools[0]["name"], "detail-skill_tool");
     // `path` must be the absolute on-disk skill dir — dashboards use it
-    // to surface a "open in editor" affordance.
+    // to surface a "open in editor" affordance. Normalize the platform
+    // separator (Windows reports `...\skills\detail-skill`, sometimes with
+    // a `\\?\` UNC prefix) before comparing against the cross-platform
+    // forward-slash suffix.
+    let normalized_path = body["path"]
+        .as_str()
+        .unwrap_or("")
+        .replace('\\', "/");
     assert!(
-        body["path"]
-            .as_str()
-            .unwrap_or("")
-            .ends_with("skills/detail-skill"),
+        normalized_path.ends_with("skills/detail-skill"),
         "path should point at the skill dir: {body:?}"
     );
     // Evolution metadata block is always present, even for fresh installs.

--- a/crates/librefang-api/tests/skills_routes_test.rs
+++ b/crates/librefang-api/tests/skills_routes_test.rs
@@ -253,7 +253,7 @@ async fn skills_detail_returns_full_manifest() {
     // forward-slash suffix.
     let normalized_path = body["path"]
         .as_str()
-        .unwrap_or("")
+        .expect("path field present and is a string")
         .replace('\\', "/");
     assert!(
         normalized_path.ends_with("skills/detail-skill"),

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -388,7 +388,7 @@ impl CredentialVault {
     /// the public `set` would reject it. Marked `pub(crate)` so external
     /// crates can't accidentally bypass the guard — the rotate-key CLI
     /// goes through [`Self::rewrap_with_new_key`] instead.
-    #[allow(dead_code)] // intentional public-crate hook for the rotate-key migration; see doc above.
+    #[expect(dead_code, reason = "public-crate hook for rotate-key migration; see doc above")]
     pub(crate) fn set_internal(
         &mut self,
         key: String,

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -388,6 +388,7 @@ impl CredentialVault {
     /// the public `set` would reject it. Marked `pub(crate)` so external
     /// crates can't accidentally bypass the guard — the rotate-key CLI
     /// goes through [`Self::rewrap_with_new_key`] instead.
+    #[allow(dead_code)] // intentional public-crate hook for the rotate-key migration; see doc above.
     pub(crate) fn set_internal(
         &mut self,
         key: String,

--- a/crates/librefang-kernel/Cargo.toml
+++ b/crates/librefang-kernel/Cargo.toml
@@ -18,6 +18,7 @@ librefang-llm-driver = { path = "../librefang-llm-driver" }
 librefang-wire = { path = "../librefang-wire" }
 librefang-channels = { path = "../librefang-channels", default-features = false }
 tokio = { workspace = true }
+bytes = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }

--- a/crates/librefang-runtime/Cargo.toml
+++ b/crates/librefang-runtime/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 base64 = { workspace = true }
+bytes = { workspace = true }
 ed25519-dalek = { version = "2", features = ["alloc"] }
 sha2 = { workspace = true }
 hmac = { workspace = true }


### PR DESCRIPTION
Refs #4457.

## Why

A 24h audit (script: `gh api .../check-runs` over 100 merged PRs)
showed **62 of 100 merged PRs** landed with red `Test/Quality` CI on
their head SHA. But the failure set is tiny — only **9 distinct tests**
recur across all 62 PRs:

- 5 already covered by **PR #4517** (`fix: post-merge regressions for
  #3571 #3603 #3692 #3776`): the auto_dream i18n trio + the two
  route_smoke discovery assertions.
- **4 baseline pre-existing fails** that no recent PR introduced and
  that affect every queued PR:
  - `prompts_routes_integration::activate_prompt_version_with_agent_id_in_body_succeeds`
    (Ubuntu/macOS/Windows)
  - `skills_routes_test::skills_list_returns_installed_skill_metadata`
    (macOS/Windows; passes Ubuntu)
  - `skills_routes_test::skills_detail_returns_full_manifest`
    (Windows only)
  - 2 baseline build errors that block compilation locally and on a
    cold-cache CI runner

This PR closes the 4 baseline items so once #4517 also lands, the next
PR up the queue inherits a green main.

## What

### Commit 1 — `fix(api): handle Ok(None) from get_prompt_version after activate`

Cherry-picked from existing orphan branch
`claude/parallel-issue-agents-vCuYv-issue-4457` (commit `5c9ecfd3`).
`activate_prompt_version` was matching `Ok(version)` where `version` is
`Option<PromptVersion>` and serializing `None` as JSON `null` in the
non-persisted-fixture path. Pattern-match `Ok(Some(v))` for the entity
path and fold `Ok(None)` into the existing legacy ack envelope.

### Commit 2 — `fix(extensions,kernel,runtime): unblock baseline cargo build`

Two compile errors visible on a clean clone of `origin/main`:

- `librefang-extensions::vault::CredentialVault::set_internal` — added
  by #3651 (PR #4514) as a `pub(crate)` rotate-key escape hatch but
  has no live caller yet. After #3554 (PR #4512) tightened the
  `-D warnings` clamp, `dead_code` becomes a hard error. Suppress the
  lint locally — the function's doc-comment documents the intent so
  deletion would lose the design note.
- `librefang-runtime::tool_runner` and `librefang-kernel::kernel::mod`
  call `bytes::Bytes::from(...)` after #3553 (PR #4505), but neither
  crate declared `bytes` in its `[dependencies]`. The crate is already
  declared at workspace level (`Cargo.toml:112 bytes = "1"`); add
  `bytes = { workspace = true }` to both crates, mirroring
  `librefang-kernel-handle/Cargo.toml:11`.

Cargo.lock is auto-updated by cargo on first resolve.

### Commit 3 — `fix(test): clear baseline-red skills_routes_test failures`

Both failures are in test fixtures, not the production handlers:

- `skills_list_returns_installed_skill_metadata` installs `beta` with
  tag set `["linux", "writing"]`. `skill_matches_platform`
  (`registry.rs:68`) treats `"linux"` as a platform restriction and
  silently drops `beta` on macOS / Windows runners, so
  `body["total"] == 2` observes `Number(1)` and panics. Use
  `["writing"]` (no platform hint).
- `skills_detail_returns_full_manifest` asserts
  `body["path"].ends_with("skills/detail-skill")`. On Windows the
  on-disk path is `\\?\C:\…\skills\detail-skill` (backslash + UNC
  prefix), so the forward-slash suffix never matches. Normalize
  separators to `/` before the comparison.

## Out of scope

- `api_integration_test::list_active_hands_includes_definition_metadata`
  appeared in the 24h failure tally (18 early PRs) but already passes
  on the most recent runs — no action needed.

## Verification

Local `cargo test -p librefang-api` cold-build was killed by the
session timeout repeatedly (kernel mod is 19k LoC, ~10 min cold).
Each commit is low-risk and CI-validatable in isolation:

- Commit 1 is a verbatim cherry-pick of an upstream commit that ran
  on its own branch.
- Commit 2 is dep-toml only + a single `#[allow(dead_code)]`
  attribute — zero behavior change.
- Commit 3 only touches test code, with reasoning above.

Relying on this PR's CI run to validate end-to-end. If anything
unexpected surfaces, follow up on a per-finding basis.