### PR TITLE
fix(test): escape literal {name} in providers route assert message

### DIFF
--- a/crates/librefang-api/tests/providers_routes_test.rs
+++ b/crates/librefang-api/tests/providers_routes_test.rs
@@ -492,7 +492,7 @@ async fn capability_override_flips_effective_value_in_get_model() {
     assert_eq!(
         prov_entry["capabilities_catalog"]["supports_thinking"].as_bool(),
         Some(base_thinking),
-        "capabilities_catalog in /api/providers/{name} must be unmerged"
+        "capabilities_catalog in /api/providers/{{name}} must be unmerged"
     );
 
     // DELETE — effective values revert to catalog defaults.


### PR DESCRIPTION
## Summary

Coverage CI on `main` has been red since #4781 landed because of a
single-character bug in `crates/librefang-api/tests/providers_routes_test.rs:495`.

`assert_eq!`'s third argument is a `format_args!`-style format string, so

```rust
"capabilities_catalog in /api/providers/{name} must be unmerged"
```

is parsed as an implicit-format-arg reference to a `name` variable. The
surrounding scope has no such binding, so the compiler emits
`error[E0425]: cannot find value 'name' in this scope` and the entire
workspace fails to compile under `cargo nextest run --workspace`. Escape
the brace pair to keep the path template literal:

```rust
"capabilities_catalog in /api/providers/{{name}} must be unmerged"
```

Reference failing run: https://github.com/librefang/librefang/actions/runs/25540494047

## Test plan

- [ ] Coverage / nextest workflow turns green on this branch (this is the
      single compile error blocking it).

## Out of scope

- The other `{ident}` literals in this file all reference real variables
  (`body`, `model_id`, `key`, `p`) — they are deliberately implicit format
  args. Only line 495 is a literal-template typo. No other site needs
  escaping.
- Docker Build is currently red for an unrelated reason (vite 8 / rolldown
  engines constraint vs. pinned Node base image) — separate PR.