### PR TITLE
fix(api): redirect dashboard login to / instead of /dashboard (#4860)

### DIFF
--- a/crates/librefang-api/src/login_page.html
+++ b/crates/librefang-api/src/login_page.html
@@ -106,9 +106,16 @@
         var d = res.data || {};
         if (d.ok && d.token) {
           try { localStorage.setItem('librefang-api-key', d.token); } catch (e) {}
-          // Preserve the original destination when possible.
-          var target = location.pathname + location.search + location.hash;
-          if (!target || target === '/') target = '/dashboard/';
+          // Preserve the original destination when possible. The SPA shell is
+          // served at `/`, not `/dashboard` or `/dashboard/` — those paths only
+          // exist to host the inline login page (and SPA build assets under
+          // `/dashboard/<asset>`), so redirecting back to them lands on a 404.
+          // See #4860.
+          var path = location.pathname;
+          var target = path + location.search + location.hash;
+          if (!path || path === '/' || path === '/dashboard' || path === '/dashboard/') {
+            target = '/';
+          }
           location.replace(target);
           return;
         }

--- a/crates/librefang-api/src/login_page.html
+++ b/crates/librefang-api/src/login_page.html
@@ -110,10 +110,12 @@
           // served at `/`, not `/dashboard` or `/dashboard/` — those paths only
           // exist to host the inline login page (and SPA build assets under
           // `/dashboard/<asset>`), so redirecting back to them lands on a 404.
-          // See #4860.
+          // We intentionally drop search/hash on the collapse branch: those
+          // URLs were 404s pre-fix, so any `?foo=bar#x` on them is not
+          // meaningful application state worth preserving. See #4860.
           var path = location.pathname;
           var target = path + location.search + location.hash;
-          if (!path || path === '/' || path === '/dashboard' || path === '/dashboard/') {
+          if (path === '/' || path === '/dashboard' || path === '/dashboard/') {
             target = '/';
           }
           location.replace(target);

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -2715,4 +2715,22 @@ mod tests {
             );
         }
     }
+
+    /// Regression for #4860: the inline login page must redirect to `/`
+    /// (the SPA shell) when it was itself served at `/`, `/dashboard`, or
+    /// `/dashboard/`. The router only registers `/` and
+    /// `/dashboard/{*path}`, so redirecting back to `/dashboard` or
+    /// `/dashboard/` after a successful sign-in lands on a 404.
+    #[test]
+    fn login_page_redirects_dashboard_root_to_spa_shell() {
+        let html = super::LOGIN_PAGE_HTML;
+        assert!(
+            html.contains("path === '/dashboard'") && html.contains("path === '/dashboard/'"),
+            "login page must collapse /dashboard and /dashboard/ to the SPA shell at /"
+        );
+        assert!(
+            !html.contains("target = '/dashboard/';"),
+            "login page must not redirect to /dashboard/ — that path 404s (#4860)"
+        );
+    }
 }

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -2724,9 +2724,13 @@ mod tests {
     #[test]
     fn login_page_redirects_dashboard_root_to_spa_shell() {
         let html = super::LOGIN_PAGE_HTML;
+        // Pin the full collapse condition so neither the bare `/dashboard`
+        // case nor the trailing-slash case can be silently dropped — a
+        // substring like `path === '/dashboard'` would also match
+        // `path === '/dashboard/'` and let one half regress unnoticed.
         assert!(
-            html.contains("path === '/dashboard'") && html.contains("path === '/dashboard/'"),
-            "login page must collapse /dashboard and /dashboard/ to the SPA shell at /"
+            html.contains("path === '/dashboard' || path === '/dashboard/'"),
+            "login page must collapse both /dashboard and /dashboard/ to the SPA shell at /"
         );
         assert!(
             !html.contains("target = '/dashboard/';"),


### PR DESCRIPTION
## Summary

Fixes #4860 — the inline login page (`login_page.html`) served when `dashboard_user`/`dashboard_pass` is configured used to redirect to `/dashboard/` after a successful sign-in, which 404s. The router only registers `/` (the SPA shell) and `/dashboard/{*path}` (build assets); plain `/dashboard` and `/dashboard/` never resolve to the React app.

- `crates/librefang-api/src/login_page.html` — when the login page is served at `/`, `/dashboard`, or `/dashboard/`, redirect to `/` after sign-in. Deep-links into `/dashboard/<sub-path>` are preserved unchanged and still resolve via the existing SPA fallback in `react_asset`.
- `crates/librefang-api/src/middleware.rs` — adds a regression unit test (`login_page_redirects_dashboard_root_to_spa_shell`) asserting the embedded HTML contains the new branch and no longer points at the broken `/dashboard/` target.

## Verification

- `cargo check --workspace --lib` — passed
- `cargo clippy -p librefang-api --lib -- -D warnings` — passed
- `cargo test -p librefang-api --lib login_page_redirects` — 1 passed

The redirect logic itself is JS, so behavioral end-to-end coverage of the success path requires a real browser; the regression test pins the embedded HTML so a future revert breaks the build instead of users.

## Test plan
- [ ] Configure `dashboard_user` / `dashboard_pass`, restart daemon
- [ ] Browse to `http://127.0.0.1:4545/dashboard`, sign in → lands on `/` (SPA shell), no 404
- [ ] Browse to `http://127.0.0.1:4545/`, sign in → lands on `/`, no 404
- [ ] Browse to `http://127.0.0.1:4545/dashboard/config/general` (deep-link), sign in → lands on the same path, SPA renders