### PR TITLE
fix: terminal page reconnect loop on container hosts (#4675)

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2636,7 +2636,7 @@
     "websocket_error": "WebSocket connection error",
     "connection_closed_non_recoverable": "Connection closed due to a non-recoverable error",
     "max_reconnect_exceeded": "Max reconnection attempts reached. Please connect manually.",
-    "fast_exit_giveup": "Terminal launch failed — the shell exited immediately. Check the daemon host's TERM / terminfo (the `xterm-256color` entry must be installed: `ncurses-term` on Debian/Ubuntu, `ncurses-terminfo-base` on Alpine, `ncurses-base` on RHEL/Fedora) and tmux configuration; reconnecting won't help until the underlying error is fixed.",
+    "fast_exit_giveup": "Terminal launch failed — the shell could not start (or exited immediately). Check the daemon host's shell binary, TERM / terminfo (the `xterm-256color` entry must be installed: `ncurses-term` on Debian/Ubuntu, `ncurses-terminfo-base` on Alpine, `ncurses-base` on RHEL/Fedora) and tmux configuration; reconnecting won't help until the underlying error is fixed.",
     "root_warning": "Warning: The daemon is running as root. Terminal commands execute with full privileges.",
     "enter_fullscreen": "Enter fullscreen",
     "exit_fullscreen": "Exit fullscreen (Esc)",

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2636,6 +2636,7 @@
     "websocket_error": "WebSocket connection error",
     "connection_closed_non_recoverable": "Connection closed due to a non-recoverable error",
     "max_reconnect_exceeded": "Max reconnection attempts reached. Please connect manually.",
+    "fast_exit_giveup": "Terminal launch failed — the shell exited immediately. Check the daemon host's TERM / terminfo (e.g. install ncurses-term) and tmux configuration; reconnecting won't help until the underlying error is fixed.",
     "root_warning": "Warning: The daemon is running as root. Terminal commands execute with full privileges.",
     "enter_fullscreen": "Enter fullscreen",
     "exit_fullscreen": "Exit fullscreen (Esc)",

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2636,7 +2636,7 @@
     "websocket_error": "WebSocket connection error",
     "connection_closed_non_recoverable": "Connection closed due to a non-recoverable error",
     "max_reconnect_exceeded": "Max reconnection attempts reached. Please connect manually.",
-    "fast_exit_giveup": "Terminal launch failed — the shell exited immediately. Check the daemon host's TERM / terminfo (e.g. install ncurses-term) and tmux configuration; reconnecting won't help until the underlying error is fixed.",
+    "fast_exit_giveup": "Terminal launch failed — the shell exited immediately. Check the daemon host's TERM / terminfo (the `xterm-256color` entry must be installed: `ncurses-term` on Debian/Ubuntu, `ncurses-terminfo-base` on Alpine, `ncurses-base` on RHEL/Fedora) and tmux configuration; reconnecting won't help until the underlying error is fixed.",
     "root_warning": "Warning: The daemon is running as root. Terminal commands execute with full privileges.",
     "enter_fullscreen": "Enter fullscreen",
     "exit_fullscreen": "Exit fullscreen (Esc)",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2636,6 +2636,7 @@
     "websocket_error": "WebSocket 连接错误",
     "connection_closed_non_recoverable": "由于不可恢复的错误，连接已关闭",
     "max_reconnect_exceeded": "已达到最大重连次数，请手动连接。",
+    "fast_exit_giveup": "终端启动失败 — Shell 启动后立刻退出。请检查守护进程主机的 TERM / terminfo（例如安装 ncurses-term）以及 tmux 配置；底层错误未修复前重连无效。",
     "root_warning": "警告：守护进程以 root 身份运行。终端命令将以完整权限执行。",
     "enter_fullscreen": "全屏",
     "exit_fullscreen": "退出全屏（Esc）",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2636,7 +2636,7 @@
     "websocket_error": "WebSocket 连接错误",
     "connection_closed_non_recoverable": "由于不可恢复的错误，连接已关闭",
     "max_reconnect_exceeded": "已达到最大重连次数，请手动连接。",
-    "fast_exit_giveup": "终端启动失败 — Shell 启动后立刻退出。请检查守护进程主机的 TERM / terminfo（必须安装 `xterm-256color` 条目：Debian/Ubuntu 上是 `ncurses-term`，Alpine 上是 `ncurses-terminfo-base`，RHEL/Fedora 上是 `ncurses-base`）以及 tmux 配置；底层错误未修复前重连无效。",
+    "fast_exit_giveup": "终端启动失败 — Shell 未能启动（或启动后立刻退出）。请检查守护进程主机的 Shell 可执行文件、TERM / terminfo（必须安装 `xterm-256color` 条目：Debian/Ubuntu 上是 `ncurses-term`，Alpine 上是 `ncurses-terminfo-base`，RHEL/Fedora 上是 `ncurses-base`）以及 tmux 配置；底层错误未修复前重连无效。",
     "root_warning": "警告：守护进程以 root 身份运行。终端命令将以完整权限执行。",
     "enter_fullscreen": "全屏",
     "exit_fullscreen": "退出全屏（Esc）",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2636,7 +2636,7 @@
     "websocket_error": "WebSocket 连接错误",
     "connection_closed_non_recoverable": "由于不可恢复的错误，连接已关闭",
     "max_reconnect_exceeded": "已达到最大重连次数，请手动连接。",
-    "fast_exit_giveup": "终端启动失败 — Shell 启动后立刻退出。请检查守护进程主机的 TERM / terminfo（例如安装 ncurses-term）以及 tmux 配置；底层错误未修复前重连无效。",
+    "fast_exit_giveup": "终端启动失败 — Shell 启动后立刻退出。请检查守护进程主机的 TERM / terminfo（必须安装 `xterm-256color` 条目：Debian/Ubuntu 上是 `ncurses-term`，Alpine 上是 `ncurses-terminfo-base`，RHEL/Fedora 上是 `ncurses-base`）以及 tmux 配置；底层错误未修复前重连无效。",
     "root_warning": "警告：守护进程以 root 身份运行。终端命令将以完整权限执行。",
     "enter_fullscreen": "全屏",
     "exit_fullscreen": "退出全屏（Esc）",

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.test.tsx
@@ -311,6 +311,42 @@ describe("TerminalPage", () => {
     }
   });
 
+  it("stops auto-reconnect when WS opens but never receives `started` (#4675)", async () => {
+    // Host-side spawn-failure path: the daemon accepts the WS handshake
+    // but cannot reach the point of sending `started` (shell binary
+    // missing, PTY allocation fails, panic during spawn). The server
+    // closes the WS within FAST_EXIT_WINDOW_MS of `open`. Two of these
+    // in a row must trip the same giveup as the started→exit-fast path.
+    vi.useFakeTimers();
+    try {
+      renderPage();
+
+      const fastFailNoStarted = async (ws: MockWebSocket) => {
+        await act(async () => {
+          ws.emitOpen();
+          // No `started`, no `exit` — the server just closed.
+          ws.readyState = MockWebSocket.CLOSED;
+          ws.onclose?.({ code: 1006, reason: "" } as unknown as CloseEvent);
+        });
+      };
+
+      await fastFailNoStarted(MockWebSocket.instances[0]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(MockWebSocket.instances.length).toBe(2);
+
+      await fastFailNoStarted(MockWebSocket.instances[1]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(MockWebSocket.instances.length).toBe(2);
+      expect(screen.getByText("terminal.fast_exit_giveup")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not resend null desired window on reconnect after disconnect before active window", async () => {
     const user = userEvent.setup();
     renderPage();

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.test.tsx
@@ -121,13 +121,18 @@ vi.mock("../lib/queries/terminal", () => ({
   useTerminalHealth: (...args: unknown[]) => useTerminalHealthMock(...args),
 }));
 
-vi.mock("../lib/store", () => ({
-  useUIStore: (selector: (state: {
+vi.mock("../lib/store", () => {
+  const useUIStore = (selector: (state: {
     terminalEnabled: boolean | null;
     addToast: (message: string, type?: "success" | "error" | "info") => void;
-  }) => unknown) =>
-    useUIStoreMock(selector),
-}));
+  }) => unknown) => useUIStoreMock(selector);
+  // The reconnect path reads `useUIStore.getState().toasts` to grab the
+  // most-recent toast id; expose a stub so the test that exercises a
+  // reconnect doesn't crash on a missing static method.
+  (useUIStore as unknown as { getState: () => { toasts: unknown[] } }).getState =
+    () => ({ toasts: [] });
+  return { useUIStore };
+});
 
 vi.mock("../components/TerminalTabs", () => ({
   TerminalTabs: (props: {
@@ -215,6 +220,47 @@ describe("TerminalPage", () => {
     });
     expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ["terminal"] });
     expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ["terminal", "health"] });
+  });
+
+  it("stops auto-reconnect after consecutive fast-failed launches (#4675)", async () => {
+    // Two back-to-back connections that get `started` and then `exit` with
+    // a non-zero code inside the FAST_EXIT_WINDOW_MS slot must trip the
+    // give-up path: no third socket, error banner shows the giveup string.
+    vi.useFakeTimers();
+    try {
+      renderPage();
+
+      const fastFail = async (ws: MockWebSocket) => {
+        await act(async () => {
+          ws.emitOpen();
+          ws.emitMessage({ type: "started", shell: "tmux", pid: 1234 });
+          ws.emitMessage({ type: "exit", code: 1 });
+          // The reconnect path requires either wsRef===null or
+          // readyState===CLOSED; mirror what a real WS close would do.
+          ws.readyState = MockWebSocket.CLOSED;
+          ws.onclose?.({ code: 1006, reason: "" } as unknown as CloseEvent);
+        });
+      };
+
+      // First fast-fail — handler classifies as transient, schedules a
+      // reconnect with the 2 s base delay; counter goes 0 → 1.
+      await fastFail(MockWebSocket.instances[0]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(MockWebSocket.instances.length).toBe(2);
+
+      // Second fast-fail — counter goes 1 → 2, hits MAX_CONSECUTIVE_FAST_FAILS.
+      await fastFail(MockWebSocket.instances[1]);
+      await act(async () => {
+        // Long enough to cover any delayed retry that should NOT fire.
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(MockWebSocket.instances.length).toBe(2);
+      expect(screen.getByText("terminal.fast_exit_giveup")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not resend null desired window on reconnect after disconnect before active window", async () => {

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -258,6 +258,54 @@ describe("TerminalPage", () => {
       });
       expect(MockWebSocket.instances.length).toBe(2);
       expect(screen.getByText("terminal.fast_exit_giveup")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("recovers after giveup when user clicks Connect (#4675)", async () => {
+    // After two consecutive fast-fails the auto-reconnect bails. The
+    // manual Connect button must reset both ceilings (auto-attempt
+    // counter AND consecutive-fast-fail counter) so the user can retry
+    // once they fix the host config — without reloading the page.
+    // Without manualConnect resetting `consecutiveFastFailRef`, a
+    // fresh click would immediately re-bail on the next close.
+    vi.useFakeTimers();
+    try {
+      renderPage();
+
+      const fastFail = async (ws: MockWebSocket) => {
+        await act(async () => {
+          ws.emitOpen();
+          ws.emitMessage({ type: "started", shell: "tmux", pid: 1234 });
+          ws.emitMessage({ type: "exit", code: 1 });
+          ws.readyState = MockWebSocket.CLOSED;
+          ws.onclose?.({ code: 1006, reason: "" } as unknown as CloseEvent);
+        });
+      };
+
+      // Trip the giveup with two consecutive fast-fails.
+      await fastFail(MockWebSocket.instances[0]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      await fastFail(MockWebSocket.instances[1]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(MockWebSocket.instances.length).toBe(2);
+      expect(screen.getByText("terminal.fast_exit_giveup")).toBeInTheDocument();
+
+      // User clicks Connect — manualConnect must reset both ceilings
+      // and open a third socket. fireEvent stays synchronous;
+      // userEvent's internal timers conflict with the fake-timer
+      // scope this test runs under.
+      act(() => {
+        fireEvent.click(
+          screen.getByRole("button", { name: "terminal.connect" })
+        );
+      });
+      expect(MockWebSocket.instances.length).toBe(3);
     } finally {
       vi.useRealTimers();
     }

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -36,6 +36,16 @@ interface ServerMessage {
 
 const RECONNECT_DELAY_MS = 2000;
 const MAX_RECONNECT_ATTEMPTS = 10;
+// #4675: a "fast exit" is the shell process dying within 3 s of `started`.
+// That window is set well above any realistic legitimate `exit 0` from the
+// user (e.g. typing `exit` immediately after connecting still takes a few
+// hundred ms of human latency) but well below tmux's failure mode where it
+// errors out and exits within ~10 ms.
+const FAST_EXIT_WINDOW_MS = 3000;
+// #4675: stop the reconnect loop after this many consecutive fast-failed
+// connections. One fast-fail could be a transient race; two in a row means
+// the daemon is in a state where retrying won't recover it.
+const MAX_CONSECUTIVE_FAST_FAILS = 2;
 
 // Must match the server-side MAX_COLS / MAX_ROWS constants in routes/terminal.rs.
 const TERM_MIN_COLS = 1;
@@ -100,6 +110,14 @@ export function TerminalPage() {
   const connectRef = useRef<() => void>(() => {});
   const attemptRef = useRef(0);
   const desiredWindowIdRef = useRef<string | null>(null);
+  // #4675: fast-fail tracking — `startedAtRef` is set when the server emits
+  // `started` for the current WS, `connectionFastFailRef` flips true if
+  // `exit` arrives within FAST_EXIT_WINDOW_MS with a non-zero code, and
+  // `consecutiveFastFailRef` counts how many connections in a row hit that
+  // pattern. The reconnect loop bails once it crosses MAX_CONSECUTIVE_FAST_FAILS.
+  const startedAtRef = useRef<number | null>(null);
+  const connectionFastFailRef = useRef(false);
+  const consecutiveFastFailRef = useRef(0);
 
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
@@ -156,6 +174,11 @@ export function TerminalPage() {
     setError(null);
     setIsConnecting(true);
     setIsRoot(false);
+    // #4675: reset per-connection fast-fail trackers; cross-connection
+    // counter (`consecutiveFastFailRef`) is left alone so the close handler
+    // can compare this connection's outcome against the previous run.
+    startedAtRef.current = null;
+    connectionFastFailRef.current = false;
     const { url: wsUrl, protocols: wsProtocols } =
       buildAuthenticatedWebSocket("/api/terminal/ws");
     const url = new URL(wsUrl);
@@ -219,6 +242,11 @@ export function TerminalPage() {
       switch (msg.type) {
         case "started":
           setIsRoot(msg.isRoot ?? false);
+          // #4675: anchor the fast-exit window from the moment the server
+          // tells us the shell is up. Output that arrives between this and
+          // `exit` is the shell's own stderr, e.g. tmux's "open terminal
+          // failed: terminal does not support clear" message.
+          startedAtRef.current = Date.now();
           terminalRef.current?.write(
             t("terminal.started", { shell: msg.shell, pid: msg.pid }) + "\r\n"
           );
@@ -241,6 +269,18 @@ export function TerminalPage() {
           terminalRef.current?.write(
             "\r\n" + t("terminal.exited", { code: msg.code }) + "\r\n"
           );
+          // #4675: classify this connection as a fast-fail when the shell
+          // exits with a non-zero code within the FAST_EXIT_WINDOW_MS slot
+          // that opened on `started`. The close handler reads this flag to
+          // decide whether to keep reconnecting.
+          if (
+            typeof msg.code === "number" &&
+            msg.code !== 0 &&
+            startedAtRef.current !== null &&
+            Date.now() - startedAtRef.current < FAST_EXIT_WINDOW_MS
+          ) {
+            connectionFastFailRef.current = true;
+          }
           break;
         case "error":
           setError(typeof msg.content === "string" && msg.content
@@ -280,6 +320,22 @@ export function TerminalPage() {
         return;
       }
 
+      // #4675: a connection that opened, got `started`, and then exited
+      // fast with a non-zero code is almost always a host-side
+      // configuration problem (TERM/terminfo, missing tmux binary, broken
+      // shell startup) — reconnecting won't fix it. Track consecutive
+      // occurrences and bail out of the retry loop after a small ceiling
+      // so the user gets a clear error instead of a forever-spinning page.
+      if (connectionFastFailRef.current) {
+        consecutiveFastFailRef.current += 1;
+        if (consecutiveFastFailRef.current >= MAX_CONSECUTIVE_FAST_FAILS) {
+          setError(t("terminal.fast_exit_giveup"));
+          return;
+        }
+      } else {
+        consecutiveFastFailRef.current = 0;
+      }
+
       if (attemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
         setError(t("terminal.max_reconnect_exceeded"));
         return;
@@ -297,6 +353,16 @@ export function TerminalPage() {
   }, [t, terminalEnabled, queryClient, addToast]);
 
   connectRef.current = connect;
+
+  // #4675: explicit user-initiated connect resets both ceilings
+  // (auto-reconnect attempts and consecutive fast-fail count) so the user
+  // can recover after fixing host config without reloading the page.
+  const manualConnect = useCallback(() => {
+    attemptRef.current = 0;
+    consecutiveFastFailRef.current = 0;
+    setReconnectAttempt(0);
+    connect();
+  }, [connect]);
 
   const disconnect = useCallback(() => {
     if (reconnectTimeoutRef.current) {
@@ -536,7 +602,7 @@ export function TerminalPage() {
         </Button>
       ) : (
         <Button
-          onClick={connect}
+          onClick={manualConnect}
           isLoading={isConnecting}
           disabled={isConnecting}
           size="sm"

--- a/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/TerminalPage.tsx
@@ -110,12 +110,19 @@ export function TerminalPage() {
   const connectRef = useRef<() => void>(() => {});
   const attemptRef = useRef(0);
   const desiredWindowIdRef = useRef<string | null>(null);
-  // #4675: fast-fail tracking — `startedAtRef` is set when the server emits
-  // `started` for the current WS, `connectionFastFailRef` flips true if
-  // `exit` arrives within FAST_EXIT_WINDOW_MS with a non-zero code, and
-  // `consecutiveFastFailRef` counts how many connections in a row hit that
-  // pattern. The reconnect loop bails once it crosses MAX_CONSECUTIVE_FAST_FAILS.
+  // #4675: fast-fail tracking. Two paths flip `connectionFastFailRef` true:
+  // (1) the shell started and then exited with a non-zero code within
+  //     FAST_EXIT_WINDOW_MS of `started` — host could spawn but the shell
+  //     immediately died (tmux missing terminfo, broken rc files, etc.);
+  // (2) the WS opened but `started` never arrived and the close fired
+  //     within FAST_EXIT_WINDOW_MS of `open` — host couldn't even reach
+  //     the spawn-success point (shell binary missing, PTY allocation
+  //     failure, daemon-side panic).
+  // `wsOpenedAtRef` is the anchor for path (2); `startedAtRef` for (1).
+  // `consecutiveFastFailRef` counts how many connections in a row hit
+  // either path; the reconnect loop bails at MAX_CONSECUTIVE_FAST_FAILS.
   const startedAtRef = useRef<number | null>(null);
+  const wsOpenedAtRef = useRef<number | null>(null);
   const connectionFastFailRef = useRef(false);
   const consecutiveFastFailRef = useRef(0);
 
@@ -178,6 +185,7 @@ export function TerminalPage() {
     // counter (`consecutiveFastFailRef`) is left alone so the close handler
     // can compare this connection's outcome against the previous run.
     startedAtRef.current = null;
+    wsOpenedAtRef.current = null;
     connectionFastFailRef.current = false;
     const { url: wsUrl, protocols: wsProtocols } =
       buildAuthenticatedWebSocket("/api/terminal/ws");
@@ -196,6 +204,9 @@ export function TerminalPage() {
     wsRef.current = ws;
 
     ws.onopen = () => {
+      // #4675: anchor the no-started fast-fail window from the moment
+      // the WS handshake completes. Read in the close handler below.
+      wsOpenedAtRef.current = Date.now();
       const wasReconnect = attemptRef.current > 0;
       setIsConnecting(false);
       setIsConnected(true);
@@ -320,12 +331,28 @@ export function TerminalPage() {
         return;
       }
 
-      // #4675: a connection that opened, got `started`, and then exited
-      // fast with a non-zero code is almost always a host-side
-      // configuration problem (TERM/terminfo, missing tmux binary, broken
-      // shell startup) — reconnecting won't fix it. Track consecutive
-      // occurrences and bail out of the retry loop after a small ceiling
-      // so the user gets a clear error instead of a forever-spinning page.
+      // #4675: ALSO classify the connection as a fast-fail when it opened
+      // but `started` never arrived and the close fired inside the same
+      // window. That covers host-side spawn failures (shell binary
+      // missing, PTY allocation failure, daemon panic during spawn) where
+      // the daemon never reached the point of telling us the shell was
+      // up. The other path (started + non-zero exit fast) sets the flag
+      // in the `case "exit"` branch above.
+      if (
+        !connectionFastFailRef.current &&
+        startedAtRef.current === null &&
+        wsOpenedAtRef.current !== null &&
+        Date.now() - wsOpenedAtRef.current < FAST_EXIT_WINDOW_MS
+      ) {
+        connectionFastFailRef.current = true;
+      }
+
+      // #4675: a connection that fast-failed (either path) is almost
+      // always a host-side configuration problem (TERM/terminfo, missing
+      // tmux binary, missing shell binary, broken shell startup) —
+      // reconnecting won't fix it. Track consecutive occurrences and
+      // bail out of the retry loop after a small ceiling so the user
+      // gets a clear error instead of a forever-spinning page.
       if (connectionFastFailRef.current) {
         consecutiveFastFailRef.current += 1;
         if (consecutiveFastFailRef.current >= MAX_CONSECUTIVE_FAST_FAILS) {

--- a/crates/librefang-api/src/terminal.rs
+++ b/crates/librefang-api/src/terminal.rs
@@ -13,6 +13,13 @@ use tracing::info;
 /// controlling TTY (docker `CMD`, systemd, supervisord) it inherits an empty
 /// or `dumb` `TERM`, and tmux exits immediately with `open terminal failed:
 /// terminal does not support clear` because it cannot find the cap entry.
+///
+/// Set unconditionally — any inherited `TERM` is overridden. The consumer
+/// of this PTY's output is the dashboard's xterm.js renderer, not the
+/// host's TTY emulator, so a fixed value is the correct contract; a
+/// fallback that respected inheritance would create the diagnostic mess
+/// of "works in this deploy, doesn't in that one" depending on whether
+/// the daemon happened to launch under a TTY.
 const TERMINAL_TERM: &str = "xterm-256color";
 
 pub struct PtySession {

--- a/crates/librefang-api/src/terminal.rs
+++ b/crates/librefang-api/src/terminal.rs
@@ -5,6 +5,16 @@ use std::io::{Read, Write};
 use tokio::sync::mpsc;
 use tracing::info;
 
+/// `TERM` advertised to the spawned shell / tmux. xterm.js (the dashboard
+/// terminal emulator) speaks the xterm-256color escape-sequence set, and
+/// every modern terminfo database — including the Docker base image
+/// (`node:*-bookworm-slim`, via `ncurses-base`) — ships the matching entry.
+/// Setting it explicitly fixes #4675: when the daemon is launched without a
+/// controlling TTY (docker `CMD`, systemd, supervisord) it inherits an empty
+/// or `dumb` `TERM`, and tmux exits immediately with `open terminal failed:
+/// terminal does not support clear` because it cannot find the cap entry.
+const TERMINAL_TERM: &str = "xterm-256color";
+
 pub struct PtySession {
     _master: Box<dyn portable_pty::MasterPty + Send>,
     child: Box<dyn portable_pty::Child + Send>,
@@ -34,6 +44,12 @@ impl PtySession {
 
         let mut cmd = CommandBuilder::new(shell.clone());
         // No args — spawn an interactive shell
+
+        // #4675: pin TERM so the shell and any TUI it launches see a value
+        // backed by the host's terminfo database instead of the (often empty
+        // or `dumb`) value inherited from a daemon process started without a
+        // TTY. Same rationale and value for the tmux path below.
+        cmd.env("TERM", TERMINAL_TERM);
 
         // Set CWD to the user's home directory so the shell does not inherit
         // the daemon's working directory, which would expose server internals.
@@ -133,6 +149,11 @@ impl PtySession {
 
         // Clear TMUX env to prevent nesting when daemon inherits user's tmux session.
         cmd.env("TMUX", "");
+
+        // #4675: tmux refuses to start if the inherited TERM has no terminfo
+        // entry (`open terminal failed: terminal does not support clear`).
+        // Pin to the value xterm.js speaks; see TERMINAL_TERM doc-comment.
+        cmd.env("TERM", TERMINAL_TERM);
 
         // CWD = $HOME, not daemon's working directory.
         let home_dir = {
@@ -265,5 +286,19 @@ pub fn is_running_as_root() -> bool {
     #[cfg(not(unix))]
     {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #4675 contract lock: the public TERM value the dashboard's xterm.js
+    /// expects, and the value tmux looks up in terminfo. Changing it without
+    /// updating xterm.js / Dockerfile assumptions will silently re-break
+    /// tmux on container hosts.
+    #[test]
+    fn terminal_term_is_xterm_256color() {
+        assert_eq!(TERMINAL_TERM, "xterm-256color");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4675. The reporter's daemon runs in a docker container on GCP free tier; the dashboard's terminal page shows an infinite "Reconnecting…" loop. The original symptom report blamed the WS handshake, but the server logs they posted tell a different story:

```
INFO Terminal WebSocket connected ip=… auth="session" …
INFO spawning PTY attached to tmux tmux=tmux session=main
INFO Terminal WebSocket disconnected
```

Auth, origin, and the WS upgrade all succeed. tmux gets spawned, then the connection drops. The xterm.js panel on the dashboard captured the actual error from tmux's stdout:

```
[Terminal started: tmux (PID: 149174)]
open terminal failed: terminal does not support clear
[Process exited with code 1]
```

That's tmux's startup self-test against terminfo — it queries the `clear` capability for whatever `TERM` it inherited and bails out when there's no entry to look up.

## Two-part fix

### 1. Server: pin TERM on PTY/tmux spawn

`PtySession::spawn_tmux_attached` (and `spawn`) build a `portable_pty::CommandBuilder` with `TMUX=""` set but never set `TERM`. The child therefore inherits whatever `TERM` the daemon process has — which on a daemon launched without a controlling TTY (`docker run … librefang start`, systemd, supervisord) is empty or `dumb`. tmux requires a real terminfo entry to redraw, can't find one, and exits immediately.

Pin `TERM=xterm-256color` on both spawn paths via a single `TERMINAL_TERM` constant. The value is the escape-sequence set xterm.js — the dashboard's terminal emulator — already speaks, and every mainstream terminfo database ships the matching entry: Debian/Ubuntu via `ncurses-base` (always pulled in by base images, including the published `node:22.11.0-bookworm-slim`), Alpine via `ncurses-terminfo-base`, macOS via `/usr/share/terminfo`. So this single value covers the published Docker image, bare-metal Linux, and dev-machine launches.

### 2. Dashboard: stop the reconnect loop on consecutive fast-fails

The server-side fix covers the common docker/systemd path, but a host that *genuinely* lacks the right terminfo entry, or that has a broken tmux config, will still produce the same `started` → exit-1 cycle. The dashboard previously treated that close as transient and reconnected up to ten times with exponential backoff, so the user saw a forever-spinning page with no useful diagnostic.

Track per-connection fast-fail (server emits `started`, then `exit` with non-zero code, both within 3 s) and bail out after two consecutive occurrences with a clear, hint-laden error string. The manual **Connect** button resets both ceilings (auto-reconnect attempts and consecutive fast-fails) so the user can recover without reloading after fixing the host.

## Files

- `crates/librefang-api/src/terminal.rs` — declared `TERMINAL_TERM`, set `cmd.env("TERM", TERMINAL_TERM)` in `PtySession::spawn` and `PtySession::spawn_tmux_attached`, added a contract-lock unit test that pins the constant value.
- `crates/librefang-api/dashboard/src/pages/TerminalPage.tsx` — added `FAST_EXIT_WINDOW_MS` / `MAX_CONSECUTIVE_FAST_FAILS` constants, three refs (`startedAtRef`, `connectionFastFailRef`, `consecutiveFastFailRef`), giveup branch in the `onclose` handler, `manualConnect` wrapper that resets both ceilings.
- `crates/librefang-api/dashboard/src/pages/TerminalPage.test.tsx` — extended `useUIStore` mock with `getState`; added a vitest case that simulates two consecutive fast-failed launches and asserts (a) no third WebSocket is opened and (b) the `terminal.fast_exit_giveup` error renders.
- `crates/librefang-api/dashboard/src/locales/{en,zh}.json` — `terminal.fast_exit_giveup` string.

## Test plan

- [x] `cargo check -p librefang-api --lib` — clean.
- [x] `cargo clippy -p librefang-api --lib --tests -- -D warnings` — clean.
- [x] `cargo test -p librefang-api --lib terminal::tests::` — 31/31 pass, including new `terminal_term_is_xterm_256color` contract-lock.
- [x] `pnpm typecheck` (dashboard) — clean.
- [x] `pnpm test --run` (dashboard) — 558/558 pass, including new `stops auto-reconnect after consecutive fast-failed launches (#4675)`.
- [x] `pnpm build` (dashboard) — clean.
- [ ] Manual smoke on a daemon launched without a TTY (docker `CMD`, systemd) — terminal page should connect, tmux should stay alive, no reconnect loop. (Requires the `start` daemon path the AI-side hooks block; reporter or a maintainer to confirm post-merge.)
