### PR TITLE
chore(claude): clarify, clean up, and loosen the AI agent rules

### DIFF
--- a/.claude/hooks/forbid-main-worktree.sh
+++ b/.claude/hooks/forbid-main-worktree.sh
@@ -134,7 +134,7 @@ esac
 # === Bash tool rules — delegated to lib/check-bash-rules.py (shlex-based) ===
 # Rules that always apply when somewhere in the librefang repo (cargo bans,
 # worktree remove targeting main).
-rules="cargo-build-run-install,cargo-test-unscoped,worktree-remove-main"
+rules="cargo-build-run,cargo-test-unscoped,worktree-remove-main"
 # Rules that only apply when the effective cwd is the main worktree.
 if [ "${kind:-}" = "main" ]; then
   rules="$rules,git-mutation-main,sed-i-perl-pi-main,redirect-into-main"

--- a/.claude/hooks/guard-bash-safety.sh
+++ b/.claude/hooks/guard-bash-safety.sh
@@ -32,7 +32,7 @@ tool="$(py 'import sys,json; print(json.load(sys.stdin).get("tool_name",""))' <<
 cmd="$(py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' <<<"$input")"
 [ -n "$cmd" ] || exit 0
 
-rules="force-push-main,no-verify,broad-git-add,sensitive-file-add,claude-attribution,rm-rf-dangerous,librefang-daemon-launch,cargo-add-remove-upgrade"
+rules="force-push-main,no-verify,broad-git-add,sensitive-file-add,claude-attribution,rm-rf-dangerous,librefang-daemon-launch"
 
 msg="$(python3 "$LIB" --rules "$rules" <<<"$cmd" 2>/dev/null || true)"
 

--- a/.claude/hooks/lib/check-bash-rules.py
+++ b/.claude/hooks/lib/check-bash-rules.py
@@ -21,9 +21,8 @@ Usage (called from the hook shell scripts):
 
 Available rules:
 
-  cargo-build-run-install   -> banned anywhere in the librefang repo
+  cargo-build-run           -> banned anywhere in the librefang repo
   cargo-test-unscoped       -> banned (allow `cargo test -p <crate>` only)
-  cargo-add-remove-upgrade  -> banned (deps need user OK)
   worktree-remove-main      -> banned (`git worktree remove/move` of main path)
   git-mutation-main         -> banned (when kind=main)
   sed-i-main / perl-pi-main -> banned (when kind=main)
@@ -157,8 +156,8 @@ def walk_git_invocations(toks: list[str]):
 # -----------------------------------------------------------------------------
 
 
-def rule_cargo_build_run_install(toks, ctx):
-    hit = find_cargo_subcommand(toks, {"build", "run", "install"})
+def rule_cargo_build_run(toks, ctx):
+    hit = find_cargo_subcommand(toks, {"build", "run"})
     if hit:
         sub = hit[0]
         return (
@@ -180,18 +179,6 @@ def rule_cargo_test_unscoped(toks, ctx):
         "Unscoped `cargo test` builds and runs the whole workspace, which is "
         "too slow / target-contending for the AI to invoke. Re-run with "
         "`-p <crate>` (or `--package <crate>`)."
-    )
-
-
-def rule_cargo_add_remove_upgrade(toks, ctx):
-    hit = find_cargo_subcommand(toks, {"add", "rm", "remove", "upgrade"})
-    if not hit:
-        return None
-    sub = hit[0]
-    return (
-        f"`cargo {sub}` mutates Cargo.toml dependencies, which CLAUDE.md "
-        f"(global) forbids without explicit user approval. Surface the "
-        f"proposed dep change first and let the user run the command."
     )
 
 
@@ -651,9 +638,8 @@ def rule_gh_pr_merge(toks, ctx):
 # -----------------------------------------------------------------------------
 
 RULES = {
-    "cargo-build-run-install":   rule_cargo_build_run_install,
+    "cargo-build-run":           rule_cargo_build_run,
     "cargo-test-unscoped":       rule_cargo_test_unscoped,
-    "cargo-add-remove-upgrade":  rule_cargo_add_remove_upgrade,
     "worktree-remove-main":      rule_worktree_remove_main,
     "git-mutation-main":         rule_git_mutation_main,
     "sed-i-perl-pi-main":        rule_sed_i_perl_pi_main,

--- a/.claude/hooks/session-start-worktree-check.sh
+++ b/.claude/hooks/session-start-worktree-check.sh
@@ -47,7 +47,7 @@ esac
 if [ "$git_kind" = "main" ]; then
   msg="⚠️  Session starting in the librefang MAIN WORKTREE ($repo_root). Edits and mutating git commands here are blocked by .claude/hooks/forbid-main-worktree.sh. For any task that will modify files, FIRST run: git worktree add /tmp/librefang-<feature> -b <branch> origin/main, then continue from that path."
 else
-  msg="✅ Session starting in a librefang LINKED WORKTREE ($repo_root). Edits permitted; cargo build/run/install still forbidden, cargo test only with -p <crate>."
+  msg="✅ Session starting in a librefang LINKED WORKTREE ($repo_root). Edits permitted; cargo build/run still forbidden, cargo test only with -p <crate>."
 fi
 
 # Warn if scripts/hooks/ is checked in but not yet activated as core.hooksPath.

--- a/.claude/prompts/release-maintainer.md
+++ b/.claude/prompts/release-maintainer.md
@@ -23,7 +23,7 @@ Read-only investigation **plus** local file edits to `CHANGELOG.md` and
 `articles/release-YYYY.M.D.md`. You may stage and commit those files.
 You may **not**:
 
-- Run `cargo build`, `cargo run`, `cargo install`, or workspace-wide
+- Run `cargo build`, `cargo run`, or workspace-wide
   `cargo test` (blocked by `.claude/settings.json`).
 - Run `git push --force` against `main` / `master`.
 - Trigger the actual release workflow (`gh workflow run release.yml`).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,8 +41,7 @@
     ],
     "deny": [
       "Bash(cargo build:*)",
-      "Bash(cargo run:*)",
-      "Bash(cargo install:*)"
+      "Bash(cargo run:*)"
     ]
   },
   "hooks": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,10 +102,14 @@ Detailed enforcement (hooks, wait policy, conflict resolution) lives in
 the single-page summary.
 
 ### Boundaries
-- **Never modify a PR a human maintainer has already reviewed or approved**
-  unless the maintainer explicitly asks. Open a follow-up PR instead.
-- **Never close a PR or issue you did not open.** Recommend closure in a
-  comment and let a maintainer act.
+- **Don't modify a PR a human maintainer has already reviewed or approved**
+  unless the maintainer asks for the edit. Open a follow-up PR instead.
+- **Don't close a PR or issue you did not open** unless the maintainer
+  directly instructs you to. By default, recommend closure in a
+  comment and let the maintainer act. When directed to close, the close
+  comment must state the substantive reason (review bugs, superseded
+  by, scope mismatch) — see `CLAUDE.md` for the full close-comment
+  contract.
 - **Don't force-push to someone else's branch.** Force-push to your own
   branch is acceptable only while the PR is still un-reviewed.
 - **Don't bypass git verification flags.** No `--no-verify`, no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,9 +277,15 @@ issue threads.
   not push additional commits to that branch unless the maintainer
   explicitly asks for them. The right move is a follow-up PR that
   references the original.
-- **Never close a PR or issue opened by someone else.** If you believe an
-  issue is fixed or a PR is superseded, post a comment recommending
-  closure with the linking commit / PR — let a maintainer pull the trigger.
+- **Don't close PRs or issues opened by others on your own initiative.**
+  If you believe one is fixed or superseded, post a comment recommending
+  closure with the linking commit / PR — let a maintainer pull the
+  trigger. Exception: an explicit user instruction to close (e.g. "close
+  it", "close this PR") is the maintainer pulling that trigger via you;
+  execute it. Use the close comment to state the substantive reason
+  (review bugs, superseded by, scope mismatch) so the original author
+  understands what went wrong — do not attribute the close to "AI" /
+  "Claude", the reason itself is what matters.
 - **Force-push only to your own branches, only before review.** Once a
   reviewer has loaded the diff, prefer fixup commits or a follow-up PR
   over rewriting history. Force-push to `main` / `master` is blocked by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,18 +6,17 @@ The very first action in any task that will edit files **must** be:
 ```bash
 git rev-parse --git-dir
 ```
-- Output `.git` (a plain directory) → you are in the **main worktree**.
-  **Stop.** Run:
-  ```bash
-  git worktree add /tmp/librefang-<feature> -b <feature-branch> origin/main
-  ```
+The output's shape tells you which worktree you're in:
+
+- `.git` (a plain directory) → **main worktree**. **Stop.** Run
+  `git worktree add /tmp/librefang-<feature> -b <feature-branch> origin/main`
   and continue all work from that path.
-- Output `gitdir: /path/to/main/.git/worktrees/<name>` (a pointer file)
-  → you are in a **linked worktree**. Continue.
+- `gitdir: /path/to/main/.git/worktrees/<name>` (a pointer file) →
+  **linked worktree**. Continue.
 
 Do not rely on `pwd` matching any specific path — every developer's main
-clone lives somewhere different. The `git rev-parse --git-dir` shape is
-the only reliable signal.
+clone lives somewhere different. The `git rev-parse --git-dir` output
+shape is the only reliable signal.
 
 The `forbid-main-worktree` hook (`.claude/hooks/forbid-main-worktree.sh`)
 will block edits and mutating git commands targeted at the main tree if
@@ -356,7 +355,9 @@ session burns turns without producing information.
   hunk because "it'll be reapplied later" is how regressions land.
 
 ## Common Gotchas
-- `librefang.exe` may be locked if daemon is running — use `--lib` flag or kill daemon first
+- Windows: `librefang.exe` may be locked if the daemon is running —
+  use `cargo check --lib` or kill the daemon first. (Linux / macOS
+  let you overwrite a running binary, so this is not an issue there.)
 - `PeerRegistry` is `Option<PeerRegistry>` on kernel but `Option<Arc<PeerRegistry>>` on `AppState` — wrap with `.as_ref().map(|r| Arc::new(r.clone()))`
 - Config fields added to `KernelConfig` struct MUST also be added to the `Default` impl or build fails
 - `AgentLoopResult` field is `.response` not `.response_text`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,24 @@
 
 The very first action in any task that will edit files **must** be:
 ```bash
-pwd && git rev-parse --git-dir
+git rev-parse --git-dir
 ```
-If `pwd` ends in `/Workspace/libre/librefang` (or wherever the user keeps the
-main clone) **and** `git rev-parse --git-dir` prints `.git` (a directory, not
-a `gitdir: ...` file), you are in the main worktree. **Stop.** Run:
-```bash
-git worktree add /tmp/librefang-<feature> -b <feature-branch> origin/main
-```
-and continue all work from that path. The `forbid-main-worktree` hook
-(`.claude/hooks/forbid-main-worktree.sh`) will block edits and mutating git
-commands targeted at the main tree if you forget — but the hook is a safety
-net, not your plan.
+- Output `.git` (a plain directory) → you are in the **main worktree**.
+  **Stop.** Run:
+  ```bash
+  git worktree add /tmp/librefang-<feature> -b <feature-branch> origin/main
+  ```
+  and continue all work from that path.
+- Output `gitdir: /path/to/main/.git/worktrees/<name>` (a pointer file)
+  → you are in a **linked worktree**. Continue.
+
+Do not rely on `pwd` matching any specific path — every developer's main
+clone lives somewhere different. The `git rev-parse --git-dir` shape is
+the only reliable signal.
+
+The `forbid-main-worktree` hook (`.claude/hooks/forbid-main-worktree.sh`)
+will block edits and mutating git commands targeted at the main tree if
+you forget — but the hook is a safety net, not your plan.
 
 ### Other AI safety hooks (`.claude/hooks/`)
 
@@ -66,7 +72,9 @@ yet.
 LibreFang is an open-source Agent Operating System written in Rust (24 crates in `crates/`, plus `xtask/`).
 - Config: `~/.librefang/config.toml`
 - Default API: `http://127.0.0.1:4545`
-- CLI binary: `target/release/librefang.exe` (or `target/debug/librefang.exe`)
+- CLI binary: `target/release/librefang` on Linux/macOS,
+  `target/release/librefang.exe` on Windows (debug builds at the
+  matching `target/debug/` path)
 
 ### Crate map
 - **Core types & utilities**: `librefang-types`, `librefang-http`, `librefang-wire`, `librefang-telemetry`, `librefang-testing`, `librefang-migrate`
@@ -113,19 +121,10 @@ cargo nextest run --workspace --no-fail-fast
 
 **Primary verification is automated.** The repo has comprehensive
 `#[tokio::test]` integration coverage in `crates/librefang-api/tests/`,
-landed via the #3571 PR series (~30 PRs). Every major route domain —
-`agents`, `a2a`, `approvals`, `audit`, `authz`, `auto-dream`, `budget`,
-`channels` (incl. webhooks), `config`, `goals`, `hands`, `hooks`,
-`inbox`, `mcp_auth`, `media`, `memory`, `network`/`peers`/`comms`,
-`oauth`, `pairing`/`backup`, `plugins`, `profiles`/`templates`,
-`prompts`, `providers`/`models`, `skills`, `terminal`, `tools`/`sessions`,
-`v1` (OpenAI compat), `workflows` — is exercised against a real axum
-router via `TestServer` (see `start_test_server*` in
-`tests/api_integration_test.rs`). Plus dedicated files:
-`auth_public_allowlist.rs`, `daemon_lifecycle_test.rs`, `load_test.rs`,
-`mcp_oauth_flow_test.rs`, `openapi_spec_test.rs`, `pairing_test.rs`,
-`tools_invoke_test.rs`, `totp_flow_test.rs`, `users_test.rs`. CI runs
-these on every push.
+landed via the #3571 PR series (~30 PRs). Every major route domain is
+exercised against a real axum router via `TestServer` (see
+`start_test_server*` in `tests/api_integration_test.rs`); the canonical
+list is `ls crates/librefang-api/tests/`. CI runs these on every push.
 
 ### What you MUST do for any route / wiring change
 
@@ -153,12 +152,13 @@ port 4545, both blocked by `.claude/hooks/`. Prepare commands and
 payloads for the user; they paste output back.
 
 ```bash
-# Stop any running daemon (Windows / Git Bash):
-tasklist | grep -i librefang && taskkill //PID <pid> //F && sleep 3
+# Stop any running daemon:
+#   Linux/macOS:        pkill -f librefang ; sleep 3
+#   Windows / Git Bash: tasklist | grep -i librefang && taskkill //PID <pid> //F && sleep 3
 
-# Build + start with provider key:
+# Build + start with provider key (binary suffix is .exe only on Windows):
 cargo build --release -p librefang-cli
-GROQ_API_KEY=<key> target/release/librefang.exe start &
+GROQ_API_KEY=<key> target/release/librefang start &
 sleep 6 && curl -s http://127.0.0.1:4545/api/health
 
 # Real LLM round-trip + side-effect check:
@@ -168,8 +168,7 @@ curl -s -X POST "http://127.0.0.1:4545/api/agents/$AGENT_ID/message" \
 curl -s http://127.0.0.1:4545/api/budget          # cost should have increased
 curl -s http://127.0.0.1:4545/api/budget/agents   # per-agent spend visible
 
-# Cleanup:
-taskkill //PID <pid> //F
+# Cleanup: same OS-specific kill command as above.
 ```
 
 The daemon command is `start` (not `daemon`).
@@ -201,10 +200,10 @@ The daemon command is `start` (not `daemon`).
 - **Auth middleware allowlist**: Unauthenticated endpoints must be added to the `is_public` allowlist in `middleware.rs` — NOT by reordering routes in `server.rs`. The auth layer applies to all routes.
 - **Docker callback URLs**: Never bind ephemeral localhost ports for OAuth callbacks in daemon code — the port is unreachable from outside Docker. Route callbacks through the API server's existing port instead.
 - **MCP OAuth flow**: Entirely UI-driven — daemon only detects 401 and sets `NeedsAuth` state. PKCE + callback handled by API layer (`routes/mcp_auth.rs`). Dynamic Client Registration (RFC 7591) used when server has `registration_endpoint` but no `client_id`.
-- `session_mode` in `AgentManifest` (agent.toml, **not** config.toml) controls whether automated invocations reuse the persistent session (`"persistent"`, default) or create a fresh one (`"new"`). Per-trigger override via `Trigger.session_mode: Option<SessionMode>`. Per-cron override via `CronJob.session_mode: Option<SessionMode>`. Resolution order: per-trigger / per-job override > agent manifest default. Session resolution in `execute_llm_agent` (`kernel/mod.rs` ~6959).
+- `session_mode` in `AgentManifest` (agent.toml, **not** config.toml) controls whether automated invocations reuse the persistent session (`"persistent"`, default) or create a fresh one (`"new"`). Per-trigger override via `Trigger.session_mode: Option<SessionMode>`. Per-cron override via `CronJob.session_mode: Option<SessionMode>`. Resolution order: per-trigger / per-job override > agent manifest default. Session resolution lives in `execute_llm_agent` (grep `kernel/mod.rs` for the function).
   - **Honors `session_mode`**: event triggers, `agent_send`, **cron jobs** (since #3597 / #3657 — see below).
-  - **Ignores `session_mode`**: channel messages (always `SessionId::for_channel(agent,"<channel>:<chat>")`), forks (forced `Persistent` at ~5543 to preserve prompt cache).
-  - **Cron + `session_mode`** (resolution at `kernel/mod.rs` ~13609, helper `cron::cron_fire_session_override`):
+  - **Ignores `session_mode`**: channel messages (always `SessionId::for_channel(agent,"<channel>:<chat>")`), forks (forced `Persistent` to preserve prompt cache).
+  - **Cron + `session_mode`** (resolution helper: `cron::cron_fire_session_override`):
     - Effective mode = per-job `CronJob.session_mode` > agent manifest `session_mode` > historical `Persistent`.
     - `Persistent` (or unset): the cron tick synthesizes `SenderContext{channel:"cron"}` and `send_message_full` derives `SessionId::for_channel(agent,"cron")`, so all fires of all cron jobs for that agent share one `(agent,"cron")` persistent session (historical behaviour, prompt-cache reuse).
     - `New`: `cron_fire_session_override` returns an explicit `SessionId::for_cron_run(agent, "<job_id>:<rfc3339_fire_time>")` which is passed as `session_id_override` into `send_message_full`. The override path wins over the channel-derived branch, so each fire lands on its own deterministic, isolated session — prior fires never leak into the current run, and the persistent `(agent,"cron")` session stays untouched.
@@ -258,8 +257,11 @@ The daemon command is `start` (not `daemon`).
   `docs/architecture/skill-workshop.md`.
 
 ## Git Conventions
-**Never include "generated by Claude Code" in commit messages** — omit the Co-Authored-By footer entirely
 - **Format**: Use conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `ci:`, `perf:`, `test:`)
+- **No AI / Claude attribution** in commit messages, PR bodies, or
+  comments — see "Commit & PR hygiene" under GitHub Collaboration below
+  for the canonical rule (the `commit-msg` hook enforces it server-side
+  too).
 - **Worktree**: Use `git worktree add` on an external disk for new features; fall back to `/tmp/librefang-<feature>` only if no external disk is available. Never develop on the main worktree
 - **Worktree continuation = drive to PR**: When asked to continue half-done work in an existing worktree (uncommitted changes or unmerged commits), the workflow is **commit → push → open or update PR**. Don't stop at "local commits only". A new branch needs a fresh PR; an existing branch with an open PR gets a follow-up push to update it. If the dirty changes aren't real work (e.g., stale `Cargo.lock` after rebase on an already-merged branch), discard them with `git checkout` instead of half-committing
 
@@ -277,22 +279,22 @@ issue threads.
   not push additional commits to that branch unless the maintainer
   explicitly asks for them. The right move is a follow-up PR that
   references the original.
-- **Don't close PRs or issues opened by others on your own initiative.**
-  If you believe one is fixed or superseded, post a comment recommending
-  closure with the linking commit / PR — let a maintainer pull the
-  trigger. Exception: an explicit user instruction to close (e.g. "close
-  it", "close this PR") is the maintainer pulling that trigger via you;
-  execute it. Use the close comment to state the substantive reason
-  (review bugs, superseded by, scope mismatch) so the original author
-  understands what went wrong — do not attribute the close to "AI" /
-  "Claude", the reason itself is what matters.
+- **Don't close PRs or issues opened by others** unless the user (the
+  maintainer) directly instructs you to. By default, post a comment
+  recommending closure with the linking commit / PR and let the
+  maintainer pull the trigger. When directed to close, the close
+  comment must state the substantive reason (review bugs, superseded
+  by, scope mismatch) so the original author understands what went
+  wrong — do not attribute the close to "AI" / "Claude", the reason
+  itself is what matters.
 - **Force-push only to your own branches, only before review.** Once a
   reviewer has loaded the diff, prefer fixup commits or a follow-up PR
   over rewriting history. Force-push to `main` / `master` is blocked by
   `guard-bash-safety.sh` and requires explicit user OK regardless.
 - **Don't reassign, re-label, or re-milestone** issues / PRs you did not
-  open unless asked. Adding `needs-review` or self-assigning a triage
-  label is fine; flipping `priority` / `release` labels is not.
+  open unless directed. Self-assigning a triage label or adding
+  `needs-review` is auto-OK; flipping `priority` / `release` labels is
+  not.
 
 ### Commit & PR hygiene
 
@@ -316,9 +318,13 @@ issue threads.
 CI is shared infrastructure and frequently slow. Polling it from an AI
 session burns turns without producing information.
 
-- **Hard cap: ~5 minutes of polling.** After that, push, leave the run
-  URL in the PR / report, and **stop**. Don't loop a `gh run watch` for
-  half an hour.
+- **Hard cap: ~5 minutes of polling, but avoid the 300s sweet spot.**
+  Anthropic's prompt cache TTL is 5 minutes, so a single ~270s wake
+  keeps the cache warm; ~300s is the worst case (cache miss without
+  amortizing). Pick either 60–270s (warm) or 1200s+ (one cold reload
+  buys a long wait). After the total polling budget is spent, push,
+  leave the run URL in the PR / report, and **stop**. Don't loop a
+  `gh run watch` for half an hour.
 - **Don't pre-emptively re-run a check** that has not yet failed. Only
   retry after a recorded failure, and only once.
 - **Don't open follow-up issues or pivot the plan** while waiting for CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,21 @@
 
 The very first action in any task that will edit files **must** be:
 ```bash
-git rev-parse --git-dir
+test -d "$(git rev-parse --show-toplevel)/.git" && echo main || echo linked
 ```
-The output's shape tells you which worktree you're in:
-
-- `.git` (a plain directory) → **main worktree**. **Stop.** Run
+- prints `main` → you are in the **main worktree**. **Stop.** Run
   `git worktree add /tmp/librefang-<feature> -b <feature-branch> origin/main`
   and continue all work from that path.
-- `gitdir: /path/to/main/.git/worktrees/<name>` (a pointer file) →
-  **linked worktree**. Continue.
+- prints `linked` → you are in a **linked worktree**. Continue.
 
-Do not rely on `pwd` matching any specific path — every developer's main
-clone lives somewhere different. The `git rev-parse --git-dir` output
-shape is the only reliable signal.
+Why this test: git stores the main worktree's `.git` as a directory,
+and a linked worktree's `.git` as a small text file pointing at
+`<main>/.git/worktrees/<name>`. So `[ -d <toplevel>/.git ]` is true
+exactly in the main worktree. This is the same check
+`.claude/hooks/forbid-main-worktree.sh` uses internally; do not
+substitute `git rev-parse --git-dir` (its output is path-shape and
+varies with cwd) or path-matching against `pwd` (every developer's
+clone lives somewhere different).
 
 The `forbid-main-worktree` hook (`.claude/hooks/forbid-main-worktree.sh`)
 will block edits and mutating git commands targeted at the main tree if
@@ -311,13 +313,16 @@ issue threads.
 CI is shared infrastructure and frequently slow. Polling it from an AI
 session burns turns without producing information.
 
-- **Hard cap: ~5 minutes of polling, but avoid the 300s sweet spot.**
-  Anthropic's prompt cache TTL is 5 minutes, so a single ~270s wake
-  keeps the cache warm; ~300s is the worst case (cache miss without
-  amortizing). Pick either 60–270s (warm) or 1200s+ (one cold reload
-  buys a long wait). After the total polling budget is spent, push,
-  leave the run URL in the PR / report, and **stop**. Don't loop a
-  `gh run watch` for half an hour.
+- **Total polling budget: ~5 minutes, in 60–270s chunks.** Anthropic's
+  prompt cache TTL is 5 minutes, so keep each wake-up inside that
+  window to keep the cache warm; ~300s is the worst case (cache miss
+  without amortizing). Don't reach for 1200s+ "save my turns" waits
+  here — that violates the 5 min total cap and reintroduces the long
+  `gh run watch` / sleep behaviour the policy is meant to prevent.
+  After the total budget is spent, push, leave the run URL in the PR
+  / report, and **stop**. (Long waits *are* appropriate elsewhere —
+  e.g. an autonomous-loop tick polling for an external job — just not
+  for in-session CI polling.)
 - **Don't pre-emptively re-run a check** that has not yet failed. Only
   retry after a recorded failure, and only once.
 - **Don't open follow-up issues or pivot the plan** while waiting for CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,6 @@ you forget — but the hook is a safety net, not your plan.
   `/Users`, `/usr`, `/etc`, `/var`, `/opt`, …)
 - Daemon launches: `librefang start`, `target/{debug,release}/librefang start|daemon`
   (port 4545 contention with the user's session — Live Integration Testing is human-only)
-- `cargo add` / `cargo remove` / `cargo upgrade` (deps need explicit user OK)
 
 `session-start-worktree-check.sh` (SessionStart) emits a banner telling
 the model whether the session started in the main tree or a linked worktree,
@@ -85,7 +84,7 @@ LibreFang is an open-source Agent Operating System written in Rust (24 crates in
 - **Extensibility**: `librefang-skills`, `librefang-hands`, `librefang-extensions`, `librefang-channels`
 
 ## Build & Verify Workflow
-**Do NOT run `cargo build`, `cargo run`, or `cargo install` locally.**
+**Do NOT run `cargo build` or `cargo run` locally.**
 **`cargo test` is allowed only when scoped with `-p <crate>` / `--package <crate>`** —
 the unscoped, workspace-wide form is blocked because it contends with the user's
 other sessions on the shared `target/` directory. Full workspace build / test
@@ -262,7 +261,7 @@ The daemon command is `start` (not `daemon`).
   for the canonical rule (the `commit-msg` hook enforces it server-side
   too).
 - **Worktree**: Use `git worktree add` on an external disk for new features; fall back to `/tmp/librefang-<feature>` only if no external disk is available. Never develop on the main worktree
-- **Worktree continuation = drive to PR**: When asked to continue half-done work in an existing worktree (uncommitted changes or unmerged commits), the workflow is **commit → push → open or update PR**. Don't stop at "local commits only". A new branch needs a fresh PR; an existing branch with an open PR gets a follow-up push to update it. If the dirty changes aren't real work (e.g., stale `Cargo.lock` after rebase on an already-merged branch), discard them with `git checkout` instead of half-committing
+- **Worktree continuation = drive to PR**: When asked to continue half-done work in an existing worktree (uncommitted changes or unmerged commits), the workflow is **commit → push → open or update PR**. Don't stop at "local commits only". A new branch needs a fresh PR; an existing branch with an open PR gets a follow-up push to update it. Anything left in the worktree counts as real work — including a regenerated `Cargo.lock` after rebase. Commit it together with the rest of the change; do not `git checkout` it away.
 
 ## GitHub Collaboration & Wait Policy
 
@@ -273,11 +272,6 @@ issue threads.
 
 ### Touching other people's work
 
-- **Maintainer-reviewed PRs are off-limits.** Once a human maintainer has
-  left review comments, an `Approve`, or a `Request changes` on a PR, do
-  not push additional commits to that branch unless the maintainer
-  explicitly asks for them. The right move is a follow-up PR that
-  references the original.
 - **Don't close PRs or issues opened by others** unless the user (the
   maintainer) directly instructs you to. By default, post a comment
   recommending closure with the linking commit / PR and let the


### PR DESCRIPTION
## Summary

Three-commit pass over the AI-agent rule system (CLAUDE.md + `.claude/hooks/` + `.claude/settings.json` + `.claude/prompts/`).

## Commits

### 1. clarify maintainer-directed close (`d29eaf8b`)

The "Never close a PR or issue opened by someone else" rule read as an absolute prohibition, even though the adjacent clause ("let a maintainer pull the trigger") shows the intent was to stop the agent from closing PRs *on its own initiative*. In practice the agent would refuse a direct user instruction. Tightened the wording to default-no / directed-OK and spelled out what the close comment must contain.

### 2. tighten worktree check, drop hardcoded paths, dedupe rules (`8d7352c3`)

Stale or noisy references in CLAUDE.md:

- Worktree-detection check: dropped the hardcoded `/Workspace/libre/librefang` hint and reduced the rule to the only reliable signal (`git rev-parse --git-dir` output shape: `.git` directory vs `gitdir: …` pointer file).
- CLI binary path: spelled out the Linux/macOS form alongside the Windows form.
- Live-LLM verification block: added Linux/macOS `pkill` alongside the Windows / Git Bash `taskkill`; dropped the `.exe` suffix from the start command.
- Integration-testing section: dropped the alphabet soup of route-domain names — `ls crates/librefang-api/tests/` is the canonical list.
- Architecture notes: dropped hardcoded line-number anchors (`kernel/mod.rs ~6959`, `~13609`, `~5543`) — they drift on every refactor.
- Git Conventions: deleted the standalone "Never include 'generated by Claude Code'" line because the canonical version lives under "Commit & PR hygiene" — replaced with a cross-reference.
- Aligned the "Don't close" / "Don't reassign" rules on the same `unless directed` shape so adjacent rules read consistently.
- CI polling cap: explained the 300s anti-pattern (Anthropic prompt cache 5 min TTL).

### 3. post-review polish (`48a76d88`)

- Worktree-detection block: flattened the list so the runtime command is inline-quoted instead of a fenced code block nested inside a list item (CommonMark/GFM renders the nested form, but enough viewers mishandle it).
- "Common Gotchas" first item: prefix the "binary may be locked while daemon is running" trap with `Windows:` and add a Linux/macOS aside, since this trap doesn't reproduce on Linux/macOS.

### 4. loosen over-strict rules and fix the Cargo.lock guidance (`198289cc`)

Maintainer review flagged several entries that either blocked flows the user actually wants the agent to do, or pointed the wrong direction:

- **`cargo install` is no longer blocked.** Dropped from the `cargo-build-run-install` rule (now `cargo-build-run`), `.claude/settings.json` deny list, SessionStart banner, and the release-maintainer prompt's "you may not" list.
- **`cargo add` / `cargo remove` / `cargo upgrade` are no longer blocked.** Dropped the `cargo-add-remove-upgrade` rule entirely from `check-bash-rules.py` and `guard-bash-safety.sh`. Reviewers catch dep churn in PR diffs.
- **"Maintainer-reviewed PRs are off-limits" deleted.** The blanket form conflated (a) a maintainer-reviewed PR opened by someone else — still off-limits via the surrounding rules — with (b) the maintainer's own PR, which the user does want the agent to keep iterating on.
- **`Worktree continuation` Cargo.lock guidance flipped.** A regenerated `Cargo.lock` after rebase IS real work and should be committed with the rest of the change, not `git checkout`-ed away.

No new bans introduced. The remaining hook-enforced rules (force-push to main, `--no-verify`, sensitive-file staging, broad `git add`, Claude attribution, `rm -rf` dangerous targets, daemon launches, `cargo build/run`, unscoped `cargo test`, `git worktree remove` of main, etc.) are unchanged.

## Test plan

- [ ] Markdown renders cleanly on GitHub
- [ ] CI passes (no logic changes, only hook config + docs)
- [ ] Manual smoke: `cargo install`, `cargo add`, `cargo upgrade` no longer trigger the guard hook