### PR TITLE
fix(dashboard): a11y polish and UX fixes across UI components

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/CommandPalette.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/CommandPalette.tsx
@@ -172,7 +172,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
           <input
             type="text"
             value={search}
-            onChange={(e) => { setSearch(e.target.value); setSelectedIndex(0); }}
+            onChange={(e) => setSearch(e.target.value)}
             placeholder={t("command_palette.search_placeholder")}
             className="flex-1 bg-transparent text-sm font-medium outline-none placeholder:text-text-dim"
             autoFocus

--- a/crates/librefang-api/dashboard/src/components/ui/CommandPalette.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/CommandPalette.tsx
@@ -16,8 +16,8 @@ interface CommandItem {
   external?: boolean;
 }
 
-// Public librefang.ai registry catalog. Keys match the registry categories
-// in librefang-registry, labels are i18n keys already in the dashboard.
+const REGISTRY_BASE_URL = import.meta.env.VITE_REGISTRY_URL ?? "https://librefang.ai";
+
 const REGISTRY_ITEMS: { slug: string; labelKey: string; icon: LucideIcon }[] = [
   { slug: "skills",    labelKey: "nav.skills",    icon: Shield },
   { slug: "hands",     labelKey: "nav.hands",     icon: Hand },
@@ -82,7 +82,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
       categoryKey: "command_palette.registry",
       icon,
       external: true,
-      action: () => window.open(`https://librefang.ai/${slug}`, "_blank", "noopener,noreferrer"),
+      action: () => window.open(`${REGISTRY_BASE_URL}/${slug}`, "_blank", "noopener,noreferrer"),
     })),
   ], [navigate]);
 
@@ -103,6 +103,10 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
       setSelectedIndex(0);
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    setSelectedIndex(i => (filteredCommands.length === 0 ? 0 : Math.min(i, filteredCommands.length - 1)));
+  }, [filteredCommands]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -127,12 +131,18 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
-  const groupedCommands = filteredCommands.reduce((acc, cmd) => {
+  const groupedCommands = useMemo(() => filteredCommands.reduce((acc, cmd) => {
     const key = t(cmd.categoryKey);
     if (!acc[key]) acc[key] = [];
     acc[key].push(cmd);
     return acc;
-  }, {} as Record<string, CommandItem[]>);
+  }, {} as Record<string, CommandItem[]>), [filteredCommands, t]);
+
+  const indexMap = useMemo(() => {
+    const m = new Map<string, number>();
+    for (let i = 0; i < filteredCommands.length; i++) m.set(filteredCommands[i].id, i);
+    return m;
+  }, [filteredCommands]);
 
   return (
     <AnimatePresence>
@@ -183,7 +193,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
               <div key={category}>
                 <p className="px-3 py-2 text-[11px] font-bold uppercase tracking-widest text-text-dim">{category}</p>
                 {cmds.map((cmd) => {
-                  const globalIndex = filteredCommands.indexOf(cmd);
+                  const globalIndex = indexMap.get(cmd.id) ?? 0;
                   return (
                     <button
                       key={cmd.id}

--- a/crates/librefang-api/dashboard/src/components/ui/MarkdownContent.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/MarkdownContent.tsx
@@ -22,36 +22,50 @@ const urlTransform = (url: string): string => {
 // props instead so we don't have to add a top-level import.
 type PluggableList = NonNullable<ComponentProps<typeof Markdown>["remarkPlugins"]>;
 
-// `Components` provides contextual typing for each entry — props (incl.
-// `children`, which is optional in react-markdown's HTML element types)
-// are inferred per HTML tag. Don't add explicit param annotations here:
-// they re-narrow `children` to required and break the assignability.
-const defaultComponents: Components = {
-  p: ({ children }) => <p className="mb-1.5 last:mb-0">{children}</p>,
-  h1: ({ children }) => <h1 className="text-sm font-bold mb-1.5">{children}</h1>,
-  h2: ({ children }) => <h2 className="text-xs font-bold mb-1">{children}</h2>,
-  h3: ({ children }) => <h3 className="text-xs font-bold mb-1">{children}</h3>,
-  ul: ({ children }) => <ul className="list-disc pl-4 mb-1.5 space-y-0.5">{children}</ul>,
-  ol: ({ children }) => <ol className="list-decimal pl-4 mb-1.5 space-y-0.5">{children}</ol>,
-  li: ({ children }) => <li className="text-xs">{children}</li>,
-  code: ({ node, children, ...props }) => {
-    const isBlock = node?.position?.start?.line !== node?.position?.end?.line || String(children).includes("\n");
-    return isBlock
-      ? <pre className="p-2 rounded-lg bg-main font-mono text-[11px] overflow-x-auto mb-1.5"><code>{children}</code></pre>
-      : <code className="px-1 py-0.5 rounded bg-main font-mono text-[11px]" {...props}>{children}</code>;
-  },
-  pre: ({ children }) => <>{children}</>,
-  table: ({ children }) => (
-    <div className="overflow-x-auto mb-1.5">
-      <table className="w-full text-xs border-collapse">{children}</table>
-    </div>
-  ),
-  th: ({ children }) => <th className="border border-border-subtle px-2 py-1 bg-main font-bold text-left">{children}</th>,
-  td: ({ children }) => <td className="border border-border-subtle px-2 py-1">{children}</td>,
-  blockquote: ({ children }) => <blockquote className="border-l-2 border-brand pl-3 italic text-text-dim mb-1.5">{children}</blockquote>,
-  strong: ({ children }) => <strong className="font-bold">{children}</strong>,
-  a: ({ href, children }) => <a href={href} className="text-brand underline" target="_blank" rel="noopener noreferrer">{children}</a>,
-};
+function buildComponents(overrides?: Components): Components {
+  const { pre: customPre, ...restOverrides } = overrides ?? {};
+  const passThroughPre: Components["pre"] = ({ children }) => <>{children}</>;
+
+  return {
+    p: ({ children }) => <p className="mb-1.5 last:mb-0">{children}</p>,
+    h1: ({ children }) => <h1 className="text-sm font-bold mb-1.5">{children}</h1>,
+    h2: ({ children }) => <h2 className="text-xs font-bold mb-1">{children}</h2>,
+    h3: ({ children }) => <h3 className="text-xs font-bold mb-1">{children}</h3>,
+    ul: ({ children }) => <ul className="list-disc pl-4 mb-1.5 space-y-0.5">{children}</ul>,
+    ol: ({ children }) => <ol className="list-decimal pl-4 mb-1.5 space-y-0.5">{children}</ol>,
+    li: ({ children }) => <li className="text-xs">{children}</li>,
+    code: ({ node, children, ...props }) => {
+      const isBlock =
+        node?.position
+          ? node.position.start.line !== node.position.end.line
+          : typeof children === "string" && children.includes("\n");
+      if (isBlock) {
+        if (customPre) {
+          const Pre = customPre;
+          return <Pre><code {...props}>{children}</code></Pre>;
+        }
+        return (
+          <pre className="p-2 rounded-lg bg-main font-mono text-[11px] overflow-x-auto mb-1.5">
+            <code>{children}</code>
+          </pre>
+        );
+      }
+      return <code className="px-1 py-0.5 rounded bg-main font-mono text-[11px]" {...props}>{children}</code>;
+    },
+    pre: passThroughPre,
+    table: ({ children }) => (
+      <div className="overflow-x-auto mb-1.5">
+        <table className="w-full text-xs border-collapse">{children}</table>
+      </div>
+    ),
+    th: ({ children }) => <th className="border border-border-subtle px-2 py-1 bg-main font-bold text-left">{children}</th>,
+    td: ({ children }) => <td className="border border-border-subtle px-2 py-1">{children}</td>,
+    blockquote: ({ children }) => <blockquote className="border-l-2 border-brand pl-3 italic text-text-dim mb-1.5">{children}</blockquote>,
+    strong: ({ children }) => <strong className="font-bold">{children}</strong>,
+    a: ({ href, children }) => <a href={href} className="text-brand underline" target="_blank" rel="noopener noreferrer">{children}</a>,
+    ...restOverrides,
+  };
+}
 
 // Stable default plugin array — never changes between renders
 const defaultPlugins: PluggableList = [remarkGfm];
@@ -72,7 +86,7 @@ export const MarkdownContent = memo(function MarkdownContent({
   components,
 }: MarkdownContentProps) {
   const merged = useMemo(
-    () => components ? { ...defaultComponents, ...components } : defaultComponents,
+    () => buildComponents(components),
     [components],
   );
   const plugins = useMemo(

--- a/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useId, memo, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, useId, memo, type ReactNode } from "react";
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { AnimatePresence, motion } from "motion/react";
@@ -92,9 +92,18 @@ export const Modal = memo(function Modal({
   // pointer-events-none) without first hitting Esc.
   useFocusTrap(isOpen, dialogRef, true, !isDrawer);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     onCloseRef.current = onClose;
   }, [onClose]);
+
+  useEffect(() => {
+    if (!isOpen || isDrawer) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen, isDrawer]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -165,9 +174,10 @@ export const Modal = memo(function Modal({
         >
           <motion.div
             ref={dialogRef}
-            role="dialog"
-            aria-modal={isDrawer ? "false" : "true"}
-            aria-labelledby={titleId}
+            {...(isDrawer
+              ? { role: "complementary" as const }
+              : { role: "dialog" as const, "aria-modal": true })}
+            {...(title ? { "aria-labelledby": titleId } : {})}
             className={dialogClass}
             onClick={(e) => e.stopPropagation()}
             {...dialogMotion}
@@ -176,7 +186,7 @@ export const Modal = memo(function Modal({
               <div className="flex items-center justify-between px-5 py-3 border-b border-border-subtle shrink-0">
                 {title ? (
                   <h3 id={titleId} className="text-sm font-bold tracking-tight">{title}</h3>
-                ) : <span />}
+                ) : <span aria-hidden="true" />}
                 {!hideCloseButton && (
                   <button
                     onClick={onClose}

--- a/crates/librefang-api/dashboard/src/components/ui/ResponsiveTable.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ResponsiveTable.tsx
@@ -34,6 +34,20 @@ interface Props<T> {
   className?: string;
   /** Message shown when `rows` is empty. */
   empty?: ReactNode;
+  /** Accessible table caption rendered inside `<table>`. */
+  caption?: string;
+}
+
+function safeCellValue(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "[complex value]";
+    }
+  }
+  return String(value);
 }
 
 export function ResponsiveTable<T>({
@@ -42,6 +56,7 @@ export function ResponsiveTable<T>({
   rowKey,
   className = "",
   empty,
+  caption,
 }: Props<T>) {
   if (rows.length === 0 && empty) {
     return <div className={className}>{empty}</div>;
@@ -54,11 +69,13 @@ export function ResponsiveTable<T>({
       {/* ── Desktop table (md+) ───────────────────────────── */}
       <div className="hidden md:block overflow-x-auto rounded-xl border border-border-subtle">
         <table className="w-full text-sm">
+          {caption && <caption className="sr-only">{caption}</caption>}
           <thead>
             <tr className="border-b border-border-subtle bg-surface-hover/50">
               {columns.map((col) => (
                 <th
                   key={col.key}
+                  scope="col"
                   className={
                     col.thClass ??
                     "px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-text-dim"
@@ -80,7 +97,7 @@ export function ResponsiveTable<T>({
                     key={col.key}
                     className={col.tdClass ?? "px-4 py-3 text-sm"}
                   >
-                    {col.render ? col.render(row) : String((row as Record<string, unknown>)[col.key] ?? "—")}
+                    {col.render ? col.render(row) : safeCellValue((row as Record<string, unknown>)[col.key])}
                   </td>
                 ))}
               </tr>
@@ -90,10 +107,11 @@ export function ResponsiveTable<T>({
       </div>
 
       {/* ── Mobile cards (< md) ───────────────────────────── */}
-      <div className="md:hidden flex flex-col gap-2">
+      <div className="md:hidden flex flex-col gap-2" role="list">
         {rows.map((row) => (
           <div
             key={rowKey(row)}
+            role="listitem"
             className="rounded-xl border border-border-subtle bg-surface p-3 text-sm space-y-1.5"
           >
             {visibleCols.map((col) => (
@@ -102,7 +120,7 @@ export function ResponsiveTable<T>({
                   {col.label}
                 </span>
                 <span className="flex-1 min-w-0 text-text break-words">
-                  {col.render ? col.render(row) : String((row as Record<string, unknown>)[col.key] ?? "—")}
+                  {col.render ? col.render(row) : safeCellValue((row as Record<string, unknown>)[col.key])}
                 </span>
               </div>
             ))}

--- a/crates/librefang-api/dashboard/src/components/ui/SkillOutputPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/SkillOutputPanel.tsx
@@ -68,7 +68,7 @@ export function SkillOutputPanel() {
                   </div>
                   <button
                     onClick={() => dismissSkillOutput(output.id)}
-                    className="p-1 rounded text-text-dim/20 hover:text-text-dim opacity-0 group-hover:opacity-100 transition-[colors,opacity] shrink-0"
+                    className="p-1 rounded text-text-dim/20 hover:text-text-dim opacity-100 sm:pointer-fine:opacity-0 sm:pointer-fine:group-hover:opacity-100 transition-[colors,opacity] shrink-0"
                   >
                     <X className="w-3 h-3" />
                   </button>


### PR DESCRIPTION
## Type

- [x] Refactor / Performance

## Summary

Accessibility and UX improvements across five dashboard UI components. Covers ARIA roles, keyboard navigation, scroll lock, mobile touch targets, and render performance.

## Changes

- **CommandPalette**: extract `REGISTRY_BASE_URL` from env, memoize `groupedCommands` and `indexMap` (O(1) lookup replaces `indexOf`), clamp `selectedIndex` via effect instead of reset-on-type
- **MarkdownContent**: `buildComponents(overrides?)` factory enables custom `pre` renderer for code blocks, safe block detection fallback when `node.position` absent
- **Modal**: `useLayoutEffect` for `onClose` ref sync, body scroll lock when modal open, correct `role` per variant (`dialog` vs `complementary`), conditional `aria-labelledby`
- **ResponsiveTable**: `<caption>` via `caption` prop, `scope="col"` on `<th>`, `role="list"`/`listitem` on mobile cards, `safeCellValue()` guards `[object Object]`
- **SkillOutputPanel**: dismiss button always visible on touch devices, hover-reveal only on pointer-fine screens

## Attribution

- [x] This PR preserves author attribution for any adapted prior work

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries