### PR TITLE
ci: split test job into unit-fast + integration lanes (#3696)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,56 @@ jobs:
       - name: Verify sibling CLAUDE.md symlink
         run: sh scripts/check-agents-claude-pair.sh
 
+  # ── Unit-fast lane: lib + bin tests only, single runner, no sharding ──────────
+  # Runs `cargo nextest run --lib --bins` across the full workspace so that a
+  # pure unit-test failure surfaces in ~2 minutes without waiting for the heavier
+  # integration shards. Separate from the `--tests` lane below so contributors
+  # can replicate the fast lane locally with:
+  #   cargo nextest run --workspace --lib --bins --no-fail-fast
+  # and CI runs both lanes independently. (#3696)
+  test-unit:
+    name: Test / Unit (lib+bin)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: test-unit-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install nextest
+        uses: taiki-e/install-action@4616abf838e456930a67014fba647f87c185cc6c # nextest
+      - name: Ensure dashboard build dir exists
+        run: mkdir -p crates/librefang-api/static/react
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libdbus-1-dev libsecret-1-dev pkg-config
+      - name: Run unit tests (lib + bin)
+        run: |
+          if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
+            echo "Running workspace unit tests (lib+bin, full run)…"
+            cargo nextest run --workspace --lib --bins --no-fail-fast
+          else
+            CRATES="${{ needs.changes.outputs.crates }}"
+            if [ -z "$CRATES" ]; then
+              echo "No crates affected — nothing to run."
+              exit 0
+            fi
+            echo "Running unit tests for: $CRATES"
+            PFLAGS=""
+            for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
+            cargo nextest run $PFLAGS --lib --bins --no-fail-fast --no-tests=pass
+          fi
+
   # ── Ubuntu tests: selective on PR, full on main ────────────────────────────────
   # Full-run lane (push to main, workspace Cargo.toml change) runs the full
   # workspace test matrix sharded 4 ways via `cargo nextest run --partition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -432,6 +432,10 @@ _338 PRs from 7 contributors since v2026.4.28-beta7._
 - **Outbound `[channels.webhook] callback_url` is SSRF-guarded.** Adapters refuse to start if the URL resolves to a private (`10/8`, `172.16/12`, `192.168/16`), CGN (`100.64/10`), loopback (`127/8`, `::1`), link-local, multicast, or cloud-metadata range. Catches IPv6 short forms like `[::]`, IPv4-mapped (`[::ffff:127.0.0.1]`), NAT64, and trailing-dot FQDNs. **Action required**: local dev setups using `callback_url = "http://127.0.0.1/..."` must switch to a public tunnel (ngrok, cloudflared) or omit `callback_url`. (#3942)
 - **BREAKING**: `require_auth_for_reads` now defaults to *enabled* whenever any form of authentication is configured (`api_key`, `user_api_keys`, or dashboard credentials). Previously the flag had to be set explicitly, leaving read endpoints open even on instances with an `api_key`. Operators who deliberately want open reads on an authenticated instance (e.g. behind a trusted reverse proxy) must now set `require_auth_for_reads = false` in `config.toml`. A boot-time INFO log records when the flag is auto-enabled. (#2448)
 
+### Quality
+
+- CI Test job split into **Unit** (`lib+bin`, ~2 min, single Ubuntu runner) and **Integration** (`--tests`, sharded across 4 Ubuntu shards + macOS + Windows). Unit failures now surface in ~2 min without waiting for the full integration matrix. Local fast iteration: `cargo nextest run --workspace --lib --bins`. Full validation: `cargo nextest run --workspace --no-fail-fast`. Closes #3696. (@houko)
+
 ### Maintenance
 
 - Wire `cargo xtask integration-test` into CI as a `live-integration-smoke` job — spawns a real `target/debug/librefang start` daemon on every PR touching Rust or CI files, hits `/api/health`, `/api/agents`, `/api/budget`, `/api/network/status`, and SIGTERMs. Catches the failure modes the in-process integration tests miss (route not registered in `server.rs`, daemon failing to bind, config fields not deserializing). Runs with `--skip-llm` to keep the gate hermetic; the live-LLM branch is reserved for the release/nightly workflow that has provider keys. (#3405) (@houko)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,24 @@ cargo clippy --workspace --all-targets -- -D warnings  # Zero warnings
 cargo test -p <crate>                                  # Only when verifying behavior in one crate
 ```
 
+### CI test lanes (refs #3696)
+
+CI splits tests into two separate jobs so a unit failure surfaces quickly:
+
+- **Unit-fast** (`Test / Unit (lib+bin)`, ~2 min): `cargo nextest run --workspace --lib --bins --no-fail-fast`
+  — lib and binary unit tests only; no integration test binaries. Run this locally for quick iteration.
+- **Integration** (`Test / Ubuntu (shard N/4)`, ~10-20 min): sharded across 4 Ubuntu runners via
+  `--partition hash:N/4`; also single jobs on macOS and Windows. Runs all `--tests` targets.
+
+Local equivalents:
+```bash
+# Fast lane — unit tests only:
+cargo nextest run --workspace --lib --bins --no-fail-fast
+
+# Full validation — integration tests (mirrors the Ubuntu shard lane):
+cargo nextest run --workspace --no-fail-fast
+```
+
 ## MANDATORY: Integration Testing (refs #3721)
 
 **Primary verification is automated.** The repo has comprehensive


### PR DESCRIPTION
## Summary

- Add `Test / Unit (lib+bin)` CI job: runs `cargo nextest run --workspace --lib --bins --no-fail-fast` on a single Ubuntu runner. Expected wall-clock: ~2 min. Unit failures surface before the heavier integration matrix completes.
- Existing `Test / Ubuntu (shard N/4)`, `Test / Windows`, and `Test / macOS` jobs are unchanged — they continue running all targets (including `--tests`) as the integration lane.
- CLAUDE.md: new "CI test lanes" subsection under Build & Verify Workflow documents both lanes and their local equivalents.
- CHANGELOG: one `### Quality` entry in `[Unreleased]` with `(@houko)` attribution.

## Verification

- YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → valid
- `cargo nextest run --workspace --lib --bins --no-fail-fast` is the exact flag set used in the new job (mirrors the job step verbatim)
- No existing job renamed or removed; path-filter logic (`Detect Changes`) is untouched
- Pre-commit hook passed (attribution check + fmt check)

## Out-of-scope follow-ups

- Per-crate nextest profiles (`nextest.toml`) for finer timeout tuning — not required by #3696
- `cargo xtask test-fast` / `cargo xtask test-integration` shortcuts — can be added separately

Closes #3696