### PR TITLE
test: align kill/delete + channel-creds assertions with #3509 / #3507

### DIFF
--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -1213,7 +1213,12 @@ async fn test_invalid_agent_id_returns_400() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_kill_nonexistent_agent_returns_404() {
+async fn test_kill_nonexistent_agent_is_idempotent() {
+    // #3509: DELETE on a valid UUID that doesn't exist no longer returns 404
+    // — that status is now reserved for the malformed-UUID case alone, and
+    // a kill of an already-absent agent succeeds with a tagged body so
+    // retried/replayed deletes by clients (network blip, dashboard double
+    // click) don't surface a phantom error.
     let server = start_test_server().await;
     let client = reqwest::Client::new();
 
@@ -1223,7 +1228,9 @@ async fn test_kill_nonexistent_agent_returns_404() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 404);
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "already-deleted");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -293,10 +293,11 @@ async fn channels_test_unknown_channel_returns_404() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn channels_test_known_channel_with_no_creds_reports_missing_env() {
-    // The handler returns 200 even when credentials are missing — the
-    // diagnostic lives in the JSON body so the dashboard can render it
-    // without a separate error pipeline. Telegram requires
-    // `TELEGRAM_BOT_TOKEN`, which is not set in this test process.
+    // #3507 reshaped this handler so the HTTP status reflects the actual
+    // outcome — `412 Precondition Failed` for missing credentials, while
+    // the JSON body shape is unchanged so dashboards branching on
+    // `body.status` keep working. Previously this returned 200 + body
+    // diagnostic, which made `fetch().ok` lie to clients.
     //
     // We deliberately do not assert on a specific env var name to avoid
     // coupling the test to the registry; we only require the handler to
@@ -317,7 +318,7 @@ async fn channels_test_known_channel_with_no_creds_reports_missing_env() {
 
     let h = boot().await;
     let (status, body) = json_request(&h, Method::POST, "/api/channels/telegram/test", None).await;
-    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert_eq!(status, StatusCode::PRECONDITION_FAILED, "{body:?}");
     assert_eq!(
         body["status"], "error",
         "missing creds must surface as status=error: {body}"

--- a/crates/librefang-testing/src/tests.rs
+++ b/crates/librefang-testing/src/tests.rs
@@ -184,9 +184,15 @@ system_prompt = "You are a test bot."
     );
 }
 
-/// Tests DELETE /api/agents/{id} — deleting a nonexistent agent should return an error.
+/// Tests DELETE /api/agents/{id} — deleting a nonexistent agent is idempotent (#3509).
+///
+/// 404 is reserved for the malformed-UUID case; a valid UUID that doesn't
+/// resolve to an agent succeeds with `200 OK` and a tagged body so retried
+/// deletes (network blip, dashboard double-click) don't surface a phantom
+/// error. The previous "DELETE → 404" assertion contradicted that contract
+/// and was the upstream cause of the `Test / *` red on `main`.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_delete_agent_not_found() {
+async fn test_delete_nonexistent_agent_is_idempotent() {
     let app = TestAppState::new();
     let router = app.router();
 
@@ -195,11 +201,10 @@ async fn test_delete_agent_not_found() {
     let req = test_request(Method::DELETE, &path, None);
     let resp = router.oneshot(req).await.expect("request failed");
 
-    // Deleting a nonexistent agent should return 404
-    let json = assert_json_error(resp, StatusCode::NOT_FOUND).await;
-    assert!(
-        json.get("error").is_some(),
-        "DELETE 404 response should contain an error field, got: {json}"
+    let json = assert_json_ok(resp).await;
+    assert_eq!(
+        json["status"], "already-deleted",
+        "missing-agent DELETE must surface idempotency tag, got: {json}"
     );
 }
 


### PR DESCRIPTION
## Summary

`Test / Ubuntu`, `Test / macOS`, and `Workspace coverage (llvm-cov)` have all been red on `main` since #3509 (idempotent agent delete) and #3507 (channel-test status semantics) landed — the handlers were updated but the matching tests weren't. The `gh run view --log-failed` API is admin-only (HTTP 403 for read collaborators), so non-admins couldn't see *which* tests were failing. Recovered the failure list from the `nextest-output.log` artifact that #4525's coverage diagnostic now uploads on every red run:

```
FAIL [ 1.176s] librefang-api::api_integration_test
                test_kill_nonexistent_agent_returns_404
FAIL [ 1.137s] librefang-api::channels_routes_test
                channels_test_known_channel_with_no_creds_reports_missing_env
FAIL [ 1.138s] librefang-testing
                tests::test_delete_agent_not_found
```

This PR brings the assertions back in line with the contract that's already documented in `openapi.json` (after #4526's regen):

| Test | Old assertion | New assertion |
|---|---|---|
| `api_integration_test::test_kill_nonexistent_agent_returns_404` (renamed `…_is_idempotent`) | `status == 404` | `status == 200`, `body.status == "already-deleted"` |
| `librefang-testing::tests::test_delete_agent_not_found` (renamed `test_delete_nonexistent_agent_is_idempotent`) | `assert_json_error(404)` with `error` field | `assert_json_ok` with `status == "already-deleted"` |
| `channels_routes_test::channels_test_known_channel_with_no_creds_reports_missing_env` | `status == 200`, body has `status: "error"` | `status == 412 Precondition Failed`, body shape unchanged |

The two `…_returns_404` / `…_not_found` test names are misleading after #3509 (404 is reserved for the malformed-UUID case alone), so they're renamed inline. The channel test name still reflects what it's checking — only the HTTP status assertion changes.

No production-code change. No new tests. Verified locally against `5a39d13d` (current `main` tip) in a `rust:1-bookworm` container — all three pass.

## Test plan

- [ ] `Test / Ubuntu` `Run tests` step passes (was failing for these three).
- [ ] `Test / macOS` `Run tests` step passes.
- [ ] `Workspace coverage (llvm-cov)` `Generate coverage` step passes; LCOV artifact uploads on success path.
- [ ] No other test names reference the renamed functions (verified via `grep` — none found).
