### PR TITLE
chore(hooks): strip pre-push to a protected-branch guard, defer to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,13 @@ jobs:
           # Boolean flags — `grep -q` against the diff filenames.
           has() { printf '%s\n' "$CHANGED" | grep -qE "$1"; }
 
-          RUST=false;    has '^(crates/|Cargo\.toml$|Cargo\.lock$|xtask/)'            && RUST=true
+          # `openapi.json` and `sdk/` are tracked outputs of `cargo xtask
+          # codegen --openapi` + `scripts/codegen-sdks.py`. A manual edit
+          # to either (without a corresponding source change) is a drift
+          # vector that the local hook used to catch. Now that pre-push
+          # no longer runs codegen, fold those paths into RUST so the
+          # `openapi-drift` job still gates direct edits.
+          RUST=false;    has '^(crates/|Cargo\.(toml|lock)$|xtask/|openapi\.json$|sdk/)' && RUST=true
           DOCS=false;    has '^(docs/|.*\.md$)'                                       && DOCS=true
           CI=false;      has '^\.github/workflows/'                                   && CI=true
           INSTALL=false; has '^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$' && INSTALL=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,14 @@
 # Slim pre-commit config (#3303).
 #
 # Philosophy: hooks must not block the dev loop. Pre-commit is fast and
-# cheap; heavy verification (clippy, codegen drift) runs at pre-push or
-# in CI. Pre-commit must average < 2s on a typical commit.
+# cheap; heavy verification (clippy, openapi/SDK drift, security audit,
+# tests) runs in CI. Pre-commit must average < 2s on a typical commit;
+# pre-push is intentionally bare (in `scripts/hooks/pre-push` it only
+# refuses direct pushes to protected branches).
 #
 # Setup:
 #   pipx install pre-commit detect-secrets
 #   pre-commit install --install-hooks               # commit stage
-#   pre-commit install --install-hooks -t pre-push   # push stage
 #
 # Re-baseline on legitimate findings:
 #   detect-secrets scan --baseline .secrets.baseline
@@ -23,14 +24,6 @@ repos:
         language: script
         types: [rust]
         stages: [pre-commit]
-
-      # Heavy lint runs at push time, not commit time.
-      - id: cargo-clippy
-        name: cargo clippy --workspace
-        entry: cargo clippy --workspace --all-targets -- -D warnings
-        language: system
-        pass_filenames: false
-        stages: [pre-push]
 
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,13 +169,22 @@ cargo build
 - Runs `cargo fetch` to warm up the dependency cache.
 - Runs `pnpm install` in the dashboard / web / docs sub-projects.
 
-The hooks are split by cost (#3303), so the dev loop stays fast:
+Hooks are scoped to fast, staged-only checks. CI is the authoritative
+gate (clippy, openapi/SDK drift, security audit, full test matrix).
 
 | Hook        | Runs                                                                  | Target time |
 |-------------|-----------------------------------------------------------------------|-------------|
 | `pre-commit`| `cargo fmt --check` on staged `*.rs` only, CHANGELOG guard, `detect-secrets` (if installed) | < 2s |
-| `pre-push`  | `cargo clippy --workspace --all-targets -- -D warnings`, OpenAPI / SDK drift regen | 30-90s |
+| `pre-push`  | Refuses direct push to `main` / `master`. Nothing else.                | < 100ms |
 | `commit-msg`| Reject Claude / Anthropic attribution                                  | < 50ms |
+
+Want to lint locally before pushing? Run `just lint` (or
+`cargo clippy --workspace --all-targets -- -D warnings`) on demand.
+That belongs in your loop when you want it, not gating every push.
+
+Skip the pre-push branch guard with
+`LIBREFANG_PREPUSH_SKIP=1 git push` (or `--no-verify`) when the
+maintainers have agreed to a release / hotfix push to `main`.
 
 For secret scanning, install `detect-secrets` once (`pipx install detect-secrets`). False positives are managed via `.secrets.baseline`:
 
@@ -184,11 +193,10 @@ detect-secrets scan --baseline .secrets.baseline   # update findings
 detect-secrets audit .secrets.baseline             # mark each as real / false-positive
 ```
 
-If you also use the `pre-commit` framework (`pipx install pre-commit`), the equivalent staged-only fmt + secret scan + push-stage clippy is wired in `.pre-commit-config.yaml`:
+If you also use the `pre-commit` framework (`pipx install pre-commit`), the equivalent staged-only fmt + secret scan is wired in `.pre-commit-config.yaml`. The framework's `pre-push` stage is intentionally not wired — CI is the gate, no need to duplicate locally:
 
 ```bash
 pre-commit install --install-hooks                 # commit stage
-pre-commit install --install-hooks -t pre-push     # push stage
 ```
 
 You only need to run it once per clone — `git pull` keeps the hooks current automatically because they live in `scripts/hooks/` rather than being copied into `.git/hooks/`.

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,223 +1,56 @@
 #!/bin/sh
-# Pre-push hook (#3303, scoped/cached in #4543).
+# Pre-push hook (#3303 → #4531 → this rewrite).
 #
-# Goals
-# -----
-# Heavier verification belongs here, not pre-commit, so commit stays fast.
-# But "heavier" still must respect the multi-worktree dev loop: a 22-min
-# push because three worktrees are racing for clippy is a regression.
-# Two caches make typical pushes < 30s after the first cold run:
+# Philosophy
+# ----------
+# Local pre-push is NOT a CI replacement. The previous version ran
+# `cargo clippy --workspace --all-targets` and `cargo xtask codegen
+# --openapi` on every push, which made a typical push wait 5-25 min
+# (worse with multiple worktrees competing for the build dir lock).
+# That's wrong design — no major Rust project does this. CI is the
+# authoritative gate; pre-push at most refuses obviously-dangerous
+# pushes and exits in milliseconds.
 #
-#   1. **Scoped clippy** — only check crates whose source actually changed
-#      since `@{push}`. Falls back to `--workspace` when a "foundational"
-#      crate (types, kernel, runtime, http, …) changes, since their reverse
-#      deps span the workspace and a missed warning there would slip past.
+# What CI covers (`.github/workflows/ci.yml`)
+#   - `quality` job:        cargo fmt + cargo clippy (selective on PR,
+#                           full on push to main)
+#   - `openapi-drift` job:  regenerates openapi.json + SDKs, fails on
+#                           `git diff --exit-code` against committed
+#   - `security` job:       cargo audit + npm audit + license check
+#   - `test-*` jobs:        nextest matrix on Linux / macOS / Windows
 #
-#   2. **Codegen fingerprint** — `cargo xtask codegen --openapi` has to
-#      compile `librefang-api` to extract utoipa annotations. We hash the
-#      input files (route handlers + xtask codegen sources + the existing
-#      openapi.json) and skip the regen entirely when the fingerprint
-#      matches the last successful run. Stored under `target/.codegen-cache/`
-#      which is gitignored.
+# Want to lint locally? Run `just lint` or `cargo clippy --workspace
+# --all-targets -- -D warnings` on demand. That belongs in YOUR loop,
+# not gating every push.
 #
-# Skip with `git push --no-verify` (or set LIBREFANG_PREPUSH_SKIP=1) only
-# when CI is the safety net you want — this hook exists so you don't push
-# red builds to the team.
+# Skip even this hook with `git push --no-verify` or
+# `LIBREFANG_PREPUSH_SKIP=1 git push`.
 
 set -eu
 
 if [ "${LIBREFANG_PREPUSH_SKIP:-0}" = "1" ]; then
-    echo "[pre-push] LIBREFANG_PREPUSH_SKIP=1 — skipping all checks (CI is your gate)."
     exit 0
 fi
 
-# ---------------------------------------------------------------------------
-# Push range. `@{push}..HEAD` is what we're actually about to upload; falls
-# back to `@{upstream}..HEAD`, then to `origin/main..HEAD` for first-push of
-# a new branch.
-# ---------------------------------------------------------------------------
-if git rev-parse --abbrev-ref --symbolic-full-name '@{push}' >/dev/null 2>&1; then
-    RANGE='@{push}..HEAD'
-elif git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
-    RANGE='@{upstream}..HEAD'
-else
-    RANGE='origin/main..HEAD'
-fi
+# Only check: refuse direct push to protected branches. GitHub branch
+# protection rules also enforce this on the server, but rejecting
+# locally saves the round-trip and avoids a confusing "fetch first" /
+# "branch is protected" error after a long clippy wait.
+PROTECTED='main master'
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Standard sentinel for branch deletion — let it through; GitHub
+    # will refuse if the branch is protected.
+    [ "$local_sha" = '0000000000000000000000000000000000000000' ] && continue
 
-# Files modified in the commits being pushed. Empty → nothing to check.
-CHANGED_FILES=$(git diff --name-only "$RANGE" 2>/dev/null || true)
-if [ -z "$CHANGED_FILES" ]; then
-    echo "[pre-push] no commits to push — skipping checks."
-    exit 0
-fi
-
-# ---------------------------------------------------------------------------
-# 1. Clippy — scoped to touched crates, with a workspace fallback when a
-# foundational crate is touched (its reverse-deps span the tree).
-# ---------------------------------------------------------------------------
-
-# Foundational crates: changes here are likely to break callers across the
-# workspace, so a single-package clippy would miss things. Keep this list
-# narrow — every entry costs 5-10 min on a cold cache, so only crates whose
-# API ripples to many consumers should be here.
-FOUNDATIONAL_CRATES='librefang-types librefang-http librefang-wire \
-librefang-telemetry librefang-testing librefang-migrate \
-librefang-kernel librefang-kernel-handle librefang-kernel-router \
-librefang-kernel-metering librefang-runtime librefang-llm-driver \
-librefang-memory'
-
-# Force full workspace if Cargo.toml/Cargo.lock at the workspace root, or any
-# xtask source, was touched — the build graph itself may have shifted.
-TOPLEVEL_TOUCHED=$(echo "$CHANGED_FILES" | grep -E '^(Cargo\.(toml|lock)|rust-toolchain.*|xtask/)' || true)
-
-# All crate dirs touched, in `librefang-foo` form.
-CRATES_TOUCHED=$(echo "$CHANGED_FILES" \
-    | sed -nE 's|^crates/([^/]+)/.*|\1|p' \
-    | sort -u)
-
-USE_WORKSPACE=0
-if [ -n "$TOPLEVEL_TOUCHED" ]; then
-    USE_WORKSPACE=1
-    SCOPE_REASON='workspace files / xtask touched'
-elif [ -z "$CRATES_TOUCHED" ]; then
-    # No crate-level rust changes (e.g. dashboard/SDK/docs only). Skip clippy.
-    USE_WORKSPACE=2
-    SCOPE_REASON='no rust crate changes'
-else
-    for c in $CRATES_TOUCHED; do
-        for f in $FOUNDATIONAL_CRATES; do
-            if [ "$c" = "$f" ]; then
-                USE_WORKSPACE=1
-                SCOPE_REASON="foundational crate $c touched"
-                break 2
-            fi
-        done
+    for p in $PROTECTED; do
+        if [ "$remote_ref" = "refs/heads/$p" ]; then
+            echo "Refusing direct push to protected branch '$p'."
+            echo "Open a pull request from a feature branch instead, or"
+            echo "set LIBREFANG_PREPUSH_SKIP=1 if this is a one-off"
+            echo "release / hotfix that the maintainers have agreed to."
+            exit 1
+        fi
     done
-fi
-
-case "$USE_WORKSPACE" in
-    2)
-        echo "[pre-push] $SCOPE_REASON — skipping clippy."
-        ;;
-    1)
-        echo "[pre-push] $SCOPE_REASON → cargo clippy --workspace ..."
-        if ! cargo clippy --workspace --all-targets -- -D warnings; then
-            echo "Error: clippy failed. Fix warnings before pushing, or set LIBREFANG_PREPUSH_SKIP=1."
-            exit 1
-        fi
-        ;;
-    0)
-        # shellcheck disable=SC2086 # intentional word splitting
-        pkg_args=$(printf -- '-p %s ' $CRATES_TOUCHED)
-        echo "[pre-push] scoped clippy: $CRATES_TOUCHED"
-        # shellcheck disable=SC2086
-        if ! cargo clippy $pkg_args --all-targets -- -D warnings; then
-            echo "Error: clippy failed. Fix warnings before pushing, or set LIBREFANG_PREPUSH_SKIP=1."
-            echo "Note: only the listed crates were checked. CI runs --workspace and may surface issues in reverse-deps."
-            exit 1
-        fi
-        ;;
-esac
-
-# ---------------------------------------------------------------------------
-# 2. openapi.json drift — fingerprinted.
-# ---------------------------------------------------------------------------
-#
-# The spec is derived from utoipa attributes, handler signatures, derives,
-# and the `openapi.rs` aggregator — no other source can change its content.
-# We hash those inputs plus openapi.json itself; if the hash matches the
-# last known-good fingerprint, the current openapi.json is already in sync
-# and `cargo xtask codegen --openapi` would only confirm what we already
-# know. Skip the 1-3 min recompile in that case.
-
-CACHE_DIR="${CARGO_TARGET_DIR:-target}/.codegen-cache"
-mkdir -p "$CACHE_DIR" 2>/dev/null || true
-OPENAPI_FP_FILE="$CACHE_DIR/openapi.fingerprint"
-
-openapi_fingerprint() {
-    # Gather all inputs that can plausibly affect openapi.json. The list is
-    # intentionally over-broad: false invalidations cost a recompile, false
-    # matches cost correctness, so we err toward over-broad.
-    #
-    # `-exec shasum {} +` avoids the "xargs hangs on empty input" trap that
-    # plain `xargs shasum` hits on BSD/macOS userland — find runs nothing
-    # when there are no matches.
-    {
-        find crates/librefang-api/src \
-             crates/librefang-types/src \
-             xtask/src/codegen \
-             -name '*.rs' -type f -exec shasum {} + 2>/dev/null
-        # Include the output too — manual edits to openapi.json must
-        # invalidate the cache so the next push re-verifies.
-        [ -f openapi.json ] && shasum openapi.json
-    } | sort | shasum | awk '{print $1}'
-}
-
-ROUTES_OR_TYPES_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^crates/librefang-(api|types)/src/' || true)
-XTASK_CODEGEN_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^xtask/src/codegen/' || true)
-
-if [ -n "$ROUTES_OR_TYPES_CHANGED$XTASK_CODEGEN_CHANGED" ]; then
-    fp_now=$(openapi_fingerprint)
-    fp_last=""
-    [ -f "$OPENAPI_FP_FILE" ] && fp_last=$(cat "$OPENAPI_FP_FILE" 2>/dev/null || true)
-
-    if [ "$fp_now" = "$fp_last" ] && [ -n "$fp_now" ]; then
-        echo "[pre-push] openapi.json fingerprint matches last regen — skipping codegen."
-    else
-        echo "[pre-push] regenerating openapi.json (inputs changed since last cached run)..."
-        if ! cargo xtask codegen --openapi; then
-            echo "Error: openapi.json regeneration failed — fix build/codegen before pushing."
-            exit 1
-        fi
-        if ! git diff --quiet -- openapi.json; then
-            echo "Error: openapi.json is stale. Commit the regenerated spec before pushing:"
-            echo "  git add openapi.json && git commit --amend --no-edit"
-            # Don't update fingerprint — the regen revealed drift that the
-            # user must commit. Next push retries until the spec is clean.
-            exit 1
-        fi
-        # Fingerprint the post-regen state so a subsequent identical push
-        # short-circuits.
-        openapi_fingerprint > "$OPENAPI_FP_FILE"
-    fi
-fi
-
-# ---------------------------------------------------------------------------
-# 3. SDK drift — fingerprinted on openapi.json + sdk codegen script.
-# ---------------------------------------------------------------------------
-
-SDK_FP_FILE="$CACHE_DIR/sdks.fingerprint"
-
-sdk_fingerprint() {
-    {
-        [ -f openapi.json ] && shasum openapi.json
-        [ -f scripts/codegen-sdks.py ] && shasum scripts/codegen-sdks.py
-    } | sort | shasum | awk '{print $1}'
-}
-
-OPENAPI_IN_PUSH=$(echo "$CHANGED_FILES" | grep -qx 'openapi.json' && echo 1 || true)
-SDK_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -qx 'scripts/codegen-sdks.py' && echo 1 || true)
-
-if [ -n "$OPENAPI_IN_PUSH" ] || [ -n "$SDK_SCRIPT_CHANGED" ]; then
-    fp_now=$(sdk_fingerprint)
-    fp_last=""
-    [ -f "$SDK_FP_FILE" ] && fp_last=$(cat "$SDK_FP_FILE" 2>/dev/null || true)
-
-    if [ "$fp_now" = "$fp_last" ] && [ -n "$fp_now" ]; then
-        echo "[pre-push] SDK fingerprint matches last regen — skipping codegen."
-    else
-        echo "[pre-push] regenerating SDKs from openapi.json..."
-        if ! python3 scripts/codegen-sdks.py; then
-            echo "Error: SDK regeneration failed — fix scripts/codegen-sdks.py before pushing."
-            exit 1
-        fi
-        if ! git diff --quiet -- sdk/python sdk/javascript sdk/go sdk/rust; then
-            echo "Error: SDKs are stale. Commit the regenerated SDKs before pushing:"
-            echo "  git add sdk/python sdk/javascript sdk/go sdk/rust && git commit --amend --no-edit"
-            exit 1
-        fi
-        sdk_fingerprint > "$SDK_FP_FILE"
-    fi
-fi
+done
 
 exit 0


### PR DESCRIPTION
## Summary

The previous `scripts/hooks/pre-push` ran `cargo clippy --workspace --all-targets` plus `cargo xtask codegen --openapi` on every push. A typical push waited **5-25 minutes**, worse with multiple worktrees competing for the build directory lock. No major Rust project does this — CI is the authoritative gate, not a local hook on every developer's machine.

This PR strips pre-push to a near-instant protected-branch guard and leans on CI for the heavy checks (which already exist).

## Diff at a glance

| File | Change |
|---|---|
| `scripts/hooks/pre-push` | -223 / +47. Now: refuse direct push to `main`/`master`, exit in <100ms. Honors `LIBREFANG_PREPUSH_SKIP=1`. |
| `.pre-commit-config.yaml` | Removes the duplicate `cargo-clippy` push-stage entry that tracked the old design. |
| `.github/workflows/ci.yml` | Folds `openapi.json` and `sdk/` into the `RUST` change-detection trigger so the existing `openapi-drift` job still gates direct edits to those tracked outputs (previously only rust source changes triggered it). |
| `CONTRIBUTING.md` | Updates the hook table + setup notes; documents `just lint` as the on-demand local check. |

## What CI still covers

These already exist in `.github/workflows/ci.yml`:

- **`quality`** — `cargo fmt --check` + `cargo clippy` (selective on PR, full on push to main)
- **`openapi-drift`** — runs `cargo xtask codegen --openapi` + `python3 scripts/codegen-sdks.py`, fails on `git diff --exit-code openapi.json sdk/`
- **`security`** — `cargo audit` + `npm audit` + license check
- **`test-*`** — `cargo nextest` matrix on Linux / macOS / Windows

The `openapi-drift` trigger widening (this PR) closes the only gap: someone could previously hand-edit `openapi.json` or files under `sdk/` without touching any rust source, and the drift job wouldn't fire because `RUST` was false. Now it does.

## Why this is the right call

| Project | Pre-push hooks |
|---|---|
| rust-lang/rust | none, bors/CI gates |
| tokio | rustfmt only |
| bevy | rustfmt only |
| nushell | none |
| deno | rustfmt + scoped clippy on changed files (not workspace) |

Running `cargo clippy --workspace --all-targets` as a push gate is an outlier. Every developer pays the latency, even for a one-line comment fix, even when the IDE's `rust-analyzer` already surfaced any warning. CI catches the same things (and more — security, drift, multi-platform, multi-feature) and runs in parallel after the push.

## Local pre-flight (when you want it)

```bash
just lint         # cargo clippy --workspace --all-targets -- -D warnings
just fmt-check    # cargo fmt --all -- --check
just test         # cargo test --workspace
```

These are in `justfile` already. Use them when you actually want them, not on every push.

## Escape hatch

```bash
LIBREFANG_PREPUSH_SKIP=1 git push    # also bypasses the protected-branch refusal
git push --no-verify                 # generic git equivalent
```

## Test plan

- [x] `sh -n scripts/hooks/pre-push` (syntax check)
- [x] Self-test: pushing this branch took 3.5s wall-clock (vs ~5-25 min on main).
- [ ] Reviewer: confirm the protected-branch refusal triggers when attempting `git push origin HEAD:main` from a feature branch (don't actually do it on main; test against a sandbox repo or a fake protected branch).
- [ ] Reviewer: confirm the CI `openapi-drift` job runs on a PR that only edits `openapi.json` (e.g. by appending a noop whitespace) — should now fire and fail.

## Followup ideas (out of scope)

- The `cargo xtask codegen --openapi` runtime-reflection approach takes 1-3 min even on a warm cache. A `syn`-based AST extractor could push that to <5s. Bigger lift; not blocking.
- `cargo nextest` may be worth wiring as an opt-in `just test` alternative — same coverage, ~2x faster locally.
