### PR TITLE
feat(dashboard): collapse chat tool calls into a per-message popup

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ToolCallsPanel } from "./ToolCallsPanel";
+import type { AgentTool } from "../../api";
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>(
+    "react-i18next",
+  );
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) => {
+        if (opts && typeof opts === "object" && "count" in opts) {
+          return `${key}:${opts.count}`;
+        }
+        return key;
+      },
+    }),
+  };
+});
+
+type PanelTool = AgentTool & { _call_id?: string };
+
+function makeTool(overrides: Partial<PanelTool> = {}): PanelTool {
+  return {
+    name: "shell.exec",
+    input: { cmd: "ls" },
+    result: "ok",
+    running: false,
+    is_error: false,
+    ...overrides,
+  };
+}
+
+describe("ToolCallsPanel", () => {
+  it("renders nothing when there are no tool calls", () => {
+    const { container } = render(<ToolCallsPanel tools={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the total count and the most recent tool name on the bar", () => {
+    const tools: PanelTool[] = [
+      makeTool({ name: "shell.exec", _call_id: "a" }),
+      makeTool({ name: "fs.read", _call_id: "b" }),
+    ];
+    render(<ToolCallsPanel tools={tools} />);
+    const trigger = screen.getByRole("button", { name: /chat\.tool_calls:2/ });
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(within(trigger).getByText(/Fs Read/i)).toBeInTheDocument();
+  });
+
+  it("surfaces running and error counts when present", () => {
+    const tools: PanelTool[] = [
+      makeTool({ _call_id: "a", running: true }),
+      makeTool({ _call_id: "b", is_error: true, result: "boom" }),
+      makeTool({ _call_id: "c" }),
+    ];
+    render(<ToolCallsPanel tools={tools} />);
+    const trigger = screen.getByRole("button", { name: /chat\.tool_calls:3/ });
+    // Running badge ("1") and error badge ("1") both render as span text
+    // children of the trigger button, so two matches are expected.
+    const numericBadges = within(trigger)
+      .getAllByText("1", { selector: "span" });
+    expect(numericBadges.length).toBe(2);
+  });
+
+  it("opens the modal with one ToolCallCard per tool when clicked", async () => {
+    const user = userEvent.setup();
+    const tools: PanelTool[] = [
+      makeTool({ name: "shell.exec", _call_id: "a" }),
+      makeTool({ name: "fs.read", _call_id: "b" }),
+      makeTool({ name: "memory.recall", _call_id: "c" }),
+    ];
+    render(<ToolCallsPanel tools={tools} />);
+    const trigger = screen.getByRole("button", { name: /chat\.tool_calls:3/ });
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    const dialog = await screen.findByRole("dialog");
+    // Each ToolCallCard renders a header button bearing the prettified tool
+    // name. Use a name-based query so we don't depend on internal markup.
+    expect(within(dialog).getByRole("button", { name: /Shell Exec/i })).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: /Fs Read/i })).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: /Memory Recall/i })).toBeInTheDocument();
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.tsx
@@ -29,6 +29,7 @@ export const ToolCallsPanel = React.memo(function ToolCallsPanel({ tools }: Tool
   if (tools.length === 0) return null;
 
   const lastTool = tools[tools.length - 1];
+  const titleText = t("chat.tool_calls", { count: stats.total, defaultValue: "{{count}} tool calls" });
 
   return (
     <>
@@ -36,36 +37,37 @@ export const ToolCallsPanel = React.memo(function ToolCallsPanel({ tools }: Tool
         type="button"
         onClick={() => setOpen(true)}
         aria-haspopup="dialog"
-        className="shrink-0 w-full flex items-center gap-2 px-3 py-2 text-left border-t border-border-subtle bg-surface hover:bg-surface-hover transition-colors"
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 max-w-full px-2 py-1 rounded-md border border-border-subtle bg-surface text-[10px] font-medium text-text-dim hover:text-text hover:border-border transition-colors"
       >
-        <Wrench className="w-3.5 h-3.5 text-brand shrink-0" aria-hidden="true" />
-        <span className="text-[11px] font-bold uppercase tracking-wider text-text-dim shrink-0">
-          {t("chat.tool_calls", { count: stats.total, defaultValue: "{{count}} tool calls" })}
+        <Wrench className="w-3 h-3 text-brand shrink-0" aria-hidden="true" />
+        <span className="shrink-0 font-bold uppercase tracking-wider">
+          {titleText}
         </span>
         {stats.running > 0 && (
-          <span className="inline-flex items-center gap-1 text-[10px] font-medium text-brand shrink-0" title={t("chat.tool_running", { defaultValue: "Running…" })}>
+          <span className="inline-flex items-center gap-0.5 text-brand shrink-0" title={t("chat.tool_running", { defaultValue: "Running…" })}>
             <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
             {stats.running}
           </span>
         )}
         {stats.errors > 0 && (
-          <span className="inline-flex items-center gap-1 text-[10px] font-medium text-error shrink-0" title={t("chat.tool_error", { defaultValue: "Error" })}>
+          <span className="inline-flex items-center gap-0.5 text-error shrink-0" title={t("chat.tool_error", { defaultValue: "Error" })}>
             <AlertCircle className="w-3 h-3" aria-hidden="true" />
             {stats.errors}
           </span>
         )}
         {lastTool && (
-          <span className="text-[10px] text-text-dim/70 truncate min-w-0">
-            {prettifyToolName(lastTool.name)}
+          <span className="truncate text-text-dim/70 min-w-0">
+            · {prettifyToolName(lastTool.name)}
           </span>
         )}
-        <ChevronRight className="ml-auto shrink-0 w-3.5 h-3.5 text-text-dim/60" aria-hidden="true" />
+        <ChevronRight className="shrink-0 w-3 h-3 text-text-dim/60" aria-hidden="true" />
       </button>
 
       <Modal
         isOpen={open}
         onClose={() => setOpen(false)}
-        title={t("chat.tool_calls", { count: stats.total, defaultValue: "{{count}} tool calls" })}
+        title={titleText}
         size="2xl"
       >
         <div className="px-4 py-3">

--- a/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronRight, Wrench, Loader2, AlertCircle } from "lucide-react";
+import type { AgentTool } from "../../api";
+import { ToolCallCard } from "./ToolCallCard";
+import { Modal } from "./Modal";
+import { prettifyToolName } from "../../lib/string";
+
+type PanelTool = AgentTool & { _call_id?: string };
+
+interface ToolCallsPanelProps {
+  tools: ReadonlyArray<PanelTool>;
+}
+
+export const ToolCallsPanel = React.memo(function ToolCallsPanel({ tools }: ToolCallsPanelProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const stats = useMemo(() => {
+    let running = 0;
+    let errors = 0;
+    for (const tool of tools) {
+      if (tool.running) running += 1;
+      if (tool.is_error) errors += 1;
+    }
+    return { total: tools.length, running, errors };
+  }, [tools]);
+
+  if (tools.length === 0) return null;
+
+  const lastTool = tools[tools.length - 1];
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        className="shrink-0 w-full flex items-center gap-2 px-3 py-2 text-left border-t border-border-subtle bg-surface hover:bg-surface-hover transition-colors"
+      >
+        <Wrench className="w-3.5 h-3.5 text-brand shrink-0" aria-hidden="true" />
+        <span className="text-[11px] font-bold uppercase tracking-wider text-text-dim shrink-0">
+          {t("chat.tool_calls", { count: stats.total, defaultValue: "{{count}} tool calls" })}
+        </span>
+        {stats.running > 0 && (
+          <span className="inline-flex items-center gap-1 text-[10px] font-medium text-brand shrink-0" title={t("chat.tool_running", { defaultValue: "Running…" })}>
+            <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+            {stats.running}
+          </span>
+        )}
+        {stats.errors > 0 && (
+          <span className="inline-flex items-center gap-1 text-[10px] font-medium text-error shrink-0" title={t("chat.tool_error", { defaultValue: "Error" })}>
+            <AlertCircle className="w-3 h-3" aria-hidden="true" />
+            {stats.errors}
+          </span>
+        )}
+        {lastTool && (
+          <span className="text-[10px] text-text-dim/70 truncate min-w-0">
+            {prettifyToolName(lastTool.name)}
+          </span>
+        )}
+        <ChevronRight className="ml-auto shrink-0 w-3.5 h-3.5 text-text-dim/60" aria-hidden="true" />
+      </button>
+
+      <Modal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        title={t("chat.tool_calls", { count: stats.total, defaultValue: "{{count}} tool calls" })}
+        size="2xl"
+      >
+        <div className="px-4 py-3">
+          {tools.map((tool, i) => (
+            <ToolCallCard
+              key={tool._call_id ?? `${tool.name}-${i}`}
+              tool={tool}
+            />
+          ))}
+        </div>
+      </Modal>
+    </>
+  );
+});

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2160,6 +2160,7 @@
     "new_session": "New session",
     "search_providers": "Search providers...",
     "select_provider": "Select Provider",
+    "tool_calls": "{{count}} tool calls",
     "tool_error": "Error",
     "tool_input": "Input",
     "tool_result": "Result",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2119,6 +2119,7 @@
     "new_session": "新建会话",
     "search_providers": "搜索供应商...",
     "select_provider": "选择供应商",
+    "tool_calls": "{{count}} 个工具调用",
     "tool_error": "错误",
     "tool_input": "输入",
     "tool_result": "结果",

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1194,8 +1194,13 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
           </div>
         )}
 
-        {/* Tool calls are surfaced in the fixed ToolCallsPanel at the
-            bottom of the chat column, not inline in the bubble. */}
+        {/* Tool calls — one pill per message bubble that opens a Modal
+            listing every call in this turn (input/result for each). */}
+        {!isUser && message.tools && message.tools.length > 0 && (
+          <div className="w-full mb-1.5">
+            <ToolCallsPanel tools={message.tools} />
+          </div>
+        )}
 
         {/* Image attachments — rendered above the text bubble. Backend
             stores all uploaded files (image/audio/text/pdf) under the
@@ -2695,20 +2700,6 @@ export function ChatPage() {
   // can compose the next message immediately.
   const isStreaming = messages.some(m => m.role === "assistant" && m.isStreaming);
 
-  // Flattened list of every tool call in the current conversation, in
-  // chronological order. Surfaced via the fixed ToolCallsPanel at the
-  // bottom of the chat column so individual cards no longer clutter the
-  // message stream.
-  const allToolCalls = useMemo(() => {
-    const out: ChatToolCall[] = [];
-    for (const m of messages) {
-      if (m.tools && m.tools.length > 0) {
-        out.push(...m.tools);
-      }
-    }
-    return out;
-  }, [messages]);
-
   // Bug #3849: Track message count changes to announce new messages to screen
   // readers via the aria-live region.
   const [msgAriaAnnouncement, setMsgAriaAnnouncement] = useState("");
@@ -3207,12 +3198,6 @@ export function ChatPage() {
             )}
             </div>
           </div>
-
-          {/* Tool calls panel — collapsed bar above the input. Replaces
-              the per-message inline ToolCallCard rendering so the chat
-              stream stays focused on text while the user can drill into
-              tool inputs/results on demand. */}
-          {selectedAgentId && <ToolCallsPanel tools={allToolCalls} />}
 
           {/* Input area — sticks to the bottom of the chat column. The
               app-shell's <main> already keeps this row above the

--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -24,7 +24,7 @@ import { Badge } from "../components/ui/Badge";
 import { MarkdownContent } from "../components/ui/MarkdownContent";
 import { useUIStore } from "../lib/store";
 import { copyToClipboard } from "../lib/clipboard";
-import { ToolCallCard } from "../components/ui/ToolCallCard";
+import { ToolCallsPanel } from "../components/ui/ToolCallsPanel";
 import { filterVisible } from "../lib/hiddenModels";
 import { useVoiceInput } from "../lib/useVoiceInput";
 import { Typewriter_v2 } from "../components/Typewriter_v2";
@@ -1194,14 +1194,8 @@ const MessageBubble = memo(function MessageBubble({ message, usageFooter, onCopy
           </div>
         )}
 
-        {/* Tool calls — rendered above text for assistant messages */}
-        {!isUser && message.tools && message.tools.length > 0 && (
-          <div className="w-full mb-1">
-            {message.tools.map((tool, i) => (
-              <ToolCallCard key={tool._call_id ?? `${tool.name}-${i}`} tool={tool} />
-            ))}
-          </div>
-        )}
+        {/* Tool calls are surfaced in the fixed ToolCallsPanel at the
+            bottom of the chat column, not inline in the bubble. */}
 
         {/* Image attachments — rendered above the text bubble. Backend
             stores all uploaded files (image/audio/text/pdf) under the
@@ -2701,6 +2695,20 @@ export function ChatPage() {
   // can compose the next message immediately.
   const isStreaming = messages.some(m => m.role === "assistant" && m.isStreaming);
 
+  // Flattened list of every tool call in the current conversation, in
+  // chronological order. Surfaced via the fixed ToolCallsPanel at the
+  // bottom of the chat column so individual cards no longer clutter the
+  // message stream.
+  const allToolCalls = useMemo(() => {
+    const out: ChatToolCall[] = [];
+    for (const m of messages) {
+      if (m.tools && m.tools.length > 0) {
+        out.push(...m.tools);
+      }
+    }
+    return out;
+  }, [messages]);
+
   // Bug #3849: Track message count changes to announce new messages to screen
   // readers via the aria-live region.
   const [msgAriaAnnouncement, setMsgAriaAnnouncement] = useState("");
@@ -3199,6 +3207,12 @@ export function ChatPage() {
             )}
             </div>
           </div>
+
+          {/* Tool calls panel — collapsed bar above the input. Replaces
+              the per-message inline ToolCallCard rendering so the chat
+              stream stays focused on text while the user can drill into
+              tool inputs/results on demand. */}
+          {selectedAgentId && <ToolCallsPanel tools={allToolCalls} />}
 
           {/* Input area — sticks to the bottom of the chat column. The
               app-shell's <main> already keeps this row above the


### PR DESCRIPTION
## Summary

- Inline `ToolCallCard`s in `MessageBubble` were fragmenting long
  assistant turns into walls of card UI that buried the actual reply.
  Replaced the per-card stack with a single compact pill rendered
  below each assistant bubble.
- New `components/ui/ToolCallsPanel`: an inline pill summarising the
  turn's total / running / error counts and the most recent tool
  name. Clicking it opens a centred `Modal` (`size="2xl"`) listing
  every tool call from that turn, reusing the existing
  `ToolCallCard` for input/result drill-down.
- The panel is per-message — each assistant turn keeps its own tool
  history, so attribution (which calls produced which reply) is
  preserved while the chat stream stays scannable.

## Files

- `crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.tsx` (new)
- `crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.test.tsx` (new — 4 cases: empty-state, count + last-tool label, running/error badges, modal-open render)
- `crates/librefang-api/dashboard/src/pages/ChatPage.tsx` (swap inline `ToolCallCard.map` in `MessageBubble` for one `ToolCallsPanel` pill)
- `crates/librefang-api/dashboard/src/locales/{en,zh}.json` (`chat.tool_calls` key)

## Verification

- [x] `pnpm typecheck`
- [x] `pnpm test --run` — 557 / 557 passed (57 files)
- [x] `pnpm build`
- [ ] Manual UI smoke (deferred — daemon launch is HUMAN-only per repo rules)

## Accessibility

- Trigger button carries `aria-haspopup="dialog"` + `aria-expanded={open}` so screen readers announce the modal's open/closed state.
- `Modal` already provides focus trap, Esc-to-close, and focus restoration.
