### PR TITLE
fix(ci): unit-fast lane should not error on binary-only crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,12 +559,20 @@ jobs:
         run: sh scripts/check-agents-claude-pair.sh
 
   # ── Unit-fast lane: lib + bin tests only, single runner, no sharding ──────────
-  # Runs `cargo nextest run --lib --bins` across the full workspace so that a
-  # pure unit-test failure surfaces in ~2 minutes without waiting for the heavier
+  # Runs the lib + bin unit tests across the full workspace so that a pure
+  # unit-test failure surfaces in ~2 minutes without waiting for the heavier
   # integration shards. Separate from the `--tests` lane below so contributors
   # can replicate the fast lane locally with:
-  #   cargo nextest run --workspace --lib --bins --no-fail-fast
+  #   cargo nextest run --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast
   # and CI runs both lanes independently. (#3696)
+  #
+  # Filter via nextest's expression language (`-E`) instead of `--lib --bins`:
+  # the latter errors with "no library targets found" when a `-p <crate>`
+  # selector targets a binary-only crate (librefang-cli, librefang-desktop).
+  # The `-E 'kind(lib) | kind(bin)'` form matches whichever target kinds the
+  # selected crates actually contain — silently skipping the missing kind for
+  # bin-only crates — so the selective lane no longer breaks when a PR (or a
+  # stale base diff) drags one of those into the affected-crate set.
   test-unit:
     name: Test / Unit (lib+bin)
     needs: changes
@@ -595,7 +603,7 @@ jobs:
         run: |
           if [ "${{ needs.changes.outputs.full_test }}" = "true" ]; then
             echo "Running workspace unit tests (lib+bin, full run)…"
-            cargo nextest run --workspace --lib --bins --no-fail-fast --no-tests=pass
+            cargo nextest run --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast --no-tests=pass
           else
             CRATES="${{ needs.changes.outputs.crates }}"
             if [ -z "$CRATES" ]; then
@@ -605,7 +613,7 @@ jobs:
             echo "Running unit tests for: $CRATES"
             PFLAGS=""
             for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
-            cargo nextest run $PFLAGS --lib --bins --no-fail-fast --no-tests=pass
+            cargo nextest run $PFLAGS -E 'kind(lib) | kind(bin)' --no-fail-fast --no-tests=pass
           fi
 
   # ── Ubuntu tests: selective on PR, full on main ────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,15 +103,23 @@ cargo test -p <crate>                                  # Only when verifying beh
 
 CI splits tests into two separate jobs so a unit failure surfaces quickly:
 
-- **Unit-fast** (`Test / Unit (lib+bin)`, ~2 min): `cargo nextest run --workspace --lib --bins --no-fail-fast`
+- **Unit-fast** (`Test / Unit (lib+bin)`, ~2 min): `cargo nextest run --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast`
   — lib and binary unit tests only; no integration test binaries. Run this locally for quick iteration.
 - **Integration** (`Test / Ubuntu (shard N/4)`, ~10-20 min): sharded across 4 Ubuntu runners via
   `--partition hash:N/4`; also single jobs on macOS and Windows. Runs all `--tests` targets.
 
+The unit-fast lane uses nextest's `-E 'kind(lib) | kind(bin)'` filter rather
+than `--lib --bins` because the latter errors with "no library targets found"
+when a `-p <crate>` selector targets a binary-only crate
+(`librefang-cli`, `librefang-desktop`). The expression form matches whichever
+kinds the selected crates actually have, so the selective CI lane stays green
+when a PR touches only `librefang-cli/main.rs` (or when a stale-base diff
+drags it in).
+
 Local equivalents:
 ```bash
 # Fast lane — unit tests only:
-cargo nextest run --workspace --lib --bins --no-fail-fast
+cargo nextest run --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast
 
 # Full validation — integration tests (mirrors the Ubuntu shard lane):
 cargo nextest run --workspace --no-fail-fast


### PR DESCRIPTION
## Summary

The selective branch of the `Test / Unit (lib+bin)` lane runs:

```bash
cargo nextest run -p <crate>... --lib --bins ...
```

which fails with `error: no library targets found in package librefang-cli` whenever the affected-crate set computed by the `Detect Changes` job contains a binary-only crate (today: `librefang-cli`, `librefang-desktop`).

The workspace branch (`--workspace --lib --bins`) doesn't trip because cargo silently skips workspace members without a lib when asked for `--lib` at workspace scope. Only the selective `-p X --lib` form is strict about X having a lib.

### How this surfaced

PR #4821 (release.yml-only diff) inherited a real failure of this lane: [25596052521 / Test / Unit (lib+bin)](https://github.com/librefang/librefang/actions/runs/25596052521/job/75142111842). Root cause was a stale-base diff — `Detect Changes` uses two-dot `git diff base..head`, so when #4820 merged into main while #4821 was open, the diff lit up `crates/librefang-cli/main.rs` as "changed" (it wasn't, but it differed between `base` and `head`). The selective lane then ran with `-p librefang-cli --lib --bins` and exited 101.

This isn't a #4821-specific problem — it would fire on **any** PR whose affected-crate set contains a binary-only crate. The `Quality` lane already documents this exact pitfall at `ci.yml:243-252` and works around it by dropping `--lib`; the `Test / Unit (lib+bin)` lane just never inherited the same fix.

### Fix

Replace `--lib --bins` with nextest's expression filter `-E 'kind(lib) | kind(bin)'` in **both** workspace and selective paths so they stay symmetric:

```diff
- cargo nextest run --workspace --lib --bins --no-fail-fast --no-tests=pass
+ cargo nextest run --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast --no-tests=pass

- cargo nextest run $PFLAGS --lib --bins --no-fail-fast --no-tests=pass
+ cargo nextest run $PFLAGS -E 'kind(lib) | kind(bin)' --no-fail-fast --no-tests=pass
```

The filter matches whichever target kinds each selected crate actually contains, so a binary-only crate just contributes its `kind(bin)` matches and the missing `kind(lib)` is a no-op rather than a hard error. No semantic change for crates that have both lib and bins — same set of test binaries gets collected.

Why not drop `--lib` like the Quality lane does? Because `cargo nextest run` defaults to "all targets including integration tests", which is the wrong fast-lane semantics — `kind(lib) | kind(bin)` is the explicit unit-only filter.

CLAUDE.md updated to document the new local-replication command and a short rationale block so the next person who touches this lane doesn't reintroduce `--lib --bins`. AGENTS.md doesn't have the same snippet, so no sync needed.

## Test plan

- [x] YAML parses cleanly.
- [x] `nextest 0.9.133` accepts `-E 'kind(lib) | kind(bin)'` per its filterset reference (operators `|`, `+`, `or` all map to set union; `kind()` is a documented set predicate).
- [ ] Local smoke: `cargo nextest list -p librefang-cli -E 'kind(lib) | kind(bin)'` (cli is binary-only — must not error with "no library targets found"). Currently running; will post output as a comment if the build picks up surprises.
- [ ] CI on this PR is the real test — its own `Test / Unit (lib+bin)` selective run will exercise the new filter against whichever crates the diff lights up.

Independent of #4819, #4820, #4821.