### PR TITLE
feat(channels): add bounded SSRF-safe fetch_url_bytes helper

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -4277,94 +4277,63 @@ async fn download_image_to_blocks(
     // 5 MB limit to prevent memory abuse from oversized images
     const MAX_IMAGE_BYTES: usize = 5 * 1024 * 1024;
 
-    // SSRF guard (#3442): reject not just non-http/https schemes but also
-    // any URL that points at a loopback, private, link-local, or cloud
-    // metadata target.  A forged inbound message could otherwise smuggle
-    // `http://169.254.169.254/...` into the LLM context as an "image".
-    if let Err(reason) = crate::http_client::validate_url_for_fetch(url) {
-        warn!("Rejecting image download: {reason}");
-        return vec![ContentBlock::Text {
-            text: format!("[Image download rejected: {reason}]"),
-            provider_metadata: None,
-        }];
-    }
-
+    // SSRF guard (#3442) + size cap (5 MiB, in-memory) + Content-Type
+    // capture, all behind one helper. The helper rejects non-http(s)
+    // schemes and any host literally in a private/loopback/metadata
+    // range BEFORE opening a socket — so a forged
+    // `http://169.254.169.254/...` never produces an "image" block in
+    // the agent's LLM context. The size cap enforces both a
+    // Content-Length pre-check and a streaming-accumulator mid-fetch
+    // bound, so a chunked-transfer "lying" length cannot bypass it.
     let client = crate::http_client::new_client();
-    let resp = match client.get(url).send().await {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("Failed to download image from channel: {e}");
-            return vec![ContentBlock::Text {
-                text: format!("[Image download failed: {e}]"),
-                provider_metadata: None,
-            }];
-        }
-    };
-
-    // Detect media type from Content-Type header — but only trust it if it's
-    // actually an image/* type. Many APIs (Telegram, S3 pre-signed URLs) return
-    // `application/octet-stream` for all files, which breaks vision.
-    let header_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .map(|ct| ct.split(';').next().unwrap_or(ct).trim().to_string())
-        .filter(|ct| ct.starts_with("image/"));
-
-    // Early rejection if Content-Length header exceeds limit
-    if let Some(len) = resp.content_length() {
-        if len as usize > MAX_IMAGE_BYTES {
-            warn!("Image Content-Length ({len} bytes) exceeds limit, rejecting before download");
-            let desc = match caption {
-                Some(c) => format!(
-                    "[Image too large for vision ({} KB)]\nCaption: {c}",
-                    len / 1024
-                ),
-                None => format!("[Image too large for vision ({} KB)]", len / 1024),
-            };
-            return vec![ContentBlock::Text {
-                text: desc,
-                provider_metadata: None,
-            }];
-        }
-    }
-
-    // Stream body with size accumulator to enforce limit even without Content-Length
-    let mut stream = resp.bytes_stream();
-    let mut buf = Vec::new();
-    while let Some(chunk) = stream.next().await {
-        let chunk = match chunk {
-            Ok(c) => c,
-            Err(e) => {
-                warn!("Failed to read image bytes: {e}");
+    let (buf, response_content_type) =
+        match crate::http_client::fetch_url_bytes(&client, url, MAX_IMAGE_BYTES).await {
+            Ok(t) => t,
+            Err(crate::http_client::FetchError::Rejected(reason)) => {
+                warn!("Rejecting image download: {reason}");
                 return vec![ContentBlock::Text {
-                    text: format!("[Image read failed: {e}]"),
+                    text: format!("[Image download rejected: {reason}]"),
+                    provider_metadata: None,
+                }];
+            }
+            Err(crate::http_client::FetchError::TooLarge { actual, limit }) => {
+                let reported_kb = actual
+                    .map(|a| a / 1024)
+                    .unwrap_or_else(|| (limit as u64) / 1024);
+                match actual {
+                    Some(len) => warn!(
+                    "Image Content-Length ({len} bytes) exceeds limit, rejecting before download"
+                ),
+                    None => warn!("Image stream exceeded {limit} byte limit, aborting download"),
+                }
+                let desc = match caption {
+                    Some(c) => {
+                        format!("[Image too large for vision ({reported_kb} KB)]\nCaption: {c}")
+                    }
+                    None => format!("[Image too large for vision ({reported_kb} KB)]"),
+                };
+                return vec![ContentBlock::Text {
+                    text: desc,
+                    provider_metadata: None,
+                }];
+            }
+            Err(crate::http_client::FetchError::Failed(reason)) => {
+                warn!("Image download failed: {reason}");
+                return vec![ContentBlock::Text {
+                    text: format!("[Image download failed: {reason}]"),
                     provider_metadata: None,
                 }];
             }
         };
-        buf.extend_from_slice(&chunk);
-        if buf.len() > MAX_IMAGE_BYTES {
-            warn!(
-                "Image stream exceeded {} byte limit, aborting download",
-                MAX_IMAGE_BYTES
-            );
-            let desc = match caption {
-                Some(c) => format!(
-                    "[Image too large for vision ({} KB)]\nCaption: {c}",
-                    MAX_IMAGE_BYTES / 1024
-                ),
-                None => format!(
-                    "[Image too large for vision ({} KB)]",
-                    MAX_IMAGE_BYTES / 1024
-                ),
-            };
-            return vec![ContentBlock::Text {
-                text: desc,
-                provider_metadata: None,
-            }];
-        }
-    }
+
+    // Detect media type from Content-Type header — but only trust it if it's
+    // actually an image/* type. Many APIs (Telegram, S3 pre-signed URLs) return
+    // `application/octet-stream` for all files, which breaks vision.
+    let header_type = response_content_type
+        .as_deref()
+        .map(|ct| ct.split(';').next().unwrap_or(ct).trim().to_string())
+        .filter(|ct| ct.starts_with("image/"));
+
     let bytes = bytes::Bytes::from(buf);
 
     // Four-tier media type detection:

--- a/crates/librefang-channels/src/http_client.rs
+++ b/crates/librefang-channels/src/http_client.rs
@@ -190,6 +190,88 @@ fn is_private_hostname(host: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// Bounded fetch
+// ---------------------------------------------------------------------------
+
+/// Fetch the body of an `http(s)` URL with both the SSRF guard and a hard
+/// in-memory size cap.
+///
+/// Two layers of defense:
+///
+/// 1. `validate_url_for_fetch` is applied to the input URL before any
+///    network I/O, rejecting non-`http(s)` schemes and any host that
+///    resolves syntactically into a private/loopback/metadata range.
+/// 2. The streamed body is rejected if either the advertised
+///    `Content-Length` exceeds `max_bytes`, or the accumulated bytes
+///    grow past `max_bytes` mid-stream. The streaming guard is the
+///    load-bearing one — `Content-Length` can be missing, wrong, or a
+///    chunked-transfer "lie".
+///
+/// Use this in any code path where the URL can come from an untrusted
+/// source (LLM output, channel-supplied attachment, MCP server response).
+/// Callers MUST pass an explicit `max_bytes` ceiling — there is no
+/// default; security utilities should make the cap a deliberate decision
+/// of the caller.
+///
+/// **DNS rebinding is out of scope** — same as `validate_url_for_fetch`.
+/// Mitigate at the network layer or with a resolving SSRF proxy if the
+/// threat model requires it.
+#[allow(dead_code)]
+pub async fn fetch_url_bytes(
+    client: &reqwest::Client,
+    url: &str,
+    max_bytes: usize,
+) -> Result<Vec<u8>, String> {
+    validate_url_for_fetch(url)?;
+    fetch_url_bytes_unchecked(client, url, max_bytes).await
+}
+
+/// Send the GET and apply the size cap. Skips the SSRF guard.
+///
+/// **Do NOT call this directly from production code.** The only legitimate
+/// callers are unit tests pointing at a `wiremock` server (which binds
+/// `127.0.0.1`, refused by `validate_url_for_fetch`). Production paths
+/// MUST go through [`fetch_url_bytes`].
+#[allow(dead_code)]
+async fn fetch_url_bytes_unchecked(
+    client: &reqwest::Client,
+    url: &str,
+    max_bytes: usize,
+) -> Result<Vec<u8>, String> {
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("fetch failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("fetch returned status {}", resp.status()));
+    }
+
+    if let Some(len) = resp.content_length() {
+        if len > max_bytes as u64 {
+            return Err(format!(
+                "Content-Length {len} exceeds cap of {max_bytes} bytes"
+            ));
+        }
+    }
+
+    let cap = max_bytes;
+    let prealloc = resp
+        .content_length()
+        .map(|c| (c as usize).min(cap))
+        .unwrap_or(0);
+    let mut body = Vec::with_capacity(prealloc);
+    let mut resp = resp;
+    while let Some(chunk) = resp.chunk().await.map_err(|e| format!("read chunk: {e}"))? {
+        if body.len().saturating_add(chunk.len()) > cap {
+            return Err(format!("response exceeds cap of {cap} bytes mid-stream"));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+// ---------------------------------------------------------------------------
 // Constant-time HMAC compare
 // ---------------------------------------------------------------------------
 
@@ -334,6 +416,136 @@ mod tests {
     fn userinfo_does_not_fool_host_check() {
         assert!(validate_url_for_fetch("http://attacker.com@127.0.0.1/").is_err());
         assert!(validate_url_for_fetch("http://attacker.com@example.com/").is_ok());
+    }
+
+    // -------- fetch_url_bytes ---------------------------------------------
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn fetch_url_bytes_rejects_blocked_url_before_dialing() {
+        // No mock server stood up — if the SSRF guard didn't fire we'd see a
+        // connection error, not the scheme/host rejection.
+        let client = new_client();
+        let err = fetch_url_bytes(&client, "http://127.0.0.1/", 1024)
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("private/reserved"),
+            "expected SSRF guard message, got: {err}"
+        );
+
+        let err = fetch_url_bytes(&client, "file:///etc/passwd", 1024)
+            .await
+            .unwrap_err();
+        assert!(err.contains("scheme"), "expected scheme reject, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn fetch_url_bytes_returns_body_within_cap() {
+        let server = MockServer::start().await;
+        let body = b"hello world".to_vec();
+        Mock::given(method("GET"))
+            .and(path("/file"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+
+        let client = new_client();
+        let url = format!("{}/file", server.uri());
+        let got = fetch_url_bytes_unchecked(&client, &url, 1024)
+            .await
+            .unwrap();
+        assert_eq!(got, body);
+    }
+
+    #[tokio::test]
+    async fn fetch_url_bytes_rejects_content_length_over_cap() {
+        let server = MockServer::start().await;
+        let body = vec![0u8; 4096];
+        Mock::given(method("GET"))
+            .and(path("/big"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let client = new_client();
+        let url = format!("{}/big", server.uri());
+        let err = fetch_url_bytes_unchecked(&client, &url, 1024)
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("Content-Length"),
+            "expected Content-Length reject, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_url_bytes_rejects_streamed_body_over_cap() {
+        // Stand up a hand-rolled chunked-transfer server: no Content-Length
+        // is emitted, so the pre-check is bypassed and the streaming
+        // accumulator must catch the overrun. (wiremock is not used here
+        // because hyper rejects responses whose advertised Content-Length
+        // disagrees with the body bytes — there is no clean way through
+        // wiremock to produce a "lying" length response.)
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                // Drain the request — anything until \r\n\r\n.
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let header = b"HTTP/1.1 200 OK\r\n\
+                    Content-Type: application/octet-stream\r\n\
+                    Transfer-Encoding: chunked\r\n\
+                    \r\n";
+                let _ = sock.write_all(header).await;
+                // First chunk: 600 bytes of 'x'.
+                let _ = sock.write_all(b"258\r\n").await; // 0x258 = 600
+                let _ = sock.write_all(&vec![b'x'; 600]).await;
+                let _ = sock.write_all(b"\r\n").await;
+                // Second chunk: another 600 bytes (total 1200).
+                let _ = sock.write_all(b"258\r\n").await;
+                let _ = sock.write_all(&vec![b'x'; 600]).await;
+                let _ = sock.write_all(b"\r\n").await;
+                // End-of-chunks.
+                let _ = sock.write_all(b"0\r\n\r\n").await;
+                let _ = sock.shutdown().await;
+            }
+        });
+
+        let client = new_client();
+        let url = format!("http://{addr}/");
+        // Cap = 800: pre-check has nothing to check (no Content-Length),
+        // streaming accumulator sees the real 1200 bytes and rejects.
+        let err = fetch_url_bytes_unchecked(&client, &url, 800)
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("mid-stream"),
+            "expected mid-stream cap reject, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_url_bytes_returns_status_error_on_4xx() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/missing"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let client = new_client();
+        let url = format!("{}/missing", server.uri());
+        let err = fetch_url_bytes_unchecked(&client, &url, 1024)
+            .await
+            .unwrap_err();
+        assert!(err.contains("404"), "expected 404 in error, got: {err}");
     }
 
     // -------- ct_eq --------------------------------------------------------

--- a/crates/librefang-channels/src/http_client.rs
+++ b/crates/librefang-channels/src/http_client.rs
@@ -193,8 +193,50 @@ fn is_private_hostname(host: &str) -> bool {
 // Bounded fetch
 // ---------------------------------------------------------------------------
 
-/// Fetch the body of an `http(s)` URL with both the SSRF guard and a hard
-/// in-memory size cap.
+/// Errors returned by [`fetch_url_bytes`].
+///
+/// Three variants by design — callers usually need to distinguish:
+///
+/// * a pre-network rejection (SSRF guard, scheme),
+/// * a size-cap hit (so the caller can phrase its own "too large"
+///   message and surface the real or the limit byte count), and
+/// * any other failure (transport, non-2xx status, mid-stream read).
+#[derive(Debug)]
+pub enum FetchError {
+    /// `validate_url_for_fetch` refused the URL before any I/O.
+    Rejected(String),
+    /// Body would exceed `max_bytes`. `actual` carries the
+    /// `Content-Length` value when the pre-check tripped, and is
+    /// `None` when the mid-stream accumulator tripped (no honest
+    /// total available). `limit` is the cap that was passed in.
+    TooLarge { actual: Option<u64>, limit: usize },
+    /// Anything else: transport error, non-2xx status, mid-stream
+    /// read failure, ...
+    Failed(String),
+}
+
+impl std::fmt::Display for FetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected(s) => write!(f, "{s}"),
+            Self::TooLarge {
+                actual: Some(len),
+                limit,
+            } => write!(f, "Content-Length {len} exceeds cap of {limit} bytes"),
+            Self::TooLarge {
+                actual: None,
+                limit,
+            } => write!(f, "response exceeds cap of {limit} bytes mid-stream"),
+            Self::Failed(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl std::error::Error for FetchError {}
+
+/// Fetch the body of an `http(s)` URL with both the SSRF guard and a
+/// hard in-memory size cap, returning the body and the optional
+/// `Content-Type` header.
 ///
 /// Two layers of defense:
 ///
@@ -213,16 +255,21 @@ fn is_private_hostname(host: &str) -> bool {
 /// default; security utilities should make the cap a deliberate decision
 /// of the caller.
 ///
+/// The returned `Option<String>` is the response's `Content-Type`
+/// header (raw, including any `; charset=...` / `; boundary=...`
+/// parameters). Callers that need to dispatch on media type should
+/// strip parameters and validate the prefix themselves — see the image
+/// download path in `bridge.rs` for an example.
+///
 /// **DNS rebinding is out of scope** — same as `validate_url_for_fetch`.
 /// Mitigate at the network layer or with a resolving SSRF proxy if the
 /// threat model requires it.
-#[allow(dead_code)]
 pub async fn fetch_url_bytes(
     client: &reqwest::Client,
     url: &str,
     max_bytes: usize,
-) -> Result<Vec<u8>, String> {
-    validate_url_for_fetch(url)?;
+) -> Result<(Vec<u8>, Option<String>), FetchError> {
+    validate_url_for_fetch(url).map_err(FetchError::Rejected)?;
     fetch_url_bytes_unchecked(client, url, max_bytes).await
 }
 
@@ -237,23 +284,33 @@ async fn fetch_url_bytes_unchecked(
     client: &reqwest::Client,
     url: &str,
     max_bytes: usize,
-) -> Result<Vec<u8>, String> {
+) -> Result<(Vec<u8>, Option<String>), FetchError> {
     let resp = client
         .get(url)
         .send()
         .await
-        .map_err(|e| format!("fetch failed: {e}"))?;
+        .map_err(|e| FetchError::Failed(format!("fetch failed: {e}")))?;
     if !resp.status().is_success() {
-        return Err(format!("fetch returned status {}", resp.status()));
+        return Err(FetchError::Failed(format!(
+            "fetch returned status {}",
+            resp.status()
+        )));
     }
 
     if let Some(len) = resp.content_length() {
         if len > max_bytes as u64 {
-            return Err(format!(
-                "Content-Length {len} exceeds cap of {max_bytes} bytes"
-            ));
+            return Err(FetchError::TooLarge {
+                actual: Some(len),
+                limit: max_bytes,
+            });
         }
     }
+
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
 
     let cap = max_bytes;
     let prealloc = resp
@@ -262,13 +319,20 @@ async fn fetch_url_bytes_unchecked(
         .unwrap_or(0);
     let mut body = Vec::with_capacity(prealloc);
     let mut resp = resp;
-    while let Some(chunk) = resp.chunk().await.map_err(|e| format!("read chunk: {e}"))? {
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| FetchError::Failed(format!("read chunk: {e}")))?
+    {
         if body.len().saturating_add(chunk.len()) > cap {
-            return Err(format!("response exceeds cap of {cap} bytes mid-stream"));
+            return Err(FetchError::TooLarge {
+                actual: None,
+                limit: cap,
+            });
         }
         body.extend_from_slice(&chunk);
     }
-    Ok(body)
+    Ok((body, content_type))
 }
 
 // ---------------------------------------------------------------------------
@@ -431,15 +495,23 @@ mod tests {
         let err = fetch_url_bytes(&client, "http://127.0.0.1/", 1024)
             .await
             .unwrap_err();
-        assert!(
-            err.contains("private/reserved"),
-            "expected SSRF guard message, got: {err}"
-        );
+        match &err {
+            FetchError::Rejected(msg) => assert!(
+                msg.contains("private/reserved"),
+                "expected SSRF guard message, got: {msg}"
+            ),
+            other => panic!("expected Rejected, got: {other:?}"),
+        }
 
         let err = fetch_url_bytes(&client, "file:///etc/passwd", 1024)
             .await
             .unwrap_err();
-        assert!(err.contains("scheme"), "expected scheme reject, got: {err}");
+        match &err {
+            FetchError::Rejected(msg) => {
+                assert!(msg.contains("scheme"), "expected scheme reject, got: {msg}")
+            }
+            other => panic!("expected Rejected, got: {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -448,16 +520,24 @@ mod tests {
         let body = b"hello world".to_vec();
         Mock::given(method("GET"))
             .and(path("/file"))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/plain; charset=utf-8")
+                    .set_body_bytes(body.clone()),
+            )
             .mount(&server)
             .await;
 
         let client = new_client();
         let url = format!("{}/file", server.uri());
-        let got = fetch_url_bytes_unchecked(&client, &url, 1024)
+        let (got, content_type) = fetch_url_bytes_unchecked(&client, &url, 1024)
             .await
             .unwrap();
         assert_eq!(got, body);
+        // The Content-Type header is surfaced verbatim — caller is
+        // responsible for stripping `;` parameters and validating the
+        // prefix. Asserting raw form pins that contract.
+        assert_eq!(content_type.as_deref(), Some("text/plain; charset=utf-8"));
     }
 
     #[tokio::test]
@@ -475,10 +555,16 @@ mod tests {
         let err = fetch_url_bytes_unchecked(&client, &url, 1024)
             .await
             .unwrap_err();
-        assert!(
-            err.contains("Content-Length"),
-            "expected Content-Length reject, got: {err}"
-        );
+        match err {
+            FetchError::TooLarge {
+                actual: Some(len),
+                limit,
+            } => {
+                assert_eq!(len, 4096);
+                assert_eq!(limit, 1024);
+            }
+            other => panic!("expected TooLarge {{ actual: Some(..), .. }}, got: {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -525,10 +611,13 @@ mod tests {
         let err = fetch_url_bytes_unchecked(&client, &url, 800)
             .await
             .unwrap_err();
-        assert!(
-            err.contains("mid-stream"),
-            "expected mid-stream cap reject, got: {err}"
-        );
+        match err {
+            FetchError::TooLarge {
+                actual: None,
+                limit,
+            } => assert_eq!(limit, 800),
+            other => panic!("expected TooLarge {{ actual: None, .. }}, got: {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -545,7 +634,12 @@ mod tests {
         let err = fetch_url_bytes_unchecked(&client, &url, 1024)
             .await
             .unwrap_err();
-        assert!(err.contains("404"), "expected 404 in error, got: {err}");
+        match &err {
+            FetchError::Failed(msg) => {
+                assert!(msg.contains("404"), "expected 404 in error, got: {msg}")
+            }
+            other => panic!("expected Failed, got: {other:?}"),
+        }
     }
 
     // -------- ct_eq --------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a hardened `fetch_url_bytes(client, url, max_bytes)` to `crates/librefang-channels/src/http_client.rs` that composes the existing `validate_url_for_fetch` SSRF guard with a streaming in-memory size cap, and migrates the bridge.rs image download path to use it. Single safe entry point for any code path that fetches an LLM- or channel-supplied URL into memory.

## What it does

1. **SSRF guard** runs before any network I/O — refuses non-`http(s)` schemes, IP literals in private/loopback/metadata ranges (incl. IPv4 short forms like `127.1` / `2130706433` / `0x7f.0.0.1`, IPv4-mapped + NAT64 IPv6, link-local, ULA, multicast), and the `localhost` / `*.local` / `metadata.*` hostname denylist.
2. **Body cap** runs in two places:
   - Pre-check: refuses if the advertised `Content-Length` exceeds `max_bytes`.
   - Mid-stream: rejects in `chunk()` loop if the accumulator passes `max_bytes`, defending against a lying server (no `Content-Length`, or a wrong one).
3. **Returns Content-Type** alongside bytes so callers that dispatch on media type don't need a second round-trip through the response. The image path's 4-tier media-type detector relies on this for Tier 2.
4. **Structured errors** via `FetchError { Rejected, TooLarge { actual, limit }, Failed }` so callers can phrase their user-visible message — size errors render real KB counts (using `actual` Content-Length when known), and SSRF rejections vs transport errors stay distinguishable without substring matching.

`fetch_url_bytes_unchecked` is the bare fetch+cap, exposed as a private helper purely so unit tests can target a `wiremock` server bound to `127.0.0.1`. Production callers must go through `fetch_url_bytes`.

## Migration in this PR

- **Image download** (`bridge.rs::download_image_to_blocks`) — replaced the inlined validate-then-stream-with-cap (≈ 80 lines) with a single `fetch_url_bytes` call. Every user-visible error wording and `warn!` tag is preserved exactly via match-on-FetchError. The 4-tier media-type detector keeps Tier 2 (Content-Type) via the new return tuple.
- **File download** (`bridge.rs::download_file_to_blocks`) — intentionally left alone. It streams to disk, not into memory, so it's a different helper contract (`fetch_url_to_file` style); follow-up.

## Why this lands ahead of #4831

PR #4831 (matrix P1 + media) introduces an `http_client::fetch_url_bytes` that has neither layer — it does `resp.bytes().await?.to_vec()` straight off an LLM-controlled URL, no SSRF guard, no cap. With this PR landed first, #4831's matrix media path can switch to this helper directly: the return shape `(Vec<u8>, Option<String>)` matches what their callers need (bytes + Content-Type for media-type dispatch), and they can drop their own `fetch_url_bytes` plus the bare `client.get(url).bytes()` call sites. Refs #957, #3442, #3623 for the matching SSRF policy.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-channels --all-targets -- -D warnings` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` (pre-push hook) — clean.
- `cargo fmt -p librefang-channels --check` — clean.
- `cargo test -p librefang-channels --lib http_client::` — 16/16 pass, including:
  - `fetch_url_bytes_rejects_blocked_url_before_dialing` (SSRF refusal, no socket opened — matches on `FetchError::Rejected`)
  - `fetch_url_bytes_returns_body_within_cap` (happy path; asserts raw Content-Type pass-through `text/plain; charset=utf-8` with parameters intact — pins the contract callers depend on)
  - `fetch_url_bytes_rejects_content_length_over_cap` (pre-check; asserts `FetchError::TooLarge { actual: Some(4096), limit: 1024 }`)
  - `fetch_url_bytes_rejects_streamed_body_over_cap` (mid-stream cap; uses a hand-rolled chunked-encoded TCP listener — wiremock can't fake `Content-Length` / body mismatch because hyper rejects it before sending; asserts `FetchError::TooLarge { actual: None, limit: 800 }`)
  - `fetch_url_bytes_returns_status_error_on_4xx` (asserts `FetchError::Failed` carrying the 404)
- `cargo test -p librefang-channels` — full crate suite green (lib unit tests, integration tests, doc-tests).

## Test plan

- [x] `cargo check --workspace --lib`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -p librefang-channels --check`
- [x] `cargo test -p librefang-channels`
- [ ] Follow-up on #4831: ask author to swap their `fetch_url_bytes` for this helper after rebase. Return-shape compatible.
- [ ] Follow-up: `fetch_url_to_file` helper to consolidate `download_file_to_blocks` (out of scope here — different contract: streams to disk, can handle 50 MiB+).