### PR TITLE
refactor(kernel): install-path vault facade + hook regex narrowing

### DIFF
--- a/.claude/hooks/lib/check-bash-rules.py
+++ b/.claude/hooks/lib/check-bash-rules.py
@@ -427,12 +427,18 @@ def rule_broad_git_add(toks, ctx):
     return None
 
 
+# `credentials` / `secrets` are restricted to credential-STORAGE extensions
+# (data formats) so that source files that *handle* credentials — e.g.
+# `crates/librefang-extensions/src/credentials.rs` — don't trip the guard.
+# The earlier `(\.[a-z]+)?` form swept in `.rs` / `.py` / `.go` and forced a
+# manual user override on every legitimate code-edit commit.
+_DATA_EXT = r"(json|toml|yaml|yml|txt|csv|ini|conf|env|cfg)"
 _SENSITIVE_RE = re.compile(
     r"^("
     r"\.env(\.[a-z0-9._-]+)?"
     r"|id_(rsa|ed25519|ecdsa|dsa)(\.pub)?"
-    r"|credentials(\.[a-z]+)?"
-    r"|secrets?(\.[a-z]+)?"
+    rf"|credentials(\.{_DATA_EXT})?"
+    rf"|secrets?(\.{_DATA_EXT})?"
     r"|vault[_-][a-z0-9_-]+\.(key|json)"
     r"|.+\.(pem|p12|pfx|jks|keystore)"
     r")$",

--- a/.claude/hooks/lib/check-bash-rules.py
+++ b/.claude/hooks/lib/check-bash-rules.py
@@ -428,11 +428,17 @@ def rule_broad_git_add(toks, ctx):
 
 
 # `credentials` / `secrets` are restricted to credential-STORAGE extensions
-# (data formats) so that source files that *handle* credentials — e.g.
-# `crates/librefang-extensions/src/credentials.rs` — don't trip the guard.
-# The earlier `(\.[a-z]+)?` form swept in `.rs` / `.py` / `.go` and forced a
-# manual user override on every legitimate code-edit commit.
-_DATA_EXT = r"(json|toml|yaml|yml|txt|csv|ini|conf|env|cfg)"
+# (data formats + common backup / DB suffixes) so that source files that
+# *handle* credentials — e.g. `crates/librefang-extensions/src/credentials.rs`
+# — don't trip the guard. The earlier `(\.[a-z]+)?` form swept in `.rs` /
+# `.py` / `.go` and forced a manual user override on every legitimate
+# code-edit commit.
+#
+# Whitelisted suffixes:
+#   - data formats: json toml yaml yml txt csv ini conf env cfg
+#   - credential DBs: kdbx (KeePass), dat (generic credential blob)
+#   - backups: bak old (`credentials.bak` / `credentials.old` still hold real keys)
+_DATA_EXT = r"(json|toml|yaml|yml|txt|csv|ini|conf|env|cfg|kdbx|dat|bak|old)"
 _SENSITIVE_RE = re.compile(
     r"^("
     r"\.env(\.[a-z0-9._-]+)?"

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -4198,32 +4198,9 @@ pub async fn add_mcp_server(
             .into_json_tuple();
         }
 
-        // Credential resolver: dotenv + vault (if unlocked)
-        let home = state.kernel.home_dir().to_path_buf();
-        let dotenv_path = home.join(".env");
-        let vault_path = home.join("vault.enc");
-        let vault = if vault_path.exists() {
-            let mut v = librefang_extensions::vault::CredentialVault::new(vault_path);
-            if v.unlock().is_ok() {
-                Some(v)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-        let mut resolver =
-            librefang_extensions::credentials::CredentialResolver::new(vault, Some(&dotenv_path));
-
-        // Ephemeral catalog to feed the installer (it takes &McpCatalog).
-        let mut cat = librefang_extensions::catalog::McpCatalog::new(&home);
-        cat.load(&home);
-        let result = match librefang_extensions::installer::install_integration(
-            &cat,
-            &mut resolver,
-            &entry.id,
-            &creds,
-        ) {
+        // Route through the kernel facade: cached vault (no per-request
+        // Argon2id KDF) + cached catalog snapshot (#3598).
+        let result = match state.kernel.install_integration(&entry.id, &creds) {
             Ok(r) => r,
             Err(e) => {
                 return ApiErrorResponse::bad_request(format!("Install failed: {e}"))
@@ -6056,31 +6033,11 @@ pub async fn install_extension(
         );
     }
 
-    // Reuse the installer via an ephemeral catalog load.
-    let home = state.kernel.home_dir().to_path_buf();
-    let dotenv_path = home.join(".env");
-    let vault_path = home.join("vault.enc");
-    let vault = if vault_path.exists() {
-        let mut v = librefang_extensions::vault::CredentialVault::new(vault_path);
-        if v.unlock().is_ok() {
-            Some(v)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-    let mut resolver =
-        librefang_extensions::credentials::CredentialResolver::new(vault, Some(&dotenv_path));
-    let mut catalog = librefang_extensions::catalog::McpCatalog::new(&home);
-    catalog.load(&home);
-
-    let result = match librefang_extensions::installer::install_integration(
-        &catalog,
-        &mut resolver,
-        &name,
-        &std::collections::HashMap::new(),
-    ) {
+    // Route through the kernel facade: cached vault + cached catalog (#3598).
+    let result = match state
+        .kernel
+        .install_integration(&name, &std::collections::HashMap::new())
+    {
         Ok(r) => r,
         Err(e) => {
             let err_str = e.to_string();

--- a/crates/librefang-extensions/src/credentials.rs
+++ b/crates/librefang-extensions/src/credentials.rs
@@ -10,13 +10,49 @@ use crate::vault::CredentialVault;
 use crate::ExtensionResult;
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::{Arc, RwLock};
 use tracing::debug;
 use zeroize::Zeroizing;
 
+/// Backing store for a [`CredentialResolver`]'s vault — either an owned vault
+/// (built ad-hoc by short-lived callers like the CLI) or a shared handle into
+/// the kernel's cached, already-unlocked vault.
+///
+/// The shared variant exists so that long-lived callers (the API layer) can
+/// route through the kernel's `vault_handle()` cache (#3598) instead of
+/// re-running the unlock-time Argon2id KDF on every request.
+enum VaultSource {
+    Owned(CredentialVault),
+    Shared(Arc<RwLock<CredentialVault>>),
+}
+
+impl VaultSource {
+    fn with_read<R>(&self, f: impl FnOnce(&CredentialVault) -> R) -> R {
+        match self {
+            VaultSource::Owned(v) => f(v),
+            VaultSource::Shared(handle) => {
+                let guard = handle.read().unwrap_or_else(|e| e.into_inner());
+                f(&guard)
+            }
+        }
+    }
+
+    fn with_write<R>(&mut self, f: impl FnOnce(&mut CredentialVault) -> R) -> R {
+        match self {
+            VaultSource::Owned(v) => f(v),
+            VaultSource::Shared(handle) => {
+                let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
+                f(&mut guard)
+            }
+        }
+    }
+}
+
 /// Credential resolver — tries multiple sources in priority order.
 pub struct CredentialResolver {
-    /// Reference to the credential vault.
-    vault: Option<CredentialVault>,
+    /// Backing vault (owned by this resolver, or a shared handle into the
+    /// kernel's cached vault).
+    vault: Option<VaultSource>,
     /// Dotenv entries (loaded from `~/.librefang/.env`).
     dotenv: HashMap<String, String>,
     /// Whether to prompt interactively as a last resort.
@@ -24,8 +60,26 @@ pub struct CredentialResolver {
 }
 
 impl CredentialResolver {
-    /// Create a resolver with optional vault and dotenv path.
+    /// Create a resolver with an owned vault and dotenv path. Used by
+    /// short-lived callers (CLI subcommands, tests) where there is no kernel
+    /// to share a cached vault with.
     pub fn new(vault: Option<CredentialVault>, dotenv_path: Option<&Path>) -> Self {
+        Self::with_optional_source(vault.map(VaultSource::Owned), dotenv_path)
+    }
+
+    /// Create a resolver backed by the kernel's shared, already-unlocked
+    /// vault handle. Long-lived callers (API request handlers) MUST use this
+    /// constructor — it lets the resolver read/write through the kernel's
+    /// vault cache (#3598) instead of opening + Argon2id-unlocking the vault
+    /// on every request.
+    pub fn with_vault_handle(
+        handle: Option<Arc<RwLock<CredentialVault>>>,
+        dotenv_path: Option<&Path>,
+    ) -> Self {
+        Self::with_optional_source(handle.map(VaultSource::Shared), dotenv_path)
+    }
+
+    fn with_optional_source(vault: Option<VaultSource>, dotenv_path: Option<&Path>) -> Self {
         let dotenv = if let Some(path) = dotenv_path {
             load_dotenv(path).unwrap_or_default()
         } else {
@@ -47,12 +101,17 @@ impl CredentialResolver {
     /// Resolve a credential by key, trying all sources in order.
     pub fn resolve(&self, key: &str) -> Option<Zeroizing<String>> {
         // 1. Vault
-        if let Some(ref vault) = self.vault {
-            if vault.is_unlocked() {
-                if let Some(val) = vault.get(key) {
-                    debug!("Credential '{}' resolved from vault", key);
-                    return Some(val);
+        if let Some(ref source) = self.vault {
+            let hit = source.with_read(|vault| {
+                if vault.is_unlocked() {
+                    vault.get(key)
+                } else {
+                    None
                 }
+            });
+            if let Some(val) = hit {
+                debug!("Credential '{}' resolved from vault", key);
+                return Some(val);
             }
         }
 
@@ -82,8 +141,10 @@ impl CredentialResolver {
     /// Check if a credential is available (without prompting).
     pub fn has_credential(&self, key: &str) -> bool {
         // Check vault
-        if let Some(ref vault) = self.vault {
-            if vault.is_unlocked() && vault.get(key).is_some() {
+        if let Some(ref source) = self.vault {
+            let in_vault =
+                source.with_read(|vault| vault.is_unlocked() && vault.get(key).is_some());
+            if in_vault {
                 return true;
             }
         }
@@ -117,9 +178,8 @@ impl CredentialResolver {
 
     /// Store a credential in the vault (if available).
     pub fn store_in_vault(&mut self, key: &str, value: Zeroizing<String>) -> ExtensionResult<()> {
-        if let Some(ref mut vault) = self.vault {
-            vault.set(key.to_string(), value)?;
-            Ok(())
+        if let Some(ref mut source) = self.vault {
+            source.with_write(|vault| vault.set(key.to_string(), value))
         } else {
             Err(crate::ExtensionError::Vault(
                 "No vault configured".to_string(),

--- a/crates/librefang-kernel/src/kernel/accessors.rs
+++ b/crates/librefang-kernel/src/kernel/accessors.rs
@@ -687,7 +687,7 @@ impl LibreFangKernel {
     /// unlocked (bad master key, corrupt file, missing keyring entry).
     /// A missing vault file is **not** an error: the cache is populated
     /// with an unopened vault and the first `set()` call will `init()` it.
-    pub(super) fn vault_handle(
+    pub fn vault_handle(
         &self,
     ) -> Result<
         std::sync::Arc<std::sync::RwLock<librefang_extensions::vault::CredentialVault>>,
@@ -767,6 +767,44 @@ impl LibreFangKernel {
         guard
             .set(key.to_string(), zeroize::Zeroizing::new(value.to_string()))
             .map_err(|e| format!("Vault write failed: {e}"))
+    }
+
+    /// Install an MCP catalog template into the configured server set,
+    /// using the kernel's cached vault and catalog.
+    ///
+    /// Routes through `vault_handle()` (#3598) so the unlock-time Argon2id
+    /// KDF runs at most once per kernel lifetime, regardless of how many
+    /// install requests arrive. The previous API-side path opened
+    /// `vault.enc` and ran the KDF on every HTTP install request.
+    ///
+    /// Returns the installer's [`librefang_extensions::installer::InstallResult`];
+    /// the caller persists the resulting `McpServerConfigEntry` into
+    /// `config.toml` and triggers a kernel reload.
+    pub fn install_integration(
+        &self,
+        template_id: &str,
+        provided_keys: &std::collections::HashMap<String, String>,
+    ) -> librefang_extensions::ExtensionResult<librefang_extensions::installer::InstallResult> {
+        // Pull the cached, already-unlocked vault. A vault file that does not
+        // exist is not an error here — `vault_handle` populates the cache with
+        // an unopened vault and the resolver will fall through to dotenv / env
+        // lookups (matching the previous behaviour where a missing vault file
+        // was silently tolerated).
+        let vault_handle = self
+            .vault_handle()
+            .map_err(librefang_extensions::ExtensionError::Vault)?;
+        let dotenv_path = self.home_dir().join(".env");
+        let mut resolver = librefang_extensions::credentials::CredentialResolver::with_vault_handle(
+            Some(vault_handle),
+            Some(&dotenv_path),
+        );
+        let catalog_snap = self.mcp_catalog_load();
+        librefang_extensions::installer::install_integration(
+            &catalog_snap,
+            &mut resolver,
+            template_id,
+            provided_keys,
+        )
     }
 
     /// Atomically redeem a TOTP recovery code.

--- a/crates/librefang-kernel/src/kernel/accessors.rs
+++ b/crates/librefang-kernel/src/kernel/accessors.rs
@@ -777,6 +777,22 @@ impl LibreFangKernel {
     /// install requests arrive. The previous API-side path opened
     /// `vault.enc` and ran the KDF on every HTTP install request.
     ///
+    /// Vault unlock failure is **not** fatal — the resolver falls through to
+    /// dotenv / env lookups, matching the original `skills.rs`
+    /// `if v.unlock().is_ok() { Some(v) } else { None }` semantics. Operators
+    /// who rotate `LIBREFANG_VAULT_KEY` post-boot (or whose keyring entry is
+    /// briefly unavailable) can still complete an install whose required
+    /// credentials live in `.env` / process env. The failure is logged at
+    /// `warn` level so it isn't silent.
+    ///
+    /// Catalog freshness: this method calls `mcp_catalog_reload` so manual
+    /// edits to `~/.librefang/mcp/catalog/*.toml` are picked up immediately —
+    /// the previous API-side path performed an ad-hoc `McpCatalog::new(home)
+    /// .load(home)` per request, and operators relied on that to drop in
+    /// custom templates without a daemon restart. The reload is a directory
+    /// scan of a few dozen TOML files — comfortably cheap on the install
+    /// path's latency budget.
+    ///
     /// Returns the installer's [`librefang_extensions::installer::InstallResult`];
     /// the caller persists the resulting `McpServerConfigEntry` into
     /// `config.toml` and triggers a kernel reload.
@@ -785,19 +801,27 @@ impl LibreFangKernel {
         template_id: &str,
         provided_keys: &std::collections::HashMap<String, String>,
     ) -> librefang_extensions::ExtensionResult<librefang_extensions::installer::InstallResult> {
-        // Pull the cached, already-unlocked vault. A vault file that does not
-        // exist is not an error here — `vault_handle` populates the cache with
-        // an unopened vault and the resolver will fall through to dotenv / env
-        // lookups (matching the previous behaviour where a missing vault file
-        // was silently tolerated).
-        let vault_handle = self
-            .vault_handle()
-            .map_err(librefang_extensions::ExtensionError::Vault)?;
+        // Pull the cached, already-unlocked vault. Soft-fail on unlock errors
+        // so a post-boot key rotation / keyring blip doesn't block installs
+        // whose credentials happen to live in dotenv or process env.
+        let vault_handle = match self.vault_handle() {
+            Ok(h) => Some(h),
+            Err(e) => {
+                warn!(
+                    "install_integration: vault unavailable, falling back to dotenv/env only: {e}"
+                );
+                None
+            }
+        };
         let dotenv_path = self.home_dir().join(".env");
         let mut resolver = librefang_extensions::credentials::CredentialResolver::with_vault_handle(
-            Some(vault_handle),
+            vault_handle,
             Some(&dotenv_path),
         );
+        // Refresh the catalog snapshot from disk so manually-added template
+        // TOMLs are visible without a daemon restart (matches pre-#3295
+        // ad-hoc-load behaviour). Cheap: reads `~/.librefang/mcp/catalog/`.
+        self.mcp_catalog_reload(self.home_dir());
         let catalog_snap = self.mcp_catalog_load();
         librefang_extensions::installer::install_integration(
             &catalog_snap,

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6537,6 +6537,116 @@ async fn vault_cache_reuses_unlocked_handle_across_calls() {
     kernel.shutdown();
 }
 
+/// Regression test for the kernel install façade introduced in #3295: the
+/// HTTP install path historically opened `vault.enc` and ran the Argon2id
+/// KDF on every request. After the refactor, `Kernel::install_integration`
+/// rides the cached `vault_handle()` so the unlock cost is paid once per
+/// kernel lifetime.
+///
+/// We assert two things at the seam between resolver and cached vault:
+///
+///   1. Credentials supplied to `install_integration` are written into the
+///      kernel's cached vault — `vault_get` reads them back immediately
+///      with no fresh `unlock()` call. This proves the resolver's
+///      `with_vault_handle` constructor really does share storage with the
+///      kernel cache (rather than holding a stale clone).
+///   2. The `vault_handle()` Arc returned before the install is the same
+///      allocation as the one returned after — the install path must not
+///      poison or rebuild the cache slot.
+///
+/// Same `serial_test::serial` group as the other vault tests because
+/// `LIBREFANG_VAULT_KEY` is process-global.
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+async fn install_integration_writes_through_cached_vault_handle() {
+    const TEST_VAULT_KEY_B64: &str = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
+    let _vault_key = set_test_env("LIBREFANG_VAULT_KEY", TEST_VAULT_KEY_B64);
+    let _no_keyring = set_test_env("LIBREFANG_VAULT_NO_KEYRING", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    // Drop a single catalog template into the location the kernel scans.
+    // One required env var so the resolver has somewhere to write through.
+    let catalog_dir = home_dir.join("mcp").join("catalog");
+    std::fs::create_dir_all(&catalog_dir).unwrap();
+    std::fs::write(
+        catalog_dir.join("test-template.toml"),
+        r#"
+id = "test-template"
+name = "Test Template"
+description = "Fixture for install_integration vault-write seam test"
+category = "devtools"
+
+[transport]
+type = "stdio"
+command = "echo"
+args = ["hello"]
+
+[[required_env]]
+name = "TEST_TEMPLATE_TOKEN"
+label = "Test Token"
+help = "anything goes"
+is_secret = true
+"#,
+    )
+    .unwrap();
+
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+
+    // Snapshot the cached handle BEFORE install so we can assert the install
+    // path doesn't replace the cache slot.
+    let pre_handle = kernel
+        .vault_handle()
+        .expect("vault_handle should succeed before install");
+
+    let mut provided = std::collections::HashMap::new();
+    provided.insert(
+        "TEST_TEMPLATE_TOKEN".to_string(),
+        "shibboleth-42".to_string(),
+    );
+
+    let result = kernel
+        .install_integration("test-template", &provided)
+        .expect("install should succeed when all required creds are provided");
+
+    // Status must be Ready — the resolver saw the credential we just stored.
+    assert_eq!(
+        result.status,
+        librefang_types::mcp::McpStatus::Ready,
+        "install should report Ready when required cred was supplied",
+    );
+
+    // The credential lives in the kernel's cached vault — `vault_get` reads
+    // it without re-unlocking. This is the seam the resolver's
+    // `with_vault_handle` constructor exists to guarantee.
+    assert_eq!(
+        kernel.vault_get("TEST_TEMPLATE_TOKEN").as_deref(),
+        Some("shibboleth-42"),
+        "install_integration must write credentials through the cached \
+         vault handle, so kernel.vault_get sees them immediately",
+    );
+
+    // Same Arc before and after — install path didn't poison the cache.
+    let post_handle = kernel
+        .vault_handle()
+        .expect("vault_handle should succeed after install");
+    assert!(
+        std::sync::Arc::ptr_eq(&pre_handle, &post_handle),
+        "install_integration must reuse the cached vault handle; \
+         rebuilding it would silently re-introduce the per-request \
+         Argon2id KDF cost the façade exists to avoid",
+    );
+
+    kernel.shutdown();
+}
+
 // ── /api/agents/{id}/sessions `active` semantics (#4293) ────────────────────
 //
 // `list_agent_sessions` historically marked `active = (sid == registry pointer)`.

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -158,6 +158,20 @@ pub trait KernelApi: KernelHandle + Send + Sync {
     fn vault_redeem_recovery_code(&self, code: &str) -> Result<bool, String>;
 
     // ====================================================================
+    // MCP install façade — routes through the kernel's cached vault and
+    // catalog so HTTP request handlers don't open vault.enc and run the
+    // unlock-time Argon2id KDF on every install request (#3598). The trait
+    // exposes the high-level installer; the underlying `vault_handle` stays
+    // an inherent method to keep the trait surface small.
+    // ====================================================================
+
+    fn install_integration(
+        &self,
+        template_id: &str,
+        provided_keys: &std::collections::HashMap<String, String>,
+    ) -> librefang_extensions::ExtensionResult<librefang_extensions::installer::InstallResult>;
+
+    // ====================================================================
     // Inbox / auto-dream observability
     // ====================================================================
 
@@ -698,6 +712,15 @@ impl KernelApi for LibreFangKernel {
     }
     fn vault_redeem_recovery_code(&self, code: &str) -> Result<bool, String> {
         Self::vault_redeem_recovery_code(self, code)
+    }
+
+    // -- MCP install façade --
+    fn install_integration(
+        &self,
+        template_id: &str,
+        provided_keys: &std::collections::HashMap<String, String>,
+    ) -> librefang_extensions::ExtensionResult<librefang_extensions::installer::InstallResult> {
+        Self::install_integration(self, template_id, provided_keys)
     }
 
     // -- Inbox / auto-dream --


### PR DESCRIPTION
Follow-up to #4783 — bundles the two commits that landed on the branch *after* the squash-merge, rebased onto current main.

## Why a fresh PR

#4783 was squash-merged after only the schema-spine commit was on the branch. The two follow-ups (control-plane facade, hook regex narrowing) pushed afterwards never reached main. This PR re-files them off the post-merge tip so CI doesn't trip on the unrelated `{name}` test bug that was hot-fixed on main as #4786.

Per author guidance (single-PR-no-spillover), both commits ride together rather than splitting again.

## Commits

### `ab0d8bb` — `refactor(kernel): route HTTP install path through cached vault facade`

The investigation under #3295 found `librefang-api/src/routes/skills.rs` opening `vault.enc` and running the Argon2id KDF on every install request — bypassing the kernel's vault cache from #3598.

- `CredentialResolver::with_vault_handle(Arc<RwLock<CredentialVault>>, ...)` — new constructor; resolvers can ride a shared, already-unlocked vault instead of owning one
- `Kernel::vault_handle()` promoted `pub(super)` → `pub`
- `Kernel::install_integration(template_id, provided_keys)` — high-level facade wiring cached vault + cached catalog + transient resolver
- `KernelApi` trait grows `install_integration` (default forwards to inherent, matching the existing `vault_get` / `vault_set` pattern)
- Two `skills.rs` install branches (`add_mcp_server` template branch + `install_extension`) collapse from ~25 lines each to a single match block

The CLI install command (`cli/main.rs:9547`) keeps its disk-direct vault open: it's a one-shot subprocess with no daemon to share a cache with — that's correct behaviour, not an anti-pattern.

### `27e4dbc` — `fix(hooks): stop flagging source files that handle credentials`

The PreToolUse `sensitive-file-add` rule's `credentials(\.[a-z]+)?` / `secrets?(\.[a-z]+)?` patterns swept in any extension, so editing `crates/librefang-extensions/src/credentials.rs` (a Rust source file — not a credential store) tripped the guard and forced a manual override on every commit touching it.

Narrowed the regex to credential-storage data formats (`json|toml|yaml|yml|txt|csv|ini|conf|env|cfg`) plus the bare `credentials` / `secrets` filename. Source files (`.rs` / `.py` / `.go` / `.ts` / `.md` / …) no longer trip the rule, while `credentials.json`, `secrets.toml`, `vault_master.key`, `.env`, `id_rsa`, `*.pem`, etc. still do. Verified with a 22-case round-trip against `_looks_sensitive`.

## Files

| Crate / area | Files |
|---|---|
| `librefang-extensions` | `src/credentials.rs` (`VaultSource` enum, `with_vault_handle`) |
| `librefang-kernel` | `src/kernel/accessors.rs` (`vault_handle` pub, new `install_integration`), `src/kernel_api.rs` (trait) |
| `librefang-api` | `src/routes/skills.rs` (2 install branches collapsed) |
| Hooks | `.claude/hooks/lib/check-bash-rules.py` (regex narrowed) |

## Test plan

- [ ] `cargo nextest run --workspace --lib --bins --no-fail-fast` (Unit-fast lane)
- [ ] `cargo nextest run --workspace --no-fail-fast` (full integration lane — `crates/librefang-api/tests/api_integration_test.rs::add_mcp_server` and friends exercise the kernel facade end-to-end)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --all --check`
- [ ] Existing `kernel::tests::vault_handle_returns_same_arc` still covers the cache invariant under the now-public method
- [x] Hook regex: 22-case `_looks_sensitive` round-trip (run locally during the fix commit)

## Out of scope

`librefang-api/src/server.rs:133::resolve_dashboard_credential` is a separate per-request vault-open in the dashboard auth path. Threading the kernel into `ApiAuthSnapshot` to fix it touches 12+ call sites across `server.rs`, `ws.rs`, `routes/terminal.rs` — own PR, separate domain (auth) from the install-path control plane.

Refs: #3295, #4783