### PR TITLE
fix(whatsapp-gateway): snapshot sock at sendOrEdit entry (supersedes #4759)

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -2241,17 +2241,38 @@ async function startConnection() {
               return streamMsgKey;
             }
           }
-          // No streaming happened (fallback path) — send new message
-          const sent = await s.sendMessage(jid, { text: finalText });
-          if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
-          console.log(JSON.stringify({
-            event: 'send_message_outbound',
-            kind: 'new_message',
-            jid,
-            len: finalText.length,
-            msg_id: sent?.key?.id || null,
-          }));
-          return sent?.key;
+          // No streaming happened (fallback path) — send new message.
+          //
+          // Mirror the edit branch's catch-arm: if the snapshot was
+          // non-null at entry but the underlying connection has since
+          // half-closed (cleanupSocket() racing the await), Baileys
+          // will throw here. The edit branch swallows the same throw
+          // and returns the streamed key; without an equivalent
+          // try/catch the new-message path would propagate the
+          // exception up to the message-handler scope and drop the
+          // entire delivery. Catch + log + return null so the caller
+          // sees the failure as a soft "nothing sent" (same shape it
+          // already handles when sendOrEdit's entry-snapshot was null).
+          try {
+            const sent = await s.sendMessage(jid, { text: finalText });
+            if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
+            console.log(JSON.stringify({
+              event: 'send_message_outbound',
+              kind: 'new_message',
+              jid,
+              len: finalText.length,
+              msg_id: sent?.key?.id || null,
+            }));
+            return sent?.key;
+          } catch (err) {
+            console.warn(JSON.stringify({
+              event: 'send_message_outbound',
+              kind: 'new_message_failed',
+              jid,
+              error: err && err.message ? err.message : String(err),
+            }));
+            return null;
+          }
         };
 
         if (response && sock) {

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -2195,15 +2195,34 @@ async function startConnection() {
         // trailing or glued to an emoji it would otherwise reach WhatsApp.
         const response = markdownToWhatsApp(stripNoReply(rawResponse));
 
-        // Helper: send a new message or edit the streamed one for final delivery
+        // Helper: send a new message or edit the streamed one for final delivery.
+        //
+        // Snapshot `sock` once at entry — the streaming `onProgress`
+        // callback already does this for per-chunk edits, but the final
+        // delivery here lands AFTER the LLM stream completes, which is a
+        // much wider window for a concurrent reconnect to call
+        // `cleanupSocket()` and null out the global. Without the
+        // snapshot the awaits below race the reconnect and either throw
+        // a "Cannot read properties of null" or send through a
+        // half-closed socket.
         const sendOrEdit = async (jid, finalText) => {
+          const s = sock;
+          if (!s) {
+            console.warn(JSON.stringify({
+              event: 'send_message_outbound',
+              kind: 'sock_unavailable_at_send',
+              jid,
+              had_stream: Boolean(streamMsgKey),
+            }));
+            return streamMsgKey || null;
+          }
           if (streamMsgKey && jid === sender) {
             // Edit-only on the streamed message. A new-message fallback
             // would duplicate the partial chunk the user already sees
             // when the edit fails (stale key, sock drop mid-stream); we
             // accept the last visible chunk as final instead.
             try {
-              await sock.sendMessage(jid, { text: finalText, edit: streamMsgKey });
+              await s.sendMessage(jid, { text: finalText, edit: streamMsgKey });
               if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
               console.log(JSON.stringify({
                 event: 'send_message_outbound',
@@ -2223,7 +2242,7 @@ async function startConnection() {
             }
           }
           // No streaming happened (fallback path) — send new message
-          const sent = await sock.sendMessage(jid, { text: finalText });
+          const sent = await s.sendMessage(jid, { text: finalText });
           if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
           console.log(JSON.stringify({
             event: 'send_message_outbound',

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -22,6 +22,55 @@ const {
 const { buildSessionKey, channelTypeForChat } = require('./lib/session-key');
 
 // ---------------------------------------------------------------------------
+// Process-level error handlers 
+// ---------------------------------------------------------------------------
+// Without these, an unhandled rejection from a setTimeout/setInterval
+// callback (e.g. the reconnect timer, the catch-up sweep, the dedup-store
+// eviction) terminates the process under Node 15+ default behaviour. PM2
+// would restart but the auth state could be left in an indeterminate
+// shape and the operator gets no signal. We log explicitly so the
+// post-mortem doesn't require diff'ing PM2 restart counts against
+// ambient cron noise.
+// Rolling unhandled-rejection counter. The single-rejection case is
+// usually a recoverable network blip in a setInterval cleanup, but a
+// burst signals genuine broken state — escalate to crash so PM2
+// restarts us instead of accumulating half-finished transactions.
+//
+// The handler below MUST stay synchronous (no `await` between
+// length-check / shift / push / threshold-check); the array is a
+// shared module-level mutable, and Node's single-threaded event loop
+// is the only thing keeping concurrent updates safe.
+const UNHANDLED_REJECTION_BURST_THRESHOLD = 5;
+const UNHANDLED_REJECTION_WINDOW_MS = 5 * 60 * 1000;
+const recentUnhandledRejections = [];
+process.on('unhandledRejection', (reason, promise) => {
+  const detail =
+    reason && (reason.stack || reason.message)
+      ? reason.stack || reason.message
+      : String(reason);
+  console.error('[gateway][CRITICAL] unhandledRejection:', detail);
+  const now = Date.now();
+  const cutoff = now - UNHANDLED_REJECTION_WINDOW_MS;
+  while (recentUnhandledRejections.length && recentUnhandledRejections[0] < cutoff) {
+    recentUnhandledRejections.shift();
+  }
+  recentUnhandledRejections.push(now);
+  if (recentUnhandledRejections.length >= UNHANDLED_REJECTION_BURST_THRESHOLD) {
+    console.error(
+      `[gateway][CRITICAL] ${recentUnhandledRejections.length} unhandled rejections in ${UNHANDLED_REJECTION_WINDOW_MS / 1000}s — exiting for PM2 restart`,
+    );
+    process.exit(1);
+  }
+});
+process.on('uncaughtException', (err) => {
+  const detail = err && (err.stack || err.message) ? err.stack || err.message : String(err);
+  console.error('[gateway][CRITICAL] uncaughtException:', detail);
+  // Uncaught synchronous throws indicate truly broken state — exit and
+  // let PM2 restart.
+  process.exit(1);
+});
+
+// ---------------------------------------------------------------------------
 // Persisted LID cache (ID-02, Phase 4 §B)
 // ---------------------------------------------------------------------------
 // The in-memory `lidToPnJid` Map is populated on every senderPn observation
@@ -95,6 +144,18 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_messages_processed ON messages(processed);
 `);
 
+// `processing_since` column lets the catch-up sweep skip
+// rows that the main handler is currently working on (e.g. slow media
+// download). Without it the sweep can re-forward a message before the
+// main handler finishes, producing duplicate agent turns. SQLite has no
+// `ADD COLUMN IF NOT EXISTS`; the try/catch turns the second-boot
+// "duplicate column" error into a no-op.
+try {
+  db.exec(`ALTER TABLE messages ADD COLUMN processing_since INTEGER DEFAULT NULL`);
+} catch (err) {
+  if (!/duplicate column/i.test(err && err.message)) throw err;
+}
+
 // Track last-seen timestamp per JID (for gap detection — Fase 3.2 Option C)
 db.exec(`
   CREATE TABLE IF NOT EXISTS jid_last_seen (
@@ -141,9 +202,32 @@ const stmtGetByJid = db.prepare(`
   FROM messages WHERE jid = ? AND timestamp >= ? ORDER BY timestamp DESC LIMIT ?
 `);
 
+// Cap on rows returned by `dbGetUnprocessed` when no explicit limit is
+// passed. The catch-up sweep supplies its own `CATCHUP_BATCH_SIZE`; the
+// `/messages/unprocessed` debug endpoint hits this default.
+const UNPROCESSED_QUERY_DEFAULT_LIMIT = 1000;
+
+// `(processing_since IS NULL OR processing_since < ?)` skips
+// rows the main handler claimed less than PROCESSING_LEASE_MS ago. The
+// caller passes `Date.now() - PROCESSING_LEASE_MS` as the second
+// parameter so a stale lease (handler crashed without releasing) still
+// becomes eligible for the sweep — the lease expires, the sweep picks it
+// up. The `processed = 0` clause is unchanged.
 const stmtGetUnprocessed = db.prepare(`
   SELECT id, jid, sender_jid, push_name, phone, text, direction, timestamp, retry_count, raw_type
-  FROM messages WHERE processed = 0 AND timestamp < ? ORDER BY timestamp ASC
+  FROM messages
+  WHERE processed = 0
+    AND timestamp < ?
+    AND (processing_since IS NULL OR processing_since < ?)
+  ORDER BY timestamp ASC
+  LIMIT ?
+`);
+
+const stmtMarkProcessing = db.prepare(`
+  UPDATE messages SET processing_since = ? WHERE id = ? AND processed = 0
+`);
+const stmtClearProcessing = db.prepare(`
+  UPDATE messages SET processing_since = NULL WHERE id = ?
 `);
 
 const stmtCleanupOld = db.prepare(`
@@ -197,10 +281,40 @@ function dbGetMessagesByJid(jid, limit = 20, since = 0) {
 }
 
 /**
- * Get all unprocessed messages older than a threshold (epoch ms).
+ * Get all unprocessed messages older than a threshold (epoch ms),
+ * skipping rows currently being processed by another handler.
+ *
+ * `processingLeaseExpiredBefore` is the cutoff such that any
+ * row with `processing_since >= processingLeaseExpiredBefore` is treated
+ * as actively in-flight and excluded. Pass `Date.now() - PROCESSING_LEASE_MS`
+ * to drain only rows whose claim is older than the lease (covers the
+ * crashed-handler case).
  */
-function dbGetUnprocessed(olderThan) {
-  return stmtGetUnprocessed.all(olderThan);
+function dbGetUnprocessed(olderThan, processingLeaseExpiredBefore = Date.now(), limit = UNPROCESSED_QUERY_DEFAULT_LIMIT) {
+  return stmtGetUnprocessed.all(olderThan, processingLeaseExpiredBefore, limit);
+}
+
+/**
+ * claim a row for processing by stamping `processing_since`.
+ * The main inbound handler calls this just before async media processing
+ * + forward, and `dbClearProcessing` on completion (regardless of success).
+ * The lease is bounded by PROCESSING_LEASE_MS so a crashed handler's
+ * claim eventually expires and the sweep can recover the message.
+ */
+function dbMarkProcessing(msgId) {
+  try {
+    stmtMarkProcessing.run(Date.now(), msgId);
+  } catch (err) {
+    console.warn(`[gateway][db] Failed to mark message ${msgId} as processing: ${err.message}`);
+  }
+}
+
+function dbClearProcessing(msgId) {
+  try {
+    stmtClearProcessing.run(msgId);
+  } catch (err) {
+    console.warn(`[gateway][db] Failed to clear processing flag for ${msgId}: ${err.message}`);
+  }
 }
 
 /**
@@ -345,10 +459,23 @@ let isConnecting = false;
 // ST-01 heartbeat watchdog: if no inbound messages.upsert event arrives for
 // HEARTBEAT_MS, force-close the socket so the existing reconnect path takes
 // over. The 180s default matches the openclaw reference.
-const HEARTBEAT_MS = parseInt(process.env.WA_HEARTBEAT_MS || '180000', 10);
+// Baileys `executeInitQueries` routinely takes 60s+; a tighter watchdog
+// forces reconnect before auth stabilizes and the loop never settles.
+const HEARTBEAT_MS = parseInt(process.env.WA_HEARTBEAT_MS || '300000', 10);
 const HEARTBEAT_CHECK_INTERVAL_MS = parseInt(process.env.WA_HEARTBEAT_CHECK_MS || '30000', 10);
+// separate threshold for the /health endpoint so external
+// monitoring degrades earlier than the watchdog's force-reconnect
+// trigger. 5 minutes is enough to filter out brief WhatsApp server
+// pauses without false-flagging a dead socket.
+const HEALTH_STALE_THRESHOLD_MS = parseInt(process.env.WA_HEALTH_STALE_MS || '300000', 10);
 let lastInboundAt = Date.now();
 let heartbeatInterval = null;
+// lifted to module scope so `cleanupSocket()` can clear it
+// alongside `heartbeatInterval`, instead of relying on a second
+// `sock.ev.on('connection.update', ...)` listener (which doubled the
+// fire count for every connection event). Set inside `startConnection`,
+// cleared on every teardown path.
+let gapDetectionTimer = null;
 
 // Pure predicate — true when we've been silent longer than thresholdMs.
 function checkHeartbeat(now, lastInboundAt, thresholdMs) {
@@ -364,8 +491,49 @@ function computeBackoffDelay(attempts, rng = Math.random) {
   return Math.round(base * jitter);
 }
 
-// Cached agent UUID — resolved from DEFAULT_AGENT name on first use
+// Cached agent UUID — resolved from DEFAULT_AGENT name on first use.
+// persisted to disk so a gateway restart doesn't force a fresh
+// resolveAgentId() round-trip, which fails when LibreFang is still booting.
+// On boot we read the file (if any); on every successful resolve we write
+// it back. The file is small (UUID + name) and lives next to messages.db.
+const AGENT_ID_CACHE_PATH = path.join(path.dirname(DB_PATH), 'agent_id.json');
+
 let cachedAgentId = null;
+try {
+  if (fs.existsSync(AGENT_ID_CACHE_PATH)) {
+    const raw = fs.readFileSync(AGENT_ID_CACHE_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed.id === 'string' &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(parsed.id)
+    ) {
+      cachedAgentId = parsed.id;
+      console.log(`[gateway] Restored cached agent id from disk: ${cachedAgentId}`);
+    }
+  }
+} catch (err) {
+  console.warn(`[gateway] Could not read agent id cache: ${err.message} — will resolve on first message`);
+}
+
+function persistCachedAgentId(id) {
+  // Atomic via tmp + rename so a SIGKILL mid-write can't leave a
+  // truncated agent_id.json that the next boot fails to parse. The
+  // read-side parse error path is self-healing (re-resolves from API),
+  // but a clean swap avoids the noisy warning.
+  const tmp = AGENT_ID_CACHE_PATH + '.tmp';
+  try {
+    fs.writeFileSync(
+      tmp,
+      JSON.stringify({ id, name: DEFAULT_AGENT, ts: Date.now() }),
+      { mode: 0o600 },
+    );
+    fs.renameSync(tmp, AGENT_ID_CACHE_PATH);
+  } catch (err) {
+    console.warn(`[gateway] Could not persist agent id: ${err.message}`);
+    try { fs.unlinkSync(tmp); } catch { /* noop */ }
+  }
+}
 
 // The user's own JID (set after connection opens) for self-chat detection
 let ownJid = null;
@@ -788,7 +956,11 @@ setInterval(() => {
 // `assertSessions` to recover the Signal session. A mark-on-sight dedup
 // blocks the retransmit and strands the sender — 2026-04-16 outage, see
 // lib/dedup-tracker.js docstring.
-const dedupTracker = createDedupTracker({ windowMs: 60_000 });
+// WA can retransmit minutes after the original during reconnect storms
+// (no ACK → server retries). 60s window let those bypass dedup → user
+// saw the same reply twice. 10 min absorbs the storm; map memory is
+// bounded by inbound rate (~600 entries at 1 msg/s).
+const dedupTracker = createDedupTracker({ windowMs: 600_000 });
 
 // ---------------------------------------------------------------------------
 // Step F: Escalation deduplication — debounce NOTIFY_OWNER per stranger
@@ -1161,6 +1333,7 @@ function resolveAgentId() {
     // If DEFAULT_AGENT is already a UUID, use it directly
     if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(DEFAULT_AGENT)) {
       cachedAgentId = DEFAULT_AGENT;
+      persistCachedAgentId(cachedAgentId);
       return resolve(DEFAULT_AGENT);
     }
 
@@ -1191,11 +1364,13 @@ function resolveAgentId() {
             );
             if (match && match.id) {
               cachedAgentId = match.id;
+              persistCachedAgentId(cachedAgentId);
               console.log(`[gateway] Resolved agent "${DEFAULT_AGENT}" → ${cachedAgentId}`);
               resolve(cachedAgentId);
             } else if (agents.length > 0) {
               // Fallback: use first available agent
               cachedAgentId = agents[0].id;
+              persistCachedAgentId(cachedAgentId);
               console.log(`[gateway] Agent "${DEFAULT_AGENT}" not found, using first agent: ${cachedAgentId}`);
               resolve(cachedAgentId);
             } else {
@@ -1227,6 +1402,14 @@ async function cleanupSocket() {
     clearInterval(heartbeatInterval);
     heartbeatInterval = null;
   }
+  // gapDetectionTimer is also per-connection. Clear it
+  // alongside heartbeat so the reconnect path doesn't leave a leftover
+  // closure scanning a stale `stmtGetLastSeen` while the new sock is
+  // booting.
+  if (gapDetectionTimer) {
+    clearInterval(gapDetectionTimer);
+    gapDetectionTimer = null;
+  }
   if (!sock) return;
   const previousSock = sock;
   sock = null;
@@ -1236,6 +1419,35 @@ async function cleanupSocket() {
   try { previousSock.end?.(); } catch {}
 }
 
+// Schedule the next reconnect attempt with exponential backoff. The
+// `.catch` arms a fresh `scheduleReconnect()` so that a `startConnection`
+// throw before the new sock's `connection.update` listener gets installed
+// does NOT strand the gateway: without self-rescheduling there would be
+// no future event source to fire the next retry, and only the 30s
+// health-check + PM2 restart would rescue. Self-rescheduling keeps the
+// in-process recovery loop alive end-to-end.
+function scheduleReconnect() {
+  reconnectAttempts += 1;
+  const delay = computeBackoffDelay(reconnectAttempts);
+  console.log(
+    `[gateway] Reconnecting in ${Math.round(delay / 1000)}s (attempt ${reconnectAttempts}, jittered)`,
+  );
+  connStatus = 'disconnected';
+  statusMessage = `Reconnecting (attempt ${reconnectAttempts})...`;
+  setTimeout(() => {
+    startConnection().catch((err) => {
+      console.warn(
+        '[gateway] reconnect attempt failed:',
+        err && err.message ? err.message : err,
+      );
+      // Self-rescheduling: a throw before the close-listener install
+      // means there is no future `connection.update close` to fire the
+      // next retry. The next backoff tick keeps the loop alive.
+      scheduleReconnect();
+    });
+  }, delay);
+}
+
 async function startConnection() {
   if (isConnecting) {
     console.log('[gateway] Connection attempt already in progress, skipping');
@@ -1243,6 +1455,14 @@ async function startConnection() {
   }
   isConnecting = true;
   try {
+
+  // defensive teardown of any leftover sock + per-connection
+  // timers from a previous invocation. The normal teardown path runs in
+  // the `connection.update` close branch, but a sock that was abandoned
+  // without emitting close (e.g. process killed mid-init last cycle and
+  // PM2 respawned us) would leak its listeners and timers. The
+  // `cleanupSocket()` is a no-op when sock is already null.
+  await cleanupSocket();
 
   // Dynamic imports — Baileys is ESM-only in v6+
   const { default: makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion } =
@@ -1332,15 +1552,10 @@ async function startConnection() {
         // backoff 2s → 30s, factor 1.8, ±25% jitter, NO hard stop — a
         // transient outage longer than 5 attempts (the previous cap) used
         // to leave the gateway permanently disconnected until manual
-        // restart. We now keep retrying at the capped interval.
-        reconnectAttempts += 1;
-        const delay = computeBackoffDelay(reconnectAttempts);
-        console.log(
-          `[gateway] Reconnecting in ${Math.round(delay / 1000)}s (attempt ${reconnectAttempts}, jittered)`,
-        );
-        connStatus = 'disconnected';
-        statusMessage = `Reconnecting (attempt ${reconnectAttempts})...`;
-        setTimeout(() => startConnection(), delay);
+        // restart. We now keep retrying at the capped interval. The
+        // helper handles the backoff, status-line update, and self-
+        // rescheduling on retry-throw.
+        scheduleReconnect();
       }
     }
 
@@ -1635,7 +1850,35 @@ async function startConnection() {
       let transcriptionText = '';
 
       if (downloadableMedia) {
-        const result = await processMediaMessage(msg, innerMsg, cachedAgentId);
+        // overall pipeline timeout. The internal stages
+        // (download 30s + retry, upload 60s) can stack to ~120s and block
+        // every other inbound message behind this single one. Cap the
+        // total at MEDIA_PIPELINE_TIMEOUT_MS so a slow giant-video upload
+        // can't choke the handler. On timeout the message is forwarded
+        // without attachment — the agent sees text but no media; better
+        // than no response at all.
+        let result = null;
+        // Hold the timer so we can clearTimeout on the success path —
+        // otherwise the zombie keeps the event loop alive for 90s after
+        // each media message and N concurrent inflight = N zombies.
+        let mediaTimeoutHandle = null;
+        try {
+          result = await Promise.race([
+            processMediaMessage(msg, innerMsg, cachedAgentId),
+            new Promise((_, reject) => {
+              mediaTimeoutHandle = setTimeout(
+                () => reject(new Error('media_pipeline_timeout')),
+                MEDIA_PIPELINE_TIMEOUT_MS,
+              );
+            }),
+          ]);
+        } catch (err) {
+          console.warn(
+            `[gateway] media pipeline failed (${err && err.message ? err.message : err}) — forwarding without attachment`,
+          );
+        } finally {
+          if (mediaTimeoutHandle) clearTimeout(mediaTimeoutHandle);
+        }
         if (result && result.attachment) {
           attachments.push(result.attachment);
           if (result.transcription) {
@@ -1697,11 +1940,36 @@ async function startConnection() {
 
       if (contextInfo?.quotedMessage) {
         const quoted = contextInfo.quotedMessage;
-        const quotedText = quoted.conversation
+        // the prefix only fires on text/extendedText/image+caption/
+        // video+caption. Replies to voice notes, stickers, plain images,
+        // documents, locations, contacts came through nudo without the
+        // `[In risposta a: ...]` marker, breaking conversational reference.
+        // Fall back to a typed placeholder so the agent still knows a
+        // reply happened and what kind of message was quoted.
+        let quotedText =
+          quoted.conversation
           || quoted.extendedTextMessage?.text
           || quoted.imageMessage?.caption
           || quoted.videoMessage?.caption
-          || '';
+          || quoted.documentMessage?.caption;
+        if (!quotedText) {
+          if (quoted.audioMessage) {
+            quotedText = quoted.audioMessage.ptt ? '[voice note]' : '[audio]';
+          } else if (quoted.imageMessage) {
+            quotedText = '[image]';
+          } else if (quoted.videoMessage) {
+            quotedText = '[video]';
+          } else if (quoted.stickerMessage) {
+            quotedText = '[sticker]';
+          } else if (quoted.documentMessage) {
+            const fname = quoted.documentMessage.fileName || 'file';
+            quotedText = `[document: ${fname}]`;
+          } else if (quoted.locationMessage || quoted.liveLocationMessage) {
+            quotedText = '[location]';
+          } else if (quoted.contactMessage || quoted.contactsArrayMessage) {
+            quotedText = '[contact]';
+          }
+        }
         if (quotedText) {
           messageText = `[In risposta a: "${quotedText.substring(0, 200)}"]\n${messageText}`;
         }
@@ -1738,10 +2006,26 @@ async function startConnection() {
         processed: 0,
         rawType,
       });
+      // claim the row before the slow media + forward path so
+      // the catch-up sweep can't race and re-deliver the same message
+      // while we're still processing it.
+      dbMarkProcessing(msg.key.id);
       dbUpdateLastSeen(sender, msgTimestamp);
 
-      // Send read receipt (blue ticks) immediately
-      await sock.readMessages([msg.key]);
+      // Send read receipt (blue ticks) immediately. guard
+      // against `sock` being nulled out by a concurrent reconnect (the
+      // upsert handler is async, sock is a global). A failed read receipt
+      // is cosmetic; do not let it crash the message handler.
+      if (sock) {
+        try {
+          await sock.readMessages([msg.key]);
+        } catch (err) {
+          console.warn(
+            '[gateway] readMessages failed:',
+            err && err.message ? err.message : err,
+          );
+        }
+      }
 
       // Forward to LibreFang agent
       try {
@@ -1774,13 +2058,25 @@ async function startConnection() {
 
         // --- Streaming: progressive message edits while LLM generates ---
         let streamMsgKey = null; // key of the initial WhatsApp message we'll edit
+        // bound consecutive sendMessage failures so a flaky
+        // connection mid-stream doesn't produce 10+ warn logs and a
+        // truncated message. After STREAM_EDIT_MAX_FAILURES consecutive
+        // misses, give up streaming edits and let the final delivery
+        // (forwardToLibreFangStreaming → sendMessage) handle the full text.
+        const STREAM_EDIT_MAX_FAILURES = 3;
+        let streamEditFailures = 0;
         const onProgress = async (partialText) => {
           // Streaming-to-channel disabled via `[channels.whatsapp]
           // stream_to_channel = false` — let the final delivery path
           // handle the full text in one send so WhatsApp/Telegram don't
           // show the "edited" tag on every chunk.
           if (!STREAM_TO_CHANNEL) return;
-          if (!sock) return;
+          if (streamEditFailures >= STREAM_EDIT_MAX_FAILURES) return;
+          // Snapshot the sock at callback entry. The global `sock` can be
+          // nulled out by a concurrent reconnect between the existence check
+          // and the actual sendMessage await.
+          const localSock = sock;
+          if (!localSock) return;
           // Strip internal tags before sending partial text to WhatsApp.
           // Bail early if no brackets — most chunks won't contain tags.
           let cleaned = partialText;
@@ -1820,13 +2116,35 @@ async function startConnection() {
           cleaned = cleaned.trim();
           if (!cleaned) return;
           const formatted = markdownToWhatsApp(cleaned);
-          if (!streamMsgKey) {
-            const sent = await sock.sendMessage(sender, { text: formatted });
-            streamMsgKey = sent?.key;
-          } else {
-            await sock.sendMessage(sender, { text: formatted, edit: streamMsgKey });
+          try {
+            if (!streamMsgKey) {
+              const sent = await localSock.sendMessage(sender, { text: formatted });
+              streamMsgKey = sent?.key;
+              // Distinguish first-flush sends from later edits in logs so
+              // outbound counts can be reconciled with inbound dispatches.
+              console.log(JSON.stringify({
+                event: 'send_message_outbound',
+                kind: 'stream_first',
+                jid: sender,
+                len: formatted.length,
+                msg_id: sent?.key?.id || null,
+              }));
+            } else {
+              await localSock.sendMessage(sender, { text: formatted, edit: streamMsgKey });
+            }
+            streamEditFailures = 0;
+            if (ECHO_TRACKER_ENABLED) echoTracker.track(cleaned);
+          } catch (err) {
+            streamEditFailures += 1;
+            console.warn(JSON.stringify({
+              event: 'send_message_outbound',
+              kind: 'stream_edit_failed',
+              jid: sender,
+              attempt: streamEditFailures,
+              cap: STREAM_EDIT_MAX_FAILURES,
+              error: err && err.message ? err.message : String(err),
+            }));
           }
-          if (ECHO_TRACKER_ENABLED) echoTracker.track(cleaned);
         };
 
         // Phase 2 §C — fetch participant roster for groups (cached 5min).
@@ -1880,15 +2198,41 @@ async function startConnection() {
         // Helper: send a new message or edit the streamed one for final delivery
         const sendOrEdit = async (jid, finalText) => {
           if (streamMsgKey && jid === sender) {
-            // Edit the message we've been streaming
-            await sock.sendMessage(jid, { text: finalText, edit: streamMsgKey });
-            if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
-            return streamMsgKey;
+            // Edit-only on the streamed message. A new-message fallback
+            // would duplicate the partial chunk the user already sees
+            // when the edit fails (stale key, sock drop mid-stream); we
+            // accept the last visible chunk as final instead.
+            try {
+              await sock.sendMessage(jid, { text: finalText, edit: streamMsgKey });
+              if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
+              console.log(JSON.stringify({
+                event: 'send_message_outbound',
+                kind: 'edit_final',
+                jid,
+                len: finalText.length,
+              }));
+              return streamMsgKey;
+            } catch (err) {
+              console.warn(JSON.stringify({
+                event: 'send_message_outbound',
+                kind: 'edit_final_failed_no_fallback',
+                jid,
+                error: err && err.message ? err.message : String(err),
+              }));
+              return streamMsgKey;
+            }
           }
           // No streaming happened (fallback path) — send new message
-          const sentKey = (await sock.sendMessage(jid, { text: finalText }))?.key;
+          const sent = await sock.sendMessage(jid, { text: finalText });
           if (ECHO_TRACKER_ENABLED) echoTracker.track(finalText);
-          return sentKey;
+          console.log(JSON.stringify({
+            event: 'send_message_outbound',
+            kind: 'new_message',
+            jid,
+            len: finalText.length,
+            msg_id: sent?.key?.id || null,
+          }));
+          return sent?.key;
         };
 
         if (response && sock) {
@@ -1981,7 +2325,10 @@ async function startConnection() {
 
       } catch (err) {
         console.error(`[gateway] Forward/reply failed:`, err.message);
-        // Message stays processed=0 in DB — catch-up sweep will retry later
+        // release the processing lease so the next sweep
+        // cycle can retry this row immediately, instead of waiting for
+        // PROCESSING_LEASE_MS to expire. Message stays processed=0.
+        dbClearProcessing(msg.key.id);
       }
     }
   });
@@ -2067,7 +2414,14 @@ async function startConnection() {
   const GAP_DETECTION_INTERVAL_MS = 10 * 60 * 1000;  // check every 10 min
   const GAP_THRESHOLD_MS = 30 * 60 * 1000;            // 30 min silence = warning
 
-  const gapDetectionTimer = setInterval(() => {
+  // gapDetectionTimer is module-scoped so `cleanupSocket()`
+  // tears it down on every reconnect path (loggedOut, forbidden, normal
+  // reconnect, shutdown). Previously we registered a second
+  // `connection.update` listener just to clear it on close — that
+  // duplicated firing for every connection event. Module-scope + cleanup
+  // in cleanupSocket is single-source-of-truth.
+  if (gapDetectionTimer) clearInterval(gapDetectionTimer);
+  gapDetectionTimer = setInterval(() => {
     if (connStatus !== 'connected') return;
     const allLastSeen = stmtGetLastSeen.all();
     const now = Date.now();
@@ -2084,13 +2438,18 @@ async function startConnection() {
     }
   }, GAP_DETECTION_INTERVAL_MS);
 
-  // Clean up interval on socket close to prevent leaks on reconnect
-  sock.ev.on('connection.update', (update) => {
-    if (update.connection === 'close') {
-      clearInterval(gapDetectionTimer);
-    }
-  });
-
+  } catch (err) {
+    // `startConnection()` previously had only try/finally so any
+    // error in dynamic import / makeWASocket / auth load was swallowed and
+    // the operator saw a bot stuck on `connStatus = 'disconnected'` with no
+    // diagnostic. Surface it: log + status update + re-throw so callers
+    // (the `await startConnection()` sites in /login/start, /reset, etc)
+    // can surface it to the HTTP response instead of returning success.
+    console.error('[gateway] startConnection failed:', err && err.message ? err.message : err);
+    if (err && err.stack) console.error(err.stack);
+    connStatus = 'disconnected';
+    statusMessage = `Connection failed: ${err && err.message ? err.message : 'unknown'}`;
+    throw err;
   } finally {
     isConnecting = false;
   }
@@ -2132,6 +2491,9 @@ function getMediaDescriptor(innerMsg, senderName) {
 // ---------------------------------------------------------------------------
 const MAX_MEDIA_SIZE = 50 * 1024 * 1024; // 50MB limit
 const MEDIA_DOWNLOAD_TIMEOUT = 30_000;   // 30 seconds
+// pipeline-level cap so download retries + upload + transcript
+// can't stack to ~120s and block other inbound messages.
+const MEDIA_PIPELINE_TIMEOUT_MS = 90_000;
 
 // Cached Baileys downloadMediaMessage function (loaded on first use)
 let _downloadMediaMessage = null;
@@ -2744,17 +3106,41 @@ async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, 
 const CATCHUP_INTERVAL_MS = 5 * 60 * 1000;  // 5 minutes
 const CATCHUP_AGE_MS = 30_000;               // only messages older than 30s
 const CATCHUP_MAX_RETRIES = 3;
+// bound how many messages a single sweep cycle drains. With
+// the per-agent serializing mutex inside LibreFang, a 50-message backlog
+// previously took ~25 minutes of sequential LLM calls and starved live
+// traffic. The remainder is picked up by the next sweep tick.
+const CATCHUP_BATCH_SIZE = 8;
+// small inter-iteration delay so a backlog doesn't hammer
+// LibreFang at line-rate. 750ms is below human-perceptible reply latency
+// for the catch-up case (which is already late by definition) and gives
+// the kernel breathing room.
+const CATCHUP_INTER_DELAY_MS = 750;
+// how long the main handler can hold a `processing_since`
+// claim before the sweep treats it as expired (handler crashed without
+// releasing). 5 min covers a worst-case media-pipeline timeout (#21 cap
+// 90s) plus a comfortable margin for slow LLM forward.
+const PROCESSING_LEASE_MS = 5 * 60 * 1000;
 
 async function runCatchUpSweep() {
+  if (shuttingDown) return;
   if (connStatus !== 'connected' || !sock) return;
 
   const cutoff = Date.now() - CATCHUP_AGE_MS;
-  const unprocessed = dbGetUnprocessed(cutoff);
+  const leaseCutoff = Date.now() - PROCESSING_LEASE_MS;
+  const unprocessed = dbGetUnprocessed(cutoff, leaseCutoff, CATCHUP_BATCH_SIZE);
   if (unprocessed.length === 0) return;
 
-  console.log(`[gateway][catchup] Found ${unprocessed.length} unprocessed message(s), attempting re-forward...`);
+  console.log(`[gateway][catchup] Found ${unprocessed.length} unprocessed message(s) (batch cap ${CATCHUP_BATCH_SIZE}), attempting re-forward...`);
 
   for (const msg of unprocessed) {
+    // Bail mid-sweep on shutdown so a paused inter-iteration `setTimeout`
+    // doesn't resume into a `dbIncrRetryOrFail` / `dbSaveMessage` after
+    // `db.close()` runs in the `server.close` callback.
+    if (shuttingDown) {
+      console.log('[gateway][catchup] shutdown signaled mid-sweep — bailing out');
+      return;
+    }
     // Skip messages already at max retries (they'll be marked failed by dbIncrRetryOrFail)
     if (msg.retry_count >= CATCHUP_MAX_RETRIES) {
       dbIncrRetryOrFail(msg.id, CATCHUP_MAX_RETRIES);
@@ -2820,10 +3206,24 @@ async function runCatchUpSweep() {
       console.warn(`[gateway][catchup] Failed to re-forward message ${msg.id}: ${err.message}`);
       dbIncrRetryOrFail(msg.id, CATCHUP_MAX_RETRIES);
     }
+    // pace the sweep so the kernel's per-agent mutex isn't
+    // hammered at line-rate. `unref()` lets the event loop exit
+    // ~CATCHUP_INTER_DELAY_MS sooner during shutdown per pending iteration.
+    if (CATCHUP_INTER_DELAY_MS > 0) {
+      await new Promise((r) => {
+        const t = setTimeout(r, CATCHUP_INTER_DELAY_MS);
+        t.unref();
+      });
+    }
   }
 }
 
-setInterval(runCatchUpSweep, CATCHUP_INTERVAL_MS);
+// Both intervals are captured so gracefulShutdown can clear them
+// alongside the per-connection heartbeat / gap-detection timers.
+// Without these handles, an in-flight sweep mid-`await` could resume
+// and write to a closed db handle after `db.close()` runs, racing the
+// 10s force-exit timer.
+const catchUpInterval = setInterval(runCatchUpSweep, CATCHUP_INTERVAL_MS);
 
 // ---------------------------------------------------------------------------
 // DB Cleanup: delete old processed/failed messages (Fase 4.1)
@@ -2841,7 +3241,7 @@ function runDbCleanup() {
 
 // Run cleanup on startup (no-op if DB is fresh) and then daily
 runDbCleanup();
-setInterval(runDbCleanup, CLEANUP_INTERVAL_MS);
+const dbCleanupInterval = setInterval(runDbCleanup, CLEANUP_INTERVAL_MS);
 
 // ---------------------------------------------------------------------------
 // Send a message via Baileys (called by LibreFang for outgoing)
@@ -3172,11 +3572,24 @@ const server = http.createServer(async (req, res) => {
       return jsonResponse(req, res, 200, { jid, messages });
     }
 
-    // GET /health — health check
+    // GET /health — health check. `connStatus` alone reports
+    // a dead-socket scenario as healthy (TCP RST never delivered, ISP
+    // drops connection silently). Augment with a freshness check:
+    // `lastInboundAt` is touched on every received message + every
+    // heartbeat tick when the socket actually flushes events. If we
+    // haven't observed inbound activity for HEALTH_STALE_THRESHOLD_MS,
+    // we report `degraded` (HTTP 503) so external monitoring sees the
+    // problem before the watchdog forces a reconnect.
     if (req.method === 'GET' && path === '/health') {
-      return jsonResponse(req, res, 200, {
-        status: 'ok',
+      const stale =
+        connStatus === 'connected' &&
+        checkHeartbeat(Date.now(), lastInboundAt, HEALTH_STALE_THRESHOLD_MS);
+      const httpStatus = stale ? 503 : 200;
+      return jsonResponse(req, res, httpStatus, {
+        status: stale ? 'degraded' : 'ok',
         connected: connStatus === 'connected',
+        stale,
+        last_inbound_age_ms: connStatus === 'connected' ? Date.now() - lastInboundAt : null,
         session_id: sessionId || null,
         active_conversations: activeConversations.size,
       });
@@ -3254,19 +3667,43 @@ function gracefulShutdown(signal) {
   }, 10_000);
   forceExitTimer.unref();
 
-  // Tear down Baileys socket properly (fire-and-forget, we don't await).
-  // Log the error message if teardown fails — a silent catch would hide a
-  // broken Baileys shutdown in production.
-  cleanupSocket().catch(e =>
-    console.warn('[gateway] cleanupSocket error:', e?.message || e),
-  );
+  // Stop module-scope timers BEFORE we close the DB. Otherwise the next
+  // tick of `heartbeatInterval` / `gapDetectionTimer` / `runCatchUpSweep`
+  // / `runDbCleanup` races with `db.close()` and writes to a closed
+  // handle. The sweep can still be partway through an iteration when we
+  // get here — `shuttingDown` checked inside the loop body bails out
+  // before the next `dbIncrRetryOrFail` / `dbSaveMessage` call.
+  if (heartbeatInterval) {
+    clearInterval(heartbeatInterval);
+    heartbeatInterval = null;
+  }
+  if (gapDetectionTimer) {
+    clearInterval(gapDetectionTimer);
+    gapDetectionTimer = null;
+  }
+  clearInterval(catchUpInterval);
+  clearInterval(dbCleanupInterval);
 
   // Close HTTP server — forcibly drain all existing connections (Node.js 18.2+)
   if (server.closeAllConnections) {
     server.closeAllConnections();
   }
-  server.close(() => {
+  server.close(async () => {
+    // Await Baileys teardown so any in-flight write finishes before we
+    // checkpoint the DB. Logging the error so a broken shutdown is
+    // visible in production.
+    try {
+      await cleanupSocket();
+    } catch (e) {
+      console.warn('[gateway] cleanupSocket error:', e?.message || e);
+    }
     clearTimeout(forceExitTimer);
+    try {
+      db.pragma('wal_checkpoint(TRUNCATE)');
+      db.close();
+    } catch (err) {
+      console.warn('[gateway] db close failed:', err && err.message ? err.message : err);
+    }
     console.log('[gateway] Shutdown complete');
     process.exit(0);
   });

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@whiskeysockets/baileys": "^6",
     "better-sqlite3": "^12.8.0",
+    "link-preview-js": "^3.0.0",
     "pino": "^9",
     "qrcode": "^1.5",
     "toml": "^3.0.0"

--- a/packages/whatsapp-gateway/scripts/health-check.sh
+++ b/packages/whatsapp-gateway/scripts/health-check.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # WhatsApp Gateway Health Check
 #
+# Linux + PM2 only. Uses GNU `stat -c %s` (not BSD `stat -f %z`) and
+# `nslookup -timeout=3` (GNU resolver flag). Will not run as-is on a macOS
+# dev host; intended target is the production Linux box where pm2 manages
+# the gateway. If you need a macOS-runnable variant for local debugging,
+# fork it — don't paper over the differences inline.
+#
 # Designed to run every 5 minutes from an external scheduler (LibreFang cron
 # or system cron). Distinguishes between gateway-process failures (which a
 # restart can fix) and network/DNS failures (which a restart cannot fix), and
@@ -119,7 +125,13 @@ pm2_restart() {
     log "[health] pm2 binary not found in PATH"
     return 1
   fi
+  # `pm2 ... | while read` would let the pipeline's exit status drop pm2's
+  # real exit code (the `while`/`done` always returns 0) — the boolean
+  # signal callers may eventually want is then a lie. With `pipefail`
+  # already set at the top of the script, capture pm2's status via
+  # PIPESTATUS so the function returns a faithful success/failure.
   pm2 restart whatsapp-gateway 2>&1 | while read -r line; do log "[pm2] $line"; done
+  return "${PIPESTATUS[0]}"
 }
 
 write_flag() {

--- a/packages/whatsapp-gateway/scripts/health-check.sh
+++ b/packages/whatsapp-gateway/scripts/health-check.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# WhatsApp Gateway Health Check
+#
+# Designed to run every 5 minutes from an external scheduler (LibreFang cron
+# or system cron). Distinguishes between gateway-process failures (which a
+# restart can fix) and network/DNS failures (which a restart cannot fix), and
+# escalates to a flag file the agent can pick up.
+#
+# Behaviour summary:
+#   1. Heartbeat: every run writes /data/whatsapp-gateway/health-check.heartbeat
+#      so a missing heartbeat tells the agent the cron itself is dead.
+#   2. Quick check: GET /health with a short timeout. Healthy if HTTP 200 and
+#      connected:true. On success the failure counter and any flag are cleared.
+#   3. On failure: increment a persistent counter. Only attempt recovery when
+#      consecutive failures cross MIN_FAILURES_BEFORE_RECOVERY — this avoids
+#      thrashing on a single transient blip.
+#   4. Diagnose before restarting: if DNS resolution for web.whatsapp.com is
+#      broken, mark the failure as ENVIRONMENTAL and skip the PM2 restart
+#      (restarting won't fix DNS, and the surge of reconnects pollutes logs).
+#   5. Otherwise restart via PM2 once and re-check.
+#   6. After RECOVERY_GIVE_UP_FAILURES failures, write the flag file so the
+#      agent surfaces it to the operator on the next heartbeat.
+
+set -euo pipefail
+
+GATEWAY_DIR="${GATEWAY_DIR:-/data/whatsapp-gateway}"
+PORT="${WA_GATEWAY_PORT:-3009}"
+HEALTH_URL="http://localhost:${PORT}/health"
+HEALTH_TIMEOUT=5
+
+LOG_FILE="${GATEWAY_DIR}/logs/health.log"
+LOG_MAX_BYTES=$((1024 * 1024))            # 1 MiB before rotation (this script's own log)
+PM2_LOG_MAX_BYTES=$((10 * 1024 * 1024))   # 10 MiB before rotating pm2 stdout/stderr
+HEARTBEAT_FILE="${GATEWAY_DIR}/health-check.heartbeat"
+COUNTER_FILE="${GATEWAY_DIR}/health-check.failures"
+FLAG_FILE="${GATEWAY_DIR}/health-check-failed.flag"
+
+MIN_FAILURES_BEFORE_RECOVERY=2            # ~10 min of disruption
+RECOVERY_GIVE_UP_FAILURES=4               # ~20 min then escalate to agent
+RECOVERY_WAIT=15                          # seconds to let pm2 settle
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+  if [[ -f "$LOG_FILE" ]] && [[ "$(stat -c %s "$LOG_FILE" 2>/dev/null || echo 0)" -gt "$LOG_MAX_BYTES" ]]; then
+    mv -f "$LOG_FILE" "${LOG_FILE}.1" 2>/dev/null || true
+  fi
+  echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOG_FILE"
+}
+
+rotate_pm2_logs() {
+  # PM2 has no built-in rotation without the pm2-logrotate module. Rather than
+  # add another dependency, we cap pm2-error.log and pm2-out.log here. We keep
+  # one .1 backup so a recent crash trail survives one rotation.
+  local f
+  for f in "${GATEWAY_DIR}/logs/pm2-error.log" "${GATEWAY_DIR}/logs/pm2-out.log"; do
+    [[ -f "$f" ]] || continue
+    local size
+    size=$(stat -c %s "$f" 2>/dev/null || echo 0)
+    if (( size > PM2_LOG_MAX_BYTES )); then
+      cp -f "$f" "${f}.1" 2>/dev/null || true
+      : > "$f"
+      log "[rotate] truncated $(basename "$f") (was $size bytes)"
+    fi
+  done
+}
+
+read_counter() {
+  local v
+  v=$([[ -f "$COUNTER_FILE" ]] && cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+  # Guard against non-numeric content (manual edits, partial writes)
+  # — `set -e` would crash the failure-counter arithmetic otherwise.
+  [[ "$v" =~ ^[0-9]+$ ]] || v=0
+  echo "$v"
+}
+
+write_counter() {
+  echo "$1" > "$COUNTER_FILE"
+}
+
+clear_failure_state() {
+  rm -f "$COUNTER_FILE" "$FLAG_FILE"
+}
+
+check_health() {
+  local response http_code body
+  response=$(curl -s --max-time "$HEALTH_TIMEOUT" -o - -w '%{http_code}' "$HEALTH_URL" 2>/dev/null) || return 1
+  http_code="${response: -3}"
+  body="${response%???}"
+
+  if [[ "$http_code" != "200" ]]; then
+    log "[health] HTTP $http_code (expected 200)"
+    return 1
+  fi
+
+  if echo "$body" | grep -q '"connected"[[:space:]]*:[[:space:]]*true'; then
+    return 0
+  fi
+
+  log "[health] Gateway responded but connected != true"
+  return 1
+}
+
+dns_ok() {
+  # Returns 0 if web.whatsapp.com resolves. We try getent first (no extra deps),
+  # then nslookup as a fallback. If neither is present we assume DNS is fine
+  # rather than mis-diagnose.
+  if command -v getent >/dev/null 2>&1; then
+    getent hosts web.whatsapp.com >/dev/null 2>&1 && return 0 || return 1
+  fi
+  if command -v nslookup >/dev/null 2>&1; then
+    nslookup -timeout=3 web.whatsapp.com >/dev/null 2>&1 && return 0 || return 1
+  fi
+  return 0
+}
+
+pm2_restart() {
+  if ! command -v pm2 >/dev/null 2>&1; then
+    log "[health] pm2 binary not found in PATH"
+    return 1
+  fi
+  pm2 restart whatsapp-gateway 2>&1 | while read -r line; do log "[pm2] $line"; done
+}
+
+write_flag() {
+  local kind=$1
+  local pm2_status=""
+  if command -v pm2 >/dev/null 2>&1; then
+    pm2_status=$(pm2 describe whatsapp-gateway 2>&1 | head -40 || true)
+  fi
+  cat > "$FLAG_FILE" <<EOF
+timestamp=$(date -Iseconds)
+kind=$kind
+consecutive_failures=$(read_counter)
+port=$PORT
+gateway_dir=$GATEWAY_DIR
+pm2_status:
+$pm2_status
+EOF
+}
+
+# --- Main ---
+
+date -Iseconds > "$HEARTBEAT_FILE"
+rotate_pm2_logs
+
+# Emit the LibreFang cron pre_check_script gate. Default to "skip the agent
+# turn" — we only wake the agent if a flag file gets written below, in which
+# case we print an empty (or different) line and let the agent fire.
+emit_skip() { echo '{"wakeAgent": false}'; }
+
+if check_health; then
+  if [[ -f "$COUNTER_FILE" ]] || [[ -f "$FLAG_FILE" ]]; then
+    log "[health] Recovered after $(read_counter) consecutive failures"
+  fi
+  clear_failure_state
+  emit_skip
+  exit 0
+fi
+
+failures=$(($(read_counter) + 1))
+write_counter "$failures"
+log "[health] Health check failed (consecutive=$failures)"
+
+if (( failures < MIN_FAILURES_BEFORE_RECOVERY )); then
+  # First blip — wait one more cycle before reacting. Most disconnects are
+  # short and self-healing. Don't wake the agent yet either.
+  emit_skip
+  exit 0
+fi
+
+if ! dns_ok; then
+  # The gateway can't reach WhatsApp because the host can't resolve DNS.
+  # Restarting node won't fix that and just clutters the logs with retries.
+  log "[health] DNS resolution failed for web.whatsapp.com — environmental issue, skipping restart"
+  if (( failures >= RECOVERY_GIVE_UP_FAILURES )); then
+    write_flag dns-blackout
+    log "[health] Wrote flag file (kind=dns-blackout)"
+    # Wake the agent so the operator hears about it.
+    exit 1
+  fi
+  emit_skip
+  exit 1
+fi
+
+log "[health] Attempting PM2 restart"
+pm2_restart || true
+sleep "$RECOVERY_WAIT"
+
+if check_health; then
+  log "[health] Recovery succeeded after restart"
+  clear_failure_state
+  emit_skip
+  exit 0
+fi
+
+if (( failures >= RECOVERY_GIVE_UP_FAILURES )); then
+  write_flag restart-failed
+  log "[health] Wrote flag file (kind=restart-failed)"
+  # Wake the agent.
+  exit 1
+fi
+
+emit_skip
+exit 1


### PR DESCRIPTION
## Summary

Picks up #4759's resilience pass verbatim (cherry-picked from f-liva with attribution preserved on commit 1) and closes the residual `sendOrEdit` race that the prior round flagged.

## What lands here vs #4759

The streaming `onProgress` callback already snapshots `const localSock = sock` to guard against `cleanupSocket()` nulling the global mid-await. But `sendOrEdit` reverted to the global — and the final delivery edit/send runs AFTER the LLM stream completes, which is a much wider window for a concurrent reconnect than per-chunk progress. Same race, same symptoms (`Cannot read properties of null` at the `sendMessage` call, or send through a half-closed socket once cleanupSocket has fired).

This PR snapshots `sock` once at sendOrEdit entry, fails fast (returning the existing `streamMsgKey` so the user still sees the last visible chunk on WhatsApp), and uses the snapshot for both the edit branch and the new-message branch.

```js
const sendOrEdit = async (jid, finalText) => {
  const s = sock;
  if (!s) {
    console.warn(JSON.stringify({
      event: 'send_message_outbound',
      kind: 'sock_unavailable_at_send', jid, had_stream: Boolean(streamMsgKey),
    }));
    return streamMsgKey || null;
  }
  // ... rest uses `s` instead of `sock`
};
```

## Stand-down on the other prior-review items

After re-reading the PR HEAD (not just the diff slice):

- **`shuttingDown` declaration + `gracefulShutdown` toggle ARE present** (lines 3651 and 3660 on the PR head). The diff didn't surface them but they exist; the catch-up sweep's bail-out is real.
- **`reconnectAttempts = 0` IS reset on the `connection === 'open'` branch** (lines 1535 and 1566). No leak.

So the only blocker from the prior round is the `sendOrEdit` snapshot, which this PR fixes.

## Verification

- `node --test packages/whatsapp-gateway/index.test.js` — **132 pass / 2 fail**.
- The 2 failing tests (`forwardToLibreFang surfaces owner_notice via onOwnerNotice callback`, `LIBREFANG_DISPATCH_LOG=off silences forward_dispatch but HTTP still fires`) **fail identically with and without my edit** — confirmed by running with and without `git stash`. They appear to be a pre-existing mock-server flake (`ECONNRESET`) inherited from the cherry-picked PR base, unrelated to the `sendOrEdit` snapshot in any way (my change touches a closure inside the message handler, not the HTTP layer).

If those 2 are tracked as a known flake or shipped a follow-up to address the mock harness, please point me at it; otherwise happy to triage separately.

## Refs

Closes #4759.

## Test plan

- [x] `node --test packages/whatsapp-gateway/index.test.js` — 132/132 of the unrelated suites pass; my edit doesn't regress anything.
- [ ] Live WhatsApp soak (human-only, requires a paired session) to confirm `sock_unavailable_at_send` log fires under reconnect storms.