### PR TITLE
ci(coverage): surface failing tests via step summary + always-on artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -73,13 +73,39 @@ jobs:
         env:
           RUST_TEST_THREADS: "1"
         run: |
+          # pipefail: tee always exits 0, so without this the cargo failure
+          # would be masked and the job would falsely succeed.
+          set -o pipefail
+          # Tee combined stdout+stderr to a log so a follow-up step can
+          # surface failing test names even when the run-log download API
+          # is admin-only (HTTP 403 for non-admin readers).
           cargo llvm-cov nextest \
             --workspace \
             --no-fail-fast \
             --lcov \
-            --output-path lcov.info
+            --output-path lcov.info 2>&1 | tee nextest-output.log
+
+      - name: Surface failing tests
+        if: failure()
+        run: |
+          {
+            echo "## Failing tests (nextest)"
+            echo ""
+            echo '```'
+            # nextest prints lines like "        FAIL [   0.123s] crate test::name"
+            # in the run summary; TIMEOUT and LEAK are the other terminal states.
+            grep -E '^\s+(FAIL|TIMEOUT|LEAK)\b' nextest-output.log \
+              || echo "(no FAIL/TIMEOUT/LEAK lines found — inspect the nextest-output artifact)"
+            echo '```'
+            echo ""
+            echo "### Last 200 lines of nextest output"
+            echo '```'
+            tail -n 200 nextest-output.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate coverage summary
+        if: success()
         run: |
           cargo llvm-cov report --summary-only | tee coverage-summary.txt
           {
@@ -90,7 +116,17 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Upload nextest output
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nextest-output
+          path: nextest-output.log
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Upload LCOV artifact
+        if: success()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-lcov


### PR DESCRIPTION
## Summary

- The `Coverage` workflow has been red on every run since #4443 introduced it. The error annotation says only `Process completed with exit code 100.` and the run-log download API returns `HTTP 403: Must have admin rights to Repository.` for read-level collaborators, so non-admins can't see which tests are failing.
- This PR makes the failure self-describing without admin rights:
  - Tee combined `stdout`+`stderr` from `cargo llvm-cov nextest` into `nextest-output.log` with `set -o pipefail` so cargo's exit status survives the pipe.
  - On failure, grep `FAIL` / `TIMEOUT` / `LEAK` lines and the trailing 200 lines of nextest output into `$GITHUB_STEP_SUMMARY` (publicly readable on the run page).
  - Always upload `nextest-output.log` as an artifact (gated `if: always()`), so failed runs leave a downloadable trace.
  - Gate the existing `Generate coverage summary` and `Upload LCOV artifact` steps on `success()` so they no-op when tests didn't pass instead of cascading their own failures.
- Same `cargo nextest run --workspace --no-fail-fast` invocation in `ci.yml` is green on the same SHA, so the failure is specific to coverage instrumentation. Once this PR lands and the next Coverage run posts the failing test list, a follow-up PR will fix the underlying tests.

## Test plan

- [ ] Coverage workflow on this PR runs to completion and posts a `## Failing tests (nextest)` section in the run-page step summary listing the actual failing tests.
- [ ] `nextest-output` artifact is attached to the run.
- [ ] No regressions in the rest of the Coverage steps (the `Generate coverage summary` / `Upload LCOV artifact` steps stay no-op on failure, run normally on success).
