### PR TITLE
test(runtime-wasm): assert CWD has Cargo.toml in fs_read deny test

### DIFF
--- a/crates/librefang-runtime-wasm/tests/sandbox_integration.rs
+++ b/crates/librefang-runtime-wasm/tests/sandbox_integration.rs
@@ -201,6 +201,18 @@ async fn sandbox_accepts_module_loaded_from_disk() {
 async fn sandbox_denies_fs_read_without_capability() {
     let sandbox = WasmSandbox::new().unwrap();
 
+    // Defensive: cargo runs each crate's tests with CWD = crate dir, so
+    // `Cargo.toml` resolves. If a future test runner (nextest with a custom
+    // workdir, sandboxed exec, …) changes CWD, fail loudly here instead of
+    // silently misattributing the resulting fs_read failure to capability
+    // denial — the test would still "pass" but stop exercising the deny
+    // path it claims to.
+    assert!(
+        std::path::Path::new("Cargo.toml").exists(),
+        "test assumes CWD = crate dir; Cargo.toml not found in {:?}",
+        std::env::current_dir()
+    );
+
     // Cargo.toml exists in every crate's working dir during test runs;
     // fs_read canonicalises before the capability check (#3814) so the
     // path must resolve.


### PR DESCRIPTION
Defensive guard requested in the [PR #4628 review](https://github.com/librefang/librefang/pull/4628#issuecomment-4378159740). The `sandbox_denies_fs_read_without_capability` test reads `Cargo.toml` from the test process's CWD; cargo runs each crate's tests with `CWD = crate dir` today, but a future runner (nextest with custom workdir, sandboxed exec, …) could change that. Without the assert, the test would still 'pass' but stop exercising the deny path it claims to — the resulting fs_read failure would be misattributed to capability denial.

Tried direct-on-main per maintainer instruction; GitHub branch-protection rule "Changes must be made through a pull request" forces this through PR. One-line test hardening, no behaviour change.

Verified: `cargo test -p librefang-runtime-wasm --test sandbox_integration sandbox_denies_fs_read_without_capability` passes.