### PR TITLE
ci(auto-update-branches): only update PRs with failing CI

### DIFF
--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 */6 * * *'  # every 6 hours — safety net for stragglers
   push:
-    branches: [main]       # rebase open PRs immediately after every main update
+    branches: [main]       # re-evaluate open PRs immediately after every main update
   workflow_dispatch:
 
 permissions:
@@ -26,20 +26,74 @@ jobs:
           # that protection.
           github-token: ${{ secrets.WEBSITE_REPO_TOKEN }}
           script: |
+            // Only update PRs whose CI is currently failing. Skipping
+            // green / pending PRs avoids a cascade of redundant CI runs
+            // every time main moves — the previous unconditional update
+            // burnt CI minutes on every open PR after every merge.
+            //
+            // Trade-off: a PR that is currently green will not pick up
+            // newer main commits until either its own CI later turns red
+            // or the 6h cron fires. Acceptable because (a) green PRs are
+            // by definition still building against a viable base, and
+            // (b) the merge queue / final pre-merge "Update branch" click
+            // still re-validates against fresh main before the actual
+            // merge.
+            const FAIL_CONCLUSIONS = new Set([
+              'failure',
+              'timed_out',
+              'action_required',
+              'startup_failure',
+              'cancelled',
+            ]);
+
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               per_page: 100,
             });
+
             for (const pr of prs) {
+              const ref = pr.head.sha;
+              let failing = false;
+              try {
+                // GitHub Actions check runs (the primary signal for this repo).
+                const checks = await github.rest.checks.listForRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref,
+                  per_page: 100,
+                });
+                failing = checks.data.check_runs.some(
+                  (r) => r.conclusion && FAIL_CONCLUSIONS.has(r.conclusion),
+                );
+                // Fall through to legacy commit statuses (third-party CIs
+                // that post via the older statuses API rather than checks).
+                if (!failing) {
+                  const status = await github.rest.repos.getCombinedStatusForRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref,
+                  });
+                  failing = status.data.state === 'failure';
+                }
+              } catch (e) {
+                console.log(`PR #${pr.number}: status query failed (${e.message}) — skipping`);
+                continue;
+              }
+
+              if (!failing) {
+                console.log(`PR #${pr.number}: CI not failing — skipping`);
+                continue;
+              }
+
               try {
                 await github.rest.pulls.updateBranch({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: pr.number,
                 });
-                console.log(`Updated PR #${pr.number}`);
+                console.log(`Updated PR #${pr.number} (CI was failing)`);
               } catch (e) {
                 console.log(`Skipped PR #${pr.number}: ${e.message}`);
               }


### PR DESCRIPTION
## Summary

Make `auto-update-branches.yml` only run `pulls.updateBranch` on PRs whose CI is **currently failing**. Previously every push to `main` (and the 6h cron) blasted `updateBranch` on every open PR, re-triggering a full CI run on each — burning CI minutes on PRs whose previous run was already green and whose merge would still be valid against the new base.

## Behaviour

For every open PR, query the head SHA against:

1. `checks.listForRef` — the GitHub Actions check-run signal used by this repo. The PR is considered failing if any check has `conclusion ∈ {failure, timed_out, action_required, startup_failure, cancelled}`.
2. `repos.getCombinedStatusForRef` — legacy commit-statuses fallback for any third-party CI that does not post check runs (`state === 'failure'`).

Outcome matrix:

| CI state | Action |
| --- | --- |
| failing (per above) | `pulls.updateBranch` |
| pending / running (`conclusion === null`) | skip |
| all green | skip |
| no checks at all (e.g. PR opened seconds ago) | skip |
| status query throws | skip + log |

`updateBranch` itself keeps its existing try/catch so an `updateBranch` failure (merge conflict, branch protections, race with a force-push) is still logged and does not fail the job.

## Trade-off

A green PR will **not** pick up newer `main` commits until either its own CI later turns red, or the 6h cron sweeps. Acceptable because:

- A green PR is by definition still building against a viable base — the merge result will only become invalid if `main` introduces a semantic conflict, which will surface as a red run on the PR's own next push or as a merge-time check.
- The pre-merge "Update branch" button (and the merge queue, when used) still force-validate against fresh `main` immediately before the actual merge.

## Test plan

- [ ] After merge, push a no-op commit to `main` and confirm the workflow run logs `CI not failing — skipping` for currently-green PRs and `Updated PR #N (CI was failing)` only for PRs with red checks.
- [ ] Manually re-run via `workflow_dispatch` and verify the same selection.
- [ ] Confirm a PR with only `pending` checks (CI mid-flight) is **not** updated.
