### PR TITLE
perf(dashboard): split chunks + lazy-load KaTeX (#3381)

### DIFF
--- a/crates/librefang-api/dashboard/src/components/Typewriter_v2.tsx
+++ b/crates/librefang-api/dashboard/src/components/Typewriter_v2.tsx
@@ -2,9 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { animate } from 'motion/react';
 import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import remarkMath from 'remark-math';
-import rehypeKatex from 'rehype-katex';
-import 'katex/dist/katex.min.css';
+import { useMathPlugins } from '../lib/hooks/useMathPlugins';
 
 const mdComponents: Components = {
   p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
@@ -40,6 +38,12 @@ const mdComponents: Components = {
 /// (e.g. the upstream message restarted), the typewriter rewinds to 0.
 export function Typewriter_v2({ text, speed = 20 }: { text: string; speed?: number }) {
   const [displayed, setDisplayed] = useState("");
+  // Lazy-load remark-math / rehype-katex / katex CSS only when the source
+  // contains math delimiters. While the dynamic import is in flight the
+  // arrays are empty, so math notation transiently shows as raw text — that's
+  // the same fallback react-markdown would produce without the plugins, and
+  // it avoids paying ~280 KB of KaTeX on every chat (#3381).
+  const { remarkPlugins: mathRemark, rehypePlugins: mathRehype } = useMathPlugins(text);
 
   useEffect(() => {
     // If upstream restarted the stream (new text shorter than what we already
@@ -62,13 +66,18 @@ export function Typewriter_v2({ text, speed = 20 }: { text: string; speed?: numb
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [text, speed]);
 
+  const remarkPlugins = useMemo(
+    () => [remarkGfm, ...mathRemark],
+    [mathRemark],
+  );
+
   return useMemo(() => (
     <Markdown
-      remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeKatex]}
+      remarkPlugins={remarkPlugins}
+      rehypePlugins={mathRehype}
       components={mdComponents}
     >
       {displayed}
     </Markdown>
-  ), [displayed]);
+  ), [displayed, remarkPlugins, mathRehype]);
 }

--- a/crates/librefang-api/dashboard/src/lib/hooks/useMathPlugins.ts
+++ b/crates/librefang-api/dashboard/src/lib/hooks/useMathPlugins.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState, type ComponentProps } from "react";
+import type Markdown from "react-markdown";
+
+// react-markdown's plugin lists alias to `PluggableList` from `unified`,
+// but `unified` is not a direct dependency. Re-derive the type from the
+// public component props so we don't have to add a top-level import.
+type PluggableList = NonNullable<ComponentProps<typeof Markdown>["remarkPlugins"]>;
+
+export interface MathPlugins {
+  remarkPlugins: PluggableList;
+  rehypePlugins: PluggableList;
+}
+
+const EMPTY: MathPlugins = { remarkPlugins: [], rehypePlugins: [] };
+
+// Detect math delimiters: `$...$`, `$$...$$`, `\(...\)`, `\[...\]`.
+// Cheap regex; false positives (e.g. price text "$5") only cost a one-time
+// dynamic import of katex on a chat that wouldn't have rendered math anyway.
+const MATH_DELIMITER_RE =
+  /\$\$[\s\S]+?\$\$|\$[^\s$][^$\n]*?[^\s$]\$|\\\([\s\S]+?\\\)|\\\[[\s\S]+?\\\]/;
+
+export function containsMathDelimiters(s: string): boolean {
+  if (!s) return false;
+  return MATH_DELIMITER_RE.test(s);
+}
+
+// Cache the resolved plugin pair across components so the second consumer
+// doesn't re-trigger dynamic imports / CSS injection.
+let cachedPromise: Promise<MathPlugins> | null = null;
+
+async function loadMathPlugins(): Promise<MathPlugins> {
+  if (cachedPromise) return cachedPromise;
+  cachedPromise = (async () => {
+    const [{ default: remarkMath }, { default: rehypeKatex }] = await Promise.all([
+      import("remark-math"),
+      import("rehype-katex"),
+    ]);
+    // Side-effect CSS import — bundler emits a separate stylesheet that's
+    // injected on demand the first time a math block renders.
+    await import("katex/dist/katex.min.css");
+    return {
+      remarkPlugins: [remarkMath],
+      rehypePlugins: [rehypeKatex],
+    } satisfies MathPlugins;
+  })();
+  return cachedPromise;
+}
+
+/**
+ * Lazily load `remark-math` + `rehype-katex` (+ KaTeX CSS) only when the
+ * given content actually contains math delimiters. Returns empty plugin
+ * arrays until the dynamic import resolves; consumers can pass the result
+ * straight into `<MarkdownContent remarkPlugins={...} rehypePlugins={...}>`
+ * without conditional logic.
+ *
+ * Pulling KaTeX (~280 KB) out of the eager bundle was the main motivation
+ * — see #3381.
+ */
+export function useMathPlugins(content: string): MathPlugins {
+  const [plugins, setPlugins] = useState<MathPlugins>(EMPTY);
+
+  useEffect(() => {
+    if (!containsMathDelimiters(content)) return;
+    let cancelled = false;
+    loadMathPlugins().then((p) => {
+      if (!cancelled) setPlugins(p);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [content]);
+
+  return plugins;
+}

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1,7 +1,5 @@
 import { formatCost } from "../lib/format";
 import { memo, useEffect, useMemo, useRef, useState, useCallback } from "react";
-import rehypeKatex from "rehype-katex";
-import remarkMath from "remark-math";
 import { useTranslation } from "react-i18next";
 import { motion } from "motion/react";
 import { messageIn, fadeInUp } from "../lib/motion";
@@ -30,6 +28,7 @@ import { ToolCallCard } from "../components/ui/ToolCallCard";
 import { filterVisible } from "../lib/hiddenModels";
 import { useVoiceInput } from "../lib/useVoiceInput";
 import { Typewriter_v2 } from "../components/Typewriter_v2";
+import { useMathPlugins } from "../lib/hooks/useMathPlugins";
 import {
   useCreateAgentSession,
   useDeleteAgentSession,
@@ -40,7 +39,6 @@ import {
   useStopAgent,
   useUploadAgentFile,
 } from "../lib/mutations/agents";
-import "katex/dist/katex.min.css";
 
 const isAuthUnavailable = (status?: string) =>
   !!status && status !== "configured" && status !== "validated_key" && status !== "configured_cli" && status !== "not_required" && status !== "auto_detected";
@@ -118,9 +116,6 @@ const SLASH_COMMANDS = [
 
 // Commands that require backend processing via WebSocket command protocol
 const BACKEND_COMMANDS = SLASH_COMMANDS.filter(c => c.backend).map(c => c.cmd.slice(1));
-
-const REMARK_PLUGINS = [remarkMath];
-const REHYPE_PLUGINS = [rehypeKatex];
 
 let _nextMessageId = 0;
 function makeMessageId(prefix: string): string {
@@ -1139,6 +1134,11 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
       .trim();
   }, [message.content, isUser]);
 
+  // Lazy-load remark-math / rehype-katex / katex CSS only when this message
+  // actually contains math delimiters. Saves ~280 KB of KaTeX from the
+  // initial bundle on math-free chats (#3381).
+  const mathPlugins = useMathPlugins(displayContent);
+
   return (
     <motion.div className={`flex ${isUser ? "justify-end" : "justify-start"}`} variants={messageIn} initial="initial" animate="animate">
       <div className={`flex flex-col min-w-0 w-fit max-w-[90%] sm:max-w-[min(75%,70ch)] ${isUser ? "items-end" : "items-start"}`}>
@@ -1262,8 +1262,8 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
             <p className="whitespace-pre-line [overflow-wrap:anywhere]">{displayContent}</p>
           ) : (
             <MarkdownContent
-              remarkPlugins={REMARK_PLUGINS}
-              rehypePlugins={REHYPE_PLUGINS}
+              remarkPlugins={mathPlugins.remarkPlugins}
+              rehypePlugins={mathPlugins.rehypePlugins}
             >
               {displayContent}
             </MarkdownContent>

--- a/crates/librefang-api/dashboard/vite.config.ts
+++ b/crates/librefang-api/dashboard/vite.config.ts
@@ -128,6 +128,28 @@ export default defineConfig({
           if (id.includes("@tanstack/react-router") || id.includes("@tanstack/react-query")) return "router";
           if (id.includes("recharts")) return "charts";
           if (id.includes("@xyflow/react")) return "flow";
+          // Order matters: more specific rules must come before broader ones
+          // (katex/remark-math/rehype-katex must match before the generic
+          // remark-/rehype- catch-all in the markdown chunk). See issue #3381.
+          if (
+            id.includes("node_modules/katex") ||
+            id.includes("node_modules/remark-math") ||
+            id.includes("node_modules/rehype-katex")
+          ) return "katex";
+          if (
+            id.includes("node_modules/react-markdown") ||
+            /[\\/]node_modules[\\/]remark-/.test(id) ||
+            /[\\/]node_modules[\\/]rehype-/.test(id)
+          ) return "markdown";
+          if (id.includes("node_modules/@xterm")) return "xterm";
+          if (
+            id.includes("node_modules/motion") ||
+            id.includes("node_modules/framer-motion")
+          ) return "motion";
+          if (
+            id.includes("node_modules/i18next") ||
+            id.includes("node_modules/react-i18next")
+          ) return "i18n";
           // Isolate lucide-react named imports into their own chunk so adding
           // a single icon to a route doesn't bloat its first-load bundle.
           // See issue #3768.


### PR DESCRIPTION
## Summary

- Split `markdown`, `katex`, `xterm`, `motion`, and `i18n` into their own chunks via `vite.config.ts` `manualChunks`, so the eager `index-*.js` no longer carries them.
- Lazy-load `remark-math` + `rehype-katex` + KaTeX CSS only when a chat message actually contains math delimiters (`$...$`, `$$...$$`, `\(...\)`, `\[...\]`). Implemented as a shared `useMathPlugins(content)` hook used by both `ChatPage` and `Typewriter_v2`.
- Math-free chats no longer pay for ~280 KB of KaTeX. Terminal-bundled `xterm` is now route-local instead of shared.

Closes #3381.

## Bundle size: before vs after

Raw / gzip, top chunks only. Run via `pnpm build` (Vite 8 / Rolldown).

| Chunk            | Before (KB)     | After (KB)      | Δ raw    | Δ gzip  |
|------------------|-----------------|-----------------|---------:|--------:|
| `index`          | 570.25 / 193.71 | 392.28 / 136.25 | -177.97  | -57.46  |
| `ChatPage`       | 348.90 / 102.81 |  77.92 /  21.06 | -270.98  | -81.75  |
| `TerminalPage`   | 401.35 / 104.71 |  22.84 /   7.13 | -378.51  | -97.58  |
| `MarkdownContent`| 155.85 /  46.50 |   2.31 /   0.84 | -153.54  | -45.66  |
| `katex` (new)    |        —        | 292.66 /  89.26 | lazy     | lazy    |
| `xterm` (new)    |        —        | 378.28 /  97.85 | route    | route   |
| `markdown` (new) |        —        | 132.88 /  38.97 | shared   | shared  |
| `motion` (new)   |        —        | 131.64 /  43.18 | shared   | shared  |
| `i18n` (new)     |        —        |  53.68 /  17.30 | shared   | shared  |

The `katex` chunk is loaded **on demand** via `import('rehype-katex')` / `import('remark-math')` / `import('katex/dist/katex.min.css')` inside `useMathPlugins`, so users who never trigger math notation never download it.

The pre-existing `icons` (`lucide-react`) chunk is unchanged — the issue's lucide cleanup was already landed in #3768.

## `manualChunks` rules added

Order matters — KaTeX must match before the broader `remark-` / `rehype-` catch-all in the `markdown` chunk:

```ts
if (
  id.includes("node_modules/katex") ||
  id.includes("node_modules/remark-math") ||
  id.includes("node_modules/rehype-katex")
) return "katex";
if (
  id.includes("node_modules/react-markdown") ||
  /[\\/]node_modules[\\/]remark-/.test(id) ||
  /[\\/]node_modules[\\/]rehype-/.test(id)
) return "markdown";
if (id.includes("node_modules/@xterm")) return "xterm";
if (
  id.includes("node_modules/motion") ||
  id.includes("node_modules/framer-motion")
) return "motion";
if (
  id.includes("node_modules/i18next") ||
  id.includes("node_modules/react-i18next")
) return "i18n";
```

## Lazy-load path: `useMathPlugins`

`crates/librefang-api/dashboard/src/lib/hooks/useMathPlugins.ts`:

- Cheap regex `containsMathDelimiters(content)` checks for `$...$`, `$$...$$`, `\(...\)`, `\[...\]`.
- On first match, `Promise.all([import('remark-math'), import('rehype-katex')])` + side-effect import of `katex/dist/katex.min.css`. The promise is module-level cached so a second consumer doesn't re-trigger the import.
- Returns empty plugin arrays until the dynamic import resolves. During the in-flight window, math notation transiently shows as raw text — the same fallback react-markdown produces without the plugins. No layout shift on math-free messages.

Wired into:
- `Typewriter_v2.tsx` — removed top-level `import remarkMath / rehypeKatex / katex/dist/katex.min.css`; merges the lazy plugin arrays into the existing `[remarkGfm, ...]` list.
- `ChatPage.tsx` (`MessageBubble`) — removed top-level KaTeX imports + `REMARK_PLUGINS` / `REHYPE_PLUGINS` constants; `useMathPlugins(displayContent)` now drives `<MarkdownContent>` props per message.

## Verification

- `pnpm typecheck` — passes (no errors).
- `pnpm build` — succeeds (`✓ built in 986ms`); see size table above.
- `cargo` not run locally — multi-worktree convention forbids concurrent cargo invocations against the shared `target/`. CI will run `cargo check` / `clippy` on push. No Rust source touched in this PR (dashboard SPA only).

## Out of scope

- The `icons-*.js` chunk (~615 KB raw / 153 KB gz) is the next-largest unsplit item. It's already isolated to its own chunk (#3768) but `lucide-react/dynamic` lookup-by-string remains; further reduction would need switching call-sites off the dynamic registry. Tracked separately, not blocking this PR.
- The `charts-*.js` (recharts, ~381 KB) chunk was already isolated; no change here.
