### PR TITLE
ci(openapi-drift): auto-commit regenerated openapi.json + sdk on internal PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,23 @@ jobs:
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Same-repo PRs need write to push the auto-codegen commit back to the
+    # PR branch. Fork PRs run with read-only GITHUB_TOKEN regardless of
+    # what we declare here — they fall through to the fail-with-instructions
+    # path below.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Check out the PR head branch (not the merge commit) so the
+          # auto-codegen step below can `git push` back. For pushes to main
+          # this resolves to empty and `actions/checkout` falls back to its
+          # default — that path never reaches the push branch.
+          ref: ${{ github.head_ref }}
+          # `persist-credentials: true` is the default; we re-state it for
+          # readability. Required for the auto-commit step below.
+          persist-credentials: true
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -280,17 +295,38 @@ jobs:
         run: cargo xtask codegen --openapi
       - name: Regenerate SDKs
         run: python3 scripts/codegen-sdks.py
-      - name: Verify no drift
+      - name: Verify no drift (auto-commit on internal PRs)
+        env:
+          # Same-repo PR: GITHUB_TOKEN has write scope -> we can push the
+          # regenerated artifacts back to the PR branch.
+          # Fork PR or push event: GITHUB_TOKEN is read-only -> fall back
+          # to the original "fail with reproduce instructions" behaviour.
+          IS_INTERNAL_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
-          if ! git diff --exit-code -- openapi.json sdk/; then
-            echo "::error::openapi.json or generated SDKs are out of sync with the source code."
-            echo "Reproduce locally:"
-            echo "  cargo xtask codegen --openapi"
-            echo "  python3 scripts/codegen-sdks.py"
-            echo "Then commit the regenerated openapi.json and sdk/* files."
-            exit 1
+          if git diff --quiet -- openapi.json sdk/; then
+            echo "openapi.json and SDKs are in sync."
+            exit 0
           fi
-          echo "openapi.json and SDKs are in sync."
+          if [ "$IS_INTERNAL_PR" = "true" ]; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add openapi.json sdk/
+            git commit -m "chore(codegen): auto-regenerate openapi.json + sdk [skip ci]"
+            git push
+            echo "::notice::Auto-committed regenerated openapi.json + sdk/ to the PR branch."
+            echo "::notice::The [skip ci] marker prevents an immediate re-run; if you want full CI"
+            echo "::notice::on the post-codegen tip, push an empty commit or close+reopen the PR."
+            exit 0
+          fi
+          # Fork PR or push to main — fail loudly.
+          echo "::error::openapi.json or generated SDKs are out of sync with the source code."
+          echo "Reproduce locally:"
+          echo "  cargo xtask codegen --openapi"
+          echo "  python3 scripts/codegen-sdks.py"
+          echo "Then commit the regenerated openapi.json and sdk/* files."
+          echo "(Fork PRs cannot use the auto-commit path because GITHUB_TOKEN"
+          echo "is read-only on cross-repository pull requests.)"
+          exit 1
       # Schema drift gate (#3300): verifies the sha256 baselines committed
       # under xtask/baselines/ match the on-disk schema artifacts. Catches
       # forgotten baseline regeneration after intentional schema changes


### PR DESCRIPTION
## Summary

Today the \`openapi-drift\` job regenerates \`openapi.json\` + the four SDKs and \`git diff --exit-code\`s the result. If anything moved, the job fails loudly and the PR sits red until the contributor regenerates locally and force-pushes. This PR makes the bot do the regen + commit on the contributor's behalf for same-repo PRs.

This was an explicit ask — see the #3300 / #3842 / #3749 series of PRs in the last two days, every one of which had a maintainer-side "regenerate openapi.json then push" loop because utoipa annotations moved.

## Behaviour matrix

| Event | Old | New |
| --- | --- | --- |
| Same-repo PR with utoipa drift | Job fails red | Bot commits regenerated artifacts back to PR branch with \`[skip ci]\` and ends green |
| Fork PR with utoipa drift | Job fails red | **Same — fails red** with reproduce instructions (GITHUB_TOKEN is read-only on fork PRs) |
| Push to main with drift | Job fails red | **Same — fails red** (we never want auto-commit straight onto main) |

The condition \`github.event_name == 'pull_request' && head.repo.full_name == github.repository\` cleanly separates the auto-commit path from the two failure cases.

## Trade-offs (worth a maintainer call)

- **PR history grows a robot commit per utoipa-touching PR.** \`[skip ci]\` bracket marker makes it easy to filter / squash on merge.
- **\`[skip ci]\` skips the *whole* CI run, not just \`openapi-drift\`.** The PR's status checks therefore reflect the pre-codegen tip after auto-commit. If a maintainer wants the post-codegen tip validated end-to-end (clippy, tests, etc.) they push an empty commit or close+reopen the PR. This is the standard pattern; the alternative is re-running every gate immediately and burning compute.
- **Fork PRs are second-class citizens here.** This is a GitHub design decision (\`GITHUB_TOKEN\` is read-only on cross-repo PRs by design) and not something we can route around without a personal access token, which would be a much bigger ask.
- **Permissions widening is scoped to this one job.** Workflow-level \`permissions: contents: read\` is unchanged; only the \`openapi-drift\` job declares \`contents: write\`.

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(open(...))"\` parses cleanly.
- [ ] Reviewer: touch any \`utoipa\` annotation in a same-repo PR (e.g. flip a \`body = T\` to \`body = U\` in a route file). Confirm:
  - bot pushes a \`chore(codegen): auto-regenerate openapi.json + sdk [skip ci]\` commit to the PR branch
  - the \`openapi-drift\` job ends green on that run
  - subsequent CI is skipped (\`[skip ci]\`) — the PR's status reflects the pre-codegen SHA, which is the documented trade-off
- [ ] Reviewer: same change from a fork. Confirm:
  - bot does NOT push (cannot — GITHUB_TOKEN is read-only)
  - the job fails with the legacy reproduce-locally message

## Why not a brand-new workflow file

I considered splitting this into \`.github/workflows/auto-codegen.yml\` triggered by \`pull_request_target\` (which gives writable token even for forks). Rejected because:

1. \`pull_request_target\` runs against the **base** ref of the PR, not the PR's actual code. To run codegen against the PR, we'd have to checkout the PR head explicitly, which is the same security pitfall \`pull_request_target\` is famous for. Out of scope.
2. The existing \`openapi-drift\` job already does the regen — adding a second job would duplicate the build and double the spend.

The minimal-diff approach is to keep \`openapi-drift\` as the single source of truth and conditionalise its tail step. That's what this PR does.