### PR TITLE
feat(dashboard): render historical thinking blocks on session reload (re-publish #4542 as internal PR)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -441,13 +441,25 @@ export interface AgentSessionMessage {
   role?: string;
   /** Either a plain string (legacy `MessageContent::Text`) or an array
    *  of structured blocks (`MessageContent::Blocks`) — the Rust enum is
-   *  `#[serde(untagged)]` so both shapes appear on the wire. */
+   *  `#[serde(untagged)]` so both shapes appear on the wire.
+   *
+   *  The agent-scoped session endpoint (`/api/agents/{id}/session`) flattens
+   *  blocks server-side and returns a string here; the raw-blocks endpoint
+   *  (`/api/sessions/{id}`) returns the full `ContentBlock[]`. The mapper
+   *  handles both shapes via `extractAssistantHistoryParts`. */
   content?: string | ContentBlock[];
   tools?: AgentTool[];
   images?: AgentSessionImage[];
   /** RFC 3339 timestamp from the server; may be absent for messages
    * persisted before the field was introduced. */
   timestamp?: string;
+  /** Flat reasoning trace surfaced by the agent-scoped session endpoint
+   *  for assistant messages that contained `ContentBlock::Thinking`. The
+   *  server joins multiple thinking blocks with a blank line, mirroring
+   *  the live-streaming `thinking_delta` accumulation. Absent when the
+   *  message had no thinking blocks (preserves response shape for
+   *  non-thinking models). */
+  thinking?: string;
 }
 
 export interface AgentSessionResponse {

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -376,9 +376,73 @@ export interface AgentFileUploadResult {
   transcription?: string;
 }
 
+/** Mirrors `ContentBlock` in `crates/librefang-types/src/message.rs` —
+ *  serde-tagged on `type`. Keep variants in sync with the Rust enum;
+ *  unknown server-side variants land in `ContentBlockUnknown` so the
+ *  client never throws on a forward-compatible payload. */
+export interface ContentBlockText {
+  type: "text";
+  text: string;
+  provider_metadata?: unknown;
+}
+
+export interface ContentBlockThinking {
+  type: "thinking";
+  thinking: string;
+  provider_metadata?: unknown;
+}
+
+export interface ContentBlockToolUse {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: unknown;
+  provider_metadata?: unknown;
+}
+
+export interface ContentBlockToolResult {
+  type: "tool_result";
+  tool_use_id: string;
+  tool_name?: string;
+  content: string;
+  is_error: boolean;
+  status?: unknown;
+  approval_request_id?: string;
+}
+
+export interface ContentBlockImage {
+  type: "image";
+  media_type: string;
+  data: string;
+}
+
+export interface ContentBlockImageFile {
+  type: "image_file";
+  media_type: string;
+  path: string;
+}
+
+/** Forward-compat fallback for variants the Rust enum may add later. */
+export interface ContentBlockUnknown {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type ContentBlock =
+  | ContentBlockText
+  | ContentBlockThinking
+  | ContentBlockToolUse
+  | ContentBlockToolResult
+  | ContentBlockImage
+  | ContentBlockImageFile
+  | ContentBlockUnknown;
+
 export interface AgentSessionMessage {
   role?: string;
-  content?: unknown;
+  /** Either a plain string (legacy `MessageContent::Text`) or an array
+   *  of structured blocks (`MessageContent::Blocks`) — the Rust enum is
+   *  `#[serde(untagged)]` so both shapes appear on the wire. */
+  content?: string | ContentBlock[];
   tools?: AgentTool[];
   images?: AgentSessionImage[];
   /** RFC 3339 timestamp from the server; may be absent for messages

--- a/crates/librefang-api/dashboard/src/lib/chat.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/chat.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { asText, formatMeta, normalizeRole, normalizeToolOutput } from "./chat";
+import {
+  asText,
+  extractAssistantHistoryParts,
+  formatMeta,
+  normalizeRole,
+  normalizeToolOutput,
+} from "./chat";
+import type { ContentBlock } from "../api";
 
 describe("chat utilities", () => {
   it("normalizes API message roles", () => {
@@ -50,5 +57,82 @@ describe("chat utilities", () => {
     });
     expect(output?.isError).toBe(true);
     expect(output?.content).toBe("Tool failed without a preview.");
+  });
+});
+
+describe("extractAssistantHistoryParts", () => {
+  it("returns plain string content unchanged as text, with empty thinking", () => {
+    expect(extractAssistantHistoryParts("hello world")).toEqual({
+      text: "hello world",
+      thinking: "",
+    });
+  });
+
+  it("returns empty parts for null/undefined content", () => {
+    expect(extractAssistantHistoryParts(null)).toEqual({ text: "", thinking: "" });
+    expect(extractAssistantHistoryParts(undefined)).toEqual({ text: "", thinking: "" });
+  });
+
+  it("extracts text blocks and concatenates them with newlines", () => {
+    const blocks: ContentBlock[] = [
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
+    ];
+    expect(extractAssistantHistoryParts(blocks)).toEqual({
+      text: "first\nsecond",
+      thinking: "",
+    });
+  });
+
+  it("extracts thinking blocks and joins them with double newlines", () => {
+    const blocks: ContentBlock[] = [
+      { type: "thinking", thinking: "step 1" },
+      { type: "thinking", thinking: "step 2" },
+    ];
+    expect(extractAssistantHistoryParts(blocks)).toEqual({
+      text: "",
+      thinking: "step 1\n\nstep 2",
+    });
+  });
+
+  it("handles mixed thinking + text + tool_use, ignoring tool blocks", () => {
+    const blocks: ContentBlock[] = [
+      { type: "thinking", thinking: "let me think" },
+      { type: "tool_use", id: "t1", name: "shell", input: { cmd: "ls" } },
+      { type: "text", text: "here is the result" },
+      { type: "thinking", thinking: "more thinking" },
+      { type: "text", text: "final answer" },
+    ];
+    expect(extractAssistantHistoryParts(blocks)).toEqual({
+      text: "here is the result\nfinal answer",
+      thinking: "let me think\n\nmore thinking",
+    });
+  });
+
+  it("silently skips redacted_thinking and unknown block types (forward-compat)", () => {
+    // redacted_thinking handling is deferred — see follow-up.
+    // Treat as unknown so plaintext thinking still surfaces.
+    const blocks = [
+      { type: "redacted_thinking", data: "encrypted" },
+      { type: "thinking", thinking: "visible reasoning" },
+      { type: "future_block", payload: 42 },
+    ] as unknown as ContentBlock[];
+    expect(extractAssistantHistoryParts(blocks)).toEqual({
+      text: "",
+      thinking: "visible reasoning",
+    });
+  });
+
+  it("returns empty parts for an empty block array", () => {
+    expect(extractAssistantHistoryParts([])).toEqual({ text: "", thinking: "" });
+  });
+
+  it("falls back to String(value) for non-string, non-array, non-null content", () => {
+    // Defensive: server should never send a number, but if it does we
+    // should not throw and we should not corrupt the chat transcript.
+    expect(extractAssistantHistoryParts(42 as unknown as string)).toEqual({
+      text: "42",
+      thinking: "",
+    });
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/chat.ts
+++ b/crates/librefang-api/dashboard/src/lib/chat.ts
@@ -1,4 +1,5 @@
 import { formatCost } from "./format";
+import type { ContentBlock } from "../api";
 
 export type ChatRole = "user" | "assistant" | "system";
 
@@ -60,5 +61,56 @@ export function normalizeToolOutput(event: {
     content,
     isError,
     timestamp: new Date(),
+  };
+}
+
+/** Result of walking a persisted assistant message's `content` field
+ *  (`string | ContentBlock[]`) and pulling out the two display strings
+ *  the chat UI tracks: visible text and the collapsible reasoning trace.
+ *
+ *  Mirrors the live-streaming model where `ChatMessage.thinking` is a
+ *  flat string accumulated from `thinking_delta` events. Multiple
+ *  thinking blocks in one turn are joined with a blank line so the
+ *  collapsible drawer reads naturally.
+ *
+ *  `tool_use` / `tool_result` blocks are intentionally ignored here —
+ *  the mapper at `ChatPage.tsx:542-579` reads tool data from the
+ *  separate `msg.tools` field instead.
+ *
+ *  `redacted_thinking` blocks (if/when the backend emits them) are
+ *  silently skipped via the unknown-variant fallback. A follow-up will
+ *  add a placeholder UI; until then, the plaintext-thinking path
+ *  matches the live-streaming behavior. */
+export interface AssistantHistoryParts {
+  text: string;
+  thinking: string;
+}
+
+export function extractAssistantHistoryParts(
+  content: string | ContentBlock[] | null | undefined,
+): AssistantHistoryParts {
+  if (content == null) return { text: "", thinking: "" };
+  if (typeof content === "string") return { text: content, thinking: "" };
+  if (!Array.isArray(content)) return { text: String(content), thinking: "" };
+
+  const textParts: string[] = [];
+  const thinkingParts: string[] = [];
+  for (const block of content) {
+    if (block && typeof block === "object" && "type" in block) {
+      if (block.type === "text" && typeof (block as { text?: unknown }).text === "string") {
+        textParts.push((block as { text: string }).text);
+      } else if (
+        block.type === "thinking" &&
+        typeof (block as { thinking?: unknown }).thinking === "string"
+      ) {
+        thinkingParts.push((block as { thinking: string }).thinking);
+      }
+      // tool_use / tool_result / image / image_file / redacted_thinking /
+      // unknown future variants — skipped intentionally.
+    }
+  }
+  return {
+    text: textParts.join("\n"),
+    thinking: thinkingParts.join("\n\n"),
   };
 }

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -540,7 +540,14 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
       .then(session => {
         if (session.messages?.length) {
           const historical: ChatMessage[] = session.messages.flatMap((msg, idx) => {
-            const { text, thinking } = extractAssistantHistoryParts(msg.content);
+            const { text, thinking: extractedThinking } = extractAssistantHistoryParts(msg.content);
+            // The agent-scoped session endpoint (which this page uses)
+            // flattens content to a string server-side and surfaces thinking
+            // via a separate `thinking` field — prefer that. The helper's
+            // own thinking extraction stays as a fallback for any future
+            // consumer of the raw-blocks endpoint (`/api/sessions/{id}`)
+            // where content is a `ContentBlock[]` and no flat field exists.
+            const thinking = msg.thinking ?? extractedThinking;
 
             const hasTools = msg.tools && msg.tools.length > 0;
             const hasImages = msg.images && msg.images.length > 0;

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -19,7 +19,7 @@ import { useSessionStream } from "../lib/queries/sessions";
 import { useActiveHandsWhen } from "../lib/queries/hands";
 import { agentKeys, approvalKeys } from "../lib/queries/keys";
 import { groupedPicker } from "../lib/chatPicker";
-import { normalizeToolOutput } from "../lib/chat";
+import { extractAssistantHistoryParts, normalizeToolOutput } from "../lib/chat";
 import { useTtsManager } from "../lib/tts";
 import { MessageCircle, Send, Square, Bot, User, RefreshCw, AlertCircle, Wifi, Sparkles, X, ArrowRight, ArrowLeft, Zap, ShieldAlert, CheckCircle, XCircle, Clock, Plus, Trash2, ChevronDown, Loader2, Copy, Volume2, Pause, Download, Brain, Eye, EyeOff, Mic, MicOff, Globe, Paperclip, FileText, Menu } from "lucide-react";
 import { Badge } from "../components/ui/Badge";
@@ -540,22 +540,16 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
       .then(session => {
         if (session.messages?.length) {
           const historical: ChatMessage[] = session.messages.flatMap((msg, idx) => {
-            let content: string;
-            if (typeof msg.content === "string") {
-              content = msg.content;
-            } else if (Array.isArray(msg.content)) {
-              // Extract only text blocks — skip tool_use/tool_result
-              content = (msg.content as Array<Record<string, unknown>>)
-                .filter((b) => b.type === "text" && typeof b.text === "string")
-                .map((b) => b.text as string)
-                .join("\n");
-            } else {
-              content = msg.content == null ? "" : String(msg.content);
-            }
+            const { text, thinking } = extractAssistantHistoryParts(msg.content);
 
             const hasTools = msg.tools && msg.tools.length > 0;
             const hasImages = msg.images && msg.images.length > 0;
-            if (!content.trim() && !hasTools && !hasImages) return [];
+            const hasThinking = thinking.trim().length > 0;
+            // Drop messages with no displayable content. Thinking counts:
+            // a turn that produced only reasoning (no visible text or tools)
+            // should still render as an assistant turn with the collapsible
+            // thinking drawer, otherwise reload silently loses it.
+            if (!text.trim() && !hasTools && !hasImages && !hasThinking) return [];
 
             return [{
               id: `hist-${idx}`,
@@ -564,7 +558,7 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
                 : msg.role === "System"
                   ? "system"
                   : "assistant",
-              content,
+              content: text,
               // Use the real server-side timestamp when available so
               // resumed sessions render the original send time instead of
               // the page-load time. Fall back to `now` only for messages
@@ -576,6 +570,7 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
                 filename: img.filename,
                 content_type: img.content_type,
               })),
+              thinking: hasThinking ? thinking : undefined,
             }];
           });
           // Refresh the cache unconditionally — the data is still correct

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -578,6 +578,11 @@ function useChatMessages(agentId: string | null, agents: AgentItem[] = [], sessi
                 content_type: img.content_type,
               })),
               thinking: hasThinking ? thinking : undefined,
+              // Collapsed by default on history reload — long sessions with
+              // many reasoning turns would otherwise be a wall of text. Live
+              // streaming keeps its expanded default so the user can watch
+              // reasoning happen in real time.
+              thinkingCollapsed: hasThinking ? true : undefined,
             }];
           });
           // Refresh the cache unconditionally — the data is still correct

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -2015,6 +2015,16 @@ pub async fn get_agent_session(
             for m in &session.messages {
                 let mut tools: Vec<serde_json::Value> = Vec::new();
                 let mut msg_images: Vec<serde_json::Value> = Vec::new();
+                // Extended-thinking traces are flattened the same way text /
+                // tool_use / images already are. The dashboard renders these
+                // in a collapsible drawer; without surfacing them here, the
+                // reload path silently loses reasoning that was visible during
+                // streaming. Multiple thinking blocks in a single turn are
+                // joined with a blank line so the drawer reads naturally —
+                // matches the live `thinking_delta` accumulation on the WS
+                // path. `redacted_thinking` is not modeled separately yet and
+                // would fall through the catch-all, same as today.
+                let mut thinkings: Vec<String> = Vec::new();
                 let content = match &m.content {
                     librefang_types::message::MessageContent::Text(t) => t.clone(),
                     librefang_types::message::MessageContent::Blocks(blocks) => {
@@ -2023,6 +2033,12 @@ pub async fn get_agent_session(
                             match b {
                                 librefang_types::message::ContentBlock::Text { text, .. } => {
                                     texts.push(text.clone());
+                                }
+                                librefang_types::message::ContentBlock::Thinking {
+                                    thinking,
+                                    ..
+                                } => {
+                                    thinkings.push(thinking.clone());
                                 }
                                 librefang_types::message::ContentBlock::Image {
                                     media_type,
@@ -2111,6 +2127,12 @@ pub async fn get_agent_session(
                 }
                 if !msg_images.is_empty() {
                     msg["images"] = serde_json::Value::Array(msg_images);
+                }
+                if !thinkings.is_empty() {
+                    // Joined the same way the dashboard's history mapper joins
+                    // thinking deltas during live streaming — a blank line
+                    // between blocks keeps the collapsible drawer readable.
+                    msg["thinking"] = serde_json::Value::String(thinkings.join("\n\n"));
                 }
                 // Expose the real message timestamp so the dashboard can
                 // render historical times correctly on resume instead of

--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -417,3 +417,145 @@ async fn test_delete_agent_unknown_uuid_is_idempotent_200() {
     assert_eq!(status, StatusCode::OK, "body={body:?}");
     assert_eq!(body["status"], "already-deleted", "body={body:?}");
 }
+
+// ---------------------------------------------------------------------------
+// GET /api/agents/{id}/session — thinking blocks reach the dashboard
+// ---------------------------------------------------------------------------
+
+/// Persisted `ContentBlock::Thinking` blocks must be surfaced on the
+/// agent-scoped session endpoint so the dashboard can render the
+/// collapsible reasoning drawer on history reload — same UX as live
+/// streaming, where `thinking_delta` events accumulate into the message.
+///
+/// Before this fix the endpoint flattened blocks into a string and silently
+/// swallowed Thinking via the catch-all match arm, so reload showed an
+/// assistant turn with no reasoning even though the session JSON had it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_agent_session_endpoint_surfaces_thinking_blocks() {
+    use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+
+    let h = boot(TEST_TOKEN).await;
+    let id = spawn_named(&h.state, "thinking-target");
+
+    // Seed a session with an assistant turn that has interleaved thinking
+    // and text blocks. Two thinking blocks exercise the multi-block join.
+    let mut session = h
+        .state
+        .kernel
+        .memory_substrate()
+        .create_session(id)
+        .expect("create_session");
+    session.agent_id = id;
+    session.push_message(Message {
+        role: Role::User,
+        content: MessageContent::Text("hi".to_string()),
+        pinned: false,
+        timestamp: None,
+    });
+    session.push_message(Message {
+        role: Role::Assistant,
+        content: MessageContent::Blocks(vec![
+            ContentBlock::Thinking {
+                thinking: "first reasoning step".to_string(),
+                provider_metadata: None,
+            },
+            ContentBlock::Text {
+                text: "visible answer".to_string(),
+                provider_metadata: None,
+            },
+            ContentBlock::Thinking {
+                thinking: "follow-up reasoning".to_string(),
+                provider_metadata: None,
+            },
+        ]),
+        pinned: false,
+        timestamp: None,
+    });
+    let session_id = session.id.0;
+    h.state
+        .kernel
+        .memory_substrate()
+        .save_session(&session)
+        .expect("save_session");
+
+    let (status, body) = send(
+        h.app.clone(),
+        get(&format!(
+            "/api/agents/{}/session?session_id={}",
+            id, session_id
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body:?}");
+    let messages = body["messages"].as_array().expect("messages array").clone();
+    let assistant = messages
+        .iter()
+        .find(|m| m["role"] == "Assistant")
+        .expect("assistant message");
+    // Visible text still flattens — same shape the dashboard already
+    // rendered before this change.
+    assert_eq!(assistant["content"], "visible answer");
+    // Thinking now surfaces as a flat string with multi-block join. The
+    // dashboard's history mapper reads this directly into
+    // `ChatMessage.thinking`, mirroring the live-streaming flat-string
+    // accumulation from `thinking_delta` events.
+    assert_eq!(
+        assistant["thinking"], "first reasoning step\n\nfollow-up reasoning",
+        "thinking field missing or wrong join — body={body:?}",
+    );
+}
+
+/// Sessions without thinking blocks must NOT include a `thinking` field
+/// on assistant messages. Omitting (vs. emitting `""`) keeps the response
+/// shape unchanged for non-thinking models and avoids triggering the
+/// dashboard's empty-drawer render gate.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_agent_session_endpoint_omits_thinking_when_none_present() {
+    use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+
+    let h = boot(TEST_TOKEN).await;
+    let id = spawn_named(&h.state, "no-thinking-target");
+
+    let mut session = h
+        .state
+        .kernel
+        .memory_substrate()
+        .create_session(id)
+        .expect("create_session");
+    session.agent_id = id;
+    session.push_message(Message {
+        role: Role::Assistant,
+        content: MessageContent::Blocks(vec![ContentBlock::Text {
+            text: "plain answer".to_string(),
+            provider_metadata: None,
+        }]),
+        pinned: false,
+        timestamp: None,
+    });
+    let session_id = session.id.0;
+    h.state
+        .kernel
+        .memory_substrate()
+        .save_session(&session)
+        .expect("save_session");
+
+    let (status, body) = send(
+        h.app.clone(),
+        get(&format!(
+            "/api/agents/{}/session?session_id={}",
+            id, session_id
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body:?}");
+    let messages = body["messages"].as_array().expect("messages array");
+    let assistant = messages
+        .iter()
+        .find(|m| m["role"] == "Assistant")
+        .expect("assistant message");
+    assert_eq!(assistant["content"], "plain answer");
+    assert!(
+        assistant.get("thinking").is_none(),
+        "thinking field should be absent — body={body:?}",
+    );
+}


### PR DESCRIPTION
## Why

Re-publishes #4542 as an internal-repo PR so the OpenAPI Drift gate can run.

#4542 is from a fork (`neo-wanderer/librefang`); its branch was created
before the fork-PR checkout fix landed in main (#4557 — `fix(ci): skip
ref override for fork PRs in openapi-drift checkout`), so the drift job
on that PR fails at `actions/checkout` before it can even fetch the
PR branch (`git fetch origin feat/...` returns 404 because the branch
lives on the fork, not upstream).

Rebasing #4542 onto current main would pick up the workflow fix, but
even then the auto-commit codegen path is gated on `IS_INTERNAL_PR=true`
and falls through to "fail loudly" on fork PRs. Republishing the same
five commits on an internal branch routes around both problems.

## What's in here

Five commits cherry-picked from #4542 (`pull/4542/head` snapshot,
non-merge commits only, original authorship preserved):

- `feat(dashboard): type AgentSessionMessage.content as discriminated union`
- `feat(dashboard): add extractAssistantHistoryParts helper`
- `feat(dashboard): render historical thinking blocks on session reload`
- `feat(agents): surface thinking blocks on /agents/{id}/session`
- `feat(dashboard): collapse historical thinking drawers by default`

No content changes vs. #4542. Cherry-picks cleanly onto current main
(only auto-merge hunks on `dashboard/src/api.ts` and
`routes/agents.rs`).

## Codegen drift check (local)

Ran the same three steps the OpenAPI Drift CI job runs:

- `cargo xtask codegen --openapi` → 0 changes to `openapi.json`
- `python3 scripts/codegen-sdks.py` → 0 changes to `sdk/`
- `cargo xtask schema-check gen` → 0 changes to `xtask/baselines/`

The new `thinking` field on `/api/agents/{id}/session` doesn't surface
in the OpenAPI spec because that endpoint builds its response with
`serde_json::Value` (no typed schema for the inner message shape).
So this PR adds nothing under `openapi.json` / `sdk/` / `xtask/baselines/`
— the drift gate is expected to be a no-op.

## After merge

Original #4542 will be redundant — its content will already be in main.
Either close it as superseded, or click "Update branch" on the GitHub
UI; the resulting branch will have no commits ahead of main and the
PR will close itself.

## Test plan

- [ ] CI green (`Test/*`, `Quality`, `Security`, `OpenAPI Drift`).
- [ ] Manual smoke (deferred to merger): load a session that ran with
  extended thinking, confirm the collapsible "Thinking" drawer renders
  on reload exactly like it did during live streaming.

Refs: #4542, #4557.
