### PR TITLE
fix(runtime): expose ModelCatalog::from_entries outside cfg(test) — unbreak main

### DIFF
--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -96,12 +96,20 @@ fn resolve_discovered_capabilities(
     (has_vision, supports_tools, has_thinking)
 }
 
-#[cfg(test)]
 impl ModelCatalog {
-    /// Test-only constructor: build a catalog directly from owned entries
-    /// without going through TOML loading. Used by sibling modules' unit
-    /// tests (`model_metadata`, etc.) so they can inject deterministic
-    /// fixtures without touching the filesystem.
+    /// Construct a catalog directly from owned entries without going
+    /// through TOML loading. Used by:
+    /// - this crate's sibling-module unit tests (`model_metadata`, etc.)
+    ///   for deterministic fixture injection;
+    /// - `librefang-testing::MockKernelBuilder::with_catalog_seed` (#4796)
+    ///   so integration tests can pin a known catalog without depending
+    ///   on the network-fed `registry_sync` baseline.
+    ///
+    /// Only assembles owned data — no invariant beyond the alias-lowering
+    /// rule — so exposing it outside `cfg(test)` is safe. Production
+    /// paths still go through `ModelCatalog::new()` and the
+    /// `registry_sync` pipeline; this constructor exists purely as a
+    /// fixture-building seam.
     pub fn from_entries(models: Vec<ModelCatalogEntry>, providers: Vec<ProviderInfo>) -> Self {
         let mut aliases: HashMap<String, String> = HashMap::new();
         for m in &models {


### PR DESCRIPTION
## Summary

Fixes the post-merge `main` red on commit `abb3853e` (CI run [`25545272302`](https://github.com/librefang/librefang/actions/runs/25545272302)). #4796 (just merged) added a call to `ModelCatalog::from_entries` from `librefang-testing::mock_kernel`, but that function was inside an `impl` block gated behind `#[cfg(test)]` (`crates/librefang-runtime/src/model_catalog.rs:99`). `librefang-testing` is a regular library crate, not a test target, so its lib build cannot see `cfg(test)` items. The workspace lib build now fails with:

```
error[E0599]: no function or associated item named `from_entries`
found for struct `ModelCatalog` in the current scope
```

Nine jobs failed at compile time on the post-merge run: Quality, Test/Unit (lib+bin), Test/Ubuntu (shard 1..4 of 4), Test/macOS, Test/Windows, OpenAPI Drift.

## Fix

Move `from_entries` out of the `#[cfg(test)] impl` block into the unconditional `impl ModelCatalog`. The doc-comment is updated to enumerate both consumers:

1. This crate's own sibling-module unit tests (`model_metadata`, etc.) — the original use case.
2. `librefang-testing::MockKernelBuilder::with_catalog_seed` (#4796) — the integration-test seam introduced last PR.

The function only assembles owned data (the only invariant is the alias-lowercasing pass), so exposing it on lib builds is safe. Production code paths still flow through `ModelCatalog::new()` and the `registry_sync` pipeline; this constructor stays a fixture-building seam.

## Test plan

- [ ] `Quality`, `Test/Unit (lib+bin)`, `Test/Ubuntu (shard 1..4)`, `Test/macOS`, `Test/Windows`, `OpenAPI Drift` all turn green on this branch — they were red purely from the compile failure, so a successful build is the validation.

## Why this wasn't caught on the #4796 PR

`librefang-testing` is a regular dependency of `librefang-api`, but the dependency graph between `librefang-runtime` (where `from_entries` lives) and `librefang-testing` only triggers a lib build of `librefang-testing` when `librefang-api`'s test target compiles, which the PR-level selective lane runs. PR-level CI on #4796 _did_ compile this code path successfully — but the workspace cargo cache between selective and full lanes diverges on which `cfg(test)` flags are propagated through transitive deps; specifically, the `librefang-testing` lib was being rebuilt in a context where `cfg(test)` was active for `librefang-runtime` from the integration-test crate's perspective. On main, the `cargo nextest run --workspace --lib --bins` lane builds without `cfg(test)` for transitive deps and exposes the gap.

A long-term mitigation would be to add a workspace-level `--lib --bins` build step to the PR-level lane (#3696 already mentions the unit-fast lane shape), but that's out of scope here.

Refs #4796.
