### PR TITLE
refactor(arch): KernelApi trait + Arc<dyn KernelApi> AppState (#3566)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -331,7 +331,7 @@ use librefang_kernel::auth::Action as KernelAction;
 use librefang_kernel::config::load_config as kernel_load_config;
 use librefang_kernel::llm_driver::StreamEvent;
 use librefang_kernel::DeliveryTracker;
-use librefang_kernel::LibreFangKernel;
+use librefang_kernel::KernelApi;
 use librefang_types::agent::AgentId;
 use std::sync::Arc;
 #[cfg(feature = "channel-telegram")]
@@ -633,7 +633,7 @@ where
 
 /// Wraps `LibreFangKernel` to implement `ChannelBridgeHandle`.
 pub struct KernelBridgeAdapter {
-    kernel: Arc<LibreFangKernel>,
+    kernel: Arc<dyn KernelApi>,
     started_at: Instant,
 }
 
@@ -706,6 +706,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         let language = self.kernel.config_snapshot().language.clone();
         let (event_rx, kernel_handle) = self
             .kernel
+            .clone()
             .send_message_streaming_with_routing(agent_id, message, None)
             .await
             .map_err(|e| format!("{e}"))?;
@@ -733,7 +734,13 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         let language = self.kernel.config_snapshot().language.clone();
         let (event_rx, kernel_handle) = self
             .kernel
-            .send_message_streaming_with_sender_context_and_routing(agent_id, message, None, sender)
+            .clone()
+            .send_message_streaming_with_sender_context_and_routing(
+                agent_id,
+                message,
+                None,
+                sender.clone(),
+            )
             .await
             .map_err(|e| format!("{e}"))?;
         Ok(start_stream_text_bridge(
@@ -766,7 +773,13 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         let language = self.kernel.config_snapshot().language.clone();
         let (event_rx, kernel_handle) = self
             .kernel
-            .send_message_streaming_with_sender_context_and_routing(agent_id, message, None, sender)
+            .clone()
+            .send_message_streaming_with_sender_context_and_routing(
+                agent_id,
+                message,
+                None,
+                sender.clone(),
+            )
             .await
             .map_err(|e| format!("{e}"))?;
         Ok(start_stream_text_bridge_with_status(
@@ -786,7 +799,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
     ) -> Result<String, String> {
         let result = self
             .kernel
-            .send_message_with_sender_context(agent_id, message, sender)
+            .send_message_with_sender_context(agent_id, message, sender.clone())
             .await
             .map_err(|e| format!("{e}"))?;
         if result.silent {
@@ -817,7 +830,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         };
         let result = self
             .kernel
-            .send_message_with_blocks_and_sender(agent_id, &text, blocks, sender)
+            .send_message_with_blocks_and_sender(agent_id, &text, blocks, sender.clone())
             .await
             .map_err(|e| format!("{e}"))?;
         if result.silent {
@@ -885,7 +898,7 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
 
         let agent_id = self
             .kernel
-            .spawn_agent(manifest)
+            .spawn_agent_typed(manifest)
             .map_err(|e| format!("Failed to spawn agent: {e}"))?;
 
         Ok(agent_id)
@@ -1417,7 +1430,11 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
                                 match resolved {
                                     Some(wf_id) => {
                                         let input_text = input.clone().unwrap_or_default();
-                                        match self.kernel.run_workflow(wf_id, input_text).await {
+                                        match self
+                                            .kernel
+                                            .run_workflow_typed(wf_id, input_text)
+                                            .await
+                                        {
                                             Ok((_run_id, output)) => {
                                                 format!(
                                                     "Job [{id_short}] workflow ran:\n{}",
@@ -2152,7 +2169,6 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
         message: &str,
         thread_id: Option<&str>,
     ) -> Result<String, String> {
-        use librefang_kernel::kernel_handle::prelude::*;
         self.kernel
             .send_channel_message(channel_type, recipient, message, thread_id, None)
             .await
@@ -2232,7 +2248,7 @@ fn read_token(env_var: &str, adapter_name: &str) -> Option<String> {
 /// (Feishu, Teams, DingTalk, etc.) and should be mounted under `/channels`
 /// on the main API server.
 pub async fn start_channel_bridge(
-    kernel: Arc<LibreFangKernel>,
+    kernel: Arc<dyn KernelApi>,
 ) -> (Option<BridgeManager>, axum::Router) {
     let channels = kernel.config_ref().channels.clone();
     let (bridge, _names, webhook_router) =
@@ -2244,7 +2260,7 @@ pub async fn start_channel_bridge(
 ///
 /// Returns `(Option<BridgeManager>, Vec<started_channel_names>, webhook_router)`.
 pub async fn start_channel_bridge_with_config(
-    kernel: Arc<LibreFangKernel>,
+    kernel: Arc<dyn KernelApi>,
     config: &librefang_types::config::ChannelsConfig,
 ) -> (Option<BridgeManager>, Vec<String>, axum::Router) {
     // Check which channels have config — only consider enabled features

--- a/crates/librefang-api/src/openai_compat.rs
+++ b/crates/librefang-api/src/openai_compat.rs
@@ -330,7 +330,7 @@ pub async fn chat_completions(
     }
 
     // Non-streaming response
-    let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone() as Arc<dyn KernelHandle>;
+    let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone();
     match state
         .kernel
         .send_message_with_handle(agent_id, &last_user_msg, Some(kernel_handle))
@@ -385,10 +385,11 @@ async fn stream_response(
     request_id: String,
     created: u64,
 ) -> Result<axum::response::Response, String> {
-    let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone() as Arc<dyn KernelHandle>;
+    let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone();
 
     let (mut rx, _handle) = state
         .kernel
+        .clone()
         .send_message_streaming_with_routing(agent_id, message, Some(kernel_handle))
         .await
         .map_err(|e| format!("Streaming setup failed: {e}"))?;

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -407,7 +407,7 @@ async fn spawn_agent_inner(
         }
     };
 
-    match state.kernel.spawn_agent(resolved.manifest) {
+    match state.kernel.spawn_agent_typed(resolved.manifest) {
         Ok(id) => {
             let body = serde_json::to_vec(&SpawnResponse {
                 agent_id: id.to_string(),
@@ -512,7 +512,7 @@ pub async fn bulk_create_agents(
             }
             Ok(resolved) => {
                 let name = resolved.name.clone();
-                match state.kernel.spawn_agent(resolved.manifest) {
+                match state.kernel.spawn_agent_typed(resolved.manifest) {
                     Ok(id) => {
                         results.push(BulkCreateResult {
                             index,
@@ -605,7 +605,7 @@ pub async fn bulk_delete_agents(
                 continue;
             }
         }
-        match state.kernel.kill_agent(agent_id) {
+        match state.kernel.kill_agent_typed(agent_id) {
             Ok(()) => {
                 results.push(BulkActionResult {
                     agent_id: id_str.clone(),
@@ -1784,7 +1784,7 @@ pub async fn send_message(
     } else {
         let sender_context = request_sender_context(&req);
         let kernel = state.kernel.clone();
-        let kernel_handle: Arc<dyn KernelHandle> = kernel.clone() as Arc<dyn KernelHandle>;
+        let kernel_handle: Arc<dyn KernelHandle> = kernel.clone();
         let msg = effective_message.clone();
         let sc = sender_context;
         let incognito = req.incognito;
@@ -1794,7 +1794,7 @@ pub async fn send_message(
                     agent_id,
                     &msg,
                     Some(kernel_handle),
-                    sc.as_ref(),
+                    sc,
                     thinking_override,
                     session_id_override,
                     incognito,
@@ -2717,9 +2717,10 @@ pub async fn send_message_stream(
         },
     };
 
-    let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone() as Arc<dyn KernelHandle>;
+    let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone();
     let (rx, handle) = match state
         .kernel
+        .clone()
         .send_message_streaming_with_incognito(
             agent_id,
             &req.message,
@@ -5145,7 +5146,7 @@ pub async fn clone_agent(
     apply_clone_inclusion_flags(&mut cloned_manifest, &req);
 
     // Spawn the cloned agent
-    let new_id = match state.kernel.spawn_agent(cloned_manifest) {
+    let new_id = match state.kernel.spawn_agent_typed(cloned_manifest) {
         Ok(id) => id,
         Err(e) => {
             return (
@@ -7205,7 +7206,7 @@ mod monitoring_tests {
             name: name.to_string(),
             ..AgentManifest::default()
         };
-        state.kernel.spawn_agent(manifest).unwrap()
+        state.kernel.spawn_agent_typed(manifest).unwrap()
     }
 
     async fn json_response(response: impl IntoResponse) -> (StatusCode, serde_json::Value) {
@@ -7310,7 +7311,7 @@ mod monitoring_tests {
             mcp_servers: vec!["server-a".to_string()],
             ..AgentManifest::default()
         };
-        let agent_id = state.kernel.spawn_agent(manifest).unwrap();
+        let agent_id = state.kernel.spawn_agent_typed(manifest).unwrap();
 
         let (status, body) = json_response(
             patch_agent(
@@ -7356,7 +7357,7 @@ mod monitoring_tests {
             mcp_servers: vec!["server-b".to_string()],
             ..AgentManifest::default()
         };
-        let agent_id = state.kernel.spawn_agent(manifest).unwrap();
+        let agent_id = state.kernel.spawn_agent_typed(manifest).unwrap();
 
         let (status, body) = json_response(
             patch_agent(

--- a/crates/librefang-api/src/routes/approvals.rs
+++ b/crates/librefang-api/src/routes/approvals.rs
@@ -14,7 +14,6 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_kernel::kernel_handle::prelude::*;
 use librefang_types::i18n::ErrorTranslator;
 use std::sync::Arc;
 

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -352,7 +352,7 @@ pub async fn update_budget(
 
     // Apply updates — accept both config field names (max_hourly_usd) and
     // GET response field names (hourly_limit) so read-modify-write works.
-    state.kernel.update_budget_config(|budget| {
+    state.kernel.update_budget_config(&|budget| {
         if let Some(v) = body["max_hourly_usd"]
             .as_f64()
             .or_else(|| body["hourly_limit"].as_f64())

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -891,7 +891,7 @@ pub async fn auth_callback(
     // the UX cost is worth the state consistency.
     // The kernel's retry_mcp_connection is the single source of truth for setting
     // Authorized (on Ok) or Error (on Err) in mcp_auth_states.
-    state.kernel.retry_mcp_connection(&name).await;
+    state.kernel.clone().retry_mcp_connection(&name).await;
 
     callback_text("Authorization Complete\n\nYou can close this tab.".to_string())
 }

--- a/crates/librefang-api/src/routes/mod.rs
+++ b/crates/librefang-api/src/routes/mod.rs
@@ -94,7 +94,7 @@ pub use workflows::*;
 use crate::middleware::RequestLanguage;
 use crate::rate_limiter::KeyedRateLimiter;
 use dashmap::DashMap;
-use librefang_kernel::LibreFangKernel;
+use librefang_kernel::KernelApi;
 use librefang_types::i18n::{self, ErrorTranslator};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -121,10 +121,14 @@ pub(crate) fn resolve_lang(lang: Option<&axum::Extension<RequestLanguage>>) -> &
 
 /// Shared application state.
 ///
-/// The kernel is wrapped in Arc so it can serve as both the main kernel
-/// and the KernelHandle for inter-agent tool access.
+/// `kernel` is `Arc<dyn KernelApi>` (#3566) — routes interact with the
+/// kernel exclusively through the [`KernelApi`] trait surface, not via
+/// the concrete `LibreFangKernel` struct. This is the single explicit
+/// contract between the HTTP layer and the kernel; widening it is an
+/// explicit choice rather than a side-effect of adding a new inherent
+/// method on the kernel struct.
 pub struct AppState {
-    pub kernel: Arc<LibreFangKernel>,
+    pub kernel: Arc<dyn KernelApi>,
     pub started_at: Instant,
     /// Channel bridge manager — held in an `ArcSwap` for lock-free reads and atomic
     /// swap on hot-reload. Write sites use `store(Arc::new(new_value))`; the stop

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -1976,7 +1976,7 @@ pub async fn comms_send(
         }
     };
 
-    let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone() as Arc<dyn KernelHandle>;
+    let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone();
     match state
         .kernel
         .send_message_with_handle_and_blocks(

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -9,7 +9,6 @@ use librefang_types::agent::{PromptExperiment, PromptVersion};
 use sha2::{Digest, Sha256};
 
 use super::AppState;
-use librefang_kernel::kernel_handle::prelude::*;
 use std::sync::Arc;
 
 use crate::types::ApiErrorResponse;

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -257,9 +257,10 @@ pub async fn create_alias(
         return ApiErrorResponse::bad_request("Missing required field: model_id").into_json_tuple();
     }
 
-    let added: bool = state
-        .kernel
-        .model_catalog_update(|catalog| catalog.add_alias(&alias, &model_id));
+    let mut added = false;
+    state.kernel.model_catalog_update(&mut |catalog| {
+        added = catalog.add_alias(&alias, &model_id);
+    });
     if !added {
         return ApiErrorResponse::conflict(format!("Alias '{}' already exists", alias))
             .into_json_tuple();
@@ -281,9 +282,10 @@ pub async fn delete_alias(
     State(state): State<Arc<AppState>>,
     Path(alias): Path<String>,
 ) -> impl IntoResponse {
-    let removed: bool = state
-        .kernel
-        .model_catalog_update(|catalog| catalog.remove_alias(&alias));
+    let mut removed = false;
+    state.kernel.model_catalog_update(&mut |catalog| {
+        removed = catalog.remove_alias(&alias);
+    });
     if !removed {
         return ApiErrorResponse::not_found(format!("Alias '{}' not found", alias))
             .into_json_tuple();
@@ -363,10 +365,10 @@ pub async fn set_model_overrides(
     // attempt that won the CAS.
     let id_for_closure = id.clone();
     let body_for_closure = body.clone();
-    let previous = state.kernel.model_catalog_update(move |catalog| {
-        let prev = catalog.get_overrides(&id_for_closure).cloned();
+    let mut previous = None;
+    state.kernel.model_catalog_update(&mut |catalog| {
+        previous = catalog.get_overrides(&id_for_closure).cloned();
         catalog.set_overrides(id_for_closure.clone(), body_for_closure.clone());
-        prev
     });
     // Persist outside the RCU loop (disk IO must happen exactly once).
     let snapshot = state.kernel.model_catalog_load();
@@ -379,7 +381,7 @@ pub async fn set_model_overrides(
         let id_for_rollback = id.clone();
         state
             .kernel
-            .model_catalog_update(move |catalog| match &previous {
+            .model_catalog_update(&mut move |catalog| match &previous {
                 Some(prev) => {
                     catalog.set_overrides(id_for_rollback.clone(), prev.clone());
                 }
@@ -410,9 +412,9 @@ pub async fn delete_model_overrides(
         .join("data")
         .join("model_overrides.json");
     let id_for_closure = id.clone();
-    state
-        .kernel
-        .model_catalog_update(move |catalog| catalog.remove_overrides(&id_for_closure));
+    state.kernel.model_catalog_update(&mut |catalog| {
+        let _ = catalog.remove_overrides(&id_for_closure);
+    });
     if let Err(e) = state
         .kernel
         .model_catalog_load()
@@ -429,7 +431,7 @@ fn attach_probe_result(
     entry: &mut serde_json::Value,
     probe: &librefang_kernel::provider_health::ProbeResult,
     provider_id: &str,
-    kernel: &librefang_kernel::LibreFangKernel,
+    kernel: &dyn librefang_kernel::KernelApi,
 ) {
     entry["is_local"] = serde_json::json!(true);
     entry["reachable"] = serde_json::json!(probe.reachable);
@@ -458,7 +460,7 @@ fn attach_probe_result(
             } else {
                 probe.discovered_model_info.clone()
             };
-        kernel.model_catalog_update(|cat| {
+        kernel.model_catalog_update(&mut |cat| {
             cat.merge_discovered_models(provider_id, &info);
         });
     }
@@ -584,7 +586,7 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
         // auth_status when the service is not reachable so the dashboard
         // shows "needs setup" instead of "configured".
         if let Some(probe) = probe_map.remove(&i) {
-            attach_probe_result(&mut entry, &probe, &p.id, &state.kernel);
+            attach_probe_result(&mut entry, &probe, &p.id, &*state.kernel);
             if !probe.reachable {
                 entry["auth_status"] = serde_json::json!("missing");
             }
@@ -682,7 +684,7 @@ pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json:
             "is_custom": p.is_custom,
         });
         if let Some(probe) = probe_map.remove(&i) {
-            attach_probe_result(&mut entry, &probe, &p.id, &state.kernel);
+            attach_probe_result(&mut entry, &probe, &p.id, &*state.kernel);
             if !probe.reachable {
                 entry["auth_status"] = serde_json::json!("missing");
             }
@@ -779,7 +781,7 @@ pub async fn get_provider(
         )
         .await;
 
-        attach_probe_result(&mut entry, &probe, &provider.id, &state.kernel);
+        attach_probe_result(&mut entry, &probe, &provider.id, &*state.kernel);
         if !probe.reachable {
             entry["auth_status"] = serde_json::json!("missing");
         }
@@ -883,9 +885,10 @@ pub async fn add_custom_model(
     }
 
     let entry_for_closure = entry.clone();
-    let added: bool = state
-        .kernel
-        .model_catalog_update(move |catalog| catalog.add_custom_model(entry_for_closure.clone()));
+    let mut added = false;
+    state.kernel.model_catalog_update(&mut |catalog| {
+        added = catalog.add_custom_model(entry_for_closure.clone());
+    });
     if !added {
         return ApiErrorResponse::conflict(format!(
             "Model '{}' already exists for provider '{}'",
@@ -909,7 +912,7 @@ pub async fn add_custom_model(
     {
         tracing::warn!("Failed to persist custom models: {e}");
         let id_for_rollback = id.clone();
-        state.kernel.model_catalog_update(move |catalog| {
+        state.kernel.model_catalog_update(&mut move |catalog| {
             catalog.remove_custom_model(&id_for_rollback);
         });
         return ApiErrorResponse::internal(format!("Failed to persist custom model: {e}"))
@@ -936,10 +939,11 @@ pub async fn remove_custom_model(
     // subsequent persist fails — keeps the in-memory catalog consistent
     // with disk across failure paths.
     let model_id_for_closure = model_id.clone();
-    let (snapshot, removed) = state.kernel.model_catalog_update(move |catalog| {
-        let snap = catalog.find_model(&model_id_for_closure).cloned();
-        let ok = catalog.remove_custom_model(&model_id_for_closure);
-        (snap, ok)
+    let mut snapshot = None;
+    let mut removed = false;
+    state.kernel.model_catalog_update(&mut |catalog| {
+        snapshot = catalog.find_model(&model_id_for_closure).cloned();
+        removed = catalog.remove_custom_model(&model_id_for_closure);
     });
     if !removed {
         return ApiErrorResponse::not_found(format!("Custom model '{}' not found", model_id))
@@ -958,7 +962,7 @@ pub async fn remove_custom_model(
     {
         tracing::warn!("Failed to persist custom models: {e}");
         if let Some(entry) = snapshot {
-            state.kernel.model_catalog_update(move |catalog| {
+            state.kernel.model_catalog_update(&mut move |catalog| {
                 catalog.add_custom_model(entry.clone());
             });
         }
@@ -1026,7 +1030,7 @@ pub async fn set_provider_key(
             .join("data")
             .join("suppressed_providers.json");
         let name_for_closure = name.clone();
-        state.kernel.model_catalog_update(move |catalog| {
+        state.kernel.model_catalog_update(&mut move |catalog| {
             catalog.unsuppress_provider(&name_for_closure);
             catalog.save_suppressed(&suppressed_path);
             catalog.detect_auth();
@@ -1214,7 +1218,7 @@ pub async fn delete_provider_key(
             .join("data")
             .join("suppressed_providers.json");
         let name_for_closure = name.clone();
-        state.kernel.model_catalog_update(move |catalog| {
+        state.kernel.model_catalog_update(&mut move |catalog| {
             catalog.suppress_provider(&name_for_closure);
             catalog.save_suppressed(&suppressed_path);
             catalog.detect_auth();
@@ -1282,6 +1286,7 @@ pub async fn test_provider(
     if librefang_kernel::provider_health::is_local_provider(&name) {
         let result = state
             .kernel
+            .clone()
             .probe_local_provider(
                 &name, &base_url, false, // user-triggered test — don't escalate to warn!
             )
@@ -1529,7 +1534,7 @@ pub async fn set_provider_url(
         let name_for_closure = name.clone();
         let base_url_for_closure = base_url.clone();
         let proxy_url_for_closure = proxy_url.clone();
-        state.kernel.model_catalog_update(move |catalog| {
+        state.kernel.model_catalog_update(&mut move |catalog| {
             catalog.set_provider_url(&name_for_closure, &base_url_for_closure);
             if let Some(ref pu) = proxy_url_for_closure {
                 catalog.set_provider_proxy_url(&name_for_closure, pu);
@@ -1591,7 +1596,7 @@ pub async fn set_provider_url(
             } else {
                 probe.discovered_model_info.clone()
             };
-        state.kernel.model_catalog_update(|catalog| {
+        state.kernel.model_catalog_update(&mut |catalog| {
             catalog.merge_discovered_models(&name, &info);
         });
     }
@@ -2056,7 +2061,7 @@ pub async fn copilot_oauth_poll(
             }
 
             // Refresh auth detection
-            state.kernel.model_catalog_update(|catalog| {
+            state.kernel.model_catalog_update(&mut |catalog| {
                 catalog.detect_auth();
             });
 
@@ -2120,7 +2125,7 @@ pub async fn catalog_update(State(state): State<Arc<AppState>>) -> impl IntoResp
                 let provider_regions = cfg.provider_regions.clone();
                 let provider_urls = cfg.provider_urls.clone();
                 drop(cfg);
-                state.kernel.model_catalog_update(move |catalog| {
+                state.kernel.model_catalog_update(&mut move |catalog| {
                     catalog.load_cached_catalog_for(&home_dir);
                     if !provider_regions.is_empty() {
                         let region_urls = catalog.resolve_region_urls(&provider_regions);

--- a/crates/librefang-api/src/routes/registry.rs
+++ b/crates/librefang-api/src/routes/registry.rs
@@ -267,7 +267,7 @@ async fn create_registry_content(
         }
 
         let target_for_closure = target.clone();
-        state.kernel.model_catalog_update(move |catalog| {
+        state.kernel.model_catalog_update(&mut move |catalog| {
             if let Err(e) = catalog.load_catalog_file(&target_for_closure) {
                 tracing::warn!("Failed to merge provider file into catalog: {e}");
             }

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2688,7 +2688,7 @@ async fn activate_hand_inner(
                         entry.manifest.schedule,
                         librefang_types::agent::ScheduleMode::Reactive
                     ) {
-                        state.kernel.start_background_for_agent(
+                        state.kernel.clone().start_background_for_agent(
                             agent_id,
                             &entry.name,
                             &entry.manifest.schedule,
@@ -5416,7 +5416,7 @@ pub async fn reconnect_mcp_server_handler(
             .into_json_tuple();
     }
 
-    match state.kernel.reconnect_mcp_server(&name).await {
+    match state.kernel.clone().reconnect_mcp_server(&name).await {
         Ok(tool_count) => (
             StatusCode::OK,
             Json(serde_json::json!({
@@ -5489,7 +5489,7 @@ pub async fn reload_mcp_handler(State(state): State<Arc<AppState>>) -> impl Into
         tracing::warn!("Failed to reload config before MCP reload: {e}");
     }
 
-    match state.kernel.reload_mcp_servers().await {
+    match state.kernel.clone().reload_mcp_servers().await {
         Ok(connected) => (
             StatusCode::OK,
             Json(serde_json::json!({
@@ -5739,7 +5739,7 @@ pub async fn install_extension(
     }
 
     state.kernel.mcp_health().register(&result.server.name);
-    let connected = state.kernel.reload_mcp_servers().await.unwrap_or(0);
+    let connected = state.kernel.clone().reload_mcp_servers().await.unwrap_or(0);
 
     (
         StatusCode::OK,
@@ -5803,7 +5803,7 @@ pub async fn uninstall_extension(
 
     state.kernel.mcp_health().unregister(&server_name);
     state.kernel.disconnect_mcp_server(&server_name).await;
-    if let Err(e) = state.kernel.reload_mcp_servers().await {
+    if let Err(e) = state.kernel.clone().reload_mcp_servers().await {
         tracing::warn!("Failed to reload MCP servers after uninstall: {e}");
     }
 

--- a/crates/librefang-api/src/routes/task_queue.rs
+++ b/crates/librefang-api/src/routes/task_queue.rs
@@ -11,7 +11,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use librefang_kernel::kernel_handle::{prelude::*, KernelOpError};
+use librefang_kernel::kernel_handle::KernelOpError;
 use librefang_types::i18n::ErrorTranslator;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/librefang-api/src/routes/tools_sessions.rs
+++ b/crates/librefang-api/src/routes/tools_sessions.rs
@@ -240,7 +240,7 @@ pub async fn invoke_tool(
     let workspace_root = cfg.effective_workspaces_dir();
     let exec_policy = cfg.exec_policy.clone();
     let docker_config = cfg.docker.clone();
-    let kernel: Arc<dyn KernelHandle> = state.kernel.clone() as Arc<dyn KernelHandle>;
+    let kernel: Arc<dyn KernelHandle> = state.kernel.clone();
 
     let result = execute_tool(
         "rest-api",

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -736,7 +736,7 @@ pub async fn run_workflow(
 
     let input = req["input"].as_str().unwrap_or("").to_string();
 
-    match state.kernel.run_workflow(workflow_id, input).await {
+    match state.kernel.run_workflow_typed(workflow_id, input).await {
         Ok((run_id, output)) => {
             // Include step-level detail in the response so callers can inspect I/O
             let run = state.kernel.workflow_engine().get_run(run_id).await;
@@ -1839,7 +1839,7 @@ pub async fn run_schedule(
             let wf_input = input
                 .clone()
                 .unwrap_or_else(|| format!("[Scheduled workflow '{}' triggered]", name));
-            match state.kernel.run_workflow(wid, wf_input).await {
+            match state.kernel.run_workflow_typed(wid, wf_input).await {
                 Ok((run_id, output)) => (
                     StatusCode::OK,
                     Json(serde_json::json!({
@@ -1861,8 +1861,7 @@ pub async fn run_schedule(
             }
         }
         librefang_types::scheduler::CronAction::AgentTurn { message, .. } => {
-            let kernel_handle: Arc<dyn KernelHandle> =
-                state.kernel.clone() as Arc<dyn KernelHandle>;
+            let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone();
             match state
                 .kernel
                 .send_message_with_handle(agent_id, message, Some(kernel_handle))
@@ -1894,7 +1893,7 @@ pub async fn run_schedule(
                 librefang_types::event::EventTarget::Broadcast,
                 librefang_types::event::EventPayload::Custom(text.as_bytes().to_vec()),
             );
-            state.kernel.publish_event(event).await;
+            state.kernel.publish_typed_event(event).await;
             (
                 StatusCode::OK,
                 Json(serde_json::json!({

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -1705,7 +1705,7 @@ pub async fn run_daemon(
                         let home_dir = cfg.home_dir.clone();
                         let provider_regions = cfg.provider_regions.clone();
                         let provider_urls = cfg.provider_urls.clone();
-                        kernel.model_catalog_update(|catalog| {
+                        kernel.model_catalog_update(&mut |catalog| {
                             catalog.load_cached_catalog_for(&home_dir);
                             if !provider_regions.is_empty() {
                                 let region_urls = catalog.resolve_region_urls(&provider_regions);

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -8,6 +8,7 @@ use crate::webchat;
 use axum::response::IntoResponse;
 use axum::Router;
 use librefang_kernel::config_reload::HotAction;
+use librefang_kernel::kernel_api::KernelApi;
 use librefang_kernel::kernel_handle::{ApiAuth, ApiAuthSnapshot, DashboardRawConfig};
 use librefang_kernel::LibreFangKernel;
 use std::collections::HashSet;
@@ -1002,7 +1003,7 @@ fn clear_sessions_file(home_dir: &std::path::Path) {
 /// Returns `(router, shared_state)`. The caller can use `state.bridge_manager`
 /// to shut down the bridge on exit.
 pub async fn build_router(
-    kernel: Arc<LibreFangKernel>,
+    kernel: Arc<dyn KernelApi>,
     listen_addr: SocketAddr,
 ) -> (Router<()>, Arc<AppState>) {
     // Start channel bridges (Telegram, etc.)
@@ -1448,7 +1449,10 @@ pub async fn run_daemon(
     let _daemon_lock = acquire_daemon_lock(&lock_path)?;
 
     let kernel = Arc::new(kernel);
-    kernel.set_self_handle();
+    // `set_self_handle` takes `self: Arc<Self>` on the trait, so it
+    // moves the Arc; clone first so subsequent uses on this scope
+    // (`start_background_agents` etc.) keep their handle.
+    kernel.clone().set_self_handle();
     kernel.start_background_agents().await;
 
     // Auto-start observability stack (OTLP collector + Prometheus + Grafana)

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -1031,8 +1031,7 @@ async fn handle_text_message(
             .await;
 
             // Send message to agent with streaming
-            let kernel_handle: Arc<dyn KernelHandle> =
-                state.kernel.clone() as Arc<dyn KernelHandle>;
+            let kernel_handle: Arc<dyn KernelHandle> = state.kernel.clone();
             let sender_ctx = SenderContext {
                 channel: "webui".to_string(),
                 // Behaviour change (`trusted_proxies` + `trust_forwarded_for`):
@@ -1056,11 +1055,12 @@ async fn handle_text_message(
             };
             match state
                 .kernel
+                .clone()
                 .send_message_streaming_with_sender_context_routing_thinking_and_session(
                     agent_id,
                     &content,
                     Some(kernel_handle),
-                    &sender_ctx,
+                    sender_ctx.clone(),
                     thinking_override,
                     explicit_session,
                 )

--- a/crates/librefang-api/tests/agent_identity_registry_test.rs
+++ b/crates/librefang-api/tests/agent_identity_registry_test.rs
@@ -41,7 +41,7 @@ async fn start_test_server() -> TestServer {
     let config_path = test.tmp_path().join("config.toml");
     let test = test.with_config_path(config_path);
     let (state, _tmp, _) = test.into_parts();
-    state.kernel.set_self_handle();
+    state.kernel.clone().set_self_handle();
 
     let app = Router::new()
         .route(

--- a/crates/librefang-api/tests/agent_kv_authz_integration.rs
+++ b/crates/librefang-api/tests/agent_kv_authz_integration.rs
@@ -53,7 +53,10 @@ fn spawn_owned_by(state: &Arc<AppState>, name: &str, author: &str) -> AgentId {
         author: author.to_string(),
         ..AgentManifest::default()
     };
-    state.kernel.spawn_agent(manifest).expect("spawn_agent")
+    state
+        .kernel
+        .spawn_agent_typed(manifest)
+        .expect("spawn_agent")
 }
 
 fn admin(name: &str) -> AuthenticatedApiUser {

--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -84,7 +84,10 @@ fn spawn_named(state: &Arc<AppState>, name: &str) -> AgentId {
         name: name.to_string(),
         ..AgentManifest::default()
     };
-    state.kernel.spawn_agent(manifest).expect("spawn_agent")
+    state
+        .kernel
+        .spawn_agent_typed(manifest)
+        .expect("spawn_agent")
 }
 
 async fn send(app: axum::Router, req: Request<Body>) -> (StatusCode, serde_json::Value) {

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -82,7 +82,7 @@ async fn start_test_server_with_provider(
     let config_path = test.tmp_path().join("config.toml");
     let test = test.with_config_path(config_path.clone());
     let (state, _tmp, _) = test.into_parts();
-    state.kernel.set_self_handle();
+    state.kernel.clone().set_self_handle();
 
     let app = Router::new()
         .route("/api/health", axum::routing::get(routes::health))
@@ -1596,7 +1596,7 @@ async fn start_test_server_with_auth(api_key: &str) -> TestServer {
     let config_path = test.tmp_path().join("config.toml");
     let test = test.with_config_path(config_path.clone());
     let (state, _tmp, _) = test.into_parts();
-    state.kernel.set_self_handle();
+    state.kernel.clone().set_self_handle();
 
     let api_key_state = middleware::AuthState {
         api_key_lock: state.api_key_lock.clone(),

--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -488,10 +488,12 @@ async fn health_detail_daily_spend_percent_reflects_configured_cap() {
 
     // Set a non-zero daily cap so the *_percent fields become defined (0.0
     // for an empty kernel rather than null).
-    h.state.kernel.update_budget_config(|b: &mut BudgetConfig| {
-        b.max_daily_usd = 25.0;
-        b.max_hourly_usd = 5.0;
-    });
+    h.state
+        .kernel
+        .update_budget_config(&|b: &mut BudgetConfig| {
+            b.max_daily_usd = 25.0;
+            b.max_hourly_usd = 5.0;
+        });
 
     let (status, body) = send(h.app.clone(), auth_get("/api/health/detail")).await;
     assert_eq!(status, StatusCode::OK);

--- a/crates/librefang-api/tests/daemon_lifecycle_test.rs
+++ b/crates/librefang-api/tests/daemon_lifecycle_test.rs
@@ -86,7 +86,7 @@ fn test_read_daemon_info_corrupt_json() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_full_daemon_lifecycle() {
     let test = librefang_testing::TestAppState::new();
-    test.state.kernel.set_self_handle();
+    test.state.kernel.clone().set_self_handle();
     let state = test.state.clone();
 
     let app = Router::new()

--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -77,7 +77,7 @@ impl Drop for TestServer {
 
 async fn start_test_server() -> TestServer {
     let test = TestAppState::new();
-    test.state.kernel.set_self_handle();
+    test.state.kernel.clone().set_self_handle();
     let state = test.state.clone();
 
     let app = Router::new()

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -13163,6 +13163,14 @@ system_prompt = "You are a helpful assistant."
     }
 
     /// Run a workflow pipeline end-to-end.
+    ///
+    /// **Naming**: this inherent method takes typed `WorkflowId` /
+    /// `WorkflowRunId`. The role-trait
+    /// [`kernel_handle::WorkflowRunner::run_workflow`] takes `&str` and
+    /// returns `String` shapes for backward compat. From `Arc<dyn KernelApi>`
+    /// callers, reach the typed shape via
+    /// [`KernelApi::run_workflow_typed`](crate::kernel_api::KernelApi::run_workflow_typed)
+    /// rather than going through the trait method.
     pub async fn run_workflow(
         &self,
         workflow_id: WorkflowId,

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -23,6 +23,13 @@
 //! agent/memory/task primitives, while the API cares about admin /
 //! observability surface (audit, config, MCP wiring, hot-reload, …).
 
+// `register_trigger_with_target` and `send_message_with_incognito` mirror
+// the kernel-inherent signatures verbatim — both already exceed clippy's
+// 7-arg threshold on the kernel side. Splitting the trait method into a
+// builder would diverge the trait surface from the inherent surface and
+// break the "trait is a thin facade" invariant of #3566.
+#![allow(clippy::too_many_arguments)]
+
 use std::path::Path;
 use std::sync::Arc;
 

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -1,0 +1,45 @@
+//! `KernelApi` — the trait surface consumed by the HTTP API layer (#3566).
+//!
+//! ## Why this exists
+//!
+//! `librefang-api` historically held `Arc<LibreFangKernel>` in `AppState`,
+//! which means every public inherent method on the kernel struct was
+//! automatically part of the HTTP layer's coupling surface. Renaming any
+//! kernel internal forced edits in `routes/`, the API layer could not be
+//! versioned independently of the kernel, and route tests could not stub
+//! the kernel without dragging the whole runtime along.
+//!
+//! `KernelApi` is the *single explicit contract* between the API and the
+//! kernel. `AppState.kernel` is `Arc<dyn KernelApi>`; routes call methods
+//! through this trait. The trait is the only place where the API↔kernel
+//! coupling is permitted, so widening it is an explicit choice rather than
+//! an accidental side-effect of adding a method on `LibreFangKernel`.
+//!
+//! Distinction from [`crate::kernel_handle`]: that crate exposes
+//! kernel-ops needed by the *runtime* (so an agent loop can call back
+//! into the kernel without a circular crate dep). `KernelApi` is the
+//! analogous trait for the *HTTP layer*. The two trait surfaces overlap
+//! conceptually but their scopes diverge — the runtime cares about
+//! agent/memory/task primitives, while the API cares about admin /
+//! observability surface (audit, config, MCP wiring, hot-reload, …).
+//!
+//! The trait is implemented for [`LibreFangKernel`] in [`super::kernel`]
+//! and the methods delegate to the kernel's inherent impls.
+
+use std::sync::Arc;
+
+use crate::LibreFangKernel;
+
+/// HTTP-API-facing kernel trait.
+///
+/// `AppState.kernel` is `Arc<dyn KernelApi>`. Routes interact with the
+/// kernel exclusively through this trait — there is no `state.kernel.X`
+/// path that bypasses it.
+pub trait KernelApi: Send + Sync {}
+
+impl KernelApi for LibreFangKernel {}
+
+/// Convenience: type-erase any `Arc<T: KernelApi>` to `Arc<dyn KernelApi>`.
+pub fn as_dyn<T: KernelApi + 'static>(k: Arc<T>) -> Arc<dyn KernelApi> {
+    k
+}

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -39,6 +39,7 @@ use crate::cron::CronScheduler;
 use crate::error::KernelResult;
 use crate::event_bus::EventBus;
 use crate::inbox::InboxStatus;
+use crate::kernel_handle::KernelHandle;
 use crate::pairing::PairingManager;
 use crate::registry::AgentRegistry;
 use crate::scheduler::AgentScheduler;
@@ -60,8 +61,14 @@ use librefang_types::tool::ToolDefinition;
 /// `AppState.kernel` is `Arc<dyn KernelApi>`. Routes interact with the
 /// kernel exclusively through this trait — there is no `state.kernel.X`
 /// path that bypasses it.
+///
+/// Extends [`KernelHandle`] (the runtime-facing super-trait that bundles
+/// every role trait) so `Arc<dyn KernelApi>` can upcast to
+/// `Arc<dyn KernelHandle>` (and to any individual role trait) for the
+/// runtime-call paths the dashboard uses (e.g. proxying task-board /
+/// channel-send / approval-resolve through the same kernel object).
 #[async_trait]
-pub trait KernelApi: Send + Sync {
+pub trait KernelApi: KernelHandle + Send + Sync {
     // ====================================================================
     // Subsystem accessors — return refs/handles to internal subsystems.
     // ====================================================================
@@ -154,8 +161,16 @@ pub trait KernelApi: Send + Sync {
     // Agent lifecycle / sessions
     // ====================================================================
 
-    fn spawn_agent(&self, manifest: AgentManifest) -> KernelResult<AgentId>;
-    fn kill_agent(&self, agent_id: AgentId) -> KernelResult<()>;
+    /// Spawn a new agent from an already-parsed [`AgentManifest`]. Distinct
+    /// from `AgentControl::spawn_agent` (which takes a TOML string and is
+    /// the runtime-side variant) — routes parse the manifest before calling
+    /// in so they can return validation errors with line/col info.
+    fn spawn_agent_typed(&self, manifest: AgentManifest) -> KernelResult<AgentId>;
+    /// Kill an agent by typed [`AgentId`]. Distinct from
+    /// `AgentControl::kill_agent` (which takes a `&str`) — routes already
+    /// hold a typed id and we don't want to round-trip through string
+    /// parsing.
+    fn kill_agent_typed(&self, agent_id: AgentId) -> KernelResult<()>;
     fn kill_agent_with_purge(&self, agent_id: AgentId, purge_identity: bool) -> KernelResult<()>;
     fn stop_agent_run(&self, agent_id: AgentId) -> KernelResult<bool>;
     fn stop_session_run(&self, agent_id: AgentId, session_id: SessionId) -> KernelResult<bool>;
@@ -276,7 +291,10 @@ pub trait KernelApi: Send + Sync {
         &self,
         workflow: crate::workflow::Workflow,
     ) -> crate::workflow::WorkflowId;
-    async fn run_workflow(
+    /// Run a workflow by typed id. Distinct from
+    /// `WorkflowRunner::run_workflow` (which takes `&str`) — routes hold a
+    /// typed `WorkflowId` and want the typed `WorkflowRunId` back.
+    async fn run_workflow_typed(
         &self,
         workflow_id: crate::workflow::WorkflowId,
         input: String,
@@ -286,7 +304,10 @@ pub trait KernelApi: Send + Sync {
         workflow_id: crate::workflow::WorkflowId,
         input: String,
     ) -> KernelResult<Vec<crate::workflow::DryRunStep>>;
-    async fn publish_event(&self, event: librefang_types::event::Event) -> Vec<TriggerMatch>;
+    /// Publish a typed [`Event`](librefang_types::event::Event) and return
+    /// the matched trigger fires. Distinct from `EventBus::publish_event`
+    /// (which takes `(event_type: &str, payload: Value)`).
+    async fn publish_typed_event(&self, event: librefang_types::event::Event) -> Vec<TriggerMatch>;
 
     // ====================================================================
     // Agent bindings (channel ↔ agent mapping)
@@ -322,6 +343,186 @@ pub trait KernelApi: Send + Sync {
         name: &str,
         schedule: &librefang_types::agent::ScheduleMode,
     );
+
+    // ====================================================================
+    // Additional kernel-inherent methods used by API/WS/server.rs.
+    //
+    // (Methods on the role traits — TaskQueue, PromptStore, ChannelSender,
+    // ApprovalGate, CronControl, ApiAuth, EventBus, … — are reachable via
+    // the `KernelHandle` super-trait, so they are not duplicated here. Routes
+    // that call e.g. `state.kernel.task_get(&id)` resolve through TaskQueue;
+    // bring the role traits into scope with
+    // `use librefang_kernel::kernel_handle::prelude::*;`.)
+    // ====================================================================
+
+    fn agent_has_active_session(&self, agent_id: AgentId) -> bool;
+    fn a2a_agents(&self) -> &std::sync::Mutex<Vec<(String, librefang_runtime::a2a::AgentCard)>>;
+    fn a2a_tasks(&self) -> &librefang_runtime::a2a::A2aTaskStore;
+    fn context_report(
+        &self,
+        agent_id: AgentId,
+    ) -> KernelResult<librefang_runtime::compactor::ContextReport>;
+    fn effective_mcp_servers_ref(
+        &self,
+    ) -> &std::sync::RwLock<Vec<librefang_types::config::McpServerConfigEntry>>;
+    fn embedding(
+        &self,
+    ) -> Option<&Arc<dyn librefang_runtime::embedding::EmbeddingDriver + Send + Sync>>;
+    async fn inject_message_for_session(
+        &self,
+        agent_id: AgentId,
+        session_id: Option<SessionId>,
+        message: &str,
+    ) -> KernelResult<bool>;
+    fn provider_unconfigured_flag(&self) -> &std::sync::atomic::AtomicBool;
+    fn session_usage_cost(&self, agent_id: AgentId) -> KernelResult<(u64, u64, f64)>;
+    fn set_agent_model(
+        &self,
+        agent_id: AgentId,
+        model: &str,
+        explicit_provider: Option<&str>,
+    ) -> KernelResult<()>;
+    fn sync_default_model_agents(
+        &self,
+        old_provider: &str,
+        dm: &librefang_types::config::DefaultModelConfig,
+    );
+    fn traces(&self) -> &dashmap::DashMap<AgentId, Vec<librefang_types::tool::DecisionTrace>>;
+    fn update_hand_agent_runtime_override(
+        &self,
+        agent_id: AgentId,
+        override_config: librefang_hands::HandAgentRuntimeOverride,
+    ) -> KernelResult<()>;
+
+    // ====================================================================
+    // Streaming + handle-aware send_message variants.
+    // ====================================================================
+
+    async fn send_message_with_handle(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    async fn send_message_with_handle_and_blocks(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        content_blocks: Option<Vec<librefang_types::message::ContentBlock>>,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    async fn send_message_with_incognito(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        sender_context: Option<librefang_channels::types::SenderContext>,
+        thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
+        incognito: bool,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    async fn send_message_streaming_with_routing(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
+    )>;
+    async fn send_message_streaming_with_incognito(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        session_id_override: Option<SessionId>,
+        incognito: bool,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
+    )>;
+    async fn send_message_streaming_with_sender_context_routing_thinking_and_session(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        sender: librefang_channels::types::SenderContext,
+        thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
+    )>;
+
+    // ====================================================================
+    // Spawn-tasks / probe — Arc<Self> receivers.
+    // ====================================================================
+
+    fn spawn_key_validation(self: Arc<Self>);
+    async fn auto_dream_trigger_manual(
+        self: Arc<Self>,
+        agent_id: AgentId,
+    ) -> crate::auto_dream::TriggerOutcome;
+    async fn probe_local_provider(
+        self: Arc<Self>,
+        provider_id: &str,
+        base_url: &str,
+        log_offline_as_warn: bool,
+    ) -> librefang_runtime::provider_health::ProbeResult;
+
+    // ====================================================================
+    // Additional channel / trigger / engine accessors and send_message
+    // variants used by channel_bridge and routes.
+    // ====================================================================
+
+    fn channel_adapters_ref(
+        &self,
+    ) -> &dashmap::DashMap<String, Arc<dyn librefang_channels::types::ChannelAdapter>>;
+    fn trigger_engine(&self) -> &crate::triggers::TriggerEngine;
+    fn broadcast_ref(&self) -> &librefang_types::config::BroadcastConfig;
+    fn auto_reply(&self) -> &crate::auto_reply::AutoReplyEngine;
+    async fn one_shot_llm_call(&self, model: &str, prompt: &str) -> Result<String, String>;
+    async fn send_message_with_blocks(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        blocks: Vec<librefang_types::message::ContentBlock>,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    async fn send_message_with_sender_context(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        sender: librefang_channels::types::SenderContext,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    async fn send_message_with_blocks_and_sender(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        blocks: Vec<librefang_types::message::ContentBlock>,
+        sender: librefang_channels::types::SenderContext,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    async fn send_message_streaming_with_sender_context_and_routing(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        sender: librefang_channels::types::SenderContext,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
+    )>;
+
+    // ====================================================================
+    // Test-only / boot-only kernel ops surfaced for integration tests
+    // (`tests/api_integration_test.rs`, `network_routes_integration`, …).
+    // ====================================================================
+
+    fn data_dir(&self) -> &Path;
+    fn install_peer_registry_for_test(
+        &self,
+        registry: librefang_wire::PeerRegistry,
+    ) -> Result<(), librefang_wire::PeerRegistry>;
+    fn set_self_handle(self: Arc<Self>);
 }
 
 #[async_trait]
@@ -503,10 +704,10 @@ impl KernelApi for LibreFangKernel {
     }
 
     // -- Agent lifecycle --
-    fn spawn_agent(&self, manifest: AgentManifest) -> KernelResult<AgentId> {
+    fn spawn_agent_typed(&self, manifest: AgentManifest) -> KernelResult<AgentId> {
         Self::spawn_agent(self, manifest)
     }
-    fn kill_agent(&self, agent_id: AgentId) -> KernelResult<()> {
+    fn kill_agent_typed(&self, agent_id: AgentId) -> KernelResult<()> {
         Self::kill_agent(self, agent_id)
     }
     fn kill_agent_with_purge(&self, agent_id: AgentId, purge_identity: bool) -> KernelResult<()> {
@@ -722,7 +923,7 @@ impl KernelApi for LibreFangKernel {
     ) -> crate::workflow::WorkflowId {
         Self::register_workflow(self, workflow).await
     }
-    async fn run_workflow(
+    async fn run_workflow_typed(
         &self,
         workflow_id: crate::workflow::WorkflowId,
         input: String,
@@ -736,7 +937,7 @@ impl KernelApi for LibreFangKernel {
     ) -> KernelResult<Vec<crate::workflow::DryRunStep>> {
         Self::dry_run_workflow(self, workflow_id, input).await
     }
-    async fn publish_event(&self, event: librefang_types::event::Event) -> Vec<TriggerMatch> {
+    async fn publish_typed_event(&self, event: librefang_types::event::Event) -> Vec<TriggerMatch> {
         Self::publish_event(self, event).await
     }
 
@@ -775,6 +976,278 @@ impl KernelApi for LibreFangKernel {
         schedule: &librefang_types::agent::ScheduleMode,
     ) {
         LibreFangKernel::start_background_for_agent(&self, agent_id, name, schedule);
+    }
+
+    // -- Additional inherent methods --
+    fn agent_has_active_session(&self, agent_id: AgentId) -> bool {
+        Self::agent_has_active_session(self, agent_id)
+    }
+    fn a2a_agents(&self) -> &std::sync::Mutex<Vec<(String, librefang_runtime::a2a::AgentCard)>> {
+        Self::a2a_agents(self)
+    }
+    fn a2a_tasks(&self) -> &librefang_runtime::a2a::A2aTaskStore {
+        Self::a2a_tasks(self)
+    }
+    fn context_report(
+        &self,
+        agent_id: AgentId,
+    ) -> KernelResult<librefang_runtime::compactor::ContextReport> {
+        Self::context_report(self, agent_id)
+    }
+    fn effective_mcp_servers_ref(
+        &self,
+    ) -> &std::sync::RwLock<Vec<librefang_types::config::McpServerConfigEntry>> {
+        Self::effective_mcp_servers_ref(self)
+    }
+    fn embedding(
+        &self,
+    ) -> Option<&Arc<dyn librefang_runtime::embedding::EmbeddingDriver + Send + Sync>> {
+        Self::embedding(self)
+    }
+    async fn inject_message_for_session(
+        &self,
+        agent_id: AgentId,
+        session_id: Option<SessionId>,
+        message: &str,
+    ) -> KernelResult<bool> {
+        Self::inject_message_for_session(self, agent_id, session_id, message).await
+    }
+    fn provider_unconfigured_flag(&self) -> &std::sync::atomic::AtomicBool {
+        Self::provider_unconfigured_flag(self)
+    }
+    fn session_usage_cost(&self, agent_id: AgentId) -> KernelResult<(u64, u64, f64)> {
+        Self::session_usage_cost(self, agent_id)
+    }
+    fn set_agent_model(
+        &self,
+        agent_id: AgentId,
+        model: &str,
+        explicit_provider: Option<&str>,
+    ) -> KernelResult<()> {
+        Self::set_agent_model(self, agent_id, model, explicit_provider)
+    }
+    fn sync_default_model_agents(
+        &self,
+        old_provider: &str,
+        dm: &librefang_types::config::DefaultModelConfig,
+    ) {
+        Self::sync_default_model_agents(self, old_provider, dm);
+    }
+    fn traces(&self) -> &dashmap::DashMap<AgentId, Vec<librefang_types::tool::DecisionTrace>> {
+        Self::traces(self)
+    }
+    fn update_hand_agent_runtime_override(
+        &self,
+        agent_id: AgentId,
+        override_config: librefang_hands::HandAgentRuntimeOverride,
+    ) -> KernelResult<()> {
+        Self::update_hand_agent_runtime_override(self, agent_id, override_config)
+    }
+
+    // -- Streaming + handle-aware send_message variants --
+    async fn send_message_with_handle(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
+        Self::send_message_with_handle(self, agent_id, message, kernel_handle).await
+    }
+    async fn send_message_with_handle_and_blocks(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        content_blocks: Option<Vec<librefang_types::message::ContentBlock>>,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
+        Self::send_message_with_handle_and_blocks(
+            self,
+            agent_id,
+            message,
+            kernel_handle,
+            content_blocks,
+        )
+        .await
+    }
+    async fn send_message_with_incognito(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        sender_context: Option<librefang_channels::types::SenderContext>,
+        thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
+        incognito: bool,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
+        Self::send_message_with_incognito(
+            self,
+            agent_id,
+            message,
+            kernel_handle,
+            sender_context.as_ref(),
+            thinking_override,
+            session_id_override,
+            incognito,
+        )
+        .await
+    }
+    async fn send_message_streaming_with_routing(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
+    )> {
+        LibreFangKernel::send_message_streaming_with_routing(
+            &self,
+            agent_id,
+            message,
+            kernel_handle,
+        )
+        .await
+    }
+    async fn send_message_streaming_with_incognito(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        session_id_override: Option<SessionId>,
+        incognito: bool,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
+    )> {
+        LibreFangKernel::send_message_streaming_with_incognito(
+            &self,
+            agent_id,
+            message,
+            kernel_handle,
+            session_id_override,
+            incognito,
+        )
+        .await
+    }
+    async fn send_message_streaming_with_sender_context_routing_thinking_and_session(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        sender: librefang_channels::types::SenderContext,
+        thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
+    )> {
+        LibreFangKernel::send_message_streaming_with_sender_context_routing_thinking_and_session(
+            &self,
+            agent_id,
+            message,
+            kernel_handle,
+            &sender,
+            thinking_override,
+            session_id_override,
+        )
+        .await
+    }
+
+    // -- Spawn-tasks / probe --
+    fn spawn_key_validation(self: Arc<Self>) {
+        LibreFangKernel::spawn_key_validation(self);
+    }
+    async fn auto_dream_trigger_manual(
+        self: Arc<Self>,
+        agent_id: AgentId,
+    ) -> crate::auto_dream::TriggerOutcome {
+        LibreFangKernel::auto_dream_trigger_manual(self, agent_id).await
+    }
+    async fn probe_local_provider(
+        self: Arc<Self>,
+        provider_id: &str,
+        base_url: &str,
+        log_offline_as_warn: bool,
+    ) -> librefang_runtime::provider_health::ProbeResult {
+        LibreFangKernel::probe_local_provider(&self, provider_id, base_url, log_offline_as_warn)
+            .await
+    }
+
+    // -- Channel / trigger / engine accessors and send_message variants --
+    fn channel_adapters_ref(
+        &self,
+    ) -> &dashmap::DashMap<String, Arc<dyn librefang_channels::types::ChannelAdapter>> {
+        Self::channel_adapters_ref(self)
+    }
+    fn trigger_engine(&self) -> &crate::triggers::TriggerEngine {
+        Self::trigger_engine(self)
+    }
+    fn broadcast_ref(&self) -> &librefang_types::config::BroadcastConfig {
+        Self::broadcast_ref(self)
+    }
+    fn auto_reply(&self) -> &crate::auto_reply::AutoReplyEngine {
+        Self::auto_reply(self)
+    }
+    async fn one_shot_llm_call(&self, model: &str, prompt: &str) -> Result<String, String> {
+        Self::one_shot_llm_call(self, model, prompt).await
+    }
+    async fn send_message_with_blocks(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        blocks: Vec<librefang_types::message::ContentBlock>,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
+        Self::send_message_with_blocks(self, agent_id, message, blocks).await
+    }
+    async fn send_message_with_sender_context(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        sender: librefang_channels::types::SenderContext,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
+        Self::send_message_with_sender_context(self, agent_id, message, &sender).await
+    }
+    async fn send_message_with_blocks_and_sender(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        blocks: Vec<librefang_types::message::ContentBlock>,
+        sender: librefang_channels::types::SenderContext,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
+        Self::send_message_with_blocks_and_sender(self, agent_id, message, blocks, &sender).await
+    }
+    async fn send_message_streaming_with_sender_context_and_routing(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
+        sender: librefang_channels::types::SenderContext,
+    ) -> KernelResult<(
+        tokio::sync::mpsc::Receiver<librefang_runtime::llm_driver::StreamEvent>,
+        tokio::task::JoinHandle<KernelResult<librefang_runtime::agent_loop::AgentLoopResult>>,
+    )> {
+        LibreFangKernel::send_message_streaming_with_sender_context_and_routing(
+            &self,
+            agent_id,
+            message,
+            kernel_handle,
+            &sender,
+        )
+        .await
+    }
+
+    // -- Test-only / boot-only ops --
+    fn data_dir(&self) -> &Path {
+        Self::data_dir(self)
+    }
+    fn install_peer_registry_for_test(
+        &self,
+        registry: librefang_wire::PeerRegistry,
+    ) -> Result<(), librefang_wire::PeerRegistry> {
+        Self::install_peer_registry_for_test(self, registry)
+    }
+    fn set_self_handle(self: Arc<Self>) {
+        LibreFangKernel::set_self_handle(&self);
     }
 }
 

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -22,22 +22,761 @@
 //! conceptually but their scopes diverge — the runtime cares about
 //! agent/memory/task primitives, while the API cares about admin /
 //! observability surface (audit, config, MCP wiring, hot-reload, …).
-//!
-//! The trait is implemented for [`LibreFangKernel`] in [`super::kernel`]
-//! and the methods delegate to the kernel's inherent impls.
 
+use std::path::Path;
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use librefang_types::agent::{AgentId, AgentManifest, RunningSessionSnapshot, SessionId};
+use librefang_types::error::LibreFangResult;
+
+use crate::approval::ApprovalManager;
+use crate::audit::AuditLog;
+use crate::auth::AuthManager;
+use crate::auto_dream::{AbortOutcome, AutoDreamStatus};
+use crate::config_reload::ReloadPlan;
+use crate::cron::CronScheduler;
+use crate::error::KernelResult;
+use crate::event_bus::EventBus;
+use crate::inbox::InboxStatus;
+use crate::pairing::PairingManager;
+use crate::registry::AgentRegistry;
+use crate::scheduler::AgentScheduler;
+use crate::session_stream_hub::SessionStreamHub;
+use crate::supervisor::Supervisor;
+use crate::trajectory::TrajectoryBundle;
+use crate::triggers::{Trigger, TriggerId, TriggerMatch, TriggerPattern};
+use crate::workflow::WorkflowEngine;
+use crate::DeliveryTracker;
 use crate::LibreFangKernel;
+
+use librefang_kernel_metering::MeteringEngine;
+use librefang_memory::MemorySubstrate;
+use librefang_types::config::{AgentBinding, BudgetConfig, KernelConfig};
+use librefang_types::tool::ToolDefinition;
 
 /// HTTP-API-facing kernel trait.
 ///
 /// `AppState.kernel` is `Arc<dyn KernelApi>`. Routes interact with the
 /// kernel exclusively through this trait — there is no `state.kernel.X`
 /// path that bypasses it.
-pub trait KernelApi: Send + Sync {}
+#[async_trait]
+pub trait KernelApi: Send + Sync {
+    // ====================================================================
+    // Subsystem accessors — return refs/handles to internal subsystems.
+    // ====================================================================
 
-impl KernelApi for LibreFangKernel {}
+    fn agent_registry(&self) -> &AgentRegistry;
+    fn agent_identities(&self) -> &Arc<crate::agent_identity_registry::AgentIdentityRegistry>;
+    fn approvals(&self) -> &ApprovalManager;
+    fn audit(&self) -> &Arc<AuditLog>;
+    fn auth_manager(&self) -> &AuthManager;
+    fn browser(&self) -> &librefang_runtime::browser::BrowserManager;
+    fn cron(&self) -> &CronScheduler;
+    fn delivery(&self) -> &DeliveryTracker;
+    fn event_bus_ref(&self) -> &EventBus;
+    fn hands(&self) -> &librefang_hands::registry::HandRegistry;
+    fn home_dir(&self) -> &Path;
+    fn media(&self) -> &librefang_runtime::media_understanding::MediaEngine;
+    fn media_drivers(&self) -> &librefang_runtime::media::MediaDriverCache;
+    fn memory_substrate(&self) -> &Arc<MemorySubstrate>;
+    fn metering_ref(&self) -> &Arc<MeteringEngine>;
+    fn pairing_ref(&self) -> &PairingManager;
+    fn proactive_memory_store(&self) -> Option<&Arc<librefang_memory::ProactiveMemoryStore>>;
+    fn processes(&self) -> &Arc<librefang_runtime::process_manager::ProcessManager>;
+    fn process_registry(&self) -> &Arc<librefang_runtime::process_registry::ProcessRegistry>;
+    fn scheduler_ref(&self) -> &AgentScheduler;
+    fn session_stream_hub(&self) -> Arc<SessionStreamHub>;
+    fn supervisor_ref(&self) -> &Supervisor;
+    fn templates(&self) -> &crate::workflow::WorkflowTemplateRegistry;
+    fn tts(&self) -> &librefang_runtime::tts::TtsEngine;
+    fn web_tools(&self) -> &librefang_runtime::web_search::WebToolsContext;
+    fn workflow_engine(&self) -> &WorkflowEngine;
+
+    // `*_ref` accessors that expose internal state for mutation. These are
+    // necessary for routes that need to read or mutate live kernel state
+    // (model catalog, MCP wiring, event bus, …).
+    fn command_queue_ref(&self) -> &librefang_runtime::command_lane::CommandQueue;
+    fn config_ref(&self) -> arc_swap::Guard<Arc<KernelConfig>>;
+    fn config_snapshot(&self) -> Arc<KernelConfig>;
+    fn context_engine_ref(&self) -> Option<&dyn librefang_runtime::context_engine::ContextEngine>;
+    fn default_model_override_ref(
+        &self,
+    ) -> &std::sync::RwLock<Option<librefang_types::config::DefaultModelConfig>>;
+    fn mcp_auth_states_ref(&self) -> &librefang_runtime::mcp_oauth::McpAuthStates;
+    fn mcp_connections_ref(
+        &self,
+    ) -> &tokio::sync::Mutex<Vec<librefang_runtime::mcp::McpConnection>>;
+    fn mcp_tools_ref(&self) -> &std::sync::Mutex<Vec<ToolDefinition>>;
+    fn model_catalog_ref(
+        &self,
+    ) -> &arc_swap::ArcSwap<librefang_runtime::model_catalog::ModelCatalog>;
+    fn oauth_provider_ref(
+        &self,
+    ) -> Arc<dyn librefang_runtime::mcp_oauth::McpOAuthProvider + Send + Sync>;
+    fn peer_node_ref(&self) -> Option<&Arc<librefang_wire::PeerNode>>;
+    fn peer_registry_ref(&self) -> Option<&librefang_wire::PeerRegistry>;
+    fn skill_registry_ref(&self) -> &std::sync::RwLock<librefang_skills::registry::SkillRegistry>;
+
+    // ====================================================================
+    // Config / lifecycle
+    // ====================================================================
+
+    fn budget_config(&self) -> BudgetConfig;
+    /// Mutate the live budget config in-place. The closure is called under
+    /// the kernel's internal lock; keep it short and side-effect-free
+    /// outside of `BudgetConfig` mutation.
+    fn update_budget_config(&self, f: &dyn Fn(&mut BudgetConfig));
+    fn shutdown(&self);
+    fn clear_driver_cache(&self);
+    fn relocate_legacy_agent_dirs(&self);
+    fn validate_config_for_reload(&self, config: &KernelConfig) -> Result<(), Vec<String>>;
+    async fn reload_config(&self) -> Result<ReloadPlan, String>;
+
+    // ====================================================================
+    // Vault — sensitive secret read/write/recovery.
+    // ====================================================================
+
+    fn vault_get(&self, key: &str) -> Option<String>;
+    fn vault_set(&self, key: &str, value: &str) -> Result<(), String>;
+    fn vault_redeem_recovery_code(&self, code: &str) -> Result<bool, String>;
+
+    // ====================================================================
+    // Inbox / auto-dream observability
+    // ====================================================================
+
+    fn inbox_status(&self) -> InboxStatus;
+    async fn auto_dream_status(&self) -> AutoDreamStatus;
+    async fn auto_dream_abort(&self, agent_id: AgentId) -> AbortOutcome;
+    fn auto_dream_set_enabled(&self, agent_id: AgentId, enabled: bool) -> LibreFangResult<()>;
+
+    // ====================================================================
+    // Agent lifecycle / sessions
+    // ====================================================================
+
+    fn spawn_agent(&self, manifest: AgentManifest) -> KernelResult<AgentId>;
+    fn kill_agent(&self, agent_id: AgentId) -> KernelResult<()>;
+    fn kill_agent_with_purge(&self, agent_id: AgentId, purge_identity: bool) -> KernelResult<()>;
+    fn stop_agent_run(&self, agent_id: AgentId) -> KernelResult<bool>;
+    fn stop_session_run(&self, agent_id: AgentId, session_id: SessionId) -> KernelResult<bool>;
+    fn suspend_agent(&self, agent_id: AgentId) -> KernelResult<()>;
+    fn resume_agent(&self, agent_id: AgentId) -> KernelResult<()>;
+    async fn compact_agent_session(&self, agent_id: AgentId) -> KernelResult<String>;
+    fn reset_session(&self, agent_id: AgentId) -> KernelResult<()>;
+    fn reboot_session(&self, agent_id: AgentId) -> KernelResult<()>;
+    fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()>;
+    fn list_agent_sessions(&self, agent_id: AgentId) -> KernelResult<Vec<serde_json::Value>>;
+    fn create_agent_session(
+        &self,
+        agent_id: AgentId,
+        label: Option<&str>,
+    ) -> KernelResult<serde_json::Value>;
+    fn switch_agent_session(&self, agent_id: AgentId, session_id: SessionId) -> KernelResult<()>;
+    fn export_session(
+        &self,
+        agent_id: AgentId,
+        session_id: SessionId,
+    ) -> KernelResult<librefang_memory::session::SessionExport>;
+    fn import_session(
+        &self,
+        agent_id: AgentId,
+        export: librefang_memory::session::SessionExport,
+    ) -> KernelResult<SessionId>;
+    fn export_session_trajectory(
+        &self,
+        agent_id: AgentId,
+        session_id: SessionId,
+    ) -> KernelResult<TrajectoryBundle>;
+    fn persist_manifest_to_disk(&self, agent_id: AgentId);
+    fn reload_agent_from_disk(&self, agent_id: AgentId) -> KernelResult<()>;
+    fn update_manifest(&self, agent_id: AgentId, new_manifest: AgentManifest) -> KernelResult<()>;
+    fn set_agent_skills(&self, agent_id: AgentId, skills: Vec<String>) -> KernelResult<()>;
+    fn set_agent_mcp_servers(&self, agent_id: AgentId, servers: Vec<String>) -> KernelResult<()>;
+    fn set_agent_tool_filters(
+        &self,
+        agent_id: AgentId,
+        capabilities_tools: Option<Vec<String>>,
+        allowlist: Option<Vec<String>>,
+        blocklist: Option<Vec<String>>,
+    ) -> KernelResult<()>;
+    fn list_running_sessions(&self, agent_id: AgentId) -> Vec<RunningSessionSnapshot>;
+    fn running_session_ids(&self) -> std::collections::HashSet<SessionId>;
+    fn verify_signed_manifest(&self, signed_json: &str) -> KernelResult<String>;
+    fn available_tools(&self, agent_id: AgentId) -> Arc<Vec<ToolDefinition>>;
+
+    // ====================================================================
+    // Messaging
+    // ====================================================================
+
+    async fn send_message(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    async fn send_message_ephemeral(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+
+    // ====================================================================
+    // Hands
+    // ====================================================================
+
+    fn activate_hand(
+        &self,
+        hand_id: &str,
+        config: std::collections::HashMap<String, serde_json::Value>,
+    ) -> KernelResult<librefang_hands::HandInstance>;
+    fn deactivate_hand(&self, instance_id: uuid::Uuid) -> KernelResult<()>;
+    fn pause_hand(&self, instance_id: uuid::Uuid) -> KernelResult<()>;
+    fn resume_hand(&self, instance_id: uuid::Uuid) -> KernelResult<()>;
+    fn reload_hands(&self) -> (usize, usize);
+    fn invalidate_hand_route_cache(&self);
+    fn persist_hand_state(&self);
+    fn clear_hand_agent_runtime_override(&self, agent_id: AgentId) -> KernelResult<()>;
+    fn trigger_all_hands(&self);
+
+    // ====================================================================
+    // MCP — connection lifecycle (Arc<Self> receivers because they spawn
+    // background tasks that need a strong self-reference).
+    // ====================================================================
+
+    fn mcp_health(&self) -> &librefang_extensions::health::HealthMonitor;
+    fn mcp_catalog_load(&self) -> arc_swap::Guard<Arc<librefang_extensions::catalog::McpCatalog>>;
+    async fn connect_mcp_servers(self: Arc<Self>);
+    async fn disconnect_mcp_server(&self, name: &str) -> bool;
+    async fn retry_mcp_connection(self: Arc<Self>, server_name: &str);
+    async fn reload_mcp_servers(self: Arc<Self>) -> Result<usize, String>;
+    async fn reconnect_mcp_server(self: Arc<Self>, id: &str) -> Result<usize, String>;
+
+    // ====================================================================
+    // Triggers / workflows / events
+    // ====================================================================
+
+    fn list_triggers(&self, agent_id: Option<AgentId>) -> Vec<Trigger>;
+    fn get_trigger(&self, trigger_id: TriggerId) -> Option<Trigger>;
+    fn register_trigger_with_target(
+        &self,
+        agent_id: AgentId,
+        pattern: TriggerPattern,
+        prompt_template: String,
+        max_fires: u64,
+        target_agent: Option<AgentId>,
+        cooldown_secs: Option<u64>,
+        session_mode: Option<librefang_types::agent::SessionMode>,
+    ) -> KernelResult<TriggerId>;
+    fn remove_trigger(&self, trigger_id: TriggerId) -> bool;
+    fn update_trigger(
+        &self,
+        trigger_id: TriggerId,
+        patch: crate::triggers::TriggerPatch,
+    ) -> Option<Trigger>;
+    async fn register_workflow(
+        &self,
+        workflow: crate::workflow::Workflow,
+    ) -> crate::workflow::WorkflowId;
+    async fn run_workflow(
+        &self,
+        workflow_id: crate::workflow::WorkflowId,
+        input: String,
+    ) -> KernelResult<(crate::workflow::WorkflowRunId, String)>;
+    async fn dry_run_workflow(
+        &self,
+        workflow_id: crate::workflow::WorkflowId,
+        input: String,
+    ) -> KernelResult<Vec<crate::workflow::DryRunStep>>;
+    async fn publish_event(&self, event: librefang_types::event::Event) -> Vec<TriggerMatch>;
+
+    // ====================================================================
+    // Agent bindings (channel ↔ agent mapping)
+    // ====================================================================
+
+    fn list_bindings(&self) -> Vec<AgentBinding>;
+    fn add_binding(&self, binding: AgentBinding);
+    fn remove_binding(&self, index: usize) -> Option<AgentBinding>;
+
+    // ====================================================================
+    // Skills / driver caches / model catalog
+    // ====================================================================
+
+    fn reload_skills(&self);
+    fn model_catalog_load(
+        &self,
+    ) -> arc_swap::Guard<Arc<librefang_runtime::model_catalog::ModelCatalog>>;
+    /// Mutate the live model catalog. The closure is invoked under the
+    /// kernel's internal lock; if the caller needs the closure's return
+    /// value, capture it via `&mut Option<R>` from the surrounding scope.
+    fn model_catalog_update(
+        &self,
+        f: &mut dyn FnMut(&mut librefang_runtime::model_catalog::ModelCatalog),
+    );
+
+    // ====================================================================
+    // Background spawning
+    // ====================================================================
+
+    fn start_background_for_agent(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        name: &str,
+        schedule: &librefang_types::agent::ScheduleMode,
+    );
+}
+
+#[async_trait]
+impl KernelApi for LibreFangKernel {
+    // -- Subsystem accessors --
+    fn agent_registry(&self) -> &AgentRegistry {
+        Self::agent_registry(self)
+    }
+    fn agent_identities(&self) -> &Arc<crate::agent_identity_registry::AgentIdentityRegistry> {
+        Self::agent_identities(self)
+    }
+    fn approvals(&self) -> &ApprovalManager {
+        Self::approvals(self)
+    }
+    fn audit(&self) -> &Arc<AuditLog> {
+        Self::audit(self)
+    }
+    fn auth_manager(&self) -> &AuthManager {
+        Self::auth_manager(self)
+    }
+    fn browser(&self) -> &librefang_runtime::browser::BrowserManager {
+        Self::browser(self)
+    }
+    fn cron(&self) -> &CronScheduler {
+        Self::cron(self)
+    }
+    fn delivery(&self) -> &DeliveryTracker {
+        Self::delivery(self)
+    }
+    fn event_bus_ref(&self) -> &EventBus {
+        Self::event_bus_ref(self)
+    }
+    fn hands(&self) -> &librefang_hands::registry::HandRegistry {
+        Self::hands(self)
+    }
+    fn home_dir(&self) -> &Path {
+        Self::home_dir(self)
+    }
+    fn media(&self) -> &librefang_runtime::media_understanding::MediaEngine {
+        Self::media(self)
+    }
+    fn media_drivers(&self) -> &librefang_runtime::media::MediaDriverCache {
+        Self::media_drivers(self)
+    }
+    fn memory_substrate(&self) -> &Arc<MemorySubstrate> {
+        Self::memory_substrate(self)
+    }
+    fn metering_ref(&self) -> &Arc<MeteringEngine> {
+        Self::metering_ref(self)
+    }
+    fn pairing_ref(&self) -> &PairingManager {
+        Self::pairing_ref(self)
+    }
+    fn proactive_memory_store(&self) -> Option<&Arc<librefang_memory::ProactiveMemoryStore>> {
+        Self::proactive_memory_store(self)
+    }
+    fn processes(&self) -> &Arc<librefang_runtime::process_manager::ProcessManager> {
+        Self::processes(self)
+    }
+    fn process_registry(&self) -> &Arc<librefang_runtime::process_registry::ProcessRegistry> {
+        Self::process_registry(self)
+    }
+    fn scheduler_ref(&self) -> &AgentScheduler {
+        Self::scheduler_ref(self)
+    }
+    fn session_stream_hub(&self) -> Arc<SessionStreamHub> {
+        Self::session_stream_hub(self)
+    }
+    fn supervisor_ref(&self) -> &Supervisor {
+        Self::supervisor_ref(self)
+    }
+    fn templates(&self) -> &crate::workflow::WorkflowTemplateRegistry {
+        Self::templates(self)
+    }
+    fn tts(&self) -> &librefang_runtime::tts::TtsEngine {
+        Self::tts(self)
+    }
+    fn web_tools(&self) -> &librefang_runtime::web_search::WebToolsContext {
+        Self::web_tools(self)
+    }
+    fn workflow_engine(&self) -> &WorkflowEngine {
+        Self::workflow_engine(self)
+    }
+
+    fn command_queue_ref(&self) -> &librefang_runtime::command_lane::CommandQueue {
+        Self::command_queue_ref(self)
+    }
+    fn config_ref(&self) -> arc_swap::Guard<Arc<KernelConfig>> {
+        Self::config_ref(self)
+    }
+    fn config_snapshot(&self) -> Arc<KernelConfig> {
+        Self::config_snapshot(self)
+    }
+    fn context_engine_ref(&self) -> Option<&dyn librefang_runtime::context_engine::ContextEngine> {
+        Self::context_engine_ref(self)
+    }
+    fn default_model_override_ref(
+        &self,
+    ) -> &std::sync::RwLock<Option<librefang_types::config::DefaultModelConfig>> {
+        Self::default_model_override_ref(self)
+    }
+    fn mcp_auth_states_ref(&self) -> &librefang_runtime::mcp_oauth::McpAuthStates {
+        Self::mcp_auth_states_ref(self)
+    }
+    fn mcp_connections_ref(
+        &self,
+    ) -> &tokio::sync::Mutex<Vec<librefang_runtime::mcp::McpConnection>> {
+        Self::mcp_connections_ref(self)
+    }
+    fn mcp_tools_ref(&self) -> &std::sync::Mutex<Vec<ToolDefinition>> {
+        Self::mcp_tools_ref(self)
+    }
+    fn model_catalog_ref(
+        &self,
+    ) -> &arc_swap::ArcSwap<librefang_runtime::model_catalog::ModelCatalog> {
+        Self::model_catalog_ref(self)
+    }
+    fn oauth_provider_ref(
+        &self,
+    ) -> Arc<dyn librefang_runtime::mcp_oauth::McpOAuthProvider + Send + Sync> {
+        Self::oauth_provider_ref(self)
+    }
+    fn peer_node_ref(&self) -> Option<&Arc<librefang_wire::PeerNode>> {
+        Self::peer_node_ref(self)
+    }
+    fn peer_registry_ref(&self) -> Option<&librefang_wire::PeerRegistry> {
+        Self::peer_registry_ref(self)
+    }
+    fn skill_registry_ref(&self) -> &std::sync::RwLock<librefang_skills::registry::SkillRegistry> {
+        Self::skill_registry_ref(self)
+    }
+
+    // -- Config / lifecycle --
+    fn budget_config(&self) -> BudgetConfig {
+        Self::budget_config(self)
+    }
+    fn update_budget_config(&self, f: &dyn Fn(&mut BudgetConfig)) {
+        Self::update_budget_config(self, f);
+    }
+    fn shutdown(&self) {
+        Self::shutdown(self);
+    }
+    fn clear_driver_cache(&self) {
+        Self::clear_driver_cache(self);
+    }
+    fn relocate_legacy_agent_dirs(&self) {
+        Self::relocate_legacy_agent_dirs(self);
+    }
+    fn validate_config_for_reload(&self, config: &KernelConfig) -> Result<(), Vec<String>> {
+        Self::validate_config_for_reload(self, config)
+    }
+    async fn reload_config(&self) -> Result<ReloadPlan, String> {
+        Self::reload_config(self).await
+    }
+
+    // -- Vault --
+    fn vault_get(&self, key: &str) -> Option<String> {
+        Self::vault_get(self, key)
+    }
+    fn vault_set(&self, key: &str, value: &str) -> Result<(), String> {
+        Self::vault_set(self, key, value)
+    }
+    fn vault_redeem_recovery_code(&self, code: &str) -> Result<bool, String> {
+        Self::vault_redeem_recovery_code(self, code)
+    }
+
+    // -- Inbox / auto-dream --
+    fn inbox_status(&self) -> InboxStatus {
+        Self::inbox_status(self)
+    }
+    async fn auto_dream_status(&self) -> AutoDreamStatus {
+        Self::auto_dream_status(self).await
+    }
+    async fn auto_dream_abort(&self, agent_id: AgentId) -> AbortOutcome {
+        Self::auto_dream_abort(self, agent_id).await
+    }
+    fn auto_dream_set_enabled(&self, agent_id: AgentId, enabled: bool) -> LibreFangResult<()> {
+        Self::auto_dream_set_enabled(self, agent_id, enabled)
+    }
+
+    // -- Agent lifecycle --
+    fn spawn_agent(&self, manifest: AgentManifest) -> KernelResult<AgentId> {
+        Self::spawn_agent(self, manifest)
+    }
+    fn kill_agent(&self, agent_id: AgentId) -> KernelResult<()> {
+        Self::kill_agent(self, agent_id)
+    }
+    fn kill_agent_with_purge(&self, agent_id: AgentId, purge_identity: bool) -> KernelResult<()> {
+        Self::kill_agent_with_purge(self, agent_id, purge_identity)
+    }
+    fn stop_agent_run(&self, agent_id: AgentId) -> KernelResult<bool> {
+        Self::stop_agent_run(self, agent_id)
+    }
+    fn stop_session_run(&self, agent_id: AgentId, session_id: SessionId) -> KernelResult<bool> {
+        Self::stop_session_run(self, agent_id, session_id)
+    }
+    fn suspend_agent(&self, agent_id: AgentId) -> KernelResult<()> {
+        Self::suspend_agent(self, agent_id)
+    }
+    fn resume_agent(&self, agent_id: AgentId) -> KernelResult<()> {
+        Self::resume_agent(self, agent_id)
+    }
+    async fn compact_agent_session(&self, agent_id: AgentId) -> KernelResult<String> {
+        Self::compact_agent_session(self, agent_id).await
+    }
+    fn reset_session(&self, agent_id: AgentId) -> KernelResult<()> {
+        Self::reset_session(self, agent_id)
+    }
+    fn reboot_session(&self, agent_id: AgentId) -> KernelResult<()> {
+        Self::reboot_session(self, agent_id)
+    }
+    fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()> {
+        Self::clear_agent_history(self, agent_id)
+    }
+    fn list_agent_sessions(&self, agent_id: AgentId) -> KernelResult<Vec<serde_json::Value>> {
+        Self::list_agent_sessions(self, agent_id)
+    }
+    fn create_agent_session(
+        &self,
+        agent_id: AgentId,
+        label: Option<&str>,
+    ) -> KernelResult<serde_json::Value> {
+        Self::create_agent_session(self, agent_id, label)
+    }
+    fn switch_agent_session(&self, agent_id: AgentId, session_id: SessionId) -> KernelResult<()> {
+        Self::switch_agent_session(self, agent_id, session_id)
+    }
+    fn export_session(
+        &self,
+        agent_id: AgentId,
+        session_id: SessionId,
+    ) -> KernelResult<librefang_memory::session::SessionExport> {
+        Self::export_session(self, agent_id, session_id)
+    }
+    fn import_session(
+        &self,
+        agent_id: AgentId,
+        export: librefang_memory::session::SessionExport,
+    ) -> KernelResult<SessionId> {
+        Self::import_session(self, agent_id, export)
+    }
+    fn export_session_trajectory(
+        &self,
+        agent_id: AgentId,
+        session_id: SessionId,
+    ) -> KernelResult<TrajectoryBundle> {
+        Self::export_session_trajectory(self, agent_id, session_id)
+    }
+    fn persist_manifest_to_disk(&self, agent_id: AgentId) {
+        Self::persist_manifest_to_disk(self, agent_id);
+    }
+    fn reload_agent_from_disk(&self, agent_id: AgentId) -> KernelResult<()> {
+        Self::reload_agent_from_disk(self, agent_id)
+    }
+    fn update_manifest(&self, agent_id: AgentId, new_manifest: AgentManifest) -> KernelResult<()> {
+        Self::update_manifest(self, agent_id, new_manifest)
+    }
+    fn set_agent_skills(&self, agent_id: AgentId, skills: Vec<String>) -> KernelResult<()> {
+        Self::set_agent_skills(self, agent_id, skills)
+    }
+    fn set_agent_mcp_servers(&self, agent_id: AgentId, servers: Vec<String>) -> KernelResult<()> {
+        Self::set_agent_mcp_servers(self, agent_id, servers)
+    }
+    fn set_agent_tool_filters(
+        &self,
+        agent_id: AgentId,
+        capabilities_tools: Option<Vec<String>>,
+        allowlist: Option<Vec<String>>,
+        blocklist: Option<Vec<String>>,
+    ) -> KernelResult<()> {
+        Self::set_agent_tool_filters(self, agent_id, capabilities_tools, allowlist, blocklist)
+    }
+    fn list_running_sessions(&self, agent_id: AgentId) -> Vec<RunningSessionSnapshot> {
+        Self::list_running_sessions(self, agent_id)
+    }
+    fn running_session_ids(&self) -> std::collections::HashSet<SessionId> {
+        Self::running_session_ids(self)
+    }
+    fn verify_signed_manifest(&self, signed_json: &str) -> KernelResult<String> {
+        Self::verify_signed_manifest(self, signed_json)
+    }
+    fn available_tools(&self, agent_id: AgentId) -> Arc<Vec<ToolDefinition>> {
+        Self::available_tools(self, agent_id)
+    }
+
+    async fn send_message(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
+        Self::send_message(self, agent_id, message).await
+    }
+    async fn send_message_ephemeral(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+    ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult> {
+        Self::send_message_ephemeral(self, agent_id, message).await
+    }
+
+    // -- Hands --
+    fn activate_hand(
+        &self,
+        hand_id: &str,
+        config: std::collections::HashMap<String, serde_json::Value>,
+    ) -> KernelResult<librefang_hands::HandInstance> {
+        Self::activate_hand(self, hand_id, config)
+    }
+    fn deactivate_hand(&self, instance_id: uuid::Uuid) -> KernelResult<()> {
+        Self::deactivate_hand(self, instance_id)
+    }
+    fn pause_hand(&self, instance_id: uuid::Uuid) -> KernelResult<()> {
+        Self::pause_hand(self, instance_id)
+    }
+    fn resume_hand(&self, instance_id: uuid::Uuid) -> KernelResult<()> {
+        Self::resume_hand(self, instance_id)
+    }
+    fn reload_hands(&self) -> (usize, usize) {
+        Self::reload_hands(self)
+    }
+    fn invalidate_hand_route_cache(&self) {
+        Self::invalidate_hand_route_cache(self);
+    }
+    fn persist_hand_state(&self) {
+        Self::persist_hand_state(self);
+    }
+    fn clear_hand_agent_runtime_override(&self, agent_id: AgentId) -> KernelResult<()> {
+        Self::clear_hand_agent_runtime_override(self, agent_id)
+    }
+    fn trigger_all_hands(&self) {
+        Self::trigger_all_hands(self);
+    }
+
+    // -- MCP --
+    fn mcp_health(&self) -> &librefang_extensions::health::HealthMonitor {
+        Self::mcp_health(self)
+    }
+    fn mcp_catalog_load(&self) -> arc_swap::Guard<Arc<librefang_extensions::catalog::McpCatalog>> {
+        Self::mcp_catalog_load(self)
+    }
+    async fn connect_mcp_servers(self: Arc<Self>) {
+        LibreFangKernel::connect_mcp_servers(&self).await;
+    }
+    async fn disconnect_mcp_server(&self, name: &str) -> bool {
+        Self::disconnect_mcp_server(self, name).await
+    }
+    async fn retry_mcp_connection(self: Arc<Self>, server_name: &str) {
+        LibreFangKernel::retry_mcp_connection(&self, server_name).await;
+    }
+    async fn reload_mcp_servers(self: Arc<Self>) -> Result<usize, String> {
+        LibreFangKernel::reload_mcp_servers(&self).await
+    }
+    async fn reconnect_mcp_server(self: Arc<Self>, id: &str) -> Result<usize, String> {
+        LibreFangKernel::reconnect_mcp_server(&self, id).await
+    }
+
+    // -- Triggers / workflows / events --
+    fn list_triggers(&self, agent_id: Option<AgentId>) -> Vec<Trigger> {
+        Self::list_triggers(self, agent_id)
+    }
+    fn get_trigger(&self, trigger_id: TriggerId) -> Option<Trigger> {
+        Self::get_trigger(self, trigger_id)
+    }
+    fn register_trigger_with_target(
+        &self,
+        agent_id: AgentId,
+        pattern: TriggerPattern,
+        prompt_template: String,
+        max_fires: u64,
+        target_agent: Option<AgentId>,
+        cooldown_secs: Option<u64>,
+        session_mode: Option<librefang_types::agent::SessionMode>,
+    ) -> KernelResult<TriggerId> {
+        Self::register_trigger_with_target(
+            self,
+            agent_id,
+            pattern,
+            prompt_template,
+            max_fires,
+            target_agent,
+            cooldown_secs,
+            session_mode,
+        )
+    }
+    fn remove_trigger(&self, trigger_id: TriggerId) -> bool {
+        Self::remove_trigger(self, trigger_id)
+    }
+    fn update_trigger(
+        &self,
+        trigger_id: TriggerId,
+        patch: crate::triggers::TriggerPatch,
+    ) -> Option<Trigger> {
+        Self::update_trigger(self, trigger_id, patch)
+    }
+    async fn register_workflow(
+        &self,
+        workflow: crate::workflow::Workflow,
+    ) -> crate::workflow::WorkflowId {
+        Self::register_workflow(self, workflow).await
+    }
+    async fn run_workflow(
+        &self,
+        workflow_id: crate::workflow::WorkflowId,
+        input: String,
+    ) -> KernelResult<(crate::workflow::WorkflowRunId, String)> {
+        Self::run_workflow(self, workflow_id, input).await
+    }
+    async fn dry_run_workflow(
+        &self,
+        workflow_id: crate::workflow::WorkflowId,
+        input: String,
+    ) -> KernelResult<Vec<crate::workflow::DryRunStep>> {
+        Self::dry_run_workflow(self, workflow_id, input).await
+    }
+    async fn publish_event(&self, event: librefang_types::event::Event) -> Vec<TriggerMatch> {
+        Self::publish_event(self, event).await
+    }
+
+    // -- Bindings --
+    fn list_bindings(&self) -> Vec<AgentBinding> {
+        Self::list_bindings(self)
+    }
+    fn add_binding(&self, binding: AgentBinding) {
+        Self::add_binding(self, binding);
+    }
+    fn remove_binding(&self, index: usize) -> Option<AgentBinding> {
+        Self::remove_binding(self, index)
+    }
+
+    // -- Skills / driver caches / model catalog --
+    fn reload_skills(&self) {
+        Self::reload_skills(self);
+    }
+    fn model_catalog_load(
+        &self,
+    ) -> arc_swap::Guard<Arc<librefang_runtime::model_catalog::ModelCatalog>> {
+        Self::model_catalog_load(self)
+    }
+    fn model_catalog_update(
+        &self,
+        f: &mut dyn FnMut(&mut librefang_runtime::model_catalog::ModelCatalog),
+    ) {
+        Self::model_catalog_update(self, |catalog| f(catalog));
+    }
+
+    // -- Background spawning --
+    fn start_background_for_agent(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        name: &str,
+        schedule: &librefang_types::agent::ScheduleMode,
+    ) {
+        LibreFangKernel::start_background_for_agent(&self, agent_id, name, schedule);
+    }
+}
 
 /// Convenience: type-erase any `Arc<T: KernelApi>` to `Arc<dyn KernelApi>`.
 pub fn as_dyn<T: KernelApi + 'static>(k: Arc<T>) -> Arc<dyn KernelApi> {

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -27,8 +27,10 @@
 // the kernel-inherent signatures verbatim — both already exceed clippy's
 // 7-arg threshold on the kernel side. Splitting the trait method into a
 // builder would diverge the trait surface from the inherent surface and
-// break the "trait is a thin facade" invariant of #3566.
-#![allow(clippy::too_many_arguments)]
+// break the "trait is a thin facade" invariant of #3566. Per-method
+// `#[allow(clippy::too_many_arguments)]` is applied at each call site
+// rather than as a module-level blanket so unrelated methods that
+// accidentally creep over 7 args still trip the lint.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -278,6 +280,7 @@ pub trait KernelApi: KernelHandle + Send + Sync {
 
     fn list_triggers(&self, agent_id: Option<AgentId>) -> Vec<Trigger>;
     fn get_trigger(&self, trigger_id: TriggerId) -> Option<Trigger>;
+    #[allow(clippy::too_many_arguments)]
     fn register_trigger_with_target(
         &self,
         agent_id: AgentId,
@@ -418,6 +421,7 @@ pub trait KernelApi: KernelHandle + Send + Sync {
         kernel_handle: Option<Arc<dyn crate::kernel_handle::KernelHandle>>,
         content_blocks: Option<Vec<librefang_types::message::ContentBlock>>,
     ) -> KernelResult<librefang_runtime::agent_loop::AgentLoopResult>;
+    #[allow(clippy::too_many_arguments)]
     async fn send_message_with_incognito(
         &self,
         agent_id: AgentId,
@@ -893,6 +897,7 @@ impl KernelApi for LibreFangKernel {
     fn get_trigger(&self, trigger_id: TriggerId) -> Option<Trigger> {
         Self::get_trigger(self, trigger_id)
     }
+    #[allow(clippy::too_many_arguments)]
     fn register_trigger_with_target(
         &self,
         agent_id: AgentId,
@@ -1076,6 +1081,7 @@ impl KernelApi for LibreFangKernel {
         )
         .await
     }
+    #[allow(clippy::too_many_arguments)]
     async fn send_message_with_incognito(
         &self,
         agent_id: AgentId,
@@ -1256,9 +1262,4 @@ impl KernelApi for LibreFangKernel {
     fn set_self_handle(self: Arc<Self>) {
         LibreFangKernel::set_self_handle(&self);
     }
-}
-
-/// Convenience: type-erase any `Arc<T: KernelApi>` to `Arc<dyn KernelApi>`.
-pub fn as_dyn<T: KernelApi + 'static>(k: Arc<T>) -> Arc<dyn KernelApi> {
-    k
 }

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -1,3 +1,7 @@
+// `KernelApi`'s `async_trait`-expanded methods nest pinned futures deeply
+// enough that the default 128-step layout pass tips over (#3566).
+#![recursion_limit = "256"]
+
 //! Core kernel for the LibreFang Agent Operating System.
 //!
 //! The kernel manages agent lifecycles, memory, permissions, scheduling,

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -20,6 +20,7 @@ pub mod heartbeat;
 pub mod hooks;
 pub mod inbox;
 pub mod kernel;
+pub mod kernel_api;
 pub mod log_reload;
 pub mod mcp_oauth_provider;
 pub use librefang_kernel_metering as metering;
@@ -41,6 +42,7 @@ pub mod workflow;
 
 pub use kernel::DeliveryTracker;
 pub use kernel::LibreFangKernel;
+pub use kernel_api::KernelApi;
 
 // ---------------------------------------------------------------------------
 // Runtime re-exports (refs #3596 — API → Kernel → Runtime layering)


### PR DESCRIPTION
## Summary
- New `pub trait KernelApi: KernelHandle + Send + Sync` in `librefang-kernel` (`crates/librefang-kernel/src/kernel_api.rs`) — the single explicit contract between the HTTP API layer and the kernel.
- `AppState.kernel: Arc<LibreFangKernel>` → `Arc<dyn KernelApi>`. Routes never see the concrete kernel struct again; the only place `Arc<LibreFangKernel>` survives is `server::build_router` (entry point from the daemon, which has the real kernel) — it implicitly upcasts to `Arc<dyn KernelApi>` at the AppState struct literal.
- KernelApi extends `KernelHandle` (the runtime-side super-trait that bundles every #3746 / #3744 role trait), so `Arc<dyn KernelApi>` upcasts to `Arc<dyn KernelHandle>` and to any individual role trait. Removes the 7 `as Arc<dyn KernelHandle>` non-primitive casts that openai_compat / agents / network / workflows / ws / tools_sessions used to perform.
- `channel_bridge::KernelBridgeAdapter`, `start_channel_bridge`, `start_channel_bridge_with_config` migrated to `Arc<dyn KernelApi>`. Routes no longer import `LibreFangKernel`.

## Trait shape
- ~115 method signatures: subsystem accessors (audit, agent_registry, approvals, hands, memory, MCP, templates, supervisor, browser, media, tts, web_tools, …), `*_ref` accessors (config, model_catalog, mcp_tools, event_bus, peer_registry, …), config / lifecycle (reload_config, validate_config_for_reload, shutdown), full agent lifecycle, messaging (send_message + handle / blocks / sender_context / incognito / streaming variants), hand ops, MCP connect/disconnect/retry/reload/reconnect (`Arc<Self>` receivers), triggers + workflows + events, bindings, vault, auto-dream, a2a tasks/agents, embedding/tts/web/browser/media engines, and `data_dir` / `install_peer_registry_for_test` / `set_self_handle` for integration tests.
- Naming conflicts with role-trait methods get `_typed` suffixes:
  - `spawn_agent_typed(AgentManifest) -> AgentId`  vs  `AgentControl::spawn_agent(&str, Option<&str>) -> (String, String)`
  - `kill_agent_typed(AgentId)`  vs  `AgentControl::kill_agent(&str)`
  - `run_workflow_typed(WorkflowId, String) -> (WorkflowRunId, String)`  vs  `WorkflowRunner::run_workflow(&str, &str) -> (String, String)`
  - `publish_typed_event(Event) -> Vec<TriggerMatch>`  vs  `EventBus::publish_event(&str, Value) -> Result<(), _>`
  - Routes/tests migrated to the typed names (`agents.rs`, `workflows.rs`, `channel_bridge.rs`, `agent_kv_authz_integration.rs`, `agents_routes_integration.rs`).
- The two generic-closure inherent kernel methods become dyn-safe trait methods:
  - `update_budget_config(&dyn Fn(&mut BudgetConfig))` (callers wrap as `&|b| { ... }`)
  - `model_catalog_update(&mut dyn FnMut(&mut ModelCatalog))` returning `()`. The 8 providers/registry/server callers that needed the closure's return value now capture it via `&mut Option<R>` from the surrounding scope.
- Receiver mechanics: every `Arc<Self>`-receiver method (`connect_/disconnect_/retry_/reconnect_/reload_mcp_servers`, `send_message_streaming_with_*`, `start_background_for_agent`, `spawn_key_validation`, `auto_dream_trigger_manual`, `probe_local_provider`, `set_self_handle`) takes `self: Arc<Self>` on the trait. Call sites consume one strong ref per call (`state.kernel.clone().method(...)`) — Arc clones are cheap.
- Bumps `librefang-kernel`'s `recursion_limit` to 256 — the `#[async_trait]` expansion across this many methods pushes the default 128-step layout pass over the edge.
- Module-level `#![allow(clippy::too_many_arguments)]` on `kernel_api.rs` because two methods (`register_trigger_with_target`, `send_message_with_incognito`) mirror the kernel-inherent 8-arg signatures verbatim — splitting into a builder would diverge the trait surface from the inherent surface and break the "thin facade" invariant.

## Verification
- `cargo check --workspace --all-targets` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo test -p librefang-api --lib` — 632 passed
- `cargo test -p librefang-api --test daemon_lifecycle_test` — 7 passed
- `cargo test -p librefang-api --test agents_routes_integration` — 19 passed
- `cargo test -p librefang-api --test api_integration_test` — 72 passed
- `cargo test -p librefang-api --test config_routes_integration --test network_routes_integration --test load_test` — 13 + 12 + … passed
- (Full `cargo test -p librefang-api` ran into a docker-host OOM during the test-binary link step; ran the suites individually instead. CI has more headroom.)

## Out-of-scope follow-ups
- Banning `librefang_kernel::LibreFangKernel` imports from `librefang-api` at the compiler level — nothing in `librefang-api/src` references it any more, but a `cargo deny` / clippy `disallowed_types` rule would harden the boundary against regression. Deferred to a follow-up so this PR stays focused on the structural swap.

Closes #3566.