### PR TITLE
test(channels): wiremock'd transport for Slack / Discord / Matrix (#3406)

### DIFF
--- a/crates/librefang-channels/src/discord.rs
+++ b/crates/librefang-channels/src/discord.rs
@@ -979,6 +979,82 @@ mod tests {
             .expect("send must succeed with unsupported content");
     }
 
+    // ----- transport-layer tests for #3406 -----
+    //
+    // The Discord send path (`api_send_message`) currently has *no* 429
+    // retry and *no* idempotency / nonce token in the outbound payload:
+    // a 429 (with `X-RateLimit-Reset-After` / `Retry-After`) is logged via
+    // `warn!` and the call returns `Ok(())` (fail-open). These tests pin
+    // that behaviour. Promotion to a real backoff + nonce flow is tracked
+    // as follow-up on issue #3406.
+
+    /// Discord 429 with `X-RateLimit-Reset-After` is observed exactly
+    /// once — the adapter does NOT retry, and `send()` still returns Ok.
+    /// When real retry lands, flip `expect(1)` to `expect(2)`.
+    #[tokio::test]
+    async fn discord_send_does_not_retry_on_429_today() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/channels/42/messages$"))
+            .and(header("Authorization", "Bot Bot-test-token"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("X-RateLimit-Reset-After", "1.5")
+                    .insert_header("X-RateLimit-Scope", "user")
+                    .set_body_json(serde_json::json!({
+                        "message": "You are being rate limited.",
+                        "retry_after": 1.5,
+                        "global": false,
+                    })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = make_adapter(server.uri());
+        // Current production behaviour: 429 is warned, send returns Ok.
+        adapter
+            .send(
+                &dummy_user("42"),
+                ChannelContent::Text("rate-limited write".into()),
+            )
+            .await
+            .expect("discord send is fail-open on 429 today");
+    }
+
+    /// Verify the outbound request shape is exactly the documented
+    /// `POST /channels/{id}/messages` schema — Bot auth header, JSON
+    /// body with a single `content` field. Locking this down so an
+    /// incidental refactor doesn't break Discord's payload contract.
+    #[tokio::test]
+    async fn discord_send_request_shape_matches_api() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/channels/777/messages$"))
+            .and(header("Authorization", "Bot Bot-test-token"))
+            .and(header("Content-Type", "application/json"))
+            .and(body_json(serde_json::json!({
+                "content": "exact shape",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "1",
+                "channel_id": "777",
+                "content": "exact shape",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = make_adapter(server.uri());
+        adapter
+            .send(
+                &dummy_user("777"),
+                ChannelContent::Text("exact shape".into()),
+            )
+            .await
+            .expect("send must succeed");
+    }
+
     #[test]
     fn role_resolution_parses_member_role_ids() {
         let member = serde_json::json!({

--- a/crates/librefang-channels/src/matrix.rs
+++ b/crates/librefang-channels/src/matrix.rs
@@ -377,6 +377,203 @@ pub fn calculate_backoff(current: Duration, max: Duration) -> Duration {
 mod tests {
     use super::*;
 
+    // ----- transport-layer tests for #3406 -----
+    //
+    // Stand up a local `wiremock::MockServer` and point `MatrixAdapter`
+    // at it via the `homeserver_url` argument to `new()`. Exercises the
+    // PUT `/_matrix/client/v3/rooms/{}/send/m.room.message/{txn_id}`
+    // call made by `ChannelAdapter::send`.
+    //
+    // Matrix is the only one of the three #3406 top adapters where
+    // idempotency is on the wire by design: the txn_id (last URL
+    // segment) is the protocol-level dedup key. Today
+    // `api_send_message` mints a fresh `Uuid::new_v4()` per call and
+    // does not retry — so the dedup property exists but is unused.
+    // Tests assert (a) the txn_id IS a UUID and (b) 429 / 5xx surface
+    // as `Err` (fail-loud, unlike Slack/Discord); a follow-up that
+    // adds retry must reuse the same txn_id and is tracked on #3406.
+
+    use wiremock::matchers::{body_json, header, method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn make_adapter(homeserver_url: String) -> MatrixAdapter {
+        MatrixAdapter::new(
+            homeserver_url,
+            "@bot:matrix.org".to_string(),
+            "secret-access-token".to_string(),
+            vec![],
+            false,
+        )
+    }
+
+    fn dummy_user(room_id: &str) -> ChannelUser {
+        ChannelUser {
+            platform_id: room_id.to_string(),
+            display_name: "tester".to_string(),
+            librefang_user: None,
+        }
+    }
+
+    /// Request shape: PUT to the documented Matrix CS-API path,
+    /// `Bearer` auth, `m.text` body. Path matcher accepts any UUID
+    /// txn_id segment (the txn_id assertion is in a separate test).
+    #[tokio::test]
+    async fn matrix_send_puts_room_message_event() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path_regex(
+                r"^/_matrix/client/v3/rooms/!room:example\.org/send/m\.room\.message/[0-9a-fA-F-]{36}$",
+            ))
+            .and(header("Authorization", "Bearer secret-access-token"))
+            .and(body_json(serde_json::json!({
+                "msgtype": "m.text",
+                "body": "hello matrix",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "event_id": "$evt:example.org",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = make_adapter(server.uri());
+        adapter
+            .send(
+                &dummy_user("!room:example.org"),
+                ChannelContent::Text("hello matrix".into()),
+            )
+            .await
+            .expect("matrix send must succeed against mock");
+    }
+
+    /// The txn_id MUST be a v4-shaped UUID. Capture the recorded request
+    /// URL and assert the last path segment parses as a UUID. This pins
+    /// the protocol-level idempotency key to a real opaque token (not,
+    /// say, a monotonic counter) so dedup is preserved across daemon
+    /// restarts.
+    #[tokio::test]
+    async fn matrix_send_uses_uuid_txn_id_for_idempotency() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path_regex(
+                r"^/_matrix/client/v3/rooms/!r:example\.org/send/m\.room\.message/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "event_id": "$evt",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = make_adapter(server.uri());
+        adapter
+            .send(
+                &dummy_user("!r:example.org"),
+                ChannelContent::Text("idempotent".into()),
+            )
+            .await
+            .expect("matrix send must succeed");
+
+        // Two independent send() calls produce different txn_ids
+        // (today's behaviour — retry would need to *reuse* one txn_id,
+        // tracked as follow-up on #3406). Use `received_requests()`
+        // after-the-fact instead of a `respond_with` closure so we
+        // capture txn_ids without juggling `Sync` closure state.
+        let server2 = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path_regex(
+                r"^/_matrix/client/v3/rooms/!r:example\.org/send/m\.room\.message/.+$",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "event_id": "$e",
+            })))
+            .expect(2)
+            .mount(&server2)
+            .await;
+
+        let adapter2 = make_adapter(server2.uri());
+        adapter2
+            .send(
+                &dummy_user("!r:example.org"),
+                ChannelContent::Text("first".into()),
+            )
+            .await
+            .unwrap();
+        adapter2
+            .send(
+                &dummy_user("!r:example.org"),
+                ChannelContent::Text("second".into()),
+            )
+            .await
+            .unwrap();
+
+        let recorded = server2
+            .received_requests()
+            .await
+            .expect("wiremock should have recorded requests");
+        assert_eq!(recorded.len(), 2, "expected exactly two PUT calls");
+        let observed: Vec<String> = recorded
+            .iter()
+            .map(|r| {
+                r.url
+                    .path()
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect();
+        assert_ne!(
+            observed[0], observed[1],
+            "today the adapter mints a fresh uuid per call; a future retry refactor MUST reuse one"
+        );
+        for txn in &observed {
+            assert!(
+                uuid::Uuid::parse_str(txn).is_ok(),
+                "txn_id {txn} must be a valid UUID"
+            );
+        }
+    }
+
+    /// Matrix differs from Slack/Discord: `api_send_message` is
+    /// fail-loud — non-2xx becomes `Err`, not a warn'd Ok. Pin that
+    /// here so a future fail-open refactor doesn't silently swallow
+    /// 429s. Single observation, no retry today.
+    #[tokio::test]
+    async fn matrix_send_returns_err_on_429_no_retry_today() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path_regex(
+                r"^/_matrix/client/v3/rooms/!r:example\.org/send/m\.room\.message/.+$",
+            ))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("Retry-After", "1")
+                    .set_body_json(serde_json::json!({
+                        "errcode": "M_LIMIT_EXCEEDED",
+                        "error": "Too many requests",
+                        "retry_after_ms": 1000,
+                    })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = make_adapter(server.uri());
+        let err = adapter
+            .send(
+                &dummy_user("!r:example.org"),
+                ChannelContent::Text("rate-limited".into()),
+            )
+            .await
+            .expect_err("matrix send is fail-loud on 429 today");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("429") || msg.to_ascii_lowercase().contains("too many"),
+            "error must surface the 429: {msg}"
+        );
+    }
+
     #[test]
     fn test_matrix_adapter_creation() {
         let adapter = MatrixAdapter::new(

--- a/crates/librefang-channels/src/slack.rs
+++ b/crates/librefang-channels/src/slack.rs
@@ -1189,6 +1189,115 @@ mod tests {
             .expect("send must succeed with unsupported content");
     }
 
+    // ----- transport-layer tests for #3406 -----
+    //
+    // The Slack send path (`api_send_message_opts`) currently has *no* 429
+    // retry and *no* idempotency token: a 429 from `chat.postMessage` is
+    // logged via `warn!` and the call returns `Ok(())` (fail-open). These
+    // tests pin that behaviour so a future refactor that adds retry /
+    // idempotency necessarily updates them. Promotion of the send path to
+    // a real backoff loop with an idempotency key is tracked as follow-up
+    // on issue #3406.
+
+    /// 429 + Retry-After is observed by exactly one POST — the adapter
+    /// does NOT retry, and `send()` still returns Ok (fail-open warn).
+    /// When real retry lands, flip `expect(1)` to `expect(2)` and assert
+    /// the second call body matches.
+    #[tokio::test]
+    async fn slack_send_does_not_retry_on_429_today() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat.postMessage"))
+            .and(header("Authorization", "Bearer xoxb-test-bot-token"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("Retry-After", "1")
+                    .set_body_json(serde_json::json!({
+                        "ok": false,
+                        "error": "ratelimited",
+                    })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = make_adapter(server.uri());
+        // Current production behaviour: 429 is warned, send returns Ok.
+        adapter
+            .send(
+                &dummy_user("C42"),
+                ChannelContent::Text("rate-limited write".into()),
+            )
+            .await
+            .expect("slack send is fail-open on 429 today");
+    }
+
+    /// `chat.postMessage` payload omits the optional `unfurl_links` key
+    /// when the adapter wasn't told to set it — important so we don't
+    /// silently override a workspace-level Slack default.
+    #[tokio::test]
+    async fn slack_send_omits_unfurl_links_when_unset() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat.postMessage"))
+            .and(body_json(serde_json::json!({
+                "channel": "C7",
+                "text": "no unfurl flag",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = make_adapter(server.uri());
+        adapter
+            .send(
+                &dummy_user("C7"),
+                ChannelContent::Text("no unfurl flag".into()),
+            )
+            .await
+            .expect("send must succeed");
+    }
+
+    /// When `with_unfurl_links(Some(false))` is set, the boolean appears
+    /// verbatim in the JSON body — pins the request shape so a refactor
+    /// that drops the field won't silently regress link previews.
+    #[tokio::test]
+    async fn slack_send_serialises_unfurl_links_false() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat.postMessage"))
+            .and(body_json(serde_json::json!({
+                "channel": "C8",
+                "text": "no preview please",
+                "unfurl_links": false,
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let adapter = SlackAdapter::new(
+            "xapp-test-token".to_string(),
+            "xoxb-test-bot-token".to_string(),
+            vec![],
+        )
+        .with_api_base(server.uri())
+        .with_unfurl_links(Some(false));
+
+        adapter
+            .send(
+                &dummy_user("C8"),
+                ChannelContent::Text("no preview please".into()),
+            )
+            .await
+            .expect("send must succeed");
+    }
+
     #[test]
     fn role_resolution_owner_wins() {
         // owner > admin > guest > member, regardless of which other flags


### PR DESCRIPTION
## Summary

- Adds wiremock-driven transport tests for the three highest-impact
  channel adapters (Slack, Discord, Matrix) called out as gaps in
  issue #3406.
- Each adapter's `send()` path is now exercised against a real local
  HTTP mock — auth header, request path, JSON payload schema, and
  rate-limit handling are all asserted.
- No production code is changed. The new cases pin **current**
  behaviour and explicitly note where issue #3406's wishlist
  (real 429 backoff, idempotent retry) is not yet implemented, so
  whoever picks up that work will see the test fail and update it.

## Per-adapter coverage

| Adapter | (a) request shape | (b) 429 behaviour | (c) idempotency / retry |
| --- | --- | --- | --- |
| Slack    | `slack_send_omits_unfurl_links_when_unset`, `slack_send_serialises_unfurl_links_false` (auth: `Bearer xoxb-…`, body: `chat.postMessage` schema) | `slack_send_does_not_retry_on_429_today` — pins fail-open warn-and-return-Ok behaviour, single observation | skipped — production has no idempotency token on the send path; retry is a follow-up on #3406 |
| Discord  | `discord_send_request_shape_matches_api` (auth: `Bot …`, body: `{ "content": … }`) | `discord_send_does_not_retry_on_429_today` — pins fail-open behaviour with `X-RateLimit-Reset-After`, single observation | skipped — no nonce in the outbound REST payload today; retry is a follow-up on #3406 |
| Matrix   | `matrix_send_puts_room_message_event` (PUT to `/_matrix/client/v3/rooms/{room}/send/m.room.message/{txn_id}`, `Bearer` auth, `m.text` body) | `matrix_send_returns_err_on_429_no_retry_today` — pins fail-loud behaviour (Err on non-2xx), single observation | `matrix_send_uses_uuid_txn_id_for_idempotency` — asserts txn_id is a v4 UUID; documents that today two independent sends mint **different** txn_ids (no retry → no reuse), tracked as follow-up |

## Why inline `mod tests` instead of `tests/<channel>_transport_test.rs`

Issue #3406 suggests new top-level integration test files. Both Slack
and Discord guard their `with_api_base()` test helper with
`#[cfg(test)]`, which is **not** active when the lib is consumed by an
integration test crate, so a `tests/<channel>_transport_test.rs`
cannot reach those builders without first promoting the gate. That
would touch production-facing surface area (changes the public API
under non-test profiles), which this PR deliberately avoids.

Putting the new tests inside the existing `#[cfg(test)] mod tests`
blocks alongside the existing wiremock cases (added in the gotify slice
PR #4447 / slack PR #4545) is the lighter-touch path and keeps this
strictly test-only.

## Out of scope (follow-up on #3406)

- **Real 429 backoff** in Slack `api_send_message_opts` and Discord
  `api_send_message`. Today both fail-open warn'd Ok on rate limits
  and never retry. The `*_does_not_retry_on_429_today` tests will need
  to flip from `expect(1)` to `expect(2)` (or more) once retry lands.
- **Outbound idempotency token** for Slack and Discord. Matrix has
  the txn_id by protocol design; Slack's `chat.postMessage` and
  Discord's `POST /channels/{id}/messages` need a nonce/dedup key
  added so a retry doesn't double-post.
- **Promoting `with_api_base()`** out of `#[cfg(test)]` so future
  transport tests can live in `tests/<channel>_transport_test.rs`
  files and so other crates' integration tests can stand up channel
  adapters against a fake HTTP backend.
- **Remaining 46 adapters.** This PR intentionally only does the top
  three. The same pattern applies to Telegram, WhatsApp, Mastodon,
  Mattermost, Rocket.Chat, Webex, Zulip, etc.; those are tracked
  separately as part of the #3406 follow-up wave.

## Verification

- Local: `rustfmt --edition 2021 --config-path rustfmt.toml` on the
  three modified files (clean).
- `cargo` is intentionally not run locally — this worktree shares
  `target/` with concurrent sessions and the project rule forbids
  workspace-wide cargo from non-CI hosts. The pre-push hook
  (`cargo clippy --workspace --all-targets -- -D warnings`) ran on
  push with zero warnings.
- CI runs the new `#[tokio::test]` cases as part of the
  `librefang-channels` test target.

Refs #3406
