### PR TITLE
fix(kernel): pre-dispatch provider budget gate on all 3 dispatch paths

### DIFF
--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -415,6 +415,18 @@ impl LibreFangKernel {
             return Ok(AgentLoopResult::default());
         }
 
+        // Pre-dispatch provider budget gate (ephemeral path).
+        {
+            let provider = &entry.manifest.model.provider;
+            let bc = self.metering.budget_config.load();
+            if let Some(pb) = bc.providers.get(provider.as_str()) {
+                self.metering
+                    .engine
+                    .check_provider_budget(provider, pb)
+                    .map_err(KernelError::LibreFang)?;
+            }
+        }
+
         // Ephemeral: no tools — prevents side effects (tool writes to memory/disk)
         let tools: Vec<librefang_types::tool::ToolDefinition> = vec![];
         let mut manifest = entry.manifest.clone();
@@ -833,6 +845,22 @@ impl LibreFangKernel {
                 .release_reservation(agent_id, token_reservation);
             usd_reservation.release();
             return Ok(AgentLoopResult::default());
+        }
+
+        // Pre-dispatch provider budget gate — reject calls against an
+        // already-exhausted provider before the LLM round-trip.
+        {
+            let provider = &entry.manifest.model.provider;
+            let bc = self.metering.budget_config.load();
+            if let Some(pb) = bc.providers.get(provider.as_str()) {
+                if let Err(e) = self.metering.engine.check_provider_budget(provider, pb) {
+                    self.agents
+                        .scheduler
+                        .release_reservation(agent_id, token_reservation);
+                    usd_reservation.release();
+                    return Err(KernelError::LibreFang(e));
+                }
+            }
         }
 
         // Resolve the effective session id up front for the LLM path so we
@@ -1662,6 +1690,20 @@ impl LibreFangKernel {
             .scheduler
             .check_quota_and_reserve(agent_id, estimated_tokens)
             .map_err(KernelError::LibreFang)?;
+
+        // Pre-dispatch provider budget gate (streaming path).
+        {
+            let provider = &entry.manifest.model.provider;
+            let bc = self.metering.budget_config.load();
+            if let Some(pb) = bc.providers.get(provider.as_str()) {
+                if let Err(e) = self.metering.engine.check_provider_budget(provider, pb) {
+                    self.agents
+                        .scheduler
+                        .release_reservation(agent_id, token_reservation);
+                    return Err(KernelError::LibreFang(e));
+                }
+            }
+        }
 
         let is_wasm = entry.manifest.module.starts_with("wasm:");
         let is_python = entry.manifest.module.starts_with("python:");


### PR DESCRIPTION
## Summary

Closes #4800. Supersedes #4801 (v1, closed — missed streaming path, wrong accessor).

Adds `check_provider_budget()` before the LLM round-trip on **all three** dispatch entries:
1. `send_message_full_with_upstream` — with USD + token reservation rollback
2. `send_message_ephemeral` — with early return via `?`
3. `send_message_streaming_with_sender_and_opts` — with token reservation rollback

### Fixes from v1 review
- Uses `self.metering.engine.check_provider_budget()` (not the subsystem wrapper)
- Uses `self.metering.budget_config.load()` (ArcSwap guard, no HashMap clone)
- Checks run **after** the suspended-agent gate (avoids SQL for no-ops)
- Covers the streaming path (the production leak scenario from #4800)

## Test plan
- [x] `cargo check --workspace --lib` — zero errors
- [x] All 3 dispatch paths covered