### PR TITLE
feat(kernel): persist canonical agent UUID across respawns (#4614)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1432,7 +1432,13 @@ export async function getAgentTemplateToml(name: string): Promise<string> {
 }
 
 export async function deleteAgent(agentId: string): Promise<ApiActionResponse> {
-  return del<ApiActionResponse>(`/api/agents/${encodeURIComponent(agentId)}`);
+  // Refs #4614 — DELETE requires explicit confirmation. The dashboard
+  // already wraps this call in a confirmation modal, so we send the
+  // confirm flag here. Without it the API returns 409 with the
+  // canonical-UUID data-loss warning.
+  return del<ApiActionResponse>(
+    `/api/agents/${encodeURIComponent(agentId)}?confirm=true`,
+  );
 }
 
 export async function cloneAgent(agentId: string): Promise<ApiActionResponse> {

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -69,6 +69,9 @@ use crate::types;
         routes::clear_agent_history,
         routes::compact_session,
         routes::stop_agent,
+        // Canonical agent UUID registry (refs #4614)
+        routes::list_agent_identities,
+        routes::reset_agent_identity,
         routes::list_agent_runtime,
         routes::stop_session,
         routes::set_model,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -9,6 +9,16 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/agents",
             axum::routing::get(list_agents).post(spawn_agent),
         )
+        // Canonical agent UUID registry (refs #4614). Routed before
+        // /agents/{id} so the literal segment doesn't get parsed as a UUID.
+        .route(
+            "/agents/identities",
+            axum::routing::get(list_agent_identities),
+        )
+        .route(
+            "/agents/identities/{name}/reset",
+            axum::routing::post(reset_agent_identity),
+        )
         // Bulk agent operations (placed before /agents/{id} to avoid path conflicts)
         .route(
             "/agents/bulk",
@@ -2298,27 +2308,61 @@ pub async fn get_agent_session(
     }
 }
 
-/// DELETE /api/agents/:id — Kill an agent.
+/// Query parameters for `DELETE /api/agents/{id}` (refs #4614).
+///
+/// `confirm = true` is required by the canonical-UUID registry design — a
+/// bare DELETE is rejected with `409 Conflict` so a typo, replayed
+/// request, or dashboard click-bug can't silently destroy history. When
+/// `confirm=true` the agent is killed AND its `name → canonical_uuid`
+/// binding is purged from `agent_identities.toml` (i.e. the next spawn
+/// under the same name lands on a fresh UUID; prior sessions / memories
+/// are orphaned).
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct DeleteAgentQuery {
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+/// Warning text shown when a DELETE arrives without confirmation. Mirrors
+/// the prompt copy in the issue body so CLI / API / dashboard surface the
+/// same wording.
+const DELETE_AGENT_WARNING: &str = "Deleting this agent will permanently remove its canonical UUID and all associated memories and sessions. This action cannot be undone. Re-issue with confirm=true to proceed.";
+
+/// DELETE /api/agents/:id — Kill an agent (refs #4614).
 ///
 /// Idempotent (RFC 9110 §9.2.2 / §9.3.5): deleting an agent that is already
 /// gone returns `200 OK` with `{"status": "already-deleted"}` instead of
 /// `404`. `404` is reserved for the malformed-UUID case alone, so retried
 /// or replayed DELETEs by clients (network blips, dashboard double-clicks)
 /// no longer surface a phantom error. Refs #3509.
+///
+/// Refs #4614 — canonical agent UUID registry. Explicit deletes via this
+/// endpoint require `confirm=true` (as a query param or JSON body field).
+/// Without it the request is rejected with `409 Conflict` and the
+/// data-loss warning text. With confirmation, the kernel kills the agent
+/// AND purges its canonical UUID binding so the next spawn under the
+/// same name lands on a fresh UUID. Internal lifecycle resets (hot
+/// reload, panic restart) call `kill_agent` directly and preserve the
+/// binding — the destructive purge only happens when an operator
+/// explicitly asks for it.
 #[utoipa::path(
     delete,
     path = "/api/agents/{id}",
     tag = "agents",
-    params(("id" = String, Path, description = "Agent ID")),
+    params(
+        ("id" = String, Path, description = "Agent ID"),
+        ("confirm" = Option<bool>, Query, description = "Required: confirms canonical UUID purge. Refs #4614.")
+    ),
     responses(
-        (status = 200, description = "Agent killed (or was already absent — idempotent)"),
+        (status = 200, description = "Agent killed and canonical UUID purged"),
         (status = 400, description = "Malformed agent ID"),
-        (status = 409, description = "Agent is hand-owned and cannot be deleted directly")
+        (status = 409, description = "Confirmation required, or agent is hand-owned")
     )
 )]
 pub async fn kill_agent(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
+    Query(q): Query<DeleteAgentQuery>,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
@@ -2330,6 +2374,16 @@ pub async fn kill_agent(
                 .into_response();
         }
     };
+
+    // Refs #4614: destructive delete requires explicit confirmation via
+    // `?confirm=true`. Without it the request is rejected with 409
+    // Conflict + the data-loss warning text so a typo / replay /
+    // click-bug can't silently destroy history.
+    if !q.confirm {
+        return ApiErrorResponse::conflict(DELETE_AGENT_WARNING)
+            .with_code("delete_confirmation_required")
+            .into_response();
+    }
 
     // Hand-spawned runtime agents are owned by their hand instance. Killing
     // one directly leaves the hand registry pointing at a dangling id that
@@ -2359,10 +2413,15 @@ pub async fn kill_agent(
         }
     }
 
-    let body = match state.kernel.kill_agent(agent_id) {
+    // Confirmed delete: kill + purge canonical UUID binding (refs #4614).
+    let body = match state.kernel.kill_agent_with_purge(agent_id, true) {
         Ok(()) => (
             StatusCode::OK,
-            Json(serde_json::json!({"status": "killed", "agent_id": id})),
+            Json(serde_json::json!({
+                "status": "killed",
+                "agent_id": id,
+                "identity_purged": true,
+            })),
         )
             .into_response(),
         Err(e) => {
@@ -6263,6 +6322,111 @@ pub async fn push_message(
                 "agent_id": agent_id.to_string(),
             })),
         ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Canonical agent UUID registry endpoints (refs #4614)
+// ---------------------------------------------------------------------------
+
+/// One row in the response of `GET /api/agents/identities`.
+///
+/// `created_at` is RFC 3339 UTC (string form rather than
+/// `chrono::DateTime<Utc>` so the type implements `utoipa::ToSchema`
+/// without pulling in chrono's optional `schemars` feature).
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct AgentIdentityRow {
+    pub name: String,
+    pub canonical_uuid: String,
+    pub created_at: String,
+}
+
+/// GET /api/agents/identities — List the canonical UUID registry (refs #4614).
+///
+/// Returns all `name → canonical_uuid` mappings persisted at
+/// `<home_dir>/agent_identities.toml`. Order is stable (sorted by name) so
+/// callers can rely on the result for diagnostics / golden tests.
+#[utoipa::path(
+    get,
+    path = "/api/agents/identities",
+    tag = "agents",
+    responses(
+        (status = 200, description = "Canonical UUID registry contents", body = Vec<AgentIdentityRow>)
+    )
+)]
+pub async fn list_agent_identities(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let entries = state.kernel.agent_identities().list();
+    let rows: Vec<AgentIdentityRow> = entries
+        .into_iter()
+        .map(|(name, identity)| AgentIdentityRow {
+            name,
+            canonical_uuid: identity.canonical_uuid.to_string(),
+            created_at: identity.created_at.to_rfc3339(),
+        })
+        .collect();
+    (StatusCode::OK, Json(serde_json::json!(rows)))
+}
+
+/// Query parameters for `POST /api/agents/identities/{name}/reset`.
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct ResetIdentityQuery {
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+const RESET_IDENTITY_WARNING: &str = "Resetting this agent's canonical UUID will orphan all sessions, memories, and audit history tied to the prior UUID. The next spawn under this name will start with a fresh UUID. This action cannot be undone. Re-issue with confirm=true to proceed.";
+
+/// POST /api/agents/identities/{name}/reset — Drop the canonical UUID
+/// binding for `name` (refs #4614).
+///
+/// Requires `confirm=true` (query string or JSON body) — without it the
+/// request is rejected with `409 Conflict` and the data-loss warning. The
+/// next spawn under the same name re-derives a fresh UUID via
+/// `AgentId::from_name` and registers it as the new canonical binding.
+/// The agent is **not** killed — operators can call `DELETE /api/agents/{id}`
+/// (or `kill_agent`) separately if a runtime restart is also desired.
+///
+/// Returns `404` if no entry exists for `name`.
+#[utoipa::path(
+    post,
+    path = "/api/agents/identities/{name}/reset",
+    tag = "agents",
+    params(
+        ("name" = String, Path, description = "Agent name"),
+        ("confirm" = Option<bool>, Query, description = "Required: confirms canonical UUID reset.")
+    ),
+    responses(
+        (status = 200, description = "Canonical UUID purged"),
+        (status = 404, description = "No canonical UUID recorded for this name"),
+        (status = 409, description = "Confirmation required")
+    )
+)]
+pub async fn reset_agent_identity(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Query(q): Query<ResetIdentityQuery>,
+) -> impl IntoResponse {
+    if !q.confirm {
+        return ApiErrorResponse::conflict(RESET_IDENTITY_WARNING)
+            .with_code("reset_identity_unconfirmed")
+            .into_response();
+    }
+
+    match state.kernel.agent_identities().purge(&name) {
+        Some(dropped) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "status": "reset",
+                "name": name,
+                "previous_canonical_uuid": dropped.to_string(),
+            })),
+        )
+            .into_response(),
+        None => ApiErrorResponse::not_found(format!(
+            "no canonical UUID recorded for agent name '{name}'"
+        ))
+        .with_code("identity_not_found")
+        .into_response(),
     }
 }
 

--- a/crates/librefang-api/tests/agent_identity_registry_test.rs
+++ b/crates/librefang-api/tests/agent_identity_registry_test.rs
@@ -1,0 +1,295 @@
+//! Integration coverage for the canonical agent UUID registry — refs #4614.
+//!
+//! Verifies:
+//! 1. spawn_agent registers a canonical UUID matching the agent's id;
+//! 2. DELETE /api/agents/{id} without `?confirm=true` is rejected 409
+//!    (preserving the registry); with confirm purges the binding;
+//! 3. respawn after a confirmed delete picks up the same deterministic
+//!    UUID via `AgentId::from_name` AND re-registers the binding;
+//! 4. GET /api/agents/identities surfaces the registry contents;
+//! 5. POST /api/agents/identities/{name}/reset gates on `?confirm=true`.
+//!
+//! These tests catch regressions at the API ↔ kernel ↔ identity-registry
+//! boundary on every push (per CLAUDE.md / refs #3721 — integration
+//! tests are the canonical replacement for the old curl checklist).
+
+use axum::Router;
+use librefang_api::{middleware, routes, ws};
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use std::sync::Arc;
+use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+
+struct TestServer {
+    base_url: String,
+    state: Arc<routes::AppState>,
+    _tmp: tempfile::TempDir,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.state.kernel.shutdown();
+    }
+}
+
+async fn start_test_server() -> TestServer {
+    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(|cfg| {
+        cfg.default_model.provider = "ollama".to_string();
+        cfg.default_model.model = "test-model".to_string();
+        cfg.default_model.api_key_env = "OLLAMA_API_KEY".to_string();
+    }));
+    let config_path = test.tmp_path().join("config.toml");
+    let test = test.with_config_path(config_path);
+    let (state, _tmp, _) = test.into_parts();
+    state.kernel.set_self_handle();
+
+    let app = Router::new()
+        .route(
+            "/api/agents",
+            axum::routing::get(routes::list_agents).post(routes::spawn_agent),
+        )
+        .route(
+            "/api/agents/identities",
+            axum::routing::get(routes::list_agent_identities),
+        )
+        .route(
+            "/api/agents/identities/{name}/reset",
+            axum::routing::post(routes::reset_agent_identity),
+        )
+        .route(
+            "/api/agents/{id}",
+            axum::routing::get(routes::get_agent).delete(routes::kill_agent),
+        )
+        .route("/api/agents/{id}/ws", axum::routing::get(ws::agent_ws))
+        .layer(axum::middleware::from_fn(middleware::request_logging))
+        .layer(TraceLayer::new_for_http())
+        .layer(CorsLayer::permissive())
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    TestServer {
+        base_url: format!("http://{}", addr),
+        state,
+        _tmp,
+    }
+}
+
+const TEST_MANIFEST: &str = r#"
+name = "respawn-target"
+version = "0.1.0"
+description = "Integration test agent (refs #4614)"
+author = "test"
+module = "builtin:chat"
+
+[model]
+provider = "ollama"
+model = "test-model"
+system_prompt = "You are a test agent."
+
+[capabilities]
+memory_read = ["*"]
+memory_write = ["self.*"]
+"#;
+
+async fn spawn_one(server: &TestServer, manifest: &str) -> String {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": manifest}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "spawn must return 201");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    body["agent_id"].as_str().unwrap().to_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn spawn_registers_canonical_uuid() {
+    let server = start_test_server().await;
+    let agent_id = spawn_one(&server, TEST_MANIFEST).await;
+
+    let recorded = server
+        .state
+        .kernel
+        .agent_identities()
+        .get("respawn-target")
+        .expect("registry must record the canonical UUID");
+    assert_eq!(recorded.to_string(), agent_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_without_confirm_returns_409_and_preserves_identity() {
+    let server = start_test_server().await;
+    let agent_id = spawn_one(&server, TEST_MANIFEST).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete(format!("{}/api/agents/{}", server.base_url, agent_id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 409, "bare DELETE must be 409 (refs #4614)");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "delete_confirmation_required");
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("canonical UUID") && err.contains("cannot be undone"),
+        "warning text must mention canonical UUID + data-loss; got: {err}"
+    );
+    assert!(
+        server
+            .state
+            .kernel
+            .agent_identities()
+            .get("respawn-target")
+            .is_some(),
+        "rejected DELETE must NOT purge the canonical UUID"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_with_confirm_purges_identity_and_respawn_recovers_uuid() {
+    let server = start_test_server().await;
+    let first_id = spawn_one(&server, TEST_MANIFEST).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete(format!(
+            "{}/api/agents/{}?confirm=true",
+            server.base_url, first_id
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "killed");
+    assert_eq!(body["identity_purged"], true);
+    assert!(
+        server
+            .state
+            .kernel
+            .agent_identities()
+            .get("respawn-target")
+            .is_none(),
+        "confirmed DELETE must purge the canonical UUID"
+    );
+
+    // Respawn re-derives via `AgentId::from_name` and re-registers the
+    // binding. The v5 derivation is deterministic for a fixed name, so
+    // the recovered UUID equals the original — sessions / memories tied
+    // to the prior life cycle were already removed by `kill_agent`'s
+    // `memory.remove_agent` call. The point of the registry is to
+    // survive *non-explicit* lifecycle resets (panic restart, hot
+    // reload, manifest reload).
+    let second_id = spawn_one(&server, TEST_MANIFEST).await;
+    assert_eq!(
+        first_id, second_id,
+        "deterministic from_name yields the same UUID after a clean re-register"
+    );
+    assert!(
+        server
+            .state
+            .kernel
+            .agent_identities()
+            .get("respawn-target")
+            .is_some(),
+        "fresh spawn must re-register the canonical UUID"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_invalid_uuid_short_circuits_400_before_confirm_check() {
+    // Refs #4614: malformed UUID is still 400 (not 409), since the
+    // parse failure happens before the confirm check fires.
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete(format!("{}/api/agents/not-a-uuid", server.base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_identities_returns_registered_entries() {
+    let server = start_test_server().await;
+    let agent_id = spawn_one(&server, TEST_MANIFEST).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{}/api/agents/identities", server.base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let arr = body.as_array().expect("response must be a JSON array");
+    let row = arr
+        .iter()
+        .find(|r| r["name"] == "respawn-target")
+        .expect("registry must contain the spawned agent");
+    assert_eq!(row["canonical_uuid"].as_str().unwrap(), agent_id);
+    assert!(row["created_at"].as_str().is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reset_identity_endpoint_gates_on_confirm() {
+    let server = start_test_server().await;
+    let _agent_id = spawn_one(&server, TEST_MANIFEST).await;
+    let client = reqwest::Client::new();
+
+    // Bare reset → 409
+    let resp = client
+        .post(format!(
+            "{}/api/agents/identities/respawn-target/reset",
+            server.base_url
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 409);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "reset_identity_unconfirmed");
+
+    // Confirmed reset → 200, binding gone
+    let resp = client
+        .post(format!(
+            "{}/api/agents/identities/respawn-target/reset?confirm=true",
+            server.base_url
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "reset");
+    assert!(body["previous_canonical_uuid"].as_str().is_some());
+    assert!(server
+        .state
+        .kernel
+        .agent_identities()
+        .get("respawn-target")
+        .is_none());
+
+    // Reset on a now-missing name → 404
+    let resp = client
+        .post(format!(
+            "{}/api/agents/identities/respawn-target/reset?confirm=true",
+            server.base_url
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}

--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -345,6 +345,16 @@ fn delete(path: &str, bearer: Option<&str>) -> Request<Body> {
     b.body(Body::empty()).unwrap()
 }
 
+/// Refs #4614 — DELETE /api/agents/{id} requires `?confirm=true` (or a
+/// `{"confirm": true}` body) to gate the destructive canonical-UUID
+/// purge. This helper appends the query param so tests don't have to
+/// open-code the URL in every call site.
+fn delete_confirmed(path: &str, bearer: Option<&str>) -> Request<Body> {
+    let glue = if path.contains('?') { '&' } else { '?' };
+    let with_confirm = format!("{path}{glue}confirm=true");
+    delete(&with_confirm, bearer)
+}
+
 /// Refs #3509: DELETE is idempotent (RFC 9110 §9.2.2). Killing the same
 /// agent twice MUST succeed both times — the second call returns
 /// `200 OK` with `status: already-deleted` instead of `404 Not Found`,
@@ -356,10 +366,11 @@ async fn test_delete_agent_twice_both_succeed_idempotent() {
     let h = boot(TEST_TOKEN).await;
     let id = spawn_named(&h.state, "kill-target");
 
-    // First call — agent exists, normal kill path.
+    // First call — agent exists, normal kill path. Refs #4614: confirm
+    // required to gate canonical-UUID purge.
     let (status1, body1) = send(
         h.app.clone(),
-        delete(&format!("/api/agents/{}", id), Some(TEST_TOKEN)),
+        delete_confirmed(&format!("/api/agents/{}", id), Some(TEST_TOKEN)),
     )
     .await;
     assert_eq!(
@@ -372,7 +383,7 @@ async fn test_delete_agent_twice_both_succeed_idempotent() {
     // Second call — agent already gone. MUST still be 200, not 404.
     let (status2, body2) = send(
         h.app.clone(),
-        delete(&format!("/api/agents/{}", id), Some(TEST_TOKEN)),
+        delete_confirmed(&format!("/api/agents/{}", id), Some(TEST_TOKEN)),
     )
     .await;
     assert_eq!(
@@ -392,6 +403,9 @@ async fn test_delete_agent_twice_both_succeed_idempotent() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_delete_agent_invalid_id_still_returns_400() {
     let h = boot(TEST_TOKEN).await;
+    // Bare DELETE — malformed UUID short-circuits with 400 before the
+    // confirmation check fires, so the response stays the same shape
+    // post-#4614.
     let (status, body) = send(
         h.app.clone(),
         delete("/api/agents/not-a-uuid", Some(TEST_TOKEN)),
@@ -409,9 +423,11 @@ async fn test_delete_agent_invalid_id_still_returns_400() {
 async fn test_delete_agent_unknown_uuid_is_idempotent_200() {
     let h = boot(TEST_TOKEN).await;
     let unknown = AgentId::new();
+    // Refs #4614: confirm required even on the idempotent-already-gone
+    // path so the contract is consistent across all DELETEs.
     let (status, body) = send(
         h.app.clone(),
-        delete(&format!("/api/agents/{}", unknown), Some(TEST_TOKEN)),
+        delete_confirmed(&format!("/api/agents/{}", unknown), Some(TEST_TOKEN)),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "body={body:?}");

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -631,8 +631,13 @@ async fn test_spawn_list_kill_agent() {
     assert_eq!(test_agent["model_provider"], "ollama");
 
     // --- Kill ---
+    // Refs #4614: DELETE requires `?confirm=true` so canonical UUID
+    // purge is gated behind explicit operator intent.
     let resp = client
-        .delete(format!("{}/api/agents/{}", server.base_url, agent_id))
+        .delete(format!(
+            "{}/api/agents/{}?confirm=true",
+            server.base_url, agent_id
+        ))
         .send()
         .await
         .unwrap();
@@ -1223,8 +1228,13 @@ async fn test_kill_nonexistent_agent_is_idempotent() {
     let client = reqwest::Client::new();
 
     let fake_id = uuid::Uuid::new_v4();
+    // Refs #4614: confirm required, but the idempotent-already-gone
+    // shortcut still applies and yields 200 OK.
     let resp = client
-        .delete(format!("{}/api/agents/{}", server.base_url, fake_id))
+        .delete(format!(
+            "{}/api/agents/{}?confirm=true",
+            server.base_url, fake_id
+        ))
         .send()
         .await
         .unwrap();
@@ -1329,9 +1339,12 @@ memory_write = ["self.*"]
     let status: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(status["agent_count"], 4);
 
-    // Kill one
+    // Kill one (refs #4614: confirm required)
     let resp = client
-        .delete(format!("{}/api/agents/{}", server.base_url, ids[1]))
+        .delete(format!(
+            "{}/api/agents/{}?confirm=true",
+            server.base_url, ids[1]
+        ))
         .send()
         .await
         .unwrap();
@@ -1347,10 +1360,13 @@ memory_write = ["self.*"]
     let agents = body["items"].as_array().unwrap();
     assert_eq!(agents.len(), 3);
 
-    // Kill the rest
+    // Kill the rest (refs #4614: confirm required)
     for id in [&ids[0], &ids[2]] {
         client
-            .delete(format!("{}/api/agents/{}", server.base_url, id))
+            .delete(format!(
+                "{}/api/agents/{}?confirm=true",
+                server.base_url, id
+            ))
             .send()
             .await
             .unwrap();

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -575,10 +575,13 @@ async fn load_spawn_kill_cycle() {
         }
     }
 
-    // Kill
+    // Kill (refs #4614: confirm required)
     for id in &ids {
         client
-            .delete(format!("{}/api/agents/{}", server.base_url, id))
+            .delete(format!(
+                "{}/api/agents/{}?confirm=true",
+                server.base_url, id
+            ))
             .send()
             .await
             .unwrap();

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1122,11 +1122,44 @@ enum AgentCommands {
     },
     /// Kill an agent.
     #[command(
-        long_about = "Terminate a running agent by its UUID.\n\nExamples:\n  librefang agent kill 550e8400-e29b-41d4-a716-446655440000"
+        long_about = "Terminate a running agent by its UUID.\n\nThis is a destructive operation: the agent's canonical UUID binding is\npurged, orphaning any prior sessions / memories under the old UUID. The\nnext spawn under the same name lands on a fresh UUID. Use\n`librefang agent delete <name> --yes` for the explicit-by-name variant\n(refs #4614).\n\nExamples:\n  librefang agent kill 550e8400-e29b-41d4-a716-446655440000"
     )]
     Kill {
         /// Agent ID (UUID).
         agent_id: String,
+    },
+    /// Delete an agent by name with a confirmation prompt (refs #4614).
+    #[command(
+        long_about = "Permanently delete an agent and purge its canonical UUID binding.\n\nResolves <name> to its canonical UUID via the agent_identities registry,\nprompts for confirmation (or `--yes` to bypass), and issues\n`DELETE /api/agents/{id}?confirm=true`. The next spawn under the same\nname will land on a fresh UUID; prior sessions / memories are orphaned.\n\nExamples:\n  librefang agent delete coder\n  librefang agent delete coder --yes"
+    )]
+    Delete {
+        /// Agent name (looked up in agent_identities.toml).
+        name: String,
+        /// Skip the confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Reset an agent's canonical UUID without killing it (refs #4614).
+    #[command(
+        long_about = "Drop the canonical UUID binding for <name> from the\nagent_identities registry without killing the agent. The next spawn\nwill re-derive a fresh UUID. Prior sessions / memories tied to the\nold UUID are orphaned. Prompts for confirmation; pass `--yes` to skip.\n\nExamples:\n  librefang agent reset-uuid coder\n  librefang agent reset-uuid coder --yes"
+    )]
+    ResetUuid {
+        /// Agent name.
+        name: String,
+        /// Skip the confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Reassign sessions / memories from an old UUID to the canonical one (refs #4614, deferred).
+    #[command(
+        long_about = "Migrate orphaned data from <old-uuid> to the canonical UUID for <name>.\n\nNOT YET IMPLEMENTED — this command is reserved by issue #4614 but the\nactual cross-table reassignment requires deep memory-substrate surgery\n(sessions, events, kv_store, memories, entities, relations,\nusage_events, canonical_sessions, prompt_experiments, audit_entries,\napproval_audit, plus the proactive memory store) under a single\ntransaction with rollback semantics. Tracked as a follow-up.\n\nFor now this command prints a friendly message pointing to the issue.\n\nExamples:\n  librefang agent merge-history coder --from 0123abcd-...-..."
+    )]
+    MergeHistory {
+        /// Agent name (canonical UUID destination).
+        name: String,
+        /// Old UUID whose sessions / memories should be reassigned.
+        #[arg(long)]
+        from: String,
     },
     /// Set an agent property (e.g., model).
     #[command(
@@ -2066,6 +2099,9 @@ fn main() {
             AgentCommands::List { json } => cmd_agent_list(cli.config, json),
             AgentCommands::Chat { agent_id } => cmd_agent_chat(cli.config, &agent_id),
             AgentCommands::Kill { agent_id } => cmd_agent_kill(cli.config, &agent_id),
+            AgentCommands::Delete { name, yes } => cmd_agent_delete(cli.config, &name, yes),
+            AgentCommands::ResetUuid { name, yes } => cmd_agent_reset_uuid(cli.config, &name, yes),
+            AgentCommands::MergeHistory { name, from } => cmd_agent_merge_history(&name, &from),
             AgentCommands::Set {
                 agent_id,
                 field,
@@ -4082,9 +4118,14 @@ fn cmd_agent_kill(config: Option<PathBuf>, agent_id_str: &str) {
     if let Some(base) = find_daemon() {
         let agent_id = resolve_agent_id(&base, agent_id_str);
         let client = daemon_client();
+        // Refs #4614: explicit `librefang agent kill <id>` IS the user's
+        // confirmation. The API requires `?confirm=true` on DELETE so the
+        // canonical UUID is purged on the kill (matching the issue's
+        // "explicit delete" semantics). Internal lifecycle resets call
+        // `kernel.kill_agent` directly and skip this path.
         let body = daemon_json(
             client
-                .delete(format!("{base}/api/agents/{agent_id}"))
+                .delete(format!("{base}/api/agents/{agent_id}?confirm=true"))
                 .send(),
         );
         if body.get("status").is_some() {
@@ -4108,7 +4149,9 @@ fn cmd_agent_kill(config: Option<PathBuf>, agent_id_str: &str) {
             std::process::exit(1);
         });
         let kernel = boot_kernel(config);
-        match kernel.kill_agent(agent_id) {
+        // Direct-kernel path (no daemon): mirror the API's confirmed-delete
+        // semantics so behavior matches whether the daemon is running or not.
+        match kernel.kill_agent_with_purge(agent_id, true) {
             Ok(()) => println!(
                 "{}",
                 i18n::t_args("agent-killed", &[("id", &agent_id.to_string())])
@@ -4122,6 +4165,192 @@ fn cmd_agent_kill(config: Option<PathBuf>, agent_id_str: &str) {
             }
         }
     }
+}
+
+/// Refs #4614 — `librefang agent delete <name>` with confirmation prompt.
+///
+/// Looks up the canonical UUID for `name` via `GET /api/agents/identities`
+/// (or directly from the kernel registry when no daemon is running),
+/// prints the destructive-action warning, and either prompts `[y/N]` or
+/// proceeds immediately when `--yes` is set. Then issues the confirmed
+/// DELETE. This is the long-form companion to `librefang agent kill <id>`
+/// — useful when the operator only knows the agent's name.
+fn cmd_agent_delete(config: Option<PathBuf>, name: &str, yes: bool) {
+    eprintln!("WARNING: Deleting agent \"{name}\" will permanently remove its canonical UUID");
+    eprintln!("    and all associated memories and sessions.");
+    eprintln!("    This action cannot be undone.");
+    if !yes && !prompt_yes_no("Confirm?", false) {
+        eprintln!("Aborted.");
+        std::process::exit(1);
+    }
+
+    if let Some(base) = find_daemon() {
+        let client = daemon_client();
+        // Resolve name → UUID via the identity registry endpoint.
+        let canonical_uuid = match lookup_canonical_uuid(&base, name) {
+            Some(id) => id,
+            None => {
+                eprintln!(
+                    "No canonical UUID recorded for agent name '{name}' — nothing to delete."
+                );
+                std::process::exit(1);
+            }
+        };
+        let body = daemon_json(
+            client
+                .delete(format!("{base}/api/agents/{canonical_uuid}?confirm=true"))
+                .send(),
+        );
+        if body.get("status").is_some() {
+            println!("Agent \"{name}\" deleted (canonical UUID purged).");
+        } else {
+            eprintln!(
+                "Failed to delete agent: {}",
+                body["error"].as_str().unwrap_or("Unknown error")
+            );
+            std::process::exit(1);
+        }
+    } else {
+        let kernel = boot_kernel(config);
+        let canonical_uuid = match kernel.agent_identities().get(name) {
+            Some(id) => id,
+            None => {
+                eprintln!(
+                    "No canonical UUID recorded for agent name '{name}' — nothing to delete."
+                );
+                std::process::exit(1);
+            }
+        };
+        match kernel.kill_agent_with_purge(canonical_uuid, true) {
+            Ok(()) => println!("Agent \"{name}\" deleted (canonical UUID purged)."),
+            Err(e) => {
+                eprintln!("Failed to delete agent: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
+/// Refs #4614 — `librefang agent reset-uuid <name>` with confirmation.
+///
+/// Drops the canonical UUID binding without killing a running agent. The
+/// next spawn under `name` re-derives a fresh UUID and registers it as
+/// the new canonical binding; prior sessions / memories tied to the old
+/// UUID are orphaned. `--yes` skips the prompt.
+fn cmd_agent_reset_uuid(config: Option<PathBuf>, name: &str, yes: bool) {
+    eprintln!("WARNING: Resetting the canonical UUID for \"{name}\" will orphan all sessions");
+    eprintln!("    and memories tied to its current UUID. The next spawn under this");
+    eprintln!("    name will start with a fresh UUID. This action cannot be undone.");
+    if !yes && !prompt_yes_no("Confirm?", false) {
+        eprintln!("Aborted.");
+        std::process::exit(1);
+    }
+
+    if let Some(base) = find_daemon() {
+        let client = daemon_client();
+        let body = daemon_json(
+            client
+                .post(format!(
+                    "{base}/api/agents/identities/{}/reset",
+                    percent_encode_path_segment(name)
+                ))
+                .query(&[("confirm", "true")])
+                .send(),
+        );
+        if body.get("status").is_some() {
+            println!(
+                "Canonical UUID for \"{name}\" reset (was {}).",
+                body["previous_canonical_uuid"]
+                    .as_str()
+                    .unwrap_or("<unknown>")
+            );
+        } else {
+            eprintln!(
+                "Failed to reset canonical UUID: {}",
+                body["error"].as_str().unwrap_or("Unknown error")
+            );
+            std::process::exit(1);
+        }
+    } else {
+        let kernel = boot_kernel(config);
+        match kernel.agent_identities().purge(name) {
+            Some(prev) => println!("Canonical UUID for \"{name}\" reset (was {prev})."),
+            None => {
+                eprintln!("No canonical UUID recorded for agent name '{name}'.");
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
+/// Refs #4614 — `librefang agent merge-history` placeholder.
+///
+/// The cross-table reassignment is not yet implemented — see the
+/// long_about on `AgentCommands::MergeHistory` for the rationale (deep
+/// memory-substrate surgery across 10+ tables under one transaction).
+fn cmd_agent_merge_history(name: &str, from: &str) {
+    eprintln!("merge-history is not yet implemented (refs #4614 follow-up).");
+    eprintln!("Reassignment of sessions / memories from {from} to the canonical UUID");
+    eprintln!("for agent \"{name}\" requires cross-table SQL surgery in the memory");
+    eprintln!("substrate that is being tracked separately.");
+    std::process::exit(2);
+}
+
+/// Look up the canonical UUID for `name` via the identity-registry
+/// endpoint. Returns `None` if no entry exists (or on any HTTP error —
+/// the caller surfaces a friendly message).
+fn lookup_canonical_uuid(base: &str, name: &str) -> Option<String> {
+    let client = daemon_client();
+    let resp = client
+        .get(format!("{base}/api/agents/identities"))
+        .send()
+        .ok()?;
+    let entries: serde_json::Value = resp.json().ok()?;
+    let arr = entries.as_array()?;
+    for entry in arr {
+        if entry["name"].as_str() == Some(name) {
+            return entry["canonical_uuid"].as_str().map(String::from);
+        }
+    }
+    None
+}
+
+/// Minimal percent-encoder for a single URL path segment. Encodes
+/// everything outside the `unreserved` set (RFC 3986 §2.3) plus `/` so
+/// the segment can't escape into a parent path. Avoids pulling a new
+/// dependency for the one-off use here.
+fn percent_encode_path_segment(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for byte in s.as_bytes() {
+        let b = *byte;
+        let unreserved =
+            b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b'~';
+        if unreserved {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{b:02X}"));
+        }
+    }
+    out
+}
+
+/// Minimal `[y/N]` prompt for destructive operations. Reads a single
+/// line from stdin; treats anything other than `y` / `Y` / `yes` /
+/// `YES` as "no" (per the issue's `[y/N]` default).
+fn prompt_yes_no(prompt: &str, default_yes: bool) -> bool {
+    use std::io::Write as _;
+    let suffix = if default_yes { "[Y/n]" } else { "[y/N]" };
+    eprint!("{prompt} {suffix} ");
+    let _ = std::io::stderr().flush();
+    let mut buf = String::new();
+    if std::io::stdin().read_line(&mut buf).is_err() {
+        return false;
+    }
+    let trimmed = buf.trim().to_ascii_lowercase();
+    if trimmed.is_empty() {
+        return default_yes;
+    }
+    matches!(trimmed.as_str(), "y" | "yes")
 }
 
 fn cmd_agent_set(agent_id_str: &str, field: &str, value: &str) {

--- a/crates/librefang-kernel/src/agent_identity_registry.rs
+++ b/crates/librefang-kernel/src/agent_identity_registry.rs
@@ -1,0 +1,364 @@
+//! Canonical agent UUID registry — refs #4614.
+//!
+//! Persists `agent_name → canonical_uuid` mappings *independently* of the
+//! agent registry / SQLite agent rows so that a respawn (after a panic, a
+//! manifest reload, an explicit kill, etc.) reuses the same `AgentId` instead
+//! of generating a fresh one. Without this, sessions / memories / cron jobs
+//! keyed under the prior UUID become silently orphaned.
+//!
+//! Today's spawn path already derives top-level agent IDs deterministically
+//! via [`AgentId::from_name`] (UUID v5), which preserves identity for agents
+//! whose `name` never changes. The registry adds a layer of explicit history
+//! on top:
+//!
+//! 1. **Identity stability under rename / re-derivation.** The recorded UUID
+//!    survives even if the v5 derivation later evolves (e.g. namespace bump,
+//!    name normalisation change). Rather than silently rewriting every
+//!    user's existing data, the kernel keeps honoring whatever id was first
+//!    handed out.
+//! 2. **Explicit delete-vs-purge separation.** A normal `kill_agent` keeps
+//!    the registry entry intact, so a later respawn lands back on the same
+//!    UUID — surviving sessions remain reachable. A purge (explicit
+//!    `?purge_identity=true`) drops the entry; the next spawn starts from a
+//!    clean slate.
+//!
+//! Storage: a TOML file at `<home_dir>/agent_identities.toml` written
+//! atomically (write to `.tmp.<pid>.<seq>.<nanos>`, fsync, rename). Schema is
+//! intentionally narrow — the file is *not* a config the user is expected to
+//! edit by hand, but it is human-readable for emergency surgery.
+
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use librefang_types::agent::AgentId;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use tracing::{debug, warn};
+
+/// File name used inside `home_dir`.
+const FILE_NAME: &str = "agent_identities.toml";
+
+/// One persisted entry: the canonical UUID assigned to an agent name plus
+/// the timestamp at which the binding was first recorded.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentIdentityRecord {
+    /// The canonical [`AgentId`] (UUID) for this agent name.
+    pub canonical_uuid: AgentId,
+    /// When the mapping was first registered.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Top-level on-disk shape: `[agents.<name>]` tables.
+///
+/// ```toml
+/// [agents.nika]
+/// canonical_uuid = "660bef7c-04d5-4480-8af2-0ce029981a14"
+/// created_at = "2026-04-01T10:00:00Z"
+/// ```
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct OnDisk {
+    #[serde(default)]
+    agents: std::collections::BTreeMap<String, AgentIdentityRecord>,
+}
+
+/// In-memory canonical-UUID registry.
+///
+/// Concurrency: a `DashMap` for the read/insert path; a separate `Mutex`
+/// guards the on-disk write so two concurrent persisters don't race on
+/// `rename`. The DashMap entries are the source of truth — `persist` simply
+/// snapshots them.
+#[derive(Debug)]
+pub struct AgentIdentityRegistry {
+    map: DashMap<String, AgentIdentityRecord>,
+    persist_path: Option<PathBuf>,
+    /// Serialises atomic writes so two `register` calls in flight never
+    /// produce an interleaved on-disk file.
+    persist_lock: Mutex<()>,
+}
+
+impl AgentIdentityRegistry {
+    /// Build an empty in-memory registry with no persistence (test helper).
+    pub fn in_memory() -> Self {
+        Self {
+            map: DashMap::new(),
+            persist_path: None,
+            persist_lock: Mutex::new(()),
+        }
+    }
+
+    /// Build a registry rooted at `home_dir`, eagerly loading any existing
+    /// `agent_identities.toml`. Errors during load are logged and treated
+    /// as "empty registry" — we never want to silently lose entries by
+    /// returning `Err` from boot, but we also don't want a malformed file
+    /// to wipe the user's history. See [`load_from`] for the explicit form
+    /// used by tests.
+    pub fn load(home_dir: &Path) -> Self {
+        let persist_path = home_dir.join(FILE_NAME);
+        let map = match Self::read_file(&persist_path) {
+            Ok(entries) => {
+                let map = DashMap::with_capacity(entries.len());
+                for (name, identity) in entries {
+                    map.insert(name, identity);
+                }
+                map
+            }
+            Err(e) => {
+                warn!(
+                    path = %persist_path.display(),
+                    error = %e,
+                    "agent_identities.toml: failed to load — starting empty (existing file left intact)"
+                );
+                DashMap::new()
+            }
+        };
+        Self {
+            map,
+            persist_path: Some(persist_path),
+            persist_lock: Mutex::new(()),
+        }
+    }
+
+    /// Read raw entries from a path. Missing file ⇒ `Ok(empty)`.
+    fn read_file(
+        path: &Path,
+    ) -> Result<std::collections::BTreeMap<String, AgentIdentityRecord>, std::io::Error> {
+        match std::fs::read_to_string(path) {
+            Ok(s) => {
+                let parsed: OnDisk = toml::from_str(&s).map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("agent_identities.toml: parse error: {e}"),
+                    )
+                })?;
+                Ok(parsed.agents)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                Ok(std::collections::BTreeMap::new())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Look up the canonical UUID for `name`, if one was previously recorded.
+    pub fn get(&self, name: &str) -> Option<AgentId> {
+        self.map.get(name).map(|e| e.canonical_uuid)
+    }
+
+    /// Snapshot the current entries. Stable order (BTreeMap) so callers can
+    /// rely on deterministic output for diagnostics.
+    pub fn list(&self) -> std::collections::BTreeMap<String, AgentIdentityRecord> {
+        self.map
+            .iter()
+            .map(|e| (e.key().clone(), e.value().clone()))
+            .collect()
+    }
+
+    /// Number of recorded mappings.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// `true` when no mappings are recorded.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Register `name → canonical_uuid` if no entry exists. If an entry
+    /// already exists, it is **not** overwritten — the first UUID issued
+    /// to that name wins, even if the caller passes a different one.
+    /// Returns the canonical UUID after the call (existing or freshly
+    /// inserted).
+    ///
+    /// Persists to disk on insert. A persistence error is logged but does
+    /// not fail the in-memory write — the kernel needs the in-memory map
+    /// to be authoritative for the running process even if the disk is
+    /// momentarily wedged.
+    pub fn register_if_absent(&self, name: &str, canonical_uuid: AgentId) -> AgentId {
+        if let Some(existing) = self.map.get(name) {
+            return existing.canonical_uuid;
+        }
+        let entry = AgentIdentityRecord {
+            canonical_uuid,
+            created_at: Utc::now(),
+        };
+        // Race-window: between the `get` above and the insert below, another
+        // thread could register the same name. `entry().or_insert_with` would
+        // be cleaner, but DashMap's `entry` API holds a write guard for the
+        // duration of the closure — fine here since the closure is cheap.
+        let final_uuid = self
+            .map
+            .entry(name.to_string())
+            .or_insert(entry)
+            .canonical_uuid;
+        if let Err(e) = self.persist() {
+            warn!(
+                name,
+                error = %e,
+                "agent_identities.toml: persist failed (in-memory entry retained)"
+            );
+        }
+        final_uuid
+    }
+
+    /// Remove the entry for `name`, if any. Returns the dropped UUID so
+    /// callers can audit what was purged. Persists on success.
+    pub fn purge(&self, name: &str) -> Option<AgentId> {
+        let dropped = self.map.remove(name).map(|(_, v)| v.canonical_uuid)?;
+        if let Err(e) = self.persist() {
+            warn!(
+                name,
+                error = %e,
+                "agent_identities.toml: persist failed after purge (in-memory removal retained)"
+            );
+        }
+        Some(dropped)
+    }
+
+    /// Persist the current in-memory state to disk via atomic write.
+    /// No-op when the registry was constructed without a persist path.
+    pub fn persist(&self) -> Result<(), std::io::Error> {
+        let path = match &self.persist_path {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+        let _guard = self.persist_lock.lock().unwrap_or_else(|e| e.into_inner());
+
+        let snapshot: std::collections::BTreeMap<String, AgentIdentityRecord> = self
+            .map
+            .iter()
+            .map(|e| (e.key().clone(), e.value().clone()))
+            .collect();
+
+        let on_disk = OnDisk { agents: snapshot };
+        let body = toml::to_string_pretty(&on_disk).map_err(|e| {
+            std::io::Error::other(format!("agent_identities.toml: serialize failed: {e}"))
+        })?;
+
+        // Ensure parent dir exists. `home_dir` is normally created at boot,
+        // but tests sometimes hand in a path under a freshly-made tempdir
+        // before the boot scaffolding ran.
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let tmp_path = crate::persist_tmp_path(path);
+        {
+            use std::io::Write as _;
+            let mut f = std::fs::File::create(&tmp_path)?;
+            f.write_all(body.as_bytes())?;
+            f.sync_all()?;
+        }
+        std::fs::rename(&tmp_path, path)?;
+        debug!(
+            path = %path.display(),
+            count = self.map.len(),
+            "Persisted agent_identities.toml"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn round_trip_is_lossless() {
+        let dir = tempdir().unwrap();
+        let reg = AgentIdentityRegistry::load(dir.path());
+        assert!(reg.is_empty());
+
+        let alice_uuid = AgentId::from_name("alice");
+        let bob_uuid = AgentId::from_name("bob");
+        let returned = reg.register_if_absent("alice", alice_uuid);
+        assert_eq!(returned, alice_uuid);
+        reg.register_if_absent("bob", bob_uuid);
+        assert_eq!(reg.len(), 2);
+
+        // Re-load — same path — should reproduce the same entries.
+        let reloaded = AgentIdentityRegistry::load(dir.path());
+        assert_eq!(reloaded.len(), 2);
+        assert_eq!(reloaded.get("alice"), Some(alice_uuid));
+        assert_eq!(reloaded.get("bob"), Some(bob_uuid));
+    }
+
+    #[test]
+    fn first_register_wins() {
+        let dir = tempdir().unwrap();
+        let reg = AgentIdentityRegistry::load(dir.path());
+        let first = AgentId::from_name("nika");
+        let intruder = AgentId::new(); // random — different UUID
+        assert_ne!(first, intruder);
+
+        let got1 = reg.register_if_absent("nika", first);
+        assert_eq!(got1, first);
+        let got2 = reg.register_if_absent("nika", intruder);
+        assert_eq!(
+            got2, first,
+            "second register must not clobber the canonical UUID"
+        );
+    }
+
+    #[test]
+    fn purge_removes_and_persists() {
+        let dir = tempdir().unwrap();
+        let reg = AgentIdentityRegistry::load(dir.path());
+        let uuid = AgentId::from_name("ephemeral");
+        reg.register_if_absent("ephemeral", uuid);
+
+        let dropped = reg.purge("ephemeral");
+        assert_eq!(dropped, Some(uuid));
+        assert!(reg.is_empty());
+
+        // Re-load: the file on disk must reflect the purge.
+        let reloaded = AgentIdentityRegistry::load(dir.path());
+        assert!(reloaded.is_empty());
+    }
+
+    #[test]
+    fn purge_missing_is_ok() {
+        let dir = tempdir().unwrap();
+        let reg = AgentIdentityRegistry::load(dir.path());
+        assert!(reg.purge("never-existed").is_none());
+    }
+
+    #[test]
+    fn malformed_file_is_treated_as_empty_and_left_alone() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(FILE_NAME);
+        std::fs::write(&path, "this is not valid toml ===\n").unwrap();
+        let original = std::fs::read_to_string(&path).unwrap();
+
+        let reg = AgentIdentityRegistry::load(dir.path());
+        assert!(reg.is_empty());
+        // The malformed file must NOT have been overwritten by the
+        // empty-registry view — load() is a *read*, and silently rewriting
+        // the file would destroy the operator's chance to recover by hand.
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original);
+    }
+
+    #[test]
+    fn in_memory_persist_is_noop() {
+        let reg = AgentIdentityRegistry::in_memory();
+        let uuid = AgentId::from_name("foo");
+        reg.register_if_absent("foo", uuid);
+        // No persist path — must not panic, must succeed.
+        reg.persist().expect("in-memory persist is a no-op");
+    }
+
+    #[test]
+    fn list_is_deterministic() {
+        let dir = tempdir().unwrap();
+        let reg = AgentIdentityRegistry::load(dir.path());
+        for name in ["c", "a", "b"] {
+            reg.register_if_absent(name, AgentId::from_name(name));
+        }
+        let listed: Vec<String> = reg.list().keys().cloned().collect();
+        assert_eq!(
+            listed,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+}

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -572,6 +572,12 @@ pub struct LibreFangKernel {
     pub(crate) raw_config_toml: ArcSwap<toml::Value>,
     /// Agent registry.
     pub(crate) registry: AgentRegistry,
+    /// Canonical agent UUID registry (refs #4614). Persists `agent_name →
+    /// canonical_uuid` independently of the agent registry / SQLite agent
+    /// rows so that respawn after kill / panic / manifest reload reuses the
+    /// same `AgentId` and surviving sessions remain reachable. See
+    /// `crate::agent_identity_registry` for layout and rationale.
+    pub(crate) agent_identities: Arc<crate::agent_identity_registry::AgentIdentityRegistry>,
     /// Capability manager.
     pub(crate) capabilities: CapabilityManager,
     /// Event bus.
@@ -1441,6 +1447,16 @@ impl LibreFangKernel {
     #[inline]
     pub fn agent_registry(&self) -> &AgentRegistry {
         &self.registry
+    }
+
+    /// Canonical agent UUID registry (refs #4614). Persists
+    /// `agent_name → canonical_uuid` independently of agent lifecycle so
+    /// that respawns reuse the same `AgentId` instead of orphaning
+    /// history. Read-only handle exposed for tests, diagnostics, and
+    /// API surfaces.
+    #[inline]
+    pub fn agent_identities(&self) -> &Arc<crate::agent_identity_registry::AgentIdentityRegistry> {
+        &self.agent_identities
     }
 
     /// Memory substrate (structured storage, vector search).
@@ -3671,12 +3687,27 @@ impl LibreFangKernel {
         // empty table, which is the same semantics as the previous on-miss
         // path.
         let initial_raw_config_toml = load_raw_config_toml(&config.home_dir.join("config.toml"));
+
+        // Canonical agent UUID registry (refs #4614). Loaded from
+        // `<home_dir>/agent_identities.toml`; missing or malformed files
+        // start the registry empty (the load helper logs the cause).
+        let agent_identities = Arc::new(
+            crate::agent_identity_registry::AgentIdentityRegistry::load(&config.home_dir),
+        );
+        if !agent_identities.is_empty() {
+            info!(
+                count = agent_identities.len(),
+                "Loaded canonical agent UUID registry"
+            );
+        }
+
         let kernel = Self {
             home_dir_boot: config.home_dir.clone(),
             data_dir_boot: config.data_dir.clone(),
             config: ArcSwap::new(std::sync::Arc::new(config)),
             raw_config_toml: ArcSwap::new(std::sync::Arc::new(initial_raw_config_toml)),
             registry: AgentRegistry::new(),
+            agent_identities,
             capabilities: CapabilityManager::new(),
             event_bus: EventBus::new(),
             session_lifecycle_bus: Arc::new(crate::session_lifecycle::SessionLifecycleBus::new(
@@ -4563,9 +4594,38 @@ system_prompt = "You are a helpful assistant."
         // same agent gets the same UUID across daemon restarts. This preserves
         // session history associations in SQLite. Child agents spawned at
         // runtime still use random IDs (via predetermined_id = None + parent).
+        //
+        // Refs #4614 — canonical UUID registry: for top-level agents
+        // (`parent.is_none()`), consult `agent_identities` first. If a prior
+        // spawn already registered a UUID for this name, reuse it verbatim
+        // — even if the v5 derivation later changes (namespace bump, name
+        // normalisation tweak), the agent's history stays reachable. If no
+        // entry exists yet, fall back to the historical
+        // `AgentId::from_name(&name)` derivation and atomically register
+        // it as the canonical UUID for this name (first-spawn wins).
         let agent_id = predetermined_id.unwrap_or_else(|| {
             if parent.is_none() {
-                AgentId::from_name(&name)
+                if let Some(existing) = self.agent_identities.get(&name) {
+                    debug!(
+                        agent = %name,
+                        id = %existing,
+                        "Reusing canonical UUID from agent_identities registry (#4614)"
+                    );
+                    existing
+                } else {
+                    let derived = AgentId::from_name(&name);
+                    let recorded = self.agent_identities.register_if_absent(&name, derived);
+                    if recorded != derived {
+                        // Someone else won the race; honor their UUID.
+                        debug!(
+                            agent = %name,
+                            chosen = %recorded,
+                            derived = %derived,
+                            "agent_identities: lost register race, honoring existing entry"
+                        );
+                    }
+                    recorded
+                }
             } else {
                 AgentId::new()
             }
@@ -10806,8 +10866,32 @@ system_prompt = "You are a helpful assistant."
         }
     }
 
-    /// Kill an agent.
+    /// Kill an agent. By default the canonical UUID registry entry
+    /// (refs #4614) is **kept** so a later respawn of the same name lands
+    /// on the same `AgentId`. Use [`Self::kill_agent_with_purge`] to also
+    /// drop the canonical-UUID binding (i.e. fully orphan history).
     pub fn kill_agent(&self, agent_id: AgentId) -> KernelResult<()> {
+        self.kill_agent_with_purge(agent_id, false)
+    }
+
+    /// Kill an agent and optionally purge its canonical UUID binding from
+    /// the identity registry (refs #4614).
+    ///
+    /// `purge_identity = false` (the default for `kill_agent`) is the
+    /// safe choice — sessions and memories tied to this UUID stay
+    /// reachable on respawn.
+    ///
+    /// `purge_identity = true` permanently removes the `name → uuid`
+    /// mapping. The next spawn under the same name will derive a fresh
+    /// UUID via `AgentId::from_name`, and any prior history is orphaned.
+    /// This is the destructive path the issue describes ("explicit
+    /// delete + confirmation"); confirmation is enforced at the API/CLI
+    /// layer.
+    pub fn kill_agent_with_purge(
+        &self,
+        agent_id: AgentId,
+        purge_identity: bool,
+    ) -> KernelResult<()> {
         let entry = self
             .registry
             .remove(agent_id)
@@ -10844,11 +10928,26 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
+        // Refs #4614: canonical UUID registry. Default `kill_agent` keeps
+        // the binding so a respawn under the same name reuses this UUID.
+        // `kill_agent_with_purge(agent, true)` (gated behind explicit
+        // confirmation at the API/CLI surface) also drops the entry,
+        // which is the destructive path the issue describes.
+        if purge_identity {
+            if let Some(dropped) = self.agent_identities.purge(&entry.name) {
+                info!(
+                    agent = %entry.name,
+                    id = %dropped,
+                    "Purged canonical UUID from agent_identities registry (#4614)"
+                );
+            }
+        }
+
         // SECURITY: Record agent kill in audit trail
         self.audit_log.record(
             agent_id.to_string(),
             librefang_runtime::audit::AuditAction::AgentKill,
-            format!("name={}", entry.name),
+            format!("name={}, purge_identity={}", entry.name, purge_identity),
             "ok",
         );
 

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -3,6 +3,7 @@
 //! The kernel manages agent lifecycles, memory, permissions, scheduling,
 //! and inter-agent communication.
 
+pub mod agent_identity_registry;
 pub mod approval;
 pub mod auth;
 pub mod auto_dream;


### PR DESCRIPTION
## Summary

Adds a canonical agent UUID registry so respawns reuse the same
`AgentId` instead of orphaning history (refs #4614).

- New `AgentIdentityRegistry` persists `agent_name -> canonical_uuid`
  at `<home_dir>/agent_identities.toml`. Atomic writes
  (`.tmp.<pid>.<seq>.<nanos>` + `fsync` + `rename`).
- Spawn path consults the registry first; on miss, derives via
  `AgentId::from_name` (UUID v5) and registers as the canonical
  binding. Hand / child agents keep their existing UUID semantics.
- `kill_agent` now preserves the binding (so panic restarts / hot
  reloads no longer silently orphan history). Destructive purge is
  reachable only through the explicit confirmation flow via the new
  `kill_agent_with_purge(id, true)` kernel helper.

## API

- `DELETE /api/agents/{id}` requires `?confirm=true`; without it
  returns `409 Conflict` with the data-loss warning text from the
  issue (mentions canonical UUID + cannot be undone). With confirm
  the agent is killed AND the canonical UUID is purged. Idempotent
  shortcut for an already-gone agent (#3509) still applies.
- `GET /api/agents/identities` lists the registry contents.
- `POST /api/agents/identities/{name}/reset?confirm=true` drops the
  binding without touching a running agent. Same 409-without-confirm
  gate. `404` on a missing name.

## CLI

- `librefang agent kill <id>` now auto-sends `?confirm=true`.
- `librefang agent delete <name> [--yes]` — name resolution via the
  identity endpoint, `[y/N]` prompt with the warning text, then the
  confirmed DELETE.
- `librefang agent reset-uuid <name> [--yes]` — purges the binding
  via the reset endpoint.
- `librefang agent merge-history <name> --from <old-uuid>` —
  documented stub (see Deferred).

Dashboard `deleteAgent()` updated to send `?confirm=true`.

## Tests

- 7 unit tests in `agent_identity_registry::tests` (round-trip,
  first-register-wins, purge persists, malformed file is left
  intact, in-memory no-op, deterministic list ordering).
- 6 new integration tests in
  `crates/librefang-api/tests/agent_identity_registry_test.rs`:
  - `spawn_registers_canonical_uuid`
  - `delete_without_confirm_returns_409_and_preserves_identity`
  - `delete_with_confirm_purges_identity_and_respawn_recovers_uuid`
  - `delete_invalid_uuid_short_circuits_400_before_confirm_check`
  - `list_identities_returns_registered_entries`
  - `reset_identity_endpoint_gates_on_confirm`
- Existing `api_integration_test` / `load_test` /
  `agents_routes_integration` callers updated to use
  `?confirm=true`; a `delete_confirmed` helper added in the latter
  so future tests don't have to open-code the URL.

## Deferred to follow-up

- `librefang agent merge-history` cross-table reassignment. Moving
  sessions / memories / events / kv_store / entities / relations /
  usage_events / canonical_sessions / prompt_experiments /
  audit_entries / approval_audit + the proactive memory store from
  one UUID to another under a single transaction with rollback is
  deep memory-substrate surgery and warrants its own PR with
  data-integrity tests.

## Verification

- `cargo check --workspace --lib` — clean
- `cargo check -p librefang-cli` — clean
- pre-push hook (clippy `--workspace --all-targets -- -D warnings`
  + OpenAPI drift) — passed on push
- Scoped `cargo test -p librefang-kernel` / `-p librefang-api`
  deferred to CI per coordinator instruction

Closes #4614