### PR TITLE
ci(coverage): skip workflow on tooling/docs-only PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,34 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Skip coverage on PRs whose entire diff is non-runtime files. The
+    # workflow runs `cargo llvm-cov nextest --workspace` (~20-30 min) and
+    # is report-only, so spending the time on a PR that can't shift the
+    # number is pure waste. `paths-ignore` skips the workflow only when
+    # *every* changed path matches — a PR that touches a real crate plus
+    # one of these still runs.
+    #
+    # Companion to ci.yml's `full_test` gating (#4533): same intent, but
+    # this workflow has no `Detect Changes` step of its own, so we filter
+    # at the trigger layer rather than per-job.
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'xtask/**'                    # build tooling, not runtime
+      - '.github/workflows/**'        # pipeline YAML, not runtime
+      - 'sdk/**'                      # generated SDKs (not rust-measured)
+      - 'web/**'                      # web frontend (not rust)
+      - 'crates/librefang-api/dashboard/**'  # react dashboard (not rust)
+      - '**/*.svg'
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.jpeg'
+      - '**/*.gif'
+      - '**/*.ico'
+      - 'CODEOWNERS'
+      - '.gitignore'
+      - '.editorconfig'
+      - '.secrets.baseline'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Coverage runs `cargo llvm-cov nextest --workspace` (~20-30 min) on every PR to main, even when the diff is entirely non-runtime files. Spending that time on docs / xtask / workflow-yaml-only PRs is pure waste — the coverage number can't move when zero rust source code changed.

Companion to #4533, which split `full_test` from `full_run` in `ci.yml`. `coverage.yml` is a separate workflow with no `Detect Changes` step of its own, so we filter at the trigger layer instead of duplicating the diff logic.

## Approach

Add `paths-ignore` to the `pull_request` trigger:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
    paths-ignore:
      - 'docs/**'
      - '**.md'
      - 'xtask/**'                    # build tooling, not runtime
      - '.github/workflows/**'        # pipeline YAML, not runtime
      - 'sdk/**'                      # generated SDKs (not rust-measured)
      - 'web/**'                      # web frontend (not rust)
      - 'crates/librefang-api/dashboard/**'  # react dashboard (not rust)
      - '**/*.svg' / '*.png' / '*.jpg' / etc.
      - 'CODEOWNERS' / '.gitignore' / '.editorconfig' / '.secrets.baseline'
```

## Semantics

`paths-ignore` skips the workflow only when **every** changed file matches. A PR that touches a real crate plus an xtask file or a doc still runs coverage. So:

| Diff | Coverage runs? |
|---|---|
| `docs/foo.md` only | skip |
| `xtask/src/foo.rs` only | skip |
| `.github/workflows/ci.yml` only | skip |
| `crates/librefang-memory/src/foo.rs` only | run |
| `xtask/foo.rs` + `crates/foo/src/foo.rs` | run |

Push-to-main has no filter — we always want main's coverage report regardless of what was changed.

## Out of scope

- Per-crate coverage scoping (e.g. `cargo llvm-cov -p librefang-memory`) is technically possible but would require duplicating the changes-detection step into `coverage.yml`, or moving coverage into `ci.yml` as a job that reuses the existing detection. paths-ignore is the 80% win for 5 lines.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/coverage.yml'))"` — yaml parses
- [ ] On merge: this PR itself touches `.github/workflows/coverage.yml` only — should match `paths-ignore: '.github/workflows/**'` and skip coverage. Reviewer can confirm by checking the PR's Actions tab and seeing the Coverage workflow either not started or marked "skipped".
- [ ] Smoke: open a follow-up PR that touches a real crate → coverage runs as before.
- [ ] Smoke: open a docs-only PR → coverage workflow doesn't appear in the check list.
