### PR TITLE
ci(release): scaffold split per-target workflows (#3304 1/N)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,596 @@
+name: release-cli
+
+# Manual CLI rebuild + re-upload. Issue #3304 1/N (non-destructive split).
+#
+# Mirrors the cli_* + sign_release_artifacts + cli_npm + cli_pypi +
+# sync_homebrew jobs in release.yml. release.yml stays the canonical
+# entrypoint on tag push — this workflow is for "an artifact failed and
+# I just want to redo the CLI slice without rerunning the entire 30-job
+# release pipeline".
+#
+# Inputs:
+#   tag      — existing release tag to (re)build for, e.g. v2026.5.4
+#   targets  — comma-separated subset of jobs to run; default 'all'
+#
+# Maintainer must configure the `release-cli` GitHub environment (with
+# required reviewers) before this stub becomes useful for redirecting
+# real release traffic — see docs/operations/release.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to rebuild for (e.g. v2026.5.4)'
+        required: true
+        type: string
+      include_pypi:
+        description: 'Re-publish CLI PyPI wheels (the JS npm binary side lives in release-npm-binaries.yml)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-cli-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_dashboard:
+    name: Build Dashboard
+    runs-on: ubuntu-latest
+    environment: release-cli
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6
+        with:
+          version: 10
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+      - name: Install dependencies
+        working-directory: crates/librefang-api/dashboard
+        run: pnpm install --frozen-lockfile --config.strict-dep-builds=false
+      - name: Build dashboard
+        working-directory: crates/librefang-api/dashboard
+        run: pnpm run build
+      - name: Upload dashboard artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dashboard-dist
+          path: crates/librefang-api/static/react/
+          retention-days: 1
+
+  cli_mac:
+    name: CLI / ${{ matrix.target }}
+    needs: [build_dashboard]
+    runs-on: macos-latest
+    environment: release-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+          - target: aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dashboard-dist
+          path: crates/librefang-api/static/react/
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cli-${{ matrix.target }}-${{ inputs.tag }}
+      - name: Build CLI
+        run: cargo build --release --target ${{ matrix.target }} --bin librefang
+      - name: Ad-hoc codesign
+        run: |
+          xattr -cr target/${{ matrix.target }}/release/librefang || true
+          codesign --force --sign - target/${{ matrix.target }}/release/librefang
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../librefang-${{ matrix.target }}.tar.gz librefang
+          cd ../../..
+          shasum -a 256 librefang-${{ matrix.target }}.tar.gz > librefang-${{ matrix.target }}.tar.gz.sha256
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in $(seq 1 5); do
+            if gh release upload "${{ inputs.tag }}" librefang-${{ matrix.target }}.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
+
+  cli_linux:
+    name: CLI / ${{ matrix.target }}
+    needs: [build_dashboard]
+    runs-on: ubuntu-22.04
+    environment: release-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            use_cross: false
+          - target: aarch64-unknown-linux-gnu
+            use_cross: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dashboard-dist
+          path: crates/librefang-api/static/react/
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libdbus-1-dev
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --locked
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cli-${{ matrix.target }}-${{ inputs.tag }}
+      - name: Build CLI
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }} --bin librefang
+          else
+            cargo build --release --target ${{ matrix.target }} --bin librefang
+          fi
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../librefang-${{ matrix.target }}.tar.gz librefang
+          cd ../../..
+          sha256sum librefang-${{ matrix.target }}.tar.gz > librefang-${{ matrix.target }}.tar.gz.sha256
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in $(seq 1 5); do
+            if gh release upload "${{ inputs.tag }}" librefang-${{ matrix.target }}.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
+
+  cli_android:
+    name: CLI / aarch64-linux-android
+    needs: [build_dashboard]
+    runs-on: ubuntu-22.04
+    environment: release-cli
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dashboard-dist
+          path: crates/librefang-api/static/react/
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Install cross
+        run: cargo install cross --locked
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cli-aarch64-linux-android-${{ inputs.tag }}
+      - name: Build CLI (Android aarch64)
+        # channel-email excluded: rustls-connector 0.23.0 calls Verifier::new_with_extra_roots
+        # which is not implemented in rustls-platform-verifier 0.7.0 on Android.
+        run: cross build --release --target aarch64-linux-android --bin librefang --no-default-features --features android,telemetry
+      - name: Package
+        run: |
+          cd target/aarch64-linux-android/release
+          tar czf ../../../librefang-aarch64-linux-android.tar.gz librefang
+          cd ../../..
+          sha256sum librefang-aarch64-linux-android.tar.gz > librefang-aarch64-linux-android.tar.gz.sha256
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in $(seq 1 5); do
+            if gh release upload "${{ inputs.tag }}" librefang-aarch64-linux-android.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
+
+  cli_linux_mini:
+    name: CLI / ${{ matrix.target }} (mini)
+    needs: [build_dashboard]
+    runs-on: ubuntu-22.04
+    environment: release-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dashboard-dist
+          path: crates/librefang-api/static/react/
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libdbus-1-dev
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cli-mini-${{ matrix.target }}-${{ inputs.tag }}
+      - name: Build CLI (mini)
+        run: cargo build --release --target ${{ matrix.target }} --bin librefang --no-default-features --features mini
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../librefang-${{ matrix.target }}-mini.tar.gz librefang
+          cd ../../..
+          sha256sum librefang-${{ matrix.target }}-mini.tar.gz > librefang-${{ matrix.target }}-mini.tar.gz.sha256
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in $(seq 1 5); do
+            if gh release upload "${{ inputs.tag }}" librefang-${{ matrix.target }}-mini.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
+
+  cli_musl:
+    name: CLI / ${{ matrix.target }} (static)
+    needs: [build_dashboard]
+    runs-on: ubuntu-22.04
+    environment: release-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+          - target: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dashboard-dist
+          path: crates/librefang-api/static/react/
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install cross
+        run: cargo install cross --locked
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cli-${{ matrix.target }}-${{ inputs.tag }}
+      - name: Build static CLI
+        run: cross build --release --target ${{ matrix.target }} --bin librefang
+      - name: Verify static linking
+        run: |
+          FILE_OUT=$(file target/${{ matrix.target }}/release/librefang)
+          echo "$FILE_OUT"
+          if ! echo "$FILE_OUT" | grep -qE "statically linked|static-pie linked"; then
+            echo "::error::Binary is not statically linked!"
+            exit 1
+          fi
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../librefang-${{ matrix.target }}.tar.gz librefang
+          cd ../../..
+          sha256sum librefang-${{ matrix.target }}.tar.gz > librefang-${{ matrix.target }}.tar.gz.sha256
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in $(seq 1 5); do
+            if gh release upload "${{ inputs.tag }}" librefang-${{ matrix.target }}.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
+
+  cli_windows:
+    name: CLI / ${{ matrix.target }}
+    needs: [build_dashboard]
+    runs-on: windows-latest
+    environment: release-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+          - target: aarch64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dashboard-dist
+          path: crates/librefang-api/static/react/
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cli-${{ matrix.target }}-${{ inputs.tag }}
+      - name: Build CLI
+        run: cargo build --release --target ${{ matrix.target }} --bin librefang
+      - name: Package
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/librefang.exe" -DestinationPath "librefang-${{ matrix.target }}.zip"
+          $hash = (Get-FileHash "librefang-${{ matrix.target }}.zip" -Algorithm SHA256).Hash.ToLower()
+          "$hash  librefang-${{ matrix.target }}.zip" | Out-File -Encoding ASCII "librefang-${{ matrix.target }}.zip.sha256"
+      - name: Upload to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in $(seq 1 5); do
+            if gh release upload "${{ inputs.tag }}" librefang-${{ matrix.target }}.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
+
+  cli_mac_mini:
+    name: CLI / ${{ matrix.target }} (mini)
+    needs: [build_dashboard]
+    runs-on: macos-latest
+    environment: release-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dashboard-dist
+          path: crates/librefang-api/static/react/
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cli-mini-${{ matrix.target }}-${{ inputs.tag }}
+      - name: Build CLI (mini)
+        run: cargo build --release --target ${{ matrix.target }} --bin librefang --no-default-features --features mini
+      - name: Ad-hoc codesign
+        run: |
+          xattr -cr target/${{ matrix.target }}/release/librefang || true
+          codesign --force --sign - target/${{ matrix.target }}/release/librefang
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../librefang-${{ matrix.target }}-mini.tar.gz librefang
+          cd ../../..
+          shasum -a 256 librefang-${{ matrix.target }}-mini.tar.gz > librefang-${{ matrix.target }}-mini.tar.gz.sha256
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in $(seq 1 5); do
+            if gh release upload "${{ inputs.tag }}" librefang-${{ matrix.target }}-mini.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
+
+  cli_windows_mini:
+    name: CLI / ${{ matrix.target }} (mini)
+    needs: [build_dashboard]
+    runs-on: windows-latest
+    environment: release-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dashboard-dist
+          path: crates/librefang-api/static/react/
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cli-mini-${{ matrix.target }}-${{ inputs.tag }}
+      - name: Build CLI (mini)
+        run: cargo build --release --target ${{ matrix.target }} --bin librefang --no-default-features --features mini
+      - name: Package
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/librefang.exe" -DestinationPath "librefang-${{ matrix.target }}-mini.zip"
+          $hash = (Get-FileHash "librefang-${{ matrix.target }}-mini.zip" -Algorithm SHA256).Hash.ToLower()
+          "$hash  librefang-${{ matrix.target }}-mini.zip" | Out-File -Encoding ASCII "librefang-${{ matrix.target }}-mini.zip.sha256"
+      - name: Upload to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in $(seq 1 5); do
+            if gh release upload "${{ inputs.tag }}" librefang-${{ matrix.target }}-mini.* --clobber; then
+              echo "✓ Upload succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Upload failed (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Upload failed after 5 attempts"
+          exit 1
+
+  sign_release_artifacts:
+    name: Sign Release Artifacts
+    needs:
+      - cli_mac
+      - cli_linux
+      - cli_android
+      - cli_linux_mini
+      - cli_musl
+      - cli_windows
+      - cli_mac_mini
+      - cli_windows_mini
+    runs-on: ubuntu-latest
+    environment: release-cli
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        with:
+          cosign-release: "v2.6.3"
+      - name: Build SHA256SUMS manifest from release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p sums
+          cd sums
+          gh release view "${{ inputs.tag }}" --json assets \
+            --jq '.assets[].name | select(endswith(".sha256")) | select(. != "SHA256SUMS")' \
+            > asset-list.txt
+          if [ ! -s asset-list.txt ]; then
+            echo "::error::no *.sha256 sibling files attached to release ${{ inputs.tag }}"
+            exit 1
+          fi
+          # Same EXPECTED_PLATFORMS gate as release.yml — change in lockstep.
+          EXPECTED_PLATFORMS=12
+          ACTUAL=$(wc -l < asset-list.txt | tr -d ' ')
+          if [ "$ACTUAL" -ne "$EXPECTED_PLATFORMS" ]; then
+            echo "::error::expected exactly $EXPECTED_PLATFORMS .sha256 siblings, got $ACTUAL"
+            cat asset-list.txt
+            exit 1
+          fi
+          while IFS= read -r name; do
+            echo "Fetching $name"
+            gh release download "${{ inputs.tag }}" --pattern "$name" --clobber
+          done < asset-list.txt
+          ls *.sha256 | sort | xargs awk 1 > ../SHA256SUMS
+          cd ..
+          echo "::group::SHA256SUMS"
+          cat SHA256SUMS
+          echo "::endgroup::"
+      - name: Sign SHA256SUMS with cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign-blob \
+            --yes \
+            --output-signature SHA256SUMS.sig \
+            --output-certificate SHA256SUMS.pem \
+            SHA256SUMS
+      - name: Verify signature locally before upload
+        run: |
+          cosign verify-blob \
+            --certificate SHA256SUMS.pem \
+            --signature SHA256SUMS.sig \
+            --certificate-identity-regexp "^https://github\\.com/${GITHUB_REPOSITORY}/" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            SHA256SUMS
+      - name: Upload signed manifest to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ inputs.tag }}" \
+            SHA256SUMS \
+            SHA256SUMS.sig \
+            SHA256SUMS.pem \
+            --clobber
+
+  cli_pypi:
+    name: CLI / PyPI
+    if: ${{ inputs.include_pypi }}
+    needs: [cli_mac, cli_linux, cli_musl, cli_windows]
+    runs-on: ubuntu-latest
+    environment: release-pypi
+    permissions:
+      id-token: write   # OIDC trusted publishing to PyPI
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+      - name: Build CLI wheels (no upload)
+        run: |
+          VERSION="${TAG#v}"
+          mkdir -p "${{ runner.temp }}/cli-pypi-dist"
+          cargo xtask publish-pypi-binaries \
+            --version "$VERSION" \
+            --repo "${{ github.repository }}" \
+            --tag "${TAG}" \
+            --build-only \
+            --dist-dir "${{ runner.temp }}/cli-pypi-dist"
+        env:
+          TAG: ${{ inputs.tag }}
+      - name: Publish CLI wheels to PyPI (OIDC)
+        # OIDC trusted publishing — configure at:
+        # pypi.org/manage/project/librefang/settings/publishing
+        # workflow filename: release-cli.yml, environment: release-pypi
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: ${{ runner.temp }}/cli-pypi-dist
+          skip-existing: true

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,426 @@
+name: release-desktop
+
+# Manual desktop bundle rebuild. Issue #3304 1/N (non-destructive split).
+#
+# Mirrors release.yml's `desktop` matrix and `sync_homebrew_cask` job,
+# gated behind workflow_dispatch only. release.yml is still the
+# canonical entrypoint for tag pushes; this workflow exists so a single
+# desktop platform that fails on a real release can be rerun without
+# re-driving the entire 30-job pipeline.
+#
+# Mobile (`mobile_android`, `mobile_ios`) is intentionally NOT split
+# into this PR — those jobs need the same `tauri.conf.json` /
+# `gen/apple` mutations and store-upload secrets as the monolithic
+# version, and the cutover risk is higher. They get their own split
+# in a follow-up PR. Until then mobile stays only in release.yml.
+#
+# Inputs:
+#   tag         — existing release tag whose desktop bundles should be rebuilt
+#   sync_cask   — also re-run the Homebrew cask sync after rebuilds (default off:
+#                 only meaningful when DMG hashes actually changed)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag (e.g. v2026.5.4)'
+        required: true
+        type: string
+      sync_cask:
+        description: 'Re-sync Homebrew cask after desktop rebuild'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-desktop-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  desktop:
+    name: Desktop / ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.os }}
+    environment: release-desktop
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: Linux x86_64
+            os: ubuntu-22.04
+            args: "--target x86_64-unknown-linux-gnu"
+            rust_target: x86_64-unknown-linux-gnu
+          - name: macOS x86_64
+            os: macos-latest
+            args: "--target x86_64-apple-darwin"
+            rust_target: x86_64-apple-darwin
+          - name: macOS ARM64
+            os: macos-latest
+            args: "--target aarch64-apple-darwin"
+            rust_target: aarch64-apple-darwin
+          - name: Windows x86_64
+            os: windows-latest
+            args: "--target x86_64-pc-windows-msvc"
+            rust_target: x86_64-pc-windows-msvc
+          - name: Windows ARM64
+            os: windows-latest
+            args: "--target aarch64-pc-windows-msvc"
+            rust_target: aarch64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - name: Install system deps (Linux)
+        if: runner.os == 'Linux'
+        # libdbus-1-dev is required by libdbus-sys, pulled in transitively
+        # by the keyring crate's secret-service backend on glibc Linux.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libdbus-1-dev \
+            patchelf
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.platform.rust_target }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 20
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: desktop-${{ matrix.platform.rust_target }}-${{ inputs.tag }}
+      - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6
+        with:
+          version: 10
+
+      - name: Build embedded dashboard assets
+        working-directory: crates/librefang-api/dashboard
+        run: |
+          pnpm install --frozen-lockfile --config.strict-dep-builds=false
+          pnpm run build
+
+      - name: Import macOS signing certificate
+        if: runner.os == 'macOS'
+        env:
+          MAC_CERT_BASE64: ${{ secrets.MAC_CERT_BASE64 }}
+          MAC_CERT_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+        run: |
+          if [ -z "$MAC_CERT_BASE64" ]; then
+            echo "No certificate configured, skipping..."
+            exit 0
+          fi
+          echo "$MAC_CERT_BASE64" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import $RUNNER_TEMP/certificate.p12 -P "$MAC_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          PRIOR=$(security list-keychains -d user | tr -d '"' | tr '\n' ' ')
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $PRIOR
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application" | head -1 | awk -F'"' '{print $2}')
+          echo "Using signing identity: $IDENTITY"
+          echo "APPLE_SIGNING_IDENTITY=$IDENTITY" >> $GITHUB_ENV
+          rm -f $RUNNER_TEMP/certificate.p12
+
+      - name: Check notarization readiness
+        if: runner.os == 'macOS' && env.APPLE_SIGNING_IDENTITY != ''
+        env:
+          TEAM_ID: ${{ secrets.MAC_NOTARIZE_TEAM_ID }}
+        run: |
+          if [ -z "$TEAM_ID" ] || [ ${#TEAM_ID} -lt 3 ]; then
+            echo "::warning::MAC_NOTARIZE_TEAM_ID is missing or invalid, falling back to unsigned build"
+            echo "APPLE_SIGNING_IDENTITY=" >> $GITHUB_ENV
+          fi
+
+      - name: Verify Tauri version (CalVer, Major ≤ 255 for WiX MSI)
+        shell: bash
+        run: |
+          cd crates/librefang-desktop
+          TAURI_VER=$(grep '"version"' tauri.conf.json | head -1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+          echo "Tauri version: $TAURI_VER"
+          MAJOR=$(echo "$TAURI_VER" | cut -d. -f1)
+          MINOR=$(echo "$TAURI_VER" | cut -d. -f2)
+          PATCH=$(echo "$TAURI_VER" | cut -d. -f3)
+          if [ "$MAJOR" -gt 255 ] || [ "$MINOR" -gt 255 ] || [ "$PATCH" -gt 65535 ]; then
+            echo "::error::Tauri version $TAURI_VER exceeds MSI limits (Major/Minor ≤ 255, Patch ≤ 65535)"
+            exit 1
+          fi
+          echo "✓ Version $TAURI_VER is MSI-compatible"
+
+      - name: Delete existing assets for this target (allows re-release)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          ASSETS=""
+          for attempt in $(seq 1 5); do
+            if ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null); then
+              break
+            fi
+            echo "Failed to fetch release assets (attempt $attempt/5), retrying in 10s..."
+            sleep 10
+          done
+          echo "$ASSETS" | while read -r name; do
+            [ -z "$name" ] && continue
+            case "$name" in
+              *${{ matrix.platform.rust_target }}*|*latest.json)
+                echo "Deleting existing asset: $name"
+                gh release delete-asset "$TAG" "$name" --yes 2>/dev/null || true
+                ;;
+            esac
+          done
+
+      - name: Build and bundle Tauri desktop app
+        if: runner.os != 'macOS' || env.APPLE_SIGNING_IDENTITY == ''
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ inputs.tag }}
+          releaseName: "${{ inputs.tag }}"
+          releaseDraft: false
+          prerelease: false
+          includeUpdaterJson: true
+          projectPath: crates/librefang-desktop
+          args: ${{ matrix.platform.args }}
+
+      - name: Build and bundle Tauri desktop app (signed macOS)
+        if: runner.os == 'macOS' && env.APPLE_SIGNING_IDENTITY != ''
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.MAC_NOTARIZE_APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.MAC_NOTARIZE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.MAC_NOTARIZE_TEAM_ID }}
+        with:
+          tagName: ${{ inputs.tag }}
+          releaseName: "${{ inputs.tag }}"
+          releaseDraft: false
+          prerelease: false
+          includeUpdaterJson: true
+          projectPath: crates/librefang-desktop
+          args: ${{ matrix.platform.args }}
+
+  sync_homebrew_cask:
+    name: Sync Homebrew Cask
+    if: ${{ inputs.sync_cask }}
+    runs-on: ubuntu-latest
+    environment: release-desktop
+    needs: [desktop]
+    steps:
+      - name: Check out tap repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: librefang/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Fetch release metadata (with retry for DMG availability)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 10); do
+            curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/tags/$TAG" \
+              > release.json
+            ARM_DMG=$(jq -r '[.assets[].name | select(endswith("_aarch64.dmg"))][0] // empty' release.json)
+            X86_DMG=$(jq -r '[.assets[].name | select(endswith("_x64.dmg"))][0] // empty' release.json)
+            if [ -n "$ARM_DMG" ] && [ -n "$X86_DMG" ]; then
+              echo "✓ Both DMG assets found on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq 10 ]; then
+              echo "::error::DMG assets not found in release after 10 attempts"
+              exit 1
+            fi
+            echo "Waiting for DMG assets... ($attempt/10)"
+            sleep 10
+          done
+
+      - name: Generate Casks (channel-based)
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+
+          ARM_DMG=$(jq -r '[.assets[].name | select(endswith("_aarch64.dmg"))][0] // empty' release.json)
+          X86_DMG=$(jq -r '[.assets[].name | select(endswith("_x64.dmg"))][0] // empty' release.json)
+          TAURI_VERSION=$(echo "$ARM_DMG" | sed 's/^LibreFang_//; s/_aarch64\.dmg$//')
+
+          if [ -z "$ARM_DMG" ] || [ -z "$X86_DMG" ]; then
+            echo "::error::DMG assets not found in release.json"
+            exit 1
+          fi
+          echo "DMG version (Tauri): $TAURI_VERSION"
+
+          asset_sha() {
+            local sha_url
+            sha_url="$(jq -r --arg name "${1}.sha256" '.assets[] | select(.name == $name) | .browser_download_url' release.json)"
+            if [ -z "$sha_url" ] || [ "$sha_url" = "null" ]; then
+              local asset_url
+              asset_url="$(jq -r --arg name "$1" '.assets[] | select(.name == $name) | .browser_download_url' release.json)"
+              curl -fsSL "$asset_url" | sha256sum | awk '{print $1}'
+            else
+              curl -fsSL "$sha_url" | awk '{print $1}'
+            fi
+          }
+
+          ARM_SHA="$(asset_sha "$ARM_DMG")"
+          X86_SHA="$(asset_sha "$X86_DMG")"
+
+          for required in ARM_SHA X86_SHA; do
+            if [ -z "${!required}" ] || [ "${!required}" = "null" ]; then
+              echo "Missing SHA256 for $required" >&2
+              exit 1
+            fi
+          done
+
+          if echo "$VERSION" | grep -qE '\-rc'; then
+            CHANNELS=(rc)
+          elif echo "$VERSION" | grep -qE '\-beta'; then
+            CHANNELS=(beta rc)
+          else
+            CHANNELS=(stable beta rc)
+          fi
+          echo "Release $VERSION → updating cask channels: ${CHANNELS[*]}"
+
+          ALL_CHANNELS=(stable beta rc)
+
+          generate_cask() {
+            local channel="$1"
+            local cask_name="librefang"
+            local display_name="LibreFang"
+            local desc_suffix=""
+            if [ "$channel" != "stable" ]; then
+              cask_name="librefang-${channel}"
+              display_name="LibreFang (${channel})"
+              desc_suffix=" (${channel} channel)"
+            fi
+
+            local conflicts=""
+            for other in "${ALL_CHANNELS[@]}"; do
+              [ "$other" = "$channel" ] && continue
+              local other_name="librefang"
+              [ "$other" != "stable" ] && other_name="librefang-${other}"
+              conflicts="${conflicts}
+            conflicts_with cask: \"${other_name}\""
+            done
+
+            local livecheck=""
+            if [ "$channel" = "stable" ]; then
+              livecheck='
+
+            livecheck do
+              url "https://github.com/librefang/librefang/releases/latest"
+              strategy :header_match
+            end'
+            fi
+
+            mkdir -p tap/Casks
+            cat > "tap/Casks/${cask_name}.rb" <<CASK
+          cask "${cask_name}" do
+            arch arm: "aarch64", intel: "x64"
+
+            version "${TAURI_VERSION}"
+
+            on_arm do
+              sha256 "${ARM_SHA}"
+            end
+            on_intel do
+              sha256 "${X86_SHA}"
+            end
+
+            url "https://github.com/librefang/librefang/releases/download/${TAG}/LibreFang_#{version}_#{arch}.dmg",
+                verified: "github.com/librefang/librefang/"
+            name "${display_name}"
+            desc "Community-Maintained Agent Operating System written in Rust${desc_suffix}"
+            homepage "https://librefang.ai"
+          ${conflicts}${livecheck}
+
+            depends_on macos: ">= :ventura"
+
+            app "LibreFang.app"
+
+            zap trash: [
+              "~/Library/Application Support/ai.librefang.desktop",
+              "~/Library/Caches/ai.librefang.desktop",
+              "~/Library/Preferences/ai.librefang.desktop.plist",
+            ]
+          end
+          CASK
+            echo "=== Cask: ${cask_name} ==="
+            cat "tap/Casks/${cask_name}.rb"
+          }
+
+          for channel in "${CHANNELS[@]}"; do
+            generate_cask "$channel"
+          done
+
+          VERSIONED_NAME="librefang@${VERSION}"
+          mkdir -p tap/Casks
+          cat > "tap/Casks/${VERSIONED_NAME}.rb" <<CASK
+          cask "${VERSIONED_NAME}" do
+            arch arm: "aarch64", intel: "x64"
+
+            version "${TAURI_VERSION}"
+
+            on_arm do
+              sha256 "${ARM_SHA}"
+            end
+            on_intel do
+              sha256 "${X86_SHA}"
+            end
+
+            url "https://github.com/librefang/librefang/releases/download/${TAG}/LibreFang_#{version}_#{arch}.dmg",
+                verified: "github.com/librefang/librefang/"
+            name "LibreFang ${VERSION}"
+            desc "Community-Maintained Agent Operating System written in Rust (pinned to ${VERSION})"
+            homepage "https://librefang.ai"
+
+            depends_on macos: ">= :ventura"
+
+            app "LibreFang.app"
+
+            zap trash: [
+              "~/Library/Application Support/ai.librefang.desktop",
+              "~/Library/Caches/ai.librefang.desktop",
+              "~/Library/Preferences/ai.librefang.desktop.plist",
+            ]
+          end
+          CASK
+          echo "=== Versioned cask: ${VERSIONED_NAME} ==="
+          cat "tap/Casks/${VERSIONED_NAME}.rb"
+
+      - name: Commit and push
+        working-directory: tap
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          mkdir -p Casks
+          git add .
+          git commit -m "chore: update cask channels to ${{ inputs.tag }}" || echo "No changes"
+          git push

--- a/.github/workflows/release-npm-binaries.yml
+++ b/.github/workflows/release-npm-binaries.yml
@@ -1,0 +1,73 @@
+name: release-npm-binaries
+
+# Manual re-publish of CLI npm binary packages. Issue #3304 1/N
+# (non-destructive split). Mirrors the `cli_npm` job in release.yml but
+# is triggered only via workflow_dispatch — release.yml stays the
+# canonical entrypoint on tag push.
+#
+# Auth model differs from release.yml's monolithic path: this workflow
+# is wired for npm OIDC trusted publishing (`id-token: write` +
+# `npm publish --provenance`) instead of the legacy NPM_TOKEN PAT. The
+# maintainer must configure the npm trusted-publisher relationship
+# (https://docs.npmjs.com/trusted-publishers) before this workflow can
+# replace the monolithic publish path. Until then it serves as the
+# scaffold; the monolithic NPM_TOKEN path in release.yml continues to
+# handle real releases. See docs/operations/release.md.
+#
+# Inputs:
+#   tag — existing release tag whose CLI binaries should be re-published.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag (e.g. v2026.5.4)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-npm-binaries-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cli_npm:
+    name: CLI / npm (binary packages)
+    runs-on: ubuntu-latest
+    environment: release-npm
+    permissions:
+      id-token: write   # OIDC token for npm provenance attestations
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish CLI binaries to npm (OIDC + provenance)
+        # No NODE_AUTH_TOKEN set — the publish call relies on npm's
+        # OIDC trusted-publisher exchange. `cargo xtask
+        # publish-npm-binaries` must propagate `--provenance` to its
+        # underlying `npm publish` invocation; if it does not, the
+        # follow-up cutover PR adds that flag before flipping traffic
+        # to this workflow. Maintainer must configure the npm trusted
+        # publisher BEFORE enabling this workflow as the real publish
+        # path.
+        env:
+          TAG: ${{ inputs.tag }}
+          NPM_CONFIG_PROVENANCE: "true"
+        run: |
+          VERSION="${TAG#v}"
+          cargo xtask publish-npm-binaries \
+            --version "$VERSION" \
+            --repo "${{ github.repository }}" \
+            --tag "$TAG"

--- a/.github/workflows/release-sdks.yml
+++ b/.github/workflows/release-sdks.yml
@@ -1,0 +1,299 @@
+name: release-sdks
+
+# Manual SDK re-publish. Issue #3304 1/N (non-destructive split).
+#
+# Mirrors release.yml's sdk_javascript / sdk_cli_npm / sdk_python /
+# sdk_rust / sdk_go jobs, gated behind workflow_dispatch only. The
+# monolithic release.yml continues to handle the auto-trigger path on
+# tag push. This workflow is the "redo just the SDK slice" tool.
+#
+# Auth deltas vs. release.yml:
+#   - npm publishes here are wired for OIDC trusted publishing
+#     (id-token: write + --provenance) instead of NPM_TOKEN. Maintainer
+#     must configure the npm trusted-publisher relationship before this
+#     becomes the canonical publish path; see docs/operations/release.md.
+#   - PyPI is OIDC in both monolithic and split (already trusted-publishing).
+#   - crates.io still uses CARGO_REGISTRY_TOKEN (no OIDC support yet).
+#
+# Inputs:
+#   tag             — existing release tag whose SDKs should be (re)published
+#   include_javascript / include_cli_npm / include_python / include_rust / include_go
+#                   — toggle individual SDK jobs (default: all on)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag (e.g. v2026.5.4)'
+        required: true
+        type: string
+      include_javascript:
+        description: 'Re-publish JavaScript SDK to npm'
+        required: false
+        type: boolean
+        default: true
+      include_cli_npm:
+        description: 'Re-publish @librefang/cli to npm'
+        required: false
+        type: boolean
+        default: true
+      include_python:
+        description: 'Re-publish Python SDK to PyPI'
+        required: false
+        type: boolean
+        default: true
+      include_rust:
+        description: 'Re-publish Rust SDK to crates.io'
+        required: false
+        type: boolean
+        default: true
+      include_go:
+        description: 'Tag Go module'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-sdks-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  sdk_javascript:
+    name: SDK / JavaScript (npm)
+    if: ${{ inputs.include_javascript }}
+    runs-on: ubuntu-latest
+    environment: release-npm
+    permissions:
+      id-token: write   # OIDC for npm provenance
+      contents: read
+    defaults:
+      run:
+        working-directory: sdk/javascript
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Sync version from tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          echo "Publishing @librefang/sdk@$VERSION"
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Publish to npm (with OIDC provenance)
+        # OIDC trusted-publisher relationship must be configured at
+        # https://www.npmjs.com/package/@librefang/sdk/access before
+        # this workflow can replace the monolithic NPM_TOKEN path.
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version 2>/dev/null; then
+            echo "✓ ${PKG_NAME}@${PKG_VERSION} already published to npm, skipping"
+          else
+            NPM_TAG=""
+            if echo "$PKG_VERSION" | grep -qE -- '-(beta|rc)[0-9]'; then
+              NPM_TAG="--tag next"
+            elif echo "$PKG_VERSION" | grep -qE -- '\-lts'; then
+              NPM_TAG="--tag lts"
+            fi
+            npm publish --access public --provenance --ignore-scripts $NPM_TAG
+          fi
+          echo "- **npm**: https://www.npmjs.com/package/${PKG_NAME}/v/${PKG_VERSION}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm config set registry https://npm.pkg.github.com
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          GPR_TAG=""
+          if echo "$PKG_VERSION" | grep -qE -- '-(beta|rc)[0-9]'; then
+            GPR_TAG="--tag next"
+          elif echo "$PKG_VERSION" | grep -qE -- '-lts'; then
+            GPR_TAG="--tag lts"
+          fi
+          npm publish --access public --ignore-scripts $GPR_TAG 2>/dev/null || echo "✓ Already published to GitHub Packages, skipping"
+
+  sdk_cli_npm:
+    name: SDK / CLI npm (@librefang/cli)
+    if: ${{ inputs.include_cli_npm }}
+    runs-on: ubuntu-latest
+    environment: release-npm
+    permissions:
+      id-token: write   # OIDC for npm provenance
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/cli-npm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Sync version from tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          echo "Publishing @librefang/cli@$VERSION"
+
+      - name: Publish to npm (with OIDC provenance)
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version 2>/dev/null; then
+            echo "✓ ${PKG_NAME}@${PKG_VERSION} already published, skipping"
+          else
+            NPM_TAG=""
+            if echo "$PKG_VERSION" | grep -qE -- '-(beta|rc)[0-9]'; then
+              NPM_TAG="--tag next"
+            fi
+            npm publish --access public --provenance --ignore-scripts $NPM_TAG
+          fi
+          echo "- **npm**: https://www.npmjs.com/package/${PKG_NAME}/v/${PKG_VERSION}" >> $GITHUB_STEP_SUMMARY
+
+  sdk_python:
+    name: SDK / Python (PyPI)
+    if: ${{ inputs.include_python }}
+    runs-on: ubuntu-latest
+    environment: release-pypi
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: sdk/python
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Sync version from tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          # PEP 440: convert -beta1 → b1, -rc1 → rc1, strip -lts (no PEP 440 equivalent)
+          PYPI_VERSION=$(echo "$VERSION" | sed 's/-beta/b/; s/-rc/rc/; s/-lts//')
+          sed -i "s/^version = .*/version = \"$PYPI_VERSION\"/" pyproject.toml
+          echo "Publishing librefang-sdk==$PYPI_VERSION"
+          grep '^version' pyproject.toml
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to PyPI
+        # OIDC trusted publishing — configure at:
+        # pypi.org/manage/project/librefang-sdk/settings/publishing
+        # workflow filename: release-sdks.yml, environment: release-pypi
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: sdk/python/dist/
+          skip-existing: true
+
+      - name: Output publish link
+        run: |
+          PYPI_VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "- **PyPI**: https://pypi.org/project/librefang-sdk/${PYPI_VERSION}/" >> $GITHUB_STEP_SUMMARY
+
+  sdk_rust:
+    name: SDK / Rust (crates.io)
+    if: ${{ inputs.include_rust }}
+    runs-on: ubuntu-latest
+    environment: release-crates
+    defaults:
+      run:
+        working-directory: sdk/rust
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Sync version from tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" Cargo.toml
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          sed -i '/^\[dependencies\]/,/^```/ s/librefang = "[^"]*"/librefang = "'"$MAJOR_MINOR"'"/' README.md
+          echo "Publishing librefang@$VERSION"
+          grep '^version' Cargo.toml
+
+      - name: Test
+        run: cargo test
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if cargo search librefang --limit 1 2>/dev/null | grep -q "librefang = \"$VERSION\""; then
+            echo "✓ librefang@$VERSION already published to crates.io, skipping"
+          else
+            cargo publish --allow-dirty
+          fi
+          echo "- **crates.io**: https://crates.io/crates/librefang/${VERSION}" >> $GITHUB_STEP_SUMMARY
+
+  sdk_go:
+    name: SDK / Go (tag)
+    if: ${{ inputs.include_go }}
+    runs-on: ubuntu-latest
+    environment: release-tag
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag }}
+      - name: Create Go module tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          REPO="${{ github.repository }}"
+
+          # Map CalVer to Go-compatible v0.YYYYMMDD.0 (keeps major=0, no /v2026 import path)
+          # e.g. 2026.3.21 → v0.20260321.0, 2026.3.21-rc1 → v0.20260321.0-rc1
+          YEAR=$(echo "$VERSION" | cut -d. -f1)
+          MONTH=$(printf '%02d' "$(echo "$VERSION" | cut -d. -f2)")
+          DD=$(echo "$VERSION" | cut -d. -f3 | sed 's/-.*//')
+          PRERELEASE=$(echo "$VERSION" | grep -oE '\-.*' || true)
+          GO_VERSION="0.${YEAR}${MONTH}${DD}.0${PRERELEASE}"
+          GO_TAG="sdk/go/v${GO_VERSION}"
+
+          if gh api "repos/$REPO/git/refs/tags/$GO_TAG" &>/dev/null; then
+            echo "Tag $GO_TAG already exists, skipping"
+            exit 0
+          fi
+
+          SHA=$(gh api "repos/$REPO/git/ref/tags/$TAG" --jq '.object.sha')
+
+          gh api "repos/$REPO/git/refs" \
+            -f ref="refs/tags/$GO_TAG" \
+            -f sha="$SHA"
+          echo "✓ Published Go module tag: $GO_TAG (from $VERSION)"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,82 @@
+name: release-tag
+
+# Manual release-tag creator. Issue #3304 1/N (non-destructive split).
+#
+# This is a workflow_dispatch-only stub that mirrors the tag-creation
+# slice of release.yml's `tag_on_merge` + `create_release` jobs. It does
+# NOT replace those jobs — release.yml remains the canonical entrypoint
+# (auto-tagging via PR merge + release entry creation). This workflow is
+# the manual fallback for re-tagging or fixing a botched tag without
+# rerunning the full pipeline.
+#
+# Maintainer must configure the `release-tag` GitHub environment with
+# at least one required reviewer before this workflow becomes useful in
+# practice — see docs/operations/release.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          Tag to create on the current main branch (e.g. v2026.5.4 or v2026.5.4-beta.1).
+          Must match [workspace.package].version in Cargo.toml on main.
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-tag-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Create release tag
+    runs-on: ubuntu-latest
+    environment: release-tag
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Verify tag format
+        run: |
+          # CalVer YYYY.M.PATCH with optional -beta.N / -rc.N / -lts suffix
+          if ! echo "${{ inputs.version }}" | grep -qE '^v[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-(beta|rc)\.?[0-9]+|-lts)?$'; then
+            echo "::error::tag '${{ inputs.version }}' does not match expected CalVer pattern"
+            exit 1
+          fi
+
+      - name: Verify tag matches workspace version
+        run: |
+          # Same gate as release.yml `create_release` — the manifest
+          # section must match the tag the maintainer is requesting.
+          TAG="${{ inputs.version }}"
+          WS_VERSION=$(sed -n '/^\[workspace\.package\]/,/^\[/{ s/^version *= *"\([^"]*\)".*/\1/p }' Cargo.toml | head -1)
+          if [ "${TAG#v}" != "$WS_VERSION" ]; then
+            echo "::error::requested tag $TAG does not match [workspace.package].version $WS_VERSION"
+            exit 1
+          fi
+          echo "Tag $TAG matches workspace version $WS_VERSION"
+
+      - name: Verify tag does not already exist
+        run: |
+          if git rev-parse "${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::tag '${{ inputs.version }}' already exists locally"
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/${{ inputs.version }}" | grep -q "${{ inputs.version }}"; then
+            echo "::error::tag '${{ inputs.version }}' already exists on origin"
+            exit 1
+          fi
+
+      - name: Create + push tag
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git tag "${{ inputs.version }}"
+          git push origin "${{ inputs.version }}"
+          echo "✓ Pushed tag ${{ inputs.version }}"
+          echo "Note: this push will trigger release.yml on the tag — split workflows below are only needed if individual targets need to be re-run."

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -1,0 +1,122 @@
+# Release pipeline
+
+LibreFang's release pipeline lives in `.github/workflows/`. As of #3304
+1/N it is in a transitional state: the monolithic `release.yml`
+remains the canonical entrypoint, and a set of `workflow_dispatch`-only
+"split" workflows have been added alongside it as scaffolding for a
+later cutover.
+
+## Current state (post #3304 1/N)
+
+- **Canonical entrypoint:** `release.yml` (~2,500 lines, ~30 jobs).
+  Triggered by `push: tags: v*`, the `release-bump` `workflow_dispatch`
+  flow, and the `pull_request: closed` auto-tag flow. Everything that
+  ships to npm, PyPI, crates.io, GHCR, the Homebrew tap, Fly, Render,
+  Play Internal Testing, and TestFlight goes through this file.
+- **Manual single-target reruns:** five new files added in this PR.
+  They are `workflow_dispatch`-only — they never fire automatically
+  on tag push, so they cannot accidentally double-publish.
+
+| File | Purpose | Inputs | Mirrors monolithic jobs |
+| ---- | ------- | ------ | ----------------------- |
+| `release-tag.yml`          | Manual tag verify + push                    | `version`                                                         | `tag_on_merge` (PAT-pushed tag), `create_release` precondition |
+| `release-cli.yml`          | CLI binaries, signed manifest, optional PyPI | `tag`, `include_pypi`                                             | `build_dashboard`, `cli_*`, `sign_release_artifacts`, `cli_pypi` |
+| `release-sdks.yml`         | JS / Python / Rust / Go SDK publishes       | `tag`, `include_javascript`, `include_cli_npm`, `include_python`, `include_rust`, `include_go` | `sdk_javascript`, `sdk_cli_npm`, `sdk_python`, `sdk_rust`, `sdk_go` |
+| `release-desktop.yml`      | Tauri desktop bundle (5 platforms) + cask sync | `tag`, `sync_cask`                                                | `desktop`, `sync_homebrew_cask` |
+| `release-npm-binaries.yml` | CLI npm binary packages (per-arch)          | `tag`                                                             | `cli_npm` |
+
+When you trigger any split workflow, it operates on an already-existing
+GitHub Release tag. It checks out the source tree at that tag,
+rebuilds the artifact, and re-uploads with `gh release upload --clobber`,
+which is the same idempotent path the monolithic jobs use on rerun.
+
+## When to use each path
+
+- **Normal release:** push a tag (or merge a `chore/bump-version-…` PR).
+  `release.yml` runs end-to-end. **Do nothing else.**
+- **One target failed and you want to redo it without rerunning the
+  whole 30-job pipeline:** trigger the matching split workflow from the
+  Actions UI. Provide the existing tag as `tag` (and any other input
+  the workflow declares).
+- **You messed up a tag:** delete the tag from origin via Releases UI,
+  then trigger `release-tag` to re-create it on the corrected commit
+  (or just push again with `git push origin <tag>`).
+
+## Authentication deltas in the split files
+
+The split workflows are wired for **OIDC-based publishing** wherever
+possible, instead of the long-lived PATs the monolithic file uses:
+
+- **npm** (`release-npm-binaries`, `release-sdks` JavaScript jobs):
+  uses `permissions: id-token: write` + `npm publish --provenance`.
+  The maintainer must configure the npm trusted-publisher relationship
+  for each package on https://www.npmjs.com/package/<pkg>/access *before*
+  any cutover that flips traffic from `release.yml` (NPM_TOKEN) to a
+  split workflow. Until then, only the monolithic NPM_TOKEN path
+  publishes real releases.
+- **PyPI** (`release-cli` CLI wheels, `release-sdks` Python SDK):
+  already OIDC in both monolithic and split.
+- **crates.io** (`release-sdks` Rust SDK): still uses
+  `CARGO_REGISTRY_TOKEN`. crates.io has no OIDC trusted-publisher path
+  yet; this stays a PAT until upstream supports it.
+
+`release.yml` itself is not modified by this PR — its existing NPM_TOKEN
+path stays in place and is the actual publish path until cutover.
+
+## GitHub environments referenced
+
+Each split job sets `environment: <name>`. None of these environments
+exist yet — GitHub creates them on first reference but with no
+protection rules, which means anyone with `actions: write` can run the
+workflow. The maintainer must configure each via
+https://github.com/librefang/librefang/settings/environments before
+relying on these workflows for real releases. Recommended settings:
+
+| Environment       | Required reviewers          | Wait timer | Notes |
+| ----------------- | --------------------------- | ---------- | ----- |
+| `release-tag`     | 1 release maintainer        | 0 min      | Tag pushes are recoverable; reviewer is the gate |
+| `release-cli`     | 1 release maintainer        | 0 min      | Re-uploading existing CLI tarballs is low-risk |
+| `release-desktop` | 1 release maintainer        | 0 min      | Same reasoning; cask sync writes to the tap repo |
+| `release-npm`     | 2 release maintainers       | 5 min      | Publish is irrevocable on npm |
+| `release-pypi`    | 2 release maintainers       | 5 min      | Yank exists on PyPI but is not "delete" |
+| `release-crates`  | 2 release maintainers       | 5 min      | crates.io publish is irrevocable beyond yank |
+
+## Maintainer follow-up checklist (after this PR merges)
+
+- [ ] Configure each environment listed above with required reviewers
+      and wait timer via the repo Settings → Environments page.
+- [ ] Configure npm trusted-publisher for `@librefang/sdk`,
+      `@librefang/cli`, and the per-arch binary packages emitted by
+      `cargo xtask publish-npm-binaries`. Workflow filename is the
+      split file; environment name is `release-npm`.
+- [ ] Confirm `cargo xtask publish-npm-binaries` propagates
+      `--provenance` to its underlying `npm publish` calls. If it does
+      not, add the flag in `xtask/src/publish_npm_binaries.rs` (or
+      whichever module owns it) before any cutover PR — otherwise the
+      OIDC-equipped split workflow still publishes without provenance
+      attestations.
+- [ ] Smoke-test each split workflow on a real tag that already
+      shipped. The split jobs use `gh release upload --clobber`, so
+      re-uploading identical artifacts is a no-op as far as
+      consumers are concerned.
+
+## Migration plan
+
+1. **Phase 1 (this PR):** scaffold the split workflows alongside
+   `release.yml`. No traffic moves. Configure environments + npm
+   trusted publishers. **Done when** maintainers have manually run
+   each split workflow at least once on a recent tag and confirmed it
+   re-uploads the right artifacts.
+2. **Phase 2 (follow-up PR):** convert each split file to also accept
+   `on: workflow_call:` so `release.yml` can call them as reusable
+   workflows. Replace the inlined `cli_*` / `desktop` / `sdk_*` /
+   `cli_npm` / `cli_pypi` blocks in `release.yml` with `uses:
+   ./.github/workflows/release-<area>.yml` references. Mobile splits
+   (`mobile_android`, `mobile_ios`) join in this phase too; they were
+   intentionally left in `release.yml` for Phase 1.
+3. **Phase 3 (follow-up PR):** flip npm SDK/CLI publishes from
+   NPM_TOKEN to the OIDC path by removing `NODE_AUTH_TOKEN` from the
+   reusable workflow callers. Requires Phase 2 + npm trusted-publisher
+   configuration to be live.
+
+Refs #3304.


### PR DESCRIPTION
## Summary

- Non-destructive scaffold of split per-target release workflows (`release-tag`, `release-cli`, `release-sdks`, `release-desktop`, `release-npm-binaries`) so a single failed artifact can be rerun without re-driving the entire ~30-job pipeline.
- All five new workflows are `workflow_dispatch`-only — they never fire on tag push, so they cannot accidentally double-publish alongside `release.yml`.
- npm publishes in the new files are wired for OIDC trusted publishing + `npm publish --provenance` instead of the legacy `NPM_TOKEN` PAT, ready for cutover once the maintainer configures the npm trusted-publisher relationship. `release.yml` is **not** modified, so the legacy NPM_TOKEN path keeps shipping real releases until then.

## What this PR does NOT do

- **Does not modify `release.yml`** — it remains the canonical release entrypoint on tag push, PR-merge auto-tagging, and the `release-bump` `workflow_dispatch` flow.
- **Does not redirect any release traffic.** Triggering one of the new split workflows operates on an already-existing tag and re-uploads with `gh release upload --clobber` (idempotent).
- **Does not enable OIDC for SDK/CLI npm publishes in the real release path** — that flip happens in a follow-up PR, after npm trusted-publisher relationships are in place.
- **Does not split mobile (`mobile_android`, `mobile_ios`) or Docker (`docker`, `docker-manifest`, `deploy_fly`, `deploy_render`) jobs** — those need their own dedicated PRs; the keystore / provisioning-profile + GHCR-manifest cutover risk warrants separation.

## Files added

```
.github/workflows/release-tag.yml          (1 job)
.github/workflows/release-cli.yml          (11 jobs: build_dashboard + 8x cli matrix + sign + cli_pypi)
.github/workflows/release-sdks.yml         (5 jobs: javascript, cli_npm, python, rust, go)
.github/workflows/release-desktop.yml      (2 jobs: 5-platform desktop matrix + cask sync)
.github/workflows/release-npm-binaries.yml (1 job: cli npm binary packages with OIDC)
docs/operations/release.md                 (runbook: phases, env config, follow-up checklist)
```

`release.yml` diff: **zero lines**.

## Maintainer follow-up checklist (after this PR merges)

- [ ] Configure GitHub environments via Settings → Environments:
  - `release-tag`, `release-cli`, `release-desktop` — 1 release maintainer reviewer each, 0-min wait timer.
  - `release-npm`, `release-pypi`, `release-crates` — 2 release maintainer reviewers each, 5-min wait timer (irrevocable publishes).
- [ ] Configure npm trusted-publisher relationships for `@librefang/sdk`, `@librefang/cli`, and the per-arch packages emitted by `cargo xtask publish-npm-binaries`. Workflow filename = the matching split file; environment = `release-npm`.
- [ ] Verify `cargo xtask publish-npm-binaries` propagates `--provenance` to `npm publish`. If not, add the flag in `xtask` before any cutover PR.
- [ ] Smoke-test each split workflow on a recent existing tag in dry-run-equivalent mode (`gh release upload --clobber` is a no-op when artifacts are byte-identical).

## Migration plan

1. **Phase 1 (this PR):** scaffold split workflows next to `release.yml`. No traffic moves. Maintainer configures environments and npm trusted publishers, then manually exercises each split workflow.
2. **Phase 2 (follow-up PR):** add `on: workflow_call:` to each split file and replace the inlined blocks in `release.yml` with `uses: ./.github/workflows/release-<area>.yml` references. Mobile + Docker splits land here.
3. **Phase 3 (follow-up PR):** flip npm SDK/CLI publishes from `NPM_TOKEN` to the OIDC path by removing `NODE_AUTH_TOKEN` from the reusable callers. Requires Phase 2 + npm trusted publishers live.

Refs #3304
