### PR TITLE
docs(architecture): clarify manifest allowlist vs MCP server registry split

### DIFF
--- a/docs/architecture/manifest-and-mcp-registry.md
+++ b/docs/architecture/manifest-and-mcp-registry.md
@@ -1,0 +1,101 @@
+# Manifest-first control plane: MCP allowlist vs server registry
+
+This note records the **current** architecture, not a proposal. It exists
+because the split between `AgentManifest.mcp_servers` and
+`KernelConfig.mcp_servers` looks redundant on first reading; the two
+fields hold different things and live at different layers.
+
+## The three values
+
+| Where | Type | What it holds |
+|---|---|---|
+| `AgentManifest.mcp_servers` | `Vec<String>` (server **names**) | Per-agent **allowlist**. Empty = "all configured servers". Lives in `agent.toml`. |
+| `KernelConfig.mcp_servers` | `Vec<McpServerConfigEntry>` (full configs) | Global **registry** of installed servers — transport, env, OAuth, taint policy, headers. Lives in `~/.librefang/config.toml`. |
+| `kernel.mcp.effective_mcp_servers` | `RwLock<Vec<McpServerConfigEntry>>` | Hot-reloadable runtime mirror of `KernelConfig.mcp_servers`. Bumped together with `mcp_generation` so cached prompt summaries invalidate atomically. |
+
+`crates/librefang-types/src/agent.rs:803` — manifest field.
+`crates/librefang-kernel/src/kernel/subsystems/mcp.rs:63` — runtime mirror.
+`crates/librefang-kernel/src/kernel/mcp_setup.rs:324` — `reload_mcp_servers`
+copies `cfg.mcp_servers` into `effective_mcp_servers` on hot-reload.
+
+## Resolution
+
+The registry mirror is **not** pre-intersected with any agent's allowlist.
+Intersection happens at the prompt boundary, per agent, per turn:
+
+```
+render_mcp_summary(tool_names, configured_servers, mcp_allowlist)
+```
+
+— `crates/librefang-kernel/src/kernel/prompt_context.rs:281`. The
+`configured_servers` argument is the registry snapshot
+(`effective_mcp_servers`); the `mcp_allowlist` argument is the agent's
+manifest field. An empty allowlist means "every configured server is
+visible to this agent".
+
+The same pattern is used elsewhere any time a per-agent view of MCP is
+needed (tool list rendering, route handlers): pull the registry
+snapshot, then filter through the manifest allowlist. Never store the
+intersection.
+
+## Why the split is intentional
+
+- **Different change frequency.** The registry is rewritten when an
+  operator installs / uninstalls / reconfigures a server (rare, global,
+  hot-reloaded). The allowlist changes when an operator decides which
+  agent gets which server (frequent, per-agent, no reconnection).
+- **Different blast radius.** Removing a server from the registry tears
+  down its connection. Removing it from one agent's allowlist only
+  hides it from that agent's prompt — connection stays up for other
+  agents.
+- **Different ownership.** The registry is what `librefang-extensions`
+  manages (catalog → installer → `[[mcp_servers]]` write). The
+  allowlist is what the agent author edits in `agent.toml`. Conflating
+  the two would put extension installers into the agent-authoring
+  surface and vice versa.
+
+## Control-plane boundary for `librefang-extensions`
+
+The extensions crate is the **only** code path that should write the
+registry. It owns:
+
+- `catalog::McpCatalog` — read-only set of templates loaded from
+  `~/.librefang/mcp/catalog/*.toml`.
+- `installer::install_integration` — pure transform from a catalog
+  entry + provided credentials to a fresh `McpServerConfigEntry`. Does
+  not write — caller persists the entry into `config.toml` and triggers
+  a kernel reload.
+- `credentials::CredentialResolver` — pulls secrets out of the vault /
+  env / dotenv before they're baked into the registry entry.
+- `vault`, `oauth`, `health`, `dotenv`, `http_client` — leaf modules
+  consumed by the above.
+
+The agent-side allowlist never flows through this crate. Mutating it is
+a kernel API operation:
+`KernelApi::set_agent_mcp_servers(agent_id, Vec<String>)` —
+`crates/librefang-kernel/src/kernel_api.rs:232` — which writes back to
+the agent's manifest on disk and bumps the per-agent reload generation.
+
+## Surfaces (HTTP)
+
+- `GET /api/agents/{id}/mcp_servers` — returns the agent's allowlist
+  plus the resolved effective list (registry filtered through
+  allowlist). `routes/agents.rs:4091`.
+- `PUT /api/agents/{id}/mcp_servers` — replaces the agent's allowlist.
+  `routes/agents.rs:4162`. Does **not** touch the registry.
+- `GET /api/mcp/servers` — registry view (`routes/skills.rs:3972`).
+  Used by the dashboard's Integrations page to render install /
+  uninstall.
+
+## What this means for new code
+
+- Adding an MCP server to an agent: write to the allowlist via
+  `set_agent_mcp_servers`. Do **not** mutate the registry.
+- Installing a new server template: go through `install_integration`,
+  persist the returned `McpServerConfigEntry`, then call
+  `reload_mcp_servers`. Do **not** write to any agent manifest.
+- Reading "what MCP tools does agent X see right now": snapshot the
+  registry from `effective_mcp_servers`, filter through the agent's
+  manifest allowlist. The filtered view is never cached across turns
+  beyond the `mcp_summary_cache`, which is keyed on `(allowlist,
+  mcp_generation)` so registry hot-reloads invalidate it.

--- a/docs/src/app/architecture/manifest-mcp/page.mdx
+++ b/docs/src/app/architecture/manifest-mcp/page.mdx
@@ -104,6 +104,9 @@ the agent's manifest on disk and bumps the per-agent reload generation.
 - **Reading "what MCP tools does agent X see right now".** Snapshot
   the registry from `effective_mcp_servers`, filter through the
   agent's manifest allowlist. The filtered view is never cached
-  across turns beyond the `mcp_summary_cache`, which is keyed on
-  `(allowlist, mcp_generation)` so registry hot-reloads invalidate
-  it.
+  across turns beyond the `mcp_summary_cache`. That cache is a
+  `DashMap<String, (u64, String)>` keyed on the sorted allowlist;
+  each entry stores `(mcp_generation, rendered_string)`. A registry
+  hot-reload bumps `mcp_generation`, so the next read sees the stored
+  generation no longer matches and re-renders, overwriting the stale
+  entry — `prompt_context.rs:252-285`.

--- a/docs/src/app/architecture/manifest-mcp/page.mdx
+++ b/docs/src/app/architecture/manifest-mcp/page.mdx
@@ -1,42 +1,48 @@
-# Manifest-first control plane: MCP allowlist vs server registry
+# Manifest Allowlist vs MCP Server Registry
 
-This note records the **current** architecture, not a proposal. It exists
-because the split between `AgentManifest.mcp_servers` and
-`KernelConfig.mcp_servers` looks redundant on first reading; the two
-fields hold different things and live at different layers.
+> **Status:** documents the current state of the runtime.
+> **Crates:** `librefang-types`, `librefang-kernel`, `librefang-extensions`, `librefang-api`.
+
+The split between `AgentManifest.mcp_servers` (per-agent allowlist) and
+`KernelConfig.mcp_servers` (global server registry) reads as duplication
+on first encounter. The two fields hold different things and live at
+different layers. This page records the boundary, the resolution rule,
+and which crate is allowed to mutate which side.
 
 ## The three values
 
 | Where | Type | What it holds |
 |---|---|---|
-| `AgentManifest.mcp_servers` | `Vec<String>` (server **names**) | Per-agent **allowlist**. Empty = "all configured servers". Lives in `agent.toml`. |
+| `AgentManifest.mcp_servers` | `Vec<String>` (server **names**) | Per-agent **allowlist**. Empty = "every configured server is visible to this agent". Lives in `agent.toml`. |
 | `KernelConfig.mcp_servers` | `Vec<McpServerConfigEntry>` (full configs) | Global **registry** of installed servers — transport, env, OAuth, taint policy, headers. Lives in `~/.librefang/config.toml`. |
 | `kernel.mcp.effective_mcp_servers` | `RwLock<Vec<McpServerConfigEntry>>` | Hot-reloadable runtime mirror of `KernelConfig.mcp_servers`. Bumped together with `mcp_generation` so cached prompt summaries invalidate atomically. |
 
-`crates/librefang-types/src/agent.rs:803` — manifest field.
-`crates/librefang-kernel/src/kernel/subsystems/mcp.rs:63` — runtime mirror.
-`crates/librefang-kernel/src/kernel/mcp_setup.rs:324` — `reload_mcp_servers`
-copies `cfg.mcp_servers` into `effective_mcp_servers` on hot-reload.
+References:
+
+- `crates/librefang-types/src/agent.rs:803` — manifest field.
+- `crates/librefang-kernel/src/kernel/subsystems/mcp.rs:63` — runtime mirror.
+- `crates/librefang-kernel/src/kernel/mcp_setup.rs:324` — `reload_mcp_servers` copies `cfg.mcp_servers` into `effective_mcp_servers` on hot-reload.
 
 ## Resolution
 
-The registry mirror is **not** pre-intersected with any agent's allowlist.
-Intersection happens at the prompt boundary, per agent, per turn:
+The registry mirror is **not** pre-intersected with any agent's
+allowlist. Intersection happens at the prompt boundary, per agent, per
+turn:
 
-```
+```rust
 render_mcp_summary(tool_names, configured_servers, mcp_allowlist)
 ```
 
 — `crates/librefang-kernel/src/kernel/prompt_context.rs:281`. The
 `configured_servers` argument is the registry snapshot
 (`effective_mcp_servers`); the `mcp_allowlist` argument is the agent's
-manifest field. An empty allowlist means "every configured server is
-visible to this agent".
+manifest field. An empty allowlist means every configured server is
+visible to this agent.
 
 The same pattern is used elsewhere any time a per-agent view of MCP is
 needed (tool list rendering, route handlers): pull the registry
-snapshot, then filter through the manifest allowlist. Never store the
-intersection.
+snapshot, then filter through the manifest allowlist. **Never store the
+intersection.**
 
 ## Why the split is intentional
 
@@ -76,26 +82,28 @@ a kernel API operation:
 `crates/librefang-kernel/src/kernel_api.rs:232` — which writes back to
 the agent's manifest on disk and bumps the per-agent reload generation.
 
-## Surfaces (HTTP)
+## HTTP surfaces
 
 - `GET /api/agents/{id}/mcp_servers` — returns the agent's allowlist
   plus the resolved effective list (registry filtered through
   allowlist). `routes/agents.rs:4091`.
 - `PUT /api/agents/{id}/mcp_servers` — replaces the agent's allowlist.
   `routes/agents.rs:4162`. Does **not** touch the registry.
-- `GET /api/mcp/servers` — registry view (`routes/skills.rs:3972`).
+- `GET /api/mcp/servers` — registry view. `routes/skills.rs:3972`.
   Used by the dashboard's Integrations page to render install /
   uninstall.
 
 ## What this means for new code
 
-- Adding an MCP server to an agent: write to the allowlist via
+- **Adding an MCP server to an agent.** Write to the allowlist via
   `set_agent_mcp_servers`. Do **not** mutate the registry.
-- Installing a new server template: go through `install_integration`,
-  persist the returned `McpServerConfigEntry`, then call
-  `reload_mcp_servers`. Do **not** write to any agent manifest.
-- Reading "what MCP tools does agent X see right now": snapshot the
-  registry from `effective_mcp_servers`, filter through the agent's
-  manifest allowlist. The filtered view is never cached across turns
-  beyond the `mcp_summary_cache`, which is keyed on `(allowlist,
-  mcp_generation)` so registry hot-reloads invalidate it.
+- **Installing a new server template.** Go through
+  `install_integration`, persist the returned `McpServerConfigEntry`,
+  then call `reload_mcp_servers`. Do **not** write to any agent
+  manifest.
+- **Reading "what MCP tools does agent X see right now".** Snapshot
+  the registry from `effective_mcp_servers`, filter through the
+  agent's manifest allowlist. The filtered view is never cached
+  across turns beyond the `mcp_summary_cache`, which is keyed on
+  `(allowlist, mcp_generation)` so registry hot-reloads invalidate
+  it.

--- a/docs/src/app/zh/architecture/manifest-mcp/page.mdx
+++ b/docs/src/app/zh/architecture/manifest-mcp/page.mdx
@@ -1,0 +1,95 @@
+# Manifest 白名单 vs MCP 服务器注册表
+
+> **状态：** 描述运行时当前实际行为。
+> **Crate：** `librefang-types`、`librefang-kernel`、`librefang-extensions`、`librefang-api`。
+
+`AgentManifest.mcp_servers`（每个 agent 的白名单）和
+`KernelConfig.mcp_servers`（全局服务器注册表）这两个字段在第一次读到
+时常被误认为重复定义。它们存放的内容不同，所处的层次也不同。本页
+记录边界、解析规则，以及谁有权限改谁。
+
+## 三个值
+
+| 位置 | 类型 | 存放什么 |
+|---|---|---|
+| `AgentManifest.mcp_servers` | `Vec<String>`（服务器**名字**） | 单个 agent 的**白名单**。空 = "所有已配置服务器都对该 agent 可见"。位于 `agent.toml`。 |
+| `KernelConfig.mcp_servers` | `Vec<McpServerConfigEntry>`（完整配置） | 已安装服务器的全局**注册表** —— transport、env、OAuth、taint 策略、headers。位于 `~/.librefang/config.toml`。 |
+| `kernel.mcp.effective_mcp_servers` | `RwLock<Vec<McpServerConfigEntry>>` | `KernelConfig.mcp_servers` 的可热重载运行时镜像。与 `mcp_generation` 一起递增，保证缓存的 prompt 摘要原子失效。 |
+
+引用位置：
+
+- `crates/librefang-types/src/agent.rs:803` —— manifest 字段。
+- `crates/librefang-kernel/src/kernel/subsystems/mcp.rs:63` —— 运行时镜像。
+- `crates/librefang-kernel/src/kernel/mcp_setup.rs:324` —— `reload_mcp_servers` 在热重载时把 `cfg.mcp_servers` 拷贝进 `effective_mcp_servers`。
+
+## 解析规则
+
+注册表镜像**不会**预先和任何 agent 的白名单做交集。交集发生在 prompt
+边界上，按 agent、按轮次：
+
+```rust
+render_mcp_summary(tool_names, configured_servers, mcp_allowlist)
+```
+
+—— `crates/librefang-kernel/src/kernel/prompt_context.rs:281`。其中
+`configured_servers` 是注册表快照（`effective_mcp_servers`），
+`mcp_allowlist` 是 agent 的 manifest 字段。空白名单表示该 agent
+能看到所有已配置服务器。
+
+任何需要"按 agent 视角看 MCP"的地方（tool 列表渲染、路由处理器）都
+走同一套：先取注册表快照，再用 manifest 白名单过滤。**永远不要缓存
+交集结果。**
+
+## 为什么要拆开
+
+- **变更频率不同。** 注册表在运维安装 / 卸载 / 重新配置服务器时被改
+  写（少、全局、热重载）。白名单在运维决定"哪个 agent 能用哪个服务
+  器"时被改写（多、按 agent、不需要重连）。
+- **影响范围不同。** 从注册表里删一个服务器会断开连接。从某个 agent
+  的白名单里删一个服务器，仅仅是把它从该 agent 的 prompt 里隐藏 ——
+  连接对其他 agent 仍然有效。
+- **所有权不同。** 注册表归 `librefang-extensions` 管理（catalog →
+  installer → 写入 `[[mcp_servers]]`）。白名单是 agent 作者在
+  `agent.toml` 里编辑的。把两者合并会把 extension 安装器塞进 agent
+  作者的工作面，反之亦然。
+
+## `librefang-extensions` 的控制面边界
+
+extensions crate 是**唯一**应该写注册表的代码路径。它负责：
+
+- `catalog::McpCatalog` —— 只读模板集合，从
+  `~/.librefang/mcp/catalog/*.toml` 加载。
+- `installer::install_integration` —— 纯函数变换：catalog 条目 +
+  提供的凭据 → 新的 `McpServerConfigEntry`。不写文件 —— 调用方负责把
+  返回值持久化进 `config.toml` 并触发 kernel 重载。
+- `credentials::CredentialResolver` —— 在凭据被烧进注册表条目之前，
+  从 vault / env / dotenv 中取出。
+- `vault`、`oauth`、`health`、`dotenv`、`http_client` —— 上面这些
+  模块依赖的叶子模块。
+
+agent 端的白名单从不流经这个 crate。修改白名单是一次 kernel API
+调用：`KernelApi::set_agent_mcp_servers(agent_id, Vec<String>)` ——
+`crates/librefang-kernel/src/kernel_api.rs:232`，它会把变更写回磁盘
+上的 agent manifest 并递增 per-agent 重载代际。
+
+## HTTP 接口
+
+- `GET /api/agents/{id}/mcp_servers` —— 返回 agent 的白名单和已解析
+  的有效列表（注册表经白名单过滤后的结果）。`routes/agents.rs:4091`。
+- `PUT /api/agents/{id}/mcp_servers` —— 替换 agent 的白名单。
+  `routes/agents.rs:4162`。**不**触碰注册表。
+- `GET /api/mcp/servers` —— 注册表视图。`routes/skills.rs:3972`。
+  Dashboard 的 Integrations 页面用它来渲染安装 / 卸载。
+
+## 对新代码意味着什么
+
+- **给某个 agent 加 MCP 服务器：** 通过 `set_agent_mcp_servers` 写白
+  名单。**不要**改注册表。
+- **安装新的服务器模板：** 走 `install_integration`，把返回的
+  `McpServerConfigEntry` 持久化，然后调用 `reload_mcp_servers`。
+  **不要**改任何 agent manifest。
+- **读取"agent X 当前能看到哪些 MCP 工具"：** 从
+  `effective_mcp_servers` 取注册表快照，再用 agent 的 manifest 白名单
+  过滤。过滤后的视图除了 `mcp_summary_cache` 之外不会跨轮缓存，而该
+  缓存的 key 是 `(allowlist, mcp_generation)`，注册表热重载会自然
+  使其失效。

--- a/docs/src/app/zh/architecture/manifest-mcp/page.mdx
+++ b/docs/src/app/zh/architecture/manifest-mcp/page.mdx
@@ -90,6 +90,8 @@ agent 端的白名单从不流经这个 crate。修改白名单是一次 kernel 
   **不要**改任何 agent manifest。
 - **读取"agent X 当前能看到哪些 MCP 工具"：** 从
   `effective_mcp_servers` 取注册表快照，再用 agent 的 manifest 白名单
-  过滤。过滤后的视图除了 `mcp_summary_cache` 之外不会跨轮缓存，而该
-  缓存的 key 是 `(allowlist, mcp_generation)`，注册表热重载会自然
-  使其失效。
+  过滤。过滤后的视图除了 `mcp_summary_cache` 之外不会跨轮缓存。该
+  缓存是一个 `DashMap<String, (u64, String)>`，key 是排序后的白名单，
+  value 存 `(mcp_generation, rendered_string)`。注册表热重载会递增
+  `mcp_generation`，下一次读取会发现存储的代际不再匹配，重新渲染
+  并覆盖旧条目 —— 见 `prompt_context.rs:252-285`。

--- a/docs/src/components/Navigation.tsx
+++ b/docs/src/components/Navigation.tsx
@@ -354,6 +354,7 @@ const zhNavigation: Array<NavGroup> = [
 			{ title: "系统架构", href: withPrefix("/zh/architecture") },
 			{ title: "安全", href: withPrefix("/zh/architecture/security") },
 			{ title: "OFP 链路加密", href: withPrefix("/zh/architecture/ofp-wire") },
+			{ title: "Manifest 与 MCP 注册表", href: withPrefix("/zh/architecture/manifest-mcp") },
 		],
 	},
 	{
@@ -455,6 +456,7 @@ export const enNavigation: Array<NavGroup> = [
 			{ title: "Architecture", href: withPrefix("/architecture") },
 			{ title: "Security", href: withPrefix("/architecture/security") },
 			{ title: "OFP Wire Encryption", href: withPrefix("/architecture/ofp-wire") },
+			{ title: "Manifest & MCP Registry", href: withPrefix("/architecture/manifest-mcp") },
 		],
 	},
 	{


### PR DESCRIPTION
## Summary

- Adds `docs/src/app/architecture/manifest-mcp/page.mdx` (English) and `docs/src/app/zh/architecture/manifest-mcp/page.mdx` (Chinese mirror) on the docs site, registered under the Architecture group in `Navigation.tsx` (both `enNavigation` and `zhNavigation`).
- Documents the intentional split between `AgentManifest.mcp_servers` (per-agent allowlist) and `KernelConfig.mcp_servers` (global server registry), the resolution boundary (`render_mcp_summary` filters the registry through the allowlist at prompt-render time), and the `librefang-extensions` control-plane ownership rules (catalog → installer → registry; `set_agent_mcp_servers` → allowlist; the two paths never cross).
- Accurately describes the `mcp_summary_cache` shape: `DashMap<String, (u64, String)>` keyed on the sorted allowlist, with `(mcp_generation, rendered_string)` stored as the value — generation is the freshness check, not part of the key.

## Why

The two-field shape (allowlist + registry) regularly reads as duplication on first encounter and drove the framing of #3295. The design is already in place; what was missing was a single page that names the boundary, the resolution rule, and which crate is allowed to mutate which side. With this page, future contributors can grep one location instead of re-deriving the design from kernel + extension sources.

Doc-only — no code changes.

Closes #3295.

## Test plan

- [ ] All cited file paths and line numbers resolve in `main` (verified locally for: `librefang-types/src/agent.rs:803`, `subsystems/mcp.rs:63`, `mcp_setup.rs:324`, `prompt_context.rs:252-285`, `kernel_api.rs:232`, `routes/agents.rs:4091`, `routes/agents.rs:4162`, `routes/skills.rs:3972`).
- [ ] Docs site builds (`pnpm --filter docs build`) — not run locally; CI to verify.
- [ ] Both nav entries reachable: `/architecture/manifest-mcp` and `/zh/architecture/manifest-mcp`.