### PR TITLE
ci(smoke): wire xtask integration-test as live-integration-smoke job (#3405)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,9 +484,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # Default `Swatinem/rust-cache` key (job-name + Cargo.lock hash) so this
+      # job shares its target/ with the rest of the Rust jobs. A per-job
+      # `live-smoke-${hashFiles}` key forced a cold compile (~15-20 min debug)
+      # on every first run, eating most of the 25-min timeout.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: live-smoke-${{ hashFiles('**/Cargo.lock') }}
       - name: Ensure dashboard build dir exists
         run: mkdir -p crates/librefang-api/static/react
       - name: Build daemon (debug)
@@ -495,7 +497,19 @@ jobs:
         run: |
           cargo run -p xtask -- integration-test \
             --binary target/debug/librefang \
-            --skip-llm
+            --skip-llm \
+            --daemon-log /tmp/librefang-daemon.log \
+            --health-timeout-secs 60
+      - name: Show daemon log on failure
+        if: failure()
+        run: |
+          if [ -f /tmp/librefang-daemon.log ]; then
+            echo "::group::daemon log"
+            cat /tmp/librefang-daemon.log
+            echo "::endgroup::"
+          else
+            echo "(no daemon log captured)"
+          fi
       - name: Stop any leftover daemon (best-effort)
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,47 @@ jobs:
       - name: Parse PowerShell installer
         run: pwsh -NoProfile -Command '$tokens=$null; $errors=$null; [void][System.Management.Automation.Language.Parser]::ParseFile("web/public/install.ps1",[ref]$tokens,[ref]$errors); if ($errors) { $errors | ForEach-Object { Write-Error $_.Message }; exit 1 }'
 
+  # ── Live-integration smoke (#3405) ────────────────────────────────────────────
+  # Spawn a real `target/debug/librefang start` daemon on port 4545, hit
+  # `/api/health`, `/api/agents`, `/api/budget`, `/api/network/status`, then
+  # SIGTERM. Catches the failure modes the in-process integration tests miss:
+  # missing route registration in `server.rs`, config fields not deserializing,
+  # daemon refusing to bind, etc.
+  #
+  # `--skip-llm` is set: the per-PR smoke does not call a real provider (no
+  # API keys exposed to PR runners). The provider-call branch of
+  # `xtask integration-test` is exercised separately by the release / nightly
+  # workflow when a real `GROQ_API_KEY` secret is available.
+  live-integration-smoke:
+    name: Live Integration Smoke
+    needs: changes
+    # PR-only: push to main already runs the full test matrix; the smoke
+    # adds spawn-a-real-daemon coverage that the in-process tests miss.
+    if: github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: live-smoke-${{ hashFiles('**/Cargo.lock') }}
+      - name: Ensure dashboard build dir exists
+        run: mkdir -p crates/librefang-api/static/react
+      - name: Build daemon (debug)
+        run: cargo build -p librefang-cli --bin librefang
+      - name: Run live-integration smoke (skip LLM)
+        run: |
+          cargo run -p xtask -- integration-test \
+            --binary target/debug/librefang \
+            --skip-llm
+      - name: Stop any leftover daemon (best-effort)
+        if: always()
+        run: |
+          if command -v lsof >/dev/null 2>&1; then
+            lsof -ti :4545 | xargs -r kill -9 || true
+          fi
+
   # ── Ubuntu tests: selective on PR, full on main ────────────────────────────────
   # Full-run lane (push to main, workspace Cargo.toml change) runs the full
   # workspace test matrix sharded 4 ways via `cargo nextest run --partition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,6 +404,10 @@ _338 PRs from 7 contributors since v2026.4.28-beta7._
 - **Outbound `[channels.webhook] callback_url` is SSRF-guarded.** Adapters refuse to start if the URL resolves to a private (`10/8`, `172.16/12`, `192.168/16`), CGN (`100.64/10`), loopback (`127/8`, `::1`), link-local, multicast, or cloud-metadata range. Catches IPv6 short forms like `[::]`, IPv4-mapped (`[::ffff:127.0.0.1]`), NAT64, and trailing-dot FQDNs. **Action required**: local dev setups using `callback_url = "http://127.0.0.1/..."` must switch to a public tunnel (ngrok, cloudflared) or omit `callback_url`. (#3942)
 - **BREAKING**: `require_auth_for_reads` now defaults to *enabled* whenever any form of authentication is configured (`api_key`, `user_api_keys`, or dashboard credentials). Previously the flag had to be set explicitly, leaving read endpoints open even on instances with an `api_key`. Operators who deliberately want open reads on an authenticated instance (e.g. behind a trusted reverse proxy) must now set `require_auth_for_reads = false` in `config.toml`. A boot-time INFO log records when the flag is auto-enabled. (#2448)
 
+### Maintenance
+
+- Wire `cargo xtask integration-test` into CI as a `live-integration-smoke` job — spawns a real `target/debug/librefang start` daemon on every PR touching Rust or CI files, hits `/api/health`, `/api/agents`, `/api/budget`, `/api/network/status`, and SIGTERMs. Catches the failure modes the in-process integration tests miss (route not registered in `server.rs`, daemon failing to bind, config fields not deserializing). Runs with `--skip-llm` to keep the gate hermetic; the live-LLM branch is reserved for the release/nightly workflow that has provider keys. (#3405) (@houko)
+
 ## [2026.4.28] - 2026-04-28
 
 _67 PRs from 4 contributors since v2026.4.27-beta6._

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-a57e5b59e34ea86d2a446ba95bd51f23ac5bbfbe24fcc935a965e25fdad183e1
+a57e5b59e34ea86d2a446ba95bd51f23ac5bbfbe24fcc935a965e25fdad183e1  openapi.json

--- a/xtask/src/integration_test.rs
+++ b/xtask/src/integration_test.rs
@@ -1,5 +1,6 @@
 use crate::common::repo_root;
 use clap::Parser;
+use std::fs::File;
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -23,6 +24,20 @@ pub struct IntegrationTestArgs {
     /// Path to the librefang binary
     #[arg(long)]
     pub binary: Option<String>,
+
+    /// Capture daemon stdout+stderr to this file. Without this flag the
+    /// daemon's output is dropped, which means a startup failure surfaces
+    /// as nothing more than "Health check timed out". CI callers should set
+    /// this and `cat` the file in an `if: failure()` step.
+    #[arg(long)]
+    pub daemon_log: Option<PathBuf>,
+
+    /// Seconds to wait for `/api/health` to return 200. Default 30: cold
+    /// debug-build startup on a CI runner (binary just compiled, no OS file
+    /// cache, SQLite migration on a fresh DB) routinely needs more than the
+    /// historical 10s, producing flake.
+    #[arg(long, default_value = "30")]
+    pub health_timeout_secs: u64,
 }
 
 fn default_binary(root: &Path) -> PathBuf {
@@ -192,10 +207,22 @@ pub fn run(args: IntegrationTestArgs) -> Result<(), Box<dyn std::error::Error>> 
     println!("Starting daemon: {} start", binary.display());
     let mut daemon = {
         let mut cmd = Command::new(&binary);
-        cmd.arg("start")
-            .current_dir(&root)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
+        cmd.arg("start").current_dir(&root);
+        match &args.daemon_log {
+            Some(path) => {
+                let stdout_file = File::create(path)
+                    .map_err(|e| format!("create daemon log {}: {e}", path.display()))?;
+                let stderr_file = stdout_file
+                    .try_clone()
+                    .map_err(|e| format!("clone daemon log handle: {e}"))?;
+                cmd.stdout(Stdio::from(stdout_file))
+                    .stderr(Stdio::from(stderr_file));
+                println!("  Capturing daemon output to {}", path.display());
+            }
+            None => {
+                cmd.stdout(Stdio::null()).stderr(Stdio::null());
+            }
+        }
         if let Some(ref key) = args.api_key {
             cmd.env("GROQ_API_KEY", key);
         }
@@ -205,9 +232,20 @@ pub fn run(args: IntegrationTestArgs) -> Result<(), Box<dyn std::error::Error>> 
     println!("  Daemon started (PID: {})", daemon.id());
 
     // Wait for health
-    println!("Waiting for health endpoint (up to 10s)...");
-    if let Err(e) = wait_for_health(port, Duration::from_secs(10)) {
+    println!(
+        "Waiting for health endpoint (up to {}s)...",
+        args.health_timeout_secs
+    );
+    if let Err(e) = wait_for_health(port, Duration::from_secs(args.health_timeout_secs)) {
         cleanup_daemon(&mut daemon, port);
+        if let Some(path) = &args.daemon_log {
+            eprintln!("--- daemon log ({}) ---", path.display());
+            match std::fs::read_to_string(path) {
+                Ok(contents) => eprintln!("{contents}"),
+                Err(read_err) => eprintln!("(failed to read daemon log: {read_err})"),
+            }
+            eprintln!("--- end daemon log ---");
+        }
         return Err(format!("Daemon failed to start: {}", e).into());
     }
     println!("  Daemon is healthy");

--- a/xtask/src/integration_test.rs
+++ b/xtask/src/integration_test.rs
@@ -28,7 +28,8 @@ pub struct IntegrationTestArgs {
     /// Capture daemon stdout+stderr to this file. Without this flag the
     /// daemon's output is dropped, which means a startup failure surfaces
     /// as nothing more than "Health check timed out". CI callers should set
-    /// this and `cat` the file in an `if: failure()` step.
+    /// this and `cat` the file in an `if: failure()` step. The file is
+    /// truncated on each run; rotate yourself if you need historical logs.
     #[arg(long)]
     pub daemon_log: Option<PathBuf>,
 
@@ -83,6 +84,22 @@ fn cleanup_daemon(daemon: &mut Child, port: u16) {
     let _ = daemon.kill();
     let _ = daemon.wait();
     kill_process_on_port(port);
+}
+
+/// Dump captured daemon log to stderr when present. No-op if `--daemon-log`
+/// wasn't passed (we never captured anything in that case). Called from every
+/// failure path so a CI step / local user always gets the root cause without
+/// having to know the file location.
+fn dump_daemon_log(args: &IntegrationTestArgs) {
+    let Some(path) = &args.daemon_log else {
+        return;
+    };
+    eprintln!("--- daemon log ({}) ---", path.display());
+    match std::fs::read_to_string(path) {
+        Ok(contents) => eprintln!("{contents}"),
+        Err(read_err) => eprintln!("(failed to read daemon log: {read_err})"),
+    }
+    eprintln!("--- end daemon log ---");
 }
 
 fn wait_for_health(port: u16, timeout: Duration) -> Result<(), Box<dyn std::error::Error>> {
@@ -238,14 +255,7 @@ pub fn run(args: IntegrationTestArgs) -> Result<(), Box<dyn std::error::Error>> 
     );
     if let Err(e) = wait_for_health(port, Duration::from_secs(args.health_timeout_secs)) {
         cleanup_daemon(&mut daemon, port);
-        if let Some(path) = &args.daemon_log {
-            eprintln!("--- daemon log ({}) ---", path.display());
-            match std::fs::read_to_string(path) {
-                Ok(contents) => eprintln!("{contents}"),
-                Err(read_err) => eprintln!("(failed to read daemon log: {read_err})"),
-            }
-            eprintln!("--- end daemon log ---");
-        }
+        dump_daemon_log(&args);
         return Err(format!("Daemon failed to start: {}", e).into());
     }
     println!("  Daemon is healthy");
@@ -375,6 +385,10 @@ pub fn run(args: IntegrationTestArgs) -> Result<(), Box<dyn std::error::Error>> 
         for err in &results.errors {
             println!("  - {}", err);
         }
+        // Endpoint test failures usually mean the daemon hit an error path
+        // (5xx, panic, deserialize error, etc.) — daemon log is the root
+        // cause source. Symmetric with the wait_for_health failure path.
+        dump_daemon_log(&args);
         Err(format!("{} test(s) failed", results.failed).into())
     } else {
         println!("All integration tests passed!");


### PR DESCRIPTION
## Summary

CLAUDE.md documents a "MANDATORY: Live Integration Testing" section requiring a daemon-spawn → curl → assert ritual after every feature, but no CI workflow actually runs it. The eight-step manual ritual got skipped routinely, shipping dead-code endpoints (the canonical failure mode it warned about: routes registered in `routes.rs` but missed in `server.rs`).

`cargo xtask integration-test` was already implemented (#3721 lineage) — a curl-driven harness that spawns a real daemon on a port, hits the core endpoints, and SIGTERMs cleanly. This wires it into `ci.yml` as a new `live-integration-smoke` job.

## What it does

- Triggered on **PR only** (push to main runs the full test matrix anyway, and the smoke is a pre-merge gate, not post-merge detection).
- **Skips on pure docs/dashboard PRs** (`needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'`).
- `cargo build -p librefang-cli --bin librefang` → debug binary.
- `cargo run -p xtask -- integration-test --binary target/debug/librefang --skip-llm` → spawns daemon, waits for `/api/health`, exercises `/api/agents`, `/api/budget`, `/api/network/status`, SIGTERMs.
- `--skip-llm`: hermetic — no provider key exposed to PR runners. The live-LLM branch of `xtask integration-test` is reserved for the release / nightly workflow.
- 25-minute timeout (build + smoke).

## Hardening from review

- **Daemon log captured**: `xtask integration-test` gained `--daemon-log <path>`. Without it the daemon's stdout/stderr were dropped via `Stdio::null()`, so a startup failure surfaced as nothing more than "Health check timed out". CI now passes `--daemon-log /tmp/librefang-daemon.log` and an `if: failure()` step `cat`s it inside an `::group::` so the panic / config-deserialize / bind-failure is visible in the CI log.
- **Health timeout**: new `--health-timeout-secs <n>` (default 30) replaces the hardcoded 10s. CI passes 60. Cold-build daemon startup on a runner — just-compiled binary, no OS file cache, fresh-DB SQLite migration — routinely needed more than 10s and was producing flake.
- **Cache sharing**: dropped the per-job `key: live-smoke-${hashFiles}` override. The custom key forced a cold compile (~15-20 min debug) on every first run, eating most of the 25-min timeout. Default `Swatinem/rust-cache` key shares `target/` with the other Rust jobs via job-name buckets.

## Test plan

- [ ] CI run on this PR — `live-integration-smoke` job appears, builds, passes
- [ ] Verify `--skip-llm` exits 0 with all 4 endpoints green and no LLM call attempted
- [ ] Verify the gate skips pure docs PR (no Rust/CI changes)
- [ ] Verify `Show daemon log on failure` step actually fires when smoke fails (e.g., by transient bind error in a future PR)

Refs #3405. CLAUDE.md was already updated (PR #4593 / #3721 1/N) to retire the manual checklist; this PR closes the loop by adding the automated equivalent.