### PR TITLE
fix(skills): hub install/uninstall surface stale state across all 4 hubs (#4689)

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx
@@ -3,7 +3,15 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useCompleteExperiment } from "./agents";
 import { useSetSessionLabel } from "./sessions";
 import { useInstallSkill } from "./skills";
-import { agentKeys, sessionKeys, skillKeys, fanghubKeys } from "../queries/keys";
+import {
+  agentKeys,
+  sessionKeys,
+  skillKeys,
+  fanghubKeys,
+  clawhubKeys,
+  clawhubCnKeys,
+  skillhubKeys,
+} from "../queries/keys";
 import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../http/client", async () => {
@@ -94,7 +102,18 @@ describe("useSetSessionLabel", () => {
 });
 
 describe("useInstallSkill", () => {
-  it("invalidates skillKeys.all and fanghubKeys.all", async () => {
+  // #4689 — skill install must invalidate every hub surface so the per-hub
+  // browse buttons (FangHub / SkillHub / ClawHub / ClawHub-CN) flip to
+  // "Installed" without waiting for the next refetchInterval.
+  const ALL_SKILL_SURFACE_KEYS = [
+    skillKeys.all,
+    fanghubKeys.all,
+    clawhubKeys.all,
+    clawhubCnKeys.all,
+    skillhubKeys.all,
+  ] as const;
+
+  it("invalidates every skill surface", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -105,17 +124,14 @@ describe("useInstallSkill", () => {
     await result.current.mutateAsync({ name: "test-skill" });
 
     await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+      expect(invalidateSpy).toHaveBeenCalledTimes(ALL_SKILL_SURFACE_KEYS.length);
     });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: skillKeys.all,
-    });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: fanghubKeys.all,
-    });
+    for (const key of ALL_SKILL_SURFACE_KEYS) {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: key });
+    }
   });
 
-  it("invalidates skillKeys.all and fanghubKeys.all with hand parameter", async () => {
+  it("invalidates every skill surface with hand parameter", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -126,13 +142,10 @@ describe("useInstallSkill", () => {
     await result.current.mutateAsync({ name: "test-skill", hand: "test-hand" });
 
     await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+      expect(invalidateSpy).toHaveBeenCalledTimes(ALL_SKILL_SURFACE_KEYS.length);
     });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: skillKeys.all,
-    });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: fanghubKeys.all,
-    });
+    for (const key of ALL_SKILL_SURFACE_KEYS) {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: key });
+    }
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx
@@ -13,9 +13,20 @@ import {
   useFangHubInstall,
   useUninstallSkill,
   useClawHubInstall,
+  useClawHubCnInstall,
   useSkillHubInstall,
+  useReloadSkills,
 } from "./skills";
-import { runtimeKeys, overviewKeys, skillKeys, fanghubKeys, sessionKeys } from "../queries/keys";
+import {
+  runtimeKeys,
+  overviewKeys,
+  skillKeys,
+  fanghubKeys,
+  clawhubKeys,
+  clawhubCnKeys,
+  skillhubKeys,
+  sessionKeys,
+} from "../queries/keys";
 import { createQueryClientWrapper } from "../test/query-client";
 
 vi.mock("../../api", () => ({
@@ -31,9 +42,35 @@ vi.mock("../../api", () => ({
 vi.mock("../http/client", () => ({
   installSkill: vi.fn().mockResolvedValue({ status: "ok" }),
   clawhubInstall: vi.fn().mockResolvedValue({ status: "ok" }),
+  clawhubCnInstall: vi.fn().mockResolvedValue({ status: "ok" }),
   skillhubInstall: vi.fn().mockResolvedValue({ status: "ok" }),
   uninstallSkill: vi.fn().mockResolvedValue({ status: "ok" }),
+  reloadSkills: vi.fn().mockResolvedValue({ status: "ok" }),
+  createSkill: vi.fn().mockResolvedValue({ status: "ok" }),
+  evolveUpdateSkill: vi.fn().mockResolvedValue({ status: "ok" }),
+  evolvePatchSkill: vi.fn().mockResolvedValue({ status: "ok" }),
+  evolveRollbackSkill: vi.fn().mockResolvedValue({ status: "ok" }),
+  evolveDeleteSkill: vi.fn().mockResolvedValue({ status: "ok" }),
+  evolveWriteFile: vi.fn().mockResolvedValue({ status: "ok" }),
+  evolveRemoveFile: vi.fn().mockResolvedValue({ status: "ok" }),
 }));
+
+// Every install / uninstall / reload mutation must invalidate every hub
+// surface — see #4689. Keep this list in sync with
+// `invalidateAllSkillSurfaces` in mutations/skills.ts.
+const ALL_SKILL_SURFACE_KEYS = [
+  skillKeys.all,
+  fanghubKeys.all,
+  clawhubKeys.all,
+  clawhubCnKeys.all,
+  skillhubKeys.all,
+] as const;
+
+function expectAllSurfacesInvalidated(spy: ReturnType<typeof vi.spyOn>) {
+  for (const key of ALL_SKILL_SURFACE_KEYS) {
+    expect(spy).toHaveBeenCalledWith({ queryKey: key });
+  }
+}
 
 describe("useRestoreBackup", () => {
   it("invalidates runtimeKeys.backups() and overviewKeys.snapshot()", async () => {
@@ -57,7 +94,7 @@ describe("useRestoreBackup", () => {
 });
 
 describe("useFangHubInstall", () => {
-  it("invalidates skillKeys.all and fanghubKeys.all", async () => {
+  it("invalidates every skill surface (#4689)", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -68,15 +105,10 @@ describe("useFangHubInstall", () => {
       expect(invalidateSpy).toHaveBeenCalled();
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: skillKeys.all,
-    });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: fanghubKeys.all,
-    });
+    expectAllSurfacesInvalidated(invalidateSpy);
   });
 
-  it("invalidates skillKeys.all and fanghubKeys.all with hand parameter", async () => {
+  it("invalidates every skill surface with hand parameter", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -87,12 +119,7 @@ describe("useFangHubInstall", () => {
       expect(invalidateSpy).toHaveBeenCalled();
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: skillKeys.all,
-    });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: fanghubKeys.all,
-    });
+    expectAllSurfacesInvalidated(invalidateSpy);
   });
 });
 
@@ -194,7 +221,7 @@ describe("useShutdownServer", () => {
 });
 
 describe("useUninstallSkill", () => {
-  it("invalidates skillKeys.all", async () => {
+  it("invalidates every skill surface (#4689)", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -205,14 +232,12 @@ describe("useUninstallSkill", () => {
       expect(invalidateSpy).toHaveBeenCalled();
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: skillKeys.all,
-    });
+    expectAllSurfacesInvalidated(invalidateSpy);
   });
 });
 
 describe("useClawHubInstall", () => {
-  it("invalidates skillKeys.all", async () => {
+  it("invalidates every skill surface (#4689)", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -223,14 +248,28 @@ describe("useClawHubInstall", () => {
       expect(invalidateSpy).toHaveBeenCalled();
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: skillKeys.all,
+    expectAllSurfacesInvalidated(invalidateSpy);
+  });
+});
+
+describe("useClawHubCnInstall", () => {
+  it("invalidates every skill surface (#4689)", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useClawHubCnInstall(), { wrapper });
+
+    result.current.mutate({ slug: "test-skill", version: "1.0.0" });
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
     });
+
+    expectAllSurfacesInvalidated(invalidateSpy);
   });
 });
 
 describe("useSkillHubInstall", () => {
-  it("invalidates skillKeys.all", async () => {
+  it("invalidates every skill surface (#4689)", async () => {
     const { queryClient, wrapper } = createQueryClientWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -241,8 +280,22 @@ describe("useSkillHubInstall", () => {
       expect(invalidateSpy).toHaveBeenCalled();
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: skillKeys.all,
+    expectAllSurfacesInvalidated(invalidateSpy);
+  });
+});
+
+describe("useReloadSkills", () => {
+  it("invalidates every skill surface (#4689)", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useReloadSkills(), { wrapper });
+
+    result.current.mutate();
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalled();
     });
+
+    expectAllSurfacesInvalidated(invalidateSpy);
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/mutations/skills.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/skills.ts
@@ -14,17 +14,35 @@ import {
   evolveWriteFile,
   evolveRemoveFile,
 } from "../http/client";
-import { skillKeys, fanghubKeys } from "../queries/keys";
+import {
+  skillKeys,
+  fanghubKeys,
+  clawhubKeys,
+  clawhubCnKeys,
+  skillhubKeys,
+} from "../queries/keys";
+
+// Install/uninstall flips `is_installed` on every hub's browse / search /
+// detail responses (the daemon computes it from the local skills directory),
+// so any successful mutation must invalidate _all_ hub query domains in
+// addition to the installed-skills list. Otherwise the source-of-skill grid
+// keeps showing stale "Install" buttons until the next refetchInterval — see
+// #4689 (FangHub Installed-tab gap, SkillHub / ClawHub / ClawHub-CN button
+// not flipping post-install).
+function invalidateAllSkillSurfaces(qc: ReturnType<typeof useQueryClient>) {
+  qc.invalidateQueries({ queryKey: skillKeys.all });
+  qc.invalidateQueries({ queryKey: fanghubKeys.all });
+  qc.invalidateQueries({ queryKey: clawhubKeys.all });
+  qc.invalidateQueries({ queryKey: clawhubCnKeys.all });
+  qc.invalidateQueries({ queryKey: skillhubKeys.all });
+}
 
 export function useInstallSkill() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ name, hand }: { name: string; hand?: string }) =>
       installSkill(name, hand),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: skillKeys.all });
-      qc.invalidateQueries({ queryKey: fanghubKeys.all });
-    },
+    onSuccess: () => invalidateAllSkillSurfaces(qc),
   });
 }
 
@@ -32,7 +50,7 @@ export function useUninstallSkill() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: uninstallSkill,
-    onSuccess: () => qc.invalidateQueries({ queryKey: skillKeys.all }),
+    onSuccess: () => invalidateAllSkillSurfaces(qc),
   });
 }
 
@@ -41,7 +59,7 @@ export function useClawHubInstall() {
   return useMutation({
     mutationFn: ({ slug, version, hand }: { slug: string; version?: string; hand?: string }) =>
       clawhubInstall(slug, version, hand),
-    onSuccess: () => qc.invalidateQueries({ queryKey: skillKeys.all }),
+    onSuccess: () => invalidateAllSkillSurfaces(qc),
   });
 }
 
@@ -50,7 +68,7 @@ export function useClawHubCnInstall() {
   return useMutation({
     mutationFn: ({ slug, version, hand }: { slug: string; version?: string; hand?: string }) =>
       clawhubCnInstall(slug, version, hand),
-    onSuccess: () => qc.invalidateQueries({ queryKey: skillKeys.all }),
+    onSuccess: () => invalidateAllSkillSurfaces(qc),
   });
 }
 
@@ -59,7 +77,7 @@ export function useSkillHubInstall() {
   return useMutation({
     mutationFn: ({ slug, hand }: { slug: string; hand?: string }) =>
       skillhubInstall(slug, hand),
-    onSuccess: () => qc.invalidateQueries({ queryKey: skillKeys.all }),
+    onSuccess: () => invalidateAllSkillSurfaces(qc),
   });
 }
 
@@ -68,10 +86,7 @@ export function useFangHubInstall() {
   return useMutation({
     mutationFn: ({ name, hand }: { name: string; hand?: string }) =>
       installSkill(name, hand),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: skillKeys.all });
-      qc.invalidateQueries({ queryKey: fanghubKeys.all });
-    },
+    onSuccess: () => invalidateAllSkillSurfaces(qc),
   });
 }
 
@@ -97,7 +112,9 @@ export function useReloadSkills() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: reloadSkills,
-    onSuccess: () => qc.invalidateQueries({ queryKey: skillKeys.all }),
+    // Reload re-reads every skill manifest from disk; any hub's browse cache
+    // could now show a different `is_installed`, so invalidate every surface.
+    onSuccess: () => invalidateAllSkillSurfaces(qc),
   });
 }
 

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -1567,9 +1567,30 @@ export function SkillsPage() {
         src === "clawhub" || src === "clawhub-cn"
           ? ["clawhub", "clawhub-cn"]
           : [src];
-      return installedSkills.some(
-        (s) => matchTypes.includes(s.source?.type ?? "") && s.source?.slug === slug,
-      );
+      return installedSkills.some((s) => {
+        const sourceType = s.source?.type ?? "";
+        const sourceSlug = s.source?.slug;
+        if (matchTypes.includes(sourceType) && sourceSlug === slug) {
+          return true;
+        }
+        // #4689 fallback — some install paths (notably the FangHub registry
+        // copy and historical ClawHub installs that pre-date provenance
+        // patching) leave `manifest.source` either unset or set to "local",
+        // which makes the strict (type, slug) match miss freshly installed
+        // skills. Falling back to a name match against the slug is conservative
+        // because skill names and hub slugs share a kebab-case namespace and
+        // collisions across hubs are rare; the user-visible cost of a false
+        // positive (button shows "Installed" when it isn't) is far smaller
+        // than the false negative the issue reports (button stays clickable
+        // and re-clicking 409s with "already installed").
+        if (
+          (sourceType === "" || sourceType === "local") &&
+          s.name === slug
+        ) {
+          return true;
+        }
+        return false;
+      });
     },
     [installedSkills],
   );

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -1023,6 +1023,64 @@ pub async fn clawhub_install(
 
     match client.install(&req.slug, &skills_dir).await {
         Ok(result) => {
+            // #4689 — patch source provenance to ClawHub. Without this, the
+            // installed skill's manifest.source stays None and `listSkills()`
+            // surfaces it as `source.type = "local"`, which makes the
+            // dashboard's per-hub `isInstalledFromMarketplace("clawhub", slug)`
+            // check miss the freshly installed skill — the hub's "Install"
+            // button keeps showing as clickable until the user reloads. The
+            // ClawHubCn handler already does this; bringing ClawHub in line.
+            let skill_dir = skills_dir.join(&req.slug);
+            let manifest_path = skill_dir.join("skill.toml");
+            if manifest_path.exists() {
+                match std::fs::read_to_string(&manifest_path) {
+                    Ok(toml_str) => {
+                        match toml::from_str::<librefang_skills::SkillManifest>(&toml_str) {
+                            Ok(mut manifest) => {
+                                manifest.source = Some(librefang_skills::SkillSource::ClawHub {
+                                    slug: req.slug.clone(),
+                                    version: result.version.clone(),
+                                });
+                                match toml::to_string_pretty(&manifest) {
+                                    Ok(updated) => {
+                                        if let Err(e) = std::fs::write(&manifest_path, updated) {
+                                            tracing::warn!(
+                                                slug = %req.slug,
+                                                path = %manifest_path.display(),
+                                                "Failed to write provenance to skill.toml: {e}"
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            slug = %req.slug,
+                                            "Failed to serialize skill manifest for provenance patch: {e}"
+                                        );
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    slug = %req.slug,
+                                    "Failed to parse skill.toml for provenance patch: {e}"
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            slug = %req.slug,
+                            path = %manifest_path.display(),
+                            "Failed to read skill.toml for provenance patch: {e}"
+                        );
+                    }
+                }
+            }
+
+            // Reload so the kernel sees the patched provenance immediately —
+            // mirrors what reload_skills() does for the FangHub install path.
+            state.kernel.reload_skills();
+
             let warnings: Vec<serde_json::Value> = result
                 .warnings
                 .iter()


### PR DESCRIPTION
Closes #4689.

## Background

The dashboard exposes four skill sources — FangHub, SkillHub, ClawHub, ClawHub-CN. Each one renders an Install button that flips to "Installed" when the local installed-skills list contains a matching \`(source.type, source.slug)\` pair. Issue #4689 reports four overlapping symptoms that all reduce to two independent root causes:

| # | Hub | Symptom |
|---|---|---|
| 1 | FangHub | Install succeeds, Installed tab stays empty |
| 2 | SkillHub | Install popup says success, button stays clickable, re-click 409s |
| 3 | ClawHub | Same as SkillHub from the grid; detail card dims correctly |
| 4 | ClawHub-CN | Identical to SkillHub |

## Root causes

**A. Cache invalidation gap (frontend).** Every install / uninstall mutation \`onSuccess\` invalidated only \`skillKeys.all\` and (FangHub specifically) \`fanghubKeys.all\`. The four hubs each have their own browse / search / detail query domain, and \`is_installed\` is computed daemon-side from the local skills directory — so a successful install flips the answer for **every** hub's listing, not just the one the user came in through. After the mutation resolved, the originating hub's grid kept the stale \`is_installed: false\` until the next \`refetchInterval\` fired. Same shape for uninstall in reverse.

**B. Provenance gap (backend).** FangHub and ClawHub-CN tag the installed manifest's \`source = SkillSource::FangHub / ClawHubCn\` so the dashboard can later identify the source. **ClawHub did not** — after install, \`manifest.source\` stayed unset, the daemon serialized it as \`{type: "local"}\`, and \`isInstalledFromMarketplace("clawhub", slug)\` missed the freshly-installed skill on the strict \`(type, slug)\` match. Even after the cache fix, the ClawHub button would have stayed clickable until a different code path re-tagged it.

## Fix

### Frontend mutations (\`crates/librefang-api/dashboard/src/lib/mutations/skills.ts\`)

- Extract \`invalidateAllSkillSurfaces(qc)\` that invalidates every hub query domain plus \`skillKeys.all\`.
- Use it from every install / uninstall / reload mutation. Adding a fifth hub later is one line.

### Frontend SkillsPage (\`crates/librefang-api/dashboard/src/pages/SkillsPage.tsx\`)

- \`isInstalledFromMarketplace\` falls back to a name-vs-slug match when \`manifest.source\` is unset or \`"local"\`. Conservative — skill names and hub slugs share a kebab-case namespace and cross-hub collisions are rare; the user-visible cost of a false positive (button shows "Installed" when it isn't) is far smaller than the false negative the issue reports (button stays clickable, re-click 409s).

### Backend \`clawhub_install\` (\`crates/librefang-api/src/routes/skills.rs\`)

- Patch the installed manifest's \`source = SkillSource::ClawHub{slug, version}\` after a successful install — bringing it in line with the existing \`clawhub_cn_install\` handler.
- Failures during the patch are logged at \`warn!\` and the install still succeeds, so this can never make the install path more brittle than it was.
- \`state.kernel.reload_skills()\` right after the patch, mirroring the FangHub install path so the patched provenance is visible without a daemon restart.

### Tests

- \`crates/librefang-api/dashboard/src/lib/mutations/runtime-skills.test.tsx\` — extended to assert that every install / uninstall mutation invalidates every hub query key.
- \`crates/librefang-api/dashboard/src/lib/mutations/misc-mutations.test.tsx\` — same for reload.

## Verification

- \`cargo check --workspace --lib\` — green.
- \`cargo clippy -p librefang-api --all-targets -- -D warnings\` — green.
- \`cargo test -p librefang-api --lib\` — green.
- \`pnpm build\` (dashboard) — green.

## Out-of-scope

- Symptom #1 (FangHub Installed tab empty) was a special case of root cause A — fixed by the same \`invalidateAllSkillSurfaces\` change. No FangHub-specific code change.
- The 409 "already installed" response from a re-clicked Install button is the correct backend behavior; the bug was that the button reached that state at all.
- Hub slug ↔ skill name disambiguation: the fallback match is intentionally conservative. If real-world collisions surface, a follow-up should add a stronger heuristic (e.g. version-on-disk match) without altering the strict-match path.