### PR TITLE
fix(dashboard/ui): DrawerPanel parent-close must check slot ownership (#4714)

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.test.tsx
@@ -91,4 +91,90 @@ describe("DrawerPanel", () => {
 
     expect(calls).toBe(1);
   });
+
+  // Regression test for #4714: the picker → config flow.
+  //
+  // ProvidersPage and ChannelsPage both use a pattern where clicking an
+  // item in an "Add" picker drawer closes the picker and opens a
+  // configuration drawer in the same React commit:
+  //
+  //     handlePick = (item) => {
+  //       setPickerOpen(false);     // → picker DrawerPanel isOpen=true → false
+  //       setConfiguringItem(item); // → mounts config DrawerPanel (isOpen=true)
+  //     };
+  //
+  // Before the ownership check, the picker's parent-driven close watcher
+  // would unconditionally call `store.close()` after the config drawer
+  // had already pushed its own body into the slot. The slot then went
+  // `{isOpen=false, content=config_body}`, the existing external-close
+  // watcher saw `!drawerOpen && wasOpen` for the config drawer and fired
+  // ITS `onClose`, which made the parent unmount the config drawer.
+  // Net visible effect: clicking a picker item closed the picker AND
+  // immediately closed the configuration window the user was trying
+  // to reach. See https://github.com/librefang/librefang/issues/4714.
+  //
+  // Fix: each DrawerPanel only fires `close()` when the slot's content
+  // is still the body it pushed. A freshly-mounted DrawerPanel that
+  // pushed in the same commit "wins" the slot.
+  it("does not collateral-close the freshly-mounted drawer when a sibling drawer's parent flips isOpen=false in the same commit", () => {
+    // Step 1: picker drawer is open and owns the slot.
+    let pickerOnCloseCalls = 0;
+    const PickerOnClose = () => {
+      pickerOnCloseCalls += 1;
+    };
+    let configOnCloseCalls = 0;
+    const ConfigOnClose = () => {
+      configOnCloseCalls += 1;
+    };
+
+    function Harness({
+      pickerOpen,
+      configMounted,
+    }: {
+      pickerOpen: boolean;
+      configMounted: boolean;
+    }) {
+      return (
+        <>
+          {/* Conditionally-mounted config drawer with isOpen literal true,
+              same shape as ChannelsPage::ConfigDialog. */}
+          {configMounted && (
+            <DrawerPanel isOpen onClose={ConfigOnClose} title="config">
+              <p data-testid="config-body">config body</p>
+            </DrawerPanel>
+          )}
+          {/* Always-mounted picker drawer with toggling isOpen, same shape
+              as ChannelsPage's Add picker. */}
+          <DrawerPanel isOpen={pickerOpen} onClose={PickerOnClose} title="picker">
+            <p data-testid="picker-body">picker body</p>
+          </DrawerPanel>
+        </>
+      );
+    }
+
+    const { rerender } = render(<Harness pickerOpen={true} configMounted={false} />);
+    expect(useDrawerStore.getState().isOpen).toBe(true);
+    expect(useDrawerStore.getState().content?.title).toBe("picker");
+
+    // Step 2: simulate the picker's onClick handler running:
+    //   setPickerOpen(false);     // picker DrawerPanel isOpen → false
+    //   setConfiguringItem(item); // mounts config DrawerPanel
+    act(() => {
+      rerender(<Harness pickerOpen={false} configMounted={true} />);
+    });
+
+    // Slot must hold the config drawer, not be closed by the picker's
+    // parent-driven close watcher.
+    expect(useDrawerStore.getState().isOpen).toBe(true);
+    expect(useDrawerStore.getState().content?.title).toBe("config");
+
+    // The config drawer's onClose must NOT have fired — the user
+    // didn't dismiss it.
+    expect(configOnCloseCalls).toBe(0);
+
+    // The picker's onClose must NOT have fired either — its parent
+    // flipped `isOpen=false` itself, so the parent-driven close path
+    // applies (silent), not the external-close bubble-up.
+    expect(pickerOnCloseCalls).toBe(0);
+  });
 });

--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
@@ -47,17 +47,25 @@ export function DrawerPanel({
     onCloseRef.current = onClose;
   }, [onClose]);
 
+  // Track the body identity we last pushed into the slot. The
+  // parent-driven close watcher uses this to skip `close()` when another
+  // DrawerPanel has taken over the slot in the same commit — see
+  // ownership check below (#4714).
+  const lastPushedBodyRef = useRef<ReactNode>(null);
+
   // Push children into the slot whenever we're open. Re-runs on every
   // re-render that changes any of the deps — including `children`, which
   // gets a fresh identity each render. That's intended: the body should
   // mirror the parent's current state.
   useEffect(() => {
     if (!isOpen) return;
+    const body = children;
+    lastPushedBodyRef.current = body;
     open({
       title,
       size,
       hideCloseButton,
-      body: children,
+      body,
       onClose: () => onCloseRef.current(),
     });
   }, [isOpen, title, size, hideCloseButton, children, open]);
@@ -70,15 +78,32 @@ export function DrawerPanel({
   // dismissals from the parent silently no-op'd, leaving the form
   // visible with a perpetually spinning submit button (#4687).
   //
-  // The watcher above guards on `isOpen && wasOpen && !drawerOpen` and
-  // therefore won't double-fire `onClose` on this path: by the time the
-  // store flip lands, `isOpen` is already false.
+  // Ownership check (#4714): only fire `close()` when our body still
+  // owns the slot. In a picker → config / "select item closes one
+  // drawer and opens another" flow, the picker DrawerPanel transitions
+  // isOpen=true → false in the same commit that the config DrawerPanel
+  // mounts and pushes its own body. If we close() unconditionally here
+  // we yank the slot closed underneath the freshly-mounted config
+  // drawer, and the existing external-close watcher then fires its
+  // onClose, which makes the parent unmount the config drawer — net
+  // result: user picks an item and the configuration window vanishes
+  // immediately. Comparing against `lastPushedBodyRef` lets the
+  // late-mounting drawer's push "win" the slot without the previous
+  // owner clobbering it.
+  //
+  // The external-close watcher below guards on
+  // `isOpen && wasOpen && !drawerOpen` and therefore won't double-fire
+  // `onClose` on this path: by the time the store flip lands, `isOpen`
+  // is already false.
   const prevIsOpenRef = useRef(isOpen);
   useEffect(() => {
     const wasOpen = prevIsOpenRef.current;
     prevIsOpenRef.current = isOpen;
     if (wasOpen && !isOpen && drawerOpen) {
-      close();
+      const currentBody = useDrawerStore.getState().content?.body;
+      if (currentBody === lastPushedBodyRef.current) {
+        close();
+      }
     }
   }, [isOpen, drawerOpen, close]);
 


### PR DESCRIPTION
## Summary

Fixes #4714 — **P0**: clicking any provider or channel in the "Add" picker on the dashboard closed the picker AND immediately closed the configuration window the user was trying to reach. Net effect: configuration unreachable from the dashboard.

## Root cause

PR #4691 (#4687) added a parent-driven close watcher to `DrawerPanel` so a programmatic `setOpen(false)` from the parent (mutation `onSuccess`, Cancel button) tears the global drawer slot down. Correct in isolation, but **didn't account for two cooperating DrawerPanel instances** where one closes in the same React commit that the other opens.

The picker → config flow (ProvidersPage and ChannelsPage `handlePick`) does exactly this:

```ts
handlePick = (item) => {
  setPickerOpen(false);     // picker DrawerPanel isOpen=true→false
  setConfiguringItem(item); // mounts config DrawerPanel (isOpen=true)
};
```

What happened with the unconditional `close()`:

1. Render: ConfigDialog mounts; its DrawerPanel pushes `config_body`. Slot is now `{isOpen=true, content=config_body}`.
2. Same render: picker DrawerPanel sees isOpen=true→false, parent-close watcher fires, calls `store.close()`. Slot becomes `{isOpen=false, content=config_body}` — **inconsistent**.
3. Subscriber re-render: config DrawerPanel's existing external-close watcher fires (`isOpen=true && wasOpen=true && !drawerOpen=true`) and calls onClose, which makes ChannelsPage / ProvidersPage unmount the config drawer.

User sees: pick item → window vanishes immediately.

## Fix

Each DrawerPanel only fires `close()` when it still owns the slot. A new `lastPushedBodyRef` tracks the body the panel last pushed; the parent-close watcher reads `useDrawerStore.getState().content?.body` synchronously and only calls `close()` when the slot's body still matches ours. A late-mounting drawer that pushed in the same commit naturally "wins" the slot without the previous owner clobbering it.

Two-line change in the watcher; one new `useRef` for ownership tracking.

## Test plan

`crates/librefang-api/dashboard/src/components/ui/DrawerPanel.test.tsx`:

- Existing 4 tests still pass (push-on-open; parent-flip-close from #4687; no double onClose on parent-initiated close; external-close bubble-up).
- New regression test `does not collateral-close the freshly-mounted drawer when a sibling drawer's parent flips isOpen=false in the same commit` simulates the picker → config flow with two `<DrawerPanel>` instances and asserts:
  - the slot ends up holding the config drawer's body, not closed
  - neither drawer's onClose fires (no spurious unmount)

Verified locally:
- `npx vitest run src/components/ui/DrawerPanel.test.tsx` → **5/5 pass**
- `npx tsc --noEmit` clean

## Why not roll back #4691 instead

The submit-button-spinning-forever symptom #4691 fixed (#4687) is also a real bug that needs to stay fixed. Ownership check threads the needle: parent-driven close still works for the single-drawer case, doesn't fire when a sibling has taken over.

## Severity

P0 — pure-frontend regression, ships in v2026.5.6-beta.9, blocks every new user from configuring providers or channels via the dashboard. Recommend cherry-picking to the next patch release.