### PR TITLE
fix(dashboard/ui): close DrawerPanel on parent-driven isOpen=false (#4687)

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import { DrawerPanel } from "./DrawerPanel";
+import { useDrawerStore } from "../../lib/drawerStore";
+
+describe("DrawerPanel", () => {
+  beforeEach(() => {
+    // Reset the global drawer slot between tests so cross-test state
+    // can't leak (the store is a singleton).
+    useDrawerStore.setState({ isOpen: false, content: null });
+  });
+
+  it("pushes content into the global drawer store while isOpen is true", () => {
+    render(
+      <DrawerPanel isOpen={true} onClose={() => {}} title="Create agent">
+        <p>body</p>
+      </DrawerPanel>,
+    );
+    const state = useDrawerStore.getState();
+    expect(state.isOpen).toBe(true);
+    expect(state.content?.title).toBe("Create agent");
+  });
+
+  // Regression test for #4687: when the parent flips `isOpen` from true →
+  // false (e.g. the create-agent mutation `onSuccess` calls
+  // `setShowCreate(false)`, or the user clicks a Cancel button bound to
+  // the same setter), the drawer must close. Before the fix, only Esc /
+  // X / mobile backdrop / unmount could collapse the global slot, so
+  // programmatic dismissals silently no-op'd and the form stayed visible
+  // with a perpetually spinning submit button.
+  it("closes the global drawer store when the parent flips isOpen from true to false", () => {
+    const { rerender } = render(
+      <DrawerPanel isOpen={true} onClose={() => {}}>
+        <p>body</p>
+      </DrawerPanel>,
+    );
+    expect(useDrawerStore.getState().isOpen).toBe(true);
+
+    act(() => {
+      rerender(
+        <DrawerPanel isOpen={false} onClose={() => {}}>
+          <p>body</p>
+        </DrawerPanel>,
+      );
+    });
+
+    expect(useDrawerStore.getState().isOpen).toBe(false);
+  });
+
+  // The parent-driven close path must NOT double-fire `onClose`. The
+  // existing external-close watcher only invokes `onClose` while the
+  // parent still thinks `isOpen=true`; by the time we tear the store
+  // down here, `isOpen` is already false, so the watcher stays quiet.
+  it("does not invoke onClose when the parent itself initiates the close", () => {
+    let calls = 0;
+    const onClose = () => {
+      calls += 1;
+    };
+    const { rerender } = render(
+      <DrawerPanel isOpen={true} onClose={onClose}>
+        <p>body</p>
+      </DrawerPanel>,
+    );
+    act(() => {
+      rerender(
+        <DrawerPanel isOpen={false} onClose={onClose}>
+          <p>body</p>
+        </DrawerPanel>,
+      );
+    });
+    expect(calls).toBe(0);
+  });
+
+  it("bubbles up an external store close (Esc / X / backdrop) to the parent's onClose", () => {
+    let calls = 0;
+    const onClose = () => {
+      calls += 1;
+    };
+    render(
+      <DrawerPanel isOpen={true} onClose={onClose}>
+        <p>body</p>
+      </DrawerPanel>,
+    );
+    expect(useDrawerStore.getState().isOpen).toBe(true);
+
+    act(() => {
+      // Simulate the PushDrawer host calling `store.close()` (e.g.
+      // the user pressed Escape or clicked the X button).
+      useDrawerStore.getState().close();
+    });
+
+    expect(calls).toBe(1);
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
@@ -24,7 +24,11 @@ export interface DrawerPanelProps {
 //      The watcher below detects the external close while we still think
 //      `isOpen=true` and calls `props.onClose()` so the parent flips its
 //      own state. Single source of close-callback firing.
-//   3. Unmount while open → close the store, so a body referencing this
+//   3. Parent-driven close: when the parent flips `isOpen` from true →
+//      false (mutation `onSuccess`, Cancel button, etc.) we tear the
+//      store back down ourselves; otherwise the global slot stays
+//      mounted and the drawer never disappears (#4687).
+//   4. Unmount while open → close the store, so a body referencing this
 //      page's local state never lingers in the global slot.
 export function DrawerPanel({
   isOpen,
@@ -57,6 +61,26 @@ export function DrawerPanel({
       onClose: () => onCloseRef.current(),
     });
   }, [isOpen, title, size, hideCloseButton, children, open]);
+
+  // Parent-driven close: when the parent flips `isOpen` from true → false
+  // (e.g. after a successful mutation in `onSuccess`, or when the Cancel
+  // button calls `setOpen(false)`), tear the store back down so the
+  // global drawer slot collapses. Without this, only Esc / X / mobile
+  // backdrop / unmount could close the drawer — programmatic
+  // dismissals from the parent silently no-op'd, leaving the form
+  // visible with a perpetually spinning submit button (#4687).
+  //
+  // The watcher above guards on `isOpen && wasOpen && !drawerOpen` and
+  // therefore won't double-fire `onClose` on this path: by the time the
+  // store flip lands, `isOpen` is already false.
+  const prevIsOpenRef = useRef(isOpen);
+  useEffect(() => {
+    const wasOpen = prevIsOpenRef.current;
+    prevIsOpenRef.current = isOpen;
+    if (wasOpen && !isOpen && drawerOpen) {
+      close();
+    }
+  }, [isOpen, drawerOpen, close]);
 
   // External close → bubble up to the parent so it can flip its state.
   // Only fires on a real `true → false` transition. On first mount the


### PR DESCRIPTION
Closes #4687.

## Summary

The agent creation flow renders its form into a `DrawerPanel`, which pushes content into a global drawer slot via `useDrawerStore`. The component already handled external closes (Esc / X / mobile backdrop) by bubbling up to `onClose`, but had no path back the other way: when the parent flipped `isOpen` from `true` to `false` — which happens on every successful create-agent mutation (`onSuccess` calls `setShowCreate(false)`) and every Cancel button click bound to the same setter — the watcher only re-pushed the existing content with `open: false` on the next render. The store had already been opened by the previous render with `open: true`, so the slot stayed visible. The submit button kept its loading prop because the form was still mounted, exactly matching the reporter's screenshot.

## Fix

Add a one-shot watcher in `DrawerPanel` that detects parent-driven `true → false` transitions (`prevIsOpenRef`) and tears the store down via `close()`. The new effect:

- Guards on `drawerOpen` so it does not fight the external-close path.
- Lets the existing external-close watcher's `wasOpen && !drawerOpen` guard naturally suppress double-`onClose` firing on this path: by the time the store flip lands, `isOpen` is already `false` so the external watcher stays quiet.
- Touches no other surface — the fix is in the shared `DrawerPanel` so every drawer-using page (agent create, agent edit, etc.) inherits the correct behavior.

## Tests

`DrawerPanel.test.tsx` (new) — four cases:

1. push-on-open — store reflects open content.
2. **parent-flip-close** — regression for #4687: parent flipping `isOpen` from `true → false` collapses the global slot.
3. no-double-onClose — the parent-flip path does NOT call `onClose` (the parent already knows).
4. external-close-bubble — Esc / X / backdrop still call `onClose` so the parent can flip its state.

## Verification

- `pnpm build` — green.
- `pnpm typecheck` — same pre-existing TS errors as on `origin/main` (`router.tsx` JSX intrinsics, `setupTests.ts` global) — out-of-scope and not introduced by this change.

## Out-of-scope follow-ups

- The dashboard `pnpm typecheck` is broken on `origin/main` (`@tanstack/react-router` augmentation + `setupTests.ts` `global` resolution). Worth a separate fix; this PR does not touch it.