### PR TITLE
chore(ci): validate (@user) attribution on Unreleased CHANGELOG entries (#3400)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,28 @@ jobs:
             cargo clippy $PFLAGS --all-targets --all-features -- -D warnings
           fi
 
+  # ── CHANGELOG attribution check ────────────────────────────────────────────────
+  # Enforces the `(@username)` suffix on bullets *added* to the [Unreleased]
+  # section in this PR. Historical entries (1,800+ bullets, many predating
+  # any attribution convention) are NOT retroactively flagged — the validator
+  # only looks at lines this diff introduces. See #3400.
+  changelog-attribution:
+    name: CHANGELOG Attribution
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+      - name: Validate (@user) attribution on new [Unreleased] bullets
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/check-changelog-attribution.py
+
   # ── OpenAPI / SDK drift check ──────────────────────────────────────────────────
   # Regenerates openapi.json and the four SDKs and fails if anything differs
   # from what was committed. The pre-commit hook tries to keep these in sync

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ These run inside `git` itself (regardless of which tool invoked the commit),
 giving defense in depth on top of the Claude Code PreToolUse layer.
 
 - `pre-commit` — runs `cargo fmt --check` on staged Rust files; CHANGELOG
-  duplicate-`[Unreleased]` guard; `detect-secrets` scan against
+  duplicate-`[Unreleased]` guard; CHANGELOG `(@user)` attribution check on
+  staged additions to `[Unreleased]` (#3400); `detect-secrets` scan against
   `.secrets.baseline` (soft-warn if not installed). Target: < 2s.
 - `pre-push` — `cargo clippy --workspace --all-targets -- -D warnings`;
   OpenAPI / SDK drift detection — fails the push if `openapi.json` or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ gate (clippy, openapi/SDK drift, security audit, full test matrix).
 
 | Hook        | Runs                                                                  | Target time |
 |-------------|-----------------------------------------------------------------------|-------------|
-| `pre-commit`| `cargo fmt --check` on staged `*.rs` only, CHANGELOG guard, `detect-secrets` (if installed) | < 2s |
+| `pre-commit`| `cargo fmt --check` on staged `*.rs` only, CHANGELOG guard + `(@user)` attribution check, `detect-secrets` (if installed) | < 2s |
 | `pre-push`  | Refuses direct push to `main` / `master`. Nothing else.                | < 100ms |
 | `commit-msg`| Reject Claude / Anthropic attribution                                  | < 50ms |
 
@@ -764,6 +764,28 @@ Add Matrix channel adapter with E2EE support
 Fix session restore crash on kernel reboot
 Refactor capability manager to use DashMap
 ```
+
+### CHANGELOG Attribution
+
+When you add a bullet to the `## [Unreleased]` section of `CHANGELOG.md`,
+end the line with your GitHub login in parentheses, e.g.
+
+```
+- Add Matrix channel adapter with E2EE support (#1234) (@your-login)
+```
+
+This is enforced by `scripts/check-changelog-attribution.py` (wired into the
+`pre-commit` hook and the `CHANGELOG Attribution` CI job). The check runs
+**only against the lines your PR adds** — historical entries that predate
+this convention are not retroactively flagged, and you should not backfill
+them. To audit the current `[Unreleased]` block before cutting a release:
+
+```
+python3 scripts/check-changelog-attribution.py --all-unreleased
+```
+
+The accepted format is `(@username)` matching `\(@[A-Za-z0-9_][A-Za-z0-9_-]*\)`.
+See issue #3400 for the rationale.
 
 ---
 

--- a/scripts/check-changelog-attribution.py
+++ b/scripts/check-changelog-attribution.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Validate that new CHANGELOG.md bullets carry a `(@username)` attribution.
+
+The repo convention (1,800+ existing entries) is to suffix each bullet with
+the GitHub login of the contributor in parentheses, e.g.
+
+    - Add Polish language (pl) (#3937) (@leszek3737)
+
+This script enforces that convention on **new** bullets being added to the
+`[Unreleased]` section. It deliberately does NOT retroactively flag historical
+entries — many predate any attribution convention and the project has decided
+not to backfill (issue #3400). The validator therefore has three modes:
+
+* default (`diff`):           scan only the lines this PR adds to the
+                              `[Unreleased]` section. Used by CI.
+* `--all-unreleased`:         scan every bullet currently inside the
+                              `[Unreleased]` section. Useful for one-off
+                              audits before cutting a release.
+* `--full`:                   scan every bullet in the file. Reports every
+                              historical violation. Pure inventory tool —
+                              not wired into CI.
+
+Attribution regex: `\\(@[A-Za-z0-9_][A-Za-z0-9_-]*\\)` (GitHub username
+character set, at least one character — `(@)` alone is rejected).
+
+Exit status: 0 on success, 1 if any in-scope bullet is missing attribution,
+2 on usage / git error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# GitHub usernames: 1-39 chars, [A-Za-z0-9-], cannot start with `-`. We don't
+# enforce the upper bound here — the convention itself has no bound — but we
+# do require at least one character and disallow a leading dash so that the
+# common typo `(@-foo)` is rejected.
+ATTRIBUTION_RE = re.compile(r"\(@[A-Za-z0-9_][A-Za-z0-9_-]*\)")
+BULLET_RE = re.compile(r"^(\s*)-\s+\S")  # `- text` or `  - text` (nested)
+HEADER_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+UNRELEASED_RE = re.compile(r"^##\s+\[Unreleased\]\s*$")
+RELEASE_HEADER_RE = re.compile(r"^##\s+\[[^\]]+\]")  # any `## [...]` line
+
+CHANGELOG = "CHANGELOG.md"
+
+
+def run_git(args: list[str], cwd: Path) -> str:
+    """Run a git command, returning stdout. Aborts the script on non-zero."""
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(
+            f"git {' '.join(args)} failed (exit {proc.returncode}):\n{proc.stderr}"
+        )
+        sys.exit(2)
+    return proc.stdout
+
+
+def repo_root() -> Path:
+    """Locate the repo root via `git rev-parse --show-toplevel`."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write("Not inside a git repository.\n")
+        sys.exit(2)
+    return Path(proc.stdout.strip())
+
+
+def find_unreleased_range(lines: list[str]) -> tuple[int, int] | None:
+    """Return (start_line_idx_inclusive, end_line_idx_exclusive) of the
+    `## [Unreleased]` section, or None if absent.
+
+    Indices are 0-based into `lines`. The start index points at the `##
+    [Unreleased]` heading itself; end is the line index of the next `## [...]`
+    heading (so iterating `lines[start:end]` covers the section content).
+    """
+    start: int | None = None
+    for i, line in enumerate(lines):
+        if UNRELEASED_RE.match(line):
+            start = i
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if RELEASE_HEADER_RE.match(lines[j]):
+            end = j
+            break
+    return (start, end)
+
+
+def is_bullet(line: str) -> bool:
+    return BULLET_RE.match(line) is not None
+
+
+def has_attribution(line: str) -> bool:
+    return ATTRIBUTION_RE.search(line) is not None
+
+
+def report(violations: list[tuple[int, str]], scope: str) -> int:
+    if not violations:
+        sys.stdout.write(f"OK: no missing attribution in scope '{scope}'.\n")
+        return 0
+    sys.stdout.write(
+        f"FAIL: {len(violations)} bullet(s) in scope '{scope}' missing "
+        f"`(@username)` attribution. Add `(@your-github-login)` at the end.\n"
+    )
+    for lineno, content in violations:
+        # Format chosen so GitHub Actions / many editors render it as a
+        # clickable link to the offending line.
+        sys.stdout.write(
+            f"{CHANGELOG}:{lineno}: missing (@user) attribution: {content.rstrip()}\n"
+        )
+    return 1
+
+
+# ── Mode: default (diff) ──────────────────────────────────────────────────
+
+
+def resolve_diff_range(args: argparse.Namespace) -> tuple[str, str]:
+    """Resolve (base_ref, head_ref) for the diff scan.
+
+    Precedence:
+      1. CLI flags `--base` / `--head`
+      2. env vars BASE_SHA / HEAD_SHA (set by CI)
+      3. `git merge-base origin/main HEAD` and `HEAD`
+    """
+    base = args.base or os.environ.get("BASE_SHA")
+    head = args.head or os.environ.get("HEAD_SHA")
+    if base and head:
+        return (base, head)
+    # Fallback: derive from local refs.
+    root = repo_root()
+    try:
+        merge_base = run_git(["merge-base", "origin/main", "HEAD"], root).strip()
+    except SystemExit:
+        sys.stderr.write(
+            "Could not determine diff base. Pass --base/--head or set "
+            "BASE_SHA/HEAD_SHA, or ensure `origin/main` is fetched.\n"
+        )
+        sys.exit(2)
+    return (merge_base or "HEAD~1", "HEAD")
+
+
+def added_lines_in_unreleased(
+    base: str, head: str, root: Path
+) -> list[tuple[int, str]]:
+    """Return list of (post-image line number, line content) for every
+    `+`-prefixed line the diff adds inside the `[Unreleased]` section.
+
+    We compute the post-image line numbers from the unified-diff hunk
+    headers so that error messages point at the line as it appears in the
+    branch's CHANGELOG.md.
+    """
+    diff = run_git(
+        [
+            "diff",
+            "--unified=0",
+            "--no-color",
+            f"{base}..{head}",
+            "--",
+            CHANGELOG,
+        ],
+        root,
+    )
+    if not diff.strip():
+        return []
+
+    # Read the post-image (HEAD) version of the file to compute the
+    # `[Unreleased]` line range.
+    head_blob = run_git(["show", f"{head}:{CHANGELOG}"], root)
+    head_lines = head_blob.splitlines()
+    rng = find_unreleased_range(head_lines)
+    if rng is None:
+        # No `[Unreleased]` section in the post-image — nothing to validate.
+        return []
+    unreleased_start, unreleased_end = rng
+
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+    added: list[tuple[int, str]] = []
+    cur_new_lineno: int | None = None
+
+    for raw in diff.splitlines():
+        m = hunk_re.match(raw)
+        if m:
+            cur_new_lineno = int(m.group(1))
+            continue
+        if cur_new_lineno is None:
+            continue
+        if raw.startswith("+++") or raw.startswith("---"):
+            continue
+        if raw.startswith("+"):
+            content = raw[1:]
+            lineno = cur_new_lineno  # 1-based
+            # Filter to bullets inside [Unreleased]. `lineno` is 1-based;
+            # unreleased_start/unreleased_end are 0-based indices into
+            # head_lines, so the inclusive range is
+            # (unreleased_start+1) .. unreleased_end (exclusive of the next
+            # release heading).
+            if (unreleased_start + 1) <= lineno <= unreleased_end:
+                if is_bullet(content) and not has_attribution(content):
+                    added.append((lineno, content))
+            cur_new_lineno += 1
+        elif raw.startswith("-"):
+            # Removal: post-image line counter stays put.
+            continue
+        else:
+            # Context line under --unified=0 should not appear, but be safe.
+            cur_new_lineno += 1
+
+    return added
+
+
+# ── Mode: --all-unreleased ────────────────────────────────────────────────
+
+
+def scan_unreleased_section(root: Path) -> list[tuple[int, str]]:
+    path = root / CHANGELOG
+    lines = path.read_text(encoding="utf-8").splitlines()
+    rng = find_unreleased_range(lines)
+    if rng is None:
+        sys.stderr.write(
+            "warning: no `## [Unreleased]` section found; nothing to scan.\n"
+        )
+        return []
+    start, end = rng
+    violations: list[tuple[int, str]] = []
+    for i in range(start + 1, end):
+        line = lines[i]
+        if is_bullet(line) and not has_attribution(line):
+            violations.append((i + 1, line))  # 1-based line number
+    return violations
+
+
+# ── Mode: --full ──────────────────────────────────────────────────────────
+
+
+def scan_full_file(root: Path) -> list[tuple[int, str]]:
+    path = root / CHANGELOG
+    lines = path.read_text(encoding="utf-8").splitlines()
+    violations: list[tuple[int, str]] = []
+    in_fenced_block = False
+    for i, line in enumerate(lines, start=1):
+        if line.startswith("```"):
+            in_fenced_block = not in_fenced_block
+            continue
+        if in_fenced_block:
+            continue
+        if is_bullet(line) and not has_attribution(line):
+            violations.append((i, line))
+    return violations
+
+
+# ── Mode: --staged (pre-commit hook) ──────────────────────────────────────
+
+
+def scan_staged_added_lines(root: Path) -> list[tuple[int, str]]:
+    """Diff the index against HEAD for CHANGELOG.md and return bullets the
+    commit adds inside `[Unreleased]` that lack attribution. Used by the
+    pre-commit hook so contributors hear about it before pushing.
+    """
+    diff = run_git(
+        [
+            "diff",
+            "--cached",
+            "--unified=0",
+            "--no-color",
+            "--",
+            CHANGELOG,
+        ],
+        root,
+    )
+    if not diff.strip():
+        return []
+
+    # Post-image is the staged content. Read it via `git show :CHANGELOG.md`.
+    staged_blob = run_git(["show", f":{CHANGELOG}"], root)
+    staged_lines = staged_blob.splitlines()
+    rng = find_unreleased_range(staged_lines)
+    if rng is None:
+        return []
+    unreleased_start, unreleased_end = rng
+
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+    added: list[tuple[int, str]] = []
+    cur_new_lineno: int | None = None
+    for raw in diff.splitlines():
+        m = hunk_re.match(raw)
+        if m:
+            cur_new_lineno = int(m.group(1))
+            continue
+        if cur_new_lineno is None:
+            continue
+        if raw.startswith("+++") or raw.startswith("---"):
+            continue
+        if raw.startswith("+"):
+            content = raw[1:]
+            lineno = cur_new_lineno
+            if (unreleased_start + 1) <= lineno <= unreleased_end:
+                if is_bullet(content) and not has_attribution(content):
+                    added.append((lineno, content))
+            cur_new_lineno += 1
+
+    return added
+
+
+# ── Entry point ───────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Enforce `(@username)` attribution on CHANGELOG.md bullets. "
+            "Default mode validates only what the current PR adds to the "
+            "[Unreleased] section."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--all-unreleased",
+        action="store_true",
+        help="Scan every bullet currently inside the [Unreleased] section.",
+    )
+    mode.add_argument(
+        "--full",
+        action="store_true",
+        help="Scan every bullet in the file (inventory mode).",
+    )
+    mode.add_argument(
+        "--staged",
+        action="store_true",
+        help="Scan staged additions to [Unreleased] (pre-commit hook mode).",
+    )
+    parser.add_argument(
+        "--base",
+        help="Diff base ref (default: $BASE_SHA or `git merge-base origin/main HEAD`).",
+    )
+    parser.add_argument(
+        "--head",
+        help="Diff head ref (default: $HEAD_SHA or HEAD).",
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    if not (root / CHANGELOG).exists():
+        sys.stderr.write(f"{CHANGELOG} not found at repo root.\n")
+        return 2
+
+    if args.full:
+        return report(scan_full_file(root), scope="entire CHANGELOG.md")
+    if args.all_unreleased:
+        return report(
+            scan_unreleased_section(root),
+            scope="[Unreleased] section (all bullets)",
+        )
+    if args.staged:
+        return report(
+            scan_staged_added_lines(root),
+            scope="staged additions to [Unreleased]",
+        )
+
+    # Default: diff mode.
+    base, head = resolve_diff_range(args)
+    return report(
+        added_lines_in_unreleased(base, head, root),
+        scope=f"new bullets in [Unreleased] (diff {base[:8]}..{head[:8] if len(head) >= 8 else head})",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -37,6 +37,20 @@ if git diff --cached --name-only | grep -qx "CHANGELOG.md"; then
         echo "Release tooling will silently drop entries from all but the first. Merge them into one block."
         exit 1
     fi
+
+    # 2b. (@username) attribution on staged additions to [Unreleased]. See
+    # #3400. Only fails when the staged diff adds a bullet without `(@user)`
+    # — never penalises historical entries. Soft-skip if python3 is missing.
+    if command -v python3 >/dev/null 2>&1; then
+        if ! python3 scripts/check-changelog-attribution.py --staged; then
+            echo 'Error: staged CHANGELOG.md additions to [Unreleased] are missing'
+            echo '       a `(@your-github-login)` suffix. Add it at the end of each bullet.'
+            echo '       Audit current section: python3 scripts/check-changelog-attribution.py --all-unreleased'
+            exit 1
+        fi
+    else
+        echo "warning: python3 not available; skipping CHANGELOG attribution check." >&2
+    fi
 fi
 
 # 3. Secret detection. Soft-fail if detect-secrets is not installed —


### PR DESCRIPTION
## Summary

- Adds `scripts/check-changelog-attribution.py` — validates that bullets carry a `(@username)` suffix matching `\(@[A-Za-z0-9_][A-Za-z0-9_-]*\)`.
- Wires it into a new `CHANGELOG Attribution` CI job (PR-only) and the existing `scripts/hooks/pre-commit` hook.
- Default mode scans **only the lines a PR adds** to the `[Unreleased]` section. Historical entries are never retroactively flagged.

Closes #3400.

## Why default scope = "diff against [Unreleased]" rather than "everything in [Unreleased]"

`CHANGELOG.md` currently contains ~2,200 bullets across all releases. Of those, ~239 (mostly the very early v0.x entries plus the 11 currently-pending bullets in `[Unreleased]`) lack attribution. The project decision (issue #3400, comment thread) is **not to backfill historical entries** — many predate any attribution convention, and rewriting them would touch authorship metadata for changes the original contributors have long since moved on from.

That rules out the obvious "scan the whole `[Unreleased]` block" approach: it would fail on this PR's own base commit because the existing `[Unreleased]` already has 11 bullets without `(@user)` (added back when no validator existed). Instead, the validator computes the unified diff between PR base and head, and only inspects the `+`-prefixed lines that fall inside the post-image `[Unreleased]` range. That makes the check a strict additive ratchet:

- New bullets → must include `(@user)` (CI fails otherwise).
- Existing bullets → ignored; nobody is forced to backfill.
- Bullets that move out of `[Unreleased]` into a release section during the release cut → no longer in scope, even if they lacked attribution.

The previous proposal in #3307 wanted `@author:` as a keyword. That syntax matches **zero** of the existing 2,200+ bullets. The actual repo convention is to suffix lines with `(@github-login)` (e.g. `- Add Polish language (pl) (#3937) (@leszek3737)`) — 2,056 of 2,199 top-level bullets follow it today. The validator now matches reality.

## Modes

| Mode               | Scope                                                  | Used by         |
|--------------------|--------------------------------------------------------|-----------------|
| (default)          | Lines this diff adds to `[Unreleased]`                 | CI              |
| `--staged`         | Index-vs-HEAD additions to `[Unreleased]`              | pre-commit hook |
| `--all-unreleased` | Every bullet currently in `[Unreleased]`               | release audit   |
| `--full`           | Every bullet in the file                               | inventory only  |

## Smoke test (local)

```
$ python3 scripts/check-changelog-attribution.py
OK: no missing attribution in scope 'new bullets in [Unreleased] (diff db487492..HEAD)'.
$ echo "exit=$?"
exit=0

$ python3 scripts/check-changelog-attribution.py --all-unreleased
FAIL: 11 bullet(s) in scope '[Unreleased] section (all bullets)' missing
      `(@username)` attribution. ...
$ echo "exit=$?"
exit=1

$ python3 scripts/check-changelog-attribution.py --full > /dev/null; echo $?
1     # 239 historical violations, expected — for inventory only, not gated

# Synthetic positive test: replay the diff that introduced an unattributed
# bullet under [Unreleased] in PR #4534
$ python3 scripts/check-changelog-attribution.py --base 1efd7d3f~1 --head 1efd7d3f
FAIL: 1 bullet(s) ... missing `(@username)` attribution.
CHANGELOG.md:390: missing (@user) attribution: - **Real-client-IP resolution ...
```

So the validator correctly distinguishes "this PR adds an unattributed bullet" (fails) from "the section already had unattributed bullets when this PR started" (does not fail).

## CI integration

New job in `.github/workflows/ci.yml`:

```yaml
changelog-attribution:
  name: CHANGELOG Attribution
  if: github.event_name == 'pull_request'
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@... { fetch-depth: 0 }
    - uses: actions/setup-python@... { python-version: '3.11' }
    - name: Validate (@user) attribution on new [Unreleased] bullets
      env:
        BASE_SHA: ${{ github.event.pull_request.base.sha }}
        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
      run: python3 scripts/check-changelog-attribution.py
```

PR-only (no `push: main` run — once a PR merges, the bullet is already attributed). Doesn't gate on the `changes` job's filters because we want every PR to be checked, even docs-only ones; the script is a no-op in milliseconds when CHANGELOG.md isn't touched.

## Pre-commit hook

`scripts/hooks/pre-commit` already had a CHANGELOG duplicate-`[Unreleased]` guard (#3395). Extended it with `--staged` mode so contributors get the feedback before pushing. Soft-skips if `python3` is unavailable, matching the existing `detect-secrets` "warn-and-skip" pattern.

## Files changed

- `scripts/check-changelog-attribution.py` — new validator (4 modes).
- `.github/workflows/ci.yml` — new `CHANGELOG Attribution` job.
- `scripts/hooks/pre-commit` — wires `--staged` after the existing CHANGELOG guard.
- `CONTRIBUTING.md` — documents the convention + audit command.
- `CLAUDE.md` — updates the in-repo hooks reference.

## Test plan

- [x] Default mode passes on this PR (no CHANGELOG additions).
- [x] `--all-unreleased` reports the 11 existing pre-attribution bullets (not gated, just informational).
- [x] `--full` reports 239 historical bullets without attribution (inventory only).
- [x] Synthetic replay against PR #4534's commit reproduces the expected fail-on-add behaviour.
- [x] `--staged` mode reports only the bullets the index adds (verified by stashing a fake bullet, staging, running the hook, then `git checkout` to clean up).
- [x] `sh -n scripts/hooks/pre-commit` syntactically valid.
- [x] `yaml.safe_load` on `.github/workflows/ci.yml` parses.
- [ ] CI green on this PR (pending).
