### PR TITLE
ci: scope test matrix away from xtask/workflow-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       ci: ${{ steps.diff.outputs.ci }}
       install: ${{ steps.diff.outputs.install }}
       full_run: ${{ steps.diff.outputs.full_run }}
+      full_test: ${{ steps.diff.outputs.full_test }}
       crates: ${{ steps.diff.outputs.crates }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -84,24 +85,54 @@ jobs:
           DOCS=false;    has '^(docs/|.*\.md$)'                                       && DOCS=true
           CI=false;      has '^\.github/workflows/'                                   && CI=true
           INSTALL=false; has '^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$' && INSTALL=true
-          ROOT_CARGO=false; has '^Cargo\.toml$|^xtask/'                               && ROOT_CARGO=true
+          # Workspace-level Cargo manifest ≠ xtask source. A workspace
+          # `Cargo.toml` change can shift dep versions, profile flags,
+          # workspace lints, or membership — anything in the tree may
+          # break. An xtask source change only affects the xtask binary
+          # itself; runtime crates' libraries are untouched.
+          WORKSPACE_CARGO=false; has '^Cargo\.(toml|lock)$'                            && WORKSPACE_CARGO=true
+          XTASK_SRC=false;       has '^xtask/'                                         && XTASK_SRC=true
 
-          # Full run policy — stated plainly so it's auditable from the log:
-          # 1. Push to main (merge) → catch cross-crate breakage before it rots
-          # 2. CI file itself changed → test the new pipeline on every platform
-          # 3. Root Cargo.toml / xtask → graph-level change, per-crate logic
-          #    can't safely predict the blast radius
-          #
-          # Platform regressions don't need a special full_run bucket — PR lane
-          # test jobs on Windows/macOS cover their affected crates directly.
+          # `full_run` (build + clippy job): wider net. Any of these is a
+          # legitimate reason to run workspace-wide build + clippy:
+          #   1. push to main — sanity check before merge rots the index
+          #   2. CI workflow changed — exercise the new pipeline once
+          #   3. workspace Cargo.toml/Cargo.lock changed — dep / lints
+          #      drift can ripple anywhere
+          #   4. xtask source changed — a few CI jobs (`cargo xtask ci`,
+          #      `cargo xtask codegen --openapi`) wrap xtask; broken xtask
+          #      breaks the build pipeline, so re-running build+clippy
+          #      across the workspace catches cascading damage cheaply.
           if [ "$EVENT_NAME" = "push" ]; then
             FULL=true; REASON="push to main"
           elif [ "$CI" = "true" ]; then
             FULL=true; REASON="CI workflow changed"
-          elif [ "$ROOT_CARGO" = "true" ]; then
-            FULL=true; REASON="workspace Cargo.toml or xtask changed"
+          elif [ "$WORKSPACE_CARGO" = "true" ]; then
+            FULL=true; REASON="workspace Cargo.toml/Cargo.lock changed"
+          elif [ "$XTASK_SRC" = "true" ]; then
+            FULL=true; REASON="xtask source changed"
           else
             FULL=false; REASON="selective"
+          fi
+
+          # `full_test` (test matrix job): strictly narrower. Re-running
+          # 6500+ unit tests across the workspace only pays off when a
+          # change can plausibly affect runtime behaviour of unrelated
+          # crates. CI-pipeline tweaks and xtask source changes do NOT
+          # affect runtime — they're build tooling. Excluding them here
+          # is what unblocks PRs like #4528 (xtask + ci.yml only) from
+          # paying a 20-30 min nextest matrix on every push.
+          #
+          #   • push to main      → full_test=true (last-line catch-all)
+          #   • workspace Cargo.toml/Cargo.lock → full_test=true (dep
+          #     upgrade can break runtime)
+          #   • everything else   → selective (per-crate from DIRECT)
+          if [ "$EVENT_NAME" = "push" ]; then
+            FULL_TEST=true; TREASON="push to main"
+          elif [ "$WORKSPACE_CARGO" = "true" ]; then
+            FULL_TEST=true; TREASON="workspace Cargo.toml/Cargo.lock changed"
+          else
+            FULL_TEST=false; TREASON="selective"
           fi
 
           {
@@ -110,13 +141,23 @@ jobs:
             echo "ci=$CI"
             echo "install=$INSTALL"
             echo "full_run=$FULL"
+            echo "full_test=$FULL_TEST"
           } >> "$GITHUB_OUTPUT"
-          echo "Route: full_run=$FULL ($REASON)"
+          echo "Route: full_run=$FULL ($REASON), full_test=$FULL_TEST ($TREASON)"
 
           # Directly-touched crates (no downstream fan-out — on purpose).
           DIRECT=$(printf '%s\n' "$CHANGED" \
             | sed -n 's|^crates/\([^/]*\)/.*|\1|p' \
             | sort -u | tr '\n' ' ')
+
+          # xtask isn't under `crates/`, so the regex above misses it.
+          # Pull it in explicitly when its source changes so that the
+          # selective test lane runs `cargo nextest -p xtask` (xtask
+          # self-tests) instead of compiling-but-skipping the package.
+          if [ "$XTASK_SRC" = "true" ] && ! printf '%s\n' $DIRECT | grep -qx 'xtask'; then
+            DIRECT="$DIRECT xtask"
+            echo "Pulling xtask into affected set (xtask source changed)"
+          fi
 
           # Schema-mirror rule. `librefang-types` is the source of the
           # schemars-derived `KernelConfig` schema, but the golden-file guard
@@ -364,7 +405,7 @@ jobs:
             patchelf
       - name: Build tests
         run: |
-          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+          if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
             echo "Building workspace tests (full run)…"
             cargo test --workspace --no-run -j 2
           else
@@ -382,7 +423,7 @@ jobs:
         env:
           RUST_TEST_THREADS: "1"
         run: |
-          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+          if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
             echo "Running workspace tests (full run)…"
             cargo nextest run --workspace --no-fail-fast
           else
@@ -421,7 +462,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+          if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
             echo "Running workspace tests (full run)…"
             cargo nextest run --workspace --no-fail-fast
           else
@@ -458,7 +499,7 @@ jobs:
         run: mkdir -p crates/librefang-api/static/react
       - name: Run tests
         run: |
-          if [ "${{ needs.changes.outputs.full_run }}" = "true" ]; then
+          if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
             echo "Running workspace tests (full run)…"
             cargo nextest run --workspace --no-fail-fast
           else


### PR DESCRIPTION
## Summary

The `Test / Ubuntu` / `macOS` / `Windows` jobs were running the full 6500+ test workspace whenever a CI workflow YAML or `xtask/` source file changed, because they shared the `full_run` gate with the build+clippy job. Those two file kinds are build tooling, not runtime — re-running every unit test on every xtask tweak burns ~20-30 min of wall-clock per PR for zero correctness benefit.

Concrete trigger: PR #4528 (`.github/workflows/ci.yml` + `xtask/src/schema_check.rs` only) ran 6550 tests across three platforms.

## Fix

Split `full_run` into two outputs with different scopes:

| Output | Scope | Triggers |
|---|---|---|
| `full_run` | build + clippy + openapi-drift (existing wider net) | push to main, CI workflow change, workspace `Cargo.toml`/`Cargo.lock`, **xtask source** |
| `full_test` *(new)* | nextest matrix only | push to main, workspace `Cargo.toml`/`Cargo.lock` |

Why drop xtask + CI YAML from `full_test`:

- xtask source changes don't affect any production crate's library/runtime code. They affect the xtask binary, which a few CI jobs (`cargo xtask ci`, `cargo xtask codegen --openapi`) wrap — those still trigger via the wider `full_run` gate, so cascading breakage is still caught at build+clippy time.
- CI workflow YAML changes don't affect runtime code at all. Validation comes from running the new pipeline at all (which it does — itself).

## Selective lane gets `xtask`

The DIRECT crates regex previously only matched `crates/X/...`, so xtask changes resulted in an empty `crates` set and the selective test lane silently ran `cargo nextest` with no `-p` flags (which expands to nothing useful). Pulled in xtask explicitly when its source changes:

```bash
if [ "$XTASK_SRC" = "true" ] && ! printf '%s\n' $DIRECT | grep -qx 'xtask'; then
    DIRECT="$DIRECT xtask"
fi
```

## Impact on PR #4528

| | Before | After |
|---|---|---|
| Test scope | `cargo nextest --workspace` (~6550 tests) | `cargo nextest -p xtask` (xtask self-tests) |
| Wall-clock per platform | ~20-30 min | ~30 s |
| Build + clippy | full workspace (kept) | full workspace (kept — `full_run` still true via CI yaml change) |
| OpenAPI drift | runs (kept) | runs (kept) |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — yaml parses
- [ ] On merge: this PR itself touches `.github/workflows/ci.yml` only — should trigger `full_run=true` (CI workflow changed) and `full_test=false` (CI yaml is not a runtime input). Test job should run selectively against an empty crates set, build+clippy job should run workspace.
- [ ] Smoke: open a follow-up PR that bumps a workspace `Cargo.toml` dep version → expect `full_test=true`, full nextest matrix.
- [ ] Smoke: open a follow-up PR that touches only `crates/librefang-memory/src/foo.rs` → expect `full_test=false`, selective lane runs `-p librefang-memory`.

## Out of scope

- `.github/workflows/coverage.yml` (Workspace coverage / llvm-cov) is a separate workflow with no changes-detection step, always full-workspace. Same affliction, but the fix needs a callable workflow or duplicated diff logic — tracked as a follow-up rather than bundled here.
