### PR TITLE
fix(plugins): split canonical name from localized display_name (404 on Chinese labels)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3125,7 +3125,13 @@ export async function getMetricsText(): Promise<string> {
 // ── Plugins ──────────────────────────────────────────
 
 export interface PluginItem {
+  // Canonical identifier — used as the path segment for
+  // /plugins/{name}/{enable,disable,reload,install-deps,uninstall}.
+  // Must NOT be the localized label.
   name: string;
+  // Localized display label resolved from `[i18n.<lang>]` on the
+  // plugin manifest. Falls back to `name` when no override is set.
+  display_name?: string;
   version: string;
   description?: string;
   author?: string;
@@ -3136,7 +3142,11 @@ export interface PluginItem {
 }
 
 export interface RegistryPluginListing {
+  // Canonical identifier sent back to POST /api/plugins/install — must
+  // match the directory name on the GitHub registry. Localized labels
+  // go on `display_name`.
   name: string;
+  display_name?: string;
   installed: boolean;
   version?: string | null;
   description?: string | null;

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.test.tsx
@@ -303,6 +303,66 @@ describe("PluginsPage", () => {
     });
   });
 
+  // Regression: when a registry plugin ships a localized `display_name` (e.g.
+  // a Chinese label resolved by the backend from `[i18n.zh]`), the card must
+  // RENDER the localized label but INSTALL with the canonical `name`. The
+  // previous behavior wrote the localized string into `name`, and the install
+  // request hit GitHub at /contents/plugins/上下文衰减 → 404.
+  it("renders display_name on the card but installs with the canonical name", async () => {
+    const user = userEvent.setup();
+    const installMutate = vi.fn();
+    useInstallPluginMock.mockReturnValue({
+      mutate: installMutate,
+      isPending: false,
+      error: null,
+    });
+    usePluginsMock.mockReturnValue(makeQuery([]));
+    usePluginRegistriesMock.mockReturnValue(
+      makeQuery({
+        registries: [
+          {
+            name: "official",
+            github_repo: "librefang/registry",
+            plugins: [
+              {
+                name: "context_decay",
+                display_name: "上下文衰减",
+                installed: false,
+                version: "1.0.0",
+                description: "上下文衰减描述",
+                hooks: ["ingest"],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    renderPage();
+    await user.click(screen.getByText("plugins.registry_tab"));
+
+    // Localized label is what the user sees.
+    const displayHeading = await screen.findByText("上下文衰减");
+    expect(displayHeading).toBeInTheDocument();
+    // Canonical id is *not* shown anywhere on the card body.
+    expect(screen.queryByText("context_decay")).not.toBeInTheDocument();
+
+    // Click install — the payload must use the canonical `name`, not the label.
+    const card = displayHeading.closest("div[class*='cursor-pointer']");
+    const installButton = within(card as HTMLElement).getByText(
+      "plugins.install",
+    );
+    await user.click(installButton);
+
+    expect(installMutate).toHaveBeenCalledTimes(1);
+    const [payload] = installMutate.mock.calls[0];
+    expect(payload).toEqual({
+      source: "registry",
+      name: "context_decay",
+      github_repo: "librefang/registry",
+    });
+  });
+
   it("opens the scaffold drawer and disables Create when name is empty", async () => {
     const user = userEvent.setup();
     usePluginsMock.mockReturnValue(makeQuery(samplePlugins()));

--- a/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/PluginsPage.tsx
@@ -210,7 +210,7 @@ export function PluginsPage() {
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
-                      <h3 className="text-xs sm:text-sm font-bold">{p.name}</h3>
+                      <h3 className="text-xs sm:text-sm font-bold">{p.display_name ?? p.name}</h3>
                       <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-main text-text-dim font-mono">{p.version}</span>
                       {p.hooks?.ingest && <Badge variant="brand">ingest</Badge>}
                       {p.hooks?.after_turn && <Badge variant="brand">after_turn</Badge>}
@@ -298,7 +298,7 @@ export function PluginsPage() {
                             </div>
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-1.5 flex-wrap">
-                                <h4 className="text-sm font-bold truncate">{rp.name}</h4>
+                                <h4 className="text-sm font-bold truncate">{rp.display_name ?? rp.name}</h4>
                                 {rp.version && (
                                   <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-main text-text-dim font-mono">
                                     {rp.version}
@@ -575,7 +575,7 @@ export function PluginsPage() {
       <DrawerPanel
         isOpen={!!detailsRegistryPlugin}
         onClose={() => setDetailsRegistryPlugin(null)}
-        title={detailsRegistryPlugin?.rp.name ?? ""}
+        title={detailsRegistryPlugin?.rp.display_name ?? detailsRegistryPlugin?.rp.name ?? ""}
         size="md"
       >
         {detailsRegistryPlugin && (() => {
@@ -589,7 +589,7 @@ export function PluginsPage() {
                 </div>
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <h2 className="text-lg font-black tracking-tight truncate">{rp.name}</h2>
+                    <h2 className="text-lg font-black tracking-tight truncate">{rp.display_name ?? rp.name}</h2>
                     {rp.version && (
                       <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-main text-text-dim font-mono">v{rp.version}</span>
                     )}

--- a/crates/librefang-api/src/routes/plugins.rs
+++ b/crates/librefang-api/src/routes/plugins.rs
@@ -220,14 +220,22 @@ pub async fn list_plugins(
     let items: Vec<serde_json::Value> = plugins
         .iter()
         .map(|p| {
-            let (name, description) = resolve_plugin_i18n(
+            // `name` MUST stay canonical — it's the path-segment identifier
+            // for /plugins/{name}/* (uninstall, enable, disable, reload,
+            // install-deps). `display_name` carries the localized override
+            // for UI rendering. Substituting the localized string into
+            // `name` (the previous behavior) caused install/uninstall to
+            // hit `/plugins/上下文衰减` and 404 against the ASCII directory
+            // names actually present in the registry.
+            let (display_name, description) = resolve_plugin_i18n(
                 lang,
                 &p.manifest.name,
                 &p.manifest.description,
                 &p.manifest.i18n,
             );
             serde_json::json!({
-                "name": name,
+                "name": p.manifest.name,
+                "display_name": display_name,
                 "version": p.manifest.version,
                 "description": description,
                 "author": p.manifest.author,
@@ -276,7 +284,10 @@ pub async fn get_plugin(
     let lang = resolve_lang(lang.as_ref());
     match librefang_runtime::plugin_manager::get_plugin_info(&name) {
         Ok(info) => {
-            let (loc_name, description) = resolve_plugin_i18n(
+            // Same canonical-vs-display split as `list_plugins` — `name`
+            // is the route identifier, `display_name` is the localized UI
+            // label.
+            let (display_name, description) = resolve_plugin_i18n(
                 lang,
                 &info.manifest.name,
                 &info.manifest.description,
@@ -285,7 +296,8 @@ pub async fn get_plugin(
             (
                 StatusCode::OK,
                 Json(serde_json::json!({
-                    "name": loc_name,
+                    "name": info.manifest.name,
+                    "display_name": display_name,
                     "version": info.manifest.version,
                     "description": description,
                     "author": info.manifest.author,
@@ -708,10 +720,17 @@ pub async fn list_plugin_registries(
             Ok(entries) => entries
                 .into_iter()
                 .map(|e| {
-                    let (name, description) =
+                    // `name` is the registry directory name on GitHub —
+                    // it's the install identifier the dashboard sends back
+                    // to POST /api/plugins/install. Localized labels go on
+                    // `display_name`; substituting them into `name` would
+                    // make the install URL fetch a non-existent directory
+                    // (the original report: 上下文衰减 → 404).
+                    let (display_name, description) =
                         resolve_plugin_i18n(lang, &e.name, &e.description, &e.i18n);
                     serde_json::json!({
-                        "name": name,
+                        "name": e.name,
+                        "display_name": display_name,
                         "installed": installed_names.contains(&e.name),
                         "version": e.version,
                         "description": description,


### PR DESCRIPTION
## Summary

Plugin install / uninstall / enable / disable / reload all 404 when the
caller's language matches a plugin's `[i18n.<lang>]` block.

Reported in dashboard at `/dashboard/plugins`:

```
Plugin '上下文衰减' not found in registry (HTTP 404 Not Found)
```

## Root cause

`crates/librefang-api/src/routes/plugins.rs` substitutes the localized
label resolved by `resolve_plugin_i18n` into the JSON `name` field on
three endpoints:

- `GET /api/plugins` (installed plugin list)
- `GET /api/plugins/{name}` (single plugin detail)
- `GET /api/plugins/registries` (registry browse)

The dashboard reads that `name` as both display label *and* install /
uninstall / enable identifier. When `Accept-Language: zh` is set on a
plugin that ships `[i18n.zh] name = "上下文衰减"`:

1. Dashboard renders the card as `上下文衰减`.
2. Dashboard click → `POST /api/plugins/install { name: "上下文衰减" }`.
3. `install_from_registry` builds
   `https://api.github.com/repos/librefang/librefang-registry/contents/plugins/上下文衰减`
   → 404 (the actual directory name is canonical ASCII).

`validate_plugin_name`'s `is_alphanumeric()` check is Unicode-aware and
accepts CJK, so the bad name passes validation and only fails at the
GitHub Contents API.

## Fix

Split canonical from display:

- `name` reverts to the canonical manifest / registry directory name —
  used as the path segment for `/plugins/{name}/{enable,disable,reload,
  install-deps,uninstall}` and as the install identifier sent to
  GitHub.
- `display_name` is a new optional field carrying the localized label
  resolved by `resolve_plugin_i18n` (helper itself unchanged — its
  existing unit tests still pass).
- Dashboard renders `display_name ?? name`; identifier sites (`key`,
  install/uninstall mutation args, `installingName` cache, install
  drawer's `installKey`) keep `name`.

## Files

- `crates/librefang-api/src/routes/plugins.rs` — 3 endpoints
  (`list_plugins`, `get_plugin`, `list_plugin_registries`) emit
  `{name, display_name}` instead of overwriting `name`.
- `crates/librefang-api/dashboard/src/api.ts` — `PluginItem` and
  `RegistryPluginListing` get an optional `display_name` with comments
  documenting the canonical-vs-display split.
- `crates/librefang-api/dashboard/src/pages/PluginsPage.tsx` — 4
  render sites switched to `display_name ?? name`.
- `crates/librefang-api/dashboard/src/pages/PluginsPage.test.tsx` —
  regression test:
    - fixture `{ name: "context_decay", display_name: "上下文衰减" }`
    - asserts the localized label is what the user sees on the card
    - asserts the canonical id is *not* shown
    - asserts the install mutation payload uses `name: "context_decay"`,
      not `"上下文衰减"`

## Verification

- `pnpm vitest run src/pages/PluginsPage.test.tsx` — 10 passed (9 pre-
  existing + 1 new regression test).
- `pnpm tsc --noEmit` — clean.
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean.
- `resolve_plugin_i18n_tests` (existing 7-case unit suite) — unchanged
  helper, untouched.

## Test plan

- [x] vitest regression test exercises the bug scenario (Chinese
  display label, canonical install id).
- [x] No backwards-compat break: pre-i18n plugins (no `display_name`)
  fall through `display_name ?? name` and render exactly as before.
- [ ] Manual: load `/dashboard/plugins` with `Accept-Language: zh`,
  install a plugin that has `[i18n.zh]`, confirm it resolves the
  GitHub directory and downloads.

## Ref

Reported via dashboard error toast — no GitHub issue.
