### PR TITLE
 fix(dashboard): a11y improvements and UI bugfixes

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/Badge.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Badge.tsx
@@ -44,7 +44,7 @@ export function Badge({
       `}
       {...props}
     >
-      {dot ? <span className={`w-1.5 h-1.5 rounded-full ${dotColors[variant]}`} /> : null}
+      {dot ? <span aria-hidden="true" className={`w-1.5 h-1.5 rounded-full ${dotColors[variant]}`} /> : null}
       {children}
     </span>
   );

--- a/crates/librefang-api/dashboard/src/components/ui/Button.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Button.tsx
@@ -69,12 +69,16 @@ export const Button = memo(forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         {isLoading ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
+          <Loader2
+            className={`animate-spin ${
+              size === "sm" ? "h-3 w-3" : size === "lg" ? "h-5 w-5" : "h-4 w-4"
+            }`}
+          />
         ) : (
           leftIcon
         )}
         {children}
-        {rightIcon}
+        {!isLoading && rightIcon}
       </button>
     );
   }

--- a/crates/librefang-api/dashboard/src/components/ui/Button.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Button.tsx
@@ -35,6 +35,12 @@ const sizeStyles: Record<ButtonSize, string> = {
   lg: "px-4 h-9 text-sm",
 };
 
+const spinnerSizeStyles: Record<ButtonSize, string> = {
+  sm: "h-3 w-3",
+  md: "h-4 w-4",
+  lg: "h-5 w-5",
+};
+
 export const Button = memo(forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
@@ -69,11 +75,7 @@ export const Button = memo(forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         {isLoading ? (
-          <Loader2
-            className={`animate-spin ${
-              size === "sm" ? "h-3 w-3" : size === "lg" ? "h-5 w-5" : "h-4 w-4"
-            }`}
-          />
+          <Loader2 className={`animate-spin ${spinnerSizeStyles[size]}`} />
         ) : (
           leftIcon
         )}

--- a/crates/librefang-api/dashboard/src/components/ui/ErrorState.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ErrorState.tsx
@@ -10,7 +10,7 @@ export function ErrorState({ message, onRetry }: ErrorStateProps) {
   const { t } = useTranslation();
 
   return (
-    <div className="flex flex-col items-center justify-center py-16 border border-dashed border-error/20 rounded-3xl bg-error/5">
+    <div role="alert" className="flex flex-col items-center justify-center py-16 border border-dashed border-error/20 rounded-3xl bg-error/5">
       <div className="h-12 w-12 rounded-2xl bg-error/10 flex items-center justify-center text-error mb-4">
         <AlertCircle className="h-6 w-6" />
       </div>
@@ -21,7 +21,7 @@ export function ErrorState({ message, onRetry }: ErrorStateProps) {
           onClick={onRetry}
           className="mt-4 px-5 py-2 rounded-xl border border-error/20 bg-error/5 text-error text-xs font-black uppercase tracking-widest hover:bg-error/10 transition-colors"
         >
-          {t("common.refresh")}
+          {t("common.refresh", { defaultValue: "Refresh" })}
         </button>
       )}
     </div>

--- a/crates/librefang-api/dashboard/src/components/ui/Sparkline.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Sparkline.tsx
@@ -21,8 +21,8 @@ export function Sparkline({
 }: SparklineProps) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
   if (!data || data.length === 0) return null;
-  const max = Math.max(...data);
-  const min = Math.min(...data);
+  const max = data.reduce((a, b) => Math.max(a, b), -Infinity);
+  const min = data.reduce((a, b) => Math.min(a, b), Infinity);
   const range = max - min || 1;
   const stepX = width / (data.length - 1);
   const pts = data.map((v, i) => {

--- a/crates/librefang-api/dashboard/src/components/ui/Toast.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Toast.tsx
@@ -17,6 +17,8 @@ const TOAST_ICONS: Record<"success" | "error" | "info", React.ReactNode> = {
   info: <AlertCircle className="h-4 w-4 shrink-0" />,
 };
 
+const MAX_TOASTS = 5;
+
 export function ToastContainer() {
   const toasts = useUIStore((s) => s.toasts);
   const removeToast = useUIStore((s) => s.removeToast);
@@ -28,7 +30,7 @@ export function ToastContainer() {
       aria-atomic="false"
     >
       <AnimatePresence>
-        {toasts.map((toast) => (
+        {toasts.slice(-MAX_TOASTS).map((toast) => (
           <ToastItem key={toast.id} id={toast.id} message={toast.message} type={toast.type} removeToast={removeToast} />
         ))}
       </AnimatePresence>
@@ -63,7 +65,7 @@ const ToastItem = memo(function ToastItem({ id, message, type, removeToast }: { 
       <button
         onClick={onDismiss}
         className="ml-2 opacity-60 hover:opacity-100 transition-opacity"
-        aria-label={t("common.close")}
+        aria-label={t("common.close", { defaultValue: "Close" })}
       >
         <X className="h-3.5 w-3.5" />
       </button>

--- a/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ToolCallsPanel.tsx
@@ -12,6 +12,16 @@ interface ToolCallsPanelProps {
   tools: ReadonlyArray<PanelTool>;
 }
 
+function stableToolKey(tool: PanelTool, i: number): string {
+  if (tool._call_id) return tool._call_id;
+  const raw = `${tool.name ?? ""}:${JSON.stringify(tool.input ?? "")}`;
+  let h = 0;
+  for (let j = 0; j < raw.length; j++) {
+    h = ((h << 5) - h + raw.charCodeAt(j)) | 0;
+  }
+  return `${tool.name ?? "tool"}-${(h >>> 0).toString(36)}-${i}`;
+}
+
 export const ToolCallsPanel = React.memo(function ToolCallsPanel({ tools }: ToolCallsPanelProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -71,9 +81,9 @@ export const ToolCallsPanel = React.memo(function ToolCallsPanel({ tools }: Tool
         size="2xl"
       >
         <div className="px-4 py-3">
-          {tools.map((tool, i) => (
+          {tools.map((tool, idx) => (
             <ToolCallCard
-              key={tool._call_id ?? `${tool.name}-${i}`}
+              key={stableToolKey(tool, idx)}
               tool={tool}
             />
           ))}

--- a/crates/librefang-api/dashboard/src/lib/store.ts
+++ b/crates/librefang-api/dashboard/src/lib/store.ts
@@ -89,9 +89,13 @@ export const useUIStore = create<UIState>()(
       setNavLayout: (layout) => set({ navLayout: layout }),
       toggleNavGroup: (key) => set((state) => ({ collapsedNavGroups: { ...state.collapsedNavGroups, [key]: !state.collapsedNavGroups[key] } })),
       addToast: (message, type = "info") =>
-        set((state) => ({
-          toasts: [...state.toasts, { id: createClientId(), message, type }],
-        })),
+        set((state) => {
+          const MAX_TOASTS = 50;
+          const next = [...state.toasts, { id: createClientId(), message, type }];
+          return {
+            toasts: next.length > MAX_TOASTS ? next.slice(-MAX_TOASTS) : next,
+          };
+        }),
       removeToast: (id) =>
         set((state) => ({
           toasts: state.toasts.filter((t) => t.id !== id),


### PR DESCRIPTION
## Type
- [x] Refactor / Performance

## Summary

Accessibility hardening and bug fixes across shared dashboard UI components. No business logic changes.

## Changes

- `Badge` — `aria-hidden` on decorative dot
- `ErrorState` — `role="alert"` on error container; i18n `defaultValue` fallback
- `Toast` — render cap at 5 visible; store cap at 50; `defaultValue` fallback on dismiss label
- `Button` — spinner scales with `size` prop; hide `rightIcon` while loading
- `Sparkline` — replace `Math.max(...data)` with `reduce` to avoid stack overflow on large arrays
- `ToolCallsPanel` — stable React keys via content hash instead of index-based keys
- `store` — bound toast array growth in `addToast`

## Attribution

- [x] This PR preserves author attribution for any adapted prior work

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

## Security
- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries