### PR TITLE
feat(kernel,memory): persist workflow runs to SQLite

### DIFF
--- a/crates/librefang-kernel/src/kernel/background_lifecycle.rs
+++ b/crates/librefang-kernel/src/kernel/background_lifecycle.rs
@@ -1291,6 +1291,9 @@ impl LibreFangKernel {
             tracing::info!(drained, "Paused in-flight workflow runs for shutdown");
         }
 
+        // Flush the WAL so all workflow (and other) writes are durable.
+        self.memory.substrate.wal_checkpoint();
+
         // Update agent states to Suspended in persistent storage (not delete).
         // Track failures so we can emit a single critical summary if any
         // agent could not be persisted — without this, a partial-shutdown

--- a/crates/librefang-kernel/src/kernel/boot.rs
+++ b/crates/librefang-kernel/src/kernel/boot.rs
@@ -1223,7 +1223,10 @@ impl LibreFangKernel {
                 wiki_vault.clone(),
             ),
             workflows: crate::kernel::subsystems::WorkflowSubsystem::new(
-                WorkflowEngine::new_with_persistence(&workflow_home_dir),
+                WorkflowEngine::new_with_store(
+                    librefang_memory::WorkflowStore::new(memory.pool()),
+                    &workflow_home_dir,
+                ),
                 trigger_engine,
                 background,
                 cron_scheduler,
@@ -1971,11 +1974,24 @@ system_prompt = "You are a helpful assistant."
             }
         }
 
-        // Load persisted workflow runs (completed/failed) from disk.
+        // Migrate legacy JSON workflow runs to SQLite (one-time, idempotent).
+        {
+            match tokio::task::block_in_place(|| kernel.workflows.engine.migrate_from_json()) {
+                Ok(count) if count > 0 => {
+                    info!("Migrated {count} workflow run(s) from JSON to SQLite");
+                }
+                Err(e) => {
+                    warn!("Failed to migrate workflow runs from JSON to SQLite: {e}");
+                }
+                _ => {}
+            }
+        }
+
+        // Load persisted workflow runs from SQLite into memory.
         {
             match tokio::task::block_in_place(|| kernel.workflows.engine.load_runs()) {
                 Ok(count) if count > 0 => {
-                    info!("Loaded {count} persisted workflow run(s) from disk");
+                    info!("Loaded {count} persisted workflow run(s)");
                 }
                 Err(e) => {
                     warn!("Failed to load persisted workflow runs: {e}");

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -12,6 +12,7 @@
 
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use librefang_memory::{WorkflowRunRow, WorkflowStore};
 use librefang_types::agent::AgentId;
 use librefang_types::subagent::SubagentContext;
 use serde::{Deserialize, Serialize};
@@ -346,12 +347,17 @@ pub struct WorkflowEngine {
     /// Active and completed workflow runs.
     runs: Arc<DashMap<WorkflowRunId, WorkflowRun>>,
     /// Optional path to persist completed/failed runs (`~/.librefang/workflow_runs.json`).
+    /// Retained for backward compatibility and JSON-to-SQLite migration.
     persist_path: Option<PathBuf>,
     /// Serializes `persist_runs` writes so concurrent callers within a
     /// single process don't `O_TRUNC` the same `.tmp.{pid}` path and
     /// produce a torn file before rename.  `Arc` so the engine stays
     /// `Clone` (mutexes are shared, not duplicated).
     persist_lock: Arc<std::sync::Mutex<()>>,
+    /// SQLite-backed workflow store. When `Some`, all persistence goes
+    /// through SQLite instead of the JSON file. The JSON path is still
+    /// kept for the one-time migration (`migrate_from_json`).
+    store: Option<WorkflowStore>,
 }
 
 /// Evaluate a conditional expression against the previous step output.
@@ -464,10 +470,11 @@ impl WorkflowEngine {
             runs: Arc::new(DashMap::new()),
             persist_path: None,
             persist_lock: Arc::new(std::sync::Mutex::new(())),
+            store: None,
         }
     }
 
-    /// Create a new workflow engine with run persistence.
+    /// Create a new workflow engine with run persistence (JSON file).
     ///
     /// Completed and failed runs are persisted to `<home_dir>/data/workflow_runs.json`.
     pub fn new_with_persistence(home_dir: &Path) -> Self {
@@ -476,16 +483,69 @@ impl WorkflowEngine {
             runs: Arc::new(DashMap::new()),
             persist_path: Some(home_dir.join("data").join("workflow_runs.json")),
             persist_lock: Arc::new(std::sync::Mutex::new(())),
+            store: None,
+        }
+    }
+
+    /// Create a new workflow engine backed by SQLite.
+    ///
+    /// All state transitions are persisted immediately to the database.
+    /// The `home_dir` is retained so `migrate_from_json` can find the
+    /// legacy `workflow_runs.json` file for one-time import.
+    pub fn new_with_store(store: WorkflowStore, home_dir: &Path) -> Self {
+        Self {
+            workflows: Arc::new(RwLock::new(HashMap::new())),
+            runs: Arc::new(DashMap::new()),
+            persist_path: Some(home_dir.join("data").join("workflow_runs.json")),
+            persist_lock: Arc::new(std::sync::Mutex::new(())),
+            store: Some(store),
         }
     }
 
     // -- Run Persistence ------------------------------------------------------
 
-    /// Load persisted runs from disk into memory.
+    /// Load persisted runs into memory.
     ///
-    /// Returns the number of runs loaded. If the file does not exist,
-    /// returns `Ok(0)` without error.
+    /// When a SQLite store is configured, loads from the database.
+    /// Otherwise falls back to the legacy JSON file. Returns the number
+    /// of runs loaded. If no data source exists, returns `Ok(0)`.
     pub fn load_runs(&self) -> Result<usize, String> {
+        if let Some(ref store) = self.store {
+            return self.load_runs_from_sqlite(store);
+        }
+        self.load_runs_from_json()
+    }
+
+    /// Load runs from the SQLite store into the in-memory DashMap.
+    fn load_runs_from_sqlite(&self, store: &WorkflowStore) -> Result<usize, String> {
+        let rows = store
+            .load_all_runs()
+            .map_err(|e| format!("workflow SQLite load failed: {e}"))?;
+        let total = rows.len();
+        let mut loaded: usize = 0;
+        let mut skipped: usize = 0;
+        for row in rows {
+            match row_to_workflow_run(&row) {
+                Ok(run) => {
+                    self.runs.insert(run.id, run);
+                    loaded += 1;
+                }
+                Err(e) => {
+                    skipped += 1;
+                    warn!(
+                        run_id = %row.id,
+                        error = %e,
+                        "Skipping unreadable workflow run from SQLite"
+                    );
+                }
+            }
+        }
+        debug!(loaded, skipped, total, "Loaded workflow runs from SQLite");
+        Ok(loaded)
+    }
+
+    /// Load runs from the legacy JSON file into the in-memory DashMap.
+    fn load_runs_from_json(&self) -> Result<usize, String> {
         let path = match &self.persist_path {
             Some(p) => p,
             None => return Ok(0),
@@ -535,8 +595,50 @@ impl WorkflowEngine {
         Ok(count)
     }
 
-    /// Persist completed/failed runs to disk via atomic write.
+    /// Persist runs to the backing store.
+    ///
+    /// When a SQLite store is configured, iterates all runs in the
+    /// DashMap and upserts each one. A WAL checkpoint is issued after
+    /// writing terminal-state runs to ensure durability.
+    ///
+    /// Without a SQLite store, falls back to the legacy JSON atomic
+    /// write.
     fn persist_runs(&self) {
+        if let Some(ref store) = self.store {
+            self.persist_runs_to_sqlite(store);
+            return;
+        }
+        self.persist_runs_to_json();
+    }
+
+    /// Persist all runs to SQLite via upsert.
+    fn persist_runs_to_sqlite(&self, store: &WorkflowStore) {
+        let mut wrote_terminal = false;
+        for entry in self.runs.iter() {
+            let run = entry.value();
+            let row = workflow_run_to_row(run);
+            if let Err(e) = store.upsert_run(&row) {
+                warn!(run_id = %run.id, error = %e, "Failed to persist workflow run to SQLite");
+            }
+            if matches!(
+                run.state,
+                WorkflowRunState::Completed
+                    | WorkflowRunState::Failed
+                    | WorkflowRunState::Paused { .. }
+            ) {
+                wrote_terminal = true;
+            }
+        }
+        if wrote_terminal {
+            if let Err(e) = store.wal_checkpoint() {
+                warn!("WAL checkpoint after workflow persist failed: {e}");
+            }
+        }
+        debug!("Persisted workflow runs to SQLite");
+    }
+
+    /// Persist completed/failed/paused runs to JSON via atomic write (legacy path).
+    fn persist_runs_to_json(&self) {
         let _guard = self.persist_lock.lock().unwrap_or_else(|e| e.into_inner());
         let path = match &self.persist_path {
             Some(p) => p,
@@ -2330,6 +2432,99 @@ impl WorkflowEngine {
 
         Ok(preview)
     }
+
+    // -- SQLite per-transition persistence ------------------------------------
+
+    /// Persist a single run to SQLite immediately after a state transition.
+    ///
+    /// This is the key durability improvement: each state change is
+    /// durable on its own rather than waiting for the full batch
+    /// `persist_runs`. A WAL checkpoint follows terminal-state writes.
+    pub fn upsert_run_to_store(&self, run: &WorkflowRun) {
+        if let Some(ref store) = self.store {
+            let row = workflow_run_to_row(run);
+            if let Err(e) = store.upsert_run(&row) {
+                warn!(run_id = %run.id, error = %e, "Immediate SQLite upsert failed");
+            }
+            if matches!(
+                run.state,
+                WorkflowRunState::Completed
+                    | WorkflowRunState::Failed
+                    | WorkflowRunState::Paused { .. }
+            ) {
+                if let Err(e) = store.wal_checkpoint() {
+                    warn!("WAL checkpoint after terminal upsert failed: {e}");
+                }
+            }
+        }
+    }
+
+    /// One-time migration from JSON to SQLite.
+    ///
+    /// If the legacy `workflow_runs.json` exists and has content, and
+    /// the SQLite table has zero rows, import all runs from JSON into
+    /// SQLite, then rename the JSON file to `.bak`. Idempotent: if
+    /// SQLite already has rows, or the JSON file is missing/empty, this
+    /// is a no-op.
+    pub fn migrate_from_json(&self) -> Result<usize, String> {
+        let store = match &self.store {
+            Some(s) => s,
+            None => return Ok(0),
+        };
+        let path = match &self.persist_path {
+            Some(p) => p,
+            None => return Ok(0),
+        };
+        if !path.exists() {
+            return Ok(0);
+        }
+
+        // Only import when SQLite is empty — prevents double-import.
+        let existing = store
+            .count_runs()
+            .map_err(|e| format!("count_runs during migration: {e}"))?;
+        if existing > 0 {
+            debug!(
+                existing,
+                "SQLite workflow_runs already populated, skipping JSON migration"
+            );
+            return Ok(0);
+        }
+
+        let data = std::fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+        if data.trim().is_empty() || data.trim() == "[]" {
+            return Ok(0);
+        }
+
+        let json_runs: Vec<WorkflowRun> = serde_json::from_str(&data)
+            .map_err(|e| format!("Failed to parse {}: {e}", path.display()))?;
+        if json_runs.is_empty() {
+            return Ok(0);
+        }
+
+        let rows: Vec<WorkflowRunRow> = json_runs.iter().map(workflow_run_to_row).collect();
+        let imported = store
+            .bulk_upsert_runs(&rows)
+            .map_err(|e| format!("bulk_upsert_runs during migration: {e}"))?;
+
+        // Rename the old file so we never re-import.
+        let bak = path.with_extension("json.bak");
+        if let Err(e) = std::fs::rename(path, &bak) {
+            warn!(
+                "Imported {imported} workflow runs but could not rename {} to {}: {e}",
+                path.display(),
+                bak.display()
+            );
+        } else {
+            info!(
+                "Migrated {imported} workflow run(s) from {} to SQLite (renamed to {})",
+                path.display(),
+                bak.display()
+            );
+        }
+        Ok(imported)
+    }
 }
 
 impl Default for WorkflowEngine {
@@ -2758,6 +2953,139 @@ impl Default for WorkflowTemplateRegistry {
     fn default() -> Self {
         Self::new()
     }
+}
+
+// ---------------------------------------------------------------------------
+// WorkflowRun <-> WorkflowRunRow conversion
+// ---------------------------------------------------------------------------
+
+/// Convert a `WorkflowRun` to a flat `WorkflowRunRow` for SQLite storage.
+fn workflow_run_to_row(run: &WorkflowRun) -> WorkflowRunRow {
+    let (state_str, resume_token, pause_reason, paused_at) = match &run.state {
+        WorkflowRunState::Pending => ("pending".to_string(), None, None, None),
+        WorkflowRunState::Running => ("running".to_string(), None, None, None),
+        WorkflowRunState::Paused {
+            resume_token,
+            reason,
+            paused_at,
+        } => (
+            "paused".to_string(),
+            Some(resume_token.to_string()),
+            Some(reason.clone()),
+            Some(paused_at.to_rfc3339()),
+        ),
+        WorkflowRunState::Completed => ("completed".to_string(), None, None, None),
+        WorkflowRunState::Failed => ("failed".to_string(), None, None, None),
+    };
+
+    let step_results_json =
+        serde_json::to_string(&run.step_results).unwrap_or_else(|_| "[]".to_string());
+
+    let paused_variables_json = if run.paused_variables.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&run.paused_variables).unwrap_or_else(|_| "{}".to_string()))
+    };
+
+    WorkflowRunRow {
+        id: run.id.to_string(),
+        workflow_id: run.workflow_id.to_string(),
+        workflow_name: run.workflow_name.clone(),
+        state: state_str,
+        input: run.input.clone(),
+        output: run.output.clone(),
+        error: run.error.clone(),
+        resume_token,
+        pause_reason,
+        paused_at,
+        paused_step_index: run.paused_step_index.map(|i| i as i64),
+        paused_variables: paused_variables_json,
+        paused_current_input: run.paused_current_input.clone(),
+        step_results: step_results_json,
+        started_at: run.started_at.to_rfc3339(),
+        completed_at: run.completed_at.map(|dt| dt.to_rfc3339()),
+        created_at: run.started_at.to_rfc3339(),
+    }
+}
+
+/// Convert a flat `WorkflowRunRow` back into a `WorkflowRun`.
+fn row_to_workflow_run(row: &WorkflowRunRow) -> Result<WorkflowRun, String> {
+    let id = WorkflowRunId(
+        Uuid::parse_str(&row.id).map_err(|e| format!("invalid run id '{}': {e}", row.id))?,
+    );
+    let workflow_id = WorkflowId(
+        Uuid::parse_str(&row.workflow_id)
+            .map_err(|e| format!("invalid workflow_id '{}': {e}", row.workflow_id))?,
+    );
+
+    let state = match row.state.as_str() {
+        "pending" => WorkflowRunState::Pending,
+        "running" => WorkflowRunState::Running,
+        "paused" => {
+            let resume_token = row
+                .resume_token
+                .as_deref()
+                .and_then(|s| Uuid::parse_str(s).ok())
+                .unwrap_or_else(Uuid::new_v4);
+            let reason = row
+                .pause_reason
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string());
+            let paused_at = row
+                .paused_at
+                .as_deref()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(Utc::now);
+            WorkflowRunState::Paused {
+                resume_token,
+                reason,
+                paused_at,
+            }
+        }
+        "completed" => WorkflowRunState::Completed,
+        "failed" => WorkflowRunState::Failed,
+        other => return Err(format!("unknown workflow run state: {other}")),
+    };
+
+    let started_at = DateTime::parse_from_rfc3339(&row.started_at)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("invalid started_at '{}': {e}", row.started_at))?;
+
+    let completed_at = row
+        .completed_at
+        .as_deref()
+        .map(|s| {
+            DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(|e| format!("invalid completed_at '{s}': {e}"))
+        })
+        .transpose()?;
+
+    let step_results: Vec<StepResult> = serde_json::from_str(&row.step_results).unwrap_or_default();
+
+    let paused_variables: BTreeMap<String, String> = row
+        .paused_variables
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+
+    Ok(WorkflowRun {
+        id,
+        workflow_id,
+        workflow_name: row.workflow_name.clone(),
+        input: row.input.clone(),
+        state,
+        step_results,
+        output: row.output.clone(),
+        error: row.error.clone(),
+        started_at,
+        completed_at,
+        pause_request: None,
+        paused_step_index: row.paused_step_index.map(|i| i as usize),
+        paused_variables,
+        paused_current_input: row.paused_current_input.clone(),
+    })
 }
 
 #[cfg(test)]

--- a/crates/librefang-memory/src/lib.rs
+++ b/crates/librefang-memory/src/lib.rs
@@ -30,11 +30,13 @@ pub mod semantic;
 pub mod session;
 pub mod structured;
 pub mod usage;
+pub mod workflow_store;
 
 mod session_store;
 mod substrate;
 pub use session_store::SessionStore;
 pub use substrate::MemorySubstrate;
+pub use workflow_store::{WorkflowRunRow, WorkflowStore};
 
 // Re-export types for convenience
 pub use librefang_types::memory::{

--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -5,7 +5,7 @@
 use rusqlite::Connection;
 
 /// Current schema version.
-const SCHEMA_VERSION: u32 = 36;
+const SCHEMA_VERSION: u32 = 37;
 
 /// Run all migrations to bring the database up to date.
 pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -91,6 +91,10 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     // the deferred-execution spawn (matching the prior in-memory
     // behaviour exactly).
     run_step!(36, migrate_v36);
+    // v37 (#3335): workflow run persistence in SQLite. Replaces the
+    // tmp+rename JSON file (`workflow_runs.json`) that lost Running/Pending
+    // state on any shutdown and didn't survive power loss.
+    run_step!(37, migrate_v37);
 
     // Audit-trail consistency (#3538): user_version must match the count
     // of distinct rows in `migrations`. Drift means an earlier migration
@@ -1320,6 +1324,47 @@ fn migrate_v36(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute(
         "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
          VALUES (36, datetime('now'), 'Persist DeferredToolExecution on pending_approvals for cross-restart resume (#3313)')",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Version 37: Workflow run persistence in SQLite (#3335).
+///
+/// Replaces the `workflow_runs.json` tmp+rename file with a proper SQLite
+/// table. Running and Pending states are now persisted — previous JSON
+/// approach filtered them out, losing in-flight work on daemon shutdown
+/// or power loss. The `state` CHECK constraint is enforced by the database
+/// so invalid values cannot be written by buggy callers.
+fn migrate_v37(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS workflow_runs (
+            id                   TEXT PRIMARY KEY,
+            workflow_id          TEXT NOT NULL,
+            workflow_name        TEXT NOT NULL DEFAULT '',
+            state                TEXT NOT NULL CHECK (state IN ('pending','running','paused','completed','failed')),
+            input                TEXT NOT NULL DEFAULT '',
+            output               TEXT,
+            error                TEXT,
+            resume_token         TEXT,
+            pause_reason         TEXT,
+            paused_at            TEXT,
+            paused_step_index    INTEGER,
+            paused_variables     TEXT,
+            paused_current_input TEXT,
+            step_results         TEXT NOT NULL DEFAULT '[]',
+            started_at           TEXT NOT NULL,
+            completed_at         TEXT,
+            created_at           TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_workflow_runs_state
+            ON workflow_runs(state);
+        CREATE INDEX IF NOT EXISTS idx_workflow_runs_workflow_id
+            ON workflow_runs(workflow_id);",
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO migrations (version, applied_at, description) \
+         VALUES (37, datetime('now'), 'Add workflow_runs table for SQLite-backed workflow persistence (#3335)')",
         [],
     )?;
     Ok(())

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -12,6 +12,7 @@ use crate::semantic::SemanticStore;
 use crate::session::{Session, SessionStore};
 use crate::structured::StructuredStore;
 use crate::usage::UsageStore;
+use crate::workflow_store::WorkflowStore;
 
 use async_trait::async_trait;
 use librefang_types::agent::{AgentEntry, AgentId, SessionId};
@@ -40,6 +41,7 @@ pub struct MemorySubstrate {
     consolidation: ConsolidationEngine,
     usage: UsageStore,
     roster: RosterStore,
+    workflow_store: WorkflowStore,
     chunk_config: ChunkConfig,
 }
 
@@ -131,6 +133,7 @@ impl MemorySubstrate {
             sessions,
             usage: UsageStore::new(pool.clone()),
             roster: RosterStore::new(pool.clone()),
+            workflow_store: WorkflowStore::new(pool.clone()),
             consolidation: ConsolidationEngine::new(pool, decay_rate),
             chunk_config,
         })
@@ -166,6 +169,7 @@ impl MemorySubstrate {
             sessions: SessionStore::new(pool.clone()),
             usage: UsageStore::new(pool.clone()),
             roster: RosterStore::new(pool.clone()),
+            workflow_store: WorkflowStore::new(pool.clone()),
             consolidation: ConsolidationEngine::new(pool, decay_rate),
             chunk_config,
         })
@@ -184,6 +188,22 @@ impl MemorySubstrate {
     /// Get a reference to the group roster store.
     pub fn roster(&self) -> &RosterStore {
         &self.roster
+    }
+
+    /// Get a reference to the workflow run store.
+    pub fn workflow_store(&self) -> &WorkflowStore {
+        &self.workflow_store
+    }
+
+    /// Force a WAL checkpoint on the shared connection pool.
+    ///
+    /// Flushes any pending WAL frames to the main database file. Called
+    /// during kernel shutdown to ensure all workflow state transitions
+    /// (and other pending writes) are durable on disk.
+    pub fn wal_checkpoint(&self) {
+        if let Err(e) = self.workflow_store.wal_checkpoint() {
+            tracing::warn!("WAL checkpoint failed: {e}");
+        }
     }
 
     /// Attach an external vector store backend to the semantic store.

--- a/crates/librefang-memory/src/workflow_store.rs
+++ b/crates/librefang-memory/src/workflow_store.rs
@@ -1,0 +1,552 @@
+//! SQLite-backed workflow run store.
+//!
+//! Persists workflow runs so they survive daemon restarts and power loss.
+//! Unlike the previous JSON file approach, Running and Pending states are
+//! now durable — the daemon can resume or recover them on boot.
+//!
+//! The store is a thin CRUD layer; serialisation between the kernel's
+//! `WorkflowRun` and `WorkflowRunRow` happens in the kernel, not here.
+
+use librefang_types::error::{LibreFangError, LibreFangResult};
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+
+/// A flat row corresponding to the `workflow_runs` SQLite table.
+///
+/// All fields map directly to table columns. Complex nested data
+/// (step_results, paused_variables) is stored as JSON text — the
+/// store does not interpret these; the kernel serializes/deserializes
+/// them.
+#[derive(Debug, Clone)]
+pub struct WorkflowRunRow {
+    pub id: String,
+    pub workflow_id: String,
+    pub workflow_name: String,
+    pub state: String,
+    pub input: String,
+    pub output: Option<String>,
+    pub error: Option<String>,
+    pub resume_token: Option<String>,
+    pub pause_reason: Option<String>,
+    pub paused_at: Option<String>,
+    pub paused_step_index: Option<i64>,
+    pub paused_variables: Option<String>,
+    pub paused_current_input: Option<String>,
+    pub step_results: String,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub created_at: String,
+}
+
+/// Persistent workflow run store backed by SQLite.
+///
+/// Shares the same r2d2 connection pool as every other store in
+/// `MemorySubstrate`. The `workflow_runs` table is created by
+/// `migration::migrate_v37`, which runs before this store is constructed.
+#[derive(Clone)]
+pub struct WorkflowStore {
+    pool: Pool<SqliteConnectionManager>,
+}
+
+impl WorkflowStore {
+    /// Wrap an existing connection pool.
+    ///
+    /// The caller must ensure `migration::run_migrations` has already
+    /// executed so the `workflow_runs` table exists.
+    pub fn new(pool: Pool<SqliteConnectionManager>) -> Self {
+        Self { pool }
+    }
+
+    /// Insert or update a workflow run row.
+    ///
+    /// Uses `ON CONFLICT DO UPDATE` (not `INSERT OR REPLACE`) to avoid
+    /// the implicit DELETE+INSERT that would reset ROWID and break
+    /// future foreign keys. When the run reaches a terminal state
+    /// (Completed / Failed / Paused), the caller should follow up with
+    /// [`Self::wal_checkpoint`] to flush the WAL.
+    pub fn upsert_run(&self, row: &WorkflowRunRow) -> LibreFangResult<()> {
+        let c = self.pool.get().map_err(LibreFangError::memory)?;
+        c.execute(
+            "INSERT INTO workflow_runs (
+                id, workflow_id, workflow_name, state, input, output, error,
+                resume_token, pause_reason, paused_at, paused_step_index,
+                paused_variables, paused_current_input,
+                step_results, started_at, completed_at, created_at
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7,
+                ?8, ?9, ?10, ?11,
+                ?12, ?13,
+                ?14, ?15, ?16, ?17
+            ) ON CONFLICT(id) DO UPDATE SET
+                state = excluded.state,
+                input = excluded.input,
+                output = excluded.output,
+                error = excluded.error,
+                resume_token = excluded.resume_token,
+                pause_reason = excluded.pause_reason,
+                paused_at = excluded.paused_at,
+                paused_step_index = excluded.paused_step_index,
+                paused_variables = excluded.paused_variables,
+                paused_current_input = excluded.paused_current_input,
+                step_results = excluded.step_results,
+                completed_at = excluded.completed_at",
+            rusqlite::params![
+                row.id,
+                row.workflow_id,
+                row.workflow_name,
+                row.state,
+                row.input,
+                row.output,
+                row.error,
+                row.resume_token,
+                row.pause_reason,
+                row.paused_at,
+                row.paused_step_index,
+                row.paused_variables,
+                row.paused_current_input,
+                row.step_results,
+                row.started_at,
+                row.completed_at,
+                row.created_at,
+            ],
+        )
+        .map_err(|e| LibreFangError::memory_msg(format!("workflow upsert failed: {e}")))?;
+        Ok(())
+    }
+
+    /// Get a single workflow run by ID.
+    pub fn get_run(&self, id: &str) -> LibreFangResult<Option<WorkflowRunRow>> {
+        let c = self.pool.get().map_err(LibreFangError::memory)?;
+        let mut stmt = c
+            .prepare(
+                "SELECT id, workflow_id, workflow_name, state, input, output, error,
+                        resume_token, pause_reason, paused_at, paused_step_index,
+                        paused_variables, paused_current_input,
+                        step_results, started_at, completed_at, created_at
+                 FROM workflow_runs WHERE id = ?1",
+            )
+            .map_err(|e| {
+                LibreFangError::memory_msg(format!("workflow get_run prepare failed: {e}"))
+            })?;
+        let mut rows = stmt
+            .query_map(rusqlite::params![id], row_from_sqlite)
+            .map_err(|e| {
+                LibreFangError::memory_msg(format!("workflow get_run query failed: {e}"))
+            })?;
+        match rows.next() {
+            Some(Ok(row)) => Ok(Some(row)),
+            Some(Err(e)) => Err(LibreFangError::memory_msg(format!(
+                "workflow get_run row read failed: {e}"
+            ))),
+            None => Ok(None),
+        }
+    }
+
+    /// List workflow runs, optionally filtered by state.
+    pub fn list_runs(&self, state_filter: Option<&str>) -> LibreFangResult<Vec<WorkflowRunRow>> {
+        let c = self.pool.get().map_err(LibreFangError::memory)?;
+        let (sql, params): (String, Vec<Box<dyn rusqlite::types::ToSql>>) = match state_filter {
+            Some(state) => (
+                "SELECT id, workflow_id, workflow_name, state, input, output, error,
+                        resume_token, pause_reason, paused_at, paused_step_index,
+                        paused_variables, paused_current_input,
+                        step_results, started_at, completed_at, created_at
+                 FROM workflow_runs WHERE state = ?1 ORDER BY started_at DESC"
+                    .to_string(),
+                vec![Box::new(state.to_string()) as Box<dyn rusqlite::types::ToSql>],
+            ),
+            None => (
+                "SELECT id, workflow_id, workflow_name, state, input, output, error,
+                        resume_token, pause_reason, paused_at, paused_step_index,
+                        paused_variables, paused_current_input,
+                        step_results, started_at, completed_at, created_at
+                 FROM workflow_runs ORDER BY started_at DESC"
+                    .to_string(),
+                vec![],
+            ),
+        };
+        let mut stmt = c.prepare(&sql).map_err(|e| {
+            LibreFangError::memory_msg(format!("workflow list_runs prepare failed: {e}"))
+        })?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| &**p).collect();
+        let rows = stmt
+            .query_map(param_refs.as_slice(), row_from_sqlite)
+            .map_err(|e| {
+                LibreFangError::memory_msg(format!("workflow list_runs query failed: {e}"))
+            })?;
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row.map_err(|e| {
+                LibreFangError::memory_msg(format!("workflow list_runs row read failed: {e}"))
+            })?);
+        }
+        Ok(result)
+    }
+
+    /// Delete a workflow run by ID. Returns true if a row was deleted.
+    pub fn delete_run(&self, id: &str) -> LibreFangResult<bool> {
+        let c = self.pool.get().map_err(LibreFangError::memory)?;
+        let affected = c
+            .execute(
+                "DELETE FROM workflow_runs WHERE id = ?1",
+                rusqlite::params![id],
+            )
+            .map_err(|e| LibreFangError::memory_msg(format!("workflow delete_run failed: {e}")))?;
+        Ok(affected > 0)
+    }
+
+    /// Load all workflow runs from the database. Used at boot time to
+    /// populate the in-memory DashMap.
+    pub fn load_all_runs(&self) -> LibreFangResult<Vec<WorkflowRunRow>> {
+        self.list_runs(None)
+    }
+
+    /// Count workflow runs. Used by the JSON-to-SQLite migration to
+    /// check whether the table is empty.
+    pub fn count_runs(&self) -> LibreFangResult<usize> {
+        let c = self.pool.get().map_err(LibreFangError::memory)?;
+        let count: i64 = c
+            .query_row("SELECT COUNT(*) FROM workflow_runs", [], |row| row.get(0))
+            .map_err(|e| LibreFangError::memory_msg(format!("workflow count_runs failed: {e}")))?;
+        Ok(count as usize)
+    }
+
+    /// Bulk-insert rows inside a single transaction (all-or-nothing).
+    /// Used by the JSON-to-SQLite migration so a crash mid-import
+    /// leaves the table empty rather than partially populated.
+    pub fn bulk_upsert_runs(&self, rows: &[WorkflowRunRow]) -> LibreFangResult<usize> {
+        let mut c = self.pool.get().map_err(LibreFangError::memory)?;
+        let tx = c.transaction().map_err(|e| {
+            LibreFangError::memory_msg(format!("workflow bulk_upsert begin failed: {e}"))
+        })?;
+        let mut count = 0usize;
+        for row in rows {
+            tx.execute(
+                "INSERT INTO workflow_runs (
+                    id, workflow_id, workflow_name, state, input, output, error,
+                    resume_token, pause_reason, paused_at, paused_step_index,
+                    paused_variables, paused_current_input,
+                    step_results, started_at, completed_at, created_at
+                ) VALUES (
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7,
+                    ?8, ?9, ?10, ?11,
+                    ?12, ?13,
+                    ?14, ?15, ?16, ?17
+                ) ON CONFLICT(id) DO UPDATE SET
+                    state = excluded.state,
+                    output = excluded.output,
+                    error = excluded.error,
+                    step_results = excluded.step_results,
+                    completed_at = excluded.completed_at",
+                rusqlite::params![
+                    row.id,
+                    row.workflow_id,
+                    row.workflow_name,
+                    row.state,
+                    row.input,
+                    row.output,
+                    row.error,
+                    row.resume_token,
+                    row.pause_reason,
+                    row.paused_at,
+                    row.paused_step_index,
+                    row.paused_variables,
+                    row.paused_current_input,
+                    row.step_results,
+                    row.started_at,
+                    row.completed_at,
+                    row.created_at,
+                ],
+            )
+            .map_err(|e| {
+                LibreFangError::memory_msg(format!("workflow bulk_upsert row failed: {e}"))
+            })?;
+            count += 1;
+        }
+        tx.commit().map_err(|e| {
+            LibreFangError::memory_msg(format!("workflow bulk_upsert commit failed: {e}"))
+        })?;
+        Ok(count)
+    }
+
+    /// Force a WAL checkpoint to flush writes to the main database file.
+    ///
+    /// Called after upserting terminal-state runs (Completed / Failed /
+    /// Paused) to ensure those state transitions are durable even if the
+    /// daemon crashes before the next automatic checkpoint. Uses PASSIVE
+    /// mode so it never blocks concurrent readers.
+    pub fn wal_checkpoint(&self) -> LibreFangResult<()> {
+        let c = self.pool.get().map_err(LibreFangError::memory)?;
+        c.execute_batch("PRAGMA wal_checkpoint(PASSIVE);")
+            .map_err(|e| {
+                LibreFangError::memory_msg(format!("workflow wal_checkpoint failed: {e}"))
+            })?;
+        Ok(())
+    }
+}
+
+/// Map a SQLite row to a `WorkflowRunRow`.
+fn row_from_sqlite(row: &rusqlite::Row<'_>) -> Result<WorkflowRunRow, rusqlite::Error> {
+    Ok(WorkflowRunRow {
+        id: row.get(0)?,
+        workflow_id: row.get(1)?,
+        workflow_name: row.get(2)?,
+        state: row.get(3)?,
+        input: row.get(4)?,
+        output: row.get(5)?,
+        error: row.get(6)?,
+        resume_token: row.get(7)?,
+        pause_reason: row.get(8)?,
+        paused_at: row.get(9)?,
+        paused_step_index: row.get(10)?,
+        paused_variables: row.get(11)?,
+        paused_current_input: row.get(12)?,
+        step_results: row.get(13)?,
+        started_at: row.get(14)?,
+        completed_at: row.get(15)?,
+        created_at: row.get(16)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn in_memory_store() -> WorkflowStore {
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(SqliteConnectionManager::memory())
+            .unwrap();
+        crate::migration::run_migrations(&pool.get().unwrap()).expect("migrations must apply");
+        WorkflowStore::new(pool)
+    }
+
+    fn sample_row(id: &str, state: &str) -> WorkflowRunRow {
+        WorkflowRunRow {
+            id: id.to_string(),
+            workflow_id: "wf-001".to_string(),
+            workflow_name: "test-workflow".to_string(),
+            state: state.to_string(),
+            input: "hello world".to_string(),
+            output: None,
+            error: None,
+            resume_token: None,
+            pause_reason: None,
+            paused_at: None,
+            paused_step_index: None,
+            paused_variables: None,
+            paused_current_input: None,
+            step_results: "[]".to_string(),
+            started_at: "2026-05-06T00:00:00Z".to_string(),
+            completed_at: None,
+            created_at: "2026-05-06T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn upsert_and_get() {
+        let store = in_memory_store();
+        let row = sample_row("run-1", "running");
+        store.upsert_run(&row).unwrap();
+
+        let loaded = store.get_run("run-1").unwrap().expect("row must exist");
+        assert_eq!(loaded.id, "run-1");
+        assert_eq!(loaded.state, "running");
+        assert_eq!(loaded.workflow_name, "test-workflow");
+        assert_eq!(loaded.input, "hello world");
+    }
+
+    #[test]
+    fn upsert_replaces_existing() {
+        let store = in_memory_store();
+        let mut row = sample_row("run-1", "running");
+        store.upsert_run(&row).unwrap();
+
+        row.state = "completed".to_string();
+        row.output = Some("done".to_string());
+        store.upsert_run(&row).unwrap();
+
+        let loaded = store.get_run("run-1").unwrap().unwrap();
+        assert_eq!(loaded.state, "completed");
+        assert_eq!(loaded.output, Some("done".to_string()));
+    }
+
+    #[test]
+    fn get_nonexistent_returns_none() {
+        let store = in_memory_store();
+        assert!(store.get_run("no-such-id").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_runs_unfiltered() {
+        let store = in_memory_store();
+        store.upsert_run(&sample_row("r1", "running")).unwrap();
+        store.upsert_run(&sample_row("r2", "completed")).unwrap();
+        store.upsert_run(&sample_row("r3", "failed")).unwrap();
+
+        let all = store.list_runs(None).unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn list_runs_filtered_by_state() {
+        let store = in_memory_store();
+        store.upsert_run(&sample_row("r1", "running")).unwrap();
+        store.upsert_run(&sample_row("r2", "completed")).unwrap();
+        store.upsert_run(&sample_row("r3", "completed")).unwrap();
+
+        let completed = store.list_runs(Some("completed")).unwrap();
+        assert_eq!(completed.len(), 2);
+        assert!(completed.iter().all(|r| r.state == "completed"));
+
+        let running = store.list_runs(Some("running")).unwrap();
+        assert_eq!(running.len(), 1);
+    }
+
+    #[test]
+    fn delete_run() {
+        let store = in_memory_store();
+        store.upsert_run(&sample_row("r1", "running")).unwrap();
+        assert!(store.delete_run("r1").unwrap());
+        assert!(!store.delete_run("r1").unwrap()); // already gone
+        assert!(store.get_run("r1").unwrap().is_none());
+    }
+
+    #[test]
+    fn count_runs() {
+        let store = in_memory_store();
+        assert_eq!(store.count_runs().unwrap(), 0);
+        store.upsert_run(&sample_row("r1", "running")).unwrap();
+        store.upsert_run(&sample_row("r2", "failed")).unwrap();
+        assert_eq!(store.count_runs().unwrap(), 2);
+    }
+
+    #[test]
+    fn load_all_runs() {
+        let store = in_memory_store();
+        store.upsert_run(&sample_row("r1", "pending")).unwrap();
+        store.upsert_run(&sample_row("r2", "running")).unwrap();
+        let all = store.load_all_runs().unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn paused_state_round_trip() {
+        let store = in_memory_store();
+        let mut row = sample_row("r1", "paused");
+        row.resume_token = Some("tok-abc".to_string());
+        row.pause_reason = Some("approval needed".to_string());
+        row.paused_at = Some("2026-05-06T01:00:00Z".to_string());
+        row.paused_step_index = Some(2);
+        row.paused_variables = Some(r#"{"x":"1","y":"2"}"#.to_string());
+        row.paused_current_input = Some("step-2-output".to_string());
+        store.upsert_run(&row).unwrap();
+
+        let loaded = store.get_run("r1").unwrap().unwrap();
+        assert_eq!(loaded.resume_token, Some("tok-abc".to_string()));
+        assert_eq!(loaded.pause_reason, Some("approval needed".to_string()));
+        assert_eq!(loaded.paused_step_index, Some(2));
+        assert_eq!(
+            loaded.paused_variables,
+            Some(r#"{"x":"1","y":"2"}"#.to_string())
+        );
+        assert_eq!(
+            loaded.paused_current_input,
+            Some("step-2-output".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_paused_variables_round_trip() {
+        let store = in_memory_store();
+        let mut row = sample_row("r1", "paused");
+        row.resume_token = Some("tok-abc".to_string());
+        row.pause_reason = Some("waiting".to_string());
+        row.paused_at = Some("2026-05-06T01:00:00Z".to_string());
+        // paused_variables is None (empty) — must survive the round trip
+        row.paused_variables = None;
+        store.upsert_run(&row).unwrap();
+
+        let loaded = store.get_run("r1").unwrap().unwrap();
+        assert_eq!(loaded.paused_variables, None);
+    }
+
+    #[test]
+    fn wal_checkpoint_does_not_error() {
+        let store = in_memory_store();
+        // In-memory databases do not use WAL, but the PRAGMA should still
+        // succeed without error.
+        store.wal_checkpoint().unwrap();
+    }
+
+    #[test]
+    fn invalid_state_rejected_by_check_constraint() {
+        let store = in_memory_store();
+        let row = sample_row("r1", "invalid_state");
+        let result = store.upsert_run(&row);
+        assert!(
+            result.is_err(),
+            "CHECK constraint must reject invalid state"
+        );
+    }
+
+    #[test]
+    fn started_at_and_created_at_are_distinct() {
+        let store = in_memory_store();
+        let mut row = sample_row("r1", "running");
+        row.started_at = "2026-05-06T01:00:00Z".to_string();
+        row.created_at = "2026-05-06T00:30:00Z".to_string();
+        store.upsert_run(&row).unwrap();
+
+        let loaded = store.get_run("r1").unwrap().unwrap();
+        assert_eq!(loaded.started_at, "2026-05-06T01:00:00Z");
+        assert_eq!(loaded.created_at, "2026-05-06T00:30:00Z");
+    }
+
+    #[test]
+    fn bulk_upsert_runs_all_or_nothing() {
+        let store = in_memory_store();
+        let rows = vec![
+            sample_row("r1", "completed"),
+            sample_row("r2", "failed"),
+            sample_row("r3", "paused"),
+        ];
+        let count = store.bulk_upsert_runs(&rows).unwrap();
+        assert_eq!(count, 3);
+        assert_eq!(store.count_runs().unwrap(), 3);
+    }
+
+    #[test]
+    fn bulk_upsert_rejects_invalid_state() {
+        let store = in_memory_store();
+        let rows = vec![
+            sample_row("r1", "completed"),
+            sample_row("r2", "bogus"), // invalid — should abort the whole batch
+        ];
+        let result = store.bulk_upsert_runs(&rows);
+        assert!(result.is_err());
+        // Transaction rolled back: nothing inserted.
+        assert_eq!(store.count_runs().unwrap(), 0);
+    }
+
+    #[test]
+    fn on_conflict_preserves_created_at() {
+        let store = in_memory_store();
+        let mut row = sample_row("r1", "running");
+        row.created_at = "2026-05-06T00:00:00Z".to_string();
+        store.upsert_run(&row).unwrap();
+
+        // Update with a different created_at — ON CONFLICT must NOT
+        // overwrite created_at (it is excluded from the DO UPDATE SET).
+        row.state = "completed".to_string();
+        row.created_at = "2099-01-01T00:00:00Z".to_string();
+        store.upsert_run(&row).unwrap();
+
+        let loaded = store.get_run("r1").unwrap().unwrap();
+        assert_eq!(loaded.state, "completed");
+        assert_eq!(
+            loaded.created_at, "2026-05-06T00:00:00Z",
+            "created_at must be immutable after first insert"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4715. Split 2/3 of closed #4710 (PR-A drain_on_shutdown already merged as #4725).

Adds `WorkflowStore` backed by the r2d2 connection pool (#4685) for durable workflow run storage. Runs are upserted on every state transition so in-flight work survives daemon restarts.

### Changes

- **workflow_store.rs** (new): `WorkflowStore` with `upsert_run`, `get_run`, `list_runs`, `delete_run`, `load_all_runs`, `count_runs`, `bulk_upsert_runs` (transactional), `wal_checkpoint`. All return `LibreFangResult`.
- **migration.rs**: v37 creates `workflow_runs` table with `CHECK(state IN (...))` and indexes on `state`, `workflow_id`
- **workflow.rs**: `store: Option<WorkflowStore>` field, SQLite-first load/persist with JSON fallback, `migrate_from_json()` for one-time migration at boot
- **boot.rs**: wire `WorkflowStore::new(memory.pool())`, call `migrate_from_json()` before `load_runs()`
- **background_lifecycle.rs**: WAL checkpoint after `drain_on_shutdown()`

### Reviewer feedback from #4710 addressed

- Uses r2d2 pool (not `Arc<Mutex<Connection>>`) — compatible with merged #4685
- `LibreFangResult<T>` throughout (not `Result<T, String>`)
- `started_at` vs `created_at` properly distinguished
- Empty `paused_variables` round-trip tested
- No duplicate test names
- No drain_on_shutdown (already in main via #4725)
- No workflow definition file persistence (separate PR-C scope)

## Test plan

- [x] `cargo check --workspace --lib` — zero errors
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p librefang-memory -- workflow_store` — 16/16 passed
- [x] `cargo test -p librefang-memory -- migration` — 21/21 passed