### PR TITLE
fix(hooks): kill SIGPIPE 141 noise in PreToolUse hooks

### DIFF
--- a/.claude/hooks/forbid-main-worktree.sh
+++ b/.claude/hooks/forbid-main-worktree.sh
@@ -17,8 +17,18 @@ LIB="$script_dir/lib/check-bash-rules.py"
 
 py() { python3 -c "$1" 2>/dev/null || true; }
 
-cwd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("cwd",""))')"
-tool="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_name",""))')"
+# Use here-strings (`<<<"$input"`) instead of `printf … | py …` pipelines.
+# Bash buffers the here-string content into a temp FD before the reader
+# starts, so there's no active writer process that can collect SIGPIPE
+# when python3 finishes early. With the previous `printf | py` pattern,
+# python's `json.load` returning before printf flushed gave printf an
+# EPIPE → exit 141, and `set -o pipefail` then propagated 141 as the
+# pipeline's status, which `set -e` aborted on — even though the hook
+# logic itself never tripped a real rule. The non-blocking failure
+# surfaced in the Claude Code UI as bare "Failed with non-blocking
+# status code: No stderr output" noise.
+cwd="$(py 'import sys,json; print(json.load(sys.stdin).get("cwd",""))' <<<"$input")"
+tool="$(py 'import sys,json; print(json.load(sys.stdin).get("tool_name",""))' <<<"$input")"
 
 # detect_git <path>: prints "<repo_root> <kind>" where kind is main or worktree.
 detect_git() {
@@ -42,7 +52,7 @@ detect_git() {
 target_dir=""
 case "$tool" in
   Edit|MultiEdit|Write|NotebookEdit)
-    fp="$(printf '%s' "$input" | py 'import sys,json; t=json.load(sys.stdin).get("tool_input",{}); print(t.get("file_path") or t.get("notebook_path") or "")')"
+    fp="$(py 'import sys,json; t=json.load(sys.stdin).get("tool_input",{}); print(t.get("file_path") or t.get("notebook_path") or "")' <<<"$input")"
     if [ -n "$fp" ]; then
       case "$fp" in
         /*) target="$fp" ;;
@@ -54,8 +64,8 @@ case "$tool" in
     fi
     ;;
   Bash)
-    cmd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))')"
-    target_dir="$(printf '%s' "$cmd" | python3 -c '
+    cmd="$(py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' <<<"$input")"
+    target_dir="$(python3 -c '
 import sys, re, os
 text = sys.stdin.read()
 cwd = sys.argv[1] if len(sys.argv) > 1 else ""
@@ -75,7 +85,7 @@ if m:
     elif base:
         base = os.path.join(base, p)
 print(base)
-' "$cwd" 2>/dev/null || echo "$cwd")"
+' "$cwd" 2>/dev/null <<<"$cmd" || echo "$cwd")"
     ;;
   *)
     exit 0
@@ -92,8 +102,12 @@ main_root=""
 if [ "$tool" = "Bash" ]; then
   toplevel="$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || true)"
   if [ -n "$toplevel" ]; then
-    main_root="$(git -C "$toplevel" worktree list --porcelain 2>/dev/null \
-      | awk '/^worktree / {print $2; exit}')"
+    # Capture first; pipe-and-awk-exit would SIGPIPE the git writer, and
+    # under `set -o pipefail` that 141 would abort the hook before any
+    # rule ran. Splitting it via a here-string also avoids silently
+    # masking a real git failure (which `… | awk … || true` would).
+    worktree_list="$(git -C "$toplevel" worktree list --porcelain 2>/dev/null || true)"
+    main_root="$(awk '/^worktree / {print $2; exit}' <<<"$worktree_list")"
     [ -n "$main_root" ] || main_root="$toplevel"
   fi
 fi
@@ -133,11 +147,11 @@ case "$main_root" in
   *) exit 0 ;;
 esac
 
-msg="$(printf '%s' "$cmd" | python3 "$LIB" \
+msg="$(python3 "$LIB" \
   --rules "$rules" \
   --cwd "$cwd" \
   --main-root "$main_root" \
-  --kind "${kind:-}" 2>/dev/null || true)"
+  --kind "${kind:-}" <<<"$cmd" 2>/dev/null || true)"
 
 if [ -n "$msg" ]; then
   cat >&2 <<EOF

--- a/.claude/hooks/guard-bash-safety.sh
+++ b/.claude/hooks/guard-bash-safety.sh
@@ -15,15 +15,26 @@ LIB="$script_dir/lib/check-bash-rules.py"
 
 py() { python3 -c "$1" 2>/dev/null || true; }
 
-tool="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_name",""))')"
+# Use here-strings (`<<<"$input"`) instead of `printf … | py …` pipelines.
+# Under `set -o pipefail`, the original pattern propagated a 141 exit
+# (SIGPIPE on printf when python's `json.load` finished and exited
+# before printf had flushed the input) as the pipeline's status. With
+# `set -e` that aborted the hook before any rule even ran, surfacing as
+# "Failed with non-blocking status code: No stderr output" noise in the
+# Claude Code UI. The here-string form has no active writer process —
+# bash buffers `$input` into a temp FD before the reader starts — so
+# SIGPIPE cannot occur. This also closes a latent silent-bypass: when
+# the old `msg=…|| true` pipeline ate a 141, `msg` came back empty and
+# the hook returned 0 (allow), which would have hidden a real rule hit.
+tool="$(py 'import sys,json; print(json.load(sys.stdin).get("tool_name",""))' <<<"$input")"
 [ "$tool" = "Bash" ] || exit 0
 
-cmd="$(printf '%s' "$input" | py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))')"
+cmd="$(py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' <<<"$input")"
 [ -n "$cmd" ] || exit 0
 
 rules="force-push-main,no-verify,broad-git-add,sensitive-file-add,claude-attribution,rm-rf-dangerous,librefang-daemon-launch,cargo-add-remove-upgrade"
 
-msg="$(printf '%s' "$cmd" | python3 "$LIB" --rules "$rules" 2>/dev/null || true)"
+msg="$(python3 "$LIB" --rules "$rules" <<<"$cmd" 2>/dev/null || true)"
 
 if [ -n "$msg" ]; then
   cat >&2 <<MSG

--- a/.claude/hooks/session-start-worktree-check.sh
+++ b/.claude/hooks/session-start-worktree-check.sh
@@ -9,7 +9,10 @@
 set -euo pipefail
 
 input="$(cat)"
-cwd="$(printf '%s' "$input" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("cwd",""))' 2>/dev/null || true)"
+# here-string (not `printf | python3`) so `set -o pipefail` can't pick up
+# a SIGPIPE 141 from printf when python finishes and closes its stdin
+# early — same fix shape as the PreToolUse hooks.
+cwd="$(python3 -c 'import sys,json; print(json.load(sys.stdin).get("cwd",""))' <<<"$input" 2>/dev/null || true)"
 [ -n "$cwd" ] || { echo '{}'; exit 0; }
 
 real_cwd="$(cd "$cwd" 2>/dev/null && pwd -P || true)"
@@ -29,9 +32,11 @@ done
 
 # Find the *main* worktree path (first entry of `git worktree list`) so we can
 # tell whether this session is inside the librefang repo regardless of whether
-# we are in the main tree or a linked one.
-main_root="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null \
-  | awk '/^worktree / {print $2; exit}')"
+# we are in the main tree or a linked one. Capture git's output first; the
+# original `git … | awk … {exit}` pipeline SIGPIPE'd git when awk exited
+# early, which `set -o pipefail` then propagated as a hook abort.
+worktree_list="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null || true)"
+main_root="$(awk '/^worktree / {print $2; exit}' <<<"$worktree_list")"
 [ -n "$main_root" ] || main_root="$repo_root"
 
 case "$main_root" in


### PR DESCRIPTION
## Summary

Claude Code session logs are full of `Failed with non-blocking status code: No stderr output` from this repo's PreToolUse hooks (`forbid-main-worktree.sh`, `guard-bash-safety.sh`, `session-start-worktree-check.sh`). Hook exit in every record is **141 = SIGPIPE** (128 + 13).

Two pipeline patterns, same root cause — `set -o pipefail` propagating an unrelated SIGPIPE 141 as the script's status, which `set -e` then aborts on **before any rule check runs**:

1. `printf '%s' "$input" | py 'json.load(sys.stdin) …'` — python's `print(json.load(...))` finishes and exits, the pipe's read end closes, printf gets EPIPE on its remaining write → 141.
2. `git -C … worktree list --porcelain | awk '… {exit}'` — awk's `exit` after first match closes stdin while git is still writing → SIGPIPE on git.

## Fix

Replace both with capture-then-process forms that have no active writer at risk of SIGPIPE:

- `printf | py` → `py … <<<"$input"` (here-string buffers all input before reader starts)
- `git … | awk … {exit}` → `worktree_list="$(git …)"; awk … <<<"$worktree_list"`

Picked here-strings over `… || true` because the latter would silently swallow a real failure: when the old `msg=\$(… | python3 \"\$LIB\" … || true)` pipeline ate a 141, `msg` came back empty and the hook fell through to `exit 0` (allow). A real rule hit on a large input could have been masked. The new form has each step succeed or fail on its own merits and `pipefail`+`set -e` still abort on actual errors.

## Verification

- benign command (`echo hello`) → all 3 hooks exit 0
- main-worktree `git commit -m test` → `forbid-main-worktree.sh` exits 2 with `\`git commit\` in main worktree.`
- main-worktree `cargo build --release` → `forbid-main-worktree.sh` exits 2 with the cargo-ban message
- session-start hook still emits the worktree banner JSON

## Risk

Behaviour-preserving for the rule logic itself — only the failure mode of the data-extraction step changes (was: silent abort with empty result; now: explicit value, hook proceeds to rule check). Both `set -euo pipefail` and `--rules` semantics unchanged.