### PR TITLE
refactor(arch): API → Kernel for 15 runtime types (#3596 1/N)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -3868,7 +3868,7 @@ mod tests {
     /// filtered at ContentComplete, not forwarded to the channel (#2379).
     #[tokio::test]
     async fn test_stream_bridge_filters_agent_send_tool_call_at_content_complete() {
-        use librefang_runtime::agent_loop::AgentLoopResult;
+        use librefang_kernel::agent_loop::AgentLoopResult;
 
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok::<_, String>(AgentLoopResult::default()) });
@@ -3907,7 +3907,7 @@ mod tests {
     /// behavior of hermes-agent's commentary stream).
     #[tokio::test]
     async fn test_stream_bridge_surfaces_tool_use_progress() {
-        use librefang_runtime::agent_loop::AgentLoopResult;
+        use librefang_kernel::agent_loop::AgentLoopResult;
 
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok::<_, String>(AgentLoopResult::default()) });
@@ -3970,7 +3970,7 @@ mod tests {
     /// user knows the agent's plan hit a snag.
     #[tokio::test]
     async fn test_stream_bridge_surfaces_tool_failure() {
-        use librefang_runtime::agent_loop::AgentLoopResult;
+        use librefang_kernel::agent_loop::AgentLoopResult;
 
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok::<_, String>(AgentLoopResult::default()) });
@@ -4012,7 +4012,7 @@ mod tests {
     /// noisy fast for agents that chain many tools.
     #[tokio::test]
     async fn test_stream_bridge_quiet_on_tool_success() {
-        use librefang_runtime::agent_loop::AgentLoopResult;
+        use librefang_kernel::agent_loop::AgentLoopResult;
 
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok::<_, String>(AgentLoopResult::default()) });
@@ -4077,7 +4077,7 @@ mod tests {
     /// scenarios.
     #[tokio::test]
     async fn test_stream_bridge_show_progress_false_suppresses_all_markers() {
-        use librefang_runtime::agent_loop::AgentLoopResult;
+        use librefang_kernel::agent_loop::AgentLoopResult;
 
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok::<_, String>(AgentLoopResult::default()) });
@@ -4148,7 +4148,7 @@ mod tests {
     /// should produce only one progress line — some drivers double-fire.
     #[tokio::test]
     async fn test_stream_bridge_dedupes_consecutive_tool_progress() {
-        use librefang_runtime::agent_loop::AgentLoopResult;
+        use librefang_kernel::agent_loop::AgentLoopResult;
 
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok::<_, String>(AgentLoopResult::default()) });
@@ -4184,7 +4184,7 @@ mod tests {
     /// `record_delivery(success=true)`.
     #[tokio::test]
     async fn test_stream_bridge_status_success() {
-        use librefang_runtime::agent_loop::AgentLoopResult;
+        use librefang_kernel::agent_loop::AgentLoopResult;
 
         let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(16);
         let kernel_handle = tokio::spawn(async { Ok::<_, String>(AgentLoopResult::default()) });

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -6897,7 +6897,7 @@ mod monitoring_tests {
     use axum::extract::{Path, Query, State};
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
-    use librefang_runtime::audit::AuditAction;
+    use librefang_kernel::audit::AuditAction;
     use librefang_types::config::KernelConfig;
 
     fn monitoring_test_app_state() -> (Arc<AppState>, tempfile::TempDir) {

--- a/crates/librefang-api/src/routes/approvals.rs
+++ b/crates/librefang-api/src/routes/approvals.rs
@@ -14,7 +14,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_runtime::kernel_handle::prelude::*;
+use librefang_kernel::kernel_handle::prelude::*;
 use librefang_types::i18n::ErrorTranslator;
 use std::sync::Arc;
 

--- a/crates/librefang-api/src/routes/audit.rs
+++ b/crates/librefang-api/src/routes/audit.rs
@@ -21,7 +21,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use chrono::{DateTime, Utc};
-use librefang_runtime::audit::AuditEntry;
+use librefang_kernel::audit::AuditEntry;
 use librefang_types::agent::UserId;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -581,7 +581,7 @@ pub async fn audit_verify(State(state): State<Arc<AppState>>) -> impl IntoRespon
 #[cfg(test)]
 mod tests {
     use super::*;
-    use librefang_runtime::audit::{AuditAction, AuditEntry};
+    use librefang_kernel::audit::{AuditAction, AuditEntry};
 
     fn entry(
         seq: u64,

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1899,8 +1899,8 @@ mod tests {
     //! kernel; `auth_denied_*` tests do boot a kernel because we need to
     //! observe the audit chain.
     use super::*;
+    use librefang_kernel::audit::AuditAction;
     use librefang_memory::namespace_acl::{MemoryNamespaceGuard, NamespaceGate};
-    use librefang_runtime::audit::AuditAction;
     use librefang_types::config::KernelConfig;
 
     #[test]

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -9,7 +9,7 @@ use librefang_types::agent::{PromptExperiment, PromptVersion};
 use sha2::{Digest, Sha256};
 
 use super::AppState;
-use librefang_runtime::kernel_handle::prelude::*;
+use librefang_kernel::kernel_handle::prelude::*;
 use std::sync::Arc;
 
 use crate::types::ApiErrorResponse;

--- a/crates/librefang-api/src/routes/task_queue.rs
+++ b/crates/librefang-api/src/routes/task_queue.rs
@@ -11,7 +11,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_runtime::kernel_handle::prelude::*;
+use librefang_kernel::kernel_handle::prelude::*;
 use librefang_types::i18n::ErrorTranslator;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/librefang-api/src/routes/webhooks.rs
+++ b/crates/librefang-api/src/routes/webhooks.rs
@@ -23,7 +23,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_runtime::kernel_handle::prelude::*;
+use librefang_kernel::kernel_handle::prelude::*;
 use librefang_types::agent::AgentId;
 use librefang_types::i18n::ErrorTranslator;
 use std::collections::HashMap;

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -42,6 +42,35 @@ pub use kernel::DeliveryTracker;
 pub use kernel::LibreFangKernel;
 
 // ---------------------------------------------------------------------------
+// Runtime re-exports (refs #3596 — API → Kernel → Runtime layering)
+// ---------------------------------------------------------------------------
+//
+// `librefang-api` historically imported runtime types directly, which bypasses
+// kernel encapsulation. The intended layering is `API → Kernel → Runtime`;
+// API code should reach runtime types through the kernel boundary.
+//
+// These re-exports mirror the public modules of `librefang-runtime` that the
+// API layer needs as read-only types or trait surfaces. They do not introduce
+// new dependencies — `librefang-kernel` already depends on `librefang-runtime`.
+//
+// Migration is incremental (PR 1/N): adding the re-exports here unblocks API
+// callers from switching `use librefang_runtime::foo` to
+// `use librefang_kernel::foo` one file at a time, without breaking files that
+// have not yet been migrated. A follow-up PR will delete
+// `librefang-api/Cargo.toml`'s direct `librefang-runtime` dependency once the
+// last in-tree `use librefang_runtime::*` is gone, letting the compiler
+// enforce the boundary.
+pub use librefang_runtime::agent_loop;
+pub use librefang_runtime::audit;
+pub use librefang_runtime::kernel_handle;
+pub use librefang_runtime::llm_driver;
+pub use librefang_runtime::llm_errors;
+pub use librefang_runtime::mcp_oauth;
+pub use librefang_runtime::media;
+pub use librefang_runtime::str_utils;
+pub use librefang_runtime::tool_runner;
+
+// ---------------------------------------------------------------------------
 // Shared persist utility
 // ---------------------------------------------------------------------------
 

--- a/scripts/check-api-runtime-decoupling.sh
+++ b/scripts/check-api-runtime-decoupling.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# refs #3596 — API → Kernel → Runtime layering progress check.
+#
+# `librefang-api` historically imported runtime types directly, bypassing
+# kernel encapsulation. The intended layering is `API → Kernel → Runtime`;
+# API code should reach runtime types through the kernel boundary.
+#
+# Migration is incremental: this script counts remaining direct
+# `use librefang_runtime` occurrences in `crates/librefang-api/src/` so PR
+# diffs make progress visible. It is informational only (does not fail) —
+# a follow-up PR will delete the runtime dep line in
+# `crates/librefang-api/Cargo.toml`, at which point the compiler enforces
+# the boundary and this script becomes redundant.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+API_SRC="$ROOT/crates/librefang-api/src"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) not found; skipping API↔runtime decoupling check" >&2
+  exit 0
+fi
+
+remaining=$(rg -c 'use librefang_runtime' "$API_SRC" 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')
+
+echo "[check-api-runtime-decoupling] direct \`use librefang_runtime\` in librefang-api/src: $remaining"
+echo "[check-api-runtime-decoupling] target: 0 (then drop runtime dep from crates/librefang-api/Cargo.toml — refs #3596)"
+
+if [ "$remaining" -gt 0 ]; then
+  echo
+  echo "Remaining import sites:"
+  rg -n 'use librefang_runtime' "$API_SRC" | sed 's|^|  |'
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- First incremental step toward enforcing `API → Kernel → Runtime` layering at the compiler level (refs #3596).
- Adds runtime-module re-exports under `librefang_kernel::*` and migrates **15** of **34** `use librefang_runtime` sites in `crates/librefang-api/src/` to the kernel path.
- The runtime dep line in `crates/librefang-api/Cargo.toml` **stays** in this PR — removing it now would break the remaining 19 imports. A follow-up PR finishes the migration and deletes the dep, at which point the compiler enforces the boundary.

## Why incremental

A complete decoupling touches ~34 import sites across 13 files plus several non-trivial type surfaces (`McpConnection`, `WorkflowEngine`, `tool_runner::execute_tool`, `mcp_oauth::*`). Splitting it lets reviewers verify each batch is purely import-path migration with no behavioural change, and keeps each diff small enough to read.

## Kernel re-exports added

`crates/librefang-kernel/src/lib.rs`:

```rust
pub use librefang_runtime::agent_loop;
pub use librefang_runtime::audit;
pub use librefang_runtime::kernel_handle;
pub use librefang_runtime::llm_driver;
pub use librefang_runtime::llm_errors;
pub use librefang_runtime::mcp_oauth;
pub use librefang_runtime::media;
pub use librefang_runtime::str_utils;
pub use librefang_runtime::tool_runner;
```

No new dependencies — `librefang-kernel` already depends on `librefang-runtime`. These are pure transit re-exports so api callers can spell the same types via the kernel path.

## Migrated import sites (15)

| File | Line | Before | After |
|---|---|---|---|
| `crates/librefang-api/src/routes/audit.rs` | 24 | `use librefang_runtime::audit::AuditEntry;` | `use librefang_kernel::audit::AuditEntry;` |
| `crates/librefang-api/src/routes/audit.rs` | 584 | `use librefang_runtime::audit::{AuditAction, AuditEntry};` | `use librefang_kernel::audit::{AuditAction, AuditEntry};` |
| `crates/librefang-api/src/routes/memory.rs` | 1903 | `use librefang_runtime::audit::AuditAction;` | `use librefang_kernel::audit::AuditAction;` |
| `crates/librefang-api/src/routes/agents.rs` | 6900 | `use librefang_runtime::audit::AuditAction;` | `use librefang_kernel::audit::AuditAction;` |
| `crates/librefang-api/src/routes/approvals.rs` | 17 | `use librefang_runtime::kernel_handle::prelude::*;` | `use librefang_kernel::kernel_handle::prelude::*;` |
| `crates/librefang-api/src/routes/task_queue.rs` | 14 | `use librefang_runtime::kernel_handle::prelude::*;` | `use librefang_kernel::kernel_handle::prelude::*;` |
| `crates/librefang-api/src/routes/webhooks.rs` | 26 | `use librefang_runtime::kernel_handle::prelude::*;` | `use librefang_kernel::kernel_handle::prelude::*;` |
| `crates/librefang-api/src/routes/prompts.rs` | 12 | `use librefang_runtime::kernel_handle::prelude::*;` | `use librefang_kernel::kernel_handle::prelude::*;` |
| `crates/librefang-api/src/channel_bridge.rs` | 3871 | `use librefang_runtime::agent_loop::AgentLoopResult;` | `use librefang_kernel::agent_loop::AgentLoopResult;` |
| `crates/librefang-api/src/channel_bridge.rs` | 3910 | (same) | (same) |
| `crates/librefang-api/src/channel_bridge.rs` | 3973 | (same) | (same) |
| `crates/librefang-api/src/channel_bridge.rs` | 4015 | (same) | (same) |
| `crates/librefang-api/src/channel_bridge.rs` | 4080 | (same) | (same) |
| `crates/librefang-api/src/channel_bridge.rs` | 4151 | (same) | (same) |
| `crates/librefang-api/src/channel_bridge.rs` | 4187 | (same) | (same) |

All 15 are pure path renames (same underlying types, same trait surface) — `kernel::audit` is a `pub use` of `runtime::audit`, etc. Behaviour is unchanged.

## Inventory

`use librefang_runtime` sites in `crates/librefang-api/src/`:

| | Count |
|---|---|
| Before | 34 |
| After (this PR) | 19 |
| Migrated | 15 |

The new script `scripts/check-api-runtime-decoupling.sh` prints this number and lists remaining sites; CI / reviewers can read it from the PR diff to see progress.

## Out of scope (follow-up PRs)

The remaining 19 imports involve heavier or branchy surfaces and will land in subsequent PRs:

- `kernel_handle::prelude::*` in `ws.rs`, `routes/network.rs`, `routes/workflows.rs`, `routes/tools_sessions.rs`, `routes/agents.rs`, `channel_bridge.rs` (inner), `openai_compat.rs` — same trivial rename, deferred only to keep this diff readable.
- `llm_driver::{StreamEvent, PHASE_RESPONSE_COMPLETE}` in `ws.rs`, `routes/agents.rs` (×2), `channel_bridge.rs`, `openai_compat.rs`.
- `llm_errors` in `ws.rs`.
- `tool_runner::{builtin_tool_definitions, execute_tool}` in `routes/network.rs`, `routes/tools_sessions.rs`.
- `media::{MediaDriverCache, MediaError}` in `routes/media.rs`.
- `mcp_oauth::{McpAuthState, OAuthTokens, McpOAuthError}` in `routes/mcp_auth.rs`.
- `str_utils::safe_truncate_str` in `channel_bridge.rs`.
- **Final PR**: delete the `librefang-runtime = { path = "../librefang-runtime" }` line in `crates/librefang-api/Cargo.toml`. Once it's gone the compiler enforces the boundary, and any future regression fails the build instead of waiting for this script to flag it.

## Verification

- Per repo policy (multi-worktree contention on shared `target/`), `cargo` is not run locally — CI verifies build, clippy, and the integration suite.
- `scripts/check-api-runtime-decoupling.sh` runs locally and reports `19` remaining (down from `34`), matching this PR's migration count.
- All edits are pure import-path renames; no logic, no types, no public API touched in `librefang-api`. The `pub use` lines in `librefang-kernel/src/lib.rs` are additive.

Refs #3596
