### PR TITLE
fix(test): bump test_sidecar_adapter_spawn_echo timeout for Windows cold-start (#4676)

### DIFF
--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -555,8 +555,11 @@ mod tests {
             .await
             .expect("Failed to send message to sidecar — process may have exited early");
 
-        // Read the echo reply (10s timeout for Windows cold start)
-        let msg = tokio::time::timeout(std::time::Duration::from_secs(10), stream.next())
+        // Read the echo reply. Windows-2025 GitHub runners under load have been
+        // observed to spend > 10s in Python cold-start (panicked at 11.346s in
+        // CI for c176b2a — see #4676). 30s gives ample headroom while still
+        // catching real hangs via nextest's overall test timeout.
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(30), stream.next())
             .await
             .expect("Timed out waiting for echo reply")
             .expect("Stream ended unexpectedly");


### PR DESCRIPTION
## Summary

Fixes #4676 (main red on commit `c176b2a`).

`librefang-channels::sidecar::tests::test_sidecar_adapter_spawn_echo` panicked on Test/Windows at exactly 11.346s with `Timed out waiting for echo reply: Elapsed(())` — i.e. the test's 1 s pre-boot sleep + 10 s reply timeout boundary. The actual implementation under test (`SidecarAdapter`) was unchanged in this run, and `c176b2a` (full `KernelHandle` widening — closes the `LibreFangKernel` leaks for `librefang-api`) does not touch any sidecar code path. Diagnosis: pure Windows-2025 cold-start flake — Python interpreter spin-up under contention can exceed 10 s on the GitHub-hosted runner.

The 10 s value already had a `// 10s timeout for Windows cold start` comment, so this is the second time the same ceiling has been hit. Bumping it once and adding the rationale (CI run, panic location, fallback safety net) so the next reader doesn't have to re-derive it.

## What changed

- `crates/librefang-channels/src/sidecar.rs:559` — reply-read `tokio::time::timeout` raised from 10 s → 30 s. Comment updated to record the failing CI run and reasoning.

Out of scope (worth a follow-up issue, not this PR):

- The `tokio::time::sleep(Duration::from_secs(1))` blind boot wait at line 543 should ideally be replaced by polling for the `Ready` event the adapter emits — but the reader task currently consumes `Ready` internally and does not surface it to the stream consumer, so a real poll requires a small protocol surface change. Out of scope for the main-red unblock.

## Test plan

- [x] `cargo check -p librefang-channels --tests` — clean (warm cache, 14.7 s).
- [x] `cargo clippy -p librefang-channels --all-targets -- -D warnings` — clean.
- [x] `cargo test -p librefang-channels --lib sidecar::` — all 8 sidecar tests pass locally on macOS, including `test_sidecar_adapter_spawn_echo`.
- [ ] CI Test/Windows green on this branch (the failing job).
- [ ] No regression on Test/Ubuntu shards / Test/macOS (the test is gated on Python being on `PATH`; macOS and Linux runners have it, the test ran fine in those lanes on the failing run too).
