### PR TITLE
fix(channels,api): test fallback resolver for split email creds + regen schema golden (supersedes #4841)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2238,6 +2238,65 @@ fn read_token(env_var: &str, adapter_name: &str) -> Option<String> {
     }
 }
 
+#[cfg(feature = "channel-email")]
+#[derive(Debug)]
+pub(crate) struct EmailCredentials {
+    pub imap_username: String,
+    pub imap_password: String,
+    pub smtp_username: String,
+    pub smtp_password: String,
+}
+
+/// Resolve the four split-credential fields against an `EmailConfig`,
+/// returning `None` if either side's password env var fails to resolve.
+///
+/// Fallback order for each per-protocol field (`imap_username`,
+/// `smtp_username`, `imap_password_env`, `smtp_password_env`):
+///
+///   1. The protocol-specific override (`em_config.imap_username`, etc.)
+///   2. The shared default (`em_config.username` / `em_config.password_env`)
+///
+/// `read_env` is injected so tests can drive the env-lookup path
+/// without mutating shared process state. Production calls pass
+/// [`read_token`].
+#[cfg(feature = "channel-email")]
+pub(crate) fn resolve_email_credentials<F>(
+    em_config: &librefang_types::config::EmailConfig,
+    read_env: F,
+) -> Option<EmailCredentials>
+where
+    F: Fn(&str, &str) -> Option<String>,
+{
+    let imap_username = em_config
+        .imap_username
+        .as_deref()
+        .unwrap_or(&em_config.username)
+        .to_string();
+    let imap_password_env = em_config
+        .imap_password_env
+        .as_deref()
+        .unwrap_or(&em_config.password_env);
+    let imap_password = read_env(imap_password_env, "Email IMAP")?;
+
+    let smtp_username = em_config
+        .smtp_username
+        .as_deref()
+        .unwrap_or(&em_config.username)
+        .to_string();
+    let smtp_password_env = em_config
+        .smtp_password_env
+        .as_deref()
+        .unwrap_or(&em_config.password_env);
+    let smtp_password = read_env(smtp_password_env, "Email SMTP")?;
+
+    Some(EmailCredentials {
+        imap_username,
+        imap_password,
+        smtp_username,
+        smtp_password,
+    })
+}
+
 /// Start the channel bridge for all configured channels based on kernel config.
 ///
 /// Returns `Some(BridgeManager)` if any channels were configured and started,
@@ -2662,31 +2721,10 @@ pub async fn start_channel_bridge_with_config(
     // Email
     #[cfg(feature = "channel-email")]
     for em_config in config.email.iter() {
-        let imap_username = em_config
-            .imap_username
-            .as_deref()
-            .unwrap_or(&em_config.username)
-            .to_string();
-        let imap_password_env = em_config
-            .imap_password_env
-            .as_deref()
-            .unwrap_or(&em_config.password_env);
-        let imap_password = match read_token(imap_password_env, "Email IMAP") {
-            Some(p) => p,
-            None => continue,
-        };
-        let smtp_username = em_config
-            .smtp_username
-            .as_deref()
-            .unwrap_or(&em_config.username)
-            .to_string();
-        let smtp_password_env = em_config
-            .smtp_password_env
-            .as_deref()
-            .unwrap_or(&em_config.password_env);
-        let smtp_password = match read_token(smtp_password_env, "Email SMTP") {
-            Some(p) => p,
-            None => continue,
+        let Some(creds) = resolve_email_credentials(em_config, |env_var, adapter_name| {
+            read_token(env_var, adapter_name)
+        }) else {
+            continue;
         };
         let adapter = Arc::new(
             EmailAdapter::new(
@@ -2694,10 +2732,10 @@ pub async fn start_channel_bridge_with_config(
                 em_config.imap_port,
                 em_config.smtp_host.clone(),
                 em_config.smtp_port,
-                imap_username,
-                imap_password,
-                smtp_username,
-                smtp_password,
+                creds.imap_username,
+                creds.imap_password,
+                creds.smtp_username,
+                creds.smtp_password,
                 em_config.poll_interval_secs,
                 em_config.folders.clone(),
                 em_config.allowed_senders.clone(),
@@ -4581,5 +4619,158 @@ mod tests {
         assert_eq!(bus.dropped_count(), 5);
         bus.record_consumer_lag(3, "test-context");
         assert_eq!(bus.dropped_count(), 8);
+    }
+
+    // -- resolve_email_credentials: split-creds fallback semantics ----------
+    //
+    // Pins the four fallback paths in EmailConfig:
+    //   imap_username      -> falls back to em_config.username
+    //   imap_password_env  -> falls back to em_config.password_env
+    //   smtp_username      -> falls back to em_config.username
+    //   smtp_password_env  -> falls back to em_config.password_env
+    //
+    // Production wires `read_token` (which reads `std::env::var`); these
+    // tests inject a closure-based env lookup so they don't mutate
+    // shared process state and are race-free under cargo test's
+    // multi-threaded harness.
+
+    #[cfg(feature = "channel-email")]
+    use super::resolve_email_credentials;
+    #[cfg(feature = "channel-email")]
+    use librefang_types::config::EmailConfig;
+
+    #[cfg(feature = "channel-email")]
+    fn email_base() -> EmailConfig {
+        EmailConfig {
+            imap_host: "imap.example.com".to_string(),
+            imap_port: 993,
+            smtp_host: "smtp.example.com".to_string(),
+            smtp_port: 587,
+            username: "shared@example.com".to_string(),
+            password_env: "SHARED_PASSWORD".to_string(),
+            ..EmailConfig::default()
+        }
+    }
+
+    /// Both passwords resolve from the shared `password_env` when no
+    /// per-protocol overrides are set; usernames inherit `username`.
+    #[cfg(feature = "channel-email")]
+    #[test]
+    fn shared_credentials_resolve_to_same_password_for_both_sides() {
+        let cfg = email_base();
+        let creds = resolve_email_credentials(&cfg, |env, _| {
+            (env == "SHARED_PASSWORD").then(|| "shared-secret".to_string())
+        })
+        .expect("must resolve when shared password env is set");
+        assert_eq!(creds.imap_username, "shared@example.com");
+        assert_eq!(creds.smtp_username, "shared@example.com");
+        assert_eq!(creds.imap_password, "shared-secret");
+        assert_eq!(creds.smtp_password, "shared-secret");
+    }
+
+    /// `imap_username = Some(...)` overrides the shared username on the
+    /// IMAP side only; SMTP still falls back to `username`.
+    #[cfg(feature = "channel-email")]
+    #[test]
+    fn imap_username_override_does_not_leak_into_smtp_side() {
+        let mut cfg = email_base();
+        cfg.imap_username = Some("imap-user@example.com".to_string());
+        let creds =
+            resolve_email_credentials(&cfg, |_, _| Some("p".to_string())).expect("must resolve");
+        assert_eq!(creds.imap_username, "imap-user@example.com");
+        assert_eq!(creds.smtp_username, "shared@example.com");
+    }
+
+    /// `smtp_username = Some(...)` overrides on SMTP side only.
+    #[cfg(feature = "channel-email")]
+    #[test]
+    fn smtp_username_override_does_not_leak_into_imap_side() {
+        let mut cfg = email_base();
+        cfg.smtp_username = Some("smtp-user@example.com".to_string());
+        let creds =
+            resolve_email_credentials(&cfg, |_, _| Some("p".to_string())).expect("must resolve");
+        assert_eq!(creds.smtp_username, "smtp-user@example.com");
+        assert_eq!(creds.imap_username, "shared@example.com");
+    }
+
+    /// Per-protocol password env overrides resolve through DIFFERENT
+    /// secrets — pin against a regression where both sides accidentally
+    /// share the same fallback variable.
+    #[cfg(feature = "channel-email")]
+    #[test]
+    fn per_protocol_password_envs_resolve_independently() {
+        let mut cfg = email_base();
+        cfg.imap_password_env = Some("IMAP_SECRET".to_string());
+        cfg.smtp_password_env = Some("SMTP_SECRET".to_string());
+        let creds = resolve_email_credentials(&cfg, |env, _| match env {
+            "IMAP_SECRET" => Some("imap-pw".to_string()),
+            "SMTP_SECRET" => Some("smtp-pw".to_string()),
+            _ => None,
+        })
+        .expect("must resolve");
+        assert_eq!(creds.imap_password, "imap-pw");
+        assert_eq!(creds.smtp_password, "smtp-pw");
+    }
+
+    /// IMAP-specific override resolves; SMTP falls back to `password_env`.
+    #[cfg(feature = "channel-email")]
+    #[test]
+    fn imap_password_override_smtp_falls_back_to_shared() {
+        let mut cfg = email_base();
+        cfg.imap_password_env = Some("IMAP_SECRET".to_string());
+        let creds = resolve_email_credentials(&cfg, |env, _| match env {
+            "IMAP_SECRET" => Some("imap-pw".to_string()),
+            "SHARED_PASSWORD" => Some("shared-pw".to_string()),
+            _ => None,
+        })
+        .expect("must resolve");
+        assert_eq!(creds.imap_password, "imap-pw");
+        assert_eq!(creds.smtp_password, "shared-pw");
+    }
+
+    /// If the IMAP password resolution yields `None` (env var missing
+    /// or empty), the entire adapter is skipped — `None` is returned
+    /// short-circuit BEFORE the SMTP side is consulted.
+    #[cfg(feature = "channel-email")]
+    #[test]
+    fn missing_imap_password_short_circuits_to_none() {
+        use std::cell::Cell;
+        let cfg = email_base();
+        let lookups = Cell::new(0_u32);
+        let result = resolve_email_credentials(&cfg, |env, _| {
+            lookups.set(lookups.get() + 1);
+            // Both sides default to "SHARED_PASSWORD"; returning None
+            // here forces the IMAP `?` to short-circuit.
+            let _ = env;
+            None
+        });
+        assert!(result.is_none(), "missing password must yield None");
+        assert_eq!(
+            lookups.get(),
+            1,
+            "SMTP-side lookup must NOT run after IMAP fails — short-circuit via the `?` operator on the first read_env call"
+        );
+    }
+
+    /// Smoke test for the silent-skip-on-empty case my comment flagged:
+    /// when `password_env = ""` (operator wiped it intending the
+    /// per-protocol fields to take over) and only one side is
+    /// configured, the OTHER side hits the empty fallback and the
+    /// adapter is skipped. Surfaces clearly via `None`.
+    #[cfg(feature = "channel-email")]
+    #[test]
+    fn empty_shared_password_env_with_single_side_override_skips_adapter() {
+        let mut cfg = email_base();
+        cfg.password_env = String::new();
+        cfg.imap_password_env = Some("IMAP_SECRET".to_string());
+        // SMTP side has neither override nor a usable shared env.
+        let result = resolve_email_credentials(&cfg, |env, _| match env {
+            "IMAP_SECRET" => Some("imap-pw".to_string()),
+            _ => None, // empty `password_env` looks up "" and gets None
+        });
+        assert!(
+            result.is_none(),
+            "operator must set BOTH per-protocol envs when wiping the shared one"
+        );
     }
 }

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2662,27 +2662,53 @@ pub async fn start_channel_bridge_with_config(
     // Email
     #[cfg(feature = "channel-email")]
     for em_config in config.email.iter() {
-        if let Some(password) = read_token(&em_config.password_env, "Email") {
-            let adapter = Arc::new(
-                EmailAdapter::new(
-                    em_config.imap_host.clone(),
-                    em_config.imap_port,
-                    em_config.smtp_host.clone(),
-                    em_config.smtp_port,
-                    em_config.username.clone(),
-                    password,
-                    em_config.poll_interval_secs,
-                    em_config.folders.clone(),
-                    em_config.allowed_senders.clone(),
-                )
-                .with_account_id(em_config.account_id.clone()),
-            );
-            adapters.push((
-                adapter,
-                em_config.default_agent.clone(),
-                em_config.account_id.clone(),
-            ));
-        }
+        let imap_username = em_config
+            .imap_username
+            .as_deref()
+            .unwrap_or(&em_config.username)
+            .to_string();
+        let imap_password_env = em_config
+            .imap_password_env
+            .as_deref()
+            .unwrap_or(&em_config.password_env);
+        let imap_password = match read_token(imap_password_env, "Email IMAP") {
+            Some(p) => p,
+            None => continue,
+        };
+        let smtp_username = em_config
+            .smtp_username
+            .as_deref()
+            .unwrap_or(&em_config.username)
+            .to_string();
+        let smtp_password_env = em_config
+            .smtp_password_env
+            .as_deref()
+            .unwrap_or(&em_config.password_env);
+        let smtp_password = match read_token(smtp_password_env, "Email SMTP") {
+            Some(p) => p,
+            None => continue,
+        };
+        let adapter = Arc::new(
+            EmailAdapter::new(
+                em_config.imap_host.clone(),
+                em_config.imap_port,
+                em_config.smtp_host.clone(),
+                em_config.smtp_port,
+                imap_username,
+                imap_password,
+                smtp_username,
+                smtp_password,
+                em_config.poll_interval_secs,
+                em_config.folders.clone(),
+                em_config.allowed_senders.clone(),
+            )
+            .with_account_id(em_config.account_id.clone()),
+        );
+        adapters.push((
+            adapter,
+            em_config.default_agent.clone(),
+            em_config.account_id.clone(),
+        ));
     }
 
     // Teams

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -2699,12 +2699,26 @@
           "description": "IMAP server host.",
           "type": "string"
         },
+        "imap_password_env": {
+          "description": "Env var for IMAP-specific password (falls back to `password_env` if not set).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "imap_port": {
           "default": 993,
           "description": "IMAP port (993 for TLS).",
           "format": "uint16",
           "minimum": 0.0,
           "type": "integer"
+        },
+        "imap_username": {
+          "description": "IMAP-specific username (falls back to `username` if not set).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "overrides": {
           "allOf": [
@@ -2760,12 +2774,26 @@
           "description": "SMTP server host.",
           "type": "string"
         },
+        "smtp_password_env": {
+          "description": "Env var for SMTP-specific password (falls back to `password_env` if not set).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "smtp_port": {
           "default": 587,
           "description": "SMTP port (587 for STARTTLS).",
           "format": "uint16",
           "minimum": 0.0,
           "type": "integer"
+        },
+        "smtp_username": {
+          "description": "SMTP-specific username (falls back to `username` if not set).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "username": {
           "default": "",
@@ -6258,12 +6286,26 @@
               "description": "IMAP server host.",
               "type": "string"
             },
+            "imap_password_env": {
+              "description": "Env var for IMAP-specific password (falls back to `password_env` if not set).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "imap_port": {
               "default": 993,
               "description": "IMAP port (993 for TLS).",
               "format": "uint16",
               "minimum": 0.0,
               "type": "integer"
+            },
+            "imap_username": {
+              "description": "IMAP-specific username (falls back to `username` if not set).",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "overrides": {
               "allOf": [
@@ -6319,12 +6361,26 @@
               "description": "SMTP server host.",
               "type": "string"
             },
+            "smtp_password_env": {
+              "description": "Env var for SMTP-specific password (falls back to `password_env` if not set).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "smtp_port": {
               "default": 587,
               "description": "SMTP port (587 for STARTTLS).",
               "format": "uint16",
               "minimum": 0.0,
               "type": "integer"
+            },
+            "smtp_username": {
+              "description": "SMTP-specific username (falls back to `username` if not set).",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "username": {
               "default": "",

--- a/crates/librefang-channels/src/email.rs
+++ b/crates/librefang-channels/src/email.rs
@@ -52,10 +52,14 @@ pub struct EmailAdapter {
     smtp_host: String,
     /// SMTP port (587 for STARTTLS, 465 for implicit TLS).
     smtp_port: u16,
-    /// Email address (used for both IMAP and SMTP).
-    username: String,
-    /// SECURITY: Password is zeroized on drop.
-    password: Zeroizing<String>,
+    /// IMAP username (may differ from SMTP username).
+    imap_username: String,
+    /// SECURITY: IMAP password is zeroized on drop.
+    imap_password: Zeroizing<String>,
+    /// SMTP username (may differ from IMAP username).
+    smtp_username: String,
+    /// SECURITY: SMTP password is zeroized on drop.
+    smtp_password: Zeroizing<String>,
     /// How often to check for new emails.
     poll_interval: Duration,
     /// Which IMAP folders to monitor.
@@ -84,8 +88,10 @@ impl EmailAdapter {
         imap_port: u16,
         smtp_host: String,
         smtp_port: u16,
-        username: String,
-        password: String,
+        imap_username: String,
+        imap_password: String,
+        smtp_username: String,
+        smtp_password: String,
         poll_interval_secs: u64,
         folders: Vec<String>,
         allowed_senders: Vec<String>,
@@ -96,8 +102,10 @@ impl EmailAdapter {
             imap_port,
             smtp_host,
             smtp_port,
-            username,
-            password: Zeroizing::new(password),
+            imap_username,
+            imap_password: Zeroizing::new(imap_password),
+            smtp_username,
+            smtp_password: Zeroizing::new(smtp_password),
             poll_interval: Duration::from_secs(poll_interval_secs),
             folders: if folders.is_empty() {
                 vec!["INBOX".to_string()]
@@ -176,7 +184,10 @@ impl EmailAdapter {
             );
         }
 
-        let creds = Credentials::new(self.username.clone(), self.password.as_str().to_string());
+        let creds = Credentials::new(
+            self.smtp_username.clone(),
+            self.smtp_password.as_str().to_string(),
+        );
 
         let transport = if self.smtp_port == 465 {
             // Implicit TLS (port 465)
@@ -523,8 +534,8 @@ impl ChannelAdapter for EmailAdapter {
         let poll_interval = self.poll_interval;
         let imap_host = self.imap_host.clone();
         let imap_port = self.imap_port;
-        let username = self.username.clone();
-        let password = self.password.clone();
+        let username = self.imap_username.clone();
+        let password = self.imap_password.clone();
         let folders = self.folders.clone();
         let allowed_senders = self.allowed_senders.clone();
         let mut shutdown_rx = self.shutdown_rx.clone();
@@ -689,9 +700,9 @@ impl ChannelAdapter for EmailAdapter {
                     .map_err(|e| format!("Invalid recipient email '{}': {}", to_addr, e))?;
 
                 let from_mailbox: Mailbox = self
-                    .username
+                    .smtp_username
                     .parse()
-                    .map_err(|e| format!("Invalid sender email '{}': {}", self.username, e))?;
+                    .map_err(|e| format!("Invalid sender email '{}': {}", self.smtp_username, e))?;
 
                 // Extract subject from text body convention: "Subject: ...\n\n..."
                 let (subject, body) = if text.starts_with("Subject: ") {
@@ -771,6 +782,8 @@ mod tests {
             587,
             "user@gmail.com".to_string(),
             "password".to_string(),
+            "user@gmail.com".to_string(),
+            "password".to_string(),
             30,
             vec![],
             vec![],
@@ -788,6 +801,8 @@ mod tests {
             587,
             "bot@example.com".to_string(),
             "pass".to_string(),
+            "bot@example.com".to_string(),
+            "pass".to_string(),
             30,
             vec![],
             vec!["boss@company.com".to_string()],
@@ -800,6 +815,8 @@ mod tests {
             993,
             "smtp.example.com".to_string(),
             587,
+            "bot@example.com".to_string(),
+            "pass".to_string(),
             "bot@example.com".to_string(),
             "pass".to_string(),
             30,
@@ -962,6 +979,8 @@ mod tests {
             587,
             "bot@example.com".to_string(),
             "password".to_string(),
+            "bot@example.com".to_string(),
+            "password".to_string(),
             30,
             vec![],
             vec![],
@@ -1089,6 +1108,8 @@ mod tests {
             993,
             host,
             port,
+            "bot@example.com".to_string(),
+            "password".to_string(),
             "bot@example.com".to_string(),
             "password".to_string(),
             30,

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -6198,6 +6198,18 @@ pub struct EmailConfig {
     pub username: String,
     /// Env var name holding the password.
     pub password_env: String,
+    /// IMAP-specific username (falls back to `username` if not set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imap_username: Option<String>,
+    /// Env var for IMAP-specific password (falls back to `password_env` if not set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imap_password_env: Option<String>,
+    /// SMTP-specific username (falls back to `username` if not set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smtp_username: Option<String>,
+    /// Env var for SMTP-specific password (falls back to `password_env` if not set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smtp_password_env: Option<String>,
     /// Poll interval in seconds.
     pub poll_interval_secs: u64,
     /// IMAP folders to monitor.
@@ -6225,6 +6237,10 @@ impl Default for EmailConfig {
             smtp_port: 587,
             username: String::new(),
             password_env: "EMAIL_PASSWORD".to_string(),
+            imap_username: None,
+            imap_password_env: None,
+            smtp_username: None,
+            smtp_password_env: None,
             poll_interval_secs: 30,
             folders: vec!["INBOX".to_string()],
             allowed_senders: vec![],


### PR DESCRIPTION
## Summary

Picks up #4841's IMAP/SMTP credential split verbatim (cherry-picked from DaBlitzStein with attribution preserved on commit 1) and adds the test coverage + schema-golden regen the prior round flagged.

## What lands here vs #4841

### 1. `resolve_email_credentials` extracted and unit-tested

The shipped PR's whole fallback story lives inline in `start_channel_bridge_with_config`'s `for em_config in config.email.iter()` loop, and was untested. A regression where `imap_username` accidentally resolved through `smtp_username`'s fallback (or vice versa) would land silently.

The resolver is now a pure function with an injected env-lookup closure — production wires `read_token`, tests inject a closure to avoid mutating shared `std::env::var` state under `cargo test`'s multi-threaded harness.

Seven tests pin every branch:

| Test | Asserts |
|---|---|
| `shared_credentials_resolve_to_same_password_for_both_sides` | both sides resolve to the shared `password_env` when no per-protocol overrides |
| `imap_username_override_does_not_leak_into_smtp_side` | `imap_username = Some(...)` overrides only IMAP |
| `smtp_username_override_does_not_leak_into_imap_side` | `smtp_username = Some(...)` overrides only SMTP |
| `per_protocol_password_envs_resolve_independently` | distinct `IMAP_SECRET` / `SMTP_SECRET` resolve to distinct values |
| `imap_password_override_smtp_falls_back_to_shared` | partial override + shared fallback combo |
| `missing_imap_password_short_circuits_to_none` | IMAP `?` short-circuits BEFORE the SMTP lookup runs (pinned via `Cell<u32>` invocation counter) |
| `empty_shared_password_env_with_single_side_override_skips_adapter` | silent-skip case my prior comment flagged: `password_env = ""` + only one per-protocol override → adapter skipped |

### 2. Nit cleanup

`match read_token(...) { Some(p) => p, None => continue }` collapsed to `let Some(creds) = resolve_email_credentials(...) else { continue };` — one early-return instead of two.

### 3. Regenerate `kernel_config_schema.golden.json`

Per `crates/librefang-types/CLAUDE.md`, any change to a `KernelConfig`-reachable field must regenerate the kernel-config golden fixture. The four new `Option<String>` fields on `EmailConfig` (`imap_username`, `imap_password_env`, `smtp_username`, `smtp_password_env`) needed to land in the fixture or the schema-drift check goes stale. +56 lines covering the four new properties.

## Verification

- `cargo check -p librefang-api --features channel-email` — clean.
- `cargo clippy -p librefang-api --all-targets --features channel-email -- -D warnings` — clean (one unrelated upstream `imap-proto` future-incompat warning, not introduced by this PR).
- `cargo fmt --check -p librefang-api` — clean.
- `cargo test -p librefang-api --lib --features channel-email -- channel_bridge::tests::` — **39/39 pass** (7 new + 32 inherited).
- `cargo test -p librefang-api --test config_schema_golden -- --ignored regenerate_golden` — fixture rewritten cleanly.

Closes #4841.