### PR TITLE
fix(dashboard/ui): scope PushDrawer focus traps to their actual viewport (#4734 followup)

### DIFF
--- a/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx
@@ -55,8 +55,13 @@ export function PushDrawer() {
   const desktopRef = useRef<HTMLDivElement>(null);
   const mobileRef = useRef<HTMLDivElement>(null);
 
-  useFocusTrap(isOpen, desktopRef, false, false);
+  // Scope each focus trap to the viewport actually showing it. Without the
+  // `!isMobile` / `isMobile` split, both traps would activate on every
+  // viewport — wasted work, and also a subtle a11y trap if either
+  // `<aside>` (desktop) or the mobile overlay <div> were visible
+  // simultaneously while the other is `display:none`.
   const isMobile = useIsMobile();
+  useFocusTrap(isOpen && !isMobile, desktopRef, false, false);
   useFocusTrap(isOpen && isMobile, mobileRef, false);
 
   // Single dismissal path — DrawerPanel observes the store flip and calls


### PR DESCRIPTION
## Summary

#4734 review N2 follow-up. PR #4734 added \`useFocusTrap\` to both the desktop \`<aside>\` and the mobile overlay sheet, but only the mobile trap is gated on \`isMobile\`:

\`\`\`ts
useFocusTrap(isOpen, desktopRef, false, false);   // ← unconditional
const isMobile = useIsMobile();
useFocusTrap(isOpen && isMobile, mobileRef, false);
\`\`\`

In practice the \`hidden lg:flex\` Tailwind class makes the desktop \`<aside>\` \`display:none\` on \`<lg\` viewports, so the desktop trap is effectively a no-op there — but it's still wasted work, and the asymmetry makes the code harder to reason about (why does only the mobile trap know about \`isMobile\`?).

## Changes

\`crates/librefang-api/dashboard/src/components/ui/PushDrawer.tsx\`:

- Move \`const isMobile = useIsMobile();\` above the desktop \`useFocusTrap\` call.
- Mirror the mobile gate on the desktop call: \`useFocusTrap(isOpen && !isMobile, desktopRef, false, false)\`.

Pure refactor — no behavioural change in any viewport that the previous tests covered. Each trap now activates only when its own pane is the visible one.

## Test plan

- \`npx tsc --noEmit\` clean.
- No new tests needed — the change tightens an already-covered code path; existing PushDrawer behaviour tests (DrawerPanel.test.tsx and live integration) still apply.