### PR TITLE
fix(release): channel=current uses main HEAD, not the tag's frozen commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,13 @@ jobs:
   # GitHub Release would still point at the old (broken) commit even
   # though the binary artifacts and SDK packages are rebuilt from main.
   #
+  # Operational note: this REWRITES the release tag's commit pointer.
+  # Anyone who already fetched the old `vX → C1` mapping (mirrors,
+  # third-party CI checking out the tag, Homebrew bottle pinning) will
+  # observe the tag jumping to a new commit on next fetch. That is the
+  # whole point of `channel=current` — we want vX to mean "main HEAD
+  # at re-publish time" — but it is intentional, not accidental.
+  #
   # Mechanics: if the tag is already at main HEAD, this is a no-op and
   # the dispatch run continues into create_release/publish normally.
   # Otherwise the force-push triggers a fresh `push: tags` run, the
@@ -81,6 +88,18 @@ jobs:
   # and the push run takes over the actual publishing — by then the
   # tag and main HEAD are the same commit, so RELEASE_REF resolves to
   # the same source either way.
+  #
+  # Race window during a force-push path: this job has no `needs:`
+  # blocker on the publish jobs, so build_dashboard / package_* /
+  # publish_* / docker / sdk jobs in this dispatch run start in
+  # parallel with `sync_tag_to_main`. Some may finish (or partially
+  # publish) before concurrency cancels the dispatch run. The follow-up
+  # `push: tags` run then redoes the same publishes. We rely on each
+  # publish step being idempotent for the same version: GitHub Release
+  # uploads overwrite, and npm / PyPI / crates.io reject duplicate
+  # publishes for an already-published version (handled as success in
+  # the publish jobs). If you add a non-idempotent publish step, gate
+  # it on `needs: sync_tag_to_main` to serialize behind this job.
   # ═════════════════════════════════════════════════════════════════════════
 
   sync_tag_to_main:
@@ -97,6 +116,14 @@ jobs:
           # PAT (not GITHUB_TOKEN) so the resulting `push: tags` event
           # actually triggers downstream workflows. GITHUB_TOKEN-driven
           # pushes intentionally do not chain workflows.
+          #
+          # Token scope note: the secret is named HOMEBREW_TAP_TOKEN
+          # because it was originally provisioned for pushing to the
+          # external `librefang/homebrew-tap` repo. It is also reused
+          # here and in `bump_version` for write access to *this*
+          # repo (PR creation and now tag force-push). Rotate / scope
+          # changes must keep `contents: write` on the main repo or
+          # this job and the bump-PR flow break.
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       - name: Force-update tag to main HEAD
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,9 @@ on:
     inputs:
       channel:
         description: |
-          `current` reruns the release for the tag picked by `--ref`.
+          `current` reruns the release for the tag picked by `--ref`,
+          using the latest `main` HEAD as the source of truth so a
+          hotfix landed after the tag re-publishes the same version.
           `stable/beta/rc/lts` kicks off `cargo xtask release --channel …`
           which opens a bump-version PR; merging that PR auto-tags and
           re-enters this workflow via the tag push. Mirrors `just release`.
@@ -57,6 +59,13 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Effective ref for source-using checkouts.
+  # - tag push (normal release): use the pushed tag's frozen commit
+  # - workflow_dispatch channel=current: use main HEAD so a hotfix
+  #   landed after the tag re-publishes the same version
+  # Other dispatch channels (stable/beta/rc/lts) only run bump_version,
+  # which always wants main.
+  RELEASE_REF: ${{ (github.event_name == 'workflow_dispatch' && inputs.channel == 'current') && 'refs/heads/main' || github.ref }}
 
 jobs:
   # ═════════════════════════════════════════════════════════════════════════
@@ -73,6 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ env.RELEASE_REF }}
           fetch-depth: 0
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
@@ -124,6 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ env.RELEASE_REF }}
           fetch-depth: 0
           # PAT (not GITHUB_TOKEN) is required so the PR is opened by a
           # user account and `release: published` events on the
@@ -160,6 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ env.RELEASE_REF }}
           fetch-depth: 0
 
       # Block any tag whose stripped form does not match
@@ -286,6 +298,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ env.RELEASE_REF }}
           fetch-depth: 0
 
       - name: Create release branch (only for .0-lts)
@@ -339,6 +352,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
         with:
           version: 10
@@ -378,6 +393,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dashboard-dist
@@ -434,6 +451,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dashboard-dist
@@ -491,6 +510,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dashboard-dist
@@ -542,6 +563,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dashboard-dist
@@ -596,6 +619,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dashboard-dist
@@ -656,6 +681,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dashboard-dist
@@ -706,6 +733,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dashboard-dist
@@ -759,6 +788,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dashboard-dist
@@ -836,6 +867,8 @@ jobs:
       id-token: write   # fetch OIDC token for cosign keyless signing
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
 
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
         with:
@@ -942,6 +975,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
@@ -969,6 +1004,8 @@ jobs:
       contents: read   # actions/checkout (job-level permissions block fully overrides top-level)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
@@ -1316,6 +1353,8 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
         # libdbus-1-dev is required by libdbus-sys, pulled in transitively
@@ -1501,6 +1540,8 @@ jobs:
       NDK_VERSION: "27.0.12077973"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Set up JDK 17 (Temurin)
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -1734,6 +1775,8 @@ jobs:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Show selected Xcode
         run: |
@@ -2223,6 +2266,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
@@ -2311,6 +2356,8 @@ jobs:
     needs: [docker-manifest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1
       - name: Deploy
         run: flyctl deploy --remote-only --config deploy/fly/fly.toml
@@ -2351,6 +2398,8 @@ jobs:
         working-directory: sdk/javascript
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
@@ -2412,6 +2461,8 @@ jobs:
         working-directory: packages/cli-npm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
@@ -2456,6 +2507,8 @@ jobs:
         working-directory: sdk/python
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
@@ -2503,6 +2556,8 @@ jobs:
         working-directory: sdk/rust
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Sync version from tag
         run: |
@@ -2537,6 +2592,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.RELEASE_REF }}
       - name: Create Go module tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,59 @@ env:
 
 jobs:
   # ═════════════════════════════════════════════════════════════════════════
+  # workflow_dispatch channel=current: force-update the dispatched tag
+  # to main HEAD before publishing. Without this step, the tag in the
+  # GitHub Release would still point at the old (broken) commit even
+  # though the binary artifacts and SDK packages are rebuilt from main.
+  #
+  # Mechanics: if the tag is already at main HEAD, this is a no-op and
+  # the dispatch run continues into create_release/publish normally.
+  # Otherwise the force-push triggers a fresh `push: tags` run, the
+  # `cancel-in-progress` concurrency rule cancels this dispatch run,
+  # and the push run takes over the actual publishing — by then the
+  # tag and main HEAD are the same commit, so RELEASE_REF resolves to
+  # the same source either way.
+  # ═════════════════════════════════════════════════════════════════════════
+
+  sync_tag_to_main:
+    name: Sync tag to main HEAD (channel=current)
+    if: github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: refs/heads/main
+          fetch-depth: 0
+          # PAT (not GITHUB_TOKEN) so the resulting `push: tags` event
+          # actually triggers downstream workflows. GITHUB_TOKEN-driven
+          # pushes intentionally do not chain workflows.
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      - name: Force-update tag to main HEAD
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          MAIN_SHA=$(git rev-parse refs/heads/main)
+          # `git rev-parse <tag>` resolves the tag's tip on the current
+          # clone. Since we just checked out main with full depth, the
+          # tag ref is present in the local repo (refs/tags/$TAG was
+          # fetched as part of the default refspec).
+          TAG_SHA=$(git rev-parse "refs/tags/$TAG^{commit}" 2>/dev/null || echo "")
+          if [ "$TAG_SHA" = "$MAIN_SHA" ]; then
+            echo "✓ Tag $TAG already at main HEAD ($MAIN_SHA); no force-push needed."
+            echo "  This dispatch run will continue into create_release and publish."
+            exit 0
+          fi
+          echo "Force-updating tag $TAG: $TAG_SHA → $MAIN_SHA"
+          git tag -f "$TAG" "$MAIN_SHA"
+          git push origin -f "refs/tags/$TAG"
+          echo "::notice::Tag $TAG force-pushed to main HEAD ($MAIN_SHA). The resulting push event will trigger a fresh release run; this dispatch run is about to be cancelled by concurrency.cancel-in-progress."
+
+  # ═════════════════════════════════════════════════════════════════════════
   # PR close → auto-tag (from release-create.yml)
   # ═════════════════════════════════════════════════════════════════════════
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,0 +1,5 @@
+// Empty library target. The real entry point is `src/main.rs`.
+// This file exists so `cargo test -p xtask --lib` does not error in
+// CI's unit-fast lane, which selects per-package targets with
+// `-p <crate> --lib --bins` and treats "no lib target" as a hard
+// failure regardless of whether other matching targets exist.

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,5 +1,15 @@
 // Empty library target. The real entry point is `src/main.rs`.
-// This file exists so `cargo test -p xtask --lib` does not error in
-// CI's unit-fast lane, which selects per-package targets with
-// `-p <crate> --lib --bins` and treats "no lib target" as a hard
-// failure regardless of whether other matching targets exist.
+//
+// This file exists so the unit-fast CI lane (`ci.yml: Test / Unit
+// (lib+bin)`) does not hard-fail when xtask is among the affected
+// crates. The selective branch of that lane builds a per-crate
+// argument list and runs:
+//
+//     cargo nextest run -p xtask … --lib --bins --no-tests=pass
+//
+// Without a lib target, cargo errors out at target-resolution with
+// `error: no library targets found in package 'xtask'` *before*
+// nextest sees it, so `--no-tests=pass` (which only forgives
+// "zero tests collected", not "zero targets matched") cannot
+// recover. The empty lib stub gives cargo a target to bind `--lib`
+// to; nextest then collects zero tests from it and exits success.

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -8,15 +8,24 @@ use std::io::{self, Write as _};
 use std::path::Path;
 use std::process::Command;
 
-/// Release channel for non-interactive version pick. Mirrors the 1/2/3/4
+/// Release channel for non-interactive version pick. Mirrors the 1/2/3/4/5
 /// prompt entries in the interactive flow so `just release` and
 /// `gh workflow run Release --input channel=…` pick versions identically.
+///
+/// `Current` is special — it does not bump the version or open a PR.
+/// Instead it dispatches the existing release run for the latest tag
+/// with `channel=current`, which causes `release.yml` to force-sync
+/// the tag to `main` HEAD and re-publish every artifact from `main`'s
+/// current code. Use it when a release tag failed on a code bug, the
+/// fix has landed on `main`, and the same version number should be
+/// re-published with the fix included.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum Channel {
     Stable,
     Beta,
     Rc,
     Lts,
+    Current,
 }
 
 #[derive(Parser, Debug)]
@@ -157,8 +166,83 @@ fn extract_changelog_section(content: &str, heading: &str) -> String {
     }
 }
 
+/// Dispatch the existing release run for the latest tag with
+/// `channel=current`. `release.yml` then force-syncs the tag to
+/// `main` HEAD and re-publishes every artifact from main's code.
+///
+/// We do not change Cargo.toml, do not open a PR, and do not push a
+/// new tag locally — every mutating step happens server-side via the
+/// dispatched workflow.
+fn run_current(
+    root: &Path,
+    no_confirm: bool,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tag = find_latest_tag(root, true)
+        .ok_or("no existing release tag found; nothing to re-publish")?;
+    println!("=== channel=current: re-publish latest tag ===");
+    println!("  Tag:      {}", tag);
+    println!("  Source:   main HEAD (release.yml's RELEASE_REF resolves to refs/heads/main)");
+    println!();
+    println!("Effect: release.yml's `sync_tag_to_main` job will force-update");
+    println!(
+        "`{}` to main HEAD, then publish every artifact from main's",
+        tag
+    );
+    println!(
+        "current code. The previous `{}` GitHub Release artifacts will be",
+        tag
+    );
+    println!("clobbered; npm / PyPI / crates.io entries will be skipped where the");
+    println!("version already exists (idempotent publish steps).");
+    println!();
+
+    if dry_run {
+        println!("Dry run — would dispatch:");
+        println!("  gh workflow run Release --ref {} -f channel=current", tag);
+        return Ok(());
+    }
+
+    if !no_confirm {
+        let answer = prompt(&format!("Dispatch Release workflow for {}? [y/N]: ", tag));
+        if answer.to_lowercase() != "y" && answer.to_lowercase() != "yes" {
+            return Err("Aborted".into());
+        }
+    }
+
+    let status = Command::new("gh")
+        .args([
+            "workflow",
+            "run",
+            "Release",
+            "--ref",
+            &tag,
+            "-f",
+            "channel=current",
+        ])
+        .current_dir(root)
+        .status()?;
+    if !status.success() {
+        return Err(format!(
+            "gh workflow run failed (exit {}); is `gh` authenticated?",
+            status.code().unwrap_or(-1)
+        )
+        .into());
+    }
+
+    println!();
+    println!("✓ Dispatched. Watch with:");
+    println!("  gh run watch (or open the Actions tab)");
+    Ok(())
+}
+
 pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
     let root = repo_root();
+
+    // --- channel=current shortcut: dispatch only, no version bump / PR ---
+    if args.channel == Some(Channel::Current) {
+        return run_current(&root, args.no_confirm, args.dry_run);
+    }
 
     // --- LTS patch shortcut ---
     if args.lts_patch {
@@ -318,6 +402,10 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
                 Channel::Beta => format!("{}-beta.{}", base_version, next_beta),
                 Channel::Rc => format!("{}-rc.{}", base_version, next_rc),
                 Channel::Lts => format!("{}.{}-lts", lts_base, next_lts_patch),
+                // Current bypasses the version pick entirely — it's
+                // handled by the early `run_current` branch above and
+                // by the `"5"` arm of the interactive prompt below.
+                Channel::Current => unreachable!(),
             }
         };
 
@@ -339,14 +427,19 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
             println!("  2) beta    -> {}", version_for(Channel::Beta));
             println!("  3) rc      -> {}", version_for(Channel::Rc));
             println!("  4) lts     -> {}", version_for(Channel::Lts));
+            println!(
+                "  5) current -> re-publish latest tag ({}) with main HEAD code",
+                prev_tag.as_deref().unwrap_or("none")
+            );
             println!();
 
-            let choice = prompt("Choose [1/2/3/4]: ");
+            let choice = prompt("Choose [1/2/3/4/5]: ");
             match choice.as_str() {
                 "1" => version_for(Channel::Stable),
                 "2" => version_for(Channel::Beta),
                 "3" => version_for(Channel::Rc),
                 "4" => version_for(Channel::Lts),
+                "5" => return run_current(&root, args.no_confirm, args.dry_run),
                 _ => return Err("Invalid choice".into()),
             }
         }
@@ -1009,6 +1102,7 @@ mod tests {
             Channel::Beta => format!("{}-beta.{}", base_version, next_beta),
             Channel::Rc => format!("{}-rc.{}", base_version, next_rc),
             Channel::Lts => format!("{}.{}-lts", lts_base, next_lts_patch),
+            Channel::Current => unreachable!(),
         }
     }
 

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -136,6 +136,25 @@ fn prompt(message: &str) -> String {
     input.trim().to_string()
 }
 
+/// Best-effort `git rev-parse --short <revspec>`. Returns `None` when
+/// git fails or the revspec does not resolve in the local repo.
+fn git_short_sha(root: &Path, revspec: &str) -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--short", revspec])
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
 fn compute_calver() -> String {
     let now = chrono::Local::now();
     format!(
@@ -180,9 +199,32 @@ fn run_current(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let tag = find_latest_tag(root, true)
         .ok_or("no existing release tag found; nothing to re-publish")?;
+
+    // Resolve the tag's current commit and main HEAD locally so the
+    // operator sees, before confirming, exactly which commit pointer
+    // is about to move. Both lookups are best-effort: if the tag is
+    // not present locally (fresh clone, shallow fetch) we fall back
+    // to "(unknown)" rather than blocking — the workflow itself
+    // re-resolves both in the runner.
+    let tag_sha = git_short_sha(root, &format!("refs/tags/{}^{{commit}}", tag))
+        .unwrap_or_else(|| "(unknown)".to_string());
+    let main_sha = git_short_sha(root, "refs/heads/main")
+        .or_else(|| git_short_sha(root, "origin/main"))
+        .unwrap_or_else(|| "(unknown)".to_string());
+    let already_synced = tag_sha != "(unknown)" && main_sha != "(unknown)" && tag_sha == main_sha;
+
     println!("=== channel=current: re-publish latest tag ===");
-    println!("  Tag:      {}", tag);
-    println!("  Source:   main HEAD (release.yml's RELEASE_REF resolves to refs/heads/main)");
+    println!("  Tag:        {}", tag);
+    println!("  Tag → SHA:  {}", tag_sha);
+    println!("  main HEAD:  {}", main_sha);
+    if already_synced {
+        println!("  Status:     tag already at main HEAD — sync_tag_to_main will be a no-op");
+    } else {
+        println!(
+            "  Status:     tag will be force-pushed: {} → {}",
+            tag_sha, main_sha
+        );
+    }
     println!();
     println!("Effect: release.yml's `sync_tag_to_main` job will force-update");
     println!(
@@ -405,7 +447,10 @@ pub fn run(args: ReleaseArgs) -> Result<(), Box<dyn std::error::Error>> {
                 // Current bypasses the version pick entirely — it's
                 // handled by the early `run_current` branch above and
                 // by the `"5"` arm of the interactive prompt below.
-                Channel::Current => unreachable!(),
+                Channel::Current => unreachable!(
+                    "Channel::Current must be intercepted before version_for() — \
+                     see the early-return in run() and the \"5\" arm of the prompt"
+                ),
             }
         };
 
@@ -1102,7 +1147,9 @@ mod tests {
             Channel::Beta => format!("{}-beta.{}", base_version, next_beta),
             Channel::Rc => format!("{}-rc.{}", base_version, next_rc),
             Channel::Lts => format!("{}.{}-lts", lts_base, next_lts_patch),
-            Channel::Current => unreachable!(),
+            Channel::Current => {
+                unreachable!("test fixture should never call with Channel::Current")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`workflow_dispatch channel=current` previously checked out the tag's frozen commit, so a hotfix that landed on main after the tag could not be re-published without first force-pushing the tag. That's the opposite of what the failure-recovery path should do — when a release fails on a code bug, the fix lands on main, and a `just release` rerun should pick that up automatically.

This PR makes `channel=current`:

1. Source every job's checkout from `main` HEAD, **and**
2. Force-push the dispatched release tag to `main` HEAD before publishing, so the GitHub Release tag and the rebuilt artifacts both correspond to the post-hotfix code.

## Changes

### `release.yml`

- New `RELEASE_REF` workflow-level env that selects the effective ref:
  - tag push (normal release) → tag's frozen commit
  - dispatch `channel=current` → `refs/heads/main`
  - dispatch `channel=stable/beta/rc/lts` → `github.ref` (typically `main`)
- 26 source-using `actions/checkout` invocations now pass `ref: ${{ env.RELEASE_REF }}`. The 2 external-repo checkouts (`librefang/homebrew-tap`) are intentionally untouched.
- **New `sync_tag_to_main` job** (gated on `dispatch && channel=current && refs/tags/v…`) that **force-pushes the dispatched tag to `main` HEAD**. If the tag is already there it's a no-op; otherwise the force-push triggers a fresh `push: tags` run, the dispatch run is cancelled by `concurrency.cancel-in-progress`, and the new push run takes over. Pushes use `HOMEBREW_TAP_TOKEN` (PAT) so the chained `push: tags` workflow actually fires — `GITHUB_TOKEN` would not chain.
- Input description and inline comments updated to call out (a) the tag-rewrite side effect, (b) the race window during force-push (publish jobs start in parallel and rely on per-version idempotency), and (c) `HOMEBREW_TAP_TOKEN`'s dual role across the tap repo and this repo.

### `xtask/src/release.rs`

- New `Channel::Current` clap variant + `run_current()` function. `cargo xtask release --channel current` (and the new `5) current` arm of the interactive prompt) does **not** bump the version, does **not** open a PR, does **not** push a tag locally — it just dispatches the existing release run for the latest tag with `channel=current`, deferring all mutation to `release.yml`.
- The CLI prints the tag's current commit and `main` HEAD before the confirm prompt, so the operator can see exactly which commit pointer is about to move (or that the tag is already in sync and `sync_tag_to_main` will no-op).

### `xtask/src/lib.rs` (new, empty)

The unit-fast CI lane runs `cargo nextest run -p xtask … --lib --bins --no-tests=pass` on selective branches. Without a lib target, cargo fails at target-resolution before nextest sees the package, and `--no-tests=pass` (which covers "zero tests collected") does not recover. The empty lib stub gives cargo a target to bind `--lib` to.

## Behaviour matrix

| Trigger | Source ref | Tag mutated? | Notes |
| --- | --- | --- | --- |
| `git push origin v…` (tag push) | tag's frozen commit | no | unchanged |
| `gh workflow run Release --ref vX -f channel=current` | `main` HEAD | **yes — force-pushed to `main` HEAD** | new |
| `gh workflow run Release -f channel=beta` | `main` HEAD (bump_version only) | no | unchanged |
| PR merge `chore/bump-version-…` | `github.ref` (PR ref) | no | unchanged |

## Safety

The "Verify tag matches workspace version" gate inside `create_release` still compares the tag suffix against `[workspace.package].version`. Re-publishing only succeeds when main is still on the same version number — the moment main bumps (e.g. via `just release --channel beta` into `2026.5.8-beta.11`), `channel=current` for an older tag fails fast with a clear error rather than silently shipping wrong code under the old tag.

**The tag rewrite is the deliberate semantics of `channel=current`**: when a release tag failed on a code bug and the fix has landed on main, we want vX to mean "main HEAD at re-publish time". Anyone who already fetched the old `vX → C1` mapping (mirrors, third-party CI, Homebrew bottle pinning) will observe the tag jumping on next fetch. This is intentional, not accidental — but it is a one-way operation and worth being explicit about.

The 2 `librefang/homebrew-tap` external checkouts are intentionally untouched — those need to fetch the tap repo's own ref, not librefang's.

## Drive-by: OpenAPI drift

CI on this PR will trigger `ci.yml`'s `openapi-drift` job (CI workflow change → `changes.outputs.ci == true`). On internal PRs, that job auto-commits regenerated `openapi.json` / `sdk/*` / `xtask/baselines/*` back to this branch. So merging this PR also clears the standing OpenAPI drift error on main.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → OK
- Mechanical YAML diff: 1 input description tweak, 1 env addition (`RELEASE_REF`), 1 new job (`sync_tag_to_main`), 26 `ref:` injections.
- xtask diff is local to `release.rs` (new `Channel::Current` + `run_current`) and a new empty `lib.rs`.

## Test plan

- [ ] CI passes on this branch (incl. openapi-drift auto-commit)
- [ ] After merge, `gh workflow run Release --ref v2026.5.8-beta.10 -f channel=current` rebuilds beta.10 with main HEAD code (which contains #4811 #4812 fixes). All previously-failing jobs (musl, mobile, SDK Python) should succeed.