### PR TITLE
ci: fix PR Status Labels 403 by splitting pull_request_review trigger

### DIFF
--- a/.github/workflows/pr-review-collector.yml
+++ b/.github/workflows/pr-review-collector.yml
@@ -1,0 +1,52 @@
+name: PR Review Sync (collector)
+
+# Captures pull_request_review.submitted events and emits an artifact
+# with the PR number and review state. The companion applier workflow
+# (`pr-review-state-applier.yml`) is keyed off `workflow_run` against
+# this workflow and applies the resulting label changes there.
+#
+# Why split: GitHub downgrades GITHUB_TOKEN to read-only for any
+# pull_request_review-triggered workflow — even on internal (non-fork)
+# PRs and even when the workflow declares `permissions: write`. So a
+# direct `issues.addLabels` call from this trigger 403s with
+# "Resource not accessible by integration". `workflow_run` runs in the
+# default branch's context with the default-write token, which is why
+# the applier can perform the writes.
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  collect:
+    name: Capture review event
+    runs-on: ubuntu-latest
+    # Only the two states the applier acts on need a full collection
+    # run; commented/dismissed/pending events are dropped here so we
+    # don't churn artifacts.
+    if: github.event.review.state == 'changes_requested' || github.event.review.state == 'approved'
+    steps:
+      - name: Write event payload
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+        run: |
+          mkdir -p ./payload
+          # Use jq to construct JSON safely (avoids shell injection from
+          # any future expansion of the consumed event fields).
+          jq -n \
+            --argjson pr "$PR_NUMBER" \
+            --arg state "$REVIEW_STATE" \
+            '{pr_number: $pr, review_state: $state}' \
+            > ./payload/event.json
+          cat ./payload/event.json
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pr-review-event
+          path: ./payload/event.json
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/pr-review-state-applier.yml
+++ b/.github/workflows/pr-review-state-applier.yml
@@ -1,0 +1,106 @@
+name: PR Review Sync (applier)
+
+# Triggered by completion of `PR Review Sync (collector)`. Reads the
+# captured event payload and applies the ready-for-review /
+# needs-changes labels.
+#
+# Runs in the default-branch context, so the GITHUB_TOKEN here gets
+# the workflow's declared permissions (issues: write, pull-requests:
+# write) — unlike the collector's pull_request_review token, which
+# GitHub forces read-only.
+
+on:
+  workflow_run:
+    workflows: ["PR Review Sync (collector)"]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  apply:
+    name: Apply review-state labels
+    runs-on: ubuntu-latest
+    # Skip if the collector failed (e.g. the review state filter
+    # excluded it, jq missing, etc.). The artifact would also be
+    # absent in that case.
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download payload
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pr-review-event
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./payload
+
+      - name: Apply labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const fs = require('fs');
+            const payload = JSON.parse(fs.readFileSync('./payload/event.json', 'utf8'));
+
+            const prNumber = payload.pr_number;
+            const reviewState = payload.review_state;
+
+            // Defensive: collector pre-filters but double-check here so
+            // a stale or hand-crafted artifact can't drive label state.
+            if (reviewState !== 'changes_requested' && reviewState !== 'approved') {
+              core.info(`Ignoring review_state=${reviewState}`);
+              return;
+            }
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid pr_number in payload: ${prNumber}`);
+              return;
+            }
+
+            const READY = 'ready-for-review';
+            const NEEDS = 'needs-changes';
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const labels = pr.labels.map(l => l.name);
+
+            async function addLabel(label) {
+              if (!labels.includes(label)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: [label],
+                });
+              }
+            }
+            async function removeLabel(label) {
+              if (labels.includes(label)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: label,
+                }).catch(() => {});
+              }
+            }
+
+            const hasBlocker = labels.includes('has-conflicts') || labels.includes('ci-failed');
+
+            if (reviewState === 'changes_requested') {
+              await addLabel(NEEDS);
+              await removeLabel(READY);
+              core.info(`#${prNumber}: changes requested → +${NEEDS} -${READY}`);
+            } else {
+              // approved
+              await removeLabel(NEEDS);
+              if (!hasBlocker) {
+                await addLabel(READY);
+                core.info(`#${prNumber}: approved → -${NEEDS} +${READY}`);
+              } else {
+                core.info(`#${prNumber}: approved but has blockers, skipping ${READY}`);
+              }
+            }

--- a/.github/workflows/pr-review-state-applier.yml
+++ b/.github/workflows/pr-review-state-applier.yml
@@ -16,6 +16,11 @@ on:
 
 permissions:
   contents: read
+  # Required by `actions/download-artifact` when fetching an artifact
+  # from a different workflow run (the collector). Without this the
+  # download step 403s — once a workflow declares `permissions:`,
+  # unspecified scopes default to `none`.
+  actions: read
   issues: write
   pull-requests: write
 

--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -14,8 +14,13 @@ on:
     branches: [main]
   check_suite:
     types: [completed]
-  pull_request_review:
-    types: [submitted]
+  # NOTE: pull_request_review submissions are handled by
+  # `pr-review-collector.yml` + `pr-review-state-applier.yml`. GitHub
+  # downgrades GITHUB_TOKEN to read-only for pull_request_review-triggered
+  # workflows, even on internal PRs and even when the workflow declares
+  # `permissions: write`, so the addLabels/removeLabel calls would 403
+  # if we kept that trigger here. The applier runs in workflow_run
+  # context where the default-branch token retains write access.
   workflow_dispatch:
 
 permissions:
@@ -341,13 +346,20 @@ jobs:
               core.info(`#${pr.number}: removed "${LABEL}" (has .rs files)`);
             }
 
-  # ── Review state: ready-for-review ↔ needs-changes ───────────────
+  # ── Review state: needs-changes cleanup on push ──────────────────
+  # Real-time sync of approve / changes_requested labels lives in
+  # `pr-review-collector.yml` + `pr-review-state-applier.yml` (split via
+  # workflow_run because pull_request_review tokens are read-only). This
+  # job only handles the post-push case: a new push may have addressed
+  # an outstanding changes_requested review, in which case needs-changes
+  # should clear if no reviewer still has CHANGES_REQUESTED as their
+  # latest state.
   review-state:
     name: Review State
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_review' || (github.event_name == 'pull_request_target' && github.event.action == 'synchronize')
+    if: github.event_name == 'pull_request_target' && github.event.action == 'synchronize'
     steps:
-      - name: Sync review labels
+      - name: Clear needs-changes after push if all reviews resolved
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -384,58 +396,38 @@ jobs:
               }
             }
 
-            // Don't add ready-for-review if blocking labels are present
             const hasBlocker = labels.includes('has-conflicts') || labels.includes('ci-failed');
 
-            if (context.eventName === 'pull_request_review') {
-              const state = context.payload.review.state;
-              if (state === 'changes_requested') {
-                await addLabel(NEEDS);
-                await removeLabel(READY);
-                core.info(`#${prNumber}: changes requested → +${NEEDS} -${READY}`);
-              } else if (state === 'approved') {
-                await removeLabel(NEEDS);
-                if (!hasBlocker) {
-                  await addLabel(READY);
-                  core.info(`#${prNumber}: approved → -${NEEDS} +${READY}`);
-                } else {
-                  core.info(`#${prNumber}: approved but has blockers, skipping ${READY}`);
-                }
-              }
-            } else if (context.eventName === 'pull_request_target' && context.payload.action === 'synchronize') {
-              // New push — check whether any changes_requested reviews are still
-              // pending (not superseded by a later approved/dismissed review from
-              // the same reviewer). Only clear needs-changes when all such reviews
-              // have been resolved.
-              if (labels.includes(NEEDS)) {
-                const reviews = await github.paginate(github.rest.pulls.listReviews, {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: prNumber,
-                  per_page: 100,
-                });
+            // Only act if needs-changes is currently set; otherwise nothing to do.
+            if (!labels.includes(NEEDS)) return;
 
-                // Build per-reviewer latest state (last review wins)
-                const latestByReviewer = new Map();
-                for (const r of reviews) {
-                  if (!r.user || r.state === 'COMMENTED' || r.state === 'PENDING') continue;
-                  latestByReviewer.set(r.user.login, r.state);
-                }
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
 
-                const hasPendingChangesRequested = [...latestByReviewer.values()].some(
-                  s => s === 'CHANGES_REQUESTED'
-                );
+            // Build per-reviewer latest state (last review wins)
+            const latestByReviewer = new Map();
+            for (const r of reviews) {
+              if (!r.user || r.state === 'COMMENTED' || r.state === 'PENDING') continue;
+              latestByReviewer.set(r.user.login, r.state);
+            }
 
-                if (hasPendingChangesRequested) {
-                  core.info(`#${prNumber}: new push but changes_requested still pending, keeping ${NEEDS}`);
-                } else {
-                  await removeLabel(NEEDS);
-                  if (!hasBlocker) {
-                    await addLabel(READY);
-                    core.info(`#${prNumber}: new push, all reviews resolved → -${NEEDS} +${READY}`);
-                  } else {
-                    core.info(`#${prNumber}: new push → -${NEEDS}, skipping ${READY} (blockers)`);
-                  }
-                }
-              }
+            const hasPendingChangesRequested = [...latestByReviewer.values()].some(
+              s => s === 'CHANGES_REQUESTED'
+            );
+
+            if (hasPendingChangesRequested) {
+              core.info(`#${prNumber}: new push but changes_requested still pending, keeping ${NEEDS}`);
+              return;
+            }
+
+            await removeLabel(NEEDS);
+            if (!hasBlocker) {
+              await addLabel(READY);
+              core.info(`#${prNumber}: new push, all reviews resolved → -${NEEDS} +${READY}`);
+            } else {
+              core.info(`#${prNumber}: new push → -${NEEDS}, skipping ${READY} (blockers)`);
             }


### PR DESCRIPTION
## Problem

`PR Status Labels / Review State` has been failing on every
review submission. Latest example:
https://github.com/librefang/librefang/actions/runs/25473539562/job/74742060153

```
POST /repos/librefang/librefang/issues/4716/labels
  → 403 Resource not accessible by integration
  x-accepted-github-permissions: issues=write; pull_requests=write
```

## Root cause

GitHub forces `GITHUB_TOKEN` to read-only on any
`pull_request_review`-triggered workflow — even on internal (non-fork)
PRs and even when the workflow declares `permissions: write` at the
top level. The repo-level setting `default_workflow_permissions = write`
does not lift the downgrade. The runner's own log confirms it:

```
GITHUB_TOKEN Permissions
  Contents: read
  Issues: read
  Metadata: read
  PullRequests: read
```

So the existing `Review State` job's `addLabels` / `removeLabel` calls
were always going to 403 once a `CHANGES_REQUESTED` / `APPROVED` review
landed. The job's `pull_request_target.synchronize` branch was fine
(that token retains write); only the `pull_request_review` branch was
broken.

## Summary

- **`.github/workflows/pr-review-collector.yml`** (new) — only workflow
  listening on `pull_request_review.submitted`. Holds the read-only
  token, just serializes `{pr_number, review_state}` into an artifact
  (using `jq --argjson` / `--arg` to avoid shell-injection through
  event fields). Filters `commented` / `dismissed` / `pending` so the
  applier never wakes up for no-op events.

- **`.github/workflows/pr-review-state-applier.yml`** (new) — triggered
  by `workflow_run` against the collector. `workflow_run` runs in the
  default-branch context, so its declared `issues: write` /
  `pull-requests: write` actually take effect. Downloads the artifact
  and applies the same `ready-for-review` ↔ `needs-changes` rules the
  old `Review State` job ran. Defensive re-validation of
  `review_state` and `pr_number` guards against a tampered artifact.

- **`.github/workflows/pr-status-labels.yml`** — drops the
  `pull_request_review` trigger; the surviving `review-state` job now
  only handles the `pull_request_target.synchronize` cleanup case
  (clear `needs-changes` after a push when no reviewer's latest state
  is `CHANGES_REQUESTED`), which retains a write-capable token. Dead
  code in the script removed.

## Test plan

- [x] `python3 -c 'import yaml; …'` parses all three workflows.
- [x] `yamllint -d relaxed` reports only `line-length` warnings, in
  line with the rest of the workflows in this repo.
- [ ] After merge, the next `CHANGES_REQUESTED` review on any open PR
  should produce a successful `PR Review Sync (collector)` run +
  `PR Review Sync (applier)` run, with `needs-changes` applied (and
  `ready-for-review` removed). Inverse on `APPROVED`.
- [ ] After merge, push to a PR carrying `needs-changes` whose latest
  reviews are no longer `CHANGES_REQUESTED` should still clear the
  label via the surviving `review-state` job in `pr-status-labels.yml`.

## Out-of-scope follow-ups

None — this is the minimum surgical fix for the 403.