### PR TITLE
fix(kernel): reload_config must reject invalid TOML, not silently swap to defaults (#4664)

### DIFF
--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -592,6 +592,80 @@ async fn config_reload_requires_auth_when_key_set() {
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
 
+/// Regression for #4664: a syntactically-broken `config.toml` (the bug report
+/// hit a duplicate `[web.searxng]` key) used to silently reset the live config
+/// to defaults on the next hot-reload tick because `crate::config::load_config`
+/// is tolerant. From the operator's POV the dashboard "stopped loading" because
+/// `default_model`, `provider_api_keys`, channels, etc. all reverted to
+/// defaults. The fix makes `reload_config` strict-parse the file first and
+/// surface the error so the live config stays intact.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_reload_with_invalid_toml_returns_error_and_preserves_live_config() {
+    let h = boot_router_with_api_key(API_KEY).await;
+
+    // Capture the live `default_model` BEFORE the bad reload so we can prove
+    // it survived. The harness boots with `model = "test-model"`.
+    let (status, body) = send(h.app.clone(), auth_get("/api/config")).await;
+    assert_eq!(status, StatusCode::OK);
+    let before: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
+    let before_model = before
+        .get("default_model")
+        .and_then(|m| m.get("model"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+    assert_eq!(
+        before_model, "test-model",
+        "harness must seed default_model.model = test-model"
+    );
+
+    // Write a config.toml with a TOML duplicate-key error. This mirrors the
+    // exact failure shape from the user's report: two `[web.searxng]` sections.
+    let bad_toml =
+        "[web.searxng]\nurl = \"http://first\"\n\n[web.searxng]\nurl = \"http://second\"\n";
+    std::fs::write(h.home.join("config.toml"), bad_toml).expect("write bad config.toml");
+
+    // Reload must report a parse error (400) — NOT silently apply defaults (200).
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/config/reload")
+        .header(header::AUTHORIZATION, format!("Bearer {API_KEY}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = send(h.app.clone(), req).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "bad TOML must produce a 400 with an explicit error, not a 200 + silent defaults; body={}",
+        String::from_utf8_lossy(&body)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
+    let err_str = json
+        .get("error")
+        .and_then(|e| e.as_str())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        err_str.contains("invalid TOML") && err_str.contains("live config unchanged"),
+        "error must be operator-actionable; got: {err_str}"
+    );
+
+    // Live config must be unchanged — the failed reload did not blow away
+    // `default_model.model` (which is the symptom that broke the dashboard).
+    let (status, body) = send(h.app.clone(), auth_get("/api/config")).await;
+    assert_eq!(status, StatusCode::OK);
+    let after: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
+    let after_model = after
+        .get("default_model")
+        .and_then(|m| m.get("model"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("");
+    assert_eq!(
+        after_model, before_model,
+        "live default_model.model must be preserved after a failed reload"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/health/detail (#3776)
 //

--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -666,6 +666,126 @@ async fn config_reload_with_invalid_toml_returns_error_and_preserves_live_config
     );
 }
 
+/// Internal helper: drop a `config.toml` into the harness's home dir,
+/// POST `/api/config/reload`, and assert that it returns 400 *and* that
+/// `GET /api/config` still reports the seeded `default_model.model`.
+///
+/// Used by the next two regressions to cover the two non-syntax failure
+/// modes that `try_load_config` (introduced in #4664) refuses: a
+/// deserialize-shape mismatch and a broken `include = [...]` chain. The
+/// duplicate-key TOML-syntax case has its own dedicated test above
+/// (preserved with its own assertion text so a regression on the syntax
+/// path stays distinguishable in test output).
+async fn assert_reload_rejects_and_preserves_default_model(
+    h: &RouterHarness,
+    bad_toml_filename: &str,
+    bad_toml_contents: &str,
+    extra_files: &[(&str, &str)],
+    failure_label: &str,
+) {
+    // Capture pre-reload `default_model.model`.
+    let (status, body) = send(h.app.clone(), auth_get("/api/config")).await;
+    assert_eq!(status, StatusCode::OK);
+    let before: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
+    let before_model = before
+        .get("default_model")
+        .and_then(|m| m.get("model"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+    assert_eq!(before_model, "test-model");
+
+    for (name, contents) in extra_files {
+        std::fs::write(h.home.join(name), contents)
+            .unwrap_or_else(|e| panic!("write helper file {name}: {e}"));
+    }
+    std::fs::write(h.home.join(bad_toml_filename), bad_toml_contents)
+        .expect("write bad config.toml");
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/config/reload")
+        .header(header::AUTHORIZATION, format!("Bearer {API_KEY}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = send(h.app.clone(), req).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "{failure_label} must produce a 400, not silent defaults; body={}",
+        String::from_utf8_lossy(&body)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
+    let err_str = json
+        .get("error")
+        .and_then(|e| e.as_str())
+        .unwrap_or("")
+        .to_string();
+    // Every reload-time rejection MUST go through the strict loader's
+    // `try_load_config` and be wrapped with the "live config unchanged"
+    // pledge, so future failure modes can be asserted with the same
+    // substring without needing to know which inner branch tripped.
+    assert!(
+        err_str.contains("live config unchanged"),
+        "{failure_label} error must carry the reload-boundary pledge; got: {err_str}"
+    );
+
+    let (status, body) = send(h.app.clone(), auth_get("/api/config")).await;
+    assert_eq!(status, StatusCode::OK);
+    let after: serde_json::Value = serde_json::from_slice(&body).expect("response is JSON");
+    let after_model = after
+        .get("default_model")
+        .and_then(|m| m.get("model"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("");
+    assert_eq!(
+        after_model, before_model,
+        "{failure_label}: live default_model.model must be preserved after a failed reload"
+    );
+}
+
+/// End-to-end regression for the second silent-defaults path that
+/// `try_load_config` (#4664) closes: TOML parses cleanly but a field
+/// has the wrong shape (`default_model = "string"` where a table is
+/// expected). Pre-fix, `load_config` would warn and return defaults
+/// and the reload would silently overwrite the live config; post-fix,
+/// `POST /api/config/reload` must return 400.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_reload_with_deserialize_shape_mismatch_returns_error_and_preserves_live_config() {
+    let h = boot_router_with_api_key(API_KEY).await;
+    assert_reload_rejects_and_preserves_default_model(
+        &h,
+        "config.toml",
+        // TOML parses fine; deserialize fails because `default_model` is a struct.
+        "default_model = \"not-a-table\"\n",
+        &[],
+        "deserialize-shape mismatch",
+    )
+    .await;
+}
+
+/// End-to-end regression for the third silent-defaults path: root
+/// config is well-formed but `include = ["bad.toml"]` points at a
+/// file that fails TOML parsing. Pre-fix, `resolve_config_includes`'s
+/// error was swallowed by `load_config` and the reload proceeded with
+/// the root only; post-fix, the reload must refuse.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_reload_with_broken_include_returns_error_and_preserves_live_config() {
+    let h = boot_router_with_api_key(API_KEY).await;
+    assert_reload_rejects_and_preserves_default_model(
+        &h,
+        "config.toml",
+        "include = [\"bad.toml\"]\nlog_level = \"debug\"\n",
+        &[(
+            "bad.toml",
+            // Same duplicate-key shape as #4664, just inside the include.
+            "[memory]\ndecay_rate = 0.1\n[memory]\ndecay_rate = 0.2\n",
+        )],
+        "broken include chain",
+    )
+    .await;
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/health/detail (#3776)
 //

--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -786,6 +786,33 @@ async fn config_reload_with_broken_include_returns_error_and_preserves_live_conf
     .await;
 }
 
+/// End-to-end regression locking in the `live config unchanged` reload-
+/// boundary contract for the *post-loader* validation path
+/// (`config_reload::validate_config_for_reload`). The strict loader
+/// accepts the file (parses cleanly, deserialises into a valid
+/// `KernelConfig`), but the validator rejects the result — e.g.
+/// `network_enabled = true` with an empty `network.shared_secret`.
+///
+/// Without the contract being uniform, a future regression on this
+/// branch would surface as a confusing assertion-helper diff rather
+/// than the clear "wrapper missing" message. Asserting the substring
+/// here means the helper covers every reload-rejection branch
+/// regardless of which one trips.
+#[tokio::test(flavor = "multi_thread")]
+async fn config_reload_with_validation_failure_returns_error_and_preserves_live_config() {
+    let h = boot_router_with_api_key(API_KEY).await;
+    assert_reload_rejects_and_preserves_default_model(
+        &h,
+        "config.toml",
+        // Parses + deserialises fine; validator refuses because
+        // network_enabled requires a non-empty shared_secret.
+        "network_enabled = true\n[network]\nshared_secret = \"\"\n",
+        &[],
+        "post-loader validation failure",
+    )
+    .await;
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/health/detail (#3776)
 //

--- a/crates/librefang-kernel/src/config.rs
+++ b/crates/librefang-kernel/src/config.rs
@@ -194,6 +194,97 @@ pub fn load_config(path: Option<&Path>) -> KernelConfig {
     KernelConfig::default()
 }
 
+/// Strict counterpart of [`load_config`] that returns `Err` on every failure
+/// mode instead of silently falling back to [`KernelConfig::default`].
+///
+/// Used by [`crate::kernel::Kernel::reload_config`] (issue #4664) so a bad
+/// on-disk config — TOML syntax error, broken `include = [...]`, migration
+/// failure, deserialize-shape mismatch — never wipes the operator's live
+/// in-memory state. The hot-reload watcher and `POST /api/config/reload`
+/// handler both already map `Err(...)` to a warning + 400 respectively,
+/// so the live config stays intact and the operator gets an actionable
+/// error.
+///
+/// Differences from `load_config`:
+///
+/// - No write-back of the migrated TOML to disk. The reload path doesn't
+///   own the file, and a partial migration that fails downstream would
+///   leave the disk file in a half-migrated state. The next initial-boot
+///   `load_config` call still does the write-back.
+/// - Unknown fields under `strict_config = true` produce `Err` instead of
+///   "return defaults with `strict_config: true`" — same intent, but
+///   surfaced as an error so the reload path can refuse to apply it.
+/// - Unknown fields under `strict_config = false` (or unset) still warn
+///   and proceed, matching `load_config`'s tolerant behaviour.
+pub fn try_load_config(path: &Path) -> Result<KernelConfig, String> {
+    if !path.exists() {
+        return Err(format!("Config file not found: {}", path.display()));
+    }
+    let contents =
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read config file: {e}"))?;
+    let mut root_value: toml::Value =
+        toml::from_str(&contents).map_err(|e| format!("Config file has invalid TOML: {e}"))?;
+
+    // Resolve `include = [...]` chains. Failures here include: missing
+    // file, unparseable include, traversal / absolute-path attempts,
+    // circular references, depth overflow.
+    let config_dir = path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    let mut visited = HashSet::new();
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        visited.insert(canonical);
+    } else {
+        visited.insert(path.to_path_buf());
+    }
+    resolve_config_includes(&mut root_value, &config_dir, &mut visited, 0)
+        .map_err(|e| format!("Config include resolution failed: {e}"))?;
+    if let toml::Value::Table(ref mut tbl) = root_value {
+        tbl.remove("include");
+    }
+
+    // Migrate older config versions in place. We do NOT write the result
+    // back to disk from the reload path (see doc comment above).
+    let file_version = root_value
+        .as_table()
+        .and_then(|t| t.get("config_version"))
+        .and_then(|v| v.as_integer())
+        .map(|v| v as u32)
+        .unwrap_or_else(default_config_version);
+    if file_version < CONFIG_VERSION {
+        run_migrations(&mut root_value, file_version).map_err(|e| {
+            format!("Config migration failed (from v{file_version} to v{CONFIG_VERSION}): {e}")
+        })?;
+    }
+
+    // Strict mode: refuse to load when unknown / typo'd fields are present.
+    let unknown_fields = KernelConfig::detect_unknown_fields(&root_value);
+    let unknown_nested = KernelConfig::detect_unknown_nested_fields(&root_value);
+    let is_strict = root_value
+        .as_table()
+        .and_then(|t| t.get("strict_config"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let mut all_unknown: Vec<String> = unknown_fields.into_iter().chain(unknown_nested).collect();
+    all_unknown.sort();
+    if !all_unknown.is_empty() {
+        if is_strict {
+            return Err(format!(
+                "strict_config is enabled and config contains unknown fields: {}",
+                all_unknown.join(", ")
+            ));
+        }
+        for field in &all_unknown {
+            tracing::warn!(field, "Unknown config field (ignored on reload)");
+        }
+    }
+
+    root_value
+        .try_into::<KernelConfig>()
+        .map_err(|e| format!("Failed to deserialize config: {e}"))
+}
+
 /// Resolve config includes by deep-merging included files into the root value.
 ///
 /// Included files are loaded first and the root config overrides them.
@@ -843,5 +934,147 @@ mod tests {
         // Should fall back to defaults (users deserialization fails)
         assert_eq!(config.log_level, "info"); // default, not "warn"
         assert!(config.users.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // try_load_config — strict variant used by reload (#4664)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_try_load_config_happy_path_returns_kernel_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "log_level = \"warn\"").unwrap();
+        drop(f);
+
+        let cfg = try_load_config(&root).expect("strict load must succeed on a clean file");
+        assert_eq!(cfg.log_level, "warn");
+    }
+
+    #[test]
+    fn test_try_load_config_missing_file_is_error_not_default() {
+        // Tolerant `load_config` returns defaults for a missing file because
+        // initial boot wants to come up. The strict variant must `Err` so the
+        // reload path does not silently rewrite the live state.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("nonexistent.toml");
+
+        let err = try_load_config(&root).expect_err("missing file must surface as Err");
+        assert!(
+            err.contains("not found"),
+            "missing-file error must be operator-actionable; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_try_load_config_invalid_toml_is_error() {
+        // The exact failure shape from #4664: duplicate `[web.searxng]` key.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "[web.searxng]").unwrap();
+        writeln!(f, "url = \"http://first\"").unwrap();
+        writeln!(f, "[web.searxng]").unwrap();
+        writeln!(f, "url = \"http://second\"").unwrap();
+        drop(f);
+
+        let err = try_load_config(&root).expect_err("duplicate key must surface as Err");
+        assert!(
+            err.contains("invalid TOML"),
+            "TOML syntax error must be tagged so the reload caller can wrap it; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_try_load_config_broken_include_chain_is_error() {
+        // Root is well-formed but points at an unparseable include — tolerant
+        // `load_config` warns and silently proceeds with root-only, which on a
+        // reload path would still effectively zero the operator's settings
+        // that lived in the include. Strict variant must refuse.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+        let bad_include = dir.path().join("bad.toml");
+
+        let mut f = std::fs::File::create(&bad_include).unwrap();
+        // Same duplicate-key shape as the bug report, just inside the include.
+        writeln!(f, "[memory]").unwrap();
+        writeln!(f, "decay_rate = 0.1").unwrap();
+        writeln!(f, "[memory]").unwrap();
+        writeln!(f, "decay_rate = 0.2").unwrap();
+        drop(f);
+
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "include = [\"bad.toml\"]").unwrap();
+        writeln!(f, "log_level = \"debug\"").unwrap();
+        drop(f);
+
+        let err = try_load_config(&root).expect_err("broken include must surface as Err");
+        assert!(
+            err.contains("include"),
+            "include-failure error must be tagged so the operator knows where to look; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_try_load_config_deserialize_shape_mismatch_is_error() {
+        // TOML parses cleanly but a field has the wrong shape — `default_model`
+        // is a struct, not a scalar. Tolerant `load_config` warns and returns
+        // defaults; strict variant must refuse so the reload caller cannot
+        // accidentally apply defaults as the diff target.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "default_model = \"not-a-table\"").unwrap();
+        drop(f);
+
+        let err = try_load_config(&root).expect_err("wrong-shape field must surface as Err");
+        assert!(
+            err.contains("deserialize"),
+            "deserialize-failure error must be tagged; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_try_load_config_strict_mode_rejects_unknown_field() {
+        // Mirrors the tolerant `load_config` behaviour test, but the strict
+        // variant returns `Err` instead of "defaults with strict_config=true"
+        // so the reload path can refuse to swap rather than silently zeroing.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "strict_config = true").unwrap();
+        writeln!(f, "log_level = \"warn\"").unwrap();
+        writeln!(f, "bogus_field = \"oops\"").unwrap();
+        drop(f);
+
+        let err =
+            try_load_config(&root).expect_err("strict_config + unknown field must surface as Err");
+        assert!(
+            err.contains("unknown field"),
+            "unknown-field error must be tagged; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_try_load_config_tolerant_mode_warns_on_unknown_field_but_still_loads() {
+        // strict_config defaults to false. Unknown fields warn but don't block,
+        // matching `load_config`'s tolerant semantics — otherwise a typo
+        // anywhere would brick the reload.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "log_level = \"warn\"").unwrap();
+        writeln!(f, "bogus_field = \"oops\"").unwrap();
+        drop(f);
+
+        let cfg =
+            try_load_config(&root).expect("tolerant unknown fields must not fail strict load");
+        assert_eq!(cfg.log_level, "warn");
     }
 }

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12396,11 +12396,31 @@ system_prompt = "You are a helpful assistant."
 
         // Read and parse config file (using load_config to process $include directives)
         let config_path = self.home_dir_boot.join("config.toml");
-        let mut new_config = if config_path.exists() {
-            crate::config::load_config(Some(&config_path))
-        } else {
+        if !config_path.exists() {
             return Err("Config file not found".to_string());
-        };
+        }
+
+        // Strict TOML pre-check (issue #4664): `load_config` is *tolerant* — on
+        // a parse error it warns and silently returns `KernelConfig::default()`.
+        // The reload path then diffs the live config against those defaults and
+        // applies the diff via `apply_hot_actions_inner` + a final `config.store`,
+        // wiping the user's in-memory `default_model`, `provider_api_keys`,
+        // channels, etc. From the dashboard's POV the daemon "loses" its config
+        // — which is exactly the symptom the bug report describes (a duplicate
+        // `[web.searxng]` key in `config.toml` makes the dashboard stop loading
+        // after the next 30s reload tick).
+        //
+        // Surface the parse error here so the watcher's `Err(e) => warn!(...)`
+        // branch fires and the live config stays untouched.
+        let raw = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("Failed to read config file: {e}"))?;
+        if let Err(e) = toml::from_str::<toml::Value>(&raw) {
+            return Err(format!(
+                "Config file has invalid TOML; reload aborted, live config unchanged: {e}"
+            ));
+        }
+
+        let mut new_config = crate::config::load_config(Some(&config_path));
 
         // Clamp bounds on the new config before validating or applying.
         // Initial boot calls clamp_bounds() at kernel construction time,

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12420,9 +12420,17 @@ system_prompt = "You are a helpful assistant."
         // startup path normally corrects.
         new_config.clamp_bounds();
 
-        // Validate new config
+        // Validate new config. Use the same `live config unchanged` wrapper as
+        // the strict-loader path so every reload-rejection error carries the
+        // operator-actionable pledge — both for log readability and so the
+        // integration helper `assert_reload_rejects_and_preserves_default_model`
+        // (api crate) can assert reload-boundary semantics with one substring
+        // regardless of which inner branch tripped.
         if let Err(errors) = validate_config_for_reload(&new_config) {
-            return Err(format!("Validation failed: {}", errors.join("; ")));
+            return Err(format!(
+                "Config reload failed; live config unchanged: validation: {}",
+                errors.join("; ")
+            ));
         }
 
         // Build the reload plan against the live capability set so changes

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -12394,33 +12394,24 @@ system_prompt = "You are a helpful assistant."
         let old_cfg = self.config.load();
         use crate::config_reload::{should_apply_hot, validate_config_for_reload};
 
-        // Read and parse config file (using load_config to process $include directives)
-        let config_path = self.home_dir_boot.join("config.toml");
-        if !config_path.exists() {
-            return Err("Config file not found".to_string());
-        }
-
-        // Strict TOML pre-check (issue #4664): `load_config` is *tolerant* — on
-        // a parse error it warns and silently returns `KernelConfig::default()`.
-        // The reload path then diffs the live config against those defaults and
-        // applies the diff via `apply_hot_actions_inner` + a final `config.store`,
-        // wiping the user's in-memory `default_model`, `provider_api_keys`,
-        // channels, etc. From the dashboard's POV the daemon "loses" its config
-        // — which is exactly the symptom the bug report describes (a duplicate
-        // `[web.searxng]` key in `config.toml` makes the dashboard stop loading
-        // after the next 30s reload tick).
+        // Read and parse the on-disk config via the strict loader (#4664).
+        // Unlike `crate::config::load_config`, `try_load_config` returns `Err`
+        // on every failure mode (TOML syntax error, broken `include = [...]`
+        // chain, migration failure, deserialize-shape mismatch) instead of
+        // silently falling back to `KernelConfig::default()`. Without this,
+        // the diff-and-apply path below would treat the defaults as the
+        // operator's intent and wipe out their `default_model`,
+        // `provider_api_keys`, channels, etc. — the symptom the bug report
+        // describes (a duplicate `[web.searxng]` key in `config.toml` made
+        // the dashboard stop loading after the next 30 s reload tick).
         //
-        // Surface the parse error here so the watcher's `Err(e) => warn!(...)`
-        // branch fires and the live config stays untouched.
-        let raw = std::fs::read_to_string(&config_path)
-            .map_err(|e| format!("Failed to read config file: {e}"))?;
-        if let Err(e) = toml::from_str::<toml::Value>(&raw) {
-            return Err(format!(
-                "Config file has invalid TOML; reload aborted, live config unchanged: {e}"
-            ));
-        }
-
-        let mut new_config = crate::config::load_config(Some(&config_path));
+        // Surfacing `Err` here lets the watcher's
+        // `Err(e) => tracing::warn!("Config hot-reload failed: {e}")` branch
+        // fire and the `POST /api/config/reload` handler return 400, both
+        // without touching the live config.
+        let config_path = self.home_dir_boot.join("config.toml");
+        let mut new_config = crate::config::try_load_config(&config_path)
+            .map_err(|e| format!("Config reload failed; live config unchanged: {e}"))?;
 
         // Clamp bounds on the new config before validating or applying.
         // Initial boot calls clamp_bounds() at kernel construction time,

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -7289,3 +7289,87 @@ mod try_summarize_trim_tests {
         );
     }
 }
+
+/// Regression for #4664: when `~/.librefang/config.toml` becomes syntactically
+/// invalid (e.g. a duplicate `[web.searxng]` key as in the bug report), the
+/// hot-reload watcher used to silently reset the live in-memory config to
+/// `KernelConfig::default()` because `crate::config::load_config` is tolerant
+/// and falls back to defaults on parse errors. The reload would then diff the
+/// live config against the defaults and apply the diff, blowing away
+/// `default_model`, `provider_api_keys`, channels, etc. — which surfaced to
+/// the user as "the dashboard stops loading".
+///
+/// `reload_config` must now strict-parse the file *before* doing anything
+/// destructive and return `Err` on TOML syntax errors so the watcher logs the
+/// failure and the live config stays intact.
+#[tokio::test(flavor = "multi_thread")]
+async fn reload_config_with_invalid_toml_preserves_live_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    // Write a valid baseline config.toml that round-trips through KernelConfig
+    // serialization — this is what the kernel will load at boot AND what
+    // `reload_config` will read on the next tick if we leave it untouched.
+    let baseline = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        default_model: DefaultModelConfig {
+            provider: "anthropic".to_string(),
+            model: "user-picked-model".to_string(),
+            api_key_env: "ANTHROPIC_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        },
+        ..KernelConfig::default()
+    };
+    let baseline_toml = toml::to_string_pretty(&baseline).expect("serialize baseline config");
+    let config_path = home_dir.join("config.toml");
+    std::fs::write(&config_path, &baseline_toml).expect("write baseline config.toml");
+
+    let kernel =
+        LibreFangKernel::boot_with_config(baseline.clone()).expect("kernel boot with baseline");
+
+    // Sanity: live config has the user-picked model.
+    assert_eq!(
+        kernel.config_ref().default_model.model,
+        "user-picked-model",
+        "boot must seed the live config with the baseline model"
+    );
+
+    // Now corrupt config.toml the way the bug report did: append a duplicate
+    // `[web.searxng]` key that already appears earlier in the file (or in this
+    // case, two consecutive `[web.searxng]` sections — same TOML parse error).
+    let bad_toml = format!(
+        "{baseline_toml}\n\n[web.searxng]\nurl = \"http://first\"\n\n[web.searxng]\nurl = \"http://second\"\n"
+    );
+    std::fs::write(&config_path, &bad_toml).expect("write bad config.toml");
+
+    // Reload must fail loudly and refuse to touch the live config.
+    let err = kernel
+        .reload_config()
+        .await
+        .expect_err("reload must reject invalid TOML, not swallow it into defaults");
+    assert!(
+        err.contains("invalid TOML") && err.contains("live config unchanged"),
+        "error must clearly attribute the failure and reassure the operator that \
+         live config is intact; got: {err}"
+    );
+
+    // Live config must still hold the operator's chosen model — proves the
+    // watcher's reload tick won't silently revert their settings.
+    assert_eq!(
+        kernel.config_ref().default_model.model,
+        "user-picked-model",
+        "live default_model must be preserved when the on-disk file is unparseable"
+    );
+    assert_eq!(
+        kernel.config_ref().default_model.provider,
+        "anthropic",
+        "live default_model.provider must be preserved when the on-disk file is unparseable"
+    );
+
+    kernel.shutdown();
+}

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -7311,7 +7311,13 @@ async fn reload_config_with_invalid_toml_preserves_live_config() {
     // Write a valid baseline config.toml that round-trips through KernelConfig
     // serialization — this is what the kernel will load at boot AND what
     // `reload_config` will read on the next tick if we leave it untouched.
-    let baseline = KernelConfig {
+    //
+    // Clamp first so the on-disk file matches what `boot_with_config` actually
+    // holds in memory (it clamps too at construction time). Without this, a
+    // future change that lands a `Default` value outside the clamp window
+    // would silently desync test fixture vs. live state and quietly hollow
+    // out this regression's coverage.
+    let mut baseline = KernelConfig {
         home_dir: home_dir.clone(),
         data_dir: home_dir.join("data"),
         default_model: DefaultModelConfig {
@@ -7325,6 +7331,7 @@ async fn reload_config_with_invalid_toml_preserves_live_config() {
         },
         ..KernelConfig::default()
     };
+    baseline.clamp_bounds();
     let baseline_toml = toml::to_string_pretty(&baseline).expect("serialize baseline config");
     let config_path = home_dir.join("config.toml");
     std::fs::write(&config_path, &baseline_toml).expect("write baseline config.toml");


### PR DESCRIPTION
Closes part 2 of #4664. (Part 1 — exposing the `[web]` section in the new
single-page Config UI — is #4682, already merged.)

## Problem

`Kernel::reload_config` called the tolerant `crate::config::load_config`,
which on a TOML parse error logged a warning and returned
`KernelConfig::default()`. The reload then diffed the live config against
those defaults and applied the diff via `apply_hot_actions_inner` + a
final `config.store`, silently wiping the operator's `default_model`,
`provider_api_keys`, channels, etc.

From the operator's POV the dashboard "stopped loading" because the live
config had been reset. The bug-report repro is a duplicate
`[web.searxng]` key that fails TOML parsing — the next 30 s reload tick
then nukes the in-memory state. Quoted log:

```
INFO Config file changed, reloading...
WARN failed to parse raw config.toml ... duplicate key
```

`load_config` was tolerant in *three* ways, all of which the reload path
silently rode straight into a defaults-swap:

1. TOML syntax error at the root file (the bug repro)
2. `try_into::<KernelConfig>()` failure (e.g. wrong field shape)
3. Broken `include = [...]` chain (missing / unparseable / circular / depth-exceeded include)

## Fix

Introduce `crate::config::try_load_config(path) -> Result<KernelConfig, _>`
that mirrors `load_config`'s parsing pipeline (read → parse →
resolve_includes → migrate → unknown-field check → deserialize) but
returns `Err` at every failure point — covering all three classes above.
`Kernel::reload_config` switches to the strict variant; initial boot
keeps the tolerant `load_config` so the daemon can still come up far
enough for the operator to fix things via the dashboard.

Side benefit: drops the parse-twice pattern from the first attempt
(d81f0566), closing the cosmetic TOCTOU window between the pre-check
`read_to_string` and `load_config`'s subsequent re-read.

`reload_config` wraps every reload-rejection error — strict-loader AND
post-loader validator — with the prefix
`Config reload failed; live config unchanged: ...`. The hot-reload
watcher's `Err(e) => tracing::warn!("Config hot-reload failed: {e}")`
branch fires and the `POST /api/config/reload` handler returns 400 —
both without touching the live config. The `live config unchanged`
substring is the reload-boundary contract that callers and tests can
rely on regardless of which inner failure tripped (loader, validator, or
future addition).

## Coverage

`crates/librefang-kernel/src/config.rs::tests` (strict-loader unit tests):
- `test_try_load_config_happy_path_returns_kernel_config`
- `test_try_load_config_missing_file_is_error_not_default`
- `test_try_load_config_invalid_toml_is_error` (#4664 repro shape)
- `test_try_load_config_broken_include_chain_is_error`
- `test_try_load_config_deserialize_shape_mismatch_is_error`
- `test_try_load_config_strict_mode_rejects_unknown_field`
- `test_try_load_config_tolerant_mode_warns_on_unknown_field_but_still_loads`

`crates/librefang-kernel/src/kernel/tests.rs` (kernel-level):
- `reload_config_with_invalid_toml_preserves_live_config` — boots with
  a clamp-normalised baseline, corrupts `config.toml` with the
  duplicate-key shape, asserts both the error string and that
  `default_model.{model,provider}` are unchanged.

`crates/librefang-api/tests/config_routes_integration.rs` (end-to-end
through `POST /api/config/reload` + `GET /api/config`):
- `config_reload_with_invalid_toml_returns_error_and_preserves_live_config`
  — duplicate-key TOML syntax error
- `config_reload_with_deserialize_shape_mismatch_returns_error_and_preserves_live_config`
  — `default_model = "string"` (wrong shape) refused
- `config_reload_with_broken_include_returns_error_and_preserves_live_config`
  — root-level `include = ["bad.toml"]` where `bad.toml` has the
  same duplicate-key shape as #4664
- `config_reload_with_validation_failure_returns_error_and_preserves_live_config`
  — `network_enabled = true` with empty `shared_secret` (post-loader
  `validate_config_for_reload` branch)
- All four share an
  `assert_reload_rejects_and_preserves_default_model` helper that locks
  in the "live config unchanged" reload-boundary contract — future
  failure modes inherit the assertion for free.

## Verification

- `cargo check -p librefang-kernel --lib` — passes
- `cargo test -p librefang-kernel --lib config::tests::` — 33 passed
  (7 new + 26 pre-existing)
- `cargo test -p librefang-kernel --lib reload_config_with_invalid_toml`
  — 1 passed
- `cargo test -p librefang-api --test config_routes_integration` —
  21 passed (4 reload-rejection + 17 pre-existing)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `rustfmt --check` on touched files — clean

## Out-of-scope follow-ups (NOT in this PR)

- **Initial boot remains tolerant** by design: at startup,
  `load_config` still falls back to defaults on parse errors so the
  daemon can come up far enough for the operator to fix things via the
  dashboard. A future PR could surface a `last_load_error` on the
  kernel so the dashboard shows a banner instead of "everything is
  suspiciously default". Out of scope here because the bug fired on
  hot reload, not boot.
- **`load_raw_config_toml`** (used by `[skills.config.*]` injection)
  keeps its empty-table fallback. It only affects skill prompt
  injection, not the live `KernelConfig`, so silent fallback there is
  a degraded-but-non-destructive state and acceptable.
- **Sharing the parsing pipeline between `load_config` and
  `try_load_config`**: `load_config` does write-back of migrated TOML
  to disk which the reload path deliberately doesn't do (a partial
  migration that fails downstream would corrupt the file). Refactoring
  to share the common 80% would be a small cleanup but is genuinely
  out of scope and unrelated to the bug.

## Commits

- d81f0566 — first cut: strict TOML pre-check in `reload_config`
- 6e5cf4c8 — test hardening (`clamp_bounds()` on the fixture)
- 5d239d99 — refactor to `try_load_config`, closes the remaining two
  silent-defaults paths flagged by review
- 4b4a1903 — end-to-end integration tests for the deserialize-shape
  and broken-include reload-rejection paths
- 97f9e8ad — unify reload-rejection wrapper across loader and validator
  branches; integration test for the validator-failure path