### PR TITLE
fix(dashboard): state-correctness and a11y bugs in UI primitives

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/Avatar.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Avatar.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, memo, useState } from "react";
+import { type HTMLAttributes, memo, useEffect, useState } from "react";
 
 type AvatarSize = "sm" | "md" | "lg" | "xl";
 
@@ -16,12 +16,13 @@ const sizeStyles: Record<AvatarSize, string> = {
 };
 
 function getInitials(name: string): string {
-  return name
+  const initials = name
     .split(" ")
     .map((n) => n[0])
     .join("")
     .toUpperCase()
     .slice(0, 2);
+  return initials || "?";
 }
 
 export const Avatar = memo(function Avatar({
@@ -32,6 +33,7 @@ export const Avatar = memo(function Avatar({
   ...props
 }: AvatarProps) {
   const [imgError, setImgError] = useState(false);
+  useEffect(() => setImgError(false), [src]);
 
   return (
     <div
@@ -49,7 +51,7 @@ export const Avatar = memo(function Avatar({
       {src && !imgError ? (
         <img
           src={src}
-          alt={fallback}
+          alt=""
           loading="lazy"
           onError={() => setImgError(true)}
           className="h-full w-full object-cover"

--- a/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useId, useRef } from "react";
 import { AlertTriangle, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { AnimatePresence, motion } from "motion/react";
@@ -37,6 +37,8 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
   const isConfirming = useRef(false);
   const onCloseRef = useRef(onClose);
   const onConfirmRef = useRef(onConfirm);
+  const titleId = useId();
+  const messageId = useId();
   onCloseRef.current = onClose;
   onConfirmRef.current = onConfirm;
   useFocusTrap(isOpen, dialogRef, true);
@@ -45,6 +47,15 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
     if (isOpen) {
       isConfirming.current = false;
     }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
   }, [isOpen]);
 
   useEffect(() => {
@@ -64,6 +75,7 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
       // Enter confirms — safer on non-destructive dialogs; for destructive
       // we still require a click so users can't accidentally nuke data.
       if (e.key === "Enter" && tone !== "destructive" && !isEditableTarget(e.target)) {
+        e.preventDefault();
         onConfirmRef.current();
       }
     };
@@ -91,8 +103,8 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-labelledby="confirm-dialog-title"
-        aria-describedby="confirm-dialog-message"
+        aria-labelledby={titleId}
+        aria-describedby={messageId}
         className="relative w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl border border-border-subtle bg-surface shadow-2xl"
         onClick={(e) => e.stopPropagation()}
         variants={fadeInScale}
@@ -116,8 +128,8 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
             <AlertTriangle className="h-5 w-5" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 id="confirm-dialog-title" className="text-sm font-black tracking-tight">{title}</h3>
-            <p id="confirm-dialog-message" className="mt-1.5 text-xs text-text-dim leading-relaxed">{message}</p>
+            <h3 id={titleId} className="text-sm font-black tracking-tight">{title}</h3>
+            <p id={messageId} className="mt-1.5 text-xs text-text-dim leading-relaxed">{message}</p>
           </div>
         </div>
         <div className="flex gap-2 border-t border-border-subtle/50 px-5 py-3">
@@ -125,7 +137,7 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
             onClick={onClose}
             className="flex-1 rounded-xl border border-border-subtle bg-surface py-2.5 text-xs font-bold text-text-dim hover:bg-surface-hover transition-colors"
           >
-            {cancelLabel ?? t("common.cancel")}
+            {cancelLabel ?? t("common.cancel", { defaultValue: "Cancel" })}
           </button>
           <button
             onClick={() => {

--- a/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
@@ -75,8 +75,11 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
       // Enter confirms — safer on non-destructive dialogs; for destructive
       // we still require a click so users can't accidentally nuke data.
       if (e.key === "Enter" && tone !== "destructive" && !isEditableTarget(e.target)) {
+        if (isConfirming.current) return;
         e.preventDefault();
+        isConfirming.current = true;
         onConfirmRef.current();
+        onCloseRef.current();
       }
     };
     window.addEventListener("keydown", handleKey);

--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
@@ -47,6 +47,11 @@ export function DrawerPanel({
     onCloseRef.current = onClose;
   }, [onClose]);
 
+  const isOpenRef = useRef(isOpen);
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
   // Track the body identity we last pushed into the slot. The
   // parent-driven close watcher uses this to skip `close()` when another
   // DrawerPanel has taken over the slot in the same commit — see
@@ -127,7 +132,7 @@ export function DrawerPanel({
   // Cleanup on unmount.
   useEffect(
     () => () => {
-      if (isOpen) close();
+      if (isOpenRef.current) close();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],

--- a/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { X } from "lucide-react";
 import { useDrawerStore, type DrawerSize } from "../../lib/drawerStore";
+import { useFocusTrap } from "../../lib/useFocusTrap";
 
 const DESKTOP_WIDTH: Record<DrawerSize, string> = {
   sm: "lg:w-[360px]",
@@ -25,6 +26,18 @@ const MIN_WIDTH: Record<DrawerSize, string> = {
   "5xl": "lg:min-w-[1280px]",
 };
 
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia("(max-width: 1023px)");
+    setIsMobile(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+  return isMobile;
+}
+
 // Push-style global drawer host. Renders as a flex sibling of the main
 // column in App.tsx — its width animates from 0 → target so the main
 // content shrinks to make room (mirrors the left sidebar's collapse).
@@ -39,6 +52,13 @@ export function PushDrawer() {
   const content = useDrawerStore((s) => s.content);
   const close = useDrawerStore((s) => s.close);
 
+  const desktopRef = useRef<HTMLDivElement>(null);
+  const mobileRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(isOpen, desktopRef, false, false);
+  const isMobile = useIsMobile();
+  useFocusTrap(isOpen && isMobile, mobileRef, false);
+
   // Single dismissal path — DrawerPanel observes the store flip and calls
   // its own onClose to keep parent state in sync. We don't fire content
   // .onClose here directly; the store-flip-watcher in DrawerPanel does
@@ -49,7 +69,12 @@ export function PushDrawer() {
   useEffect(() => {
     if (!isOpen) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") triggerClose();
+      if (e.defaultPrevented) return;
+      if (e.key !== "Escape") return;
+      const target = e.target as HTMLElement;
+      if (target.closest("[role='dialog']") && !target.closest("[role='dialog'][data-drawer-root]")) return;
+      e.stopImmediatePropagation();
+      triggerClose();
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
@@ -80,6 +105,7 @@ export function PushDrawer() {
           wrapper has a min-width so content doesn't reflow as the outer
           width animates between 0 and target. */}
       <aside
+        ref={desktopRef}
         className={`hidden lg:flex shrink-0 ${desktopWidth} flex-col border-l border-border-subtle bg-surface overflow-hidden transition-[width] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]`}
         aria-hidden={!isOpen}
       >
@@ -98,8 +124,12 @@ export function PushDrawer() {
         <div
           className="fixed inset-0 z-50 lg:hidden bg-black/40 backdrop-blur-sm flex items-stretch justify-end"
           onClick={triggerClose}
+          role="dialog"
+          aria-modal="true"
+          data-drawer-root
         >
           <div
+            ref={mobileRef}
             className="w-full bg-surface flex flex-col"
             onClick={(e) => e.stopPropagation()}
           >

--- a/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
@@ -71,7 +71,8 @@ export function PushDrawer() {
     const handleKey = (e: KeyboardEvent) => {
       if (e.defaultPrevented) return;
       if (e.key !== "Escape") return;
-      const target = e.target as HTMLElement;
+      const target = e.target;
+      if (!(target instanceof HTMLElement)) return;
       if (target.closest("[role='dialog']") && !target.closest("[role='dialog'][data-drawer-root]")) return;
       e.stopImmediatePropagation();
       triggerClose();

--- a/crates/librefang-api/dashboard/src/components/ui/ScheduleModal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ScheduleModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./Button";
 import { DrawerPanel } from "./DrawerPanel";
@@ -58,7 +58,7 @@ function parseCronType(cron: string): { type: ScheduleType; min?: number; hour?:
   if (m.startsWith("*/") && h === "*") return { type: "interval_min", interval: parseInt(m.slice(2)) || 5 };
   if (m === "0" && h.startsWith("*/")) return { type: "interval_hour", interval: parseInt(h.slice(2)) || 1 };
   if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && RE_DIGITS.test(dom) && dow === "*") return { type: "monthly", hour: +h, min: +m, day: +dom };
-  if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && dom === "*" && RE_SINGLE_DIGIT.test(dow)) return { type: "weekly", hour: +h, min: +m, weekday: +dow };
+  if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && dom === "*" && RE_SINGLE_DIGIT.test(dow)) return { type: "weekly", hour: +h, min: +m, weekday: +dow === 0 ? 7 : +dow };
   if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && dom === "*" && dow === "1-5") return { type: "weekday", hour: +h, min: +m };
   if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && dom === "*" && dow === "*") return { type: "daily", hour: +h, min: +m };
   return { type: "custom" };
@@ -89,7 +89,7 @@ function buildCronFrom(
     case "interval_hour": return `0 */${intervalHour} * * *`;
     case "daily": return `${minute} ${hour} * * *`;
     case "weekday": return `${minute} ${hour} * * 1-5`;
-    case "weekly": return `${minute} ${hour} * * ${weekday}`;
+    case "weekly": return `${minute} ${hour} * * ${weekday === 7 ? 0 : weekday}`;
     case "monthly": return `${minute} ${hour} ${monthDay} * *`;
     case "custom": return customCron;
   }
@@ -116,6 +116,26 @@ export function ScheduleModal({ isOpen, title, subtitle, initialCron, initialTz,
   const [monthDay, setMonthDay] = useState(parsed.day ?? 1);
   const [customCron, setCustomCron] = useState(initialCron || "0 9 * * *");
 
+  const prevInitialCron = useRef(initialCron);
+  useEffect(() => {
+    if (prevInitialCron.current !== initialCron) {
+      prevInitialCron.current = initialCron;
+      const p = parseCronType(initialCron || "0 9 * * *");
+      setScheduleType(p.type);
+      setIntervalMin(p.type === "interval_min" ? (p.interval ?? 5) : 5);
+      setIntervalHour(p.type === "interval_hour" ? (p.interval ?? 1) : 1);
+      setHour(p.hour ?? 9);
+      setMinute(p.min ?? 0);
+      setWeekday(p.weekday ?? 1);
+      setMonthDay(p.day ?? 1);
+      setCustomCron(initialCron || "0 9 * * *");
+    }
+  }, [initialCron]);
+
+  useEffect(() => {
+    setTimezone(initialTz || detectBrowserTimezone());
+  }, [initialTz]);
+
   const validateCron = (cron: string): boolean => {
     const parts = cron.trim().split(/\s+/);
     if (parts.length !== 5) return false;
@@ -136,7 +156,7 @@ export function ScheduleModal({ isOpen, title, subtitle, initialCron, initialTz,
     if (m.startsWith("*/") && h === "*") return t("scheduler.cron_every_n_min", { n: m.slice(2) });
     if (m === "0" && h.startsWith("*/")) return t("scheduler.cron_every_n_hour", { n: h.slice(2) });
     if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && RE_DIGITS.test(dom) && dow === "*") return t("scheduler.cron_monthly", { dom, time });
-    if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && dom === "*" && RE_SINGLE_DIGIT.test(dow)) return t("scheduler.cron_weekly", { day: weekdays[+dow], time });
+    if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && dom === "*" && RE_SINGLE_DIGIT.test(dow)) return t("scheduler.cron_weekly", { day: weekdays[+dow === 7 ? 0 : +dow], time });
     if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && dom === "*" && dow === "1-5") return t("scheduler.cron_weekdays", { time });
     if (RE_DIGITS.test(m) && RE_DIGITS.test(h) && dom === "*" && dow === "*") return t("scheduler.cron_daily", { time });
     return cron;


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

Fixes state staleness, double-fire, a11y, and edge-case bugs uncovered in the dashboard4 review across five shared UI components.

## Changes

- **Avatar**: reset `imgError` on `src` change via `useEffect`; return `"?"` for empty initials; decorative `alt=""`
- **ConfirmDialog**: `useId()` for unique ARIA IDs (multi-instance safety); lock body scroll while open; prevent double Enter confirm; i18n fallback `defaultValue`
- **DrawerPanel**: use `isOpenRef` in unmount cleanup to avoid stale closure read
- **PushDrawer**: `useIsMobile` hook; `useFocusTrap` on both viewports; Escape key scoped to drawer (skip nested `role="dialog"`); mobile overlay gets `aria-modal="true"` and `data-drawer-root`
- **ScheduleModal**: ISO↔cron weekday conversion (`0`↔`7`); reset all form state when `initialCron` prop changes; sync `initialTz`

## Attribution

- [x] This PR preserves author attribution for any adapted prior work

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries