### PR TITLE
feat(observability): expand agent_id access-log coverage to hot-path routes (#3511)

### DIFF
--- a/crates/librefang-api/src/routes/auto_dream.rs
+++ b/crates/librefang-api/src/routes/auto_dream.rs
@@ -66,7 +66,9 @@ pub async fn auto_dream_trigger(
     let outcome = Arc::clone(&state.kernel)
         .auto_dream_trigger_manual(agent_id)
         .await;
-    Json(outcome).into_response()
+    // #3511: tag response so request_logging middleware can emit
+    // `agent_id` as a structured field on the access-log line.
+    crate::extensions::with_agent_id(agent_id, Json(outcome))
 }
 
 #[utoipa::path(
@@ -84,7 +86,8 @@ pub async fn auto_dream_abort(
     AgentIdPath(agent_id): AgentIdPath,
 ) -> impl IntoResponse {
     let outcome = state.kernel.auto_dream_abort(agent_id).await;
-    Json(outcome).into_response()
+    // #3511: tag response with agent_id for the access-log middleware.
+    crate::extensions::with_agent_id(agent_id, Json(outcome))
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -108,7 +111,7 @@ pub async fn auto_dream_set_enabled(
     AgentIdPath(agent_id): AgentIdPath,
     Json(req): Json<SetEnabledRequest>,
 ) -> impl IntoResponse {
-    match state.kernel.auto_dream_set_enabled(agent_id, req.enabled) {
+    let body = match state.kernel.auto_dream_set_enabled(agent_id, req.enabled) {
         Ok(()) => Json(serde_json::json!({
             "agent_id": agent_id.to_string(),
             "enabled": req.enabled,
@@ -119,5 +122,7 @@ pub async fn auto_dream_set_enabled(
             Json(serde_json::json!({"error": e.to_string()})),
         )
             .into_response(),
-    }
+    };
+    // #3511: tag response with agent_id for the access-log middleware.
+    crate::extensions::with_agent_id(agent_id, body)
 }

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -410,7 +410,11 @@ pub async fn agent_budget_status(
     let entry = match state.kernel.agent_registry().get(agent_id) {
         Some(e) => e,
         None => {
-            return ApiErrorResponse::not_found("Agent not found").into_response();
+            // #3511: even on 404 we know agent_id was well-formed, so emit it.
+            return crate::extensions::with_agent_id(
+                agent_id,
+                ApiErrorResponse::not_found("Agent not found"),
+            );
         }
     };
 
@@ -425,7 +429,7 @@ pub async fn agent_budget_status(
     let token_usage = state.kernel.scheduler_ref().get_usage(agent_id);
     let tokens_used = token_usage.map(|s| s.total_tokens).unwrap_or(0);
 
-    (
+    let body = (
         StatusCode::OK,
         Json(serde_json::json!({
             "agent_id": agent_id.to_string(),
@@ -451,8 +455,9 @@ pub async fn agent_budget_status(
                 "pct": if quota.effective_token_limit() > 0 { tokens_used as f64 / quota.effective_token_limit() as f64 } else { 0.0 },
             },
         })),
-    )
-        .into_response()
+    );
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 /// GET /api/budget/agents — Per-agent cost ranking (top spenders).
@@ -536,10 +541,13 @@ pub async fn update_agent_budget(
     let tokens = body["max_llm_tokens_per_hour"].as_u64();
 
     if hourly.is_none() && daily.is_none() && monthly.is_none() && tokens.is_none() {
-        return ApiErrorResponse::bad_request(
-            "Provide at least one of: max_cost_per_hour_usd, max_cost_per_day_usd, max_cost_per_month_usd, max_llm_tokens_per_hour",
-        )
-        .into_response();
+        // #3511: tag even validation failures with agent_id (path was well-formed).
+        return crate::extensions::with_agent_id(
+            agent_id,
+            ApiErrorResponse::bad_request(
+                "Provide at least one of: max_cost_per_hour_usd, max_cost_per_day_usd, max_cost_per_month_usd, max_llm_tokens_per_hour",
+            ),
+        );
     }
 
     // Capture OLD per-agent caps BEFORE the in-memory mutation so the
@@ -552,7 +560,7 @@ pub async fn update_agent_budget(
         .get(agent_id)
         .map(|e| e.manifest.resources.clone());
 
-    match state
+    let body = match state
         .kernel
         .agent_registry()
         .update_resources(agent_id, hourly, daily, monthly, tokens)
@@ -601,7 +609,9 @@ pub async fn update_agent_budget(
             }
         }
         Err(e) => ApiErrorResponse::not_found(format!("{e}")).into_response(),
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1592,21 +1592,26 @@ pub async fn get_agent_kv(
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     if let Err(resp) = assert_kv_owner_or_admin(&state, agent_id, api_user.as_ref(), &t) {
-        return resp;
+        // #3511: tag the ACL-denial response with the resolved agent_id.
+        return crate::extensions::with_agent_id(agent_id, resp);
     }
-    match state.kernel.memory_substrate().list_kv(agent_id) {
+    let body = match state.kernel.memory_substrate().list_kv(agent_id) {
         Ok(pairs) => {
             let kv: Vec<serde_json::Value> = pairs
                 .into_iter()
                 .map(|(k, v)| serde_json::json!({"key": k, "value": v}))
                 .collect();
-            (StatusCode::OK, Json(serde_json::json!({"kv_pairs": kv})))
+            (StatusCode::OK, Json(serde_json::json!({"kv_pairs": kv}))).into_response()
         }
         Err(e) => {
             tracing::warn!("Memory list_kv failed: {e}");
-            ApiErrorResponse::internal(t.t("api-error-memory-operation-failed")).into_json_tuple()
+            ApiErrorResponse::internal(t.t("api-error-memory-operation-failed"))
+                .into_json_tuple()
+                .into_response()
         }
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 /// GET /api/memory/agents/:id/kv/:key — Get a specific KV value.
@@ -1616,19 +1621,20 @@ pub async fn get_agent_kv_key(
     Path((id, key)): Path<(String, String)>,
     lang: Option<axum::Extension<RequestLanguage>>,
     api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     let agent_id: AgentId = match id.parse() {
         Ok(aid) => aid,
         Err(_) => {
             return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
-                .into_json_tuple();
+                .into_json_tuple()
+                .into_response();
         }
     };
     if let Err(resp) = assert_kv_owner_or_admin(&state, agent_id, api_user.as_ref(), &t) {
-        return resp;
+        return crate::extensions::with_agent_id(agent_id, resp);
     }
-    match state
+    let body = match state
         .kernel
         .memory_substrate()
         .structured_get(agent_id, &key)
@@ -1636,15 +1642,20 @@ pub async fn get_agent_kv_key(
         Ok(Some(val)) => (
             StatusCode::OK,
             Json(serde_json::json!({"key": key, "value": val})),
-        ),
-        Ok(None) => {
-            ApiErrorResponse::not_found(t.t("api-error-kv-key-not-found")).into_json_tuple()
-        }
+        )
+            .into_response(),
+        Ok(None) => ApiErrorResponse::not_found(t.t("api-error-kv-key-not-found"))
+            .into_json_tuple()
+            .into_response(),
         Err(e) => {
             tracing::warn!("Memory get failed for key '{key}': {e}");
-            ApiErrorResponse::internal(t.t("api-error-memory-operation-failed")).into_json_tuple()
+            ApiErrorResponse::internal(t.t("api-error-memory-operation-failed"))
+                .into_json_tuple()
+                .into_response()
         }
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 /// PUT /api/memory/agents/:id/kv/:key — Set a KV value.
@@ -1655,21 +1666,22 @@ pub async fn set_agent_kv_key(
     lang: Option<axum::Extension<RequestLanguage>>,
     api_user: Option<axum::Extension<crate::middleware::AuthenticatedApiUser>>,
     Json(body): Json<serde_json::Value>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
     let agent_id: AgentId = match id.parse() {
         Ok(aid) => aid,
         Err(_) => {
             return ApiErrorResponse::bad_request(t.t("api-error-agent-invalid-id"))
-                .into_json_tuple();
+                .into_json_tuple()
+                .into_response();
         }
     };
     if let Err(resp) = assert_kv_owner_or_admin(&state, agent_id, api_user.as_ref(), &t) {
-        return resp;
+        return crate::extensions::with_agent_id(agent_id, resp);
     }
     let value = body.get("value").cloned().unwrap_or(body);
 
-    match state
+    let body = match state
         .kernel
         .memory_substrate()
         .structured_set(agent_id, &key, value)
@@ -1677,12 +1689,17 @@ pub async fn set_agent_kv_key(
         Ok(()) => (
             StatusCode::OK,
             Json(serde_json::json!({"status": "stored", "key": key})),
-        ),
+        )
+            .into_response(),
         Err(e) => {
             tracing::warn!("Memory set failed for key '{key}': {e}");
-            ApiErrorResponse::internal(t.t("api-error-memory-operation-failed")).into_json_tuple()
+            ApiErrorResponse::internal(t.t("api-error-memory-operation-failed"))
+                .into_json_tuple()
+                .into_response()
         }
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 /// DELETE /api/memory/agents/:id/kv/:key — Delete a KV value.
@@ -1703,9 +1720,9 @@ pub async fn delete_agent_kv_key(
         }
     };
     if let Err(resp) = assert_kv_owner_or_admin(&state, agent_id, api_user.as_ref(), &t) {
-        return resp.into_response();
+        return crate::extensions::with_agent_id(agent_id, resp);
     }
-    match state
+    let body = match state
         .kernel
         .memory_substrate()
         .structured_delete(agent_id, &key)
@@ -1717,7 +1734,9 @@ pub async fn delete_agent_kv_key(
                 .into_json_tuple()
                 .into_response()
         }
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 /// GET /api/agents/:id/memory/export — Export all KV memory for an agent as JSON.
@@ -1736,13 +1755,16 @@ pub async fn export_agent_memory(
     // clean 404 instead of falling through to a `list_kv` against a
     // non-existent id.
     if state.kernel.agent_registry().get(agent_id).is_none() {
-        return ApiErrorResponse::not_found(t.t("api-error-agent-not-found")).into_json_tuple();
+        return crate::extensions::with_agent_id(
+            agent_id,
+            ApiErrorResponse::not_found(t.t("api-error-agent-not-found")).into_json_tuple(),
+        );
     }
     if let Err(resp) = assert_kv_owner_or_admin(&state, agent_id, api_user.as_ref(), &t) {
-        return resp;
+        return crate::extensions::with_agent_id(agent_id, resp);
     }
 
-    match state.kernel.memory_substrate().list_kv(agent_id) {
+    let body = match state.kernel.memory_substrate().list_kv(agent_id) {
         Ok(pairs) => {
             let kv_map: serde_json::Map<String, serde_json::Value> = pairs.into_iter().collect();
             (
@@ -1753,12 +1775,17 @@ pub async fn export_agent_memory(
                     "kv": kv_map,
                 })),
             )
+                .into_response()
         }
         Err(e) => {
             tracing::warn!("Memory export failed for agent {agent_id}: {e}");
-            ApiErrorResponse::internal(t.t("api-error-kv-export-failed")).into_json_tuple()
+            ApiErrorResponse::internal(t.t("api-error-kv-export-failed"))
+                .into_json_tuple()
+                .into_response()
         }
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 /// POST /api/agents/:id/memory/import — Import KV memory from JSON into an agent.
@@ -1802,17 +1829,23 @@ pub async fn import_agent_memory(
     // Verify agent exists (admins skip the owner check below, so we still
     // need this branch for them — see `export_agent_memory`).
     if state.kernel.agent_registry().get(agent_id).is_none() {
-        return ApiErrorResponse::not_found(t.t("api-error-agent-not-found")).into_json_tuple();
+        return crate::extensions::with_agent_id(
+            agent_id,
+            ApiErrorResponse::not_found(t.t("api-error-agent-not-found")).into_json_tuple(),
+        );
     }
     if let Err(resp) = assert_kv_owner_or_admin(&state, agent_id, api_user.as_ref(), &t) {
-        return resp;
+        return crate::extensions::with_agent_id(agent_id, resp);
     }
 
     let kv = match body.get("kv").and_then(|v| v.as_object()) {
         Some(obj) => obj.clone(),
         None => {
-            return ApiErrorResponse::bad_request(t.t("api-error-kv-missing-kv-object"))
-                .into_json_tuple();
+            return crate::extensions::with_agent_id(
+                agent_id,
+                ApiErrorResponse::bad_request(t.t("api-error-kv-missing-kv-object"))
+                    .into_json_tuple(),
+            );
         }
     };
 
@@ -1837,8 +1870,11 @@ pub async fn import_agent_memory(
             }
             Err(e) => {
                 tracing::warn!("Failed to list existing KV during import clear: {e}");
-                return ApiErrorResponse::internal(t.t("api-error-kv-import-clear-failed"))
-                    .into_json_tuple();
+                return crate::extensions::with_agent_id(
+                    agent_id,
+                    ApiErrorResponse::internal(t.t("api-error-kv-import-clear-failed"))
+                        .into_json_tuple(),
+                );
             }
         }
     }
@@ -1860,7 +1896,7 @@ pub async fn import_agent_memory(
         }
     }
 
-    if errors.is_empty() {
+    let body = if errors.is_empty() {
         (
             StatusCode::OK,
             Json(serde_json::json!({
@@ -1877,7 +1913,9 @@ pub async fn import_agent_memory(
                 "failed_keys": errors,
             })),
         )
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 #[cfg(test)]

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -62,7 +62,7 @@ async fn list_prompt_versions(
                 .into_response()
         }
     };
-    match state.kernel.list_prompt_versions(agent_id) {
+    let body = match state.kernel.list_prompt_versions(agent_id) {
         Ok(versions) => {
             let total = versions.len();
             Json(crate::types::PaginatedResponse {
@@ -76,7 +76,9 @@ async fn list_prompt_versions(
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()
             .into_response(),
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 async fn create_prompt_version(
@@ -99,12 +101,14 @@ async fn create_prompt_version(
     let mut hasher = Sha256::new();
     hasher.update(version.system_prompt.as_bytes());
     version.content_hash = format!("{:x}", hasher.finalize());
-    match state.kernel.create_prompt_version(&version) {
+    let body = match state.kernel.create_prompt_version(&version) {
         Ok(_) => Json(version).into_response(),
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()
             .into_response(),
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 async fn get_prompt_version(
@@ -173,7 +177,7 @@ async fn list_experiments(
                 .into_response()
         }
     };
-    match state.kernel.list_experiments(agent_id) {
+    let body = match state.kernel.list_experiments(agent_id) {
         Ok(experiments) => {
             let total = experiments.len();
             Json(crate::types::PaginatedResponse {
@@ -187,7 +191,9 @@ async fn list_experiments(
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()
             .into_response(),
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 async fn create_experiment(
@@ -210,12 +216,14 @@ async fn create_experiment(
     for variant in &mut experiment.variants {
         variant.id = uuid::Uuid::new_v4();
     }
-    match state.kernel.create_experiment(&experiment) {
+    let body = match state.kernel.create_experiment(&experiment) {
         Ok(_) => Json(experiment).into_response(),
         Err(e) => ApiErrorResponse::internal(e)
             .into_json_tuple()
             .into_response(),
-    }
+    };
+    // #3511: tag response so request_logging middleware can emit `agent_id`.
+    crate::extensions::with_agent_id(agent_id, body)
 }
 
 async fn get_experiment(

--- a/crates/librefang-api/tests/access_log_agent_id_test.rs
+++ b/crates/librefang-api/tests/access_log_agent_id_test.rs
@@ -1,0 +1,153 @@
+//! Integration tests for #3511 — `agent_id` propagation into the HTTP
+//! access log via `Response::extensions`.
+//!
+//! The middleware in `crates/librefang-api/src/middleware.rs::request_logging`
+//! reads back an [`AgentIdField`](librefang_api::extensions::AgentIdField)
+//! marker after `next.run().await` and emits it as a structured `tracing`
+//! field. The test surface here is the marker itself — we boot the route
+//! handlers via `tower::oneshot`, hit a path-scoped endpoint, and assert
+//! the response carries the marker for the agent we addressed in the path.
+//!
+//! We do not exercise the `tracing` subscriber: the read of
+//! `response.extensions().get::<AgentIdField>()` in the middleware is a
+//! one-liner and the only thing that can break it is a handler forgetting
+//! to call `with_agent_id` at the end of its happy / error path. Asserting
+//! on `extensions` directly is the precise contract.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use axum::Router;
+use librefang_api::extensions::AgentIdField;
+use librefang_api::routes::{self, AppState};
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use librefang_types::agent::AgentId;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+/// Minimal harness: nest the route module under `/api` exactly as
+/// `server.rs` does, so the URI we hit in the test mirrors production.
+struct Harness {
+    app: Router,
+    _test: TestAppState,
+}
+
+fn boot_auto_dream() -> Harness {
+    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(|cfg| {
+        // Non-LLM provider keeps boot fast and avoids any accidental egress.
+        cfg.default_model = librefang_types::config::DefaultModelConfig {
+            provider: "ollama".to_string(),
+            model: "test-model".to_string(),
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        };
+    }));
+    let state: Arc<AppState> = test.state.clone();
+    let app = Router::new()
+        .nest("/api", routes::auto_dream::router())
+        .with_state(state);
+    Harness { app, _test: test }
+}
+
+fn boot_budget() -> Harness {
+    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(|cfg| {
+        cfg.default_model = librefang_types::config::DefaultModelConfig {
+            provider: "ollama".to_string(),
+            model: "test-model".to_string(),
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        };
+    }));
+    let state: Arc<AppState> = test.state.clone();
+    let app = Router::new()
+        .nest("/api", routes::budget::router())
+        .with_state(state);
+    Harness { app, _test: test }
+}
+
+/// `PUT /api/auto-dream/agents/{id}/enabled` for an unknown agent returns
+/// `404 NOT_FOUND` (the kernel does the lookup), and the handler must
+/// still tag the response with the `agent_id` that was successfully
+/// parsed from the path. Without the tag the access-log line would say
+/// `agent_id=""` even though the routing layer clearly knew which agent
+/// the operator was trying to address.
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_dream_set_enabled_tags_response_with_agent_id_on_404() {
+    let h = boot_auto_dream();
+    let unknown = AgentId::new();
+
+    let req = Request::builder()
+        .method(Method::PUT)
+        .uri(format!("/api/auto-dream/agents/{unknown}/enabled"))
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({"enabled": true})).unwrap(),
+        ))
+        .unwrap();
+
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let field = resp
+        .extensions()
+        .get::<AgentIdField>()
+        .expect("AgentIdField must be present even when the agent is not in the registry");
+    assert_eq!(field.0, unknown);
+}
+
+/// `GET /api/budget/agents/{id}` for an unknown agent returns `404`, but
+/// the handler must still tag the response with the resolved `agent_id`
+/// — the path was well-formed, the operator's intent is clear, the
+/// access log should reflect that.
+#[tokio::test(flavor = "multi_thread")]
+async fn budget_agent_status_tags_response_with_agent_id_on_404() {
+    let h = boot_budget();
+    let unknown = AgentId::new();
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/api/budget/agents/{unknown}"))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let field = resp
+        .extensions()
+        .get::<AgentIdField>()
+        .expect("AgentIdField must be present on the 404 response");
+    assert_eq!(field.0, unknown);
+}
+
+/// Malformed agent id never reaches the handler — the `AgentIdPath`
+/// extractor rejects with `400` before the handler runs, so the
+/// `with_agent_id` call site never executes. The access-log line for
+/// such a request will carry an empty `agent_id` field, which is the
+/// documented behavior (no resolved agent, no marker).
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_dream_set_enabled_no_marker_when_path_is_malformed() {
+    let h = boot_auto_dream();
+
+    let req = Request::builder()
+        .method(Method::PUT)
+        .uri("/api/auto-dream/agents/not-a-uuid/enabled")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({"enabled": true})).unwrap(),
+        ))
+        .unwrap();
+
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        resp.extensions().get::<AgentIdField>().is_none(),
+        "marker must NOT be set when the path id failed to parse — \
+         the handler never ran, so no agent_id was ever resolved"
+    );
+}

--- a/docs/architecture/access-log-fields.md
+++ b/docs/architecture/access-log-fields.md
@@ -1,0 +1,108 @@
+# HTTP access log structured fields
+
+LibreFang's `request_logging` middleware (`crates/librefang-api/src/middleware.rs`)
+emits one structured `tracing` event per HTTP request. Operators grep these
+lines to trace requests across the kernel boundary; the kernel orchestration
+spans and the per-driver `llm.complete` / `llm.stream` spans inherit the
+same `request_id` field, so a single grep on `request_id=<uuid>` lights up
+the full execution path.
+
+This document is the canonical reference for the shape of those events.
+
+## Field schema
+
+Every access-log event carries the following structured fields:
+
+| Field        | Source                                                 | Cardinality / notes                                                |
+|--------------|--------------------------------------------------------|--------------------------------------------------------------------|
+| `request_id` | `request_logging` middleware (UUID v4)                 | Per-request, unique. Inherited by every child span.                |
+| `method`     | `request.method()`                                     | HTTP verb, low cardinality.                                        |
+| `path`       | `request.uri().path()`                                 | Raw URI path. UUIDs are NOT normalized in the log line.            |
+| `status`     | Response status code                                   | 100–599.                                                           |
+| `latency_ms` | `Instant::now() - start`                               | Wall-clock latency in milliseconds.                                |
+| `agent_id`   | Response extension `AgentIdField` (see below)          | Empty string when the route does not carry an agent in its path.   |
+
+The level of the event depends on `status`:
+
+- `5xx` → `error!` (server faults must surface).
+- `4xx` → `warn!` (auth storms, validation errors).
+- `2xx` / `3xx` `GET` → `debug!` (poll noise suppressed by default).
+- everything else → `info!`.
+
+## How `agent_id` gets there
+
+The middleware itself only sees the raw URI; `path` normalization in
+`metrics.rs` collapses agent UUIDs to `{id}` (Prometheus label hygiene),
+so the path-substring fallback no longer works either. To attach a
+structured `agent_id` field without forcing every handler to take a
+`tracing::Span` argument, handlers that have already extracted a typed
+`AgentId` from the request path drop a marker into `Response::extensions`:
+
+```rust
+// crates/librefang-api/src/extensions.rs
+pub struct AgentIdField(pub AgentId);
+
+pub fn with_agent_id<R: IntoResponse>(agent_id: AgentId, body: R) -> Response {
+    let mut response = body.into_response();
+    response.extensions_mut().insert(AgentIdField(agent_id));
+    response
+}
+```
+
+The middleware reads it back after `next.run().await`:
+
+```rust
+let agent_id = response
+    .extensions()
+    .get::<crate::extensions::AgentIdField>()
+    .map(|f| f.0.to_string());
+```
+
+Handlers opt into the enrichment by ending their happy and error paths
+with `crate::extensions::with_agent_id(agent_id, body)`. The call is a
+no-op for the wire format — extensions are an in-process channel
+between handler and middleware and never cross the wire.
+
+Closes [#3511](https://github.com/librefang/librefang/issues/3511).
+
+## Cardinality and metrics: do NOT add `agent_id` as a Prometheus label
+
+`agent_id` is a UUID and effectively unbounded. It belongs in the
+`tracing` event stream, where lines are written and discarded, but it
+must NOT be added to any Prometheus label set in `metrics.rs` — every
+new agent would mint a new time series and blow up the metric
+cardinality budget. The path-normalization to `{id}` in
+`crates/librefang-api/src/metrics.rs` is deliberate for this reason.
+
+If you need per-agent metrics, aggregate them in the kernel into
+bounded buckets (`ok` / `4xx` / `5xx`, or coarse latency histograms)
+before exposing them.
+
+## Coverage
+
+As of the PR closing the bulk of [#3511](https://github.com/librefang/librefang/issues/3511),
+`with_agent_id` is wired up in the hot-path handlers under:
+
+- `routes/agents.rs` — agent CRUD, suspend/resume, kill, mode, status.
+- `routes/auto_dream.rs` — trigger / abort / set-enabled.
+- `routes/budget.rs` — `agent_budget_status`, `update_agent_budget`.
+- `routes/memory.rs` — KV list/get/set/delete and import/export.
+- `routes/prompts.rs` — list/create prompt versions and experiments.
+
+Handlers whose `agent_id` lives in the request body (e.g.
+`webhooks::webhook_agent`, `network::a2a_send_task`) or in a query
+string are not yet covered; the path is taken as the source of truth
+for the access-log marker and body-derived agents are tracked as a
+follow-up under #3511.
+
+## Follow-ups still tracked under #3511
+
+- **`session_id`** — surfacing the resolved `SessionId` from
+  `KernelHandle::send_message` requires extending the kernel↔API
+  trait surface; that is its own review.
+- **Auto-extractor layer** — making `AgentIdPath` (and any future
+  `AgentScopedPath` extractors) drop the marker for free, so the
+  per-handler `with_agent_id(...)` call goes away.
+- **Body-derived agent IDs** — endpoints that take `agent_id` in the
+  JSON body need a different injection point (after deserialization)
+  and are out of scope for the path-marker pattern documented here.


### PR DESCRIPTION
## Summary

- Extends `crate::extensions::with_agent_id(...)` coverage from
  `routes/agents.rs` (already landed) to **15 additional path-scoped
  handlers** across `auto_dream`, `budget`, `memory`, and `prompts`,
  so every hot-path agent operation now emits a structured `agent_id`
  field on its access-log line.
- Documents the access-log schema, the response-extension propagation
  mechanism, and the cardinality contract in
  `docs/architecture/access-log-fields.md` — including the explicit
  "do NOT add `agent_id` to Prometheus labels" guard so the next reader
  doesn't accidentally regress `metrics.rs`.
- Adds an integration test file pinning the `AgentIdField` contract on
  both happy-path and 404 / 400 branches so a future refactor that drops
  the `with_agent_id` call surfaces as a test failure, not a silent
  log-field regression.

## Mechanism

```
Handler                                            Middleware
─────────────────────────────────────────         ──────────────────────────────
let agent_id: AgentId = ...;                      let resp = next.run(req).await;
let body = match ... { ... }.into_response();     let agent_id = resp.extensions()
crate::extensions::with_agent_id(                     .get::<AgentIdField>()
    agent_id, body)  ──────────────► extensions ──►   .map(|f| f.0.to_string());
                                                  tracing::info!(
                                                      agent_id = %agent_id_field,
                                                      ... );
```

Extensions are an in-process channel; nothing crosses the wire.
`AgentIdField` is `pub` from `librefang-api::extensions` purely so the
integration tests can assert on it.

## Handlers covered (15)

`crates/librefang-api/src/routes/auto_dream.rs`
- `auto_dream_trigger`
- `auto_dream_abort`
- `auto_dream_set_enabled`

`crates/librefang-api/src/routes/budget.rs`
- `agent_budget_status`
- `update_agent_budget`

`crates/librefang-api/src/routes/memory.rs`
- `get_agent_kv`
- `get_agent_kv_key`
- `set_agent_kv_key`
- `delete_agent_kv_key`
- `export_agent_memory`
- `import_agent_memory`

`crates/librefang-api/src/routes/prompts.rs`
- `list_prompt_versions`
- `create_prompt_version`
- `list_experiments`
- `create_experiment`

The hot-path injection covers the routes that operators most often
need to trace through (KV reads, budget queries, dream toggles,
prompt experiments).

## Out of scope (follow-up still tracked under #3511)

- **`session_id` propagation.** Surfacing the resolved `SessionId`
  from `KernelHandle::send_message` to the API layer requires
  extending the kernel↔API trait surface — it's a bigger change
  than agent_id and warrants its own review.
- **Auto-extractor layer.** Making `AgentIdPath` (and any future
  `AgentScopedPath` extractors) drop the marker for free would
  retire the per-handler `with_agent_id(...)` call. Out of scope
  for this PR because it touches axum routing internals and would
  inflate the diff.
- **Body-derived agent IDs.** Endpoints that take `agent_id` in the
  JSON body (e.g. `webhooks::webhook_agent`, `network::a2a_send_task`,
  `network::comms_send`) need a different injection point — after
  deserialization rather than in the path extractor — and are tracked
  separately.

## Verification

- New test file: `crates/librefang-api/tests/access_log_agent_id_test.rs`
  (3 cases — 404 still tags, 404 on budget tags, malformed UUID 400 does
  not tag).
- `extensions.rs` already has unit tests covering the
  `with_agent_id` helper and the marker placement.
- Local `cargo` is intentionally not run from this worktree per the
  multi-worktree contention contract documented in `CLAUDE.md` — CI
  is the authoritative verification surface for compile + tests +
  clippy.

## Refs

- #3511 — the umbrella issue.
- #4504 — the prior PR that landed `routes/agents.rs` coverage and
  the middleware read-back.
