### PR TITLE
fix(dashboard): invalidate full plugin domain so Marketplace 'Installed' badge updates

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/plugins.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/plugins.ts
@@ -2,11 +2,18 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { installPlugin, uninstallPlugin, scaffoldPlugin, installPluginDeps } from "../http/client";
 import { pluginKeys } from "../queries/keys";
 
+// Install / uninstall / scaffold all change the *installed* state of a
+// plugin. The Marketplace tab's `rp.installed` flag is derived server-side
+// in `pluginKeys.registries()`, NOT `pluginKeys.lists()` — those are two
+// sibling keys under `pluginKeys.all`, so invalidating only `lists()`
+// leaves the Marketplace tab showing the stale "Install" button after a
+// successful install. Invalidate the whole domain to keep both views in
+// sync.
 export function useInstallPlugin() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: installPlugin,
-    onSuccess: () => qc.invalidateQueries({ queryKey: pluginKeys.lists() }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: pluginKeys.all }),
   });
 }
 
@@ -14,7 +21,7 @@ export function useUninstallPlugin() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: uninstallPlugin,
-    onSuccess: () => qc.invalidateQueries({ queryKey: pluginKeys.lists() }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: pluginKeys.all }),
   });
 }
 
@@ -23,7 +30,7 @@ export function useScaffoldPlugin() {
   return useMutation({
     mutationFn: ({ name, desc, runtime }: { name: string; desc: string; runtime?: string }) =>
       scaffoldPlugin(name, desc, runtime),
-    onSuccess: () => qc.invalidateQueries({ queryKey: pluginKeys.lists() }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: pluginKeys.all }),
   });
 }
 


### PR DESCRIPTION
## Summary

After a successful registry plugin install, the Marketplace tab on the
Plugins page kept showing the **Install** button instead of flipping to
**Installed** — even though the success toast confirmed the install
landed.

Root cause: cache-invalidation key mismatch in TanStack Query.

`useInstallPlugin` / `useUninstallPlugin` / `useScaffoldPlugin` were
invalidating only `pluginKeys.lists()`, but the Marketplace tab's
`rp.installed` flag is computed server-side and surfaced through
`pluginKeys.registries()`. Those two keys are siblings under
`pluginKeys.all`:

```
plugins
├── list           ← installed-plugins query (Installed tab)
└── registries     ← registry-with-installed-flag query (Marketplace tab)
```

Invalidating one does not refetch the other, so the Marketplace tab
served stale data with `rp.installed === false` until the user manually
hit refresh.

## Change

Bumped the three mutations to invalidate `pluginKeys.all`, matching the
pattern `useInstallPluginDeps` was already using. Both views stay in
sync after any state-changing call now.

## Test plan

- [x] `pnpm test` (170/170 dashboard tests pass)
- [ ] Manual: click Install on a Marketplace plugin → toast says
      "Plugin installed" AND the row's button flips to "Installed"
- [ ] Manual: switch to Installed tab → the new plugin appears
- [ ] Manual: click Uninstall → row drops from Installed tab AND
      Marketplace row's button flips back to "Install"
