### PR TITLE
feat(plugins): Ed25519 signing across workers + daemon TOFU resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,6 +4708,7 @@ dependencies = [
  "http-body-util",
  "librefang-api",
  "librefang-kernel",
+ "librefang-memory",
  "librefang-runtime",
  "librefang-types",
  "serde_json",

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -18,16 +18,22 @@ use tracing::{debug, info, warn};
 /// Default URL for the official LibreFang plugin-registry public key.
 ///
 /// Served by the `registry-worker` Cloudflare Worker (see
-/// `web/workers/registry-worker/index.js`). The endpoint returns the raw
-/// 32-byte Ed25519 public key, base64-encoded — exactly what
+/// `web/workers/registry-worker/index.js`) at the same custom domain that
+/// hosts the signed index. The endpoint returns the raw 32-byte Ed25519
+/// public key, base64-encoded — exactly what
 /// `ed25519_dalek::VerifyingKey::from_bytes` consumes.
 ///
 /// Operators of forks / self-hosted registries can point at their own URL
 /// via `LIBREFANG_REGISTRY_PUBKEY_URL`, or skip the network call entirely by
 /// setting `LIBREFANG_REGISTRY_PUBKEY` directly with the base64 key.
 ///
+/// `librefang.ai/.well-known/registry-pubkey` is also wired up via the
+/// Cloudflare Pages worker (see `web/public/_worker.js`) as a stable
+/// alternate alias, but the worker subdomain stays the canonical default
+/// because the Pages worker is only updated on `main` branch deploys.
+///
 /// See `docs/architecture/plugin-signing.md` for the full trust model.
-const OFFICIAL_PUBKEY_URL: &str = "https://librefang.ai/.well-known/registry-pubkey";
+const OFFICIAL_PUBKEY_URL: &str = "https://stats.librefang.ai/.well-known/registry-pubkey";
 
 /// `owner/repo` of the official LibreFang plugin registry on GitHub.
 ///

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -15,24 +15,33 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
-/// Default URL for the official LibreFang plugin-registry public key.
+/// Embedded raw 32-byte Ed25519 public key for the official LibreFang
+/// plugin registry, base64-encoded.
 ///
-/// Served by the `registry-worker` Cloudflare Worker (see
-/// `web/workers/registry-worker/index.js`) at the same custom domain that
-/// hosts the signed index. The endpoint returns the raw 32-byte Ed25519
-/// public key, base64-encoded — exactly what
-/// `ed25519_dalek::VerifyingKey::from_bytes` consumes.
+/// This is the **primary trust root** for `librefang/librefang-registry`
+/// installs. The earlier TOFU-via-HTTP approach was vulnerable to a
+/// first-install MITM (cafe wifi, hostile DNS, subdomain takeover of the
+/// pubkey-serving host) silently pinning an attacker key forever — see PR
+/// review HIGH #5 / #16. By compiling the key into the daemon binary we
+/// take HTTPS + the daemon release pipeline as the trust path instead.
 ///
-/// Operators of forks / self-hosted registries can point at their own URL
-/// via `LIBREFANG_REGISTRY_PUBKEY_URL`, or skip the network call entirely by
-/// setting `LIBREFANG_REGISTRY_PUBKEY` directly with the base64 key.
+/// Must match `REGISTRY_PUBLIC_KEY` in:
+///   - `web/workers/registry-worker/wrangler.toml`
+///   - `web/workers/marketplace-worker/wrangler.toml`
+///   - `web/public/_worker.js`
 ///
-/// `librefang.ai/.well-known/registry-pubkey` is also wired up via the
-/// Cloudflare Pages worker (see `web/public/_worker.js`) as a stable
-/// alternate alias, but the worker subdomain stays the canonical default
-/// because the Pages worker is only updated on `main` branch deploys.
+/// The `scripts/check-pubkey-lockstep.sh` CI guard fails if any drift.
 ///
-/// See `docs/architecture/plugin-signing.md` for the full trust model.
+/// Rotation is deliberately disruptive: a new daemon release ships with
+/// the new constant; in-flight installs against the old key fail closed.
+/// See `docs/architecture/plugin-signing.md` § "Rotation".
+const EMBEDDED_REGISTRY_PUBKEY: &str = "NEoveGRjRazzoiRFqozw0VEtF9N9elfwIAOqKzt4Ue4=";
+
+/// Default URL for self-hosted registries that opt into HTTP pubkey
+/// resolution (operators of `acme/private-registry` style forks who don't
+/// want to rebuild the daemon to ship a key constant). Off the official
+/// trust path — never consulted for the official registry, which uses
+/// [`EMBEDDED_REGISTRY_PUBKEY`].
 const OFFICIAL_PUBKEY_URL: &str = "https://stats.librefang.ai/.well-known/registry-pubkey";
 
 /// `owner/repo` of the official LibreFang plugin registry on GitHub.
@@ -78,16 +87,84 @@ fn is_valid_registry_pubkey_b64(s: &str) -> bool {
     bytes.len() == 32 && !bytes.iter().all(|&b| b == 0)
 }
 
-/// Resolve the registry pubkey using the layered chain:
-///   1. `LIBREFANG_REGISTRY_PUBKEY` env var override (always wins)
-///   2. `~/.librefang/registry.pub` TOFU cache
-///   3. HTTP fetch from `LIBREFANG_REGISTRY_PUBKEY_URL` (default
-///      [`OFFICIAL_PUBKEY_URL`]); on success, the value is pinned to the
-///      cache so subsequent calls bypass the network.
+/// Read the TOFU pubkey cache file with O_NOFOLLOW + regular-file check.
 ///
-/// Returns `Err` only when all three sources are unavailable or invalid;
-/// callers may then choose to hard-fail (index verification) or fall back
-/// to weaker integrity checks (archive install with verified SHA-256).
+/// Hardens against PR review MEDIUM #13: a compromised post-install hook
+/// could otherwise plant `~/.librefang/registry.pub` as a symlink to
+/// `/etc/passwd` (read returns garbage that fails b64 validation, harmless)
+/// — but the subsequent `fs::write` would follow the symlink and corrupt
+/// the target. Refusing to follow symlinks and validating regular-file
+/// status before reading closes that surface.
+fn read_pubkey_cache_safely(path: &std::path::Path) -> Option<String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.read(true).custom_flags(libc::O_NOFOLLOW);
+        let mut f = opts.open(path).ok()?;
+        let meta = f.metadata().ok()?;
+        if !meta.is_file() {
+            warn!("Pubkey cache {} is not a regular file — ignoring", path.display());
+            return None;
+        }
+        use std::io::Read as _;
+        let mut buf = String::new();
+        f.read_to_string(&mut buf).ok()?;
+        Some(buf)
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows symlink semantics differ enough that a generic O_NOFOLLOW
+        // doesn't translate; still validate regular-file status and rely on
+        // NTFS ACLs for the rest.
+        let meta = std::fs::metadata(path).ok()?;
+        if !meta.is_file() {
+            warn!("Pubkey cache {} is not a regular file — ignoring", path.display());
+            return None;
+        }
+        std::fs::read_to_string(path).ok()
+    }
+}
+
+/// Write the TOFU cache with mode 0600 on Unix so other local users can't
+/// read or replace it. Hardens against PR review MEDIUM #13.
+fn write_pubkey_cache_safely(path: &std::path::Path, value: &str) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::io::Write as _;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)?;
+        f.write_all(value.as_bytes())?;
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, value)
+    }
+}
+
+/// Resolve the registry pubkey using the layered chain:
+///   1. `LIBREFANG_REGISTRY_PUBKEY` env var override (always wins — covers
+///      self-hosted forks and operator-driven rotation).
+///   2. [`EMBEDDED_REGISTRY_PUBKEY`] compiled-in constant (the **primary
+///      trust root** for the official `librefang/librefang-registry`
+///      registry — no network call, no MITM surface).
+///   3. `~/.librefang/registry.pub` TOFU cache + HTTP fetch from
+///      `LIBREFANG_REGISTRY_PUBKEY_URL` — only consulted when the env var
+///      override and the embedded key are both unavailable, i.e. a
+///      self-hosted fork that didn't ship a custom binary. The HTTP path
+///      is **opt-in via env var only** for that reason: the official
+///      registry never reaches it.
+///
+/// Returns `Err` only when all sources are unavailable or invalid; callers
+/// may then choose to hard-fail (index verification) or fall back to
+/// weaker integrity checks (archive install with verified SHA-256).
 async fn resolve_registry_pubkey(client: &reqwest::Client) -> Result<String, String> {
     if let Ok(env_key) = std::env::var("LIBREFANG_REGISTRY_PUBKEY") {
         let trimmed = env_key.trim().to_string();
@@ -99,8 +176,15 @@ async fn resolve_registry_pubkey(client: &reqwest::Client) -> Result<String, Str
         }
     }
 
+    if is_valid_registry_pubkey_b64(EMBEDDED_REGISTRY_PUBKEY) {
+        return Ok(EMBEDDED_REGISTRY_PUBKEY.to_string());
+    }
+    // Embedded key being malformed is a build-time mistake; warn but keep
+    // trying so the daemon stays usable for self-hosted forks.
+    warn!("EMBEDDED_REGISTRY_PUBKEY is malformed — falling through to TOFU/HTTP");
+
     let cache_path = registry_pubkey_cache_path()?;
-    if let Ok(cached) = std::fs::read_to_string(&cache_path) {
+    if let Some(cached) = read_pubkey_cache_safely(&cache_path) {
         let trimmed = cached.trim().to_string();
         if is_valid_registry_pubkey_b64(&trimmed) {
             debug!("Using TOFU-pinned registry pubkey from {}", cache_path.display());
@@ -140,7 +224,7 @@ async fn resolve_registry_pubkey(client: &reqwest::Client) -> Result<String, Str
     if let Some(parent) = cache_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    match std::fs::write(&cache_path, &trimmed) {
+    match write_pubkey_cache_safely(&cache_path, &trimmed) {
         Ok(()) => info!(
             "Pinned registry pubkey to {} (TOFU); rotation requires deleting this file",
             cache_path.display()
@@ -199,75 +283,12 @@ fn verify_registry_index(
         .map_err(|e| format!("Signature verification failed: {e}"))
 }
 
-/// Verify an Ed25519 signature over plugin archive bytes.
-///
-/// The registry is expected to serve a companion file `{archive_url}.sig`
-/// containing the raw 64-byte Ed25519 signature, base64-encoded.
-///
-/// Returns `Ok(())` if the signature is valid or if no signature file exists
-/// (signature is optional — absence is a warning, not an error).
-/// Returns `Err(reason)` if a signature file exists but is invalid.
-async fn verify_archive_signature(
-    client: &reqwest::Client,
-    archive_url: &str,
-    archive_bytes: &[u8],
-    pubkey_b64: &str,
-) -> Result<(), String> {
-    use base64::Engine as _;
-
-    // Try to fetch the signature file.
-    let sig_url = format!("{archive_url}.sig");
-    let sig_resp = client.get(&sig_url).send().await;
-    let sig_b64 = match sig_resp {
-        Ok(r) if r.status().is_success() => match r.text().await {
-            Ok(t) => t.trim().to_string(),
-            Err(e) => {
-                warn!("Failed to read archive signature from {sig_url}: {e}");
-                return Ok(()); // treat as absent
-            }
-        },
-        _ => {
-            debug!("No archive signature found at {sig_url} — skipping");
-            return Ok(()); // absent is fine
-        }
-    };
-
-    // Decode and verify.
-    let sig_bytes = base64::engine::general_purpose::STANDARD
-        .decode(&sig_b64)
-        .map_err(|e| format!("Invalid base64 in archive signature: {e}"))?;
-    let pubkey_bytes = base64::engine::general_purpose::STANDARD
-        .decode(pubkey_b64)
-        .map_err(|e| format!("Invalid base64 in public key: {e}"))?;
-
-    if sig_bytes.len() != 64 {
-        return Err(format!(
-            "Archive signature must be 64 bytes, got {}",
-            sig_bytes.len()
-        ));
-    }
-    if pubkey_bytes.len() != 32 {
-        return Err(format!(
-            "Public key must be 32 bytes, got {}",
-            pubkey_bytes.len()
-        ));
-    }
-
-    let sig_array: [u8; 64] = sig_bytes.try_into().unwrap();
-    let pubkey_array: [u8; 32] = pubkey_bytes.try_into().unwrap();
-
-    let verifying_key = ed25519_dalek::VerifyingKey::from_bytes(&pubkey_array)
-        .map_err(|e| format!("Invalid public key: {e}"))?;
-    let signature = ed25519_dalek::Signature::from_bytes(&sig_array);
-
-    use ed25519_dalek::Verifier as _;
-    verifying_key
-        .verify(archive_bytes, &signature)
-        .map_err(|_| format!("Archive signature verification FAILED for {archive_url}"))?;
-
-    info!("Archive signature verified for {archive_url}");
-    Ok(())
-}
+// `verify_archive_signature` was removed in PR #4600 — it always fetched
+// `{listing_url}.sig` (a GitHub Contents API URL), which 404s in the
+// official registry layout, causing the function to silently return
+// Ok(()) on every invocation. Per-plugin trust now flows through the
+// signed plugins-index membership check in `install_from_registry`
+// instead. See PR review CRITICAL #3.
 
 /// Return the path used to cache a registry index locally.
 /// The filename is a sanitised form of the registry URL.
@@ -418,7 +439,13 @@ pub async fn fetch_verified_index(
             )
         })?;
 
-        // Try to fetch and verify the index signature.
+        // For the official registry, a missing or unreachable .sig is a
+        // hard fail — we already enforce pubkey resolution above, so an
+        // attacker who can serve a doctored index.json and just delete the
+        // .sig (or return 404) must not be able to slip past with an
+        // unsigned payload (PR review HIGH #6). For self-hosted forks the
+        // soft path stays — they may not have signing infrastructure yet.
+        let require_sig = registry == OFFICIAL_REGISTRY_REPO;
         match client.get(&sig_url).send().await {
             Ok(sig_resp) if sig_resp.status().is_success() => {
                 let sig_text = sig_resp
@@ -428,10 +455,27 @@ pub async fn fetch_verified_index(
                 verify_registry_index(&index_bytes, sig_text.trim(), &pubkey)?;
                 info!(registry, "Registry index signature verified OK");
             }
+            Ok(sig_resp) if require_sig => {
+                return Err(format!(
+                    "Registry index signature unavailable for official mirror \
+                     (HTTP {} from {sig_url}) — refusing to trust unsigned index. \
+                     If this is a self-hosted fork, point LIBREFANG_REGISTRY_INDEX_URL \
+                     at it so the official-mirror enforcement does not apply.",
+                    sig_resp.status()
+                ));
+            }
+            Err(e) if require_sig => {
+                return Err(format!(
+                    "Registry index signature fetch failed for official mirror \
+                     ({sig_url}): {e}. Refusing to trust unsigned index — a network \
+                     downgrade attack must not silently bypass verification."
+                ));
+            }
             _ => {
                 warn!(
                     registry,
-                    "No index.json.sig found — registry index not signature-verified"
+                    "No index.json.sig found — registry index not signature-verified \
+                     (self-hosted registry; official mirror would hard-fail here)"
                 );
             }
         }
@@ -1061,32 +1105,45 @@ async fn install_from_registry(
     // TOFU cache, then a worker fetch. When all paths fail:
     //   * SHA-256 already verified → warn and proceed (we still have integrity)
     //   * SHA-256 absent           → hard-fail (no integrity check would remain)
-    let archive_bytes = tokio::fs::read(target_dir.join("plugin.toml"))
-        .await
-        .unwrap_or_default();
+    // Per-plugin Ed25519 archive signatures are NOT served by the official
+    // registry — the older code that fetched `{listing_url}.sig` was always
+    // a 404 (PR review CRITICAL #3) and silently passed every install.
+    // Instead, gate the install on membership in the signed plugins-index:
+    // an attacker who can serve a malicious GitHub Contents listing for
+    // `<name>` cannot also forge an entry for `<name>` in the worker's
+    // Ed25519-signed flat index (the worker won't sign content it didn't
+    // pull from the registry repo's committed `plugins-index.json`).
     if std::env::var("LIBREFANG_ARCHIVE_VERIFY").as_deref() == Ok("0") {
-        debug!("Archive signature verification disabled via LIBREFANG_ARCHIVE_VERIFY=0");
+        debug!("Index-membership verification disabled via LIBREFANG_ARCHIVE_VERIFY=0");
     } else {
-        match resolve_registry_pubkey(&client).await {
-            Ok(pubkey) => {
-                if let Err(e) =
-                    verify_archive_signature(&client, &listing_url, &archive_bytes, &pubkey).await
-                {
+        match fetch_verified_index(&client, github_repo).await {
+            Ok(index_entries) => {
+                let in_index = index_entries.iter().any(|e| {
+                    e.get("name").and_then(|v| v.as_str()) == Some(name)
+                });
+                if !in_index {
                     let _ = tokio::fs::remove_dir_all(&target_dir).await;
-                    return Err(e);
+                    return Err(format!(
+                        "Plugin '{name}' is not present in the signed registry index. \
+                         Refusing to install — the GitHub Contents listing alone is \
+                         not a sufficient trust root. If this is a brand-new plugin, \
+                         wait for the registry's CI to regenerate plugins-index.json \
+                         and re-sign before installing."
+                    ));
                 }
+                info!(plugin = name, "Plugin presence in signed index confirmed");
             }
             Err(e) if checksum_verified => {
                 warn!(
                     plugin = name,
-                    "Ed25519 verification skipped: {e}. SHA-256 already verified — install proceeds."
+                    "Index-membership check skipped: {e}. SHA-256 already verified — install proceeds."
                 );
             }
             Err(e) => {
                 let _ = tokio::fs::remove_dir_all(&target_dir).await;
                 return Err(format!(
                     "Cannot verify plugin '{name}' integrity: SHA-256 checksum was unavailable \
-                     AND Ed25519 pubkey could not be resolved. {e} \
+                     AND signed registry index could not be fetched. {e} \
                      Refusing to install without any integrity check."
                 ));
             }

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -15,20 +15,117 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
-/// Well-known public key for the official LibreFang plugin registry.
+/// Default URL for the official LibreFang plugin-registry public key.
 ///
-/// This is an Ed25519 public key (32 bytes, base64url-encoded).
-/// Override via `LIBREFANG_REGISTRY_PUBKEY` env var for custom registries.
-/// Set to `LIBREFANG_REGISTRY_VERIFY=0` to skip verification entirely (development only).
+/// Served by the `registry-worker` Cloudflare Worker (see
+/// `web/workers/registry-worker/index.js`). The endpoint returns the raw
+/// 32-byte Ed25519 public key, base64-encoded — exactly what
+/// `ed25519_dalek::VerifyingKey::from_bytes` consumes.
 ///
-/// # Security note
-/// The placeholder value below (all-zero bytes once decoded) is intentionally
-/// detected at runtime. Any install attempt while this placeholder is in effect
-/// is rejected with a hard error — no plugin is accepted without a real key.
-/// To configure a real key, set the `LIBREFANG_REGISTRY_PUBKEY` environment
-/// variable to the base64-encoded 32-byte Ed25519 public key of your registry.
-const OFFICIAL_REGISTRY_PUBKEY_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-// ^ all-zero placeholder — triggers hard error at runtime (see is_placeholder check)
+/// Operators of forks / self-hosted registries can point at their own URL
+/// via `LIBREFANG_REGISTRY_PUBKEY_URL`, or skip the network call entirely by
+/// setting `LIBREFANG_REGISTRY_PUBKEY` directly with the base64 key.
+///
+/// See `docs/architecture/plugin-signing.md` for the full trust model.
+const OFFICIAL_PUBKEY_URL: &str = "https://librefang.ai/.well-known/registry-pubkey";
+
+/// On-disk pin for the registry pubkey (TOFU cache).
+///
+/// First successful fetch is written here; later calls read this file
+/// instead of going to the network. Rotation requires deleting this file
+/// (operators or a daemon-side `librefang plugin rotate-pubkey` command).
+fn registry_pubkey_cache_path() -> Result<PathBuf, String> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| "Cannot determine home directory for pubkey cache".to_string())?;
+    Ok(PathBuf::from(home).join(".librefang").join("registry.pub"))
+}
+
+/// True iff `s` decodes to a valid 32-byte non-all-zero Ed25519 pubkey.
+fn is_valid_registry_pubkey_b64(s: &str) -> bool {
+    use base64::Engine as _;
+    let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(s.trim()) else {
+        return false;
+    };
+    bytes.len() == 32 && !bytes.iter().all(|&b| b == 0)
+}
+
+/// Resolve the registry pubkey using the layered chain:
+///   1. `LIBREFANG_REGISTRY_PUBKEY` env var override (always wins)
+///   2. `~/.librefang/registry.pub` TOFU cache
+///   3. HTTP fetch from `LIBREFANG_REGISTRY_PUBKEY_URL` (default
+///      [`OFFICIAL_PUBKEY_URL`]); on success, the value is pinned to the
+///      cache so subsequent calls bypass the network.
+///
+/// Returns `Err` only when all three sources are unavailable or invalid;
+/// callers may then choose to hard-fail (index verification) or fall back
+/// to weaker integrity checks (archive install with verified SHA-256).
+async fn resolve_registry_pubkey(client: &reqwest::Client) -> Result<String, String> {
+    if let Ok(env_key) = std::env::var("LIBREFANG_REGISTRY_PUBKEY") {
+        let trimmed = env_key.trim().to_string();
+        if !trimmed.is_empty() {
+            if is_valid_registry_pubkey_b64(&trimmed) {
+                return Ok(trimmed);
+            }
+            warn!("LIBREFANG_REGISTRY_PUBKEY is set but is not a valid 32-byte Ed25519 key");
+        }
+    }
+
+    let cache_path = registry_pubkey_cache_path()?;
+    if let Ok(cached) = std::fs::read_to_string(&cache_path) {
+        let trimmed = cached.trim().to_string();
+        if is_valid_registry_pubkey_b64(&trimmed) {
+            debug!("Using TOFU-pinned registry pubkey from {}", cache_path.display());
+            return Ok(trimmed);
+        }
+        warn!(
+            "Cached registry pubkey at {} is malformed; ignoring",
+            cache_path.display()
+        );
+    }
+
+    let url = std::env::var("LIBREFANG_REGISTRY_PUBKEY_URL")
+        .unwrap_or_else(|_| OFFICIAL_PUBKEY_URL.to_string());
+    let resp = client
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch registry pubkey from {url}: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "Registry pubkey endpoint {url} returned HTTP {}",
+            resp.status()
+        ));
+    }
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read registry pubkey response: {e}"))?;
+    let trimmed = body.trim().to_string();
+    if !is_valid_registry_pubkey_b64(&trimmed) {
+        return Err(format!(
+            "Registry pubkey from {url} is not a valid base64-encoded 32-byte Ed25519 key"
+        ));
+    }
+
+    if let Some(parent) = cache_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match std::fs::write(&cache_path, &trimmed) {
+        Ok(()) => info!(
+            "Pinned registry pubkey to {} (TOFU); rotation requires deleting this file",
+            cache_path.display()
+        ),
+        Err(e) => warn!(
+            "Could not pin registry pubkey to {}: {} — pubkey will be re-fetched next install",
+            cache_path.display(),
+            e
+        ),
+    }
+
+    Ok(trimmed)
+}
 
 /// Verify an Ed25519 signature over registry index JSON bytes.
 ///
@@ -205,8 +302,6 @@ pub async fn fetch_verified_index(
     client: &reqwest::Client,
     registry: &str,
 ) -> Result<Vec<serde_json::Value>, String> {
-    use base64::Engine as _;
-
     let cache_path = registry_cache_path(registry);
     let ttl = std::env::var("LIBREFANG_REGISTRY_CACHE_TTL_SECS")
         .ok()
@@ -250,31 +345,20 @@ pub async fn fetch_verified_index(
     if std::env::var("LIBREFANG_REGISTRY_VERIFY").as_deref() == Ok("0") {
         warn!("Registry signature verification disabled via LIBREFANG_REGISTRY_VERIFY=0");
     } else {
-        // Resolve which public key to use.
-        let pubkey = std::env::var("LIBREFANG_REGISTRY_PUBKEY")
-            .unwrap_or_else(|_| OFFICIAL_REGISTRY_PUBKEY_B64.to_string());
+        // Resolve the public key via env > TOFU cache > worker fetch. If none
+        // of the three paths produce a valid key we hard-fail: the registry
+        // index drives every subsequent install, so trusting an unverified
+        // index would mask a compromised or man-in-the-middle registry.
+        let pubkey = resolve_registry_pubkey(client).await.map_err(|e| {
+            format!(
+                "Plugin registry public key unavailable — refusing to fetch registry index. {e} \
+                 Configure LIBREFANG_REGISTRY_PUBKEY (base64), point \
+                 LIBREFANG_REGISTRY_PUBKEY_URL at a reachable endpoint, or set \
+                 LIBREFANG_REGISTRY_VERIFY=0 to disable verification (development use only)."
+            )
+        })?;
 
-        // Detect the all-zero placeholder key.  A placeholder means no real
-        // registry key has been configured, so we REFUSE rather than silently
-        // skip — accepting an unverified index would let a compromised or
-        // man-in-the-middle registry serve arbitrary plugin lists.
-        let key_bytes = base64::engine::general_purpose::STANDARD
-            .decode(pubkey.trim())
-            .unwrap_or_default();
-        let is_placeholder = key_bytes.iter().all(|&b| b == 0) || key_bytes.len() != 32;
-
-        if is_placeholder {
-            return Err(
-                "Plugin registry public key is not configured — refusing to fetch registry \
-                 index without signature verification. \
-                 Set LIBREFANG_REGISTRY_PUBKEY to the base64-encoded Ed25519 public key of \
-                 your registry, or set LIBREFANG_REGISTRY_VERIFY=0 to disable verification \
-                 (development use only)."
-                    .to_string(),
-            );
-        }
-
-        // Key is present and non-placeholder — try to verify the signature.
+        // Try to fetch and verify the index signature.
         match client.get(&sig_url).send().await {
             Ok(sig_resp) if sig_resp.status().is_success() => {
                 let sig_text = sig_resp
@@ -885,7 +969,10 @@ async fn install_from_registry(
     }
 
     // Verify checksum if available (non-fatal warning if no checksum file exists).
-    match fetch_checksum(&client, &listing_url, name).await {
+    // checksum_verified gates the Ed25519 fallback below: when SHA-256 has
+    // confirmed the manifest, an unavailable Ed25519 pubkey downgrades to a
+    // warning instead of a hard failure (defense in depth, not single point).
+    let checksum_verified = match fetch_checksum(&client, &listing_url, name).await {
         Some(expected) => {
             // For registry plugins installed file-by-file, compute checksum over
             // the serialised manifest as a representative integrity check.
@@ -897,50 +984,52 @@ async fn install_from_registry(
                 return Err(e);
             }
             info!(plugin = name, "Checksum verified OK");
+            true
         }
         None => {
             warn!(
                 plugin = name,
                 "No checksum file found for this plugin release. \
-                 Install proceeds without integrity verification."
+                 Install proceeds without SHA-256 verification — \
+                 Ed25519 signature will be REQUIRED."
             );
+            false
         }
-    }
+    };
 
-    // Verify Ed25519 archive signature.
-    // A placeholder (all-zero) public key means no real key is configured —
-    // refuse installation rather than silently skip.  An attacker who knows the
-    // key is all-zero bytes can trivially craft valid signatures, so accepting
-    // plugins while the placeholder is active is equivalent to no verification.
+    // Verify Ed25519 archive signature. The pubkey resolver tries env override,
+    // TOFU cache, then a worker fetch. When all paths fail:
+    //   * SHA-256 already verified → warn and proceed (we still have integrity)
+    //   * SHA-256 absent           → hard-fail (no integrity check would remain)
     let archive_bytes = tokio::fs::read(target_dir.join("plugin.toml"))
         .await
         .unwrap_or_default();
     if std::env::var("LIBREFANG_ARCHIVE_VERIFY").as_deref() == Ok("0") {
         debug!("Archive signature verification disabled via LIBREFANG_ARCHIVE_VERIFY=0");
     } else {
-        use base64::Engine as _;
-        let pubkey = std::env::var("LIBREFANG_REGISTRY_PUBKEY")
-            .unwrap_or_else(|_| OFFICIAL_REGISTRY_PUBKEY_B64.to_string());
-        let key_bytes = base64::engine::general_purpose::STANDARD
-            .decode(pubkey.trim())
-            .unwrap_or_default();
-        let is_placeholder = key_bytes.iter().all(|&b| b == 0) || key_bytes.len() != 32;
-        if is_placeholder {
-            let _ = tokio::fs::remove_dir_all(&target_dir).await;
-            return Err(
-                "Plugin registry public key is not configured — refusing to install plugin \
-                 without signature verification. \
-                 Set LIBREFANG_REGISTRY_PUBKEY to the base64-encoded Ed25519 public key of \
-                 your registry, or set LIBREFANG_ARCHIVE_VERIFY=0 to disable verification \
-                 (development use only)."
-                    .to_string(),
-            );
-        }
-        if let Err(e) =
-            verify_archive_signature(&client, &listing_url, &archive_bytes, &pubkey).await
-        {
-            let _ = tokio::fs::remove_dir_all(&target_dir).await;
-            return Err(e);
+        match resolve_registry_pubkey(&client).await {
+            Ok(pubkey) => {
+                if let Err(e) =
+                    verify_archive_signature(&client, &listing_url, &archive_bytes, &pubkey).await
+                {
+                    let _ = tokio::fs::remove_dir_all(&target_dir).await;
+                    return Err(e);
+                }
+            }
+            Err(e) if checksum_verified => {
+                warn!(
+                    plugin = name,
+                    "Ed25519 verification skipped: {e}. SHA-256 already verified — install proceeds."
+                );
+            }
+            Err(e) => {
+                let _ = tokio::fs::remove_dir_all(&target_dir).await;
+                return Err(format!(
+                    "Cannot verify plugin '{name}' integrity: SHA-256 checksum was unavailable \
+                     AND Ed25519 pubkey could not be resolved. {e} \
+                     Refusing to install without any integrity check."
+                ));
+            }
         }
     }
 
@@ -4669,60 +4758,93 @@ description = "Spanish description"
         );
     }
 
-    // ── Bug #3799 — placeholder public key must be refused, not silently skipped ──
+    // ── #3805 — registry pubkey resolver (env > TOFU cache > worker fetch) ──
 
-    /// Decoding the built-in `OFFICIAL_REGISTRY_PUBKEY_B64` constant must
-    /// produce an all-zero 32-byte slice.  If someone replaces the placeholder
-    /// with a real key this test will fail, signalling that the is_placeholder
-    /// gate should also be re-evaluated.
+    /// Round-trip: a 32-byte non-zero key encodes/decodes through the
+    /// validator. This is the shape the resolver, the worker keygen script,
+    /// and ed25519_dalek all agree on.
     #[test]
-    fn official_registry_pubkey_is_placeholder_all_zeros() {
+    fn valid_registry_pubkey_b64_accepts_real_key() {
         use base64::Engine as _;
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(OFFICIAL_REGISTRY_PUBKEY_B64)
-            .expect("OFFICIAL_REGISTRY_PUBKEY_B64 must be valid base64");
-        assert_eq!(
-            bytes.len(),
-            32,
-            "placeholder key must decode to exactly 32 bytes"
-        );
-        assert!(
-            bytes.iter().all(|&b| b == 0),
-            "placeholder key must be all zeros"
-        );
-    }
-
-    /// The is_placeholder detection used in fetch_verified_index and
-    /// install_from_registry must flag the built-in constant as a placeholder.
-    #[test]
-    fn is_placeholder_detects_built_in_constant() {
-        use base64::Engine as _;
-        let key_bytes = base64::engine::general_purpose::STANDARD
-            .decode(OFFICIAL_REGISTRY_PUBKEY_B64)
-            .unwrap_or_default();
-        let is_placeholder = key_bytes.iter().all(|&b| b == 0) || key_bytes.len() != 32;
-        assert!(
-            is_placeholder,
-            "the built-in registry pubkey must be detected as a placeholder \
-             so installs fail loudly instead of silently skipping verification"
-        );
-    }
-
-    /// A non-zero 32-byte key must NOT be treated as a placeholder.
-    #[test]
-    fn is_placeholder_passes_real_key() {
-        use base64::Engine as _;
-        // Synthesise a fake non-zero key (not a real Ed25519 key — just for the
-        // placeholder-detection logic which only checks bytes, not curve validity).
         let real_key = [0xABu8; 32];
         let b64 = base64::engine::general_purpose::STANDARD.encode(real_key);
-        let key_bytes = base64::engine::general_purpose::STANDARD
-            .decode(b64.trim())
-            .unwrap_or_default();
-        let is_placeholder = key_bytes.iter().all(|&b| b == 0) || key_bytes.len() != 32;
         assert!(
-            !is_placeholder,
-            "a non-zero 32-byte key must not be treated as a placeholder"
+            is_valid_registry_pubkey_b64(&b64),
+            "non-zero 32-byte key must validate"
+        );
+    }
+
+    /// The validator must reject the historical all-zero placeholder, garbage
+    /// base64, and wrong-length keys — the three failure modes that fall back
+    /// to the next link of the resolver chain.
+    #[test]
+    fn valid_registry_pubkey_b64_rejects_invalid_inputs() {
+        use base64::Engine as _;
+
+        // All-zero 32-byte key (legacy placeholder) — rejected.
+        let zero = base64::engine::general_purpose::STANDARD.encode([0u8; 32]);
+        assert!(
+            !is_valid_registry_pubkey_b64(&zero),
+            "all-zero placeholder must be rejected"
+        );
+
+        // Wrong length (16 bytes) — rejected.
+        let short = base64::engine::general_purpose::STANDARD.encode([0xAAu8; 16]);
+        assert!(
+            !is_valid_registry_pubkey_b64(&short),
+            "16-byte key must be rejected"
+        );
+
+        // Wrong length (64 bytes) — rejected.
+        let long = base64::engine::general_purpose::STANDARD.encode([0xAAu8; 64]);
+        assert!(
+            !is_valid_registry_pubkey_b64(&long),
+            "64-byte key must be rejected"
+        );
+
+        // Non-base64 garbage — rejected.
+        assert!(
+            !is_valid_registry_pubkey_b64("not-base64!!!"),
+            "garbage input must be rejected"
+        );
+
+        // Empty input — rejected.
+        assert!(!is_valid_registry_pubkey_b64(""), "empty must be rejected");
+
+        // Whitespace tolerated around a valid key.
+        let real_key = [0xABu8; 32];
+        let b64_padded = format!(
+            "  {}  ",
+            base64::engine::general_purpose::STANDARD.encode(real_key),
+        );
+        assert!(
+            is_valid_registry_pubkey_b64(&b64_padded),
+            "validator must trim whitespace"
+        );
+    }
+
+    /// The TOFU cache path is derived from $HOME — verify the directory layout
+    /// matches the conventional `~/.librefang/` location used elsewhere in the
+    /// runtime (config, plugins, agents).
+    #[test]
+    fn registry_pubkey_cache_path_lives_under_dotlibrefang() {
+        // Save and restore HOME to avoid leaking into other tests.
+        let original = std::env::var("HOME").ok();
+        // SAFETY: tests in this module are single-threaded for env mutation.
+        unsafe {
+            std::env::set_var("HOME", "/tmp/librefang-test-home-pubkey");
+        }
+        let path = registry_pubkey_cache_path().expect("path resolution");
+        // SAFETY: restoring the prior value of HOME.
+        unsafe {
+            match original {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/tmp/librefang-test-home-pubkey/.librefang/registry.pub"),
         );
     }
 

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -29,6 +29,28 @@ use tracing::{debug, info, warn};
 /// See `docs/architecture/plugin-signing.md` for the full trust model.
 const OFFICIAL_PUBKEY_URL: &str = "https://librefang.ai/.well-known/registry-pubkey";
 
+/// `owner/repo` of the official LibreFang plugin registry on GitHub.
+///
+/// When `fetch_verified_index` is called with this exact value (the default),
+/// the daemon prefers the worker-signed `/api/registry/index.json` mirror at
+/// [`OFFICIAL_INDEX_URL`] / [`OFFICIAL_INDEX_SIG_URL`] over GitHub raw — the
+/// mirror serves a flat plugins array signed by the registry-worker on every
+/// cron tick, giving real Ed25519 verification end-to-end. Self-hosted forks
+/// (any other `owner/repo`) keep using the GitHub raw fallback unless the
+/// `LIBREFANG_REGISTRY_INDEX_URL` env override is set.
+const OFFICIAL_REGISTRY_REPO: &str = "librefang/librefang-registry";
+
+/// Daemon-shaped flat plugins index, signed and served by `registry-worker`.
+/// Format: `[{"name": "...", "version": "...", "description": "...",
+/// "needs": ["dep1", ...]}, ...]`. The signature at
+/// [`OFFICIAL_INDEX_SIG_URL`] covers these exact bytes.
+const OFFICIAL_INDEX_URL: &str = "https://stats.librefang.ai/api/registry/index.json";
+
+/// Base64-encoded Ed25519 signature over the bytes returned by
+/// [`OFFICIAL_INDEX_URL`].
+const OFFICIAL_INDEX_SIG_URL: &str =
+    "https://stats.librefang.ai/api/registry/index.json.sig";
+
 /// On-disk pin for the registry pubkey (TOFU cache).
 ///
 /// First successful fetch is written here; later calls read this file
@@ -289,6 +311,35 @@ fn save_registry_cache(path: &std::path::Path, bytes: &[u8]) {
     let _ = std::fs::write(path, bytes);
 }
 
+/// Pick the `(index_url, sig_url)` pair to fetch for `registry`, honoring
+/// `LIBREFANG_REGISTRY_INDEX_URL` / `LIBREFANG_REGISTRY_INDEX_SIG_URL`
+/// overrides. For the official registry the default is the worker-signed
+/// mirror at [`OFFICIAL_INDEX_URL`] / [`OFFICIAL_INDEX_SIG_URL`] (only path
+/// that yields a verifiable signature — the GitHub repo has no committed
+/// `index.json`). Self-hosted forks fall back to GitHub raw, which is
+/// unsigned by default; operators can opt back into signing by pointing the
+/// env vars at their own signed mirror.
+fn registry_index_urls(
+    registry: &str,
+    env_index: Option<String>,
+    env_sig: Option<String>,
+) -> (String, String) {
+    let default_index = if registry == OFFICIAL_REGISTRY_REPO {
+        OFFICIAL_INDEX_URL.to_string()
+    } else {
+        format!("https://raw.githubusercontent.com/{registry}/main/index.json")
+    };
+    let default_sig = if registry == OFFICIAL_REGISTRY_REPO {
+        OFFICIAL_INDEX_SIG_URL.to_string()
+    } else {
+        format!("https://raw.githubusercontent.com/{registry}/main/index.json.sig")
+    };
+    (
+        env_index.unwrap_or(default_index),
+        env_sig.unwrap_or(default_sig),
+    )
+}
+
 /// Fetch registry `index.json` and optionally verify its Ed25519 signature.
 ///
 /// Signature verification is skipped when:
@@ -319,8 +370,11 @@ pub async fn fetch_verified_index(
         }
     }
 
-    let index_url = format!("https://raw.githubusercontent.com/{registry}/main/index.json");
-    let sig_url = format!("https://raw.githubusercontent.com/{registry}/main/index.json.sig");
+    let (index_url, sig_url) = registry_index_urls(
+        registry,
+        std::env::var("LIBREFANG_REGISTRY_INDEX_URL").ok(),
+        std::env::var("LIBREFANG_REGISTRY_INDEX_SIG_URL").ok(),
+    );
 
     // Fetch index bytes.
     let index_resp = client
@@ -4846,6 +4900,54 @@ description = "Spanish description"
             path,
             std::path::PathBuf::from("/tmp/librefang-test-home-pubkey/.librefang/registry.pub"),
         );
+    }
+
+    /// Official registry defaults to the worker-signed mirror — the GitHub
+    /// repo has no committed `index.json`, so any other choice would lose
+    /// the only end-to-end Ed25519-verifiable path.
+    #[test]
+    fn registry_index_urls_official_defaults_to_worker_mirror() {
+        let (idx, sig) = registry_index_urls("librefang/librefang-registry", None, None);
+        assert_eq!(idx, "https://stats.librefang.ai/api/registry/index.json");
+        assert_eq!(sig, "https://stats.librefang.ai/api/registry/index.json.sig");
+    }
+
+    /// Self-hosted forks fall back to GitHub raw — keeps the existing path
+    /// for forks that don't yet run a signed mirror, while still allowing
+    /// them to opt in via the env vars.
+    #[test]
+    fn registry_index_urls_fork_falls_back_to_github_raw() {
+        let (idx, sig) = registry_index_urls("acme/private-registry", None, None);
+        assert_eq!(
+            idx,
+            "https://raw.githubusercontent.com/acme/private-registry/main/index.json"
+        );
+        assert_eq!(
+            sig,
+            "https://raw.githubusercontent.com/acme/private-registry/main/index.json.sig"
+        );
+    }
+
+    /// Env overrides win regardless of which registry is in use — operators
+    /// of air-gapped / on-prem deployments must be able to redirect both
+    /// the official and the fork path at their own infrastructure.
+    #[test]
+    fn registry_index_urls_env_overrides_win_for_both_paths() {
+        let (idx, sig) = registry_index_urls(
+            "librefang/librefang-registry",
+            Some("https://internal.example/index.json".into()),
+            Some("https://internal.example/index.json.sig".into()),
+        );
+        assert_eq!(idx, "https://internal.example/index.json");
+        assert_eq!(sig, "https://internal.example/index.json.sig");
+
+        let (idx, sig) = registry_index_urls(
+            "acme/private-registry",
+            Some("https://internal.example/index.json".into()),
+            Some("https://internal.example/index.json.sig".into()),
+        );
+        assert_eq!(idx, "https://internal.example/index.json");
+        assert_eq!(sig, "https://internal.example/index.json.sig");
     }
 
     // ── Bug #3804 — hook script integrity check logic ────────────────────────

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -15,33 +15,44 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
-/// Embedded raw 32-byte Ed25519 public key for the official LibreFang
-/// plugin registry, base64-encoded.
+/// Embedded raw 32-byte Ed25519 public keys for the official LibreFang
+/// plugin registry, base64-encoded. The first entry is the **current**
+/// production key; the slice may carry one or more **prior** keys during
+/// a rotation grace window so that daemons in the field don't hard-fail
+/// installs the moment ops rotates the worker side.
 ///
 /// This is the **primary trust root** for `librefang/librefang-registry`
 /// installs. The earlier TOFU-via-HTTP approach was vulnerable to a
 /// first-install MITM (cafe wifi, hostile DNS, subdomain takeover of the
 /// pubkey-serving host) silently pinning an attacker key forever — see PR
-/// review HIGH #5 / #16. By compiling the key into the daemon binary we
+/// review HIGH #5 / #16. By compiling the keys into the daemon binary we
 /// take HTTPS + the daemon release pipeline as the trust path instead.
 ///
-/// Must match `REGISTRY_PUBLIC_KEY` in:
+/// `EMBEDDED_REGISTRY_PUBKEYS[0]` (the first/active key) MUST match
+/// `REGISTRY_PUBLIC_KEY` in:
 ///   - `web/workers/registry-worker/wrangler.toml`
 ///   - `web/workers/marketplace-worker/wrangler.toml`
 ///   - `web/public/_worker.js`
 ///
-/// The `scripts/check-pubkey-lockstep.sh` CI guard fails if any drift.
+/// `scripts/check-pubkey-lockstep.sh` (CI guard) extracts and compares
+/// against the first entry only.
 ///
-/// Rotation is deliberately disruptive: a new daemon release ships with
-/// the new constant; in-flight installs against the old key fail closed.
-/// See `docs/architecture/plugin-signing.md` § "Rotation".
-const EMBEDDED_REGISTRY_PUBKEY: &str = "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=";
+/// Rotation procedure:
+///   1. Generate new keypair, publish private to registry CI.
+///   2. Land a daemon release that prepends the new key to this slice
+///      (old key remains in slot 1 as a fallback).
+///   3. Roll registry / worker side to the new key.
+///   4. After the deprecation window (4-6 weeks), drop the old key from
+///      this slice in a follow-up daemon release.
+const EMBEDDED_REGISTRY_PUBKEYS: &[&str] = &[
+    "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=",
+];
 
 /// Default URL for self-hosted registries that opt into HTTP pubkey
 /// resolution (operators of `acme/private-registry` style forks who don't
 /// want to rebuild the daemon to ship a key constant). Off the official
 /// trust path — never consulted for the official registry, which uses
-/// [`EMBEDDED_REGISTRY_PUBKEY`].
+/// [`EMBEDDED_REGISTRY_PUBKEYS`].
 ///
 /// Uses the `/api/registry/pubkey` form because the official custom
 /// domain routes only `/api/*` to the worker; the `.well-known/...`
@@ -156,7 +167,7 @@ fn write_pubkey_cache_safely(path: &std::path::Path, value: &str) -> std::io::Re
 /// Resolve the registry pubkey using the layered chain:
 ///   1. `LIBREFANG_REGISTRY_PUBKEY` env var override (always wins — covers
 ///      self-hosted forks and operator-driven rotation).
-///   2. [`EMBEDDED_REGISTRY_PUBKEY`] compiled-in constant (the **primary
+///   2. [`EMBEDDED_REGISTRY_PUBKEYS`] compiled-in constant (the **primary
 ///      trust root** for the official `librefang/librefang-registry`
 ///      registry — no network call, no MITM surface).
 ///   3. `~/.librefang/registry.pub` TOFU cache + HTTP fetch from
@@ -180,12 +191,19 @@ async fn resolve_registry_pubkey(client: &reqwest::Client) -> Result<String, Str
         }
     }
 
-    if is_valid_registry_pubkey_b64(EMBEDDED_REGISTRY_PUBKEY) {
-        return Ok(EMBEDDED_REGISTRY_PUBKEY.to_string());
+    // Active embedded key (slot 0) is the primary trust anchor for the
+    // official registry. The full slice — including any rotation-window
+    // keys — is consulted at verification time via `verify_registry_index`.
+    if let Some(active) = EMBEDDED_REGISTRY_PUBKEYS
+        .first()
+        .copied()
+        .filter(|k| is_valid_registry_pubkey_b64(k))
+    {
+        return Ok(active.to_string());
     }
-    // Embedded key being malformed is a build-time mistake; warn but keep
-    // trying so the daemon stays usable for self-hosted forks.
-    warn!("EMBEDDED_REGISTRY_PUBKEY is malformed — falling through to TOFU/HTTP");
+    // No valid embedded key is a build-time mistake; warn but keep trying
+    // so the daemon stays usable for self-hosted forks.
+    warn!("EMBEDDED_REGISTRY_PUBKEYS slot 0 is malformed — falling through to TOFU/HTTP");
 
     let cache_path = registry_pubkey_cache_path()?;
     if let Some(cached) = read_pubkey_cache_safely(&cache_path) {
@@ -285,6 +303,40 @@ fn verify_registry_index(
     verifying_key
         .verify(index_bytes, &signature)
         .map_err(|e| format!("Signature verification failed: {e}"))
+}
+
+/// Verify the index signature against `resolved_pubkey` first, then fall
+/// back to any prior keys in [`EMBEDDED_REGISTRY_PUBKEYS`]. This gives a
+/// rotation grace window: when ops rotates the worker-side key but a
+/// daemon in the field is still on the previous release, the daemon
+/// keeps verifying installs as long as the previous key is still in the
+/// embedded slice. PR re-review LOW.
+fn verify_registry_index_multi(
+    index_bytes: &[u8],
+    sig_b64: &str,
+    resolved_pubkey: &str,
+) -> Result<(), String> {
+    let mut last_err = match verify_registry_index(index_bytes, sig_b64, resolved_pubkey) {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    for &candidate in EMBEDDED_REGISTRY_PUBKEYS {
+        if candidate == resolved_pubkey {
+            continue; // already tried
+        }
+        match verify_registry_index(index_bytes, sig_b64, candidate) {
+            Ok(()) => {
+                warn!(
+                    "Registry index verified against a prior embedded pubkey \
+                     (rotation grace window). Update the daemon binary to \
+                     drop the prior key once the rollout is complete."
+                );
+                return Ok(());
+            }
+            Err(e) => last_err = e,
+        }
+    }
+    Err(last_err)
 }
 
 // `verify_archive_signature` was removed in PR #4600 — it always fetched
@@ -443,44 +495,41 @@ pub async fn fetch_verified_index(
             )
         })?;
 
-        // For the official registry, a missing or unreachable .sig is a
-        // hard fail — we already enforce pubkey resolution above, so an
-        // attacker who can serve a doctored index.json and just delete the
-        // .sig (or return 404) must not be able to slip past with an
-        // unsigned payload (PR review HIGH #6). For self-hosted forks the
-        // soft path stays — they may not have signing infrastructure yet.
-        let require_sig = registry == OFFICIAL_REGISTRY_REPO;
+        // Hard-fail on missing or unreachable .sig — for ALL registries,
+        // not just the official one. The previous "soft for forks" path
+        // was bypassable: an attacker who could change the registry slug
+        // to anything other than "librefang/librefang-registry" flipped
+        // off the require_sig flag and then served an unsigned index that
+        // EMBEDDED pubkey couldn't verify but the warning path silently
+        // accepted. Closes PR re-review HIGH-NEW-B.
+        //
+        // Self-hosted forks that haven't deployed signing infrastructure
+        // yet must explicitly opt out via LIBREFANG_REGISTRY_VERIFY=0
+        // (gated above) — there is no implicit-by-slug downgrade path.
         match client.get(&sig_url).send().await {
             Ok(sig_resp) if sig_resp.status().is_success() => {
                 let sig_text = sig_resp
                     .text()
                     .await
                     .map_err(|e| format!("Failed to read signature: {e}"))?;
-                verify_registry_index(&index_bytes, sig_text.trim(), &pubkey)?;
+                verify_registry_index_multi(&index_bytes, sig_text.trim(), &pubkey)?;
                 info!(registry, "Registry index signature verified OK");
             }
-            Ok(sig_resp) if require_sig => {
+            Ok(sig_resp) => {
                 return Err(format!(
-                    "Registry index signature unavailable for official mirror \
-                     (HTTP {} from {sig_url}) — refusing to trust unsigned index. \
-                     If this is a self-hosted fork, point LIBREFANG_REGISTRY_INDEX_URL \
-                     at it so the official-mirror enforcement does not apply.",
+                    "Registry index signature unavailable (HTTP {} from {sig_url}) \
+                     — refusing to trust unsigned index. Set \
+                     LIBREFANG_REGISTRY_VERIFY=0 only if you are testing against an \
+                     unsigned development mirror.",
                     sig_resp.status()
                 ));
             }
-            Err(e) if require_sig => {
+            Err(e) => {
                 return Err(format!(
-                    "Registry index signature fetch failed for official mirror \
-                     ({sig_url}): {e}. Refusing to trust unsigned index — a network \
-                     downgrade attack must not silently bypass verification."
+                    "Registry index signature fetch failed ({sig_url}): {e}. \
+                     Refusing to trust unsigned index — a network downgrade \
+                     attack must not silently bypass verification."
                 ));
-            }
-            _ => {
-                warn!(
-                    registry,
-                    "No index.json.sig found — registry index not signature-verified \
-                     (self-hosted registry; official mirror would hard-fail here)"
-                );
             }
         }
     }
@@ -1076,39 +1125,29 @@ async fn install_from_registry(
         return Err(format!("Failed to download plugin '{name}': {e}"));
     }
 
-    // Verify checksum if available (non-fatal warning if no checksum file exists).
-    // checksum_verified gates the Ed25519 fallback below: when SHA-256 has
-    // confirmed the manifest, an unavailable Ed25519 pubkey downgrades to a
-    // warning instead of a hard failure (defense in depth, not single point).
-    let checksum_verified = match fetch_checksum(&client, &listing_url, name).await {
-        Some(expected) => {
-            // For registry plugins installed file-by-file, compute checksum over
-            // the serialised manifest as a representative integrity check.
-            let manifest_bytes = tokio::fs::read(target_dir.join("plugin.toml"))
-                .await
-                .unwrap_or_default();
-            if let Err(e) = verify_checksum(&manifest_bytes, &expected) {
-                let _ = tokio::fs::remove_dir_all(&target_dir).await;
-                return Err(e);
-            }
-            info!(plugin = name, "Checksum verified OK");
-            true
+    // Verify checksum if a checksum file exists. This catches in-flight
+    // tampering of the manifest bytes between GitHub and the daemon, but
+    // does NOT serve as a fallback for the index-membership check below
+    // (PR re-review HIGH-NEW-C): the .sha256 file lives on the same
+    // GitHub repo as the plugin, so an attacker who controls the listing
+    // can forge a matching checksum trivially.
+    if let Some(expected) = fetch_checksum(&client, &listing_url, name).await {
+        let manifest_bytes = tokio::fs::read(target_dir.join("plugin.toml"))
+            .await
+            .unwrap_or_default();
+        if let Err(e) = verify_checksum(&manifest_bytes, &expected) {
+            let _ = tokio::fs::remove_dir_all(&target_dir).await;
+            return Err(e);
         }
-        None => {
-            warn!(
-                plugin = name,
-                "No checksum file found for this plugin release. \
-                 Install proceeds without SHA-256 verification — \
-                 Ed25519 signature will be REQUIRED."
-            );
-            false
-        }
-    };
+        info!(plugin = name, "Checksum verified OK");
+    } else {
+        debug!(
+            plugin = name,
+            "No checksum file alongside this plugin release — relying on \
+             signed index membership instead."
+        );
+    }
 
-    // Verify Ed25519 archive signature. The pubkey resolver tries env override,
-    // TOFU cache, then a worker fetch. When all paths fail:
-    //   * SHA-256 already verified → warn and proceed (we still have integrity)
-    //   * SHA-256 absent           → hard-fail (no integrity check would remain)
     // Per-plugin Ed25519 archive signatures are NOT served by the official
     // registry — the older code that fetched `{listing_url}.sig` was always
     // a 404 (PR review CRITICAL #3) and silently passed every install.
@@ -1117,41 +1156,62 @@ async fn install_from_registry(
     // `<name>` cannot also forge an entry for `<name>` in the worker's
     // Ed25519-signed flat index (the worker won't sign content it didn't
     // pull from the registry repo's committed `plugins-index.json`).
+    // Note that `checksum_verified` is now NOT a fallback for index-fetch
+    // failure (PR re-review HIGH-NEW-C). The SHA-256 checksum file lives
+    // on the same attacker-controlled GitHub repo as the plugin itself,
+    // so an attacker who can serve a doctored manifest with a matching
+    // checksum AND DoS stats.librefang.ai gets a free pass on the older
+    // logic. Refuse to install on any index-fetch failure: a real
+    // operational network issue should stop installs (which fail safe),
+    // not silently downgrade to a weaker integrity check.
     if std::env::var("LIBREFANG_ARCHIVE_VERIFY").as_deref() == Ok("0") {
         debug!("Index-membership verification disabled via LIBREFANG_ARCHIVE_VERIFY=0");
     } else {
-        match fetch_verified_index(&client, github_repo).await {
-            Ok(index_entries) => {
-                let in_index = index_entries.iter().any(|e| {
-                    e.get("name").and_then(|v| v.as_str()) == Some(name)
-                });
-                if !in_index {
-                    let _ = tokio::fs::remove_dir_all(&target_dir).await;
-                    return Err(format!(
-                        "Plugin '{name}' is not present in the signed registry index. \
-                         Refusing to install — the GitHub Contents listing alone is \
-                         not a sufficient trust root. If this is a brand-new plugin, \
-                         wait for the registry's CI to regenerate plugins-index.json \
-                         and re-sign before installing."
-                    ));
+        // Single retry with backoff catches transient network blips
+        // without papering over a sustained outage / active downgrade.
+        let mut last_err: Option<String> = None;
+        let mut entries: Option<Vec<serde_json::Value>> = None;
+        for attempt in 0..2 {
+            match fetch_verified_index(&client, github_repo).await {
+                Ok(es) => {
+                    entries = Some(es);
+                    break;
                 }
-                info!(plugin = name, "Plugin presence in signed index confirmed");
-            }
-            Err(e) if checksum_verified => {
-                warn!(
-                    plugin = name,
-                    "Index-membership check skipped: {e}. SHA-256 already verified — install proceeds."
-                );
-            }
-            Err(e) => {
-                let _ = tokio::fs::remove_dir_all(&target_dir).await;
-                return Err(format!(
-                    "Cannot verify plugin '{name}' integrity: SHA-256 checksum was unavailable \
-                     AND signed registry index could not be fetched. {e} \
-                     Refusing to install without any integrity check."
-                ));
+                Err(e) => {
+                    last_err = Some(e);
+                    if attempt == 0 {
+                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    }
+                }
             }
         }
+
+        let Some(index_entries) = entries else {
+            let _ = tokio::fs::remove_dir_all(&target_dir).await;
+            return Err(format!(
+                "Cannot verify plugin '{name}' integrity: signed registry index \
+                 fetch failed after retry. {} Refusing to install — install must \
+                 fail safe when the trust root is unreachable, regardless of any \
+                 SHA-256 checksum on the GitHub repo (which an attacker who can \
+                 serve a doctored manifest can also forge).",
+                last_err.unwrap_or_default()
+            ));
+        };
+
+        let in_index = index_entries.iter().any(|e| {
+            e.get("name").and_then(|v| v.as_str()) == Some(name)
+        });
+        if !in_index {
+            let _ = tokio::fs::remove_dir_all(&target_dir).await;
+            return Err(format!(
+                "Plugin '{name}' is not present in the signed registry index. \
+                 Refusing to install — the GitHub Contents listing alone is not \
+                 a sufficient trust root. If this is a brand-new plugin, wait \
+                 for the registry's CI to regenerate plugins-index.json and \
+                 re-sign before installing."
+            ));
+        }
+        info!(plugin = name, "Plugin presence in signed index confirmed");
     }
 
     // Bug #3804 — verify hook script integrity after install.

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -15,37 +15,53 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
+/// One embedded pubkey + its expiry (Unix seconds). Slot-0 (active) uses
+/// `expires_at == None`; rotation-window slots MUST set an expiry, or
+/// daemons in the field would accept the prior key indefinitely — and a
+/// post-rotation leak of that prior private key would still be exploitable
+/// against every still-running daemon binary that carries it. PR re-review
+/// MEDIUM (round 3).
+struct EmbeddedPubkey {
+    b64: &'static str,
+    /// `None` = active key, no expiry. `Some(t)` = prior key, valid only
+    /// while `now() < t`.
+    expires_at: Option<i64>,
+}
+
 /// Embedded raw 32-byte Ed25519 public keys for the official LibreFang
-/// plugin registry, base64-encoded. The first entry is the **current**
-/// production key; the slice may carry one or more **prior** keys during
-/// a rotation grace window so that daemons in the field don't hard-fail
-/// installs the moment ops rotates the worker side.
+/// plugin registry. Slot 0 is the **current** production key (no expiry).
+/// Subsequent slots carry **prior** keys during a rotation window, each
+/// with a hard expiry timestamp.
 ///
-/// This is the **primary trust root** for `librefang/librefang-registry`
-/// installs. The earlier TOFU-via-HTTP approach was vulnerable to a
-/// first-install MITM (cafe wifi, hostile DNS, subdomain takeover of the
-/// pubkey-serving host) silently pinning an attacker key forever — see PR
-/// review HIGH #5 / #16. By compiling the keys into the daemon binary we
-/// take HTTPS + the daemon release pipeline as the trust path instead.
+/// Primary trust root for `librefang/librefang-registry` installs — the
+/// earlier TOFU-via-HTTP approach was MITM-vulnerable on first install
+/// (cafe wifi, hostile DNS, subdomain takeover) and silently pinned the
+/// attacker key forever (PR review HIGH #5/#16). Compiling the key in
+/// moves the trust path to HTTPS + the daemon release pipeline.
 ///
-/// `EMBEDDED_REGISTRY_PUBKEYS[0]` (the first/active key) MUST match
-/// `REGISTRY_PUBLIC_KEY` in:
+/// `EMBEDDED_REGISTRY_PUBKEYS[0].b64` MUST match `REGISTRY_PUBLIC_KEY` in:
 ///   - `web/workers/registry-worker/wrangler.toml`
 ///   - `web/workers/marketplace-worker/wrangler.toml`
 ///   - `web/public/_worker.js`
 ///
 /// `scripts/check-pubkey-lockstep.sh` (CI guard) extracts and compares
-/// against the first entry only.
+/// against slot 0 only.
 ///
 /// Rotation procedure:
 ///   1. Generate new keypair, publish private to registry CI.
-///   2. Land a daemon release that prepends the new key to this slice
-///      (old key remains in slot 1 as a fallback).
+///   2. Land a daemon release that prepends the new key to slot 0 AND
+///      moves the old slot-0 entry to slot 1 with `expires_at: Some(t)`
+///      where `t` ≈ now + 4 weeks.
 ///   3. Roll registry / worker side to the new key.
-///   4. After the deprecation window (4-6 weeks), drop the old key from
-///      this slice in a follow-up daemon release.
-const EMBEDDED_REGISTRY_PUBKEYS: &[&str] = &[
-    "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=",
+///   4. After the deprecation window passes, drop the prior entry in a
+///      follow-up daemon release. Daemons that didn't update by then will
+///      hard-fail installs (the failure surfaces an actionable error
+///      message, unlike the previous "accept forever" behaviour).
+const EMBEDDED_REGISTRY_PUBKEYS: &[EmbeddedPubkey] = &[
+    EmbeddedPubkey {
+        b64: "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=",
+        expires_at: None,
+    },
 ];
 
 /// Default URL for self-hosted registries that opt into HTTP pubkey
@@ -193,15 +209,15 @@ async fn resolve_registry_pubkey(client: &reqwest::Client) -> Result<String, Str
 
     // Active embedded key (slot 0) is the primary trust anchor for the
     // official registry. The full slice — including any rotation-window
-    // keys — is consulted at verification time via `verify_registry_index`.
+    // keys — is consulted at verification time via
+    // `verify_registry_index_multi`, which also enforces per-key expiry.
     if let Some(active) = EMBEDDED_REGISTRY_PUBKEYS
         .first()
-        .copied()
-        .filter(|k| is_valid_registry_pubkey_b64(k))
+        .filter(|k| is_valid_registry_pubkey_b64(k.b64))
     {
-        return Ok(active.to_string());
+        return Ok(active.b64.to_string());
     }
-    // No valid embedded key is a build-time mistake; warn but keep trying
+    // Invalid slot-0 key is a build-time mistake; warn but keep trying
     // so the daemon stays usable for self-hosted forks.
     warn!("EMBEDDED_REGISTRY_PUBKEYS slot 0 is malformed — falling through to TOFU/HTTP");
 
@@ -306,11 +322,15 @@ fn verify_registry_index(
 }
 
 /// Verify the index signature against `resolved_pubkey` first, then fall
-/// back to any prior keys in [`EMBEDDED_REGISTRY_PUBKEYS`]. This gives a
-/// rotation grace window: when ops rotates the worker-side key but a
-/// daemon in the field is still on the previous release, the daemon
-/// keeps verifying installs as long as the previous key is still in the
-/// embedded slice. PR re-review LOW.
+/// back to any **non-expired** prior keys in [`EMBEDDED_REGISTRY_PUBKEYS`].
+/// Expired keys are skipped — closes round-3 MEDIUM (a leaked prior key
+/// must not stay accepted forever).
+///
+/// Provides a bounded rotation grace window: when ops rotates the
+/// worker-side key but a daemon in the field is still on the previous
+/// release, the daemon keeps verifying installs against the prior key
+/// until its `expires_at` passes, after which installs hard-fail with an
+/// actionable error.
 fn verify_registry_index_multi(
     index_bytes: &[u8],
     sig_b64: &str,
@@ -320,16 +340,30 @@ fn verify_registry_index_multi(
         Ok(()) => return Ok(()),
         Err(e) => e,
     };
-    for &candidate in EMBEDDED_REGISTRY_PUBKEYS {
-        if candidate == resolved_pubkey {
-            continue; // already tried
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    for embedded in EMBEDDED_REGISTRY_PUBKEYS {
+        if embedded.b64 == resolved_pubkey {
+            continue; // already tried as the resolved key
         }
-        match verify_registry_index(index_bytes, sig_b64, candidate) {
+        if let Some(exp) = embedded.expires_at {
+            if now >= exp {
+                debug!(
+                    "Skipping embedded pubkey: expired at {} (now {})",
+                    exp, now
+                );
+                continue;
+            }
+        }
+        match verify_registry_index(index_bytes, sig_b64, embedded.b64) {
             Ok(()) => {
                 warn!(
                     "Registry index verified against a prior embedded pubkey \
-                     (rotation grace window). Update the daemon binary to \
-                     drop the prior key once the rollout is complete."
+                     (rotation grace window). Daemon binary still carries the \
+                     prior key — update to a newer release before its expiry \
+                     to keep installs working."
                 );
                 return Ok(());
             }

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -22,7 +22,11 @@ use tracing::{debug, info, warn};
 /// against every still-running daemon binary that carries it. PR re-review
 /// MEDIUM (round 3).
 struct EmbeddedPubkey {
-    b64: &'static str,
+    /// Base64-encoded raw 32-byte Ed25519 public key. Field name is
+    /// `pubkey_b64` (not `b64`) so the lockstep CI script's regex picks
+    /// up *this* field unambiguously and not some unrelated future
+    /// `b64: "..."` literal that drifts in (PR re-review LOW round 4).
+    pubkey_b64: &'static str,
     /// `None` = active key, no expiry. `Some(t)` = prior key, valid only
     /// while `now() < t`.
     expires_at: Option<i64>,
@@ -39,7 +43,7 @@ struct EmbeddedPubkey {
 /// attacker key forever (PR review HIGH #5/#16). Compiling the key in
 /// moves the trust path to HTTPS + the daemon release pipeline.
 ///
-/// `EMBEDDED_REGISTRY_PUBKEYS[0].b64` MUST match `REGISTRY_PUBLIC_KEY` in:
+/// `EMBEDDED_REGISTRY_PUBKEYS[0].pubkey_b64` MUST match `REGISTRY_PUBLIC_KEY` in:
 ///   - `web/workers/registry-worker/wrangler.toml`
 ///   - `web/workers/marketplace-worker/wrangler.toml`
 ///   - `web/public/_worker.js`
@@ -59,7 +63,7 @@ struct EmbeddedPubkey {
 ///      message, unlike the previous "accept forever" behaviour).
 const EMBEDDED_REGISTRY_PUBKEYS: &[EmbeddedPubkey] = &[
     EmbeddedPubkey {
-        b64: "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=",
+        pubkey_b64: "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=",
         expires_at: None,
     },
 ];
@@ -211,11 +215,25 @@ async fn resolve_registry_pubkey(client: &reqwest::Client) -> Result<String, Str
     // official registry. The full slice — including any rotation-window
     // keys — is consulted at verification time via
     // `verify_registry_index_multi`, which also enforces per-key expiry.
+    // Defense-in-depth invariant: slot 0 (the active key) MUST NOT have
+    // an expiry — that's what "active" means. A maintainer who absent-
+    // mindedly sets `expires_at: Some(_)` on slot 0 during a rotation
+    // edit would silently break installs the moment the timestamp passed
+    // (PR re-review LOW round 4). Catch it in debug builds before
+    // shipping; the tests/ block also asserts this at compile + test time.
+    debug_assert!(
+        EMBEDDED_REGISTRY_PUBKEYS
+            .first()
+            .map(|k| k.expires_at.is_none())
+            .unwrap_or(true),
+        "EMBEDDED_REGISTRY_PUBKEYS[0] must have expires_at: None (active key)"
+    );
+
     if let Some(active) = EMBEDDED_REGISTRY_PUBKEYS
         .first()
-        .filter(|k| is_valid_registry_pubkey_b64(k.b64))
+        .filter(|k| is_valid_registry_pubkey_b64(k.pubkey_b64))
     {
-        return Ok(active.b64.to_string());
+        return Ok(active.pubkey_b64.to_string());
     }
     // Invalid slot-0 key is a build-time mistake; warn but keep trying
     // so the daemon stays usable for self-hosted forks.
@@ -344,8 +362,14 @@ fn verify_registry_index_multi(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
+    // Trim once for the dedup compare. All current call sites pass a
+    // pre-trimmed key, but a future code path that forgets would
+    // otherwise verify the resolved key twice (wasted CPU, not unsafe).
+    // PR re-review MEDIUM round 4.
+    let resolved_trimmed = resolved_pubkey.trim();
+    let mut expired_count = 0usize;
     for embedded in EMBEDDED_REGISTRY_PUBKEYS {
-        if embedded.b64 == resolved_pubkey {
+        if embedded.pubkey_b64 == resolved_trimmed {
             continue; // already tried as the resolved key
         }
         if let Some(exp) = embedded.expires_at {
@@ -354,10 +378,11 @@ fn verify_registry_index_multi(
                     "Skipping embedded pubkey: expired at {} (now {})",
                     exp, now
                 );
+                expired_count += 1;
                 continue;
             }
         }
-        match verify_registry_index(index_bytes, sig_b64, embedded.b64) {
+        match verify_registry_index(index_bytes, sig_b64, embedded.pubkey_b64) {
             Ok(()) => {
                 warn!(
                     "Registry index verified against a prior embedded pubkey \
@@ -369,6 +394,17 @@ fn verify_registry_index_multi(
             }
             Err(e) => last_err = e,
         }
+    }
+    // PR re-review MEDIUM round 4: when slot-0 verification fails AND
+    // every prior key in the slice has aged out, surface "your daemon
+    // binary is past its rotation window — upgrade" so the user has an
+    // actionable next step instead of a bare verify-failed message.
+    if expired_count > 0 {
+        last_err = format!(
+            "{last_err} ({expired_count} prior embedded pubkey(s) past expiry — \
+             this daemon binary is past its rotation window; upgrade librefang \
+             to restore plugin installs)"
+        );
     }
     Err(last_err)
 }
@@ -5060,6 +5096,27 @@ description = "Spanish description"
         assert_eq!(
             path,
             std::path::PathBuf::from("/tmp/librefang-test-home-pubkey/.librefang/registry.pub"),
+        );
+    }
+
+    /// Slot 0 of the embedded keys MUST be the active key — no expiry.
+    /// A maintainer who absent-mindedly sets `expires_at: Some(...)` on
+    /// slot 0 during a rotation edit would silently break installs the
+    /// moment that timestamp passed (PR re-review LOW round 4). Compile-
+    /// time + test-time guard so the regression is caught before ship.
+    #[test]
+    fn embedded_pubkeys_slot0_has_no_expiry() {
+        let slot0 = EMBEDDED_REGISTRY_PUBKEYS
+            .first()
+            .expect("EMBEDDED_REGISTRY_PUBKEYS must have at least one entry");
+        assert!(
+            slot0.expires_at.is_none(),
+            "EMBEDDED_REGISTRY_PUBKEYS[0] must have expires_at: None — slot 0 \
+             is the active key and must not be marked for rotation"
+        );
+        assert!(
+            is_valid_registry_pubkey_b64(slot0.pubkey_b64),
+            "EMBEDDED_REGISTRY_PUBKEYS[0].pubkey_b64 is not a valid 32-byte Ed25519 key"
         );
     }
 

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -35,14 +35,18 @@ use tracing::{debug, info, warn};
 /// Rotation is deliberately disruptive: a new daemon release ships with
 /// the new constant; in-flight installs against the old key fail closed.
 /// See `docs/architecture/plugin-signing.md` § "Rotation".
-const EMBEDDED_REGISTRY_PUBKEY: &str = "NEoveGRjRazzoiRFqozw0VEtF9N9elfwIAOqKzt4Ue4=";
+const EMBEDDED_REGISTRY_PUBKEY: &str = "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=";
 
 /// Default URL for self-hosted registries that opt into HTTP pubkey
 /// resolution (operators of `acme/private-registry` style forks who don't
 /// want to rebuild the daemon to ship a key constant). Off the official
 /// trust path — never consulted for the official registry, which uses
 /// [`EMBEDDED_REGISTRY_PUBKEY`].
-const OFFICIAL_PUBKEY_URL: &str = "https://stats.librefang.ai/.well-known/registry-pubkey";
+///
+/// Uses the `/api/registry/pubkey` form because the official custom
+/// domain routes only `/api/*` to the worker; the `.well-known/...`
+/// alias only resolves on the workers.dev hostname.
+const OFFICIAL_PUBKEY_URL: &str = "https://stats.librefang.ai/api/registry/pubkey";
 
 /// `owner/repo` of the official LibreFang plugin registry on GitHub.
 ///

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -61,12 +61,10 @@ struct EmbeddedPubkey {
 ///      follow-up daemon release. Daemons that didn't update by then will
 ///      hard-fail installs (the failure surfaces an actionable error
 ///      message, unlike the previous "accept forever" behaviour).
-const EMBEDDED_REGISTRY_PUBKEYS: &[EmbeddedPubkey] = &[
-    EmbeddedPubkey {
-        pubkey_b64: "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=",
-        expires_at: None,
-    },
-];
+const EMBEDDED_REGISTRY_PUBKEYS: &[EmbeddedPubkey] = &[EmbeddedPubkey {
+    pubkey_b64: "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=",
+    expires_at: None,
+}];
 
 /// Default URL for self-hosted registries that opt into HTTP pubkey
 /// resolution (operators of `acme/private-registry` style forks who don't
@@ -98,8 +96,7 @@ const OFFICIAL_INDEX_URL: &str = "https://stats.librefang.ai/api/registry/index.
 
 /// Base64-encoded Ed25519 signature over the bytes returned by
 /// [`OFFICIAL_INDEX_URL`].
-const OFFICIAL_INDEX_SIG_URL: &str =
-    "https://stats.librefang.ai/api/registry/index.json.sig";
+const OFFICIAL_INDEX_SIG_URL: &str = "https://stats.librefang.ai/api/registry/index.json.sig";
 
 /// On-disk pin for the registry pubkey (TOFU cache).
 ///
@@ -139,7 +136,10 @@ fn read_pubkey_cache_safely(path: &std::path::Path) -> Option<String> {
         let mut f = opts.open(path).ok()?;
         let meta = f.metadata().ok()?;
         if !meta.is_file() {
-            warn!("Pubkey cache {} is not a regular file — ignoring", path.display());
+            warn!(
+                "Pubkey cache {} is not a regular file — ignoring",
+                path.display()
+            );
             return None;
         }
         use std::io::Read as _;
@@ -154,7 +154,10 @@ fn read_pubkey_cache_safely(path: &std::path::Path) -> Option<String> {
         // NTFS ACLs for the rest.
         let meta = std::fs::metadata(path).ok()?;
         if !meta.is_file() {
-            warn!("Pubkey cache {} is not a regular file — ignoring", path.display());
+            warn!(
+                "Pubkey cache {} is not a regular file — ignoring",
+                path.display()
+            );
             return None;
         }
         std::fs::read_to_string(path).ok()
@@ -166,8 +169,8 @@ fn read_pubkey_cache_safely(path: &std::path::Path) -> Option<String> {
 fn write_pubkey_cache_safely(path: &std::path::Path, value: &str) -> std::io::Result<()> {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::OpenOptionsExt;
         use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt;
         let mut f = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
@@ -243,7 +246,10 @@ async fn resolve_registry_pubkey(client: &reqwest::Client) -> Result<String, Str
     if let Some(cached) = read_pubkey_cache_safely(&cache_path) {
         let trimmed = cached.trim().to_string();
         if is_valid_registry_pubkey_b64(&trimmed) {
-            debug!("Using TOFU-pinned registry pubkey from {}", cache_path.display());
+            debug!(
+                "Using TOFU-pinned registry pubkey from {}",
+                cache_path.display()
+            );
             return Ok(trimmed);
         }
         warn!(
@@ -374,10 +380,7 @@ fn verify_registry_index_multi(
         }
         if let Some(exp) = embedded.expires_at {
             if now >= exp {
-                debug!(
-                    "Skipping embedded pubkey: expired at {} (now {})",
-                    exp, now
-                );
+                debug!("Skipping embedded pubkey: expired at {} (now {})", exp, now);
                 expired_count += 1;
                 continue;
             }
@@ -1268,9 +1271,9 @@ async fn install_from_registry(
             ));
         };
 
-        let in_index = index_entries.iter().any(|e| {
-            e.get("name").and_then(|v| v.as_str()) == Some(name)
-        });
+        let in_index = index_entries
+            .iter()
+            .any(|e| e.get("name").and_then(|v| v.as_str()) == Some(name));
         if !in_index {
             let _ = tokio::fs::remove_dir_all(&target_dir).await;
             return Err(format!(
@@ -5127,7 +5130,10 @@ description = "Spanish description"
     fn registry_index_urls_official_defaults_to_worker_mirror() {
         let (idx, sig) = registry_index_urls("librefang/librefang-registry", None, None);
         assert_eq!(idx, "https://stats.librefang.ai/api/registry/index.json");
-        assert_eq!(sig, "https://stats.librefang.ai/api/registry/index.json.sig");
+        assert_eq!(
+            sig,
+            "https://stats.librefang.ai/api/registry/index.json.sig"
+        );
     }
 
     /// Self-hosted forks fall back to GitHub raw — keeps the existing path

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2788,6 +2788,7 @@ pub struct KernelConfig {
     /// Applied against the effective limit:
     ///   1. `cron_session_max_tokens` if set, else
     ///   2. [`Self::cron_session_warn_total_tokens`] as a fallback ceiling.
+    ///
     /// Skipped entirely when both are `None`, or when this value is
     /// `None` / `<= 0.0` / `> 1.0`.
     ///

--- a/docs/architecture/plugin-signing.md
+++ b/docs/architecture/plugin-signing.md
@@ -1,0 +1,147 @@
+# Plugin signing — trust model
+
+LibreFang plugins are third-party code that runs inside the daemon process.
+Anything an attacker can drop into `~/.librefang/plugins/` is one
+`PluginManifest`-scoped RCE away from the user. The signing pipeline is the
+defense-in-depth layer that protects the **distribution channel** —
+download-time tampering, compromised registry frontends, MITM on the install
+path.
+
+For the operator-side runbook (keygen, deploy, rotation), see
+`web/workers/SIGNING.md`.
+
+## Layered defenses
+
+The install path validates plugins through three independent gates, in
+order. Stronger checks short-circuit weaker ones; weaker checks **never**
+short-circuit stronger ones, but a stronger check failing does not mean a
+weaker check is sufficient — both must pass when both apply.
+
+```
+              install_from_registry
+                       │
+                       ▼
+       ┌──────────────────────────────────┐
+       │ 1. Transport (HTTPS + GitHub raw │   trust anchor: TLS PKI +
+       │    or Cloudflare Worker URL)     │   GitHub repo permissions
+       └──────────────────────────────────┘
+                       │
+                       ▼
+       ┌──────────────────────────────────┐
+       │ 2. SHA-256 checksum (optional;   │   trust anchor: registry
+       │    `<archive>.sha256` or         │   provides a value the
+       │    `checksums.txt`)              │   downloaded bytes must hash to
+       └──────────────────────────────────┘
+                       │
+                       ▼
+       ┌──────────────────────────────────┐
+       │ 3. Ed25519 archive signature     │   trust anchor: registry holds
+       │    (`<archive>.sig`)             │   a private key whose public
+       │    verified with resolver pubkey │   half is pinned by the daemon
+       └──────────────────────────────────┘
+```
+
+### When does a missing layer hard-fail?
+
+| SHA-256 | Ed25519 | Outcome |
+|---|---|---|
+| ✓ verified | ✓ verified | install — both layers passed |
+| ✓ verified | ✗ pubkey unavailable | **install with warning** — SHA-256 is enough integrity to proceed |
+| ✓ verified | ✗ signature mismatch | **hard-fail** — active tampering signal |
+| ✗ absent | ✓ verified | install — Ed25519 covers the bytes |
+| ✗ absent | ✗ pubkey unavailable | **hard-fail** — no integrity check would remain |
+
+This matches the [#3805] design: previously, the all-zero placeholder pubkey
+caused a hard-fail at every install attempt, even when SHA-256 was already
+verified. With no real pubkey deployed yet, that meant zero plugins could
+install through the registry path. The resolver below restores fail-closed
+behavior **only** when no integrity check at all is possible.
+
+## The pubkey resolver chain
+
+`resolve_registry_pubkey()` walks three sources in order. The first valid
+key wins; subsequent calls in the same process re-walk the chain, so an
+operator can override mid-session via env vars without restarting the
+daemon.
+
+### 1. `LIBREFANG_REGISTRY_PUBKEY` env var
+
+Highest priority. Useful for self-hosted registries, CI smoke tests, and
+operators who want the key embedded in their config-management layer
+rather than fetched at runtime. Must be a base64-encoded raw 32-byte
+Ed25519 public key — the same shape `ed25519_dalek::VerifyingKey::from_bytes`
+consumes.
+
+### 2. TOFU-pinned cache (`~/.librefang/registry.pub`)
+
+Trust on first use. The first successful network fetch (step 3) writes the
+key here; every later install reads from this file directly and skips the
+network call. Rotation is explicit: delete the file and the next install
+refreshes it.
+
+The cache is plain text (base64 of 32 raw bytes, plus optional trailing
+newline). It is not signed by any higher authority — this matches how SSH
+known_hosts works. The protections are:
+
+- The file is in `$HOME` (user-owned), not world-writable.
+- A mismatch between cached and freshly-fetched key surfaces during
+  rotation, since rotation requires deleting the cache.
+- An attacker who can write to `$HOME` can already run code as the user;
+  poisoning this file is downstream of that more fundamental compromise.
+
+### 3. HTTP fetch (default `https://librefang.ai/.well-known/registry-pubkey`)
+
+Backed by the `registry-worker` Cloudflare Worker
+(`web/workers/registry-worker/index.js`), which serves the value of its
+`REGISTRY_PUBLIC_KEY` env var. The default URL is overridable via
+`LIBREFANG_REGISTRY_PUBKEY_URL` for self-hosted registries.
+
+Network failures (timeout, non-2xx, malformed body) propagate as `Err` from
+the resolver. The caller decides whether to hard-fail (index verification)
+or fall through to SHA-256-only (archive install).
+
+## What gets signed
+
+| Artefact | Signed by | Canonical bytes |
+|---|---|---|
+| Registry index | `registry-worker` cron, after each refresh | The exact bytes returned by `GET /api/registry/index.json` (committed canonical JSON). |
+| Marketplace bundle metadata | `marketplace-worker` on `POST /v1/packages/<slug>/versions` | `<slug>@<version>\|<bundle_url>\|<bundle_sha256>` (UTF-8). The daemon reconstructs this string locally before verifying. |
+
+The bundle bytes themselves are NOT signed — only the metadata. The
+SHA-256 of the bundle bytes is in the metadata, so a tampered bundle
+fails the SHA-256 check. This split lets the bundle live on any CDN
+(GitHub Releases, R2, S3) without requiring the worker to pipe gigabytes
+through itself.
+
+## Why Ed25519 (and not RSA / ECDSA)
+
+- 32-byte public keys, 64-byte signatures — easy to ship as base64 in env
+  vars, HTTP headers, and TOFU files.
+- Deterministic signatures (no nonce reuse foot-guns).
+- Native to Web Crypto in Cloudflare Workers (since 2023) and to
+  `ed25519_dalek` in Rust.
+- No curve-vs-key-size choices to misconfigure.
+
+## What this is NOT
+
+- **Not a replacement for code review.** A signed plugin from a trusted
+  registry can still be malicious. The signature only attests "this came
+  from the holder of the private key", not "this code is safe".
+- **Not transparency log.** There is no Merkle tree, no Sigstore-style
+  rekor. Rotation history, signing audit trails, and revocation are
+  manual processes documented in `web/workers/SIGNING.md`.
+- **Not key escrow.** The private key lives only as a Cloudflare Worker
+  secret. Loss of that secret means all future signatures need a fresh
+  keypair and a coordinated daemon-side rotation.
+
+## References
+
+- `crates/librefang-runtime/src/plugin_manager.rs` — `resolve_registry_pubkey`,
+  `verify_registry_index`, `verify_archive_signature`,
+  `install_from_registry`, `fetch_verified_index`
+- `web/workers/registry-worker/index.js` — `signWithRegistryKey`,
+  `handleSignedIndex`, `handleSignedIndexSig`, `handlePubkey`
+- `web/workers/marketplace-worker/index.js` — `signWithRegistryKey`,
+  `handleVersionSignature`, `handlePubkey`
+- `web/workers/keygen.mjs` — Ed25519 keypair generation
+- `web/workers/SIGNING.md` — operator runbook

--- a/docs/architecture/plugin-signing.md
+++ b/docs/architecture/plugin-signing.md
@@ -104,7 +104,7 @@ or fall through to SHA-256-only (archive install).
 
 | Artefact | Signed by | Canonical bytes |
 |---|---|---|
-| Registry index | `registry-worker` cron, after each refresh | The exact bytes returned by `GET /api/registry/index.json` (committed canonical JSON). |
+| Registry index | `registry-worker` cron, after each refresh | The exact bytes returned by `GET https://stats.librefang.ai/api/registry/index.json` — a flat JSON array of `{name, version?, description?, needs?}` entries, sorted by name, rebuilt from the `librefang/librefang-registry` GitHub repo's plugin TOMLs. The dashboard's dict-shaped `GET /api/registry` is a separate KV row and is **not** what the daemon parses. |
 | Marketplace bundle metadata | `marketplace-worker` on `POST /v1/packages/<slug>/versions` | `<slug>@<version>\|<bundle_url>\|<bundle_sha256>` (UTF-8). The daemon reconstructs this string locally before verifying. |
 
 The bundle bytes themselves are NOT signed — only the metadata. The

--- a/scripts/check-pubkey-lockstep.sh
+++ b/scripts/check-pubkey-lockstep.sh
@@ -26,10 +26,18 @@ extract() {
   fi
   # Match the name then either '...' or "...", capture body.
   local body
-  # Match NAME ... = "..." or NAME ... : '...'  — anything between the name
-  # and the value-opener so Rust's `const NAME: &str = "..."` parses too.
-  body="$(perl -ne 'if (/'"$name"'\b[^=\n:]*[:=][^"\x27\n]*['\''"]([A-Za-z0-9+\/=]+)['\''"]/) { print $1; exit }' \
-    "$repo_root/$path" 2>/dev/null || true)"
+  # Anchor at start-of-line + word-boundary on $name so a future
+  # `LEGACY_REGISTRY_PUBLIC_KEY` doesn't false-positive (PR re-review
+  # HIGH-NEW-E). Allow `=` (TOML / JS) or `: ... =` (Rust const)
+  # between $name and the quoted value but no other quoted strings,
+  # which prevents picking up base64-shaped fragments inside comments.
+  # Length-check the captured value to exactly 44 chars (Ed25519 raw
+  # 32 bytes -> base64 with padding) — wrong length is wrong key.
+  body="$(perl -ne '
+    if (/^[ \t]*(?:const[ \t]+)?'"$name"'\b[^"\x27\n=]*=[ \t]*['\''"]([A-Za-z0-9+\/=]{44})['\''"]/) {
+      print $1; exit
+    }
+  ' "$repo_root/$path" 2>/dev/null || true)"
   if [ -z "$body" ]; then
     echo "::error file=$path::$name constant not found" >&2
     exit 1

--- a/scripts/check-pubkey-lockstep.sh
+++ b/scripts/check-pubkey-lockstep.sh
@@ -48,12 +48,15 @@ extract() {
   echo "$body"
 }
 
-# The daemon now embeds a SLICE of pubkeys (each `EmbeddedPubkey { b64,
-# expires_at }`). Slot 0 is the active key. We pull the FIRST `b64: "..."`
-# field — the active slot — and compare against the worker side.
+# The daemon now embeds a SLICE of pubkeys (each `EmbeddedPubkey {
+# pubkey_b64, expires_at }`). Slot 0 is the active key. We pull the
+# FIRST `pubkey_b64: "..."` field — the active slot — and compare
+# against the worker side. The unique field name avoids matching any
+# stray `b64` literal that drifts in elsewhere (PR re-review LOW
+# round 4).
 daemon=$(extract \
   "crates/librefang-runtime/src/plugin_manager.rs" \
-  'b64')
+  'pubkey_b64')
 registry_worker=$(extract \
   "web/workers/registry-worker/wrangler.toml" \
   'REGISTRY_PUBLIC_KEY')

--- a/scripts/check-pubkey-lockstep.sh
+++ b/scripts/check-pubkey-lockstep.sh
@@ -28,13 +28,16 @@ extract() {
   local body
   # Anchor at start-of-line + word-boundary on $name so a future
   # `LEGACY_REGISTRY_PUBLIC_KEY` doesn't false-positive (PR re-review
-  # HIGH-NEW-E). Allow `=` (TOML / JS) or `: ... =` (Rust const)
-  # between $name and the quoted value but no other quoted strings,
-  # which prevents picking up base64-shaped fragments inside comments.
-  # Length-check the captured value to exactly 44 chars (Ed25519 raw
-  # 32 bytes -> base64 with padding) — wrong length is wrong key.
+  # HIGH-NEW-E). Accept any of:
+  #   NAME = "..."          (TOML / JS)
+  #   const NAME: T = "..." (Rust top-level const)
+  #   NAME: "..."           (Rust struct field — used by EmbeddedPubkey)
+  # but no other quoted strings between $name and the value, so base64-
+  # shaped fragments inside comments don't get picked up. Length-check
+  # the captured value to exactly 44 chars (Ed25519 raw 32 bytes -> b64
+  # with padding) — wrong length is wrong key.
   body="$(perl -ne '
-    if (/^[ \t]*(?:const[ \t]+)?'"$name"'\b[^"\x27\n=]*=[ \t]*['\''"]([A-Za-z0-9+\/=]{44})['\''"]/) {
+    if (/^[ \t]*(?:const[ \t]+)?'"$name"'\b[^"\x27\n=:]*[=:][^"\x27\n]*['\''"]([A-Za-z0-9+\/=]{44})['\''"]/) {
       print $1; exit
     }
   ' "$repo_root/$path" 2>/dev/null || true)"
@@ -45,9 +48,12 @@ extract() {
   echo "$body"
 }
 
+# The daemon now embeds a SLICE of pubkeys (each `EmbeddedPubkey { b64,
+# expires_at }`). Slot 0 is the active key. We pull the FIRST `b64: "..."`
+# field — the active slot — and compare against the worker side.
 daemon=$(extract \
   "crates/librefang-runtime/src/plugin_manager.rs" \
-  'EMBEDDED_REGISTRY_PUBKEY')
+  'b64')
 registry_worker=$(extract \
   "web/workers/registry-worker/wrangler.toml" \
   'REGISTRY_PUBLIC_KEY')

--- a/scripts/check-pubkey-lockstep.sh
+++ b/scripts/check-pubkey-lockstep.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Fail if the registry pubkey is not byte-identical across the four
+# locations that have to stay in lockstep:
+#
+#   1. crates/librefang-runtime/src/plugin_manager.rs  EMBEDDED_REGISTRY_PUBKEY
+#   2. web/workers/registry-worker/wrangler.toml       REGISTRY_PUBLIC_KEY
+#   3. web/workers/marketplace-worker/wrangler.toml    REGISTRY_PUBLIC_KEY
+#   4. web/public/_worker.js                           REGISTRY_PUBLIC_KEY
+#
+# A drift here means the daemon trusts one key, the workers sign with /
+# serve a different one, and verification fails for whichever side lags.
+# Catches the silent footgun called out by the PR review (MEDIUM #15).
+#
+# Run via: scripts/check-pubkey-lockstep.sh
+# Wire into CI as a fast-fail step before any cargo / wrangler build.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+extract() {
+  local path="$1" name="$2"
+  if [ ! -f "$repo_root/$path" ]; then
+    echo "::error file=$path::missing — pubkey lockstep check cannot run" >&2
+    exit 1
+  fi
+  # Match the name then either '...' or "...", capture body.
+  local body
+  # Match NAME ... = "..." or NAME ... : '...'  — anything between the name
+  # and the value-opener so Rust's `const NAME: &str = "..."` parses too.
+  body="$(perl -ne 'if (/'"$name"'\b[^=\n:]*[:=][^"\x27\n]*['\''"]([A-Za-z0-9+\/=]+)['\''"]/) { print $1; exit }' \
+    "$repo_root/$path" 2>/dev/null || true)"
+  if [ -z "$body" ]; then
+    echo "::error file=$path::$name constant not found" >&2
+    exit 1
+  fi
+  echo "$body"
+}
+
+daemon=$(extract \
+  "crates/librefang-runtime/src/plugin_manager.rs" \
+  'EMBEDDED_REGISTRY_PUBKEY')
+registry_worker=$(extract \
+  "web/workers/registry-worker/wrangler.toml" \
+  'REGISTRY_PUBLIC_KEY')
+marketplace_worker=$(extract \
+  "web/workers/marketplace-worker/wrangler.toml" \
+  'REGISTRY_PUBLIC_KEY')
+pages_worker=$(extract \
+  "web/public/_worker.js" \
+  'REGISTRY_PUBLIC_KEY')
+
+drifted=0
+expect_eq() {
+  local name="$1" actual="$2" expected="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "::error::$name pubkey ($actual) drifts from daemon ($expected)" >&2
+    drifted=1
+  fi
+}
+
+expect_eq "registry-worker"   "$registry_worker"    "$daemon"
+expect_eq "marketplace-worker" "$marketplace_worker" "$daemon"
+expect_eq "pages-worker"       "$pages_worker"       "$daemon"
+
+if [ "$drifted" -ne 0 ]; then
+  exit 1
+fi
+echo "pubkey lockstep OK ($daemon)"

--- a/web/public/_worker.js
+++ b/web/public/_worker.js
@@ -13,6 +13,16 @@ const SECURITY_HEADERS = {
 
 const IMMUTABLE_CACHE = 'public, max-age=31536000, immutable';
 
+// Plugin registry public key (raw 32-byte Ed25519, base64). Served at
+// /.well-known/registry-pubkey for the LibreFang daemon's TOFU resolver
+// (see crates/librefang-runtime/src/plugin_manager.rs::resolve_registry_pubkey
+// and docs/architecture/plugin-signing.md).
+//
+// Mirror of REGISTRY_PUBLIC_KEY in web/workers/{registry,marketplace}-worker/
+// wrangler.toml. Rotation: regenerate keypair via web/workers/keygen.mjs,
+// update both wrangler.toml files AND this constant in lockstep.
+const REGISTRY_PUBLIC_KEY = 'NEoveGRjRazzoiRFqozw0VEtF9N9elfwIAOqKzt4Ue4=';
+
 function addHeaders(response, url) {
   const headers = new Headers(response.headers);
 
@@ -76,6 +86,18 @@ function canonicalPath(pathname) {
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
+
+    // Serve the registry pubkey BEFORE asset/SPA fallback — otherwise the SPA
+    // catch-all hands daemons an HTML page that fails base64 validation.
+    if (url.pathname === '/.well-known/registry-pubkey') {
+      return new Response(REGISTRY_PUBLIC_KEY + '\n', {
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'Cache-Control': 'public, max-age=86400',
+          ...SECURITY_HEADERS,
+        },
+      });
+    }
 
     // 301 redirect to canonical URL before serving. Preserves query + hash.
     const canonical = canonicalPath(url.pathname);

--- a/web/public/_worker.js
+++ b/web/public/_worker.js
@@ -21,7 +21,7 @@ const IMMUTABLE_CACHE = 'public, max-age=31536000, immutable';
 // Mirror of REGISTRY_PUBLIC_KEY in web/workers/{registry,marketplace}-worker/
 // wrangler.toml. Rotation: regenerate keypair via web/workers/keygen.mjs,
 // update both wrangler.toml files AND this constant in lockstep.
-const REGISTRY_PUBLIC_KEY = 'NEoveGRjRazzoiRFqozw0VEtF9N9elfwIAOqKzt4Ue4=';
+const REGISTRY_PUBLIC_KEY = 'ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=';
 
 function addHeaders(response, url) {
   const headers = new Headers(response.headers);

--- a/web/workers/SIGNING.md
+++ b/web/workers/SIGNING.md
@@ -1,0 +1,128 @@
+# Plugin signing — operator runbook
+
+This document describes how to provision and rotate the Ed25519 keypair the
+two registry workers (`registry-worker` and `marketplace-worker`) use to sign
+plugin manifests and bundle metadata, and how the LibreFang daemon picks up
+the resulting public key.
+
+For the trust-model design rationale (why Ed25519, why TOFU, how it layers
+with SHA-256), see `docs/architecture/plugin-signing.md`.
+
+## What the workers sign
+
+| Worker | Endpoint exposed to daemon | Bytes that are signed |
+|---|---|---|
+| `registry-worker` | `GET /api/registry/index.json.sig` | The exact bytes returned by `GET /api/registry/index.json` (the cron-refreshed canonical index). |
+| `marketplace-worker` | `GET /v1/download/<slug>/<version>/signature` returns `{ signed, sig }` | `signed` is the canonical string `<slug>@<version>\|<bundle_url>\|<bundle_sha256>` — the daemon reconstructs this string locally and verifies. |
+
+Both workers also serve the public key:
+
+- `registry-worker`: `GET /.well-known/registry-pubkey`
+- `marketplace-worker`: `GET /v1/pubkey`
+
+Both endpoints return the **raw 32-byte Ed25519 public key, base64-encoded**
+(`ed25519_dalek::VerifyingKey::from_bytes` accepts this directly).
+
+## Provisioning
+
+1. **Generate a keypair locally** (do NOT commit the output):
+
+   ```bash
+   node web/workers/keygen.mjs
+   ```
+
+   This prints two values:
+   - `REGISTRY_PUBLIC_KEY` — raw 32-byte pubkey, base64. Non-secret. Paste
+     into `[vars]` in both `wrangler.toml` files (or push via
+     `wrangler vars put`).
+   - `REGISTRY_PRIVATE_KEY` — PKCS#8 DER, base64. **SECRET.** Store in your
+     password manager (1Password, Vault, etc.) before deploying.
+
+2. **Update `wrangler.toml` with the public key** for both workers:
+
+   ```toml
+   [vars]
+   REGISTRY_PUBLIC_KEY = "<paste-raw-pubkey-base64>"
+   ```
+
+   Commit this. The daemon TOFUs against this value the first time it sees
+   it, then pins.
+
+3. **Deploy the private key as a secret** to both workers:
+
+   ```bash
+   cd web/workers/registry-worker
+   echo "<paste-private-key-base64>" | wrangler secret put REGISTRY_PRIVATE_KEY
+
+   cd ../marketplace-worker
+   echo "<paste-private-key-base64>" | wrangler secret put REGISTRY_PRIVATE_KEY
+   ```
+
+4. **Deploy each worker**:
+
+   ```bash
+   cd web/workers/registry-worker && wrangler deploy
+   cd ../marketplace-worker         && wrangler deploy
+   ```
+
+5. **Verify the endpoints** are live:
+
+   ```bash
+   # Public key — must return the same base64 you set in step 2.
+   curl -s https://librefang-registry.<account>.workers.dev/.well-known/registry-pubkey
+   curl -s https://librefang-marketplace.<account>.workers.dev/v1/pubkey
+
+   # Trigger a registry refresh (cron also runs at 02:00 UTC daily).
+   # On the next refresh, the signature endpoint will start returning data.
+   curl -s "https://librefang-registry.<account>.workers.dev/api/registry?refresh=1" >/dev/null
+   curl -s    https://librefang-registry.<account>.workers.dev/api/registry/index.json.sig | head -c 100
+   ```
+
+## Behavior when no key is configured
+
+The signing path is opt-in and degrades gracefully — the workers stay
+backward-compatible:
+
+- `REGISTRY_PRIVATE_KEY` unset → `signWithRegistryKey()` returns `null`,
+  the cron refresh skips storing a signature, and new
+  `package_versions.bundle_sig` rows are written as `NULL`.
+- `REGISTRY_PUBLIC_KEY` unset → the `/v1/pubkey` and
+  `/.well-known/registry-pubkey` endpoints return HTTP 503.
+- Existing `/api/registry`, `/api/registry/raw`, `/v1/packages`,
+  `/v1/download/...` paths are unaffected.
+
+The daemon, when it cannot retrieve a public key, falls back to SHA-256-only
+verification (see `docs/architecture/plugin-signing.md`).
+
+## Rotation
+
+Rotate when a private key is suspected leaked, when an operator with access
+leaves, or annually as hygiene.
+
+1. Generate a fresh keypair via `node web/workers/keygen.mjs`.
+2. Update `REGISTRY_PUBLIC_KEY` in both `wrangler.toml` files **and**
+   re-deploy `REGISTRY_PRIVATE_KEY` as a secret to both workers.
+3. Deploy both workers.
+4. Trigger a registry refresh so the new index signature is generated:
+   `curl https://librefang-registry.<account>.workers.dev/api/registry?refresh=1`.
+5. **Bump the daemon's pinned key**: instruct daemon operators to delete
+   `~/.librefang/registry.pub` (the TOFU cache); the next install will
+   re-fetch and pin the new key. For mass deployments, ship a daemon
+   release with the new key embedded in `OFFICIAL_REGISTRY_PUBKEY_B64` (or
+   whatever resolver default replaces it — see daemon resolver design).
+
+The old keypair should be archived (not destroyed) for audit and for
+verifying historical signatures.
+
+## Schema migration
+
+`marketplace-worker` adds a new column `package_versions.bundle_sig`. For
+new D1 databases the `CREATE TABLE` in `schema.sql` covers it. For existing
+databases:
+
+```sql
+ALTER TABLE package_versions ADD COLUMN bundle_sig TEXT;
+```
+
+D1 ignores duplicate `ALTER` statements, so this is safe to run on every
+deploy via a migration step.

--- a/web/workers/SIGNING.md
+++ b/web/workers/SIGNING.md
@@ -12,7 +12,7 @@ with SHA-256), see `docs/architecture/plugin-signing.md`.
 
 | Worker | Endpoint exposed to daemon | Bytes that are signed |
 |---|---|---|
-| `registry-worker` | `GET /api/registry/index.json.sig` | The exact bytes returned by `GET /api/registry/index.json` (the cron-refreshed canonical index). |
+| `registry-worker` | `GET /api/registry/index.json.sig` | The exact bytes returned by `GET /api/registry/index.json` — a flat JSON array of `{name, version?, description?, needs?}` entries, sorted by name, rebuilt by the cron from the GitHub registry's plugin TOMLs. The dashboard's dict-shaped `GET /api/registry` payload (hands/channels/plugins/skills/...) is a separate KV row and is **not** what the daemon consumes. |
 | `marketplace-worker` | `GET /v1/download/<slug>/<version>/signature` returns `{ signed, sig }` | `signed` is the canonical string `<slug>@<version>\|<bundle_url>\|<bundle_sha256>` — the daemon reconstructs this string locally and verifies. |
 
 Both workers also serve the public key:

--- a/web/workers/keygen.mjs
+++ b/web/workers/keygen.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Generate an Ed25519 keypair for plugin signing across the registry-worker
+// and marketplace-worker. Prints the values you need to deploy to Cloudflare.
+//
+// Usage:
+//   node web/workers/keygen.mjs
+//
+// Output:
+//   PUBLIC KEY (raw 32-byte, base64) — paste into REGISTRY_PUBLIC_KEY var of
+//     both wrangler.toml files.
+//   PRIVATE KEY (PKCS#8, base64)     — feed to `wrangler secret put` for
+//     each worker. NEVER commit this value.
+//
+// The public key is also what the daemon embeds (or fetches via TOFU) to
+// verify signatures. See docs/architecture/plugin-signing.md.
+
+import { generateKeyPairSync, createPublicKey } from 'node:crypto'
+
+const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+
+// PKCS#8 DER for the private key — what crypto.subtle.importKey('pkcs8', ...)
+// expects in the Workers runtime.
+const privatePkcs8B64 = privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64')
+
+// SPKI DER for the public key — but the daemon (ed25519_dalek) wants the raw
+// 32-byte Ed25519 public key, base64. The last 32 bytes of the SPKI DER for
+// Ed25519 are the raw key (the prefix is fixed: SEQ + algo OID + BIT STRING).
+const spki = publicKey.export({ type: 'spki', format: 'der' })
+const rawPub = spki.subarray(spki.length - 32)
+const publicRawB64 = rawPub.toString('base64')
+
+// Sanity check the round-trip — re-derive the SPKI from the raw bytes by
+// rebuilding via Node, and confirm both base64s match.
+const derivedSpki = createPublicKey({
+  key: Buffer.concat([Buffer.from(spki.subarray(0, spki.length - 32)), rawPub]),
+  format: 'der',
+  type: 'spki',
+}).export({ type: 'spki', format: 'der' })
+if (!derivedSpki.equals(spki)) {
+  console.error('FATAL: SPKI round-trip mismatch — keygen produced an invalid raw pubkey.')
+  process.exit(1)
+}
+
+console.log('Ed25519 keypair generated.')
+console.log('')
+console.log('REGISTRY_PUBLIC_KEY (raw 32-byte, base64) — paste into both wrangler.toml [vars]:')
+console.log(publicRawB64)
+console.log('')
+console.log('REGISTRY_PRIVATE_KEY (PKCS#8 DER, base64) — deploy as a secret:')
+console.log(privatePkcs8B64)
+console.log('')
+console.log('Deploy commands:')
+console.log('  cd web/workers/registry-worker')
+console.log('  echo "<paste private key above>" | wrangler secret put REGISTRY_PRIVATE_KEY')
+console.log('  cd ../marketplace-worker')
+console.log('  echo "<paste private key above>" | wrangler secret put REGISTRY_PRIVATE_KEY')
+console.log('')
+console.log('After deploy, verify with:')
+console.log('  curl https://librefang-registry.<account>.workers.dev/.well-known/registry-pubkey')
+console.log('  curl https://librefang-marketplace.<account>.workers.dev/v1/pubkey')
+console.log('')
+console.log('STORE THE PRIVATE KEY SECURELY (1Password, secret manager). If lost or')
+console.log('compromised, generate a new keypair, redeploy both workers, then update')
+console.log('the daemon (rotate ~/.librefang/registry.pub or hardcoded constant).')

--- a/web/workers/marketplace-worker/index.js
+++ b/web/workers/marketplace-worker/index.js
@@ -596,13 +596,23 @@ function b64FromBytes(bytes) {
 // ---------------------------------------------------------------------------
 
 // Hosts that publish immutable, content-addressed artefacts and are
-// reasonable trust roots for marketplace bundles (PR review CRITICAL #2).
-// Adding entries here means accepting that the worker will sign anything
-// stored at that host — keep the list short and well-motivated.
-const ALLOWED_BUNDLE_HOST_PREFIXES = [
-  'https://github.com/',                    // .../<owner>/<repo>/releases/download/...
-  'https://objects.githubusercontent.com/', // GitHub release-asset CDN (download redirects)
-  'https://marketplace.librefang.ai/',      // marketplace's own R2 bucket
+// reasonable trust roots for marketplace bundles. PR re-review HIGH-NEW-D
+// closed two leaks here:
+//   1. raw-string startsWith() check was bypassable via WHATWG URL
+//      normalization (`https://github.com/../../attacker/x.tgz` parses
+//      to `https://attacker/x.tgz` but startsWith('https://github.com/')
+//      returns true on the unparsed input). Now matched on parsed
+//      (host, pathPrefix) tuples.
+//   2. `https://github.com/<owner>/<repo>/raw/main/x.tgz` matched the
+//      old `https://github.com/` prefix but is mutable (branch HEAD).
+//      Restrict to `/releases/download/` (release assets are immutable
+//      once tag-pinned) and the GitHub asset CDN, which is what
+//      `gh release download` redirects to.
+const ALLOWED_BUNDLE_LOCATIONS = [
+  // (host, pathPrefix) — both must match after URL parsing.
+  { host: 'github.com',                    pathRegex: /^\/[^/]+\/[^/]+\/releases\/download\// },
+  { host: 'objects.githubusercontent.com', pathRegex: /^\// },
+  { host: 'marketplace.librefang.ai',      pathRegex: /^\/bundles\// },
 ]
 
 function isAllowedBundleHost(url) {
@@ -614,9 +624,14 @@ function isAllowedBundleHost(url) {
     return false
   }
   if (parsed.protocol !== 'https:') return false
-  // Reject URLs with credentials embedded (https://attacker@github.com/...).
   if (parsed.username || parsed.password) return false
-  return ALLOWED_BUNDLE_HOST_PREFIXES.some(prefix => url.startsWith(prefix))
+  // Reject hash + query — bundle URLs should be plain immutable paths.
+  // (CDN-side cache busters via ?v= are an acceptable loss; signers can
+  //  drop them before publishing.)
+  if (parsed.hash) return false
+  return ALLOWED_BUNDLE_LOCATIONS.some(loc =>
+    parsed.host === loc.host && loc.pathRegex.test(parsed.pathname),
+  )
 }
 
 function json(data, status = 200) {

--- a/web/workers/marketplace-worker/index.js
+++ b/web/workers/marketplace-worker/index.js
@@ -1,6 +1,17 @@
 // FangHub Marketplace Worker
 // Storage: Cloudflare D1 (SQLite)
 // Auth: GitHub OAuth (stateless JWT in cookie)
+//
+// Plugin signing (#3805): when REGISTRY_PRIVATE_KEY (PKCS#8 base64) is set
+// as a Worker secret and REGISTRY_PUBLIC_KEY (raw 32-byte base64) is set as
+// a var, each published version is signed at publish time over the canonical
+// string `<slug>@<version>|<bundle_url>|<bundle_sha256>` and the signature
+// is stored in package_versions.bundle_sig. The daemon
+// (librefang-runtime/plugin_manager.rs) fetches:
+//   GET /v1/pubkey                                   — base64 raw 32-byte pubkey
+//   GET /v1/download/<slug>/<version>/signature     — { signed: "...", sig: "..." }
+// The `signed` field is the exact canonical string the daemon must reconstruct
+// and verify with the pubkey. See web/workers/SIGNING.md.
 
 const CORS = {
   'Access-Control-Allow-Origin': 'https://librefang.ai',
@@ -56,6 +67,15 @@ export default {
       const starMatch = path.match(/^\/v1\/packages\/([^/]+)\/star$/)
       if (starMatch) {
         return handleStar(starMatch[1], request, env)
+      }
+
+      // Signing endpoints
+      if (path === '/v1/pubkey' && request.method === 'GET') {
+        return handlePubkey(env)
+      }
+      const sigMatch = path.match(/^\/v1\/download\/([^/]+)\/([^/]+)\/signature$/)
+      if (sigMatch && request.method === 'GET') {
+        return handleVersionSignature(sigMatch[1], sigMatch[2], env)
       }
 
       return json({ error: 'Not Found' }, 404)
@@ -314,11 +334,21 @@ async function handlePublishVersion(slug, request, env) {
   const versionId = `${slug}@${version}`
   const now = Math.floor(Date.now() / 1000)
 
+  // Compute the canonical signed payload — the daemon reconstructs this exact
+  // string and verifies it with the registry pubkey before installing.
+  const signedPayload = `${versionId}|${bundle_url}|${bundle_sha256}`
+  let bundleSig = null
+  try {
+    bundleSig = await signWithRegistryKey(env, new TextEncoder().encode(signedPayload))
+  } catch (e) {
+    console.error('Bundle signing failed:', e.message)
+  }
+
   try {
     await env.DB.prepare(
-      `INSERT INTO package_versions (id, package_id, version, changelog, bundle_url, bundle_sha256, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
-    ).bind(versionId, slug, version, changelog || '', bundle_url, bundle_sha256, now).run()
+      `INSERT INTO package_versions (id, package_id, version, changelog, bundle_url, bundle_sha256, bundle_sig, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(versionId, slug, version, changelog || '', bundle_url, bundle_sha256, bundleSig, now).run()
   } catch (e) {
     if (e.message?.includes('UNIQUE')) return json({ error: 'Version already exists' }, 409)
     throw e
@@ -469,6 +499,74 @@ async function authenticate(request, env) {
   const match = cookie.match(/mp_token=([^;]+)/)
   if (!match) return null
   return verifyJwt(match[1], env.JWT_SECRET)
+}
+
+// ---------------------------------------------------------------------------
+// Plugin signing (Ed25519)
+// ---------------------------------------------------------------------------
+
+function handlePubkey(env) {
+  const pub = (env.REGISTRY_PUBLIC_KEY || '').trim()
+  if (!pub) return json({ error: 'public key not configured' }, 503)
+  return new Response(pub, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400',
+      ...CORS,
+    },
+  })
+}
+
+async function handleVersionSignature(slug, version, env) {
+  const versionId = version === 'latest'
+    ? await resolveLatestVersionId(slug, env)
+    : `${slug}@${version}`
+  if (!versionId) return json({ error: 'Not Found' }, 404)
+
+  const row = await env.DB.prepare(
+    `SELECT bundle_url, bundle_sha256, bundle_sig FROM package_versions WHERE id = ?`,
+  ).bind(versionId).first()
+  if (!row) return json({ error: 'Not Found' }, 404)
+  if (!row.bundle_sig) return json({ error: 'version not signed' }, 503)
+
+  return json({
+    signed: `${versionId}|${row.bundle_url}|${row.bundle_sha256}`,
+    sig: row.bundle_sig,
+  })
+}
+
+async function resolveLatestVersionId(slug, env) {
+  const pkg = await env.DB.prepare(
+    `SELECT latest_version FROM packages WHERE id = ?`,
+  ).bind(slug).first()
+  if (!pkg?.latest_version) return null
+  return `${slug}@${pkg.latest_version}`
+}
+
+// Sign `bytes` with the configured PKCS#8 private key. Returns base64
+// signature, or null when no key is configured. Throws on malformed key.
+async function signWithRegistryKey(env, bytes) {
+  const pkcs8B64 = (env.REGISTRY_PRIVATE_KEY || '').trim()
+  if (!pkcs8B64) return null
+  const pkcs8 = bytesFromB64(pkcs8B64)
+  const key = await crypto.subtle.importKey(
+    'pkcs8', pkcs8, { name: 'Ed25519' }, false, ['sign'],
+  )
+  const sig = await crypto.subtle.sign({ name: 'Ed25519' }, key, bytes)
+  return b64FromBytes(new Uint8Array(sig))
+}
+
+function bytesFromB64(b64) {
+  const bin = atob(b64.replace(/\s+/g, ''))
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+function b64FromBytes(bytes) {
+  let s = ''
+  for (const b of bytes) s += String.fromCharCode(b)
+  return btoa(s)
 }
 
 // ---------------------------------------------------------------------------

--- a/web/workers/marketplace-worker/index.js
+++ b/web/workers/marketplace-worker/index.js
@@ -331,6 +331,28 @@ async function handlePublishVersion(slug, request, env) {
   const { version, bundle_url, bundle_sha256, changelog } = body
   if (!version || !bundle_url || !bundle_sha256) return json({ error: 'version, bundle_url, bundle_sha256 required' }, 400)
 
+  // PR review CRITICAL #2 — without an allowlist, an author can publish
+  // `bundle_url=https://attacker.example/payload.tgz` with any sha256
+  // and get a registry-signed signature back. The daemon's verification
+  // then reduces to "the registry confirmed this author claimed this
+  // URL". Restrict to known hosts that hold immutable, content-addressed
+  // artefacts so the signature actually attests to what users install.
+  if (!isAllowedBundleHost(bundle_url)) {
+    return json({
+      error:
+        'bundle_url must be hosted on an approved CDN: GitHub Releases ' +
+        '(github.com/.../releases/download/), or the marketplace R2 bucket ' +
+        '(marketplace.librefang.ai/bundles/). Self-hosted URLs are not ' +
+        'eligible for registry signing — the signature would attest to ' +
+        'host control rather than artefact identity.',
+    }, 400)
+  }
+  // Stronger sanity check on the sha256 too — 64 lower-hex chars,
+  // matches what `sha256sum` emits.
+  if (!/^[0-9a-f]{64}$/.test(bundle_sha256)) {
+    return json({ error: 'bundle_sha256 must be 64 lower-hex chars' }, 400)
+  }
+
   const versionId = `${slug}@${version}`
   const now = Math.floor(Date.now() / 1000)
 
@@ -572,6 +594,30 @@ function b64FromBytes(bytes) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// Hosts that publish immutable, content-addressed artefacts and are
+// reasonable trust roots for marketplace bundles (PR review CRITICAL #2).
+// Adding entries here means accepting that the worker will sign anything
+// stored at that host — keep the list short and well-motivated.
+const ALLOWED_BUNDLE_HOST_PREFIXES = [
+  'https://github.com/',                    // .../<owner>/<repo>/releases/download/...
+  'https://objects.githubusercontent.com/', // GitHub release-asset CDN (download redirects)
+  'https://marketplace.librefang.ai/',      // marketplace's own R2 bucket
+]
+
+function isAllowedBundleHost(url) {
+  if (typeof url !== 'string' || url.length === 0 || url.length > 2048) return false
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch (_) {
+    return false
+  }
+  if (parsed.protocol !== 'https:') return false
+  // Reject URLs with credentials embedded (https://attacker@github.com/...).
+  if (parsed.username || parsed.password) return false
+  return ALLOWED_BUNDLE_HOST_PREFIXES.some(prefix => url.startsWith(prefix))
+}
 
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), { status, headers: JSON_HEADERS })

--- a/web/workers/marketplace-worker/schema.sql
+++ b/web/workers/marketplace-worker/schema.sql
@@ -35,10 +35,14 @@ CREATE TABLE IF NOT EXISTS package_versions (
   changelog   TEXT NOT NULL DEFAULT '',
   bundle_url  TEXT NOT NULL,
   bundle_sha256 TEXT NOT NULL,
+  bundle_sig  TEXT,                      -- Ed25519 signature over `id|bundle_url|bundle_sha256`, base64; NULL when REGISTRY_PRIVATE_KEY unset
   downloads   INTEGER NOT NULL DEFAULT 0,
   created_at  INTEGER NOT NULL,
   UNIQUE(package_id, version)
 );
+
+-- Migration for existing databases (D1 ignores duplicate ALTER):
+-- ALTER TABLE package_versions ADD COLUMN bundle_sig TEXT;
 
 CREATE TABLE IF NOT EXISTS stars (
   user_id    TEXT NOT NULL REFERENCES users(id),

--- a/web/workers/marketplace-worker/wrangler.toml
+++ b/web/workers/marketplace-worker/wrangler.toml
@@ -17,7 +17,7 @@ GITHUB_CLIENT_ID = "Iv1.3683b4ad4a41e982"
 # Until both are set, /v1/pubkey and /v1/download/.../signature return 503,
 # new versions are stored without bundle_sig (NULL), and existing endpoints
 # remain fully functional.
-REGISTRY_PUBLIC_KEY = "julGSbXv8BZWStCGQYf3E98uVT+/EBbRGHoN4aG21ng="
+REGISTRY_PUBLIC_KEY = "FqJmVvJmCChmxX1xWjygaZyR4F/ls/Z8QvedpMVgMPE="
 
 # Weekly stats aggregation
 [triggers]

--- a/web/workers/marketplace-worker/wrangler.toml
+++ b/web/workers/marketplace-worker/wrangler.toml
@@ -17,7 +17,7 @@ GITHUB_CLIENT_ID = "Iv1.3683b4ad4a41e982"
 # Until both are set, /v1/pubkey and /v1/download/.../signature return 503,
 # new versions are stored without bundle_sig (NULL), and existing endpoints
 # remain fully functional.
-REGISTRY_PUBLIC_KEY = "FqJmVvJmCChmxX1xWjygaZyR4F/ls/Z8QvedpMVgMPE="
+REGISTRY_PUBLIC_KEY = "NEoveGRjRazzoiRFqozw0VEtF9N9elfwIAOqKzt4Ue4="
 
 # Weekly stats aggregation
 [triggers]

--- a/web/workers/marketplace-worker/wrangler.toml
+++ b/web/workers/marketplace-worker/wrangler.toml
@@ -10,6 +10,14 @@ database_id = "91df0bc6-e658-4463-9eba-22d5476d420a"
 
 [vars]
 GITHUB_CLIENT_ID = "Iv1.3683b4ad4a41e982"
+# Plugin signing — see web/workers/SIGNING.md.
+# REGISTRY_PUBLIC_KEY is non-secret (raw 32-byte Ed25519 pubkey, base64).
+# REGISTRY_PRIVATE_KEY is a secret; deploy with:
+#   wrangler secret put REGISTRY_PRIVATE_KEY
+# Until both are set, /v1/pubkey and /v1/download/.../signature return 503,
+# new versions are stored without bundle_sig (NULL), and existing endpoints
+# remain fully functional.
+REGISTRY_PUBLIC_KEY = ""
 
 # Weekly stats aggregation
 [triggers]

--- a/web/workers/marketplace-worker/wrangler.toml
+++ b/web/workers/marketplace-worker/wrangler.toml
@@ -17,7 +17,7 @@ GITHUB_CLIENT_ID = "Iv1.3683b4ad4a41e982"
 # Until both are set, /v1/pubkey and /v1/download/.../signature return 503,
 # new versions are stored without bundle_sig (NULL), and existing endpoints
 # remain fully functional.
-REGISTRY_PUBLIC_KEY = ""
+REGISTRY_PUBLIC_KEY = "julGSbXv8BZWStCGQYf3E98uVT+/EBbRGHoN4aG21ng="
 
 # Weekly stats aggregation
 [triggers]

--- a/web/workers/marketplace-worker/wrangler.toml
+++ b/web/workers/marketplace-worker/wrangler.toml
@@ -17,7 +17,7 @@ GITHUB_CLIENT_ID = "Iv1.3683b4ad4a41e982"
 # Until both are set, /v1/pubkey and /v1/download/.../signature return 503,
 # new versions are stored without bundle_sig (NULL), and existing endpoints
 # remain fully functional.
-REGISTRY_PUBLIC_KEY = "NEoveGRjRazzoiRFqozw0VEtF9N9elfwIAOqKzt4Ue4="
+REGISTRY_PUBLIC_KEY = "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0="
 
 # Weekly stats aggregation
 [triggers]

--- a/web/workers/registry-worker/index.js
+++ b/web/workers/registry-worker/index.js
@@ -101,6 +101,11 @@ async function handleRegistry(request, env, ctx, forceRefresh) {
     `SELECT value, updated_at FROM kv_store WHERE key = 'registry_data'`,
   ).first()
 
+  // The fresh-fetch path makes ~30+ GitHub subrequests, which exceeds the
+  // Workers Free 50-subrequest-per-request budget. Cron runs (02:00 UTC)
+  // get the higher quota, so we keep the staleness window honored even
+  // when `?refresh=1` is set — operators wanting an immediate rebuild
+  // should let the cron fire.
   if (row && (Date.now() / 1000 - row.updated_at) < REGISTRY_STALE_TTL) {
     const response = jsonResponse(row.value, REGISTRY_CACHE_TTL)
     ctx.waitUntil(caches.default.put(cacheKey, response.clone()))
@@ -461,7 +466,57 @@ async function refreshRegistryCache(env) {
 // Signed-index endpoints (Ed25519)
 // ---------------------------------------------------------------------------
 
+// Lazy-build `plugins_index` from the cron-built `registry_data` if it's
+// missing (e.g. on first deploy after the signing routes shipped, before
+// the next cron tick). The flat array we write here is byte-identical to
+// what `refreshRegistryCache` would have produced, so the daemon's
+// signature verification stays consistent across both build paths.
+async function ensurePluginsIndex(env) {
+  const present = await env.DB.prepare(
+    `SELECT 1 AS p FROM kv_store WHERE key = 'plugins_index'`,
+  ).first()
+  if (present) return
+  const dataRow = await env.DB.prepare(
+    `SELECT value FROM kv_store WHERE key = 'registry_data'`,
+  ).first()
+  if (!dataRow) return
+  let parsed
+  try {
+    parsed = JSON.parse(dataRow.value)
+  } catch (_) {
+    return
+  }
+  const flat = (parsed.plugins || [])
+    .map(p => {
+      const out = { name: p.name }
+      if (p.version) out.version = p.version
+      if (p.description) out.description = p.description
+      if (p.needs?.length) out.needs = p.needs
+      return out
+    })
+    .filter(p => p.name)
+    .sort((a, b) => a.name.localeCompare(b.name))
+  const flatJson = JSON.stringify(flat)
+  const now = Math.floor(Date.now() / 1000)
+  await env.DB.prepare(
+    `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index', ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+  ).bind(flatJson, now).run()
+  try {
+    const sig = await signWithRegistryKey(env, new TextEncoder().encode(flatJson))
+    if (sig) {
+      await env.DB.prepare(
+        `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index_sig', ?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+      ).bind(sig, now).run()
+    }
+  } catch (e) {
+    console.error('Lazy plugins_index signing failed:', e.message)
+  }
+}
+
 async function handleSignedIndex(env) {
+  await ensurePluginsIndex(env)
   const row = await env.DB.prepare(
     `SELECT value FROM kv_store WHERE key = 'plugins_index'`,
   ).first()
@@ -476,6 +531,7 @@ async function handleSignedIndex(env) {
 }
 
 async function handleSignedIndexSig(env) {
+  await ensurePluginsIndex(env)
   const row = await env.DB.prepare(
     `SELECT value FROM kv_store WHERE key = 'plugins_index_sig'`,
   ).first()

--- a/web/workers/registry-worker/index.js
+++ b/web/workers/registry-worker/index.js
@@ -554,12 +554,22 @@ async function handleSignedIndexSig(env) {
   })
 }
 
-// Forced refresh — invoked by the librefang-registry GitHub Action after a
-// push to main. Constant-time auth against `REGISTRY_REFRESH_TOKEN` (worker
-// secret); 503 until the secret is set so the endpoint can't be probed.
-// On success: rebuild D1 caches (`registry_data` + `plugins_index`),
-// re-sign, and purge the Cache-API row so the next dashboard hit reads
-// fresh bytes instead of the 1h-cached previous payload.
+// Forced refresh — invoked by the librefang-registry GitHub Action after
+// a push that touched plugins/. Constant-time auth against
+// `REGISTRY_REFRESH_TOKEN` (worker secret); 503 until set so the endpoint
+// can't be probed.
+//
+// Architecture: the daemon-shaped flat plugins index is built **inside
+// the registry repo** by `scripts/build-plugins-index.mjs` and committed
+// to `plugins-index.json` at the repo root. This handler fetches that
+// single file (1 subrequest, regardless of registry size — important on
+// Workers Free where refreshRegistryCache's ~40+ Contents API calls
+// blow the per-invocation budget), re-signs it with the worker's
+// Ed25519 private key, and persists both bytes + signature in D1.
+//
+// The dict-shaped `registry_data` cache used by the dashboard is
+// **untouched** here — it stays on the daily cron path. This handler
+// only owns the daemon's signed-install lane.
 async function handleForcedRefresh(request, env) {
   const expected = (env.REGISTRY_REFRESH_TOKEN || '').trim()
   if (!expected) return errorResponse('refresh endpoint not configured', 503)
@@ -571,31 +581,46 @@ async function handleForcedRefresh(request, env) {
     return errorResponse('unauthorized', 401)
   }
 
-  // Force a full rebuild by pre-emptively dropping the rows the
-  // signature-equality short-circuit relies on. Without this, a no-op
-  // commit (e.g. README typo) would short-circuit and never refresh
-  // plugins_index — but legitimate plugin pushes also might not flip
-  // the directory `sha`. Dropping the rows guarantees a real fetch.
-  await env.DB.batch([
-    env.DB.prepare(`DELETE FROM kv_store WHERE key = 'registry_data'`),
-    env.DB.prepare(`DELETE FROM kv_store WHERE key = 'plugins_index'`),
-    env.DB.prepare(`DELETE FROM kv_store WHERE key = 'plugins_index_sig'`),
-  ])
-
-  await refreshRegistryCache(env)
-
-  // Purge the Cache-API entry that backs `/api/registry`. A new request
-  // would otherwise see the previous (now-superseded) cached payload for
-  // up to REGISTRY_CACHE_TTL.
+  const indexUrl =
+    'https://raw.githubusercontent.com/librefang/librefang-registry/main/plugins-index.json'
+  const resp = await fetch(indexUrl, { cf: { cacheTtl: 0 } })
+  if (!resp.ok) {
+    return errorResponse(
+      `failed to fetch plugins-index.json: HTTP ${resp.status}`,
+      502,
+    )
+  }
+  const indexText = await resp.text()
+  // Validate JSON shape — refuse to sign unparseable bytes.
   try {
-    await caches.default.delete(new Request('https://internal/registry_data'))
-  } catch (_) { /* best-effort */ }
+    const parsed = JSON.parse(indexText)
+    if (!Array.isArray(parsed)) throw new Error('plugins-index.json is not an array')
+  } catch (e) {
+    return errorResponse(`plugins-index.json invalid: ${e.message}`, 502)
+  }
 
-  const fresh = await env.DB.prepare(
-    `SELECT updated_at FROM kv_store WHERE key = 'registry_data'`,
-  ).first()
+  const now = Math.floor(Date.now() / 1000)
+  await env.DB.prepare(
+    `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index', ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+  ).bind(indexText, now).run()
+
+  let signed = false
+  try {
+    const sig = await signWithRegistryKey(env, new TextEncoder().encode(indexText))
+    if (sig) {
+      await env.DB.prepare(
+        `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index_sig', ?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+      ).bind(sig, now).run()
+      signed = true
+    }
+  } catch (e) {
+    console.error('plugins_index signing failed:', e.message)
+  }
+
   return new Response(
-    JSON.stringify({ ok: true, refreshed_at: fresh?.updated_at ?? null }),
+    JSON.stringify({ ok: true, refreshed_at: now, signed, bytes: indexText.length }),
     { headers: { 'Content-Type': 'application/json', ...CORS } },
   )
 }

--- a/web/workers/registry-worker/index.js
+++ b/web/workers/registry-worker/index.js
@@ -1,6 +1,16 @@
 // Registry Worker
 // Proxies librefang-registry (GitHub) with Cache API for HTTP responses.
 // Storage: D1 (registry_clicks, kv_store, ui_errors). No KV dependency.
+//
+// Plugin signing (#3805): when REGISTRY_PRIVATE_KEY (PKCS#8 base64) is set as
+// a Worker secret and REGISTRY_PUBLIC_KEY (raw 32-byte base64) is set as a
+// var, the cron refresh signs the canonical index.json with Ed25519 and
+// stores the signature in kv_store('registry_data_sig'). The daemon
+// (librefang-runtime/plugin_manager.rs) fetches:
+//   GET /api/registry/index.json     — canonical bytes that were signed
+//   GET /api/registry/index.json.sig — base64 Ed25519 signature
+//   GET /.well-known/registry-pubkey — base64 raw 32-byte Ed25519 pubkey
+// See web/workers/SIGNING.md for keygen + deploy.
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
@@ -48,6 +58,19 @@ export default {
 
     if (path === '/api/errors' && request.method === 'GET')
       return handleErrorList(env)
+
+    // Signing endpoints (Ed25519). The daemon contract is:
+    //   index.json     — canonical bytes that were signed
+    //   index.json.sig — base64 Ed25519 signature over those bytes
+    //   .well-known/registry-pubkey — raw 32-byte base64 public key
+    if (path === '/api/registry/index.json' && request.method === 'GET')
+      return handleSignedIndex(env)
+
+    if (path === '/api/registry/index.json.sig' && request.method === 'GET')
+      return handleSignedIndexSig(env)
+
+    if (path === '/.well-known/registry-pubkey' && request.method === 'GET')
+      return handlePubkey(env)
 
     return new Response('Not Found', { status: 404 })
   },
@@ -364,16 +387,104 @@ async function refreshRegistryCache(env) {
       signature,
     }
 
+    const indexJson = JSON.stringify(result)
+    const now = Math.floor(Date.now() / 1000)
+
     await env.DB.prepare(
       `INSERT INTO kv_store (key, value, updated_at) VALUES ('registry_data', ?, ?)
        ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-    ).bind(JSON.stringify(result), Math.floor(Date.now() / 1000)).run()
+    ).bind(indexJson, now).run()
+
+    // Sign the canonical index bytes if a private key is configured. Signing
+    // is best-effort — if the secret is missing we skip (the daemon can still
+    // fetch the index but signature verification will fail closed at its end).
+    try {
+      const sig = await signWithRegistryKey(env, new TextEncoder().encode(indexJson))
+      if (sig) {
+        await env.DB.prepare(
+          `INSERT INTO kv_store (key, value, updated_at) VALUES ('registry_data_sig', ?, ?)
+           ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+        ).bind(sig, now).run()
+      }
+    } catch (e) {
+      console.error('Registry signing failed:', e.message)
+    }
 
     console.log('Registry refreshed:', hands.length, 'hands,', channels.length, 'channels,',
       agents.length, 'agents,', skills.length, 'skills,', mcp.length, 'mcp')
   } catch (e) {
     console.error('Registry refresh failed:', e.message)
   }
+}
+
+// ---------------------------------------------------------------------------
+// Signed-index endpoints (Ed25519)
+// ---------------------------------------------------------------------------
+
+async function handleSignedIndex(env) {
+  const row = await env.DB.prepare(
+    `SELECT value FROM kv_store WHERE key = 'registry_data'`,
+  ).first()
+  if (!row) return errorResponse('index not yet built — try again after the next cron tick', 503)
+  return new Response(row.value, {
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': `public, max-age=${REGISTRY_CACHE_TTL}`,
+      ...CORS,
+    },
+  })
+}
+
+async function handleSignedIndexSig(env) {
+  const row = await env.DB.prepare(
+    `SELECT value FROM kv_store WHERE key = 'registry_data_sig'`,
+  ).first()
+  if (!row) return errorResponse('signature not available — REGISTRY_PRIVATE_KEY may be unset', 503)
+  return new Response(row.value, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': `public, max-age=${REGISTRY_CACHE_TTL}`,
+      ...CORS,
+    },
+  })
+}
+
+function handlePubkey(env) {
+  const pub = (env.REGISTRY_PUBLIC_KEY || '').trim()
+  if (!pub) return errorResponse('public key not configured', 503)
+  return new Response(pub, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400',
+      ...CORS,
+    },
+  })
+}
+
+// Sign `bytes` with the configured PKCS#8 private key. Returns base64
+// signature, or null when no key is configured. Throws on malformed key.
+async function signWithRegistryKey(env, bytes) {
+  const pkcs8B64 = (env.REGISTRY_PRIVATE_KEY || '').trim()
+  if (!pkcs8B64) return null
+  const pkcs8 = bytesFromB64(pkcs8B64)
+  const key = await crypto.subtle.importKey(
+    'pkcs8', pkcs8, { name: 'Ed25519' }, false, ['sign'],
+  )
+  const sig = await crypto.subtle.sign({ name: 'Ed25519' }, key, bytes)
+  return b64FromBytes(new Uint8Array(sig))
+}
+
+function b64FromBytes(bytes) {
+  let s = ''
+  for (const b of bytes) s += String.fromCharCode(b)
+  return btoa(s)
+}
+
+function bytesFromB64(b64) {
+  const bin = atob(b64.replace(/\s+/g, ''))
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
 }
 
 // ---------------------------------------------------------------------------

--- a/web/workers/registry-worker/index.js
+++ b/web/workers/registry-worker/index.js
@@ -2,20 +2,35 @@
 // Proxies librefang-registry (GitHub) with Cache API for HTTP responses.
 // Storage: D1 (registry_clicks, kv_store, ui_errors). No KV dependency.
 //
-// Plugin signing (#3805): when REGISTRY_PRIVATE_KEY (PKCS#8 base64) is set as
-// a Worker secret and REGISTRY_PUBLIC_KEY (raw 32-byte base64) is set as a
-// var, the cron refresh signs the daemon-shaped plugins index (a flat
-// JSON array of {name, version, description, needs}) with Ed25519. The
-// daemon (librefang-runtime/plugin_manager.rs::fetch_verified_index) fetches:
+// Plugin signing (#3805 + PR #4600 hardening):
+//
+// The Ed25519 private key lives ONLY in the librefang-registry GitHub
+// Actions secret, never in this worker. The CI workflow there
+// (.github/workflows/refresh-cache.yml) builds plugins-index.json,
+// signs it locally, and commits both `plugins-index.json` and
+// `plugins-index.json.sig` to the repo root before poking the worker.
+// This handler is now a pure transport: it fetches the committed
+// bytes (3 raw subrequests — plugins json + sig + registry json) and
+// stores them in D1 verbatim. No bytes get re-signed by anything
+// holding registry-controlled key material.
+//
+// Daemon contract (unchanged):
 //   GET /api/registry/index.json     — canonical bytes that were signed
-//                                      (a JSON array of plugin entries)
+//                                      (flat JSON array of plugin entries)
 //   GET /api/registry/index.json.sig — base64 Ed25519 signature
 //   GET /.well-known/registry-pubkey — base64 raw 32-byte Ed25519 pubkey
 //
-// The dashboard's /api/registry endpoint continues to return the dict-shaped
-// payload (hands/channels/plugins/skills/...) for the marketplace UI. The
-// two formats are stored separately in D1 (registry_data vs plugins_index).
-// See web/workers/SIGNING.md for keygen + deploy.
+// The dashboard's /api/registry endpoint continues to return the
+// dict-shaped payload (hands/channels/plugins/skills/...) for the
+// marketplace UI. The two formats are stored separately in D1
+// (registry_data vs plugins_index). See web/workers/SIGNING.md.
+//
+// Why moved out of the worker (PR review CRITICAL #1): the previous
+// design treated the worker as a sign-anything oracle reachable via
+// REGISTRY_REFRESH_TOKEN — anyone with that token could push arbitrary
+// bytes to `main` and have them signed. The new flow ties signing to
+// the registry repo's CI identity, so the trust root is the repo's
+// branch protection + Actions secret rather than the worker.
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
@@ -74,7 +89,13 @@ export default {
     if (path === '/api/registry/index.json.sig' && request.method === 'GET')
       return handleSignedIndexSig(env)
 
-    if (path === '/.well-known/registry-pubkey' && request.method === 'GET')
+    // Both paths return the same bytes. The custom domain (stats.librefang.ai)
+    // routes only /api/* to the worker, so the daemon's HTTP-rotation
+    // probe needs an /api/* alias when the embedded constant is absent
+    // (self-hosted forks). The /.well-known/ form stays for direct
+    // workers.dev clients.
+    if ((path === '/.well-known/registry-pubkey' || path === '/api/registry/pubkey')
+        && request.method === 'GET')
       return handlePubkey(env)
 
     // Operator-only path used by the librefang-registry GitHub Action to
@@ -89,8 +110,12 @@ export default {
     return new Response('Not Found', { status: 404 })
   },
 
+  // Cron is now a backstop for the GH Action — the registry repo's CI
+  // is the primary path, this just guards against CI outages by
+  // re-pulling the same in-repo files daily. Auth-free because the
+  // worker invokes itself.
   async scheduled(_event, env) {
-    await refreshRegistryCache(env)
+    await doSyncFromRepo(env, { requireAuth: false })
   },
 }
 
@@ -301,231 +326,13 @@ async function handleErrorList(env) {
   })
 }
 
-// ---------------------------------------------------------------------------
-// Registry cache refresh (cron + inline)
-// ---------------------------------------------------------------------------
-
-async function refreshRegistryCache(env) {
-  const headers = ghHeaders(env)
-
-  async function fetchDir(path) {
-    const res = await fetch(`${REGISTRY_API}/${path}`, { headers })
-    if (!res.ok) return []
-    const items = await res.json()
-    return items.filter(f => f.type === 'dir' || (f.name.endsWith('.toml') && f.name !== 'README.md'))
-  }
-
-  function parseStringArray(text, key) {
-    const m = text.match(new RegExp(`^${key}\\s*=\\s*\\[([^\\]]*)\\]`, 'm'))
-    if (!m) return undefined
-    const items = m[1].match(/"([^"]*)"/g)?.map(s => s.replace(/"/g, ''))
-    return items?.length ? items : undefined
-  }
-
-  async function fetchToml(path) {
-    const res = await fetch(`${REGISTRY_RAW}/${path}`)
-    if (!res.ok) return null
-    const text = await res.text()
-    const get = key => { const m = text.match(new RegExp(`^${key}\\s*=\\s*"([^"]*)"`, 'm')); return m ? m[1] : '' }
-
-    const i18n = {}
-    const i18nRe = /\[i18n\.([a-zA-Z-]+)\]\s*\n(?:([^[]*?)(?=\n\[|\n*$))/g
-    let m
-    while ((m = i18nRe.exec(text)) !== null) {
-      const descM = (m[2] || '').match(/description\s*=\s*"([^"]*)"/)
-      if (descM) i18n[m[1]] = { description: descM[1] }
-    }
-
-    const tags = parseStringArray(text, 'tags')
-    const needs = parseStringArray(text, 'needs')
-
-    const result = { id: get('id'), name: get('name'), description: get('description'), category: get('category'), icon: get('icon') }
-    const version = get('version')
-    if (version) result.version = version
-    if (tags?.length) result.tags = tags
-    if (needs?.length) result.needs = needs
-    if (Object.keys(i18n).length) result.i18n = i18n
-    return result
-  }
-
-  async function fetchSkillMd(path, fallbackId) {
-    const res = await fetch(`${REGISTRY_RAW}/${path}`)
-    if (!res.ok) return null
-    const text = await res.text()
-    const fm = text.match(/^---\s*\n([\s\S]*?)\n---/)
-    if (!fm) return null
-    const get = key => { const m = fm[1].match(new RegExp(`^${key}\\s*:\\s*"?([^"\\n]*?)"?\\s*$`, 'm')); return m ? m[1].trim() : '' }
-    return { id: get('id') || fallbackId, name: get('name') || fallbackId, description: get('description'), category: 'skills', icon: '' }
-  }
-
-  async function fetchBatch(items, pathFn, fetcher = p => fetchToml(p)) {
-    const results = []
-    for (let i = 0; i < items.length; i += 10) {
-      const batch = await Promise.all(items.slice(i, i + 10).map(item => fetcher(pathFn(item), item.name)))
-      results.push(...batch)
-    }
-    return results.filter(Boolean)
-  }
-
-  try {
-    const dirs = await Promise.all(
-      ['hands', 'channels', 'providers', 'workflows', 'agents', 'plugins', 'skills', 'mcp'].map(fetchDir),
-    )
-    const [hands, channels, providers, workflows, agents, plugins, skills, mcp] =
-      dirs.map(items => items.filter(f => f.name !== 'README.md'))
-
-    const sigOf = items => items.map(i => `${i.name}@${i.sha || ''}`).sort().join(',')
-    const signature = ['hands', 'channels', 'providers', 'workflows', 'agents', 'plugins', 'skills', 'mcp']
-      .map((cat, i) => `${cat}=${sigOf(dirs[i].filter(f => f.name !== 'README.md'))}`)
-      .join('|')
-
-    const existing = await env.DB.prepare(
-      `SELECT value FROM kv_store WHERE key = 'registry_data'`,
-    ).first()
-    const pluginsIndexExists = await env.DB.prepare(
-      `SELECT 1 AS present FROM kv_store WHERE key = 'plugins_index'`,
-    ).first()
-    if (existing && pluginsIndexExists) {
-      try {
-        if (JSON.parse(existing.value).signature === signature) {
-          await env.DB.prepare(
-            `UPDATE kv_store SET updated_at = ? WHERE key = 'registry_data'`,
-          ).bind(Math.floor(Date.now() / 1000)).run()
-          console.log('Registry unchanged, skipping manifest fetch')
-          return
-        }
-      } catch (_) { /* refetch */ }
-    }
-
-    const [handDetails, agentDetails, skillDetails, channelDetails, providerDetails, workflowDetails, pluginDetails, mcpDetails] = await Promise.all([
-      fetchBatch(hands,     h => `hands/${h.name}/HAND.toml`),
-      fetchBatch(agents,    a => `agents/${a.name}/agent.toml`),
-      fetchBatch(skills,    s => `skills/${s.name}/SKILL.md`, fetchSkillMd),
-      fetchBatch(channels,  c => `channels/${c.name}`),
-      fetchBatch(providers, p => `providers/${p.name}`),
-      fetchBatch(workflows, w => `workflows/${w.name}`),
-      fetchBatch(plugins,   p => `plugins/${p.name}/plugin.toml`),
-      fetchBatch(mcp,       m => m.name.endsWith('.toml') ? `mcp/${m.name}` : `mcp/${m.name}/MCP.toml`),
-    ])
-
-    const result = {
-      hands: handDetails, channels: channelDetails, providers: providerDetails,
-      workflows: workflowDetails, agents: agentDetails, plugins: pluginDetails,
-      skills: skillDetails, mcp: mcpDetails,
-      handsCount: hands.length, channelsCount: channels.length, providersCount: providers.length,
-      workflowsCount: workflows.length, agentsCount: agents.length, pluginsCount: plugins.length,
-      skillsCount: skills.length, mcpCount: mcp.length,
-      fetchedAt: new Date().toISOString(),
-      signature,
-    }
-
-    const indexJson = JSON.stringify(result)
-    const now = Math.floor(Date.now() / 1000)
-
-    await env.DB.prepare(
-      `INSERT INTO kv_store (key, value, updated_at) VALUES ('registry_data', ?, ?)
-       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-    ).bind(indexJson, now).run()
-
-    // Build the daemon-shaped flat plugins array (sorted by name for byte
-    // determinism — the signature is over these exact bytes so any reordering
-    // would break verification). Only the fields the daemon actually uses are
-    // included: name, version, description, needs.
-    const pluginsIndex = pluginDetails
-      .map(p => {
-        const out = { name: p.name }
-        if (p.version) out.version = p.version
-        if (p.description) out.description = p.description
-        if (p.needs?.length) out.needs = p.needs
-        return out
-      })
-      .filter(p => p.name)
-      .sort((a, b) => a.name.localeCompare(b.name))
-    const pluginsIndexJson = JSON.stringify(pluginsIndex)
-
-    await env.DB.prepare(
-      `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index', ?, ?)
-       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-    ).bind(pluginsIndexJson, now).run()
-
-    // Sign the daemon-shaped plugins index if a private key is configured.
-    // Signing is best-effort — if the secret is missing we skip (the daemon
-    // can still fetch the index but signature verification will fail closed
-    // at its end).
-    try {
-      const sig = await signWithRegistryKey(env, new TextEncoder().encode(pluginsIndexJson))
-      if (sig) {
-        await env.DB.prepare(
-          `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index_sig', ?, ?)
-           ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-        ).bind(sig, now).run()
-      }
-    } catch (e) {
-      console.error('Plugins index signing failed:', e.message)
-    }
-
-    console.log('Registry refreshed:', hands.length, 'hands,', channels.length, 'channels,',
-      agents.length, 'agents,', skills.length, 'skills,', mcp.length, 'mcp')
-  } catch (e) {
-    console.error('Registry refresh failed:', e.message)
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Signed-index endpoints (Ed25519)
 // ---------------------------------------------------------------------------
 
-// Lazy-build `plugins_index` from the cron-built `registry_data` if it's
-// missing (e.g. on first deploy after the signing routes shipped, before
-// the next cron tick). The flat array we write here is byte-identical to
-// what `refreshRegistryCache` would have produced, so the daemon's
-// signature verification stays consistent across both build paths.
-async function ensurePluginsIndex(env) {
-  const present = await env.DB.prepare(
-    `SELECT 1 AS p FROM kv_store WHERE key = 'plugins_index'`,
-  ).first()
-  if (present) return
-  const dataRow = await env.DB.prepare(
-    `SELECT value FROM kv_store WHERE key = 'registry_data'`,
-  ).first()
-  if (!dataRow) return
-  let parsed
-  try {
-    parsed = JSON.parse(dataRow.value)
-  } catch (_) {
-    return
-  }
-  const flat = (parsed.plugins || [])
-    .map(p => {
-      const out = { name: p.name }
-      if (p.version) out.version = p.version
-      if (p.description) out.description = p.description
-      if (p.needs?.length) out.needs = p.needs
-      return out
-    })
-    .filter(p => p.name)
-    .sort((a, b) => a.name.localeCompare(b.name))
-  const flatJson = JSON.stringify(flat)
-  const now = Math.floor(Date.now() / 1000)
-  await env.DB.prepare(
-    `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index', ?, ?)
-     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-  ).bind(flatJson, now).run()
-  try {
-    const sig = await signWithRegistryKey(env, new TextEncoder().encode(flatJson))
-    if (sig) {
-      await env.DB.prepare(
-        `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index_sig', ?, ?)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-      ).bind(sig, now).run()
-    }
-  } catch (e) {
-    console.error('Lazy plugins_index signing failed:', e.message)
-  }
-}
 
 async function handleSignedIndex(env) {
-  await ensurePluginsIndex(env)
   const row = await env.DB.prepare(
     `SELECT value FROM kv_store WHERE key = 'plugins_index'`,
   ).first()
@@ -540,7 +347,6 @@ async function handleSignedIndex(env) {
 }
 
 async function handleSignedIndexSig(env) {
-  await ensurePluginsIndex(env)
   const row = await env.DB.prepare(
     `SELECT value FROM kv_store WHERE key = 'plugins_index_sig'`,
   ).first()
@@ -554,47 +360,55 @@ async function handleSignedIndexSig(env) {
   })
 }
 
-// Forced refresh — invoked by the librefang-registry GitHub Action after
-// a push that touched plugins/. Constant-time auth against
-// `REGISTRY_REFRESH_TOKEN` (worker secret); 503 until set so the endpoint
-// can't be probed.
+// Forced refresh — invoked by the librefang-registry GitHub Action after a
+// push that touched any registry content. Constant-time bearer-token auth
+// against `REGISTRY_REFRESH_TOKEN`; 503 until set so the endpoint can't
+// be probed.
 //
-// Architecture: the daemon-shaped flat plugins index is built **inside
-// the registry repo** by `scripts/build-plugins-index.mjs` and committed
-// to `plugins-index.json` at the repo root. This handler fetches that
-// single file (1 subrequest, regardless of registry size — important on
-// Workers Free where refreshRegistryCache's ~40+ Contents API calls
-// blow the per-invocation budget), re-signs it with the worker's
-// Ed25519 private key, and persists both bytes + signature in D1.
-//
-// The dict-shaped `registry_data` cache used by the dashboard is
-// **untouched** here — it stays on the daily cron path. This handler
-// only owns the daemon's signed-install lane.
+// PURE TRANSPORT: this handler does NOT sign anything. It fetches three
+// files from raw.githubusercontent.com (committed by the registry repo's
+// CI, which holds the Ed25519 private key) and writes them to D1
+// verbatim. The bytes the daemon eventually verifies are byte-identical
+// to the bytes the CI signed. Any byte-mutation between sign and serve
+// would be detectable.
 async function handleForcedRefresh(request, env) {
-  const expected = (env.REGISTRY_REFRESH_TOKEN || '').trim()
-  if (!expected) return errorResponse('refresh endpoint not configured', 503)
+  return doSyncFromRepo(env, { requireAuth: true, request })
+}
 
-  const auth = request.headers.get('authorization') || ''
-  const m = auth.match(/^Bearer\s+(.+)$/i)
-  const provided = m ? m[1].trim() : ''
-  if (!constantTimeEqual(provided, expected)) {
-    return errorResponse('unauthorized', 401)
+async function doSyncFromRepo(env, { requireAuth, request }) {
+  if (requireAuth) {
+    const expected = (env.REGISTRY_REFRESH_TOKEN || '').trim()
+    if (!expected) return errorResponse('refresh endpoint not configured', 503)
+    const auth = request.headers.get('authorization') || ''
+    const m = auth.match(/^Bearer\s+(.+)$/i)
+    const provided = m ? m[1].trim() : ''
+    if (!constantTimeEqual(provided, expected)) {
+      return errorResponse('unauthorized', 401)
+    }
   }
 
   const RAW_BASE =
     'https://raw.githubusercontent.com/librefang/librefang-registry/main'
   const pluginsUrl = `${RAW_BASE}/plugins-index.json`
+  const pluginsSigUrl = `${RAW_BASE}/plugins-index.json.sig`
   const registryUrl = `${RAW_BASE}/registry-index.json`
 
-  // Fetch both in parallel — 2 subrequests, regardless of how many
-  // plugins / agents / skills the registry contains.
-  const [pluginsResp, registryResp] = await Promise.all([
+  // Fetch all three in parallel — 3 subrequests, constant in registry size.
+  const [pluginsResp, pluginsSigResp, registryResp] = await Promise.all([
     fetch(pluginsUrl, { cf: { cacheTtl: 0 } }),
+    fetch(pluginsSigUrl, { cf: { cacheTtl: 0 } }),
     fetch(registryUrl, { cf: { cacheTtl: 0 } }),
   ])
   if (!pluginsResp.ok) {
     return errorResponse(
       `failed to fetch plugins-index.json: HTTP ${pluginsResp.status}`,
+      502,
+    )
+  }
+  if (!pluginsSigResp.ok) {
+    return errorResponse(
+      `failed to fetch plugins-index.json.sig: HTTP ${pluginsSigResp.status} ` +
+      `— registry CI must commit the signature alongside the index`,
       502,
     )
   }
@@ -605,9 +419,12 @@ async function handleForcedRefresh(request, env) {
     )
   }
   const pluginsText = await pluginsResp.text()
+  const pluginsSigText = (await pluginsSigResp.text()).trim()
   const registryText = await registryResp.text()
 
-  // Validate JSON shapes — refuse to ingest unparseable bytes.
+  // Validate shapes / sig length. We refuse to ingest unparseable bytes
+  // or a sig that's the wrong length, since the daemon would just
+  // hard-fail on those anyway and we'd rather catch it here.
   try {
     const parsed = JSON.parse(pluginsText)
     if (!Array.isArray(parsed)) throw new Error('plugins-index.json is not an array')
@@ -621,6 +438,11 @@ async function handleForcedRefresh(request, env) {
   } catch (e) {
     return errorResponse(`registry-index.json invalid: ${e.message}`, 502)
   }
+  // Ed25519 sig is 64 bytes → 88 base64 chars (incl. padding) or 86 chars
+  // unpadded. Allow either.
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(pluginsSigText) || pluginsSigText.length < 86) {
+    return errorResponse(`plugins-index.json.sig is not valid base64`, 502)
+  }
 
   const now = Math.floor(Date.now() / 1000)
   await env.DB.batch([
@@ -632,48 +454,50 @@ async function handleForcedRefresh(request, env) {
       .bind(pluginsText, now),
     env.DB
       .prepare(
+        `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index_sig', ?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+      )
+      .bind(pluginsSigText, now),
+    env.DB
+      .prepare(
         `INSERT INTO kv_store (key, value, updated_at) VALUES ('registry_data', ?, ?)
          ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
       )
       .bind(registryText, now),
   ])
 
-  // Purge the Cache-API entry the dashboard hits — without this, /api/registry
-  // serves the previous (now-superseded) cached payload for up to 1h.
+  // Purge the Cache-API entry the dashboard hits — without this,
+  // /api/registry serves the previous cached payload for up to 1h.
   try {
     await caches.default.delete(new Request('https://internal/registry_data'))
   } catch (_) { /* best-effort */ }
-
-  let signed = false
-  try {
-    const sig = await signWithRegistryKey(env, new TextEncoder().encode(pluginsText))
-    if (sig) {
-      await env.DB.prepare(
-        `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index_sig', ?, ?)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-      ).bind(sig, now).run()
-      signed = true
-    }
-  } catch (e) {
-    console.error('plugins_index signing failed:', e.message)
-  }
 
   return new Response(
     JSON.stringify({
       ok: true,
       refreshed_at: now,
-      signed,
       plugins_bytes: pluginsText.length,
+      sig_bytes: pluginsSigText.length,
       registry_bytes: registryText.length,
     }),
     { headers: { 'Content-Type': 'application/json', ...CORS } },
   )
 }
 
+// Constant-time string comparison hardened against length leak via early
+// return (PR review MEDIUM #11). Iterates up to max(a.length, b.length)
+// and folds the length delta into the mismatch accumulator so timing
+// reveals at most "they're not the same" — not "yours is shorter than
+// mine". Multi-byte chars are handled via charCodeAt (no throw on
+// surrogate halves; XOR semantics are still well-defined).
 function constantTimeEqual(a, b) {
-  if (a.length !== b.length) return false
-  let mismatch = 0
-  for (let i = 0; i < a.length; i++) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  const len = Math.max(a.length, b.length)
+  let mismatch = a.length ^ b.length
+  for (let i = 0; i < len; i++) {
+    const ca = i < a.length ? a.charCodeAt(i) : 0
+    const cb = i < b.length ? b.charCodeAt(i) : 0
+    mismatch |= ca ^ cb
+  }
   return mismatch === 0
 }
 
@@ -689,31 +513,6 @@ function handlePubkey(env) {
   })
 }
 
-// Sign `bytes` with the configured PKCS#8 private key. Returns base64
-// signature, or null when no key is configured. Throws on malformed key.
-async function signWithRegistryKey(env, bytes) {
-  const pkcs8B64 = (env.REGISTRY_PRIVATE_KEY || '').trim()
-  if (!pkcs8B64) return null
-  const pkcs8 = bytesFromB64(pkcs8B64)
-  const key = await crypto.subtle.importKey(
-    'pkcs8', pkcs8, { name: 'Ed25519' }, false, ['sign'],
-  )
-  const sig = await crypto.subtle.sign({ name: 'Ed25519' }, key, bytes)
-  return b64FromBytes(new Uint8Array(sig))
-}
-
-function b64FromBytes(bytes) {
-  let s = ''
-  for (const b of bytes) s += String.fromCharCode(b)
-  return btoa(s)
-}
-
-function bytesFromB64(b64) {
-  const bin = atob(b64.replace(/\s+/g, ''))
-  const out = new Uint8Array(bin.length)
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
-  return out
-}
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/web/workers/registry-worker/index.js
+++ b/web/workers/registry-worker/index.js
@@ -77,6 +77,15 @@ export default {
     if (path === '/.well-known/registry-pubkey' && request.method === 'GET')
       return handlePubkey(env)
 
+    // Operator-only path used by the librefang-registry GitHub Action to
+    // rebuild the D1 cache + signed index right after a push to main, so
+    // dashboard / daemon don't have to wait for the next 02:00 UTC cron
+    // tick. Auth is a shared bearer token deployed as a worker secret;
+    // until it is set, the route returns 503 and stays inert. See
+    // `web/workers/SIGNING.md` § "Forced refresh from the registry repo".
+    if (path === '/api/registry/refresh' && request.method === 'POST')
+      return handleForcedRefresh(request, env)
+
     return new Response('Not Found', { status: 404 })
   },
 
@@ -543,6 +552,59 @@ async function handleSignedIndexSig(env) {
       ...CORS,
     },
   })
+}
+
+// Forced refresh — invoked by the librefang-registry GitHub Action after a
+// push to main. Constant-time auth against `REGISTRY_REFRESH_TOKEN` (worker
+// secret); 503 until the secret is set so the endpoint can't be probed.
+// On success: rebuild D1 caches (`registry_data` + `plugins_index`),
+// re-sign, and purge the Cache-API row so the next dashboard hit reads
+// fresh bytes instead of the 1h-cached previous payload.
+async function handleForcedRefresh(request, env) {
+  const expected = (env.REGISTRY_REFRESH_TOKEN || '').trim()
+  if (!expected) return errorResponse('refresh endpoint not configured', 503)
+
+  const auth = request.headers.get('authorization') || ''
+  const m = auth.match(/^Bearer\s+(.+)$/i)
+  const provided = m ? m[1].trim() : ''
+  if (!constantTimeEqual(provided, expected)) {
+    return errorResponse('unauthorized', 401)
+  }
+
+  // Force a full rebuild by pre-emptively dropping the rows the
+  // signature-equality short-circuit relies on. Without this, a no-op
+  // commit (e.g. README typo) would short-circuit and never refresh
+  // plugins_index — but legitimate plugin pushes also might not flip
+  // the directory `sha`. Dropping the rows guarantees a real fetch.
+  await env.DB.batch([
+    env.DB.prepare(`DELETE FROM kv_store WHERE key = 'registry_data'`),
+    env.DB.prepare(`DELETE FROM kv_store WHERE key = 'plugins_index'`),
+    env.DB.prepare(`DELETE FROM kv_store WHERE key = 'plugins_index_sig'`),
+  ])
+
+  await refreshRegistryCache(env)
+
+  // Purge the Cache-API entry that backs `/api/registry`. A new request
+  // would otherwise see the previous (now-superseded) cached payload for
+  // up to REGISTRY_CACHE_TTL.
+  try {
+    await caches.default.delete(new Request('https://internal/registry_data'))
+  } catch (_) { /* best-effort */ }
+
+  const fresh = await env.DB.prepare(
+    `SELECT updated_at FROM kv_store WHERE key = 'registry_data'`,
+  ).first()
+  return new Response(
+    JSON.stringify({ ok: true, refreshed_at: fresh?.updated_at ?? null }),
+    { headers: { 'Content-Type': 'application/json', ...CORS } },
+  )
+}
+
+function constantTimeEqual(a, b) {
+  if (a.length !== b.length) return false
+  let mismatch = 0
+  for (let i = 0; i < a.length; i++) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return mismatch === 0
 }
 
 function handlePubkey(env) {

--- a/web/workers/registry-worker/index.js
+++ b/web/workers/registry-worker/index.js
@@ -438,10 +438,19 @@ async function doSyncFromRepo(env, { requireAuth, request }) {
   } catch (e) {
     return errorResponse(`registry-index.json invalid: ${e.message}`, 502)
   }
-  // Ed25519 sig is 64 bytes → 88 base64 chars (incl. padding) or 86 chars
-  // unpadded. Allow either.
-  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(pluginsSigText) || pluginsSigText.length < 86) {
-    return errorResponse(`plugins-index.json.sig is not valid base64`, 502)
+  // Ed25519 sig is exactly 64 bytes → 88 base64 chars (with `==` padding)
+  // or 86 chars unpadded. Anything else is wrong-shape garbage that the
+  // daemon would reject; better to bounce here than poison D1 with it
+  // (PR re-review MEDIUM-NEW-F).
+  if (
+    (pluginsSigText.length !== 88 && pluginsSigText.length !== 86) ||
+    !/^[A-Za-z0-9+/]+(?:==)?$/.test(pluginsSigText)
+  ) {
+    return errorResponse(
+      `plugins-index.json.sig is not a valid Ed25519 signature ` +
+      `(expected 86 or 88 base64 chars; got ${pluginsSigText.length})`,
+      502,
+    )
   }
 
   const now = Math.floor(Date.now() / 1000)
@@ -467,10 +476,18 @@ async function doSyncFromRepo(env, { requireAuth, request }) {
   ])
 
   // Purge the Cache-API entry the dashboard hits — without this,
-  // /api/registry serves the previous cached payload for up to 1h.
+  // /api/registry serves the previous cached payload for up to 1h. PR
+  // re-review MEDIUM-NEW-G: surface the outcome so the GH Action can
+  // see partial-success runs (D1 stored, cache stale) instead of
+  // assuming fresh-everywhere on a 200.
+  let cachePurged = false
+  let cachePurgeError = null
   try {
-    await caches.default.delete(new Request('https://internal/registry_data'))
-  } catch (_) { /* best-effort */ }
+    cachePurged = await caches.default.delete(new Request('https://internal/registry_data'))
+  } catch (e) {
+    cachePurgeError = e?.message || String(e)
+    console.error('Cache purge failed:', cachePurgeError)
+  }
 
   return new Response(
     JSON.stringify({
@@ -479,6 +496,8 @@ async function doSyncFromRepo(env, { requireAuth, request }) {
       plugins_bytes: pluginsText.length,
       sig_bytes: pluginsSigText.length,
       registry_bytes: registryText.length,
+      cache_purged: cachePurged,
+      ...(cachePurgeError ? { cache_purge_error: cachePurgeError } : {}),
     }),
     { headers: { 'Content-Type': 'application/json', ...CORS } },
   )

--- a/web/workers/registry-worker/index.js
+++ b/web/workers/registry-worker/index.js
@@ -4,12 +4,17 @@
 //
 // Plugin signing (#3805): when REGISTRY_PRIVATE_KEY (PKCS#8 base64) is set as
 // a Worker secret and REGISTRY_PUBLIC_KEY (raw 32-byte base64) is set as a
-// var, the cron refresh signs the canonical index.json with Ed25519 and
-// stores the signature in kv_store('registry_data_sig'). The daemon
-// (librefang-runtime/plugin_manager.rs) fetches:
+// var, the cron refresh signs the daemon-shaped plugins index (a flat
+// JSON array of {name, version, description, needs}) with Ed25519. The
+// daemon (librefang-runtime/plugin_manager.rs::fetch_verified_index) fetches:
 //   GET /api/registry/index.json     — canonical bytes that were signed
+//                                      (a JSON array of plugin entries)
 //   GET /api/registry/index.json.sig — base64 Ed25519 signature
 //   GET /.well-known/registry-pubkey — base64 raw 32-byte Ed25519 pubkey
+//
+// The dashboard's /api/registry endpoint continues to return the dict-shaped
+// payload (hands/channels/plugins/skills/...) for the marketplace UI. The
+// two formats are stored separately in D1 (registry_data vs plugins_index).
 // See web/workers/SIGNING.md for keygen + deploy.
 
 const CORS = {
@@ -296,6 +301,13 @@ async function refreshRegistryCache(env) {
     return items.filter(f => f.type === 'dir' || (f.name.endsWith('.toml') && f.name !== 'README.md'))
   }
 
+  function parseStringArray(text, key) {
+    const m = text.match(new RegExp(`^${key}\\s*=\\s*\\[([^\\]]*)\\]`, 'm'))
+    if (!m) return undefined
+    const items = m[1].match(/"([^"]*)"/g)?.map(s => s.replace(/"/g, ''))
+    return items?.length ? items : undefined
+  }
+
   async function fetchToml(path) {
     const res = await fetch(`${REGISTRY_RAW}/${path}`)
     if (!res.ok) return null
@@ -310,11 +322,14 @@ async function refreshRegistryCache(env) {
       if (descM) i18n[m[1]] = { description: descM[1] }
     }
 
-    const tagsM = text.match(/^tags\s*=\s*\[([^\]]*)\]/m)
-    const tags = tagsM ? tagsM[1].match(/"([^"]*)"/g)?.map(s => s.replace(/"/g, '')) : undefined
+    const tags = parseStringArray(text, 'tags')
+    const needs = parseStringArray(text, 'needs')
 
     const result = { id: get('id'), name: get('name'), description: get('description'), category: get('category'), icon: get('icon') }
+    const version = get('version')
+    if (version) result.version = version
     if (tags?.length) result.tags = tags
+    if (needs?.length) result.needs = needs
     if (Object.keys(i18n).length) result.i18n = i18n
     return result
   }
@@ -353,7 +368,10 @@ async function refreshRegistryCache(env) {
     const existing = await env.DB.prepare(
       `SELECT value FROM kv_store WHERE key = 'registry_data'`,
     ).first()
-    if (existing) {
+    const pluginsIndexExists = await env.DB.prepare(
+      `SELECT 1 AS present FROM kv_store WHERE key = 'plugins_index'`,
+    ).first()
+    if (existing && pluginsIndexExists) {
       try {
         if (JSON.parse(existing.value).signature === signature) {
           await env.DB.prepare(
@@ -395,19 +413,41 @@ async function refreshRegistryCache(env) {
        ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
     ).bind(indexJson, now).run()
 
-    // Sign the canonical index bytes if a private key is configured. Signing
-    // is best-effort — if the secret is missing we skip (the daemon can still
-    // fetch the index but signature verification will fail closed at its end).
+    // Build the daemon-shaped flat plugins array (sorted by name for byte
+    // determinism — the signature is over these exact bytes so any reordering
+    // would break verification). Only the fields the daemon actually uses are
+    // included: name, version, description, needs.
+    const pluginsIndex = pluginDetails
+      .map(p => {
+        const out = { name: p.name }
+        if (p.version) out.version = p.version
+        if (p.description) out.description = p.description
+        if (p.needs?.length) out.needs = p.needs
+        return out
+      })
+      .filter(p => p.name)
+      .sort((a, b) => a.name.localeCompare(b.name))
+    const pluginsIndexJson = JSON.stringify(pluginsIndex)
+
+    await env.DB.prepare(
+      `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index', ?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    ).bind(pluginsIndexJson, now).run()
+
+    // Sign the daemon-shaped plugins index if a private key is configured.
+    // Signing is best-effort — if the secret is missing we skip (the daemon
+    // can still fetch the index but signature verification will fail closed
+    // at its end).
     try {
-      const sig = await signWithRegistryKey(env, new TextEncoder().encode(indexJson))
+      const sig = await signWithRegistryKey(env, new TextEncoder().encode(pluginsIndexJson))
       if (sig) {
         await env.DB.prepare(
-          `INSERT INTO kv_store (key, value, updated_at) VALUES ('registry_data_sig', ?, ?)
+          `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index_sig', ?, ?)
            ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
         ).bind(sig, now).run()
       }
     } catch (e) {
-      console.error('Registry signing failed:', e.message)
+      console.error('Plugins index signing failed:', e.message)
     }
 
     console.log('Registry refreshed:', hands.length, 'hands,', channels.length, 'channels,',
@@ -423,7 +463,7 @@ async function refreshRegistryCache(env) {
 
 async function handleSignedIndex(env) {
   const row = await env.DB.prepare(
-    `SELECT value FROM kv_store WHERE key = 'registry_data'`,
+    `SELECT value FROM kv_store WHERE key = 'plugins_index'`,
   ).first()
   if (!row) return errorResponse('index not yet built — try again after the next cron tick', 503)
   return new Response(row.value, {
@@ -437,7 +477,7 @@ async function handleSignedIndex(env) {
 
 async function handleSignedIndexSig(env) {
   const row = await env.DB.prepare(
-    `SELECT value FROM kv_store WHERE key = 'registry_data_sig'`,
+    `SELECT value FROM kv_store WHERE key = 'plugins_index_sig'`,
   ).first()
   if (!row) return errorResponse('signature not available — REGISTRY_PRIVATE_KEY may be unset', 503)
   return new Response(row.value, {

--- a/web/workers/registry-worker/index.js
+++ b/web/workers/registry-worker/index.js
@@ -581,33 +581,72 @@ async function handleForcedRefresh(request, env) {
     return errorResponse('unauthorized', 401)
   }
 
-  const indexUrl =
-    'https://raw.githubusercontent.com/librefang/librefang-registry/main/plugins-index.json'
-  const resp = await fetch(indexUrl, { cf: { cacheTtl: 0 } })
-  if (!resp.ok) {
+  const RAW_BASE =
+    'https://raw.githubusercontent.com/librefang/librefang-registry/main'
+  const pluginsUrl = `${RAW_BASE}/plugins-index.json`
+  const registryUrl = `${RAW_BASE}/registry-index.json`
+
+  // Fetch both in parallel — 2 subrequests, regardless of how many
+  // plugins / agents / skills the registry contains.
+  const [pluginsResp, registryResp] = await Promise.all([
+    fetch(pluginsUrl, { cf: { cacheTtl: 0 } }),
+    fetch(registryUrl, { cf: { cacheTtl: 0 } }),
+  ])
+  if (!pluginsResp.ok) {
     return errorResponse(
-      `failed to fetch plugins-index.json: HTTP ${resp.status}`,
+      `failed to fetch plugins-index.json: HTTP ${pluginsResp.status}`,
       502,
     )
   }
-  const indexText = await resp.text()
-  // Validate JSON shape — refuse to sign unparseable bytes.
+  if (!registryResp.ok) {
+    return errorResponse(
+      `failed to fetch registry-index.json: HTTP ${registryResp.status}`,
+      502,
+    )
+  }
+  const pluginsText = await pluginsResp.text()
+  const registryText = await registryResp.text()
+
+  // Validate JSON shapes — refuse to ingest unparseable bytes.
   try {
-    const parsed = JSON.parse(indexText)
+    const parsed = JSON.parse(pluginsText)
     if (!Array.isArray(parsed)) throw new Error('plugins-index.json is not an array')
   } catch (e) {
     return errorResponse(`plugins-index.json invalid: ${e.message}`, 502)
   }
+  try {
+    const parsed = JSON.parse(registryText)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+      throw new Error('registry-index.json is not an object')
+  } catch (e) {
+    return errorResponse(`registry-index.json invalid: ${e.message}`, 502)
+  }
 
   const now = Math.floor(Date.now() / 1000)
-  await env.DB.prepare(
-    `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index', ?, ?)
-     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-  ).bind(indexText, now).run()
+  await env.DB.batch([
+    env.DB
+      .prepare(
+        `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index', ?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+      )
+      .bind(pluginsText, now),
+    env.DB
+      .prepare(
+        `INSERT INTO kv_store (key, value, updated_at) VALUES ('registry_data', ?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+      )
+      .bind(registryText, now),
+  ])
+
+  // Purge the Cache-API entry the dashboard hits — without this, /api/registry
+  // serves the previous (now-superseded) cached payload for up to 1h.
+  try {
+    await caches.default.delete(new Request('https://internal/registry_data'))
+  } catch (_) { /* best-effort */ }
 
   let signed = false
   try {
-    const sig = await signWithRegistryKey(env, new TextEncoder().encode(indexText))
+    const sig = await signWithRegistryKey(env, new TextEncoder().encode(pluginsText))
     if (sig) {
       await env.DB.prepare(
         `INSERT INTO kv_store (key, value, updated_at) VALUES ('plugins_index_sig', ?, ?)
@@ -620,7 +659,13 @@ async function handleForcedRefresh(request, env) {
   }
 
   return new Response(
-    JSON.stringify({ ok: true, refreshed_at: now, signed, bytes: indexText.length }),
+    JSON.stringify({
+      ok: true,
+      refreshed_at: now,
+      signed,
+      plugins_bytes: pluginsText.length,
+      registry_bytes: registryText.length,
+    }),
     { headers: { 'Content-Type': 'application/json', ...CORS } },
   )
 }

--- a/web/workers/registry-worker/wrangler.toml
+++ b/web/workers/registry-worker/wrangler.toml
@@ -19,4 +19,4 @@ crons = ["0 2 * * *"]
 # Until both are set, the signing endpoints return 503 and the cron refresh
 # skips signing — the existing /api/registry path remains fully functional.
 [vars]
-REGISTRY_PUBLIC_KEY = "NEoveGRjRazzoiRFqozw0VEtF9N9elfwIAOqKzt4Ue4="
+REGISTRY_PUBLIC_KEY = "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0="

--- a/web/workers/registry-worker/wrangler.toml
+++ b/web/workers/registry-worker/wrangler.toml
@@ -19,4 +19,4 @@ crons = ["0 2 * * *"]
 # Until both are set, the signing endpoints return 503 and the cron refresh
 # skips signing — the existing /api/registry path remains fully functional.
 [vars]
-REGISTRY_PUBLIC_KEY = "julGSbXv8BZWStCGQYf3E98uVT+/EBbRGHoN4aG21ng="
+REGISTRY_PUBLIC_KEY = "FqJmVvJmCChmxX1xWjygaZyR4F/ls/Z8QvedpMVgMPE="

--- a/web/workers/registry-worker/wrangler.toml
+++ b/web/workers/registry-worker/wrangler.toml
@@ -11,3 +11,12 @@ database_id = "91df0bc6-e658-4463-9eba-22d5476d420a"
 # Daily registry refresh at UTC 02:00
 [triggers]
 crons = ["0 2 * * *"]
+
+# Plugin signing — see web/workers/SIGNING.md for keygen + deploy.
+# REGISTRY_PUBLIC_KEY is non-secret (raw 32-byte Ed25519 pubkey, base64).
+# REGISTRY_PRIVATE_KEY is a secret; deploy with:
+#   wrangler secret put REGISTRY_PRIVATE_KEY
+# Until both are set, the signing endpoints return 503 and the cron refresh
+# skips signing — the existing /api/registry path remains fully functional.
+[vars]
+REGISTRY_PUBLIC_KEY = ""

--- a/web/workers/registry-worker/wrangler.toml
+++ b/web/workers/registry-worker/wrangler.toml
@@ -19,4 +19,4 @@ crons = ["0 2 * * *"]
 # Until both are set, the signing endpoints return 503 and the cron refresh
 # skips signing — the existing /api/registry path remains fully functional.
 [vars]
-REGISTRY_PUBLIC_KEY = "FqJmVvJmCChmxX1xWjygaZyR4F/ls/Z8QvedpMVgMPE="
+REGISTRY_PUBLIC_KEY = "NEoveGRjRazzoiRFqozw0VEtF9N9elfwIAOqKzt4Ue4="

--- a/web/workers/registry-worker/wrangler.toml
+++ b/web/workers/registry-worker/wrangler.toml
@@ -19,4 +19,4 @@ crons = ["0 2 * * *"]
 # Until both are set, the signing endpoints return 503 and the cron refresh
 # skips signing — the existing /api/registry path remains fully functional.
 [vars]
-REGISTRY_PUBLIC_KEY = ""
+REGISTRY_PUBLIC_KEY = "julGSbXv8BZWStCGQYf3E98uVT+/EBbRGHoN4aG21ng="

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-a57e5b59e34ea86d2a446ba95bd51f23ac5bbfbe24fcc935a965e25fdad183e1
+a57e5b59e34ea86d2a446ba95bd51f23ac5bbfbe24fcc935a965e25fdad183e1  openapi.json


### PR DESCRIPTION
## Summary

End-to-end Ed25519 signing for the LibreFang plugin registry, plus an in-repo build/sign pipeline that keeps plugin pushes auto-publishing within seconds while staying inside Cloudflare Workers Free quotas.

Closes the original blocker: `librefang plugin install <name>` was hard-failing with "Plugin registry public key is not configured" because no key existed anywhere in the chain. After this PR, the daemon trusts a compiled-in pubkey, the worker carries no signing material at all, and the registry repo's CI signs the bytes ops actually serves.

## What changed

**Daemon (`librefang-runtime/plugin_manager.rs`)**
- Compiled-in `EMBEDDED_REGISTRY_PUBKEYS: &[EmbeddedPubkey]` slice (slot 0 active, prior keys carry `expires_at: Option<i64>` for bounded rotation).
- `resolve_registry_pubkey` chain: env override → embedded → TOFU/HTTP fallback (only reachable for self-hosted forks, never the official path).
- TOFU file open hardened with `O_NOFOLLOW` + regular-file check + 0600.
- `fetch_verified_index` defaults to the worker-signed mirror at
  `stats.librefang.ai/api/registry/index.json[.sig]` for the official
  registry; self-hosted forks fall back to GitHub raw with env overrides.
- Index signature is **mandatory** — no soft-fail-by-slug downgrade, no SHA-256 fallback rescue. Missing or unreachable `.sig` hard-fails after a single 500ms-backoff retry. Self-hosted forks that haven't deployed signing yet must explicitly opt out via `LIBREFANG_REGISTRY_VERIFY=0`.
- Single-plugin install replaces the per-plugin Ed25519 archive check (which was dead code that always 404'd and silently passed) with an index-membership check: refuse to install plugins not present in the signed `plugins-index.json`.

**Workers (`web/workers/`)**
- `registry-worker` is now a pure transport — it carries no private key,
  performs no signing. Forced refresh fetches `plugins-index.json` +
  `.sig` + `registry-index.json` from the registry repo's raw URLs
  (3 subrequests, constant in registry size) and stores them verbatim.
- Cron `scheduled` handler reuses the same path as a daily backstop.
- Sig length validated at 86 or 88 base64 chars (exact Ed25519 sig size).
- Cache-purge outcome surfaced in the response body.
- `marketplace-worker` `bundle_url` allowlist matches on `(parsed.host,
  pathname regex)` tuples — `github.com/.../releases/download/`,
  `objects.githubusercontent.com/`, and `marketplace.librefang.ai/bundles/`
  only. Tightens `bundle_sha256` to `^[0-9a-f]{64}$`.
- `constantTimeEqual` padded to fixed length.

**Pages worker (`web/public/_worker.js`)**
- `/.well-known/registry-pubkey` short-circuit before SPA fallback so
  daemons that probe `librefang.ai` get the raw key instead of HTML.

**Sister repo `librefang/librefang-registry`**
- `scripts/build-plugins-index.mjs` — walks `plugins/<name>/plugin.toml`,
  emits sorted flat array as `plugins-index.json`.
- `scripts/build-registry-index.mjs` — walks all 8 category dirs, emits
  dict-shaped `registry-index.json` for the dashboard.
- `scripts/sign-plugins-index.mjs` — signs `plugins-index.json` with
  `REGISTRY_PRIVATE_KEY` (GitHub Actions secret) and writes
  `plugins-index.json.sig` next to it.
- `.github/workflows/refresh-cache.yml` — on push to plugins/agents/
  skills/etc, builds + signs + commits + pokes the worker. SHA-pinned
  actions, scoped secret env, post-sign self-verify against the
  committed pubkey.
- `.github/CODEOWNERS` — `/scripts/`, `/.github/`, and `wrangler.toml`
  require registry-owner approval.
- All 11 existing plugins under `plugins/` got `[integrity]` SHA-256
  hashes for their hook scripts (daemon's
  `manifest_missing_integrity_hooks` check would otherwise hard-fail).
- Branch protection on `main` enabled via `gh api`: PR-required,
  CODEOWNERS-enforced, force-push + deletion blocked, bypass for the
  registry owner and the github-actions[bot] app.

**Tooling**
- `scripts/check-pubkey-lockstep.sh` — fails CI if the daemon's slot-0
  pubkey doesn't match the three worker-side `REGISTRY_PUBLIC_KEY`
  values byte-for-byte (anchored regex, length-checked to 44 chars).

## Trust model

| Layer | Trust root |
|---|---|
| Daemon → registry index | Compiled-in `EMBEDDED_REGISTRY_PUBKEYS[0]` |
| Worker → daemon | Pure transport — daemon verifies signature, worker doesn't sign |
| Registry CI → worker | `REGISTRY_PRIVATE_KEY` (GH Actions secret on librefang-registry); CODEOWNERS + branch protection on main |
| Plugin authors → registry | PR review + branch protection on librefang-registry/main |

Three rounds of code-reviewer-agent review caught:
- Round 1: 4 CRITICAL / 5 HIGH / 5 MEDIUM / 3 LOW
- Round 2: 5 new HIGH / 2 new MEDIUM / 1 LOW introduced by round-1 fixes
- Round 3: 1 new CRITICAL (branch protection wasn't actually enabled
  via API, only documented) / 1 HIGH (post-sign verify overclaim) /
  1 MEDIUM (no rotation expiry) / 1 LOW (CODEOWNERS gaps)

All 13 distinct issues are now closed; reviewer's stop-iterating verdict
was issued after round 3. Residual threats reduce to "compromised
maintainer account" / "GitHub itself compromised" / "Anthropic SDK chain
compromised" — outside what this PR can mitigate.

## Verification

- `cargo check -p librefang-runtime --lib` clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` clean
- `cargo test -p librefang-runtime --lib plugin_manager`: 29 tests pass
- `scripts/check-pubkey-lockstep.sh` passes
- Both worker JS files `node --check` clean
- End-to-end live: pushed `librefang-registry@fe15ae5`, GH Action
  ran build → sign → commit → poke worker; daemon-facing
  `https://stats.librefang.ai/api/registry/index.json[.sig]` serves
  the new bytes, signature verifies against `/api/registry/pubkey`
  for all 11 plugins.

## Pre-merge actions for ops

- Back up the new private key (only copy is the librefang-registry
  GitHub Actions secret) to a password manager. Old key (in Bitwarden
  item `d8a43180-...`) is superseded and can be deleted.
- Optional: delete unused `REGISTRY_PRIVATE_KEY` worker secrets on
  `librefang-registry` and `librefang-marketplace` workers (no longer
  read by either codebase).

## Out-of-scope follow-ups

- `LIBREFANG_REGISTRY_VERIFY=0` env-var bypass should move to a CLI
  flag so it can't be set ambiently by a malicious post-install hook.
- Marketplace `/v1/download/<slug>/<version>/signature` path still
  signs publish-time URL claims; consider tightening to a registry-
  controlled CDN-only flow.
- A daemon-side `librefang plugin rotate-pubkey` command would smooth
  the rotation UX.
