### PR TITLE
refactor(api): rename prompts::routes to router for module-naming consistency (#3748)

### DIFF
--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -13,7 +13,7 @@ use librefang_runtime::kernel_handle::prelude::*;
 use std::sync::Arc;
 
 use crate::types::ApiErrorResponse;
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route(
             "/agents/{agent_id}/prompts/versions",

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -63,7 +63,7 @@ fn api_v1_routes() -> Router<Arc<AppState>> {
         .merge(routes::goals::router())
         .merge(routes::inbox::router())
         .merge(routes::media::router())
-        .merge(routes::prompts::routes())
+        .merge(routes::prompts::router())
         .merge(routes::terminal::router())
         .merge(routes::users::router())
         .merge(routes::webhooks::router())

--- a/crates/librefang-api/tests/prompts_routes_integration.rs
+++ b/crates/librefang-api/tests/prompts_routes_integration.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the prompts router (#3571 — prompts slice).
 //!
-//! Mounts `routes::prompts::routes()` directly under `/api` against a
+//! Mounts `routes::prompts::router()` directly under `/api` against a
 //! `TestAppState` + `MockKernelBuilder`-built `LibreFangKernel`. The kernel
 //! has a real prompt store wired in, so mutating endpoints persist data
 //! that subsequent reads can observe. Tests cover happy-path round trips
@@ -25,7 +25,7 @@ async fn boot() -> Harness {
     let test = TestAppState::with_builder(MockKernelBuilder::new());
     let state = test.state.clone();
     let app = Router::new()
-        .nest("/api", routes::prompts::routes())
+        .nest("/api", routes::prompts::router())
         .with_state(state.clone());
     Harness {
         app,


### PR DESCRIPTION
## Summary

- Rename `prompts::routes()` → `prompts::router()` so it matches the
  convention used by every other route module in
  `crates/librefang-api/src/routes/`.
- Pure naming cleanup; no behaviour change, no API surface change.

## Why

Issue #3748 calls out four route-layer inconsistencies. The smallest
of them — module-level naming — is the only one that can be fixed
without touching the public HTTP surface. This PR knocks it out so the
remaining items can be discussed on their own merits without being
blocked by a trivial rename.

## Changes

- `crates/librefang-api/src/routes/prompts.rs` — function rename.
- `crates/librefang-api/src/server.rs` — call-site update at the
  `.merge(...)` mount.
- `crates/librefang-api/tests/prompts_routes_integration.rs` — call
  site + doc-comment update.

A repo-wide grep confirms no other callers of `prompts::routes`
remain (no SDK / dashboard references — the dashboard never imported
the Rust function name).

## Out of scope (tracked under #3748)

- **Verb mixing for agent state transitions** (`PUT` vs `POST` on
  suspend/resume/mode/etc. in `agents.rs`). Picking a winner here is a
  public-API change that affects every generated SDK and needs an ADR.
- **`skills.rs` RPC-style endpoints** (`POST /api/skills/install`,
  `POST /api/skills/uninstall`, …). Reshaping these to REST would be
  an API breaking change for every existing skills client and also
  warrants its own ADR + migration plan.
- The duplicate `PUT /agents/{id}/update` endpoint flagged in #3748
  was already removed in earlier work; the legacy "full-manifest
  replacement" semantics now live inside `PATCH /agents/{id}` (see
  the comments at `routes/agents.rs:4059-4065` and
  `rate_limiter.rs:91-94`). No further action needed for that bullet.

## Migration

None — `prompts::router` is a Rust-internal symbol. No HTTP routes
move, no SDK regeneration, no dashboard change.

## Verification

- `cargo` was not run locally (multi-worktree concurrency rule —
  see `CLAUDE.md`); CI is the source of truth.
- Manual `rg` confirms zero remaining references to `prompts::routes`.
- `rustfmt --edition 2021 --config-path rustfmt.toml` was run on each
  modified `.rs` file.

Refs #3748
