### PR TITLE
fix(testing): add deterministic catalog seed for mock kernel — fix capability_override flake

### DIFF
--- a/crates/librefang-api/tests/providers_routes_test.rs
+++ b/crates/librefang-api/tests/providers_routes_test.rs
@@ -23,7 +23,7 @@ use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 use axum::Router;
 use librefang_api::routes::{self, AppState};
-use librefang_testing::{MockKernelBuilder, TestAppState};
+use librefang_testing::{test_catalog_baseline, MockKernelBuilder, TestAppState};
 use std::sync::Arc;
 use tower::ServiceExt;
 
@@ -36,18 +36,30 @@ struct Harness {
 /// Boots a kernel with a sane default-model provider so handlers that fall
 /// back to `config.default_model.provider` (notably `add_custom_model`)
 /// don't end up tagging entries with the placeholder `"auto"` provider.
+///
+/// Seeds the model catalog with [`test_catalog_baseline`] so tests that
+/// reference specific ids (notably `openai:gpt-4o-mini` for the
+/// capability-override flow) don't depend on the network-fed
+/// `sync_registry` baseline that flakes on CI when GitHub rate-limits or
+/// the runner is partitioned. Validation/error-path tests in this file
+/// either target unknown ids (404 paths) or only inspect envelope shape,
+/// so a non-empty deterministic catalog leaves them unaffected.
 fn boot() -> Harness {
-    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(|cfg| {
-        cfg.default_model = librefang_types::config::DefaultModelConfig {
-            provider: "openai".to_string(),
-            model: "gpt-4o-mini".to_string(),
-            api_key_env: "OPENAI_API_KEY".to_string(),
-            base_url: None,
-            message_timeout_secs: 300,
-            extra_params: std::collections::HashMap::new(),
-            cli_profile_dirs: Vec::new(),
-        };
-    }));
+    let test = TestAppState::with_builder(
+        MockKernelBuilder::new()
+            .with_config(|cfg| {
+                cfg.default_model = librefang_types::config::DefaultModelConfig {
+                    provider: "openai".to_string(),
+                    model: "gpt-4o-mini".to_string(),
+                    api_key_env: "OPENAI_API_KEY".to_string(),
+                    base_url: None,
+                    message_timeout_secs: 300,
+                    extra_params: std::collections::HashMap::new(),
+                    cli_profile_dirs: Vec::new(),
+                };
+            })
+            .with_catalog_seed(test_catalog_baseline()),
+    );
 
     let state = test.state.clone();
     let app = Router::new()

--- a/crates/librefang-testing/src/lib.rs
+++ b/crates/librefang-testing/src/lib.rs
@@ -16,7 +16,7 @@ pub mod test_app;
 
 pub use helpers::{assert_json_error, assert_json_ok, test_request};
 pub use mock_driver::{FailingLlmDriver, MockLlmDriver};
-pub use mock_kernel::MockKernelBuilder;
+pub use mock_kernel::{test_catalog_baseline, CatalogSeed, MockKernelBuilder};
 pub use test_app::TestAppState;
 
 #[cfg(test)]

--- a/crates/librefang-testing/src/mock_kernel.rs
+++ b/crates/librefang-testing/src/mock_kernel.rs
@@ -5,9 +5,64 @@
 //! to construct a real kernel instance.
 
 use librefang_kernel::LibreFangKernel;
+use librefang_runtime::model_catalog::ModelCatalog;
 use librefang_types::config::KernelConfig;
+use librefang_types::model_catalog::{
+    AuthStatus, Modality, ModelCatalogEntry, ModelTier, ProviderInfo,
+};
 use std::sync::{Arc, Once};
 use tempfile::TempDir;
+
+/// Catalog seed pair: `(providers, models)` in the same order
+/// `ModelCatalog::from_entries` accepts.
+pub type CatalogSeed = (Vec<ProviderInfo>, Vec<ModelCatalogEntry>);
+
+/// A minimal, deterministic catalog covering ids referenced by the
+/// `librefang-api` integration test suite (`gpt-4o-mini` under `openai`).
+///
+/// Use this when a test asserts on a specific model id and you need a
+/// stable baseline regardless of network conditions. `MockKernelBuilder`
+/// boots through the real `LibreFangKernel::boot_with_config`, which
+/// calls `librefang_runtime::registry_sync::sync_registry` — that talks
+/// to `github.com/librefang-registry`, and CI runners that flake or
+/// rate-limit produce an empty (or partially populated) catalog. Tests
+/// referencing specific ids then panic with 404 in one shard while
+/// passing in another. Seeding via the builder bypasses the network
+/// dependency.
+///
+/// Add entries here as other tests grow demands — keep the list small
+/// and intentional.
+pub fn test_catalog_baseline() -> CatalogSeed {
+    let providers = vec![ProviderInfo {
+        id: "openai".to_string(),
+        display_name: "OpenAI".to_string(),
+        api_key_env: "OPENAI_API_KEY".to_string(),
+        base_url: "https://api.openai.com/v1".to_string(),
+        key_required: true,
+        auth_status: AuthStatus::default(),
+        model_count: 1,
+        ..ProviderInfo::default()
+    }];
+    let models = vec![ModelCatalogEntry {
+        id: "gpt-4o-mini".to_string(),
+        display_name: "GPT-4o mini (test fixture)".to_string(),
+        provider: "openai".to_string(),
+        tier: ModelTier::Custom,
+        modality: Modality::default(),
+        context_window: 128_000,
+        max_output_tokens: 16_384,
+        input_cost_per_m: 0.15,
+        output_cost_per_m: 0.6,
+        image_input_cost_per_m: None,
+        image_output_cost_per_m: None,
+        supports_tools: true,
+        supports_vision: true,
+        supports_streaming: true,
+        supports_thinking: false,
+        aliases: Vec::new(),
+    }];
+    (providers, models)
+}
 
 /// Pin a deterministic vault master key for the test process the first
 /// time a mock kernel is built. Without this, parallel integration tests
@@ -54,6 +109,11 @@ pub struct MockKernelBuilder {
     config: KernelConfig,
     /// Custom config modification function.
     config_fn: Option<ConfigFn>,
+    /// Optional model-catalog seed applied after boot. When `Some`, replaces
+    /// whatever catalog `boot_with_config` produced (including any partial
+    /// state left behind by `sync_registry`'s network fetch) with a
+    /// deterministic baseline.
+    catalog_seed: Option<CatalogSeed>,
 }
 
 impl MockKernelBuilder {
@@ -62,6 +122,7 @@ impl MockKernelBuilder {
         Self {
             config: KernelConfig::default(),
             config_fn: None,
+            catalog_seed: None,
         }
     }
 
@@ -79,6 +140,23 @@ impl MockKernelBuilder {
     /// ```
     pub fn with_config<F: FnOnce(&mut KernelConfig) + 'static>(mut self, f: F) -> Self {
         self.config_fn = Some(Box::new(f));
+        self
+    }
+
+    /// Seed the model catalog with the given providers and models, replacing
+    /// whatever `LibreFangKernel::boot_with_config` produced.
+    ///
+    /// Use this when tests assert on specific model ids. Without seeding,
+    /// the catalog is whatever `librefang_runtime::registry_sync::sync_registry`
+    /// fetched from `github.com/librefang-registry` — flaky on CI when the
+    /// runner is rate-limited or the network is partitioned, and entirely
+    /// undefined when no network is available at all.
+    ///
+    /// Pass [`test_catalog_baseline()`] for a sane minimum that covers the
+    /// `librefang-api` integration test suite, or build your own pair when
+    /// you need provider/model shapes the baseline doesn't include.
+    pub fn with_catalog_seed(mut self, seed: CatalogSeed) -> Self {
+        self.catalog_seed = Some(seed);
         self
     }
 
@@ -122,6 +200,12 @@ impl MockKernelBuilder {
             LibreFangKernel::boot_with_config(self.config).expect("failed to boot test kernel"),
         );
         kernel.set_self_handle();
+
+        if let Some((providers, models)) = self.catalog_seed.take() {
+            kernel.model_catalog_update(|cat| {
+                *cat = ModelCatalog::from_entries(models.clone(), providers.clone());
+            });
+        }
 
         (kernel, tmp)
     }


### PR DESCRIPTION
## Summary

Fixes the second `main`-red wave on commit `bd3f8bde` (CI run [`25543956232`](https://github.com/librefang/librefang/actions/runs/25543956232)). After #4793 unblocked the install-integration test, the post-merge full-run lane exposed a different pre-existing failure in #4781's `capability_override_*` tests:

- `capability_override_flips_effective_value_in_get_model` — `assertion left == right failed; left: 404, right: 200` at `providers_routes_test.rs:412`
- `capability_override_partial_only_flips_set_fields` — `Option::unwrap()` on `None` at `:523:55`

Same commit, same `boot()`. Shards 2/3/4 green, shard 1 red — the canonical signature of a network-dependent fixture.

## Root cause

Both tests do `GET /api/models/gpt-4o-mini` and expect 200. The mock kernel's catalog ultimately comes from `librefang_runtime::registry_sync::sync_registry`, which talks to `github.com/librefang-registry` over HTTP/git. CI runners that flake or rate-limit produce an empty (or partially populated) catalog, and the tests panic with 404 in whatever shard happens to land them.

The dependency is wrong by construction: `MockKernelBuilder::build()` is the seam through which integration tests reach a kernel, and a network call in that path makes every test using a specific id non-deterministic. The `capability_override_*` tests are just the first to assert on a specific id — every future test that does will inherit the same flake.

## Fix

Treat `MockKernelBuilder` as the right layer to own this. Add:

- **`MockKernelBuilder::with_catalog_seed(seed)`** — builder method that replaces whatever `boot_with_config` produced with a deterministic `(providers, models)` pair after boot. Bypasses the registry-sync dependency without touching production code (real daemons still want `sync_registry` on startup).
- **`librefang_testing::test_catalog_baseline()`** — a minimal `(providers, models)` covering `openai:gpt-4o-mini`, the id the api integration suite references. The doc comment captures the policy: extend this list as other tests grow demands, keep it intentional.
- **`CatalogSeed`** — type alias for `(Vec<ProviderInfo>, Vec<ModelCatalogEntry>)` so callers don't re-spell it.

`providers_routes_test.rs::boot()` adopts `.with_catalog_seed(test_catalog_baseline())`. **The two failing tests' bodies are not touched** — the fixture is now a property of the kernel they boot against, not a hand-rolled setup call.

## Why this layer, not test-local injection

A first pass tried adding an `inject_openai_gpt4o_fixture` helper to `providers_routes_test.rs`. Maintainer feedback (correctly) pointed out that this is a patch over the symptom: the next file that needs a deterministic catalog re-implements the same helper, and the network dependency stays in `MockKernelBuilder`. Pulling the seam up to `librefang-testing` exposes one canonical entry point and lets every integration test in the workspace opt into determinism with one method call.

## Other tests in `providers_routes_test.rs`

A non-empty seeded catalog could in theory perturb tests that assume "catalog is empty." Walked the file:

- `list_models_returns_well_formed_envelope` — already asserts `total > 0`. Was previously passing only because `sync_registry` happened to fetch a non-empty registry; now passes deterministically.
- `list_models_filters_by_unknown_provider_yields_empty` — filters by an unknown provider; baseline contains `openai`, filter still yields empty.
- `get_model_unknown_id_returns_404`, `set_default_provider_unknown_returns_404`, `copilot_oauth_poll_unknown_id_returns_404`, etc. — target unknown ids.
- `create_alias_then_list_then_delete_round_trips` — uses `gpt-4o-mini` as `model_id`. Baseline has it, so the alias call still resolves.
- `add_custom_model_then_get_then_delete_round_trips` — uses a Custom id distinct from baseline.
- `list_providers_returns_well_formed_envelope` — only inspects envelope shape.

No regressions expected.

## Test plan

- [ ] `Test / Ubuntu (shard 1/4)` and `Test / macOS` go green on this branch.
- [ ] Other shards stay green.

## Out of scope

- Whether `boot_with_config` should gate `sync_registry` on `network_enabled` or some new `offline_mode` flag. Defensible argument for it (air-gapped deploys), but a different change with a different risk surface — covered for tests by this PR.
- A property test that the `(providers, models)` baseline actually deserialises into a usable catalog. The `from_entries` path is already covered by the runtime crate's own tests; the additional helper is just data.
