### PR TITLE
fix(dashboard): a11y on historical thinking drawer toggle (#4542 follow-up)

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1170,16 +1170,24 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
             <button
               type="button"
               onClick={() => setThinkingExpanded((v) => !v)}
+              aria-expanded={thinkingExpanded}
+              aria-controls={`thinking-block-${message.id}`}
               className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-border-subtle bg-surface text-[10px] font-medium text-text-dim hover:text-text hover:border-border transition-colors"
             >
-              <Brain className="h-3 w-3" />
+              <Brain className="h-3 w-3" aria-hidden="true" />
               <span>{t("chat.thinking_label")}</span>
               <ChevronDown
                 className={`h-3 w-3 transition-transform ${thinkingExpanded ? "rotate-180" : ""}`}
+                aria-hidden="true"
               />
             </button>
             {thinkingExpanded && (
-              <div className="mt-1 px-3 py-2 rounded-lg border border-border-subtle bg-surface/50 text-[12px] leading-relaxed text-text-dim break-words prose-sm">
+              <div
+                id={`thinking-block-${message.id}`}
+                role="region"
+                aria-label={t("chat.thinking_label")}
+                className="mt-1 px-3 py-2 rounded-lg border border-border-subtle bg-surface/50 text-[12px] leading-relaxed text-text-dim break-words prose-sm"
+              >
                 <MarkdownContent>{message.thinking ?? ""}</MarkdownContent>
               </div>
             )}


### PR DESCRIPTION
## Summary

Follow-up to #4542. The toggle button gained no a11y wiring on merge — addressing the MEDIUM note from the post-merge review.

## Changes

`crates/librefang-api/dashboard/src/pages/ChatPage.tsx` — the thinking-drawer toggle now:

- Carries `aria-expanded={thinkingExpanded}` so screen readers announce open/closed state.
- Carries `aria-controls` pointing at the rendered region so AT users can navigate from toggle to content.
- The brain icon and the chevron are marked `aria-hidden="true"` — they're decorative and would otherwise be announced as redundant noise.

The expanded content `<div>` is now wrapped as a `role="region"` with `aria-label={t("chat.thinking_label")}` so it appears as a navigable landmark.

## Out of scope

The other MEDIUM from the review — *no render-layer test for the collapsed drawer* — is **not** in this PR. Adding one requires extracting `MessageBubble` out of `ChatPage.tsx` (currently a private `memo`'d inner component with ~10 props). Tracking as a separate follow-up.

## Test plan

- [ ] Manual: toggle drawer, verify `aria-expanded` flips between `true`/`false` in DevTools.
- [ ] Manual: tab to the toggle in VoiceOver / NVDA, verify state change is announced.
- [ ] CI: dashboard build green.