### PR TITLE
fix(runtime-mcp): expand leading ~ in stdio transport args (#4680)

### DIFF
--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -1088,9 +1088,15 @@ impl McpConnection {
         // Expand environment variable references ($VAR, ${VAR}) in args so
         // templates can use e.g. "$HOME" without wrapping in `sh -c`.
         // Expansion is restricted to the allowlist above. (#3823)
+        // Then expand a leading tilde (`~` or `~/...`) to the user's home
+        // directory so user-edited args using shell-style paths work too.
+        // Tilde expansion runs after env-var expansion so it has the final
+        // word — e.g. an arg of `$UNSET/sub` is left as `$UNSET/sub` and is
+        // not silently treated as a tilde. (#4680)
         let args_owned: Vec<String> = args
             .iter()
             .map(|a| expand_env_vars(a, &expand_allowlist))
+            .map(|a| expand_leading_tilde(&a))
             .collect();
         let env_owned: Vec<String> = extra_env.to_vec();
 
@@ -2516,6 +2522,37 @@ fn expand_env_vars(input: &str, allowed_vars: &std::collections::HashSet<String>
         }
     }
     result
+}
+
+/// Expand a leading tilde (`~` or `~/...` / `~\...`) to the user's home
+/// directory.
+///
+/// Embedded tildes (`foo~bar`), tilde-user (`~alice/...`), and strings whose
+/// first segment is already a literal path are left unchanged. Returns the
+/// input unchanged if neither `HOME` nor `USERPROFILE` is set, so the caller
+/// surfaces the original arg in the spawn error rather than silently
+/// substituting the wrong path. (#4680)
+fn expand_leading_tilde(input: &str) -> String {
+    if input == "~" {
+        return std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_else(|_| input.to_string());
+    }
+    let rest = if let Some(r) = input.strip_prefix("~/") {
+        r
+    } else if let Some(r) = input.strip_prefix("~\\") {
+        r
+    } else {
+        return input.to_string();
+    };
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_default();
+    if home.is_empty() {
+        return input.to_string();
+    }
+    let trimmed = home.trim_end_matches(['/', '\\']);
+    format!("{trimmed}/{rest}")
 }
 
 #[cfg(test)]
@@ -3984,6 +4021,56 @@ mod tests {
         let result = expand_env_vars("$_TEST_UNSET_DECLARED/bin", &allowed);
         // Must keep the original token, not substitute empty string or panic.
         assert_eq!(result, "$_TEST_UNSET_DECLARED/bin");
+    }
+
+    // ── expand_leading_tilde tests (#4680) ────────────────────────────────
+
+    #[test]
+    fn test_expand_leading_tilde_alone() {
+        std::env::set_var("HOME", "/Users/alice");
+        assert_eq!(expand_leading_tilde("~"), "/Users/alice");
+    }
+
+    #[test]
+    fn test_expand_leading_tilde_with_subpath() {
+        std::env::set_var("HOME", "/Users/alice");
+        assert_eq!(
+            expand_leading_tilde("~/work/repo"),
+            "/Users/alice/work/repo"
+        );
+    }
+
+    #[test]
+    fn test_expand_leading_tilde_strips_trailing_separators_in_home() {
+        // Defends against double-slash if HOME ends with `/`.
+        std::env::set_var("HOME", "/Users/alice/");
+        assert_eq!(expand_leading_tilde("~/work"), "/Users/alice/work");
+    }
+
+    #[test]
+    fn test_expand_leading_tilde_does_not_expand_embedded() {
+        std::env::set_var("HOME", "/Users/alice");
+        assert_eq!(expand_leading_tilde("/tmp/~foo"), "/tmp/~foo");
+        assert_eq!(expand_leading_tilde("foo~"), "foo~");
+    }
+
+    #[test]
+    fn test_expand_leading_tilde_does_not_expand_tilde_user() {
+        // `~bob/...` is shell tilde-user expansion which we intentionally do
+        // not support — leave the literal alone so the spawn surfaces the
+        // real path in any downstream error.
+        std::env::set_var("HOME", "/Users/alice");
+        assert_eq!(expand_leading_tilde("~bob/work"), "~bob/work");
+    }
+
+    #[test]
+    fn test_expand_leading_tilde_plain_string_unchanged() {
+        std::env::set_var("HOME", "/Users/alice");
+        assert_eq!(expand_leading_tilde("/usr/local/bin"), "/usr/local/bin");
+        assert_eq!(
+            expand_leading_tilde("@scope/pkg@latest"),
+            "@scope/pkg@latest"
+        );
     }
 
     // ── read_response_bytes_capped tests (#3801) ──────────────────────────


### PR DESCRIPTION
Closes #4680.

## Summary

The filesystem MCP template (and any npx-style template that wants a portable home reference) emits `\$HOME` or `~` in its `args`. `\$HOME` expansion has worked since #3823 via the env-var allowlist on the stdio spawn boundary, but a leading **tilde** was passed through verbatim — the spawned `npx` process saw `\"~\"` as a literal directory name and failed to mount the user's home as the filesystem root. That is the symptom the reporter hit on a freshly-installed filesystem MCP server.

## Fix

Add `expand_leading_tilde`, applied **after** `expand_env_vars` in `McpConnection`'s stdio spawn path. Scope is intentionally narrow:

- Only the leading position is expanded — `~` alone or `~/...` / `~\\...`. Embedded tildes (`/tmp/~foo`, `foo~`) and tilde-user form (`~bob/...`) are **left untouched** so the spawn surfaces the literal in any downstream error rather than silently substituting the current user's home for someone else's path.
- `HOME` is consulted first, `USERPROFILE` second (Windows). If neither is set the **original arg is returned unchanged** so the spawn fails loudly with the actual literal in the error message — better than silently materializing an empty path.
- Trailing separators in `HOME` are trimmed before joining, so a `HOME` like `\"/Users/alice/\"` does not produce `\"/Users/alice//work\"`.

## Tests

`crates/librefang-runtime-mcp/src/lib.rs` — six new unit tests under `tests`:

- `test_expand_leading_tilde_alone` — `~` → `\$HOME`.
- `test_expand_leading_tilde_with_subpath` — `~/work/repo` → `\$HOME/work/repo`.
- `test_expand_leading_tilde_strips_trailing_separators_in_home` — defends against the `//` join.
- `test_expand_leading_tilde_does_not_expand_embedded` — `/tmp/~foo` and `foo~` pass through.
- `test_expand_leading_tilde_does_not_expand_tilde_user` — `~bob/work` passes through.
- `test_expand_leading_tilde_plain_string_unchanged` — `/usr/local/bin` and `@scope/pkg@latest` pass through.

## Verification

- `cargo check -p librefang-runtime-mcp` — green.
- `cargo clippy -p librefang-runtime-mcp --all-targets -- -D warnings` — green.
- `cargo test -p librefang-runtime-mcp expand_leading_tilde` — 6 passed.

## Out-of-scope follow-ups

- HTTP-transport headers / URLs go through a different path and are not changed here. If the same `~` issue surfaces on a non-stdio transport we can lift the helper to a shared utility.
- Daytona / SSH backends in #3332 will need the same expansion when they spawn — once that PR lands, fold the call into the shared spawn helper.