### PR TITLE
feat(channels): multi-instance management from the dashboard (#4837)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -129,6 +129,9 @@ export interface ChannelItem {
   name: string;
   display_name?: string;
   configured?: boolean;
+  /** Number of `[[channels.<name>]]` instances currently configured (#4837).
+   *  `0` means no instances; `1` matches the legacy single-instance shape. */
+  instance_count?: number;
   has_token?: boolean;
   category?: string;
   description?: string;
@@ -146,6 +149,26 @@ export interface ChannelItem {
    *  the `channel` column. Surfaced as the `kind · N msgs/24h`
    *  meta-line on the Channels page card. */
   msgs_24h?: number;
+}
+
+/** One configured `[[channels.<name>]]` instance. (#4837) */
+export interface ChannelInstance {
+  /** Array index — stable within a session, may shift after a delete.
+   *  Always re-fetch the list after a mutation. */
+  index: number;
+  /** Field schema with per-instance `value` and `has_value` populated. */
+  fields: ChannelField[];
+  /** Raw per-instance config map keyed by field. */
+  config: Record<string, unknown>;
+  /** True iff every required secret env var (the env var the instance's
+   *  field points at) is present and non-empty. */
+  has_token: boolean;
+}
+
+export interface ChannelInstancesResponse {
+  channel: string;
+  items: ChannelInstance[];
+  total: number;
 }
 
 export interface SkillItem {
@@ -1686,6 +1709,47 @@ export async function configureChannel(channelName: string, config: Record<strin
 
 export async function reloadChannels(): Promise<ApiActionResponse> {
   return post<ApiActionResponse>("/api/channels/reload", {});
+}
+
+// Per-instance channel management (#4837).
+//
+// The legacy `configureChannel` overwrites the single `[channels.<name>]`
+// section. The four functions below let the dashboard manage individual
+// `[[channels.<name>]]` array entries — supporting multiple Telegram bots,
+// Slack workspaces, etc. on the same channel type.
+
+export async function listChannelInstances(channelName: string): Promise<ChannelInstancesResponse> {
+  return get<ChannelInstancesResponse>(
+    `/api/channels/${encodeURIComponent(channelName)}/instances`,
+  );
+}
+
+export async function createChannelInstance(
+  channelName: string,
+  fields: Record<string, unknown>,
+): Promise<{ index: number; activated: boolean; started_channels: string[] }> {
+  return post<{ index: number; activated: boolean; started_channels: string[] }>(
+    `/api/channels/${encodeURIComponent(channelName)}/instances`,
+    { fields },
+  );
+}
+
+export async function updateChannelInstance(
+  channelName: string,
+  index: number,
+  fields: Record<string, unknown>,
+): Promise<{ index: number; activated: boolean; started_channels: string[] }> {
+  return put<{ index: number; activated: boolean; started_channels: string[] }>(
+    `/api/channels/${encodeURIComponent(channelName)}/instances/${index}`,
+    { fields },
+  );
+}
+
+export async function deleteChannelInstance(
+  channelName: string,
+  index: number,
+): Promise<void> {
+  await del<void>(`/api/channels/${encodeURIComponent(channelName)}/instances/${index}`);
 }
 
 export interface QrStartResponse {

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -163,6 +163,10 @@ export interface ChannelInstance {
   /** True iff every required secret env var (the env var the instance's
    *  field points at) is present and non-empty. */
   has_token: boolean;
+  /** Compare-and-swap token. Send back unchanged on PUT/DELETE so the
+   *  server can reject the write if a concurrent edit shifted indices
+   *  or modified this instance after the list was read (#4865). */
+  signature: string;
 }
 
 export interface ChannelInstancesResponse {
@@ -1738,18 +1742,24 @@ export async function updateChannelInstance(
   channelName: string,
   index: number,
   fields: Record<string, unknown>,
+  signature: string,
+  clearSecrets?: string[],
 ): Promise<{ index: number; activated: boolean; started_channels: string[] }> {
+  const body: Record<string, unknown> = { fields, signature };
+  if (clearSecrets && clearSecrets.length > 0) body.clear_secrets = clearSecrets;
   return put<{ index: number; activated: boolean; started_channels: string[] }>(
     `/api/channels/${encodeURIComponent(channelName)}/instances/${index}`,
-    { fields },
+    body,
   );
 }
 
 export async function deleteChannelInstance(
   channelName: string,
   index: number,
+  signature: string,
 ): Promise<void> {
-  await del<void>(`/api/channels/${encodeURIComponent(channelName)}/instances/${index}`);
+  const qs = `?signature=${encodeURIComponent(signature)}`;
+  await del<void>(`/api/channels/${encodeURIComponent(channelName)}/instances/${index}${qs}`);
 }
 
 export interface QrStartResponse {

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -36,6 +36,7 @@ export {
   getBudgetStatus,
   // channels & comms
   listChannels,
+  listChannelInstances,
   getCommsTopology,
   listCommsEvents,
   // config & registry
@@ -157,6 +158,8 @@ export type {
   UserBudgetWindow,
   UserBudgetPayload,
   ListSessionsResult,
+  ChannelInstance,
+  ChannelInstancesResponse,
 } from "../../api";
 
 // ---------------------------------------------------------------------------
@@ -194,6 +197,9 @@ export {
   updateBudget,
   // channels & comms
   configureChannel,
+  createChannelInstance,
+  updateChannelInstance,
+  deleteChannelInstance,
   testChannel,
   reloadChannels,
   sendCommsMessage,

--- a/crates/librefang-api/dashboard/src/lib/mutations/channels.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/channels.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   configureChannel,
+  createChannelInstance,
+  updateChannelInstance,
+  deleteChannelInstance,
   testChannel,
   reloadChannels,
   sendCommsMessage,
@@ -18,6 +21,61 @@ export function useConfigureChannel() {
       channelName: string;
       config: Record<string, unknown>;
     }) => configureChannel(channelName, config),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: channelKeys.all });
+    },
+  });
+}
+
+// Per-instance mutations (#4837). Each one invalidates the entire
+// `channelKeys.all` subtree because every CRUD changes both the per-channel
+// instance list AND the top-level channel list's `instance_count` /
+// `configured` fields.
+
+export function useCreateChannelInstance() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      channelName,
+      fields,
+    }: {
+      channelName: string;
+      fields: Record<string, unknown>;
+    }) => createChannelInstance(channelName, fields),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: channelKeys.all });
+    },
+  });
+}
+
+export function useUpdateChannelInstance() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      channelName,
+      index,
+      fields,
+    }: {
+      channelName: string;
+      index: number;
+      fields: Record<string, unknown>;
+    }) => updateChannelInstance(channelName, index, fields),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: channelKeys.all });
+    },
+  });
+}
+
+export function useDeleteChannelInstance() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      channelName,
+      index,
+    }: {
+      channelName: string;
+      index: number;
+    }) => deleteChannelInstance(channelName, index),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: channelKeys.all });
     },

--- a/crates/librefang-api/dashboard/src/lib/mutations/channels.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/channels.ts
@@ -55,11 +55,20 @@ export function useUpdateChannelInstance() {
       channelName,
       index,
       fields,
+      signature,
+      clearSecrets,
     }: {
       channelName: string;
       index: number;
       fields: Record<string, unknown>;
-    }) => updateChannelInstance(channelName, index, fields),
+      /** CAS token from the list response. The server rejects the PUT with
+       *  409 if a concurrent edit shifted indices or modified this row. */
+      signature: string;
+      /** Field keys whose secret env-var ref should be actively dropped
+       *  (and the env-var line removed from secrets.env, if no sibling
+       *  instance still references it). */
+      clearSecrets?: string[];
+    }) => updateChannelInstance(channelName, index, fields, signature, clearSecrets),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: channelKeys.all });
     },
@@ -72,10 +81,13 @@ export function useDeleteChannelInstance() {
     mutationFn: ({
       channelName,
       index,
+      signature,
     }: {
       channelName: string;
       index: number;
-    }) => deleteChannelInstance(channelName, index),
+      /** CAS token from the list response — see `useUpdateChannelInstance`. */
+      signature: string;
+    }) => deleteChannelInstance(channelName, index, signature),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: channelKeys.all });
     },

--- a/crates/librefang-api/dashboard/src/lib/queries/channels.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/channels.ts
@@ -1,6 +1,7 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import {
   listChannels,
+  listChannelInstances,
   getCommsTopology,
   listCommsEvents,
 } from "../http/client";
@@ -20,6 +21,16 @@ export const channelQueries = {
       staleTime: STALE_MS,
       refetchInterval: REFRESH_MS,
       refetchIntervalInBackground: false, // #3393
+    }),
+  // Per-instance list (#4837). No background refresh — the dashboard
+  // re-reads via the standard `invalidateQueries` pattern after every
+  // create/update/delete mutation, and the form drawer is short-lived
+  // so a periodic refetch would be wasted load.
+  instances: (name: string) =>
+    queryOptions({
+      queryKey: channelKeys.instances(name),
+      queryFn: () => listChannelInstances(name),
+      staleTime: STALE_MS,
     }),
 };
 
@@ -42,6 +53,17 @@ export const commsQueries = {
 
 export function useChannels(options: QueryOverrides = {}) {
   return useQuery(withOverrides(channelQueries.list(), options));
+}
+
+export function useChannelInstances(
+  name: string,
+  options: QueryOverrides & { enabled?: boolean } = {},
+) {
+  const base = channelQueries.instances(name);
+  return useQuery({
+    ...withOverrides(base, options),
+    enabled: options.enabled ?? Boolean(name),
+  });
 }
 
 export function useCommsTopology(options: QueryOverrides = {}) {

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -72,6 +72,12 @@ export const providerKeys = {
 export const channelKeys = {
   all: ["channels"] as const,
   lists: () => [...channelKeys.all, "list"] as const,
+  // Per-instance keys (#4837). Hierarchical so
+  // `invalidateQueries({ queryKey: channelKeys.all })` from any
+  // instance mutation also clears the channel list/snapshot
+  // (`instance_count` changes on every CRUD).
+  instances: (name: string) =>
+    [...channelKeys.all, "instances", name] as const,
 };
 
 export const commsKeys = {

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.test.tsx
@@ -471,12 +471,14 @@ describe("ChannelsPage", () => {
             fields: [],
             config: { bot_token_env: "TELEGRAM_BOT_TOKEN" },
             has_token: true,
+            signature: "sig-instance-0",
           },
           {
             index: 1,
             fields: [],
             config: { bot_token_env: "TELEGRAM_BOT_TOKEN_2" },
             has_token: false,
+            signature: "sig-instance-1",
           },
         ],
         total: 2,
@@ -492,7 +494,8 @@ describe("ChannelsPage", () => {
     expect(within(drawer).getByText(/TELEGRAM_BOT_TOKEN_2/)).toBeInTheDocument();
 
     // Delete the second instance — first click stages confirmation, second
-    // click fires the mutation.
+    // click fires the mutation. Mutation must include the per-instance
+    // signature CAS token (#4865) so the server can detect concurrent edits.
     const deleteButtons = within(drawer).getAllByLabelText("common.delete");
     expect(deleteButtons).toHaveLength(2);
     fireEvent.click(deleteButtons[1]);
@@ -500,7 +503,11 @@ describe("ChannelsPage", () => {
 
     expect(muts.remove.mutate).toHaveBeenCalledTimes(1);
     const [args] = muts.remove.mutate.mock.calls[0];
-    expect(args).toEqual({ channelName: "telegram", index: 1 });
+    expect(args).toEqual({
+      channelName: "telegram",
+      index: 1,
+      signature: "sig-instance-1",
+    });
   });
 
   it("refetches channels when the header refresh action fires", () => {

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.test.tsx
@@ -3,20 +3,27 @@ import { render, screen, fireEvent, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ChannelsPage } from "./ChannelsPage";
 import { useDrawerStore } from "../lib/drawerStore";
-import { useChannels } from "../lib/queries/channels";
+import { useChannels, useChannelInstances } from "../lib/queries/channels";
 import {
   useConfigureChannel,
-  useTestChannel,
+  useCreateChannelInstance,
+  useDeleteChannelInstance,
   useReloadChannels,
+  useTestChannel,
+  useUpdateChannelInstance,
 } from "../lib/mutations/channels";
-import type { ChannelItem } from "../api";
+import type { ChannelInstance, ChannelItem } from "../api";
 
 vi.mock("../lib/queries/channels", () => ({
   useChannels: vi.fn(),
+  useChannelInstances: vi.fn(),
 }));
 
 vi.mock("../lib/mutations/channels", () => ({
   useConfigureChannel: vi.fn(),
+  useCreateChannelInstance: vi.fn(),
+  useUpdateChannelInstance: vi.fn(),
+  useDeleteChannelInstance: vi.fn(),
   useTestChannel: vi.fn(),
   useReloadChannels: vi.fn(),
 }));
@@ -44,9 +51,18 @@ vi.mock("react-i18next", async () => {
 });
 
 const useChannelsMock = useChannels as unknown as ReturnType<typeof vi.fn>;
+const useChannelInstancesMock = useChannelInstances as unknown as ReturnType<
+  typeof vi.fn
+>;
 const useConfigureChannelMock = useConfigureChannel as unknown as ReturnType<
   typeof vi.fn
 >;
+const useCreateChannelInstanceMock =
+  useCreateChannelInstance as unknown as ReturnType<typeof vi.fn>;
+const useUpdateChannelInstanceMock =
+  useUpdateChannelInstance as unknown as ReturnType<typeof vi.fn>;
+const useDeleteChannelInstanceMock =
+  useDeleteChannelInstance as unknown as ReturnType<typeof vi.fn>;
 const useTestChannelMock = useTestChannel as unknown as ReturnType<typeof vi.fn>;
 const useReloadChannelsMock = useReloadChannels as unknown as ReturnType<
   typeof vi.fn
@@ -103,16 +119,35 @@ function makeMutation(overrides: Partial<MutationStub> = {}): MutationStub {
 
 function setMutationDefaults(): {
   configure: MutationStub;
+  create: MutationStub;
+  update: MutationStub;
+  remove: MutationStub;
   test: MutationStub;
   reload: MutationStub;
 } {
   const configure = makeMutation();
+  const create = makeMutation();
+  const update = makeMutation();
+  const remove = makeMutation();
   const test = makeMutation();
   const reload = makeMutation();
   useConfigureChannelMock.mockReturnValue(configure);
+  useCreateChannelInstanceMock.mockReturnValue(create);
+  useUpdateChannelInstanceMock.mockReturnValue(update);
+  useDeleteChannelInstanceMock.mockReturnValue(remove);
   useTestChannelMock.mockReturnValue(test);
   useReloadChannelsMock.mockReturnValue(reload);
-  return { configure, test, reload };
+  return { configure, create, update, remove, test, reload };
+}
+
+function setInstancesDefault(items: ChannelInstance[] = []): void {
+  useChannelInstancesMock.mockReturnValue(
+    makeQuery<{ channel: string; items: ChannelInstance[]; total: number }>({
+      channel: "test",
+      items,
+      total: items.length,
+    }),
+  );
 }
 
 function renderPage(): void {
@@ -142,6 +177,7 @@ describe("ChannelsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setMutationDefaults();
+    setInstancesDefault();
     // Drawer state is a global zustand store — reset between tests so a
     // drawer left open by one test doesn't bleed into the next.
     useDrawerStore.setState({ isOpen: false, content: null });
@@ -275,7 +311,7 @@ describe("ChannelsPage", () => {
     expect(muts.reload.mutate).toHaveBeenCalledTimes(1);
   });
 
-  it("opens the configure drawer with form fields when a channel's gear is clicked", () => {
+  it("opens the instances drawer with an Add CTA when the gear is clicked (#4837)", () => {
     useChannelsMock.mockReturnValue(
       makeQuery<ChannelItem[]>([
         makeChannel({
@@ -298,12 +334,43 @@ describe("ChannelsPage", () => {
 
     fireEvent.click(screen.getByLabelText("channels.config"));
 
-    // Configure drawer header
-    expect(screen.getByText("channels.configure")).toBeInTheDocument();
-    expect(screen.getByText(/Bot Token/)).toBeInTheDocument();
+    // The instance manager opens in "list" phase. With no instances seeded
+    // the empty-state copy and the "Add instance" CTA must both render.
+    const drawer = screen.getByTestId("drawer-slot");
+    expect(within(drawer).getByText("channels.no_instances")).toBeInTheDocument();
+    expect(within(drawer).getByText("channels.add_instance")).toBeInTheDocument();
+    // The form fields must NOT render in the list phase — they only appear
+    // after the user clicks "Add instance" / "Edit".
+    expect(within(drawer).queryByText(/Bot Token/)).not.toBeInTheDocument();
   });
 
-  it("submits the configure mutation with only edited values when Save is clicked", () => {
+  it("clicking Add instance reveals the form fields", () => {
+    useChannelsMock.mockReturnValue(
+      makeQuery<ChannelItem[]>([
+        makeChannel({
+          name: "slack",
+          display_name: "Slack",
+          configured: true,
+          fields: [
+            {
+              key: "bot_token",
+              label: "Bot Token",
+              type: "secret",
+              required: true,
+            },
+          ],
+        }),
+      ]),
+    );
+
+    renderPage();
+    fireEvent.click(screen.getByLabelText("channels.config"));
+    const drawer = screen.getByTestId("drawer-slot");
+    fireEvent.click(within(drawer).getByText("channels.add_instance"));
+    expect(within(drawer).getByText(/Bot Token/)).toBeInTheDocument();
+  });
+
+  it("submits createChannelInstance with only typed values when Save is clicked (#4837)", () => {
     useChannelsMock.mockReturnValue(
       makeQuery<ChannelItem[]>([
         makeChannel({
@@ -330,27 +397,27 @@ describe("ChannelsPage", () => {
     const muts = setMutationDefaults();
 
     renderPage();
-
     fireEvent.click(screen.getByLabelText("channels.config"));
-
     const drawer = screen.getByTestId("drawer-slot");
-    // Type a new bot token only — workspace stays blank, so payload should
-    // omit it (the configure handler skips empty values).
+    fireEvent.click(within(drawer).getByText("channels.add_instance"));
+
     const allInputs = drawer.querySelectorAll<HTMLInputElement>("input");
     expect(allInputs.length).toBeGreaterThanOrEqual(2);
+    // Type a new bot token only — workspace stays blank, so payload should
+    // omit it (the create handler skips empty values).
     fireEvent.change(allInputs[0], { target: { value: "xoxb-secret" } });
 
-    fireEvent.click(within(drawer).getByText("common.save"));
+    fireEvent.click(within(drawer).getByText("common.create"));
 
-    expect(muts.configure.mutate).toHaveBeenCalledTimes(1);
-    const [payload] = muts.configure.mutate.mock.calls[0];
+    expect(muts.create.mutate).toHaveBeenCalledTimes(1);
+    const [payload] = muts.create.mutate.mock.calls[0];
     expect(payload).toEqual({
       channelName: "slack",
-      config: { bot_token: "xoxb-secret" },
+      fields: { bot_token: "xoxb-secret" },
     });
   });
 
-  it("disables the Save button while the configure mutation is pending", () => {
+  it("disables the Create button while createChannelInstance is pending", () => {
     useChannelsMock.mockReturnValue(
       makeQuery<ChannelItem[]>([
         makeChannel({
@@ -362,16 +429,78 @@ describe("ChannelsPage", () => {
       ]),
     );
     setMutationDefaults();
-    useConfigureChannelMock.mockReturnValue(
+    useCreateChannelInstanceMock.mockReturnValue(
       makeMutation({ isPending: true }),
     );
 
     renderPage();
-
     fireEvent.click(screen.getByLabelText("channels.config"));
+    const drawer = screen.getByTestId("drawer-slot");
+    fireEvent.click(within(drawer).getByText("channels.add_instance"));
 
-    const save = screen.getByText("common.saving").closest("button");
+    const save = within(drawer).getByText("common.saving").closest("button");
     expect(save).toBeDisabled();
+  });
+
+  it("lists seeded instances and routes Delete through useDeleteChannelInstance (#4837)", () => {
+    useChannelsMock.mockReturnValue(
+      makeQuery<ChannelItem[]>([
+        makeChannel({
+          name: "telegram",
+          display_name: "Telegram",
+          configured: true,
+          instance_count: 2,
+          fields: [
+            {
+              key: "bot_token_env",
+              label: "Bot Token",
+              type: "secret",
+              env_var: "TELEGRAM_BOT_TOKEN",
+            },
+          ],
+        }),
+      ]),
+    );
+    const muts = setMutationDefaults();
+    useChannelInstancesMock.mockReturnValue(
+      makeQuery({
+        channel: "telegram",
+        items: [
+          {
+            index: 0,
+            fields: [],
+            config: { bot_token_env: "TELEGRAM_BOT_TOKEN" },
+            has_token: true,
+          },
+          {
+            index: 1,
+            fields: [],
+            config: { bot_token_env: "TELEGRAM_BOT_TOKEN_2" },
+            has_token: false,
+          },
+        ],
+        total: 2,
+      }),
+    );
+
+    renderPage();
+    fireEvent.click(screen.getByLabelText("channels.config"));
+    const drawer = screen.getByTestId("drawer-slot");
+
+    // Both instances render with their pointed-at env var name as label.
+    expect(within(drawer).getByText(/TELEGRAM_BOT_TOKEN(?!_)/)).toBeInTheDocument();
+    expect(within(drawer).getByText(/TELEGRAM_BOT_TOKEN_2/)).toBeInTheDocument();
+
+    // Delete the second instance — first click stages confirmation, second
+    // click fires the mutation.
+    const deleteButtons = within(drawer).getAllByLabelText("common.delete");
+    expect(deleteButtons).toHaveLength(2);
+    fireEvent.click(deleteButtons[1]);
+    fireEvent.click(within(drawer).getByText("common.confirm"));
+
+    expect(muts.remove.mutate).toHaveBeenCalledTimes(1);
+    const [args] = muts.remove.mutate.mock.calls[0];
+    expect(args).toEqual({ channelName: "telegram", index: 1 });
   });
 
   it("refetches channels when the header refresh action fires", () => {

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -1,8 +1,23 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { wechatQrStart, wechatQrStatus, whatsappQrStart, whatsappQrStatus, type ChannelItem } from "../api";
-import { useChannels } from "../lib/queries/channels";
-import { useConfigureChannel, useTestChannel, useReloadChannels } from "../lib/mutations/channels";
+import {
+  wechatQrStart,
+  wechatQrStatus,
+  whatsappQrStart,
+  whatsappQrStatus,
+  type ChannelField,
+  type ChannelInstance,
+  type ChannelItem,
+} from "../api";
+import { useChannels, useChannelInstances } from "../lib/queries/channels";
+import {
+  useConfigureChannel,
+  useCreateChannelInstance,
+  useDeleteChannelInstance,
+  useReloadChannels,
+  useTestChannel,
+  useUpdateChannelInstance,
+} from "../lib/mutations/channels";
 import { useUIStore } from "../lib/store";
 import { toastErr } from "../lib/errors";
 import { copyToClipboard } from "../lib/clipboard";
@@ -17,7 +32,7 @@ import { Input } from "../components/ui/Input";
 import { DrawerPanel } from "../components/ui/DrawerPanel";
 import {
   Network, Search, CheckCircle2, XCircle, ChevronRight, X, Grid3X3, List,
-  Settings, AlertCircle, CheckSquare, Square, Plus,
+  Settings, AlertCircle, CheckSquare, Square, Plus, Trash2, Pencil, ArrowLeft,
   MessageCircle, Mail, Phone, Link2, Radio, Send, Bell, Wifi, Globe
 } from "lucide-react";
 
@@ -87,6 +102,9 @@ const ChannelCard = memo(function ChannelCard({ channel: c, isSelected, viewMode
   // drawer where they actually help selection).
   const msgs = typeof c.msgs_24h === "number" ? c.msgs_24h : 0;
   const kind = c.category || c.name;
+  // #4837: when a channel type has multiple instances configured, surface
+  // the count as a left-side meta tag so cards make sense at a glance.
+  const instanceCount = typeof c.instance_count === "number" ? c.instance_count : (c.configured ? 1 : 0);
   return (
     <Card
       hover
@@ -105,8 +123,13 @@ const ChannelCard = memo(function ChannelCard({ channel: c, isSelected, viewMode
         {getChannelIcon(c.name)}
       </div>
       <div className="min-w-0 flex-1">
-        <div className="font-mono text-[13px] truncate text-text-main">
+        <div className="font-mono text-[13px] truncate text-text-main flex items-center gap-1.5">
           {c.display_name || c.name}
+          {instanceCount > 1 && (
+            <span className="font-mono text-[10px] px-1.5 py-0.5 rounded bg-brand/10 text-brand border border-brand/20">
+              {t("channels.instance_count_short", { defaultValue: `${instanceCount}×` })}
+            </span>
+          )}
         </div>
         <div className="font-mono text-[11px] text-text-dim mt-0.5 truncate">
           {kind} · {msgs} {t("channels.msgs_24h", { defaultValue: "msgs/24h" })}
@@ -281,142 +304,451 @@ function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
   );
 }
 
-// Config Dialog — standard form with controlled inputs
-function ConfigDialog({ channel, onClose, t }: { channel: Channel; onClose: () => void; t: (key: string) => string }) {
+// Form for one channel instance — used by both the create-new and edit-existing
+// flows in `InstancesDialog`. The same form was previously the whole of
+// `ConfigDialog` and drove the legacy single-instance `/configure` endpoint.
+//
+// `fields` is the schema (with `value` / `has_value` populated for edits).
+// `onSubmit` receives the non-empty, non-readonly values; the parent decides
+// which mutation to fire.
+function ChannelForm({
+  channel,
+  fields,
+  description,
+  submitLabel,
+  isPending,
+  onSubmit,
+  onCancel,
+  t,
+}: {
+  channel: Channel;
+  fields: ChannelField[];
+  description?: string;
+  submitLabel: string;
+  isPending: boolean;
+  onSubmit: (payload: Record<string, string>) => void;
+  onCancel: () => void;
+  t: (key: string, opts?: { defaultValue?: string }) => string;
+}) {
   const addToast = useUIStore((s) => s.addToast);
-  const fields = useMemo(() => (channel.fields ?? []).filter(f => !f.advanced), [channel.fields]);
+  const visibleSchema = useMemo(() => fields.filter(f => !f.advanced), [fields]);
 
-  // Build initial form values: non-secret fields use saved value, secrets start empty
   const initialValues = useMemo(() => {
     const vals: Record<string, string> = {};
-    for (const f of fields) {
+    for (const f of visibleSchema) {
       if (f.readonly) continue;
       if (f.type === "select" && f.options?.length) {
-        // Select: use saved value or fall back to first option
         vals[f.key] = f.value || f.options[0];
       } else {
         vals[f.key] = (f.type !== "secret" && f.value) ? f.value : "";
       }
     }
     return vals;
-  }, [fields]);
+  }, [visibleSchema]);
   const [values, setValues] = useState<Record<string, string>>(initialValues);
+  // Reset form values when the schema (i.e. instance) changes — without this,
+  // switching from "edit instance 0" to "edit instance 1" would keep the
+  // previous instance's typed values in the inputs.
+  useEffect(() => {
+    setValues(initialValues);
+  }, [initialValues]);
 
   const setValue = (key: string, val: string) => setValues(prev => ({ ...prev, [key]: val }));
 
-  // Find the "controlling" select field (e.g. mode) to drive show_when visibility
-  const controlField = useMemo(() => fields.find(f => f.type === "select" && f.options), [fields]);
+  const controlField = useMemo(
+    () => visibleSchema.find(f => f.type === "select" && f.options),
+    [visibleSchema],
+  );
   const controlValue = controlField ? (values[controlField.key] || "") : "";
 
-  // Filter visible fields: hide those whose show_when doesn't match the control value
-  const visibleFields = useMemo(
-    () => fields.filter(f => !f.show_when || f.show_when === controlValue),
-    [fields, controlValue],
+  const filteredFields = useMemo(
+    () => visibleSchema.filter(f => !f.show_when || f.show_when === controlValue),
+    [visibleSchema, controlValue],
   );
 
-  // Only submit non-readonly, non-empty values (skip untouched secrets)
-  const configMutation = useConfigureChannel();
   const handleSubmit = () => {
     const payload: Record<string, string> = {};
-    for (const f of visibleFields) {
+    for (const f of filteredFields) {
       if (f.readonly) continue;
       const v = values[f.key];
       if (v) payload[f.key] = v;
     }
-    configMutation.mutate(
-      { channelName: channel.name, config: payload },
-      {
-        onSuccess: () => {
-          addToast(t("channels.config_success") || `${channel.display_name || channel.name} configured`, "success");
-          onClose();
-        },
-        onError: (err) => addToast(toastErr(err, t("channels.config_failed") || "Failed to configure channel"), "error"),
-      },
-    );
+    onSubmit(payload);
   };
 
   return (
-    <DrawerPanel isOpen onClose={onClose} size="md" hideCloseButton>
-        <div className="px-6 py-5 border-b border-border-subtle">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-xl bg-brand/10 flex items-center justify-center">
-                <Settings className="w-5 h-5 text-brand" />
-              </div>
-              <div>
-                <h3 className="text-base font-black">{channel.display_name || channel.name}</h3>
-                <p className="text-[10px] text-text-dim mt-0.5">{t("channels.configure")}</p>
-              </div>
-            </div>
-            <button onClick={onClose} className="p-2 rounded-xl hover:bg-main transition-colors" aria-label={t("common.close")}><X className="w-4 h-4" /></button>
-          </div>
-        </div>
-        <div className="p-6">
-        <p className="text-xs text-text-dim mb-5">{channel.description}</p>
+    <div className="p-6">
+      {description && <p className="text-xs text-text-dim mb-5">{description}</p>}
 
-        {/* Configuration Fields */}
-        {visibleFields.length > 0 ? (
-          <div className="space-y-3 mb-6 max-h-80 overflow-y-auto">
-            {visibleFields.map((field) => (
-              <div key={field.key}>
-                <label className="text-xs font-bold text-text-dim mb-1 block">
-                  {field.label || field.key} {field.required && <span className="text-error">*</span>}
-                </label>
-                {field.readonly ? (
-                  <div className="flex gap-2">
-                    <input
-                      type="text"
-                      value={field.value || field.placeholder || ""}
-                      readOnly
-                      className="flex-1 rounded-lg border border-border-subtle bg-main/50 px-3 py-2 text-xs text-text-dim font-mono"
-                    />
-                    <button
-                      onClick={async () => {
-                        const ok = await copyToClipboard(field.value || field.placeholder || "");
-                        addToast(ok ? t("common.copied") : t("common.copy_failed"), ok ? "success" : "error");
-                      }}
-                      className="px-3 py-2 rounded-lg bg-brand/10 text-brand text-xs hover:bg-brand/20 transition-colors shrink-0"
-                      title={t("common.copy")}
-                    >
-                      {t("common.copy")}
-                    </button>
-                  </div>
-                ) : field.type === "select" && field.options ? (
-                  <select
-                    value={values[field.key] || ""}
-                    onChange={(e) => setValue(field.key, e.target.value)}
-                    className="w-full rounded-lg border border-border-subtle bg-main px-3 py-2 text-xs focus:border-brand focus:ring-1 focus:ring-brand/20 outline-none"
-                  >
-                    {field.options.map((opt) => (
-                      <option key={opt} value={opt}>{opt}</option>
-                    ))}
-                  </select>
-                ) : (
-                  <input
-                    type={field.type === "secret" ? "password" : "text"}
-                    value={values[field.key] || ""}
-                    onChange={(e) => setValue(field.key, e.target.value)}
-                    placeholder={field.has_value ? "••••••••  (leave empty to keep)" : (field.placeholder || field.env_var || field.key)}
-                    className="w-full rounded-lg border border-border-subtle bg-main px-3 py-2 text-xs focus:border-brand focus:ring-1 focus:ring-brand/20 outline-none"
-                  />
+      {filteredFields.length > 0 ? (
+        <div className="space-y-3 mb-6 max-h-80 overflow-y-auto">
+          {filteredFields.map((field) => (
+            <div key={field.key}>
+              <label className="text-xs font-bold text-text-dim mb-1 block">
+                {field.label || field.key} {field.required && <span className="text-error">*</span>}
+                {field.type === "secret" && field.env_var && (
+                  <span className="ml-2 font-mono text-[10px] text-text-dim/80 normal-case">{field.env_var}</span>
                 )}
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="mb-6 p-4 rounded-lg bg-main/30 text-center">
-            <p className="text-xs text-text-dim">{t("channels.no_fields_required")}</p>
-          </div>
-        )}
+              </label>
+              {field.readonly ? (
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={field.value || field.placeholder || ""}
+                    readOnly
+                    className="flex-1 rounded-lg border border-border-subtle bg-main/50 px-3 py-2 text-xs text-text-dim font-mono"
+                  />
+                  <button
+                    onClick={async () => {
+                      const ok = await copyToClipboard(field.value || field.placeholder || "");
+                      addToast(ok ? t("common.copied") : t("common.copy_failed"), ok ? "success" : "error");
+                    }}
+                    className="px-3 py-2 rounded-lg bg-brand/10 text-brand text-xs hover:bg-brand/20 transition-colors shrink-0"
+                    title={t("common.copy")}
+                  >
+                    {t("common.copy")}
+                  </button>
+                </div>
+              ) : field.type === "select" && field.options ? (
+                <select
+                  value={values[field.key] || ""}
+                  onChange={(e) => setValue(field.key, e.target.value)}
+                  className="w-full rounded-lg border border-border-subtle bg-main px-3 py-2 text-xs focus:border-brand focus:ring-1 focus:ring-brand/20 outline-none"
+                >
+                  {field.options.map((opt) => (
+                    <option key={opt} value={opt}>{opt}</option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type={field.type === "secret" ? "password" : "text"}
+                  value={values[field.key] || ""}
+                  onChange={(e) => setValue(field.key, e.target.value)}
+                  placeholder={field.has_value ? "••••••••  (leave empty to keep)" : (field.placeholder || field.env_var || field.key)}
+                  className="w-full rounded-lg border border-border-subtle bg-main px-3 py-2 text-xs focus:border-brand focus:ring-1 focus:ring-brand/20 outline-none"
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mb-6 p-4 rounded-lg bg-main/30 text-center">
+          <p className="text-xs text-text-dim">{t("channels.no_fields_required")}</p>
+        </div>
+      )}
 
-        {/* Buttons */}
-        <div className="flex gap-3">
-          <Button variant="secondary" className="flex-1" onClick={onClose}>{t("common.cancel")}</Button>
-          <Button variant="primary" className="flex-1" onClick={handleSubmit} disabled={configMutation.isPending}>
-            {configMutation.isPending ? t("common.saving") : t("common.save")}
+      <div className="flex gap-3">
+        <Button variant="secondary" className="flex-1" onClick={onCancel} disabled={isPending}>
+          {t("common.cancel")}
+        </Button>
+        <Button
+          variant="primary"
+          className="flex-1"
+          onClick={handleSubmit}
+          disabled={isPending}
+        >
+          {isPending ? t("common.saving") : submitLabel}
+        </Button>
+      </div>
+      {/* Channel name pinned for context */}
+      <p className="mt-3 text-[10px] text-text-dim/60 text-center">
+        {channel.display_name || channel.name}
+      </p>
+    </div>
+  );
+}
+
+// Multi-instance manager (#4837). Replaces the legacy single-form
+// `ConfigDialog` for any non-QR channel. Three internal phases:
+//   - "list" (default): shows configured instances + "Add instance" CTA
+//   - "create": embedded `ChannelForm` driving `useCreateChannelInstance`
+//   - "edit": embedded `ChannelForm` driving `useUpdateChannelInstance`
+// Delete uses an inline confirm because the destructive action is small and
+// a separate modal would be overkill.
+function InstancesDialog({
+  channel,
+  onClose,
+  t,
+}: {
+  channel: Channel;
+  onClose: () => void;
+  t: (key: string, opts?: { defaultValue?: string; count?: number }) => string;
+}) {
+  const addToast = useUIStore((s) => s.addToast);
+  const [phase, setPhase] = useState<"list" | "create" | "edit">("list");
+  const [editIndex, setEditIndex] = useState<number | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<number | null>(null);
+
+  const instancesQuery = useChannelInstances(channel.name);
+  const createMut = useCreateChannelInstance();
+  const updateMut = useUpdateChannelInstance();
+  const deleteMut = useDeleteChannelInstance();
+
+  const instances: ChannelInstance[] = instancesQuery.data?.items ?? [];
+  const channelLabel = channel.display_name || channel.name;
+
+  const handleCreate = useCallback(
+    (payload: Record<string, string>) => {
+      createMut.mutate(
+        { channelName: channel.name, fields: payload },
+        {
+          onSuccess: () => {
+            addToast(
+              t("channels.instance_added", { defaultValue: `${channelLabel} instance added` }),
+              "success",
+            );
+            setPhase("list");
+          },
+          onError: (err) =>
+            addToast(
+              toastErr(err, t("channels.config_failed", { defaultValue: "Failed to save instance" })),
+              "error",
+            ),
+        },
+      );
+    },
+    [createMut, channel.name, channelLabel, addToast, t],
+  );
+
+  const handleUpdate = useCallback(
+    (payload: Record<string, string>) => {
+      if (editIndex === null) return;
+      updateMut.mutate(
+        { channelName: channel.name, index: editIndex, fields: payload },
+        {
+          onSuccess: () => {
+            addToast(
+              t("channels.instance_updated", { defaultValue: `${channelLabel} instance updated` }),
+              "success",
+            );
+            setPhase("list");
+            setEditIndex(null);
+          },
+          onError: (err) =>
+            addToast(
+              toastErr(err, t("channels.config_failed", { defaultValue: "Failed to save instance" })),
+              "error",
+            ),
+        },
+      );
+    },
+    [updateMut, channel.name, channelLabel, editIndex, addToast, t],
+  );
+
+  const handleDelete = useCallback(
+    (idx: number) => {
+      deleteMut.mutate(
+        { channelName: channel.name, index: idx },
+        {
+          onSuccess: () => {
+            addToast(
+              t("channels.instance_removed", { defaultValue: `${channelLabel} instance removed` }),
+              "success",
+            );
+            setPendingDelete(null);
+          },
+          onError: (err) => {
+            addToast(
+              toastErr(err, t("common.error", { defaultValue: "Error" })),
+              "error",
+            );
+            setPendingDelete(null);
+          },
+        },
+      );
+    },
+    [deleteMut, channel.name, channelLabel, addToast, t],
+  );
+
+  const fieldsForEdit: ChannelField[] = useMemo(() => {
+    if (phase !== "edit" || editIndex === null) return [];
+    const inst = instances[editIndex];
+    return inst?.fields ?? channel.fields ?? [];
+  }, [phase, editIndex, instances, channel.fields]);
+
+  const renderInstanceLabel = (inst: ChannelInstance, idx: number) => {
+    // Prefer a meaningful identifier from the instance's config: either the
+    // env-var name a secret field points at (e.g. `TELEGRAM_BOT_TOKEN_2`)
+    // or the first non-empty stringy field. Falls back to the index.
+    const obj = inst.config ?? {};
+    const candidates: string[] = [];
+    for (const f of channel.fields ?? []) {
+      const v = obj[f.key];
+      if (typeof v === "string" && v.trim() !== "") {
+        candidates.push(`${f.label || f.key}: ${v}`);
+      }
+    }
+    return candidates[0] || t("channels.instance_n", { defaultValue: `Instance #${idx}`, count: idx });
+  };
+
+  const headerTitle = phase === "create"
+    ? t("channels.add_instance", { defaultValue: "Add instance" })
+    : phase === "edit"
+      ? t("channels.edit_instance", { defaultValue: "Edit instance" })
+      : channelLabel;
+
+  const headerSub = phase === "list"
+    ? t("channels.manage_instances", { defaultValue: "Manage configured instances" })
+    : channelLabel;
+
+  return (
+    <DrawerPanel isOpen onClose={onClose} size="md" hideCloseButton>
+      <div className="px-6 py-5 border-b border-border-subtle">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3 min-w-0">
+            {phase !== "list" && (
+              <button
+                onClick={() => {
+                  setPhase("list");
+                  setEditIndex(null);
+                }}
+                className="p-1.5 rounded-lg hover:bg-main transition-colors shrink-0"
+                aria-label={t("common.back", { defaultValue: "Back" })}
+              >
+                <ArrowLeft className="w-4 h-4" />
+              </button>
+            )}
+            <div className="w-10 h-10 rounded-xl bg-brand/10 flex items-center justify-center shrink-0">
+              <Settings className="w-5 h-5 text-brand" />
+            </div>
+            <div className="min-w-0">
+              <h3 className="text-base font-black truncate">{headerTitle}</h3>
+              <p className="text-[10px] text-text-dim mt-0.5 truncate">{headerSub}</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-xl hover:bg-main transition-colors shrink-0"
+            aria-label={t("common.close", { defaultValue: "Close" })}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {phase === "list" && (
+        <div className="p-6">
+          <p className="text-xs text-text-dim mb-4">
+            {channel.description}
+          </p>
+
+          {instancesQuery.isLoading ? (
+            <div className="space-y-2 mb-4">
+              {[1, 2].map((i) => <div key={i} className="h-14 rounded-lg bg-main/30 animate-pulse" />)}
+            </div>
+          ) : instances.length === 0 ? (
+            <div className="mb-4 p-4 rounded-lg bg-main/30 text-center">
+              <p className="text-xs text-text-dim">
+                {t("channels.no_instances", { defaultValue: "No instances configured yet." })}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2 mb-4">
+              {instances.map((inst, idx) => {
+                const label = renderInstanceLabel(inst, idx);
+                const isDeleting = pendingDelete === idx;
+                return (
+                  <div
+                    key={idx}
+                    className="flex items-center gap-3 p-3 rounded-lg border border-border-subtle bg-main/30"
+                  >
+                    <div className="w-7 h-7 rounded-md bg-brand/10 grid place-items-center text-brand text-xs font-bold shrink-0">
+                      {idx + 1}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono text-[12px] text-text-main truncate">{label}</div>
+                      <div className="font-mono text-[10px] text-text-dim mt-0.5 flex items-center gap-1.5">
+                        {inst.has_token ? (
+                          <><CheckCircle2 className="w-3 h-3 text-success" /> {t("channels.creds_ok", { defaultValue: "credentials set" })}</>
+                        ) : (
+                          <><AlertCircle className="w-3 h-3 text-warning" /> {t("channels.creds_missing", { defaultValue: "credentials missing" })}</>
+                        )}
+                      </div>
+                    </div>
+                    {isDeleting ? (
+                      <div className="flex gap-1 shrink-0">
+                        <button
+                          onClick={() => handleDelete(idx)}
+                          disabled={deleteMut.isPending}
+                          className="px-2 py-1 rounded-md bg-error/10 text-error text-[10px] font-bold hover:bg-error/20"
+                        >
+                          {t("common.confirm", { defaultValue: "Confirm" })}
+                        </button>
+                        <button
+                          onClick={() => setPendingDelete(null)}
+                          className="px-2 py-1 rounded-md bg-main/50 text-text-dim text-[10px] font-bold hover:bg-main"
+                        >
+                          {t("common.cancel", { defaultValue: "Cancel" })}
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="flex gap-1 shrink-0">
+                        <button
+                          onClick={() => {
+                            setEditIndex(idx);
+                            setPhase("edit");
+                          }}
+                          className="p-1.5 rounded-md text-text-dim hover:text-text-main hover:bg-main/40"
+                          aria-label={t("common.edit", { defaultValue: "Edit" })}
+                          title={t("common.edit", { defaultValue: "Edit" })}
+                        >
+                          <Pencil className="w-3.5 h-3.5" />
+                        </button>
+                        <button
+                          onClick={() => setPendingDelete(idx)}
+                          className="p-1.5 rounded-md text-text-dim hover:text-error hover:bg-error/10"
+                          aria-label={t("common.delete", { defaultValue: "Delete" })}
+                          title={t("common.delete", { defaultValue: "Delete" })}
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <Button
+            variant="primary"
+            className="w-full"
+            onClick={() => setPhase("create")}
+            leftIcon={<Plus className="w-4 h-4" />}
+          >
+            {t("channels.add_instance", { defaultValue: "Add instance" })}
           </Button>
         </div>
-        </div>
+      )}
+
+      {phase === "create" && (
+        <ChannelForm
+          channel={channel}
+          fields={channel.fields ?? []}
+          description={channel.description}
+          submitLabel={t("common.create", { defaultValue: "Create" })}
+          isPending={createMut.isPending}
+          onSubmit={handleCreate}
+          onCancel={() => setPhase("list")}
+          t={t}
+        />
+      )}
+
+      {phase === "edit" && editIndex !== null && (
+        <ChannelForm
+          channel={channel}
+          fields={fieldsForEdit}
+          description={channel.description}
+          submitLabel={t("common.save", { defaultValue: "Save" })}
+          isPending={updateMut.isPending}
+          onSubmit={handleUpdate}
+          onCancel={() => {
+            setPhase("list");
+            setEditIndex(null);
+          }}
+          t={t}
+        />
+      )}
     </DrawerPanel>
   );
 }
@@ -847,9 +1179,11 @@ export function ChannelsPage() {
         />
       )}
 
-      {/* Config Dialog */}
+      {/* Instance manager dialog (#4837) — drives create / edit / delete
+          for `[[channels.<name>]]` array entries. Replaces the legacy
+          single-form ConfigDialog for non-QR channels. */}
       {configuringChannel && (
-        <ConfigDialog
+        <InstancesDialog
           key={configuringChannel?.name}
           channel={configuringChannel}
           onClose={() => setConfiguringChannel(null)}

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -513,8 +513,28 @@ function InstancesDialog({
   const handleUpdate = useCallback(
     (payload: Record<string, string>) => {
       if (editIndex === null) return;
+      const target = instances[editIndex];
+      if (!target) {
+        // Defensive: the list refetch races with the edit form's submit.
+        // If the row vanished, surface the 409-equivalent inline instead of
+        // sending an unsigned PUT.
+        addToast(
+          t("channels.instance_stale", {
+            defaultValue: "Instance was removed by another tab; refresh and retry",
+          }),
+          "error",
+        );
+        setPhase("list");
+        setEditIndex(null);
+        return;
+      }
       updateMut.mutate(
-        { channelName: channel.name, index: editIndex, fields: payload },
+        {
+          channelName: channel.name,
+          index: editIndex,
+          fields: payload,
+          signature: target.signature,
+        },
         {
           onSuccess: () => {
             addToast(
@@ -532,13 +552,24 @@ function InstancesDialog({
         },
       );
     },
-    [updateMut, channel.name, channelLabel, editIndex, addToast, t],
+    [updateMut, channel.name, channelLabel, editIndex, instances, addToast, t],
   );
 
   const handleDelete = useCallback(
     (idx: number) => {
+      const target = instances[idx];
+      if (!target) {
+        addToast(
+          t("channels.instance_stale", {
+            defaultValue: "Instance was removed by another tab; refresh and retry",
+          }),
+          "error",
+        );
+        setPendingDelete(null);
+        return;
+      }
       deleteMut.mutate(
-        { channelName: channel.name, index: idx },
+        { channelName: channel.name, index: idx, signature: target.signature },
         {
           onSuccess: () => {
             addToast(
@@ -557,7 +588,7 @@ function InstancesDialog({
         },
       );
     },
-    [deleteMut, channel.name, channelLabel, addToast, t],
+    [deleteMut, channel.name, channelLabel, instances, addToast, t],
   );
 
   const fieldsForEdit: ChannelField[] = useMemo(() => {

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -191,6 +191,13 @@ use crate::types;
         routes::remove_channel,
         routes::test_channel,
         routes::reload_channels,
+        // Per-instance management (#4837): the dashboard manages multiple
+        // `[[channels.<name>]]` entries via these endpoints; the legacy
+        // `/configure` ones above stay registered for backwards compat.
+        routes::list_channel_instances,
+        routes::create_channel_instance,
+        routes::update_channel_instance_handler,
+        routes::delete_channel_instance,
         routes::whatsapp_qr_start,
         routes::whatsapp_qr_status,
         routes::wechat_qr_start,

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -50,9 +50,10 @@ pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
 use super::skills::{
     append_channel_instance, remove_channel_config, remove_channel_instance, remove_secret_env,
     update_channel_instance, upsert_channel_config, validate_env_var, write_secret_env,
+    CHANNEL_AOT_CONFLICT_PREFIX,
 };
 use super::AppState;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
@@ -1597,6 +1598,12 @@ pub async fn configure_channel(
     {
         let _config_guard = state.config_write_lock.lock().await;
         if let Err(e) = upsert_channel_config(&config_path, &name, &config_fields) {
+            let msg = e.to_string();
+            if let Some(rest) = msg.strip_prefix(CHANNEL_AOT_CONFLICT_PREFIX) {
+                return ApiErrorResponse::bad_request(rest.to_string())
+                    .with_status(StatusCode::CONFLICT)
+                    .into_json_tuple();
+            }
             return ApiErrorResponse::internal(format!("Failed to write config: {e}"))
                 .into_json_tuple();
         }
@@ -1680,6 +1687,12 @@ pub async fn remove_channel(
     {
         let _config_guard = state.config_write_lock.lock().await;
         if let Err(e) = remove_channel_config(&config_path, &name) {
+            let msg = e.to_string();
+            if let Some(rest) = msg.strip_prefix(CHANNEL_AOT_CONFLICT_PREFIX) {
+                return ApiErrorResponse::bad_request(rest.to_string())
+                    .with_status(StatusCode::CONFLICT)
+                    .into_json_tuple();
+            }
             return ApiErrorResponse::internal(format!("Failed to remove config: {e}"))
                 .into_json_tuple();
         }
@@ -1762,22 +1775,164 @@ fn build_instance_fields_json(
     fields
 }
 
-/// Process the submitted `fields` object into:
-///   1. a `config_fields` map ready to write to TOML,
-///   2. a side-effecting set of `secrets.env` writes for any secret values
-///      provided in the request.
+/// Resolve secret env var name overrides for a write to instance
+/// `target_index` of `channel`.
 ///
-/// `secret_env_overrides` lets per-instance handlers pick a custom env var
-/// name (e.g. `TELEGRAM_BOT_TOKEN_2` for the second instance) instead of
-/// the field schema's default. When the override is `None`, the schema
-/// default is used — this matches the legacy single-instance flow.
-async fn process_fields_for_write(
+/// Two cases:
+///
+///   - `target_index == existing_instances.len()` → caller is appending a new
+///     instance. `existing_instances.get(target_index)` returns `None`, so we
+///     fall through to the suffix-search branch and pick the lowest unused
+///     `<env>_<N>` name (or the bare default name when free).
+///   - `target_index < existing_instances.len()` → caller is updating an
+///     existing instance. We preserve whatever env-var name that instance is
+///     already pointing at, so re-typing the secret writes to the SAME
+///     env var (rotation in place) rather than allocating a fresh suffix
+///     that may collide with siblings or leak a stale env var.
+///
+/// The previous implementation always synthesised `<env>_<index+1>` and
+/// blindly wrote there. After deleting a middle instance, indices shift, so
+/// "add a new instance" would land on a suffix already in use by a survivor
+/// — silently overwriting the live token (#4865).
+fn resolve_secret_env_overrides(
+    meta: &ChannelMeta,
+    existing_instances: &[serde_json::Value],
+    target_index: usize,
+) -> HashMap<String, String> {
+    let mut overrides = HashMap::new();
+    for field_def in meta.fields {
+        let Some(default_env) = field_def.env_var else {
+            continue;
+        };
+
+        // Update path: preserve the env-var name the existing instance is
+        // already pointing at.
+        if let Some(existing_name) = existing_instances
+            .get(target_index)
+            .and_then(|i| i.as_object())
+            .and_then(|o| o.get(field_def.key))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            overrides.insert(field_def.key.to_string(), existing_name.to_string());
+            continue;
+        }
+
+        // Create path (or update on an instance that has no env-var ref yet):
+        // pick the lowest-unused `<env>_<N>` name across siblings.
+        let used: std::collections::HashSet<String> = existing_instances
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != target_index)
+            .filter_map(|(_, inst)| {
+                inst.as_object()
+                    .and_then(|o| o.get(field_def.key))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+            })
+            .collect();
+        let chosen = if !used.contains(default_env) {
+            default_env.to_string()
+        } else {
+            (2..)
+                .map(|n| format!("{default_env}_{n}"))
+                .find(|name| !used.contains(name))
+                .expect("counter is unbounded")
+        };
+        overrides.insert(field_def.key.to_string(), chosen);
+    }
+    overrides
+}
+
+/// Canonical JSON serialisation with object keys sorted lexicographically and
+/// no whitespace, so the same logical config always produces byte-identical
+/// output. Used as the input to `instance_signature` for an opaque-content
+/// fingerprint (CAS token) of each channel instance.
+fn canonical_json(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::Object(map) => {
+            let mut entries: Vec<(&String, &serde_json::Value)> = map.iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            let parts: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(k).unwrap_or_default(),
+                        canonical_json(v)
+                    )
+                })
+                .collect();
+            format!("{{{}}}", parts.join(","))
+        }
+        serde_json::Value::Array(arr) => {
+            let parts: Vec<String> = arr.iter().map(canonical_json).collect();
+            format!("[{}]", parts.join(","))
+        }
+        _ => serde_json::to_string(v).unwrap_or_default(),
+    }
+}
+
+/// SHA-256 of `canonical_json(instance)`, hex-encoded. The dashboard receives
+/// this as `signature` on every list response and echoes it back on PUT/DELETE
+/// so the server can detect when an intervening write moved or modified the
+/// instance the client thought it was operating on (compare-and-swap).
+fn instance_signature(instance: &serde_json::Value) -> String {
+    use sha2::{Digest, Sha256};
+    let canonical = canonical_json(instance);
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Re-deserialise `[channels]` from disk under the write lock, so handlers
+/// validate against the authoritative on-disk state rather than the stale
+/// in-memory `state.channels_config` snapshot (which only catches up after
+/// the post-write hot-reload). Without this, two concurrent PUT/DELETE
+/// requests can both pass an in-memory range check, then race to write a
+/// shifted disk view — the second write lands on the wrong instance.
+fn read_disk_channels(
+    config_path: &std::path::Path,
+) -> Result<librefang_types::config::ChannelsConfig, Box<dyn std::error::Error + Send + Sync>> {
+    if !config_path.exists() {
+        return Ok(librefang_types::config::ChannelsConfig::default());
+    }
+    let content = std::fs::read_to_string(config_path)?;
+    if content.trim().is_empty() {
+        return Ok(librefang_types::config::ChannelsConfig::default());
+    }
+    let root: toml::Value = toml::from_str(&content)?;
+    let Some(channels_val) = root.get("channels") else {
+        return Ok(librefang_types::config::ChannelsConfig::default());
+    };
+    let channels: librefang_types::config::ChannelsConfig = channels_val.clone().try_into()?;
+    Ok(channels)
+}
+
+/// Pure pre-write validation: run the user-submitted `fields` through the
+/// channel schema, resolve each secret field's effective env-var name from
+/// `secret_env_overrides`, and accumulate (a) the TOML config payload and
+/// (b) the side-effecting secret writes that need to land in `secrets.env`.
+///
+/// No I/O happens here — secrets are NOT written until `apply_secret_writes`
+/// is called, which lets handlers defer the writes until they are inside the
+/// `config_write_lock` critical section and have verified the CAS signature.
+struct PreparedWrite {
+    config_fields: HashMap<String, (String, FieldType)>,
+    /// `(env_var_name, value)` pairs to write to `secrets.env`. Distinct from
+    /// `config_fields` because the same env-var name could be referenced by
+    /// multiple fields (defensive — the schema does not currently allow it).
+    secret_writes: Vec<(String, String)>,
+}
+
+fn prepare_fields_write(
     meta: &ChannelMeta,
     fields: &serde_json::Map<String, serde_json::Value>,
-    secrets_path: &std::path::Path,
     secret_env_overrides: &HashMap<String, String>,
-) -> Result<HashMap<String, (String, FieldType)>, (StatusCode, Json<serde_json::Value>)> {
+) -> Result<PreparedWrite, (StatusCode, Json<serde_json::Value>)> {
     let mut config_fields: HashMap<String, (String, FieldType)> = HashMap::new();
+    let mut secret_writes: Vec<(String, String)> = Vec::new();
 
     for field_def in meta.fields {
         let value = fields
@@ -1789,37 +1944,16 @@ async fn process_fields_for_write(
         }
 
         if let Some(default_env_var) = field_def.env_var {
-            // Resolve the env var name to write under: per-instance override
-            // wins, else fall back to the field schema's default.
             let env_var_name = secret_env_overrides
                 .get(field_def.key)
                 .cloned()
                 .unwrap_or_else(|| default_env_var.to_string());
 
-            // Validate the resolved env var name + secret value before
-            // touching the filesystem.
             if let Err(msg) = validate_env_var(&env_var_name, value) {
                 return Err(ApiErrorResponse::bad_request(msg).into_json_tuple());
             }
-            if let Err(e) = write_secret_env(secrets_path, &env_var_name, value) {
-                return Err(
-                    ApiErrorResponse::internal(format!("Failed to write secret: {e}"))
-                        .into_json_tuple(),
-                );
-            }
-            // `std::env::set_var` is not thread-safe inside the multithreaded
-            // tokio runtime; delegate to a blocking thread to avoid UB.
-            {
-                let env_var_owned = env_var_name.clone();
-                let value_owned = value.to_string();
-                let _ = tokio::task::spawn_blocking(move || {
-                    // SAFETY: single mutation on a dedicated blocking thread.
-                    unsafe { std::env::set_var(&env_var_owned, &value_owned) };
-                })
-                .await;
-            }
-            // Store the env var NAME (not the value) in TOML so the kernel
-            // knows which env var to read when activating the instance.
+
+            secret_writes.push((env_var_name.clone(), value.to_string()));
             config_fields.insert(field_def.key.to_string(), (env_var_name, FieldType::Text));
         } else {
             config_fields.insert(
@@ -1829,33 +1963,37 @@ async fn process_fields_for_write(
         }
     }
 
-    Ok(config_fields)
+    Ok(PreparedWrite {
+        config_fields,
+        secret_writes,
+    })
 }
 
-/// Compute per-instance secret env var name overrides for instance `index`.
-///
-/// Index 0 keeps the field's default env var name (e.g. `TELEGRAM_BOT_TOKEN`)
-/// for backwards compatibility with the legacy single-instance flow. Index
-/// N>0 appends `_<N+1>` so writes don't collide:
-///   - instance 0 → `TELEGRAM_BOT_TOKEN`
-///   - instance 1 → `TELEGRAM_BOT_TOKEN_2`
-///   - instance 2 → `TELEGRAM_BOT_TOKEN_3`
-///
-/// If the user wants a custom env var name they can edit `secrets.env`
-/// directly and update the per-instance `bot_token_env` field; the dashboard
-/// surfaces the resolved env var name in the form so this is discoverable.
-fn default_secret_env_overrides(meta: &ChannelMeta, index: usize) -> HashMap<String, String> {
-    let mut overrides = HashMap::new();
-    if index == 0 {
-        return overrides;
-    }
-    let suffix = format!("_{}", index + 1);
-    for field_def in meta.fields {
-        if let Some(env_var) = field_def.env_var {
-            overrides.insert(field_def.key.to_string(), format!("{env_var}{suffix}"));
+/// Apply the deferred secret writes from `prepare_fields_write` under the
+/// `config_write_lock` critical section. Each pair is written to
+/// `secrets.env` and pushed into the running process's environment via a
+/// dedicated blocking thread (`std::env::set_var` is not thread-safe in the
+/// async runtime).
+async fn apply_secret_writes(
+    secrets_path: &std::path::Path,
+    secret_writes: &[(String, String)],
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    for (env_var, value) in secret_writes {
+        if let Err(e) = write_secret_env(secrets_path, env_var, value) {
+            return Err(
+                ApiErrorResponse::internal(format!("Failed to write secret: {e}"))
+                    .into_json_tuple(),
+            );
         }
+        let env_var_owned = env_var.clone();
+        let value_owned = value.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            // SAFETY: single mutation on a dedicated blocking thread.
+            unsafe { std::env::set_var(&env_var_owned, &value_owned) };
+        })
+        .await;
     }
-    overrides
+    Ok(())
 }
 
 #[utoipa::path(
@@ -1907,11 +2045,16 @@ pub async fn list_channel_instances(
                         .map(|v| !v.is_empty())
                         .unwrap_or(false)
                 });
+            // CAS token. The dashboard echoes this back on PUT/DELETE so the
+            // server can reject writes that target an instance that has been
+            // moved or modified since the client read it (#4865).
+            let signature = instance_signature(inst);
             serde_json::json!({
                 "index": idx,
                 "fields": fields,
                 "config": inst,
                 "has_token": has_token,
+                "signature": signature,
             })
         })
         .collect();
@@ -1943,6 +2086,12 @@ pub async fn list_channel_instances(
     )
 )]
 /// POST /api/channels/{name}/instances — Append a new `[[channels.<name>]]`.
+///
+/// The whole "compute target index → resolve env-var name overrides → write
+/// secrets → append config" sequence runs inside the `config_write_lock`
+/// critical section, against a freshly re-read on-disk view of `[channels]`,
+/// so two concurrent creates can't pick the same suffix or land at the same
+/// index (#4865).
 pub async fn create_channel_instance(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -1962,24 +2111,33 @@ pub async fn create_channel_instance(
     let secrets_path = home.join("secrets.env");
     let config_path = home.join("config.toml");
 
-    // Compute the index this new instance will land at (under the live
-    // channels read lock for a consistent snapshot — `config_write_lock`
-    // below serialises against concurrent writers).
-    let next_index = {
-        let live_channels = state.channels_config.read().await;
-        channel_instance_count(&live_channels, meta.name)
-    };
-    let overrides = default_secret_env_overrides(meta, next_index);
+    let written_index = {
+        let _config_guard = state.config_write_lock.lock().await;
 
-    let config_fields =
-        match process_fields_for_write(meta, fields, &secrets_path, &overrides).await {
-            Ok(f) => f,
+        // Re-read `[channels]` from disk under the lock, so override resolution
+        // sees the authoritative state (the in-memory snapshot only catches
+        // up after the post-write hot-reload).
+        let disk_channels = match read_disk_channels(&config_path) {
+            Ok(c) => c,
+            Err(e) => {
+                return ApiErrorResponse::internal(format!("Failed to read config: {e}"))
+                    .into_json_tuple();
+            }
+        };
+        let existing_instances = channel_instances_serialized(&disk_channels, meta.name);
+        let next_index = existing_instances.len();
+        let overrides = resolve_secret_env_overrides(meta, &existing_instances, next_index);
+
+        let prepared = match prepare_fields_write(meta, fields, &overrides) {
+            Ok(p) => p,
             Err(resp) => return resp,
         };
 
-    let written_index = {
-        let _config_guard = state.config_write_lock.lock().await;
-        match append_channel_instance(&config_path, &name, &config_fields) {
+        if let Err(resp) = apply_secret_writes(&secrets_path, &prepared.secret_writes).await {
+            return resp;
+        }
+
+        match append_channel_instance(&config_path, &name, &prepared.config_fields) {
             Ok(idx) => idx,
             Err(e) => {
                 return ApiErrorResponse::internal(format!("Failed to append instance: {e}"))
@@ -2026,6 +2184,27 @@ pub async fn create_channel_instance(
     )
 )]
 /// PUT /api/channels/{name}/instances/{index} — Replace one instance's fields.
+///
+/// Body shape:
+/// ```json
+/// {
+///   "fields": { "bot_token_env": "...", "default_agent": "assistant" },
+///   "signature": "<hex from GET response>",
+///   "clear_secrets": ["bot_token_env"]   // optional
+/// }
+/// ```
+///
+/// `signature` is REQUIRED and acts as a compare-and-swap token: the server
+/// re-reads disk under the write lock, computes the signature of the
+/// instance currently at `index`, and rejects with 409 Conflict if it
+/// doesn't match. This eliminates the silent-wrong-write bug where a
+/// concurrent delete on a sibling row shifted indices between the client's
+/// list-fetch and its PUT (#4865).
+///
+/// `clear_secrets` lets the caller actively drop a secret reference instead
+/// of preserving it. Listed keys have their `<key>_env` field removed from
+/// the rebuilt instance and, when no sibling instance references the same
+/// env-var name, the env-var line is also removed from `secrets.env`.
 pub async fn update_channel_instance_handler(
     State(state): State<Arc<AppState>>,
     Path((name, index)): Path<(String, usize)>,
@@ -2041,67 +2220,141 @@ pub async fn update_channel_instance_handler(
         None => return ApiErrorResponse::bad_request("Missing 'fields' object").into_json_tuple(),
     };
 
-    // Range-check before touching the filesystem so a 404 is clean.
-    let current_count = {
-        let live_channels = state.channels_config.read().await;
-        channel_instance_count(&live_channels, meta.name)
+    // Required CAS token. Reject before touching disk so a missing field is
+    // a clean 400 rather than an opaque race surface.
+    let client_signature = match body.get("signature").and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            return ApiErrorResponse::bad_request(
+                "Missing 'signature' (compare-and-swap token from list response)",
+            )
+            .into_json_tuple();
+        }
     };
-    if index >= current_count {
-        return ApiErrorResponse::not_found(format!(
-            "Instance {index} out of range (have {current_count} instance(s))"
-        ))
-        .into_json_tuple();
-    }
+
+    let clear_secrets: Vec<String> = body
+        .get("clear_secrets")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
 
     let home = librefang_home();
     let secrets_path = home.join("secrets.env");
     let config_path = home.join("config.toml");
 
-    let overrides = default_secret_env_overrides(meta, index);
-    let mut config_fields =
-        match process_fields_for_write(meta, fields, &secrets_path, &overrides).await {
-            Ok(f) => f,
+    {
+        let _config_guard = state.config_write_lock.lock().await;
+
+        // Re-read disk so range/CAS check + override resolution see the
+        // authoritative state.
+        let disk_channels = match read_disk_channels(&config_path) {
+            Ok(c) => c,
+            Err(e) => {
+                return ApiErrorResponse::internal(format!("Failed to read config: {e}"))
+                    .into_json_tuple();
+            }
+        };
+        let existing_instances = channel_instances_serialized(&disk_channels, meta.name);
+        if index >= existing_instances.len() {
+            return ApiErrorResponse::not_found(format!(
+                "Instance {index} out of range (have {} instance(s))",
+                existing_instances.len()
+            ))
+            .into_json_tuple();
+        }
+
+        let on_disk_signature = instance_signature(&existing_instances[index]);
+        if on_disk_signature != client_signature {
+            return ApiErrorResponse::bad_request(
+                "Instance has been modified or moved since the list was read; refresh and retry",
+            )
+            .with_status(StatusCode::CONFLICT)
+            .into_json_tuple();
+        }
+
+        let overrides = resolve_secret_env_overrides(meta, &existing_instances, index);
+        let mut prepared = match prepare_fields_write(meta, fields, &overrides) {
+            Ok(p) => p,
             Err(resp) => return resp,
         };
 
-    // Preserve the existing instance's secret-field env-var-name reference
-    // when the user didn't retype the secret. Without this, the form's
-    // "leave empty to keep" placeholder would lie: editing any non-secret
-    // field while leaving the bot token blank would drop `bot_token_env`
-    // from the rebuilt entry, breaking authentication. Only secret fields
-    // get this treatment because the form pre-fills non-secret fields with
-    // their saved values, so they round-trip naturally.
-    let existing_instance = {
-        let live_channels = state.channels_config.read().await;
-        channel_instances_serialized(&live_channels, meta.name)
-            .get(index)
-            .cloned()
-    };
-    if let Some(obj) = existing_instance.as_ref().and_then(|v| v.as_object()) {
-        for field_def in meta.fields {
-            if field_def.field_type != FieldType::Secret {
-                continue;
+        // Preserve the existing instance's secret-field env-var-name when the
+        // user didn't retype the secret AND didn't list it under
+        // `clear_secrets`. Without this, editing any non-secret field while
+        // leaving a secret blank would silently drop the env-var ref, breaking
+        // authentication.
+        if let Some(obj) = existing_instances[index].as_object() {
+            for field_def in meta.fields {
+                if field_def.field_type != FieldType::Secret {
+                    continue;
+                }
+                if prepared.config_fields.contains_key(field_def.key) {
+                    continue;
+                }
+                if clear_secrets.iter().any(|k| k == field_def.key) {
+                    continue;
+                }
+                let existing_env_name = obj
+                    .get(field_def.key)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if existing_env_name.is_empty() {
+                    continue;
+                }
+                prepared.config_fields.insert(
+                    field_def.key.to_string(),
+                    (existing_env_name.to_string(), FieldType::Text),
+                );
             }
-            if config_fields.contains_key(field_def.key) {
-                continue;
-            }
-            let existing_env_name = obj
-                .get(field_def.key)
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            if existing_env_name.is_empty() {
-                continue;
-            }
-            config_fields.insert(
-                field_def.key.to_string(),
-                (existing_env_name.to_string(), FieldType::Text),
-            );
         }
-    }
 
-    {
-        let _config_guard = state.config_write_lock.lock().await;
-        if let Err(e) = update_channel_instance(&config_path, &name, index, &config_fields) {
+        // For each cleared secret: drop the env-var line from secrets.env if
+        // no sibling instance still references the same env-var name. This
+        // avoids leaving stale tokens on disk after the user has removed an
+        // instance's auth, while preventing collateral damage to siblings
+        // that happen to share the env-var name.
+        if !clear_secrets.is_empty() {
+            if let Some(obj) = existing_instances[index].as_object() {
+                let sibling_env_refs: std::collections::HashSet<String> = existing_instances
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != index)
+                    .filter_map(|(_, inst)| inst.as_object())
+                    .flat_map(|o| o.values())
+                    .filter_map(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+                    .collect();
+                for key in &clear_secrets {
+                    let Some(env_name) = obj.get(key).and_then(|v| v.as_str()) else {
+                        continue;
+                    };
+                    if env_name.is_empty() || sibling_env_refs.contains(env_name) {
+                        continue;
+                    }
+                    if let Err(e) = remove_secret_env(&secrets_path, env_name) {
+                        tracing::warn!(error = %e, env_var = %env_name, "Failed to remove cleared secret env var");
+                    }
+                    let env_owned = env_name.to_string();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        // SAFETY: single mutation on a dedicated blocking thread.
+                        unsafe { std::env::remove_var(&env_owned) };
+                    })
+                    .await;
+                }
+            }
+        }
+
+        if let Err(resp) = apply_secret_writes(&secrets_path, &prepared.secret_writes).await {
+            return resp;
+        }
+
+        if let Err(e) = update_channel_instance(&config_path, &name, index, &prepared.config_fields)
+        {
             return ApiErrorResponse::internal(format!("Failed to update instance: {e}"))
                 .into_json_tuple();
         }
@@ -2142,36 +2395,68 @@ pub async fn update_channel_instance_handler(
         (status = 500, description = "Internal server error", body = crate::types::JsonObject)
     )
 )]
-/// DELETE /api/channels/{name}/instances/{index} — Remove a single instance.
+/// DELETE /api/channels/{name}/instances/{index}?signature=<hex>
+///
+/// `signature` is REQUIRED (query string) and acts as a compare-and-swap
+/// token: the server re-reads disk under the write lock and rejects with
+/// 409 Conflict if the instance currently at `index` doesn't match the
+/// signature the client read from the GET response (#4865).
 ///
 /// Note: this does NOT clear the secret env var the instance pointed at —
 /// the env var may be shared with another instance, and we don't want to
-/// silently break a running bot. The user can clear stale entries from
-/// `secrets.env` manually.
+/// silently break a running bot. To explicitly clear secrets while editing,
+/// use PUT with `clear_secrets`.
 pub async fn delete_channel_instance(
     State(state): State<Arc<AppState>>,
     Path((name, index)): Path<(String, usize)>,
+    Query(query): Query<HashMap<String, String>>,
 ) -> impl IntoResponse {
-    if find_channel_meta(&name).is_none() {
-        return ApiErrorResponse::not_found("Unknown channel").into_json_tuple();
+    let meta = match find_channel_meta(&name) {
+        Some(m) => m,
+        None => return ApiErrorResponse::not_found("Unknown channel").into_json_tuple(),
     };
 
-    let current_count = {
-        let live_channels = state.channels_config.read().await;
-        channel_instance_count(&live_channels, &name)
+    let client_signature = match query.get("signature") {
+        Some(s) if !s.is_empty() => s.clone(),
+        _ => {
+            return ApiErrorResponse::bad_request(
+                "Missing 'signature' query parameter (compare-and-swap token from list response)",
+            )
+            .into_json_tuple();
+        }
     };
-    if index >= current_count {
-        return ApiErrorResponse::not_found(format!(
-            "Instance {index} out of range (have {current_count} instance(s))"
-        ))
-        .into_json_tuple();
-    }
 
     let home = librefang_home();
     let config_path = home.join("config.toml");
 
     {
         let _config_guard = state.config_write_lock.lock().await;
+
+        let disk_channels = match read_disk_channels(&config_path) {
+            Ok(c) => c,
+            Err(e) => {
+                return ApiErrorResponse::internal(format!("Failed to read config: {e}"))
+                    .into_json_tuple();
+            }
+        };
+        let existing_instances = channel_instances_serialized(&disk_channels, meta.name);
+        if index >= existing_instances.len() {
+            return ApiErrorResponse::not_found(format!(
+                "Instance {index} out of range (have {} instance(s))",
+                existing_instances.len()
+            ))
+            .into_json_tuple();
+        }
+
+        let on_disk_signature = instance_signature(&existing_instances[index]);
+        if on_disk_signature != client_signature {
+            return ApiErrorResponse::bad_request(
+                "Instance has been modified or moved since the list was read; refresh and retry",
+            )
+            .with_status(StatusCode::CONFLICT)
+            .into_json_tuple();
+        }
+
         if let Err(e) = remove_channel_instance(&config_path, &name, index) {
             return ApiErrorResponse::internal(format!("Failed to remove instance: {e}"))
                 .into_json_tuple();
@@ -2901,5 +3186,133 @@ mod test_channel_status_tests {
             StatusCode::OK,
             "downstream send failure must NOT be reported as 200"
         );
+    }
+}
+
+#[cfg(test)]
+mod instance_helper_tests {
+    //! Unit coverage for the per-instance write helpers added in #4865:
+    //! `resolve_secret_env_overrides` and `instance_signature`. Both
+    //! eliminate silent-data-loss footguns the original PR shipped with
+    //! and have no business reaching production untested.
+    use super::*;
+
+    fn telegram_meta() -> &'static ChannelMeta {
+        find_channel_meta("telegram").expect("telegram is in the registry")
+    }
+
+    fn inst_with_env(env_name: &str) -> serde_json::Value {
+        serde_json::json!({ "bot_token_env": env_name })
+    }
+
+    /// First-instance create on an empty channel returns the bare default
+    /// env-var name (no suffix), matching the legacy single-instance flow.
+    #[test]
+    fn resolve_overrides_picks_default_for_first_instance() {
+        let meta = telegram_meta();
+        let overrides = resolve_secret_env_overrides(meta, &[], 0);
+        assert_eq!(
+            overrides.get("bot_token_env").map(|s| s.as_str()),
+            Some("TELEGRAM_BOT_TOKEN"),
+            "first instance must use the bare default env-var name: {overrides:?}"
+        );
+    }
+
+    /// After deleting the middle of three instances, the survivors point at
+    /// `_BOT_TOKEN` and `_BOT_TOKEN_3`. Adding a new instance must NOT pick
+    /// `_BOT_TOKEN_3` (which would silently overwrite the surviving instance
+    /// at idx 1) — it must pick `_BOT_TOKEN_2`, the lowest unused suffix.
+    #[test]
+    fn resolve_overrides_picks_lowest_unused_suffix_after_middle_delete() {
+        let meta = telegram_meta();
+        let existing = vec![
+            inst_with_env("TELEGRAM_BOT_TOKEN"),
+            inst_with_env("TELEGRAM_BOT_TOKEN_3"),
+        ];
+        let overrides = resolve_secret_env_overrides(meta, &existing, existing.len());
+        assert_eq!(
+            overrides.get("bot_token_env").map(|s| s.as_str()),
+            Some("TELEGRAM_BOT_TOKEN_2"),
+            "must reuse the freed `_2` slot, not append `_3` and clobber the survivor: {overrides:?}"
+        );
+    }
+
+    /// Update on an existing instance preserves the env-var name that
+    /// instance is already pointing at — no fresh suffix allocated, no
+    /// drift onto a sibling's env var. This is what makes "rotate the
+    /// bot token in place" actually rotate in place.
+    #[test]
+    fn resolve_overrides_preserves_existing_env_name_on_update() {
+        let meta = telegram_meta();
+        let existing = vec![
+            inst_with_env("TELEGRAM_BOT_TOKEN"),
+            inst_with_env("MY_CUSTOM_TG_TOKEN"),
+        ];
+        let overrides = resolve_secret_env_overrides(meta, &existing, 1);
+        assert_eq!(
+            overrides.get("bot_token_env").map(|s| s.as_str()),
+            Some("MY_CUSTOM_TG_TOKEN"),
+            "update path must preserve the instance's existing env-var name: {overrides:?}"
+        );
+    }
+
+    /// Sibling-set excludes the target index. An update should not skip
+    /// `_BOT_TOKEN_2` just because the row being updated currently points
+    /// at it (we'd never reach the suffix branch for a non-empty existing
+    /// ref anyway, but a future caller passing target_index for an empty
+    /// row should still be allowed to pick its own slot).
+    #[test]
+    fn resolve_overrides_excludes_target_index_from_sibling_set() {
+        let meta = telegram_meta();
+        let existing = vec![
+            inst_with_env("TELEGRAM_BOT_TOKEN"),
+            inst_with_env(""), // empty — falls through to suffix search
+            inst_with_env("TELEGRAM_BOT_TOKEN_3"),
+        ];
+        let overrides = resolve_secret_env_overrides(meta, &existing, 1);
+        // Slot 1 is empty, so we go to suffix search. Used by siblings: KEY,
+        // KEY_3. Lowest unused: KEY_2.
+        assert_eq!(
+            overrides.get("bot_token_env").map(|s| s.as_str()),
+            Some("TELEGRAM_BOT_TOKEN_2")
+        );
+    }
+
+    /// Signature is stable across object-key insertion order, so two
+    /// processes seeing identical content always emit the same hex string.
+    #[test]
+    fn instance_signature_stable_across_key_order() {
+        let a = serde_json::json!({ "x": 1, "y": "two", "z": [3, 4] });
+        let b = serde_json::json!({ "z": [3, 4], "y": "two", "x": 1 });
+        assert_eq!(
+            instance_signature(&a),
+            instance_signature(&b),
+            "signature must be canonical across key order"
+        );
+    }
+
+    /// Any content change flips the signature so the CAS check fires.
+    #[test]
+    fn instance_signature_detects_mutation() {
+        let a = serde_json::json!({ "bot_token_env": "TG_TOKEN", "default_agent": "alice" });
+        let b = serde_json::json!({ "bot_token_env": "TG_TOKEN", "default_agent": "bob" });
+        assert_ne!(
+            instance_signature(&a),
+            instance_signature(&b),
+            "signature must change when any field changes"
+        );
+    }
+
+    /// Output is hex (so the dashboard can put it in a JSON string and
+    /// query string without escaping concerns).
+    #[test]
+    fn instance_signature_is_lowercase_hex() {
+        let sig = instance_signature(&serde_json::json!({ "x": 1 }));
+        assert!(
+            sig.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "signature must be lowercase hex: {sig}"
+        );
+        assert_eq!(sig.len(), 64, "sha-256 hex length: {sig}");
     }
 }

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1520,7 +1520,8 @@ pub async fn get_channel(
     responses(
         (status = 200, description = "Channel configured successfully", body = crate::types::JsonObject),
         (status = 400, description = "Bad request", body = crate::types::JsonObject),
-        (status = 404, description = "Unknown channel", body = crate::types::JsonObject)
+        (status = 404, description = "Unknown channel", body = crate::types::JsonObject),
+        (status = 409, description = "Channel is in multi-instance form; use the per-instance API", body = crate::types::JsonObject)
     )
 )]
 /// POST /api/channels/{name}/configure — Save channel secrets + config fields.
@@ -1652,6 +1653,7 @@ pub async fn configure_channel(
     responses(
         (status = 200, description = "Channel removed successfully", body = crate::types::JsonObject),
         (status = 404, description = "Unknown channel", body = crate::types::JsonObject),
+        (status = 409, description = "Channel is in multi-instance form; use the per-instance API", body = crate::types::JsonObject),
         (status = 500, description = "Internal server error", body = crate::types::JsonObject)
     )
 )]
@@ -1849,6 +1851,18 @@ fn resolve_secret_env_overrides(
 /// no whitespace, so the same logical config always produces byte-identical
 /// output. Used as the input to `instance_signature` for an opaque-content
 /// fingerprint (CAS token) of each channel instance.
+///
+/// **Invariant for signature stability:** both the GET-side hash (computed
+/// over `channel_instances_serialized(...)` of in-memory `ChannelsConfig`)
+/// and the recomputed PUT/DELETE-side hash (computed over
+/// `channel_instances_serialized(...)` of `read_disk_channels(...)`) must
+/// flow through the SAME serialiser. Concretely: never mix a hash computed
+/// over a `toml_edit::Table` with one computed over `serde_json::Value`
+/// — `OneOrMany`'s deserialiser coerces TOML integers to JSON strings in
+/// some fields (see `librefang-types/src/config/serde_helpers.rs`), and
+/// the two views diverge. All sites that build the hash today route
+/// through `serde_json::to_value(&TelegramConfig)` (and friends) so this
+/// holds; the test `instance_signature_stable_across_key_order` pins it.
 fn canonical_json(v: &serde_json::Value) -> String {
     match v {
         serde_json::Value::Object(map) => {
@@ -1892,6 +1906,17 @@ fn instance_signature(instance: &serde_json::Value) -> String {
 /// the post-write hot-reload). Without this, two concurrent PUT/DELETE
 /// requests can both pass an in-memory range check, then race to write a
 /// shifted disk view — the second write lands on the wrong instance.
+///
+/// **Dual-parser note:** the WRITE path (`update_channel_instance`,
+/// `remove_channel_instance` in skills.rs) parses with
+/// `toml_edit::DocumentMut` to preserve comments/key-order; this READ
+/// path parses with `toml::from_str` → `try_into::<ChannelsConfig>` so it
+/// can use the canonical struct definitions. Both grammars are TOML and
+/// agree on the channel-section shape; the downstream signature CAS only
+/// compares the read-side serialisation against itself (GET + recompute
+/// both go through this fn → `channel_instances_serialized`), so even an
+/// edge-case parser disagreement on a non-channel section can't cause a
+/// false 409.
 fn read_disk_channels(
     config_path: &std::path::Path,
 ) -> Result<librefang_types::config::ChannelsConfig, Box<dyn std::error::Error + Send + Sync>> {
@@ -2175,11 +2200,15 @@ pub async fn create_channel_instance(
         ("name" = String, Path, description = "Channel adapter name"),
         ("index" = usize, Path, description = "Instance array index (0-based)")
     ),
-    request_body = crate::types::JsonObject,
+    request_body(
+        content = crate::types::JsonObject,
+        description = "REQUIRED body fields: `fields` (object of channel-schema fields) and `signature` (hex CAS token from the matching `GET /instances` item, used to detect concurrent edits — mismatch yields 409). OPTIONAL: `clear_secrets` (array of secret-field keys to actively drop)."
+    ),
     responses(
         (status = 200, description = "Instance updated", body = crate::types::JsonObject),
-        (status = 400, description = "Bad request", body = crate::types::JsonObject),
+        (status = 400, description = "Bad request (missing fields or signature)", body = crate::types::JsonObject),
         (status = 404, description = "Unknown channel or instance index out of range", body = crate::types::JsonObject),
+        (status = 409, description = "Signature mismatch — instance was modified or moved by another writer", body = crate::types::JsonObject),
         (status = 500, description = "Internal server error", body = crate::types::JsonObject)
     )
 )]
@@ -2387,11 +2416,14 @@ pub async fn update_channel_instance_handler(
     tag = "channels",
     params(
         ("name" = String, Path, description = "Channel adapter name"),
-        ("index" = usize, Path, description = "Instance array index (0-based)")
+        ("index" = usize, Path, description = "Instance array index (0-based)"),
+        ("signature" = String, Query, description = "REQUIRED hex CAS token from the matching `GET /instances` item; mismatch yields 409 (#4865)")
     ),
     responses(
         (status = 204, description = "Instance removed"),
+        (status = 400, description = "Missing `signature` query parameter", body = crate::types::JsonObject),
         (status = 404, description = "Unknown channel or instance index out of range", body = crate::types::JsonObject),
+        (status = 409, description = "Signature mismatch — instance was modified or moved by another writer", body = crate::types::JsonObject),
         (status = 500, description = "Internal server error", body = crate::types::JsonObject)
     )
 )]

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -9,6 +9,20 @@ pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
             "/channels/{name}/configure",
             axum::routing::post(configure_channel).delete(remove_channel),
         )
+        // Per-instance endpoints (#4837) — let the dashboard manage multiple
+        // `[[channels.<name>]]` entries (e.g. two Telegram bots, three Slack
+        // workspaces) instead of treating every channel type as a single
+        // instance. The legacy `/configure` endpoints remain for backwards
+        // compatibility and continue to drive the single-instance flow.
+        .route(
+            "/channels/{name}/instances",
+            axum::routing::get(list_channel_instances).post(create_channel_instance),
+        )
+        .route(
+            "/channels/{name}/instances/{index}",
+            axum::routing::put(update_channel_instance_handler)
+                .delete(delete_channel_instance),
+        )
         .route("/channels/{name}/test", axum::routing::post(test_channel))
         .route("/channels/reload", axum::routing::post(reload_channels))
         .route(
@@ -34,8 +48,8 @@ pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
 }
 
 use super::skills::{
-    remove_channel_config, remove_secret_env, upsert_channel_config, validate_env_var,
-    write_secret_env,
+    append_channel_instance, remove_channel_config, remove_channel_instance, remove_secret_env,
+    update_channel_instance, upsert_channel_config, validate_env_var, write_secret_env,
 };
 use super::AppState;
 use axum::extract::{Path, State};
@@ -1156,6 +1170,129 @@ fn channel_config_values(
     }
 }
 
+/// Returns the number of configured instances for a channel type.
+///
+/// Mirrors `is_channel_configured` but returns the underlying
+/// `OneOrMany.len()` so the dashboard can render
+/// "Telegram · 2 bots" subtitles and the list endpoint can populate
+/// `instance_count`.
+fn channel_instance_count(config: &librefang_types::config::ChannelsConfig, name: &str) -> usize {
+    match name {
+        "telegram" => config.telegram.len(),
+        "discord" => config.discord.len(),
+        "slack" => config.slack.len(),
+        "whatsapp" => config.whatsapp.len(),
+        "signal" => config.signal.len(),
+        "matrix" => config.matrix.len(),
+        "email" => config.email.len(),
+        "line" => config.line.len(),
+        "viber" => config.viber.len(),
+        "messenger" => config.messenger.len(),
+        "threema" => config.threema.len(),
+        "keybase" => config.keybase.len(),
+        "reddit" => config.reddit.len(),
+        "mastodon" => config.mastodon.len(),
+        "bluesky" => config.bluesky.len(),
+        "linkedin" => config.linkedin.len(),
+        "nostr" => config.nostr.len(),
+        "teams" => config.teams.len(),
+        "mattermost" => config.mattermost.len(),
+        "google_chat" => config.google_chat.len(),
+        "webex" => config.webex.len(),
+        "feishu" => config.feishu.len(),
+        "dingtalk" => config.dingtalk.len(),
+        "pumble" => config.pumble.len(),
+        "flock" => config.flock.len(),
+        "twist" => config.twist.len(),
+        "zulip" => config.zulip.len(),
+        "irc" => config.irc.len(),
+        "xmpp" => config.xmpp.len(),
+        "gitter" => config.gitter.len(),
+        "discourse" => config.discourse.len(),
+        "revolt" => config.revolt.len(),
+        "guilded" => config.guilded.len(),
+        "nextcloud" => config.nextcloud.len(),
+        "rocketchat" => config.rocketchat.len(),
+        "twitch" => config.twitch.len(),
+        "ntfy" => config.ntfy.len(),
+        "gotify" => config.gotify.len(),
+        "webhook" => config.webhook.len(),
+        "voice" => config.voice.len(),
+        "mumble" => config.mumble.len(),
+        "wechat" => config.wechat.len(),
+        "wecom" => config.wecom.len(),
+        "qq" => config.qq.len(),
+        _ => 0,
+    }
+}
+
+/// Serialize each configured instance of `name` to a JSON value.
+///
+/// Returns an empty vector when the channel is unknown or has no instances.
+/// Each element is the per-instance config (same shape as the legacy
+/// `channel_config_values` returns for the first instance), so it can be
+/// fed straight into `build_field_json` to render the per-instance form.
+fn channel_instances_serialized(
+    config: &librefang_types::config::ChannelsConfig,
+    name: &str,
+) -> Vec<serde_json::Value> {
+    fn ser<T: serde::Serialize>(
+        items: &librefang_types::config::OneOrMany<T>,
+    ) -> Vec<serde_json::Value> {
+        items
+            .iter()
+            .filter_map(|c| serde_json::to_value(c).ok())
+            .collect()
+    }
+    match name {
+        "telegram" => ser(&config.telegram),
+        "discord" => ser(&config.discord),
+        "slack" => ser(&config.slack),
+        "whatsapp" => ser(&config.whatsapp),
+        "signal" => ser(&config.signal),
+        "matrix" => ser(&config.matrix),
+        "email" => ser(&config.email),
+        "line" => ser(&config.line),
+        "viber" => ser(&config.viber),
+        "messenger" => ser(&config.messenger),
+        "threema" => ser(&config.threema),
+        "keybase" => ser(&config.keybase),
+        "reddit" => ser(&config.reddit),
+        "mastodon" => ser(&config.mastodon),
+        "bluesky" => ser(&config.bluesky),
+        "linkedin" => ser(&config.linkedin),
+        "nostr" => ser(&config.nostr),
+        "teams" => ser(&config.teams),
+        "mattermost" => ser(&config.mattermost),
+        "google_chat" => ser(&config.google_chat),
+        "webex" => ser(&config.webex),
+        "feishu" => ser(&config.feishu),
+        "dingtalk" => ser(&config.dingtalk),
+        "pumble" => ser(&config.pumble),
+        "flock" => ser(&config.flock),
+        "twist" => ser(&config.twist),
+        "zulip" => ser(&config.zulip),
+        "irc" => ser(&config.irc),
+        "xmpp" => ser(&config.xmpp),
+        "gitter" => ser(&config.gitter),
+        "discourse" => ser(&config.discourse),
+        "revolt" => ser(&config.revolt),
+        "guilded" => ser(&config.guilded),
+        "nextcloud" => ser(&config.nextcloud),
+        "rocketchat" => ser(&config.rocketchat),
+        "twitch" => ser(&config.twitch),
+        "ntfy" => ser(&config.ntfy),
+        "gotify" => ser(&config.gotify),
+        "webhook" => ser(&config.webhook),
+        "voice" => ser(&config.voice),
+        "mumble" => ser(&config.mumble),
+        "wechat" => ser(&config.wechat),
+        "wecom" => ser(&config.wecom),
+        "qq" => ser(&config.qq),
+        _ => Vec::new(),
+    }
+}
+
 /// GET /api/channels — List all 40 channel adapters with status and field metadata.
 ///
 /// Envelope is the canonical `PaginatedResponse{items,total,offset,limit}`
@@ -1192,6 +1329,7 @@ pub async fn list_channels(State(state): State<Arc<AppState>>) -> impl IntoRespo
         if configured {
             configured_count += 1;
         }
+        let instance_count = channel_instance_count(&live_channels, meta.name);
 
         // Check if all required secret env vars are set
         let has_token = meta
@@ -1223,6 +1361,7 @@ pub async fn list_channels(State(state): State<Arc<AppState>>) -> impl IntoRespo
             "quick_setup": meta.quick_setup,
             "setup_type": meta.setup_type,
             "configured": configured,
+            "instance_count": instance_count,
             "has_token": has_token,
             "fields": fields,
             "setup_steps": meta.setup_steps,
@@ -1255,6 +1394,7 @@ pub(crate) async fn channels_snapshot(state: &Arc<AppState>) -> Vec<serde_json::
 
     for meta in CHANNEL_REGISTRY {
         let configured = is_channel_configured(&live_channels, meta.name);
+        let instance_count = channel_instance_count(&live_channels, meta.name);
         let has_token = meta
             .fields
             .iter()
@@ -1282,6 +1422,7 @@ pub(crate) async fn channels_snapshot(state: &Arc<AppState>) -> Vec<serde_json::
             "quick_setup": meta.quick_setup,
             "setup_type": meta.setup_type,
             "configured": configured,
+            "instance_count": instance_count,
             "has_token": has_token,
             "fields": fields,
             "setup_steps": meta.setup_steps,
@@ -1323,6 +1464,7 @@ pub async fn get_channel(
 
     let live_channels = state.channels_config.read().await;
     let configured = is_channel_configured(&live_channels, meta.name);
+    let instance_count = channel_instance_count(&live_channels, meta.name);
 
     let has_token = meta
         .fields
@@ -1353,6 +1495,7 @@ pub async fn get_channel(
         "quick_setup": meta.quick_setup,
         "setup_type": meta.setup_type,
         "configured": configured,
+        "instance_count": instance_count,
         "has_token": has_token,
         "fields": fields,
         "setup_steps": meta.setup_steps,
@@ -1551,6 +1694,497 @@ pub async fn remove_channel(
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Per-instance endpoints (#4837)
+//
+// The legacy `/configure` endpoints treat every channel name as a single
+// `[channels.<name>]` entry. The kernel has supported `[[channels.<name>]]`
+// (multiple instances) since #240, but the dashboard had no UI to add a
+// second Telegram bot or Slack workspace. The four handlers below let the
+// dashboard list / create / update / delete individual instances. The
+// instance ID is the array index — stable within a session, may shift after
+// a deletion (the dashboard re-fetches via the standard query invalidation
+// pattern in `mutations/channels.ts`).
+// ---------------------------------------------------------------------------
+
+/// Render the per-instance fields for the dashboard form.
+///
+/// Each instance gets the channel's full field schema (same shape as
+/// `build_field_json` returns for the legacy single-instance flow), with
+/// `value` populated from the per-instance config so the form pre-fills
+/// when editing. Secret fields never have their value exposed — only
+/// `has_value` (env-var presence check on the *named* env var the instance
+/// points at) flips so the UI can show "secret already set" vs "needs setup".
+fn build_instance_fields_json(
+    meta: &ChannelMeta,
+    instance: &serde_json::Value,
+) -> Vec<serde_json::Value> {
+    let mut fields: Vec<serde_json::Value> = meta
+        .fields
+        .iter()
+        .map(|f| build_field_json(f, Some(instance)))
+        .collect();
+
+    // For per-instance secret fields, override `has_value` to check the env
+    // var that THIS instance's `<key>` points at (e.g. `TELEGRAM_BOT_TOKEN_2`)
+    // instead of the field schema's default env var. Without this, every
+    // instance would report the same `has_value` derived from the default
+    // env var, defeating the purpose of multiple instances.
+    let obj = match instance.as_object() {
+        Some(o) => o,
+        None => return fields,
+    };
+    for field_def in meta.fields {
+        if field_def.field_type != FieldType::Secret {
+            continue;
+        }
+        let pointed_env_name = obj
+            .get(field_def.key)
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if pointed_env_name.is_empty() {
+            continue;
+        }
+        let has_value = std::env::var(pointed_env_name)
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        for field_json in fields.iter_mut() {
+            if field_json.get("key").and_then(|v| v.as_str()) == Some(field_def.key) {
+                field_json["has_value"] = serde_json::Value::Bool(has_value);
+                // Surface the env-var name the instance is pointing at so
+                // the UI can show "TELEGRAM_BOT_TOKEN_2" next to the secret
+                // field — otherwise the user can't tell instances apart.
+                field_json["env_var"] = serde_json::Value::String(pointed_env_name.to_string());
+            }
+        }
+    }
+    fields
+}
+
+/// Process the submitted `fields` object into:
+///   1. a `config_fields` map ready to write to TOML,
+///   2. a side-effecting set of `secrets.env` writes for any secret values
+///      provided in the request.
+///
+/// `secret_env_overrides` lets per-instance handlers pick a custom env var
+/// name (e.g. `TELEGRAM_BOT_TOKEN_2` for the second instance) instead of
+/// the field schema's default. When the override is `None`, the schema
+/// default is used — this matches the legacy single-instance flow.
+async fn process_fields_for_write(
+    meta: &ChannelMeta,
+    fields: &serde_json::Map<String, serde_json::Value>,
+    secrets_path: &std::path::Path,
+    secret_env_overrides: &HashMap<String, String>,
+) -> Result<HashMap<String, (String, FieldType)>, (StatusCode, Json<serde_json::Value>)> {
+    let mut config_fields: HashMap<String, (String, FieldType)> = HashMap::new();
+
+    for field_def in meta.fields {
+        let value = fields
+            .get(field_def.key)
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if value.is_empty() {
+            continue;
+        }
+
+        if let Some(default_env_var) = field_def.env_var {
+            // Resolve the env var name to write under: per-instance override
+            // wins, else fall back to the field schema's default.
+            let env_var_name = secret_env_overrides
+                .get(field_def.key)
+                .cloned()
+                .unwrap_or_else(|| default_env_var.to_string());
+
+            // Validate the resolved env var name + secret value before
+            // touching the filesystem.
+            if let Err(msg) = validate_env_var(&env_var_name, value) {
+                return Err(ApiErrorResponse::bad_request(msg).into_json_tuple());
+            }
+            if let Err(e) = write_secret_env(secrets_path, &env_var_name, value) {
+                return Err(
+                    ApiErrorResponse::internal(format!("Failed to write secret: {e}"))
+                        .into_json_tuple(),
+                );
+            }
+            // `std::env::set_var` is not thread-safe inside the multithreaded
+            // tokio runtime; delegate to a blocking thread to avoid UB.
+            {
+                let env_var_owned = env_var_name.clone();
+                let value_owned = value.to_string();
+                let _ = tokio::task::spawn_blocking(move || {
+                    // SAFETY: single mutation on a dedicated blocking thread.
+                    unsafe { std::env::set_var(&env_var_owned, &value_owned) };
+                })
+                .await;
+            }
+            // Store the env var NAME (not the value) in TOML so the kernel
+            // knows which env var to read when activating the instance.
+            config_fields.insert(field_def.key.to_string(), (env_var_name, FieldType::Text));
+        } else {
+            config_fields.insert(
+                field_def.key.to_string(),
+                (value.to_string(), field_def.field_type),
+            );
+        }
+    }
+
+    Ok(config_fields)
+}
+
+/// Compute per-instance secret env var name overrides for instance `index`.
+///
+/// Index 0 keeps the field's default env var name (e.g. `TELEGRAM_BOT_TOKEN`)
+/// for backwards compatibility with the legacy single-instance flow. Index
+/// N>0 appends `_<N+1>` so writes don't collide:
+///   - instance 0 → `TELEGRAM_BOT_TOKEN`
+///   - instance 1 → `TELEGRAM_BOT_TOKEN_2`
+///   - instance 2 → `TELEGRAM_BOT_TOKEN_3`
+///
+/// If the user wants a custom env var name they can edit `secrets.env`
+/// directly and update the per-instance `bot_token_env` field; the dashboard
+/// surfaces the resolved env var name in the form so this is discoverable.
+fn default_secret_env_overrides(meta: &ChannelMeta, index: usize) -> HashMap<String, String> {
+    let mut overrides = HashMap::new();
+    if index == 0 {
+        return overrides;
+    }
+    let suffix = format!("_{}", index + 1);
+    for field_def in meta.fields {
+        if let Some(env_var) = field_def.env_var {
+            overrides.insert(field_def.key.to_string(), format!("{env_var}{suffix}"));
+        }
+    }
+    overrides
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/channels/{name}/instances",
+    tag = "channels",
+    params(
+        ("name" = String, Path, description = "Channel adapter name (e.g. telegram, discord)")
+    ),
+    responses(
+        (status = 200, description = "List configured instances", body = crate::types::JsonObject),
+        (status = 404, description = "Unknown channel", body = crate::types::JsonObject)
+    )
+)]
+/// GET /api/channels/{name}/instances — List every configured instance.
+pub async fn list_channel_instances(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let meta = match find_channel_meta(&name) {
+        Some(m) => m,
+        None => return ApiErrorResponse::not_found("Unknown channel").into_json_tuple(),
+    };
+
+    let live_channels = state.channels_config.read().await;
+    let instances = channel_instances_serialized(&live_channels, meta.name);
+
+    let items: Vec<serde_json::Value> = instances
+        .iter()
+        .enumerate()
+        .map(|(idx, inst)| {
+            let fields = build_instance_fields_json(meta, inst);
+            // `has_token` for THIS instance: every required secret field's
+            // pointed-at env var must be set.
+            let has_token = meta
+                .fields
+                .iter()
+                .filter(|f| f.required && f.field_type == FieldType::Secret)
+                .all(|f| {
+                    let pointed = inst
+                        .as_object()
+                        .and_then(|o| o.get(f.key))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    if pointed.is_empty() {
+                        return false;
+                    }
+                    std::env::var(pointed)
+                        .map(|v| !v.is_empty())
+                        .unwrap_or(false)
+                });
+            serde_json::json!({
+                "index": idx,
+                "fields": fields,
+                "config": inst,
+                "has_token": has_token,
+            })
+        })
+        .collect();
+
+    let total = items.len();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "channel": meta.name,
+            "items": items,
+            "total": total,
+        })),
+    )
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/channels/{name}/instances",
+    tag = "channels",
+    params(
+        ("name" = String, Path, description = "Channel adapter name")
+    ),
+    request_body = crate::types::JsonObject,
+    responses(
+        (status = 201, description = "Instance created", body = crate::types::JsonObject),
+        (status = 400, description = "Bad request", body = crate::types::JsonObject),
+        (status = 404, description = "Unknown channel", body = crate::types::JsonObject),
+        (status = 500, description = "Internal server error", body = crate::types::JsonObject)
+    )
+)]
+/// POST /api/channels/{name}/instances — Append a new `[[channels.<name>]]`.
+pub async fn create_channel_instance(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let meta = match find_channel_meta(&name) {
+        Some(m) => m,
+        None => return ApiErrorResponse::not_found("Unknown channel").into_json_tuple(),
+    };
+
+    let fields = match body.get("fields").and_then(|v| v.as_object()) {
+        Some(f) => f,
+        None => return ApiErrorResponse::bad_request("Missing 'fields' object").into_json_tuple(),
+    };
+
+    let home = librefang_home();
+    let secrets_path = home.join("secrets.env");
+    let config_path = home.join("config.toml");
+
+    // Compute the index this new instance will land at (under the live
+    // channels read lock for a consistent snapshot — `config_write_lock`
+    // below serialises against concurrent writers).
+    let next_index = {
+        let live_channels = state.channels_config.read().await;
+        channel_instance_count(&live_channels, meta.name)
+    };
+    let overrides = default_secret_env_overrides(meta, next_index);
+
+    let config_fields =
+        match process_fields_for_write(meta, fields, &secrets_path, &overrides).await {
+            Ok(f) => f,
+            Err(resp) => return resp,
+        };
+
+    let written_index = {
+        let _config_guard = state.config_write_lock.lock().await;
+        match append_channel_instance(&config_path, &name, &config_fields) {
+            Ok(idx) => idx,
+            Err(e) => {
+                return ApiErrorResponse::internal(format!("Failed to append instance: {e}"))
+                    .into_json_tuple();
+            }
+        }
+    };
+
+    let (activated, started) = match crate::channel_bridge::reload_channels_from_disk(&state).await
+    {
+        Ok(s) => (s.iter().any(|x| x.eq_ignore_ascii_case(&name)), s),
+        Err(e) => {
+            tracing::warn!(error = %e, "Channel hot-reload failed after instance create");
+            (false, Vec::new())
+        }
+    };
+
+    (
+        StatusCode::CREATED,
+        Json(serde_json::json!({
+            "status": "created",
+            "channel": name,
+            "index": written_index,
+            "activated": activated,
+            "started_channels": started,
+        })),
+    )
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/channels/{name}/instances/{index}",
+    tag = "channels",
+    params(
+        ("name" = String, Path, description = "Channel adapter name"),
+        ("index" = usize, Path, description = "Instance array index (0-based)")
+    ),
+    request_body = crate::types::JsonObject,
+    responses(
+        (status = 200, description = "Instance updated", body = crate::types::JsonObject),
+        (status = 400, description = "Bad request", body = crate::types::JsonObject),
+        (status = 404, description = "Unknown channel or instance index out of range", body = crate::types::JsonObject),
+        (status = 500, description = "Internal server error", body = crate::types::JsonObject)
+    )
+)]
+/// PUT /api/channels/{name}/instances/{index} — Replace one instance's fields.
+pub async fn update_channel_instance_handler(
+    State(state): State<Arc<AppState>>,
+    Path((name, index)): Path<(String, usize)>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let meta = match find_channel_meta(&name) {
+        Some(m) => m,
+        None => return ApiErrorResponse::not_found("Unknown channel").into_json_tuple(),
+    };
+
+    let fields = match body.get("fields").and_then(|v| v.as_object()) {
+        Some(f) => f,
+        None => return ApiErrorResponse::bad_request("Missing 'fields' object").into_json_tuple(),
+    };
+
+    // Range-check before touching the filesystem so a 404 is clean.
+    let current_count = {
+        let live_channels = state.channels_config.read().await;
+        channel_instance_count(&live_channels, meta.name)
+    };
+    if index >= current_count {
+        return ApiErrorResponse::not_found(format!(
+            "Instance {index} out of range (have {current_count} instance(s))"
+        ))
+        .into_json_tuple();
+    }
+
+    let home = librefang_home();
+    let secrets_path = home.join("secrets.env");
+    let config_path = home.join("config.toml");
+
+    let overrides = default_secret_env_overrides(meta, index);
+    let mut config_fields =
+        match process_fields_for_write(meta, fields, &secrets_path, &overrides).await {
+            Ok(f) => f,
+            Err(resp) => return resp,
+        };
+
+    // Preserve the existing instance's secret-field env-var-name reference
+    // when the user didn't retype the secret. Without this, the form's
+    // "leave empty to keep" placeholder would lie: editing any non-secret
+    // field while leaving the bot token blank would drop `bot_token_env`
+    // from the rebuilt entry, breaking authentication. Only secret fields
+    // get this treatment because the form pre-fills non-secret fields with
+    // their saved values, so they round-trip naturally.
+    let existing_instance = {
+        let live_channels = state.channels_config.read().await;
+        channel_instances_serialized(&live_channels, meta.name)
+            .get(index)
+            .cloned()
+    };
+    if let Some(obj) = existing_instance.as_ref().and_then(|v| v.as_object()) {
+        for field_def in meta.fields {
+            if field_def.field_type != FieldType::Secret {
+                continue;
+            }
+            if config_fields.contains_key(field_def.key) {
+                continue;
+            }
+            let existing_env_name = obj
+                .get(field_def.key)
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if existing_env_name.is_empty() {
+                continue;
+            }
+            config_fields.insert(
+                field_def.key.to_string(),
+                (existing_env_name.to_string(), FieldType::Text),
+            );
+        }
+    }
+
+    {
+        let _config_guard = state.config_write_lock.lock().await;
+        if let Err(e) = update_channel_instance(&config_path, &name, index, &config_fields) {
+            return ApiErrorResponse::internal(format!("Failed to update instance: {e}"))
+                .into_json_tuple();
+        }
+    }
+
+    let (activated, started) = match crate::channel_bridge::reload_channels_from_disk(&state).await
+    {
+        Ok(s) => (s.iter().any(|x| x.eq_ignore_ascii_case(&name)), s),
+        Err(e) => {
+            tracing::warn!(error = %e, "Channel hot-reload failed after instance update");
+            (false, Vec::new())
+        }
+    };
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "status": "updated",
+            "channel": name,
+            "index": index,
+            "activated": activated,
+            "started_channels": started,
+        })),
+    )
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/channels/{name}/instances/{index}",
+    tag = "channels",
+    params(
+        ("name" = String, Path, description = "Channel adapter name"),
+        ("index" = usize, Path, description = "Instance array index (0-based)")
+    ),
+    responses(
+        (status = 204, description = "Instance removed"),
+        (status = 404, description = "Unknown channel or instance index out of range", body = crate::types::JsonObject),
+        (status = 500, description = "Internal server error", body = crate::types::JsonObject)
+    )
+)]
+/// DELETE /api/channels/{name}/instances/{index} — Remove a single instance.
+///
+/// Note: this does NOT clear the secret env var the instance pointed at —
+/// the env var may be shared with another instance, and we don't want to
+/// silently break a running bot. The user can clear stale entries from
+/// `secrets.env` manually.
+pub async fn delete_channel_instance(
+    State(state): State<Arc<AppState>>,
+    Path((name, index)): Path<(String, usize)>,
+) -> impl IntoResponse {
+    if find_channel_meta(&name).is_none() {
+        return ApiErrorResponse::not_found("Unknown channel").into_json_tuple();
+    };
+
+    let current_count = {
+        let live_channels = state.channels_config.read().await;
+        channel_instance_count(&live_channels, &name)
+    };
+    if index >= current_count {
+        return ApiErrorResponse::not_found(format!(
+            "Instance {index} out of range (have {current_count} instance(s))"
+        ))
+        .into_json_tuple();
+    }
+
+    let home = librefang_home();
+    let config_path = home.join("config.toml");
+
+    {
+        let _config_guard = state.config_write_lock.lock().await;
+        if let Err(e) = remove_channel_instance(&config_path, &name, index) {
+            return ApiErrorResponse::internal(format!("Failed to remove instance: {e}"))
+                .into_json_tuple();
+        }
+    }
+
+    if let Err(e) = crate::channel_bridge::reload_channels_from_disk(&state).await {
+        tracing::warn!(error = %e, "Channel hot-reload failed after instance delete");
+    }
+
+    (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
+}
+
 #[utoipa::path(
     post,
     path = "/api/channels/{name}/test",

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -5503,6 +5503,15 @@ pub(crate) fn remove_secret_env(path: &std::path::Path, key: &str) -> Result<(),
 
 // ── Config.toml channel management helpers ──────────────────────────
 
+/// Sentinel error message produced by `upsert_channel_config` and
+/// `remove_channel_config` when the channel is in `[[channels.<name>]]`
+/// (array-of-tables) shape. The handler matches on this prefix to map the
+/// failure to 409 Conflict instead of 500. Multi-instance channels must
+/// use the per-instance API (`/api/channels/<name>/instances/...`); the
+/// legacy single-instance `/configure` endpoint cannot represent them
+/// without silently dropping every instance after the first (#4865).
+pub(crate) const CHANNEL_AOT_CONFLICT_PREFIX: &str = "channel-is-multi-instance:";
+
 /// Upsert a `[channels.<name>]` section in config.toml with the given non-secret fields.
 ///
 /// Uses `toml_edit::DocumentMut` to preserve comments, key ordering, and
@@ -5511,6 +5520,11 @@ pub(crate) fn remove_secret_env(path: &std::path::Path, key: &str) -> Result<(),
 /// channel write — see issue #3183. Callers must hold
 /// `AppState::config_write_lock` to serialize against `POST /api/config/set`,
 /// which performs an asymmetric read-modify-write on the same file.
+///
+/// Refuses to write when the channel already exists as `[[channels.<name>]]`
+/// (multi-instance) — the legacy single-table write would silently delete
+/// every instance after the first. Callers must route to the per-instance
+/// API in that case (#4865).
 pub(crate) fn upsert_channel_config(
     config_path: &std::path::Path,
     channel_name: &str,
@@ -5538,6 +5552,19 @@ pub(crate) fn upsert_channel_config(
         .as_table_mut()
         .ok_or("channels is not a table")?;
 
+    // Refuse to clobber an existing `[[channels.<name>]]` array. The
+    // legacy single-table replace path below would otherwise silently drop
+    // every instance after the first — see issue #4865.
+    if matches!(
+        channels_table.get(channel_name),
+        Some(toml_edit::Item::ArrayOfTables(_))
+    ) {
+        return Err(format!(
+            "{CHANNEL_AOT_CONFLICT_PREFIX}channel '{channel_name}' has multiple instances; use the per-instance API"
+        )
+        .into());
+    }
+
     // Build channel sub-table with correct TOML types
     let ch_table = build_channel_toml_table(fields);
     channels_table.insert(channel_name, toml_edit::Item::Table(ch_table));
@@ -5555,6 +5582,11 @@ pub(crate) fn upsert_channel_config(
 ///
 /// Mirrors `upsert_channel_config`: format-preserving via `toml_edit`, and
 /// callers must hold `AppState::config_write_lock`.
+///
+/// Refuses to delete when the channel exists as `[[channels.<name>]]`
+/// (multi-instance) — the bulk delete would silently nuke every instance.
+/// Callers must use `DELETE /api/channels/<name>/instances/<id>` to remove
+/// instances individually (#4865).
 pub(crate) fn remove_channel_config(
     config_path: &std::path::Path,
     channel_name: &str,
@@ -5573,6 +5605,15 @@ pub(crate) fn remove_channel_config(
     let mut doc: toml_edit::DocumentMut = content.parse()?;
 
     if let Some(channels) = doc.get_mut("channels").and_then(|i| i.as_table_mut()) {
+        if matches!(
+            channels.get(channel_name),
+            Some(toml_edit::Item::ArrayOfTables(_))
+        ) {
+            return Err(format!(
+                "{CHANNEL_AOT_CONFLICT_PREFIX}channel '{channel_name}' has multiple instances; use the per-instance API"
+            )
+            .into());
+        }
         channels.remove(channel_name);
     }
 
@@ -6925,5 +6966,84 @@ bot_token_env = \"DISCORD_BOT_TOKEN\"
             err.to_string().contains("out of bounds"),
             "out-of-range remove should error: {err}"
         );
+    }
+
+    /// Regression for #4865: legacy `POST /api/channels/<name>/configure`
+    /// silently replaced the entire `[[channels.<name>]]` array with a
+    /// single `[channels.<name>]` table, losing every instance after the
+    /// first. The helper must refuse with the AoT-conflict sentinel so the
+    /// handler can map to 409 Conflict.
+    #[test]
+    fn upsert_channel_config_refuses_when_aot_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[[channels.telegram]]\nbot_token_env = \"TG_A\"\n\n\
+             [[channels.telegram]]\nbot_token_env = \"TG_B\"\n",
+        )
+        .unwrap();
+        let mut fields: HashMap<String, (String, FieldType)> = HashMap::new();
+        fields.insert(
+            "bot_token_env".to_string(),
+            ("TG_REPLACEMENT".to_string(), FieldType::Text),
+        );
+        let err = upsert_channel_config(&path, "telegram", &fields).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.starts_with(CHANNEL_AOT_CONFLICT_PREFIX),
+            "expected AoT-conflict sentinel, got: {msg}"
+        );
+        // Disk must be untouched — both original instances still present.
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("TG_A"), "instance A was clobbered: {raw}");
+        assert!(raw.contains("TG_B"), "instance B was clobbered: {raw}");
+        assert!(
+            !raw.contains("TG_REPLACEMENT"),
+            "refused write must not appear on disk: {raw}"
+        );
+    }
+
+    /// Regression for #4865: `DELETE /api/channels/<name>/configure` would
+    /// drop the entire `[[channels.<name>]]` array, including instances the
+    /// user had created via the per-instance API. Helper must refuse.
+    #[test]
+    fn remove_channel_config_refuses_when_aot_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[[channels.telegram]]\nbot_token_env = \"TG_A\"\n\n\
+             [[channels.telegram]]\nbot_token_env = \"TG_B\"\n",
+        )
+        .unwrap();
+        let err = remove_channel_config(&path, "telegram").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.starts_with(CHANNEL_AOT_CONFLICT_PREFIX),
+            "expected AoT-conflict sentinel, got: {msg}"
+        );
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("TG_A"), "instance A was clobbered: {raw}");
+        assert!(raw.contains("TG_B"), "instance B was clobbered: {raw}");
+    }
+
+    /// Single-instance legacy table form must keep working with /configure
+    /// (the back-compat path). The AoT-refusal must NOT trigger when the
+    /// channel is stored as a single table.
+    #[test]
+    fn upsert_channel_config_still_replaces_legacy_single_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "[channels.telegram]\nbot_token_env = \"OLD\"\n").unwrap();
+        let mut fields: HashMap<String, (String, FieldType)> = HashMap::new();
+        fields.insert(
+            "bot_token_env".to_string(),
+            ("NEW_TOKEN".to_string(), FieldType::Text),
+        );
+        upsert_channel_config(&path, "telegram", &fields).expect("legacy single-table replace");
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("NEW_TOKEN"), "replacement must land: {raw}");
+        assert!(!raw.contains("OLD"), "old value must be gone: {raw}");
     }
 }

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -5539,30 +5539,7 @@ pub(crate) fn upsert_channel_config(
         .ok_or("channels is not a table")?;
 
     // Build channel sub-table with correct TOML types
-    let mut ch_table = toml_edit::Table::new();
-    for (k, (v, ft)) in fields {
-        let item = match ft {
-            FieldType::Number => {
-                if let Ok(n) = v.parse::<i64>() {
-                    toml_edit::value(n)
-                } else {
-                    toml_edit::value(v.clone())
-                }
-            }
-            FieldType::List => {
-                // Always store list items as strings so that numeric IDs
-                // (e.g. Discord guild snowflakes, Telegram user IDs) are
-                // deserialized correctly into Vec<String> config fields.
-                let mut arr = toml_edit::Array::new();
-                for s in v.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
-                    arr.push(s);
-                }
-                toml_edit::value(arr)
-            }
-            _ => toml_edit::value(v.clone()),
-        };
-        ch_table.insert(k, item);
-    }
+    let ch_table = build_channel_toml_table(fields);
     channels_table.insert(channel_name, toml_edit::Item::Table(ch_table));
 
     // Ensure parent directory exists
@@ -5600,6 +5577,263 @@ pub(crate) fn remove_channel_config(
     }
 
     std::fs::write(config_path, doc.to_string())?;
+    Ok(())
+}
+
+/// Build a TOML table from a `(key, (value, field_type))` field map.
+///
+/// Shared between `upsert_channel_config` and the per-instance helpers
+/// (`append_channel_instance`, `update_channel_instance`) so number / list
+/// coercion stays consistent across all channel write paths.
+fn build_channel_toml_table(fields: &HashMap<String, (String, FieldType)>) -> toml_edit::Table {
+    let mut ch_table = toml_edit::Table::new();
+    for (k, (v, ft)) in fields {
+        let item = match ft {
+            FieldType::Number => {
+                if let Ok(n) = v.parse::<i64>() {
+                    toml_edit::value(n)
+                } else {
+                    toml_edit::value(v.clone())
+                }
+            }
+            FieldType::List => {
+                let mut arr = toml_edit::Array::new();
+                for s in v.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                    arr.push(s);
+                }
+                toml_edit::value(arr)
+            }
+            _ => toml_edit::value(v.clone()),
+        };
+        ch_table.insert(k, item);
+    }
+    ch_table
+}
+
+/// Open `config.toml` as a `DocumentMut` (creating an empty doc if the file
+/// is absent or empty) and return both the doc and the parent dir to create
+/// before writing back. Centralises the read-validate-parse boilerplate
+/// shared by every channel-instance helper.
+fn open_config_doc(
+    config_path: &std::path::Path,
+) -> Result<toml_edit::DocumentMut, Box<dyn std::error::Error>> {
+    validate_static_file_path(config_path, "config.toml")
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let content = if config_path.exists() {
+        std::fs::read_to_string(config_path)?
+    } else {
+        String::new()
+    };
+    let doc: toml_edit::DocumentMut = if content.trim().is_empty() {
+        toml_edit::DocumentMut::new()
+    } else {
+        content.parse()?
+    };
+    Ok(doc)
+}
+
+fn write_config_doc(
+    config_path: &std::path::Path,
+    doc: &toml_edit::DocumentMut,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(config_path, doc.to_string())?;
+    Ok(())
+}
+
+/// Append a new `[[channels.<name>]]` instance to config.toml.
+///
+/// Auto-promotes a single `[channels.<name>]` table to an `ArrayOfTables`
+/// containing the previous entry plus the new one, so the user can keep
+/// the channel they configured via the legacy `/configure` endpoint and
+/// still add another instance on top. Callers must hold
+/// `AppState::config_write_lock` (same locking discipline as
+/// `upsert_channel_config` — see issue #3183).
+pub(crate) fn append_channel_instance(
+    config_path: &std::path::Path,
+    channel_name: &str,
+    fields: &HashMap<String, (String, FieldType)>,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let mut doc = open_config_doc(config_path)?;
+
+    if !doc.contains_table("channels") {
+        doc["channels"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let channels_table = doc["channels"]
+        .as_table_mut()
+        .ok_or("channels is not a table")?;
+
+    let new_entry = build_channel_toml_table(fields);
+
+    // Resolve the existing item under channels.<name>, if any. Three shapes
+    // are possible:
+    //   - missing: create a new ArrayOfTables containing the new entry
+    //   - single Table (legacy `[channels.<name>]`): promote to
+    //     ArrayOfTables = [old, new]
+    //   - existing ArrayOfTables: push the new entry
+    let new_index = match channels_table.remove(channel_name) {
+        None => {
+            let mut aot = toml_edit::ArrayOfTables::new();
+            aot.push(new_entry);
+            channels_table.insert(channel_name, toml_edit::Item::ArrayOfTables(aot));
+            0
+        }
+        Some(toml_edit::Item::Table(existing)) => {
+            let mut aot = toml_edit::ArrayOfTables::new();
+            aot.push(existing);
+            aot.push(new_entry);
+            channels_table.insert(channel_name, toml_edit::Item::ArrayOfTables(aot));
+            1
+        }
+        Some(toml_edit::Item::ArrayOfTables(mut aot)) => {
+            aot.push(new_entry);
+            let idx = aot.len() - 1;
+            channels_table.insert(channel_name, toml_edit::Item::ArrayOfTables(aot));
+            idx
+        }
+        Some(other) => {
+            // Re-insert what we removed so the file isn't accidentally mutated.
+            channels_table.insert(channel_name, other);
+            return Err(format!(
+                "channels.{channel_name} has an unsupported TOML shape (expected table or array of tables)"
+            )
+            .into());
+        }
+    };
+
+    write_config_doc(config_path, &doc)?;
+    Ok(new_index)
+}
+
+/// Replace a single `[[channels.<name>]]` instance at `index`.
+///
+/// Accepts either the legacy single-table form (when `index == 0`) or an
+/// `ArrayOfTables`. Returns `Err` if the index is out of bounds or the
+/// channel is not present in the document. Callers must hold
+/// `AppState::config_write_lock`.
+pub(crate) fn update_channel_instance(
+    config_path: &std::path::Path,
+    channel_name: &str,
+    index: usize,
+    fields: &HashMap<String, (String, FieldType)>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut doc = open_config_doc(config_path)?;
+
+    let channels_table = doc
+        .get_mut("channels")
+        .and_then(|i| i.as_table_mut())
+        .ok_or_else(|| format!("channels.{channel_name} is not configured"))?;
+
+    let new_entry = build_channel_toml_table(fields);
+
+    match channels_table.get_mut(channel_name) {
+        None => {
+            return Err(format!("channels.{channel_name} is not configured").into());
+        }
+        Some(toml_edit::Item::Table(table)) => {
+            if index != 0 {
+                return Err(format!(
+                    "channels.{channel_name}[{index}] is out of bounds (only one instance configured)"
+                )
+                .into());
+            }
+            *table = new_entry;
+        }
+        Some(toml_edit::Item::ArrayOfTables(aot)) => {
+            if index >= aot.len() {
+                return Err(format!(
+                    "channels.{channel_name}[{index}] is out of bounds (have {} instance(s))",
+                    aot.len()
+                )
+                .into());
+            }
+            // ArrayOfTables doesn't expose direct index assignment, so rebuild
+            // by iterating: collect the existing entries, swap at `index`, and
+            // reinsert the rebuilt array.
+            let mut rebuilt = toml_edit::ArrayOfTables::new();
+            for (i, existing) in aot.iter().enumerate() {
+                if i == index {
+                    rebuilt.push(new_entry.clone());
+                } else {
+                    rebuilt.push(existing.clone());
+                }
+            }
+            *aot = rebuilt;
+        }
+        Some(_other) => {
+            return Err(format!(
+                "channels.{channel_name} has an unsupported TOML shape (expected table or array of tables)"
+            )
+            .into());
+        }
+    }
+
+    write_config_doc(config_path, &doc)?;
+    Ok(())
+}
+
+/// Remove the `[[channels.<name>]]` instance at `index`.
+///
+/// If the channel is stored as a single legacy table, the entire section is
+/// removed when `index == 0`. If stored as an `ArrayOfTables` and the array
+/// becomes empty, the whole `channels.<name>` key is removed. Callers must
+/// hold `AppState::config_write_lock`.
+pub(crate) fn remove_channel_instance(
+    config_path: &std::path::Path,
+    channel_name: &str,
+    index: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut doc = open_config_doc(config_path)?;
+
+    let channels_table = match doc.get_mut("channels").and_then(|i| i.as_table_mut()) {
+        Some(t) => t,
+        None => return Err(format!("channels.{channel_name} is not configured").into()),
+    };
+
+    match channels_table.get_mut(channel_name) {
+        None => {
+            return Err(format!("channels.{channel_name} is not configured").into());
+        }
+        Some(toml_edit::Item::Table(_)) => {
+            if index != 0 {
+                return Err(format!(
+                    "channels.{channel_name}[{index}] is out of bounds (only one instance configured)"
+                )
+                .into());
+            }
+            channels_table.remove(channel_name);
+        }
+        Some(toml_edit::Item::ArrayOfTables(aot)) => {
+            if index >= aot.len() {
+                return Err(format!(
+                    "channels.{channel_name}[{index}] is out of bounds (have {} instance(s))",
+                    aot.len()
+                )
+                .into());
+            }
+            let mut rebuilt = toml_edit::ArrayOfTables::new();
+            for (i, existing) in aot.iter().enumerate() {
+                if i != index {
+                    rebuilt.push(existing.clone());
+                }
+            }
+            if rebuilt.is_empty() {
+                channels_table.remove(channel_name);
+            } else {
+                *aot = rebuilt;
+            }
+        }
+        Some(_other) => {
+            return Err(format!(
+                "channels.{channel_name} has an unsupported TOML shape (expected table or array of tables)"
+            )
+            .into());
+        }
+    }
+
+    write_config_doc(config_path, &doc)?;
     Ok(())
 }
 
@@ -6468,6 +6702,228 @@ bot_token_env = \"DISCORD_BOT_TOKEN\"
         assert!(
             !path.exists(),
             "secrets.env must not be created on validation error"
+        );
+    }
+
+    // ── Channel instance helpers (#4837) ────────────────────────────────
+
+    fn fields_for(values: &[(&str, &str, FieldType)]) -> HashMap<String, (String, FieldType)> {
+        values
+            .iter()
+            .map(|(k, v, ft)| (k.to_string(), (v.to_string(), *ft)))
+            .collect()
+    }
+
+    #[test]
+    fn append_channel_instance_creates_array_of_tables_from_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        let f = fields_for(&[
+            ("bot_token_env", "TELEGRAM_BOT_TOKEN", FieldType::Text),
+            ("default_agent", "support", FieldType::Text),
+        ]);
+        let idx = append_channel_instance(&path, "telegram", &f).unwrap();
+        assert_eq!(idx, 0, "first append must land at index 0");
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            raw.contains("[[channels.telegram]]"),
+            "first append should write [[channels.telegram]] (array of tables): {raw}"
+        );
+        assert!(raw.contains("bot_token_env = \"TELEGRAM_BOT_TOKEN\""));
+    }
+
+    #[test]
+    fn append_channel_instance_promotes_legacy_single_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        // Seed with a legacy `[channels.telegram]` single-table layout — the
+        // shape produced by every previous version of the dashboard.
+        std::fs::write(
+            &path,
+            "[channels.telegram]\nbot_token_env = \"FIRST\"\ndefault_agent = \"alpha\"\n",
+        )
+        .unwrap();
+        let f = fields_for(&[
+            ("bot_token_env", "SECOND", FieldType::Text),
+            ("default_agent", "beta", FieldType::Text),
+        ]);
+        let idx = append_channel_instance(&path, "telegram", &f).unwrap();
+        assert_eq!(idx, 1, "appending to single table should land at index 1");
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        // Must now be an array-of-tables — the single-table form cannot
+        // coexist with a second instance.
+        assert!(
+            raw.contains("[[channels.telegram]]"),
+            "single Table must be promoted to ArrayOfTables: {raw}"
+        );
+        assert!(
+            raw.contains("FIRST"),
+            "legacy entry must be preserved: {raw}"
+        );
+        assert!(raw.contains("SECOND"), "new entry must be present: {raw}");
+
+        // Round-trip through the typed config to make sure the kernel will
+        // see both instances post-promotion.
+        #[derive(serde::Deserialize)]
+        struct Doc {
+            channels: librefang_types::config::ChannelsConfig,
+        }
+        let parsed: Doc = toml::from_str(&raw).unwrap();
+        assert_eq!(parsed.channels.telegram.len(), 2);
+    }
+
+    #[test]
+    fn append_channel_instance_pushes_to_existing_array() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[[channels.telegram]]\nbot_token_env = \"A\"\n\n[[channels.telegram]]\nbot_token_env = \"B\"\n",
+        )
+        .unwrap();
+        let f = fields_for(&[("bot_token_env", "C", FieldType::Text)]);
+        let idx = append_channel_instance(&path, "telegram", &f).unwrap();
+        assert_eq!(idx, 2, "third instance must land at index 2");
+        let raw = std::fs::read_to_string(&path).unwrap();
+        for needle in ["\"A\"", "\"B\"", "\"C\""] {
+            assert!(raw.contains(needle), "{needle} must be present: {raw}");
+        }
+    }
+
+    #[test]
+    fn update_channel_instance_replaces_array_entry_at_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[[channels.telegram]]\nbot_token_env = \"A\"\n\n[[channels.telegram]]\nbot_token_env = \"B\"\n",
+        )
+        .unwrap();
+        let f = fields_for(&[
+            ("bot_token_env", "B_UPDATED", FieldType::Text),
+            ("default_agent", "ops", FieldType::Text),
+        ]);
+        update_channel_instance(&path, "telegram", 1, &f).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("\"A\""), "instance 0 must be preserved: {raw}");
+        assert!(
+            raw.contains("B_UPDATED"),
+            "instance 1 must reflect update: {raw}"
+        );
+        assert!(
+            !raw.contains("\"B\"\n"),
+            "old instance 1 value must be gone: {raw}"
+        );
+    }
+
+    #[test]
+    fn update_channel_instance_replaces_legacy_single_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "[channels.telegram]\nbot_token_env = \"OLD\"\n").unwrap();
+        let f = fields_for(&[("bot_token_env", "NEW", FieldType::Text)]);
+        update_channel_instance(&path, "telegram", 0, &f).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            raw.contains("NEW"),
+            "legacy single-table edit at idx 0 should land: {raw}"
+        );
+        assert!(!raw.contains("OLD"), "legacy value must be replaced: {raw}");
+    }
+
+    #[test]
+    fn update_channel_instance_out_of_bounds_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "[[channels.telegram]]\nbot_token_env = \"A\"\n").unwrap();
+        let f = fields_for(&[("bot_token_env", "X", FieldType::Text)]);
+        let err = update_channel_instance(&path, "telegram", 5, &f).unwrap_err();
+        assert!(
+            err.to_string().contains("out of bounds"),
+            "out-of-range update should error: {err}"
+        );
+    }
+
+    #[test]
+    fn update_channel_instance_unknown_channel_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "[other]\nx = 1\n").unwrap();
+        let f = fields_for(&[("bot_token_env", "X", FieldType::Text)]);
+        let err = update_channel_instance(&path, "telegram", 0, &f).unwrap_err();
+        assert!(
+            err.to_string().contains("not configured"),
+            "unconfigured channel update should error: {err}"
+        );
+    }
+
+    #[test]
+    fn remove_channel_instance_drops_one_array_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[[channels.telegram]]\nbot_token_env = \"A\"\n\n[[channels.telegram]]\nbot_token_env = \"B\"\n\n[[channels.telegram]]\nbot_token_env = \"C\"\n",
+        )
+        .unwrap();
+        remove_channel_instance(&path, "telegram", 1).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("\"A\""));
+        assert!(raw.contains("\"C\""));
+        assert!(
+            !raw.contains("\"B\""),
+            "removed instance must be gone: {raw}"
+        );
+
+        #[derive(serde::Deserialize)]
+        struct Doc {
+            channels: librefang_types::config::ChannelsConfig,
+        }
+        let parsed: Doc = toml::from_str(&raw).unwrap();
+        assert_eq!(parsed.channels.telegram.len(), 2);
+    }
+
+    #[test]
+    fn remove_channel_instance_drops_section_when_array_empties() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "[[channels.telegram]]\nbot_token_env = \"ONLY\"\n").unwrap();
+        remove_channel_instance(&path, "telegram", 0).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        // Either the channels.telegram entry is gone entirely, or the channels
+        // table itself is empty — both forms parse back to zero instances.
+        #[derive(serde::Deserialize, Default)]
+        struct Doc {
+            #[serde(default)]
+            channels: librefang_types::config::ChannelsConfig,
+        }
+        let parsed: Doc = toml::from_str(&raw).unwrap_or_default();
+        assert_eq!(parsed.channels.telegram.len(), 0);
+    }
+
+    #[test]
+    fn remove_channel_instance_drops_legacy_single_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "[channels.telegram]\nbot_token_env = \"OLD\"\n").unwrap();
+        remove_channel_instance(&path, "telegram", 0).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !raw.contains("bot_token_env"),
+            "legacy single-table delete at idx 0 must remove the section: {raw}"
+        );
+    }
+
+    #[test]
+    fn remove_channel_instance_out_of_bounds_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "[[channels.telegram]]\nbot_token_env = \"A\"\n").unwrap();
+        let err = remove_channel_instance(&path, "telegram", 7).unwrap_err();
+        assert!(
+            err.to_string().contains("out of bounds"),
+            "out-of-range remove should error: {err}"
         );
     }
 }

--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -434,7 +434,10 @@ async fn channels_update_instance_unknown_channel_returns_404() {
 #[tokio::test(flavor = "multi_thread")]
 async fn channels_update_instance_out_of_range_returns_404() {
     // Seed one instance, then try to PUT index 7. The handler must reject
-    // before touching disk because the index is out of range.
+    // because the index is out of range. The body carries a placeholder
+    // signature — the post-#4865 PUT requires the CAS field, but a stale
+    // value here is fine since the range check fires first under the
+    // write lock.
     let channels = ChannelsConfig {
         telegram: OneOrMany(vec![TelegramConfig::default()]),
         ..ChannelsConfig::default()
@@ -444,7 +447,10 @@ async fn channels_update_instance_out_of_range_returns_404() {
         &h,
         Method::PUT,
         "/api/channels/telegram/instances/7",
-        Some(serde_json::json!({"fields": {"default_agent": "x"}})),
+        Some(serde_json::json!({
+            "fields": {"default_agent": "x"},
+            "signature": "stale-signature",
+        })),
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
@@ -454,6 +460,34 @@ async fn channels_update_instance_out_of_range_returns_404() {
             .unwrap_or("")
             .contains("out of range"),
         "error must mention 'out of range': {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_update_instance_missing_signature_returns_400() {
+    // The post-#4865 PUT requires a `signature` body field for CAS so the
+    // server can reject writes that target an instance which has been
+    // moved or modified since the client read it. A missing signature is
+    // a clean 400 — the handler must not silently fall through to a write.
+    let channels = ChannelsConfig {
+        telegram: OneOrMany(vec![TelegramConfig::default()]),
+        ..ChannelsConfig::default()
+    };
+    let h = boot_with_channels(channels).await;
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/channels/telegram/instances/0",
+        Some(serde_json::json!({"fields": {"default_agent": "x"}})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("signature"),
+        "error must call out the missing 'signature' field: {body}"
     );
 }
 
@@ -494,10 +528,12 @@ async fn channels_delete_instance_out_of_range_returns_404() {
         ..ChannelsConfig::default()
     };
     let h = boot_with_channels(channels).await;
+    // Post-#4865 DELETE requires `?signature=` for CAS — a stale value
+    // here is fine, the range check fires first under the write lock.
     let (status, body) = json_request(
         &h,
         Method::DELETE,
-        "/api/channels/telegram/instances/3",
+        "/api/channels/telegram/instances/3?signature=stale",
         None,
     )
     .await;
@@ -508,6 +544,34 @@ async fn channels_delete_instance_out_of_range_returns_404() {
             .unwrap_or("")
             .contains("out of range"),
         "error must mention 'out of range': {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_delete_instance_missing_signature_returns_400() {
+    // The post-#4865 DELETE requires `?signature=` query parameter for
+    // CAS. Without it the handler must reject with 400 before touching
+    // disk — silently deleting based on an index alone is the bug class
+    // the CAS token closes off.
+    let channels = ChannelsConfig {
+        telegram: OneOrMany(vec![TelegramConfig::default()]),
+        ..ChannelsConfig::default()
+    };
+    let h = boot_with_channels(channels).await;
+    let (status, body) = json_request(
+        &h,
+        Method::DELETE,
+        "/api/channels/telegram/instances/0",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("signature"),
+        "error must call out the missing 'signature' query parameter: {body}"
     );
 }
 

--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -301,6 +301,250 @@ async fn channels_test_unknown_channel_returns_404() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Per-instance endpoints (#4837)
+//
+// The legacy `/configure` endpoints treat every channel as a single
+// `[channels.<name>]` table. The new `/instances` endpoints let the
+// dashboard manage `[[channels.<name>]]` array entries — supporting two
+// Telegram bots, three Slack workspaces, etc. on the same channel type.
+//
+// As with `/configure`, we deliberately do NOT exercise happy-path WRITES
+// here. POST/PUT mutate `~/.librefang/secrets.env` and process-wide env
+// vars (`std::env::set_var`), which would race with parallel tests. The
+// underlying TOML write logic is covered by the unit tests in
+// `routes::skills::tests::{append,update,remove}_channel_instance_*`.
+// What we DO cover here:
+//   - GET /instances reflects the seeded `OneOrMany<T>` from KernelConfig
+//   - All four routes 404 on unknown channel
+//   - POST/PUT 400 on missing `fields`
+//   - PUT/DELETE 404 when the instance index is out of range
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_instances_list_empty_when_unconfigured() {
+    let h = boot().await;
+    let (status, body) =
+        json_request(&h, Method::GET, "/api/channels/telegram/instances", None).await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert_eq!(body["channel"], "telegram");
+    assert_eq!(body["total"], 0);
+    let arr = body["items"].as_array().expect("items must be array");
+    assert!(arr.is_empty(), "no instances seeded → items must be empty");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_instances_list_returns_seeded_instances() {
+    // Seed two telegram instances and assert both come through with
+    // their configured fields and `index` values.
+    let channels = ChannelsConfig {
+        telegram: OneOrMany(vec![
+            TelegramConfig {
+                bot_token_env: "TG_SUPPORT".into(),
+                ..TelegramConfig::default()
+            },
+            TelegramConfig {
+                bot_token_env: "TG_OPS".into(),
+                ..TelegramConfig::default()
+            },
+        ]),
+        ..ChannelsConfig::default()
+    };
+    let h = boot_with_channels(channels).await;
+
+    let (status, body) =
+        json_request(&h, Method::GET, "/api/channels/telegram/instances", None).await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert_eq!(body["total"], 2, "two instances seeded: {body}");
+    let arr = body["items"].as_array().expect("items array");
+    assert_eq!(arr.len(), 2);
+    assert_eq!(arr[0]["index"], 0);
+    assert_eq!(arr[1]["index"], 1);
+    assert_eq!(arr[0]["config"]["bot_token_env"], "TG_SUPPORT");
+    assert_eq!(arr[1]["config"]["bot_token_env"], "TG_OPS");
+    // Each instance must carry the field schema so the dashboard can
+    // render the form without an extra `/api/channels/{name}` round-trip.
+    assert!(
+        arr[0]["fields"].is_array(),
+        "fields schema must travel with each instance"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_instances_list_unknown_channel_returns_404() {
+    let h = boot().await;
+    let (status, body) =
+        json_request(&h, Method::GET, "/api/channels/not-a-real/instances", None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Unknown channel"),
+        "error must mention 'Unknown channel': {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_create_instance_unknown_channel_returns_404() {
+    let h = boot().await;
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/channels/not-a-real/instances",
+        Some(serde_json::json!({"fields": {}})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_create_instance_missing_fields_returns_400() {
+    let h = boot().await;
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/channels/telegram/instances",
+        Some(serde_json::json!({"not_fields": "oops"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("fields"),
+        "error must mention 'fields': {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_update_instance_unknown_channel_returns_404() {
+    let h = boot().await;
+    let (status, _body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/channels/not-a-real/instances/0",
+        Some(serde_json::json!({"fields": {}})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_update_instance_out_of_range_returns_404() {
+    // Seed one instance, then try to PUT index 7. The handler must reject
+    // before touching disk because the index is out of range.
+    let channels = ChannelsConfig {
+        telegram: OneOrMany(vec![TelegramConfig::default()]),
+        ..ChannelsConfig::default()
+    };
+    let h = boot_with_channels(channels).await;
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/channels/telegram/instances/7",
+        Some(serde_json::json!({"fields": {"default_agent": "x"}})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("out of range"),
+        "error must mention 'out of range': {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_update_instance_missing_fields_returns_400() {
+    let channels = ChannelsConfig {
+        telegram: OneOrMany(vec![TelegramConfig::default()]),
+        ..ChannelsConfig::default()
+    };
+    let h = boot_with_channels(channels).await;
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/channels/telegram/instances/0",
+        Some(serde_json::json!({"not_fields": "oops"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_delete_instance_unknown_channel_returns_404() {
+    let h = boot().await;
+    let (status, _body) = json_request(
+        &h,
+        Method::DELETE,
+        "/api/channels/not-a-real/instances/0",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_delete_instance_out_of_range_returns_404() {
+    let channels = ChannelsConfig {
+        telegram: OneOrMany(vec![TelegramConfig::default()]),
+        ..ChannelsConfig::default()
+    };
+    let h = boot_with_channels(channels).await;
+    let (status, body) = json_request(
+        &h,
+        Method::DELETE,
+        "/api/channels/telegram/instances/3",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("out of range"),
+        "error must mention 'out of range': {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_list_includes_instance_count() {
+    // The dashboard's card subtitle ("Telegram · 2 bots") depends on
+    // `instance_count` riding alongside the existing `configured` flag.
+    let channels = ChannelsConfig {
+        telegram: OneOrMany(vec![
+            TelegramConfig::default(),
+            TelegramConfig::default(),
+            TelegramConfig::default(),
+        ]),
+        ..ChannelsConfig::default()
+    };
+    let h = boot_with_channels(channels).await;
+    let (status, body) = json_request(&h, Method::GET, "/api/channels", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let arr = body["items"].as_array().expect("items");
+    let telegram = arr
+        .iter()
+        .find(|r| r["name"] == "telegram")
+        .expect("telegram row");
+    assert_eq!(
+        telegram["instance_count"], 3,
+        "telegram seeded with 3 instances must report instance_count=3: {telegram}"
+    );
+    let discord = arr
+        .iter()
+        .find(|r| r["name"] == "discord")
+        .expect("discord row");
+    assert_eq!(
+        discord["instance_count"], 0,
+        "discord untouched must report instance_count=0: {discord}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn channels_test_known_channel_with_no_creds_reports_missing_env() {
     // #3507 reshaped this handler so the HTTP status reflects the actual

--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -30,8 +30,65 @@ use axum::Router;
 use librefang_api::routes::{self, AppState};
 use librefang_testing::{MockKernelBuilder, TestAppState};
 use librefang_types::config::{ChannelsConfig, OneOrMany, TelegramConfig};
+use std::path::Path;
 use std::sync::Arc;
 use tower::ServiceExt;
+
+/// Serialises every test in this binary that touches `LIBREFANG_HOME`.
+/// The handlers added in #4865 read `[channels]` from disk under the
+/// `config_write_lock`, so any test that needs to drive that path must
+/// own the env var for its full duration. Tests that don't read disk
+/// run in parallel as before — they're insensitive to whatever
+/// `LIBREFANG_HOME` happens to point at because they fail-fast at
+/// validation before reaching the disk read. (#4865)
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Drop guard that points `LIBREFANG_HOME` at a tempdir for the
+/// duration of a test and restores the previous value on drop. Must be
+/// constructed only while `ENV_LOCK` is held.
+struct DiskHomeGuard {
+    tmp: tempfile::TempDir,
+    prev: Option<String>,
+}
+
+impl DiskHomeGuard {
+    fn new() -> Self {
+        let prev = std::env::var("LIBREFANG_HOME").ok();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: serialised via `ENV_LOCK`. Caller holds the lock.
+        unsafe {
+            std::env::set_var("LIBREFANG_HOME", tmp.path());
+        }
+        Self { tmp, prev }
+    }
+
+    fn home(&self) -> &Path {
+        self.tmp.path()
+    }
+}
+
+impl Drop for DiskHomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: same reasoning as `new`.
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var("LIBREFANG_HOME", v),
+                None => std::env::remove_var("LIBREFANG_HOME"),
+            }
+        }
+    }
+}
+
+/// Write a `config.toml` containing one `[[channels.telegram]]` per pair.
+/// Used by the disk-roundtrip tests below.
+fn write_telegram_instances(home: &Path, instances: &[&str]) {
+    let mut content = String::new();
+    for env_name in instances {
+        content.push_str("[[channels.telegram]]\n");
+        content.push_str(&format!("bot_token_env = \"{env_name}\"\n\n"));
+    }
+    std::fs::write(home.join("config.toml"), content).expect("write config.toml");
+}
 
 struct Harness {
     app: Router,
@@ -572,6 +629,269 @@ async fn channels_delete_instance_missing_signature_returns_400() {
             .unwrap_or("")
             .contains("signature"),
         "error must call out the missing 'signature' query parameter: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Per-instance CAS round-trip (#4865)
+// ---------------------------------------------------------------------------
+//
+// These tests own `LIBREFANG_HOME` (via `ENV_LOCK` + `DiskHomeGuard`) so
+// they can seed an actual `config.toml` and drive the post-#4865 handler
+// flow that re-reads disk under the `config_write_lock`. Cheaper unit-
+// level coverage of the same primitives lives next to the helpers in
+// `routes::channels::instance_helper_tests` and `routes::skills::tests`;
+// these guard the HTTP-layer wiring.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_update_instance_signature_mismatch_returns_409() {
+    let _lock = ENV_LOCK.lock().await;
+    let guard = DiskHomeGuard::new();
+    write_telegram_instances(guard.home(), &["TG_DISK_A"]);
+
+    let h = boot_with_channels(ChannelsConfig {
+        telegram: OneOrMany(vec![TelegramConfig {
+            bot_token_env: "TG_DISK_A".into(),
+            ..TelegramConfig::default()
+        }]),
+        ..ChannelsConfig::default()
+    })
+    .await;
+
+    // PUT idx=0 with a deliberately stale signature. After #4865 the
+    // handler re-reads disk, recomputes the signature for the current
+    // disk-side instance, and rejects on mismatch with 409 Conflict.
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/channels/telegram/instances/0",
+        Some(serde_json::json!({
+            "fields": { "default_agent": "smoke" },
+            "signature": "0".repeat(64),
+        })),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "stale signature must yield 409, not 500/200: {body:?}"
+    );
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("modified or moved"),
+        "error must explain the conflict so the dashboard can surface a refresh prompt: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_delete_instance_signature_mismatch_returns_409() {
+    let _lock = ENV_LOCK.lock().await;
+    let guard = DiskHomeGuard::new();
+    write_telegram_instances(guard.home(), &["TG_DISK_B", "TG_DISK_C"]);
+
+    let h = boot_with_channels(ChannelsConfig {
+        telegram: OneOrMany(vec![
+            TelegramConfig {
+                bot_token_env: "TG_DISK_B".into(),
+                ..TelegramConfig::default()
+            },
+            TelegramConfig {
+                bot_token_env: "TG_DISK_C".into(),
+                ..TelegramConfig::default()
+            },
+        ]),
+        ..ChannelsConfig::default()
+    })
+    .await;
+
+    let (status, body) = json_request(
+        &h,
+        Method::DELETE,
+        "/api/channels/telegram/instances/0?signature=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "stale signature on DELETE must yield 409, not silently delete: {body:?}"
+    );
+    // Disk must be untouched — both instances still present after the
+    // rejected delete.
+    let raw = std::fs::read_to_string(guard.home().join("config.toml")).expect("read config.toml");
+    assert!(
+        raw.contains("TG_DISK_B"),
+        "rejected DELETE must leave instance 0 intact: {raw}"
+    );
+    assert!(
+        raw.contains("TG_DISK_C"),
+        "rejected DELETE must leave instance 1 intact: {raw}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_update_instance_round_trips_real_signature() {
+    let _lock = ENV_LOCK.lock().await;
+    let guard = DiskHomeGuard::new();
+    write_telegram_instances(guard.home(), &["TG_DISK_D"]);
+
+    let h = boot_with_channels(ChannelsConfig {
+        telegram: OneOrMany(vec![TelegramConfig {
+            bot_token_env: "TG_DISK_D".into(),
+            ..TelegramConfig::default()
+        }]),
+        ..ChannelsConfig::default()
+    })
+    .await;
+
+    // GET the list to obtain the server-computed signature for the row
+    // we're about to update.
+    let (list_status, list_body) =
+        json_request(&h, Method::GET, "/api/channels/telegram/instances", None).await;
+    assert_eq!(list_status, StatusCode::OK);
+    let signature = list_body["items"][0]["signature"]
+        .as_str()
+        .expect("list must surface a per-item signature post-#4865")
+        .to_string();
+    assert_eq!(signature.len(), 64, "signature must be sha-256 hex");
+
+    // Echo it back on PUT — the handler must accept this round-trip.
+    // (Failure here is a regression on the canonical-JSON ↔ disk-reread
+    // invariant documented in `canonical_json` / `read_disk_channels`.)
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/channels/telegram/instances/0",
+        Some(serde_json::json!({
+            "fields": { "default_agent": "rotated" },
+            "signature": signature,
+        })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "round-tripped signature must be accepted: {body:?}"
+    );
+
+    // Disk now reflects the new agent name.
+    let raw = std::fs::read_to_string(guard.home().join("config.toml")).expect("read config.toml");
+    assert!(
+        raw.contains("default_agent = \"rotated\""),
+        "PUT must have written the new field to disk: {raw}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_update_instance_clear_secrets_drops_orphan_env_var() {
+    let _lock = ENV_LOCK.lock().await;
+    let guard = DiskHomeGuard::new();
+    write_telegram_instances(guard.home(), &["TG_LONELY"]);
+    // Prime `secrets.env` with the env var the instance is pointing at,
+    // so we can assert the cleanup loop actually removed it.
+    std::fs::write(guard.home().join("secrets.env"), "TG_LONELY=fake-token\n")
+        .expect("seed secrets.env");
+
+    let h = boot_with_channels(ChannelsConfig {
+        telegram: OneOrMany(vec![TelegramConfig {
+            bot_token_env: "TG_LONELY".into(),
+            ..TelegramConfig::default()
+        }]),
+        ..ChannelsConfig::default()
+    })
+    .await;
+
+    let (_, list_body) =
+        json_request(&h, Method::GET, "/api/channels/telegram/instances", None).await;
+    let signature = list_body["items"][0]["signature"]
+        .as_str()
+        .expect("signature must be present")
+        .to_string();
+
+    // PUT with `clear_secrets` listing the secret key. The instance's
+    // `bot_token_env` ref must drop, AND because no sibling references
+    // `TG_LONELY` the env-var line must be scrubbed from `secrets.env`.
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/channels/telegram/instances/0",
+        Some(serde_json::json!({
+            "fields": { "default_agent": "no-auth" },
+            "signature": signature,
+            "clear_secrets": ["bot_token_env"],
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+
+    let cfg = std::fs::read_to_string(guard.home().join("config.toml")).expect("read config.toml");
+    assert!(
+        !cfg.contains("bot_token_env"),
+        "cleared secret ref must be dropped from the rebuilt instance: {cfg}"
+    );
+    let secrets =
+        std::fs::read_to_string(guard.home().join("secrets.env")).expect("read secrets.env");
+    assert!(
+        !secrets.contains("TG_LONELY"),
+        "orphan env-var line must be scrubbed when no sibling references it: {secrets}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_update_instance_clear_secrets_preserves_shared_env_var() {
+    let _lock = ENV_LOCK.lock().await;
+    let guard = DiskHomeGuard::new();
+    // Two instances, BOTH pointing at the same env var (a possible
+    // user setup if they hand-edited secrets.env). Clearing one
+    // instance's ref must NOT remove the env var, since the sibling
+    // is still using it.
+    write_telegram_instances(guard.home(), &["TG_SHARED", "TG_SHARED"]);
+    std::fs::write(guard.home().join("secrets.env"), "TG_SHARED=fake\n").expect("seed secrets.env");
+
+    let h = boot_with_channels(ChannelsConfig {
+        telegram: OneOrMany(vec![
+            TelegramConfig {
+                bot_token_env: "TG_SHARED".into(),
+                ..TelegramConfig::default()
+            },
+            TelegramConfig {
+                bot_token_env: "TG_SHARED".into(),
+                ..TelegramConfig::default()
+            },
+        ]),
+        ..ChannelsConfig::default()
+    })
+    .await;
+
+    let (_, list_body) =
+        json_request(&h, Method::GET, "/api/channels/telegram/instances", None).await;
+    let signature = list_body["items"][0]["signature"]
+        .as_str()
+        .expect("signature")
+        .to_string();
+
+    let (status, body) = json_request(
+        &h,
+        Method::PUT,
+        "/api/channels/telegram/instances/0",
+        Some(serde_json::json!({
+            "fields": { "default_agent": "no-auth" },
+            "signature": signature,
+            "clear_secrets": ["bot_token_env"],
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+
+    let secrets =
+        std::fs::read_to_string(guard.home().join("secrets.env")).expect("read secrets.env");
+    assert!(
+        secrets.contains("TG_SHARED"),
+        "shared env var must survive — sibling instance still references it: {secrets}"
     );
 }
 

--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -46,6 +46,16 @@ static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 /// Drop guard that points `LIBREFANG_HOME` at a tempdir for the
 /// duration of a test and restores the previous value on drop. Must be
 /// constructed only while `ENV_LOCK` is held.
+///
+/// **Footgun for future tests:** `std::env::set_var` is process-global.
+/// Any new test in this binary that boots a server exercising a
+/// disk-touching handler (anything reaching `librefang_home()` — i.e.
+/// any of the `/configure`, `/instances`, or QR flow handlers) MUST
+/// acquire `ENV_LOCK` before constructing this guard, otherwise it will
+/// race with the disk-roundtrip tests below and see the tempdir's
+/// `config.toml` instead of `~/.librefang`. Tests that only exercise
+/// validation paths (unknown channel, missing field) fail-fast before
+/// reaching `librefang_home()` and are safe without the lock.
 struct DiskHomeGuard {
     tmp: tempfile::TempDir,
     prev: Option<String>,

--- a/openapi.json
+++ b/openapi.json
@@ -4278,6 +4278,254 @@
         }
       }
     },
+    "/api/channels/{name}/instances": {
+      "get": {
+        "tags": [
+          "channels"
+        ],
+        "summary": "GET /api/channels/{name}/instances — List every configured instance.",
+        "operationId": "list_channel_instances",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Channel adapter name (e.g. telegram, discord)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List configured instances",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown channel",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "channels"
+        ],
+        "summary": "POST /api/channels/{name}/instances — Append a new `[[channels.<name>]]`.",
+        "operationId": "create_channel_instance",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Channel adapter name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Instance created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown channel",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/channels/{name}/instances/{index}": {
+      "put": {
+        "tags": [
+          "channels"
+        ],
+        "summary": "PUT /api/channels/{name}/instances/{index} — Replace one instance's fields.",
+        "operationId": "update_channel_instance_handler",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Channel adapter name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "index",
+            "in": "path",
+            "description": "Instance array index (0-based)",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Instance updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown channel or instance index out of range",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "channels"
+        ],
+        "summary": "DELETE /api/channels/{name}/instances/{index} — Remove a single instance.",
+        "description": "Note: this does NOT clear the secret env var the instance pointed at —\nthe env var may be shared with another instance, and we don't want to\nsilently break a running bot. The user can clear stale entries from\n`secrets.env` manually.",
+        "operationId": "delete_channel_instance",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Channel adapter name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "index",
+            "in": "path",
+            "description": "Instance array index (0-based)",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Instance removed"
+          },
+          "404": {
+            "description": "Unknown channel or instance index out of range",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/channels/{name}/test": {
       "post": {
         "tags": [

--- a/openapi.json
+++ b/openapi.json
@@ -4224,6 +4224,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Channel is in multi-instance form; use the per-instance API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
           }
         }
       },
@@ -4257,6 +4267,16 @@
           },
           "404": {
             "description": "Unknown channel",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Channel is in multi-instance form; use the per-instance API",
             "content": {
               "application/json": {
                 "schema": {
@@ -4324,6 +4344,7 @@
           "channels"
         ],
         "summary": "POST /api/channels/{name}/instances — Append a new `[[channels.<name>]]`.",
+        "description": "The whole \"compute target index → resolve env-var name overrides → write\nsecrets → append config\" sequence runs inside the `config_write_lock`\ncritical section, against a freshly re-read on-disk view of `[channels]`,\nso two concurrent creates can't pick the same suffix or land at the same\nindex (#4865).",
         "operationId": "create_channel_instance",
         "parameters": [
           {
@@ -4396,6 +4417,7 @@
           "channels"
         ],
         "summary": "PUT /api/channels/{name}/instances/{index} — Replace one instance's fields.",
+        "description": "Body shape:\n```json\n{\n  \"fields\": { \"bot_token_env\": \"...\", \"default_agent\": \"assistant\" },\n  \"signature\": \"<hex from GET response>\",\n  \"clear_secrets\": [\"bot_token_env\"]   // optional\n}\n```\n\n`signature` is REQUIRED and acts as a compare-and-swap token: the server\nre-reads disk under the write lock, computes the signature of the\ninstance currently at `index`, and rejects with 409 Conflict if it\ndoesn't match. This eliminates the silent-wrong-write bug where a\nconcurrent delete on a sibling row shifted indices between the client's\nlist-fetch and its PUT (#4865).\n\n`clear_secrets` lets the caller actively drop a secret reference instead\nof preserving it. Listed keys have their `<key>_env` field removed from\nthe rebuilt instance and, when no sibling instance references the same\nenv-var name, the env-var line is also removed from `secrets.env`.",
         "operationId": "update_channel_instance_handler",
         "parameters": [
           {
@@ -4419,6 +4441,7 @@
           }
         ],
         "requestBody": {
+          "description": "REQUIRED body fields: `fields` (object of channel-schema fields) and `signature` (hex CAS token from the matching `GET /instances` item, used to detect concurrent edits — mismatch yields 409). OPTIONAL: `clear_secrets` (array of secret-field keys to actively drop).",
           "content": {
             "application/json": {
               "schema": {
@@ -4440,7 +4463,7 @@
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "Bad request (missing fields or signature)",
             "content": {
               "application/json": {
                 "schema": {
@@ -4451,6 +4474,16 @@
           },
           "404": {
             "description": "Unknown channel or instance index out of range",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Signature mismatch — instance was modified or moved by another writer",
             "content": {
               "application/json": {
                 "schema": {
@@ -4475,8 +4508,8 @@
         "tags": [
           "channels"
         ],
-        "summary": "DELETE /api/channels/{name}/instances/{index} — Remove a single instance.",
-        "description": "Note: this does NOT clear the secret env var the instance pointed at —\nthe env var may be shared with another instance, and we don't want to\nsilently break a running bot. The user can clear stale entries from\n`secrets.env` manually.",
+        "summary": "DELETE /api/channels/{name}/instances/{index}?signature=<hex>",
+        "description": "`signature` is REQUIRED (query string) and acts as a compare-and-swap\ntoken: the server re-reads disk under the write lock and rejects with\n409 Conflict if the instance currently at `index` doesn't match the\nsignature the client read from the GET response (#4865).\n\nNote: this does NOT clear the secret env var the instance pointed at —\nthe env var may be shared with another instance, and we don't want to\nsilently break a running bot. To explicitly clear secrets while editing,\nuse PUT with `clear_secrets`.",
         "operationId": "delete_channel_instance",
         "parameters": [
           {
@@ -4497,14 +4530,43 @@
               "type": "integer",
               "minimum": 0
             }
+          },
+          {
+            "name": "signature",
+            "in": "query",
+            "description": "REQUIRED hex CAS token from the matching `GET /instances` item; mismatch yields 409 (#4865)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "Instance removed"
           },
+          "400": {
+            "description": "Missing `signature` query parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Unknown channel or instance index out of range",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Signature mismatch — instance was modified or moved by another writer",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -682,6 +682,22 @@ func (r *ChannelsResource) RemoveChannel(name string) (interface{}, error) {
 	return r.client.request("DELETE", fmt.Sprintf("/api/channels/%s/configure", name), nil, nil)
 }
 
+func (r *ChannelsResource) ListChannelInstances(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/channels/%s/instances", name), nil, nil)
+}
+
+func (r *ChannelsResource) CreateChannelInstance(name string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/channels/%s/instances", name), data, nil)
+}
+
+func (r *ChannelsResource) UpdateChannelInstanceHandler(name string, index string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("PUT", fmt.Sprintf("/api/channels/%s/instances/%s", name, index), data, nil)
+}
+
+func (r *ChannelsResource) DeleteChannelInstance(name string, index string) (interface{}, error) {
+	return r.client.request("DELETE", fmt.Sprintf("/api/channels/%s/instances/%s", name, index), nil, nil)
+}
+
 func (r *ChannelsResource) TestChannel(name string, data map[string]interface{}) (interface{}, error) {
 	return r.client.request("POST", fmt.Sprintf("/api/channels/%s/test", name), data, nil)
 }

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -694,8 +694,8 @@ func (r *ChannelsResource) UpdateChannelInstanceHandler(name string, index strin
 	return r.client.request("PUT", fmt.Sprintf("/api/channels/%s/instances/%s", name, index), data, nil)
 }
 
-func (r *ChannelsResource) DeleteChannelInstance(name string, index string) (interface{}, error) {
-	return r.client.request("DELETE", fmt.Sprintf("/api/channels/%s/instances/%s", name, index), nil, nil)
+func (r *ChannelsResource) DeleteChannelInstance(name string, index string, query map[string]string) (interface{}, error) {
+	return r.client.request("DELETE", fmt.Sprintf("/api/channels/%s/instances/%s", name, index), nil, query)
 }
 
 func (r *ChannelsResource) TestChannel(name string, data map[string]interface{}) (interface{}, error) {

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -571,8 +571,8 @@ class ChannelsResource {
     return this._c._request("PUT", `/api/channels/${name}/instances/${index}`, data, undefined);
   }
 
-  async deleteChannelInstance(name, index) {
-    return this._c._request("DELETE", `/api/channels/${name}/instances/${index}`);
+  async deleteChannelInstance(name, index, query) {
+    return this._c._request("DELETE", `/api/channels/${name}/instances/${index}`, undefined, query);
   }
 
   async testChannel(name, data) {

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -559,6 +559,22 @@ class ChannelsResource {
     return this._c._request("DELETE", `/api/channels/${name}/configure`);
   }
 
+  async listChannelInstances(name) {
+    return this._c._request("GET", `/api/channels/${name}/instances`);
+  }
+
+  async createChannelInstance(name, data) {
+    return this._c._request("POST", `/api/channels/${name}/instances`, data, undefined);
+  }
+
+  async updateChannelInstanceHandler(name, index, data) {
+    return this._c._request("PUT", `/api/channels/${name}/instances/${index}`, data, undefined);
+  }
+
+  async deleteChannelInstance(name, index) {
+    return this._c._request("DELETE", `/api/channels/${name}/instances/${index}`);
+  }
+
   async testChannel(name, data) {
     return this._c._request("POST", `/api/channels/${name}/test`, data, undefined);
   }

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -464,6 +464,18 @@ class _ChannelsResource(_Resource):
     def remove_channel(self, name: str):
         return self._c._request("DELETE", f"/api/channels/{name}/configure")
 
+    def list_channel_instances(self, name: str):
+        return self._c._request("GET", f"/api/channels/{name}/instances")
+
+    def create_channel_instance(self, name: str, **data):
+        return self._c._request("POST", f"/api/channels/{name}/instances", data)
+
+    def update_channel_instance_handler(self, name: str, index: str, **data):
+        return self._c._request("PUT", f"/api/channels/{name}/instances/{index}", data)
+
+    def delete_channel_instance(self, name: str, index: str):
+        return self._c._request("DELETE", f"/api/channels/{name}/instances/{index}")
+
     def test_channel(self, name: str, **data):
         return self._c._request("POST", f"/api/channels/{name}/test", data)
 

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -473,8 +473,8 @@ class _ChannelsResource(_Resource):
     def update_channel_instance_handler(self, name: str, index: str, **data):
         return self._c._request("PUT", f"/api/channels/{name}/instances/{index}", data)
 
-    def delete_channel_instance(self, name: str, index: str):
-        return self._c._request("DELETE", f"/api/channels/{name}/instances/{index}")
+    def delete_channel_instance(self, name: str, index: str, signature: Any = None):
+        return self._c._request("DELETE", f"/api/channels/{name}/instances/{index}", None, query={"signature": signature})
 
     def test_channel(self, name: str, **data):
         return self._c._request("POST", f"/api/channels/{name}/test", data)

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -708,6 +708,22 @@ impl ChannelsResource {
         do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/channels/{}/configure", name), None, &[]).await
     }
 
+    pub async fn list_channel_instances(&self, name: &str) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/channels/{}/instances", name), None, &[]).await
+    }
+
+    pub async fn create_channel_instance(&self, name: &str, data: Value) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/channels/{}/instances", name), Some(data), &[]).await
+    }
+
+    pub async fn update_channel_instance_handler(&self, name: &str, index: &str, data: Value) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/channels/{}/instances/{}", name, index), Some(data), &[]).await
+    }
+
+    pub async fn delete_channel_instance(&self, name: &str, index: &str) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/channels/{}/instances/{}", name, index), None, &[]).await
+    }
+
     pub async fn test_channel(&self, name: &str, data: Value) -> Result<Value> {
         do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/channels/{}/test", name), Some(data), &[]).await
     }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -47,13 +47,24 @@ async fn do_req(
         .iter()
         .filter_map(|(k, v)| v.map(|vv| (*k, vv)))
         .collect();
-    let req = if filtered.is_empty() { req } else { req.query(&filtered) };
-    let req = if let Some(b) = body { req.json(&b) } else { req };
+    let req = if filtered.is_empty() {
+        req
+    } else {
+        req.query(&filtered)
+    };
+    let req = if let Some(b) = body {
+        req.json(&b)
+    } else {
+        req
+    };
     let res = req.send().await?;
     let status = res.status();
     let text = res.text().await?;
     if !status.is_success() {
-        return Err(Error::Api { status: status.as_u16(), body: text });
+        return Err(Error::Api {
+            status: status.as_u16(),
+            body: text,
+        });
     }
     Ok(serde_json::from_str(&text).unwrap_or(Value::String(text)))
 }
@@ -69,13 +80,23 @@ fn do_stream(
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     tokio::spawn(async move {
         let url = format!("{}{}", base_url, path);
-        let req = client.request(method, &url).header("Accept", "text/event-stream");
+        let req = client
+            .request(method, &url)
+            .header("Accept", "text/event-stream");
         let filtered: Vec<(String, String)> = query
             .into_iter()
             .filter_map(|(k, v)| v.map(|vv| (k, vv)))
             .collect();
-        let req = if filtered.is_empty() { req } else { req.query(&filtered) };
-        let req = if let Some(b) = body { req.json(&b) } else { req };
+        let req = if filtered.is_empty() {
+            req
+        } else {
+            req.query(&filtered)
+        };
+        let req = if let Some(b) = body {
+            req.json(&b)
+        } else {
+            req
+        };
         let res = match req.send().await {
             Ok(r) => r,
             Err(e) => {
@@ -124,9 +145,13 @@ fn do_stream(
                     }
                 };
                 if let Some(data) = line.strip_prefix("data: ") {
-                    if data == "[DONE]" { return; }
+                    if data == "[DONE]" {
+                        return;
+                    }
                     match serde_json::from_str::<Value>(data) {
-                        Ok(v) => { let _ = tx.send(v); }
+                        Ok(v) => {
+                            let _ = tx.send(v);
+                        }
                         Err(_) => {
                             let _ = tx.send(serde_json::json!({"raw": data}));
                         }
@@ -185,7 +210,10 @@ impl LibreFang {
             models: Arc::new(ModelsResource::new(base_url.clone(), client.clone())),
             network: Arc::new(NetworkResource::new(base_url.clone(), client.clone())),
             pairing: Arc::new(PairingResource::new(base_url.clone(), client.clone())),
-            proactive_memory: Arc::new(ProactiveMemoryResource::new(base_url.clone(), client.clone())),
+            proactive_memory: Arc::new(ProactiveMemoryResource::new(
+                base_url.clone(),
+                client.clone(),
+            )),
             sessions: Arc::new(SessionsResource::new(base_url.clone(), client.clone())),
             skills: Arc::new(SkillsResource::new(base_url.clone(), client.clone())),
             system: Arc::new(SystemResource::new(base_url.clone(), client.clone())),
@@ -213,23 +241,63 @@ impl A2AResource {
     }
 
     pub async fn a2a_list_external_agents(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/a2a/agents".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/a2a/agents".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn a2a_get_external_agent(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/a2a/agents/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/a2a/agents/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn a2a_discover_external(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/a2a/discover".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/a2a/discover".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn a2a_send_external(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/a2a/send".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/a2a/send".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn a2a_external_task_status(&self, id: &str, url: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/a2a/tasks/{}/status", id), None, &[("url", url)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/a2a/tasks/{}/status", id),
+            None,
+            &[("url", url)],
+        )
+        .await
     }
 }
 
@@ -246,236 +314,732 @@ impl AgentsResource {
         Self { base_url, client }
     }
 
-    pub async fn list_agents(&self, q: Option<&str>, status: Option<&str>, limit: Option<&str>, offset: Option<&str>, sort: Option<&str>, order: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/agents".to_string(), None, &[("q", q), ("status", status), ("limit", limit), ("offset", offset), ("sort", sort), ("order", order)]).await
+    pub async fn list_agents(
+        &self,
+        q: Option<&str>,
+        status: Option<&str>,
+        limit: Option<&str>,
+        offset: Option<&str>,
+        sort: Option<&str>,
+        order: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/agents".to_string(),
+            None,
+            &[
+                ("q", q),
+                ("status", status),
+                ("limit", limit),
+                ("offset", offset),
+                ("sort", sort),
+                ("order", order),
+            ],
+        )
+        .await
     }
 
     pub async fn spawn_agent(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/agents".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/agents".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn bulk_create_agents(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/agents/bulk".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/agents/bulk".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn bulk_delete_agents(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &"/api/agents/bulk".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &"/api/agents/bulk".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn bulk_start_agents(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/agents/bulk/start".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/agents/bulk/start".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn bulk_stop_agents(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/agents/bulk/stop".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/agents/bulk/stop".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn list_agent_identities(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/agents/identities".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/agents/identities".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn reset_agent_identity(&self, name: &str, confirm: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/identities/{}/reset", name), None, &[("confirm", confirm)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/identities/{}/reset", name),
+            None,
+            &[("confirm", confirm)],
+        )
+        .await
     }
 
     pub async fn get_agent(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn kill_agent(&self, id: &str, confirm: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/agents/{}", id), None, &[("confirm", confirm)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/agents/{}", id),
+            None,
+            &[("confirm", confirm)],
+        )
+        .await
     }
 
     pub async fn patch_agent(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/agents/{}", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PATCH,
+            &format!("/api/agents/{}", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn clone_agent(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/clone", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/clone", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn patch_agent_config(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/agents/{}/config", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PATCH,
+            &format!("/api/agents/{}/config", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_agent_deliveries(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/deliveries", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/deliveries", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_agent_events(&self, id: &str, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/events", id), None, &[("limit", limit)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/events", id),
+            None,
+            &[("limit", limit)],
+        )
+        .await
     }
 
     pub async fn list_agent_files(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/files", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/files", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_agent_file(&self, id: &str, filename: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/files/{}", id, filename), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/files/{}", id, filename),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn set_agent_file(&self, id: &str, filename: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/files/{}", id, filename), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/agents/{}/files/{}", id, filename),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_agent_file(&self, id: &str, filename: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/agents/{}/files/{}", id, filename), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/agents/{}/files/{}", id, filename),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_hand_agent_runtime_config(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/agents/{}/hand-runtime-config", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/agents/{}/hand-runtime-config", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn patch_hand_agent_runtime_config(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/agents/{}/hand-runtime-config", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PATCH,
+            &format!("/api/agents/{}/hand-runtime-config", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn clear_agent_history(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/agents/{}/history", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/agents/{}/history", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn update_agent_identity(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/agents/{}/identity", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PATCH,
+            &format!("/api/agents/{}/identity", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn inject_message(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/inject", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/inject", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
-    pub async fn agent_logs(&self, id: &str, n: Option<&str>, level: Option<&str>, offset: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/logs", id), None, &[("n", n), ("level", level), ("offset", offset)]).await
+    pub async fn agent_logs(
+        &self,
+        id: &str,
+        n: Option<&str>,
+        level: Option<&str>,
+        offset: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/logs", id),
+            None,
+            &[("n", n), ("level", level), ("offset", offset)],
+        )
+        .await
     }
 
     pub async fn get_agent_mcp_servers(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/mcp_servers", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/mcp_servers", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn set_agent_mcp_servers(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/mcp_servers", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/agents/{}/mcp_servers", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn send_message(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/message", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/message", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
-    pub fn send_message_stream(&self, id: &str, data: Value) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
-        do_stream(self.client.clone(), self.base_url.clone(), format!("/api/agents/{}/message/stream", id), reqwest::Method::POST, Some(data), Vec::new())
+    pub fn send_message_stream(
+        &self,
+        id: &str,
+        data: Value,
+    ) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
+        do_stream(
+            self.client.clone(),
+            self.base_url.clone(),
+            format!("/api/agents/{}/message/stream", id),
+            reqwest::Method::POST,
+            Some(data),
+            Vec::new(),
+        )
     }
 
     pub async fn agent_metrics(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/metrics", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/metrics", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn set_agent_mode(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/mode", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/agents/{}/mode", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn set_model(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/model", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/agents/{}/model", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn push_message(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/push", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/push", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn reload_agent_manifest(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/reload", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/reload", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn resume_agent(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/resume", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/agents/{}/resume", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_agent_runtime(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/runtime", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/runtime", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_agent_session(&self, id: &str, session_id: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/session", id), None, &[("session_id", session_id)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/session", id),
+            None,
+            &[("session_id", session_id)],
+        )
+        .await
     }
 
     pub async fn compact_session(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/session/compact", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/session/compact", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn reboot_session(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/session/reboot", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/session/reboot", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn reset_session(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/session/reset", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/session/reset", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_agent_sessions(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/sessions", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn create_agent_session(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/sessions", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn import_session(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions/import", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/sessions/import", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn export_session(&self, id: &str, session_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions/{}/export", id, session_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/sessions/{}/export", id, session_id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn stop_session(&self, id: &str, session_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions/{}/stop", id, session_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/sessions/{}/stop", id, session_id),
+            None,
+            &[],
+        )
+        .await
     }
 
-    pub fn attach_session_stream(&self, id: &str, session_id: &str) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
-        do_stream(self.client.clone(), self.base_url.clone(), format!("/api/agents/{}/sessions/{}/stream", id, session_id), reqwest::Method::GET, None, Vec::new())
+    pub fn attach_session_stream(
+        &self,
+        id: &str,
+        session_id: &str,
+    ) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
+        do_stream(
+            self.client.clone(),
+            self.base_url.clone(),
+            format!("/api/agents/{}/sessions/{}/stream", id, session_id),
+            reqwest::Method::GET,
+            None,
+            Vec::new(),
+        )
     }
 
     pub async fn switch_agent_session(&self, id: &str, session_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions/{}/switch", id, session_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/sessions/{}/switch", id, session_id),
+            None,
+            &[],
+        )
+        .await
     }
 
-    pub async fn export_session_trajectory(&self, id: &str, session_id: &str, format: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions/{}/trajectory", id, session_id), None, &[("format", format)]).await
+    pub async fn export_session_trajectory(
+        &self,
+        id: &str,
+        session_id: &str,
+        format: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/sessions/{}/trajectory", id, session_id),
+            None,
+            &[("format", format)],
+        )
+        .await
     }
 
     pub async fn get_agent_skills(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/skills", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/skills", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn set_agent_skills(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/skills", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/agents/{}/skills", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_agent_stats(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/stats", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/stats", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn stop_agent(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/stop", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/stop", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn suspend_agent(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/suspend", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/agents/{}/suspend", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_agent_tools(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/tools", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/tools", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn set_agent_tools(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/tools", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/agents/{}/tools", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_agent_traces(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/traces", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/traces", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn upload_file(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/upload", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/upload", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn serve_upload(&self, file_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/uploads/{}", file_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/uploads/{}", file_id),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -493,23 +1057,63 @@ impl ApprovalsResource {
     }
 
     pub async fn list_approvals(&self, limit: Option<&str>, offset: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/approvals".to_string(), None, &[("limit", limit), ("offset", offset)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/approvals".to_string(),
+            None,
+            &[("limit", limit), ("offset", offset)],
+        )
+        .await
     }
 
     pub async fn create_approval(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/approvals".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/approvals".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_approval(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/approvals/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/approvals/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn approve_request(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/approvals/{}/approve", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/approvals/{}/approve", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn reject_request(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/approvals/{}/reject", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/approvals/{}/reject", id),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -527,51 +1131,147 @@ impl AuthResource {
     }
 
     pub async fn auth_callback(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/callback".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/auth/callback".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn auth_callback_post(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/callback".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/auth/callback".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn change_password(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/change-password".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/auth/change-password".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn dashboard_auth_check(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/dashboard-check".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/auth/dashboard-check".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn dashboard_login(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/dashboard-login".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/auth/dashboard-login".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn auth_introspect(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/introspect".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/auth/introspect".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn auth_login(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/login".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/auth/login".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn auth_login_provider(&self, provider: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/auth/login/{}", provider), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/auth/login/{}", provider),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn dashboard_logout(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/logout".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/auth/logout".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn auth_providers(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/providers".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/auth/providers".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn auth_refresh(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/refresh".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/auth/refresh".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn auth_userinfo(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/userinfo".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/auth/userinfo".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -589,19 +1289,51 @@ impl AutoDreamResource {
     }
 
     pub async fn auto_dream_abort(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/auto-dream/agents/{}/abort", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/auto-dream/agents/{}/abort", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn auto_dream_set_enabled(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/auto-dream/agents/{}/enabled", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/auto-dream/agents/{}/enabled", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn auto_dream_trigger(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/auto-dream/agents/{}/trigger", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/auto-dream/agents/{}/trigger", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn auto_dream_status(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auto-dream/status".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/auto-dream/status".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -619,47 +1351,135 @@ impl BudgetResource {
     }
 
     pub async fn budget_status(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/budget".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/budget".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn update_budget(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &"/api/budget".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &"/api/budget".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn agent_budget_ranking(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/budget/agents".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/budget/agents".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn agent_budget_status(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/budget/agents/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/budget/agents/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn update_agent_budget(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/budget/agents/{}", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/budget/agents/{}", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn user_budget_ranking(&self, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/budget/users".to_string(), None, &[("limit", limit)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/budget/users".to_string(),
+            None,
+            &[("limit", limit)],
+        )
+        .await
     }
 
     pub async fn user_budget_detail(&self, user_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/budget/users/{}", user_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/budget/users/{}", user_id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn usage_stats(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/usage".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/usage".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn usage_by_model(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/usage/by-model".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/usage/by-model".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn usage_daily(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/usage/daily".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/usage/daily".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn usage_summary(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/usage/summary".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/usage/summary".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -677,55 +1497,169 @@ impl ChannelsResource {
     }
 
     pub async fn list_channels(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/channels".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/channels".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn reload_channels(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/channels/reload".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/channels/reload".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn wechat_qr_start(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/channels/wechat/qr/start".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/channels/wechat/qr/start".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn wechat_qr_status(&self, qr_code: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/channels/wechat/qr/status".to_string(), None, &[("qr_code", qr_code)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/channels/wechat/qr/status".to_string(),
+            None,
+            &[("qr_code", qr_code)],
+        )
+        .await
     }
 
     pub async fn whatsapp_qr_start(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/channels/whatsapp/qr/start".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/channels/whatsapp/qr/start".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn whatsapp_qr_status(&self, session_id: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/channels/whatsapp/qr/status".to_string(), None, &[("session_id", session_id)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/channels/whatsapp/qr/status".to_string(),
+            None,
+            &[("session_id", session_id)],
+        )
+        .await
     }
 
     pub async fn configure_channel(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/channels/{}/configure", name), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/channels/{}/configure", name),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn remove_channel(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/channels/{}/configure", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/channels/{}/configure", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_channel_instances(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/channels/{}/instances", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/channels/{}/instances", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn create_channel_instance(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/channels/{}/instances", name), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/channels/{}/instances", name),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
-    pub async fn update_channel_instance_handler(&self, name: &str, index: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/channels/{}/instances/{}", name, index), Some(data), &[]).await
+    pub async fn update_channel_instance_handler(
+        &self,
+        name: &str,
+        index: &str,
+        data: Value,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/channels/{}/instances/{}", name, index),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
-    pub async fn delete_channel_instance(&self, name: &str, index: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/channels/{}/instances/{}", name, index), None, &[]).await
+    pub async fn delete_channel_instance(
+        &self,
+        name: &str,
+        index: &str,
+        signature: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/channels/{}/instances/{}", name, index),
+            None,
+            &[("signature", signature)],
+        )
+        .await
     }
 
     pub async fn test_channel(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/channels/{}/test", name), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/channels/{}/test", name),
+            Some(data),
+            &[],
+        )
+        .await
     }
 }
 
@@ -743,19 +1677,51 @@ impl ExtensionsResource {
     }
 
     pub async fn list_extensions(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/extensions".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/extensions".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn install_extension(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/extensions/install".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/extensions/install".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn uninstall_extension(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/extensions/uninstall".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/extensions/uninstall".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_extension(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/extensions/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/extensions/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -773,63 +1739,183 @@ impl HandsResource {
     }
 
     pub async fn list_hands(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/hands".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/hands".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_active_hands(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/hands/active".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/hands/active".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn install_hand(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/hands/install".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/hands/install".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn deactivate_hand(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/hands/instances/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/hands/instances/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn hand_instance_browser(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/hands/instances/{}/browser", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/hands/instances/{}/browser", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn pause_hand(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/instances/{}/pause", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/hands/instances/{}/pause", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn resume_hand(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/instances/{}/resume", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/hands/instances/{}/resume", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn hand_stats(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/hands/instances/{}/stats", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/hands/instances/{}/stats", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn reload_hands(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/hands/reload".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/hands/reload".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_hand(&self, hand_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/hands/{}", hand_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/hands/{}", hand_id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn activate_hand(&self, hand_id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/{}/activate", hand_id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/hands/{}/activate", hand_id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn check_hand_deps(&self, hand_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/{}/check-deps", hand_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/hands/{}/check-deps", hand_id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn install_hand_deps(&self, hand_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/{}/install-deps", hand_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/hands/{}/install-deps", hand_id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_hand_settings(&self, hand_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/hands/{}/settings", hand_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/hands/{}/settings", hand_id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn update_hand_settings(&self, hand_id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/hands/{}/settings", hand_id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/hands/{}/settings", hand_id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 }
 
@@ -847,47 +1933,135 @@ impl McpResource {
     }
 
     pub async fn list_mcp_catalog(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/mcp/catalog".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/mcp/catalog".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_mcp_catalog_entry(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/mcp/catalog/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/mcp/catalog/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn mcp_health_handler(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/mcp/health".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/mcp/health".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn reload_mcp_handler(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/mcp/reload".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/mcp/reload".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_mcp_servers(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/mcp/servers".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/mcp/servers".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn add_mcp_server(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/mcp/servers".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/mcp/servers".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_mcp_server(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/mcp/servers/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/mcp/servers/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn update_mcp_server(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/mcp/servers/{}", name), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/mcp/servers/{}", name),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_mcp_server(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/mcp/servers/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/mcp/servers/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn reconnect_mcp_server_handler(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/mcp/servers/{}/reconnect", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/mcp/servers/{}/reconnect", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_mcp_taint_rules(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/mcp/taint-rules".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/mcp/taint-rules".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -905,27 +2079,75 @@ impl MemoryResource {
     }
 
     pub async fn export_agent_memory(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/memory/export", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/memory/export", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn import_agent_memory(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/memory/import", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/agents/{}/memory/import", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_agent_kv(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/kv", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/agents/{}/kv", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_agent_kv_key(&self, id: &str, key: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/kv/{}", id, key), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/agents/{}/kv/{}", id, key),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn set_agent_kv_key(&self, id: &str, key: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/memory/agents/{}/kv/{}", id, key), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/memory/agents/{}/kv/{}", id, key),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_agent_kv_key(&self, id: &str, key: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/memory/agents/{}/kv/{}", id, key), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/memory/agents/{}/kv/{}", id, key),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -943,75 +2165,219 @@ impl ModelsResource {
     }
 
     pub async fn catalog_status(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/catalog/status".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/catalog/status".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn catalog_update(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/catalog/update".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/catalog/update".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_all_models(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/models".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/models".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_aliases(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/models/aliases".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/models/aliases".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn create_alias(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/models/aliases".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/models/aliases".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_alias(&self, alias: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/models/aliases/{}", alias), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/models/aliases/{}", alias),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn add_custom_model(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/models/custom".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/models/custom".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn remove_custom_model(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/models/custom/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/models/custom/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_model(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/models/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/models/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_providers(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/providers".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/providers".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn copilot_oauth_poll(&self, poll_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/providers/github-copilot/oauth/poll/{}", poll_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/providers/github-copilot/oauth/poll/{}", poll_id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn copilot_oauth_start(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/providers/github-copilot/oauth/start".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/providers/github-copilot/oauth/start".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_provider(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/providers/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/providers/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn set_default_provider(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/providers/{}/default", name), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/providers/{}/default", name),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn set_provider_key(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/providers/{}/key", name), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/providers/{}/key", name),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_provider_key(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/providers/{}/key", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/providers/{}/key", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn test_provider(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/providers/{}/test", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/providers/{}/test", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn set_provider_url(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/providers/{}/url", name), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/providers/{}/url", name),
+            Some(data),
+            &[],
+        )
+        .await
     }
 }
 
@@ -1029,35 +2395,98 @@ impl NetworkResource {
     }
 
     pub async fn comms_events(&self, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/comms/events".to_string(), None, &[("limit", limit)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/comms/events".to_string(),
+            None,
+            &[("limit", limit)],
+        )
+        .await
     }
 
     pub fn comms_events_stream(&self) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
-        do_stream(self.client.clone(), self.base_url.clone(), "/api/comms/events/stream".to_string(), reqwest::Method::GET, None, Vec::new())
+        do_stream(
+            self.client.clone(),
+            self.base_url.clone(),
+            "/api/comms/events/stream".to_string(),
+            reqwest::Method::GET,
+            None,
+            Vec::new(),
+        )
     }
 
     pub async fn comms_send(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/comms/send".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/comms/send".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn comms_task(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/comms/task".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/comms/task".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn comms_topology(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/comms/topology".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/comms/topology".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn network_status(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/network/status".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/network/status".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_peers(&self, offset: Option<&str>, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/peers".to_string(), None, &[("offset", offset), ("limit", limit)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/peers".to_string(),
+            None,
+            &[("offset", offset), ("limit", limit)],
+        )
+        .await
     }
 
     pub async fn get_peer(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/peers/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/peers/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -1075,23 +2504,63 @@ impl PairingResource {
     }
 
     pub async fn pairing_complete(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/pairing/complete".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/pairing/complete".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn pairing_devices(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/pairing/devices".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/pairing/devices".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn pairing_remove_device(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/pairing/devices/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/pairing/devices/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn pairing_notify(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/pairing/notify".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/pairing/notify".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn pairing_request(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/pairing/request".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/pairing/request".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -1108,76 +2577,236 @@ impl ProactiveMemoryResource {
         Self { base_url, client }
     }
 
-    pub async fn memory_list(&self, category: Option<&str>, offset: Option<&str>, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/memory".to_string(), None, &[("category", category), ("offset", offset), ("limit", limit)]).await
+    pub async fn memory_list(
+        &self,
+        category: Option<&str>,
+        offset: Option<&str>,
+        limit: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/memory".to_string(),
+            None,
+            &[("category", category), ("offset", offset), ("limit", limit)],
+        )
+        .await
     }
 
     pub async fn memory_add(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/memory".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/memory".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
-    pub async fn memory_list_agent(&self, id: &str, category: Option<&str>, offset: Option<&str>, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}", id), None, &[("category", category), ("offset", offset), ("limit", limit)]).await
+    pub async fn memory_list_agent(
+        &self,
+        id: &str,
+        category: Option<&str>,
+        offset: Option<&str>,
+        limit: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/agents/{}", id),
+            None,
+            &[("category", category), ("offset", offset), ("limit", limit)],
+        )
+        .await
     }
 
     pub async fn memory_reset_agent(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/memory/agents/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/memory/agents/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_consolidate(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/memory/agents/{}/consolidate", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/memory/agents/{}/consolidate", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_duplicates(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/duplicates", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/agents/{}/duplicates", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_export_agent(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/export", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/agents/{}/export", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_import_agent(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/memory/agents/{}/import", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/memory/agents/{}/import", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_clear_level(&self, id: &str, level: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/memory/agents/{}/level/{}", id, level), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/memory/agents/{}/level/{}", id, level),
+            None,
+            &[],
+        )
+        .await
     }
 
-    pub async fn memory_search_agent(&self, id: &str, q: Option<&str>, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/search", id), None, &[("q", q), ("limit", limit)]).await
+    pub async fn memory_search_agent(
+        &self,
+        id: &str,
+        q: Option<&str>,
+        limit: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/agents/{}/search", id),
+            None,
+            &[("q", q), ("limit", limit)],
+        )
+        .await
     }
 
     pub async fn memory_stats_agent(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/stats", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/agents/{}/stats", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_cleanup(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/memory/cleanup".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/memory/cleanup".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_update(&self, memory_id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/memory/items/{}", memory_id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/memory/items/{}", memory_id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_delete(&self, memory_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/memory/items/{}", memory_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/memory/items/{}", memory_id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_history(&self, memory_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/items/{}/history", memory_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/items/{}/history", memory_id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_search(&self, q: Option<&str>, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/memory/search".to_string(), None, &[("q", q), ("limit", limit)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/memory/search".to_string(),
+            None,
+            &[("q", q), ("limit", limit)],
+        )
+        .await
     }
 
     pub async fn memory_stats(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/memory/stats".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/memory/stats".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn memory_get_user(&self, user_id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/user/{}", user_id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/user/{}", user_id),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -1195,27 +2824,75 @@ impl SessionsResource {
     }
 
     pub async fn find_session_by_label(&self, id: &str, label: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions/by-label/{}", id, label), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/agents/{}/sessions/by-label/{}", id, label),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_sessions(&self, limit: Option<&str>, offset: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/sessions".to_string(), None, &[("limit", limit), ("offset", offset)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/sessions".to_string(),
+            None,
+            &[("limit", limit), ("offset", offset)],
+        )
+        .await
     }
 
     pub async fn session_cleanup(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/sessions/cleanup".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/sessions/cleanup".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_session(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/sessions/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/sessions/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_session(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/sessions/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/sessions/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn set_session_label(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/sessions/{}/label", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/sessions/{}/label", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 }
 
@@ -1233,67 +2910,195 @@ impl SkillsResource {
     }
 
     pub async fn clawhub_browse(&self, q: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/clawhub/browse".to_string(), None, &[("q", q)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/clawhub/browse".to_string(),
+            None,
+            &[("q", q)],
+        )
+        .await
     }
 
     pub async fn clawhub_install(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/clawhub/install".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/clawhub/install".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn clawhub_search(&self, q: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/clawhub/search".to_string(), None, &[("q", q)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/clawhub/search".to_string(),
+            None,
+            &[("q", q)],
+        )
+        .await
     }
 
     pub async fn clawhub_skill_detail(&self, slug: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/clawhub/skill/{}", slug), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/clawhub/skill/{}", slug),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn clawhub_skill_code(&self, slug: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/clawhub/skill/{}/code", slug), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/clawhub/skill/{}/code", slug),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn marketplace_search(&self, q: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/marketplace/search".to_string(), None, &[("q", q)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/marketplace/search".to_string(),
+            None,
+            &[("q", q)],
+        )
+        .await
     }
 
     pub async fn list_skills(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/skills".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/skills".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn create_skill(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/skills/create".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/skills/create".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn install_skill(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/skills/install".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/skills/install".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn list_pending_candidates(&self, agent: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/skills/pending".to_string(), None, &[("agent", agent)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/skills/pending".to_string(),
+            None,
+            &[("agent", agent)],
+        )
+        .await
     }
 
     pub async fn show_pending_candidate(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/skills/pending/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/skills/pending/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn approve_pending_candidate(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/skills/pending/{}/approve", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/skills/pending/{}/approve", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn reject_pending_candidate(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/skills/pending/{}/reject", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/skills/pending/{}/reject", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn uninstall_skill(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/skills/uninstall".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/skills/uninstall".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn list_tools(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/tools".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/tools".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_tool(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/tools/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/tools/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -1310,144 +3115,459 @@ impl SystemResource {
         Self { base_url, client }
     }
 
-    pub async fn audit_export(&self, format: Option<&str>, user: Option<&str>, action: Option<&str>, agent: Option<&str>, channel: Option<&str>, from: Option<&str>, to: Option<&str>, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/audit/export".to_string(), None, &[("format", format), ("user", user), ("action", action), ("agent", agent), ("channel", channel), ("from", from), ("to", to), ("limit", limit)]).await
+    pub async fn audit_export(
+        &self,
+        format: Option<&str>,
+        user: Option<&str>,
+        action: Option<&str>,
+        agent: Option<&str>,
+        channel: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+        limit: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/audit/export".to_string(),
+            None,
+            &[
+                ("format", format),
+                ("user", user),
+                ("action", action),
+                ("agent", agent),
+                ("channel", channel),
+                ("from", from),
+                ("to", to),
+                ("limit", limit),
+            ],
+        )
+        .await
     }
 
-    pub async fn audit_query(&self, user: Option<&str>, action: Option<&str>, agent: Option<&str>, channel: Option<&str>, from: Option<&str>, to: Option<&str>, limit: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/audit/query".to_string(), None, &[("user", user), ("action", action), ("agent", agent), ("channel", channel), ("from", from), ("to", to), ("limit", limit)]).await
+    pub async fn audit_query(
+        &self,
+        user: Option<&str>,
+        action: Option<&str>,
+        agent: Option<&str>,
+        channel: Option<&str>,
+        from: Option<&str>,
+        to: Option<&str>,
+        limit: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/audit/query".to_string(),
+            None,
+            &[
+                ("user", user),
+                ("action", action),
+                ("agent", agent),
+                ("channel", channel),
+                ("from", from),
+                ("to", to),
+                ("limit", limit),
+            ],
+        )
+        .await
     }
 
     pub async fn audit_recent(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/audit/recent".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/audit/recent".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn audit_verify(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/audit/verify".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/audit/verify".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn create_backup(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/backup".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/backup".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_backups(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/backups".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/backups".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_backup(&self, filename: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/backups/{}", filename), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/backups/{}", filename),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_bindings(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/bindings".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/bindings".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn add_binding(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/bindings".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/bindings".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn remove_binding(&self, index: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/bindings/{}", index), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/bindings/{}", index),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_commands(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/commands".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/commands".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_command(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/commands/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/commands/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_config(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/config".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/config".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn config_reload(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/config/reload".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/config/reload".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn config_schema(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/config/schema".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/config/schema".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn config_set(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/config/set".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/config/set".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn health(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/health".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/health".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn health_detail(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/health/detail".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/health/detail".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn quick_init(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/init".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/init".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub fn logs_stream(&self) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
-        do_stream(self.client.clone(), self.base_url.clone(), "/api/logs/stream".to_string(), reqwest::Method::GET, None, Vec::new())
+        do_stream(
+            self.client.clone(),
+            self.base_url.clone(),
+            "/api/logs/stream".to_string(),
+            reqwest::Method::GET,
+            None,
+            Vec::new(),
+        )
     }
 
     pub async fn prometheus_metrics(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/metrics".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/metrics".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn run_migrate(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/migrate".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/migrate".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn migrate_detect(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/migrate/detect".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/migrate/detect".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn migrate_scan(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/migrate/scan".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/migrate/scan".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn list_profiles(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/profiles".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/profiles".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_profile(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/profiles/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/profiles/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn queue_status(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/queue/status".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/queue/status".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn restore_backup(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/restore".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/restore".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn security_status(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/security".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/security".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn shutdown(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/shutdown".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/shutdown".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn status(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/status".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/status".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_agent_templates(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/templates".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/templates".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn get_agent_template(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/templates/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/templates/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn version(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/version".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/version".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn api_versions(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/versions".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/versions".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -1464,8 +3584,21 @@ impl ToolsResource {
         Self { base_url, client }
     }
 
-    pub async fn invoke_tool(&self, name: &str, data: Value, agent_id: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/tools/{}/invoke", name), Some(data), &[("agent_id", agent_id)]).await
+    pub async fn invoke_tool(
+        &self,
+        name: &str,
+        data: Value,
+        agent_id: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/tools/{}/invoke", name),
+            Some(data),
+            &[("agent_id", agent_id)],
+        )
+        .await
     }
 }
 
@@ -1483,31 +3616,87 @@ impl UsersResource {
     }
 
     pub async fn list_users(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/users".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/users".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn create_user(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/users".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/users".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn import_users(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/users/import".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/users/import".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_user(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/users/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/users/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn update_user(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/users/{}", name), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/users/{}", name),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_user(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/users/{}", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/users/{}", name),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn rotate_user_key(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/users/{}/rotate-key", name), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/users/{}/rotate-key", name),
+            None,
+            &[],
+        )
+        .await
     }
 }
 
@@ -1525,11 +3714,27 @@ impl WebhooksResource {
     }
 
     pub async fn webhook_agent(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/hooks/agent".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/hooks/agent".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn webhook_wake(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/hooks/wake".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/hooks/wake".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 }
 
@@ -1547,99 +3752,290 @@ impl WorkflowsResource {
     }
 
     pub async fn list_cron_jobs(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/cron/jobs".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/cron/jobs".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn create_cron_job(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/cron/jobs".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/cron/jobs".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn update_cron_job(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/cron/jobs/{}", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/cron/jobs/{}", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_cron_job(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/cron/jobs/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/cron/jobs/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn toggle_cron_job(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/cron/jobs/{}/enable", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/cron/jobs/{}/enable", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn cron_job_status(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/cron/jobs/{}/status", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/cron/jobs/{}/status", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_schedules(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/schedules".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/schedules".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn create_schedule(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/schedules".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/schedules".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_schedule(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/schedules/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/schedules/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn update_schedule(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/schedules/{}", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/schedules/{}", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_schedule(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/schedules/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/schedules/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn run_schedule(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/schedules/{}/run", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/schedules/{}/run", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn list_triggers(&self, agent_id: Option<&str>) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/triggers".to_string(), None, &[("agent_id", agent_id)]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/triggers".to_string(),
+            None,
+            &[("agent_id", agent_id)],
+        )
+        .await
     }
 
     pub async fn create_trigger(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/triggers".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/triggers".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn get_trigger(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/triggers/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/triggers/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_trigger(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/triggers/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/triggers/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn update_trigger(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/triggers/{}", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PATCH,
+            &format!("/api/triggers/{}", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn list_workflows(&self) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/workflows".to_string(), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/workflows".to_string(),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn create_workflow(&self, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/workflows".to_string(), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/workflows".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn update_workflow(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/workflows/{}", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/workflows/{}", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn delete_workflow(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/workflows/{}", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/workflows/{}", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn run_workflow(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/workflows/{}/run", id), Some(data), &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/workflows/{}/run", id),
+            Some(data),
+            &[],
+        )
+        .await
     }
 
     pub async fn list_workflow_runs(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/workflows/{}/runs", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/workflows/{}/runs", id),
+            None,
+            &[],
+        )
+        .await
     }
 
     pub async fn save_workflow_as_template(&self, id: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/workflows/{}/save-as-template", id), None, &[]).await
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/workflows/{}/save-as-template", id),
+            None,
+            &[],
+        )
+        .await
     }
 }
-

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -47,24 +47,13 @@ async fn do_req(
         .iter()
         .filter_map(|(k, v)| v.map(|vv| (*k, vv)))
         .collect();
-    let req = if filtered.is_empty() {
-        req
-    } else {
-        req.query(&filtered)
-    };
-    let req = if let Some(b) = body {
-        req.json(&b)
-    } else {
-        req
-    };
+    let req = if filtered.is_empty() { req } else { req.query(&filtered) };
+    let req = if let Some(b) = body { req.json(&b) } else { req };
     let res = req.send().await?;
     let status = res.status();
     let text = res.text().await?;
     if !status.is_success() {
-        return Err(Error::Api {
-            status: status.as_u16(),
-            body: text,
-        });
+        return Err(Error::Api { status: status.as_u16(), body: text });
     }
     Ok(serde_json::from_str(&text).unwrap_or(Value::String(text)))
 }
@@ -80,23 +69,13 @@ fn do_stream(
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     tokio::spawn(async move {
         let url = format!("{}{}", base_url, path);
-        let req = client
-            .request(method, &url)
-            .header("Accept", "text/event-stream");
+        let req = client.request(method, &url).header("Accept", "text/event-stream");
         let filtered: Vec<(String, String)> = query
             .into_iter()
             .filter_map(|(k, v)| v.map(|vv| (k, vv)))
             .collect();
-        let req = if filtered.is_empty() {
-            req
-        } else {
-            req.query(&filtered)
-        };
-        let req = if let Some(b) = body {
-            req.json(&b)
-        } else {
-            req
-        };
+        let req = if filtered.is_empty() { req } else { req.query(&filtered) };
+        let req = if let Some(b) = body { req.json(&b) } else { req };
         let res = match req.send().await {
             Ok(r) => r,
             Err(e) => {
@@ -145,13 +124,9 @@ fn do_stream(
                     }
                 };
                 if let Some(data) = line.strip_prefix("data: ") {
-                    if data == "[DONE]" {
-                        return;
-                    }
+                    if data == "[DONE]" { return; }
                     match serde_json::from_str::<Value>(data) {
-                        Ok(v) => {
-                            let _ = tx.send(v);
-                        }
+                        Ok(v) => { let _ = tx.send(v); }
                         Err(_) => {
                             let _ = tx.send(serde_json::json!({"raw": data}));
                         }
@@ -210,10 +185,7 @@ impl LibreFang {
             models: Arc::new(ModelsResource::new(base_url.clone(), client.clone())),
             network: Arc::new(NetworkResource::new(base_url.clone(), client.clone())),
             pairing: Arc::new(PairingResource::new(base_url.clone(), client.clone())),
-            proactive_memory: Arc::new(ProactiveMemoryResource::new(
-                base_url.clone(),
-                client.clone(),
-            )),
+            proactive_memory: Arc::new(ProactiveMemoryResource::new(base_url.clone(), client.clone())),
             sessions: Arc::new(SessionsResource::new(base_url.clone(), client.clone())),
             skills: Arc::new(SkillsResource::new(base_url.clone(), client.clone())),
             system: Arc::new(SystemResource::new(base_url.clone(), client.clone())),
@@ -241,63 +213,23 @@ impl A2AResource {
     }
 
     pub async fn a2a_list_external_agents(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/a2a/agents".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/a2a/agents".to_string(), None, &[]).await
     }
 
     pub async fn a2a_get_external_agent(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/a2a/agents/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/a2a/agents/{}", id), None, &[]).await
     }
 
     pub async fn a2a_discover_external(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/a2a/discover".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/a2a/discover".to_string(), Some(data), &[]).await
     }
 
     pub async fn a2a_send_external(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/a2a/send".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/a2a/send".to_string(), Some(data), &[]).await
     }
 
     pub async fn a2a_external_task_status(&self, id: &str, url: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/a2a/tasks/{}/status", id),
-            None,
-            &[("url", url)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/a2a/tasks/{}/status", id), None, &[("url", url)]).await
     }
 }
 
@@ -314,732 +246,236 @@ impl AgentsResource {
         Self { base_url, client }
     }
 
-    pub async fn list_agents(
-        &self,
-        q: Option<&str>,
-        status: Option<&str>,
-        limit: Option<&str>,
-        offset: Option<&str>,
-        sort: Option<&str>,
-        order: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/agents".to_string(),
-            None,
-            &[
-                ("q", q),
-                ("status", status),
-                ("limit", limit),
-                ("offset", offset),
-                ("sort", sort),
-                ("order", order),
-            ],
-        )
-        .await
+    pub async fn list_agents(&self, q: Option<&str>, status: Option<&str>, limit: Option<&str>, offset: Option<&str>, sort: Option<&str>, order: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/agents".to_string(), None, &[("q", q), ("status", status), ("limit", limit), ("offset", offset), ("sort", sort), ("order", order)]).await
     }
 
     pub async fn spawn_agent(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/agents".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/agents".to_string(), Some(data), &[]).await
     }
 
     pub async fn bulk_create_agents(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/agents/bulk".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/agents/bulk".to_string(), Some(data), &[]).await
     }
 
     pub async fn bulk_delete_agents(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &"/api/agents/bulk".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &"/api/agents/bulk".to_string(), None, &[]).await
     }
 
     pub async fn bulk_start_agents(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/agents/bulk/start".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/agents/bulk/start".to_string(), Some(data), &[]).await
     }
 
     pub async fn bulk_stop_agents(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/agents/bulk/stop".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/agents/bulk/stop".to_string(), Some(data), &[]).await
     }
 
     pub async fn list_agent_identities(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/agents/identities".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/agents/identities".to_string(), None, &[]).await
     }
 
     pub async fn reset_agent_identity(&self, name: &str, confirm: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/identities/{}/reset", name),
-            None,
-            &[("confirm", confirm)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/identities/{}/reset", name), None, &[("confirm", confirm)]).await
     }
 
     pub async fn get_agent(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}", id), None, &[]).await
     }
 
     pub async fn kill_agent(&self, id: &str, confirm: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/agents/{}", id),
-            None,
-            &[("confirm", confirm)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/agents/{}", id), None, &[("confirm", confirm)]).await
     }
 
     pub async fn patch_agent(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PATCH,
-            &format!("/api/agents/{}", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/agents/{}", id), Some(data), &[]).await
     }
 
     pub async fn clone_agent(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/clone", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/clone", id), Some(data), &[]).await
     }
 
     pub async fn patch_agent_config(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PATCH,
-            &format!("/api/agents/{}/config", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/agents/{}/config", id), Some(data), &[]).await
     }
 
     pub async fn get_agent_deliveries(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/deliveries", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/deliveries", id), None, &[]).await
     }
 
     pub async fn list_agent_events(&self, id: &str, limit: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/events", id),
-            None,
-            &[("limit", limit)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/events", id), None, &[("limit", limit)]).await
     }
 
     pub async fn list_agent_files(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/files", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/files", id), None, &[]).await
     }
 
     pub async fn get_agent_file(&self, id: &str, filename: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/files/{}", id, filename),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/files/{}", id, filename), None, &[]).await
     }
 
     pub async fn set_agent_file(&self, id: &str, filename: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/agents/{}/files/{}", id, filename),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/files/{}", id, filename), Some(data), &[]).await
     }
 
     pub async fn delete_agent_file(&self, id: &str, filename: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/agents/{}/files/{}", id, filename),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/agents/{}/files/{}", id, filename), None, &[]).await
     }
 
     pub async fn delete_hand_agent_runtime_config(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/agents/{}/hand-runtime-config", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/agents/{}/hand-runtime-config", id), None, &[]).await
     }
 
     pub async fn patch_hand_agent_runtime_config(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PATCH,
-            &format!("/api/agents/{}/hand-runtime-config", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/agents/{}/hand-runtime-config", id), Some(data), &[]).await
     }
 
     pub async fn clear_agent_history(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/agents/{}/history", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/agents/{}/history", id), None, &[]).await
     }
 
     pub async fn update_agent_identity(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PATCH,
-            &format!("/api/agents/{}/identity", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/agents/{}/identity", id), Some(data), &[]).await
     }
 
     pub async fn inject_message(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/inject", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/inject", id), Some(data), &[]).await
     }
 
-    pub async fn agent_logs(
-        &self,
-        id: &str,
-        n: Option<&str>,
-        level: Option<&str>,
-        offset: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/logs", id),
-            None,
-            &[("n", n), ("level", level), ("offset", offset)],
-        )
-        .await
+    pub async fn agent_logs(&self, id: &str, n: Option<&str>, level: Option<&str>, offset: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/logs", id), None, &[("n", n), ("level", level), ("offset", offset)]).await
     }
 
     pub async fn get_agent_mcp_servers(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/mcp_servers", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/mcp_servers", id), None, &[]).await
     }
 
     pub async fn set_agent_mcp_servers(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/agents/{}/mcp_servers", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/mcp_servers", id), Some(data), &[]).await
     }
 
     pub async fn send_message(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/message", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/message", id), Some(data), &[]).await
     }
 
-    pub fn send_message_stream(
-        &self,
-        id: &str,
-        data: Value,
-    ) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
-        do_stream(
-            self.client.clone(),
-            self.base_url.clone(),
-            format!("/api/agents/{}/message/stream", id),
-            reqwest::Method::POST,
-            Some(data),
-            Vec::new(),
-        )
+    pub fn send_message_stream(&self, id: &str, data: Value) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
+        do_stream(self.client.clone(), self.base_url.clone(), format!("/api/agents/{}/message/stream", id), reqwest::Method::POST, Some(data), Vec::new())
     }
 
     pub async fn agent_metrics(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/metrics", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/metrics", id), None, &[]).await
     }
 
     pub async fn set_agent_mode(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/agents/{}/mode", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/mode", id), Some(data), &[]).await
     }
 
     pub async fn set_model(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/agents/{}/model", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/model", id), Some(data), &[]).await
     }
 
     pub async fn push_message(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/push", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/push", id), Some(data), &[]).await
     }
 
     pub async fn reload_agent_manifest(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/reload", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/reload", id), None, &[]).await
     }
 
     pub async fn resume_agent(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/agents/{}/resume", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/resume", id), None, &[]).await
     }
 
     pub async fn list_agent_runtime(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/runtime", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/runtime", id), None, &[]).await
     }
 
     pub async fn get_agent_session(&self, id: &str, session_id: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/session", id),
-            None,
-            &[("session_id", session_id)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/session", id), None, &[("session_id", session_id)]).await
     }
 
     pub async fn compact_session(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/session/compact", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/session/compact", id), None, &[]).await
     }
 
     pub async fn reboot_session(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/session/reboot", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/session/reboot", id), None, &[]).await
     }
 
     pub async fn reset_session(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/session/reset", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/session/reset", id), None, &[]).await
     }
 
     pub async fn list_agent_sessions(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/sessions", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions", id), None, &[]).await
     }
 
     pub async fn create_agent_session(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/sessions", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions", id), Some(data), &[]).await
     }
 
     pub async fn import_session(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/sessions/import", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions/import", id), Some(data), &[]).await
     }
 
     pub async fn export_session(&self, id: &str, session_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/sessions/{}/export", id, session_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions/{}/export", id, session_id), None, &[]).await
     }
 
     pub async fn stop_session(&self, id: &str, session_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/sessions/{}/stop", id, session_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions/{}/stop", id, session_id), None, &[]).await
     }
 
-    pub fn attach_session_stream(
-        &self,
-        id: &str,
-        session_id: &str,
-    ) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
-        do_stream(
-            self.client.clone(),
-            self.base_url.clone(),
-            format!("/api/agents/{}/sessions/{}/stream", id, session_id),
-            reqwest::Method::GET,
-            None,
-            Vec::new(),
-        )
+    pub fn attach_session_stream(&self, id: &str, session_id: &str) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
+        do_stream(self.client.clone(), self.base_url.clone(), format!("/api/agents/{}/sessions/{}/stream", id, session_id), reqwest::Method::GET, None, Vec::new())
     }
 
     pub async fn switch_agent_session(&self, id: &str, session_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/sessions/{}/switch", id, session_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/sessions/{}/switch", id, session_id), None, &[]).await
     }
 
-    pub async fn export_session_trajectory(
-        &self,
-        id: &str,
-        session_id: &str,
-        format: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/sessions/{}/trajectory", id, session_id),
-            None,
-            &[("format", format)],
-        )
-        .await
+    pub async fn export_session_trajectory(&self, id: &str, session_id: &str, format: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions/{}/trajectory", id, session_id), None, &[("format", format)]).await
     }
 
     pub async fn get_agent_skills(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/skills", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/skills", id), None, &[]).await
     }
 
     pub async fn set_agent_skills(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/agents/{}/skills", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/skills", id), Some(data), &[]).await
     }
 
     pub async fn get_agent_stats(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/stats", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/stats", id), None, &[]).await
     }
 
     pub async fn stop_agent(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/stop", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/stop", id), None, &[]).await
     }
 
     pub async fn suspend_agent(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/agents/{}/suspend", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/suspend", id), None, &[]).await
     }
 
     pub async fn get_agent_tools(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/tools", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/tools", id), None, &[]).await
     }
 
     pub async fn set_agent_tools(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/agents/{}/tools", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/agents/{}/tools", id), Some(data), &[]).await
     }
 
     pub async fn get_agent_traces(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/traces", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/traces", id), None, &[]).await
     }
 
     pub async fn upload_file(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/upload", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/upload", id), Some(data), &[]).await
     }
 
     pub async fn serve_upload(&self, file_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/uploads/{}", file_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/uploads/{}", file_id), None, &[]).await
     }
 }
 
@@ -1057,63 +493,23 @@ impl ApprovalsResource {
     }
 
     pub async fn list_approvals(&self, limit: Option<&str>, offset: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/approvals".to_string(),
-            None,
-            &[("limit", limit), ("offset", offset)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/approvals".to_string(), None, &[("limit", limit), ("offset", offset)]).await
     }
 
     pub async fn create_approval(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/approvals".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/approvals".to_string(), Some(data), &[]).await
     }
 
     pub async fn get_approval(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/approvals/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/approvals/{}", id), None, &[]).await
     }
 
     pub async fn approve_request(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/approvals/{}/approve", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/approvals/{}/approve", id), Some(data), &[]).await
     }
 
     pub async fn reject_request(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/approvals/{}/reject", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/approvals/{}/reject", id), None, &[]).await
     }
 }
 
@@ -1131,147 +527,51 @@ impl AuthResource {
     }
 
     pub async fn auth_callback(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/auth/callback".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/callback".to_string(), None, &[]).await
     }
 
     pub async fn auth_callback_post(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/auth/callback".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/callback".to_string(), Some(data), &[]).await
     }
 
     pub async fn change_password(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/auth/change-password".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/change-password".to_string(), Some(data), &[]).await
     }
 
     pub async fn dashboard_auth_check(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/auth/dashboard-check".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/dashboard-check".to_string(), None, &[]).await
     }
 
     pub async fn dashboard_login(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/auth/dashboard-login".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/dashboard-login".to_string(), Some(data), &[]).await
     }
 
     pub async fn auth_introspect(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/auth/introspect".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/introspect".to_string(), Some(data), &[]).await
     }
 
     pub async fn auth_login(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/auth/login".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/login".to_string(), None, &[]).await
     }
 
     pub async fn auth_login_provider(&self, provider: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/auth/login/{}", provider),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/auth/login/{}", provider), None, &[]).await
     }
 
     pub async fn dashboard_logout(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/auth/logout".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/logout".to_string(), None, &[]).await
     }
 
     pub async fn auth_providers(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/auth/providers".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/providers".to_string(), None, &[]).await
     }
 
     pub async fn auth_refresh(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/auth/refresh".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/auth/refresh".to_string(), Some(data), &[]).await
     }
 
     pub async fn auth_userinfo(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/auth/userinfo".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auth/userinfo".to_string(), None, &[]).await
     }
 }
 
@@ -1289,51 +589,19 @@ impl AutoDreamResource {
     }
 
     pub async fn auto_dream_abort(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/auto-dream/agents/{}/abort", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/auto-dream/agents/{}/abort", id), None, &[]).await
     }
 
     pub async fn auto_dream_set_enabled(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/auto-dream/agents/{}/enabled", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/auto-dream/agents/{}/enabled", id), Some(data), &[]).await
     }
 
     pub async fn auto_dream_trigger(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/auto-dream/agents/{}/trigger", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/auto-dream/agents/{}/trigger", id), None, &[]).await
     }
 
     pub async fn auto_dream_status(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/auto-dream/status".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/auto-dream/status".to_string(), None, &[]).await
     }
 }
 
@@ -1351,135 +619,47 @@ impl BudgetResource {
     }
 
     pub async fn budget_status(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/budget".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/budget".to_string(), None, &[]).await
     }
 
     pub async fn update_budget(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &"/api/budget".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &"/api/budget".to_string(), Some(data), &[]).await
     }
 
     pub async fn agent_budget_ranking(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/budget/agents".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/budget/agents".to_string(), None, &[]).await
     }
 
     pub async fn agent_budget_status(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/budget/agents/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/budget/agents/{}", id), None, &[]).await
     }
 
     pub async fn update_agent_budget(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/budget/agents/{}", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/budget/agents/{}", id), Some(data), &[]).await
     }
 
     pub async fn user_budget_ranking(&self, limit: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/budget/users".to_string(),
-            None,
-            &[("limit", limit)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/budget/users".to_string(), None, &[("limit", limit)]).await
     }
 
     pub async fn user_budget_detail(&self, user_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/budget/users/{}", user_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/budget/users/{}", user_id), None, &[]).await
     }
 
     pub async fn usage_stats(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/usage".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/usage".to_string(), None, &[]).await
     }
 
     pub async fn usage_by_model(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/usage/by-model".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/usage/by-model".to_string(), None, &[]).await
     }
 
     pub async fn usage_daily(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/usage/daily".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/usage/daily".to_string(), None, &[]).await
     }
 
     pub async fn usage_summary(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/usage/summary".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/usage/summary".to_string(), None, &[]).await
     }
 }
 
@@ -1497,169 +677,55 @@ impl ChannelsResource {
     }
 
     pub async fn list_channels(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/channels".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/channels".to_string(), None, &[]).await
     }
 
     pub async fn reload_channels(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/channels/reload".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/channels/reload".to_string(), None, &[]).await
     }
 
     pub async fn wechat_qr_start(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/channels/wechat/qr/start".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/channels/wechat/qr/start".to_string(), None, &[]).await
     }
 
     pub async fn wechat_qr_status(&self, qr_code: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/channels/wechat/qr/status".to_string(),
-            None,
-            &[("qr_code", qr_code)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/channels/wechat/qr/status".to_string(), None, &[("qr_code", qr_code)]).await
     }
 
     pub async fn whatsapp_qr_start(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/channels/whatsapp/qr/start".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/channels/whatsapp/qr/start".to_string(), None, &[]).await
     }
 
     pub async fn whatsapp_qr_status(&self, session_id: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/channels/whatsapp/qr/status".to_string(),
-            None,
-            &[("session_id", session_id)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/channels/whatsapp/qr/status".to_string(), None, &[("session_id", session_id)]).await
     }
 
     pub async fn configure_channel(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/channels/{}/configure", name),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/channels/{}/configure", name), Some(data), &[]).await
     }
 
     pub async fn remove_channel(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/channels/{}/configure", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/channels/{}/configure", name), None, &[]).await
     }
 
     pub async fn list_channel_instances(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/channels/{}/instances", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/channels/{}/instances", name), None, &[]).await
     }
 
     pub async fn create_channel_instance(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/channels/{}/instances", name),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/channels/{}/instances", name), Some(data), &[]).await
     }
 
-    pub async fn update_channel_instance_handler(
-        &self,
-        name: &str,
-        index: &str,
-        data: Value,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/channels/{}/instances/{}", name, index),
-            Some(data),
-            &[],
-        )
-        .await
+    pub async fn update_channel_instance_handler(&self, name: &str, index: &str, data: Value) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/channels/{}/instances/{}", name, index), Some(data), &[]).await
     }
 
-    pub async fn delete_channel_instance(
-        &self,
-        name: &str,
-        index: &str,
-        signature: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/channels/{}/instances/{}", name, index),
-            None,
-            &[("signature", signature)],
-        )
-        .await
+    pub async fn delete_channel_instance(&self, name: &str, index: &str, signature: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/channels/{}/instances/{}", name, index), None, &[("signature", signature)]).await
     }
 
     pub async fn test_channel(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/channels/{}/test", name),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/channels/{}/test", name), Some(data), &[]).await
     }
 }
 
@@ -1677,51 +743,19 @@ impl ExtensionsResource {
     }
 
     pub async fn list_extensions(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/extensions".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/extensions".to_string(), None, &[]).await
     }
 
     pub async fn install_extension(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/extensions/install".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/extensions/install".to_string(), Some(data), &[]).await
     }
 
     pub async fn uninstall_extension(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/extensions/uninstall".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/extensions/uninstall".to_string(), Some(data), &[]).await
     }
 
     pub async fn get_extension(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/extensions/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/extensions/{}", name), None, &[]).await
     }
 }
 
@@ -1739,183 +773,63 @@ impl HandsResource {
     }
 
     pub async fn list_hands(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/hands".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/hands".to_string(), None, &[]).await
     }
 
     pub async fn list_active_hands(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/hands/active".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/hands/active".to_string(), None, &[]).await
     }
 
     pub async fn install_hand(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/hands/install".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/hands/install".to_string(), Some(data), &[]).await
     }
 
     pub async fn deactivate_hand(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/hands/instances/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/hands/instances/{}", id), None, &[]).await
     }
 
     pub async fn hand_instance_browser(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/hands/instances/{}/browser", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/hands/instances/{}/browser", id), None, &[]).await
     }
 
     pub async fn pause_hand(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/hands/instances/{}/pause", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/instances/{}/pause", id), None, &[]).await
     }
 
     pub async fn resume_hand(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/hands/instances/{}/resume", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/instances/{}/resume", id), None, &[]).await
     }
 
     pub async fn hand_stats(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/hands/instances/{}/stats", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/hands/instances/{}/stats", id), None, &[]).await
     }
 
     pub async fn reload_hands(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/hands/reload".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/hands/reload".to_string(), None, &[]).await
     }
 
     pub async fn get_hand(&self, hand_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/hands/{}", hand_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/hands/{}", hand_id), None, &[]).await
     }
 
     pub async fn activate_hand(&self, hand_id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/hands/{}/activate", hand_id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/{}/activate", hand_id), Some(data), &[]).await
     }
 
     pub async fn check_hand_deps(&self, hand_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/hands/{}/check-deps", hand_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/{}/check-deps", hand_id), None, &[]).await
     }
 
     pub async fn install_hand_deps(&self, hand_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/hands/{}/install-deps", hand_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/hands/{}/install-deps", hand_id), None, &[]).await
     }
 
     pub async fn get_hand_settings(&self, hand_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/hands/{}/settings", hand_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/hands/{}/settings", hand_id), None, &[]).await
     }
 
     pub async fn update_hand_settings(&self, hand_id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/hands/{}/settings", hand_id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/hands/{}/settings", hand_id), Some(data), &[]).await
     }
 }
 
@@ -1933,135 +847,47 @@ impl McpResource {
     }
 
     pub async fn list_mcp_catalog(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/mcp/catalog".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/mcp/catalog".to_string(), None, &[]).await
     }
 
     pub async fn get_mcp_catalog_entry(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/mcp/catalog/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/mcp/catalog/{}", id), None, &[]).await
     }
 
     pub async fn mcp_health_handler(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/mcp/health".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/mcp/health".to_string(), None, &[]).await
     }
 
     pub async fn reload_mcp_handler(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/mcp/reload".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/mcp/reload".to_string(), None, &[]).await
     }
 
     pub async fn list_mcp_servers(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/mcp/servers".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/mcp/servers".to_string(), None, &[]).await
     }
 
     pub async fn add_mcp_server(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/mcp/servers".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/mcp/servers".to_string(), Some(data), &[]).await
     }
 
     pub async fn get_mcp_server(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/mcp/servers/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/mcp/servers/{}", name), None, &[]).await
     }
 
     pub async fn update_mcp_server(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/mcp/servers/{}", name),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/mcp/servers/{}", name), Some(data), &[]).await
     }
 
     pub async fn delete_mcp_server(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/mcp/servers/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/mcp/servers/{}", name), None, &[]).await
     }
 
     pub async fn reconnect_mcp_server_handler(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/mcp/servers/{}/reconnect", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/mcp/servers/{}/reconnect", name), None, &[]).await
     }
 
     pub async fn list_mcp_taint_rules(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/mcp/taint-rules".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/mcp/taint-rules".to_string(), None, &[]).await
     }
 }
 
@@ -2079,75 +905,27 @@ impl MemoryResource {
     }
 
     pub async fn export_agent_memory(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/memory/export", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/memory/export", id), None, &[]).await
     }
 
     pub async fn import_agent_memory(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/agents/{}/memory/import", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/agents/{}/memory/import", id), Some(data), &[]).await
     }
 
     pub async fn get_agent_kv(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/memory/agents/{}/kv", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/kv", id), None, &[]).await
     }
 
     pub async fn get_agent_kv_key(&self, id: &str, key: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/memory/agents/{}/kv/{}", id, key),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/kv/{}", id, key), None, &[]).await
     }
 
     pub async fn set_agent_kv_key(&self, id: &str, key: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/memory/agents/{}/kv/{}", id, key),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/memory/agents/{}/kv/{}", id, key), Some(data), &[]).await
     }
 
     pub async fn delete_agent_kv_key(&self, id: &str, key: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/memory/agents/{}/kv/{}", id, key),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/memory/agents/{}/kv/{}", id, key), None, &[]).await
     }
 }
 
@@ -2165,219 +943,75 @@ impl ModelsResource {
     }
 
     pub async fn catalog_status(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/catalog/status".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/catalog/status".to_string(), None, &[]).await
     }
 
     pub async fn catalog_update(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/catalog/update".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/catalog/update".to_string(), None, &[]).await
     }
 
     pub async fn list_all_models(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/models".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/models".to_string(), None, &[]).await
     }
 
     pub async fn list_aliases(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/models/aliases".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/models/aliases".to_string(), None, &[]).await
     }
 
     pub async fn create_alias(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/models/aliases".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/models/aliases".to_string(), Some(data), &[]).await
     }
 
     pub async fn delete_alias(&self, alias: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/models/aliases/{}", alias),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/models/aliases/{}", alias), None, &[]).await
     }
 
     pub async fn add_custom_model(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/models/custom".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/models/custom".to_string(), Some(data), &[]).await
     }
 
     pub async fn remove_custom_model(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/models/custom/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/models/custom/{}", id), None, &[]).await
     }
 
     pub async fn get_model(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/models/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/models/{}", id), None, &[]).await
     }
 
     pub async fn list_providers(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/providers".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/providers".to_string(), None, &[]).await
     }
 
     pub async fn copilot_oauth_poll(&self, poll_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/providers/github-copilot/oauth/poll/{}", poll_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/providers/github-copilot/oauth/poll/{}", poll_id), None, &[]).await
     }
 
     pub async fn copilot_oauth_start(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/providers/github-copilot/oauth/start".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/providers/github-copilot/oauth/start".to_string(), None, &[]).await
     }
 
     pub async fn get_provider(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/providers/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/providers/{}", name), None, &[]).await
     }
 
     pub async fn set_default_provider(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/providers/{}/default", name),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/providers/{}/default", name), Some(data), &[]).await
     }
 
     pub async fn set_provider_key(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/providers/{}/key", name),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/providers/{}/key", name), Some(data), &[]).await
     }
 
     pub async fn delete_provider_key(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/providers/{}/key", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/providers/{}/key", name), None, &[]).await
     }
 
     pub async fn test_provider(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/providers/{}/test", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/providers/{}/test", name), None, &[]).await
     }
 
     pub async fn set_provider_url(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/providers/{}/url", name),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/providers/{}/url", name), Some(data), &[]).await
     }
 }
 
@@ -2395,98 +1029,35 @@ impl NetworkResource {
     }
 
     pub async fn comms_events(&self, limit: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/comms/events".to_string(),
-            None,
-            &[("limit", limit)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/comms/events".to_string(), None, &[("limit", limit)]).await
     }
 
     pub fn comms_events_stream(&self) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
-        do_stream(
-            self.client.clone(),
-            self.base_url.clone(),
-            "/api/comms/events/stream".to_string(),
-            reqwest::Method::GET,
-            None,
-            Vec::new(),
-        )
+        do_stream(self.client.clone(), self.base_url.clone(), "/api/comms/events/stream".to_string(), reqwest::Method::GET, None, Vec::new())
     }
 
     pub async fn comms_send(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/comms/send".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/comms/send".to_string(), Some(data), &[]).await
     }
 
     pub async fn comms_task(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/comms/task".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/comms/task".to_string(), Some(data), &[]).await
     }
 
     pub async fn comms_topology(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/comms/topology".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/comms/topology".to_string(), None, &[]).await
     }
 
     pub async fn network_status(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/network/status".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/network/status".to_string(), None, &[]).await
     }
 
     pub async fn list_peers(&self, offset: Option<&str>, limit: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/peers".to_string(),
-            None,
-            &[("offset", offset), ("limit", limit)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/peers".to_string(), None, &[("offset", offset), ("limit", limit)]).await
     }
 
     pub async fn get_peer(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/peers/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/peers/{}", id), None, &[]).await
     }
 }
 
@@ -2504,63 +1075,23 @@ impl PairingResource {
     }
 
     pub async fn pairing_complete(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/pairing/complete".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/pairing/complete".to_string(), Some(data), &[]).await
     }
 
     pub async fn pairing_devices(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/pairing/devices".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/pairing/devices".to_string(), None, &[]).await
     }
 
     pub async fn pairing_remove_device(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/pairing/devices/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/pairing/devices/{}", id), None, &[]).await
     }
 
     pub async fn pairing_notify(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/pairing/notify".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/pairing/notify".to_string(), Some(data), &[]).await
     }
 
     pub async fn pairing_request(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/pairing/request".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/pairing/request".to_string(), None, &[]).await
     }
 }
 
@@ -2577,236 +1108,76 @@ impl ProactiveMemoryResource {
         Self { base_url, client }
     }
 
-    pub async fn memory_list(
-        &self,
-        category: Option<&str>,
-        offset: Option<&str>,
-        limit: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/memory".to_string(),
-            None,
-            &[("category", category), ("offset", offset), ("limit", limit)],
-        )
-        .await
+    pub async fn memory_list(&self, category: Option<&str>, offset: Option<&str>, limit: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/memory".to_string(), None, &[("category", category), ("offset", offset), ("limit", limit)]).await
     }
 
     pub async fn memory_add(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/memory".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/memory".to_string(), Some(data), &[]).await
     }
 
-    pub async fn memory_list_agent(
-        &self,
-        id: &str,
-        category: Option<&str>,
-        offset: Option<&str>,
-        limit: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/memory/agents/{}", id),
-            None,
-            &[("category", category), ("offset", offset), ("limit", limit)],
-        )
-        .await
+    pub async fn memory_list_agent(&self, id: &str, category: Option<&str>, offset: Option<&str>, limit: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}", id), None, &[("category", category), ("offset", offset), ("limit", limit)]).await
     }
 
     pub async fn memory_reset_agent(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/memory/agents/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/memory/agents/{}", id), None, &[]).await
     }
 
     pub async fn memory_consolidate(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/memory/agents/{}/consolidate", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/memory/agents/{}/consolidate", id), None, &[]).await
     }
 
     pub async fn memory_duplicates(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/memory/agents/{}/duplicates", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/duplicates", id), None, &[]).await
     }
 
     pub async fn memory_export_agent(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/memory/agents/{}/export", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/export", id), None, &[]).await
     }
 
     pub async fn memory_import_agent(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/memory/agents/{}/import", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/memory/agents/{}/import", id), Some(data), &[]).await
     }
 
     pub async fn memory_clear_level(&self, id: &str, level: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/memory/agents/{}/level/{}", id, level),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/memory/agents/{}/level/{}", id, level), None, &[]).await
     }
 
-    pub async fn memory_search_agent(
-        &self,
-        id: &str,
-        q: Option<&str>,
-        limit: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/memory/agents/{}/search", id),
-            None,
-            &[("q", q), ("limit", limit)],
-        )
-        .await
+    pub async fn memory_search_agent(&self, id: &str, q: Option<&str>, limit: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/search", id), None, &[("q", q), ("limit", limit)]).await
     }
 
     pub async fn memory_stats_agent(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/memory/agents/{}/stats", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/agents/{}/stats", id), None, &[]).await
     }
 
     pub async fn memory_cleanup(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/memory/cleanup".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/memory/cleanup".to_string(), None, &[]).await
     }
 
     pub async fn memory_update(&self, memory_id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/memory/items/{}", memory_id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/memory/items/{}", memory_id), Some(data), &[]).await
     }
 
     pub async fn memory_delete(&self, memory_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/memory/items/{}", memory_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/memory/items/{}", memory_id), None, &[]).await
     }
 
     pub async fn memory_history(&self, memory_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/memory/items/{}/history", memory_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/items/{}/history", memory_id), None, &[]).await
     }
 
     pub async fn memory_search(&self, q: Option<&str>, limit: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/memory/search".to_string(),
-            None,
-            &[("q", q), ("limit", limit)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/memory/search".to_string(), None, &[("q", q), ("limit", limit)]).await
     }
 
     pub async fn memory_stats(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/memory/stats".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/memory/stats".to_string(), None, &[]).await
     }
 
     pub async fn memory_get_user(&self, user_id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/memory/user/{}", user_id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/memory/user/{}", user_id), None, &[]).await
     }
 }
 
@@ -2824,75 +1195,27 @@ impl SessionsResource {
     }
 
     pub async fn find_session_by_label(&self, id: &str, label: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/agents/{}/sessions/by-label/{}", id, label),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/agents/{}/sessions/by-label/{}", id, label), None, &[]).await
     }
 
     pub async fn list_sessions(&self, limit: Option<&str>, offset: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/sessions".to_string(),
-            None,
-            &[("limit", limit), ("offset", offset)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/sessions".to_string(), None, &[("limit", limit), ("offset", offset)]).await
     }
 
     pub async fn session_cleanup(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/sessions/cleanup".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/sessions/cleanup".to_string(), None, &[]).await
     }
 
     pub async fn get_session(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/sessions/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/sessions/{}", id), None, &[]).await
     }
 
     pub async fn delete_session(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/sessions/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/sessions/{}", id), None, &[]).await
     }
 
     pub async fn set_session_label(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/sessions/{}/label", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/sessions/{}/label", id), Some(data), &[]).await
     }
 }
 
@@ -2910,195 +1233,67 @@ impl SkillsResource {
     }
 
     pub async fn clawhub_browse(&self, q: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/clawhub/browse".to_string(),
-            None,
-            &[("q", q)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/clawhub/browse".to_string(), None, &[("q", q)]).await
     }
 
     pub async fn clawhub_install(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/clawhub/install".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/clawhub/install".to_string(), Some(data), &[]).await
     }
 
     pub async fn clawhub_search(&self, q: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/clawhub/search".to_string(),
-            None,
-            &[("q", q)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/clawhub/search".to_string(), None, &[("q", q)]).await
     }
 
     pub async fn clawhub_skill_detail(&self, slug: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/clawhub/skill/{}", slug),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/clawhub/skill/{}", slug), None, &[]).await
     }
 
     pub async fn clawhub_skill_code(&self, slug: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/clawhub/skill/{}/code", slug),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/clawhub/skill/{}/code", slug), None, &[]).await
     }
 
     pub async fn marketplace_search(&self, q: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/marketplace/search".to_string(),
-            None,
-            &[("q", q)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/marketplace/search".to_string(), None, &[("q", q)]).await
     }
 
     pub async fn list_skills(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/skills".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/skills".to_string(), None, &[]).await
     }
 
     pub async fn create_skill(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/skills/create".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/skills/create".to_string(), Some(data), &[]).await
     }
 
     pub async fn install_skill(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/skills/install".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/skills/install".to_string(), Some(data), &[]).await
     }
 
     pub async fn list_pending_candidates(&self, agent: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/skills/pending".to_string(),
-            None,
-            &[("agent", agent)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/skills/pending".to_string(), None, &[("agent", agent)]).await
     }
 
     pub async fn show_pending_candidate(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/skills/pending/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/skills/pending/{}", id), None, &[]).await
     }
 
     pub async fn approve_pending_candidate(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/skills/pending/{}/approve", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/skills/pending/{}/approve", id), None, &[]).await
     }
 
     pub async fn reject_pending_candidate(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/skills/pending/{}/reject", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/skills/pending/{}/reject", id), None, &[]).await
     }
 
     pub async fn uninstall_skill(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/skills/uninstall".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/skills/uninstall".to_string(), Some(data), &[]).await
     }
 
     pub async fn list_tools(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/tools".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/tools".to_string(), None, &[]).await
     }
 
     pub async fn get_tool(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/tools/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/tools/{}", name), None, &[]).await
     }
 }
 
@@ -3115,459 +1310,144 @@ impl SystemResource {
         Self { base_url, client }
     }
 
-    pub async fn audit_export(
-        &self,
-        format: Option<&str>,
-        user: Option<&str>,
-        action: Option<&str>,
-        agent: Option<&str>,
-        channel: Option<&str>,
-        from: Option<&str>,
-        to: Option<&str>,
-        limit: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/audit/export".to_string(),
-            None,
-            &[
-                ("format", format),
-                ("user", user),
-                ("action", action),
-                ("agent", agent),
-                ("channel", channel),
-                ("from", from),
-                ("to", to),
-                ("limit", limit),
-            ],
-        )
-        .await
+    pub async fn audit_export(&self, format: Option<&str>, user: Option<&str>, action: Option<&str>, agent: Option<&str>, channel: Option<&str>, from: Option<&str>, to: Option<&str>, limit: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/audit/export".to_string(), None, &[("format", format), ("user", user), ("action", action), ("agent", agent), ("channel", channel), ("from", from), ("to", to), ("limit", limit)]).await
     }
 
-    pub async fn audit_query(
-        &self,
-        user: Option<&str>,
-        action: Option<&str>,
-        agent: Option<&str>,
-        channel: Option<&str>,
-        from: Option<&str>,
-        to: Option<&str>,
-        limit: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/audit/query".to_string(),
-            None,
-            &[
-                ("user", user),
-                ("action", action),
-                ("agent", agent),
-                ("channel", channel),
-                ("from", from),
-                ("to", to),
-                ("limit", limit),
-            ],
-        )
-        .await
+    pub async fn audit_query(&self, user: Option<&str>, action: Option<&str>, agent: Option<&str>, channel: Option<&str>, from: Option<&str>, to: Option<&str>, limit: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/audit/query".to_string(), None, &[("user", user), ("action", action), ("agent", agent), ("channel", channel), ("from", from), ("to", to), ("limit", limit)]).await
     }
 
     pub async fn audit_recent(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/audit/recent".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/audit/recent".to_string(), None, &[]).await
     }
 
     pub async fn audit_verify(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/audit/verify".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/audit/verify".to_string(), None, &[]).await
     }
 
     pub async fn create_backup(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/backup".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/backup".to_string(), None, &[]).await
     }
 
     pub async fn list_backups(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/backups".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/backups".to_string(), None, &[]).await
     }
 
     pub async fn delete_backup(&self, filename: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/backups/{}", filename),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/backups/{}", filename), None, &[]).await
     }
 
     pub async fn list_bindings(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/bindings".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/bindings".to_string(), None, &[]).await
     }
 
     pub async fn add_binding(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/bindings".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/bindings".to_string(), Some(data), &[]).await
     }
 
     pub async fn remove_binding(&self, index: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/bindings/{}", index),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/bindings/{}", index), None, &[]).await
     }
 
     pub async fn list_commands(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/commands".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/commands".to_string(), None, &[]).await
     }
 
     pub async fn get_command(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/commands/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/commands/{}", name), None, &[]).await
     }
 
     pub async fn get_config(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/config".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/config".to_string(), None, &[]).await
     }
 
     pub async fn config_reload(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/config/reload".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/config/reload".to_string(), None, &[]).await
     }
 
     pub async fn config_schema(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/config/schema".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/config/schema".to_string(), None, &[]).await
     }
 
     pub async fn config_set(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/config/set".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/config/set".to_string(), Some(data), &[]).await
     }
 
     pub async fn health(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/health".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/health".to_string(), None, &[]).await
     }
 
     pub async fn health_detail(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/health/detail".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/health/detail".to_string(), None, &[]).await
     }
 
     pub async fn quick_init(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/init".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/init".to_string(), None, &[]).await
     }
 
     pub fn logs_stream(&self) -> tokio::sync::mpsc::UnboundedReceiver<Value> {
-        do_stream(
-            self.client.clone(),
-            self.base_url.clone(),
-            "/api/logs/stream".to_string(),
-            reqwest::Method::GET,
-            None,
-            Vec::new(),
-        )
+        do_stream(self.client.clone(), self.base_url.clone(), "/api/logs/stream".to_string(), reqwest::Method::GET, None, Vec::new())
     }
 
     pub async fn prometheus_metrics(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/metrics".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/metrics".to_string(), None, &[]).await
     }
 
     pub async fn run_migrate(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/migrate".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/migrate".to_string(), Some(data), &[]).await
     }
 
     pub async fn migrate_detect(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/migrate/detect".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/migrate/detect".to_string(), None, &[]).await
     }
 
     pub async fn migrate_scan(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/migrate/scan".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/migrate/scan".to_string(), Some(data), &[]).await
     }
 
     pub async fn list_profiles(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/profiles".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/profiles".to_string(), None, &[]).await
     }
 
     pub async fn get_profile(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/profiles/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/profiles/{}", name), None, &[]).await
     }
 
     pub async fn queue_status(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/queue/status".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/queue/status".to_string(), None, &[]).await
     }
 
     pub async fn restore_backup(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/restore".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/restore".to_string(), Some(data), &[]).await
     }
 
     pub async fn security_status(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/security".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/security".to_string(), None, &[]).await
     }
 
     pub async fn shutdown(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/shutdown".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/shutdown".to_string(), None, &[]).await
     }
 
     pub async fn status(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/status".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/status".to_string(), None, &[]).await
     }
 
     pub async fn list_agent_templates(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/templates".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/templates".to_string(), None, &[]).await
     }
 
     pub async fn get_agent_template(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/templates/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/templates/{}", name), None, &[]).await
     }
 
     pub async fn version(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/version".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/version".to_string(), None, &[]).await
     }
 
     pub async fn api_versions(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/versions".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/versions".to_string(), None, &[]).await
     }
 }
 
@@ -3584,21 +1464,8 @@ impl ToolsResource {
         Self { base_url, client }
     }
 
-    pub async fn invoke_tool(
-        &self,
-        name: &str,
-        data: Value,
-        agent_id: Option<&str>,
-    ) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/tools/{}/invoke", name),
-            Some(data),
-            &[("agent_id", agent_id)],
-        )
-        .await
+    pub async fn invoke_tool(&self, name: &str, data: Value, agent_id: Option<&str>) -> Result<Value> {
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/tools/{}/invoke", name), Some(data), &[("agent_id", agent_id)]).await
     }
 }
 
@@ -3616,87 +1483,31 @@ impl UsersResource {
     }
 
     pub async fn list_users(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/users".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/users".to_string(), None, &[]).await
     }
 
     pub async fn create_user(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/users".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/users".to_string(), Some(data), &[]).await
     }
 
     pub async fn import_users(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/users/import".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/users/import".to_string(), Some(data), &[]).await
     }
 
     pub async fn get_user(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/users/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/users/{}", name), None, &[]).await
     }
 
     pub async fn update_user(&self, name: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/users/{}", name),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/users/{}", name), Some(data), &[]).await
     }
 
     pub async fn delete_user(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/users/{}", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/users/{}", name), None, &[]).await
     }
 
     pub async fn rotate_user_key(&self, name: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/users/{}/rotate-key", name),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/users/{}/rotate-key", name), None, &[]).await
     }
 }
 
@@ -3714,27 +1525,11 @@ impl WebhooksResource {
     }
 
     pub async fn webhook_agent(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/hooks/agent".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/hooks/agent".to_string(), Some(data), &[]).await
     }
 
     pub async fn webhook_wake(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/hooks/wake".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/hooks/wake".to_string(), Some(data), &[]).await
     }
 }
 
@@ -3752,290 +1547,99 @@ impl WorkflowsResource {
     }
 
     pub async fn list_cron_jobs(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/cron/jobs".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/cron/jobs".to_string(), None, &[]).await
     }
 
     pub async fn create_cron_job(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/cron/jobs".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/cron/jobs".to_string(), Some(data), &[]).await
     }
 
     pub async fn update_cron_job(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/cron/jobs/{}", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/cron/jobs/{}", id), Some(data), &[]).await
     }
 
     pub async fn delete_cron_job(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/cron/jobs/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/cron/jobs/{}", id), None, &[]).await
     }
 
     pub async fn toggle_cron_job(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/cron/jobs/{}/enable", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/cron/jobs/{}/enable", id), Some(data), &[]).await
     }
 
     pub async fn cron_job_status(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/cron/jobs/{}/status", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/cron/jobs/{}/status", id), None, &[]).await
     }
 
     pub async fn list_schedules(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/schedules".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/schedules".to_string(), None, &[]).await
     }
 
     pub async fn create_schedule(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/schedules".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/schedules".to_string(), Some(data), &[]).await
     }
 
     pub async fn get_schedule(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/schedules/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/schedules/{}", id), None, &[]).await
     }
 
     pub async fn update_schedule(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/schedules/{}", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/schedules/{}", id), Some(data), &[]).await
     }
 
     pub async fn delete_schedule(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/schedules/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/schedules/{}", id), None, &[]).await
     }
 
     pub async fn run_schedule(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/schedules/{}/run", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/schedules/{}/run", id), None, &[]).await
     }
 
     pub async fn list_triggers(&self, agent_id: Option<&str>) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/triggers".to_string(),
-            None,
-            &[("agent_id", agent_id)],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/triggers".to_string(), None, &[("agent_id", agent_id)]).await
     }
 
     pub async fn create_trigger(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/triggers".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/triggers".to_string(), Some(data), &[]).await
     }
 
     pub async fn get_trigger(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/triggers/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/triggers/{}", id), None, &[]).await
     }
 
     pub async fn delete_trigger(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/triggers/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/triggers/{}", id), None, &[]).await
     }
 
     pub async fn update_trigger(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PATCH,
-            &format!("/api/triggers/{}", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PATCH, &format!("/api/triggers/{}", id), Some(data), &[]).await
     }
 
     pub async fn list_workflows(&self) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &"/api/workflows".to_string(),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &"/api/workflows".to_string(), None, &[]).await
     }
 
     pub async fn create_workflow(&self, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &"/api/workflows".to_string(),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &"/api/workflows".to_string(), Some(data), &[]).await
     }
 
     pub async fn update_workflow(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::PUT,
-            &format!("/api/workflows/{}", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::PUT, &format!("/api/workflows/{}", id), Some(data), &[]).await
     }
 
     pub async fn delete_workflow(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::DELETE,
-            &format!("/api/workflows/{}", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::DELETE, &format!("/api/workflows/{}", id), None, &[]).await
     }
 
     pub async fn run_workflow(&self, id: &str, data: Value) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/workflows/{}/run", id),
-            Some(data),
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/workflows/{}/run", id), Some(data), &[]).await
     }
 
     pub async fn list_workflow_runs(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::GET,
-            &format!("/api/workflows/{}/runs", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::GET, &format!("/api/workflows/{}/runs", id), None, &[]).await
     }
 
     pub async fn save_workflow_as_template(&self, id: &str) -> Result<Value> {
-        do_req(
-            &self.client,
-            &self.base_url,
-            reqwest::Method::POST,
-            &format!("/api/workflows/{}/save-as-template", id),
-            None,
-            &[],
-        )
-        .await
+        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/workflows/{}/save-as-template", id), None, &[]).await
     }
 }
+

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-eb78e8a1938fb61669f4fd224b4500c38006b9784c3e860a0f913028a087de20  openapi.json
+e91fcae52fab2c67302be135b3ac1db3c2e4ad5bda831ecab25873ecf6fd6c2e  openapi.json

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-e91fcae52fab2c67302be135b3ac1db3c2e4ad5bda831ecab25873ecf6fd6c2e  openapi.json
+144357707afcf88c5b1c2738fe3ef1c0cd7e7d7f8a4d10c8d9d10020e5c418d2  openapi.json


### PR DESCRIPTION
Closes #4837.

## Summary

The kernel has supported `[[channels.<name>]]` (multiple instances of the same channel type) since #240, but the dashboard had no UI to add, edit, or delete individual instances — users wanting two Telegram bots or three Slack workspaces had to hand-edit `config.toml` and `secrets.env`. This PR adds:

- four new HTTP routes for per-instance CRUD,
- TOML helpers that auto-promote the legacy single `[channels.<name>]` table to an array of tables when a second instance is added (and drop the section entirely when the array empties),
- a dashboard drawer with list / create / edit / delete phases that replaces the legacy single-form dialog for non-QR channels.

Two commits — backend first, then dashboard — so reviewers can read each layer in isolation.

## What's new

### Backend (commit 1)

- `GET    /api/channels/{name}/instances`
- `POST   /api/channels/{name}/instances`
- `PUT    /api/channels/{name}/instances/{index}`
- `DELETE /api/channels/{name}/instances/{index}`

`list_channels` and `get_channel` now report `instance_count` alongside `configured`. Per-instance secret env-var names auto-suffix (`TG_BOT_TOKEN`, `TG_BOT_TOKEN_2`, `TG_BOT_TOKEN_3` …) so adding a second bot does not clobber the first bot's token. The update handler preserves the existing `<key>_env` reference when the user does not retype the secret, honouring the form's "leave empty to keep" placeholder.

The legacy `/configure` POST/DELETE remain registered for backwards compatibility — existing CLI / docs / older dashboards keep working.

### Dashboard (commit 2)

- `ChannelInstance` / `ChannelInstancesResponse` types, four fetch helpers, `useChannelInstances` query, three new mutations (every CRUD invalidates `channelKeys.all` because instance changes also flip the top-level `instance_count` / `configured` fields).
- New `InstancesDialog` with three internal phases: list (with per-row Edit/Delete and inline two-step confirm), create, edit. The form portion is extracted as a reusable `ChannelForm` component.
- Card subtitle gains a `2×` badge when more than one instance is configured.
- QR-flow channels (WhatsApp, WeChat) keep their existing single-instance flow — multi-instance QR is out of scope for this PR.

## Out-of-scope follow-ups

- **Custom env-var names per instance** — backend auto-derives `<DEFAULT>_<N+1>`; if a user edits `secrets.env` manually the dashboard preserves their custom names on update, but does not yet let them pick names from the form.
- **Empty advanced-field preservation** — full-replace semantics (same as the existing `/configure` flow) means clearing an advanced field via the form drops it. PATCH semantics across the channel API would address this for both single- and multi-instance flows.

## Test plan

- [x] `cargo check -p librefang-api --lib` clean
- [x] `cargo clippy -p librefang-api --all-targets -- -D warnings` clean
- [x] `cargo test -p librefang-api --lib` — 665 tests pass (incl. 11 new unit tests in `routes::skills::tests::*_channel_instance_*`)
- [x] `cargo test -p librefang-api --test channels_routes_test` — 21 tests pass (10 existing + 11 new instance route tests)
- [x] `pnpm typecheck` clean
- [x] `pnpm test src/pages/ChannelsPage.test.tsx` — 13/13
- [x] `pnpm test src/lib/queries/keys.test.ts` — 34/34
- [x] `cargo xtask codegen --openapi` regenerates cleanly (288 → 292 endpoints)
- [ ] Live LLM verification — N/A; this PR adds no LLM-call paths
- [ ] Manual UI smoke (deferred to reviewer / live test): add a second Telegram bot, edit it, delete it; confirm `config.toml` round-trips through `OneOrMany<TelegramConfig>`