### PR TITLE
docs(crates): scoped AGENTS.md for 6 core crates + CLAUDE.md symlinks (#3297)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,20 @@ jobs:
             lsof -ti :4545 | xargs -r kill -9 || true
           fi
 
+  # ── AGENTS.md / CLAUDE.md sibling-symlink check (#3297) ────────────────────────
+  # Every per-crate / per-subdir AGENTS.md must have a sibling CLAUDE.md
+  # symlink pointing at it, so AI tooling that doesn't recognise AGENTS.md
+  # (older Claude Code builds, Codex CLI variants) finds the rules under
+  # the conventional name. The repo-root pair is exempt — the two files
+  # there are intentionally distinct.
+  agents-claude-pair:
+    name: AGENTS.md ↔ CLAUDE.md pair
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Verify sibling CLAUDE.md symlink
+        run: sh scripts/check-agents-claude-pair.sh
+
   # ── Ubuntu tests: selective on PR, full on main ────────────────────────────────
   # Full-run lane (push to main, workspace Cargo.toml change) runs the full
   # workspace test matrix sharded 4 ways via `cargo nextest run --partition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,6 +423,10 @@ _338 PRs from 7 contributors since v2026.4.28-beta7._
 
 - Wire `cargo xtask integration-test` into CI as a `live-integration-smoke` job — spawns a real `target/debug/librefang start` daemon on every PR touching Rust or CI files, hits `/api/health`, `/api/agents`, `/api/budget`, `/api/network/status`, and SIGTERMs. Catches the failure modes the in-process integration tests miss (route not registered in `server.rs`, daemon failing to bind, config fields not deserializing). Runs with `--skip-llm` to keep the gate hermetic; the live-LLM branch is reserved for the release/nightly workflow that has provider keys. (#3405) (@houko)
 
+### Documentation
+
+- Per-crate `AGENTS.md` for the six core crates (`librefang-{kernel,runtime,types,llm-driver,extensions,channels}`). Telegraph-style: scope, module map, lock strategy, taboos, common gotchas. Each one ships with a sibling `CLAUDE.md` symlink so AI tooling that walks up looking for `CLAUDE.md` (older Claude Code builds, Codex CLI variants) finds the same rules. New CI gate `agents-claude-pair` verifies the symlink remains in place via `scripts/check-agents-claude-pair.sh`. The dashboard's existing `AGENTS.md` also gains the symlink. (#3297) (@houko)
+
 ## [2026.4.28] - 2026-04-28
 
 _67 PRs from 4 contributors since v2026.4.27-beta6._

--- a/crates/librefang-api/dashboard/CLAUDE.md
+++ b/crates/librefang-api/dashboard/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/librefang-channels/AGENTS.md
+++ b/crates/librefang-channels/AGENTS.md
@@ -1,0 +1,70 @@
+# librefang-channels — AGENTS.md
+
+Telegraph style. Short sentences. One idea per line.
+See repo-root `CLAUDE.md` for cross-cutting rules.
+
+## Purpose
+
+40+ pluggable messaging integrations. Convert platform messages into unified `ChannelMessage` events for the kernel; route agent replies back out.
+Adapters are gated behind cargo features (`channel-xxx`).
+
+## Cargo features
+
+`default = []`. Every workspace consumer (`librefang-api`, `librefang-cli`, `librefang-desktop`) sets `default-features = false` and forwards an explicit subset.
+
+- `all-channels` — every adapter (matrix, IMAP, MQTT, Bluesky, Nostr, …). Used by release CI.
+- Per-adapter: `channel-telegram`, `channel-discord`, `channel-slack`, `channel-webhook`, `channel-ntfy`, etc.
+
+See `Cargo.toml` for the full feature matrix.
+
+## Always-compiled core
+
+The trait + dispatch glue compiles unconditionally. Only adapters are feature-gated.
+
+## Boundary
+
+- Owns: `ChannelAdapter` trait, `ChannelMessage` event type, every adapter under `src/<channel>/`.
+- Does NOT own: kernel's per-`(agent,session)` lock (channel messages always derive `SessionId::for_channel(agent,"channel:chat")`). HTTP webhook routes — those live in `librefang-api/src/routes/channels.rs`.
+- Depends on: `librefang-types`, `librefang-extensions` (for vault), `librefang-http`. NOT on `librefang-kernel` or `librefang-runtime` directly.
+
+## Webhook security (mandatory)
+
+HMAC verification is **mandatory** for Messenger, LINE, Teams, Viber, DingTalk. Missing signature → 400. Mismatch → 401. Don't silently bypass.
+
+- Messenger: `MESSENGER_APP_SECRET` (Facebook App Secret). New `app_secret_env` in `[channels.messenger]`.
+- Teams: `TEAMS_SECURITY_TOKEN` (base64 outgoing-webhook security token). New `security_token_env` in `[channels.teams]`.
+- LINE / Viber / DingTalk: platform-specific signature header.
+
+Probes without the platform's signature header (curl, monitoring health checks) now return 4xx rather than 200. That's intended.
+
+## Outbound webhook SSRF guard
+
+`[channels.webhook] callback_url` MUST resolve to a public IP. Adapters refuse to start if the URL points at:
+- Private (10/8, 172.16/12, 192.168/16)
+- CGN (100.64/10)
+- Loopback (127/8, ::1)
+- Link-local, multicast, cloud metadata
+- IPv6 short forms ([::]), IPv4-mapped ([::ffff:127.0.0.1]), NAT64, trailing-dot FQDNs
+
+Local dev: use a public tunnel (ngrok, cloudflared) or omit `callback_url`.
+
+## Send-path testing
+
+Inbound parsing has 795 tests. Outbound `send()` has historically had ~zero (#3820). New send() work MUST include a wiremock'd test in `tests/<channel>_wiremock.rs`. PRs that add an adapter without a `send()` test will be sent back.
+
+## Adding a new channel
+
+1. New file `src/<channel>/mod.rs` implementing `ChannelAdapter`.
+2. New cargo feature `channel-<name>` in `Cargo.toml`.
+3. Default-feature decision: every channel ships off-by-default. The `all-channels` feature aggregates them.
+4. Wire HTTP webhook (if needed) in `librefang-api/src/routes/channels.rs`.
+5. Add a `tests/<channel>_wiremock.rs` covering at least the send() happy path + one error response.
+6. Document any required env vars in the adapter's doc comment.
+
+## Taboos
+
+- No `librefang-kernel` import. Channels are below kernel; kernel calls into channels through dispatch.
+- No bespoke `reqwest::Client`. Use `librefang-extensions::http_client::shared_client()`.
+- No `default = ["all-channels"]`. The default is and stays empty.
+- No silently bypassing HMAC verification. Either implement, or refuse to start.
+- No SSRF-leaky `callback_url` parsing. Use the existing guard.

--- a/crates/librefang-channels/CLAUDE.md
+++ b/crates/librefang-channels/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/librefang-extensions/AGENTS.md
+++ b/crates/librefang-extensions/AGENTS.md
@@ -1,0 +1,62 @@
+# librefang-extensions — AGENTS.md
+
+Telegraph style. Short sentences. One idea per line.
+See repo-root `CLAUDE.md` for cross-cutting rules.
+
+## Purpose
+
+MCP server catalog. Credential vault. OAuth2 PKCE flows. Provider health probes. Plugin installer. Shared HTTP client.
+This crate is the "everything-side-of-an-agent" toolkit that doesn't fit in `runtime` or `kernel`.
+
+## Module map
+
+- `catalog` — MCP catalog (`~/.librefang/mcp/catalog/`). Templates, available servers.
+- `credentials` — auth-source unification (env var, vault, CLI login, …).
+- `dotenv` — `.env` parsing for agent workspaces.
+- `health` — provider liveness probes (now backed by `provider_health` in runtime).
+- `http_client` — shared `reqwest::Client` builder. Use this everywhere; do NOT spin up bespoke clients.
+- `installer` — MCP server install / update / uninstall flows.
+- `oauth` — OAuth2 PKCE client; PKCE + Dynamic Client Registration (RFC 7591) for MCP.
+- `vault` — AES-256-GCM credential vault. Master key in OS keyring (Linux/Windows) or file fallback (macOS, see #2766 lineage).
+
+## Boundary
+
+- Owns: vault, MCP catalog, OAuth client, shared HTTP client, dotenv, installer.
+- Does NOT own: kernel callback wiring (`McpOAuthProvider` trait lives in runtime; the *implementation* lives in api). HTTP routing. Channel adapters.
+- Depends on: `librefang-types`, `librefang-runtime`. **Not** depended on by kernel — extensions sit *above* kernel.
+
+## Vault invariants
+
+- Master key (32 bytes) loaded from `LIBREFANG_VAULT_KEY` (base64, MUST decode to 32 bytes — `openssl rand -base64 32` gives 44 chars), OS keyring, or file fallback.
+- macOS skips the Keychain by default (#2766). Override with `[vault] use_os_keyring = true`. Migration path: one final read from Keychain on first boot, mirror to file, never touch Keychain again.
+- File fallback path: `~/Library/Application Support/librefang/.keyring` (macOS), mode 0600.
+- All vault operations through the `Vault` API. Don't read `.keyring` directly.
+- Per-agent vault cache lives behind a `RwLock<HashMap<AgentId, Arc<Vault>>>`; invalidate on credential change.
+
+## Shared HTTP client
+
+`http_client::shared_client()` returns a configured `reqwest::Client` with:
+- `User-Agent: librefang/<version>` (matches `librefang_runtime::USER_AGENT`).
+- Sane timeout / redirect / TLS defaults.
+- Connection pooling.
+
+Bespoke clients in callers WILL be flagged in review. Use the shared one.
+
+## Docker callback URLs
+
+Don't bind ephemeral localhost ports for OAuth callbacks in daemon code — the port is unreachable from outside Docker. Route callbacks through the API server's existing port (api crate handles this).
+
+## OAuth (MCP) flow
+
+- Daemon detects 401 → sets `NeedsAuth` state on the connection.
+- API layer (`routes/mcp_auth.rs`) drives the flow: PKCE generation, callback handling, token exchange, refresh.
+- Dynamic Client Registration (RFC 7591) used when server has `registration_endpoint` but no `client_id`.
+- This crate exposes the building blocks; the API crate owns the user-facing flow.
+
+## Taboos
+
+- No bespoke `reqwest::Client::new()`. Use `http_client::shared_client()`.
+- No raw `tokio::process` for plugin installs. Go through `installer`.
+- No `librefang-api` / `librefang-cli` / `librefang-desktop` imports. Extensions sit below those layers.
+- No reading the vault `.keyring` file directly.
+- No new credential providers without thinking through the unified `credentials::resolve()` precedence (env > vault > CLI login > file).

--- a/crates/librefang-extensions/CLAUDE.md
+++ b/crates/librefang-extensions/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/librefang-kernel/AGENTS.md
+++ b/crates/librefang-kernel/AGENTS.md
@@ -1,0 +1,66 @@
+# librefang-kernel — AGENTS.md
+
+Telegraph style. Short sentences. One idea per line.
+See repo-root `CLAUDE.md` for the cross-cutting rules (worktree, hooks, CI wait policy, conventional commits).
+
+## Purpose
+
+Agent orchestration. Scheduling. Permissions. Inter-agent communication. Owns the message-handling loop that fans requests out to LLM drivers, tools, and the memory substrate.
+
+## Boundary
+
+- Owns: registry, scheduling, approval, auth, auto_dream, cron, event_bus, inbox, pairing, scheduler, session_lifecycle, metering, router (last two re-exported from `librefang-kernel-metering` / `librefang-kernel-router`).
+- Does NOT own: agent loop body, tool dispatch, channel adapters, HTTP routing, dashboard SPA. Those live in `librefang-runtime`, `librefang-channels`, `librefang-api` respectively.
+- Does NOT depend on: `librefang-api`, `librefang-extensions`. Reverse the dependency via the `KernelHandle` trait (defined in `librefang-runtime`) when runtime / extensions need a kernel callback.
+
+## Module map
+
+- `kernel::LibreFangKernel` — top-level orchestrator. Boot via `LibreFangKernel::boot_with_config(KernelConfig)`. Currently a god-struct (~18k LOC, 50+ fields — #3565). Don't add new fields without coordination.
+- `registry::AgentRegistry` — concurrent agent table; spawn / lookup / kill.
+- `kernel::cron` — cron scheduling. `session_mode` resolution lives here (per-job > manifest > historical Persistent).
+- `kernel::event_bus` — broadcast event bus. History is `parking_lot::Mutex<VecDeque<Arc<Event>>>` since #3385 — do NOT switch back to `RwLock<VecDeque<Event>>`.
+- `kernel::session_lifecycle` — session state machine.
+- `metering` (re-exported) — token + cost accounting; uses kernel's `model_catalog`.
+- `router` (re-exported) — model router, alias resolution.
+
+## Hot fields and their lock strategy
+
+- `model_catalog: arc_swap::ArcSwap<ModelCatalog>` — atomic-load reads (#3384). Writers go through `model_catalog_update(|cat| ...)` (RCU). Don't add `RwLock<ModelCatalog>` back.
+- `skill_registry: std::sync::RwLock<SkillRegistry>` — hot-reload on install/uninstall. Reads should be brief; copy out what you need.
+- `running_tasks: dashmap::DashMap<(AgentId, SessionId), RunningTask>` — keyed by `(agent, session)`, NOT by `AgentId` alone. Pre-#3172 it was the latter, which silently overwrote concurrent loops. Don't degrade.
+- `mcp_oauth_provider: Arc<dyn McpOAuthProvider + Send + Sync>` — pluggable. Implemented in `librefang-api` to keep daemon free of HTTP. New OAuth flows go through this trait, not direct kernel logic.
+
+## Determinism (refs #3298)
+
+Anything that reaches an LLM prompt MUST be ordered before stringifying. Use `BTreeMap` / `BTreeSet`. `HashMap` iteration order varies across processes and silently invalidates provider prompt caches. Regression tests live next to each boundary — see `kernel::tests::mcp_summary_is_byte_identical_across_input_orders`.
+
+## Configuration knobs (kernel-side)
+
+- `KernelConfig.max_history_messages` — global default; clamped up to `MIN_HISTORY_MESSAGES = 4` with a WARN log. Per-agent override in `agent.toml`.
+- `KernelConfig.queue.concurrency.trigger_lane` (default 8) — global semaphore on `Lane::Trigger`.
+- `KernelConfig.queue.concurrency.default_per_agent` (default 1) — fallback when `agent.toml: max_concurrent_invocations` is unset.
+- `KernelConfig.workflow_stale_timeout_minutes` — `recover_stale_running_runs` cutoff at boot.
+
+## Adding a new field to `LibreFangKernel`
+
+1. Field must be `pub(crate)` unless an external crate truly needs read access.
+2. Add to the `Default` impl on `KernelConfig` if it has a config-side counterpart, else build is silently broken.
+3. If the field is `Option<Arc<dyn Trait>>`, mark `#[serde(skip)]` and implement Serialize/Deserialize/Clone/Debug manually.
+4. Decide lock strategy:
+    - Hot read, rare write → `arc_swap::ArcSwap`.
+    - Hot read, hot write → `parking_lot::Mutex` or `dashmap`.
+    - Append-only history → `parking_lot::Mutex<VecDeque<Arc<T>>>`.
+
+## Testing
+
+- Most kernel-unit testing lives inside `crates/librefang-kernel/src/kernel/`. Integration tests against a real router live in `librefang-api/tests/` — that's where `#[tokio::test]` against `TestServer` belongs (refs #3721).
+- Workspace-wide `cargo test` is **forbidden** (target/ contention with the user's session). Use `cargo test -p librefang-kernel`.
+- `cargo build` is forbidden too. Use `cargo check --workspace --lib`. Real build runs in CI.
+
+## Taboos
+
+- No daemon spawning here. CLI binary owns `start`. Kernel just runs.
+- No tokio `block_on` in this crate. We're inside a runtime; nest at peril.
+- No direct LLM HTTP calls. Go through `librefang-runtime` drivers.
+- No new `KernelHandle::*` method that returns `Result<_, String>` (#3541) — use a typed error.
+- No `HashMap<K, V>` in any field that ends up in an LLM prompt. Use `BTreeMap` (#3298).

--- a/crates/librefang-kernel/CLAUDE.md
+++ b/crates/librefang-kernel/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/librefang-llm-driver/AGENTS.md
+++ b/crates/librefang-llm-driver/AGENTS.md
@@ -1,0 +1,48 @@
+# librefang-llm-driver — AGENTS.md
+
+Telegraph style. Short sentences. One idea per line.
+See repo-root `CLAUDE.md` for cross-cutting rules.
+
+## Purpose
+
+The trait + error types. Defines the LLM driver interface. **No concrete provider implementations live here.**
+Provider impls (anthropic, openai, gemini, groq, …) are in the sibling `librefang-llm-drivers` crate (note the trailing `s`).
+
+## Boundary
+
+- Owns: `LlmDriver` trait (or whatever the canonical name is — see `lib.rs`), `LlmError` enum (`llm_errors.rs`), shared driver-side types.
+- Does NOT own: any specific provider's HTTP wiring, retry strategy, prompt formatting. Those go to `librefang-llm-drivers`.
+- Depends on: `librefang-types`, `serde`, `thiserror`. Should remain dep-light.
+
+## Why two crates
+
+Splitting trait from impls (since this crate's inception) lets test crates depend on the trait alone — no transitive `reqwest` / TLS / vendored libs pulled into a unit test build. Don't merge the two crates "for simplicity".
+
+## Adding a new driver
+
+The new driver goes in `librefang-llm-drivers`, NOT here. Implementations of `LlmDriver` should not require touching this crate at all unless:
+
+- A new method is genuinely needed on the trait (very rare — discuss in an issue first).
+- A new error variant is needed in `LlmError`. Add it as a typed variant; preserve the `source()` chain (#3745).
+- A new shared driver-side type is needed.
+
+## Error types
+
+`LlmError` is the LLM-specific error enum surfaced through the `LlmDriver` trait. Per #3541 / #3711, we're migrating callers away from `Result<_, String>` collapse at trait boundaries; **don't** add a `String` catch-all variant here.
+
+`LlmError::*` should compose well: each variant should answer "is this retryable?", "is this a quota / auth issue?", "did the model produce something bogus?". `is_retryable()` and friends live on the enum.
+
+Partial responses on streaming errors must be preserved (#3552 lineage) — the `Partial` variant carries the bytes-so-far so callers can settle metering.
+
+## Testing
+
+- Trait conformance is exercised by mock drivers in `librefang-testing` (see `MockKernelBuilder`).
+- Don't add HTTP fixture tests here — those belong in `librefang-llm-drivers` next to the implementation under test.
+
+## Taboos
+
+- No `reqwest`, no TLS deps, no vendored client SDKs. Pure trait + types.
+- No `librefang-llm-drivers` import (would be circular).
+- No `librefang-runtime` / `librefang-kernel` imports. Driver trait should stand alone.
+- No new `String`-typed error variants. Use a structured enum field.
+- No `Box<dyn Error>` in trait return types. We have `LlmError`; use it.

--- a/crates/librefang-llm-driver/CLAUDE.md
+++ b/crates/librefang-llm-driver/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/librefang-runtime/AGENTS.md
+++ b/crates/librefang-runtime/AGENTS.md
@@ -1,0 +1,54 @@
+# librefang-runtime — AGENTS.md
+
+Telegraph style. Short sentences. One idea per line.
+See repo-root `CLAUDE.md` for cross-cutting rules.
+
+## Purpose
+
+Agent execution. Tool dispatch. Context management. Audit. A2A peer protocol. Channel registry. Sandboxes (browser, docker, process).
+Re-exports OAuth subsystems from `librefang-runtime-oauth`.
+
+## Boundary
+
+- Owns: `agent_loop`, `tool_runner`, `compactor`, `context_budget`, `context_compressor`, `context_overflow`, `audit`, `auth_cooldown`, `aux_client`, `browser`, `catalog_sync`, `channel_registry`, `checkpoint_manager`, `dangerous_command`, `docker_sandbox`, `media`, `model_catalog` (the type), `mcp` (client), `prompt_builder`.
+- Does NOT own: agent registry / scheduler / cron / orchestration → `librefang-kernel`. HTTP routing → `librefang-api`. Channel transport adapters → `librefang-channels`. Skill loader → `librefang-skills`.
+- Depends on: `librefang-types`, `librefang-http`, `librefang-kernel-handle` (NOT `librefang-kernel` directly — that would be circular).
+
+## Module map
+
+- `agent_loop` — turn-by-turn execution. ~10k LOC; a god module slated for extraction (#3710). Don't grow it without coordination.
+- `tool_runner` — tool execution path. ~9.7k LOC, also targeted by #3710.
+- `model_catalog::ModelCatalog` — registry of 130+ models / 28 providers. Kernel wraps it in `arc_swap::ArcSwap` (#3384). Changes go through kernel's `model_catalog_update(|cat| ...)`.
+- `mcp` — MCP client. OAuth state lives in `mcp_auth_states`; the OAuth provider trait is `McpOAuthProvider` (kernel side implements it).
+- `a2a` — Agent-to-Agent peer protocol.
+- `apply_patch` — tool-level patch application.
+
+## KernelHandle trait
+
+Lives in the sibling `librefang-kernel-handle` crate (NOT here). Kernel implements; runtime + API consume. Use `KernelHandle` whenever you need a kernel callback from runtime. Never depend on `librefang-kernel` directly.
+
+## Cross-cutting invariants
+
+- **Deterministic prompt ordering (#3298)**: tool definitions, MCP server summaries, capability lists must be sorted before stringifying. `BTreeMap` / `BTreeSet`, not `HashMap`.
+- **Identity files** live at `{workspace}/.identity/`, NOT workspace root. `read_identity_file()` falls back to root for pre-migration workspaces; `migrate_identity_files()` runs on every spawn.
+- **`USER_AGENT` constant** is mandatory on every outbound HTTP call (`req.header("User-Agent", librefang_runtime::USER_AGENT)`). Audit hook flags missing UAs.
+
+## Async boundaries
+
+- `ErrorTranslator` (from `RequestLanguage`) is `!Send`. Any `.await` must happen AFTER `drop(t)` or you get a cryptic axum `Handler<_, _>` trait-bound error.
+- No synchronous `std::fs` / `std::sync::RwLock` inside async handlers. Use `tokio::fs` / `arc_swap` / `parking_lot` (refs #3579).
+- No tokio `block_on` here either.
+
+## Testing
+
+- This crate has historically had ZERO integration tests (#3696). New runtime work SHOULD include at least one `#[tokio::test]` exercising the new path.
+- Scoped: `cargo test -p librefang-runtime`.
+
+## Taboos
+
+- No `librefang-kernel` import. Use `KernelHandle`.
+- No `librefang-api` import. API consumes runtime, not the other way.
+- No new `agent_loop.rs` or `tool_runner.rs` file additions; both files are slated to shrink, not grow (#3710).
+- No `unwrap()` / `panic!()` on values that come off the wire.
+- No mocking the kernel by faking `KernelHandle` inline — use `librefang-testing::MockKernelBuilder`.
+- No raw `cargo build`; use `cargo check --workspace --lib`. Real builds run in CI.

--- a/crates/librefang-runtime/CLAUDE.md
+++ b/crates/librefang-runtime/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/librefang-types/AGENTS.md
+++ b/crates/librefang-types/AGENTS.md
@@ -1,0 +1,58 @@
+# librefang-types — AGENTS.md
+
+Telegraph style. Short sentences. One idea per line.
+See repo-root `CLAUDE.md` for cross-cutting rules.
+
+## Purpose
+
+The schema spine. Shared data structures used across the kernel, runtime, memory substrate, and wire protocol.
+**Contains no business logic.** Pure types + small derive-only helpers.
+
+## Boundary
+
+- Owns: every cross-crate type — agent, approval, capability, comms, config, error, event, goal, i18n, manifest_signing, media, memory, message, model_catalog, oauth, registry_schema, scheduler, serde_compat, subagent, taint, tool, tool_class.
+- Does NOT own: implementation. Functions that *do* something belong in the crate that uses the type, not here.
+- Depends on: `serde`, `serde_json`, `chrono`, `uuid`, `thiserror`, `dirs`, `toml`, `schemars`, `utoipa`. **No** workspace crate. We're at the bottom of the dep DAG.
+
+## Schema-mirror invariant (refs #3144 → #3162 → #3167)
+
+`librefang-types` defines the schema, but the golden-file guard (`kernel_config_schema_matches_golden_fixture`) lives in `librefang-api`. Any change to a `KernelConfig` field — addition, rename, type change — requires regenerating the golden fixture in api/tests.
+
+CI catches this via the changed-lanes rule: a `librefang-types`-only PR auto-pulls `librefang-api` into the affected test set. Don't try to defeat that rule; it exists for a reason.
+
+## Adding a new type
+
+1. Place under the matching submodule. New module = decide if it's truly a cross-crate type or belongs in the consuming crate.
+2. Derive the standard quartet: `Debug`, `Clone`, `Serialize`, `Deserialize`. Add `PartialEq` / `Eq` / `Hash` only when needed downstream.
+3. For OpenAPI surface types: also derive `utoipa::ToSchema`.
+4. For configuration types: also derive `schemars::JsonSchema` (driven by the kernel-config golden fixture).
+5. Use `BTreeMap` / `BTreeSet` instead of `HashMap` / `HashSet` for any field that ends up in an LLM prompt (refs #3298).
+
+## Configuration field ritual
+
+When adding a field to a config struct:
+
+1. Add field with `#[serde(default)]` for forward-compat with old TOML.
+2. Add to the `Default` impl. Build silently breaks otherwise.
+3. Add a doc comment — `schemars` surfaces it as the field's `description` in the JSON Schema.
+4. Re-run the kernel-config golden in `librefang-api` (CI will fail otherwise).
+
+## Error types
+
+This crate exports `LibreFangError` and friends. Per #3541 / #3711 we are migrating away from `Result<_, String>` and `anyhow::Error` in trait boundaries — new error variants belong here, not as ad-hoc `String`s in consumer crates.
+
+When adding a new variant: preserve the `source()` chain (#3745). `#[from]` on a wrapped enum is the standard idiom.
+
+## Public API surface
+
+- `VERSION: &str` — workspace version, set at compile time from `CARGO_PKG_VERSION`.
+- All modules listed above.
+
+## Taboos
+
+- No `tokio` here. Sync types only.
+- No `reqwest` here. Wire types are data-only; HTTP code lives in consumers.
+- No `librefang-*` imports. We're the bottom of the DAG; reverse the dependency.
+- No implementation. If you find yourself writing a function body longer than 5 lines, it probably belongs in a consumer crate.
+- No `HashMap<K, V>` for prompt-bound types (#3298).
+- No silently dropping a serde field. `#[serde(default)]` or fail at compile-time.

--- a/crates/librefang-types/CLAUDE.md
+++ b/crates/librefang-types/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/scripts/check-agents-claude-pair.sh
+++ b/scripts/check-agents-claude-pair.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Verify that every AGENTS.md outside the repo root has a sibling
+# `CLAUDE.md` that is a symlink to `AGENTS.md` (#3297).
+#
+# Why: AI tooling that doesn't recognise AGENTS.md (older Claude Code
+# builds, Codex CLI variants) walks up looking for CLAUDE.md instead.
+# A symlink keeps the two files in lockstep without bit-rotting copies.
+#
+# Exempt: the repo root itself, where AGENTS.md and CLAUDE.md are
+# *separate* files by design (the latter carries Claude-Code-specific
+# rules that don't belong in a portable AGENTS.md).
+
+set -eu
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+fail=0
+
+# Capture into a variable first so the loop body runs in the parent
+# shell — `find … | while` would put it in a subshell on POSIX,
+# making the `fail=1` assignment invisible to the outer scope.
+agents_files=$(find . -name AGENTS.md \
+    -not -path './AGENTS.md' \
+    -not -path './target/*' \
+    -not -path './node_modules/*' \
+    -not -path './.git/*' 2>/dev/null)
+
+for agents in $agents_files; do
+    dir=$(dirname "$agents")
+    claude="$dir/CLAUDE.md"
+
+    if [ ! -e "$claude" ] && [ ! -L "$claude" ]; then
+        echo "::error file=$agents::AGENTS.md present without sibling CLAUDE.md (#3297). Run: ln -s AGENTS.md $claude"
+        fail=1
+        continue
+    fi
+
+    if [ ! -L "$claude" ]; then
+        echo "::error file=$claude::CLAUDE.md exists but is not a symlink. Replace with: rm $claude && ln -s AGENTS.md $claude"
+        fail=1
+        continue
+    fi
+
+    target=$(readlink "$claude")
+    if [ "$target" != "AGENTS.md" ]; then
+        echo "::error file=$claude::CLAUDE.md symlink points to '$target', expected 'AGENTS.md'."
+        fail=1
+        continue
+    fi
+
+    echo "ok: $agents <-> $claude"
+done
+
+if [ "$fail" != "0" ]; then
+    echo
+    echo "Pair check failed. See errors above." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Until now only the repo root and \`crates/librefang-api/dashboard/\` carried an AGENTS.md. Core crates relied entirely on the root file to convey context, and AI tooling that walked up looking for \`CLAUDE.md\` (older Claude Code builds, Codex CLI variants) picked up cross-cutting rules but missed crate-local boundaries, lock strategies, and taboos.

This PR delivers the issue's acceptance criteria:

- ✓ ≥ 6 core crates have a scoped AGENTS.md
- ✓ CI checks the CLAUDE.md symlink convention

## What's added

Per-crate \`AGENTS.md\` (telegraph style, ≤ 120 lines each) under:

- \`crates/librefang-kernel/\` — orchestration, lock strategy on hot fields (model_catalog ArcSwap, event_bus parking_lot Mutex, running_tasks DashMap), god-struct caveat (#3565).
- \`crates/librefang-runtime/\` — agent loop, tool runner, KernelHandle invariant, async / !Send gotchas, identity-file location, deterministic prompt ordering.
- \`crates/librefang-types/\` — bottom-of-DAG schema spine, schema-mirror invariant (#3144 → #3162 → #3167), config-field ritual.
- \`crates/librefang-llm-driver/\` — trait-only crate, why it's split from \`librefang-llm-drivers\`, error-typing rule.
- \`crates/librefang-extensions/\` — vault key encoding (32-byte base64), shared HTTP client mandate, MCP OAuth flow split.
- \`crates/librefang-channels/\` — feature gating, mandatory HMAC, SSRF guard on \`callback_url\`, send-path test mandate (#3820).

Each AGENTS.md ships with a sibling \`CLAUDE.md\` symlink (six new symlinks plus a backfill for \`crates/librefang-api/dashboard/\` whose AGENTS.md previously lacked one). Older Claude Code builds and Codex CLI variants now find the same rules.

## CI gate

New \`agents-claude-pair\` job runs \`scripts/check-agents-claude-pair.sh\`. The script:

- Walks every non-root AGENTS.md.
- Asserts the sibling CLAUDE.md is a symlink to literal \`"AGENTS.md"\` (not a copy, not a different target).
- Handles POSIX shell's \`while … done\` subshell scope so \`fail=1\` propagates to a non-zero exit (caught and fixed during local smoke).

The repo-root AGENTS.md / CLAUDE.md remain distinct files: the root \`CLAUDE.md\` carries Claude-Code-specific rules (worktree-forbidden hooks, integration-test workflow) that intentionally don't belong in a portable AGENTS.md. The check explicitly excludes the root pair.

## Test plan

- [x] Local smoke: \`sh scripts/check-agents-claude-pair.sh\` — exits 0, lists \`ok: <agents> <-> <claude>\` for all 7 pairs (6 new + dashboard backfill).
- [x] Local smoke before fix: detected \`crates/librefang-api/dashboard/\` had no CLAUDE.md, exited 1 with the right \`::error\` line. Confirms the failure path actually fails.
- [x] YAML lint on \`.github/workflows/ci.yml\`.
- [ ] CI workflow

Refs #3297.