### PR TITLE
fix(dashboard): drop {status,budget} envelope on updateUserBudget return type

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -4068,7 +4068,7 @@ export async function getUserBudget(name: string): Promise<UserBudgetResponse> {
 export async function updateUserBudget(
   name: string,
   payload: UserBudgetPayload,
-): Promise<{ status: string; budget: UserBudgetPayload }> {
+): Promise<UserBudgetPayload> {
   return put(
     `/api/budget/users/${encodeURIComponent(name)}`,
     payload,


### PR DESCRIPTION
## Summary

Follow-up to #4561. Server side dropped the `{status, budget}` ack envelope on `PUT /api/budget/users/{name}` and now returns the canonical `UserBudgetConfig` directly (`crates/librefang-api/src/routes/budget.rs:880`), but the dashboard TS type for `updateUserBudget` was not updated and still claims `Promise<{ status: string; budget: UserBudgetPayload }>`. Any caller destructuring `.budget` from the response gets `undefined`.

This patch aligns the TS return type with the wire shape:

- `crates/librefang-api/dashboard/src/api.ts:4071` — return type changed from `Promise<{ status: string; budget: UserBudgetPayload }>` to `Promise<UserBudgetPayload>`.

The only mutation hook (`crates/librefang-api/dashboard/src/lib/mutations/userBudget.ts:24`) already discards the response with `_data`, so no call-site changes are required.

## Verification

- `grep -rn "updateUserBudget" crates/librefang-api/dashboard/src/` confirms only the type declaration and the mutation hook (which ignores the value) reference the function.
- Diff is a single-line type change; no runtime logic touched.

## Out-of-scope

None.