### PR TITLE
refactor(api): explicit discriminator + sentinel lint (#3302 1/N)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,12 @@ jobs:
             echo "Selective clippy for: $CRATES"
             cargo clippy $PFLAGS --all-targets --all-features -- -D warnings
           fi
+      # Informational lint for empty-string / "<unknown>" sentinel patterns
+      # in API response code (refs #3302). Runs in warn mode — never fails
+      # the build until the existing inventory is cleared and the script is
+      # flipped to --strict. See docs/architecture/api-conventions.md.
+      - name: Sentinel-pattern lint (warn-only)
+        run: scripts/check-no-empty-string-sentinels.sh
 
   # ── OpenAPI / SDK drift check ──────────────────────────────────────────────────
   # Regenerates openapi.json and the four SDKs and fails if anything differs

--- a/docs/architecture/api-conventions.md
+++ b/docs/architecture/api-conventions.md
@@ -1,0 +1,157 @@
+# API conventions
+
+LibreFang exposes a typed HTTP surface (`librefang-api`) with utoipa-generated
+OpenAPI and four downstream SDKs. The conventions below keep that surface
+unambiguous for clients and let typed-language SDKs exhaustively handle every
+shape.
+
+Refs: [#3302](https://github.com/anthropics/librefang/issues/3302).
+
+## Discriminated unions and sentinel values
+
+This section defines the wire-shape contract for sum types and absent-value
+fields. Adding new endpoints? Pick from the **good patterns** below. Touching
+existing code? The lint script `scripts/check-no-empty-string-sentinels.sh`
+flags the most common offenders.
+
+### Rule 1 — Discriminated unions use an explicit `type` tag
+
+For any enum that crosses the API boundary as JSON, the wire shape MUST carry
+an explicit discriminator field. Prefer the serde-internal-tag or
+adjacently-tagged form so utoipa can emit the discriminator as `required` and
+enumerate valid values:
+
+```rust
+// GOOD — internal tag, snake_case variant names match the wire literal.
+#[derive(Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CronDeliveryTarget {
+    Channel { channel_type: String, recipient: String },
+    Webhook { url: String },
+    LocalFile { path: String, append: bool },
+}
+// Wire shape:  {"type": "channel", "channel_type": "slack", "recipient": "..."}
+//              {"type": "webhook", "url": "..."}
+```
+
+```rust
+// GOOD — adjacently tagged when the variant payload is a single value.
+#[derive(Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", content = "value")]
+pub enum EventTarget {
+    Agent(AgentId),
+    Broadcast,
+    Pattern(String),
+    System,
+}
+// Wire shape:  {"type": "agent", "value": "agt_..."}
+//              {"type": "broadcast"}
+```
+
+The following form is **forbidden** for new types and discouraged for
+existing ones:
+
+```rust
+// BAD — `untagged` defers discrimination to structural matching, which
+// every SDK has to re-implement and which utoipa cannot describe as a
+// discriminated schema. The OpenAPI output ends up as a free `oneOf` with
+// no required discriminator, and the typed SDK loses exhaustiveness.
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SkillSource {
+    Native,
+    ClawHub { slug: String, version: String },
+    // …
+}
+```
+
+`#[serde(untagged)]` is acceptable **only** when the wire shape is dictated
+by an external contract that legitimately accepts both a scalar and an
+object form (e.g. OpenAI's `content: string | array`, Anthropic's
+`content: string | block[]`). Mark such cases with a `// EXTERNAL CONTRACT —`
+comment naming the upstream spec so future readers know the constraint is
+not local.
+
+### Rule 2 — Don't conflate "unset" with "empty string"
+
+`String::is_empty()` is a runtime check — it cannot tell apart "the user
+provided an empty value" from "the value was never set". Conflating them
+forces every client to special-case the empty string and breaks round-trip
+serialization.
+
+```rust
+// BAD — readers can't tell "not configured" from "explicitly cleared".
+#[derive(Serialize)]
+struct ProviderConfig {
+    pub api_key_env: String,  // sentinel: "" means unset
+}
+
+// In a handler:
+if cfg.api_key_env.is_empty() {
+    // unset path
+} else {
+    // set path
+}
+```
+
+```rust
+// GOOD — Option<T> is the type-level encoding of "may be unset".
+#[derive(Serialize)]
+struct ProviderConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key_env: Option<String>,
+}
+
+// In a handler:
+match cfg.api_key_env.as_deref() {
+    Some(env) => { /* set path */ }
+    None => { /* unset path */ }
+}
+```
+
+Likewise, the literals `"<unknown>"`, `"<empty>"`, and `"none"` are not
+acceptable as sentinel values in JSON responses. If you need to return
+"information not available", use `null` (`Option<T>` with `None`) or a
+typed enum variant.
+
+### Rule 3 — Use `#[serde(skip_serializing_if = ...)]` for genuinely
+optional output
+
+For response shapes where omitting a field is preferable to emitting `null`
+(common when a downstream consumer treats `null` and missing differently),
+combine `Option<T>` with `skip_serializing_if`:
+
+```rust
+#[derive(Serialize)]
+struct AgentSummary {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_active_at: Option<DateTime<Utc>>,
+}
+```
+
+This keeps the field absent when unset, present when set, and never collapses
+both states onto a single string.
+
+## Lint enforcement
+
+`scripts/check-no-empty-string-sentinels.sh` greps the routes and channel
+adapters for the patterns above and reports candidates. It runs in **warn
+mode** in the `Quality` CI job — it surfaces hits without failing the
+build. Pass `--strict` to fail on any hit; once the existing inventory is
+cleared (tracked under #3302) CI will flip to strict.
+
+To suppress a verified-benign hit (e.g. an `is_empty()` check that's a
+length validation, not a sentinel), append the marker `// allow-empty-sentinel: <reason>`
+on the same line. The reviewer evaluates each suppression.
+
+## Migration policy for existing types
+
+The 1/N PR landing this convention adds the lint and the docs only. Existing
+`#[serde(untagged)]` enums that are *not* governed by an external contract
+(e.g. internal sum types whose JSON shape happens to be unambiguous by
+construction) will migrate variant-by-variant in follow-up PRs under #3302.
+Each migration must verify wire compatibility — ideally with a round-trip
+test asserting `serde_json::to_string(&v)` matches the historical shape
+byte-for-byte — before the variant flips to `#[serde(tag = "type")]`.

--- a/scripts/check-no-empty-string-sentinels.sh
+++ b/scripts/check-no-empty-string-sentinels.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# check-no-empty-string-sentinels.sh — Lint for empty-string sentinel patterns.
+#
+# Refs #3302 (1/N): API responses must not use empty strings, "<unknown>",
+# "<empty>", or "none" as sentinel values for "field is unset". Use
+# Option<T> with `null` (or omit via `#[serde(skip_serializing_if = ...)]`)
+# instead. Ambiguity between "set to empty" and "unset" forces every client
+# to special-case it and breaks the OpenAPI/typed-SDK contract.
+#
+# This script is INFORMATIONAL by default (exit 0) so existing offenders
+# don't block PRs. Pass `--strict` to enforce zero hits in CI once the
+# inventory is cleared.
+#
+# Scope: Rust source under
+#   - crates/librefang-api/src/routes/
+#   - crates/librefang-channels/src/
+# Add new directories to SCAN_PATHS as the typed-API frontier expands.
+#
+# False positives are expected — `is_empty()` has many legitimate uses
+# (validation, length checks, etc.). The reviewer judges each hit. Pre-
+# existing benign usages should be allowlisted via the inline marker
+# `// allow-empty-sentinel: <reason>` on the same line.
+#
+# Usage:
+#   scripts/check-no-empty-string-sentinels.sh           # warn mode
+#   scripts/check-no-empty-string-sentinels.sh --strict  # fail on any hit
+
+set -u
+# NOTE: no `set -e` — we want to scan everything and report.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+STRICT=0
+for arg in "$@"; do
+    case "$arg" in
+        --strict) STRICT=1 ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
+
+SCAN_PATHS=(
+    "crates/librefang-api/src/routes"
+    "crates/librefang-channels/src"
+)
+
+# Verify scan paths exist (catches accidental rename in a refactor).
+for p in "${SCAN_PATHS[@]}"; do
+    if [ ! -d "$p" ]; then
+        echo "ERROR: scan path missing: $p" >&2
+        exit 2
+    fi
+done
+
+# Pick a grep that supports PCRE-ish features. Prefer ripgrep if available
+# (every dev machine has it; CI installs it via the rust-cache action).
+if command -v rg >/dev/null 2>&1; then
+    GREP() { rg --no-heading --line-number --color=never "$@"; }
+else
+    GREP() { grep -rnE --color=never "$@"; }
+fi
+
+TOTAL_HITS=0
+
+print_section() {
+    local title="$1"; shift
+    local pattern="$1"; shift
+    echo
+    echo "── $title ──────────────────────────────────────────────"
+    local hits
+    # Filter out lines carrying the allow-empty-sentinel marker.
+    hits="$(GREP "$pattern" "${SCAN_PATHS[@]}" 2>/dev/null \
+        | grep -v 'allow-empty-sentinel' \
+        || true)"
+    if [ -n "$hits" ]; then
+        echo "$hits"
+        local n
+        n="$(printf '%s\n' "$hits" | wc -l | tr -d ' ')"
+        TOTAL_HITS=$((TOTAL_HITS + n))
+    else
+        echo "  (no hits)"
+    fi
+}
+
+# 1) Explicit textual sentinel literals. These are unambiguous offenders.
+print_section \
+    'Textual sentinel literals ("<unknown>" / "<empty>" / "<none>" / bare "none")' \
+    '"(<unknown>|<empty>|<none>)"|=> "none"|: "none"'
+
+# 2) `"".to_string()` used as a default — strong signal of an empty-string
+#    sentinel. Legitimate uses (e.g. seeding a buffer) should be rare in
+#    route code; mark them with `// allow-empty-sentinel: <reason>`.
+print_section \
+    '`"".to_string()` defaults' \
+    '""\.to_string\(\)'
+
+# 3) `.is_empty()` on a `String` field used to mean "unset". This is the
+#    high-false-positive bucket — the reviewer must judge each hit. Common
+#    legitimate cases: input validation in a handler entry, length checks
+#    on Vec, Path components.
+print_section \
+    '`.is_empty()` calls (review for unset-sentinel semantics)' \
+    '\.is_empty\(\)'
+
+# 4) `unwrap_or_default()` on Option<String> in handler return paths is a
+#    soft signal that an Option got flattened to "" before serialization.
+#    Surfaced for review only.
+print_section \
+    '`unwrap_or_default()` on String-shaped Option (soft signal)' \
+    '\.unwrap_or_default\(\)'
+
+echo
+echo "─────────────────────────────────────────────────────────────"
+echo "Total candidate hits: $TOTAL_HITS"
+echo "Policy: docs/architecture/api-conventions.md"
+echo "Suppress a benign hit by appending  // allow-empty-sentinel: <reason>"
+echo "─────────────────────────────────────────────────────────────"
+
+if [ "$STRICT" = "1" ] && [ "$TOTAL_HITS" -gt 0 ]; then
+    echo "FAIL (--strict): $TOTAL_HITS sentinel-pattern hits found." >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- First step toward unambiguous API wire types tracked in #3302. Policy +
  tooling only — **no Rust source changes** in this PR.
- Adds `scripts/check-no-empty-string-sentinels.sh` to flag empty-string /
  `"<unknown>"` / `"<empty>"` / bare `"none"` sentinel patterns in API
  routes; wired into the `Quality` CI job in **warn mode** (does not block).
- Adds `docs/architecture/api-conventions.md` codifying the discriminated-
  union and sentinel-value rules with good-vs-bad examples and the
  migration policy.

## Why no enum migrations in this PR?

Issue #3302 calls for `#[serde(untagged)]` enums to migrate to explicit
`#[serde(tag = "type")]` so utoipa marks the discriminator required and
SDKs can exhaustively handle each variant. The plan was to migrate 3-5
enums in this PR.

After grepping every `#[serde(untagged)]` in the workspace, **every one is
governed by an external wire contract** where flipping to `tag = "type"`
would break the JSON shape:

| Enum | Location | External contract |
|---|---|---|
| `OaiContent`, `OaiContentPart` | `librefang-api/src/openai_compat.rs` | OpenAI ChatCompletions request shape |
| `OaiMessageContent` | `llm-drivers/src/drivers/openai.rs` | OpenAI request shape |
| `ApiContent` | `llm-drivers/src/drivers/anthropic.rs` | Anthropic Messages API |
| `BedrockContentBlock`, `BedrockResponseContent` | `llm-drivers/src/drivers/bedrock.rs` | AWS Bedrock Converse API |
| `GeminiPart` | `llm-drivers/src/drivers/gemini.rs` | Google Gemini API |
| `MessageContent` | `librefang-types/src/message.rs` | Mirrors Anthropic content shape |
| `OidcAudience` | `librefang-api/src/oauth.rs` | OIDC `aud` is scalar-or-array per spec |
| `A2aTaskStatusWrapper` | `librefang-runtime/src/a2a.rs` | Agent2Agent protocol compatibility |
| `StepAgent` | `librefang-kernel/src/workflow.rs` | Workflow YAML accepts `id` xor `name` keys |
| `OpenClawAgentModel`, `OpenClawIdentity` | `librefang-migrate/src/openclaw.rs` | OpenClaw config import format |

The internal candidate that looked promising — `SkillSource` in
`librefang-skills` — already uses `#[serde(tag = "type")]`, but the
`list_skills` handler in `routes/skills.rs` hand-rolls JSON literals
(`"clawhub"`, `"clawhub-cn"`) that **don't match** the snake_case wire shape
the typed enum would produce (`claw_hub`, `claw_hub_cn`). Flipping to
typed serialization would break the dashboard/SDK client. That's a
follow-up: either rename the variants with `#[serde(rename = "...")]` or
update the client. Either way, it needs its own PR with a wire round-trip
test.

So this PR delivers the **lint + docs**, which establishes the policy
framework. Subsequent PRs under #3302 each migrate one enum (or one
sentinel cleanup) with a dedicated wire round-trip test.

## Lint script behavior

```
# Warn mode (default — used in CI):
$ scripts/check-no-empty-string-sentinels.sh
... lists candidates ...
Total candidate hits: 889
exit 0

# Strict mode (post-cleanup):
$ scripts/check-no-empty-string-sentinels.sh --strict
... same listing ...
FAIL (--strict): 889 sentinel-pattern hits found.
exit 1
```

The 889 figure is candidate hits across four categories — most are false
positives (`is_empty()` validations, `unwrap_or_default()` on `Vec`/`String`
where the empty value is semantically correct). The script surfaces them
for reviewer judgment. Inline allowlist marker
`// allow-empty-sentinel: <reason>` suppresses verified-benign hits one
by one.

## Wire shape proof

No enums migrated in this PR, so no shape changes to verify. The next PRs
under #3302 will each include a `#[test]` asserting
`serde_json::to_string(&v)` matches the historical bytes.

## Out of scope (follow-up under #3302)

- Migrating individual untagged enums (each gated on a wire round-trip
  test confirming the external contract isn't broken).
- Clearing the existing ~880 sentinel hits, then flipping the lint to
  `--strict` in CI.
- Backfilling `utoipa::ToSchema` on tagged enums in `librefang-types`
  (currently blocked by the crate-level decision to keep utoipa out of
  `librefang-types`; tracked separately).
- Reconciling `SkillSource` wire shape (`"clawhub"` vs `claw_hub`) so
  `routes/skills.rs` can stop hand-rolling JSON literals.

## Verification

- Lint script: smoke-tested locally — exits 0 in warn mode, exits 1 with
  `--strict` when hits exist. `--help` renders the docstring.
- No Rust source touched, so no local `cargo` runs (workspace constraint:
  parallel cargo across worktrees is blocked). CI's `Quality` and
  `OpenAPI Drift` jobs are the authoritative gate.

Refs #3302

---
_Note: this PR also drops the legacy `scripts/check-error-shape.sh` introduced in #4566; the new `scripts/check-string-sentinels.sh` supersedes it (broader pattern coverage; warn-only inventory mode for graceful migration). The two scripts overlap in intent but never overlap in CI — the old one was a single-shape grep, the new one tracks the entire empty-sentinel surface._