### PR TITLE
fix(cli): use chrono for config-backup timestamp; drop deprecated libc::time_t

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -2865,90 +2865,9 @@ fn prune_old_config_backups(backups_dir: &std::path::Path, keep: usize) {
     }
 }
 
-/// Generate a local timestamp string in YYYYMMDD-HHMMSS format without external deps.
+/// Generate a local timestamp string in YYYYMMDD-HHMMSS format.
 fn format_local_timestamp() -> String {
-    // Use libc to get local time on unix; fallback to UTC seconds on other platforms.
-    #[cfg(unix)]
-    {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as libc::time_t;
-        let mut tm: libc::tm = unsafe { std::mem::zeroed() };
-        // SAFETY: localtime_r is thread-safe and writes into our stack buffer.
-        unsafe { libc::localtime_r(&secs, &mut tm) };
-        format!(
-            "{:04}{:02}{:02}-{:02}{:02}{:02}",
-            tm.tm_year + 1900,
-            tm.tm_mon + 1,
-            tm.tm_mday,
-            tm.tm_hour,
-            tm.tm_min,
-            tm.tm_sec
-        )
-    }
-    #[cfg(not(unix))]
-    {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        // Fallback: use UTC (acceptable on Windows where libc tm isn't available)
-        let secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        // Simple UTC breakdown
-        let days = secs / 86400;
-        let day_secs = secs % 86400;
-        let hour = day_secs / 3600;
-        let min = (day_secs % 3600) / 60;
-        let sec = day_secs % 60;
-        // Days since 1970-01-01
-        let (year, month, day) = days_to_ymd(days);
-        format!("{year:04}{month:02}{day:02}-{hour:02}{min:02}{sec:02}")
-    }
-}
-
-/// Convert days since Unix epoch to (year, month, day). Used only on non-Unix platforms.
-#[cfg(not(unix))]
-fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
-    let mut year = 1970u64;
-    loop {
-        let days_in_year = if is_leap(year) { 366 } else { 365 };
-        if days < days_in_year {
-            break;
-        }
-        days -= days_in_year;
-        year += 1;
-    }
-    let leap = is_leap(year);
-    let month_days: [u64; 12] = [
-        31,
-        if leap { 29 } else { 28 },
-        31,
-        30,
-        31,
-        30,
-        31,
-        31,
-        30,
-        31,
-        30,
-        31,
-    ];
-    let mut month = 1u64;
-    for &md in &month_days {
-        if days < md {
-            break;
-        }
-        days -= md;
-        month += 1;
-    }
-    (year, month, days + 1)
-}
-
-#[cfg(not(unix))]
-fn is_leap(y: u64) -> bool {
-    y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)
+    chrono::Local::now().format("%Y%m%d-%H%M%S").to_string()
 }
 
 /// Find top-level keys in `defaults` that are missing from `existing`.


### PR DESCRIPTION
## Summary

- `libc` 0.2 deprecated `libc::time_t` ahead of musl 1.2.0's planned flip from 32-bit to 64-bit `time_t` (libc tracker #1848). With `-D warnings` (which `cargo xtask ci` and the release pipeline both pass), `-D deprecated` is implied and `cargo build --target aarch64-unknown-linux-musl -p librefang-cli` now fails at the single `as libc::time_t` cast in `format_local_timestamp`.
- That blocked the static CLI release artifact for `v2026.5.8-beta.10` — the `aarch64-unknown-linux-musl` job in the most recent Release dispatch (run [25595134525](https://github.com/librefang/librefang/actions/runs/25595134525)) failed with this exact error, and every subsequent rebuild on main inherits it.

```
error: use of deprecated type alias `libc::time_t`: This type is changed
       to 64-bit in musl 1.2.0, we'll follow that change in a future release.
   --> crates/librefang-cli/src/main.rs:2877:33
note: `-D deprecated` implied by `-D warnings`
```

### Why a full rewrite, not `#[allow(deprecated)]`

`format_local_timestamp` predates this crate gaining `chrono` as a workspace dep — its `// without external deps` comment is stale. Using `chrono::Local::now().format("%Y%m%d-%H%M%S")` deletes:

- the `unsafe { libc::localtime_r(&secs as time_t, &mut tm) }` block (compiles on every libc version, but is the only consumer of the deprecated alias);
- a hand-rolled non-unix Gregorian-calendar fallback (`days_to_ymd`, `is_leap`) that emitted **UTC** under the comment "Fallback: use UTC (acceptable on Windows where libc tm isn't available)".

### Behaviour deltas

| Platform | Before | After |
|---|---|---|
| Linux (gnu, musl), macOS | `YYYYMMDD-HHMMSS` local time via `libc::localtime_r` | Same format, same local time, no `unsafe`, no deprecated alias. |
| Windows | `YYYYMMDD-HHMMSS` **UTC** (manual calendar math) | `YYYYMMDD-HHMMSS` **local time** — quietly fixes a long-standing inconsistency. |

The single caller is the `config-{stamp}.toml` backup name in `cmd_config_edit` (line 2648 before this PR). No other callers, so the Windows local-vs-UTC shift is contained to one filename in `~/.librefang/config-backups/`.

`libc = "0.2"` stays — daemonize (`setsid`), stdout/stderr pipe redirection (`dup`, `dup2`, `pipe`, `read`, `write`, `close`), signal handlers (`signal`/`SIGPIPE`), and `geteuid` all still use it.

Refs #4818 (release-channel rebuild for `v2026.5.8-beta.10`).

## Test plan

- [x] `cargo check -p librefang-cli` — clean.
- [x] `cargo clippy -p librefang-cli --all-targets --all-features -- -D warnings` — clean.
- [ ] Re-dispatch Release `channel=current` after merge so the `aarch64-unknown-linux-musl` static-CLI job goes green.
- [ ] iOS job in the same dispatch is a separate, signing-config issue (see #4818 — `cargo tauri ios init` is not flipping the generated xcodeproj to manual signing despite `APPLE_PROFILE_NAME` being set). Out of scope for this PR.