### PR TITLE
fix(cli): PID fallback and clearer error when restart hits 401 (#4693)

### DIFF
--- a/crates/librefang-cli/locales/en/main.ftl
+++ b/crates/librefang-cli/locales/en/main.ftl
@@ -28,6 +28,22 @@ daemon-start-fail = Could not start daemon: { $error }
 daemon-start-fail-fix = Start it manually: librefang start
 shutdown-request-fail = Shutdown request failed ({ $status })
 could-not-reach-daemon = Could not reach daemon: { $error }
+# Issue #4693 — after `curl install.sh | sh` upgrades the binary without
+# restarting the running daemon, `librefang restart` (new CLI) hits the old
+# daemon's `/api/shutdown` and is rejected with 401 because the new CLI's
+# Authorization header does not match the old daemon's expected key (typical
+# trigger: locked vault, rotated `[api] api_key`, or freshly enabled
+# dashboard credentials). Surface the cause + auto-fall-back to PID-based
+# shutdown so users can move forward without hand-editing config.
+shutdown-401-detected = Shutdown request was rejected by the running daemon (401 Unauthorized).
+shutdown-401-explainer = The new CLI cannot authenticate against the daemon that is currently running. This usually happens after `curl install.sh | sh` upgrades the binary without restarting the daemon — the running daemon was started with a different api_key, or the vault that holds it could not be unlocked.
+shutdown-401-fallback-attempt = Falling back to a PID-based stop (PID { $pid })...
+shutdown-401-fallback-success = Daemon stopped via PID { $pid }
+shutdown-401-fallback-fail = PID-based stop did not work either.
+shutdown-401-fallback-fix = Stop the daemon manually, then start it again:
+    kill { $pid }    # or: kill -9 { $pid } if it does not exit
+    librefang start
+shutdown-401-no-pid-fix = Could not read the daemon PID from { $path }. Run `ps -ef | grep librefang` to find it, then `kill <pid>` and `librefang start`.
 
 # --- Labels ---
 label-api = API

--- a/crates/librefang-cli/locales/zh-CN/main.ftl
+++ b/crates/librefang-cli/locales/zh-CN/main.ftl
@@ -28,6 +28,19 @@ daemon-start-fail = 无法启动守护进程：{ $error }
 daemon-start-fail-fix = 请手动启动：librefang start
 shutdown-request-fail = 关闭请求失败（{ $status }）
 could-not-reach-daemon = 无法连接守护进程：{ $error }
+# Issue #4693 — `curl install.sh | sh` 升级二进制后没有重启守护进程，
+# 新版 CLI 调用旧守护进程的 /api/shutdown 时因 api_key 不一致而被拒绝
+# (vault 锁定 / 密钥轮换 / 刚启用控制台凭证)。直接说明原因并退回到
+# 基于 PID 的强制停止，让用户不必手动改配置。
+shutdown-401-detected = 关闭请求被运行中的守护进程拒绝（401 Unauthorized）。
+shutdown-401-explainer = 新版 CLI 无法对当前运行的守护进程进行身份认证。这种情况通常发生在 `curl install.sh | sh` 升级二进制后未重启守护进程 —— 旧守护进程使用了不同的 api_key，或保存该 key 的 vault 无法解锁。
+shutdown-401-fallback-attempt = 退回到基于 PID 的停止方式（PID { $pid }）...
+shutdown-401-fallback-success = 已通过 PID { $pid } 停止守护进程
+shutdown-401-fallback-fail = 基于 PID 的停止也失败了。
+shutdown-401-fallback-fix = 请手动停止守护进程，然后重新启动：
+    kill { $pid }    # 或：kill -9 { $pid } 如果没有退出
+    librefang start
+shutdown-401-no-pid-fix = 无法从 { $path } 读取守护进程 PID。请运行 `ps -ef | grep librefang` 找到 PID，然后 `kill <pid>` 并执行 `librefang start`。
 
 # --- Labels ---
 label-api = API

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -3735,6 +3735,48 @@ fn cmd_stop(config: Option<PathBuf>) {
                     }
                     ui::success(&i18n::t("daemon-stopped-forced"));
                 }
+                Ok(r) if r.status().as_u16() == 401 => {
+                    // Issue #4693 — the new CLI cannot authenticate against
+                    // the running daemon. Typical trigger: `curl install.sh
+                    // | sh` upgraded the binary without restarting the
+                    // daemon, so the running daemon was started with an
+                    // api_key the new CLI no longer reads (locked vault,
+                    // rotated key, freshly-enabled dashboard credentials).
+                    // Surface the cause and fall back to PID-based stop so
+                    // the user is not stuck on a half-restarted machine.
+                    ui::error(&i18n::t("shutdown-401-detected"));
+                    ui::hint(&i18n::t("shutdown-401-explainer"));
+                    if let Some(info) = read_daemon_info(&daemon.home_dir) {
+                        let pid = info.pid;
+                        ui::hint(&i18n::t_args(
+                            "shutdown-401-fallback-attempt",
+                            &[("pid", &pid.to_string())],
+                        ));
+                        force_kill_pid(pid);
+                        for _ in 0..10 {
+                            std::thread::sleep(std::time::Duration::from_millis(500));
+                            if find_daemon_in_home(&daemon.home_dir).is_none() {
+                                let _ = std::fs::remove_file(daemon.home_dir.join("daemon.json"));
+                                ui::success(&i18n::t_args(
+                                    "shutdown-401-fallback-success",
+                                    &[("pid", &pid.to_string())],
+                                ));
+                                return;
+                            }
+                        }
+                        ui::error(&i18n::t("shutdown-401-fallback-fail"));
+                        ui::hint(&i18n::t_args(
+                            "shutdown-401-fallback-fix",
+                            &[("pid", &pid.to_string())],
+                        ));
+                    } else {
+                        let info_path = daemon.home_dir.join("daemon.json");
+                        ui::hint(&i18n::t_args(
+                            "shutdown-401-no-pid-fix",
+                            &[("path", &info_path.display().to_string())],
+                        ));
+                    }
+                }
                 Ok(r) => {
                     ui::error(&i18n::t_args(
                         "shutdown-request-fail",


### PR DESCRIPTION
Closes #4693.

## Why

\`curl -fsSL https://librefang.ai/install.sh | sh\` upgrades the CLI/daemon binary in place but does NOT restart the running daemon. When the user follows up with \`librefang restart\`, the new CLI hits the old daemon's \`/api/shutdown\` and is rejected with **401 Unauthorized** — the new CLI's Authorization header doesn't match the daemon's expected \`api_key\`. Typical triggers:

- Locked vault (the issue's stderr literally shows \`Vault locked — unlock with vault key or LIBREFANG_VAULT_KEY env var; skipping vault-provided secrets\`).
- Daemon was started with one \`[api] api_key\` and the new install rotated or rewrote it.
- Dashboard credentials were enabled mid-flight.

The CLI then prints:

\`\`\`
✘ Shutdown request failed (401 Unauthorized)
✘ Daemon already running at http://127.0.0.1:4545
  fix: Use \`librefang status\` to check it, or stop it first
\`\`\`

…which neither identifies the cause nor suggests a path forward — the user is stuck on a half-upgraded machine.

## Fix

\`cmd_stop\` (\`crates/librefang-cli/src/main.rs\`) now special-cases 401 between the existing success and generic-error arms:

1. Surface the cause: one error line (\`shutdown-401-detected\`) + one explainer hint (\`shutdown-401-explainer\`) describing the typical trigger.
2. Fall back to a **PID-based stop** using \`daemon.json\` already on disk (same path as the existing post-success forced-kill fallback at line ~3732). Same wait-and-confirm loop, same final cleanup of \`daemon.json\`.
3. If \`daemon.json\` is missing or unreadable, give the user the diagnostic command + manual recovery steps (\`shutdown-401-no-pid-fix\`) instead of leaving them to grep \`ps -ef\`.

\`cmd_restart\` benefits transparently — it already calls \`cmd_stop\` before re-launching, so the new fallback unblocks the upgrade flow without touching \`cmd_restart\` at all.

## Locale parity

7 new fluent strings added in both \`en\` and \`zh-CN\` with full content parity (per CLAUDE.md i18n rule):

- \`shutdown-401-detected\`
- \`shutdown-401-explainer\`
- \`shutdown-401-fallback-attempt\`
- \`shutdown-401-fallback-success\`
- \`shutdown-401-fallback-fail\`
- \`shutdown-401-fallback-fix\`
- \`shutdown-401-no-pid-fix\`

## Verification

- \`cargo check -p librefang-cli\` — green.
- \`cargo clippy -p librefang-cli --all-targets -- -D warnings\` — green.
- Existing 401 path is now an early branch on \`r.status().as_u16() == 401\`; the generic-error arm is unchanged for any other status.

## Out-of-scope

- A real fix for the underlying api_key drift between CLI and daemon (config-key migration on upgrade) — that's the right long-term answer but a much bigger change. This PR is the unblock-the-user fallback.
- Cross-user PID kill safety — \`force_kill_pid\` already exists and is used by the post-success forced-kill path; reusing it here doesn't expand its surface.