### PR TITLE
fix(kernel): close SSRF gaps in cron webhook delivery (#4732)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4830,6 +4830,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "unic-langid",
+ "url",
  "uuid",
  "zeroize",
 ]

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -1776,6 +1776,11 @@ pub async fn update_schedule(
                 Json(serde_json::json!({"status": "updated", "schedule_id": id})),
             )
         }
+        // SSRF / shape rejections must map to 400, not the catch-all 404
+        // — see the parallel branch in `update_cron_job` (#4732).
+        Err(librefang_types::error::LibreFangError::InvalidInput(msg)) => {
+            ApiErrorResponse::bad_request(msg).into_json_tuple()
+        }
         Err(e) => ApiErrorResponse::not_found(format!("Schedule not found: {e}")).into_json_tuple(),
     }
 }
@@ -2039,6 +2044,14 @@ pub async fn update_cron_job(
                         StatusCode::OK,
                         Json(serde_json::to_value(&job).unwrap_or_default()),
                     )
+                }
+                // SSRF / shape rejections from `validate_cron_delivery*`
+                // surface as `InvalidInput` and must map to 400, not the
+                // catch-all 404 (#4732). 404 here would silently mask a
+                // refused webhook host as "schedule not found", letting
+                // attacker-controlled clients confuse the failure mode.
+                Err(librefang_types::error::LibreFangError::InvalidInput(msg)) => {
+                    ApiErrorResponse::bad_request(msg).into_json_tuple()
                 }
                 Err(e) => ApiErrorResponse::not_found(format!("{e}")).into_json_tuple(),
             }

--- a/crates/librefang-api/src/webhook_store.rs
+++ b/crates/librefang-api/src/webhook_store.rs
@@ -162,7 +162,8 @@ pub async fn validate_webhook_url_resolved(url_str: &str) -> Result<ValidatedHos
             || is_link_local(ip)
         {
             return Err(format!(
-                "host '{host}' resolves to private/loopback/link-local address {ip}"
+                "host '{host}' resolves to {ip} \
+                 (loopback / unspecified / private / link-local / zeronet)"
             ));
         }
     }
@@ -211,9 +212,10 @@ pub fn validate_webhook_url(url_str: &str) -> Result<(), String> {
         Some(url::Host::Ipv4(v4)) => {
             let ip = std::net::IpAddr::V4(v4);
             if is_blocked_ip(ip) {
-                return Err(
-                    "url must not point to a private, loopback, or link-local address".to_string(),
-                );
+                return Err(format!(
+                    "url host '{v4}' is not allowed \
+                     (loopback / unspecified / private / link-local / zeronet / metadata)"
+                ));
             }
         }
         Some(url::Host::Ipv6(v6)) => {
@@ -223,9 +225,10 @@ pub fn validate_webhook_url(url_str: &str) -> Result<(), String> {
             // is_private_ip / is_link_local do not recognise the mapped form.
             let ip = canonical_ip(std::net::IpAddr::V6(v6));
             if is_blocked_ip(ip) {
-                return Err(
-                    "url must not point to a private, loopback, or link-local address".to_string(),
-                );
+                return Err(format!(
+                    "url host '{v6}' is not allowed \
+                     (loopback / unspecified / private / link-local / zeronet / metadata)"
+                ));
             }
         }
         Some(url::Host::Domain(host)) => {
@@ -707,6 +710,14 @@ mod tests {
     #[test]
     fn validate_webhook_url_blocks_unspecified_v4() {
         assert!(validate_webhook_url("http://0.0.0.0/hook").is_err());
+    }
+
+    /// IPv6 unspecified `[::]` — symmetry with the V4 form. `is_unspecified()`
+    /// covers both, but a literal test pins the wire-level behaviour so a
+    /// future regression that splits the V4/V6 paths can't quietly drop one.
+    #[test]
+    fn validate_webhook_url_blocks_unspecified_v6() {
+        assert!(validate_webhook_url("http://[::]/hook").is_err());
     }
 
     /// RFC 1122 §3.2.1.3 reserves `0.0.0.0/8`. The pre-#4739 implementation

--- a/crates/librefang-api/src/webhook_store.rs
+++ b/crates/librefang-api/src/webhook_store.rs
@@ -155,7 +155,12 @@ pub async fn validate_webhook_url_resolved(url_str: &str) -> Result<ValidatedHos
     }
     for sa in &addrs {
         let ip = canonical_ip(sa.ip());
-        if ip.is_loopback() || is_private_ip(ip) || is_link_local(ip) {
+        if ip.is_loopback()
+            || ip.is_unspecified()
+            || is_zeronet_v4(ip)
+            || is_private_ip(ip)
+            || is_link_local(ip)
+        {
             return Err(format!(
                 "host '{host}' resolves to private/loopback/link-local address {ip}"
             ));
@@ -169,7 +174,13 @@ pub async fn validate_webhook_url_resolved(url_str: &str) -> Result<ValidatedHos
 }
 
 /// Validate that a URL is safe to send webhooks to (mitigate SSRF).
-/// Only allows http and https schemes, blocks private/link-local IPs.
+/// Only allows http and https schemes, blocks private/loopback/link-local
+/// IPs, the unspecified address, RFC 1122 `0.0.0.0/8`, and the
+/// cloud-metadata / `*.internal` / `*.localhost` hostname families.
+///
+/// Mirrors `librefang_types::scheduler::validate_webhook_url` so the cron
+/// and the dashboard webhook subscription paths apply the same blocklist
+/// (#4739).
 ///
 /// **DNS-blind**: a hostname that resolves to a private IP at request time
 /// (DNS rebind) is NOT caught here — call
@@ -188,7 +199,7 @@ pub fn validate_webhook_url(url_str: &str) -> Result<(), String> {
         }
     }
 
-    // Block private/link-local IPs to mitigate SSRF.
+    // Block private/link-local/unspecified IPs to mitigate SSRF.
     //
     // Use the typed `url::Host` enum rather than `host_str().parse::<IpAddr>()`:
     // `host_str()` returns IPv6 literals wrapped in brackets (e.g.
@@ -199,7 +210,7 @@ pub fn validate_webhook_url(url_str: &str) -> Result<(), String> {
     match parsed.host() {
         Some(url::Host::Ipv4(v4)) => {
             let ip = std::net::IpAddr::V4(v4);
-            if ip.is_loopback() || is_private_ip(ip) || is_link_local(ip) {
+            if is_blocked_ip(ip) {
                 return Err(
                     "url must not point to a private, loopback, or link-local address".to_string(),
                 );
@@ -211,26 +222,70 @@ pub fn validate_webhook_url(url_str: &str) -> Result<(), String> {
             // these checks — ip.is_loopback() and the V6 arms of
             // is_private_ip / is_link_local do not recognise the mapped form.
             let ip = canonical_ip(std::net::IpAddr::V6(v6));
-            if ip.is_loopback() || is_private_ip(ip) || is_link_local(ip) {
+            if is_blocked_ip(ip) {
                 return Err(
                     "url must not point to a private, loopback, or link-local address".to_string(),
                 );
             }
         }
         Some(url::Host::Domain(host)) => {
-            // Also block common internal hostnames
+            // Block common internal hostnames. `url::Url::parse` has
+            // already converted IDN forms to ASCII punycode, so a literal
+            // ASCII match here is sufficient for the common cases —
+            // homoglyph attacks that punycode to a non-blocked string
+            // still rely on DNS resolution and are caught by
+            // `validate_webhook_url_resolved` at fire-time.
+            //
+            // `*.localhost` is reserved by RFC 6761 §6.3.
             let lower = host.to_lowercase();
-            if lower == "localhost"
-                || lower == "metadata.google.internal"
-                || lower.ends_with(".internal")
-            {
+            if is_blocked_domain(&lower) {
                 return Err("url must not point to an internal/localhost address".to_string());
             }
         }
-        None => {}
+        None => {
+            // `url::Url::parse` populates `host` for every "special" scheme
+            // (http/https/ftp/ws/wss/file). Reaching this arm means the
+            // input is malformed in a way the parser tolerated but we
+            // cannot safely route — refuse explicitly. The pre-#4739
+            // implementation silently accepted these (#4739 review).
+            return Err("url has no host component".to_string());
+        }
     }
 
     Ok(())
+}
+
+fn is_blocked_ip(ip: std::net::IpAddr) -> bool {
+    let ip = canonical_ip(ip);
+    ip.is_loopback()
+        || ip.is_unspecified()
+        || is_zeronet_v4(ip)
+        || is_private_ip(ip)
+        || is_link_local(ip)
+}
+
+/// RFC 1122 §3.2.1.3 reserves `0.0.0.0/8` ("this network"). Some legacy
+/// stacks rewrote `0.x.y.z` to `127.x.y.z`, making the entire prefix an
+/// SSRF surface to localhost. Modern Linux rejects outbound traffic to
+/// this range, but blocking explicitly removes the platform dependency.
+fn is_zeronet_v4(ip: std::net::IpAddr) -> bool {
+    matches!(ip, std::net::IpAddr::V4(v4) if v4.octets()[0] == 0)
+}
+
+/// Hostnames that must not be webhook destinations. Mirrors
+/// `librefang_types::scheduler::is_blocked_domain` so the dashboard-side
+/// subscription store and the cron path apply the same blocklist (#4739).
+fn is_blocked_domain(lower: &str) -> bool {
+    matches!(
+        lower,
+        "localhost"
+            | "metadata"
+            | "metadata.google.internal"
+            | "metadata.aws.amazon.com"
+            | "instance-data"
+            | "instance-data.ec2.internal"
+    ) || lower.ends_with(".localhost")
+        || lower.ends_with(".internal")
 }
 
 /// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
@@ -259,9 +314,14 @@ fn is_private_ip(ip: std::net::IpAddr) -> bool {
     }
 }
 
+/// IPv4 link-local is `169.254.0.0/16` per RFC 3927; IPv6 link-local is
+/// `fe80::/10` per RFC 4291. The previous implementation also matched
+/// `octets()[0] == 169` which over-blocks globally-routable addresses
+/// outside the actual link-local range; aligned with
+/// `librefang_types::scheduler::is_link_local` (#4739 review).
 fn is_link_local(ip: std::net::IpAddr) -> bool {
     match canonical_ip(ip) {
-        std::net::IpAddr::V4(v4) => v4.is_link_local() || v4.octets()[0] == 169,
+        std::net::IpAddr::V4(v4) => v4.is_link_local(),
         std::net::IpAddr::V6(v6) => {
             // Link-local fe80::/10
             (v6.segments()[0] & 0xffc0) == 0xfe80
@@ -640,6 +700,56 @@ mod tests {
     fn validate_webhook_url_blocks_ipv4_mapped_ipv6_private() {
         assert!(validate_webhook_url("http://[::ffff:10.0.0.1]/hook").is_err());
         assert!(validate_webhook_url("http://[::ffff:192.168.1.1]/hook").is_err());
+    }
+
+    /// `0.0.0.0` is unspecified — block it so it can't be used as a
+    /// loopback alias on stacks that route it locally (#4739).
+    #[test]
+    fn validate_webhook_url_blocks_unspecified_v4() {
+        assert!(validate_webhook_url("http://0.0.0.0/hook").is_err());
+    }
+
+    /// RFC 1122 §3.2.1.3 reserves `0.0.0.0/8`. The pre-#4739 implementation
+    /// only blocked the all-zero literal; legacy stacks that rewrote
+    /// `0.x.y.z` to `127.x.y.z` would have left this prefix as an SSRF
+    /// surface.
+    #[test]
+    fn validate_webhook_url_blocks_zeronet_v4() {
+        assert!(validate_webhook_url("http://0.1.2.3/hook").is_err());
+        assert!(validate_webhook_url("http://0.255.255.255/hook").is_err());
+    }
+
+    /// New cloud-metadata aliases the cron path already blocked — backport
+    /// keeps webhook subscriptions and cron consistent (#4739 review).
+    #[test]
+    fn validate_webhook_url_blocks_extended_metadata_hosts() {
+        assert!(validate_webhook_url("http://metadata/").is_err());
+        assert!(validate_webhook_url("http://metadata.aws.amazon.com/").is_err());
+        assert!(validate_webhook_url("http://instance-data/").is_err());
+        assert!(validate_webhook_url("http://instance-data.ec2.internal/").is_err());
+    }
+
+    /// RFC 6761 §6.3 reserves the entire `.localhost` tree as loopback.
+    #[test]
+    fn validate_webhook_url_blocks_localhost_subtree() {
+        assert!(validate_webhook_url("http://api.localhost/hook").is_err());
+        assert!(validate_webhook_url("http://anything.localhost/hook").is_err());
+    }
+
+    /// `Ipv4Addr::is_link_local` matches `169.254/16` per RFC 3927; the
+    /// previous over-broad `octets()[0] == 169` check refused publicly
+    /// routable addresses outside that range. Aligned with
+    /// `librefang_types::scheduler::is_link_local` (#4739 review).
+    #[test]
+    fn validate_webhook_url_accepts_169_outside_link_local() {
+        assert!(validate_webhook_url("http://169.10.0.1/hook").is_ok());
+        assert!(validate_webhook_url("http://169.255.0.1/hook").is_ok());
+    }
+
+    /// Link-local address itself must still be refused.
+    #[test]
+    fn validate_webhook_url_blocks_link_local_v4() {
+        assert!(validate_webhook_url("http://169.254.169.254/").is_err());
     }
 
     #[test]

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -810,3 +810,128 @@ async fn cron_job_get_response_session_fields_default_zero_when_no_session() {
     assert_eq!(body["session_message_count"].as_u64(), Some(0), "{body:?}");
     assert_eq!(body["session_token_count"].as_u64(), Some(0), "{body:?}");
 }
+
+// =============================================================================
+// SSRF coverage on PUT /api/cron/jobs/{id}  (#4732)
+// =============================================================================
+//
+// `add_job` validates webhook hosts at create-time, but `update_job` and
+// `set_delivery_targets` historically skipped that check — letting an
+// authenticated client install a webhook pointing at the daemon itself,
+// RFC 1918 space, or cloud-metadata services by routing through the PUT
+// path. Validation now runs on every mutation surface; these tests pin
+// the wire-level behaviour so a future refactor can't silently regress
+// the boundary.
+
+/// Helper: seed a cron job directly via the kernel and return its id as
+/// a UUID-string suitable for the `/api/cron/jobs/{id}` path.
+async fn seed_cron_job(h: &Harness) -> String {
+    use chrono::Utc;
+    use librefang_types::agent::AgentId;
+    use librefang_types::scheduler::{CronAction, CronDelivery, CronJob, CronJobId, CronSchedule};
+
+    let job = CronJob {
+        id: CronJobId::new(),
+        agent_id: AgentId::new(),
+        name: "ssrf-fixture".to_string(),
+        enabled: true,
+        schedule: CronSchedule::Every { every_secs: 3600 },
+        action: CronAction::SystemEvent {
+            text: "ping".to_string(),
+        },
+        delivery: CronDelivery::None,
+        delivery_targets: Vec::new(),
+        peer_id: None,
+        session_mode: None,
+        created_at: Utc::now(),
+        last_run: None,
+        next_run: None,
+    };
+    let id = h
+        ._state
+        .kernel
+        .cron()
+        .add_job(job, false)
+        .expect("seed cron add_job");
+    id.0.to_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_update_rejects_ssrf_webhook_in_delivery() {
+    let h = boot().await;
+    let id = seed_cron_job(&h).await;
+
+    // Link-local cloud-metadata IP — pre-#4732 update path accepted it.
+    let body = serde_json::json!({
+        "delivery": {"kind": "webhook", "url": "http://169.254.169.254/latest/meta-data/"}
+    });
+    let (status, response) =
+        json_request(&h, Method::PUT, &format!("/api/cron/jobs/{id}"), Some(body)).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "must be 400, not 404 (#4732 mapping): {response:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_update_rejects_ssrf_webhook_in_delivery_targets() {
+    let h = boot().await;
+    let id = seed_cron_job(&h).await;
+
+    // Hex-form loopback — `0x7f000001` == `127.0.0.1`. The pre-#4732
+    // string-prefix logic missed numeric IPv4 forms entirely.
+    let body = serde_json::json!({
+        "delivery_targets": [
+            {"type": "webhook", "url": "http://0x7f000001/hook"}
+        ]
+    });
+    let (status, response) =
+        json_request(&h, Method::PUT, &format!("/api/cron/jobs/{id}"), Some(body)).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "hex-form loopback must be rejected: {response:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_update_rejects_v4_mapped_v6_loopback_in_delivery_targets() {
+    let h = boot().await;
+    let id = seed_cron_job(&h).await;
+
+    // IPv4-mapped IPv6 — bracketed `[::ffff:127.0.0.1]` resolves
+    // (transparently to most syscalls) to plain 127.0.0.1.
+    let body = serde_json::json!({
+        "delivery_targets": [
+            {"type": "webhook", "url": "http://[::ffff:127.0.0.1]/hook"}
+        ]
+    });
+    let (status, response) =
+        json_request(&h, Method::PUT, &format!("/api/cron/jobs/{id}"), Some(body)).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "IPv4-mapped IPv6 loopback must be rejected: {response:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_update_accepts_public_webhook_in_delivery_targets() {
+    let h = boot().await;
+    let id = seed_cron_job(&h).await;
+
+    // Sanity check: a public-looking https webhook still succeeds.
+    let body = serde_json::json!({
+        "delivery_targets": [
+            {"type": "webhook", "url": "https://example.com/hook"}
+        ]
+    });
+    let (status, response) =
+        json_request(&h, Method::PUT, &format!("/api/cron/jobs/{id}"), Some(body)).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "public webhook must still be accepted: {response:?}"
+    );
+}

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -935,3 +935,29 @@ async fn cron_job_update_accepts_public_webhook_in_delivery_targets() {
         "public webhook must still be accepted: {response:?}"
     );
 }
+
+// `/api/schedules/{id}` and `/api/cron/jobs/{id}` are different routes
+// that ultimately funnel into the same `CronScheduler::update_job` path,
+// so both gained the `InvalidInput → 400` mapping in #4732. Without a
+// test on this route the mapping is unverified — a future refactor that
+// drops the arm would silently regress SSRF rejection back to a 404
+// "Schedule not found" on this surface only.
+#[tokio::test(flavor = "multi_thread")]
+async fn schedule_update_rejects_ssrf_webhook_in_delivery_targets() {
+    let h = boot().await;
+    let id = seed_cron_job(&h).await;
+
+    let body = serde_json::json!({
+        "delivery_targets": [
+            {"type": "webhook", "url": "http://169.254.169.254/latest/meta-data/"}
+        ]
+    });
+    let (status, response) =
+        json_request(&h, Method::PUT, &format!("/api/schedules/{id}"), Some(body)).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "must be 400, not 404: SSRF rejection on /api/schedules/{{id}} \
+         must surface as bad request, not as a missing-resource error: {response:?}"
+    );
+}

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -858,8 +858,11 @@ async fn seed_cron_job(h: &Harness) -> String {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn cron_job_update_rejects_ssrf_webhook_in_delivery() {
+    use librefang_types::scheduler::{CronDelivery, CronJobId};
+
     let h = boot().await;
     let id = seed_cron_job(&h).await;
+    let job_id = id.parse::<uuid::Uuid>().map(CronJobId).unwrap();
 
     // Link-local cloud-metadata IP — pre-#4732 update path accepted it.
     let body = serde_json::json!({
@@ -872,12 +875,24 @@ async fn cron_job_update_rejects_ssrf_webhook_in_delivery() {
         StatusCode::BAD_REQUEST,
         "must be 400, not 404 (#4732 mapping): {response:?}"
     );
+
+    // State invariant (#4739 review): rejected update must not partially
+    // overwrite `delivery`. Seed sets `CronDelivery::None`.
+    let job = h._state.kernel.cron().get_job(job_id).expect("job exists");
+    assert!(
+        matches!(job.delivery, CronDelivery::None),
+        "delivery must remain None after rejection, got {:?}",
+        job.delivery
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn cron_job_update_rejects_ssrf_webhook_in_delivery_targets() {
+    use librefang_types::scheduler::CronJobId;
+
     let h = boot().await;
     let id = seed_cron_job(&h).await;
+    let job_id = id.parse::<uuid::Uuid>().map(CronJobId).unwrap();
 
     // Hex-form loopback — `0x7f000001` == `127.0.0.1`. The pre-#4732
     // string-prefix logic missed numeric IPv4 forms entirely.
@@ -892,6 +907,53 @@ async fn cron_job_update_rejects_ssrf_webhook_in_delivery_targets() {
         status,
         StatusCode::BAD_REQUEST,
         "hex-form loopback must be rejected: {response:?}"
+    );
+
+    // State invariant (#4739 review): targets must remain empty.
+    let job = h._state.kernel.cron().get_job(job_id).expect("job exists");
+    assert!(
+        job.delivery_targets.is_empty(),
+        "delivery_targets must remain empty after rejection, got {:?}",
+        job.delivery_targets
+    );
+}
+
+/// Two-phase mutation guarantee at the wire level (#4739 review):
+/// a request mixing a valid `delivery` and an SSRF-laden
+/// `delivery_targets` must reject as 400 AND must not smuggle the
+/// (in-isolation valid) `delivery` change into stored state.
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_update_partial_mutation_is_atomic() {
+    use librefang_types::scheduler::{CronDelivery, CronJobId};
+
+    let h = boot().await;
+    let id = seed_cron_job(&h).await;
+    let job_id = id.parse::<uuid::Uuid>().map(CronJobId).unwrap();
+
+    let body = serde_json::json!({
+        "delivery": {"kind": "webhook", "url": "https://example.com/hook"},
+        "delivery_targets": [
+            {"type": "webhook", "url": "http://0x7f000001/hook"}
+        ]
+    });
+    let (status, response) =
+        json_request(&h, Method::PUT, &format!("/api/cron/jobs/{id}"), Some(body)).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "mixed valid+SSRF must reject: {response:?}"
+    );
+
+    let job = h._state.kernel.cron().get_job(job_id).expect("job exists");
+    assert!(
+        matches!(job.delivery, CronDelivery::None),
+        "valid `delivery` must NOT be smuggled in when later phase fails, got {:?}",
+        job.delivery
+    );
+    assert!(
+        job.delivery_targets.is_empty(),
+        "delivery_targets must remain empty, got {:?}",
+        job.delivery_targets
     );
 }
 

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -284,23 +284,31 @@ impl CronScheduler {
                     meta.job.action = action;
                 }
 
-                // Replace delivery if provided.
+                // Replace delivery if provided. Re-runs the same SSRF /
+                // shape checks `add_job` does so an attacker can't bypass
+                // host-blocklist validation by routing through update
+                // (#4732).
                 if !updates["delivery"].is_null() {
                     let delivery: librefang_types::scheduler::CronDelivery =
                         serde_json::from_value(updates["delivery"].clone()).map_err(|e| {
                             LibreFangError::Internal(format!("Invalid delivery: {e}"))
                         })?;
+                    librefang_types::scheduler::validate_cron_delivery(&delivery)
+                        .map_err(LibreFangError::InvalidInput)?;
                     meta.job.delivery = delivery;
                 }
 
                 // Replace fan-out delivery_targets if provided. Must be an
                 // array of CronDeliveryTarget objects; an empty array clears
-                // all targets.
+                // all targets. Same SSRF revalidation as the `delivery`
+                // arm above (#4732).
                 if !updates["delivery_targets"].is_null() {
                     let targets: Vec<librefang_types::scheduler::CronDeliveryTarget> =
                         serde_json::from_value(updates["delivery_targets"].clone()).map_err(
                             |e| LibreFangError::Internal(format!("Invalid delivery_targets: {e}")),
                         )?;
+                    librefang_types::scheduler::validate_cron_delivery_targets(&targets)
+                        .map_err(LibreFangError::InvalidInput)?;
                     meta.job.delivery_targets = targets;
                 }
 
@@ -320,6 +328,11 @@ impl CronScheduler {
         id: CronJobId,
         targets: Vec<librefang_types::scheduler::CronDeliveryTarget>,
     ) -> LibreFangResult<()> {
+        // Validate before swapping so an SSRF-blocking webhook host or an
+        // absolute LocalFile path is rejected at the same input boundary
+        // `add_job` enforces (#4732).
+        librefang_types::scheduler::validate_cron_delivery_targets(&targets)
+            .map_err(LibreFangError::InvalidInput)?;
         match self.jobs.get_mut(&id) {
             Some(mut meta) => {
                 meta.job.delivery_targets = targets;
@@ -1816,7 +1829,9 @@ mod tests {
         // Initially empty.
         assert!(sched.get_job(id).unwrap().delivery_targets.is_empty());
 
-        // Set two targets.
+        // Set two targets. LocalFile paths must be workspace-relative —
+        // an absolute `/tmp/x.log` would now fail SSRF/path validation
+        // alongside the webhook host check (#4732).
         let targets = vec![
             CronDeliveryTarget::Channel {
                 channel_type: "slack".into(),
@@ -1825,7 +1840,7 @@ mod tests {
                 account_id: None,
             },
             CronDeliveryTarget::LocalFile {
-                path: "/tmp/x.log".into(),
+                path: "out/x.log".into(),
                 append: true,
             },
         ];
@@ -1843,6 +1858,68 @@ mod tests {
         // Clear with an empty Vec.
         sched.set_delivery_targets(id, Vec::new()).unwrap();
         assert!(sched.get_job(id).unwrap().delivery_targets.is_empty());
+    }
+
+    /// SSRF-prone webhook hosts must be rejected on the
+    /// `set_delivery_targets` path, not just on `add_job` (#4732).
+    #[test]
+    fn set_delivery_targets_rejects_ssrf_webhook() {
+        use librefang_types::scheduler::CronDeliveryTarget;
+
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let id = sched.add_job(make_job(agent), false).unwrap();
+
+        // Hex-form loopback (`0x7f000001` == `127.0.0.1`) — the
+        // pre-#4732 prefix-string check missed this entirely.
+        let targets = vec![CronDeliveryTarget::Webhook {
+            url: "http://0x7f000001/hook".into(),
+            auth_header: None,
+        }];
+        let err = sched
+            .set_delivery_targets(id, targets)
+            .expect_err("SSRF webhook must be refused");
+        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
+
+        // Original (empty) target list must remain — failed validation
+        // must not partially mutate state.
+        assert!(sched.get_job(id).unwrap().delivery_targets.is_empty());
+    }
+
+    /// `update_job` previously skipped delivery / delivery_targets
+    /// validation entirely — an attacker could route through PUT to
+    /// install an SSRF webhook even when `add_job` would have rejected
+    /// the same payload (#4732).
+    #[test]
+    fn update_job_rejects_ssrf_webhook_in_delivery() {
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let id = sched.add_job(make_job(agent), false).unwrap();
+
+        let updates = serde_json::json!({
+            "delivery": {"kind": "webhook", "url": "http://169.254.169.254/latest/meta-data/"}
+        });
+        let err = sched
+            .update_job(id, &updates)
+            .expect_err("link-local metadata IP must be refused");
+        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
+    }
+
+    #[test]
+    fn update_job_rejects_ssrf_webhook_in_delivery_targets() {
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let id = sched.add_job(make_job(agent), false).unwrap();
+
+        // Numeric/decimal-form loopback — also a #4732 bypass surface
+        // before the WHATWG URL parser was wired in.
+        let updates = serde_json::json!({
+            "delivery_targets": [{"type": "webhook", "url": "http://2130706433/hook"}]
+        });
+        let err = sched
+            .update_job(id, &updates)
+            .expect_err("decimal-form loopback must be refused");
+        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
     }
 
     #[test]
@@ -1864,7 +1941,7 @@ mod tests {
         let updates = serde_json::json!({
             "delivery_targets": [
                 {"type": "webhook", "url": "https://example.com/hook"},
-                {"type": "local_file", "path": "/tmp/y.log"},
+                {"type": "local_file", "path": "out/y.log"},
             ]
         });
         let updated = sched.update_job(id, &updates).unwrap();

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -243,101 +243,99 @@ impl CronScheduler {
         id: CronJobId,
         updates: &serde_json::Value,
     ) -> LibreFangResult<CronJob> {
-        // Two-phase pattern: parse and validate every provided field into
-        // a local first, mutate the live `meta.job` only after the last
-        // validation passes. The pre-#4739 in-place pattern would
-        // partially mutate state on later-field failure — e.g. a request
-        // carrying both a valid `delivery` and an SSRF-laden
-        // `delivery_targets` would have its `delivery` overwrite already
-        // committed before the targets check failed and the route
-        // returned 400, leaving cron state half-updated and divergent
-        // from the wire response. With staged updates an `Err` from any
-        // phase leaves `meta.job` untouched, so a subsequent successful
-        // PUT can't smuggle the abandoned half-mutation forward.
-        let new_name = updates["name"].as_str().map(str::to_string);
-        let new_enabled = updates["enabled"].as_bool();
-        let new_agent_id = if let Some(s) = updates["agent_id"].as_str() {
-            Some(
-                s.parse::<AgentId>()
-                    .map_err(|e| LibreFangError::Internal(format!("Invalid agent_id: {e}")))?,
-            )
-        } else {
-            None
+        // Candidate-validate-swap: clone the current job, apply the
+        // partial updates onto the candidate, run the same `validate(0)`
+        // that `add_job` runs, and only after that passes do we swap the
+        // candidate into place under the shard lock. This generalises
+        // the #4732 bypass closure from "delivery / delivery_targets
+        // re-validated on update" to "the entire CronJob shape is
+        // re-validated on update" — name length, schedule cron-expr
+        // syntax, every CronAction shape, and the SSRF / path checks all
+        // gate update the same way they gate add. A pre-#4739 PUT
+        // carrying e.g. an empty `name` plus a valid `delivery` was
+        // accepted; now the same payload is rejected before any field
+        // hits live state.
+        //
+        // Atomicity: `meta.job` is replaced once with a fully validated
+        // candidate, so an `Err` at any step leaves the live row
+        // untouched. The earlier in-place pattern could commit `delivery`
+        // before failing on `delivery_targets`; that race is gone.
+        let mut candidate = match self.jobs.get(&id) {
+            Some(entry) => entry.value().job.clone(),
+            None => {
+                return Err(LibreFangError::Internal(format!("Cron job {id} not found")));
+            }
         };
-        let new_schedule = if !updates["schedule"].is_null() {
-            Some(
+
+        let enabled_updated = updates["enabled"].as_bool();
+        let schedule_updated = !updates["schedule"].is_null();
+
+        if let Some(name) = updates["name"].as_str() {
+            candidate.name = name.to_string();
+        }
+        if let Some(enabled) = enabled_updated {
+            candidate.enabled = enabled;
+        }
+        if let Some(s) = updates["agent_id"].as_str() {
+            candidate.agent_id = s
+                .parse::<AgentId>()
+                .map_err(|e| LibreFangError::Internal(format!("Invalid agent_id: {e}")))?;
+        }
+        if schedule_updated {
+            candidate.schedule =
                 serde_json::from_value::<CronSchedule>(updates["schedule"].clone())
-                    .map_err(|e| LibreFangError::Internal(format!("Invalid schedule: {e}")))?,
+                    .map_err(|e| LibreFangError::Internal(format!("Invalid schedule: {e}")))?;
+        }
+        if !updates["action"].is_null() {
+            candidate.action = serde_json::from_value::<librefang_types::scheduler::CronAction>(
+                updates["action"].clone(),
             )
-        } else {
-            None
-        };
-        let new_action = if !updates["action"].is_null() {
-            Some(
-                serde_json::from_value::<librefang_types::scheduler::CronAction>(
-                    updates["action"].clone(),
+            .map_err(|e| LibreFangError::Internal(format!("Invalid action: {e}")))?;
+        }
+        if !updates["delivery"].is_null() {
+            candidate.delivery =
+                serde_json::from_value::<librefang_types::scheduler::CronDelivery>(
+                    updates["delivery"].clone(),
                 )
-                .map_err(|e| LibreFangError::Internal(format!("Invalid action: {e}")))?,
-            )
-        } else {
-            None
-        };
-        // SSRF / shape checks (`validate_cron_delivery*`) also run in
-        // `add_job`; running them again on the update boundary closes
-        // the bypass route flagged in #4732.
-        let new_delivery = if !updates["delivery"].is_null() {
-            let d: librefang_types::scheduler::CronDelivery =
-                serde_json::from_value(updates["delivery"].clone())
-                    .map_err(|e| LibreFangError::Internal(format!("Invalid delivery: {e}")))?;
-            librefang_types::scheduler::validate_cron_delivery(&d)
-                .map_err(LibreFangError::InvalidInput)?;
-            Some(d)
-        } else {
-            None
-        };
-        let new_targets = if !updates["delivery_targets"].is_null() {
-            let t: Vec<librefang_types::scheduler::CronDeliveryTarget> =
-                serde_json::from_value(updates["delivery_targets"].clone()).map_err(|e| {
-                    LibreFangError::Internal(format!("Invalid delivery_targets: {e}"))
-                })?;
-            librefang_types::scheduler::validate_cron_delivery_targets(&t)
-                .map_err(LibreFangError::InvalidInput)?;
-            Some(t)
-        } else {
-            None
-        };
+                .map_err(|e| LibreFangError::Internal(format!("Invalid delivery: {e}")))?;
+        }
+        if !updates["delivery_targets"].is_null() {
+            candidate.delivery_targets = serde_json::from_value::<
+                Vec<librefang_types::scheduler::CronDeliveryTarget>,
+            >(updates["delivery_targets"].clone())
+            .map_err(|e| LibreFangError::Internal(format!("Invalid delivery_targets: {e}")))?;
+        }
+
+        // Run the same shape + SSRF validation `add_job` runs. We pass
+        // `existing_count = 0` because this is an in-place update on an
+        // existing job — capacity (MAX_JOBS_PER_AGENT) is unaffected by
+        // an update that doesn't change `agent_id`. Cross-agent moves
+        // are NOT capacity-checked here today; tracking under a
+        // separate follow-up issue (#4732 followup).
+        candidate
+            .validate(0)
+            .map_err(LibreFangError::InvalidInput)?;
+
+        // Recompute next_run when the schedule shape changed, OR when
+        // the job is being re-enabled (mirrors the prior in-place
+        // semantics so an existing job that was paused with a stale
+        // next_run gets a fresh tick on activation).
+        if schedule_updated || matches!(enabled_updated, Some(true)) {
+            candidate.next_run = Some(compute_next_run(&candidate.schedule));
+        }
 
         match self.jobs.get_mut(&id) {
             Some(mut entry) => {
                 let meta = entry.value_mut();
-                if let Some(name) = new_name {
-                    meta.job.name = name;
-                }
-                if let Some(enabled) = new_enabled {
-                    meta.job.enabled = enabled;
-                    // Explicit update from user clears the auto_disabled flag.
+                if let Some(enabled) = enabled_updated {
+                    // An explicit toggle from the user clears the
+                    // auto_disabled flag regardless of direction.
                     meta.auto_disabled = false;
                     if enabled {
                         meta.consecutive_errors = 0;
-                        meta.job.next_run = Some(compute_next_run(&meta.job.schedule));
                     }
                 }
-                if let Some(agent_id) = new_agent_id {
-                    meta.job.agent_id = agent_id;
-                }
-                if let Some(schedule) = new_schedule {
-                    meta.job.next_run = Some(compute_next_run(&schedule));
-                    meta.job.schedule = schedule;
-                }
-                if let Some(action) = new_action {
-                    meta.job.action = action;
-                }
-                if let Some(delivery) = new_delivery {
-                    meta.job.delivery = delivery;
-                }
-                if let Some(targets) = new_targets {
-                    meta.job.delivery_targets = targets;
-                }
+                meta.job = candidate;
                 Ok(meta.job.clone())
             }
             None => Err(LibreFangError::Internal(format!("Cron job {id} not found"))),
@@ -2002,6 +2000,42 @@ mod tests {
             after.delivery
         );
         assert!(after.delivery_targets.is_empty());
+    }
+
+    /// candidate-validate-swap (#4739 review followup): non-SSRF shape
+    /// rules now also gate the update path. Empty name was previously
+    /// accepted on PUT — `add_job` rejected the same payload, so this
+    /// closes a parallel bypass surface to the SSRF webhook one.
+    #[test]
+    fn update_job_rejects_empty_name() {
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let id = sched.add_job(make_job(agent), false).unwrap();
+        let original_name = sched.get_job(id).unwrap().name;
+
+        let updates = serde_json::json!({ "name": "" });
+        let err = sched
+            .update_job(id, &updates)
+            .expect_err("empty name must be refused");
+        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
+        // State invariant: rejected payload must not partially mutate.
+        assert_eq!(sched.get_job(id).unwrap().name, original_name);
+    }
+
+    /// `validate(0)` on the candidate also catches over-long names.
+    #[test]
+    fn update_job_rejects_oversized_name() {
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let id = sched.add_job(make_job(agent), false).unwrap();
+
+        // librefang_types::scheduler::MAX_NAME_LEN is 128.
+        let long = "x".repeat(200);
+        let updates = serde_json::json!({ "name": long });
+        let err = sched
+            .update_job(id, &updates)
+            .expect_err("oversized name must be refused");
+        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
     }
 
     /// Same atomicity guarantee in the other direction: failure in the

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -243,14 +243,77 @@ impl CronScheduler {
         id: CronJobId,
         updates: &serde_json::Value,
     ) -> LibreFangResult<CronJob> {
+        // Two-phase pattern: parse and validate every provided field into
+        // a local first, mutate the live `meta.job` only after the last
+        // validation passes. The pre-#4739 in-place pattern would
+        // partially mutate state on later-field failure — e.g. a request
+        // carrying both a valid `delivery` and an SSRF-laden
+        // `delivery_targets` would have its `delivery` overwrite already
+        // committed before the targets check failed and the route
+        // returned 400, leaving cron state half-updated and divergent
+        // from the wire response. With staged updates an `Err` from any
+        // phase leaves `meta.job` untouched, so a subsequent successful
+        // PUT can't smuggle the abandoned half-mutation forward.
+        let new_name = updates["name"].as_str().map(str::to_string);
+        let new_enabled = updates["enabled"].as_bool();
+        let new_agent_id = if let Some(s) = updates["agent_id"].as_str() {
+            Some(
+                s.parse::<AgentId>()
+                    .map_err(|e| LibreFangError::Internal(format!("Invalid agent_id: {e}")))?,
+            )
+        } else {
+            None
+        };
+        let new_schedule = if !updates["schedule"].is_null() {
+            Some(
+                serde_json::from_value::<CronSchedule>(updates["schedule"].clone())
+                    .map_err(|e| LibreFangError::Internal(format!("Invalid schedule: {e}")))?,
+            )
+        } else {
+            None
+        };
+        let new_action = if !updates["action"].is_null() {
+            Some(
+                serde_json::from_value::<librefang_types::scheduler::CronAction>(
+                    updates["action"].clone(),
+                )
+                .map_err(|e| LibreFangError::Internal(format!("Invalid action: {e}")))?,
+            )
+        } else {
+            None
+        };
+        // SSRF / shape checks (`validate_cron_delivery*`) also run in
+        // `add_job`; running them again on the update boundary closes
+        // the bypass route flagged in #4732.
+        let new_delivery = if !updates["delivery"].is_null() {
+            let d: librefang_types::scheduler::CronDelivery =
+                serde_json::from_value(updates["delivery"].clone())
+                    .map_err(|e| LibreFangError::Internal(format!("Invalid delivery: {e}")))?;
+            librefang_types::scheduler::validate_cron_delivery(&d)
+                .map_err(LibreFangError::InvalidInput)?;
+            Some(d)
+        } else {
+            None
+        };
+        let new_targets = if !updates["delivery_targets"].is_null() {
+            let t: Vec<librefang_types::scheduler::CronDeliveryTarget> =
+                serde_json::from_value(updates["delivery_targets"].clone()).map_err(|e| {
+                    LibreFangError::Internal(format!("Invalid delivery_targets: {e}"))
+                })?;
+            librefang_types::scheduler::validate_cron_delivery_targets(&t)
+                .map_err(LibreFangError::InvalidInput)?;
+            Some(t)
+        } else {
+            None
+        };
+
         match self.jobs.get_mut(&id) {
             Some(mut entry) => {
                 let meta = entry.value_mut();
-
-                if let Some(name) = updates["name"].as_str() {
-                    meta.job.name = name.to_string();
+                if let Some(name) = new_name {
+                    meta.job.name = name;
                 }
-                if let Some(enabled) = updates["enabled"].as_bool() {
+                if let Some(enabled) = new_enabled {
                     meta.job.enabled = enabled;
                     // Explicit update from user clears the auto_disabled flag.
                     meta.auto_disabled = false;
@@ -259,59 +322,22 @@ impl CronScheduler {
                         meta.job.next_run = Some(compute_next_run(&meta.job.schedule));
                     }
                 }
-                if let Some(agent_id_str) = updates["agent_id"].as_str() {
-                    meta.job.agent_id = agent_id_str
-                        .parse::<AgentId>()
-                        .map_err(|e| LibreFangError::Internal(format!("Invalid agent_id: {e}")))?;
+                if let Some(agent_id) = new_agent_id {
+                    meta.job.agent_id = agent_id;
                 }
-
-                // Replace schedule if provided (must be a valid CronSchedule object).
-                if !updates["schedule"].is_null() {
-                    let schedule: CronSchedule =
-                        serde_json::from_value(updates["schedule"].clone()).map_err(|e| {
-                            LibreFangError::Internal(format!("Invalid schedule: {e}"))
-                        })?;
+                if let Some(schedule) = new_schedule {
                     meta.job.next_run = Some(compute_next_run(&schedule));
                     meta.job.schedule = schedule;
                 }
-
-                // Replace action if provided.
-                if !updates["action"].is_null() {
-                    let action: librefang_types::scheduler::CronAction =
-                        serde_json::from_value(updates["action"].clone()).map_err(|e| {
-                            LibreFangError::Internal(format!("Invalid action: {e}"))
-                        })?;
+                if let Some(action) = new_action {
                     meta.job.action = action;
                 }
-
-                // Replace delivery if provided. Re-runs the same SSRF /
-                // shape checks `add_job` does so an attacker can't bypass
-                // host-blocklist validation by routing through update
-                // (#4732).
-                if !updates["delivery"].is_null() {
-                    let delivery: librefang_types::scheduler::CronDelivery =
-                        serde_json::from_value(updates["delivery"].clone()).map_err(|e| {
-                            LibreFangError::Internal(format!("Invalid delivery: {e}"))
-                        })?;
-                    librefang_types::scheduler::validate_cron_delivery(&delivery)
-                        .map_err(LibreFangError::InvalidInput)?;
+                if let Some(delivery) = new_delivery {
                     meta.job.delivery = delivery;
                 }
-
-                // Replace fan-out delivery_targets if provided. Must be an
-                // array of CronDeliveryTarget objects; an empty array clears
-                // all targets. Same SSRF revalidation as the `delivery`
-                // arm above (#4732).
-                if !updates["delivery_targets"].is_null() {
-                    let targets: Vec<librefang_types::scheduler::CronDeliveryTarget> =
-                        serde_json::from_value(updates["delivery_targets"].clone()).map_err(
-                            |e| LibreFangError::Internal(format!("Invalid delivery_targets: {e}")),
-                        )?;
-                    librefang_types::scheduler::validate_cron_delivery_targets(&targets)
-                        .map_err(LibreFangError::InvalidInput)?;
+                if let Some(targets) = new_targets {
                     meta.job.delivery_targets = targets;
                 }
-
                 Ok(meta.job.clone())
             }
             None => Err(LibreFangError::Internal(format!("Cron job {id} not found"))),
@@ -1892,9 +1918,16 @@ mod tests {
     /// the same payload (#4732).
     #[test]
     fn update_job_rejects_ssrf_webhook_in_delivery() {
+        use librefang_types::scheduler::CronDelivery;
+
         let (sched, _tmp) = make_scheduler(100);
         let agent = AgentId::new();
         let id = sched.add_job(make_job(agent), false).unwrap();
+        // make_job() sets `CronDelivery::None`; pin that as the invariant.
+        assert!(matches!(
+            sched.get_job(id).unwrap().delivery,
+            CronDelivery::None
+        ));
 
         let updates = serde_json::json!({
             "delivery": {"kind": "webhook", "url": "http://169.254.169.254/latest/meta-data/"}
@@ -1903,6 +1936,12 @@ mod tests {
             .update_job(id, &updates)
             .expect_err("link-local metadata IP must be refused");
         assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
+
+        // State invariant: failed validation must leave delivery untouched.
+        assert!(matches!(
+            sched.get_job(id).unwrap().delivery,
+            CronDelivery::None
+        ));
     }
 
     #[test]
@@ -1910,6 +1949,8 @@ mod tests {
         let (sched, _tmp) = make_scheduler(100);
         let agent = AgentId::new();
         let id = sched.add_job(make_job(agent), false).unwrap();
+        // Seeded job has no targets; that's the state we expect to keep.
+        assert!(sched.get_job(id).unwrap().delivery_targets.is_empty());
 
         // Numeric/decimal-form loopback — also a #4732 bypass surface
         // before the WHATWG URL parser was wired in.
@@ -1920,6 +1961,71 @@ mod tests {
             .update_job(id, &updates)
             .expect_err("decimal-form loopback must be refused");
         assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
+
+        // State invariant: targets must not have been partially written.
+        assert!(sched.get_job(id).unwrap().delivery_targets.is_empty());
+    }
+
+    /// Two-phase mutation guarantee (#4739 review): if any field in a
+    /// multi-field update fails validation, no field may be applied to
+    /// `meta.job`. The pre-#4739 in-place pattern would have committed
+    /// `delivery` (a benign public webhook) before failing on
+    /// `delivery_targets` (the SSRF target), leaving cron state half
+    /// updated and divergent from the 400 the route returned.
+    #[test]
+    fn update_job_partial_mutation_is_atomic() {
+        use librefang_types::scheduler::CronDelivery;
+
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let id = sched.add_job(make_job(agent), false).unwrap();
+
+        // Valid `delivery` would succeed in isolation. The SSRF-laden
+        // `delivery_targets` must roll the whole transaction back.
+        let updates = serde_json::json!({
+            "delivery": {"kind": "webhook", "url": "https://example.com/hook"},
+            "delivery_targets": [
+                {"type": "webhook", "url": "http://0x7f000001/hook"}
+            ]
+        });
+        let err = sched
+            .update_job(id, &updates)
+            .expect_err("update with mixed valid + SSRF must fail");
+        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
+
+        // `delivery` must NOT have been smuggled in despite passing its
+        // own check — atomicity is the property we care about.
+        let after = sched.get_job(id).unwrap();
+        assert!(
+            matches!(after.delivery, CronDelivery::None),
+            "delivery must remain None (the seeded value), got {:?}",
+            after.delivery
+        );
+        assert!(after.delivery_targets.is_empty());
+    }
+
+    /// Same atomicity guarantee in the other direction: failure in the
+    /// `delivery` phase must not leak the would-be `delivery_targets` mutation.
+    #[test]
+    fn update_job_partial_mutation_targets_not_smuggled_on_delivery_failure() {
+        let (sched, _tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let id = sched.add_job(make_job(agent), false).unwrap();
+        // Seeded targets are empty; that's the invariant.
+        assert!(sched.get_job(id).unwrap().delivery_targets.is_empty());
+
+        let updates = serde_json::json!({
+            "delivery": {"kind": "webhook", "url": "http://10.0.0.1/hook"},
+            "delivery_targets": [{"type": "webhook", "url": "https://example.com/hook"}]
+        });
+        let err = sched
+            .update_job(id, &updates)
+            .expect_err("RFC 1918 delivery must reject");
+        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
+
+        // Atomicity: the would-be valid targets must not survive when
+        // `delivery` (which the parser sees first) gets rejected.
+        assert!(sched.get_job(id).unwrap().delivery_targets.is_empty());
     }
 
     #[test]

--- a/crates/librefang-types/Cargo.toml
+++ b/crates/librefang-types/Cargo.toml
@@ -24,6 +24,7 @@ unic-langid = { workspace = true }
 regex-lite = { workspace = true }
 schemars = { version = "0.8", features = ["chrono", "uuid1"] }
 tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 rmp-serde = { workspace = true }

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -760,22 +760,21 @@ pub fn validate_cron_delivery_targets(targets: &[CronDeliveryTarget]) -> Result<
 /// Validate a webhook URL against SSRF: scheme must be http/https, length
 /// within `MAX_WEBHOOK_URL_LEN`, and the host (after WHATWG URL
 /// normalisation) must not point at the daemon itself, RFC 1918 / shared
-/// CGNAT / link-local space, IPv6 ULA / link-local, or known cloud-metadata
-/// services.
+/// CGNAT / link-local space, IPv6 ULA / link-local, RFC 1122 "this network"
+/// 0.0.0.0/8, or known cloud-metadata services.
 ///
 /// `url::Url::parse` normalises non-canonical IPv4 forms — hex
 /// `0x7f000001`, single-decimal `2130706433`, octal-dotted `0177.0.0.1` —
 /// and IPv4-mapped IPv6 (`::ffff:127.0.0.1`) before the literal check, so
 /// these bypass surfaces (#4732) collapse to standard `127.0.0.1` /
-/// `::ffff:7f00:1` shapes that `is_blocked_ip` recognises.
+/// `::ffff:7f00:1` shapes that `is_blocked_ip` recognises. The parser
+/// also lowercases the scheme, so `HTTPS://…` is accepted (was rejected
+/// by the pre-#4739 prefix check).
 ///
 /// DNS-blind: a hostname that resolves to a private IP only at fire-time
 /// (DNS rebind) is NOT caught here; the resolver-time check lives in
 /// `librefang-api::webhook_store::validate_webhook_url_resolved` (#3701).
 pub fn validate_webhook_url(url: &str) -> Result<(), String> {
-    if !url.starts_with("http://") && !url.starts_with("https://") {
-        return Err("webhook URL must start with http:// or https://".into());
-    }
     if url.len() > MAX_WEBHOOK_URL_LEN {
         return Err(format!(
             "webhook URL too long ({} chars, max {MAX_WEBHOOK_URL_LEN})",
@@ -784,6 +783,17 @@ pub fn validate_webhook_url(url: &str) -> Result<(), String> {
     }
     let parsed =
         ::url::Url::parse(url).map_err(|e| format!("webhook URL is not parseable: {e}"))?;
+    // Use the parsed scheme rather than a raw `starts_with` check so
+    // upper-case forms (`HTTPS://…`) and other case-mixed inputs are
+    // canonicalised to lowercase before the comparison.
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "webhook URL scheme '{other}' is not allowed, only http/https"
+            ));
+        }
+    }
     match parsed.host() {
         Some(::url::Host::Ipv4(v4)) => {
             let ip = IpAddr::V4(v4);
@@ -812,8 +822,15 @@ pub fn validate_webhook_url(url: &str) -> Result<(), String> {
             }
         }
         None => {
-            // Special schemes always populate `host`; an empty host is
-            // either a bug in url or a malformed input we should refuse.
+            // `url::Url::parse` populates `host` for every "special"
+            // scheme (http/https/ftp/ws/wss/file). Reaching this arm
+            // means the input is malformed in a way the parser tolerated
+            // but we cannot safely route — refuse explicitly.
+            //
+            // Note: `librefang-api::webhook_store::validate_webhook_url`
+            // historically returns `Ok(())` here; the stricter behaviour
+            // is mirrored back in `webhook_store` for consistency
+            // (#4739 review).
             return Err("webhook URL has no host component".into());
         }
     }
@@ -823,6 +840,17 @@ pub fn validate_webhook_url(url: &str) -> Result<(), String> {
 /// Hostnames the daemon refuses to webhook to. Mirrors the dashboard
 /// editor so users see a consistent rejection regardless of which surface
 /// created the target.
+///
+/// `url::Url::parse` already converts IDN forms (Unicode hostnames) to
+/// ASCII punycode (`xn--…`), so the literal-match below operates on the
+/// canonical ASCII form. A Unicode homoglyph that punycode-encodes to a
+/// string other than `"localhost"` etc. WILL slip through this layer; the
+/// resolver-time check at fire-time (#3701, runtime side) is the second
+/// line of defence.
+///
+/// `*.localhost` is reserved by RFC 6761 §6.3 — some loopback adapters and
+/// browsers answer for any subdomain of `.localhost`, so we block the
+/// whole tree rather than just the literal name.
 fn is_blocked_domain(lower: &str) -> bool {
     matches!(
         lower,
@@ -837,13 +865,27 @@ fn is_blocked_domain(lower: &str) -> bool {
 }
 
 /// True for IPs that must never be webhooked to: loopback (`127.0.0.0/8`,
-/// `::1`), unspecified (`0.0.0.0`, `::`), RFC 1918 private (`10/8`,
-/// `172.16/12`, `192.168/16`), CGNAT (`100.64/10`), IPv6 ULA (`fc00::/7`),
-/// multicast (`ff00::/8`), and link-local (`169.254/16`, `fe80::/10`).
-/// Always normalises IPv4-mapped IPv6 first.
+/// `::1`), unspecified (`0.0.0.0`, `::`), RFC 1122 §3.2.1.3 "this network"
+/// (`0.0.0.0/8` — historically rewritten to `127.0.0.0/8` by some stacks),
+/// RFC 1918 private (`10/8`, `172.16/12`, `192.168/16`), CGNAT (`100.64/10`),
+/// IPv6 ULA (`fc00::/7`), multicast (`ff00::/8`), and link-local
+/// (`169.254/16`, `fe80::/10`). Always normalises IPv4-mapped IPv6 first.
 fn is_blocked_ip(ip: IpAddr) -> bool {
     let ip = canonical_ip(ip);
-    ip.is_loopback() || ip.is_unspecified() || is_private_ip(ip) || is_link_local(ip)
+    ip.is_loopback()
+        || ip.is_unspecified()
+        || is_zeronet_v4(ip)
+        || is_private_ip(ip)
+        || is_link_local(ip)
+}
+
+/// RFC 1122 §3.2.1.3 reserves `0.0.0.0/8` as "this network". Modern Linux
+/// stacks reject outbound traffic to this range, but historically (and on
+/// some embedded TCP/IP stacks) `0.x.y.z` was rewritten to `127.x.y.z`,
+/// which would make the entire prefix an SSRF surface to localhost.
+/// Blocking explicitly is cheap and removes the platform dependency.
+fn is_zeronet_v4(ip: IpAddr) -> bool {
+    matches!(ip, IpAddr::V4(v4) if v4.octets()[0] == 0)
 }
 
 /// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
@@ -876,6 +918,12 @@ fn is_private_ip(ip: IpAddr) -> bool {
     }
 }
 
+/// IPv4 link-local is `169.254.0.0/16` per RFC 3927; IPv6 link-local is
+/// `fe80::/10` per RFC 4291. We use `Ipv4Addr::is_link_local()` for the
+/// V4 arm rather than checking `octets()[0] == 169` to keep the matcher
+/// narrow to the actual link-local range — `169.0.0.0 – 169.253.255.255`
+/// and `169.255.0.0 – 169.255.255.255` are routable globally and must
+/// not be rejected here.
 fn is_link_local(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => v4.is_link_local(),
@@ -1310,7 +1358,13 @@ mod tests {
             url: "ftp://example.com/hook".into(),
         };
         let err = job.validate(0).unwrap_err();
-        assert!(err.contains("http://"), "{err}");
+        // Post-#4739: scheme is checked after `Url::parse` via
+        // `parsed.scheme()` rather than a raw `starts_with`, so the error
+        // message names the scheme rather than the prefix.
+        assert!(
+            err.contains("http/https") && err.contains("not allowed"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -1392,6 +1446,48 @@ mod tests {
     #[test]
     fn webhook_unspecified_v4_rejected() {
         assert_webhook_rejected("http://0.0.0.0/");
+    }
+
+    /// RFC 1122 §3.2.1.3 reserves `0.0.0.0/8` ("this network"). Some
+    /// legacy stacks rewrote `0.x.y.z` to `127.x.y.z`, so the whole
+    /// prefix is treated as loopback-equivalent here (#4739 review).
+    #[test]
+    fn webhook_zeronet_v4_rejected() {
+        assert_webhook_rejected("http://0.1.2.3/");
+        assert_webhook_rejected("http://0.255.255.255/");
+    }
+
+    /// `Ipv4Addr::is_link_local` matches `169.254.0.0/16` per RFC 3927.
+    /// Addresses outside that range (e.g. `169.10.0.1`) are globally
+    /// routable and must NOT be rejected — an over-broad
+    /// `octets()[0] == 169` check would block public IPs by accident.
+    #[test]
+    fn webhook_169_outside_link_local_accepted() {
+        // Caller is responsible for clearing webhook fields it does not
+        // want to set; here we just exercise validate_webhook_url.
+        assert!(super::validate_webhook_url("http://169.10.0.1/").is_ok());
+        assert!(super::validate_webhook_url("http://169.255.0.1/").is_ok());
+    }
+
+    /// `url::Url::parse` lowercases the scheme, so mixed-case forms must
+    /// be accepted (the pre-#4739 `starts_with("http://")` check would
+    /// have refused these).
+    #[test]
+    fn webhook_mixed_case_scheme_accepted() {
+        assert!(super::validate_webhook_url("HTTPS://example.com/").is_ok());
+        assert!(super::validate_webhook_url("Http://example.com/").is_ok());
+    }
+
+    /// Non-http(s) schemes must be rejected with the new
+    /// `parsed.scheme()`-based check (#4739 review).
+    #[test]
+    fn webhook_non_http_scheme_rejected() {
+        let mut job = valid_job();
+        job.delivery = CronDelivery::Webhook {
+            url: "ftp://example.com/file".into(),
+        };
+        let err = job.validate(0).expect_err("ftp scheme must be refused");
+        assert!(err.contains("not allowed"), "unexpected error: {err}");
     }
 
     #[test]

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -863,7 +863,10 @@ fn is_private_ip(ip: IpAddr) -> bool {
         IpAddr::V4(v4) => {
             // RFC 1918 (`10/8`, `172.16/12`, `192.168/16`) plus
             // `100.64.0.0/10` (CGNAT shared address space, RFC 6598).
-            v4.is_private() || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
+            // CGNAT range: second octet's top 2 bits must be `01` —
+            // i.e. `0x40` after the `0xC0` mask. Hex form is used here
+            // so the mask/value relationship is visually obvious.
+            v4.is_private() || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 0x40)
         }
         IpAddr::V6(v6) => {
             let segs = v6.segments();

--- a/crates/librefang-types/src/scheduler.rs
+++ b/crates/librefang-types/src/scheduler.rs
@@ -6,6 +6,7 @@
 use crate::agent::{AgentId, SessionMode};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
 use uuid::Uuid;
 
 /// Maximum number of scheduled jobs per agent.
@@ -656,29 +657,7 @@ impl CronJob {
     }
 
     fn validate_delivery(&self) -> Result<(), String> {
-        match &self.delivery {
-            CronDelivery::Channel { channel, to } => {
-                if channel.is_empty() {
-                    return Err("delivery channel must not be empty".into());
-                }
-                if to.is_empty() {
-                    return Err("delivery recipient must not be empty".into());
-                }
-            }
-            CronDelivery::Webhook { url } => {
-                if !url.starts_with("http://") && !url.starts_with("https://") {
-                    return Err("webhook URL must start with http:// or https://".into());
-                }
-                if url.len() > MAX_WEBHOOK_URL_LEN {
-                    return Err(format!(
-                        "webhook URL too long ({} chars, max {MAX_WEBHOOK_URL_LEN})",
-                        url.len()
-                    ));
-                }
-            }
-            CronDelivery::None | CronDelivery::LastChannel => {}
-        }
-        Ok(())
+        validate_cron_delivery(&self.delivery)
     }
 
     /// Validate the multi-destination `delivery_targets` list. Cron jobs are
@@ -686,137 +665,219 @@ impl CronJob {
     /// path/host restrictions live here at the input boundary — by the
     /// time a target reaches `cron_delivery::deliver_*` we trust it.
     fn validate_delivery_targets(&self) -> Result<(), String> {
-        for (i, target) in self.delivery_targets.iter().enumerate() {
-            match target {
-                CronDeliveryTarget::Channel {
-                    channel_type,
-                    recipient,
-                    ..
-                } => {
-                    if channel_type.trim().is_empty() {
-                        return Err(format!(
-                            "delivery_targets[{i}]: channel_type must not be empty"
-                        ));
-                    }
-                    if recipient.trim().is_empty() {
-                        return Err(format!(
-                            "delivery_targets[{i}]: recipient must not be empty"
-                        ));
-                    }
+        validate_cron_delivery_targets(&self.delivery_targets)
+    }
+}
+
+/// Validate a single [`CronDelivery`]. Exposed as a free function so the
+/// kernel `update_job` / `set_delivery_targets` paths can re-run the same
+/// check on an in-place mutation without cloning the whole job (#4732).
+pub fn validate_cron_delivery(delivery: &CronDelivery) -> Result<(), String> {
+    match delivery {
+        CronDelivery::Channel { channel, to } => {
+            if channel.is_empty() {
+                return Err("delivery channel must not be empty".into());
+            }
+            if to.is_empty() {
+                return Err("delivery recipient must not be empty".into());
+            }
+        }
+        CronDelivery::Webhook { url } => validate_webhook_url(url)?,
+        CronDelivery::None | CronDelivery::LastChannel => {}
+    }
+    Ok(())
+}
+
+/// Validate a slice of [`CronDeliveryTarget`]s for the fan-out list.
+/// Returns `Err` with `"delivery_targets[<i>]: …"` prefix so the caller
+/// can surface which entry failed.
+pub fn validate_cron_delivery_targets(targets: &[CronDeliveryTarget]) -> Result<(), String> {
+    for (i, target) in targets.iter().enumerate() {
+        match target {
+            CronDeliveryTarget::Channel {
+                channel_type,
+                recipient,
+                ..
+            } => {
+                if channel_type.trim().is_empty() {
+                    return Err(format!(
+                        "delivery_targets[{i}]: channel_type must not be empty"
+                    ));
                 }
-                CronDeliveryTarget::Webhook { url, .. } => {
-                    if !url.starts_with("http://") && !url.starts_with("https://") {
-                        return Err(format!(
-                            "delivery_targets[{i}]: webhook URL must start with http:// or https://"
-                        ));
-                    }
-                    if url.len() > MAX_WEBHOOK_URL_LEN {
-                        return Err(format!(
-                            "delivery_targets[{i}]: webhook URL too long ({} chars, max {MAX_WEBHOOK_URL_LEN})",
-                            url.len()
-                        ));
-                    }
-                    // SSRF: refuse hosts that point at the daemon itself or
-                    // at cloud metadata services. Best-effort URL parse —
-                    // malformed URLs were already rejected by the scheme
-                    // prefix check above.
-                    if let Some(host) = extract_url_host(url) {
-                        if is_blocked_webhook_host(&host) {
-                            return Err(format!(
-                                "delivery_targets[{i}]: webhook host '{host}' is not allowed (loopback / link-local / metadata service)"
-                            ));
-                        }
-                    }
+                if recipient.trim().is_empty() {
+                    return Err(format!(
+                        "delivery_targets[{i}]: recipient must not be empty"
+                    ));
                 }
-                CronDeliveryTarget::LocalFile { path, .. } => {
-                    if path.trim().is_empty() {
-                        return Err(format!(
-                            "delivery_targets[{i}]: file path must not be empty"
-                        ));
-                    }
-                    let p = std::path::Path::new(path);
-                    if p.is_absolute() {
-                        return Err(format!(
-                            "delivery_targets[{i}]: LocalFile path must be workspace-relative, not absolute ({path})"
-                        ));
-                    }
-                    // Windows drive-letter form (`C:\...` or `C:/...`) is
-                    // not flagged absolute on Unix — guard explicitly.
-                    let bytes = path.as_bytes();
-                    if bytes.len() >= 3
-                        && bytes[0].is_ascii_alphabetic()
-                        && bytes[1] == b':'
-                        && (bytes[2] == b'\\' || bytes[2] == b'/')
-                    {
-                        return Err(format!(
-                            "delivery_targets[{i}]: LocalFile path must be workspace-relative ({path})"
-                        ));
-                    }
-                    if p.components()
-                        .any(|c| matches!(c, std::path::Component::ParentDir))
-                    {
-                        return Err(format!(
-                            "delivery_targets[{i}]: LocalFile path must not contain '..' ({path})"
-                        ));
-                    }
+            }
+            CronDeliveryTarget::Webhook { url, .. } => {
+                validate_webhook_url(url).map_err(|e| format!("delivery_targets[{i}]: {e}"))?;
+            }
+            CronDeliveryTarget::LocalFile { path, .. } => {
+                if path.trim().is_empty() {
+                    return Err(format!(
+                        "delivery_targets[{i}]: file path must not be empty"
+                    ));
                 }
-                CronDeliveryTarget::Email { to, .. } => {
-                    if to.trim().is_empty() {
-                        return Err(format!(
-                            "delivery_targets[{i}]: email recipient must not be empty"
-                        ));
-                    }
+                let p = std::path::Path::new(path);
+                if p.is_absolute() {
+                    return Err(format!(
+                        "delivery_targets[{i}]: LocalFile path must be workspace-relative, not absolute ({path})"
+                    ));
+                }
+                // Windows drive-letter form (`C:\...` or `C:/...`) is
+                // not flagged absolute on Unix — guard explicitly.
+                let bytes = path.as_bytes();
+                if bytes.len() >= 3
+                    && bytes[0].is_ascii_alphabetic()
+                    && bytes[1] == b':'
+                    && (bytes[2] == b'\\' || bytes[2] == b'/')
+                {
+                    return Err(format!(
+                        "delivery_targets[{i}]: LocalFile path must be workspace-relative ({path})"
+                    ));
+                }
+                if p.components()
+                    .any(|c| matches!(c, std::path::Component::ParentDir))
+                {
+                    return Err(format!(
+                        "delivery_targets[{i}]: LocalFile path must not contain '..' ({path})"
+                    ));
+                }
+            }
+            CronDeliveryTarget::Email { to, .. } => {
+                if to.trim().is_empty() {
+                    return Err(format!(
+                        "delivery_targets[{i}]: email recipient must not be empty"
+                    ));
                 }
             }
         }
-        Ok(())
     }
+    Ok(())
 }
 
-/// Extract the lowercased host from a URL string. Returns `None` if the URL
-/// cannot be parsed. Used by webhook SSRF validation.
-fn extract_url_host(url: &str) -> Option<String> {
-    // Strip scheme.
-    let after_scheme = url
-        .strip_prefix("http://")
-        .or_else(|| url.strip_prefix("https://"))?;
-    // Host runs until the next '/', '?', '#', or end-of-string.
-    let host_end = after_scheme
-        .find(['/', '?', '#'])
-        .unwrap_or(after_scheme.len());
-    let host_part = &after_scheme[..host_end];
-    // Strip optional userinfo (user:pass@host).
-    let host_part = host_part.rsplit('@').next().unwrap_or(host_part);
-    // Strip optional port. IPv6 addresses are wrapped in `[...]` so a colon
-    // outside brackets is the port separator.
-    let host = if let Some(stripped) = host_part.strip_prefix('[') {
-        // IPv6 — keep the bracketed form for downstream matching.
-        let close = stripped.find(']')?;
-        &host_part[..=close + 1 - 1] // up to and including ']'
-    } else if let Some(colon) = host_part.find(':') {
-        &host_part[..colon]
-    } else {
-        host_part
-    };
-    if host.is_empty() {
-        None
-    } else {
-        Some(host.to_ascii_lowercase())
+/// Validate a webhook URL against SSRF: scheme must be http/https, length
+/// within `MAX_WEBHOOK_URL_LEN`, and the host (after WHATWG URL
+/// normalisation) must not point at the daemon itself, RFC 1918 / shared
+/// CGNAT / link-local space, IPv6 ULA / link-local, or known cloud-metadata
+/// services.
+///
+/// `url::Url::parse` normalises non-canonical IPv4 forms — hex
+/// `0x7f000001`, single-decimal `2130706433`, octal-dotted `0177.0.0.1` —
+/// and IPv4-mapped IPv6 (`::ffff:127.0.0.1`) before the literal check, so
+/// these bypass surfaces (#4732) collapse to standard `127.0.0.1` /
+/// `::ffff:7f00:1` shapes that `is_blocked_ip` recognises.
+///
+/// DNS-blind: a hostname that resolves to a private IP only at fire-time
+/// (DNS rebind) is NOT caught here; the resolver-time check lives in
+/// `librefang-api::webhook_store::validate_webhook_url_resolved` (#3701).
+pub fn validate_webhook_url(url: &str) -> Result<(), String> {
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err("webhook URL must start with http:// or https://".into());
     }
+    if url.len() > MAX_WEBHOOK_URL_LEN {
+        return Err(format!(
+            "webhook URL too long ({} chars, max {MAX_WEBHOOK_URL_LEN})",
+            url.len()
+        ));
+    }
+    let parsed =
+        ::url::Url::parse(url).map_err(|e| format!("webhook URL is not parseable: {e}"))?;
+    match parsed.host() {
+        Some(::url::Host::Ipv4(v4)) => {
+            let ip = IpAddr::V4(v4);
+            if is_blocked_ip(ip) {
+                return Err(format!(
+                    "webhook host '{v4}' is not allowed (loopback / unspecified / private / link-local / metadata)"
+                ));
+            }
+        }
+        Some(::url::Host::Ipv6(v6)) => {
+            // Canonicalise IPv4-mapped IPv6 before the rule check so a
+            // transparent connect to the embedded IPv4 cannot bypass.
+            let ip = canonical_ip(IpAddr::V6(v6));
+            if is_blocked_ip(ip) {
+                return Err(format!(
+                    "webhook host '{v6}' is not allowed (loopback / unspecified / private / link-local / metadata)"
+                ));
+            }
+        }
+        Some(::url::Host::Domain(host)) => {
+            let lower = host.to_ascii_lowercase();
+            if is_blocked_domain(&lower) {
+                return Err(format!(
+                    "webhook host '{host}' is not allowed (loopback / metadata / .internal)"
+                ));
+            }
+        }
+        None => {
+            // Special schemes always populate `host`; an empty host is
+            // either a bug in url or a malformed input we should refuse.
+            return Err("webhook URL has no host component".into());
+        }
+    }
+    Ok(())
 }
 
-/// Hosts the daemon refuses to webhook to. Mirrors the dashboard editor
-/// so users see a consistent rejection regardless of where the target
-/// was created.
-fn is_blocked_webhook_host(host: &str) -> bool {
+/// Hostnames the daemon refuses to webhook to. Mirrors the dashboard
+/// editor so users see a consistent rejection regardless of which surface
+/// created the target.
+fn is_blocked_domain(lower: &str) -> bool {
     matches!(
-        host,
-        "localhost" | "metadata" | "metadata.google.internal" | "metadata.aws.amazon.com"
-    ) || host.starts_with("127.")
-        || host.starts_with("169.254.")
-        || host == "[::1]"
-        || host.starts_with("[fe80:")
-        || host.starts_with("fe80:")
+        lower,
+        "localhost"
+            | "metadata"
+            | "metadata.google.internal"
+            | "metadata.aws.amazon.com"
+            | "instance-data"
+            | "instance-data.ec2.internal"
+    ) || lower.ends_with(".localhost")
+        || lower.ends_with(".internal")
+}
+
+/// True for IPs that must never be webhooked to: loopback (`127.0.0.0/8`,
+/// `::1`), unspecified (`0.0.0.0`, `::`), RFC 1918 private (`10/8`,
+/// `172.16/12`, `192.168/16`), CGNAT (`100.64/10`), IPv6 ULA (`fc00::/7`),
+/// multicast (`ff00::/8`), and link-local (`169.254/16`, `fe80::/10`).
+/// Always normalises IPv4-mapped IPv6 first.
+fn is_blocked_ip(ip: IpAddr) -> bool {
+    let ip = canonical_ip(ip);
+    ip.is_loopback() || ip.is_unspecified() || is_private_ip(ip) || is_link_local(ip)
+}
+
+/// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
+/// addresses are returned unchanged.
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(v6),
+        },
+        IpAddr::V4(_) => ip,
+    }
+}
+
+fn is_private_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            // RFC 1918 (`10/8`, `172.16/12`, `192.168/16`) plus
+            // `100.64.0.0/10` (CGNAT shared address space, RFC 6598).
+            v4.is_private() || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
+        }
+        IpAddr::V6(v6) => {
+            let segs = v6.segments();
+            // ULA `fc00::/7` (covers `fd00::/8`) plus multicast `ff00::/8`.
+            (segs[0] & 0xfe00) == 0xfc00 || (segs[0] & 0xff00) == 0xff00
+        }
+    }
+}
+
+fn is_link_local(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_link_local(),
+        IpAddr::V6(v6) => (v6.segments()[0] & 0xffc0) == 0xfe80,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1260,12 +1321,15 @@ mod tests {
     }
 
     #[test]
-    fn webhook_http_ok() {
+    fn webhook_http_external_ok() {
+        // Public-looking host on plain http is fine — the scheme is
+        // permitted (legacy on-prem systems), only SSRF-prone hosts are
+        // refused.
         let mut job = valid_job();
         job.delivery = CronDelivery::Webhook {
-            url: "http://localhost:8080/hook".into(),
+            url: "http://example.com:8080/hook".into(),
         };
-        assert!(job.validate(0).is_ok());
+        assert!(job.validate(0).is_ok(), "{:?}", job.validate(0));
     }
 
     #[test]
@@ -1275,6 +1339,139 @@ mod tests {
             url: "https://example.com/hook".into(),
         };
         assert!(job.validate(0).is_ok());
+    }
+
+    // -- Webhook SSRF coverage (#4732) -------------------------------------
+    //
+    // Each URL form below either points at a private/loopback/metadata
+    // address directly or relies on a host-form normalisation step
+    // (numeric IPv4, octal/hex octets, IPv4-mapped IPv6) that the
+    // pre-#4732 string-prefix logic missed.
+
+    fn assert_webhook_rejected(url: &str) {
+        let mut job = valid_job();
+        job.delivery = CronDelivery::Webhook { url: url.into() };
+        let err = job
+            .validate(0)
+            .expect_err(&format!("expected SSRF rejection for {url}"));
+        assert!(
+            err.contains("not allowed") || err.contains("not parseable"),
+            "unexpected error for {url}: {err}"
+        );
+    }
+
+    #[test]
+    fn webhook_localhost_name_rejected() {
+        assert_webhook_rejected("http://localhost:8080/hook");
+    }
+
+    #[test]
+    fn webhook_metadata_aws_rejected() {
+        assert_webhook_rejected("http://metadata.aws.amazon.com/latest/meta-data/");
+    }
+
+    #[test]
+    fn webhook_metadata_gcp_rejected() {
+        assert_webhook_rejected("http://metadata.google.internal/");
+    }
+
+    #[test]
+    fn webhook_dotinternal_suffix_rejected() {
+        assert_webhook_rejected("http://kube-apiserver.cluster.internal/");
+    }
+
+    #[test]
+    fn webhook_loopback_dotted_rejected() {
+        assert_webhook_rejected("http://127.0.0.1/");
+        assert_webhook_rejected("http://127.255.255.254/");
+    }
+
+    #[test]
+    fn webhook_unspecified_v4_rejected() {
+        assert_webhook_rejected("http://0.0.0.0/");
+    }
+
+    #[test]
+    fn webhook_private_v4_rejected() {
+        assert_webhook_rejected("http://10.0.0.1/");
+        assert_webhook_rejected("http://10.255.255.255/");
+        assert_webhook_rejected("http://172.16.0.1/");
+        assert_webhook_rejected("http://172.31.255.255/");
+        assert_webhook_rejected("http://192.168.1.1/");
+    }
+
+    #[test]
+    fn webhook_cgnat_rejected() {
+        assert_webhook_rejected("http://100.64.0.1/");
+    }
+
+    #[test]
+    fn webhook_link_local_v4_rejected() {
+        assert_webhook_rejected("http://169.254.169.254/");
+    }
+
+    #[test]
+    fn webhook_loopback_hex_form_rejected() {
+        // 0x7f000001 == 127.0.0.1 — WHATWG URL parser normalises both
+        // single-component hex and decimal.
+        assert_webhook_rejected("http://0x7f000001/");
+    }
+
+    #[test]
+    fn webhook_loopback_decimal_form_rejected() {
+        // 2130706433 == 127.0.0.1.
+        assert_webhook_rejected("http://2130706433/");
+    }
+
+    #[test]
+    fn webhook_loopback_octal_form_rejected() {
+        // 0177.0.0.1 == 127.0.0.1.
+        assert_webhook_rejected("http://0177.0.0.1/");
+    }
+
+    #[test]
+    fn webhook_loopback_v6_rejected() {
+        assert_webhook_rejected("http://[::1]/");
+    }
+
+    #[test]
+    fn webhook_unspecified_v6_rejected() {
+        assert_webhook_rejected("http://[::]/");
+    }
+
+    #[test]
+    fn webhook_v4_mapped_v6_rejected() {
+        // ::ffff:127.0.0.1 — IPv4-mapped IPv6 wrapping loopback.
+        assert_webhook_rejected("http://[::ffff:127.0.0.1]/");
+        // ::ffff:7f00:1 — same address in compact hex form.
+        assert_webhook_rejected("http://[::ffff:7f00:1]/");
+    }
+
+    #[test]
+    fn webhook_link_local_v6_rejected() {
+        assert_webhook_rejected("http://[fe80::1]/");
+    }
+
+    #[test]
+    fn webhook_unique_local_v6_rejected() {
+        assert_webhook_rejected("http://[fc00::1]/");
+        assert_webhook_rejected("http://[fd12:3456:789a::1]/");
+    }
+
+    #[test]
+    fn webhook_delivery_targets_share_host_validation() {
+        // Same blocklist must apply through CronDeliveryTarget::Webhook
+        // (which is what `delivery_targets` fan-out exposes).
+        let mut job = valid_job();
+        job.delivery_targets = vec![CronDeliveryTarget::Webhook {
+            url: "http://0x7f000001/hook".into(),
+            auth_header: None,
+        }];
+        let err = job.validate(0).expect_err("hex-form loopback must reject");
+        assert!(
+            err.starts_with("delivery_targets[0]:") && err.contains("not allowed"),
+            "{err}"
+        );
     }
 
     // -- Delivery: None / LastChannel --


### PR DESCRIPTION
## Summary
Closes #4732. Webhook host validation in cron delivery had three gaps:

- `is_blocked_webhook_host` did substring matching on the host string and missed numeric-form IPv4 (`0x7f000001`, `2130706433`, `0177.0.0.1`), IPv4-mapped IPv6 (`::ffff:127.0.0.1`), `0.0.0.0`, RFC 1918 private ranges, and IPv6 ULA.
- `CronScheduler::update_job` and `set_delivery_targets` skipped `delivery` / `delivery_targets` validation entirely — an authenticated client could install a webhook through PUT that `add_job` would have refused.
- The `webhook_http_ok` unit test asserted that `http://localhost:8080/hook` was *accepted* — the very behaviour the SSRF check was supposed to prevent.

## Changes

- **Replace prefix-string check with `url::Url::parse` + the typed `url::Host` enum** (mirrors `librefang-api::webhook_store`). WHATWG URL host normalisation collapses hex/decimal/octal IPv4 and IPv4-mapped IPv6 into the canonical address before the blocklist check runs. Block: loopback, unspecified, RFC 1918 + CGNAT (`100.64/10`), IPv4 link-local, IPv6 ULA + multicast + link-local, plus the `localhost` / `metadata.*` / `*.internal` hostname families.
- **Centralise** validation into `pub fn validate_webhook_url`, `validate_cron_delivery`, `validate_cron_delivery_targets` so the kernel can re-run them on update paths.
- **Wire validation into `update_job` and `set_delivery_targets`** so SSRF rejection runs on every mutation surface, not just create.
- **Map `LibreFangError::InvalidInput` → HTTP 400** in `update_cron_job` and `update_schedule` routes — the historical catch-all 404 (\"Schedule not found\") would have masked SSRF rejection as a missing-resource error.
- **Add `url = { workspace = true }` to `librefang-types`** (the dep was already declared workspace-wide; this just opts the crate in).

## Test plan
- [x] `cargo check -p librefang-types -p librefang-kernel -p librefang-api` ✅
- [x] `cargo clippy -p librefang-types -p librefang-kernel -p librefang-api --all-targets -- -D warnings` ✅ zero warnings
- [x] `cargo test -p librefang-types --lib` — 773 passed (16 new SSRF cases)
- [x] `cargo test -p librefang-kernel --lib cron::` — 55 passed (3 new SSRF cases on `update_job` / `set_delivery_targets`)
- [x] `cargo test -p librefang-kernel --lib cron_delivery` — 13 passed (delivery engine tests use absolute LocalFile paths but bypass validation, so unaffected)
- [x] `cargo test -p librefang-api --test workflows_routes_integration` — 44 passed (4 new `cron_job_update_*` integration tests against the real axum router asserting 400 for SSRF webhooks via `delivery` / `delivery_targets`, and a positive sanity check for a public webhook)

## Out-of-scope follow-ups
- The dashboard editor's `isBlockedWebhookHost` (`DeliveryTargetsEditor.tsx`) is documented in #4732 as UX-only feedback. The daemon now enforces the security boundary; consider porting the same `url::Host`-based blocklist to the UI for consistent rejection messages, but it does not gate the fix.
- The dependency-of-dependence DNS-rebind window (`#3701`) is unaffected — `librefang-api::webhook_store::validate_webhook_url_resolved` still owns the resolver-time check at fire time. The cron path validates IP literals at write time only; for hostnames, the runtime delivery layer will need the same DNS-rebind guard before this surface is fully closed against rebind. Tracking under separate issue.