### PR TITLE
ci: pin pnpm via package.json so cache: pnpm save step works

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,13 +24,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # `cache: pnpm` feature runs `pnpm --version` to compute the cache
-      # key, and that fails if pnpm isn't on PATH yet. Modern setup-node
-      # (v6 + Node ≥22, which bundles corepack) preserves corepack shims
-      # across the Node swap, so running `enable` once up front is
-      # sufficient — no need for the second call after setup-node.
-      - name: Enable corepack (activates pnpm from packageManager field)
-        run: corepack enable
+      # setup-node's `cache: pnpm` runs `pnpm store path --silent` from the
+      # repo root to compute the cache directory. Our `packageManager` field
+      # lives in docs/package.json, so corepack at the root falls back to the
+      # runner image's default pnpm 11 and records `~/.local/share/pnpm/store/v11`.
+      # The actual install (`cd docs && pnpm install`) then runs pnpm 10.x,
+      # which writes to `…/store/v10`. Post-job cache save then errors with
+      # "Path Validation Error" because the v11 directory was never populated.
+      # Pin pnpm explicitly via docs/package.json so PATH carries the right
+      # version before setup-node's cache pre-step runs.
+      - name: Install pnpm (version from docs/package.json packageManager)
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+        with:
+          package_json_file: docs/package.json
+          run_install: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -24,13 +24,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # `cache: pnpm` feature runs `pnpm --version` to compute the cache
-      # key, and that fails if pnpm isn't on PATH yet. Modern setup-node
-      # (v6 + Node ≥22, which bundles corepack) preserves corepack shims
-      # across the Node swap, so running `enable` once up front is
-      # sufficient — no need for the second call after setup-node.
-      - name: Enable corepack (activates pnpm from packageManager field)
-        run: corepack enable
+      # setup-node's `cache: pnpm` runs `pnpm store path --silent` from the
+      # repo root to compute the cache directory. Our `packageManager` field
+      # lives in web/package.json, so corepack at the root falls back to the
+      # runner image's default pnpm 11 and records `~/.local/share/pnpm/store/v11`.
+      # The actual install (`cd web && pnpm install`) then runs pnpm 10.32.1,
+      # which writes to `…/store/v10`. Post-job cache save then errors with
+      # "Path Validation Error" because the v11 directory was never populated.
+      # Pin pnpm explicitly via web/package.json so PATH carries the right
+      # version before setup-node's cache pre-step runs.
+      - name: Install pnpm (version from web/package.json packageManager)
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+        with:
+          package_json_file: web/package.json
+          run_install: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -23,13 +23,20 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # `cache: pnpm` feature runs `pnpm --version` to compute the cache
-      # key, and that fails if pnpm isn't on PATH yet. Modern setup-node
-      # (v6 + Node ≥22, which bundles corepack) preserves corepack shims
-      # across the Node swap, so running `enable` once up front is
-      # sufficient.
-      - name: Enable corepack
-        run: corepack enable
+      # setup-node's `cache: pnpm` runs `pnpm store path --silent` from the
+      # repo root to compute the cache directory. Our `packageManager` field
+      # lives in web/package.json, so corepack at the root falls back to the
+      # runner image's default pnpm 11 and records `~/.local/share/pnpm/store/v11`.
+      # The actual install (`cd web && pnpm install`) then runs pnpm 10.32.1,
+      # which writes to `…/store/v10`. Post-job cache save then errors with
+      # "Path Validation Error" because the v11 directory was never populated.
+      # Pin pnpm explicitly via web/package.json so PATH carries the right
+      # version before setup-node's cache pre-step runs.
+      - name: Install pnpm (version from web/package.json packageManager)
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+        with:
+          package_json_file: web/package.json
+          run_install: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -26,13 +26,20 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # `cache: pnpm` feature runs `pnpm --version` to compute the cache
-      # key, and that fails if pnpm isn't on PATH yet. Modern setup-node
-      # (v6 + Node ≥22, which bundles corepack) preserves corepack shims
-      # across the Node swap, so running `enable` once up front is
-      # sufficient.
-      - name: Enable corepack (activates pnpm from packageManager field)
-        run: corepack enable
+      # setup-node's `cache: pnpm` runs `pnpm store path --silent` from the
+      # repo root to compute the cache directory. Our `packageManager` field
+      # lives in web/package.json, so corepack at the root falls back to the
+      # runner image's default pnpm 11 and records `~/.local/share/pnpm/store/v11`.
+      # The actual install (`cd web && pnpm install`) then runs pnpm 10.32.1,
+      # which writes to `…/store/v10`. Post-job cache save then errors with
+      # "Path Validation Error" because the v11 directory was never populated.
+      # Pin pnpm explicitly via web/package.json so PATH carries the right
+      # version before setup-node's cache pre-step runs.
+      - name: Install pnpm (version from web/package.json packageManager)
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+        with:
+          package_json_file: web/package.json
+          run_install: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## Summary

- `Deploy Website` and `Test Web` runs on `main` (5a5fe18) failed at the `Post Run actions/setup-node` step with `##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist`.
- Root cause: setup-node v6's `cache: pnpm` runs `pnpm store path --silent` from the **repo root** to compute the cache directory. Our `packageManager` field lives in `web/package.json` (`pnpm@10.32.1`) and `docs/package.json` (`pnpm@10.11.1`), not at the repo root, so corepack at root falls back to the runner image's default pnpm 11 and records `~/.local/share/pnpm/store/v11`. The actual install (`cd web && pnpm install`) then runs the project-pinned 10.x and writes to `…/store/v10`. Post-job cache save then errors because the v11 directory was never populated.
- Fix: replace the pre-step `corepack enable` with `pnpm/action-setup@v6` (the SHA already used in `ci.yml`), passing `package_json_file:` so the project-pinned pnpm lands on PATH **before** setup-node's cache pre-step probes the store path. Applied to all four pnpm-using workflows for parity.

## Files changed

- `.github/workflows/deploy-web.yml`
- `.github/workflows/test-web.yml`
- `.github/workflows/deploy-docs.yml`
- `.github/workflows/lighthouse.yml`

## Test plan

- [ ] CI: `Deploy Website` reaches `Post Run actions/setup-node` without `Path Validation Error`.
- [ ] CI: `Test Web` reaches the same step cleanly.
- [ ] CI: pnpm install logs show `pnpm 10.32.1` (web) / `pnpm 10.11.1` (docs) — confirms the action picked up the project-pinned version, not pnpm 11.
- [ ] Cache save warning gone; subsequent runs hit the cache.