### PR TITLE
fix(xtask): unbreak main clippy on parse_github_owner_repo

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -162,17 +162,11 @@ fn infer_gh_repo(root: &Path) -> Option<String> {
 
 fn parse_github_owner_repo(url: &str) -> Option<String> {
     let url = url.strip_suffix(".git").unwrap_or(url);
-    let after_host = if let Some(rest) = url.strip_prefix("git@github.com:") {
-        rest
-    } else if let Some(rest) = url.strip_prefix("ssh://git@github.com/") {
-        rest
-    } else if let Some(rest) = url.strip_prefix("https://github.com/") {
-        rest
-    } else if let Some(rest) = url.strip_prefix("http://github.com/") {
-        rest
-    } else {
-        return None;
-    };
+    let after_host = url
+        .strip_prefix("git@github.com:")
+        .or_else(|| url.strip_prefix("ssh://git@github.com/"))
+        .or_else(|| url.strip_prefix("https://github.com/"))
+        .or_else(|| url.strip_prefix("http://github.com/"))?;
     let mut parts = after_host.split('/');
     let owner = parts.next()?;
     let repo = parts.next()?;


### PR DESCRIPTION
## Summary

- `-D clippy::question-mark` (implied by `-D warnings` in `cargo xtask ci`) flagged the trailing `else if let Some(rest) = url.strip_prefix("http://github.com/") { rest } else { return None; }` arm in `parse_github_owner_repo`, introduced by #4816 (`dd7791ce`).
- Quality CI on main is red on `Build + clippy`, so every open PR inherits the failure on its next run (refs #4818).
- Collapse the four `strip_prefix` attempts into an `or_else` chain ending with `?`. Behaviour is identical — same accepted forms (`git@github.com:`, `ssh://git@github.com/`, `https://github.com/`, `http://github.com/`), same `None` on miss.

```rust
let after_host = url
    .strip_prefix("git@github.com:")
    .or_else(|| url.strip_prefix("ssh://git@github.com/"))
    .or_else(|| url.strip_prefix("https://github.com/"))
    .or_else(|| url.strip_prefix("http://github.com/"))?;
```

Refs #4818, #4816.

## Test plan

- [x] `cargo check -p xtask` — clean.
- [x] `cargo clippy -p xtask --all-targets --all-features -- -D warnings` — clean (was the failing command on main).
- [x] `cargo test -p xtask` — 62 passed, including the existing `parse_github_owner_repo_handles_ssh` / `_rejects_non_github` / `_rejects_subpath` tests, so accepted/rejected URL forms are unchanged.
- [ ] CI Quality job goes green and unblocks the rest of the queue.