### PR TITLE
fix(runtime): align tool_runner test assertions with new pre-ACP path guard

### DIFF
--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -2922,8 +2922,14 @@ mod path_check_tests {
 
     #[test]
     fn absolute_outside_workspace_blocked() {
-        let root = PathBuf::from("/ws");
-        let err = check_absolute_path_inside_workspace(Some("/etc/passwd"), Some(&root), &[])
+        // Windows treats `/etc/passwd` as relative (no drive letter), so
+        // pick a path that `Path::is_absolute()` agrees with on the host.
+        let (root, outside) = if cfg!(windows) {
+            (PathBuf::from(r"C:\ws"), r"D:\etc\passwd")
+        } else {
+            (PathBuf::from("/ws"), "/etc/passwd")
+        };
+        let err = check_absolute_path_inside_workspace(Some(outside), Some(&root), &[])
             .expect("path outside workspace must be blocked");
         assert!(err.contains("outside the agent's workspace"));
     }
@@ -8678,7 +8684,7 @@ mod tests {
         .await;
         assert!(result.is_error);
         assert!(
-            result.content.contains("Access denied"),
+            result.content.contains("outside the agent's workspace"),
             "expected sandbox denial, got: {}",
             result.content
         );
@@ -10079,11 +10085,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_file_read_no_workspace_root_returns_error() {
-        // SECURITY: file_read must fail when workspace_root is None
+        // SECURITY: file_read must fail when workspace_root is None.
+        // Use a relative path so the inner sandbox resolver is the rejecter
+        // (the absolute-path pre-ACP guard has its own coverage above —
+        // and Windows treats `/etc/passwd` as relative, which would also
+        // mask the inner-resolver path we want to exercise here).
         let result = execute_tool(
             "test-id",
             "file_read",
-            &serde_json::json!({"path": "/etc/passwd"}),
+            &serde_json::json!({"path": "etc/passwd"}),
             None,
             None,
             None,
@@ -10123,11 +10133,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_file_write_no_workspace_root_returns_error() {
-        // SECURITY: file_write must fail when workspace_root is None
+        // SECURITY: file_write must fail when workspace_root is None.
+        // Relative path so the inner resolver — not the absolute-path
+        // pre-ACP guard — is what rejects the call (cross-platform: on
+        // Windows `/tmp/test.txt` is relative anyway).
         let result = execute_tool(
             "test-id",
             "file_write",
-            &serde_json::json!({"path": "/tmp/test.txt", "content": "pwned"}),
+            &serde_json::json!({"path": "tmp/test.txt", "content": "pwned"}),
             None,
             None,
             None,


### PR DESCRIPTION
## Summary

Fixes the 3 (Linux/macOS) + 1 (Windows-only) `librefang-runtime` test failures that have been red on `main` for 5 consecutive pushes.

Root cause: the ACP integration in #4742 added `check_absolute_path_inside_workspace` as a pre-ACP routing guard. It rejects out-of-bounds absolute paths **before** ACP forwarding or local-fs resolution runs, with a different error wording than the inner `resolve_file_path_ext`. Three pre-existing tests still asserted the old wording, and a newly added test in the same commit used Unix-only absolute paths.

The security invariant (file ops blocked when out-of-bounds or when no workspace root is configured) is unchanged — the tests just need to bind to the actual current behavior.

## Changes

- `test_file_read_outside_all_workspaces_still_blocked`: assertion `Access denied` → `outside the agent's workspace` (the new pre-check's wording).
- `test_file_read_no_workspace_root_returns_error` and `test_file_write_no_workspace_root_returns_error`: input path `/etc/passwd` / `/tmp/test.txt` → relative `etc/passwd` / `tmp/test.txt` so the inner resolver — the one that emits `Workspace sandbox not configured` — remains the rejecter, matching the test name's intent. As a bonus this also stops being silently masked on Windows, where `/etc/passwd` is treated as relative anyway.
- `path_check_tests::absolute_outside_workspace_blocked`: `cfg!(windows)`-pick a drive-letter path so the test exercises a path that `Path::is_absolute()` agrees with on the host.

## Verification

- Static review: each failing assertion's expected substring now matches the message that flows out of the corresponding code path on each OS. Cross-checked against `tool_file_read` / `tool_file_write` — they delegate to `resolve_file_path_ext`, which returns `Workspace sandbox not configured: …` when `workspace_root` is `None`, regardless of relative vs. absolute path.
- Did not run `cargo test` locally per repo rules — CI will validate.

## Out-of-scope follow-ups

Several other tests in `path_check_tests` (`absolute_inside_workspace_passes`, `absolute_inside_named_workspace_passes`) silently no-op on Windows because their `/`-prefixed paths are treated as relative there and the function happens to return `None` for relative paths. They pass by accident on Windows, not by validating the intended invariant. Worth tightening in a follow-up but not required to unblock CI.