### PR TITLE
fix(docker): bump dashboard builder node to 20.20.2-alpine for vite 8 / rolldown engines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # tagged release months later produce a bit-for-bit identical builder image.
 # Track Node 20 LTS — CI's setup-node also uses node-version: 20
 # (.github/workflows/ci.yml, .github/workflows/dashboard-build.yml).
-FROM node:20.18.1-alpine AS dashboard-builder
+FROM node:20.20.2-alpine AS dashboard-builder
 WORKDIR /build
 COPY crates/librefang-api/dashboard ./dashboard
 WORKDIR /build/dashboard
@@ -13,11 +13,12 @@ WORKDIR /build/dashboard
 # registry, which has flaked on us during builds. Activate the pinned pnpm
 # version (matches the `packageManager` field in package.json) directly so
 # the build never has to ask the registry "what's the latest stable?".
-# Node 20.18.1 ships corepack ~0.30, whose bundled keyring lacks the current
-# pnpm signing key — `corepack prepare pnpm@10.x` then fails with
-# "Internal Error: Cannot find matching keyid". Refresh corepack first so it
-# picks up the latest signing keys (upstream nodejs/corepack rolls these
-# regularly as pnpm rotates them).
+# We also refresh corepack itself first: the keyring bundled with the node
+# base image goes stale as pnpm rotates signing keys, manifesting as
+# "Internal Error: Cannot find matching keyid" during `corepack prepare`.
+# Node ≥20.19 is also required by vite 8 / rolldown's optional native
+# bindings (engines: ^20.19.0), without which `pnpm install` silently skips
+# the linux-x64-musl binding and `vite build` fails at require-time.
 RUN npm install --global corepack@latest \
     && corepack enable \
     && corepack prepare pnpm@10.33.0 --activate \


### PR DESCRIPTION
## Summary

#4784 unblocked corepack signature verification, exposing the next layer
of the Docker Build failure on `main`. `vite ^8.0.10` pulls in
`rolldown@1.0.0-rc.17`, whose native bindings declare:

```yaml
engines: { node: "^20.19.0 || >=22.12.0" }
```

The Dockerfile pin `node:20.18.1-alpine` is `20.18.1 < 20.19.0`, so pnpm
silently skipped the optional `@rolldown/binding-linux-x64-musl` package
during `pnpm install`. `pnpm run build` then failed at require-time with:

```
Cannot find native binding.
[cause]: Error: Cannot find module '@rolldown/binding-linux-x64-musl'
```

Reference failing run: https://github.com/librefang/librefang/actions/runs/25540494031

Bump to the latest Node 20.x patch (`20.20.2-alpine`, pushed
2026-04-15 — verified to exist on Docker Hub) so the engine constraint is
satisfied. We stay on the Node 20 LTS line per the existing comment block,
and reproducibility is preserved because the tag is still pinned to a
specific minor (not the floating `node:20-alpine`).

The `npm install --global corepack@latest` shim added in #4784 stays —
it's defense in depth for future pnpm key rotations and does no harm on a
newer base image.

## Test plan

- [ ] Docker Build workflow goes green on this branch (the dashboard
      stage is the only thing this PR changes).
- [ ] `pnpm install --frozen-lockfile` resolves
      `@rolldown/binding-linux-x64-musl` (visible in the buildx log).

## Out of scope

- Stage 3 (`node:22.11.0-bookworm-slim`) is the runtime image, doesn't
  run vite, so the rolldown engines constraint doesn't apply there. No
  change needed.
- Coverage workflow is currently red for an unrelated reason (test file
  format-string typo) — separate PR.