### PR TITLE
fix(runtime): allow unused_mut on chromium_candidates() for android/ios builds

### DIFF
--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -864,6 +864,12 @@ fn find_chromium(config: &BrowserConfig) -> Result<PathBuf, String> {
 
 /// Platform-specific candidate paths for Chromium-based browsers.
 fn chromium_candidates() -> Vec<String> {
+    // `mut` is exercised only under the windows / macOS / linux cfg branches
+    // below; on other targets (Android, iOS, …) every branch is stripped and
+    // the binding is never mutated. Accept the unused-mut on those targets
+    // rather than gating each platform's import — the function is meant to
+    // return an empty vec on unsupported targets.
+    #[allow(unused_mut)]
     let mut paths = Vec::new();
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

Mobile Build Smoke (Android / iOS) on `main` has been red since 5770b646. The companion CI / Coverage / unit-test breakage was already addressed by #4777, but the mobile lane was a separate failure mode left untouched — this PR closes the remaining gap with a one-line fix.

`crates/librefang-runtime/src/browser.rs:867` declares:

```rust
fn chromium_candidates() -> Vec<String> {
    let mut paths = Vec::new();
    #[cfg(windows)] { … paths.push(…) … }
    #[cfg(target_os = "macos")] { … paths.push(…) … }
    #[cfg(target_os = "linux")] { … paths.push(…) … }
    paths
}
```

When the crate is compiled for `aarch64-linux-android` (the `mobile-no-email` Android profile in Mobile Build Smoke) or for iOS, every `#[cfg]` branch is stripped — `paths` is never written. The workspace's `-D warnings` rolls in `-D unused_mut`, turning the lint into a hard compile error:

```
error: variable does not need to be mutable
 --> crates/librefang-runtime/src/browser.rs:867:9
867 |     let mut paths = Vec::new();
    |         ----^^^^^
help: remove this `mut`
= note: `-D unused-mut` implied by `-D warnings`
```

Annotated the binding with `#[allow(unused_mut)]` and a short comment explaining why. The `mut` is intentional on the supported desktop targets (each cfg block pushes into `paths`), and returning an empty `Vec` on unsupported targets is the function's documented behaviour — silently allowing the unused mut keeps the function shape intact rather than splitting it into per-platform variants.

## Test plan

Verified on macOS host (scoped, since unscoped `cargo test` is forbidden by the project rules):

- [x] `cargo check -p librefang-runtime --lib` — clean
- [x] `cargo clippy -p librefang-runtime --lib --all-targets -- -D warnings` — clean (mirrors the workspace lint gate)
- [ ] Android / iOS lanes — covered by Mobile Build Smoke jobs on this PR

## History

This branch was originally a wider sweep that also patched the three failing `tool_runner` test assertions and the Windows-only `path_check_tests::absolute_outside_workspace_blocked` panic. While that work was open, #4777 landed on `main` and addressed the same `tool_runner` items — with a slightly cleaner approach for the two `_no_workspace_root_returns_error` tests (switching their inputs from absolute to relative paths so the inner `resolve_file_path_ext` rejection — what the test names imply — remains the rejecter). Per the project's "latest maintainer intent wins" rule the branch was rebased on top of #4777 and the now-redundant `tool_runner.rs` edits dropped, leaving only the unique Mobile fix.
