### PR TITLE
ci(hooks): auto-stage refreshed openapi.sha256 when openapi.json is committed

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -11,6 +11,7 @@
 #   1. cargo fmt --check on staged *.rs files only (no full-workspace scan)
 #   2. CHANGELOG guard: reject duplicate `## [Unreleased]` headings (#3395)
 #   3. detect-secrets scan against .secrets.baseline (if installed)
+#   4. openapi.sha256 baseline auto-sync when openapi.json is staged (#4690)
 
 set -eu
 
@@ -79,5 +80,37 @@ if [ -f .secrets.baseline ]; then
     else
         echo "warning: detect-secrets not installed; skipping secret scan." >&2
         echo "  install with: pipx install detect-secrets" >&2
+    fi
+fi
+
+# 4. openapi.sha256 baseline auto-sync (#4690).
+#
+# When openapi.json is in the staged diff, recompute its sha256 and
+# auto-stage the matching xtask/baselines/openapi.sha256 line so the
+# bump commit is internally consistent. Without this, every version
+# bump (or any direct openapi.json edit) lands a baseline mismatch
+# that the openapi-drift CI gate rejects, forcing a follow-up fixup
+# commit (PR #4695 was such a fixup). cargo xtask schema-check gen
+# is too slow for a sub-2s pre-commit, so this hook does the same
+# single-line update via plain shasum.
+#
+# `shasum -a 256` is used (vs. sha256sum) because it ships by default
+# on both macOS and Linux (perl-provided), so contributors don't need
+# to install GNU coreutils.
+if git diff --cached --name-only | grep -qx "openapi.json"; then
+    BASELINE_FILE="xtask/baselines/openapi.sha256"
+    if [ -f openapi.json ] && [ -f "$BASELINE_FILE" ]; then
+        if command -v shasum >/dev/null 2>&1; then
+            EXPECTED=$(shasum -a 256 openapi.json | awk '{print $1}')
+            RECORDED=$(awk '{print $1}' "$BASELINE_FILE")
+            if [ "$EXPECTED" != "$RECORDED" ]; then
+                printf '%s  openapi.json\n' "$EXPECTED" > "$BASELINE_FILE"
+                git add "$BASELINE_FILE"
+                echo "info: auto-staged refreshed openapi.sha256 baseline (#4690)" >&2
+            fi
+        else
+            echo "warning: shasum not available; skipping openapi baseline sync." >&2
+            echo "  CI openapi-drift gate may reject this commit." >&2
+        fi
     fi
 fi


### PR DESCRIPTION
Refs #4690 — third layer of defense.

## Why

Three openapi-baseline drift incidents traced to the same shape: someone touches \`openapi.json\` outside \`cargo xtask release\`, and \`xtask/baselines/openapi.sha256\` is left stale. CI's openapi-drift gate then rejects the next push to main.

PR #4697 closed the canonical path: \`cargo xtask release\` now runs \`cargo xtask schema-check gen\` after codegen, so the bump itself produces a self-consistent commit.

This PR closes the **off-canonical** paths:

- Manual \`openapi.json\` edits (e.g. version sync done with \`sed\`).
- The auto-codegen CI bot regenerating \`openapi.json\` without re-running schema-check gen.
- A rebase / cherry-pick that re-introduces a stale \`openapi.json\` hunk.
- Anybody who skips xtask because \"I only changed one line.\"

## What changed

\`scripts/hooks/pre-commit\` — a new step 4 that fires only when \`openapi.json\` is in the staged diff:

1. \`shasum -a 256 openapi.json\` to get the expected hash.
2. Read the recorded hash from \`xtask/baselines/openapi.sha256\`.
3. If they differ, rewrite the baseline file with the expected hash and \`git add\` it. Commit then includes both files atomically.

\`shasum\` is used (not \`sha256sum\`) because it ships by default on both macOS and Linux (perl-provided) — no GNU coreutils dependency for contributors.

If \`shasum\` is unavailable on a machine, the hook warns and skips (the existing CI openapi-drift gate is still the authoritative backstop). We never block a commit on this; the goal is to make canonical outcomes the default for hand-staged commits too.

## Why auto-stage instead of error+abort

The drift is mechanical, deterministic, and recoverable from the staged file alone — no human judgment is needed. Failing the commit just forces the user to copy-paste the same recipe (\`cargo xtask schema-check gen\`) and re-stage. Auto-staging removes the round-trip.

The hook cannot pull random workspace edits into the commit because it only reacts when \`openapi.json\` is *already* in the staged diff and only ever touches the one baseline file. Out-of-tree state is untouched.

## Defense in depth (after this)

| Layer | Closes | Status |
|---|---|---|
| 1. \`cargo xtask release\` runs \`schema-check gen\` | Canonical bump path | PR #4697 |
| 2. **pre-commit auto-stages baseline** (this PR) | Manual / off-canonical edits | this PR |
| 3. CI openapi-drift gate | Final backstop | existing |

Layer 1 + Layer 2 should mean the gate at Layer 3 stays quiet for routine work.

## Verification

- \`bash -n scripts/hooks/pre-commit\` — clean.
- Drift-detection logic exercised manually: with a mock baseline, the hook correctly identifies a hash mismatch and would rewrite the file (verified via the same \`shasum -a 256 | awk\` pipeline used in the hook).
- Hook only runs section 4 when \`openapi.json\` is staged; verified by inspecting \`git diff --cached --name-only | grep -qx\`.
- Sub-2s budget: \`shasum -a 256\` on the current 280KB \`openapi.json\` runs in single-digit ms.

## Out-of-scope

- Equivalent guard for \`xtask/baselines/config.sha256\` and \`xtask/baselines/agent.sha256\`. Those baselines move only when the kernel config schema or agent manifest schema changes — much rarer than openapi drift, and the source-of-truth files are deeper into the workspace where editing them by hand is uncommon. Add when first incident lands.
- Equivalent SDK regeneration. \`scripts/codegen-sdks.py\` requires Python and reads \`openapi.json\` — too heavy for pre-commit. Stays in xtask + CI.