### PR TITLE
feat(kernel): make token burst ratio configurable per agent

### DIFF
--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -266,9 +266,15 @@ impl LibreFangKernel {
         let caps = manifest_to_capabilities(&manifest);
         self.capabilities.grant(agent_id, caps);
 
-        // Register with scheduler
-        self.scheduler
-            .register(agent_id, manifest.resources.clone());
+        // Register with scheduler — pre-resolve global burst ratio
+        let mut quota = manifest.resources.clone();
+        if quota.burst_ratio.is_none() {
+            let global = self.budget_config().default_burst_ratio;
+            if global > 0.0 {
+                quota.burst_ratio = Some(global);
+            }
+        }
+        self.scheduler.register(agent_id, quota);
 
         // Create registry entry
         let tags = manifest.tags.clone();

--- a/crates/librefang-kernel/src/scheduler.rs
+++ b/crates/librefang-kernel/src/scheduler.rs
@@ -191,7 +191,7 @@ impl AgentScheduler {
 
         // --- Burst limit: configurable fraction of the hourly token budget per minute ---
         if token_limit > 0 {
-            let burst_cap = (token_limit as f64 * quota.effective_burst_ratio() as f64) as u64;
+            let burst_cap = (token_limit as f64 * quota.effective_burst_ratio(0.0) as f64) as u64;
             let tokens_last_min = tracker.tokens_in_last_minute();
             if burst_cap > 0 && tokens_last_min > burst_cap {
                 return Err(LibreFangError::QuotaExceeded(format!(
@@ -278,7 +278,7 @@ impl AgentScheduler {
             )));
         }
         // Burst check against the projected spend
-        let burst_cap = (token_limit as f64 * quota.effective_burst_ratio() as f64) as u64;
+        let burst_cap = (token_limit as f64 * quota.effective_burst_ratio(0.0) as f64) as u64;
         let tokens_last_min = tracker.tokens_in_last_minute();
         if burst_cap > 0 && tokens_last_min.saturating_add(estimated_tokens) > burst_cap {
             return Err(LibreFangError::QuotaExceeded(format!(

--- a/crates/librefang-kernel/src/scheduler.rs
+++ b/crates/librefang-kernel/src/scheduler.rs
@@ -189,9 +189,9 @@ impl AgentScheduler {
             )));
         }
 
-        // --- Burst limit: no more than 1/5 of the hourly token budget in any single minute ---
+        // --- Burst limit: configurable fraction of the hourly token budget per minute ---
         if token_limit > 0 {
-            let burst_cap = token_limit / 5;
+            let burst_cap = (token_limit as f64 * quota.effective_burst_ratio() as f64) as u64;
             let tokens_last_min = tracker.tokens_in_last_minute();
             if burst_cap > 0 && tokens_last_min > burst_cap {
                 return Err(LibreFangError::QuotaExceeded(format!(
@@ -278,7 +278,7 @@ impl AgentScheduler {
             )));
         }
         // Burst check against the projected spend
-        let burst_cap = token_limit / 5;
+        let burst_cap = (token_limit as f64 * quota.effective_burst_ratio() as f64) as u64;
         let tokens_last_min = tracker.tokens_in_last_minute();
         if burst_cap > 0 && tokens_last_min.saturating_add(estimated_tokens) > burst_cap {
             return Err(LibreFangError::QuotaExceeded(format!(

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -548,8 +548,17 @@ impl ResourceQuota {
     }
 
     /// Return the effective burst ratio, clamped to `[0.01, 1.0]`.
-    pub fn effective_burst_ratio(&self) -> f32 {
-        self.burst_ratio.unwrap_or(0.2).clamp(0.01, 1.0)
+    ///
+    /// Resolution: agent override > global default > compiled default (0.2).
+    /// Pass `global_default` from `BudgetConfig::default_burst_ratio`;
+    /// a value of `0.0` means "not configured" and falls through to 0.2.
+    pub fn effective_burst_ratio(&self, global_default: f32) -> f32 {
+        let raw = self.burst_ratio.unwrap_or(if global_default > 0.0 {
+            global_default
+        } else {
+            0.2
+        });
+        raw.clamp(0.01, 1.0)
     }
 }
 

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -501,6 +501,14 @@ pub struct ResourceQuota {
     /// - `Some(n)` = limit to `n` tokens per hour.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_llm_tokens_per_hour: Option<u64>,
+    /// Fraction of the hourly token budget allowed in any single minute.
+    ///
+    /// - `None` = not configured (uses compiled default `0.2`, i.e. 1/5 of hourly budget).
+    /// - `Some(r)` = allow `r × max_llm_tokens_per_hour` tokens per minute.
+    ///
+    /// Clamped to `0.01..=1.0` at enforcement time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub burst_ratio: Option<f32>,
     /// Maximum network bytes per hour.
     pub max_network_bytes_per_hour: u64,
     /// Maximum cost in USD per hour.
@@ -518,6 +526,7 @@ impl Default for ResourceQuota {
             max_cpu_time_ms: 30_000,             // 30 seconds
             max_tool_calls_per_minute: 60,
             max_llm_tokens_per_hour: None, // inherit global default
+            burst_ratio: None,             // inherit compiled default (0.2 = 1/5)
             max_network_bytes_per_hour: 100 * 1024 * 1024, // 100 MB
             max_cost_per_hour_usd: 0.0,    // unlimited by default
             max_cost_per_day_usd: 0.0,     // unlimited
@@ -536,6 +545,11 @@ impl ResourceQuota {
     /// returned value is `0`.
     pub fn effective_token_limit(&self) -> u64 {
         self.max_llm_tokens_per_hour.unwrap_or(0)
+    }
+
+    /// Return the effective burst ratio, clamped to `[0.01, 1.0]`.
+    pub fn effective_burst_ratio(&self) -> f32 {
+        self.burst_ratio.unwrap_or(0.2).clamp(0.01, 1.0)
     }
 }
 

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -4068,6 +4068,10 @@ pub struct BudgetConfig {
     /// will be overridden to this value. Set to 0 to keep each agent's own limit.
     /// Use this to globally raise or lower the token budget for all agents.
     pub default_max_llm_tokens_per_hour: u64,
+    /// Default burst ratio applied to agents that don't set their own.
+    /// 0.0 = use compiled default (0.2). Values clamped to `[0.01, 1.0]`.
+    #[serde(default)]
+    pub default_burst_ratio: f32,
     /// Per-provider spending caps, keyed by provider id (e.g. `"moonshot"`,
     /// `"openai"`, `"litellm"`). Missing providers are unlimited.
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
@@ -4082,6 +4086,7 @@ impl Default for BudgetConfig {
             max_monthly_usd: 0.0,
             alert_threshold: 0.8,
             default_max_llm_tokens_per_hour: 0,
+            default_burst_ratio: 0.0,
             providers: std::collections::HashMap::new(),
         }
     }


### PR DESCRIPTION
## Summary

Closes #4748

- Adds `burst_ratio: Option<f32>` to `ResourceQuota` in `librefang-types`
- New `effective_burst_ratio()` helper returns configured value clamped to `[0.01, 1.0]`, defaulting to `0.2` (current hardcoded 1/5)
- Both `check_quota` and `check_quota_and_reserve` in `scheduler.rs` now use the configurable ratio instead of `token_limit / 5`
- Backward compatible: agents without `burst_ratio` set behave identically to before

### Usage

```toml
# agent.toml
[quota]
max_llm_tokens_per_hour = 150000
burst_ratio = 0.5  # allow 50% of hourly budget per minute
```

## Test plan

- [x] `cargo check --workspace --lib` — zero errors
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p librefang-types` — 755 passed
- [ ] `cargo test -p librefang-kernel` (CI)
- [ ] Verify agent with custom `burst_ratio` in agent.toml respects the configured cap