### PR TITLE
fix(test): deterministic two-phase driver for find_by_name_is_atomic_under_concurrent_register_and_remove (#4704)

### DIFF
--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -1025,21 +1025,34 @@ mod tests {
         use std::sync::Arc;
         use std::thread;
 
-        // Fixed-work driver instead of a wall-clock window: the writer
-        // performs a deterministic number of register/remove cycles, then
-        // signals stop.  Earlier iterations of this test slept for 100ms
-        // and asserted `lookups > 1_000`, which fired flakily on CI
-        // runners under load — the reader thread couldn't always squeeze
-        // 1k iterations into a 100ms slice — without ever indicating the
-        // torn-read invariant was actually broken.  With a fixed writer
-        // workload the reader's iteration count varies with scheduler
-        // latency but the test no longer fails on slow hosts; what
-        // matters is `torn == 0` and `hits > 0`, both of which we still
-        // check.
+        // Two-phase deterministic driver. Earlier iterations:
+        //   v1 (#4393): wall-clock 100ms slice + `lookups > 1_000`. Flaked
+        //     on Ubuntu shard 1 under load (reader couldn't squeeze 1k
+        //     iterations in time).
+        //   v2 (#4673): fixed 5_000 writer cycles + `hits > 0`. Removed
+        //     the wall-clock dependency but introduced a probabilistic
+        //     vacuous-pass: on a fast runner that gives the writer
+        //     priority (observed on macOS, #4704), the writer can drain
+        //     all 5_000 register/remove cycles before the reader thread
+        //     ever schedules — `hits` stays 0 and the assertion fires.
+        //
+        // v3 (this): split into two phases.
+        //   Phase 1 — establish that the reader actually ran. Writer
+        //     registers "racy" once and waits on `phase1_done` until
+        //     the reader has observed the entry at least once. No race
+        //     here: "racy" is permanently in the registry, so the
+        //     reader's first hit is structural, not probabilistic.
+        //   Phase 2 — race phase. Writer cycles register/remove; reader
+        //     keeps polling. This is what actually exercises the
+        //     torn-read invariant.
+        // After this, `hits > 0` is guaranteed (Phase 1 sets it),
+        // `torn == 0` is the real invariant under test, and the test
+        // is no longer schedule-dependent.
         const WRITER_CYCLES: usize = 5_000;
 
         let registry = Arc::new(AgentRegistry::new());
         let stop = Arc::new(AtomicBool::new(false));
+        let phase1_done = Arc::new(AtomicBool::new(false));
         // Count cases where `find_by_name` returned `Some` but the entry's
         // name disagreed with the lookup key (impossible if registry is
         // self-consistent; would catch torn reads).
@@ -1050,7 +1063,20 @@ mod tests {
         let writer = {
             let registry = Arc::clone(&registry);
             let stop = Arc::clone(&stop);
+            let phase1_done = Arc::clone(&phase1_done);
             thread::spawn(move || {
+                // Phase 1: register "racy" once, wait for reader to observe.
+                let entry = test_entry("racy");
+                let id = entry.id;
+                registry
+                    .register(entry)
+                    .expect("phase 1: initial register should succeed");
+                while !phase1_done.load(Ordering::Acquire) {
+                    std::hint::spin_loop();
+                }
+                registry.remove(id).ok();
+
+                // Phase 2: race cycles.
                 for _ in 0..WRITER_CYCLES {
                     let entry = test_entry("racy");
                     let id = entry.id;
@@ -1065,6 +1091,7 @@ mod tests {
         let reader = {
             let registry = Arc::clone(&registry);
             let stop = Arc::clone(&stop);
+            let phase1_done = Arc::clone(&phase1_done);
             let torn = Arc::clone(&torn);
             let lookups = Arc::clone(&lookups);
             let hits = Arc::clone(&hits);
@@ -1073,6 +1100,11 @@ mod tests {
                     lookups.fetch_add(1, Ordering::Relaxed);
                     if let Some(found) = registry.find_by_name("racy") {
                         hits.fetch_add(1, Ordering::Relaxed);
+                        // Release-store so the writer's Acquire-load on
+                        // phase1_done sees the same memory state where
+                        // we incremented `hits`. Cheap to do every hit;
+                        // the writer only checks during Phase 1.
+                        phase1_done.store(true, Ordering::Release);
                         if found.name != "racy" {
                             torn.fetch_add(1, Ordering::Relaxed);
                         }
@@ -1084,22 +1116,18 @@ mod tests {
         writer.join().unwrap();
         reader.join().unwrap();
 
-        // The reader doesn't get a fixed-iteration guarantee (a slow
-        // runner can spend ~all its time on the writer thread), but it
-        // must have run at least once to make the torn-read assertion
-        // meaningful.  In practice on every observed runner the reader
-        // logs hundreds-to-millions of lookups; we keep the floor at 1
-        // so the test passes on the most pathological scheduler without
-        // becoming vacuous.
+        // Reader ran (vacuous on a truly broken scheduler, but if Phase 1
+        // signalled `phase1_done` the reader must have observed at least
+        // once — both this and the `hits > 0` assertion below should hold).
         assert!(
             lookups.load(Ordering::Relaxed) >= 1,
             "reader thread did not run a single iteration before the writer finished"
         );
         assert!(
             hits.load(Ordering::Relaxed) > 0,
-            "reader never observed the agent across {WRITER_CYCLES} writer cycles — \
-             the writer/reader interleaving produced a vacuous pass; \
-             increase WRITER_CYCLES if this fires on a real runner"
+            "reader never observed the agent — Phase 1 was supposed to make this \
+             structural; if this fires the registry's find_by_name is broken or \
+             the phase1 hand-off is wrong"
         );
         assert_eq!(
             torn.load(Ordering::Relaxed),


### PR DESCRIPTION
Closes #4704.

## Why

The flake history of this test:

1. **v1 (#4393)** — wall-clock 100ms slice + `lookups > 1_000`. Flaked on Ubuntu shard 1 under load (reader couldn't squeeze 1k iterations in time).
2. **v2 (#4673)** — fixed 5_000 writer cycles + `hits > 0`. Removed the wall-clock dependency but introduced a probabilistic vacuous-pass: on a fast runner that gives the writer priority (observed on macOS in #4704), the writer can drain all 5_000 register/remove cycles before the reader thread is ever scheduled — `hits` stays 0, the `hits > 0` assertion fires.

The previous test message even tells you: \`increase WRITER_CYCLES if this fires on a real runner\`. That's just kicking the probabilistic can.

## Fix

Two-phase deterministic driver:

- **Phase 1** — writer registers \"racy\" once and spin-waits on \`phase1_done\` until the reader has observed it at least once. No race here: \"racy\" is permanently in the registry, so the reader's first hit is structural.
- **Phase 2** — writer cycles register/remove WRITER_CYCLES times; reader keeps polling. This is what actually exercises the torn-read invariant.

After this:
- \`lookups >= 1\` — guaranteed by reader running.
- \`hits > 0\` — guaranteed by Phase 1 (no longer probabilistic).
- \`torn == 0\` — the real invariant under test.

No wall-clock, no scheduler-dependent passing. The test fails iff the registry's \`find_by_name\` actually exposes a torn read.

## Verification

- \`cargo test -p librefang-kernel --lib find_by_name_is_atomic\` — 10 consecutive runs green on macOS (the lane that flaked in #4704).
- The torn-read assertion semantics are unchanged; only the schedule precondition is now structural.

## Out-of-scope

- Bumping WRITER_CYCLES higher \"just in case\" — unnecessary, the assertion is now schedule-independent.
- Switching to \`loom\` or shuttle for proper interleaving exploration — orders of magnitude bigger change; this fix is the minimal change to remove the flake.