### PR TITLE
fix(dashboard): toast refresh errors in AnalyticsPage (#4718 review L1)

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 import type { UsageByAgentItem, UsageByModelItem, UsageDailyItem } from "../api";
 import { useUsageSummary, useUsageByAgent, useUsageByModel, useUsageDaily, useModelPerformance, useBudgetStatus } from "../lib/queries/analytics";
 import { useUpdateBudget } from "../lib/mutations/analytics";
+import { useUIStore } from "../lib/store";
+import { toastErr } from "../lib/errors";
 
 // The kernel ships extra columns on these rows (is_hand, total_cost_usd,
 // call_count / calls) that haven't been promoted into the canonical
@@ -38,6 +40,7 @@ interface BudgetForm {
 
 export function AnalyticsPage() {
   const { t } = useTranslation();
+  const addToast = useUIStore((s) => s.addToast);
 
   const usageQuery = useUsageSummary();
   const usageByAgentQuery = useUsageByAgent();
@@ -155,15 +158,19 @@ export function AnalyticsPage() {
   }, [modelPerformance, t]);
 
   const handleRefresh = useCallback(() => {
-    void Promise.all([
+    Promise.all([
       usageQuery.refetch(),
       usageByAgentQuery.refetch(),
       usageByModelQuery.refetch(),
       dailyQuery.refetch(),
       modelPerformanceQuery.refetch(),
       budgetQuery.refetch(),
-    ]).catch(() => {});
-  }, [usageQuery, usageByAgentQuery, usageByModelQuery, dailyQuery, modelPerformanceQuery, budgetQuery]);
+    ]).catch((e) => {
+      // Match NetworkPage's pattern (#4718 review L1) — surface refresh
+      // failures as a toast rather than silently swallowing them.
+      addToast(toastErr(e, t("common.error")), "error");
+    });
+  }, [usageQuery, usageByAgentQuery, usageByModelQuery, dailyQuery, modelPerformanceQuery, budgetQuery, addToast, t]);
 
   return (
     <div className="flex flex-col gap-4 sm:gap-6 transition-colors duration-300">


### PR DESCRIPTION
## Summary

#4718 review follow-up. Replaces the silent `Promise.all(...).catch(() => {})` in `AnalyticsPage::handleRefresh` with `addToast(toastErr(e, t(\"common.error\")), \"error\")` — the same pattern `NetworkPage::handleRefresh` adopted in #4718. Refresh failures now surface to the user instead of being swallowed.

## Why a separate PR

In the #4718 review I flagged two follow-ups: M1 (WorkflowsPage StepAccordion run-switch state leak) and L1 (this).

After re-reading the code, **M1 was a false alarm** — each run row already wraps its accordion in:

```jsx
<div key={runId}>
  {isSelected && runDetailQuery.data && <StepAccordion ... />}
</div>
```

so toggling `selectedRunId` causes the previous run's `<StepAccordion>` to unmount and the new run's instance to mount fresh. The internal `expandedIdx` state is per-row and naturally isolated; no extra `key` prop is needed. Withdrawing M1.

L1 is the only remaining nit; this PR addresses it.

## Changes

- `crates/librefang-api/dashboard/src/pages/AnalyticsPage.tsx`
  - Import `useUIStore` and `toastErr`.
  - `handleRefresh` now toasts the failure with the same wording used elsewhere on the page.
  - `addToast` and `t` added to the `useCallback` dep list.

## Test plan

- `npx tsc --noEmit` clean.

## Attribution

- N/A — single-line behavioural fix authored in this PR.