### PR TITLE
fix(dashboard): defend AuditPage against missing entries on empty audit log

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AuditPage.tsx
@@ -550,7 +550,11 @@ export function AuditPage() {
   const initialSeq = useMemo(() => search.seq, []);
   useEffect(() => {
     if (initialSeq == null || detailEntry) return;
-    const match = query.data?.entries.find((e) => e.seq === initialSeq);
+    // Defensive `?? []`: the backend returns `{count:0,limit:N}` without an
+    // `entries` field on cold registries / pre-first-action, even though the
+    // typed schema marks `entries` required. Prevents a render crash before
+    // the first audit row exists.
+    const match = (query.data?.entries ?? []).find((e) => e.seq === initialSeq);
     if (match) setDetailEntry(match);
   }, [initialSeq, query.data, detailEntry]);
 
@@ -943,7 +947,7 @@ export function AuditPage() {
 
       {query.isLoading ? (
         <ListSkeleton rows={5} />
-      ) : query.data && query.data.entries.length === 0 ? (
+      ) : query.data && (query.data.entries ?? []).length === 0 ? (
         <EmptyState
           icon={<ScrollText className="h-7 w-7" />}
           title={t("audit.empty_title")}
@@ -968,7 +972,7 @@ export function AuditPage() {
         />
       ) : query.data ? (
         <div className="flex flex-col gap-4">
-          {groupByDate(query.data.entries, t).map((group) => {
+          {groupByDate(query.data.entries ?? [], t).map((group) => {
             const tally = outcomeBreakdown(group.rows);
             return (
             <section key={group.label} className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary

The Audit page crashes on a freshly-installed registry (no audit rows
recorded yet) with:

```
TypeError: Cannot read properties of undefined (reading 'length')
  at AuditPage (AuditPage.tsx)
```

Root cause: the backend returns `{count: 0, limit: 200}` without an
`entries` field when the audit log is empty, but the typed
`AuditQueryResponse` schema declares `entries: AuditQueryEntry[]` as
required. Three call sites in `AuditPage.tsx` read `query.data.entries`
directly:

- the `?seq=N` deep-link effect (`entries.find(...)`)
- the empty-state ternary (`entries.length === 0`)
- the rendering map (`groupByDate(entries, ...)`)

All three threw on `undefined.find` / `undefined.length`.

## Change

Coerce `entries ?? []` at all three reads. Two lines + a comment
explaining why the type lies.

The deeper fix — making `entries` actually optional in the openapi spec
(or guaranteeing the field server-side) — is a follow-up.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [ ] Manual: open Audit page on a registry with zero rows → loads
      empty-state instead of crashing
- [ ] Manual: open Audit page after at least one tool invocation →
      rows render normally
