### PR TITLE
fix(test): align remaining route assertions with nested error envelope (#3639)

### DIFF
--- a/crates/librefang-api/tests/memory_routes_integration.rs
+++ b/crates/librefang-api/tests/memory_routes_integration.rs
@@ -391,7 +391,7 @@ async fn post_bulk_delete_missing_ids_returns_400() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = read_json(resp).await;
-    let err = body["error"].as_str().unwrap_or("");
+    let err = body["error"]["message"].as_str().unwrap_or("");
     assert!(
         err.contains("ids"),
         "expected validation error mentioning 'ids', got: {err}"
@@ -480,7 +480,7 @@ async fn put_memory_update_rejects_empty_content_with_400() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = read_json(resp).await;
-    let err = body["error"].as_str().unwrap_or("");
+    let err = body["error"]["message"].as_str().unwrap_or("");
     assert!(
         err.to_lowercase().contains("content"),
         "expected validation error mentioning 'content', got: {err}"

--- a/crates/librefang-api/tests/memory_routes_integration.rs
+++ b/crates/librefang-api/tests/memory_routes_integration.rs
@@ -328,7 +328,10 @@ async fn delete_clear_level_rejects_unknown_level_with_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
     let body = read_json(resp).await;
-    let err = body["error"].as_str().unwrap_or("");
+    let err = body["error"]
+        .as_str()
+        .or_else(|| body["error"]["message"].as_str())
+        .unwrap_or("");
     assert!(
         err.contains("Invalid memory level") && err.contains("bogus"),
         "expected validation error mentioning 'bogus', got: {err}"

--- a/crates/librefang-api/tests/network_routes_integration.rs
+++ b/crates/librefang-api/tests/network_routes_integration.rs
@@ -163,6 +163,7 @@ async fn peers_get_returns_404_when_no_registry() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .to_lowercase()
             .contains("peer networking"),
@@ -186,6 +187,7 @@ async fn peers_get_returns_404_for_unknown_id() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .to_lowercase()
             .contains("not found"),
@@ -334,6 +336,7 @@ async fn comms_send_rejects_invalid_from_agent_id() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .to_lowercase()
             .contains("from_agent_id"),
@@ -360,6 +363,7 @@ async fn comms_send_rejects_unknown_from_agent() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .to_lowercase()
             .contains("source agent"),
@@ -417,6 +421,7 @@ async fn comms_send_rejects_oversize_message() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .to_lowercase()
             .contains("too large"),

--- a/crates/librefang-api/tests/profiles_templates_routes_integration.rs
+++ b/crates/librefang-api/tests/profiles_templates_routes_integration.rs
@@ -146,7 +146,7 @@ async fn profiles_get_unknown_profile_returns_404() {
     let (status, body) = get_json(&h, "/api/profiles/no-such-profile").await;
     assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
     assert!(
-        body["error"].is_string(),
+        body["error"].is_string() || body["error"]["message"].is_string(),
         "404 must carry a structured error payload: {body}"
     );
 }
@@ -278,7 +278,10 @@ async fn templates_get_unknown_returns_404() {
     let h = boot().await;
     let (status, body) = get_json(&h, "/api/templates/does_not_exist_xyz").await;
     assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
-    assert!(body["error"].is_string(), "{body}");
+    assert!(
+        body["error"].is_string() || body["error"]["message"].is_string(),
+        "{body}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/librefang-api/tests/skills_routes_test.rs
+++ b/crates/librefang-api/tests/skills_routes_test.rs
@@ -272,6 +272,7 @@ async fn skills_detail_unknown_returns_404() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .to_lowercase()
             .contains("not found"),
@@ -386,7 +387,11 @@ async fn skills_install_unknown_skill_returns_404() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
     assert!(
-        body["error"].as_str().unwrap_or("").contains("not found"),
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .contains("not found"),
         "error must mention not-found: {body:?}"
     );
 }
@@ -405,6 +410,7 @@ async fn skills_install_unknown_hand_returns_404() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .to_lowercase()
             .contains("hand"),

--- a/crates/librefang-api/tests/totp_flow_test.rs
+++ b/crates/librefang-api/tests/totp_flow_test.rs
@@ -337,7 +337,10 @@ async fn revoke_before_enrollment_is_bad_request() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "got body: {body:?}");
-    let err = body["error"].as_str().unwrap_or_default();
+    let err = body["error"]
+        .as_str()
+        .or_else(|| body["error"]["message"].as_str())
+        .unwrap_or_default();
     assert!(
         err.contains("not enrolled"),
         "expected 'not enrolled' error, got: {err}"

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -143,7 +143,11 @@ async fn workflow_get_unknown_uuid_returns_404() {
     let (status, body) = get(&h, "/api/workflows/00000000-0000-0000-0000-000000000000").await;
     assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
     assert!(
-        body["error"].as_str().unwrap_or("").contains("not found"),
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .contains("not found"),
         "{body:?}"
     );
 }
@@ -156,6 +160,7 @@ async fn workflow_get_invalid_id_returns_400() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .contains("Invalid workflow ID"),
         "{body:?}"
@@ -227,7 +232,11 @@ async fn workflow_create_rejects_missing_steps() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
     assert!(
-        body["error"].as_str().unwrap_or("").contains("'steps'"),
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .contains("'steps'"),
         "{body:?}"
     );
 }
@@ -247,7 +256,11 @@ async fn workflow_create_rejects_step_without_agent() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
     assert!(
-        body["error"].as_str().unwrap_or("").contains("agent_id"),
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .contains("agent_id"),
         "{body:?}"
     );
 }
@@ -291,6 +304,7 @@ async fn workflow_run_get_invalid_id_returns_400() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .contains("Invalid run ID"),
         "{body:?}"
@@ -349,7 +363,11 @@ async fn trigger_create_rejects_missing_agent_id() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
     assert!(
-        body["error"].as_str().unwrap_or("").contains("agent_id"),
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .contains("agent_id"),
         "{body:?}"
     );
 }
@@ -368,6 +386,7 @@ async fn trigger_create_rejects_invalid_agent_id() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .contains("Invalid agent_id"),
         "{body:?}"
@@ -386,7 +405,11 @@ async fn trigger_create_rejects_missing_pattern() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
     assert!(
-        body["error"].as_str().unwrap_or("").contains("pattern"),
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .contains("pattern"),
         "{body:?}"
     );
 }
@@ -415,6 +438,7 @@ async fn schedule_get_invalid_id_returns_400() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .contains("Invalid schedule ID"),
         "{body:?}"
@@ -440,7 +464,11 @@ async fn schedule_create_rejects_missing_name() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
     assert!(
-        body["error"].as_str().unwrap_or("").contains("'name'"),
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .contains("'name'"),
         "{body:?}"
     );
 }
@@ -457,7 +485,11 @@ async fn schedule_create_rejects_missing_cron() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
     assert!(
-        body["error"].as_str().unwrap_or("").contains("'cron'"),
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .contains("'cron'"),
         "{body:?}"
     );
 }
@@ -483,6 +515,7 @@ async fn cron_jobs_list_rejects_invalid_agent_id_filter() {
     assert!(
         body["error"]
             .as_str()
+            .or_else(|| body["error"]["message"].as_str())
             .unwrap_or("")
             .contains("Invalid agent_id"),
         "{body:?}"
@@ -618,7 +651,11 @@ async fn workflow_template_get_unknown_returns_404() {
     let (status, body) = get(&h, "/api/workflow-templates/no-such-template").await;
     assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
     assert!(
-        body["error"].as_str().unwrap_or("").contains("not found"),
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .contains("not found"),
         "{body:?}"
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #4629. Updates assertions in 6 test files to use the nested `body["error"]["message"]` shape introduced by the standardized error envelope. The original PR's first fix pass missed these — the llvm-cov coverage job on the 4629 branch flagged them with ~30 deterministic assertion mismatches.

## Files updated

| File | Sites |
|---|---|
| `memory_routes_integration.rs` | 2 |
| `network_routes_integration.rs` | 1 |
| `profiles_templates_routes_integration.rs` | 2 |
| `skills_routes_test.rs` | 1 |
| `totp_flow_test.rs` | 1 |
| `workflows_routes_integration.rs` | 8 |

Where the production response shape was unambiguous, the assertion was flipped to `body["error"]["message"].as_str()`. Where the same code path is shared between routes that emit different shapes, assertions use the dual-shape pattern `body["error"].as_str().or_else(|| body["error"]["message"].as_str())` so they pass on both.

Refs #3639