### PR TITLE
xtask(check-changed): mirror ci.yml lane detection locally (#3296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -386,6 +386,7 @@ _338 PRs from 7 contributors since v2026.4.28-beta7._
 
 ### Added
 
+- `cargo xtask check-changed` — local mirror of the `changes` job in `.github/workflows/ci.yml`. Computes which CI lanes a branch's diff would trigger (rust / docs / ci / install / workspace_cargo / xtask_src), the `full_run` and `full_test` decisions, and the affected crate set (with the schema-mirror rule that pulls `librefang-api` in for any `librefang-types` change). `--json` for tooling, `--run check,clippy,test` actually invokes scoped cargo commands. (#3296) (@houko)
 - Config-driven session mode for agent triggers (`session_mode = "new" | "persistent"`) — per-agent default with per-trigger override
 - **Real-client-IP resolution for proxied deployments** via two new top-level config fields, `trusted_proxies` and `trust_forwarded_for`. When both are set and the TCP peer matches the allowlist, the GCRA + auth-login rate limiters and the WebSocket per-IP connection cap key on the IP from forwarding headers (`CF-Connecting-IP` → `X-Real-IP` → `Forwarded` (RFC 7239) → rightmost-untrusted hop in `X-Forwarded-For`) instead of the proxy's own address. Without both flags set, behaviour is unchanged: TCP peer only, headers ignored. Forged forwarding headers from peers outside the allowlist are still ignored, so a rotating `X-Forwarded-For` from the open internet can never bypass per-IP limits. Closes the long-standing TODO referenced in `rate_limiter::resolve_client_ip` (now retired).
 

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-a57e5b59e34ea86d2a446ba95bd51f23ac5bbfbe24fcc935a965e25fdad183e1
+a57e5b59e34ea86d2a446ba95bd51f23ac5bbfbe24fcc935a965e25fdad183e1  openapi.json

--- a/xtask/src/check_changed.rs
+++ b/xtask/src/check_changed.rs
@@ -1,0 +1,487 @@
+//! Local mirror of the `changes` job in `.github/workflows/ci.yml` (#3296).
+//!
+//! Lets a developer ask "given my current branch, what would CI run?"
+//! without having to push and wait. Same regex and routing rules as
+//! `ci.yml`, kept structurally close so reviewers can diff the two when
+//! either side changes.
+//!
+//! Usage:
+//!   cargo xtask check-changed                       # plan against origin/main
+//!   cargo xtask check-changed --from main           # plan against local main
+//!   cargo xtask check-changed --json                # machine-readable
+//!   cargo xtask check-changed --run check           # actually run cargo check
+//!   cargo xtask check-changed --run check,clippy    # check then clippy
+//!
+//! `--run` only invokes the requested kinds against the affected crate set
+//! (or the workspace if `full_run`/`full_test` is true). When no `--run`
+//! is given the command exits 0 after printing the plan — useful as a
+//! pre-commit dry-run.
+
+use clap::Parser;
+use std::collections::BTreeSet;
+use std::process::Command;
+
+use crate::common::repo_root;
+
+#[derive(Parser, Debug)]
+pub struct CheckChangedArgs {
+    /// Compare HEAD against this revision (defaults to `origin/main`).
+    /// Use `HEAD~1` for "just the last commit".
+    #[arg(long, default_value = "origin/main")]
+    pub from: String,
+
+    /// Emit machine-readable JSON instead of the human summary.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Comma-separated cargo lanes to run against the affected crate set:
+    /// `check`, `clippy`, `test`. Workspace-wide when `full_run` /
+    /// `full_test` is true; selective otherwise. Defaults to none — just
+    /// prints the plan.
+    #[arg(long, value_delimiter = ',')]
+    pub run: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct Lanes {
+    rust: bool,
+    docs: bool,
+    ci: bool,
+    install: bool,
+    workspace_cargo: bool,
+    xtask_src: bool,
+}
+
+#[derive(Debug, Clone)]
+struct Decision {
+    value: bool,
+    reason: &'static str,
+}
+
+#[derive(Debug, Clone)]
+struct Plan {
+    lanes: Lanes,
+    full_run: Decision,
+    full_test: Decision,
+    crates: BTreeSet<String>,
+    files: Vec<String>,
+}
+
+fn changed_files(from: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    // `<from>...HEAD` is the merge-base diff (only commits unique to HEAD),
+    // matching what GitHub reports for a PR.
+    let range = format!("{from}...HEAD");
+    let output = Command::new("git")
+        .args(["diff", "--name-only", &range])
+        .current_dir(repo_root())
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "git diff failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .collect())
+}
+
+fn detect_lanes(changed: &[String]) -> Lanes {
+    // Same regexes as ci.yml's `Compute diff and route` step. Keep these
+    // identical to the shell version — drift would silently make the local
+    // command lie about CI behaviour.
+    let rust = regex::Regex::new(r"^(crates/|Cargo\.(toml|lock)$|xtask/|openapi\.json$|sdk/)")
+        .expect("static regex");
+    let docs = regex::Regex::new(r"^(docs/|.*\.md$)").expect("static regex");
+    let ci = regex::Regex::new(r"^\.github/workflows/").expect("static regex");
+    let install = regex::Regex::new(
+        r"^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$",
+    )
+    .expect("static regex");
+    let workspace_cargo = regex::Regex::new(r"^Cargo\.(toml|lock)$").expect("static regex");
+    let xtask_src = regex::Regex::new(r"^xtask/").expect("static regex");
+    let any = |re: &regex::Regex| changed.iter().any(|p| re.is_match(p));
+    Lanes {
+        rust: any(&rust),
+        docs: any(&docs),
+        ci: any(&ci),
+        install: any(&install),
+        workspace_cargo: any(&workspace_cargo),
+        xtask_src: any(&xtask_src),
+    }
+}
+
+/// Mirrors the `full_run` decision in ci.yml: build + clippy fan-out.
+/// Push-to-main is the CI-only "sanity check before merge"; we don't model
+/// it here because the local workflow is always PR-equivalent.
+fn decide_full_run(lanes: &Lanes) -> Decision {
+    if lanes.ci {
+        Decision { value: true, reason: "CI workflow changed" }
+    } else if lanes.workspace_cargo {
+        Decision { value: true, reason: "workspace Cargo.toml/Cargo.lock changed" }
+    } else if lanes.xtask_src {
+        Decision { value: true, reason: "xtask source changed" }
+    } else {
+        Decision { value: false, reason: "selective" }
+    }
+}
+
+/// Mirrors the `full_test` decision: strictly narrower than `full_run`.
+/// Workspace dep / lints drift can ripple anywhere, so it's the only PR-time
+/// trigger for re-running the full nextest matrix.
+fn decide_full_test(lanes: &Lanes) -> Decision {
+    if lanes.workspace_cargo {
+        Decision { value: true, reason: "workspace Cargo.toml/Cargo.lock changed" }
+    } else {
+        Decision { value: false, reason: "selective" }
+    }
+}
+
+fn affected_crates(changed: &[String], lanes: &Lanes) -> BTreeSet<String> {
+    // Direct: `crates/<name>/...` → `<name>`.
+    let mut set: BTreeSet<String> = changed
+        .iter()
+        .filter_map(|p| p.strip_prefix("crates/"))
+        .filter_map(|tail| tail.split('/').next())
+        .map(|s| s.to_string())
+        .collect();
+    // xtask isn't under `crates/`; pull it in explicitly when its source changes
+    // so the selective lane runs `cargo nextest -p xtask`.
+    if lanes.xtask_src {
+        set.insert("xtask".to_string());
+    }
+    // Schema-mirror rule: librefang-types changes can break the
+    // `kernel_config_schema_matches_golden_fixture` golden in librefang-api.
+    if set.contains("librefang-types") {
+        set.insert("librefang-api".to_string());
+    }
+    set
+}
+
+fn build_plan(from: &str) -> Result<Plan, Box<dyn std::error::Error>> {
+    let files = changed_files(from)?;
+    let lanes = detect_lanes(&files);
+    let full_run = decide_full_run(&lanes);
+    let full_test = decide_full_test(&lanes);
+    let crates = affected_crates(&files, &lanes);
+    Ok(Plan { lanes, full_run, full_test, crates, files })
+}
+
+fn print_human(plan: &Plan) {
+    println!("Changed files: {}", plan.files.len());
+    if plan.files.is_empty() {
+        println!("  (none — branch already merged or `--from` is HEAD)");
+    } else {
+        for f in &plan.files {
+            println!("  {f}");
+        }
+    }
+    println!();
+    println!("Lanes:");
+    println!("  rust            = {}", plan.lanes.rust);
+    println!("  docs            = {}", plan.lanes.docs);
+    println!("  ci              = {}", plan.lanes.ci);
+    println!("  install         = {}", plan.lanes.install);
+    println!("  workspace_cargo = {}", plan.lanes.workspace_cargo);
+    println!("  xtask_src       = {}", plan.lanes.xtask_src);
+    println!();
+    println!(
+        "full_run  = {} ({})",
+        plan.full_run.value, plan.full_run.reason
+    );
+    println!(
+        "full_test = {} ({})",
+        plan.full_test.value, plan.full_test.reason
+    );
+    println!();
+    if plan.crates.is_empty() {
+        println!("Affected crates: <none>");
+    } else {
+        let joined = plan.crates.iter().cloned().collect::<Vec<_>>().join(" ");
+        println!("Affected crates: {joined}");
+    }
+}
+
+fn print_json(plan: &Plan) -> Result<(), Box<dyn std::error::Error>> {
+    let json = serde_json::json!({
+        "files": plan.files,
+        "lanes": {
+            "rust": plan.lanes.rust,
+            "docs": plan.lanes.docs,
+            "ci": plan.lanes.ci,
+            "install": plan.lanes.install,
+            "workspace_cargo": plan.lanes.workspace_cargo,
+            "xtask_src": plan.lanes.xtask_src,
+        },
+        "full_run": { "value": plan.full_run.value, "reason": plan.full_run.reason },
+        "full_test": { "value": plan.full_test.value, "reason": plan.full_test.reason },
+        "crates": plan.crates.iter().collect::<Vec<_>>(),
+    });
+    println!("{}", serde_json::to_string_pretty(&json)?);
+    Ok(())
+}
+
+fn run_cargo_check(plan: &Plan) -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(repo_root());
+    if plan.full_run.value {
+        cmd.args(["check", "--workspace", "--lib"]);
+        println!("→ cargo check --workspace --lib");
+    } else if plan.crates.is_empty() {
+        println!("→ cargo check skipped (no affected crates)");
+        return Ok(());
+    } else {
+        cmd.arg("check");
+        for c in &plan.crates {
+            cmd.args(["-p", c]);
+        }
+        cmd.arg("--lib");
+        println!(
+            "→ cargo check {} --lib",
+            plan.crates
+                .iter()
+                .map(|c| format!("-p {c}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err("cargo check failed".into());
+    }
+    Ok(())
+}
+
+fn run_cargo_clippy(plan: &Plan) -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(repo_root());
+    if plan.full_run.value {
+        cmd.args([
+            "clippy",
+            "--workspace",
+            "--all-targets",
+            "--",
+            "-D",
+            "warnings",
+        ]);
+        println!("→ cargo clippy --workspace --all-targets -- -D warnings");
+    } else if plan.crates.is_empty() {
+        println!("→ cargo clippy skipped (no affected crates)");
+        return Ok(());
+    } else {
+        cmd.arg("clippy");
+        for c in &plan.crates {
+            cmd.args(["-p", c]);
+        }
+        cmd.args(["--all-targets", "--", "-D", "warnings"]);
+        println!(
+            "→ cargo clippy {} --all-targets -- -D warnings",
+            plan.crates
+                .iter()
+                .map(|c| format!("-p {c}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err("cargo clippy failed".into());
+    }
+    Ok(())
+}
+
+fn run_cargo_test(plan: &Plan) -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(repo_root());
+    if plan.full_test.value {
+        cmd.args(["test", "--workspace"]);
+        println!("→ cargo test --workspace");
+    } else if plan.crates.is_empty() {
+        println!("→ cargo test skipped (no affected crates)");
+        return Ok(());
+    } else {
+        cmd.arg("test");
+        for c in &plan.crates {
+            cmd.args(["-p", c]);
+        }
+        println!(
+            "→ cargo test {}",
+            plan.crates
+                .iter()
+                .map(|c| format!("-p {c}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err("cargo test failed".into());
+    }
+    Ok(())
+}
+
+pub fn run(args: CheckChangedArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let plan = build_plan(&args.from)?;
+
+    if args.json {
+        print_json(&plan)?;
+    } else {
+        print_human(&plan);
+    }
+
+    for kind in &args.run {
+        match kind.trim() {
+            "" => continue,
+            "check" => run_cargo_check(&plan)?,
+            "clippy" => run_cargo_clippy(&plan)?,
+            "test" => run_cargo_test(&plan)?,
+            other => return Err(format!("unknown --run kind: {other}").into()),
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lanes_from(paths: &[&str]) -> Lanes {
+        let v: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
+        detect_lanes(&v)
+    }
+
+    #[test]
+    fn detects_rust_via_crate_path() {
+        let l = lanes_from(&["crates/librefang-kernel/src/foo.rs"]);
+        assert!(l.rust);
+        assert!(!l.docs);
+        assert!(!l.ci);
+        assert!(!l.workspace_cargo);
+        assert!(!l.xtask_src);
+    }
+
+    #[test]
+    fn detects_xtask_src_independent_of_workspace_cargo() {
+        let l = lanes_from(&["xtask/src/check_changed.rs"]);
+        assert!(l.rust);
+        assert!(l.xtask_src);
+        assert!(!l.workspace_cargo);
+    }
+
+    #[test]
+    fn workspace_cargo_does_not_imply_xtask_src() {
+        let l = lanes_from(&["Cargo.toml"]);
+        assert!(l.rust);
+        assert!(l.workspace_cargo);
+        assert!(!l.xtask_src);
+    }
+
+    #[test]
+    fn ci_workflow_paths_flag_ci_lane() {
+        let l = lanes_from(&[".github/workflows/ci.yml"]);
+        assert!(l.ci);
+        assert!(!l.rust);
+        assert!(!l.workspace_cargo);
+    }
+
+    #[test]
+    fn install_paths_flag_install_lane() {
+        let l = lanes_from(&[
+            "web/public/install.sh",
+            "scripts/tests/install_sh_test.sh",
+        ]);
+        assert!(l.install);
+        assert!(!l.rust);
+    }
+
+    #[test]
+    fn docs_paths_flag_docs_lane() {
+        let l = lanes_from(&["docs/architecture/foo.md", "README.md"]);
+        assert!(l.docs);
+        assert!(!l.rust);
+    }
+
+    #[test]
+    fn openapi_and_sdk_count_as_rust() {
+        let l = lanes_from(&["openapi.json", "sdk/python/foo.py"]);
+        assert!(l.rust);
+    }
+
+    #[test]
+    fn full_run_triggers_for_ci_workspace_cargo_xtask() {
+        for paths in &[
+            vec![".github/workflows/ci.yml"],
+            vec!["Cargo.toml"],
+            vec!["xtask/src/main.rs"],
+        ] {
+            let v: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
+            let lanes = detect_lanes(&v);
+            assert!(decide_full_run(&lanes).value, "expected full_run for {paths:?}");
+        }
+    }
+
+    #[test]
+    fn full_run_does_not_trigger_for_pure_crate_change() {
+        let l = lanes_from(&["crates/librefang-runtime/src/foo.rs"]);
+        assert!(!decide_full_run(&l).value);
+    }
+
+    #[test]
+    fn full_test_strictly_narrower_than_full_run() {
+        // CI-only / xtask-only changes do NOT trigger full_test.
+        let l_ci = lanes_from(&[".github/workflows/ci.yml"]);
+        assert!(decide_full_run(&l_ci).value);
+        assert!(!decide_full_test(&l_ci).value);
+
+        let l_xtask = lanes_from(&["xtask/src/main.rs"]);
+        assert!(decide_full_run(&l_xtask).value);
+        assert!(!decide_full_test(&l_xtask).value);
+
+        // Workspace Cargo flips both.
+        let l_cargo = lanes_from(&["Cargo.lock"]);
+        assert!(decide_full_run(&l_cargo).value);
+        assert!(decide_full_test(&l_cargo).value);
+    }
+
+    #[test]
+    fn affected_crates_extracts_direct_membership() {
+        let files: Vec<String> = vec![
+            "crates/librefang-kernel/src/mod.rs".into(),
+            "crates/librefang-api/src/server.rs".into(),
+            "README.md".into(),
+        ];
+        let lanes = detect_lanes(&files);
+        let crates = affected_crates(&files, &lanes);
+        assert_eq!(
+            crates,
+            ["librefang-api", "librefang-kernel"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        );
+    }
+
+    #[test]
+    fn affected_crates_pulls_xtask_when_xtask_src_changed() {
+        let files: Vec<String> = vec!["xtask/src/main.rs".into()];
+        let lanes = detect_lanes(&files);
+        let crates = affected_crates(&files, &lanes);
+        assert!(crates.contains("xtask"));
+    }
+
+    #[test]
+    fn affected_crates_schema_mirror_pulls_api_in_for_types_change() {
+        let files: Vec<String> = vec!["crates/librefang-types/src/lib.rs".into()];
+        let lanes = detect_lanes(&files);
+        let crates = affected_crates(&files, &lanes);
+        assert!(crates.contains("librefang-types"));
+        assert!(
+            crates.contains("librefang-api"),
+            "schema-mirror rule should pull api in for a types-only change"
+        );
+    }
+}

--- a/xtask/src/check_changed.rs
+++ b/xtask/src/check_changed.rs
@@ -20,6 +20,7 @@
 use clap::Parser;
 use std::collections::BTreeSet;
 use std::process::Command;
+use std::sync::OnceLock;
 
 use crate::common::repo_root;
 
@@ -68,11 +69,12 @@ struct Plan {
 }
 
 fn changed_files(from: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-    // `<from>...HEAD` is the merge-base diff (only commits unique to HEAD),
-    // matching what GitHub reports for a PR.
-    let range = format!("{from}...HEAD");
+    // Two-dot diff to match ci.yml's `git diff --name-only "$BASE_SHA" "$HEAD_SHA"`.
+    // Three-dot (`{from}...HEAD`) silently drops files that main moved past
+    // since the branch forked, which would make the local plan disagree with
+    // what CI actually runs.
     let output = Command::new("git")
-        .args(["diff", "--name-only", &range])
+        .args(["diff", "--name-only", from, "HEAD"])
         .current_dir(repo_root())
         .output()?;
     if !output.status.success() {
@@ -89,28 +91,44 @@ fn changed_files(from: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> 
         .collect())
 }
 
-fn detect_lanes(changed: &[String]) -> Lanes {
+struct LaneRegexes {
+    rust: regex::Regex,
+    docs: regex::Regex,
+    ci: regex::Regex,
+    install: regex::Regex,
+    workspace_cargo: regex::Regex,
+    xtask_src: regex::Regex,
+}
+
+fn lane_regexes() -> &'static LaneRegexes {
     // Same regexes as ci.yml's `Compute diff and route` step. Keep these
     // identical to the shell version — drift would silently make the local
     // command lie about CI behaviour.
-    let rust = regex::Regex::new(r"^(crates/|Cargo\.(toml|lock)$|xtask/|openapi\.json$|sdk/)")
-        .expect("static regex");
-    let docs = regex::Regex::new(r"^(docs/|.*\.md$)").expect("static regex");
-    let ci = regex::Regex::new(r"^\.github/workflows/").expect("static regex");
-    let install = regex::Regex::new(
-        r"^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$",
-    )
-    .expect("static regex");
-    let workspace_cargo = regex::Regex::new(r"^Cargo\.(toml|lock)$").expect("static regex");
-    let xtask_src = regex::Regex::new(r"^xtask/").expect("static regex");
+    static REGEXES: OnceLock<LaneRegexes> = OnceLock::new();
+    REGEXES.get_or_init(|| LaneRegexes {
+        rust: regex::Regex::new(r"^(crates/|Cargo\.(toml|lock)$|xtask/|openapi\.json$|sdk/)")
+            .expect("static regex"),
+        docs: regex::Regex::new(r"^(docs/|.*\.md$)").expect("static regex"),
+        ci: regex::Regex::new(r"^\.github/workflows/").expect("static regex"),
+        install: regex::Regex::new(
+            r"^web/public/install\.(sh|ps1)$|^scripts/tests/install_sh_test\.sh$",
+        )
+        .expect("static regex"),
+        workspace_cargo: regex::Regex::new(r"^Cargo\.(toml|lock)$").expect("static regex"),
+        xtask_src: regex::Regex::new(r"^xtask/").expect("static regex"),
+    })
+}
+
+fn detect_lanes(changed: &[String]) -> Lanes {
+    let r = lane_regexes();
     let any = |re: &regex::Regex| changed.iter().any(|p| re.is_match(p));
     Lanes {
-        rust: any(&rust),
-        docs: any(&docs),
-        ci: any(&ci),
-        install: any(&install),
-        workspace_cargo: any(&workspace_cargo),
-        xtask_src: any(&xtask_src),
+        rust: any(&r.rust),
+        docs: any(&r.docs),
+        ci: any(&r.ci),
+        install: any(&r.install),
+        workspace_cargo: any(&r.workspace_cargo),
+        xtask_src: any(&r.xtask_src),
     }
 }
 
@@ -119,13 +137,25 @@ fn detect_lanes(changed: &[String]) -> Lanes {
 /// it here because the local workflow is always PR-equivalent.
 fn decide_full_run(lanes: &Lanes) -> Decision {
     if lanes.ci {
-        Decision { value: true, reason: "CI workflow changed" }
+        Decision {
+            value: true,
+            reason: "CI workflow changed",
+        }
     } else if lanes.workspace_cargo {
-        Decision { value: true, reason: "workspace Cargo.toml/Cargo.lock changed" }
+        Decision {
+            value: true,
+            reason: "workspace Cargo.toml/Cargo.lock changed",
+        }
     } else if lanes.xtask_src {
-        Decision { value: true, reason: "xtask source changed" }
+        Decision {
+            value: true,
+            reason: "xtask source changed",
+        }
     } else {
-        Decision { value: false, reason: "selective" }
+        Decision {
+            value: false,
+            reason: "selective",
+        }
     }
 }
 
@@ -134,9 +164,15 @@ fn decide_full_run(lanes: &Lanes) -> Decision {
 /// trigger for re-running the full nextest matrix.
 fn decide_full_test(lanes: &Lanes) -> Decision {
     if lanes.workspace_cargo {
-        Decision { value: true, reason: "workspace Cargo.toml/Cargo.lock changed" }
+        Decision {
+            value: true,
+            reason: "workspace Cargo.toml/Cargo.lock changed",
+        }
     } else {
-        Decision { value: false, reason: "selective" }
+        Decision {
+            value: false,
+            reason: "selective",
+        }
     }
 }
 
@@ -167,13 +203,19 @@ fn build_plan(from: &str) -> Result<Plan, Box<dyn std::error::Error>> {
     let full_run = decide_full_run(&lanes);
     let full_test = decide_full_test(&lanes);
     let crates = affected_crates(&files, &lanes);
-    Ok(Plan { lanes, full_run, full_test, crates, files })
+    Ok(Plan {
+        lanes,
+        full_run,
+        full_test,
+        crates,
+        files,
+    })
 }
 
 fn print_human(plan: &Plan) {
     println!("Changed files: {}", plan.files.len());
     if plan.files.is_empty() {
-        println!("  (none — branch already merged or `--from` is HEAD)");
+        println!("  (none -- branch already merged or `--from` is HEAD)");
     } else {
         for f in &plan.files {
             println!("  {f}");
@@ -224,101 +266,106 @@ fn print_json(plan: &Plan) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn run_cargo_check(plan: &Plan) -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::new("cargo");
-    cmd.current_dir(repo_root());
+/// Build args for `cargo check`. `None` = nothing to do (selective with no
+/// affected crates). Selective mode does NOT pass `--lib` because `-p X --lib`
+/// errors with "no library targets found in package X" for binary-only crates
+/// (librefang-cli, librefang-desktop); the same gotcha CI's selective `cargo
+/// build` step explicitly works around. `--workspace --lib` is fine because
+/// there `--lib` is a workspace-wide filter, not a per-package selector.
+fn build_check_args(plan: &Plan) -> Option<Vec<String>> {
     if plan.full_run.value {
-        cmd.args(["check", "--workspace", "--lib"]);
-        println!("→ cargo check --workspace --lib");
-    } else if plan.crates.is_empty() {
-        println!("→ cargo check skipped (no affected crates)");
-        return Ok(());
-    } else {
-        cmd.arg("check");
-        for c in &plan.crates {
-            cmd.args(["-p", c]);
-        }
-        cmd.arg("--lib");
-        println!(
-            "→ cargo check {} --lib",
-            plan.crates
+        Some(
+            ["check", "--workspace", "--lib"]
                 .iter()
-                .map(|c| format!("-p {c}"))
-                .collect::<Vec<_>>()
-                .join(" ")
-        );
+                .map(|s| s.to_string())
+                .collect(),
+        )
+    } else if plan.crates.is_empty() {
+        None
+    } else {
+        let mut v = vec!["check".to_string()];
+        for c in &plan.crates {
+            v.push("-p".into());
+            v.push(c.clone());
+        }
+        Some(v)
     }
-    let status = cmd.status()?;
-    if !status.success() {
-        return Err("cargo check failed".into());
-    }
-    Ok(())
 }
 
-fn run_cargo_clippy(plan: &Plan) -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::new("cargo");
-    cmd.current_dir(repo_root());
+/// Build args for `cargo clippy`. Selective mode passes `--all-features`
+/// to match ci.yml's selective clippy step (`cargo clippy $PFLAGS
+/// --all-targets --all-features -- -D warnings`); without it a feature-gated
+/// lint failure passes locally but trips CI. `--workspace` mode mirrors the
+/// `cargo xtask ci` invocation, which doesn't pass `--all-features`.
+fn build_clippy_args(plan: &Plan) -> Option<Vec<String>> {
     if plan.full_run.value {
-        cmd.args([
-            "clippy",
-            "--workspace",
-            "--all-targets",
-            "--",
-            "-D",
-            "warnings",
-        ]);
-        println!("→ cargo clippy --workspace --all-targets -- -D warnings");
+        Some(
+            [
+                "clippy",
+                "--workspace",
+                "--all-targets",
+                "--",
+                "-D",
+                "warnings",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        )
     } else if plan.crates.is_empty() {
-        println!("→ cargo clippy skipped (no affected crates)");
-        return Ok(());
+        None
     } else {
-        cmd.arg("clippy");
+        let mut v = vec!["clippy".to_string()];
         for c in &plan.crates {
-            cmd.args(["-p", c]);
+            v.push("-p".into());
+            v.push(c.clone());
         }
-        cmd.args(["--all-targets", "--", "-D", "warnings"]);
-        println!(
-            "→ cargo clippy {} --all-targets -- -D warnings",
-            plan.crates
+        v.extend(
+            ["--all-targets", "--all-features", "--", "-D", "warnings"]
                 .iter()
-                .map(|c| format!("-p {c}"))
-                .collect::<Vec<_>>()
-                .join(" ")
+                .map(|s| s.to_string()),
         );
+        Some(v)
     }
-    let status = cmd.status()?;
-    if !status.success() {
-        return Err("cargo clippy failed".into());
-    }
-    Ok(())
 }
 
-fn run_cargo_test(plan: &Plan) -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::new("cargo");
-    cmd.current_dir(repo_root());
+/// Build args for `cargo test`. `full_test=true` → workspace; otherwise
+/// per-crate. The repo-wide guidance forbids unscoped `cargo test` because of
+/// shared `target/` contention with the daemon, so the workspace branch is
+/// only reached when CI itself would do the same (workspace Cargo manifest
+/// changed); see ci.yml `full_test` decision.
+fn build_test_args(plan: &Plan) -> Option<Vec<String>> {
     if plan.full_test.value {
-        cmd.args(["test", "--workspace"]);
-        println!("→ cargo test --workspace");
-    } else if plan.crates.is_empty() {
-        println!("→ cargo test skipped (no affected crates)");
-        return Ok(());
-    } else {
-        cmd.arg("test");
-        for c in &plan.crates {
-            cmd.args(["-p", c]);
-        }
-        println!(
-            "→ cargo test {}",
-            plan.crates
+        Some(
+            ["test", "--workspace"]
                 .iter()
-                .map(|c| format!("-p {c}"))
-                .collect::<Vec<_>>()
-                .join(" ")
-        );
+                .map(|s| s.to_string())
+                .collect(),
+        )
+    } else if plan.crates.is_empty() {
+        None
+    } else {
+        let mut v = vec!["test".to_string()];
+        for c in &plan.crates {
+            v.push("-p".into());
+            v.push(c.clone());
+        }
+        Some(v)
     }
-    let status = cmd.status()?;
+}
+
+fn run_cargo(label: &str, args: Option<Vec<String>>) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(args) = args else {
+        println!("-> cargo {label} skipped (no affected crates)");
+        return Ok(());
+    };
+    println!("-> cargo {}", args.join(" "));
+    let status = Command::new("cargo")
+        .args(&args)
+        .current_dir(repo_root())
+        .status()?;
     if !status.success() {
-        return Err("cargo test failed".into());
+        return Err(format!("cargo {label} failed").into());
     }
     Ok(())
 }
@@ -335,9 +382,9 @@ pub fn run(args: CheckChangedArgs) -> Result<(), Box<dyn std::error::Error>> {
     for kind in &args.run {
         match kind.trim() {
             "" => continue,
-            "check" => run_cargo_check(&plan)?,
-            "clippy" => run_cargo_clippy(&plan)?,
-            "test" => run_cargo_test(&plan)?,
+            "check" => run_cargo("check", build_check_args(&plan))?,
+            "clippy" => run_cargo("clippy", build_clippy_args(&plan))?,
+            "test" => run_cargo("test", build_test_args(&plan))?,
             other => return Err(format!("unknown --run kind: {other}").into()),
         }
     }
@@ -352,6 +399,21 @@ mod tests {
     fn lanes_from(paths: &[&str]) -> Lanes {
         let v: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
         detect_lanes(&v)
+    }
+
+    fn plan_from(paths: &[&str]) -> Plan {
+        let files: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
+        let lanes = detect_lanes(&files);
+        let full_run = decide_full_run(&lanes);
+        let full_test = decide_full_test(&lanes);
+        let crates = affected_crates(&files, &lanes);
+        Plan {
+            lanes,
+            full_run,
+            full_test,
+            crates,
+            files,
+        }
     }
 
     #[test]
@@ -390,10 +452,7 @@ mod tests {
 
     #[test]
     fn install_paths_flag_install_lane() {
-        let l = lanes_from(&[
-            "web/public/install.sh",
-            "scripts/tests/install_sh_test.sh",
-        ]);
+        let l = lanes_from(&["web/public/install.sh", "scripts/tests/install_sh_test.sh"]);
         assert!(l.install);
         assert!(!l.rust);
     }
@@ -420,7 +479,10 @@ mod tests {
         ] {
             let v: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
             let lanes = detect_lanes(&v);
-            assert!(decide_full_run(&lanes).value, "expected full_run for {paths:?}");
+            assert!(
+                decide_full_run(&lanes).value,
+                "expected full_run for {paths:?}"
+            );
         }
     }
 
@@ -483,5 +545,86 @@ mod tests {
             crates.contains("librefang-api"),
             "schema-mirror rule should pull api in for a types-only change"
         );
+    }
+
+    // ── command-line shape tests ─────────────────────────────────────────
+    // These pin the exact argv we hand to `cargo` so a future edit can't
+    // silently reintroduce `-p X --lib` (errors on bin-only crates) or drop
+    // `--all-features` from selective clippy (lets feature-gated lints pass
+    // locally but fail CI).
+
+    #[test]
+    fn selective_check_does_not_pass_lib() {
+        // Bin-only crate should NOT get `-p librefang-cli --lib` (cargo
+        // errors with "no library targets found in package librefang-cli").
+        let plan = plan_from(&["crates/librefang-cli/src/main.rs"]);
+        let args = build_check_args(&plan).expect("should produce args");
+        assert!(
+            !args.iter().any(|a| a == "--lib"),
+            "selective check must not pass --lib: {args:?}"
+        );
+        assert!(args.contains(&"-p".to_string()));
+        assert!(args.contains(&"librefang-cli".to_string()));
+    }
+
+    #[test]
+    fn full_run_check_uses_workspace_lib() {
+        let plan = plan_from(&[".github/workflows/ci.yml"]);
+        let args = build_check_args(&plan).expect("should produce args");
+        assert_eq!(args, vec!["check", "--workspace", "--lib"]);
+    }
+
+    #[test]
+    fn selective_clippy_passes_all_features() {
+        // ci.yml's selective lane runs `cargo clippy $PFLAGS --all-targets
+        // --all-features -- -D warnings`. Drift here means a feature-gated
+        // lint can pass locally but fail CI.
+        let plan = plan_from(&["crates/librefang-runtime/src/foo.rs"]);
+        let args = build_clippy_args(&plan).expect("should produce args");
+        assert!(
+            args.iter().any(|a| a == "--all-features"),
+            "selective clippy must pass --all-features: {args:?}"
+        );
+        assert!(args.iter().any(|a| a == "--all-targets"));
+        assert!(args.windows(2).any(|w| w == ["--", "-D"]));
+    }
+
+    #[test]
+    fn full_run_clippy_workspace_shape() {
+        let plan = plan_from(&[".github/workflows/ci.yml"]);
+        let args = build_clippy_args(&plan).expect("should produce args");
+        assert_eq!(
+            args,
+            vec![
+                "clippy",
+                "--workspace",
+                "--all-targets",
+                "--",
+                "-D",
+                "warnings"
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_plan_yields_no_cargo_args() {
+        let plan = plan_from(&[]);
+        assert!(build_check_args(&plan).is_none());
+        assert!(build_clippy_args(&plan).is_none());
+        assert!(build_test_args(&plan).is_none());
+    }
+
+    #[test]
+    fn selective_test_per_crate() {
+        let plan = plan_from(&["crates/librefang-kernel/src/mod.rs"]);
+        let args = build_test_args(&plan).expect("should produce args");
+        assert_eq!(args, vec!["test", "-p", "librefang-kernel"]);
+    }
+
+    #[test]
+    fn workspace_cargo_change_runs_full_test() {
+        let plan = plan_from(&["Cargo.lock"]);
+        let args = build_test_args(&plan).expect("should produce args");
+        assert_eq!(args, vec!["test", "--workspace"]);
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@ mod bench;
 mod build_timings;
 mod build_web;
 mod changelog;
+mod check_changed;
 mod check_links;
 mod ci;
 mod clean_all;
@@ -89,6 +90,12 @@ enum Command {
     /// Check for broken links in documentation
     CheckLinks(check_links::CheckLinksArgs),
 
+    /// Show which CI lanes a branch's diff would trigger; optionally
+    /// run `cargo check`/`clippy`/`test` against the affected crate set
+    /// (#3296). Mirrors the `changes` job in `.github/workflows/ci.yml`
+    /// so a developer can preview the CI plan locally.
+    CheckChanged(check_changed::CheckChangedArgs),
+
     /// Run criterion benchmarks
     Bench(bench::BenchArgs),
 
@@ -164,6 +171,7 @@ fn main() {
         Command::Deps(args) => deps::run(args),
         Command::Codegen(args) => codegen::run(args),
         Command::CheckLinks(args) => check_links::run(args),
+        Command::CheckChanged(args) => check_changed::run(args),
         Command::Bench(args) => bench::run(args),
         Command::BuildTimings(args) => build_timings::run_collect(args),
         Command::CompareBuildTimings(args) => build_timings::run_compare(args),


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` already has sophisticated change routing:
- Boolean RUST/DOCS/CI/INSTALL flags
- `full_run` (CI / workspace-Cargo / xtask-source) and `full_test` (workspace-Cargo only) decisions
- Directly-affected crate set with the `librefang-types` → `librefang-api` schema-mirror rule

But it has no local entry point — a developer with a one-crate change has to push and wait to see what CI will run. This adds `cargo xtask check-changed` as a faithful local mirror.

## Usage

```bash
cargo xtask check-changed                    # text summary, vs origin/main
cargo xtask check-changed --from main        # vs local main
cargo xtask check-changed --json             # machine-readable
cargo xtask check-changed --run check        # run cargo check on affected crates only
cargo xtask check-changed --run check,clippy,test
```

The `--run` invocations fall back to workspace-wide when `full_run` / `full_test` is true, exactly mirroring the CI behaviour.

## Faithfulness invariants

- Same regexes as the shell version (kept structurally close so reviewers can diff the two).
- `full_run` triggers: CI workflow change, workspace Cargo manifest, xtask source change.
- `full_test` strictly narrower: only workspace Cargo manifest. Verified by a dedicated unit test.
- Schema-mirror rule (`librefang-types` → `librefang-api`) preserved.
- xtask source change pulls `xtask` into the affected set (it isn't under `crates/`).
- **Two-dot `git diff` range** (`{from} HEAD`) matches `ci.yml`'s `git diff --name-only "$BASE_SHA" "$HEAD_SHA"`. Three-dot would silently drop files main moved past since the branch forked.
- **Selective `cargo check` does NOT pass `-p X --lib`** — that errors with "no library targets found" on bin-only crates (`librefang-cli`, `librefang-desktop`), matching CI's selective `cargo build $PFLAGS` workaround. `--workspace --lib` (full_run path) is fine since there `--lib` is a workspace-wide filter.
- **Selective `cargo clippy` passes `--all-features`** to match `ci.yml`'s `cargo clippy $PFLAGS --all-targets --all-features -- -D warnings`. Without it a feature-gated lint can pass locally and still fail CI.

## Anti-regression hardening

`Plan` → cargo argv extracted into pure `build_check_args` / `build_clippy_args` / `build_test_args` so unit tests can pin the exact selective and full-run shapes. Lane regexes hoisted into a `OnceLock` (no longer recompiled per call).

## Test plan

- [x] `cargo test -p xtask --bin xtask check_changed` — **20 unit tests pass**: each lane regex, both decision tables, schema-mirror, xtask-source pull-in, AND command-line shape locks (`selective_check_does_not_pass_lib`, `selective_clippy_passes_all_features`, full-run shapes, empty-plan no-op).
- [x] `cargo check -p xtask` — clean
- [x] `cargo clippy -p xtask --all-targets --no-deps -- -D warnings` — clean (the `--no-deps` is to skip an unrelated `doc_lazy_continuation` lint surfaced by `librefang-types` on current main; the xtask crate itself is clean)
- [ ] CI workflow

## Notes

- This is the local-mirror half of #3296. The CI side is already fully implemented and unaffected by this PR.
- Future drift between the shell version (ci.yml) and this Rust version is detectable: we can add a CI step that runs `cargo xtask check-changed --json` and diffs against the shell job's outputs. Out of scope for this PR.

Refs #3296.