### PR TITLE
fix(mcp-oauth): pin scheme on Rule 2 eTLD+1 acceptance (supersedes #4789)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4824,6 +4824,7 @@ dependencies = [
  "http",
  "librefang-http",
  "librefang-types",
+ "psl",
  "rand 0.10.1",
  "reqwest",
  "rmcp",

--- a/crates/librefang-runtime-mcp/Cargo.toml
+++ b/crates/librefang-runtime-mcp/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
+psl = { workspace = true }
 url = { workspace = true }
 rand = { workspace = true }
 arc-swap = { workspace = true }

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -370,6 +370,24 @@ fn shares_registrable_domain(endpoint_host: &str, server_host: &str) -> bool {
 /// metadata would later be POSTed to over cleartext (the SSRF guard
 /// `is_ssrf_blocked_url` allows both http and https). Pinning the
 /// scheme keeps the #3713 floor on the dimension Rule 2 must not loosen.
+///
+/// **Port is not pinned on Rule 2** — only scheme and registrable
+/// domain. A metadata document on `https://example.com:8443/token` is
+/// accepted against `https://example.com/mcp` (origin differs by port,
+/// so Rule 1 fails; eTLD+1 + scheme match, so Rule 2 accepts). The
+/// reasoning is that the same registrable domain implies the same
+/// org, and an org running an OAuth endpoint on a non-default port
+/// within its own domain is legitimate. If a future threat model
+/// requires per-port pinning, tighten Rule 2 to compare
+/// `parsed.port_or_known_default()` as well — see the
+/// `accepts_same_etld1_different_port` test for the contract this
+/// documents.
+///
+/// **Maintenance:** this Rule 1 + Rule 2 + IP-carve-out policy is
+/// duplicated in api-side `librefang_api::routes::mcp_auth::
+/// token_endpoint_host_matches` (host-only there — no scheme floor).
+/// Both sides must change together, otherwise discovery and
+/// token-exchange will disagree on what's an acceptable endpoint.
 pub fn validate_metadata_endpoints(
     metadata: &OAuthMetadata,
     server_url: &str,
@@ -1303,6 +1321,32 @@ mod tests {
             server_url: "https://mcp.bbc.co.uk/mcp".to_string(),
         };
         assert!(validate_metadata_endpoints(&meta, "https://mcp.bbc.co.uk/mcp").is_ok());
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_accepts_same_etld1_different_port() {
+        // Server URL on the default https port, endpoint on a non-default
+        // port within the same registrable domain. Url::origin() normalises
+        // default ports to the scheme's default, so origins differ — Rule 1
+        // fails. eTLD+1 + scheme match — Rule 2 accepts.
+        //
+        // Pins the policy from the validate_metadata_endpoints doc comment:
+        // port is NOT compared on Rule 2. If a future threat model demands
+        // per-port pinning, that change must update this test (and the
+        // matching api-side `token_endpoint_host_matches`) together.
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://example.com/auth".to_string(),
+            token_endpoint: "https://example.com:8443/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://example.com/mcp".to_string(),
+        };
+        assert!(
+            validate_metadata_endpoints(&meta, "https://example.com/mcp").is_ok(),
+            "expected same-eTLD+1 different-port to be accepted under Rule 2"
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -11,7 +11,7 @@ use librefang_types::config::McpOAuthConfig;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 use url::Url;
 
 // Canonical OAuth token type lives in `librefang-types`.  Re-export so existing
@@ -319,28 +319,100 @@ pub fn well_known_url(server_url: &str) -> Option<String> {
     Some(format!("{}/.well-known/oauth-authorization-server", origin))
 }
 
-/// Verify that every OAuth endpoint URL returned by a metadata document
-/// shares the same scheme and host (origin) as `server_url`.
+/// Returns true when `endpoint_host` and `server_host` resolve to the same
+/// registrable domain (eTLD+1) under the Public Suffix List.
 ///
-/// This prevents a rogue metadata document from redirecting the token
-/// exchange or authorization flow to an attacker-controlled host.
+/// IP literals are rejected: PSL has no opinion on them, and its default
+/// rule for an unknown TLD label produces shared-tail false matches
+/// (`psl::domain_str("10.0.0.1") == Some("0.1")` would let `10.0.0.1` and
+/// `10.0.0.2` collide). They must only ever match via Rule 1 (strict
+/// origin equality) — see [`validate_metadata_endpoints`].
+///
+/// Mirrors the policy of
+/// `librefang-api::routes::mcp_auth::token_endpoint_host_matches`'s Rule 2
+/// (#4779, #4665).
+fn shares_registrable_domain(endpoint_host: &str, server_host: &str) -> bool {
+    use std::net::IpAddr;
+
+    // Strip IPv6 brackets — `Url::host_str` keeps them.
+    fn strip_brackets(h: &str) -> &str {
+        h.trim_start_matches('[').trim_end_matches(']')
+    }
+    let eh = strip_brackets(endpoint_host);
+    let sh = strip_brackets(server_host);
+
+    if eh.parse::<IpAddr>().is_ok() || sh.parse::<IpAddr>().is_ok() {
+        return false;
+    }
+
+    match (psl::domain_str(eh), psl::domain_str(sh)) {
+        (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
+        _ => false,
+    }
+}
+
+/// Verify that every OAuth endpoint URL returned by a metadata document
+/// shares the same origin (scheme + host + port) as `server_url`, or
+/// at minimum the same registrable domain (eTLD+1) **AND** the same
+/// scheme as `server_url`.
+///
+/// Two-rule acceptance policy (mirrors api-side
+/// `token_endpoint_host_matches`):
+/// - **Rule 1** (#3713): strict origin equality.
+/// - **Rule 2** (#4665, #4779): both endpoint host and server host are
+///   DNS names sharing the same eTLD+1, and `parsed.scheme() ==
+///   server_parsed.scheme()`.
+///
+/// The scheme floor on Rule 2 is load-bearing: the api-side
+/// `token_endpoint_host_matches` is host-only, so without this, a rogue
+/// metadata document could declare `http://<sibling>.<eTLD+1>/token`
+/// against an `https` MCP server, pass Rule 2, and the discovered
+/// metadata would later be POSTed to over cleartext (the SSRF guard
+/// `is_ssrf_blocked_url` allows both http and https). Pinning the
+/// scheme keeps the #3713 floor on the dimension Rule 2 must not loosen.
 pub fn validate_metadata_endpoints(
     metadata: &OAuthMetadata,
     server_url: &str,
 ) -> Result<(), String> {
     let server_parsed = Url::parse(server_url).map_err(|e| format!("Invalid server URL: {e}"))?;
     let server_origin = server_parsed.origin();
+    let server_scheme = server_parsed.scheme();
 
     let check = |endpoint: &str, label: &str| -> Result<(), String> {
         let parsed =
             Url::parse(endpoint).map_err(|e| format!("Invalid {label} URL '{endpoint}': {e}"))?;
-        if parsed.origin() != server_origin {
-            return Err(format!(
-                "OAuth metadata endpoint domain mismatch: {label} '{endpoint}' \
-                 does not share the same scheme+host as the MCP server '{server_url}'"
-            ));
+
+        // Rule 1 (#3713): strict origin equality.
+        if parsed.origin() == server_origin {
+            return Ok(());
         }
-        Ok(())
+
+        // Rule 2 (#4665, #4779): same registrable domain, same scheme.
+        if parsed.scheme() == server_scheme {
+            let endpoint_host = parsed.host_str().unwrap_or("");
+            let server_host = server_parsed.host_str().unwrap_or("");
+            if !endpoint_host.is_empty()
+                && !server_host.is_empty()
+                && shares_registrable_domain(endpoint_host, server_host)
+            {
+                let registrable = psl::domain_str(endpoint_host).unwrap_or("");
+                info!(
+                    endpoint = %endpoint,
+                    endpoint_host = %endpoint_host,
+                    server_url = %server_url,
+                    server_host = %server_host,
+                    registrable_domain = %registrable,
+                    label = %label,
+                    "accepted OAuth metadata endpoint on sibling subdomain within same registrable domain (#4665)"
+                );
+                return Ok(());
+            }
+        }
+
+        Err(format!(
+            "OAuth metadata endpoint domain mismatch: {label} '{endpoint}' \
+             does not share the same scheme+host as the MCP server '{server_url}'"
+        ))
     };
 
     check(&metadata.authorization_endpoint, "authorization_endpoint")?;
@@ -1178,6 +1250,161 @@ mod tests {
             server_url: "https://example.com/mcp".to_string(),
         };
         assert!(validate_metadata_endpoints(&meta, "https://example.com/mcp").is_ok());
+    }
+
+    // -- #4665, #4779: Rule 2 eTLD+1 acceptance with scheme floor --
+
+    #[test]
+    fn validate_metadata_endpoints_accepts_cross_subdomain_within_registrable_domain() {
+        // Slack-shaped delegation: server URL on mcp.slack.com, metadata
+        // declares endpoints on slack.com. Both share eTLD+1 = slack.com,
+        // schemes match — Rule 2 accepts (#4665, #4779).
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://slack.com/oauth/v2/authorize".to_string(),
+            token_endpoint: "https://slack.com/api/oauth.v2.access".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://mcp.slack.com/mcp".to_string(),
+        };
+        assert!(
+            validate_metadata_endpoints(&meta, "https://mcp.slack.com/mcp").is_ok(),
+            "expected legitimate cross-subdomain delegation to be accepted"
+        );
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_accepts_deeper_subdomain_within_registrable_domain() {
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://c.foo.com/auth".to_string(),
+            token_endpoint: "https://c.foo.com/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://a.b.foo.com/mcp".to_string(),
+        };
+        assert!(validate_metadata_endpoints(&meta, "https://a.b.foo.com/mcp").is_ok());
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_accepts_multilabel_psl_pair() {
+        // mcp.bbc.co.uk and bbc.co.uk share eTLD+1 = bbc.co.uk under the
+        // PSL multi-label public suffix. Pin against a naive `split('.')`
+        // implementation that would treat `co.uk` as the eTLD+1.
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://bbc.co.uk/auth".to_string(),
+            token_endpoint: "https://bbc.co.uk/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://mcp.bbc.co.uk/mcp".to_string(),
+        };
+        assert!(validate_metadata_endpoints(&meta, "https://mcp.bbc.co.uk/mcp").is_ok());
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_rejects_co_uk_neighbour() {
+        // attacker.co.uk and bbc.co.uk live under the SAME public suffix
+        // (`co.uk`) but are different registrable domains — must reject.
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://attacker.co.uk/auth".to_string(),
+            token_endpoint: "https://attacker.co.uk/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://mcp.bbc.co.uk/mcp".to_string(),
+        };
+        let err = validate_metadata_endpoints(&meta, "https://mcp.bbc.co.uk/mcp").unwrap_err();
+        assert!(err.contains("domain mismatch"), "{err}");
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_rejects_under_public_suffix_boundary() {
+        // *.github.io is a PSL private suffix; userA and userB are
+        // different registrable domains and must not trust each other.
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://userB.github.io/auth".to_string(),
+            token_endpoint: "https://userA.github.io/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://userA.github.io/mcp".to_string(),
+        };
+        let err = validate_metadata_endpoints(&meta, "https://userA.github.io/mcp").unwrap_err();
+        assert!(err.contains("domain mismatch"), "{err}");
+        assert!(err.contains("authorization_endpoint"), "{err}");
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_rejects_http_downgrade_within_same_registrable_domain() {
+        // Server URL is https; metadata declares an http token endpoint
+        // on the same eTLD+1. Without the scheme floor on Rule 2, this
+        // would pass (eTLD+1 = slack.com matches), the SSRF guard
+        // `is_ssrf_blocked_url` allows http, and credentials would be
+        // POSTed in cleartext. Rule 2 must refuse.
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://mcp.slack.com/oauth/v2/authorize".to_string(),
+            token_endpoint: "http://slack.com/api/oauth.v2.access".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://mcp.slack.com/mcp".to_string(),
+        };
+        let err = validate_metadata_endpoints(&meta, "https://mcp.slack.com/mcp").unwrap_err();
+        assert!(err.contains("domain mismatch"), "{err}");
+        assert!(err.contains("token_endpoint"), "{err}");
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_rejects_ip_literal_with_shared_psl_default_rule() {
+        // `psl::domain_str`'s unknown-TLD default rule produces shared
+        // trailing labels for unrelated IPv4 literals
+        // (`psl::domain_str("10.0.0.1") == Some("0.1")`,
+        // `psl::domain_str("10.0.0.2") == Some("0.2")` ... but
+        // `psl::domain_str("10.0.0.1") == psl::domain_str("11.0.0.1") == "0.1"`).
+        // The IP carve-out in `shares_registrable_domain` must reject all
+        // IP-literal pairs that fail Rule 1 (strict origin equality), no
+        // matter how the PSL default rule labels them. Mirrors #4779's
+        // `token_endpoint_ip_host_requires_exact_match`.
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://10.0.0.1/auth".to_string(),
+            token_endpoint: "https://11.0.0.1/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://10.0.0.1/mcp".to_string(),
+        };
+        let err = validate_metadata_endpoints(&meta, "https://10.0.0.1/mcp").unwrap_err();
+        assert!(err.contains("domain mismatch"), "{err}");
+        assert!(err.contains("token_endpoint"), "{err}");
+    }
+
+    #[test]
+    fn validate_metadata_endpoints_rejects_bracketed_ipv6_pair() {
+        // `Url::host_str` returns IPv6 in bracketed form (`[::1]`); the
+        // IP carve-out must strip brackets before parsing or both sides
+        // would fail the IpAddr parse and slip past into the PSL path,
+        // where they'd fail again — but we want the failure to be
+        // unambiguous and on the IP carve-out (so a future PSL upgrade
+        // that started recognising IPv6 literals doesn't regress).
+        let meta = OAuthMetadata {
+            authorization_endpoint: "https://[2001:db8::1]/auth".to_string(),
+            token_endpoint: "https://[2001:db8::2]/token".to_string(),
+            client_id: None,
+            registration_endpoint: None,
+            scopes: Vec::new(),
+            user_scopes: Vec::new(),
+            server_url: "https://[2001:db8::1]/mcp".to_string(),
+        };
+        let err = validate_metadata_endpoints(&meta, "https://[2001:db8::1]/mcp").unwrap_err();
+        assert!(err.contains("domain mismatch"), "{err}");
     }
 
     // -- #3727: generate_flow_id tests --


### PR DESCRIPTION
## Summary

Brings the MCP OAuth discovery-layer policy in `validate_metadata_endpoints` to parity with the api-layer `token_endpoint_host_matches` (#4779), but keeps the #3713 scheme floor that the api-side check loses by virtue of being host-only.

## Two-rule acceptance

- **Rule 1** (#3713): strict origin equality (scheme + host + port).
- **Rule 2** (#4665): both endpoint host and server host are DNS names sharing the same registrable domain (eTLD+1 per the Public Suffix List), **AND their schemes match**. Port is not pinned (intentional — see `accepts_same_etld1_different_port` test).

## Why supersede #4789

The scheme floor on Rule 2 is the load-bearing addition over the existing #4789 proposal. Without it, a rogue metadata document declaring `http://<sibling>.<eTLD+1>/token` against an `https` MCP server would pass Rule 2 (eTLD+1 matches), slip through `is_ssrf_blocked_url` (which allows http and https), and have credentials POSTed in cleartext at the token-exchange step. The scheme check restores the #3713 floor on the dimension Rule 2 must not loosen.

Also rolled in here from the prior review of #4789:
- **`psl` workspace pin** (`psl = { workspace = true }`) instead of crate-local `psl = "2"` so there's a single upgrade source-of-truth.
- **IP carve-out tightened** — `shares_registrable_domain` rejects IP literals on both sides because PSL's default rule for unknown TLDs returns shared trailing labels (`psl::domain_str("10.0.0.1") == Some("0.1")`), which would let two unrelated IPv4 addresses collide on Rule 2.
- **IPv6 brackets** stripped before `IpAddr` parse so the carve-out fires unambiguously on `[2001:db8::1]` etc. emitted by `Url::host_str`.

## Maintenance: api-side mirror

The Rule 1 + Rule 2 + IP-carve-out logic is duplicated in `librefang_api::routes::mcp_auth::token_endpoint_host_matches` (host-only there — no scheme floor; that's a deliberate asymmetry, not an oversight, because by the time api-side fires, the discovered metadata URL has already gone through this discovery-layer scheme check). **The two implementations MUST be kept in sync** — discovery and token-exchange disagreeing on what's an acceptable endpoint would either reject legitimate flows or open a window between layers. The doc comment on `validate_metadata_endpoints` flags this explicitly. Future work could extract `shares_registrable_domain` into a shared helper to remove the duplication.

## Tests (`mcp_oauth::tests::*`)

| Case | Asserts |
|---|---|
| `accepts_cross_subdomain_within_registrable_domain` | mcp.slack.com ↔ slack.com (Rule 2 happy path) |
| `accepts_deeper_subdomain_within_registrable_domain` | a.b.foo.com ↔ c.foo.com |
| `accepts_multilabel_psl_pair` | mcp.bbc.co.uk ↔ bbc.co.uk — pins against naive `split('.')` "co.uk is the eTLD+1" |
| `accepts_same_etld1_different_port` | https://example.com/mcp ↔ https://example.com:8443/token — pins port-not-pinned policy on Rule 2 (Rule 1 fails on origin/port, Rule 2 accepts on eTLD+1 + scheme) |
| `rejects_co_uk_neighbour` | attacker.co.uk ≠ bbc.co.uk |
| `rejects_under_public_suffix_boundary` | userA.github.io ≠ userB.github.io (PSL private suffix) |
| `rejects_http_downgrade_within_same_registrable_domain` | **scheme floor — http://slack.com vs https MCP server, refused** |
| `rejects_ip_literal_with_shared_psl_default_rule` | 10.0.0.1 vs 11.0.0.1 (both have eTLD+1 "0.1" under PSL default), refused |
| `rejects_bracketed_ipv6_pair` | `[2001:db8::1]` routes through the IP carve-out |

The five existing #3713 tests (`accepts_same_origin`, `rejects_cross_domain_*`, `no_registration_endpoint_ok`) are unchanged.

## Verification

- `cargo check -p librefang-runtime-mcp` — clean.
- `cargo clippy -p librefang-runtime-mcp --all-targets -- -D warnings` — clean.
- `cargo fmt --check -p librefang-runtime-mcp` — clean.
- `cargo test -p librefang-runtime-mcp --lib mcp_oauth::tests::validate_metadata_endpoints` — 14/14 pass.

## Test plan

- [x] cargo check / clippy / fmt / test
- [x] Pin port-not-pinned policy in a test
- [x] Flag api-side mirror obligation in doc comment
- [ ] Close #4789 once this is merged.

Refs #3713, #4665, #4779. Supersedes #4789.