### PR TITLE
docs(claude): require fixing review nits in-PR instead of punting to follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,23 @@ issue threads.
   refactors with the requested change. If you find a real problem
   out-of-scope, open a separate issue or follow-up PR; mention it in the
   current PR's "Out-of-scope follow-ups" section.
+- **Fix what you found — don't punt it to a "follow-up".** Anything you
+  noticed while reading or writing the code in this PR is in-scope by
+  definition: review nits, mismatched HTTP status codes, missing log
+  fields, redundant lookups, stale comments, type-shape inconsistencies,
+  small clippy noise. Treat the phrases "follow-up", "long-term
+  improvement", "next PR", "future cleanup", "out-of-scope follow-up
+  issue", "leave for later" as red flags in your own review or summary
+  output — they almost always mean "I saw the problem and decided to
+  defer the work". The bar to defer: would fixing it require touching a
+  *different* crate or domain than the one you're already in? If no, fix
+  it in this PR. If yes, surface the question to the human reviewer with
+  the concrete trade-off and ask before deferring; don't decide
+  unilaterally. The same rule applies when you re-evaluate a deferred
+  item and decide it's a "non-issue" — you must back that decision with
+  the file/line evidence that contradicts the original concern, in the
+  same response. "I looked again and it's fine" without evidence is
+  another form of punting.
 - **PR body must enumerate** the substantive changes, the verification
   performed (integration test names, `cargo check --workspace --lib`
   output, scoped `cargo test -p <crate>` runs), and any deferred work.


### PR DESCRIPTION
## Summary

Adds a new bullet under **Commit & PR hygiene** in `CLAUDE.md` that codifies the "fix what you found" rule against deferring in-scope review nits via "follow-up" / "next PR" language.

Split out of #4864 — the rule was committed there alongside an unrelated budget-config fix; per the very rule itself, mixing the two crates a scope-creep PR.

## Why

The pattern keeps showing up: an AI assistant (or human) reviewing/writing a PR notices a small nit — mismatched HTTP status, stale comment, redundant lookup, missing log field — and silently defers it with phrases like:

- "I'll leave this as a follow-up"
- "Long-term improvement"
- "Out of scope for this PR"
- "Future cleanup"
- "Leave for later"

The deferred work rarely materialises. Worse, the same nit gets re-discovered (and re-deferred) in the next review cycle. The new rule treats those phrases as **red flags** in your own output and sets a clear bar for when deferral is legitimate:

- **In-scope by default**: anything you noticed while reading/writing the code in this PR.
- **Deferral bar**: requires touching a *different* crate or domain than the one you're already in.
- **Even then**: surface the trade-off to the human reviewer and ask. Don't decide unilaterally.
- **Re-evaluation guard**: "I looked again and it's a non-issue" without file/line evidence is another form of punting.

Sits next to the existing "One PR ↔ one issue" rule which prevents the opposite failure mode (bundling unrelated work).

## Test plan

- [x] `grep "follow-up" CLAUDE.md` — new rule mentions the red-flag phrases verbatim so future search hits land on the rule itself
- [x] Pure docs change — no code paths affected