### PR TITLE
feat(channels): separate IMAP and SMTP credentials in EmailConfig

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2510,27 +2510,53 @@ pub async fn start_channel_bridge_with_config(
     // Email
     #[cfg(feature = "channel-email")]
     for em_config in config.email.iter() {
-        if let Some(password) = read_token(&em_config.password_env, "Email") {
-            let adapter = Arc::new(
-                EmailAdapter::new(
-                    em_config.imap_host.clone(),
-                    em_config.imap_port,
-                    em_config.smtp_host.clone(),
-                    em_config.smtp_port,
-                    em_config.username.clone(),
-                    password,
-                    em_config.poll_interval_secs,
-                    em_config.folders.clone(),
-                    em_config.allowed_senders.clone(),
-                )
-                .with_account_id(em_config.account_id.clone()),
-            );
-            adapters.push((
-                adapter,
-                em_config.default_agent.clone(),
-                em_config.account_id.clone(),
-            ));
-        }
+        let imap_username = em_config
+            .imap_username
+            .as_deref()
+            .unwrap_or(&em_config.username)
+            .to_string();
+        let imap_password_env = em_config
+            .imap_password_env
+            .as_deref()
+            .unwrap_or(&em_config.password_env);
+        let imap_password = match read_token(imap_password_env, "Email IMAP") {
+            Some(p) => p,
+            None => continue,
+        };
+        let smtp_username = em_config
+            .smtp_username
+            .as_deref()
+            .unwrap_or(&em_config.username)
+            .to_string();
+        let smtp_password_env = em_config
+            .smtp_password_env
+            .as_deref()
+            .unwrap_or(&em_config.password_env);
+        let smtp_password = match read_token(smtp_password_env, "Email SMTP") {
+            Some(p) => p,
+            None => continue,
+        };
+        let adapter = Arc::new(
+            EmailAdapter::new(
+                em_config.imap_host.clone(),
+                em_config.imap_port,
+                em_config.smtp_host.clone(),
+                em_config.smtp_port,
+                imap_username,
+                imap_password,
+                smtp_username,
+                smtp_password,
+                em_config.poll_interval_secs,
+                em_config.folders.clone(),
+                em_config.allowed_senders.clone(),
+            )
+            .with_account_id(em_config.account_id.clone()),
+        );
+        adapters.push((
+            adapter,
+            em_config.default_agent.clone(),
+            em_config.account_id.clone(),
+        ));
     }
 
     // Teams

--- a/crates/librefang-channels/src/email.rs
+++ b/crates/librefang-channels/src/email.rs
@@ -52,10 +52,14 @@ pub struct EmailAdapter {
     smtp_host: String,
     /// SMTP port (587 for STARTTLS, 465 for implicit TLS).
     smtp_port: u16,
-    /// Email address (used for both IMAP and SMTP).
-    username: String,
-    /// SECURITY: Password is zeroized on drop.
-    password: Zeroizing<String>,
+    /// IMAP username (may differ from SMTP username).
+    imap_username: String,
+    /// SECURITY: IMAP password is zeroized on drop.
+    imap_password: Zeroizing<String>,
+    /// SMTP username (may differ from IMAP username).
+    smtp_username: String,
+    /// SECURITY: SMTP password is zeroized on drop.
+    smtp_password: Zeroizing<String>,
     /// How often to check for new emails.
     poll_interval: Duration,
     /// Which IMAP folders to monitor.
@@ -84,8 +88,10 @@ impl EmailAdapter {
         imap_port: u16,
         smtp_host: String,
         smtp_port: u16,
-        username: String,
-        password: String,
+        imap_username: String,
+        imap_password: String,
+        smtp_username: String,
+        smtp_password: String,
         poll_interval_secs: u64,
         folders: Vec<String>,
         allowed_senders: Vec<String>,
@@ -96,8 +102,10 @@ impl EmailAdapter {
             imap_port,
             smtp_host,
             smtp_port,
-            username,
-            password: Zeroizing::new(password),
+            imap_username,
+            imap_password: Zeroizing::new(imap_password),
+            smtp_username,
+            smtp_password: Zeroizing::new(smtp_password),
             poll_interval: Duration::from_secs(poll_interval_secs),
             folders: if folders.is_empty() {
                 vec!["INBOX".to_string()]
@@ -176,7 +184,10 @@ impl EmailAdapter {
             );
         }
 
-        let creds = Credentials::new(self.username.clone(), self.password.as_str().to_string());
+        let creds = Credentials::new(
+            self.smtp_username.clone(),
+            self.smtp_password.as_str().to_string(),
+        );
 
         let transport = if self.smtp_port == 465 {
             // Implicit TLS (port 465)
@@ -523,8 +534,8 @@ impl ChannelAdapter for EmailAdapter {
         let poll_interval = self.poll_interval;
         let imap_host = self.imap_host.clone();
         let imap_port = self.imap_port;
-        let username = self.username.clone();
-        let password = self.password.clone();
+        let username = self.imap_username.clone();
+        let password = self.imap_password.clone();
         let folders = self.folders.clone();
         let allowed_senders = self.allowed_senders.clone();
         let mut shutdown_rx = self.shutdown_rx.clone();
@@ -689,9 +700,9 @@ impl ChannelAdapter for EmailAdapter {
                     .map_err(|e| format!("Invalid recipient email '{}': {}", to_addr, e))?;
 
                 let from_mailbox: Mailbox = self
-                    .username
+                    .smtp_username
                     .parse()
-                    .map_err(|e| format!("Invalid sender email '{}': {}", self.username, e))?;
+                    .map_err(|e| format!("Invalid sender email '{}': {}", self.smtp_username, e))?;
 
                 // Extract subject from text body convention: "Subject: ...\n\n..."
                 let (subject, body) = if text.starts_with("Subject: ") {
@@ -771,6 +782,8 @@ mod tests {
             587,
             "user@gmail.com".to_string(),
             "password".to_string(),
+            "user@gmail.com".to_string(),
+            "password".to_string(),
             30,
             vec![],
             vec![],
@@ -788,6 +801,8 @@ mod tests {
             587,
             "bot@example.com".to_string(),
             "pass".to_string(),
+            "bot@example.com".to_string(),
+            "pass".to_string(),
             30,
             vec![],
             vec!["boss@company.com".to_string()],
@@ -800,6 +815,8 @@ mod tests {
             993,
             "smtp.example.com".to_string(),
             587,
+            "bot@example.com".to_string(),
+            "pass".to_string(),
             "bot@example.com".to_string(),
             "pass".to_string(),
             30,
@@ -962,6 +979,8 @@ mod tests {
             587,
             "bot@example.com".to_string(),
             "password".to_string(),
+            "bot@example.com".to_string(),
+            "password".to_string(),
             30,
             vec![],
             vec![],
@@ -1089,6 +1108,8 @@ mod tests {
             993,
             host,
             port,
+            "bot@example.com".to_string(),
+            "password".to_string(),
             "bot@example.com".to_string(),
             "password".to_string(),
             30,

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -6198,6 +6198,18 @@ pub struct EmailConfig {
     pub username: String,
     /// Env var name holding the password.
     pub password_env: String,
+    /// IMAP-specific username (falls back to `username` if not set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imap_username: Option<String>,
+    /// Env var for IMAP-specific password (falls back to `password_env` if not set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imap_password_env: Option<String>,
+    /// SMTP-specific username (falls back to `username` if not set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smtp_username: Option<String>,
+    /// Env var for SMTP-specific password (falls back to `password_env` if not set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smtp_password_env: Option<String>,
     /// Poll interval in seconds.
     pub poll_interval_secs: u64,
     /// IMAP folders to monitor.
@@ -6225,6 +6237,10 @@ impl Default for EmailConfig {
             smtp_port: 587,
             username: String::new(),
             password_env: "EMAIL_PASSWORD".to_string(),
+            imap_username: None,
+            imap_password_env: None,
+            smtp_username: None,
+            smtp_password_env: None,
             poll_interval_secs: 30,
             folders: vec!["INBOX".to_string()],
             allowed_senders: vec![],


### PR DESCRIPTION
## Summary

Closes #4840

Adds optional per-protocol credentials for the email channel adapter. IMAP and SMTP can now use different usernames and passwords, with fallback to the shared `username`/`password_env` when not set.

### New fields in EmailConfig

- `imap_username: Option<String>` — falls back to `username`
- `imap_password_env: Option<String>` — falls back to `password_env`
- `smtp_username: Option<String>` — falls back to `username`
- `smtp_password_env: Option<String>` — falls back to `password_env`

### Example config

```toml
[[channels.email]]
imap_host = "imap.provider1.com"
imap_port = 993
imap_username = "user@provider1.com"
imap_password_env = "EMAIL_IMAP_PASSWORD"

smtp_host = "smtp.provider2.com"
smtp_port = 587
smtp_username = "sender@provider2.com"
smtp_password_env = "EMAIL_SMTP_PASSWORD"
```

Fully backwards compatible — existing configs with shared `username`/`password_env` work unchanged.

## Test plan

- [x] `cargo check --workspace --lib` — zero errors
- [x] `cargo test -p librefang-channels` — 15 passed