### PR TITLE
docs: correct skill_workshop default to OFF in agent guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,10 +242,17 @@ The daemon command is `start` (not `daemon`).
   cap. See `docs/architecture/trigger-dispatch-concurrency.md`.
 - **Skill workshop** (#3328) passively captures teaching signals from
   successful turns into draft skills under
-  `~/.librefang/skills/pending/<agent>/<uuid>.toml`. **Default-on with
-  the conservative knob set**: `enabled=true`, `auto_capture=true`,
-  `review_mode="heuristic"` (no LLM call), `approval_policy="pending"`
-  (every candidate waits for human approve / reject), `max_pending=20`.
+  `~/.librefang/skills/pending/<agent>/<uuid>.toml`. **Default-OFF —
+  opt-in per agent** by setting `[skill_workshop] enabled = true` in
+  the agent's manifest (`agent.toml`, or the matching `[agents.<name>]`
+  section of a `HAND.toml`). Once enabled, the conservative knob set
+  applies by default: `auto_capture = true`,
+  `review_mode = "heuristic"` (no LLM call),
+  `approval_policy = "pending"` (every candidate waits for human
+  approve / reject), `max_pending = 20`. Source of truth is
+  `SkillWorkshopConfig::default()` in
+  `crates/librefang-types/src/agent.rs` — `enabled: false` per the
+  original #3328 acceptance criteria.
   Three signals — `ExplicitInstruction` ("from now on always …"),
   `UserCorrection` ("no, do it like …"), `RepeatedToolPattern` (same
   tool sequence ≥ 3 turns). Approval routes through


### PR DESCRIPTION
## Summary

The agent guide (`CLAUDE.md`) claims the skill workshop ships default-on with the conservative knob set:

> **Default-on with the conservative knob set**: `enabled=true`, `auto_capture=true`, `review_mode="heuristic"` (no LLM call), `approval_policy="pending"` (every candidate waits for human approve / reject), `max_pending=20`.

The actual `Default` impl in `crates/librefang-types/src/agent.rs:1205` sets `enabled: false`, with the doc comment on that impl explicitly calling out the divergence from any earlier draft:

```rust
// Default-OFF — opt-in per the original #3328 acceptance
// criteria. Operators who want the workshop set
// `[skill_workshop] enabled = true` in `agent.toml`. The
// remaining knobs document the conservative shape the
// workshop takes once it IS turned on: heuristic-only review
// (no LLM call), pending policy (every candidate waits for
// human approve / reject), 20-candidate cap.
```

So the doc claim is wrong on the master switch, and right (but mis-attributed) on the conservative knobs — those describe the *opt-in shape*, not the shipped defaults.

This bites operators who follow the agent guide and assume the workshop is already capturing teaching signals across their fleet. Querying `/api/skills/pending` returns an empty list and they wonder if the heuristic detector is broken; in fact nothing has been captured because no agent has been opted in.

## Change

Reword the `Skill workshop` bullet in `CLAUDE.md` to:
- State the master switch defaults to **OFF** and is **opt-in per agent** via `[skill_workshop] enabled = true` in `agent.toml` (or the matching `[agents.<name>]` section of a `HAND.toml` for hand-derived agents).
- Reframe the conservative knob set as the **shape the workshop takes once enabled**, not the shipped defaults.
- Cite `SkillWorkshopConfig::default()` in `crates/librefang-types/src/agent.rs` as the source of truth.

## Test plan

- [x] `grep -n 'Default-on with' CLAUDE.md` returns no hits after the change.
- [x] `grep -n 'Default-OFF' CLAUDE.md` matches the new wording.
- [x] No code changes; no test runs needed.
- [x] The default cited in the change matches the `enabled: false` literal at `crates/librefang-types/src/agent.rs:1215`.