### PR TITLE
refactor(kernel-handle): split god trait into 14 role traits (#3746)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2169,7 +2169,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         message: &str,
         thread_id: Option<&str>,
     ) -> Result<String, String> {
-        use librefang_runtime::kernel_handle::KernelHandle;
+        use librefang_runtime::kernel_handle::prelude::*;
         self.kernel
             .send_channel_message(channel_type, recipient, message, thread_id, None)
             .await

--- a/crates/librefang-api/src/openai_compat.rs
+++ b/crates/librefang-api/src/openai_compat.rs
@@ -12,7 +12,7 @@ use axum::http::StatusCode;
 use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_runtime::llm_driver::StreamEvent;
 use librefang_types::agent::AgentId;
 use librefang_types::message::{ContentBlock, Message, MessageContent, Role, StopReason};

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -190,7 +190,7 @@ use axum::Json;
 use dashmap::DashMap;
 use librefang_channels::types::SenderContext;
 use librefang_kernel::LibreFangKernel;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_types::agent::{AgentId, AgentIdentity, AgentManifest};
 use librefang_types::i18n::ErrorTranslator;
 use std::collections::HashMap;

--- a/crates/librefang-api/src/routes/approvals.rs
+++ b/crates/librefang-api/src/routes/approvals.rs
@@ -14,7 +14,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_types::i18n::ErrorTranslator;
 use std::sync::Arc;
 

--- a/crates/librefang-api/src/routes/hooks_commands.rs
+++ b/crates/librefang-api/src/routes/hooks_commands.rs
@@ -13,7 +13,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_types::agent::AgentId;
 use librefang_types::i18n::ErrorTranslator;
 use std::sync::Arc;
@@ -96,7 +96,7 @@ pub async fn webhook_wake(
         "text": body.text,
     });
     if let Err(e) =
-        KernelHandle::publish_event(state.kernel.as_ref(), "webhook.wake", event_payload).await
+        EventBus::publish_event(state.kernel.as_ref(), "webhook.wake", event_payload).await
     {
         tracing::warn!("Webhook wake event publish failed: {e}");
         let err_msg = {

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -66,7 +66,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_runtime::tool_runner::builtin_tool_definitions;
 use std::collections::HashMap;
 use std::net::IpAddr;

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -9,7 +9,7 @@ use librefang_types::agent::{PromptExperiment, PromptVersion};
 use sha2::{Digest, Sha256};
 
 use super::AppState;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use std::sync::Arc;
 
 use crate::types::ApiErrorResponse;

--- a/crates/librefang-api/src/routes/task_queue.rs
+++ b/crates/librefang-api/src/routes/task_queue.rs
@@ -11,7 +11,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_types::i18n::ErrorTranslator;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/librefang-api/src/routes/tools_sessions.rs
+++ b/crates/librefang-api/src/routes/tools_sessions.rs
@@ -14,7 +14,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_runtime::tool_runner::{builtin_tool_definitions, execute_tool};
 use librefang_types::i18n::ErrorTranslator;
 use std::sync::Arc;

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -103,7 +103,7 @@ use axum::Json;
 use librefang_kernel::workflow::{
     ErrorMode, StepAgent, StepMode, Workflow, WorkflowId, WorkflowRunId, WorkflowStep,
 };
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_types::agent::AgentId;
 use serde::Deserialize;
 use std::collections::HashMap;

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -21,7 +21,7 @@ use dashmap::DashMap;
 use futures::stream::SplitSink;
 use futures::{SinkExt, StreamExt};
 use librefang_channels::types::SenderContext;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_runtime::llm_driver::{StreamEvent, PHASE_RESPONSE_COMPLETE};
 use librefang_runtime::llm_errors;
 use librefang_types::agent::{AgentId, SessionId};

--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -1,9 +1,31 @@
-//! Trait abstraction for kernel operations needed by the agent runtime.
+//! Role traits for kernel operations needed by the agent runtime.
 //!
-//! This trait allows `librefang-runtime` to call back into the kernel for
-//! inter-agent operations (spawn, send, list, kill) without creating
-//! a circular dependency. The kernel implements this trait and passes
-//! it into the agent loop.
+//! Historically this crate exposed a single 50+ method `KernelHandle`
+//! god-trait (issue #3746). It is now split into role traits — `AgentControl`,
+//! `MemoryAccess`, `TaskQueue`, `EventBus`, `KnowledgeGraph`, `CronControl`,
+//! `ApprovalGate`, `HandsControl`, `A2ARegistry`, `ChannelSender`,
+//! `PromptStore`, `WorkflowRunner`, `GoalControl`, `ToolPolicy` — so that
+//!
+//! 1. the trait file no longer mixes 14 unrelated domains in one place,
+//! 2. callers can express narrower bounds (e.g. `T: ApprovalGate`) instead of
+//!    pulling the whole kernel surface in,
+//! 3. test stubs/mocks group their fakes by capability and a missing
+//!    capability is a compile error in the role-trait impl, not a silent
+//!    `Err("not available")` at first runtime call.
+//!
+//! `KernelHandle` is preserved as a *supertrait alias* requiring all role
+//! traits, with a blanket impl, so existing `Arc<dyn KernelHandle>` call
+//! sites (117 of them at split time) keep working unchanged. Future PRs can
+//! narrow individual sites without further churn here.
+//!
+//! ### Default impls
+//!
+//! Defaults that hide a missing capability behind a runtime
+//! `Err("X not available")` are preserved as-is for now to keep this PR a
+//! pure structural refactor (zero behavior change). They are gathered onto
+//! the role trait that owns them, so a follow-up PR can tighten each role's
+//! contract independently rather than having to land 30+ default removals
+//! atomically.
 
 use async_trait::async_trait;
 
@@ -20,10 +42,14 @@ pub struct AgentInfo {
     pub tools: Vec<String>,
 }
 
-/// Handle to kernel operations, passed into the agent loop so agents
-/// can interact with each other via tools.
+// ============================================================================
+// 1. AgentControl — agent lifecycle, inter-agent send, listing, heartbeats,
+//    forked one-shot calls, plus a couple of agent-scoped config queries
+//    (`max_agent_call_depth`, `fire_agent_step`).
+// ============================================================================
+
 #[async_trait]
-pub trait KernelHandle: Send + Sync {
+pub trait AgentControl: Send + Sync {
     /// Spawn a new agent from a TOML manifest string.
     /// `parent_id` is the UUID string of the spawning agent (for lineage tracking).
     /// Returns (agent_id, agent_name) on success.
@@ -32,6 +58,21 @@ pub trait KernelHandle: Send + Sync {
         manifest_toml: &str,
         parent_id: Option<&str>,
     ) -> Result<(String, String), String>;
+
+    /// Spawn an agent with capability inheritance enforcement.
+    /// `parent_caps` are the parent's granted capabilities. The kernel MUST verify
+    /// that every capability in the child manifest is covered by `parent_caps`.
+    async fn spawn_agent_checked(
+        &self,
+        manifest_toml: &str,
+        parent_id: Option<&str>,
+        parent_caps: &[librefang_types::capability::Capability],
+    ) -> Result<(String, String), String> {
+        // Default: delegate to spawn_agent (no enforcement)
+        // The kernel MUST override this with real enforcement
+        let _ = parent_caps;
+        self.spawn_agent(manifest_toml, parent_id).await
+    }
 
     /// Send a message to another agent and get the response.
     async fn send_to_agent(&self, agent_id: &str, message: &str) -> Result<String, String>;
@@ -51,7 +92,7 @@ pub trait KernelHandle: Send + Sync {
         tracing::trace!(
             agent = %agent_id,
             parent = %parent_agent_id,
-            "send_to_agent_as: default impl — cancel cascade not supported by this KernelHandle"
+            "send_to_agent_as: default impl — cancel cascade not supported by this handle"
         );
         self.send_to_agent(agent_id, message).await
     }
@@ -62,6 +103,60 @@ pub trait KernelHandle: Send + Sync {
     /// Kill an agent by ID.
     fn kill_agent(&self, agent_id: &str) -> Result<(), String>;
 
+    /// Find agents by query (matches on name substring, tag, or tool name; case-insensitive).
+    fn find_agents(&self, query: &str) -> Vec<AgentInfo>;
+
+    /// Touch the agent's `last_active` timestamp to prevent heartbeat false-positives
+    /// during long-running operations (e.g., LLM calls).
+    fn touch_heartbeat(&self, agent_id: &str) {
+        let _ = agent_id;
+    }
+
+    /// Fire an `agent:step` external hook event.
+    /// Called by the runtime at the start of each agent loop iteration.
+    fn fire_agent_step(&self, _agent_id: &str, _step: u32) {}
+
+    /// Run a forked agent turn that collapses to a single text response —
+    /// the "structured-output via forked call" primitive. Used by the
+    /// proactive memory extractor so its LLM call shares the parent
+    /// turn's `(system + tools + messages)` prefix for Anthropic prompt
+    /// cache alignment, instead of issuing a standalone `driver.complete()`
+    /// that always starts cold.
+    ///
+    /// Internally: spawn `run_forked_agent_streaming`, drain to completion,
+    /// return the final assistant text. Fork semantics apply — the call's
+    /// messages do NOT persist into the agent's canonical session, and the
+    /// turn-end hook fires with `is_fork: true` so auto-dream won't
+    /// recurse.
+    ///
+    /// `allowed_tools = Some(vec![])` keeps the fork single-turn (no tool
+    /// calls permitted — model returns text). Pass a larger allowlist only
+    /// when the caller actually expects tool use (e.g. future extractors
+    /// that want the fork to call `memory_store` directly).
+    ///
+    /// Default: error. The real kernel overrides; tests / stubs that
+    /// don't implement the full streaming path just fall back to a
+    /// standalone driver call through the extractor's own path.
+    async fn run_forked_agent_oneshot(
+        &self,
+        _agent_id: &str,
+        _prompt: &str,
+        _allowed_tools: Option<Vec<String>>,
+    ) -> Result<String, String> {
+        Err("run_forked_agent_oneshot not available in this handle".to_string())
+    }
+
+    /// Maximum inter-agent call depth (from config). Default: 5.
+    fn max_agent_call_depth(&self) -> u32 {
+        5
+    }
+}
+
+// ============================================================================
+// 2. MemoryAccess — shared cross-agent memory + per-user RBAC ACL resolution
+// ============================================================================
+
+pub trait MemoryAccess: Send + Sync {
     /// Store a value in shared memory (cross-agent accessible).
     /// When `peer_id` is `Some`, the key is scoped to that peer so different
     /// users of the same agent get isolated memory namespaces.
@@ -84,9 +179,34 @@ pub trait KernelHandle: Send + Sync {
     /// When `peer_id` is `Some`, only returns keys within that peer's namespace.
     fn memory_list(&self, peer_id: Option<&str>) -> Result<Vec<String>, String>;
 
-    /// Find agents by query (matches on name substring, tag, or tool name; case-insensitive).
-    fn find_agents(&self, query: &str) -> Vec<AgentInfo>;
+    /// Resolve the per-user memory ACL for the given sender + channel
+    /// pair (RBAC M3, #3054 Phase 2). Returns the resolved
+    /// `UserMemoryAccess` so the runtime can build a
+    /// `MemoryNamespaceGuard` and gate proactive-memory reads.
+    ///
+    /// `None` means RBAC is disabled (no registered users) or the sender
+    /// could not be attributed to any registered user — callers should
+    /// treat this as "no per-user restriction" so the existing single-user
+    /// behaviour is preserved.
+    ///
+    /// Default impl returns `None` so embedders / stubs that haven't
+    /// wired RBAC keep the pre-M3 behaviour.
+    fn memory_acl_for_sender(
+        &self,
+        sender_id: Option<&str>,
+        channel: Option<&str>,
+    ) -> Option<librefang_types::user_policy::UserMemoryAccess> {
+        let _ = (sender_id, channel);
+        None
+    }
+}
 
+// ============================================================================
+// 3. TaskQueue — shared task queue: post / claim / complete / list / etc.
+// ============================================================================
+
+#[async_trait]
+pub trait TaskQueue: Send + Sync {
     /// Post a task to the shared task queue. Returns the task ID.
     async fn task_post(
         &self,
@@ -122,14 +242,28 @@ pub trait KernelHandle: Send + Sync {
     /// Update a task's status to `pending` (reset) or `cancelled`.
     /// Returns true if the task was found and updated.
     async fn task_update_status(&self, task_id: &str, new_status: &str) -> Result<bool, String>;
+}
 
+// ============================================================================
+// 4. EventBus — fire-and-forget custom events for proactive triggers
+// ============================================================================
+
+#[async_trait]
+pub trait EventBus: Send + Sync {
     /// Publish a custom event that can trigger proactive agents.
     async fn publish_event(
         &self,
         event_type: &str,
         payload: serde_json::Value,
     ) -> Result<(), String>;
+}
 
+// ============================================================================
+// 5. KnowledgeGraph — entity/relation insert + pattern query
+// ============================================================================
+
+#[async_trait]
+pub trait KnowledgeGraph: Send + Sync {
     /// Add an entity to the knowledge graph.
     ///
     /// Takes `entity` by reference so callers that already hold an owned
@@ -157,7 +291,14 @@ pub trait KernelHandle: Send + Sync {
         &self,
         pattern: librefang_types::memory::GraphPattern,
     ) -> Result<Vec<librefang_types::memory::GraphMatch>, String>;
+}
 
+// ============================================================================
+// 6. CronControl — agent-owned scheduled jobs
+// ============================================================================
+
+#[async_trait]
+pub trait CronControl: Send + Sync {
     /// Create a cron job for the calling agent.
     async fn cron_create(
         &self,
@@ -179,7 +320,14 @@ pub trait KernelHandle: Send + Sync {
         let _ = job_id;
         Err("Cron scheduler not available".to_string())
     }
+}
 
+// ============================================================================
+// 7. ApprovalGate — approval policy queries + pending-approval lifecycle
+// ============================================================================
+
+#[async_trait]
+pub trait ApprovalGate: Send + Sync {
     /// Check if a tool requires approval based on current policy.
     fn requires_approval(&self, tool_name: &str) -> bool {
         let _ = tool_name;
@@ -207,27 +355,6 @@ pub trait KernelHandle: Send + Sync {
     ) -> bool {
         let _ = (tool_name, sender_id, channel);
         false
-    }
-
-    /// Resolve the per-user memory ACL for the given sender + channel
-    /// pair (RBAC M3, #3054 Phase 2). Returns the resolved
-    /// `UserMemoryAccess` so the runtime can build a
-    /// `MemoryNamespaceGuard` and gate proactive-memory reads.
-    ///
-    /// `None` means RBAC is disabled (no registered users) or the sender
-    /// could not be attributed to any registered user — callers should
-    /// treat this as "no per-user restriction" so the existing single-user
-    /// behaviour is preserved.
-    ///
-    /// Default impl returns `None` so embedders / stubs that haven't
-    /// wired RBAC keep the pre-M3 behaviour.
-    fn memory_acl_for_sender(
-        &self,
-        sender_id: Option<&str>,
-        channel: Option<&str>,
-    ) -> Option<librefang_types::user_policy::UserMemoryAccess> {
-        let _ = (sender_id, channel);
-        None
     }
 
     /// Resolve the per-user RBAC gate for a tool invocation (RBAC M3,
@@ -312,7 +439,14 @@ pub trait KernelHandle: Send + Sync {
         let _ = request_id;
         Ok(None)
     }
+}
 
+// ============================================================================
+// 8. HandsControl — Hand (specialized agent) lifecycle
+// ============================================================================
+
+#[async_trait]
+pub trait HandsControl: Send + Sync {
     /// List available Hands and their activation status.
     async fn hand_list(&self) -> Result<Vec<serde_json::Value>, String> {
         Err("Hands system not available".to_string())
@@ -349,7 +483,13 @@ pub trait KernelHandle: Send + Sync {
         let _ = instance_id;
         Err("Hands system not available".to_string())
     }
+}
 
+// ============================================================================
+// 9. A2ARegistry — discovered external A2A agents (read-only directory)
+// ============================================================================
+
+pub trait A2ARegistry: Send + Sync {
     /// List discovered external A2A agents as (name, url) pairs.
     fn list_a2a_agents(&self) -> Vec<(String, String)> {
         vec![]
@@ -360,7 +500,14 @@ pub trait KernelHandle: Send + Sync {
         let _ = name;
         None
     }
+}
 
+// ============================================================================
+// 10. ChannelSender — outbound channel adapters (text / media / file / poll)
+// ============================================================================
+
+#[async_trait]
+pub trait ChannelSender: Send + Sync {
     /// Send a message to a user on a named channel adapter (e.g., "email", "telegram").
     /// When `thread_id` is provided, the message is sent as a thread reply.
     /// When `account_id` is provided, routes through the specific configured bot with that ID.
@@ -451,27 +598,43 @@ pub trait KernelHandle: Send + Sync {
         Err("Channel poll send not available".to_string())
     }
 
-    /// Touch the agent's `last_active` timestamp to prevent heartbeat false-positives
-    /// during long-running operations (e.g., LLM calls).
-    fn touch_heartbeat(&self, agent_id: &str) {
-        let _ = agent_id;
-    }
-
-    /// Spawn an agent with capability inheritance enforcement.
-    /// `parent_caps` are the parent's granted capabilities. The kernel MUST verify
-    /// that every capability in the child manifest is covered by `parent_caps`.
-    async fn spawn_agent_checked(
+    /// Upsert a group roster member (channel bridge → persistent storage).
+    fn roster_upsert(
         &self,
-        manifest_toml: &str,
-        parent_id: Option<&str>,
-        parent_caps: &[librefang_types::capability::Capability],
-    ) -> Result<(String, String), String> {
-        // Default: delegate to spawn_agent (no enforcement)
-        // The kernel MUST override this with real enforcement
-        let _ = parent_caps;
-        self.spawn_agent(manifest_toml, parent_id).await
+        _channel: &str,
+        _chat_id: &str,
+        _user_id: &str,
+        _display_name: &str,
+        _username: Option<&str>,
+    ) -> Result<(), String> {
+        Ok(())
     }
 
+    /// List group roster members for a (channel, chat_id) pair.
+    fn roster_members(
+        &self,
+        _channel: &str,
+        _chat_id: &str,
+    ) -> Result<Vec<serde_json::Value>, String> {
+        Ok(Vec::new())
+    }
+
+    /// Remove a member from the group roster.
+    fn roster_remove_member(
+        &self,
+        _channel: &str,
+        _chat_id: &str,
+        _user_id: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+// ============================================================================
+// 11. PromptStore — prompt versions + experiment metadata + auto-tracking
+// ============================================================================
+
+pub trait PromptStore: Send + Sync {
     /// Get the running experiment for an agent (if any). Default: None.
     fn get_running_experiment(
         &self,
@@ -582,7 +745,56 @@ pub trait KernelHandle: Send + Sync {
     ) -> Result<(), String> {
         Ok(())
     }
+}
 
+// ============================================================================
+// 12. WorkflowRunner — declarative workflow execution
+// ============================================================================
+
+#[async_trait]
+pub trait WorkflowRunner: Send + Sync {
+    /// Run a workflow by ID or name. The `workflow_id` can be a UUID string or a
+    /// workflow name. The `input` is an arbitrary string (typically JSON-encoded
+    /// parameters) passed to the first step. Returns `(run_id, output)` on success.
+    async fn run_workflow(
+        &self,
+        workflow_id: &str,
+        input: &str,
+    ) -> Result<(String, String), String> {
+        let _ = (workflow_id, input);
+        Err("Workflow engine not available".to_string())
+    }
+}
+
+// ============================================================================
+// 13. GoalControl — list and update agent goals
+// ============================================================================
+
+pub trait GoalControl: Send + Sync {
+    /// List active goals (pending or in_progress), optionally filtered by agent ID.
+    /// Returns a JSON array of goal objects.
+    fn goal_list_active(&self, _agent_id: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+        Ok(Vec::new())
+    }
+
+    /// Update a goal's status and/or progress. Returns the updated goal JSON.
+    fn goal_update(
+        &self,
+        _goal_id: &str,
+        _status: Option<&str>,
+        _progress: Option<u8>,
+    ) -> Result<serde_json::Value, String> {
+        Err("Goal system not available".to_string())
+    }
+}
+
+// ============================================================================
+// 14. ToolPolicy — tool/agent config queries (timeouts, env passthrough,
+//     workspace prefixes). Pure read-side surface used by the runtime to
+//     parameterize tool execution against operator config.
+// ============================================================================
+
+pub trait ToolPolicy: Send + Sync {
     /// Tool execution timeout in seconds (from config). Default: 120.
     fn tool_timeout_secs(&self) -> u64 {
         120
@@ -600,11 +812,6 @@ pub trait KernelHandle: Send + Sync {
         self.tool_timeout_secs()
     }
 
-    /// Maximum inter-agent call depth (from config). Default: 5.
-    fn max_agent_call_depth(&self) -> u32 {
-        5
-    }
-
     /// Operator-side gate over skill `env_passthrough` requests, derived from
     /// `[skills]` config. `None` = no operator gate (only the built-in
     /// FORBIDDEN/kernel-reserved hard blocks apply). Default impl returns
@@ -614,99 +821,6 @@ pub trait KernelHandle: Send + Sync {
     ) -> Option<librefang_types::config::EnvPassthroughPolicy> {
         None
     }
-
-    /// List active goals (pending or in_progress), optionally filtered by agent ID.
-    /// Returns a JSON array of goal objects.
-    fn goal_list_active(&self, _agent_id: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
-        Ok(Vec::new())
-    }
-
-    /// Run a workflow by ID or name. The `workflow_id` can be a UUID string or a
-    /// workflow name. The `input` is an arbitrary string (typically JSON-encoded
-    /// parameters) passed to the first step. Returns `(run_id, output)` on success.
-    async fn run_workflow(
-        &self,
-        workflow_id: &str,
-        input: &str,
-    ) -> Result<(String, String), String> {
-        let _ = (workflow_id, input);
-        Err("Workflow engine not available".to_string())
-    }
-
-    /// Update a goal's status and/or progress. Returns the updated goal JSON.
-    fn goal_update(
-        &self,
-        _goal_id: &str,
-        _status: Option<&str>,
-        _progress: Option<u8>,
-    ) -> Result<serde_json::Value, String> {
-        Err("Goal system not available".to_string())
-    }
-
-    /// Run a forked agent turn that collapses to a single text response —
-    /// the "structured-output via forked call" primitive. Used by the
-    /// proactive memory extractor so its LLM call shares the parent
-    /// turn's `(system + tools + messages)` prefix for Anthropic prompt
-    /// cache alignment, instead of issuing a standalone `driver.complete()`
-    /// that always starts cold.
-    ///
-    /// Internally: spawn `run_forked_agent_streaming`, drain to completion,
-    /// return the final assistant text. Fork semantics apply — the call's
-    /// messages do NOT persist into the agent's canonical session, and the
-    /// turn-end hook fires with `is_fork: true` so auto-dream won't
-    /// recurse.
-    ///
-    /// `allowed_tools = Some(vec![])` keeps the fork single-turn (no tool
-    /// calls permitted — model returns text). Pass a larger allowlist only
-    /// when the caller actually expects tool use (e.g. future extractors
-    /// that want the fork to call `memory_store` directly).
-    ///
-    /// Default: error. The real kernel overrides; tests / stubs that
-    /// don't implement the full streaming path just fall back to a
-    /// standalone driver call through the extractor's own path.
-    async fn run_forked_agent_oneshot(
-        &self,
-        _agent_id: &str,
-        _prompt: &str,
-        _allowed_tools: Option<Vec<String>>,
-    ) -> Result<String, String> {
-        Err("run_forked_agent_oneshot not available in this KernelHandle".to_string())
-    }
-
-    /// Upsert a group roster member (channel bridge → persistent storage).
-    fn roster_upsert(
-        &self,
-        _channel: &str,
-        _chat_id: &str,
-        _user_id: &str,
-        _display_name: &str,
-        _username: Option<&str>,
-    ) -> Result<(), String> {
-        Ok(())
-    }
-
-    /// List group roster members for a (channel, chat_id) pair.
-    fn roster_members(
-        &self,
-        _channel: &str,
-        _chat_id: &str,
-    ) -> Result<Vec<serde_json::Value>, String> {
-        Ok(Vec::new())
-    }
-
-    /// Remove a member from the group roster.
-    fn roster_remove_member(
-        &self,
-        _channel: &str,
-        _chat_id: &str,
-        _user_id: &str,
-    ) -> Result<(), String> {
-        Ok(())
-    }
-
-    /// Fire an `agent:step` external hook event.
-    /// Called by the runtime at the start of each agent loop iteration.
-    fn fire_agent_step(&self, _agent_id: &str, _step: u32) {}
 
     /// Return the canonicalized absolute paths of named workspaces declared as `read-only`
     /// for the given agent. Used by file-write tools to enforce workspace access modes.
@@ -749,5 +863,240 @@ pub trait KernelHandle: Send + Sync {
     /// legacy `<temp>/librefang_uploads`. See issue #4435.
     fn effective_upload_dir(&self) -> std::path::PathBuf {
         std::env::temp_dir().join("librefang_uploads")
+    }
+}
+
+// ============================================================================
+// KernelHandle — supertrait alias of all 14 role traits.
+//
+// Existing call sites take `Arc<dyn KernelHandle>`; that keeps working because
+// any type that impls every role trait automatically gets `KernelHandle` via
+// the blanket impl below. To narrow a new call site, take only the role bounds
+// you need (e.g. `fn foo<T: ApprovalGate + Send + Sync>(h: &T)`).
+// ============================================================================
+
+pub trait KernelHandle:
+    AgentControl
+    + MemoryAccess
+    + TaskQueue
+    + EventBus
+    + KnowledgeGraph
+    + CronControl
+    + ApprovalGate
+    + HandsControl
+    + A2ARegistry
+    + ChannelSender
+    + PromptStore
+    + WorkflowRunner
+    + GoalControl
+    + ToolPolicy
+    + Send
+    + Sync
+{
+}
+
+impl<T> KernelHandle for T where
+    T: AgentControl
+        + MemoryAccess
+        + TaskQueue
+        + EventBus
+        + KnowledgeGraph
+        + CronControl
+        + ApprovalGate
+        + HandsControl
+        + A2ARegistry
+        + ChannelSender
+        + PromptStore
+        + WorkflowRunner
+        + GoalControl
+        + ToolPolicy
+        + Send
+        + Sync
+        + ?Sized
+{
+}
+
+/// Prelude — glob-import this to bring `KernelHandle` plus every role trait
+/// into scope so that method calls like `kernel.send_channel_message(...)`
+/// resolve. Replaces the pre-#3746 single-trait import pattern.
+pub mod prelude {
+    pub use super::{
+        A2ARegistry, AgentControl, AgentInfo, ApprovalGate, ChannelSender, CronControl, EventBus,
+        GoalControl, HandsControl, KernelHandle, KnowledgeGraph, MemoryAccess, PromptStore,
+        TaskQueue, ToolPolicy, WorkflowRunner,
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// Compile-only stub that implements every role trait, used to prove that:
+    ///   1. `KernelHandle` is reachable purely via the blanket impl,
+    ///   2. `Arc<dyn KernelHandle>` can be constructed from such a type,
+    ///   3. each role trait is individually object-safe.
+    struct StubKernel;
+
+    #[async_trait]
+    impl AgentControl for StubKernel {
+        async fn spawn_agent(
+            &self,
+            _manifest_toml: &str,
+            _parent_id: Option<&str>,
+        ) -> Result<(String, String), String> {
+            Err("stub".to_string())
+        }
+        async fn send_to_agent(&self, _agent_id: &str, _message: &str) -> Result<String, String> {
+            Err("stub".to_string())
+        }
+        fn list_agents(&self) -> Vec<AgentInfo> {
+            vec![]
+        }
+        fn kill_agent(&self, _agent_id: &str) -> Result<(), String> {
+            Err("stub".to_string())
+        }
+        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+            vec![]
+        }
+    }
+
+    impl MemoryAccess for StubKernel {
+        fn memory_store(
+            &self,
+            _key: &str,
+            _value: serde_json::Value,
+            _peer_id: Option<&str>,
+        ) -> Result<(), String> {
+            Err("stub".to_string())
+        }
+        fn memory_recall(
+            &self,
+            _key: &str,
+            _peer_id: Option<&str>,
+        ) -> Result<Option<serde_json::Value>, String> {
+            Ok(None)
+        }
+        fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
+            Ok(vec![])
+        }
+    }
+
+    #[async_trait]
+    impl TaskQueue for StubKernel {
+        async fn task_post(
+            &self,
+            _title: &str,
+            _description: &str,
+            _assigned_to: Option<&str>,
+            _created_by: Option<&str>,
+        ) -> Result<String, String> {
+            Err("stub".to_string())
+        }
+        async fn task_claim(&self, _agent_id: &str) -> Result<Option<serde_json::Value>, String> {
+            Ok(None)
+        }
+        async fn task_complete(
+            &self,
+            _agent_id: &str,
+            _task_id: &str,
+            _result: &str,
+        ) -> Result<(), String> {
+            Err("stub".to_string())
+        }
+        async fn task_list(&self, _status: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+            Ok(vec![])
+        }
+        async fn task_delete(&self, _task_id: &str) -> Result<bool, String> {
+            Ok(false)
+        }
+        async fn task_retry(&self, _task_id: &str) -> Result<bool, String> {
+            Ok(false)
+        }
+        async fn task_get(&self, _task_id: &str) -> Result<Option<serde_json::Value>, String> {
+            Ok(None)
+        }
+        async fn task_update_status(
+            &self,
+            _task_id: &str,
+            _new_status: &str,
+        ) -> Result<bool, String> {
+            Ok(false)
+        }
+    }
+
+    #[async_trait]
+    impl EventBus for StubKernel {
+        async fn publish_event(
+            &self,
+            _event_type: &str,
+            _payload: serde_json::Value,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl KnowledgeGraph for StubKernel {
+        async fn knowledge_add_entity(
+            &self,
+            _entity: &librefang_types::memory::Entity,
+        ) -> Result<String, String> {
+            Err("stub".to_string())
+        }
+        async fn knowledge_add_relation(
+            &self,
+            _relation: &librefang_types::memory::Relation,
+        ) -> Result<String, String> {
+            Err("stub".to_string())
+        }
+        async fn knowledge_query(
+            &self,
+            _pattern: librefang_types::memory::GraphPattern,
+        ) -> Result<Vec<librefang_types::memory::GraphMatch>, String> {
+            Ok(vec![])
+        }
+    }
+
+    impl CronControl for StubKernel {}
+    impl ApprovalGate for StubKernel {}
+    impl HandsControl for StubKernel {}
+    impl A2ARegistry for StubKernel {}
+    impl ChannelSender for StubKernel {}
+    impl PromptStore for StubKernel {}
+    impl WorkflowRunner for StubKernel {}
+    impl GoalControl for StubKernel {}
+    impl ToolPolicy for StubKernel {}
+
+    #[test]
+    fn stub_satisfies_kernel_handle_via_blanket_impl() {
+        fn assert_kernel_handle<T: KernelHandle + ?Sized>(_: &T) {}
+        let s = StubKernel;
+        assert_kernel_handle(&s);
+    }
+
+    #[test]
+    fn dyn_kernel_handle_is_object_safe() {
+        let _arc: Arc<dyn KernelHandle> = Arc::new(StubKernel);
+    }
+
+    #[test]
+    fn role_traits_are_individually_object_safe() {
+        // If any role trait gained a non-object-safe method (generic, Self by
+        // value, etc.), this stops compiling. That's the point.
+        let _agent: Arc<dyn AgentControl> = Arc::new(StubKernel);
+        let _mem: Arc<dyn MemoryAccess> = Arc::new(StubKernel);
+        let _tq: Arc<dyn TaskQueue> = Arc::new(StubKernel);
+        let _ev: Arc<dyn EventBus> = Arc::new(StubKernel);
+        let _kg: Arc<dyn KnowledgeGraph> = Arc::new(StubKernel);
+        let _cron: Arc<dyn CronControl> = Arc::new(StubKernel);
+        let _appr: Arc<dyn ApprovalGate> = Arc::new(StubKernel);
+        let _hand: Arc<dyn HandsControl> = Arc::new(StubKernel);
+        let _a2a: Arc<dyn A2ARegistry> = Arc::new(StubKernel);
+        let _ch: Arc<dyn ChannelSender> = Arc::new(StubKernel);
+        let _ps: Arc<dyn PromptStore> = Arc::new(StubKernel);
+        let _wf: Arc<dyn WorkflowRunner> = Arc::new(StubKernel);
+        let _goal: Arc<dyn GoalControl> = Arc::new(StubKernel);
+        let _tp: Arc<dyn ToolPolicy> = Arc::new(StubKernel);
     }
 }

--- a/crates/librefang-kernel-handle/tests/defaults_approval.rs
+++ b/crates/librefang-kernel-handle/tests/defaults_approval.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
-use librefang_kernel_handle::{AgentInfo, KernelHandle};
+use librefang_kernel_handle::prelude::*;
 use librefang_types::approval::ApprovalDecision;
 use librefang_types::memory::{Entity, GraphMatch, GraphPattern, Relation};
 
 struct NoopKernelHandle;
 
 #[async_trait]
-impl KernelHandle for NoopKernelHandle {
+impl AgentControl for NoopKernelHandle {
     async fn spawn_agent(
         &self,
         _manifest_toml: &str,
@@ -27,6 +27,12 @@ impl KernelHandle for NoopKernelHandle {
         Err("not implemented".into())
     }
 
+    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+}
+
+impl MemoryAccess for NoopKernelHandle {
     fn memory_store(
         &self,
         _key: &str,
@@ -47,11 +53,10 @@ impl KernelHandle for NoopKernelHandle {
     fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
         Err("not implemented".into())
     }
+}
 
-    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-        vec![]
-    }
-
+#[async_trait]
+impl TaskQueue for NoopKernelHandle {
     async fn task_post(
         &self,
         _title: &str,
@@ -94,7 +99,10 @@ impl KernelHandle for NoopKernelHandle {
     async fn task_update_status(&self, _task_id: &str, _new_status: &str) -> Result<bool, String> {
         Err("not implemented".into())
     }
+}
 
+#[async_trait]
+impl EventBus for NoopKernelHandle {
     async fn publish_event(
         &self,
         _event_type: &str,
@@ -102,7 +110,10 @@ impl KernelHandle for NoopKernelHandle {
     ) -> Result<(), String> {
         Err("not implemented".into())
     }
+}
 
+#[async_trait]
+impl KnowledgeGraph for NoopKernelHandle {
     async fn knowledge_add_entity(&self, _entity: &Entity) -> Result<String, String> {
         Err("not implemented".into())
     }
@@ -115,6 +126,16 @@ impl KernelHandle for NoopKernelHandle {
         Err("not implemented".into())
     }
 }
+
+impl CronControl for NoopKernelHandle {}
+impl ApprovalGate for NoopKernelHandle {}
+impl HandsControl for NoopKernelHandle {}
+impl A2ARegistry for NoopKernelHandle {}
+impl ChannelSender for NoopKernelHandle {}
+impl PromptStore for NoopKernelHandle {}
+impl WorkflowRunner for NoopKernelHandle {}
+impl GoalControl for NoopKernelHandle {}
+impl ToolPolicy for NoopKernelHandle {}
 
 #[tokio::test]
 async fn test_request_approval_default_auto_approves() {

--- a/crates/librefang-kernel-handle/tests/defaults_delegation.rs
+++ b/crates/librefang-kernel-handle/tests/defaults_delegation.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
-use librefang_kernel_handle::{AgentInfo, KernelHandle};
+use librefang_kernel_handle::prelude::*;
 
 // ---------------------------------------------------------------------------
 // Test 1: send_to_agent_as delegates to send_to_agent
@@ -12,7 +12,7 @@ struct TrackingSendHandle {
 }
 
 #[async_trait]
-impl KernelHandle for TrackingSendHandle {
+impl AgentControl for TrackingSendHandle {
     async fn spawn_agent(
         &self,
         _manifest_toml: &str,
@@ -34,6 +34,12 @@ impl KernelHandle for TrackingSendHandle {
         Ok(())
     }
 
+    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+}
+
+impl MemoryAccess for TrackingSendHandle {
     fn memory_store(
         &self,
         _key: &str,
@@ -54,11 +60,10 @@ impl KernelHandle for TrackingSendHandle {
     fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
         Ok(vec![])
     }
+}
 
-    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-        vec![]
-    }
-
+#[async_trait]
+impl TaskQueue for TrackingSendHandle {
     async fn task_post(
         &self,
         _title: &str,
@@ -101,7 +106,10 @@ impl KernelHandle for TrackingSendHandle {
     async fn task_update_status(&self, _task_id: &str, _new_status: &str) -> Result<bool, String> {
         Ok(false)
     }
+}
 
+#[async_trait]
+impl EventBus for TrackingSendHandle {
     async fn publish_event(
         &self,
         _event_type: &str,
@@ -109,7 +117,10 @@ impl KernelHandle for TrackingSendHandle {
     ) -> Result<(), String> {
         Ok(())
     }
+}
 
+#[async_trait]
+impl KnowledgeGraph for TrackingSendHandle {
     async fn knowledge_add_entity(
         &self,
         _entity: &librefang_types::memory::Entity,
@@ -131,6 +142,16 @@ impl KernelHandle for TrackingSendHandle {
         Ok(vec![])
     }
 }
+
+impl CronControl for TrackingSendHandle {}
+impl ApprovalGate for TrackingSendHandle {}
+impl HandsControl for TrackingSendHandle {}
+impl A2ARegistry for TrackingSendHandle {}
+impl ChannelSender for TrackingSendHandle {}
+impl PromptStore for TrackingSendHandle {}
+impl WorkflowRunner for TrackingSendHandle {}
+impl GoalControl for TrackingSendHandle {}
+impl ToolPolicy for TrackingSendHandle {}
 
 #[tokio::test]
 async fn test_send_to_agent_as_delegates_to_send_to_agent() {
@@ -153,7 +174,7 @@ struct TrackingSpawnHandle {
 }
 
 #[async_trait]
-impl KernelHandle for TrackingSpawnHandle {
+impl AgentControl for TrackingSpawnHandle {
     async fn spawn_agent(
         &self,
         _manifest_toml: &str,
@@ -175,6 +196,12 @@ impl KernelHandle for TrackingSpawnHandle {
         Ok(())
     }
 
+    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+}
+
+impl MemoryAccess for TrackingSpawnHandle {
     fn memory_store(
         &self,
         _key: &str,
@@ -195,11 +222,10 @@ impl KernelHandle for TrackingSpawnHandle {
     fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
         Ok(vec![])
     }
+}
 
-    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-        vec![]
-    }
-
+#[async_trait]
+impl TaskQueue for TrackingSpawnHandle {
     async fn task_post(
         &self,
         _title: &str,
@@ -242,7 +268,10 @@ impl KernelHandle for TrackingSpawnHandle {
     async fn task_update_status(&self, _task_id: &str, _new_status: &str) -> Result<bool, String> {
         Ok(false)
     }
+}
 
+#[async_trait]
+impl EventBus for TrackingSpawnHandle {
     async fn publish_event(
         &self,
         _event_type: &str,
@@ -250,7 +279,10 @@ impl KernelHandle for TrackingSpawnHandle {
     ) -> Result<(), String> {
         Ok(())
     }
+}
 
+#[async_trait]
+impl KnowledgeGraph for TrackingSpawnHandle {
     async fn knowledge_add_entity(
         &self,
         _entity: &librefang_types::memory::Entity,
@@ -272,6 +304,16 @@ impl KernelHandle for TrackingSpawnHandle {
         Ok(vec![])
     }
 }
+
+impl CronControl for TrackingSpawnHandle {}
+impl ApprovalGate for TrackingSpawnHandle {}
+impl HandsControl for TrackingSpawnHandle {}
+impl A2ARegistry for TrackingSpawnHandle {}
+impl ChannelSender for TrackingSpawnHandle {}
+impl PromptStore for TrackingSpawnHandle {}
+impl WorkflowRunner for TrackingSpawnHandle {}
+impl GoalControl for TrackingSpawnHandle {}
+impl ToolPolicy for TrackingSpawnHandle {}
 
 #[tokio::test]
 async fn test_spawn_agent_checked_delegates_to_spawn_agent() {
@@ -294,7 +336,7 @@ struct TrackingApprovalHandle {
 }
 
 #[async_trait]
-impl KernelHandle for TrackingApprovalHandle {
+impl AgentControl for TrackingApprovalHandle {
     async fn spawn_agent(
         &self,
         _manifest_toml: &str,
@@ -315,6 +357,12 @@ impl KernelHandle for TrackingApprovalHandle {
         Ok(())
     }
 
+    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+}
+
+impl MemoryAccess for TrackingApprovalHandle {
     fn memory_store(
         &self,
         _key: &str,
@@ -335,11 +383,10 @@ impl KernelHandle for TrackingApprovalHandle {
     fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
         Ok(vec![])
     }
+}
 
-    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-        vec![]
-    }
-
+#[async_trait]
+impl TaskQueue for TrackingApprovalHandle {
     async fn task_post(
         &self,
         _title: &str,
@@ -382,7 +429,10 @@ impl KernelHandle for TrackingApprovalHandle {
     async fn task_update_status(&self, _task_id: &str, _new_status: &str) -> Result<bool, String> {
         Ok(false)
     }
+}
 
+#[async_trait]
+impl EventBus for TrackingApprovalHandle {
     async fn publish_event(
         &self,
         _event_type: &str,
@@ -390,7 +440,10 @@ impl KernelHandle for TrackingApprovalHandle {
     ) -> Result<(), String> {
         Ok(())
     }
+}
 
+#[async_trait]
+impl KnowledgeGraph for TrackingApprovalHandle {
     async fn knowledge_add_entity(
         &self,
         _entity: &librefang_types::memory::Entity,
@@ -411,12 +464,23 @@ impl KernelHandle for TrackingApprovalHandle {
     ) -> Result<Vec<librefang_types::memory::GraphMatch>, String> {
         Ok(vec![])
     }
+}
 
+impl CronControl for TrackingApprovalHandle {}
+#[async_trait]
+impl ApprovalGate for TrackingApprovalHandle {
     fn requires_approval(&self, _tool_name: &str) -> bool {
         self.approval_checked.store(true, Ordering::SeqCst);
         true
     }
 }
+impl HandsControl for TrackingApprovalHandle {}
+impl A2ARegistry for TrackingApprovalHandle {}
+impl ChannelSender for TrackingApprovalHandle {}
+impl PromptStore for TrackingApprovalHandle {}
+impl WorkflowRunner for TrackingApprovalHandle {}
+impl GoalControl for TrackingApprovalHandle {}
+impl ToolPolicy for TrackingApprovalHandle {}
 
 #[test]
 fn test_requires_approval_with_context_delegates_to_requires_approval() {

--- a/crates/librefang-kernel-handle/tests/defaults_returns.rs
+++ b/crates/librefang-kernel-handle/tests/defaults_returns.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
-use librefang_kernel_handle::{AgentInfo, KernelHandle};
+use librefang_kernel_handle::prelude::*;
 use librefang_types::memory::{Entity, GraphMatch, GraphPattern, Relation};
 use librefang_types::user_policy::UserToolGate;
 
 struct NoopKernelHandle;
 
 #[async_trait]
-impl KernelHandle for NoopKernelHandle {
+impl AgentControl for NoopKernelHandle {
     async fn spawn_agent(
         &self,
         _manifest_toml: &str,
@@ -27,6 +27,12 @@ impl KernelHandle for NoopKernelHandle {
         Err("noop".into())
     }
 
+    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+}
+
+impl MemoryAccess for NoopKernelHandle {
     fn memory_store(
         &self,
         _key: &str,
@@ -47,11 +53,10 @@ impl KernelHandle for NoopKernelHandle {
     fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
         Err("noop".into())
     }
+}
 
-    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-        vec![]
-    }
-
+#[async_trait]
+impl TaskQueue for NoopKernelHandle {
     async fn task_post(
         &self,
         _title: &str,
@@ -94,7 +99,10 @@ impl KernelHandle for NoopKernelHandle {
     async fn task_update_status(&self, _task_id: &str, _new_status: &str) -> Result<bool, String> {
         Err("noop".into())
     }
+}
 
+#[async_trait]
+impl EventBus for NoopKernelHandle {
     async fn publish_event(
         &self,
         _event_type: &str,
@@ -102,7 +110,10 @@ impl KernelHandle for NoopKernelHandle {
     ) -> Result<(), String> {
         Err("noop".into())
     }
+}
 
+#[async_trait]
+impl KnowledgeGraph for NoopKernelHandle {
     async fn knowledge_add_entity(&self, _entity: &Entity) -> Result<String, String> {
         Err("noop".into())
     }
@@ -115,6 +126,16 @@ impl KernelHandle for NoopKernelHandle {
         Err("noop".into())
     }
 }
+
+impl CronControl for NoopKernelHandle {}
+impl ApprovalGate for NoopKernelHandle {}
+impl HandsControl for NoopKernelHandle {}
+impl A2ARegistry for NoopKernelHandle {}
+impl ChannelSender for NoopKernelHandle {}
+impl PromptStore for NoopKernelHandle {}
+impl WorkflowRunner for NoopKernelHandle {}
+impl GoalControl for NoopKernelHandle {}
+impl ToolPolicy for NoopKernelHandle {}
 
 #[test]
 fn test_resolve_user_tool_decision_default_allow() {

--- a/crates/librefang-kernel-handle/tests/send_channel_file_data_zero_copy.rs
+++ b/crates/librefang-kernel-handle/tests/send_channel_file_data_zero_copy.rs
@@ -13,7 +13,7 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use librefang_kernel_handle::{AgentInfo, KernelHandle};
+use librefang_kernel_handle::prelude::*;
 use librefang_types::memory::{Entity, GraphMatch, GraphPattern, Relation};
 use std::sync::Mutex;
 
@@ -35,7 +35,7 @@ impl CapturingFileKernel {
 }
 
 #[async_trait]
-impl KernelHandle for CapturingFileKernel {
+impl AgentControl for CapturingFileKernel {
     async fn spawn_agent(
         &self,
         _manifest_toml: &str,
@@ -56,6 +56,12 @@ impl KernelHandle for CapturingFileKernel {
         Err("not used".into())
     }
 
+    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+}
+
+impl MemoryAccess for CapturingFileKernel {
     fn memory_store(
         &self,
         _key: &str,
@@ -76,11 +82,10 @@ impl KernelHandle for CapturingFileKernel {
     fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
         Err("not used".into())
     }
+}
 
-    fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-        vec![]
-    }
-
+#[async_trait]
+impl TaskQueue for CapturingFileKernel {
     async fn task_post(
         &self,
         _title: &str,
@@ -123,7 +128,10 @@ impl KernelHandle for CapturingFileKernel {
     async fn task_update_status(&self, _task_id: &str, _new_status: &str) -> Result<bool, String> {
         Err("not used".into())
     }
+}
 
+#[async_trait]
+impl EventBus for CapturingFileKernel {
     async fn publish_event(
         &self,
         _event_type: &str,
@@ -131,7 +139,10 @@ impl KernelHandle for CapturingFileKernel {
     ) -> Result<(), String> {
         Err("not used".into())
     }
+}
 
+#[async_trait]
+impl KnowledgeGraph for CapturingFileKernel {
     async fn knowledge_add_entity(&self, _entity: &Entity) -> Result<String, String> {
         Err("not used".into())
     }
@@ -143,7 +154,15 @@ impl KernelHandle for CapturingFileKernel {
     async fn knowledge_query(&self, _pattern: GraphPattern) -> Result<Vec<GraphMatch>, String> {
         Err("not used".into())
     }
+}
 
+impl CronControl for CapturingFileKernel {}
+impl ApprovalGate for CapturingFileKernel {}
+impl HandsControl for CapturingFileKernel {}
+impl A2ARegistry for CapturingFileKernel {}
+
+#[async_trait]
+impl ChannelSender for CapturingFileKernel {
     // The method under test. Records the underlying pointer + length so
     // the test can assert the kernel observed the same allocation as the
     // caller's Bytes — i.e. the trait did not silently copy the buffer.
@@ -162,6 +181,11 @@ impl KernelHandle for CapturingFileKernel {
         Ok("captured".into())
     }
 }
+
+impl PromptStore for CapturingFileKernel {}
+impl WorkflowRunner for CapturingFileKernel {}
+impl GoalControl for CapturingFileKernel {}
+impl ToolPolicy for CapturingFileKernel {}
 
 #[test]
 fn cloning_bytes_shares_underlying_allocation() {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -18191,9 +18191,6 @@ impl kernel_handle::KnowledgeGraph for LibreFangKernel {
 
 #[async_trait::async_trait]
 impl kernel_handle::CronControl for LibreFangKernel {
-    /// Spawn with capability inheritance enforcement.
-    /// Parses the child manifest, extracts its capabilities, and verifies
-    /// every child capability is covered by the parent's grants.
     async fn cron_create(
         &self,
         agent_id: &str,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -23,7 +23,7 @@ use librefang_runtime::agent_loop::{
 };
 use librefang_runtime::audit::AuditLog;
 use librefang_runtime::drivers;
-use librefang_runtime::kernel_handle::{self, KernelHandle};
+use librefang_runtime::kernel_handle::{self, prelude::*};
 use librefang_runtime::llm_driver::{
     CompletionRequest, CompletionResponse, DriverConfig, LlmDriver, LlmError, StreamEvent,
 };
@@ -17682,12 +17682,10 @@ impl LibreFangKernel {
     }
 }
 
-#[async_trait]
-impl KernelHandle for LibreFangKernel {
-    fn effective_upload_dir(&self) -> std::path::PathBuf {
-        self.config_ref().channels.effective_file_download_dir()
-    }
+// ---- BEGIN role-trait impls (split from former `impl KernelHandle for LibreFangKernel`, #3746) ----
 
+#[async_trait::async_trait]
+impl kernel_handle::AgentControl for LibreFangKernel {
     async fn spawn_agent(
         &self,
         manifest_toml: &str,
@@ -17810,6 +17808,78 @@ impl KernelHandle for LibreFangKernel {
         LibreFangKernel::kill_agent(self, id).map_err(|e| format!("Kill failed: {e}"))
     }
 
+    fn find_agents(&self, query: &str) -> Vec<kernel_handle::AgentInfo> {
+        let q = query.to_lowercase();
+        self.registry
+            .list()
+            .into_iter()
+            .filter(|e| {
+                let name_match = e.name.to_lowercase().contains(&q);
+                let tag_match = e.tags.iter().any(|t| t.to_lowercase().contains(&q));
+                let tool_match = e
+                    .manifest
+                    .capabilities
+                    .tools
+                    .iter()
+                    .any(|t| t.to_lowercase().contains(&q));
+                let desc_match = e.manifest.description.to_lowercase().contains(&q);
+                name_match || tag_match || tool_match || desc_match
+            })
+            .map(|e| kernel_handle::AgentInfo {
+                id: e.id.to_string(),
+                name: e.name.clone(),
+                state: format!("{:?}", e.state),
+                model_provider: e.manifest.model.provider.clone(),
+                model_name: e.manifest.model.model.clone(),
+                description: e.manifest.description.clone(),
+                tags: e.tags.clone(),
+                tools: e.manifest.capabilities.tools.clone(),
+            })
+            .collect()
+    }
+
+    async fn spawn_agent_checked(
+        &self,
+        manifest_toml: &str,
+        parent_id: Option<&str>,
+        parent_caps: &[librefang_types::capability::Capability],
+    ) -> Result<(String, String), String> {
+        // Parse the child manifest to extract its capabilities
+        let child_manifest: AgentManifest =
+            toml::from_str(manifest_toml).map_err(|e| format!("Invalid manifest: {e}"))?;
+        let child_caps = manifest_to_capabilities(&child_manifest);
+
+        // Enforce: child capabilities must be a subset of parent capabilities
+        librefang_types::capability::validate_capability_inheritance(parent_caps, &child_caps)?;
+
+        tracing::info!(
+            parent = parent_id.unwrap_or("kernel"),
+            child = %child_manifest.name,
+            child_caps = child_caps.len(),
+            "Capability inheritance validated — spawning child agent"
+        );
+
+        // Delegate to the normal spawn path via the AgentControl role trait.
+        kernel_handle::AgentControl::spawn_agent(self, manifest_toml, parent_id).await
+    }
+
+    fn max_agent_call_depth(&self) -> u32 {
+        let cfg = self.config.load();
+        cfg.max_agent_call_depth
+    }
+
+    fn fire_agent_step(&self, agent_id: &str, step: u32) {
+        self.external_hooks.fire(
+            crate::hooks::ExternalHookEvent::AgentStep,
+            serde_json::json!({
+                "agent_id": agent_id.to_string(),
+                "step": step,
+            }),
+        );
+    }
+}
+
+impl kernel_handle::MemoryAccess for LibreFangKernel {
     fn memory_store(
         &self,
         key: &str,
@@ -17899,36 +17969,21 @@ impl KernelHandle for LibreFangKernel {
         }
     }
 
-    fn find_agents(&self, query: &str) -> Vec<kernel_handle::AgentInfo> {
-        let q = query.to_lowercase();
-        self.registry
-            .list()
-            .into_iter()
-            .filter(|e| {
-                let name_match = e.name.to_lowercase().contains(&q);
-                let tag_match = e.tags.iter().any(|t| t.to_lowercase().contains(&q));
-                let tool_match = e
-                    .manifest
-                    .capabilities
-                    .tools
-                    .iter()
-                    .any(|t| t.to_lowercase().contains(&q));
-                let desc_match = e.manifest.description.to_lowercase().contains(&q);
-                name_match || tag_match || tool_match || desc_match
-            })
-            .map(|e| kernel_handle::AgentInfo {
-                id: e.id.to_string(),
-                name: e.name.clone(),
-                state: format!("{:?}", e.state),
-                model_provider: e.manifest.model.provider.clone(),
-                model_name: e.manifest.model.model.clone(),
-                description: e.manifest.description.clone(),
-                tags: e.tags.clone(),
-                tools: e.manifest.capabilities.tools.clone(),
-            })
-            .collect()
+    fn memory_acl_for_sender(
+        &self,
+        sender_id: Option<&str>,
+        channel: Option<&str>,
+    ) -> Option<librefang_types::user_policy::UserMemoryAccess> {
+        if !self.auth.is_enabled() {
+            return None;
+        }
+        let user_id = self.auth.resolve_user(sender_id, channel)?;
+        self.auth.memory_acl_for(user_id)
     }
+}
 
+#[async_trait::async_trait]
+impl kernel_handle::TaskQueue for LibreFangKernel {
     async fn task_post(
         &self,
         title: &str,
@@ -18075,7 +18130,10 @@ impl KernelHandle for LibreFangKernel {
             .await
             .map_err(|e| format!("Task update status failed: {e}"))
     }
+}
 
+#[async_trait::async_trait]
+impl kernel_handle::EventBus for LibreFangKernel {
     async fn publish_event(
         &self,
         event_type: &str,
@@ -18093,7 +18151,10 @@ impl KernelHandle for LibreFangKernel {
         LibreFangKernel::publish_event(self, event).await;
         Ok(())
     }
+}
 
+#[async_trait::async_trait]
+impl kernel_handle::KnowledgeGraph for LibreFangKernel {
     async fn knowledge_add_entity(
         &self,
         entity: &librefang_types::memory::Entity,
@@ -18126,7 +18187,10 @@ impl KernelHandle for LibreFangKernel {
             .await
             .map_err(|e| format!("Knowledge query failed: {e}"))
     }
+}
 
+#[async_trait::async_trait]
+impl kernel_handle::CronControl for LibreFangKernel {
     /// Spawn with capability inheritance enforcement.
     /// Parses the child manifest, extracts its capabilities, and verifies
     /// every child capability is covered by the parent's grants.
@@ -18246,7 +18310,10 @@ impl KernelHandle for LibreFangKernel {
 
         Ok(())
     }
+}
 
+#[async_trait::async_trait]
+impl kernel_handle::HandsControl for LibreFangKernel {
     async fn hand_list(&self) -> Result<Vec<serde_json::Value>, String> {
         let defs = self.hand_registry.list_definitions();
         let instances = self.hand_registry.list_instances();
@@ -18350,7 +18417,10 @@ impl KernelHandle for LibreFangKernel {
             uuid::Uuid::parse_str(instance_id).map_err(|e| format!("Invalid instance ID: {e}"))?;
         self.deactivate_hand(uuid).map_err(|e| format!("{e}"))
     }
+}
 
+#[async_trait::async_trait]
+impl kernel_handle::ApprovalGate for LibreFangKernel {
     fn requires_approval(&self, tool_name: &str) -> bool {
         self.approval_manager.requires_approval(tool_name)
     }
@@ -18373,18 +18443,6 @@ impl KernelHandle for LibreFangKernel {
     ) -> bool {
         self.approval_manager
             .is_tool_denied_with_context(tool_name, sender_id, channel)
-    }
-
-    fn memory_acl_for_sender(
-        &self,
-        sender_id: Option<&str>,
-        channel: Option<&str>,
-    ) -> Option<librefang_types::user_policy::UserMemoryAccess> {
-        if !self.auth.is_enabled() {
-            return None;
-        }
-        let user_id = self.auth.resolve_user(sender_id, channel)?;
-        self.auth.memory_acl_for(user_id)
     }
 
     fn resolve_user_tool_decision(
@@ -18753,7 +18811,9 @@ impl KernelHandle for LibreFangKernel {
         }
         Ok(None)
     }
+}
 
+impl kernel_handle::A2ARegistry for LibreFangKernel {
     fn list_a2a_agents(&self) -> Vec<(String, String)> {
         let agents = self
             .a2a_external_agents
@@ -18784,7 +18844,10 @@ impl KernelHandle for LibreFangKernel {
             .find(|(_, card)| card.name.to_lowercase() == name_lower)
             .map(|(key, _)| key.clone())
     }
+}
 
+#[async_trait::async_trait]
+impl kernel_handle::ChannelSender for LibreFangKernel {
     async fn send_channel_message(
         &self,
         channel: &str,
@@ -19056,31 +19119,52 @@ impl KernelHandle for LibreFangKernel {
         Ok(())
     }
 
-    async fn spawn_agent_checked(
+    fn roster_upsert(
         &self,
-        manifest_toml: &str,
-        parent_id: Option<&str>,
-        parent_caps: &[librefang_types::capability::Capability],
-    ) -> Result<(String, String), String> {
-        // Parse the child manifest to extract its capabilities
-        let child_manifest: AgentManifest =
-            toml::from_str(manifest_toml).map_err(|e| format!("Invalid manifest: {e}"))?;
-        let child_caps = manifest_to_capabilities(&child_manifest);
-
-        // Enforce: child capabilities must be a subset of parent capabilities
-        librefang_types::capability::validate_capability_inheritance(parent_caps, &child_caps)?;
-
-        tracing::info!(
-            parent = parent_id.unwrap_or("kernel"),
-            child = %child_manifest.name,
-            child_caps = child_caps.len(),
-            "Capability inheritance validated — spawning child agent"
-        );
-
-        // Delegate to the normal spawn path (use trait method via KernelHandle::)
-        KernelHandle::spawn_agent(self, manifest_toml, parent_id).await
+        channel: &str,
+        chat_id: &str,
+        user_id: &str,
+        display_name: &str,
+        username: Option<&str>,
+    ) -> Result<(), String> {
+        self.memory
+            .roster()
+            .upsert(channel, chat_id, user_id, display_name, username);
+        Ok(())
     }
 
+    fn roster_members(
+        &self,
+        channel: &str,
+        chat_id: &str,
+    ) -> Result<Vec<serde_json::Value>, String> {
+        let members = self.memory.roster().members(channel, chat_id);
+        Ok(members
+            .into_iter()
+            .map(|(user_id, display_name, username)| {
+                serde_json::json!({
+                    "user_id": user_id,
+                    "display_name": display_name,
+                    "username": username,
+                })
+            })
+            .collect())
+    }
+
+    fn roster_remove_member(
+        &self,
+        channel: &str,
+        chat_id: &str,
+        user_id: &str,
+    ) -> Result<(), String> {
+        self.memory
+            .roster()
+            .remove_member(channel, chat_id, user_id);
+        Ok(())
+    }
+}
+
+impl kernel_handle::PromptStore for LibreFangKernel {
     fn get_running_experiment(
         &self,
         agent_id: &str,
@@ -19333,99 +19417,10 @@ impl KernelHandle for LibreFangKernel {
             Err(e) => Err(format!("Failed to auto-track prompt version: {e}")),
         }
     }
+}
 
-    fn tool_timeout_secs(&self) -> u64 {
-        let cfg = self.config.load();
-        cfg.tool_timeout_secs
-    }
-
-    fn tool_timeout_secs_for(&self, tool_name: &str) -> u64 {
-        let cfg = self.config.load();
-        // 1. Exact match
-        if let Some(&t) = cfg.tool_timeouts.get(tool_name) {
-            return t;
-        }
-        // 2. Best glob match — longest pattern wins (most specific first).
-        // HashMap iteration is unordered; picking the longest matching pattern
-        // gives deterministic resolution when multiple globs match.
-        let best = cfg
-            .tool_timeouts
-            .iter()
-            .filter(|(pattern, _)| librefang_types::capability::glob_matches(pattern, tool_name))
-            .max_by_key(|(pattern, _)| pattern.len());
-        if let Some((_, &timeout)) = best {
-            return timeout;
-        }
-        // 3. Global fallback
-        cfg.tool_timeout_secs
-    }
-
-    fn max_agent_call_depth(&self) -> u32 {
-        let cfg = self.config.load();
-        cfg.max_agent_call_depth
-    }
-
-    fn skill_env_passthrough_policy(
-        &self,
-    ) -> Option<librefang_types::config::EnvPassthroughPolicy> {
-        let cfg = self.config.load();
-        librefang_types::config::EnvPassthroughPolicy::from_skills_config(&cfg.skills)
-    }
-
-    fn roster_upsert(
-        &self,
-        channel: &str,
-        chat_id: &str,
-        user_id: &str,
-        display_name: &str,
-        username: Option<&str>,
-    ) -> Result<(), String> {
-        self.memory
-            .roster()
-            .upsert(channel, chat_id, user_id, display_name, username);
-        Ok(())
-    }
-
-    fn roster_members(
-        &self,
-        channel: &str,
-        chat_id: &str,
-    ) -> Result<Vec<serde_json::Value>, String> {
-        let members = self.memory.roster().members(channel, chat_id);
-        Ok(members
-            .into_iter()
-            .map(|(user_id, display_name, username)| {
-                serde_json::json!({
-                    "user_id": user_id,
-                    "display_name": display_name,
-                    "username": username,
-                })
-            })
-            .collect())
-    }
-
-    fn roster_remove_member(
-        &self,
-        channel: &str,
-        chat_id: &str,
-        user_id: &str,
-    ) -> Result<(), String> {
-        self.memory
-            .roster()
-            .remove_member(channel, chat_id, user_id);
-        Ok(())
-    }
-
-    fn fire_agent_step(&self, agent_id: &str, step: u32) {
-        self.external_hooks.fire(
-            crate::hooks::ExternalHookEvent::AgentStep,
-            serde_json::json!({
-                "agent_id": agent_id.to_string(),
-                "step": step,
-            }),
-        );
-    }
-
+#[async_trait::async_trait]
+impl kernel_handle::WorkflowRunner for LibreFangKernel {
     async fn run_workflow(
         &self,
         workflow_id: &str,
@@ -19457,7 +19452,9 @@ impl KernelHandle for LibreFangKernel {
 
         Ok((run_id.to_string(), output))
     }
+}
 
+impl kernel_handle::GoalControl for LibreFangKernel {
     fn goal_list_active(
         &self,
         agent_id_filter: Option<&str>,
@@ -19527,9 +19524,48 @@ impl KernelHandle for LibreFangKernel {
 
         Ok(result)
     }
+}
+
+impl kernel_handle::ToolPolicy for LibreFangKernel {
+    fn tool_timeout_secs(&self) -> u64 {
+        let cfg = self.config.load();
+        cfg.tool_timeout_secs
+    }
+
+    fn tool_timeout_secs_for(&self, tool_name: &str) -> u64 {
+        let cfg = self.config.load();
+        // 1. Exact match
+        if let Some(&t) = cfg.tool_timeouts.get(tool_name) {
+            return t;
+        }
+        // 2. Best glob match — longest pattern wins (most specific first).
+        // HashMap iteration is unordered; picking the longest matching pattern
+        // gives deterministic resolution when multiple globs match.
+        let best = cfg
+            .tool_timeouts
+            .iter()
+            .filter(|(pattern, _)| librefang_types::capability::glob_matches(pattern, tool_name))
+            .max_by_key(|(pattern, _)| pattern.len());
+        if let Some((_, &timeout)) = best {
+            return timeout;
+        }
+        // 3. Global fallback
+        cfg.tool_timeout_secs
+    }
+
+    fn skill_env_passthrough_policy(
+        &self,
+    ) -> Option<librefang_types::config::EnvPassthroughPolicy> {
+        let cfg = self.config.load();
+        librefang_types::config::EnvPassthroughPolicy::from_skills_config(&cfg.skills)
+    }
 
     fn channel_file_download_dir(&self) -> Option<std::path::PathBuf> {
         Some(self.config.load().channels.effective_file_download_dir())
+    }
+
+    fn effective_upload_dir(&self) -> std::path::PathBuf {
+        self.config_ref().channels.effective_file_download_dir()
     }
 
     fn readonly_workspace_prefixes(&self, agent_id: &str) -> Vec<std::path::PathBuf> {
@@ -19569,6 +19605,8 @@ impl KernelHandle for LibreFangKernel {
             .collect()
     }
 }
+
+// ---- END role-trait impls (#3746) ----
 
 // ---------------------------------------------------------------------------
 // Approval resolution helpers (Step 5)

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -2441,7 +2441,7 @@ async fn no_upstream_when_parent_has_no_active_turn() {
 /// failure we expect.
 #[tokio::test(flavor = "multi_thread")]
 async fn send_to_agent_as_tolerates_unregistered_parent_uuid() {
-    use kernel_handle::KernelHandle;
+    use kernel_handle::AgentControl;
 
     let kernel = cascade_test_kernel();
 
@@ -2452,7 +2452,7 @@ async fn send_to_agent_as_tolerates_unregistered_parent_uuid() {
     // (no cascade), and the call proceeds to fail at the target agent.
     let child_id = AgentId::new();
     let parent_id = AgentId::new();
-    let err = KernelHandle::send_to_agent_as(
+    let err = AgentControl::send_to_agent_as(
         kernel.as_ref(),
         &child_id.to_string(),
         "ping",
@@ -2475,11 +2475,11 @@ async fn send_to_agent_as_tolerates_unregistered_parent_uuid() {
 /// rather than silently passed through.
 #[tokio::test(flavor = "multi_thread")]
 async fn send_to_agent_as_rejects_unparseable_parent_id() {
-    use kernel_handle::KernelHandle;
+    use kernel_handle::AgentControl;
 
     let kernel = cascade_test_kernel();
     let child_id = AgentId::new();
-    let err = KernelHandle::send_to_agent_as(
+    let err = AgentControl::send_to_agent_as(
         kernel.as_ref(),
         &child_id.to_string(),
         "ping",
@@ -4631,7 +4631,6 @@ async fn test_push_notification_omits_session_suffix_for_agent_level_alerts() {
 /// alongside the existing `"cron"` carve-out.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_resolve_user_tool_decision_autonomous_bypasses_rbac() {
-    use kernel_handle::KernelHandle;
     use librefang_types::config::UserConfig;
     use librefang_types::user_policy::UserToolGate;
 
@@ -4660,7 +4659,7 @@ async fn test_resolve_user_tool_decision_autonomous_bypasses_rbac() {
 
     // Cron channel — the existing carve-out (must remain Allow).
     assert_eq!(
-        KernelHandle::resolve_user_tool_decision(
+        kernel_handle::ApprovalGate::resolve_user_tool_decision(
             kernel.as_ref(),
             "shell_exec",
             None,
@@ -4672,7 +4671,7 @@ async fn test_resolve_user_tool_decision_autonomous_bypasses_rbac() {
 
     // Autonomous channel — the new carve-out (issue #3243).
     assert_eq!(
-        KernelHandle::resolve_user_tool_decision(
+        kernel_handle::ApprovalGate::resolve_user_tool_decision(
             kernel.as_ref(),
             "shell_exec",
             None,
@@ -4686,7 +4685,7 @@ async fn test_resolve_user_tool_decision_autonomous_bypasses_rbac() {
     // A real inbound channel WITHOUT a registered sender must still
     // hit the guest gate — proves the carve-out is targeted, not a
     // blanket fail-open.
-    let guest_decision = KernelHandle::resolve_user_tool_decision(
+    let guest_decision = kernel_handle::ApprovalGate::resolve_user_tool_decision(
         kernel.as_ref(),
         "shell_exec",
         Some("999999"),

--- a/crates/librefang-kernel/tests/rbac_m3_evaluate_tool_call.rs
+++ b/crates/librefang-kernel/tests/rbac_m3_evaluate_tool_call.rs
@@ -19,7 +19,7 @@
 //!       NeedsApproval
 
 use librefang_kernel::LibreFangKernel;
-use librefang_runtime::kernel_handle::KernelHandle;
+use librefang_runtime::kernel_handle::prelude::*;
 use librefang_types::config::{DefaultModelConfig, KernelConfig, UserConfig};
 use librefang_types::tool_policy::{ToolGroup, ToolPolicy};
 use librefang_types::user_policy::{UserToolCategories, UserToolGate, UserToolPolicy};

--- a/crates/librefang-runtime-wasm/src/host_functions.rs
+++ b/crates/librefang-runtime-wasm/src/host_functions.rs
@@ -1231,7 +1231,7 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl librefang_kernel_handle::KernelHandle for RecordingKernel {
+    impl librefang_kernel_handle::AgentControl for RecordingKernel {
         async fn spawn_agent(&self, _: &str, _: Option<&str>) -> Result<(String, String), String> {
             Err("not implemented".to_string())
         }
@@ -1244,6 +1244,12 @@ mod tests {
         fn kill_agent(&self, _: &str) -> Result<(), String> {
             Err("not implemented".to_string())
         }
+        fn find_agents(&self, _: &str) -> Vec<librefang_kernel_handle::AgentInfo> {
+            vec![]
+        }
+    }
+
+    impl librefang_kernel_handle::MemoryAccess for RecordingKernel {
         fn memory_store(
             &self,
             key: &str,
@@ -1264,9 +1270,10 @@ mod tests {
         fn memory_list(&self, _: Option<&str>) -> Result<Vec<String>, String> {
             Ok(vec![])
         }
-        fn find_agents(&self, _: &str) -> Vec<librefang_kernel_handle::AgentInfo> {
-            vec![]
-        }
+    }
+
+    #[async_trait::async_trait]
+    impl librefang_kernel_handle::TaskQueue for RecordingKernel {
         async fn task_post(
             &self,
             _: &str,
@@ -1297,9 +1304,17 @@ mod tests {
         async fn task_update_status(&self, _: &str, _: &str) -> Result<bool, String> {
             Ok(false)
         }
+    }
+
+    #[async_trait::async_trait]
+    impl librefang_kernel_handle::EventBus for RecordingKernel {
         async fn publish_event(&self, _: &str, _: serde_json::Value) -> Result<(), String> {
             Ok(())
         }
+    }
+
+    #[async_trait::async_trait]
+    impl librefang_kernel_handle::KnowledgeGraph for RecordingKernel {
         async fn knowledge_add_entity(
             &self,
             _: &librefang_types::memory::Entity,
@@ -1319,6 +1334,16 @@ mod tests {
             Ok(vec![])
         }
     }
+
+    impl librefang_kernel_handle::CronControl for RecordingKernel {}
+    impl librefang_kernel_handle::ApprovalGate for RecordingKernel {}
+    impl librefang_kernel_handle::HandsControl for RecordingKernel {}
+    impl librefang_kernel_handle::A2ARegistry for RecordingKernel {}
+    impl librefang_kernel_handle::ChannelSender for RecordingKernel {}
+    impl librefang_kernel_handle::PromptStore for RecordingKernel {}
+    impl librefang_kernel_handle::WorkflowRunner for RecordingKernel {}
+    impl librefang_kernel_handle::GoalControl for RecordingKernel {}
+    impl librefang_kernel_handle::ToolPolicy for RecordingKernel {}
 
     fn state_with_kernel(
         agent_id: &str,

--- a/crates/librefang-runtime-wasm/src/sandbox.rs
+++ b/crates/librefang-runtime-wasm/src/sandbox.rs
@@ -24,7 +24,7 @@
 //! and returns a packed pointer to JSON `{"ok": ...}` or `{"error": "..."}`.
 
 use crate::host_functions;
-use librefang_kernel_handle::KernelHandle;
+use librefang_kernel_handle::prelude::*;
 use librefang_types::capability::Capability;
 use serde_json::json;
 use std::sync::Arc;

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -9,7 +9,7 @@ use crate::context_budget::{apply_context_guard, truncate_tool_result_dynamic, C
 use crate::context_engine::ContextEngine;
 use crate::context_overflow::{recover_from_overflow, RecoveryStage};
 use crate::embedding::EmbeddingDriver;
-use crate::kernel_handle::KernelHandle;
+use crate::kernel_handle::prelude::*;
 use crate::llm_driver::{
     CompletionRequest, LlmDriver, LlmError, StreamEvent, PHASE_RESPONSE_COMPLETE,
 };

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -3,7 +3,7 @@
 //! Provides filesystem, web, shell, and inter-agent tools. Agent tools
 //! (agent_send, agent_spawn, etc.) require a KernelHandle to be passed in.
 
-use crate::kernel_handle::KernelHandle;
+use crate::kernel_handle::prelude::*;
 use crate::mcp;
 use crate::web_search::{parse_ddg_results, WebToolsContext};
 use librefang_skills::registry::SkillRegistry;
@@ -6194,8 +6194,6 @@ async fn tool_canvas_present(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kernel_handle::{AgentInfo, KernelHandle};
-    use async_trait::async_trait;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -6505,8 +6503,10 @@ mod tests {
         user_gate_override: Option<librefang_types::user_policy::UserToolGate>,
     }
 
-    #[async_trait]
-    impl KernelHandle for ApprovalKernel {
+    // ---- BEGIN role-trait impls (split from former `impl KernelHandle for ApprovalKernel`, #3746) ----
+
+    #[async_trait::async_trait]
+    impl AgentControl for ApprovalKernel {
         async fn spawn_agent(
             &self,
             _manifest_toml: &str,
@@ -6527,6 +6527,12 @@ mod tests {
             Err("not used".to_string())
         }
 
+        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+            vec![]
+        }
+    }
+
+    impl MemoryAccess for ApprovalKernel {
         fn memory_store(
             &self,
             _key: &str,
@@ -6547,11 +6553,10 @@ mod tests {
         fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
             Err("not used".to_string())
         }
+    }
 
-        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-            vec![]
-        }
-
+    #[async_trait::async_trait]
+    impl TaskQueue for ApprovalKernel {
         async fn task_post(
             &self,
             _title: &str,
@@ -6598,7 +6603,10 @@ mod tests {
         ) -> Result<bool, String> {
             Err("not used".to_string())
         }
+    }
 
+    #[async_trait::async_trait]
+    impl EventBus for ApprovalKernel {
         async fn publish_event(
             &self,
             _event_type: &str,
@@ -6606,7 +6614,10 @@ mod tests {
         ) -> Result<(), String> {
             Err("not used".to_string())
         }
+    }
 
+    #[async_trait::async_trait]
+    impl KnowledgeGraph for ApprovalKernel {
         async fn knowledge_add_entity(
             &self,
             _entity: &librefang_types::memory::Entity,
@@ -6627,7 +6638,10 @@ mod tests {
         ) -> Result<Vec<librefang_types::memory::GraphMatch>, String> {
             Err("not used".to_string())
         }
+    }
 
+    #[async_trait::async_trait]
+    impl ApprovalGate for ApprovalKernel {
         fn requires_approval(&self, tool_name: &str) -> bool {
             tool_name == "shell_exec"
         }
@@ -6669,8 +6683,22 @@ mod tests {
         }
     }
 
-    #[async_trait]
-    impl KernelHandle for ForceHumanCapturingKernel {
+    // No-op role-trait impls (#3746) — mock relies on default bodies.
+    impl CronControl for ApprovalKernel {}
+    impl HandsControl for ApprovalKernel {}
+    impl A2ARegistry for ApprovalKernel {}
+    impl ChannelSender for ApprovalKernel {}
+    impl PromptStore for ApprovalKernel {}
+    impl WorkflowRunner for ApprovalKernel {}
+    impl GoalControl for ApprovalKernel {}
+    impl ToolPolicy for ApprovalKernel {}
+
+    // ---- END role-trait impls (#3746) ----
+
+    // ---- BEGIN role-trait impls (split from former `impl KernelHandle for ForceHumanCapturingKernel`, #3746) ----
+
+    #[async_trait::async_trait]
+    impl AgentControl for ForceHumanCapturingKernel {
         async fn spawn_agent(
             &self,
             _manifest_toml: &str,
@@ -6678,15 +6706,25 @@ mod tests {
         ) -> Result<(String, String), String> {
             Err("not used".to_string())
         }
+
         async fn send_to_agent(&self, _agent_id: &str, _message: &str) -> Result<String, String> {
             Err("not used".to_string())
         }
+
         fn list_agents(&self) -> Vec<AgentInfo> {
             vec![]
         }
+
         fn kill_agent(&self, _agent_id: &str) -> Result<(), String> {
             Err("not used".to_string())
         }
+
+        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+            vec![]
+        }
+    }
+
+    impl MemoryAccess for ForceHumanCapturingKernel {
         fn memory_store(
             &self,
             _key: &str,
@@ -6695,6 +6733,7 @@ mod tests {
         ) -> Result<(), String> {
             Err("not used".to_string())
         }
+
         fn memory_recall(
             &self,
             _key: &str,
@@ -6702,12 +6741,14 @@ mod tests {
         ) -> Result<Option<serde_json::Value>, String> {
             Err("not used".to_string())
         }
+
         fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
             Err("not used".to_string())
         }
-        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-            vec![]
-        }
+    }
+
+    #[async_trait::async_trait]
+    impl TaskQueue for ForceHumanCapturingKernel {
         async fn task_post(
             &self,
             _title: &str,
@@ -6717,9 +6758,11 @@ mod tests {
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
+
         async fn task_claim(&self, _agent_id: &str) -> Result<Option<serde_json::Value>, String> {
             Err("not used".to_string())
         }
+
         async fn task_complete(
             &self,
             _agent_id: &str,
@@ -6728,18 +6771,23 @@ mod tests {
         ) -> Result<(), String> {
             Err("not used".to_string())
         }
+
         async fn task_list(&self, _status: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
             Err("not used".to_string())
         }
+
         async fn task_delete(&self, _task_id: &str) -> Result<bool, String> {
             Err("not used".to_string())
         }
+
         async fn task_retry(&self, _task_id: &str) -> Result<bool, String> {
             Err("not used".to_string())
         }
+
         async fn task_get(&self, _task_id: &str) -> Result<Option<serde_json::Value>, String> {
             Err("not used".to_string())
         }
+
         async fn task_update_status(
             &self,
             _task_id: &str,
@@ -6747,6 +6795,10 @@ mod tests {
         ) -> Result<bool, String> {
             Err("not used".to_string())
         }
+    }
+
+    #[async_trait::async_trait]
+    impl EventBus for ForceHumanCapturingKernel {
         async fn publish_event(
             &self,
             _event_type: &str,
@@ -6754,25 +6806,34 @@ mod tests {
         ) -> Result<(), String> {
             Err("not used".to_string())
         }
+    }
+
+    #[async_trait::async_trait]
+    impl KnowledgeGraph for ForceHumanCapturingKernel {
         async fn knowledge_add_entity(
             &self,
             _entity: &librefang_types::memory::Entity,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
+
         async fn knowledge_add_relation(
             &self,
             _relation: &librefang_types::memory::Relation,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
+
         async fn knowledge_query(
             &self,
             _pattern: librefang_types::memory::GraphPattern,
         ) -> Result<Vec<librefang_types::memory::GraphMatch>, String> {
             Err("not used".to_string())
         }
+    }
 
+    #[async_trait::async_trait]
+    impl ApprovalGate for ForceHumanCapturingKernel {
         fn requires_approval(&self, tool_name: &str) -> bool {
             tool_name == "shell_exec"
         }
@@ -6803,6 +6864,18 @@ mod tests {
                 .unwrap_or(librefang_types::user_policy::UserToolGate::Allow)
         }
     }
+
+    // No-op role-trait impls (#3746) — mock relies on default bodies.
+    impl CronControl for ForceHumanCapturingKernel {}
+    impl HandsControl for ForceHumanCapturingKernel {}
+    impl A2ARegistry for ForceHumanCapturingKernel {}
+    impl ChannelSender for ForceHumanCapturingKernel {}
+    impl PromptStore for ForceHumanCapturingKernel {}
+    impl WorkflowRunner for ForceHumanCapturingKernel {}
+    impl GoalControl for ForceHumanCapturingKernel {}
+    impl ToolPolicy for ForceHumanCapturingKernel {}
+
+    // ---- END role-trait impls (#3746) ----
 
     /// Regression: when the per-user gate returns `NeedsApproval`, the
     /// `DeferredToolExecution.force_human` flag MUST be set so the
@@ -7180,8 +7253,10 @@ mod tests {
         download_dir: Option<std::path::PathBuf>,
     }
 
-    #[async_trait]
-    impl KernelHandle for NamedWsKernel {
+    // ---- BEGIN role-trait impls (split from former `impl KernelHandle for NamedWsKernel`, #3746) ----
+
+    #[async_trait::async_trait]
+    impl AgentControl for NamedWsKernel {
         async fn spawn_agent(
             &self,
             _manifest_toml: &str,
@@ -7189,15 +7264,25 @@ mod tests {
         ) -> Result<(String, String), String> {
             Err("not used".to_string())
         }
+
         async fn send_to_agent(&self, _agent_id: &str, _message: &str) -> Result<String, String> {
             Err("not used".to_string())
         }
+
         fn list_agents(&self) -> Vec<AgentInfo> {
             vec![]
         }
+
         fn kill_agent(&self, _agent_id: &str) -> Result<(), String> {
             Err("not used".to_string())
         }
+
+        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+            vec![]
+        }
+    }
+
+    impl MemoryAccess for NamedWsKernel {
         fn memory_store(
             &self,
             _key: &str,
@@ -7206,6 +7291,7 @@ mod tests {
         ) -> Result<(), String> {
             Err("not used".to_string())
         }
+
         fn memory_recall(
             &self,
             _key: &str,
@@ -7213,12 +7299,14 @@ mod tests {
         ) -> Result<Option<serde_json::Value>, String> {
             Err("not used".to_string())
         }
+
         fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
             Err("not used".to_string())
         }
-        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-            vec![]
-        }
+    }
+
+    #[async_trait::async_trait]
+    impl TaskQueue for NamedWsKernel {
         async fn task_post(
             &self,
             _title: &str,
@@ -7228,9 +7316,11 @@ mod tests {
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
+
         async fn task_claim(&self, _agent_id: &str) -> Result<Option<serde_json::Value>, String> {
             Err("not used".to_string())
         }
+
         async fn task_complete(
             &self,
             _agent_id: &str,
@@ -7239,18 +7329,23 @@ mod tests {
         ) -> Result<(), String> {
             Err("not used".to_string())
         }
+
         async fn task_list(&self, _status: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
             Err("not used".to_string())
         }
+
         async fn task_delete(&self, _task_id: &str) -> Result<bool, String> {
             Err("not used".to_string())
         }
+
         async fn task_retry(&self, _task_id: &str) -> Result<bool, String> {
             Err("not used".to_string())
         }
+
         async fn task_get(&self, _task_id: &str) -> Result<Option<serde_json::Value>, String> {
             Err("not used".to_string())
         }
+
         async fn task_update_status(
             &self,
             _task_id: &str,
@@ -7258,6 +7353,10 @@ mod tests {
         ) -> Result<bool, String> {
             Err("not used".to_string())
         }
+    }
+
+    #[async_trait::async_trait]
+    impl EventBus for NamedWsKernel {
         async fn publish_event(
             &self,
             _event_type: &str,
@@ -7265,30 +7364,40 @@ mod tests {
         ) -> Result<(), String> {
             Err("not used".to_string())
         }
+    }
+
+    #[async_trait::async_trait]
+    impl KnowledgeGraph for NamedWsKernel {
         async fn knowledge_add_entity(
             &self,
             _entity: &librefang_types::memory::Entity,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
+
         async fn knowledge_add_relation(
             &self,
             _relation: &librefang_types::memory::Relation,
         ) -> Result<String, String> {
             Err("not used".to_string())
         }
+
         async fn knowledge_query(
             &self,
             _pattern: librefang_types::memory::GraphPattern,
         ) -> Result<Vec<librefang_types::memory::GraphMatch>, String> {
             Err("not used".to_string())
         }
+    }
+
+    impl ToolPolicy for NamedWsKernel {
         fn named_workspace_prefixes(
             &self,
             _agent_id: &str,
         ) -> Vec<(std::path::PathBuf, librefang_types::agent::WorkspaceMode)> {
             self.named.clone()
         }
+
         fn readonly_workspace_prefixes(&self, _agent_id: &str) -> Vec<std::path::PathBuf> {
             self.named
                 .iter()
@@ -7300,6 +7409,18 @@ mod tests {
             self.download_dir.clone()
         }
     }
+
+    // No-op role-trait impls (#3746) — mock relies on default bodies.
+    impl CronControl for NamedWsKernel {}
+    impl HandsControl for NamedWsKernel {}
+    impl ApprovalGate for NamedWsKernel {}
+    impl A2ARegistry for NamedWsKernel {}
+    impl ChannelSender for NamedWsKernel {}
+    impl PromptStore for NamedWsKernel {}
+    impl WorkflowRunner for NamedWsKernel {}
+    impl GoalControl for NamedWsKernel {}
+
+    // ---- END role-trait impls (#3746) ----
 
     fn make_named_ws_kernel(
         named: Vec<(std::path::PathBuf, librefang_types::agent::WorkspaceMode)>,
@@ -9772,8 +9893,10 @@ mod tests {
         should_fail_escalation: bool,
     }
 
-    #[async_trait]
-    impl KernelHandle for SpawnCheckKernel {
+    // ---- BEGIN role-trait impls (split from former `impl KernelHandle for SpawnCheckKernel`, #3746) ----
+
+    #[async_trait::async_trait]
+    impl AgentControl for SpawnCheckKernel {
         async fn spawn_agent(
             &self,
             _manifest_toml: &str,
@@ -9818,6 +9941,12 @@ mod tests {
             Err("not used".to_string())
         }
 
+        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
+            vec![]
+        }
+    }
+
+    impl MemoryAccess for SpawnCheckKernel {
         fn memory_store(
             &self,
             _key: &str,
@@ -9838,11 +9967,10 @@ mod tests {
         fn memory_list(&self, _peer_id: Option<&str>) -> Result<Vec<String>, String> {
             Err("not used".to_string())
         }
+    }
 
-        fn find_agents(&self, _query: &str) -> Vec<AgentInfo> {
-            vec![]
-        }
-
+    #[async_trait::async_trait]
+    impl TaskQueue for SpawnCheckKernel {
         async fn task_post(
             &self,
             _title: &str,
@@ -9889,7 +10017,10 @@ mod tests {
         ) -> Result<bool, String> {
             Err("not used".to_string())
         }
+    }
 
+    #[async_trait::async_trait]
+    impl EventBus for SpawnCheckKernel {
         async fn publish_event(
             &self,
             _event_type: &str,
@@ -9897,7 +10028,10 @@ mod tests {
         ) -> Result<(), String> {
             Err("not used".to_string())
         }
+    }
 
+    #[async_trait::async_trait]
+    impl KnowledgeGraph for SpawnCheckKernel {
         async fn knowledge_add_entity(
             &self,
             _entity: &librefang_types::memory::Entity,
@@ -9919,6 +10053,19 @@ mod tests {
             Err("not used".to_string())
         }
     }
+
+    // No-op role-trait impls (#3746) — mock relies on default bodies.
+    impl CronControl for SpawnCheckKernel {}
+    impl HandsControl for SpawnCheckKernel {}
+    impl ApprovalGate for SpawnCheckKernel {}
+    impl A2ARegistry for SpawnCheckKernel {}
+    impl ChannelSender for SpawnCheckKernel {}
+    impl PromptStore for SpawnCheckKernel {}
+    impl WorkflowRunner for SpawnCheckKernel {}
+    impl GoalControl for SpawnCheckKernel {}
+    impl ToolPolicy for SpawnCheckKernel {}
+
+    // ---- END role-trait impls (#3746) ----
 
     #[test]
     fn parse_poll_options_accepts_2_to_10_strings() {

--- a/crates/librefang-runtime/tests/tool_runner_forwarding.rs
+++ b/crates/librefang-runtime/tests/tool_runner_forwarding.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use librefang_kernel_handle::{AgentInfo, KernelHandle};
+use librefang_kernel_handle::prelude::*;
 use librefang_runtime::tool_runner::{execute_tool_raw, ToolExecContext};
 use serde_json::json;
 use std::sync::{Arc, Mutex};
@@ -40,7 +40,7 @@ impl CapturingKernel {
 }
 
 #[async_trait]
-impl KernelHandle for CapturingKernel {
+impl AgentControl for CapturingKernel {
     async fn spawn_agent(&self, _: &str, _: Option<&str>) -> Result<(String, String), String> {
         Err("not implemented".into())
     }
@@ -53,6 +53,12 @@ impl KernelHandle for CapturingKernel {
     fn kill_agent(&self, _: &str) -> Result<(), String> {
         Err("not implemented".into())
     }
+    fn find_agents(&self, _: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+}
+
+impl MemoryAccess for CapturingKernel {
     fn memory_store(
         &self,
         _key: &str,
@@ -83,9 +89,10 @@ impl KernelHandle for CapturingKernel {
             .push(peer_id.map(|s| s.to_string()));
         Ok(vec![])
     }
-    fn find_agents(&self, _: &str) -> Vec<AgentInfo> {
-        vec![]
-    }
+}
+
+#[async_trait]
+impl TaskQueue for CapturingKernel {
     async fn task_post(
         &self,
         _: &str,
@@ -116,9 +123,17 @@ impl KernelHandle for CapturingKernel {
     async fn task_update_status(&self, _: &str, _: &str) -> Result<bool, String> {
         Err("not implemented".into())
     }
+}
+
+#[async_trait]
+impl EventBus for CapturingKernel {
     async fn publish_event(&self, _: &str, _: serde_json::Value) -> Result<(), String> {
         Err("not implemented".into())
     }
+}
+
+#[async_trait]
+impl KnowledgeGraph for CapturingKernel {
     async fn knowledge_add_entity(
         &self,
         _: &librefang_types::memory::Entity,
@@ -138,6 +153,16 @@ impl KernelHandle for CapturingKernel {
         Err("not implemented".into())
     }
 }
+
+impl CronControl for CapturingKernel {}
+impl ApprovalGate for CapturingKernel {}
+impl HandsControl for CapturingKernel {}
+impl A2ARegistry for CapturingKernel {}
+impl ChannelSender for CapturingKernel {}
+impl PromptStore for CapturingKernel {}
+impl WorkflowRunner for CapturingKernel {}
+impl GoalControl for CapturingKernel {}
+impl ToolPolicy for CapturingKernel {}
 
 fn make_ctx<'a>(
     kernel: &'a Arc<dyn KernelHandle>,

--- a/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
+++ b/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use librefang_kernel_handle::{AgentInfo, KernelHandle};
+use librefang_kernel_handle::prelude::*;
 use librefang_runtime::tool_runner::{execute_tool_raw, ToolExecContext};
 use serde_json::json;
 use std::sync::{Arc, Mutex};
@@ -36,7 +36,7 @@ impl CapturingKernel {
 }
 
 #[async_trait]
-impl KernelHandle for CapturingKernel {
+impl AgentControl for CapturingKernel {
     async fn spawn_agent(&self, _: &str, _: Option<&str>) -> Result<(String, String), String> {
         Err("not implemented".into())
     }
@@ -49,6 +49,12 @@ impl KernelHandle for CapturingKernel {
     fn kill_agent(&self, _: &str) -> Result<(), String> {
         Err("not implemented".into())
     }
+    fn find_agents(&self, _: &str) -> Vec<AgentInfo> {
+        vec![]
+    }
+}
+
+impl MemoryAccess for CapturingKernel {
     fn memory_store(&self, _: &str, _: serde_json::Value, _: Option<&str>) -> Result<(), String> {
         Err("not implemented".into())
     }
@@ -58,9 +64,10 @@ impl KernelHandle for CapturingKernel {
     fn memory_list(&self, _: Option<&str>) -> Result<Vec<String>, String> {
         Err("not implemented".into())
     }
-    fn find_agents(&self, _: &str) -> Vec<AgentInfo> {
-        vec![]
-    }
+}
+
+#[async_trait]
+impl TaskQueue for CapturingKernel {
     async fn task_post(
         &self,
         _: &str,
@@ -95,9 +102,17 @@ impl KernelHandle for CapturingKernel {
     async fn task_update_status(&self, _: &str, _: &str) -> Result<bool, String> {
         Err("not implemented".into())
     }
+}
+
+#[async_trait]
+impl EventBus for CapturingKernel {
     async fn publish_event(&self, _: &str, _: serde_json::Value) -> Result<(), String> {
         Err("not implemented".into())
     }
+}
+
+#[async_trait]
+impl KnowledgeGraph for CapturingKernel {
     async fn knowledge_add_entity(
         &self,
         _: &librefang_types::memory::Entity,
@@ -116,6 +131,10 @@ impl KernelHandle for CapturingKernel {
     ) -> Result<Vec<librefang_types::memory::GraphMatch>, String> {
         Err("not implemented".into())
     }
+}
+
+#[async_trait]
+impl CronControl for CapturingKernel {
     async fn cron_create(
         &self,
         agent_id: &str,
@@ -128,6 +147,15 @@ impl KernelHandle for CapturingKernel {
         Ok("cron-id-1".to_string())
     }
 }
+
+impl ApprovalGate for CapturingKernel {}
+impl HandsControl for CapturingKernel {}
+impl A2ARegistry for CapturingKernel {}
+impl ChannelSender for CapturingKernel {}
+impl PromptStore for CapturingKernel {}
+impl WorkflowRunner for CapturingKernel {}
+impl GoalControl for CapturingKernel {}
+impl ToolPolicy for CapturingKernel {}
 
 fn make_ctx<'a>(
     kernel: &'a Arc<dyn KernelHandle>,


### PR DESCRIPTION
## Summary
- Split the 50+ method `KernelHandle` god trait (#3746) into 14 focused role traits: `AgentControl`, `MemoryAccess`, `TaskQueue`, `EventBus`, `KnowledgeGraph`, `CronControl`, `HandsControl`, `ApprovalGate`, `A2ARegistry`, `ChannelSender`, `PromptStore`, `WorkflowRunner`, `GoalControl`, `ToolPolicy`.
- `KernelHandle` is preserved as a supertrait alias requiring all 14 role traits, with a blanket impl, so all 117 existing `Arc<dyn KernelHandle>` call sites compile unchanged. New call sites can take narrower bounds (e.g. `T: ApprovalGate + Send + Sync`).
- Added `kernel_handle::prelude` module that re-exports `KernelHandle` plus all role traits; existing `use ...::KernelHandle;` sites migrated to `use ...::prelude::*;` so trait method resolution still works after the split.
- `LibreFangKernel`'s ~1.8k-line impl is split into 14 per-role impl blocks. The 4 test mocks in `runtime/tool_runner.rs` (`ApprovalKernel`, `ForceHumanCapturingKernel`, `NamedWsKernel`, `SpawnCheckKernel`) are split the same way; missing role traits get empty `impl Foo for Mock {}` blocks so the supertrait alias is satisfied.
- Behavior is unchanged: every existing default impl (including the 30 fail-open `Err("X not available")` defaults flagged in #3746) is moved verbatim onto the role trait that owns it. Tightening individual defaults (especially the dangerous `request_approval` → `Approved` fallback) is left for follow-up PRs that can be reviewed per-domain.

Closes #3746.

## Test plan
- [x] `cargo check --workspace --lib` — clean
- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — only 2 pre-existing `dead_code` errors in `librefang-desktop/src/commands.rs:192-193` (`KEYRING_SERVICE` / `KEYRING_ACCOUNT`); identical on `main`, unrelated to this refactor
- [x] `cargo test -p librefang-kernel-handle` — 3 new compile-time tests pass:
  1. stub satisfying every role trait gets `KernelHandle` via the blanket impl
  2. `dyn KernelHandle` is constructible (object safety)
  3. each role trait is individually object-safe
- [x] `cargo test -p librefang-runtime --lib` — 1426 passed; 2 failed; both pre-existing macOS-local environment failures (`media_understanding::tests::transcode_oga_smoke` missing `libvmaf.3.dylib`; `tts::tests::test_synthesize_no_provider` env-var dependent), unrelated to this refactor
