### PR TITLE
ci(live-integration-smoke): install libdbus-1-dev to unblock daemon build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,6 +489,15 @@ jobs:
       # `live-smoke-${hashFiles}` key forced a cold compile (~15-20 min debug)
       # on every first run, eating most of the 25-min timeout.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install system deps for keyring/secret-service
+        # `librefang-cli` pulls `librefang-extensions`, which on Linux pulls
+        # `keyring` → `secret-service` → `libdbus-sys`; the latter's build
+        # script panics ("explicit panic") when `dbus-1.pc` is not on
+        # PKG_CONFIG_PATH, which fails `cargo build` opaquely. Mirrors the
+        # equivalent step in the OpenAPI Drift / Test Ubuntu jobs.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev libsecret-1-dev pkg-config
       - name: Ensure dashboard build dir exists
         run: mkdir -p crates/librefang-api/static/react
       - name: Build daemon (debug)


### PR DESCRIPTION
## Summary

The `Live Integration Smoke / Build daemon (debug)` step has been failing on **every** PR that touches Rust code for at least the past day. `cargo build -p librefang-cli` panics inside `libdbus-sys-0.2.7/build.rs` with `explicit panic` because `dbus-1.pc` is not on `PKG_CONFIG_PATH`.

The crate is pulled transitively: `librefang-cli` → `librefang-extensions` → `keyring` → `secret-service` → `libdbus-sys` (Linux only).

## Evidence

Sampled three recent PR runs — same job, same step, same failure mode:

| Run | PR branch | Failed step |
|---|---|---|
| [25368648963](https://github.com/librefang/librefang/actions/runs/25368648963) | `feat/llm-trace-headers` (#4548 merged anyway) | `Build daemon (debug)` |
| [25358834672](https://github.com/librefang/librefang/actions/runs/25358834672) | `refactor/3747-appstate` | `Build daemon (debug)` |
| [25358170935](https://github.com/librefang/librefang/actions/runs/25358170935) | `feat/3511-access-log-fields` | `Build daemon (debug)` |
| [25356461583](https://github.com/librefang/librefang/actions/runs/25356461583) | `refactor/3596-api-runtime-deco` | `Build daemon (debug)` |

Log line:
```
The file `dbus-1.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
...
thread 'main' (8560) panicked at /home/runner/.cargo/registry/.../libdbus-sys-0.2.7/build.rs:25:9: explicit panic
```

## Fix

Mirror the apt-get block already present in the OpenAPI Drift and Test/Ubuntu jobs (which install `libdbus-1-dev libsecret-1-dev pkg-config`). The `live-integration-smoke` job (added later as a PR-only spawn-real-daemon check) was never updated when the keyring/secret-service path landed.

Single-step insert between `Swatinem/rust-cache` and `Ensure dashboard build dir exists`.

## Why merges still happened

`Live Integration Smoke` is **not** a required check, so PRs have been auto-merging despite this step failing. PR #4548 is the most recent example — green required checks, red smoke, merged anyway. This PR makes the smoke job actually do its job (exercise spawn-a-real-daemon coverage) instead of failing fast on a missing system package.

## Test plan

- [ ] Once this lands, confirm the next PR-triggered CI run shows `Live Integration Smoke / Build daemon (debug)` green.
- [ ] No CHANGELOG entry — CI workflow plumbing is not user-facing.
