### PR TITLE
fix(ci): skip ref override for fork PRs in openapi-drift checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,11 +268,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # Check out the PR head branch (not the merge commit) so the
-          # auto-codegen step below can `git push` back. For pushes to main
-          # this resolves to empty and `actions/checkout` falls back to its
-          # default — that path never reaches the push branch.
-          ref: ${{ github.head_ref }}
+          # Internal PRs only: check out the PR head branch (not the merge
+          # commit) so the auto-codegen step below can `git push` back. Fork
+          # PRs and push events leave `ref` empty so `actions/checkout` falls
+          # back to its default ref — that path never reaches the push branch
+          # and would otherwise fail at fetch (the fork's branch does not
+          # exist in this repo's `origin`).
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
           # `persist-credentials: true` is the default; we re-state it for
           # readability. Required for the auto-commit step below.
           persist-credentials: true


### PR DESCRIPTION
## Summary

- Fork PRs were failing the `OpenAPI Drift` job at the `actions/checkout` step (run [25305213797](https://github.com/librefang/librefang/actions/runs/25305213797/job/74180151079), PR #4548 from `neo-wanderer/librefang`).
- Root cause: #4540 added `ref: ${{ github.head_ref }}` so the auto-commit step can push regenerated artifacts back to the PR branch. That works for same-repo PRs but breaks fork PRs — the head branch lives on the fork, not in this repo's `origin`, so the depth-1 fetch (`+refs/heads/<branch>*:refs/remotes/origin/<branch>*`) finds zero matching refs and `actions/checkout` exits 1.
- Fix: gate the `ref` override on the same internal-PR predicate already used by the verify step (`event_name == 'pull_request' && pull_request.head.repo.full_name == repository`). Fork PRs and push events get an empty string, which makes `actions/checkout` fall back to its default ref handling (PR merge ref / push commit) — they continue down the existing "fail with reproduce instructions" branch unchanged.

## Test plan

- [ ] CI passes on this internal PR (proves the predicate still resolves to `head_ref` for same-repo PRs and the auto-commit path is unchanged).
- [ ] Re-run / push to PR #4548 (fork PR) and confirm `OpenAPI Drift` reaches the verify step instead of failing at checkout. If artifacts are out of sync the job should now print the reproduce instructions and exit 1; if they are in sync it should pass.
