### PR TITLE
feat(kernel): configurable burst ratio with NaN guard and tests

### DIFF
--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -272,10 +272,15 @@ impl LibreFangKernel {
         let caps = manifest_to_capabilities(&manifest);
         self.agents.capabilities.grant(agent_id, caps);
 
-        // Register with scheduler
-        self.agents
-            .scheduler
-            .register(agent_id, manifest.resources.clone());
+        // Register with scheduler — pre-resolve global burst ratio
+        let mut quota = manifest.resources.clone();
+        if quota.burst_ratio.is_none() {
+            let global = self.current_budget().default_burst_ratio;
+            if global > 0.0 {
+                quota.burst_ratio = Some(global);
+            }
+        }
+        self.agents.scheduler.register(agent_id, quota);
 
         // Create registry entry
         let tags = manifest.tags.clone();

--- a/crates/librefang-kernel/src/scheduler.rs
+++ b/crates/librefang-kernel/src/scheduler.rs
@@ -189,9 +189,10 @@ impl AgentScheduler {
             )));
         }
 
-        // --- Burst limit: no more than 1/5 of the hourly token budget in any single minute ---
+        // --- Burst limit: configurable fraction of the hourly budget in any single minute ---
         if token_limit > 0 {
-            let burst_cap = token_limit / 5;
+            let ratio = quota.effective_burst_ratio(0.0);
+            let burst_cap = (token_limit as f32 * ratio) as u64;
             let tokens_last_min = tracker.tokens_in_last_minute();
             if burst_cap > 0 && tokens_last_min > burst_cap {
                 return Err(LibreFangError::QuotaExceeded(format!(
@@ -278,7 +279,8 @@ impl AgentScheduler {
             )));
         }
         // Burst check against the projected spend
-        let burst_cap = token_limit / 5;
+        let ratio = quota.effective_burst_ratio(0.0);
+        let burst_cap = (token_limit as f32 * ratio) as u64;
         let tokens_last_min = tracker.tokens_in_last_minute();
         if burst_cap > 0 && tokens_last_min.saturating_add(estimated_tokens) > burst_cap {
             return Err(LibreFangError::QuotaExceeded(format!(

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -509,6 +509,10 @@ pub struct ResourceQuota {
     pub max_cost_per_day_usd: f64,
     /// Maximum cost in USD per month (0.0 = unlimited).
     pub max_cost_per_month_usd: f64,
+    /// Per-agent burst ratio override. `None` = inherit global
+    /// `default_burst_ratio` (or compiled default 0.2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub burst_ratio: Option<f32>,
 }
 
 impl Default for ResourceQuota {
@@ -522,6 +526,7 @@ impl Default for ResourceQuota {
             max_cost_per_hour_usd: 0.0,    // unlimited by default
             max_cost_per_day_usd: 0.0,     // unlimited
             max_cost_per_month_usd: 0.0,   // unlimited
+            burst_ratio: None,
         }
     }
 }
@@ -536,6 +541,20 @@ impl ResourceQuota {
     /// returned value is `0`.
     pub fn effective_token_limit(&self) -> u64 {
         self.max_llm_tokens_per_hour.unwrap_or(0)
+    }
+
+    /// Resolved burst ratio: agent override > global default > 0.2.
+    /// Clamped to [0.01, 1.0]. NaN/Inf fall back to 0.2.
+    pub fn effective_burst_ratio(&self, global_default: f32) -> f32 {
+        let raw = self.burst_ratio.unwrap_or(if global_default > 0.0 {
+            global_default
+        } else {
+            0.2
+        });
+        if !raw.is_finite() {
+            return 0.2;
+        }
+        raw.clamp(0.01, 1.0)
     }
 }
 
@@ -1688,6 +1707,54 @@ mod tests {
     }
 
     // ----- ToolProfile tests -----
+
+    #[test]
+    fn effective_burst_ratio_defaults_to_one_fifth() {
+        let q = ResourceQuota::default();
+        assert!((q.effective_burst_ratio(0.0) - 0.2).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn effective_burst_ratio_uses_global_default() {
+        let q = ResourceQuota::default();
+        assert!((q.effective_burst_ratio(0.5) - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn effective_burst_ratio_agent_overrides_global() {
+        let q = ResourceQuota {
+            burst_ratio: Some(0.3),
+            ..Default::default()
+        };
+        assert!((q.effective_burst_ratio(0.8) - 0.3).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn effective_burst_ratio_clamps_below_minimum() {
+        let q = ResourceQuota {
+            burst_ratio: Some(0.0),
+            ..Default::default()
+        };
+        assert!((q.effective_burst_ratio(0.0) - 0.01).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn effective_burst_ratio_clamps_above_one() {
+        let q = ResourceQuota {
+            burst_ratio: Some(2.5),
+            ..Default::default()
+        };
+        assert!((q.effective_burst_ratio(0.0) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn effective_burst_ratio_nan_falls_back_to_default() {
+        let q = ResourceQuota {
+            burst_ratio: Some(f32::NAN),
+            ..Default::default()
+        };
+        assert!((q.effective_burst_ratio(0.0) - 0.2).abs() < f32::EPSILON);
+    }
 
     #[test]
     fn test_tool_profile_minimal() {

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -4084,8 +4084,15 @@ pub struct BudgetConfig {
     pub default_max_llm_tokens_per_hour: u64,
     /// Per-provider spending caps, keyed by provider id (e.g. `"moonshot"`,
     /// `"openai"`, `"litellm"`). Missing providers are unlimited.
+    /// Per-provider spending caps, keyed by provider id (e.g. `"moonshot"`,
+    /// `"openai"`, `"litellm"`). Missing providers are unlimited.
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub providers: std::collections::HashMap<String, ProviderBudget>,
+    /// Global default burst ratio for all agents (0.0 = not set, use
+    /// compiled default 0.2). Overridden per-agent via
+    /// `ResourceQuota.burst_ratio`.
+    #[serde(default)]
+    pub default_burst_ratio: f32,
 }
 
 impl Default for BudgetConfig {
@@ -4097,6 +4104,7 @@ impl Default for BudgetConfig {
             alert_threshold: 0.8,
             default_max_llm_tokens_per_hour: 0,
             providers: std::collections::HashMap::new(),
+            default_burst_ratio: 0.0,
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #4748. Supersedes #4749 (v1, closed — missing NaN guard + tests).

- `burst_ratio: Option<f32>` on `ResourceQuota` (per-agent, agent.toml)
- `default_burst_ratio: f32` on `BudgetConfig` (global, config.toml)
- Resolution: agent override > global default > compiled 0.2
- Spawn-time pre-resolution in `spawn_agent_inner`

### Fixes from v1 review
- NaN guard: `if !raw.is_finite() { return 0.2; }` before clamp
- 6 unit tests: default, global override, agent override, clamp-below, clamp-above, NaN fallback

## Test plan
- [x] `cargo check --workspace --lib` — zero errors
- [x] Unit tests for `effective_burst_ratio` — 6 branches covered