### PR TITLE
fix(ci): unblock Dashboard / Mobile / Docker on main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@ FROM node:20.18.1-alpine AS dashboard-builder
 WORKDIR /build
 COPY crates/librefang-api/dashboard ./dashboard
 WORKDIR /build/dashboard
+# `corepack enable` alone hits `fetchLatestStableVersion2` against the npm
+# registry, which has flaked on us during builds. Activate the pinned pnpm
+# version (matches the `packageManager` field in package.json) directly so
+# the build never has to ask the registry "what's the latest stable?".
 RUN corepack enable \
+    && corepack prepare pnpm@10.33.0 --activate \
     && pnpm install --frozen-lockfile --ignore-scripts \
     && pnpm run build
 

--- a/crates/librefang-api/dashboard/src/setupTests.ts
+++ b/crates/librefang-api/dashboard/src/setupTests.ts
@@ -6,3 +6,21 @@ global.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 };
+
+// jsdom does not implement matchMedia; PushDrawer.useIsMobile and a few
+// pages call it during mount and crash the test render without a stub.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/crates/librefang-extensions/src/oauth.rs
+++ b/crates/librefang-extensions/src/oauth.rs
@@ -433,6 +433,13 @@ fn open_browser(url: &str) -> Result<(), String> {
             .spawn()
             .map_err(|e| e.to_string())?;
     }
+    // Mobile / unknown targets: no desktop browser to launch — the OAuth
+    // flow on those platforms is driven from the host shell. Consume `url`
+    // so `-D unused_variables` stays happy on e.g. aarch64-linux-android.
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        let _ = url;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Three independent fixes for the three CI jobs that have been red on every push to `main` since `cfb52266` / `83c4c7f1` / `858c79b6`. Bundled into one PR per the in-thread "fix everything I find together" rule from the root `CLAUDE.md`.

### 1. Dashboard Build — `TypeError: window.matchMedia is not a function`

`PushDrawer.useIsMobile` (added in #4737) calls `window.matchMedia` during mount. jsdom does not implement `matchMedia`, so every test that mounts a tree containing `PushDrawer` crashed. Added a no-op stub next to the existing `ResizeObserver` stub in `src/setupTests.ts`. Vitest goes from red to **567/567 passing**.

### 2. Mobile Build Smoke — `unused_variables` on `aarch64-linux-android`

`open_browser(url)` in `librefang-extensions::oauth` had three `cfg` branches (`windows` / `macos` / `linux`) and nothing else. On Android none match → `url` unused → `clippy -D warnings` rejects the build. Added a `cfg(not(any(...)))` branch that explicitly consumes `url` (`let _ = url`); the desktop OAuth flow on mobile is driven by the host shell, so silently ignoring is the correct behaviour.

### 3. Docker Build — `corepack` flake on `fetchLatestStableVersion2`

`corepack enable` alone funnels the dashboard-builder stage through `fetchLatestStableVersion2`, which has flaked against the npm registry mid-build. The `packageManager` field in `package.json` already pins `pnpm@10.33.0`, so the registry round trip is unnecessary. Drive corepack with an explicit `corepack prepare pnpm@10.33.0 --activate` so the build never has to ask "what's the latest stable version?".

## Verification

- `pnpm test --run` → **567 / 567 passing** (was: red on `PushDrawer` mounts).
- `pnpm typecheck` → clean.
- `cargo clippy -p librefang-extensions --all-targets -- -D warnings` → clean on darwin host. Android `cfg(not(any(...)))` branch can only be exercised by the Mobile Build Smoke job; structurally guaranteed to consume `url`.
- Pre-push hook (full-workspace clippy + openapi drift) → green.
- Docker change is configuration-only; smoke-tested by the Docker Build job in this PR.

## Out-of-scope

- The `Coverage` job has been red separately since `06989184` — different root cause; not touched here.