### PR TITLE
docs(dashboard/ui): document DrawerPanel ownership check in file-level sync model (#4727 followup)

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
@@ -27,7 +27,12 @@ export interface DrawerPanelProps {
 //   3. Parent-driven close: when the parent flips `isOpen` from true →
 //      false (mutation `onSuccess`, Cancel button, etc.) we tear the
 //      store back down ourselves; otherwise the global slot stays
-//      mounted and the drawer never disappears (#4687).
+//      mounted and the drawer never disappears (#4687). Guarded by
+//      an ownership check (#4714) — only call `close()` while the
+//      slot's body is still the one we last pushed, so a sibling
+//      DrawerPanel that claimed the slot in the same commit (e.g.
+//      the picker → config flow) is not yanked closed underneath
+//      the user.
 //   4. Unmount while open → close the store, so a body referencing this
 //      page's local state never lingers in the global slot.
 export function DrawerPanel({


### PR DESCRIPTION
## Summary

Doc-only follow-up to #4727. PR #4727 added the ownership check to `DrawerPanel`'s parent-driven close watcher — fixing #4714 where the picker → config flow was yanking the freshly-mounted config drawer closed. The watcher itself got a 22-line inline comment explaining the mechanism, but the file-level \"Sync model\" comment block at the top of `DrawerPanel.tsx` still summarized item 3 as plain \"tear the store back down ourselves\", which under-describes the actual semantics.

This PR extends item 3 of the file header to mention the ownership check and what it protects against, so a reader skimming the file gets the full picture without having to scroll to the inline comment.

## Changes

- `crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx`: 6 added / 1 removed in the file-level `Sync model` comment block — purely informational.

## Test plan

- `npx tsc --noEmit` clean (doc-only change).

## Out of scope

Other follow-up nits I flagged on PR #4728 (PageHeader balanced-paren regex, PushDrawer focus-trap viewport guard, `\\uFFFE` defensive check, SSRF blocklist short-decimal IPs) all touch code that #4728 introduces and can't be done from main — those will land as a follow-up after #4728 merges.