### PR TITLE
fix(api): exempt PWA static files from auth allowlist (#4529)

### DIFF
--- a/crates/librefang-api/dashboard/index.html
+++ b/crates/librefang-api/dashboard/index.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="LibreFang" />
     <meta name="theme-color" content="#020617" />
-    <link rel="manifest" href="manifest.json" />
+    <link rel="manifest" href="manifest.json" crossorigin="use-credentials" />
     <link rel="icon" type="image/png" sizes="192x192" href="icon-192.png" />
     <link rel="apple-touch-icon" href="icon-192.png" />
     <title>LibreFang Dashboard</title>

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -542,6 +542,18 @@ pub const PUBLIC_ROUTES_GET_ONLY: &[PublicRoute] = &[
     PublicRoute::exact_get("/api/config/schema"),
     // Dashboard assets (JS/CSS/fonts) — always public, SPA needs them for login page
     PublicRoute::prefix_get("/dashboard/assets/"),
+    // PWA siblings of the dashboard shell. These are static bytes baked into
+    // the binary via `include_dir!`, identical for every user, leak nothing
+    // sensitive — and the W3C manifest spec mandates `credentials="omit"`
+    // for `<link rel="manifest">` fetches absent `crossorigin="use-credentials"`,
+    // so the session cookie is intentionally not sent. Without the exemption
+    // every authenticated dashboard load logs a stream of WARN 401s for these
+    // paths (#4529). Mirrors the rate-limiter exemption list at
+    // `rate_limiter.rs::is_rate_limit_exempt`.
+    PublicRoute::exact_get("/dashboard/icon-192.png"),
+    PublicRoute::exact_get("/dashboard/icon-512.png"),
+    PublicRoute::exact_get("/dashboard/manifest.json"),
+    PublicRoute::exact_get("/dashboard/sw.js"),
     // i18n locale bundles — static, fetched before auth flow
     PublicRoute::prefix_get("/locales/"),
 ];

--- a/crates/librefang-api/tests/auth_public_allowlist.rs
+++ b/crates/librefang-api/tests/auth_public_allowlist.rs
@@ -195,6 +195,11 @@ const REGISTERED_GET_ROUTES: &[RouteEntry] = &[
     re("/api/pairing/complete", Expect::AlwaysPublic),
     re("/a2a/agents", Expect::AlwaysPublic),
     re("/dashboard/assets/main.js", Expect::AlwaysPublic),
+    // PWA static siblings of the dashboard shell (#4529).
+    re("/dashboard/icon-192.png", Expect::AlwaysPublic),
+    re("/dashboard/icon-512.png", Expect::AlwaysPublic),
+    re("/dashboard/manifest.json", Expect::AlwaysPublic),
+    re("/dashboard/sw.js", Expect::AlwaysPublic),
     re("/locales/en.json", Expect::AlwaysPublic),
     re(
         "/api/providers/github-copilot/oauth/start",


### PR DESCRIPTION
## Summary

Every authenticated dashboard session was generating a steady stream of `WARN 401` log lines for `/dashboard/manifest.json`, `/dashboard/sw.js`, and the icon assets — even though the user *was* logged in. Two stacked causes, both fixed here for defense in depth:

- **Auth allowlist gap.** `PUBLIC_ROUTES_GET_ONLY` in `middleware.rs` only exempted `/dashboard/assets/`; the PWA siblings fell through to `is_dashboard_path` and required either a Bearer header or the `librefang_session` cookie. Added as four `exact_get` entries — mirrors the existing rate-limiter exemption list (`rate_limiter.rs::is_rate_limit_exempt`).
- **Manifest fetch omits credentials by spec.** Per the [W3C App Manifest spec](https://w3c.github.io/manifest/#using-the-link-element-to-link-a-manifest), `<link rel="manifest">` without `crossorigin="use-credentials"` fetches with `credentials="omit"` even on the same origin, so the session cookie is intentionally not sent. Added the attribute so spec-compliant browsers attach the cookie too.

These bytes are baked into the binary via `include_dir!`, identical for every user, and leak nothing sensitive — exempting them is safe.

Closes #4529.

## Files changed

- `crates/librefang-api/src/middleware.rs` — 4 new `PublicRoute::exact_get` entries in `PUBLIC_ROUTES_GET_ONLY` for `manifest.json`, `sw.js`, `icon-192.png`, `icon-512.png`, with a comment explaining the W3C-spec rationale and the rate-limiter mirror.
- `crates/librefang-api/dashboard/index.html` — `crossorigin="use-credentials"` on the manifest link.
- `crates/librefang-api/tests/auth_public_allowlist.rs` — 4 new `Expect::AlwaysPublic` entries in `REGISTERED_GET_ROUTES`. The existing `always_public_routes_are_reachable_without_token` integration test then exercises each via `TestServer` with `api_key` configured and asserts non-401, locking the contract against future drift.

## Test plan

- [x] `cargo test -p librefang-api --test auth_public_allowlist` — 7/7 passing, including HTTP-level reachability assertions on the four new paths
- [x] `cargo test -p librefang-api --lib middleware::` — 45/45 passing (no regression)
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean
- [ ] Reviewer: confirm the `Authed` regression test (`authed_routes_require_token`) still keeps the 16 protected paths gated — it ran in the same job and went green