### PR TITLE
fix(api): expose cron_session_compaction_* + tool_exec via ui_sections_overlay

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -2104,6 +2104,7 @@ pub fn ui_sections_overlay() -> serde_json::Value {
                 "cors_origin", "trust_forwarded_for",
                 "cron_session_max_tokens", "cron_session_max_messages",
                 "cron_session_warn_fraction", "cron_session_warn_total_tokens",
+                "cron_session_compaction_mode", "cron_session_compaction_keep_recent",
                 "strict_config"
             ]
         },
@@ -2158,6 +2159,7 @@ pub fn ui_sections_overlay() -> serde_json::Value {
         {"key": "prompt_intelligence", "struct_field": "prompt_intelligence"},
         {"key": "rate_limit", "struct_field": "rate_limit"},
         {"key": "tool_invoke", "struct_field": "tool_invoke"},
+        {"key": "tool_exec", "struct_field": "tool_exec"},
         {"key": "parallel_tools", "struct_field": "parallel_tools"},
         {"key": "tool_results", "struct_field": "tool_results"},
         {"key": "compaction", "struct_field": "compaction"},

--- a/crates/librefang-api/tests/config_schema_overlay.rs
+++ b/crates/librefang-api/tests/config_schema_overlay.rs
@@ -241,6 +241,10 @@ fn every_kernel_config_struct_field_is_exposed_via_overlay() {
         "cron_session_max_messages",
         "cron_session_warn_fraction",
         "cron_session_warn_total_tokens",
+        // Surfaced under the synthetic "general" section as root_level entries
+        // (see #3693 / PR #4683 for the SummarizeTrim feature).
+        "cron_session_compaction_mode",
+        "cron_session_compaction_keep_recent",
         "include",
         "strict_config",
         "qwen_code_path",


### PR DESCRIPTION
## Summary

Restores main CI to green. The integration test
`every_kernel_config_struct_field_is_exposed_via_overlay` (introduced by #4678 to make schema/UI drift a build break) started failing on Ubuntu shard 1 / Windows / macOS after #4683 (cron SummarizeTrim) and the `tool_exec` landing added three `KernelConfig` fields with no entry in `ui_sections_overlay()` and no entry in EXCLUDED:

- `cron_session_compaction_keep_recent`
- `cron_session_compaction_mode`
- `tool_exec`

These were invisible in the dashboard ConfigPage; users had to edit `~/.librefang/config.toml` directly to reach them.

## Changes

- `crates/librefang-api/src/routes/config.rs`
  - **`cron_session_compaction_mode` / `cron_session_compaction_keep_recent`** — surfaced as root-level entries on the synthetic `general` section, alongside the existing `cron_session_max_*` / `cron_session_warn_*` fields. Schema-driven UI picks them up automatically.
  - **`tool_exec`** — registered as its own section descriptor (`{\"key\": \"tool_exec\", \"struct_field\": \"tool_exec\"}`), same convention as `tool_invoke` / `tool_results`. The `ToolExecConfig` sub-struct now renders as a normal config tab.

- `crates/librefang-api/tests/config_schema_overlay.rs`
  - The two cron compaction scalars added to EXCLUDED with a comment naming PR #4683 / issue #3693, matching how `cron_session_max_tokens` / `cron_session_max_messages` are handled (the test only counts `struct_field` registrations, so root-level scalars must opt out explicitly even when listed in `general.fields`).

## Test plan

- `cargo test -p librefang-api --test config_schema_overlay` — 4/4 pass:
  - `every_root_level_field_exists_on_kernel_config`
  - `every_kernel_config_struct_field_is_exposed_via_overlay`
  - `every_x_sections_struct_field_exists_on_kernel_config`
  - `every_x_ui_options_path_resolves_in_schema`
- `cargo fmt --check` clean.

## Out of scope

- Per-field UI hints (numeric ranges / select options) for the three newly exposed fields can be added to `ui_options_overlay()` in a follow-up if operator tooltips become useful. Not blocking; the schema-derived defaults render fine.