### PR TITLE
chore: ignore graphify-out/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ result
 *.swo
 *~
 .gitnexus
+
+# graphify knowledge-graph output (local-only, regenerable).
+graphify-out/


### PR DESCRIPTION
## Summary

Add `graphify-out/` to `.gitignore`. This directory is the local-only output of [graphify](https://github.com/anthropics/skills) — a knowledge-graph tool that indexes the repo for AI-assisted exploration. The output is fully regenerable (`graphify .` / `graphify update .`) and shouldn't ever be tracked.

Without this entry, anyone running graphify against a librefang checkout sees `graphify-out/` in `git status`, which invites accidental commits of large generated artifacts.

## Test plan

- [x] `git status` in a worktree with a populated `graphify-out/` shows the directory ignored
- [x] No-op for users who don't run graphify