### PR TITLE
fix(kernel): persist Paused state immediately at pause-transition site

### DIFF
--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -1689,6 +1689,16 @@ impl WorkflowEngine {
                 None
             };
             if let Some(pause) = pending_pause {
+                // Persist the Paused state immediately. Without this, a
+                // SIGKILL between here and the end-of-execute_run batch
+                // persist would lose the resume_token — the contract
+                // handed to the operator on a pause-for-approval flow.
+                // Mirrors the create_run / recover_stale_running_runs
+                // wiring; remaining per-step Failed/Completed
+                // transitions are tracked separately (see PR body).
+                if let Some(run) = self.runs.get(&run_id) {
+                    self.upsert_run_to_store(&run);
+                }
                 info!(
                     run_id = %run_id,
                     resume_step = i,


### PR DESCRIPTION
## Summary

Wires `upsert_run_to_store` at the pause-transition site in `execute_run_sequential`. This is the follow-up to #4849 that the original PR's review surfaced — but the fix was pushed *after* #4849 merged, so it never landed. Reposting as a fresh PR.

## The gap

#4849 wired per-transition upsert at `create_run` (Pending durability) and `recover_stale_running_runs` (recovered-Failed durability), but did NOT wire it at the pause-transition site in `execute_run_sequential`. Without per-row upsert here, a SIGKILL between the in-memory `run.state = Paused {...}` mutation and the eventual end-of-`execute_run` batch persist loses the `resume_token` — the contract handed to the operator on a pause-for-approval flow.

This is the same crash-window argument #4849 makes for Pending; pause is arguably a stronger durability case because the resume_token is the operator's only handle on a paused run.

## The fix

In `crates/librefang-kernel/src/workflow.rs:~1628`, immediately after the run transitions to `Paused`:

```rust
if let Some(pause) = pending_pause {
    // Persist the Paused state immediately. Without this, a SIGKILL
    // between here and the end-of-execute_run batch persist would lose
    // the resume_token — the contract handed to the operator on a
    // pause-for-approval flow.
    if let Some(run) = self.runs.get(&run_id) {
        self.upsert_run_to_store(&run);
    }
    info!(...);
    return Ok(current_input);
}
```

10 lines, mirrors the wiring pattern from #4849.

## Out of scope

The remaining per-step `Failed`/`Completed` transitions (lines 1584, 1680, 1693, 1817, 1906, 2029, 2089, 2228 / 1932, 2248) still rely on the end-of-`execute_run` batch persist. Wiring all of them inline would creep through the codebase; the right fix is a `transition_state(run_id, |run| { ... })` helper that does in-memory mutate + immediate upsert + WAL checkpoint as one operation. Tracked for a separate refactor PR — too invasive to bundle here without making this a kernel-loop rewrite.

## Verification

- `cargo check -p librefang-kernel` — clean.
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings` — clean (via pre-push hook).
- `cargo fmt --check -p librefang-kernel` — clean.
- `cargo test -p librefang-kernel --lib workflow::` — 73/73 pass (no new tests added; the existing `paused_run_round_trips_through_persist_and_load` already covers the load-side; this PR closes the WRITE-side crash window via the same DashMap → SQLite path the helper has been doing for create_run since #4849).

Refs #4849.