### PR TITLE
fix(dashboard): resolve 35 UI bugs and review follow-ups across 10 pages

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
@@ -54,7 +54,10 @@ export function AnalyticsPage() {
       .sort((a, b) => (b.total_cost_usd ?? 0) - (a.total_cost_usd ?? 0)),
     [usageByAgentQuery.data],
   );
-  const usageByModel = (usageByModelQuery.data ?? []) as AnalyticsModelRow[];
+  const usageByModel = useMemo<AnalyticsModelRow[]>(
+    () => (usageByModelQuery.data ?? []) as AnalyticsModelRow[],
+    [usageByModelQuery.data],
+  );
   const daily = dailyQuery.data ?? null;
   const modelPerformance = modelPerformanceQuery.data ?? [];
 
@@ -157,7 +160,7 @@ export function AnalyticsPage() {
       dailyQuery.refetch(),
       modelPerformanceQuery.refetch(),
       budgetQuery.refetch(),
-    ]);
+    ]).catch(() => {});
   }, [usageQuery, usageByAgentQuery, usageByModelQuery, dailyQuery, modelPerformanceQuery, budgetQuery]);
 
   return (
@@ -213,7 +216,7 @@ export function AnalyticsPage() {
               {usageByAgent.length === 0 ? (
                 <EmptyState icon={<Users />} title={t("common.no_data")} description={t("analytics.no_agent_data")} />
               ) : (
-                <ResponsiveContainer width="100%" height={Math.max(usageByAgent.length * 36, 100)}>
+                <ResponsiveContainer width="100%" height={Math.min(Math.max(usageByAgent.length * 36, 100), 600)}>
                   <BarChart data={agentChartData} layout="vertical" margin={{ left: 0, right: 20 }}>
                     <CartesianGrid strokeDasharray="3 3" opacity={0.2} horizontal={false} />
                     <XAxis type="number" tick={{ fontSize: 10 }} tickFormatter={v => `$${v}`} axisLine={false} tickLine={false} />
@@ -232,7 +235,7 @@ export function AnalyticsPage() {
               {usageByModel.length === 0 ? (
                 <EmptyState icon={<Cpu />} title={t("common.no_data")} description={t("analytics.no_model_data")} />
               ) : (
-                <ResponsiveContainer width="100%" height={Math.max(usageByModel.length * 36, 100)}>
+                <ResponsiveContainer width="100%" height={Math.min(Math.max(usageByModel.length * 36, 100), 600)}>
                   <BarChart data={modelChartData} layout="vertical" margin={{ left: 0, right: 20 }}>
                     <CartesianGrid strokeDasharray="3 3" opacity={0.2} horizontal={false} />
                     <XAxis type="number" tick={{ fontSize: 10 }} tickFormatter={v => `$${v}`} axisLine={false} tickLine={false} />
@@ -401,7 +404,12 @@ export function AnalyticsPage() {
                     const parsed = parseFloat(budgetForm.alert);
                     if (!isNaN(parsed) && parsed >= 0) payload.alert_threshold = parsed;
                   }
-                  budgetMutation.mutate(payload);
+                  budgetMutation.mutate(payload, {
+                    onSuccess: () => {
+                      setBudgetForm({});
+                      setTimeout(() => budgetMutation.reset(), 2000);
+                    },
+                  });
                 }}
                 disabled={budgetMutation.isPending}>
                 {budgetMutation.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> : <Save className="w-3.5 h-3.5 mr-1" />}

--- a/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
@@ -1,5 +1,5 @@
 import { formatCompact, formatCost } from "../lib/format";
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState, useCallback, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import type { UsageByAgentItem, UsageByModelItem, UsageDailyItem } from "../api";
 import { useUsageSummary, useUsageByAgent, useUsageByModel, useUsageDaily, useModelPerformance, useBudgetStatus } from "../lib/queries/analytics";
@@ -66,6 +66,8 @@ export function AnalyticsPage() {
   const dailyChartData = useMemo(() => (daily?.days || []).slice(-30).map((d: UsageDailyItem) => ({ ...d, date: (d.date || "").slice(5), cost: d.cost_usd || 0 })), [daily]);
 
   const [budgetForm, setBudgetForm] = useState<Partial<BudgetForm>>({});
+  const budgetResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (budgetResetTimerRef.current) clearTimeout(budgetResetTimerRef.current); }, []);
 
   const isLoading =
     usageQuery.isLoading ||
@@ -407,7 +409,8 @@ export function AnalyticsPage() {
                   budgetMutation.mutate(payload, {
                     onSuccess: () => {
                       setBudgetForm({});
-                      setTimeout(() => budgetMutation.reset(), 2000);
+                      if (budgetResetTimerRef.current) clearTimeout(budgetResetTimerRef.current);
+                      budgetResetTimerRef.current = setTimeout(() => budgetMutation.reset(), 2000);
                     },
                   });
                 }}

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { wechatQrStart, wechatQrStatus, whatsappQrStart, whatsappQrStatus, type ChannelItem } from "../api";
 import { useChannels } from "../lib/queries/channels";
@@ -57,7 +57,7 @@ interface ChannelCardProps {
   t: (key: string, opts?: { defaultValue?: string }) => string;
 }
 
-function ChannelCard({ channel: c, isSelected, viewMode, onSelect, onConfigure, onViewDetails, t }: ChannelCardProps) {
+const ChannelCard = memo(function ChannelCard({ channel: c, isSelected, viewMode, onSelect, onConfigure, onViewDetails, t }: ChannelCardProps) {
   // Whole-card click opens the details drawer. Inner controls
   // (checkbox, Configure button) call e.stopPropagation() so the
   // card-level handler doesn't fire when the user clicks them.
@@ -133,7 +133,7 @@ function ChannelCard({ channel: c, isSelected, viewMode, onSelect, onConfigure, 
       )}
     </Card>
   );
-}
+});
 
 // Details Modal
 function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
@@ -462,6 +462,7 @@ function QrLoginDialog({ channel, onClose, t }: { channel: Channel; onClose: () 
       // The backend holds each request ~30s (long-poll), so setInterval would
       // stack up parallel requests that all resolve at once on scan → flashing UI.
       const pollLoop = async () => {
+        let retries = 0;
         while (!cancelledRef.current && pollIdRef.current === pollId) {
           try {
             const status = await qrStatus(res.qr_code!);
@@ -491,6 +492,12 @@ function QrLoginDialog({ channel, onClose, t }: { channel: Channel; onClose: () 
           } catch {
             // Transient error — wait briefly then retry
             if (cancelledRef.current || pollIdRef.current !== pollId) break;
+            retries += 1;
+            if (retries >= 15) {
+              setPhase("error");
+              setMessage(t("channels.qr_failed") || "Connection lost. Please try again.");
+              return;
+            }
             await new Promise(r => setTimeout(r, 3000));
           }
         }
@@ -592,10 +599,15 @@ export function ChannelsPage() {
       onError: (err) => addToast(toastErr(err, t("common.error")), "error"),
     });
   };
+  const closeQrLogin = useCallback(() => setQrLoginChannel(null), []);
+  const handleCardConfigure = useCallback((ch: Channel) => {
+    if (ch.setup_type === "qr") setQrLoginChannel(ch);
+    else setConfiguringChannel(ch);
+  }, []);
 
   const channels = channelsQuery.data ?? [];
   const configuredCount = useMemo(() => channels.filter(c => c.configured).length, [channels]);
-  const unconfiguredCount = useMemo(() => channels.filter(c => !c.configured).length, [channels]);
+  const unconfiguredCount = channels.length - configuredCount;
 
   // Configured channels are the main page content. Filter/sort applies
   // to those only; the unconfigured catalog lives behind the Add picker.
@@ -614,8 +626,6 @@ export function ChannelsPage() {
       }),
     [channels, search, sortField, sortOrder],
   );
-
-  const paginatedChannels = filteredChannels;
 
   // Catalog of unconfigured channel types, surfaced in the Add picker.
   const pickerChannels = useMemo(
@@ -647,24 +657,24 @@ export function ChannelsPage() {
     }
   };
 
-  const handleSelect = (name: string, checked: boolean) => {
+  const handleSelect = useCallback((name: string, checked: boolean) => {
     setSelectedIds(prev => {
       const next = new Set(prev);
       if (checked) next.add(name);
       else next.delete(name);
       return next;
     });
-  };
+  }, []);
 
   const handleSelectAll = () => {
-    if (selectedIds.size === paginatedChannels.length) {
+    if (selectedIds.size === filteredChannels.length) {
       setSelectedIds(new Set());
     } else {
-      setSelectedIds(new Set(paginatedChannels.map(c => c.name)));
+      setSelectedIds(new Set(filteredChannels.map(c => c.name)));
     }
   };
 
-  const allSelected = paginatedChannels.length > 0 && selectedIds.size === paginatedChannels.length;
+  const allSelected = filteredChannels.length > 0 && selectedIds.size === filteredChannels.length;
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -801,14 +811,14 @@ export function ChannelsPage() {
           </div>
 
           <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
-            {paginatedChannels.map((c) => (
+            {filteredChannels.map((c) => (
               <ChannelCard
                 key={c.name}
                 channel={c}
                 isSelected={selectedIds.has(c.name)}
                 viewMode={viewMode}
                 onSelect={handleSelect}
-                onConfigure={(ch) => ch.setup_type === "qr" ? setQrLoginChannel(ch) : setConfiguringChannel(ch)}
+                onConfigure={handleCardConfigure}
                 onViewDetails={setDetailsChannel}
                 t={t}
               />
@@ -840,6 +850,7 @@ export function ChannelsPage() {
       {/* Config Dialog */}
       {configuringChannel && (
         <ConfigDialog
+          key={configuringChannel?.name}
           channel={configuringChannel}
           onClose={() => setConfiguringChannel(null)}
           t={t}
@@ -850,7 +861,7 @@ export function ChannelsPage() {
       {qrLoginChannel && (
         <QrLoginDialog
           channel={qrLoginChannel}
-          onClose={() => setQrLoginChannel(null)}
+          onClose={closeQrLogin}
           t={t}
         />
       )}

--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -852,16 +852,21 @@ export function ConfigPage({ category }: { category: string }) {
   // Which sections have pending changes (for tab dot indicators)
   const sectionsWithPending = useMemo(() => {
     const set = new Set<string>();
+    const rootFieldMap = new Map<string, string>();
+    for (const [sKey, desc] of Object.entries(sectionsByKey)) {
+      if (desc.root_level) {
+        for (const [fKey] of resolvedFields[sKey] ?? []) {
+          rootFieldMap.set(fKey, sKey);
+        }
+      }
+    }
     for (const path of Object.keys(pendingChanges)) {
       const dotIdx = path.indexOf(".");
       if (dotIdx !== -1) {
         set.add(path.slice(0, dotIdx));
       } else {
-        for (const [sKey, desc] of Object.entries(sectionsByKey)) {
-          if (desc.root_level && (resolvedFields[sKey] ?? []).some(([fKey]) => fKey === path)) {
-            set.add(sKey);
-          }
-        }
+        const sKey = rootFieldMap.get(path);
+        if (sKey) set.add(sKey);
       }
     }
     return set;

--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
-import { Link, useRouter } from "@tanstack/react-router";
+import { Link, useBlocker } from "@tanstack/react-router";
 import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import {
@@ -84,14 +84,17 @@ function sectionLabelFallback(key: string): string {
   return key.split("_").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
 }
 
+const ACRONYM_MAP: Record<string, string> = {
+  Api: "API", Url: "URL", Sql: "SQL", Ssl: "SSL", Tls: "TLS",
+  Ttl: "TTL", Env: "Env Var", Id: "ID", Usd: "USD", Llm: "LLM",
+  Mdns: "mDNS", Totp: "TOTP",
+};
+
 function fieldLabelFallback(key: string): string {
-  return key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
-    .replace(/\bApi\b/g, "API").replace(/\bUrl\b/g, "URL")
-    .replace(/\bSql\b/g, "SQL").replace(/\bSsl\b/g, "SSL")
-    .replace(/\bTls\b/g, "TLS").replace(/\bTtl\b/g, "TTL")
-    .replace(/\bEnv\b/g, "Env Var").replace(/\bId\b/g, "ID")
-    .replace(/\bUsd\b/g, "USD").replace(/\bLlm\b/g, "LLM")
-    .replace(/\bMdns\b/g, "mDNS").replace(/\bTotp\b/g, "TOTP");
+  return key
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/\b\w+\b/g, (w) => ACRONYM_MAP[w] ?? w);
 }
 
 /* ------------------------------------------------------------------ */
@@ -553,7 +556,6 @@ function ConfigFieldInput({
 
 export function ConfigPage({ category }: { category: string }) {
   const { t } = useTranslation();
-  const router = useRouter();
 
   const schemaQuery = useConfigSchema();
   const configQuery = useFullConfig();
@@ -565,6 +567,7 @@ export function ConfigPage({ category }: { category: string }) {
   const [activeSection, setActiveSection] = useState<string | null>(null);
   const [showRawToml, setShowRawToml] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
+  const saveStatusTimeoutRefs = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const rawTomlQuery = useRawConfigToml(showRawToml);
 
   const hasPendingChanges = Object.keys(pendingChanges).length > 0;
@@ -613,18 +616,22 @@ export function ConfigPage({ category }: { category: string }) {
     return () => window.removeEventListener("beforeunload", handler);
   }, [hasPendingChanges]);
 
+  const blocker = useBlocker({
+    shouldBlockFn: () => hasPendingChanges,
+    withResolver: true,
+  });
+  const blockerRef = useRef(blocker);
+  blockerRef.current = blocker;
+
   useEffect(() => {
-    if (!hasPendingChanges) return;
-    const unsub = router.subscribe("onBeforeNavigate", () => {
-      if (Object.keys(pendingChanges).length > 0) {
-        if (!window.confirm(t("config.unsaved_warning", "You have unsaved changes. Discard them?"))) {
-          throw new Error("Navigation cancelled");
-        }
-        setPendingChanges({});
-      }
-    });
-    return unsub;
-  }, [hasPendingChanges, pendingChanges, router, t]);
+    if (blockerRef.current.status !== "blocked") return;
+    if (window.confirm(t("config.unsaved_warning", "You have unsaved changes. Discard them?"))) {
+      setPendingChanges({});
+      blockerRef.current.proceed();
+    } else {
+      blockerRef.current.reset();
+    }
+  }, [blocker.status, t]);
 
   const handleFieldChange = useCallback(
     (sectionKey: string, fieldKey: string, value: unknown, rootLevel?: boolean) => {
@@ -677,11 +684,21 @@ export function ConfigPage({ category }: { category: string }) {
         }
         return p;
       });
-      setTimeout(() => setSaveStatus((s) => { const next = { ...s }; delete next[variables.path]; return next; }), 3000);
+      const existing = saveStatusTimeoutRefs.current[variables.path];
+      if (existing) clearTimeout(existing);
+      saveStatusTimeoutRefs.current[variables.path] = setTimeout(() => {
+        setSaveStatus((s) => { const next = { ...s }; delete next[variables.path]; return next; });
+        delete saveStatusTimeoutRefs.current[variables.path];
+      }, 3000);
     },
     onError: (err: Error, variables) => {
       setSaveStatus((s) => ({ ...s, [variables.path]: { ok: false, msg: err.message } }));
-      setTimeout(() => setSaveStatus((s) => { const next = { ...s }; delete next[variables.path]; return next; }), 3000);
+      const existing = saveStatusTimeoutRefs.current[variables.path];
+      if (existing) clearTimeout(existing);
+      saveStatusTimeoutRefs.current[variables.path] = setTimeout(() => {
+        setSaveStatus((s) => { const next = { ...s }; delete next[variables.path]; return next; });
+        delete saveStatusTimeoutRefs.current[variables.path];
+      }, 3000);
     },
   });
 
@@ -705,6 +722,9 @@ export function ConfigPage({ category }: { category: string }) {
 
   useEffect(() => () => {
     for (const timeoutId of Object.values(batchStatusTimeoutRefs.current)) {
+      clearTimeout(timeoutId);
+    }
+    for (const timeoutId of Object.values(saveStatusTimeoutRefs.current)) {
       clearTimeout(timeoutId);
     }
   }, []);
@@ -757,11 +777,16 @@ export function ConfigPage({ category }: { category: string }) {
         ...s,
         __batch__: { ok: false, msg: err.message || t("config.save_failed") },
       }));
-      setTimeout(() => setSaveStatus((s) => {
-        const next = { ...s };
-        delete next.__batch__;
-        return next;
-      }), 5000);
+      const existing = batchStatusTimeoutRefs.current["__batch__"];
+      if (existing) clearTimeout(existing);
+      batchStatusTimeoutRefs.current["__batch__"] = setTimeout(() => {
+        setSaveStatus((s) => {
+          const next = { ...s };
+          delete next.__batch__;
+          return next;
+        });
+        delete batchStatusTimeoutRefs.current["__batch__"];
+      }, 5000);
     },
   });
   const handleBatchSave = useCallback(async () => {
@@ -825,16 +850,22 @@ export function ConfigPage({ category }: { category: string }) {
     : (activeSection && sectionKeys.includes(activeSection) ? activeSection : sectionKeys[0] ?? null);
 
   // Which sections have pending changes (for tab dot indicators)
-  const sectionHasPending = useCallback((sKey: string): boolean => {
-    const desc = sectionsByKey[sKey];
-    if (!desc) return false;
-    return Object.keys(pendingChanges).some((path) => {
-      if (desc.root_level) {
-        return (resolvedFields[sKey] ?? []).some(([fKey]) => fKey === path);
+  const sectionsWithPending = useMemo(() => {
+    const set = new Set<string>();
+    for (const path of Object.keys(pendingChanges)) {
+      const dotIdx = path.indexOf(".");
+      if (dotIdx !== -1) {
+        set.add(path.slice(0, dotIdx));
+      } else {
+        for (const [sKey, desc] of Object.entries(sectionsByKey)) {
+          if (desc.root_level && (resolvedFields[sKey] ?? []).some(([fKey]) => fKey === path)) {
+            set.add(sKey);
+          }
+        }
       }
-      return path.startsWith(sKey + ".");
-    });
-  }, [sectionsByKey, resolvedFields, pendingChanges]);
+    }
+    return set;
+  }, [pendingChanges, sectionsByKey, resolvedFields]);
 
   const filteredSections = useMemo(() => {
     const keysToShow = effectiveTab ? [effectiveTab] : sectionKeys;
@@ -943,7 +974,7 @@ export function ConfigPage({ category }: { category: string }) {
         <div className="flex items-center border-b border-border-subtle -mx-6 px-6">
           {sectionKeys.map((sKey) => {
             const isActive = !isSearching && effectiveTab === sKey;
-            const hasDot = sectionHasPending(sKey);
+            const hasDot = sectionsWithPending.has(sKey);
             return (
               <button
                 key={sKey}

--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
+import React, { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
@@ -62,6 +62,7 @@ import { useCreateSchedule, useUpdateSchedule, useDeleteSchedule } from "../lib/
 import { ScheduleModal } from "../components/ui/ScheduleModal";
 import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { useCronJobs } from "../lib/queries/runtime";
+import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 
 
 
@@ -546,11 +547,15 @@ function HandSettingsEditor({
   const [draft, setDraft] = useState<Record<string, string>>({});
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveOk, setSaveOk] = useState(false);
+  const saveOkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setDraft({});
     setSaveOk(false);
     setSaveError(null);
+    return () => {
+      if (saveOkTimerRef.current) clearTimeout(saveOkTimerRef.current);
+    };
   }, [settings]);
 
   const saveMutation = useUpdateHandSettings();
@@ -589,7 +594,8 @@ function HandSettingsEditor({
           setSaveOk(true);
           setSaveError(null);
           setDraft({});
-          setTimeout(() => setSaveOk(false), 2500);
+          if (saveOkTimerRef.current) clearTimeout(saveOkTimerRef.current);
+          saveOkTimerRef.current = setTimeout(() => setSaveOk(false), 2500);
         },
         onError: (err: Error) => {
           setSaveError(err.message || String(err));
@@ -1226,10 +1232,17 @@ const HandCard = React.memo(function HandCard({
 export function HandsPage() {
   const { t } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
-  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [pendingHandId, setPendingHandId] = useState<string | null>(null);
+  const [pendingInstanceId, setPendingInstanceId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string>("all");
   const [detailHand, setDetailHand] = useState<HandDefinitionItem | null>(null);
+  const [confirmDialog, setConfirmDialog] = useState<{
+    title: string;
+    message: string;
+    onConfirm: () => void;
+    tone?: "destructive";
+  } | null>(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -1247,9 +1260,9 @@ export function HandsPage() {
   const hands = handsQuery.data ?? [];
   const instances = activeQuery.data ?? [];
 
-  const handleChat = useCallback((instanceId: string) => {
+  const handleChat = useCallback((instanceId: string, handName?: string) => {
     const inst = instances.find((i) => i.instance_id === instanceId);
-    navigate({ to: "/chat", search: { agentId: inst?.agent_id || instanceId } });
+    navigate({ to: "/chat", search: { agentId: inst?.agent_id || instanceId, handName } });
   }, [instances, navigate]);
 
   const activeInstanceIds = useMemo(() => instances.map(i => i.instance_id).filter(Boolean), [instances]);
@@ -1288,15 +1301,23 @@ export function HandsPage() {
   }, [hands]);
 
   // Active hands paired with their definitions — used by the running strip
+  const handById = useMemo(() => {
+    const map = new Map<string, HandDefinitionItem>();
+    for (const h of hands) {
+      map.set(h.id, h);
+    }
+    return map;
+  }, [hands]);
+
   const activeHandPairs = useMemo(
     () =>
       instances
         .map((inst) => ({
           instance: inst,
-          hand: hands.find((h) => h.id === inst.hand_id),
+          hand: handById.get(inst.hand_id ?? ""),
         }))
         .filter((x): x is { instance: HandInstanceItem; hand: HandDefinitionItem } => x.hand != null),
-    [instances, hands],
+    [instances, handById],
   );
 
   // Filtered hands for the catalog grid — all hands pass, active sort first
@@ -1323,7 +1344,7 @@ export function HandsPage() {
   }, [hands, search, selectedCategory, activeHandIds]);
 
   async function handleActivate(id: string) {
-    setPendingId(id);
+    setPendingHandId(id);
     try {
       await activateMutation.mutateAsync(id);
       addToast(t("common.success"), "success");
@@ -1331,12 +1352,12 @@ export function HandsPage() {
       const msg = e instanceof Error ? e.message : t("common.error");
       addToast(msg, "error");
     } finally {
-      setPendingId(null);
+      setPendingHandId(null);
     }
   }
 
   async function handleDeactivate(id: string) {
-    setPendingId(id);
+    setPendingInstanceId(id);
     try {
       await deactivateMutation.mutateAsync(id);
       addToast(t("common.success"), "success");
@@ -1345,30 +1366,36 @@ export function HandsPage() {
       const msg = e instanceof Error ? e.message : t("common.error");
       addToast(msg, "error");
     } finally {
-      setPendingId(null);
+      setPendingInstanceId(null);
     }
   }
 
-  async function handleUninstall(handId: string) {
-    const confirmMsg = t("hands.uninstall_confirm", {
-      defaultValue: "Uninstall this hand? Its HAND.toml and workspace files will be deleted. This cannot be undone.",
+  function handleUninstall(handId: string) {
+    setConfirmDialog({
+      title: t("hands.uninstall", { defaultValue: "Uninstall" }),
+      message: t("hands.uninstall_confirm", {
+        defaultValue: "Uninstall this hand? Its HAND.toml and workspace files will be deleted. This cannot be undone.",
+      }),
+      tone: "destructive",
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        setPendingHandId(handId);
+        try {
+          await uninstallMutation.mutateAsync(handId);
+          addToast(t("common.success"), "success");
+          setDetailHand(null);
+        } catch (e: unknown) {
+          const msg = e instanceof Error ? e.message : t("common.error");
+          addToast(msg, "error");
+        } finally {
+          setPendingHandId(null);
+        }
+      },
     });
-    if (!window.confirm(confirmMsg)) return;
-    setPendingId(handId);
-    try {
-      await uninstallMutation.mutateAsync(handId);
-      addToast(t("common.success"), "success");
-      setDetailHand(null);
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : t("common.error");
-      addToast(msg, "error");
-    } finally {
-      setPendingId(null);
-    }
   }
 
   async function handlePause(id: string) {
-    setPendingId(id);
+    setPendingInstanceId(id);
     try {
       await pauseMutation.mutateAsync(id);
       addToast(t("common.success"), "success");
@@ -1376,12 +1403,12 @@ export function HandsPage() {
       const msg = e instanceof Error ? e.message : t("common.error");
       addToast(msg, "error");
     } finally {
-      setPendingId(null);
+      setPendingInstanceId(null);
     }
   }
 
   async function handleResume(id: string) {
-    setPendingId(id);
+    setPendingInstanceId(id);
     try {
       await resumeMutation.mutateAsync(id);
       addToast(t("common.success"), "success");
@@ -1389,7 +1416,7 @@ export function HandsPage() {
       const msg = e instanceof Error ? e.message : t("common.error");
       addToast(msg, "error");
     } finally {
-      setPendingId(null);
+      setPendingInstanceId(null);
     }
   }
 
@@ -1453,7 +1480,7 @@ export function HandsPage() {
                 onChat={handleChat}
                 onDeactivate={handleDeactivate}
                 onDetail={setDetailHand}
-                isPending={pendingId === instance.instance_id}
+                isPending={pendingInstanceId === instance.instance_id}
               />
             ))}
           </div>
@@ -1543,7 +1570,7 @@ export function HandsPage() {
                 onDeactivate={(id) => handleDeactivate(id)}
                 onDetail={setDetailHand}
                 onChat={handleChat}
-                isPending={pendingId === h.id || (instance ? pendingId === instance.instance_id : false)}
+                isPending={pendingHandId === h.id || (instance ? pendingInstanceId === instance.instance_id : false)}
               />
             );
           })}
@@ -1564,10 +1591,18 @@ export function HandsPage() {
           onResume={handleResume}
           onChat={handleChat}
           onUninstall={handleUninstall}
-          isPending={pendingId === detailHandLatest.id}
+          isPending={pendingHandId === detailHandLatest.id || (!!detailInstance && pendingInstanceId === detailInstance.instance_id)}
         />
       )}
 
+      <ConfirmDialog
+        isOpen={confirmDialog !== null}
+        title={confirmDialog?.title ?? ""}
+        message={confirmDialog?.message ?? ""}
+        tone={confirmDialog?.tone}
+        onConfirm={() => confirmDialog?.onConfirm()}
+        onClose={() => setConfirmDialog(null)}
+      />
     </div>
   );
 }

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.test.tsx
@@ -5,6 +5,7 @@
 // mock those hooks here and assert the page renders / wires mutations
 // correctly — same convention as UserBudgetPage.test.tsx.
 
+import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -76,6 +77,20 @@ vi.mock("../components/ui/DrawerPanel", () => ({
 vi.mock("../components/ui/MarkdownContent", () => ({
   MarkdownContent: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="markdown">{children}</div>
+  ),
+}));
+
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  motion: new Proxy(
+    {},
+    {
+      get: (_target: unknown, prop: string) =>
+        ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) =>
+          React.createElement(prop, rest, children),
+    },
   ),
 }));
 
@@ -292,16 +307,15 @@ describe("MemoryPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("calls useDeleteMemory.mutate with the memory id when trash is clicked", async () => {
+  it("calls useDeleteMemory.mutate with the memory id when trash is clicked and confirmed", async () => {
     renderPage();
-    // The first memory card has Edit + Delete ghost buttons. Find delete by
-    // Trash2 icon — easier: query all buttons inside the first card.
     const firstCardId = screen.getByText("mem-aaaaaaaa");
     const card = firstCardId.closest("div.flex")?.parentElement?.parentElement;
     expect(card).toBeTruthy();
     const buttons = within(card as HTMLElement).getAllByRole("button");
-    // Last button in the action row is delete.
     fireEvent.click(buttons[buttons.length - 1]);
+    const confirmBtn = await screen.findByRole("button", { name: "Delete" });
+    fireEvent.click(confirmBtn);
     await waitFor(() => {
       expect(deleteMutate).toHaveBeenCalledTimes(1);
     });

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -17,12 +17,14 @@ import { MarkdownContent } from "../components/ui/MarkdownContent";
 import { DrawerPanel } from "../components/ui/DrawerPanel";
 import { useUIStore } from "../lib/store";
 import { useCreateShortcut } from "../lib/useCreateShortcut";
+import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 import { Database, Search, Trash2, Plus, X, Sparkles, Zap, Clock, Edit2, Loader2, Settings } from "lucide-react";
 import { StaggerList } from "../components/ui/StaggerList";
 
 // Add Memory Dialog
 function AddMemoryDialog({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
+  const addToast = useUIStore((s) => s.addToast);
   const [content, setContent] = useState("");
   const [agentId, setAgentId] = useState("");
   const [level, setLevel] = useState("session");
@@ -32,7 +34,10 @@ function AddMemoryDialog({ onClose }: { onClose: () => void }) {
   const handleAdd = () => {
     addMutation.mutate(
       { content, level, agentId: agentId || undefined },
-      { onSuccess: () => onClose() }
+      {
+        onSuccess: () => onClose(),
+        onError: (err) => addToast(err instanceof Error ? err.message : t("common.error"), "error"),
+      }
     );
   };
 
@@ -91,6 +96,7 @@ function AddMemoryDialog({ onClose }: { onClose: () => void }) {
 // Edit Memory Dialog
 function EditMemoryDialog({ memory, onClose }: { memory: { id: string; content?: string }; onClose: () => void }) {
   const { t } = useTranslation();
+  const addToast = useUIStore((s) => s.addToast);
   const [content, setContent] = useState(memory.content || "");
 
   const editMutation = useUpdateMemory();
@@ -98,7 +104,10 @@ function EditMemoryDialog({ memory, onClose }: { memory: { id: string; content?:
   const handleSave = () => {
     editMutation.mutate(
       { id: memory.id, content },
-      { onSuccess: () => onClose() }
+      {
+        onSuccess: () => onClose(),
+        onError: (err) => addToast(err instanceof Error ? err.message : t("common.error"), "error"),
+      }
     );
   };
 
@@ -272,7 +281,7 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
               ].map(opt => (
                 <label key={opt.key} className="flex items-center justify-between rounded-lg bg-main/50 px-3 py-2">
                   <span className="text-xs font-medium">{opt.label}</span>
-                  <button onClick={() => setForm({ ...form, [opt.key]: !form[opt.key as keyof MemoryConfigForm] })}
+                  <button role="switch" aria-checked={!!form[opt.key as keyof MemoryConfigForm]} aria-label={opt.label} onClick={() => setForm({ ...form, [opt.key]: !form[opt.key as keyof MemoryConfigForm] })}
                     className={`w-10 h-5 rounded-full transition-colors ${form[opt.key as keyof MemoryConfigForm] ? "bg-brand" : "bg-border-subtle"}`}>
                     <div className={`w-4 h-4 rounded-full bg-white shadow transition-transform ${form[opt.key as keyof MemoryConfigForm] ? "translate-x-5" : "translate-x-0.5"}`} />
                   </button>
@@ -330,6 +339,9 @@ const KV_VALUE_TRUNCATE = 200;
 // inflating page memory for what's only meant to be a quick peek.
 const KV_TITLE_TRUNCATE = 2000;
 
+// TODO(perf): N+1 queries — each AgentKvRows issues its own useAgentKvMemory(agentId).
+// Replace with useQueries (tanstack-query v5) in AgentKvSection to batch all agent
+// KV lookups into a single observer array and pass data as props.
 function AgentKvRows({ agentId }: { agentId: string }) {
   const { t } = useTranslation();
   const kvQuery = useAgentKvMemory(agentId);
@@ -446,7 +458,7 @@ export function MemoryPage() {
   const [showConfigDialog, setShowConfigDialog] = useState(false);
   useCreateShortcut(() => setShowAddDialog(true));
   const [editingMemory, setEditingMemory] = useState<{ id: string; content?: string } | null>(null);
-
+  const [deleteConfirm, setDeleteConfirm] = useState<{ id: string } | null>(null);
 
   const memoryConfigQuery = useMemoryConfig();
   // Server-side liveness probe — distinct from "provider is configured".
@@ -672,10 +684,7 @@ export function MemoryPage() {
                       <Button variant="ghost" size="sm" onClick={() => setEditingMemory(m)}>
                         <Edit2 className="h-3.5 w-3.5" />
                       </Button>
-                      <Button variant="ghost" size="sm" className="text-error! hover:bg-error/10!" onClick={() => deleteMutation.mutate(m.id, {
-                        onSuccess: () => addToast(t("memory.delete_success", { defaultValue: "Memory deleted" }), "success"),
-                        onError: (err) => addToast(err instanceof Error ? err.message : t("common.error"), "error"),
-                      })}>
+                      <Button variant="ghost" size="sm" className="text-error! hover:bg-error/10!" onClick={() => setDeleteConfirm({ id: m.id })}>
                         <Trash2 className="h-3.5 w-3.5" />
                       </Button>
                     </div>
@@ -715,6 +724,24 @@ export function MemoryPage() {
       {showAddDialog && <AddMemoryDialog onClose={() => setShowAddDialog(false)} />}
       {editingMemory && <EditMemoryDialog memory={editingMemory} onClose={() => setEditingMemory(null)} />}
       {showConfigDialog && <MemoryConfigDialog onClose={() => setShowConfigDialog(false)} />}
+
+      <ConfirmDialog
+        isOpen={deleteConfirm !== null}
+        title={t("memory.delete_confirm_title", { defaultValue: "Delete Memory" })}
+        message={t("memory.delete_confirm_message", { defaultValue: "This memory will be permanently deleted." })}
+        tone="destructive"
+        confirmLabel={t("common.delete", { defaultValue: "Delete" })}
+        onConfirm={() => {
+          if (deleteConfirm) {
+            deleteMutation.mutate(deleteConfirm.id, {
+              onSuccess: () => addToast(t("memory.delete_success", { defaultValue: "Memory deleted" }), "success"),
+              onError: (err) => addToast(err instanceof Error ? err.message : t("common.error"), "error"),
+            });
+          }
+          setDeleteConfirm(null);
+        }}
+        onClose={() => setDeleteConfirm(null)}
+      />
     </div>
   );
 }

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -1,6 +1,6 @@
 import { formatCost as formatCostUtil } from "../lib/format";
 import type { ModelItem, ModelOverrides } from "../api";
-import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { FormEvent, memo, useCallback, useEffect, useReducer, useRef, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useModels, useModelOverrides } from "../lib/queries/models";
 import { useAddCustomModel, useRemoveCustomModel, useUpdateModelOverrides, useDeleteModelOverrides } from "../lib/mutations/models";
@@ -45,24 +45,117 @@ const formatCtx = (tokens?: number) => {
   return String(tokens);
 };
 
-// ── ModelCard ─────────────────────────────────────────────────────
+// ── Add-form reducer (MD4) ──────────────────────────────────────
+
+type AddFormState = {
+  id: string;
+  provider: string;
+  displayName: string;
+  contextWindow: number;
+  maxOutput: number;
+  inputCost: number;
+  outputCost: number;
+  tools: boolean;
+  vision: boolean;
+  streaming: boolean;
+};
+
+type AddFormAction =
+  | { type: "SET_FIELD"; field: keyof AddFormState; value: AddFormState[keyof AddFormState] }
+  | { type: "RESET" };
+
+const addFormInitial: AddFormState = {
+  id: "",
+  provider: "",
+  displayName: "",
+  contextWindow: 128000,
+  maxOutput: 8192,
+  inputCost: 0,
+  outputCost: 0,
+  tools: true,
+  vision: false,
+  streaming: true,
+};
+
+function addFormReducer(state: AddFormState, action: AddFormAction): AddFormState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "RESET":
+      return addFormInitial;
+    default:
+      return state;
+  }
+}
+
+// ── Settings-form reducer (MD5/MD6/MD7) ────────────────────────
+
+type SettingsState = {
+  modelType: "chat" | "speech" | "embedding";
+  temperature: number;
+  tempEnabled: boolean;
+  topP: number;
+  topPEnabled: boolean;
+  maxTokens: number;
+  maxTokensEnabled: boolean;
+  freqPenalty: number;
+  freqEnabled: boolean;
+  presPenalty: number;
+  presEnabled: boolean;
+  reasoningEffort: string;
+  useMaxCompletionTokens: boolean;
+  noSystemRole: boolean;
+  forceMaxTokens: boolean;
+};
+
+type SettingsAction =
+  | { type: "SET_FIELD"; field: keyof SettingsState; value: SettingsState[keyof SettingsState] }
+  | { type: "HYDRATE"; payload: Partial<SettingsState> };
+
+const settingsInitial: SettingsState = {
+  modelType: "chat",
+  temperature: 0.7,
+  tempEnabled: false,
+  topP: 1.0,
+  topPEnabled: false,
+  maxTokens: 4096,
+  maxTokensEnabled: false,
+  freqPenalty: 0.0,
+  freqEnabled: false,
+  presPenalty: 0.0,
+  presEnabled: false,
+  reasoningEffort: "",
+  useMaxCompletionTokens: false,
+  noSystemRole: false,
+  forceMaxTokens: false,
+};
+
+function settingsReducer(state: SettingsState, action: SettingsAction): SettingsState {
+  switch (action.type) {
+    case "SET_FIELD":
+      return { ...state, [action.field]: action.value };
+    case "HYDRATE":
+      return { ...state, ...action.payload };
+    default:
+      return state;
+  }
+}
+
+// ── ModelCard (MD2: memo, MD3: stable callback signatures) ──────
 
 type CardProps = {
   m: ModelItem;
   hidden: boolean;
-  onOpen: () => void;
-  onSettings: () => void;
-  onToggleHidden: () => void;
-  onDelete: () => void;
+  onOpen: (m: ModelItem) => void;
+  onSettings: (m: ModelItem) => void;
+  onToggleHidden: (m: ModelItem) => void;
+  onDelete: (id: string) => void;
   pendingDelete: boolean;
 };
 
-function ModelCard({ m, hidden, onOpen, onSettings, onToggleHidden, onDelete, pendingDelete }: CardProps) {
+const ModelCard = memo(function ModelCard({ m, hidden, onOpen, onSettings, onToggleHidden, onDelete, pendingDelete }: CardProps) {
   const { t } = useTranslation();
   const isCustom = m.tier === "custom";
-  // Treat as free only when both costs are explicitly declared as 0 in the
-  // catalog. `undefined` means "unknown" (e.g. local-model entries that don't
-  // ship pricing) and must NOT render as the green Free badge.
   const free = m.input_cost_per_m === 0 && m.output_cost_per_m === 0;
 
   const formatCost = (cost?: number) => {
@@ -76,11 +169,11 @@ function ModelCard({ m, hidden, onOpen, onSettings, onToggleHidden, onDelete, pe
       role="button"
       tabIndex={0}
       aria-label={m.display_name || m.id}
-      onClick={onOpen}
+      onClick={() => onOpen(m)}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          onOpen();
+          onOpen(m);
         }
       }}
       className={`group relative flex flex-col gap-2.5 p-4 rounded-2xl border bg-surface hover:bg-main/40 hover:border-brand/40 focus-visible:outline-none focus-visible:border-brand focus-visible:ring-2 focus-visible:ring-brand/30 transition-colors cursor-pointer min-h-[124px] ${
@@ -146,18 +239,18 @@ function ModelCard({ m, hidden, onOpen, onSettings, onToggleHidden, onDelete, pe
         {/* Hover-revealed actions */}
         <div className="ml-auto flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
           <button type="button" title={t("models.settings_title")}
-            onClick={(e) => { e.stopPropagation(); onSettings(); }}
+            onClick={(e) => { e.stopPropagation(); onSettings(m); }}
             className="flex items-center justify-center w-6 h-6 rounded-md text-text-dim hover:bg-main hover:text-text transition-colors">
             <Settings className="w-3 h-3" />
           </button>
           <button type="button" title={hidden ? t("models.unhide_model") : t("models.hide_model")}
-            onClick={(e) => { e.stopPropagation(); onToggleHidden(); }}
+            onClick={(e) => { e.stopPropagation(); onToggleHidden(m); }}
             className="flex items-center justify-center w-6 h-6 rounded-md text-text-dim hover:bg-main hover:text-text transition-colors">
             {hidden ? <Eye className="w-3 h-3" /> : <EyeOff className="w-3 h-3" />}
           </button>
           {isCustom && (
             <button type="button" title={t("models.delete_model")}
-              onClick={(e) => { e.stopPropagation(); onDelete(); }}
+              onClick={(e) => { e.stopPropagation(); onDelete(m.id); }}
               className={`flex items-center justify-center w-6 h-6 rounded-md transition-colors ${
                 pendingDelete ? "bg-error/15 text-error" : "text-text-dim hover:bg-error/10 hover:text-error"
               }`}>
@@ -168,7 +261,7 @@ function ModelCard({ m, hidden, onOpen, onSettings, onToggleHidden, onDelete, pe
       </div>
     </div>
   );
-}
+});
 
 // ── ModelDetailBody ───────────────────────────────────────────────
 // Body rendered inside the global PushDrawer when a card is opened.
@@ -217,11 +310,11 @@ function ModelDetailBody({
         </div>
         <div>
           <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_input")}</div>
-          <span className="font-mono">${m.input_cost_per_m ?? 0} / M</span>
+          <span className="font-mono">{formatCostUtil(m.input_cost_per_m ?? 0)} / M</span>
         </div>
         <div>
           <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.col_output")}</div>
-          <span className="font-mono">${m.output_cost_per_m ?? 0} / M</span>
+          <span className="font-mono">{formatCostUtil(m.output_cost_per_m ?? 0)} / M</span>
         </div>
         <div>
           <div className="text-[10px] font-bold text-text-dim uppercase mb-1">{t("models.max_output")}</div>
@@ -284,68 +377,35 @@ export function ModelsPage() {
   const [settingsModel, setSettingsModel] = useState<ModelItem | null>(null);
   const [detailModel, setDetailModel] = useState<ModelItem | null>(null);
 
-  const [formId, setFormId] = useState("");
-  const [formProvider, setFormProvider] = useState("");
-  const [formDisplayName, setFormDisplayName] = useState("");
-  const [formContextWindow, setFormContextWindow] = useState(128000);
-  const [formMaxOutput, setFormMaxOutput] = useState(8192);
-  const [formInputCost, setFormInputCost] = useState(0);
-  const [formOutputCost, setFormOutputCost] = useState(0);
-  const [formTools, setFormTools] = useState(true);
-  const [formVision, setFormVision] = useState(false);
-  const [formStreaming, setFormStreaming] = useState(true);
+  const [form, dispatchForm] = useReducer(addFormReducer, addFormInitial);
 
   const modelsQuery = useModels();
   const addMut = useAddCustomModel();
   const deleteMut = useRemoveCustomModel();
 
-  const resetForm = () => {
+  const resetForm = useCallback(() => {
     setShowAdd(false);
-    setFormId("");
-    setFormProvider("");
-    setFormDisplayName("");
-    setFormContextWindow(128000);
-    setFormMaxOutput(8192);
-    setFormInputCost(0);
-    setFormOutputCost(0);
-    setFormTools(true);
-    setFormVision(false);
-    setFormStreaming(true);
-  };
+    dispatchForm({ type: "RESET" });
+  }, []);
 
   const handleAdd = async (e: FormEvent) => {
     e.preventDefault();
-    if (!formId.trim() || !formProvider.trim()) return;
+    if (!form.id.trim() || !form.provider.trim()) return;
     try {
       await addMut.mutateAsync({
-        id: formId.trim(),
-        provider: formProvider.trim(),
-        display_name: formDisplayName.trim() || undefined,
-        context_window: formContextWindow,
-        max_output_tokens: formMaxOutput,
-        input_cost_per_m: formInputCost,
-        output_cost_per_m: formOutputCost,
-        supports_tools: formTools,
-        supports_vision: formVision,
-        supports_streaming: formStreaming,
+        id: form.id.trim(),
+        provider: form.provider.trim(),
+        display_name: form.displayName.trim() || undefined,
+        context_window: form.contextWindow,
+        max_output_tokens: form.maxOutput,
+        input_cost_per_m: form.inputCost,
+        output_cost_per_m: form.outputCost,
+        supports_tools: form.tools,
+        supports_vision: form.vision,
+        supports_streaming: form.streaming,
       });
       addToast(t("models.model_added"), "success");
       resetForm();
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      addToast(msg || t("common.error"), "error");
-    }
-  };
-
-  const handleDelete = async (id: string) => {
-    if (confirmDeleteId !== id) { setConfirmDeleteId(id); return; }
-    setConfirmDeleteId(null);
-    try {
-      const model = allModels.find(m => m.id === id);
-      const key = model ? modelKey(model) : null;
-      await deleteMut.mutateAsync(id);
-      addToast(t("models.model_deleted"), "success");
-      if (key && hiddenModelKeys.includes(key)) unhideModelAction(key);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       addToast(msg || t("common.error"), "error");
@@ -401,7 +461,6 @@ export function ModelsPage() {
 
   const hiddenCount = useMemo(() => allModels.filter(m => hiddenSet.has(modelKey(m))).length, [allModels, hiddenSet]);
 
-  // Always group by provider — no toggle, sticky headers do the work.
   const grouped = useMemo(() => {
     const map = new Map<string, ModelItem[]>();
     for (const m of filtered) {
@@ -412,7 +471,7 @@ export function ModelsPage() {
     return new Map([...map.entries()].sort(([a], [b]) => a.localeCompare(b)));
   }, [filtered]);
 
-  const toggleHidden = (m: ModelItem) => {
+  const toggleHidden = useCallback((m: ModelItem) => {
     const key = modelKey(m);
     if (hiddenSet.has(key)) {
       unhideModelAction(key);
@@ -421,7 +480,32 @@ export function ModelsPage() {
       hideModelAction(key);
       addToast(t("models.model_hidden"), "success");
     }
-  };
+  }, [hiddenSet, unhideModelAction, hideModelAction, addToast, t]);
+
+  const handleCardOpen = useCallback((m: ModelItem) => setDetailModel(m), []);
+  const handleCardSettings = useCallback((m: ModelItem) => setSettingsModel(m), []);
+
+  const allModelsRef = useRef(allModels);
+  allModelsRef.current = allModels;
+  const hiddenModelKeysRef = useRef(hiddenModelKeys);
+  hiddenModelKeysRef.current = hiddenModelKeys;
+  const confirmDeleteIdRef = useRef(confirmDeleteId);
+  confirmDeleteIdRef.current = confirmDeleteId;
+
+  const handleDelete = useCallback(async (id: string) => {
+    if (confirmDeleteIdRef.current !== id) { setConfirmDeleteId(id); return; }
+    setConfirmDeleteId(null);
+    try {
+      const model = allModelsRef.current.find(m => m.id === id);
+      const key = model ? modelKey(model) : null;
+      await deleteMut.mutateAsync(id);
+      addToast(t("models.model_deleted"), "success");
+      if (key && hiddenModelKeysRef.current.includes(key)) unhideModelAction(key);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addToast(msg || t("common.error"), "error");
+    }
+  }, [deleteMut, addToast, t, unhideModelAction]);
 
   const detailHidden = detailModel ? hiddenSet.has(modelKey(detailModel)) : false;
 
@@ -531,10 +615,10 @@ export function ModelsPage() {
                       key={`${m.provider}:${m.id}`}
                       m={m}
                       hidden={hiddenSet.has(modelKey(m))}
-                      onOpen={() => setDetailModel(m)}
-                      onSettings={() => setSettingsModel(m)}
-                      onToggleHidden={() => toggleHidden(m)}
-                      onDelete={() => handleDelete(m.id)}
+                      onOpen={handleCardOpen}
+                      onSettings={handleCardSettings}
+                      onToggleHidden={toggleHidden}
+                      onDelete={handleDelete}
                       pendingDelete={confirmDeleteId === m.id}
                     />
                   ))}
@@ -575,40 +659,40 @@ export function ModelsPage() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="sm:col-span-2">
               <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.model_id")} *</label>
-              <input value={formId} onChange={e => setFormId(e.target.value)} placeholder={t("models.model_id_placeholder")} className={inputClass} required />
+              <input value={form.id} onChange={e => dispatchForm({ type: "SET_FIELD", field: "id", value: e.target.value })} placeholder={t("models.model_id_placeholder")} className={inputClass} required />
             </div>
             <div>
               <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.provider")} *</label>
-              <input value={formProvider} onChange={e => setFormProvider(e.target.value)} placeholder={t("models.provider_placeholder")} className={inputClass} required />
+              <input value={form.provider} onChange={e => dispatchForm({ type: "SET_FIELD", field: "provider", value: e.target.value })} placeholder={t("models.provider_placeholder")} className={inputClass} required />
             </div>
             <div>
               <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.display_name")}</label>
-              <input value={formDisplayName} onChange={e => setFormDisplayName(e.target.value)} placeholder={t("models.display_name_placeholder")} className={inputClass} />
+              <input value={form.displayName} onChange={e => dispatchForm({ type: "SET_FIELD", field: "displayName", value: e.target.value })} placeholder={t("models.display_name_placeholder")} className={inputClass} />
             </div>
             <div>
               <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.context_window")}</label>
-              <input type="number" value={formContextWindow} onChange={e => setFormContextWindow(+e.target.value)} className={inputClass} />
+              <input type="number" value={form.contextWindow} onChange={e => dispatchForm({ type: "SET_FIELD", field: "contextWindow", value: +e.target.value })} className={inputClass} />
             </div>
             <div>
               <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.max_output")}</label>
-              <input type="number" value={formMaxOutput} onChange={e => setFormMaxOutput(+e.target.value)} className={inputClass} />
+              <input type="number" value={form.maxOutput} onChange={e => dispatchForm({ type: "SET_FIELD", field: "maxOutput", value: +e.target.value })} className={inputClass} />
             </div>
             <div>
               <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.input_cost")}</label>
-              <input type="number" step="0.01" value={formInputCost} onChange={e => setFormInputCost(+e.target.value)} className={inputClass} />
+              <input type="number" step="0.01" value={form.inputCost} onChange={e => dispatchForm({ type: "SET_FIELD", field: "inputCost", value: +e.target.value })} className={inputClass} />
             </div>
             <div>
               <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.output_cost")}</label>
-              <input type="number" step="0.01" value={formOutputCost} onChange={e => setFormOutputCost(+e.target.value)} className={inputClass} />
+              <input type="number" step="0.01" value={form.outputCost} onChange={e => dispatchForm({ type: "SET_FIELD", field: "outputCost", value: +e.target.value })} className={inputClass} />
             </div>
           </div>
           <div className="flex flex-wrap gap-3">
             {([
-              ["tools", formTools, setFormTools, t("models.supports_tools")] as const,
-              ["vision", formVision, setFormVision, t("models.supports_vision")] as const,
-              ["streaming", formStreaming, setFormStreaming, t("models.supports_streaming")] as const,
-            ]).map(([key, val, setter, label]) => (
-              <button key={key} type="button" onClick={() => setter(!val)}
+              ["tools", form.tools, "tools", t("models.supports_tools")] as const,
+              ["vision", form.vision, "vision", t("models.supports_vision")] as const,
+              ["streaming", form.streaming, "streaming", t("models.supports_streaming")] as const,
+            ]).map(([key, val, field, label]) => (
+              <button key={key} type="button" onClick={() => dispatchForm({ type: "SET_FIELD", field, value: !val })}
                 className={`flex items-center gap-1.5 px-3 py-2 rounded-xl border text-xs font-bold transition-colors ${
                   val ? "border-success bg-success/10 text-success" : "border-border-subtle text-text-dim"
                 }`}>
@@ -621,7 +705,7 @@ export function ModelsPage() {
             <div className="flex items-center gap-2 text-error text-xs"><AlertCircle className="w-4 h-4" /> {(addMut.error as Error)?.message}</div>
           )}
           <div className="flex gap-2 pt-2">
-            <Button type="submit" variant="primary" className="flex-1" disabled={addMut.isPending || !formId.trim() || !formProvider.trim()}>
+            <Button type="submit" variant="primary" className="flex-1" disabled={addMut.isPending || !form.id.trim() || !form.provider.trim()}>
               {addMut.isPending ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Plus className="w-4 h-4 mr-1" />}
               {t("models.add_model")}
             </Button>
@@ -633,6 +717,7 @@ export function ModelsPage() {
       {/* Model Settings Modal */}
       {settingsModel && (
         <ModelSettingsModal
+          key={`${settingsModel.provider}:${settingsModel.id}`}
           model={settingsModel}
           onClose={() => setSettingsModel(null)}
           onSaved={() => {
@@ -682,53 +767,41 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
 
   const [saving, setSaving] = useState(false);
 
-  const [modelType, setModelType] = useState<"chat" | "speech" | "embedding">("chat");
-  const [temperature, setTemperature] = useState(0.7);
-  const [tempEnabled, setTempEnabled] = useState(false);
-  const [topP, setTopP] = useState(1.0);
-  const [topPEnabled, setTopPEnabled] = useState(false);
-  const [maxTokens, setMaxTokens] = useState(4096);
-  const [maxTokensEnabled, setMaxTokensEnabled] = useState(false);
-  const [freqPenalty, setFreqPenalty] = useState(0.0);
-  const [freqEnabled, setFreqEnabled] = useState(false);
-  const [presPenalty, setPresPenalty] = useState(0.0);
-  const [presEnabled, setPresEnabled] = useState(false);
-  const [reasoningEffort, setReasoningEffort] = useState<string>("");
-  const [useMaxCompletionTokens, setUseMaxCompletionTokens] = useState(false);
-  const [noSystemRole, setNoSystemRole] = useState(false);
-  const [forceMaxTokens, setForceMaxTokens] = useState(false);
-  const [overridesLoaded, setOverridesLoaded] = useState(false);
+  const [state, dispatch] = useReducer(settingsReducer, settingsInitial);
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
-  // Load existing overrides from query
   useEffect(() => {
     const o = overridesQuery.data;
-    if (!o || overridesLoaded) return;
-    if (o.model_type) setModelType(o.model_type);
-    if (o.temperature != null) { setTemperature(o.temperature); setTempEnabled(true); }
-    if (o.top_p != null) { setTopP(o.top_p); setTopPEnabled(true); }
-    if (o.max_tokens != null) { setMaxTokens(o.max_tokens); setMaxTokensEnabled(true); }
-    if (o.frequency_penalty != null) { setFreqPenalty(o.frequency_penalty); setFreqEnabled(true); }
-    if (o.presence_penalty != null) { setPresPenalty(o.presence_penalty); setPresEnabled(true); }
-    if (o.reasoning_effort) setReasoningEffort(o.reasoning_effort);
-    if (o.use_max_completion_tokens != null) setUseMaxCompletionTokens(o.use_max_completion_tokens);
-    if (o.no_system_role != null) setNoSystemRole(o.no_system_role);
-    if (o.force_max_tokens != null) setForceMaxTokens(o.force_max_tokens);
-    setOverridesLoaded(true);
-  }, [overridesQuery.data, overridesLoaded]);
+    if (!o) return;
+    const payload: Partial<SettingsState> = {};
+    if (o.model_type) payload.modelType = o.model_type;
+    if (o.temperature != null) { payload.temperature = o.temperature; payload.tempEnabled = true; }
+    if (o.top_p != null) { payload.topP = o.top_p; payload.topPEnabled = true; }
+    if (o.max_tokens != null) { payload.maxTokens = o.max_tokens; payload.maxTokensEnabled = true; }
+    if (o.frequency_penalty != null) { payload.freqPenalty = o.frequency_penalty; payload.freqEnabled = true; }
+    if (o.presence_penalty != null) { payload.presPenalty = o.presence_penalty; payload.presEnabled = true; }
+    if (o.reasoning_effort) payload.reasoningEffort = o.reasoning_effort;
+    if (o.use_max_completion_tokens != null) payload.useMaxCompletionTokens = o.use_max_completion_tokens;
+    if (o.no_system_role != null) payload.noSystemRole = o.no_system_role;
+    if (o.force_max_tokens != null) payload.forceMaxTokens = o.force_max_tokens;
+    dispatch({ type: "HYDRATE", payload });
+  }, [overridesQuery.data]);
 
   const handleSave = useCallback(async () => {
+    const s = stateRef.current;
     setSaving(true);
     const overrides: ModelOverrides = {};
-    if (modelType !== "chat") overrides.model_type = modelType;
-    if (tempEnabled) overrides.temperature = temperature;
-    if (topPEnabled) overrides.top_p = topP;
-    if (maxTokensEnabled) overrides.max_tokens = maxTokens;
-    if (freqEnabled) overrides.frequency_penalty = freqPenalty;
-    if (presEnabled) overrides.presence_penalty = presPenalty;
-    if (reasoningEffort) overrides.reasoning_effort = reasoningEffort;
-    if (useMaxCompletionTokens) overrides.use_max_completion_tokens = true;
-    if (noSystemRole) overrides.no_system_role = true;
-    if (forceMaxTokens) overrides.force_max_tokens = true;
+    if (s.modelType !== "chat") overrides.model_type = s.modelType;
+    if (s.tempEnabled) overrides.temperature = s.temperature;
+    if (s.topPEnabled) overrides.top_p = s.topP;
+    if (s.maxTokensEnabled) overrides.max_tokens = s.maxTokens;
+    if (s.freqEnabled) overrides.frequency_penalty = s.freqPenalty;
+    if (s.presEnabled) overrides.presence_penalty = s.presPenalty;
+    if (s.reasoningEffort) overrides.reasoning_effort = s.reasoningEffort;
+    if (s.useMaxCompletionTokens) overrides.use_max_completion_tokens = true;
+    if (s.noSystemRole) overrides.no_system_role = true;
+    if (s.forceMaxTokens) overrides.force_max_tokens = true;
     try {
       await updateMut.mutateAsync({ modelKey: overrideKey, overrides });
       onSaved();
@@ -739,7 +812,7 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
     } finally {
       setSaving(false);
     }
-  }, [overrideKey, modelType, temperature, tempEnabled, topP, topPEnabled, maxTokens, maxTokensEnabled, freqPenalty, freqEnabled, presPenalty, presEnabled, reasoningEffort, useMaxCompletionTokens, noSystemRole, forceMaxTokens, onSaved, onClose, onError, updateMut]);
+  }, [overrideKey, updateMut, onSaved, onClose, onError]);
 
   const handleReset = useCallback(async () => {
     try {
@@ -779,9 +852,9 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
           <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.model_type")}</label>
           <div className="flex gap-0.5 rounded-xl border border-border-subtle bg-surface p-0.5">
             {(["chat", "speech", "embedding"] as const).map((mt) => (
-              <button key={mt} type="button" onClick={() => setModelType(mt)}
+              <button key={mt} type="button" onClick={() => dispatch({ type: "SET_FIELD", field: "modelType", value: mt })}
                 className={`flex-1 px-3 py-1.5 rounded-lg text-xs font-bold transition-colors ${
-                  modelType === mt ? "bg-brand text-white shadow-sm" : "text-text-dim hover:text-text hover:bg-main"
+                  state.modelType === mt ? "bg-brand text-white shadow-sm" : "text-text-dim hover:text-text hover:bg-main"
                 }`}>
                 {t(`models.type_${mt}`)}
               </button>
@@ -824,47 +897,47 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
 
           <SliderInput
             label={t("models.temperature")}
-            value={temperature} onChange={setTemperature}
+            value={state.temperature} onChange={(v) => dispatch({ type: "SET_FIELD", field: "temperature", value: v })}
             min={0} max={2} step={0.01}
-            enabled={tempEnabled} onToggle={setTempEnabled}
+            enabled={state.tempEnabled} onToggle={(v) => dispatch({ type: "SET_FIELD", field: "tempEnabled", value: v })}
           />
 
           <SliderInput
             label={t("models.top_p")}
-            value={topP} onChange={setTopP}
+            value={state.topP} onChange={(v) => dispatch({ type: "SET_FIELD", field: "topP", value: v })}
             min={0} max={1} step={0.01}
-            enabled={topPEnabled} onToggle={setTopPEnabled}
+            enabled={state.topPEnabled} onToggle={(v) => dispatch({ type: "SET_FIELD", field: "topPEnabled", value: v })}
           />
 
           <SliderInput
             label={t("models.max_tokens_param")}
-            value={maxTokens} onChange={(v) => setMaxTokens(Math.round(v))}
+            value={state.maxTokens} onChange={(v) => dispatch({ type: "SET_FIELD", field: "maxTokens", value: Math.round(v) })}
             min={256} max={1048576} step={256}
-            enabled={maxTokensEnabled} onToggle={setMaxTokensEnabled}
+            enabled={state.maxTokensEnabled} onToggle={(v) => dispatch({ type: "SET_FIELD", field: "maxTokensEnabled", value: v })}
             ticks={[256, 32768, 131072, 1048576]}
             formatTick={(v) => v >= 1048576 ? "1M" : v >= 1024 ? `${Math.round(v/1024)}K` : String(v)}
           />
 
           <SliderInput
             label={t("models.frequency_penalty")}
-            value={freqPenalty} onChange={setFreqPenalty}
+            value={state.freqPenalty} onChange={(v) => dispatch({ type: "SET_FIELD", field: "freqPenalty", value: v })}
             min={-2} max={2} step={0.01}
-            enabled={freqEnabled} onToggle={setFreqEnabled}
+            enabled={state.freqEnabled} onToggle={(v) => dispatch({ type: "SET_FIELD", field: "freqEnabled", value: v })}
             ticks={[-2, 0, 2]}
           />
 
           <SliderInput
             label={t("models.presence_penalty")}
-            value={presPenalty} onChange={setPresPenalty}
+            value={state.presPenalty} onChange={(v) => dispatch({ type: "SET_FIELD", field: "presPenalty", value: v })}
             min={-2} max={2} step={0.01}
-            enabled={presEnabled} onToggle={setPresEnabled}
+            enabled={state.presEnabled} onToggle={(v) => dispatch({ type: "SET_FIELD", field: "presEnabled", value: v })}
             ticks={[-2, 0, 2]}
           />
 
           {/* Reasoning Effort */}
           <div className="space-y-1.5">
             <label className="text-xs font-bold text-text-dim">{t("models.reasoning_effort")}</label>
-            <select value={reasoningEffort} onChange={(e) => setReasoningEffort(e.target.value)}
+            <select value={state.reasoningEffort} onChange={(e) => dispatch({ type: "SET_FIELD", field: "reasoningEffort", value: e.target.value })}
               className="w-full rounded-xl border border-border-subtle bg-main px-3 py-2 text-xs outline-none focus:border-brand">
               <option value="">—</option>
               <option value="low">{t("models.effort_low")}</option>
@@ -877,9 +950,9 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
         {/* Flags */}
         <div className="space-y-1">
           <label className="text-[10px] font-bold text-text-dim uppercase">{t("models.flags")}</label>
-          <SettingsToggle value={useMaxCompletionTokens} onChange={setUseMaxCompletionTokens} label={t("models.use_max_completion_tokens")} />
-          <SettingsToggle value={noSystemRole} onChange={setNoSystemRole} label={t("models.no_system_role")} />
-          <SettingsToggle value={forceMaxTokens} onChange={setForceMaxTokens} label={t("models.force_max_tokens")} />
+          <SettingsToggle value={state.useMaxCompletionTokens} onChange={(v) => dispatch({ type: "SET_FIELD", field: "useMaxCompletionTokens", value: v })} label={t("models.use_max_completion_tokens")} />
+          <SettingsToggle value={state.noSystemRole} onChange={(v) => dispatch({ type: "SET_FIELD", field: "noSystemRole", value: v })} label={t("models.no_system_role")} />
+          <SettingsToggle value={state.forceMaxTokens} onChange={(v) => dispatch({ type: "SET_FIELD", field: "forceMaxTokens", value: v })} label={t("models.force_max_tokens")} />
         </div>
 
         {/* Actions */}

--- a/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ModelsPage.tsx
@@ -770,8 +770,10 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
   const [state, dispatch] = useReducer(settingsReducer, settingsInitial);
   const stateRef = useRef(state);
   stateRef.current = state;
+  const hydratedRef = useRef(false);
 
   useEffect(() => {
+    if (hydratedRef.current) return;
     const o = overridesQuery.data;
     if (!o) return;
     const payload: Partial<SettingsState> = {};
@@ -786,6 +788,7 @@ function ModelSettingsModal({ model, onClose, onSaved, onReset, onError }: {
     if (o.no_system_role != null) payload.noSystemRole = o.no_system_role;
     if (o.force_max_tokens != null) payload.forceMaxTokens = o.force_max_tokens;
     dispatch({ type: "HYDRATE", payload });
+    hydratedRef.current = true;
   }, [overridesQuery.data]);
 
   const handleSave = useCallback(async () => {

--- a/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/NetworkPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback } from "react";
 import { formatDateTime } from "../lib/datetime";
 import { useTranslation } from "react-i18next";
+import { useUIStore } from "../lib/store";
+import { toastErr } from "../lib/errors";
 import {
   useNetworkStatus,
   usePeers,
@@ -23,6 +25,8 @@ import {
   ShieldCheck,
 } from "lucide-react";
 
+const NETWORK_ICON = <Network className="h-4 w-4" />;
+
 export function NetworkPage() {
   const { t } = useTranslation();
 
@@ -33,15 +37,18 @@ export function NetworkPage() {
   const status = statusQuery.data;
   const peers = peersQuery.data ?? [];
   const trustedPeers = trustedQuery.data ?? [];
-  const isLoading = statusQuery.isPending || peersQuery.isPending;
+  const addToast = useUIStore((s) => s.addToast);
+  const isLoading = statusQuery.isPending || peersQuery.isPending || trustedQuery.isPending;
 
   const handleRefresh = useCallback(() => {
-    void Promise.all([
+    Promise.all([
       statusQuery.refetch(),
       peersQuery.refetch(),
       trustedQuery.refetch(),
-    ]);
-  }, [statusQuery, peersQuery, trustedQuery]);
+    ]).catch((e) => {
+      addToast(toastErr(e, t("common.error")), "error");
+    });
+  }, [statusQuery, peersQuery, trustedQuery, addToast, t]);
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -51,7 +58,7 @@ export function NetworkPage() {
         subtitle={t("network.subtitle")}
         isFetching={statusQuery.isFetching || peersQuery.isFetching}
         onRefresh={handleRefresh}
-        icon={<Network className="h-4 w-4" />}
+        icon={NETWORK_ICON}
         helpText={t("network.help")}
       />
 
@@ -196,7 +203,13 @@ export function NetworkPage() {
                 ))}
               </StaggerList>
             </div>
-          ) : null}
+          ) : (
+            <EmptyState
+              icon={<ShieldCheck className="h-8 w-8" />}
+              title={t("network.no_trusted_peers")}
+              description={t("network.no_trusted_peers_desc")}
+            />
+          )}
 
           {/* Peers list */}
           <div>
@@ -234,14 +247,14 @@ export function NetworkPage() {
                         {peer.status || t("common.unknown")}
                       </Badge>
                     </div>
-                    {(peer.version || peer.last_seen) ? (
+                    {(peer.version != null || peer.last_seen != null) ? (
                       <div className="flex items-center gap-3 mt-3 text-[10px] text-text-dim">
-                        {peer.version ? (
+                        {peer.version != null ? (
                           <span className="flex items-center gap-1">
                             <Globe className="w-3 h-3" /> v{peer.version}
                           </span>
                         ) : null}
-                        {peer.last_seen ? (
+                        {peer.last_seen != null ? (
                           <span className="flex items-center gap-1">
                             <Clock className="w-3 h-3" /> {formatDateTime(peer.last_seen)}
                           </span>

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { formatTime, formatDateTime } from "../lib/datetime";
-import { useMemo, useState, useCallback } from "react";
+import { memo, useMemo, useState, useCallback, useEffect, useReducer } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import type { ApiActionResponse, ProviderItem } from "../api";
@@ -103,12 +103,12 @@ type FilterStatus = "all" | "reachable" | "unreachable";
 
 // ── SetDefaultModelSection — model picker + "set as default" in config modal ──
 
-function SetDefaultModelSection({ providerId, currentDefault, onSetDefault, t }: {
+function SetDefaultModelSection({ providerId, currentDefault, onSetDefault }: {
   providerId: string;
   currentDefault?: string;
   onSetDefault: (id: string, model?: string) => Promise<void>;
-  t: TFunction;
 }) {
+  const { t } = useTranslation();
   const [selectedModel, setSelectedModel] = useState("");
   const [setting, setSetting] = useState(false);
   const isDefault = currentDefault === providerId;
@@ -297,10 +297,10 @@ interface ProviderCardProps {
   onViewDetails: (provider: ProviderItem) => void;
   onConfigure: (provider: ProviderItem) => void;
   onDelete: (provider: ProviderItem) => void;
-  t: (key: string) => string;
 }
 
-function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode, onSelect, onTest, onSetDefault, onViewDetails, onConfigure, onDelete, t }: ProviderCardProps) {
+const ProviderCard = memo(function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode, onSelect, onTest, onSetDefault, onViewDetails, onConfigure, onDelete }: ProviderCardProps) {
+  const { t } = useTranslation();
   const isConfigured = isProviderAvailable(p.auth_status);
   const isCli = isCliProvider(p);
 
@@ -566,17 +566,17 @@ function ProviderCard({ provider: p, isSelected, isDefault, pendingId, viewMode,
       </div>
     </Card>
   );
-}
+});
 
 // ── Details Modal ────────────────────────────────────────────────
 
-function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
+function DetailsModal({ provider, onClose, onTest, pendingId }: {
   provider: ProviderItem;
   onClose: () => void;
   onTest: (id: string) => void;
   pendingId: string | null;
-  t: TFunction;
 }) {
+  const { t } = useTranslation();
   const isConfigured = isProviderAvailable(provider.auth_status);
   const authBadge = getAuthBadge(provider.auth_status);
 
@@ -606,7 +606,7 @@ function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
           <div className="p-4 rounded-xl bg-main/30">
             <p className="text-[10px] font-black uppercase tracking-wider text-text-dim/70 mb-1">{t("providers.latency")}</p>
             <p className={`text-2xl font-black ${getLatencyColor(provider.latency_ms)}`}>
-              {provider.latency_ms ? `${provider.latency_ms}ms` : "-"}
+              {provider.latency_ms != null ? `${provider.latency_ms}ms` : "-"}
             </p>
           </div>
         </div>
@@ -701,11 +701,11 @@ function DetailsModal({ provider, onClose, onTest, pendingId, t }: {
 
 // ── Filter Chips ─────────────────────────────────────────────────
 
-function FilterChips({ activeFilter, onChange, t }: {
+function FilterChips({ activeFilter, onChange }: {
   activeFilter: FilterStatus;
   onChange: (filter: FilterStatus) => void;
-  t: (key: string) => string;
 }) {
+  const { t } = useTranslation();
   const filters: { value: FilterStatus; label: string; icon: React.ReactNode }[] = [
     { value: "all", label: t("providers.filter_all"), icon: <Filter className="w-3 h-3" /> },
     { value: "reachable", label: t("providers.filter_reachable"), icon: <CheckCircle2 className="w-3 h-3 text-success" /> },
@@ -1040,17 +1040,55 @@ function CreateProviderWizard({
   );
 }
 
+// ── Filter/Sort reducer (P8) ─────────────────────────────────────
+
+type FilterState = {
+  search: string;
+  filterStatus: FilterStatus;
+  sortField: SortField;
+  sortOrder: SortOrder;
+};
+
+type FilterAction =
+  | { type: "SEARCH"; value: string }
+  | { type: "FILTER"; status: FilterStatus }
+  | { type: "SORT"; field: SortField };
+
+function filterReducer(state: FilterState, action: FilterAction): FilterState {
+  switch (action.type) {
+    case "SEARCH":
+      return { ...state, search: action.value };
+    case "FILTER":
+      return { ...state, filterStatus: action.status };
+    case "SORT":
+      return {
+        ...state,
+        sortField: action.field,
+        sortOrder: state.sortField === action.field
+          ? (state.sortOrder === "asc" ? "desc" : "asc")
+          : "desc",
+      };
+    default:
+      return state;
+  }
+}
+
+const initialFilterState: FilterState = {
+  search: "",
+  filterStatus: "all",
+  sortField: "name",
+  sortOrder: "asc",
+};
+
 // ── Main Page ────────────────────────────────────────────────────
 
 export function ProvidersPage() {
   const { t } = useTranslation();
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [testingIds, setTestingIds] = useState<Set<string>>(new Set());
-  const [search, setSearch] = useState("");
-  const [sortField, setSortField] = useState<SortField>("name");
-  const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
+  const [filterState, dispatch] = useReducer(filterReducer, initialFilterState);
+  const { search, sortField, sortOrder, filterStatus } = filterState;
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
-  const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [detailsProvider, setDetailsProvider] = useState<ProviderItem | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -1085,6 +1123,15 @@ export function ProvidersPage() {
   const providers = providersQuery.data ?? [];
   const currentDefaultProvider = statusQuery.data?.default_provider ?? "";
   const configuredCount = useMemo(() => providers.filter(p => isProviderAvailable(p.auth_status)).length, [providers]);
+
+  useEffect(() => {
+    if (!providersQuery.data) return;
+    setDetailsProvider(prev => {
+      if (!prev) return prev;
+      const updated = providersQuery.data.find(p => p.id === prev.id);
+      return updated ?? prev;
+    });
+  }, [providersQuery.data]);
 
   // Configured providers are the main page content. Filter/sort applies
   // to those only; the unconfigured catalog lives behind the Add picker.
@@ -1128,17 +1175,14 @@ export function ProvidersPage() {
     config.open(p);
   };
 
-  const handleSearch = (value: string) => { setSearch(value); setSelectedIds(new Set()); };
-  const handleFilterChange = (filter: FilterStatus) => { setFilterStatus(filter); setSelectedIds(new Set()); };
+  const handleSearch = (value: string) => { dispatch({ type: "SEARCH", value }); setSelectedIds(new Set()); };
+  const handleFilterChange = (filter: FilterStatus) => { dispatch({ type: "FILTER", status: filter }); setSelectedIds(new Set()); };
 
-  const handleSort = (field: SortField) => {
-    if (sortField === field) setSortOrder(sortOrder === "asc" ? "desc" : "asc");
-    else { setSortField(field); setSortOrder("desc"); }
-  };
+  const handleSort = (field: SortField) => { dispatch({ type: "SORT", field }); };
 
-  const handleSelect = (id: string, checked: boolean) => {
+  const handleSelect = useCallback((id: string, checked: boolean) => {
     setSelectedIds(prev => { const next = new Set(prev); if (checked) next.add(id); else next.delete(id); return next; });
-  };
+  }, []);
 
   const handleSelectAll = () => {
     if (selectedIds.size === filteredProviders.length) setSelectedIds(new Set());
@@ -1147,20 +1191,40 @@ export function ProvidersPage() {
 
   const handleBatchTest = async () => {
     const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
     setTestingIds(new Set(ids));
-    await Promise.all(ids.map(async (id) => {
-      try {
-        await testMutation.mutateAsync(id);
-      } catch {
-        // continue
-      } finally {
-        setTestingIds(prev => { const next = new Set(prev); next.delete(id); return next; });
+    let successCount = 0;
+    let failCount = 0;
+    const CONCURRENCY = 4;
+    const queue = [...ids];
+    const worker = async () => {
+      while (queue.length > 0) {
+        const id = queue.shift()!;
+        try {
+          const result = await testMutation.mutateAsync(id);
+          if (result.status === "error") failCount++;
+          else successCount++;
+        } catch {
+          failCount++;
+        } finally {
+          setTestingIds(prev => { const next = new Set(prev); next.delete(id); return next; });
+        }
       }
-    }));
-    addToast(t("common.success"), "success");
+    };
+    await Promise.all(Array.from({ length: Math.min(CONCURRENCY, ids.length) }, () => worker()));
+    if (failCount === 0) {
+      addToast(t("common.success"), "success");
+    } else if (successCount === 0) {
+      addToast(t("providers.batch_test_all_failed", { defaultValue: "All tests failed" }), "error");
+    } else {
+      addToast(
+        t("providers.batch_test_partial", { defaultValue: `${successCount} passed, ${failCount} failed` }),
+        "error",
+      );
+    }
   };
 
-  const handleTest = async (id: string) => {
+  const handleTest = useCallback(async (id: string) => {
     setPendingId(id);
     try {
       const result = await testMutation.mutateAsync(id);
@@ -1171,16 +1235,16 @@ export function ProvidersPage() {
     } finally {
       setPendingId(null);
     }
-  };
+  }, [testMutation, addToast, t]);
 
-  const handleSetDefault = async (id: string, model?: string) => {
+  const handleSetDefault = useCallback(async (id: string, model?: string) => {
     try {
       await defaultProviderMutation.mutateAsync({ id, model });
       addToast(t("providers.default_set"), "success");
     } catch (e: unknown) {
       addToast(getErrorMessage(e) || t("common.error"), "error");
     }
-  };
+  }, [defaultProviderMutation, addToast, t]);
 
   const handleDeleteConfirm = async () => {
     if (!deleteConfirmProvider) return;
@@ -1208,6 +1272,7 @@ export function ProvidersPage() {
     || (config.provider?.key_required !== false
         && !config.hasStoredKey
         && !config.keyInput.trim());
+  const configAuthBadge = config.provider ? getAuthBadge(config.provider.auth_status) : null;
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -1247,7 +1312,7 @@ export function ProvidersPage() {
           <Input value={search} onChange={(e) => handleSearch(e.target.value)} placeholder={t("common.search")}
             leftIcon={<Search className="w-4 h-4" />}
             rightIcon={search && (
-              <button onClick={() => setSearch("")} className="hover:text-text-main" aria-label={t("common.clear_search")}>
+              <button onClick={() => dispatch({ type: "SEARCH", value: "" })} className="hover:text-text-main" aria-label={t("common.clear_search")}>
                 <X className="w-3 h-3" />
               </button>
             )} />
@@ -1280,7 +1345,7 @@ export function ProvidersPage() {
           chips that have no targets. */}
       {configuredCount > 0 && (
         <div className="flex items-center justify-between gap-3 flex-wrap overflow-x-auto">
-          <FilterChips activeFilter={filterStatus} onChange={handleFilterChange} t={t} />
+          <FilterChips activeFilter={filterStatus} onChange={handleFilterChange} />
 
           {selectedIds.size > 0 && (
             <div className="flex items-center gap-2">
@@ -1353,7 +1418,6 @@ export function ProvidersPage() {
                 onViewDetails={setDetailsProvider}
                 onConfigure={config.open}
                 onDelete={setDeleteConfirmProvider}
-                t={t}
               />
             ))}
           </div>
@@ -1368,7 +1432,6 @@ export function ProvidersPage() {
           onClose={() => setDetailsProvider(null)}
           onTest={handleTest}
           pendingId={pendingId}
-          t={t}
         />
       )}
 
@@ -1384,8 +1447,8 @@ export function ProvidersPage() {
                 <p className="text-sm font-bold">{config.provider.display_name || config.provider.id}</p>
                 <p className="text-[10px] text-text-dim font-mono">{config.provider.id}</p>
               </div>
-              <Badge variant={getAuthBadge(config.provider.auth_status).variant} className="ml-auto">
-                {getAuthBadge(config.provider.auth_status).label}
+              <Badge variant={configAuthBadge!.variant} className="ml-auto">
+                {configAuthBadge!.label}
               </Badge>
             </div>
 
@@ -1455,7 +1518,6 @@ export function ProvidersPage() {
                 providerId={config.provider.id}
                 currentDefault={statusQuery.data?.default_provider}
                 onSetDefault={handleSetDefault}
-                t={t}
               />
             )}
           </div>

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { formatDate } from "../lib/datetime";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   type ClawHubBrowseItem,
@@ -172,7 +172,7 @@ interface SkillCardProps {
   t: (key: string, opts?: Record<string, unknown>) => string;
 }
 
-function SkillCard({
+const SkillCard = React.memo(function SkillCard({
   name,
   version,
   description,
@@ -354,7 +354,6 @@ function SkillCard({
           ) : null}
         </div>
 
-        {/* Tags */}
         {tags && tags.length > 0 && (
           <div className="flex flex-wrap gap-1">
             {tags.slice(0, 4).map((tag) => (
@@ -370,7 +369,7 @@ function SkillCard({
       </div>
     </Card>
   );
-}
+});
 
 // ─── Category chips ───────────────────────────────────────────────────────────
 
@@ -884,12 +883,14 @@ function EvolveUploadPane({
   onSubmit,
   onCancel,
   busy,
+  addToast,
   t,
 }: {
   skillName: string;
   onSubmit: (params: { path: string; content: string }) => void;
   onCancel: () => void;
   busy: boolean;
+  addToast: (msg: string, type: "success" | "error" | "info") => void;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
   const [subdir, setSubdir] = useState("references");
@@ -899,8 +900,9 @@ function EvolveUploadPane({
 
   const handleFilePick = async (file: File) => {
     if (file.size > 1024 * 1024) {
-      alert(
+      addToast(
         t("skills.evo_file_too_large", { defaultValue: "File exceeds 1 MiB limit" }),
+        "error",
       );
       return;
     }
@@ -1084,11 +1086,17 @@ function SkillDetailModal({
   const [pane, setPane] = useState<EvolvePane>("none");
   const [viewingFile, setViewingFile] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<{
+    title: string;
+    message: string;
+    onConfirm: () => void;
+  } | null>(null);
 
   useEffect(() => {
     if (!isOpen) {
       setPane("none");
       setViewingFile(null);
+      setConfirmAction(null);
     }
   }, [isOpen, skillName]);
 
@@ -1109,64 +1117,68 @@ function SkillDetailModal({
 
   const handleRollback = () => {
     if (!skillName) return;
-    if (
-      !confirm(
-        t("skills.evo_rollback_confirm", {
-          defaultValue:
-            "Roll back to the previous version? This cannot be undone unless you patch again.",
-        }),
-      )
-    )
-      return;
-    void runMutation(
-      () => rollbackMutation.mutateAsync({ name: skillName }),
-      t("skills.evo_rolled_back", { defaultValue: "Skill rolled back" }),
-    );
+    setConfirmAction({
+      title: t("skills.evo_rollback", { defaultValue: "Rollback" }),
+      message: t("skills.evo_rollback_confirm", {
+        defaultValue:
+          "Roll back to the previous version? This cannot be undone unless you patch again.",
+      }),
+      onConfirm: () => {
+        setConfirmAction(null);
+        void runMutation(
+          () => rollbackMutation.mutateAsync({ name: skillName }),
+          t("skills.evo_rolled_back", { defaultValue: "Skill rolled back" }),
+        );
+      },
+    });
   };
 
   const handleRemoveFile = (path: string) => {
     if (!skillName) return;
-    if (
-      !confirm(
-        t("skills.evo_remove_file_confirm", {
-          defaultValue: `Remove ${path}?`,
-          path,
-        }),
-      )
-    )
-      return;
-    void runMutation(
-      () => removeFileMutation.mutateAsync({ name: skillName, path }),
-      t("skills.evo_file_removed", { defaultValue: "File removed" }),
-    );
+    setConfirmAction({
+      title: t("skills.evo_remove_file", { defaultValue: "Remove File" }),
+      message: t("skills.evo_remove_file_confirm", {
+        defaultValue: `Remove ${path}?`,
+        path,
+      }),
+      onConfirm: () => {
+        setConfirmAction(null);
+        void runMutation(
+          () => removeFileMutation.mutateAsync({ name: skillName, path }),
+          t("skills.evo_file_removed", { defaultValue: "File removed" }),
+        );
+      },
+    });
   };
 
   const handleDelete = () => {
     if (!skillName) return;
-    if (
-      !confirm(
-        t("skills.evo_delete_confirm", {
-          defaultValue: `Permanently delete ${skillName}? This cannot be undone.`,
-          name: skillName,
-        }),
-      )
-    )
-      return;
-    (async () => {
-      setBusy(true);
-      try {
-        await deleteSkillMutation.mutateAsync({ name: skillName });
-        addToast(
-          t("skills.evo_deleted", { defaultValue: "Skill deleted" }),
-          "success",
-        );
-        onClose();
-      } catch (e: unknown) {
-        addToast(e instanceof Error ? e.message : t("skills.evo_delete_failed"), "error");
-      } finally {
-        setBusy(false);
-      }
-    })();
+    setConfirmAction({
+      title: t("skills.evo_delete", { defaultValue: "Delete" }),
+      message: t("skills.evo_delete_confirm", {
+        defaultValue: `Permanently delete ${skillName}? This cannot be undone.`,
+        name: skillName,
+      }),
+      onConfirm: () => {
+        const name = skillName;
+        setConfirmAction(null);
+        (async () => {
+          setBusy(true);
+          try {
+            await deleteSkillMutation.mutateAsync({ name });
+            addToast(
+              t("skills.evo_deleted", { defaultValue: "Skill deleted" }),
+              "success",
+            );
+            onClose();
+          } catch (e: unknown) {
+            addToast(e instanceof Error ? e.message : t("skills.evo_delete_failed"), "error");
+          } finally {
+            setBusy(false);
+          }
+        })();
+      },
+    });
   };
 
   return (
@@ -1300,6 +1312,7 @@ function SkillDetailModal({
               }
               onCancel={() => setPane("none")}
               busy={busy}
+              addToast={addToast}
               t={t}
             />
           )}
@@ -1448,6 +1461,14 @@ function SkillDetailModal({
           {t("skills.evo_not_found", { defaultValue: "Skill not found" })}
         </p>
       )}
+      <ConfirmDialog
+        isOpen={!!confirmAction}
+        title={confirmAction?.title ?? ""}
+        message={confirmAction?.message ?? ""}
+        tone="destructive"
+        onConfirm={() => confirmAction?.onConfirm()}
+        onClose={() => setConfirmAction(null)}
+      />
     </DrawerPanel>
   );
 }
@@ -1560,39 +1581,35 @@ export function SkillsPage() {
 
   // ── Filtered data ─────────────────────────────────────────────────────────
 
+  const installedSlugSet = useMemo(() => {
+    const set = new Set<string>();
+    for (const s of installedSkills) {
+      const src = s.source;
+      const srcType = src?.type ?? "";
+      const srcSlug = src?.slug;
+      if (srcSlug) {
+        if (srcType === "clawhub" || srcType === "clawhub-cn") {
+          set.add(`clawhub:${srcSlug}`);
+          set.add(`clawhub-cn:${srcSlug}`);
+        } else {
+          set.add(`${srcType}:${srcSlug}`);
+        }
+      }
+      if (srcType === "" || srcType === "local") {
+        set.add(`name:${s.name}`);
+      }
+    }
+    return set;
+  }, [installedSkills]);
+
   const isInstalledFromMarketplace = useCallback(
     (slug: string, src: MarketplaceSource) => {
-      // clawhub and clawhub-cn share the same slug namespace (same content)
-      const matchTypes =
-        src === "clawhub" || src === "clawhub-cn"
-          ? ["clawhub", "clawhub-cn"]
-          : [src];
-      return installedSkills.some((s) => {
-        const sourceType = s.source?.type ?? "";
-        const sourceSlug = s.source?.slug;
-        if (matchTypes.includes(sourceType) && sourceSlug === slug) {
-          return true;
-        }
-        // #4689 fallback — some install paths (notably the FangHub registry
-        // copy and historical ClawHub installs that pre-date provenance
-        // patching) leave `manifest.source` either unset or set to "local",
-        // which makes the strict (type, slug) match miss freshly installed
-        // skills. Falling back to a name match against the slug is conservative
-        // because skill names and hub slugs share a kebab-case namespace and
-        // collisions across hubs are rare; the user-visible cost of a false
-        // positive (button shows "Installed" when it isn't) is far smaller
-        // than the false negative the issue reports (button stays clickable
-        // and re-clicking 409s with "already installed").
-        if (
-          (sourceType === "" || sourceType === "local") &&
-          s.name === slug
-        ) {
-          return true;
-        }
-        return false;
-      });
+      if (src === "clawhub" || src === "clawhub-cn") {
+        return installedSlugSet.has(`clawhub:${slug}`) || installedSlugSet.has(`clawhub-cn:${slug}`) || installedSlugSet.has(`name:${slug}`);
+      }
+      return installedSlugSet.has(`${src}:${slug}`) || installedSlugSet.has(`name:${slug}`);
     },
-    [installedSkills],
+    [installedSlugSet],
   );
 
   /** Items from a non-fanghub remote registry, normalized with

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -156,6 +156,31 @@ const getErrorMessage = (error: unknown): string =>
 
 const isRunState = (state: WorkflowRunItem["state"]): state is string => typeof state === "string";
 
+function StepAccordion<T>({
+  steps,
+  getKey,
+  renderHeader,
+  renderContent,
+}: {
+  steps: T[];
+  getKey: (step: T, index: number) => string | number;
+  renderHeader: (step: T, index: number, isExpanded: boolean, toggle: () => void) => React.ReactNode;
+  renderContent: (step: T, index: number) => React.ReactNode;
+}) {
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+
+  return (
+    <>
+      {steps.map((step, i) => (
+        <div key={getKey(step, i)} className="rounded-lg border border-border-subtle bg-main overflow-hidden">
+          {renderHeader(step, i, expandedIdx === i, () => setExpandedIdx(expandedIdx === i ? null : i))}
+          {expandedIdx === i && renderContent(step, i)}
+        </div>
+      ))}
+    </>
+  );
+}
+
 export function WorkflowsPage() {
   const { t, i18n } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
@@ -167,7 +192,6 @@ export function WorkflowsPage() {
   const [activeTab, setActiveTab] = useState<"workflows" | "templates">("workflows");
   const [scheduleWorkflowId, setScheduleWorkflowId] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
-  const [expandedStepIdx, setExpandedStepIdx] = useState<number | null>(null);
   const [dryRunResult, setDryRunResult] = useState<DryRunResult | null>(null);
 
   const workflowsQuery = useWorkflows();
@@ -368,6 +392,37 @@ export function WorkflowsPage() {
 
   const getStepResultKey = (step: StepResultLike, index: number) =>
     step.id ?? step.step_id ?? step.step_name ?? step.name ?? ([step.agent_name, step.duration_ms, step.input_tokens, step.output_tokens].filter(Boolean).join(":") || index);
+
+  const stepResultHeader = (step: WorkflowStepResult, _idx: number, isExpanded: boolean, toggle: () => void) => (
+    <button
+      className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-surface transition-colors"
+      onClick={toggle}>
+      <CheckCircle2 className="w-3 h-3 text-success shrink-0" />
+      <span className="text-[10px] font-bold truncate flex-1">{step.step_name}</span>
+      <span className="text-[9px] text-text-dim/50 shrink-0">{step.duration_ms}ms</span>
+      <ChevronDown className={`w-3 h-3 text-text-dim/30 shrink-0 transition-transform ${isExpanded ? "rotate-180" : ""}`} />
+    </button>
+  );
+
+  const stepResultContent = (step: WorkflowStepResult, _idx: number) => (
+    <div className="px-3 pb-3 space-y-2 border-t border-border-subtle">
+      <div>
+        <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("workflows.prompt_sent", { defaultValue: "Prompt sent:" })}</p>
+        <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
+          {step.prompt || "(empty)"}
+        </pre>
+      </div>
+      <div>
+        <p className="text-[9px] font-bold text-text-dim/50">{t("workflows.output", { defaultValue: "Output:" })}</p>
+        <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
+          {step.output || "(empty)"}
+        </pre>
+      </div>
+      <p className="text-[9px] text-text-dim/40">
+        {step.agent_name} · {step.input_tokens} in / {step.output_tokens} out tokens
+      </p>
+    </div>
+  );
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">
@@ -726,11 +781,13 @@ export function WorkflowsPage() {
                       </p>
                     </div>
                     <div className="space-y-2">
-                      {dryRunResult.steps.map((step, i) => (
-                        <div key={getStepResultKey(step, i)} className="rounded-lg border border-border-subtle bg-main overflow-hidden">
+                      <StepAccordion
+                        steps={dryRunResult.steps}
+                        getKey={getStepResultKey}
+                        renderHeader={(step, _i, isExpanded, toggle) => (
                           <button
                             className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-surface transition-colors"
-                            onClick={() => setExpandedStepIdx(expandedStepIdx === i ? null : i)}>
+                            onClick={toggle}>
                             {step.skipped
                               ? <SkipForward className="w-3 h-3 text-text-dim/40 shrink-0" />
                               : step.agent_found
@@ -743,24 +800,24 @@ export function WorkflowsPage() {
                             {step.skipped && (
                               <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-main border border-border-subtle text-text-dim/50 shrink-0">{t("workflows.skip", { defaultValue: "skip" })}</span>
                             )}
-                            <ChevronDown className={`w-3 h-3 text-text-dim/30 shrink-0 transition-transform ${expandedStepIdx === i ? "rotate-180" : ""}`} />
+                            <ChevronDown className={`w-3 h-3 text-text-dim/30 shrink-0 transition-transform ${isExpanded ? "rotate-180" : ""}`} />
                           </button>
-                          {expandedStepIdx === i && (
-                            <div className="px-3 pb-3 space-y-1.5 border-t border-border-subtle">
-                              {!step.agent_found && (
-                                <p className="text-[10px] text-warning mt-2">{t("workflows.agent_not_found", { defaultValue: "Agent not found" })}</p>
-                              )}
-                              {step.skip_reason && (
-                                <p className="text-[10px] text-text-dim mt-2">{step.skip_reason}</p>
-                              )}
-                              <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("workflows.resolved_prompt", { defaultValue: "Resolved prompt:" })}</p>
-                              <pre className="text-[10px] text-text whitespace-pre-wrap max-h-28 overflow-y-auto bg-surface rounded-lg p-2">
-                                {step.resolved_prompt || "(empty)"}
-                              </pre>
-                            </div>
-                          )}
-                        </div>
-                      ))}
+                        )}
+                        renderContent={(step) => (
+                          <div className="px-3 pb-3 space-y-1.5 border-t border-border-subtle">
+                            {!step.agent_found && (
+                              <p className="text-[10px] text-warning mt-2">{t("workflows.agent_not_found", { defaultValue: "Agent not found" })}</p>
+                            )}
+                            {step.skip_reason && (
+                              <p className="text-[10px] text-text-dim mt-2">{step.skip_reason}</p>
+                            )}
+                            <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("workflows.resolved_prompt", { defaultValue: "Resolved prompt:" })}</p>
+                            <pre className="text-[10px] text-text whitespace-pre-wrap max-h-28 overflow-y-auto bg-surface rounded-lg p-2">
+                              {step.resolved_prompt || "(empty)"}
+                            </pre>
+                          </div>
+                        )}
+                      />
                     </div>
                   </div>
                 )}
@@ -776,37 +833,12 @@ export function WorkflowsPage() {
                     {getRunStepResults(runMutation.data).length > 0 && (
                       <div className="space-y-1.5 border-t border-success/20 pt-2">
                         <p className="text-[9px] font-bold text-text-dim/50">{t("workflows.step_details", { defaultValue: "Step details" })}</p>
-                        {getRunStepResults(runMutation.data).map((s, i) => (
-                          <div key={getStepResultKey(s, i)} className="rounded-lg border border-border-subtle bg-main overflow-hidden">
-                            <button
-                              className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-surface transition-colors"
-                              onClick={() => setExpandedStepIdx(expandedStepIdx === i + 1000 ? null : i + 1000)}>
-                              <CheckCircle2 className="w-3 h-3 text-success shrink-0" />
-                              <span className="text-[10px] font-bold truncate flex-1">{s.step_name}</span>
-                              <span className="text-[9px] text-text-dim/50 shrink-0">{s.duration_ms}ms</span>
-                              <ChevronDown className={`w-3 h-3 text-text-dim/30 shrink-0 transition-transform ${expandedStepIdx === i + 1000 ? "rotate-180" : ""}`} />
-                            </button>
-                            {expandedStepIdx === i + 1000 && (
-                              <div className="px-3 pb-3 space-y-2 border-t border-border-subtle">
-                                <div>
-                                  <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("workflows.prompt_sent", { defaultValue: "Prompt sent:" })}</p>
-                                  <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
-                                    {s.prompt || "(empty)"}
-                                  </pre>
-                                </div>
-                                <div>
-                                  <p className="text-[9px] font-bold text-text-dim/50">{t("workflows.output", { defaultValue: "Output:" })}</p>
-                                  <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
-                                    {s.output || "(empty)"}
-                                  </pre>
-                                </div>
-                                <p className="text-[9px] text-text-dim/40">
-                                  {s.agent_name} · {s.input_tokens} in / {s.output_tokens} out tokens
-                                </p>
-                              </div>
-                            )}
-                          </div>
-                        ))}
+                        <StepAccordion
+                          steps={getRunStepResults(runMutation.data)}
+                          getKey={getStepResultKey}
+                          renderHeader={stepResultHeader}
+                          renderContent={stepResultContent}
+                        />
                       </div>
                     )}
                   </div>
@@ -850,7 +882,6 @@ export function WorkflowsPage() {
                             }`}
                             onClick={() => {
                               setSelectedRunId(isSelected ? null : (runId ?? null));
-                              setExpandedStepIdx(null);
                             }}>
                             <div className={`w-2 h-2 rounded-full shrink-0 ${
                               state === "completed" ? "bg-success" :
@@ -876,37 +907,12 @@ export function WorkflowsPage() {
                                   <p className="text-[10px] text-error">{runDetailQuery.data.error}</p>
                                 </div>
                               )}
-                              {runDetailQuery.data.step_results.map((step, si) => (
-                                <div key={getStepResultKey(step, si)} className="rounded-lg border border-border-subtle bg-main overflow-hidden">
-                                  <button
-                                    className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-surface transition-colors"
-                                    onClick={() => setExpandedStepIdx(expandedStepIdx === si + 2000 ? null : si + 2000)}>
-                                    <CheckCircle2 className="w-3 h-3 text-success shrink-0" />
-                                    <span className="text-[10px] font-bold truncate flex-1">{step.step_name}</span>
-                                    <span className="text-[9px] text-text-dim/50 shrink-0">{step.duration_ms}ms</span>
-                                    <ChevronDown className={`w-3 h-3 text-text-dim/30 shrink-0 transition-transform ${expandedStepIdx === si + 2000 ? "rotate-180" : ""}`} />
-                                  </button>
-                                  {expandedStepIdx === si + 2000 && (
-                                    <div className="px-3 pb-3 space-y-2 border-t border-border-subtle">
-                                      <div>
-                                  <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("workflows.prompt_sent", { defaultValue: "Prompt sent:" })}</p>
-                                        <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
-                                          {step.prompt || "(empty)"}
-                                        </pre>
-                                      </div>
-                                      <div>
-                                  <p className="text-[9px] font-bold text-text-dim/50">{t("workflows.output", { defaultValue: "Output:" })}</p>
-                                        <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
-                                          {step.output || "(empty)"}
-                                        </pre>
-                                      </div>
-                                      <p className="text-[9px] text-text-dim/40">
-                                        {step.agent_name} · {step.input_tokens} in / {step.output_tokens} out tokens
-                                      </p>
-                                    </div>
-                                  )}
-                                </div>
-                              ))}
+                              <StepAccordion
+                                steps={runDetailQuery.data.step_results}
+                                getKey={getStepResultKey}
+                                renderHeader={stepResultHeader}
+                                renderContent={stepResultContent}
+                              />
                             </div>
                           )}
                           {isSelected && runDetailQuery.isLoading && (

--- a/crates/librefang-api/dashboard/src/router.tsx
+++ b/crates/librefang-api/dashboard/src/router.tsx
@@ -150,14 +150,12 @@ const channelsRoute = createRoute({
 const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/chat",
-  validateSearch: (search: Record<string, unknown>): { agentId?: string; sessionId?: string; attach?: string } => {
-    const out: { agentId?: string; sessionId?: string; attach?: string } = {};
+  validateSearch: (search: Record<string, unknown>): { agentId?: string; sessionId?: string; attach?: string; handName?: string } => {
+    const out: { agentId?: string; sessionId?: string; attach?: string; handName?: string } = {};
     if (typeof search.agentId === "string") out.agentId = search.agentId;
     if (typeof search.sessionId === "string") out.sessionId = search.sessionId;
-    // Hidden flag: enables the multi-attach SSE viewer (see useSessionStream).
-    // Functionally testable once #3078 lands; before then the hook silently
-    // no-ops on the 404 the route returns.
     if (typeof search.attach === "string") out.attach = search.attach;
+    if (typeof search.handName === "string") out.handName = search.handName;
     return out;
   },
   component: () => <L><ChatPage /></L>


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Refactor / Performance

## Summary

Fix 35 confirmed UI bugs across 10 dashboard page components, followed by 4 review-driven refinements. All changes are frontend-only, no Rust/backend modifications.

## Changes

- **NetworkPage**: Promise.all error handling, isLoading includes trustedQuery, hoisted icon const, `!= null` for peer.version, EmptyState for trusted peers
- **AnalyticsPage**: stable `usageByModel` ref, Promise.all catch, budget form reset after save, `budgetMutation.reset()` auto-dismiss, `Math.min` cap on chart heights
- **MemoryPage**: `onError` + error toasts on add/save, `ConfirmDialog` for delete, `role=switch` + `aria-checked` on toggles
- **WorkflowsPage**: extracted `StepAccordion` generic component, eliminated triplicated accordion blocks and magic offset numbers
- **ConfigPage**: `useBlocker` replaces `throw Error()` navigation block, setTimeout cleanup via refs, `useMemo` Set for `sectionHasPending`, regex-based `fieldLabelFallback`
- **ProvidersPage**: latency_ms falsy check (`0` showed `-`), `React.memo` on ProviderCard, `useReducer` for filter state, batch test concurrency limit + conditional toasts, `detailsProvider` stale-data sync, cached `getAuthBadge`, `useTranslation` replaces `t` prop
- **ModelsPage**: `Intl.NumberFormat` for cost display, `React.memo` on ModelCard, stable `useCallback` refs, `useReducer` for add-form + settings modal, key-based reset eliminates `overridesLoaded` flag
- **ChannelsPage**: `key` prop on ConfigDialog, stable `useCallback` for QR onClose, QR retry max count (15), `React.memo` on ChannelCard, single-pass count, dead `paginatedChannels` alias removed
- **SkillsPage**: `addToast`/`ConfirmDialog` replace `alert`/`confirm`, O(1) `Set` for `installedSlugSet`, `React.memo` on SkillCard
- **HandsPage**: `handleChat` missing `handName` param, split `pendingId` into `pendingHandId`/`pendingInstanceId`, setTimeout cleanup in `HandSettingsEditor`, `Map` for `activeHandPairs` O(1) lookup, `ConfirmDialog` for uninstall
- **ModelsPage**: `useRef` guard on hydration — prevents background refetch from overwriting unsaved edits
- **ConfigPage**: pre-built `Map` for root-level field lookup in `sectionsWithPending` — O(1) instead of O(N×M)
- **AnalyticsPage**: `budgetMutation.reset` setTimeout stored in ref with cleanup effect
- **MemoryPage.test**: updated delete test for ConfirmDialog flow, added `motion/react` mock
- `router.tsx`: added `handName` search param to chat route's `validateSearch`


#### Sequence diagram for ProvidersPage batch test concurrency and toasts

```mermaid
sequenceDiagram
  actor User
  participant ProvidersPage
  participant TestMutation as ReactQueryTestMutation
  participant ToastStore as UIStore_addToast

  User->>ProvidersPage: click BatchTestButton
  ProvidersPage->>ProvidersPage: collect selectedIds
  alt no selectedIds
    ProvidersPage-->>User: no-op
  else some selectedIds
    ProvidersPage->>ProvidersPage: set testingIds
    loop up to 4 concurrent workers
      ProvidersPage->>TestMutation: mutateAsync(id)
      alt result.status == "error"
        TestMutation-->>ProvidersPage: error result
        ProvidersPage->>ProvidersPage: failCount++
      else success
        TestMutation-->>ProvidersPage: success result
        ProvidersPage->>ProvidersPage: successCount++
      end
      ProvidersPage->>ProvidersPage: remove id from testingIds
    end
    alt failCount == 0
      ProvidersPage->>ToastStore: addToast(t(common.success),"success")
    else successCount == 0
      ProvidersPage->>ToastStore: addToast(t(providers.batch_test_all_failed),"error")
    else mixed
      ProvidersPage->>ToastStore: addToast(t(providers.batch_test_partial),"error")
    end
  end
```

#### Sequence diagram for HandsPage chat navigation and uninstall confirmation

```mermaid
sequenceDiagram
  actor User
  participant HandsPage
  participant ConfirmDialog
  participant Navigate as RouterNavigate
  participant UninstallMutation as ReactQueryUninstall
  participant ToastStore as UIStore_addToast

  rect rgb(230,230,250)
    User->>HandsPage: click Chat on HandCard
    HandsPage->>HandsPage: handleChat(instanceId, handName)
    HandsPage->>Navigate: navigate({to:"/chat", search:{agentId, handName}})
    Navigate-->>User: ChatPage opened with handName
  end

  rect rgb(230,250,230)
    User->>HandsPage: click Uninstall in HandDetail
    HandsPage->>HandsPage: setConfirmDialog({...})
    HandsPage->>ConfirmDialog: open with title, message, tone destructive
    User->>ConfirmDialog: click Confirm
    ConfirmDialog->>HandsPage: onConfirm()
    HandsPage->>HandsPage: setConfirmDialog(null)
    HandsPage->>HandsPage: setPendingHandId(handId)
    HandsPage->>UninstallMutation: mutateAsync(handId)
    alt success
      UninstallMutation-->>HandsPage: resolved
      HandsPage->>ToastStore: addToast(t(common.success),"success")
      HandsPage->>HandsPage: setDetailHand(null)
    else error
      UninstallMutation-->>HandsPage: error
      HandsPage->>ToastStore: addToast(errorMessage,"error")
    end
    HandsPage->>HandsPage: setPendingHandId(null)
  end
```

#### Updated class diagram for ModelsPage reducers and ModelCard callbacks

```mermaid
classDiagram
  class ModelsPage {
    +AddFormState form
    +dispatchForm(action AddFormAction)
    +ModelItem~[]~ allModels
    +ModelItem~[]~ filtered
    +Map~string,ModelItem[]~ grouped
    +ModelItem|null settingsModel
    +ModelItem|null detailModel
    +string|null confirmDeleteId
    +useReducer(addFormReducer)
    +useMemo(allModels)
    +useMemo(filtered)
    +useMemo(grouped)
    +useCallback(resetForm)
    +useCallback(toggleHidden)
    +useCallback(handleCardOpen)
    +useCallback(handleCardSettings)
    +useCallback(handleDelete)
  }

  class AddFormState {
    +string id
    +string provider
    +string displayName
    +number contextWindow
    +number maxOutput
    +number inputCost
    +number outputCost
    +boolean tools
    +boolean vision
    +boolean streaming
  }

  class AddFormAction {
    <<union>>
    +type : "SET_FIELD"|"RESET"
    +field : keyof AddFormState
    +value : AddFormState[keyof AddFormState]
  }

  class SettingsState {
    +string modelType  // "chat" | "speech" | "embedding"
    +number temperature
    +boolean tempEnabled
    +number topP
    +boolean topPEnabled
    +number maxTokens
    +boolean maxTokensEnabled
    +number freqPenalty
    +boolean freqEnabled
    +number presPenalty
    +boolean presEnabled
    +string reasoningEffort
    +boolean useMaxCompletionTokens
    +boolean noSystemRole
    +boolean forceMaxTokens
  }

  class SettingsAction {
    <<union>>
    +type : "SET_FIELD"|"HYDRATE"
    +field : keyof SettingsState
    +value : SettingsState[keyof SettingsState]
    +payload : Partial~SettingsState~
  }

  class ModelSettingsModal {
    +SettingsState state
    +dispatch(action SettingsAction)
    +useEffect(hydrateFromOverrides)
    +handleSave()
    +handleReset()
  }

  class ModelCard {
    +ModelItem m
    +boolean hidden
    +boolean pendingDelete
    +onOpen(m ModelItem)
    +onSettings(m ModelItem)
    +onToggleHidden(m ModelItem)
    +onDelete(id string)
  }

  class ModelItem {
    +string id
    +string provider
    +string display_name
    +number context_window
    +number max_output_tokens
    +number input_cost_per_m
    +number output_cost_per_m
    +string tier
  }

  ModelsPage --> AddFormState : uses
  ModelsPage --> AddFormAction : dispatches
  ModelSettingsModal --> SettingsState : uses
  ModelSettingsModal --> SettingsAction : dispatches
  ModelsPage --> ModelCard : renders
  ModelCard --> ModelItem : displays
  ModelsPage --> ModelSettingsModal : opens

  class addFormReducer {
    +reduce(state AddFormState, action AddFormAction) AddFormState
  }

  class settingsReducer {
    +reduce(state SettingsState, action SettingsAction) SettingsState
  }

  addFormReducer ..> AddFormState
  addFormReducer ..> AddFormAction
  settingsReducer ..> SettingsState
  settingsReducer ..> SettingsAction
```

#### Updated class diagram for ProvidersPage filter reducer and cards

```mermaid
classDiagram
  class ProvidersPage {
    +FilterState filterState
    +Set~string~ selectedIds
    +string|null pendingId
    +Set~string~ testingIds
    +ProviderItem|null detailsProvider
    +boolean showCreateForm
    +useReducer(filterReducer)
    +handleSearch(value string)
    +handleFilterChange(status FilterStatus)
    +handleSort(field SortField)
    +handleSelect(id string, checked boolean)
    +handleBatchTest()
    +handleTest(id string)
    +handleSetDefault(id string, model string)
  }

  class FilterState {
    +string search
    +FilterStatus filterStatus
    +SortField sortField
    +SortOrder sortOrder
  }

  class FilterAction {
    <<union>>
    +type : "SEARCH"|"FILTER"|"SORT"
    +value : string
    +status : FilterStatus
    +field : SortField
  }

  class filterReducer {
    +reduce(state FilterState, action FilterAction) FilterState
  }

  class ProviderItem {
    +string id
    +string name
    +number? latency_ms
    +string auth_status
  }

  class ProviderCard {
    +ProviderItem provider
    +boolean isSelected
    +boolean isDefault
    +string|null pendingId
    +ViewMode viewMode
    +onSelect(id string, checked boolean)
    +onTest(id string)
    +onSetDefault(id string, model string)
    +onViewDetails(provider ProviderItem)
    +onConfigure(provider ProviderItem)
    +onDelete(provider ProviderItem)
  }

  class DetailsModal {
    +ProviderItem provider
    +string|null pendingId
    +onClose()
    +onTest(id string)
  }

  class SetDefaultModelSection {
    +string providerId
    +string? currentDefault
    +onSetDefault(id string, model string)
  }

  ProvidersPage --> FilterState : owns
  ProvidersPage --> FilterAction : dispatches
  ProvidersPage --> filterReducer : uses
  ProvidersPage --> ProviderCard : renders
  ProvidersPage --> DetailsModal : opens
  ProvidersPage --> SetDefaultModelSection : showsInConfig
  ProviderCard --> ProviderItem : displays
  DetailsModal --> ProviderItem : displays
  SetDefaultModelSection --> ProviderItem : selectsModel

  class FilterStatus {
    <<enumeration>>
    all
    reachable
    unreachable
  }

  class SortField {
    <<enumeration>>
    name
    latency
    status
  }

  class SortOrder {
    <<enumeration>>
    asc
    desc
  }

  class ViewMode {
    <<enumeration>>
    grid
    list
  }

  ProvidersPage --> FilterStatus
  ProvidersPage --> SortField
  ProvidersPage --> SortOrder
  ProviderCard --> ViewMode
```


## Attribution

- [x] N/A — all changes authored in this PR

## Testing

- [x] `npx tsc --noEmit` — zero new errors
- [x] `npx vitest run src/pages/MemoryPage.test.tsx` — 10/10 pass
- [x] `npx vite build` — 348ms, clean

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries