### PR TITLE
ci(main-build-alert): include PR number, failed jobs, and step names

### DIFF
--- a/.github/workflows/main-build-alert.yml
+++ b/.github/workflows/main-build-alert.yml
@@ -83,14 +83,99 @@ jobs:
               return; // skipped/neutral/etc — nothing to do
             }
 
-            const body = [
-              `Main CI **${conclusion}** on commit ${shortSha}.`,
-              ``,
-              `Run: ${runUrl}`,
-              ``,
-              `Every open PR will inherit this failure on its next CI run.`,
-              `Either land a fix (preferred) or revert the offending merge.`,
-            ].join('\n');
+            // ── Resolve the PR that introduced the breakage ──────────────
+            // The merge commit subject conventionally ends in `(#NNNN)`.
+            // Falling back to the listPullRequestsAssociatedWithCommit API
+            // covers squash-merges that ship without the PR suffix in the
+            // subject. Best-effort — title/body still readable if both fail.
+            let prNumber = null;
+            let commitSubject = '';
+            let commitAuthor = '';
+            try {
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: headSha,
+              });
+              commitSubject = (commit.commit.message || '').split('\n')[0];
+              commitAuthor = commit.author?.login || commit.commit.author?.name || '';
+              const m = commitSubject.match(/\(#(\d+)\)\s*$/);
+              if (m) {
+                prNumber = parseInt(m[1], 10);
+              } else {
+                const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: headSha,
+                });
+                if (prs.length > 0) prNumber = prs[0].number;
+              }
+            } catch (e) {
+              core.warning(`Could not resolve commit metadata for ${shortSha}: ${e.message}`);
+            }
+
+            // ── Enumerate failing jobs (with the failing step's name) ────
+            const failedJobs = [];
+            try {
+              const jobs = await github.paginate(
+                github.rest.actions.listJobsForWorkflowRun,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: context.payload.workflow_run.id,
+                  per_page: 100,
+                }
+              );
+              for (const job of jobs) {
+                if (job.conclusion === 'failure' || job.conclusion === 'timed_out' || job.conclusion === 'cancelled') {
+                  const failedStep = (job.steps || []).find(s => s.conclusion === 'failure' || s.conclusion === 'timed_out');
+                  failedJobs.push({
+                    name: job.name,
+                    conclusion: job.conclusion,
+                    step: failedStep ? failedStep.name : null,
+                    url: job.html_url,
+                  });
+                }
+              }
+            } catch (e) {
+              core.warning(`Could not enumerate failing jobs: ${e.message}`);
+            }
+
+            // ── Build the issue body ─────────────────────────────────────
+            const cleanSubject = commitSubject.replace(/\s*\(#\d+\)\s*$/, '');
+            const lines = [];
+            if (prNumber) {
+              const subj = cleanSubject ? ` — ${cleanSubject}` : '';
+              const by = commitAuthor ? ` by @${commitAuthor}` : '';
+              lines.push(`Main CI **${conclusion}** on PR #${prNumber}${subj}${by} (commit ${shortSha}).`);
+            } else {
+              const subj = cleanSubject ? ` — ${cleanSubject}` : '';
+              const by = commitAuthor ? ` by @${commitAuthor}` : '';
+              lines.push(`Main CI **${conclusion}** on commit ${shortSha}${subj}${by}.`);
+            }
+            lines.push('');
+            lines.push(`Run: ${runUrl}`);
+            lines.push('');
+
+            if (failedJobs.length > 0) {
+              lines.push(`**Failed jobs** (${failedJobs.length}):`);
+              for (const j of failedJobs) {
+                const stepSuffix = j.step ? ` — failed at step \`${j.step}\`` : '';
+                lines.push(`- [${j.name}](${j.url}) (${j.conclusion})${stepSuffix}`);
+              }
+              lines.push('');
+            }
+
+            lines.push(`Every open PR will inherit this failure on its next CI run.`);
+            if (prNumber) {
+              lines.push(`Either land a fix (preferred) or revert PR #${prNumber}.`);
+            } else {
+              lines.push(`Either land a fix (preferred) or revert the offending merge.`);
+            }
+
+            const body = lines.join('\n');
+            const titleSuffix = prNumber ? `PR #${prNumber}` : `${shortSha}`;
+            const title = `[main red] CI ${conclusion} on ${titleSuffix}`;
 
             if (open.length > 0) {
               await github.rest.issues.createComment({
@@ -103,7 +188,7 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `[main red] CI ${conclusion} on ${shortSha}`,
+                title,
                 body,
                 labels: [label],
               });


### PR DESCRIPTION
Refs #4690.

## Why

Open main-red issues only carried the run URL and the head SHA. To investigate a breakage, a maintainer had to:

1. Click into GitHub Actions, find the failing matrix entry.
2. Click into each red job, scroll until the failing step.
3. Run \`git log <sha>\` locally (or click around in GitHub) to find the PR that introduced it.

Issue #4690 itself is the receipt: \`Main CI **failure** on commit ef24ef9. Run: …\` — no PR number, no failing-job names, no step names. Maintainer-hostile.

## What changed

\`.github/workflows/main-build-alert.yml\` (\`actions/github-script\`):

- **Resolve the PR**: parse the conventional \`(#NNNN)\` suffix from the merge commit subject, falling back to \`listPullRequestsAssociatedWithCommit\` for squash-merges that lose the suffix. Surface \`#NNNN\`, the cleaned-up subject, and the commit author handle in both the title and the lead line.
- **Enumerate failing jobs**: page through \`listJobsForWorkflowRun\` and surface every red/timed-out/cancelled job with a clickable link to its log AND the failing step's name. No more matrix-scrolling.
- **Title**: leads with \`PR #NNNN\` instead of the head SHA when we can resolve the PR — far more readable in the issue list.

Both lookups are best-effort. If either API call fails (\`core.warning\` is logged), we fall back to the SHA-only form so a transient API hiccup never silently drops the alert.

## Sample (what the next main-red issue would have looked like)

> **Title:** \`[main red] CI failure on PR #4688\`
>
> Main CI **failure** on PR #4688 — chore: bump version to v2026.5.6-beta.9 by @evan (commit ef24ef9).
>
> Run: …
>
> **Failed jobs** (2):
> - [OpenAPI Drift](…) (failure) — failed at step \`Verify no drift\`
> - [Test / Windows](…) (failure) — failed at step \`Run integration tests\`
>
> Every open PR will inherit this failure on its next CI run.
> Either land a fix (preferred) or revert PR #4688.

vs. the current body:

> Main CI **failure** on commit ef24ef9.
> Run: …
> Either land a fix (preferred) or revert the offending merge.

## Verification

- Workflow YAML syntax validated by GitHub on push (will surface in workflow_run UI).
- Logic-level: \`listJobsForWorkflowRun\` and \`listPullRequestsAssociatedWithCommit\` are both standard \`@octokit\` REST endpoints already used elsewhere in the repo.
- Cannot end-to-end test without a real main-red event; the fallbacks ensure the worst case is "behaves the same as today".

## Out-of-scope

- Surfacing a tail of the failing log inside the issue body — would balloon the issue size and risks leaking secrets that GitHub already redacts only at log-view time. The job link is one click away.
- Auto-pinging the PR author — separate change; some authors opt out of mentions.