### PR TITLE
perf(dashboard): batch per-agent KV lookups via useQueries (#4722)

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.test.tsx
@@ -32,8 +32,10 @@ vi.mock("../lib/queries/memory", () => ({
   useMemorySearchOrList: vi.fn(),
   // MemoryPage now batches per-agent KV via useQueries(agents.map(...));
   // this stub is only consulted when the test renders agents in the section.
-  agentKvMemoryQueryOptions: vi.fn(() => ({
-    queryKey: ["memory", "agent-kv", "stub"],
+  // Key on agentId so a future multi-agent test gets independent cache
+  // entries — a fixed key would silently dedupe into one shared observer.
+  agentKvMemoryQueryOptions: vi.fn((agentId: string) => ({
+    queryKey: ["memory", "agent-kv", agentId],
     queryFn: async () => [],
   })),
 }));

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.test.tsx
@@ -15,7 +15,6 @@ import {
   useMemoryConfig,
   useMemoryHealth,
   useMemorySearchOrList,
-  useAgentKvMemory,
 } from "../lib/queries/memory";
 import { useAgents } from "../lib/queries/agents";
 import {
@@ -31,7 +30,12 @@ vi.mock("../lib/queries/memory", () => ({
   useMemoryConfig: vi.fn(),
   useMemoryHealth: vi.fn(),
   useMemorySearchOrList: vi.fn(),
-  useAgentKvMemory: vi.fn(),
+  // MemoryPage now batches per-agent KV via useQueries(agents.map(...));
+  // this stub is only consulted when the test renders agents in the section.
+  agentKvMemoryQueryOptions: vi.fn(() => ({
+    queryKey: ["memory", "agent-kv", "stub"],
+    queryFn: async () => [],
+  })),
 }));
 
 vi.mock("../lib/queries/agents", () => ({
@@ -134,7 +138,6 @@ const useMemoryHealthMock = useMemoryHealth as unknown as ReturnType<typeof vi.f
 const useMemorySearchOrListMock = useMemorySearchOrList as unknown as ReturnType<
   typeof vi.fn
 >;
-const useAgentKvMemoryMock = useAgentKvMemory as unknown as ReturnType<typeof vi.fn>;
 const useAgentsMock = useAgents as unknown as ReturnType<typeof vi.fn>;
 const useAddMemoryMock = useAddMemory as unknown as ReturnType<typeof vi.fn>;
 const useUpdateMemoryMock = useUpdateMemory as unknown as ReturnType<typeof vi.fn>;
@@ -245,11 +248,6 @@ describe("MemoryPage", () => {
       refetch: vi.fn(),
     });
     useAgentsMock.mockReturnValue({ data: [] });
-    useAgentKvMemoryMock.mockReturnValue({
-      data: [],
-      isLoading: false,
-      isError: false,
-    });
   });
 
   it("renders KPI stats from useMemoryStats", () => {

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -1,8 +1,15 @@
 import { formatDateTime } from "../lib/datetime";
 import { useState, useEffect, useMemo, useDeferredValue } from "react";
 import { useTranslation } from "react-i18next";
+import { useQueries, type UseQueryResult } from "@tanstack/react-query";
 import { type MemoryStatsResponse } from "../api";
-import { useMemoryStats, useMemoryConfig, useMemoryHealth, useMemorySearchOrList, useAgentKvMemory } from "../lib/queries/memory";
+import {
+  useMemoryStats,
+  useMemoryConfig,
+  useMemoryHealth,
+  useMemorySearchOrList,
+  agentKvMemoryQueryOptions,
+} from "../lib/queries/memory";
 import { useAgents } from "../lib/queries/agents";
 import { useAddMemory, useUpdateMemory, useDeleteMemory, useCleanupMemories, useUpdateMemoryConfig } from "../lib/mutations/memory";
 import type { AgentItem, AgentKvPair } from "../api";
@@ -339,12 +346,11 @@ const KV_VALUE_TRUNCATE = 200;
 // inflating page memory for what's only meant to be a quick peek.
 const KV_TITLE_TRUNCATE = 2000;
 
-// TODO(perf): N+1 queries — each AgentKvRows issues its own useAgentKvMemory(agentId).
-// Replace with useQueries (tanstack-query v5) in AgentKvSection to batch all agent
-// KV lookups into a single observer array and pass data as props.
-function AgentKvRows({ agentId }: { agentId: string }) {
+// Receives the per-agent KV query result from AgentKvSection (a single
+// `useQueries` observer batches all agents) so this row component stays
+// presentational — no per-row hook subscription, no N+1 churn.
+function AgentKvRows({ kvQuery }: { kvQuery: UseQueryResult<AgentKvPair[]> }) {
   const { t } = useTranslation();
-  const kvQuery = useAgentKvMemory(agentId);
 
   if (kvQuery.isLoading) {
     return (
@@ -408,6 +414,15 @@ function AgentKvRows({ agentId }: { agentId: string }) {
 function AgentKvSection({ agents }: { agents: AgentItem[] }) {
   const { t } = useTranslation();
 
+  // Batch every per-agent KV lookup into a single useQueries observer instead
+  // of mounting one `useAgentKvMemory` hook per row. Same number of network
+  // requests (the API has no batch endpoint), but only one subscription point
+  // — no N+1 React-Query churn, fewer re-renders, query results flow down as
+  // props.
+  const kvQueries = useQueries({
+    queries: agents.map((agent) => agentKvMemoryQueryOptions(agent.id)),
+  });
+
   return (
     <div className="flex flex-col gap-3">
       <h3 className="text-sm font-bold">
@@ -420,7 +435,7 @@ function AgentKvSection({ agents }: { agents: AgentItem[] }) {
         />
       ) : (
         <div className="grid gap-4">
-          {agents.map((agent) => (
+          {agents.map((agent, idx) => (
             <Card key={agent.id} padding="md">
               <div className="flex items-center gap-2 mb-3 flex-wrap">
                 <h4 className="text-xs font-bold">{agent.name}</h4>
@@ -437,7 +452,7 @@ function AgentKvSection({ agents }: { agents: AgentItem[] }) {
                     </tr>
                   </thead>
                   <tbody>
-                    <AgentKvRows agentId={agent.id} />
+                    <AgentKvRows kvQuery={kvQueries[idx]} />
                   </tbody>
                 </table>
               </div>


### PR DESCRIPTION
Closes #4722.

## Summary

- `AgentKvSection` was mounting one `useAgentKvMemory(agentId)` hook per row — the N+1 flagged in the in-source TODO at `MemoryPage.tsx:343`. Replace with a single `useQueries({ queries: agents.map(agentKvMemoryQueryOptions) })` in the section, and turn `AgentKvRows` into a presentational component that receives its `UseQueryResult<AgentKvPair[]>` as a prop.
- Network-request count is unchanged (the API has no batch endpoint), but there is now one observer subscription instead of N, which removes the per-row hook churn and its re-render fan-out.
- `AgentsPage.tsx` still calls `useAgentKvMemory(detailAgent.id)` for its single-agent detail panel — no N+1 there, left untouched.

## Test plan

- [x] `npx vitest run src/pages/MemoryPage.test.tsx src/lib/queries/memory.test.tsx` — 19/19 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — built in 969ms
- [x] `MemoryPage.test.tsx` mock updated to expose `agentKvMemoryQueryOptions` instead of `useAgentKvMemory`; existing "renders empty-state for per-agent KV" coverage still passes (agents=[])
- [ ] Manual smoke: navigate to Memory page with N agents, confirm KV rows render and refetch as before