### PR TITLE
fix(test): drop install_integration fixture after boot to dodge sync_registry orphan cleanup

### DIFF
--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6567,8 +6567,25 @@ async fn install_integration_writes_through_cached_vault_handle() {
     let home_dir = dir.path().to_path_buf();
     std::fs::create_dir_all(home_dir.join("data")).unwrap();
 
-    // Drop a single catalog template into the location the kernel scans.
-    // One required env var so the resolver has somewhere to write through.
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+
+    // Drop the catalog fixture AFTER boot. `LibreFangKernel::boot_with_config`
+    // runs `librefang_runtime::registry_sync::sync_registry`, which calls
+    // `sync_flat_files` against `home_dir/mcp/catalog/`. That helper deletes
+    // any local TOML whose basename does not exist in the upstream registry
+    // mirror — a fixture written *before* boot gets nuked the moment CI has
+    // network access (see registry_sync.rs:458-475 "remove orphans" loop).
+    //
+    // Writing the fixture post-boot is the canonical path the test wants to
+    // exercise anyway: a user manually drops a custom template into
+    // ~/.librefang/mcp/catalog/, then triggers an install. The reload-on-
+    // install behaviour added in #4788 is what makes that path work without
+    // a daemon restart, and that is precisely what this test pins.
     let catalog_dir = home_dir.join("mcp").join("catalog");
     std::fs::create_dir_all(&catalog_dir).unwrap();
     std::fs::write(
@@ -6592,13 +6609,6 @@ is_secret = true
 "#,
     )
     .unwrap();
-
-    let config = KernelConfig {
-        home_dir: home_dir.clone(),
-        data_dir: home_dir.join("data"),
-        ..KernelConfig::default()
-    };
-    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
 
     // Snapshot the cached handle BEFORE install so we can assert the install
     // path doesn't replace the cache slot.


### PR DESCRIPTION
Fix-forward for the test added in #4788, which has been red on `main` since merge (`766431ad`).

## What broke

`install_integration_writes_through_cached_vault_handle` panics on the install call:

```
thread 'kernel::tests::install_integration_writes_through_cached_vault_handle' panicked at
    crates/librefang-kernel/src/kernel/tests.rs:6617:10:
install should succeed when all required creds are provided: NotFound("test-template")
```

Failing job: https://github.com/librefang/librefang/actions/runs/25541418468/job/74968203287

## Root cause

The test wrote `home_dir/mcp/catalog/test-template.toml` **before** calling `LibreFangKernel::boot_with_config`. Boot then runs `librefang_runtime::registry_sync::sync_registry`, whose `sync_flat_files` helper has an orphan-cleanup loop at `crates/librefang-runtime/src/registry_sync.rs:458-475`:

```rust
// Remove local files that no longer exist in the registry source.
if !src_dir.join(&name).exists() && std::fs::remove_file(&path).is_ok() {
    removed += 1;
}
```

When CI has network, `sync_registry` populates `home_dir/registry/` from the upstream mirror, and the orphan-cleanup pass deletes any local catalog TOML whose basename isn't in the upstream — including my synthetic `test-template.toml` fixture. The boot-time `mcp_catalog.load(...)` then sees an empty catalog dir, and the install call returns `NotFound`.

The test passes locally when offline because the registry cache stays empty, and `sync_flat_files` early-returns on `read_dir(non_existent_src_dir)` before reaching the orphan loop.

## Fix

Drop the fixture **after** boot. The post-boot path also matches the real-world workflow this test is meant to pin: an operator manually adds a catalog TOML to `~/.librefang/mcp/catalog/`, then calls install. The reload-on-install behaviour added in #4788 is what makes that workflow work without a daemon restart, and the assertion remains the same.

No production code changed — single test edit moves the fixture write down ~30 lines.

## Test plan

- [ ] CI / Test / Unit (lib+bin) passes (the same job that's currently red)

Refs: #4788, #4790