### PR TITLE
fix(docker): bump corepack so pnpm 10.x signature check passes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,13 @@ WORKDIR /build/dashboard
 # registry, which has flaked on us during builds. Activate the pinned pnpm
 # version (matches the `packageManager` field in package.json) directly so
 # the build never has to ask the registry "what's the latest stable?".
-RUN corepack enable \
+# Node 20.18.1 ships corepack ~0.30, whose bundled keyring lacks the current
+# pnpm signing key — `corepack prepare pnpm@10.x` then fails with
+# "Internal Error: Cannot find matching keyid". Refresh corepack first so it
+# picks up the latest signing keys (upstream nodejs/corepack rolls these
+# regularly as pnpm rotates them).
+RUN npm install --global corepack@latest \
+    && corepack enable \
     && corepack prepare pnpm@10.33.0 --activate \
     && pnpm install --frozen-lockfile --ignore-scripts \
     && pnpm run build


### PR DESCRIPTION
## Summary

- Docker Build workflow has been red on every push to `main` since 2026-05-07
  (5 consecutive failures: runs `25477537199`, `25487624296`, `25506152309`,
  `25530061876`, `25536131707`).
- Root cause: `node:20.18.1-alpine` ships corepack ~0.30, whose bundled
  keyring no longer contains the current pnpm signing key. The pinned
  `corepack prepare pnpm@10.33.0 --activate` step fetches a tarball signed
  with the new key (`SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U`),
  fails verification, and aborts with
  `Internal Error: Cannot find matching keyid` (exit 1).
- Fix: `npm install --global corepack@latest` before `corepack enable`, so
  `corepack prepare` uses an up-to-date keyring. Signature verification stays
  on (no `COREPACK_INTEGRITY_KEYS=0`); the pinned pnpm 10.33.0,
  `--frozen-lockfile`, and stage layout are unchanged.

## Test plan

- [ ] Docker Build workflow passes on this branch (the only thing this PR
      changes is the dashboard-builder stage, so CI is the canonical signal).
- [ ] Built image still publishes the same dashboard bundle (verified
      indirectly by `pnpm run build` succeeding into
      `/build/static/react`, which the Rust stage then `COPY --from`s
      unchanged).

## Out of scope

- The other workflow CI jobs (Test, Clippy, etc.) don't go through corepack
  and are unaffected.
- `flake.nix` doesn't run corepack — its devShell only declares `nodejs`,
  and dashboard isn't built in the Nix path. No change needed there.