### PR TITLE
fix(test): kill wall-clock flake in registry concurrent-register-and-remove test

### DIFF
--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -1025,6 +1025,19 @@ mod tests {
         use std::sync::Arc;
         use std::thread;
 
+        // Fixed-work driver instead of a wall-clock window: the writer
+        // performs a deterministic number of register/remove cycles, then
+        // signals stop.  Earlier iterations of this test slept for 100ms
+        // and asserted `lookups > 1_000`, which fired flakily on CI
+        // runners under load — the reader thread couldn't always squeeze
+        // 1k iterations into a 100ms slice — without ever indicating the
+        // torn-read invariant was actually broken.  With a fixed writer
+        // workload the reader's iteration count varies with scheduler
+        // latency but the test no longer fails on slow hosts; what
+        // matters is `torn == 0` and `hits > 0`, both of which we still
+        // check.
+        const WRITER_CYCLES: usize = 5_000;
+
         let registry = Arc::new(AgentRegistry::new());
         let stop = Arc::new(AtomicBool::new(false));
         // Count cases where `find_by_name` returned `Some` but the entry's
@@ -1038,13 +1051,14 @@ mod tests {
             let registry = Arc::clone(&registry);
             let stop = Arc::clone(&stop);
             thread::spawn(move || {
-                while !stop.load(Ordering::Relaxed) {
+                for _ in 0..WRITER_CYCLES {
                     let entry = test_entry("racy");
                     let id = entry.id;
                     if registry.register(entry).is_ok() {
                         registry.remove(id).ok();
                     }
                 }
+                stop.store(true, Ordering::Release);
             })
         };
 
@@ -1055,7 +1069,7 @@ mod tests {
             let lookups = Arc::clone(&lookups);
             let hits = Arc::clone(&hits);
             thread::spawn(move || {
-                while !stop.load(Ordering::Relaxed) {
+                while !stop.load(Ordering::Acquire) {
                     lookups.fetch_add(1, Ordering::Relaxed);
                     if let Some(found) = registry.find_by_name("racy") {
                         hits.fetch_add(1, Ordering::Relaxed);
@@ -1067,21 +1081,25 @@ mod tests {
             })
         };
 
-        thread::sleep(std::time::Duration::from_millis(100));
-        stop.store(true, Ordering::Relaxed);
         writer.join().unwrap();
         reader.join().unwrap();
 
-        // Sanity: reader actually ran enough iterations and saw the agent
-        // some of the time, otherwise a clean pass is vacuous.
+        // The reader doesn't get a fixed-iteration guarantee (a slow
+        // runner can spend ~all its time on the writer thread), but it
+        // must have run at least once to make the torn-read assertion
+        // meaningful.  In practice on every observed runner the reader
+        // logs hundreds-to-millions of lookups; we keep the floor at 1
+        // so the test passes on the most pathological scheduler without
+        // becoming vacuous.
         assert!(
-            lookups.load(Ordering::Relaxed) > 1_000,
-            "reader did not run enough iterations to be a meaningful probe"
+            lookups.load(Ordering::Relaxed) >= 1,
+            "reader thread did not run a single iteration before the writer finished"
         );
         assert!(
             hits.load(Ordering::Relaxed) > 0,
-            "reader never observed the agent — the writer/reader interleaving \
-             produced a vacuous pass; widen the test if this fires on slow CI"
+            "reader never observed the agent across {WRITER_CYCLES} writer cycles — \
+             the writer/reader interleaving produced a vacuous pass; \
+             increase WRITER_CYCLES if this fires on a real runner"
         );
         assert_eq!(
             torn.load(Ordering::Relaxed),


### PR DESCRIPTION
## Summary

`registry::tests::find_by_name_is_atomic_under_concurrent_register_and_remove` (added in #4393) is a wall-clock flake on loaded CI runners. The test sleeps 100 ms while a writer/reader pair hammers `AgentRegistry`, then asserts the reader logged > 1 000 lookups. Under load the reader sometimes squeezes only ~700 iterations into the slice and the test panics with `reader did not run enough iterations to be a meaningful probe` — without indicating the torn-read invariant was actually broken. Hit on Test/Ubuntu shard 1 of #4661 (commit `a45de7ac`) most recently; pre-existing flake unrelated to the PR's diff.

## What changed

Switched to a fixed-work driver: the writer performs 5 000 register/remove cycles and then signals stop, instead of running for a 100 ms wall-clock window. The reader spins until stop goes `Acquire`-true. The reader's iteration count varies with scheduler latency, but the test no longer depends on the wall clock.

The 1k-iteration floor was a sanity check that the writer/reader actually overlapped — never the actual invariant. We keep `hits > 0` (proves the windows did interleave) and `torn == 0` (the real safety property).

## Test plan

- [x] 20/20 consecutive local runs passed: `cargo test -p librefang-kernel --lib -- registry::tests::find_by_name_is_atomic_under_concurrent_register_and_remove`
- [x] `lookups >= 1` floor preserved so the torn-read assertion stays meaningful even on a pathological scheduler
- [ ] CI Test/Ubuntu shard 1 should stop flaking on this assertion
