### PR TITLE
fix(providers): honour suppression for CLI/local providers + un-suppress on URL reconfigure (#4803)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -58,6 +58,12 @@ export interface ProviderItem {
   is_custom?: boolean;
   error_message?: string;
   last_tested?: string;
+  /** True when the user explicitly suppressed this provider via
+   *  `DELETE /api/providers/{id}/key`. Pairs with the
+   *  `POST /api/providers/{id}/enable` endpoint that revives it.
+   *  Lets the dashboard distinguish "user-hidden" from "never configured"
+   *  for the otherwise indistinguishable `auth_status: "missing"`. */
+  suppressed?: boolean;
 }
 
 export interface MediaProvider {
@@ -1604,6 +1610,10 @@ export async function setProviderKey(providerId: string, key: string): Promise<A
 
 export async function deleteProviderKey(providerId: string): Promise<ApiActionResponse> {
   return del<ApiActionResponse>(`/api/providers/${encodeURIComponent(providerId)}/key`);
+}
+
+export async function enableProvider(providerId: string): Promise<ApiActionResponse> {
+  return post<ApiActionResponse>(`/api/providers/${encodeURIComponent(providerId)}/enable`, {});
 }
 
 export async function setProviderUrl(providerId: string, baseUrl: string, proxyUrl?: string): Promise<ApiActionResponse> {

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -255,6 +255,7 @@ export {
   testProvider,
   setProviderKey,
   deleteProviderKey,
+  enableProvider,
   setProviderUrl,
   setDefaultProvider,
   // network / a2a

--- a/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/providers.ts
@@ -3,6 +3,7 @@ import {
   testProvider,
   setProviderKey,
   deleteProviderKey,
+  enableProvider,
   setProviderUrl,
   setDefaultProvider,
   createRegistryContent,
@@ -40,6 +41,24 @@ export function useDeleteProviderKey() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => deleteProviderKey(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: providerKeys.all });
+      qc.invalidateQueries({ queryKey: modelKeys.lists() });
+    },
+  });
+}
+
+// Counterpart to `useDeleteProviderKey` — the dashboard's only way back
+// for CLI providers (claude-code, codex-cli, gemini-cli, qwen-code) that
+// have no key/URL to set. For non-CLI providers, the existing
+// set-key/set-url flows already un-suppress, but this hook is the
+// one-click "Re-enable" entry point that works uniformly. Invalidates
+// the same slices as the delete counterpart so the picker / configured
+// grid both refetch.
+export function useEnableProvider() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => enableProvider(id),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: providerKeys.all });
       qc.invalidateQueries({ queryKey: modelKeys.lists() });

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -7,7 +7,7 @@ import type { ApiActionResponse, ProviderItem } from "../api";
 import { isProviderAvailable } from "../lib/status";
 import { useProviders, useProviderStatus } from "../lib/queries/providers";
 import { useModels } from "../lib/queries/models";
-import { useTestProvider, useSetProviderKey, useDeleteProviderKey, useSetProviderUrl, useSetDefaultProvider, useCreateRegistryContent } from "../lib/mutations/providers";
+import { useTestProvider, useSetProviderKey, useDeleteProviderKey, useEnableProvider, useSetProviderUrl, useSetDefaultProvider, useCreateRegistryContent } from "../lib/mutations/providers";
 import { PageHeader } from "../components/ui/PageHeader";
 import { CardSkeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
@@ -24,7 +24,7 @@ import {
   Server, Zap, Clock, Key, Globe, CheckCircle2, XCircle, Loader2, AlertCircle, Search,
   SortAsc, SortDesc, CheckSquare, Square, ChevronRight, X, Grid3X3, List, Filter,
   Activity, Cpu, Cloud, Bot, Globe2, Sparkles, Plus, Star, Pencil, Trash2,
-  Check, ChevronLeft
+  Check, ChevronLeft, RotateCcw
 } from "lucide-react";
 
 function getErrorMessage(e: unknown): string | null {
@@ -1107,6 +1107,7 @@ export function ProvidersPage() {
   const testMutation = useTestProvider();
   const setKeyMutation = useSetProviderKey();
   const deleteKeyMutation = useDeleteProviderKey();
+  const enableProviderMutation = useEnableProvider();
   const setUrlMutation = useSetProviderUrl();
   const defaultProviderMutation = useSetDefaultProvider();
   const createRegistryContentMutation = useCreateRegistryContent();
@@ -1174,6 +1175,23 @@ export function ProvidersPage() {
     setPickerOpen(false);
     config.open(p);
   };
+  // CLI-shape providers (`claude-code`, `codex-cli`, `gemini-cli`,
+  // `qwen-code`) have no key or URL to set, so `set_provider_key` /
+  // `set_provider_url` — which un-suppress as a side effect — never run
+  // for them. The Re-enable button on suppressed picker entries calls
+  // `POST /api/providers/{id}/enable` directly so the provider returns
+  // to the configured grid in one click. For non-CLI suppressed
+  // providers this is also the preferred path when the user is happy
+  // with the prior URL/key and only wants to revert the suppress.
+  const handleReenable = useCallback(async (p: ProviderItem) => {
+    try {
+      await enableProviderMutation.mutateAsync(p.id);
+      setPickerOpen(false);
+      addToast(t("providers.reenabled", { defaultValue: "Provider re-enabled" }), "success");
+    } catch (e) {
+      addToast(getErrorMessage(e) || t("common.error"), "error");
+    }
+  }, [enableProviderMutation, addToast, t]);
 
   const handleSearch = (value: string) => { dispatch({ type: "SEARCH", value }); setSelectedIds(new Set()); };
   const handleFilterChange = (filter: FilterStatus) => { dispatch({ type: "FILTER", status: filter }); setSelectedIds(new Set()); };
@@ -1604,27 +1622,54 @@ export function ProvidersPage() {
             </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              {pickerProviders.map((p) => (
-                <button
-                  key={p.id}
-                  type="button"
-                  onClick={() => handlePick(p)}
-                  className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-border-subtle bg-main/40 hover:border-brand/40 hover:bg-main/60 transition-colors text-left"
-                >
-                  <div className="w-9 h-9 rounded-lg bg-brand/10 border border-brand/20 grid place-items-center text-brand shrink-0">
-                    {getProviderIcon(p.id)}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="font-mono text-[13px] font-medium text-text-main truncate">
-                      {p.display_name || p.id}
+              {pickerProviders.map((p) => {
+                // Suppressed entries collapsed into the picker by
+                // `DELETE /api/providers/{id}/key` get a one-click
+                // Re-enable instead of opening the configure drawer —
+                // CLI providers have no key/URL to set, and even for
+                // local HTTP providers the prior URL is usually still
+                // what the user wants. Non-suppressed entries keep the
+                // existing "open configure drawer" flow.
+                const suppressed = p.suppressed === true;
+                const onClick = suppressed
+                  ? () => handleReenable(p)
+                  : () => handlePick(p);
+                const reenabling =
+                  suppressed
+                  && enableProviderMutation.isPending
+                  && enableProviderMutation.variables === p.id;
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={onClick}
+                    disabled={reenabling}
+                    className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-border-subtle bg-main/40 hover:border-brand/40 hover:bg-main/60 transition-colors text-left disabled:opacity-60"
+                  >
+                    <div className={`w-9 h-9 rounded-lg grid place-items-center shrink-0 ${suppressed ? "bg-warning/10 border border-warning/20 text-warning" : "bg-brand/10 border border-brand/20 text-brand"}`}>
+                      {getProviderIcon(p.id)}
                     </div>
-                    <div className="font-mono text-[10.5px] text-text-dim/80 truncate">
-                      {p.id}
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono text-[13px] font-medium text-text-main truncate">
+                        {p.display_name || p.id}
+                      </div>
+                      <div className="font-mono text-[10.5px] text-text-dim/80 truncate">
+                        {p.id}
+                      </div>
                     </div>
-                  </div>
-                  <ChevronRight className="w-4 h-4 text-text-dim shrink-0" />
-                </button>
-              ))}
+                    {suppressed ? (
+                      <span className="flex items-center gap-1 text-[10px] font-bold uppercase text-warning shrink-0">
+                        {reenabling
+                          ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                          : <RotateCcw className="w-3.5 h-3.5" />}
+                        {t("providers.reenable", { defaultValue: "Re-enable" })}
+                      </span>
+                    ) : (
+                      <ChevronRight className="w-4 h-4 text-text-dim shrink-0" />
+                    )}
+                  </button>
+                );
+              })}
             </div>
           )}
           <div className="border-t border-border-subtle pt-3 mt-1">

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -177,6 +177,7 @@ use crate::types;
         routes::get_provider,
         routes::set_provider_key,
         routes::delete_provider_key,
+        routes::enable_provider,
         routes::test_provider,
         routes::set_provider_url,
         routes::set_default_provider,

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1587,16 +1587,28 @@ pub async fn set_provider_url(
         }
     }
 
-    // Update catalog in memory
+    // Update catalog in memory. Reconfiguring the URL is an explicit signal
+    // that the user wants this provider active, so undo any suppression set
+    // by a prior `delete_provider_key` (#4803) and refresh auth status —
+    // otherwise a suppressed local provider stays Missing even after the
+    // user re-points it at a reachable host.
     {
         let name_for_closure = name.clone();
         let base_url_for_closure = base_url.clone();
         let proxy_url_for_closure = proxy_url.clone();
+        let suppressed_path = state
+            .kernel
+            .home_dir()
+            .join("data")
+            .join("suppressed_providers.json");
         state.kernel.model_catalog_update(&mut move |catalog| {
             catalog.set_provider_url(&name_for_closure, &base_url_for_closure);
             if let Some(ref pu) = proxy_url_for_closure {
                 catalog.set_provider_proxy_url(&name_for_closure, pu);
             }
+            catalog.unsuppress_provider(&name_for_closure);
+            catalog.save_suppressed(&suppressed_path);
+            catalog.detect_auth();
         });
     }
 

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1606,8 +1606,14 @@ pub async fn set_provider_url(
             if let Some(ref pu) = proxy_url_for_closure {
                 catalog.set_provider_proxy_url(&name_for_closure, pu);
             }
-            catalog.unsuppress_provider(&name_for_closure);
-            catalog.save_suppressed(&suppressed_path);
+            // Skip the unsuppress + disk write when nothing is suppressed —
+            // otherwise every URL edit (including those on already-active
+            // providers) issues a no-op `remove_file` on
+            // `suppressed_providers.json`.
+            if catalog.is_suppressed(&name_for_closure) {
+                catalog.unsuppress_provider(&name_for_closure);
+                catalog.save_suppressed(&suppressed_path);
+            }
             catalog.detect_auth();
         });
     }

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -43,6 +43,10 @@ pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
             "/providers/{name}/key",
             axum::routing::post(set_provider_key).delete(delete_provider_key),
         )
+        .route(
+            "/providers/{name}/enable",
+            axum::routing::post(enable_provider),
+        )
         .route("/providers/{name}/test", axum::routing::post(test_provider))
         .route(
             "/providers/{name}/url",
@@ -507,9 +511,23 @@ fn attach_probe_result(
     )
 )]
 pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let provider_list: Vec<librefang_types::model_catalog::ProviderInfo> = {
+    // Snapshot both the provider list and the matching suppression flags
+    // from the same catalog load — racing a `delete_provider_key` /
+    // `enable_provider` mid-iteration would otherwise let the JSON show a
+    // provider with `auth_status: "missing"` AND `suppressed: false` (or
+    // vice versa), giving the dashboard inconsistent state to render.
+    let (provider_list, suppressed_ids): (
+        Vec<librefang_types::model_catalog::ProviderInfo>,
+        std::collections::HashSet<String>,
+    ) = {
         let catalog = state.kernel.model_catalog_ref().load();
-        catalog.list_providers().to_vec()
+        let providers = catalog.list_providers().to_vec();
+        let suppressed: std::collections::HashSet<String> = providers
+            .iter()
+            .filter(|p| catalog.is_suppressed(&p.id))
+            .map(|p| p.id.clone())
+            .collect();
+        (providers, suppressed)
     };
 
     // Collect local providers that need probing
@@ -574,6 +592,7 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
             "proxy_url": p.proxy_url,
             "media_capabilities": p.media_capabilities,
             "is_custom": p.is_custom,
+            "suppressed": suppressed_ids.contains(&p.id),
         });
 
         // Attach region map so the dashboard can show available regions
@@ -640,9 +659,20 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
 
 /// Returns providers list for the dashboard snapshot endpoint.
 pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json::Value> {
-    let provider_list: Vec<librefang_types::model_catalog::ProviderInfo> = {
+    // Same single-load suppression snapshot as `list_providers` — see the
+    // comment there for the rationale.
+    let (provider_list, suppressed_ids): (
+        Vec<librefang_types::model_catalog::ProviderInfo>,
+        std::collections::HashSet<String>,
+    ) = {
         let catalog = state.kernel.model_catalog_ref().load();
-        catalog.list_providers().to_vec()
+        let providers = catalog.list_providers().to_vec();
+        let suppressed: std::collections::HashSet<String> = providers
+            .iter()
+            .filter(|p| catalog.is_suppressed(&p.id))
+            .map(|p| p.id.clone())
+            .collect();
+        (providers, suppressed)
     };
 
     let local_providers: Vec<(usize, String, String, Option<String>)> = provider_list
@@ -699,6 +729,7 @@ pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json:
             "proxy_url": p.proxy_url,
             "media_capabilities": p.media_capabilities,
             "is_custom": p.is_custom,
+            "suppressed": suppressed_ids.contains(&p.id),
         });
         if let Some(probe) = probe_map.remove(&i) {
             attach_probe_result(&mut entry, &probe, &p.id, &*state.kernel);
@@ -1234,8 +1265,19 @@ pub async fn delete_provider_key(
             .into_json_tuple();
     }
 
-    // Remove from process environment
-    std::env::remove_var(&env_var);
+    // Remove from process environment. `std::env::remove_var` became unsafe
+    // in Rust 1.82 for the same reason `set_var` did — concurrent reads
+    // from other threads race the mutation. Delegate to a blocking thread
+    // so the tokio worker stays unblocked, mirroring the `set_provider_key`
+    // path above.
+    {
+        let env_var_clone = env_var.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            // SAFETY: single mutation on a dedicated blocking thread.
+            unsafe { std::env::remove_var(&env_var_clone) };
+        })
+        .await;
+    }
 
     // Suppress fallback/CLI detection for this provider and refresh auth
     {
@@ -1253,6 +1295,66 @@ pub async fn delete_provider_key(
     }
 
     (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
+}
+
+/// POST /api/providers/{name}/enable — Re-enable a previously suppressed
+/// provider.
+///
+/// Pairs with DELETE /api/providers/{name}/key, which writes the provider
+/// id into `suppressed_providers.json` so `detect_auth` stops promoting
+/// the row back to `Configured` / `NotRequired` / `AutoDetected` via
+/// CLI binary probes, local HTTP probes, or alias env vars. For
+/// CLI-shape providers (`claude-code`, `codex-cli`, `gemini-cli`,
+/// `qwen-code`) the existing `set_provider_key` / `set_provider_url`
+/// un-suppress side-effects don't apply — there's no key or URL to
+/// set — so without this endpoint a user who clicked "remove key" on a
+/// CLI provider had no UI to revert. This endpoint is the explicit
+/// re-enable signal and works uniformly for every provider shape.
+///
+/// Idempotent: calling on a non-suppressed provider is a no-op aside
+/// from the `detect_auth` refresh.
+#[utoipa::path(
+    post,
+    path = "/api/providers/{name}/enable",
+    tag = "models",
+    params(("name" = String, Path, description = "Provider name")),
+    responses(
+        (status = 200, description = "Provider re-enabled", body = crate::types::JsonObject),
+    ),
+)]
+pub async fn enable_provider(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let suppressed_path = state
+        .kernel
+        .home_dir()
+        .join("data")
+        .join("suppressed_providers.json");
+    let name_for_closure = name.clone();
+    state.kernel.model_catalog_update(&mut move |catalog| {
+        // Skip the disk write when nothing is suppressed — `save_suppressed`
+        // unlinks the file when the set is empty, so an unconditional save
+        // would touch the FS on every idempotent call.
+        if catalog.is_suppressed(&name_for_closure) {
+            catalog.unsuppress_provider(&name_for_closure);
+            catalog.save_suppressed(&suppressed_path);
+        }
+        catalog.detect_auth();
+    });
+
+    // Kick off a background probe so any key still present in the
+    // environment is re-validated and reflected as `ValidatedKey`
+    // without waiting for the user's next dashboard refresh.
+    state.kernel.clone().spawn_key_validation();
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "status": "enabled",
+            "provider": name,
+        })),
+    )
 }
 
 /// POST /api/providers/{name}/test — Test a provider's connectivity.

--- a/crates/librefang-api/tests/providers_routes_test.rs
+++ b/crates/librefang-api/tests/providers_routes_test.rs
@@ -919,3 +919,196 @@ async fn set_provider_url_unsuppresses_after_delete() {
         "PUT /api/providers/ollama/url must drop ollama from the suppressed list; on-disk content: {still_suppressed:?}",
     );
 }
+
+// ---------------------------------------------------------------------------
+// POST /api/providers/{name}/enable — explicit re-enable for suppressed
+// providers, the CLI-shape counterpart to `set_provider_url` un-suppression
+// (#4803 follow-up). CLI providers (`claude-code`, `codex-cli`, …) have no
+// key or URL to set, so they can only leave the suppressed bucket via this
+// endpoint. The tests assert on the on-disk suppression file rather than
+// `/api/providers` for the same reason `set_provider_url_unsuppresses_after_delete`
+// does: the list endpoint's local-probe override would mask the flip for
+// the ollama row, and the on-disk file is the persistence layer that
+// survives restart anyway.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn enable_provider_unsuppresses_cli_provider() {
+    // claude-code can only escape suppression via this endpoint: no key to
+    // POST, no URL to PUT. Pre-fix the user had to hand-edit
+    // suppressed_providers.json.
+    let h = boot_with_provider(ProviderInfo {
+        id: "claude-code".to_string(),
+        display_name: "Claude Code".to_string(),
+        api_key_env: String::new(),
+        base_url: String::new(),
+        key_required: false,
+        auth_status: AuthStatus::Configured,
+        model_count: 1,
+        ..ProviderInfo::default()
+    });
+
+    let suppressed_path = h
+        ._state
+        .kernel
+        .home_dir()
+        .join("data")
+        .join("suppressed_providers.json");
+
+    // Suppress first — same setup as `delete_provider_key_flips_cli_provider_to_missing`.
+    let (status, _) =
+        json_request(&h, Method::DELETE, "/api/providers/claude-code/key", None).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let suppressed_after_delete: Vec<String> =
+        serde_json::from_str(&std::fs::read_to_string(&suppressed_path).unwrap()).unwrap();
+    assert!(
+        suppressed_after_delete.iter().any(|s| s == "claude-code"),
+        "DELETE should add claude-code to suppressed_providers.json; got {suppressed_after_delete:?}",
+    );
+
+    // Re-enable via the new endpoint.
+    let (status, body) =
+        json_request(&h, Method::POST, "/api/providers/claude-code/enable", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"].as_str(), Some("enabled"));
+    assert_eq!(body["provider"].as_str(), Some("claude-code"));
+
+    let still_suppressed: Option<Vec<String>> = std::fs::read_to_string(&suppressed_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok());
+    let any_suppressed_after_enable = still_suppressed
+        .as_ref()
+        .map(|v| v.iter().any(|s| s == "claude-code"))
+        .unwrap_or(false);
+    assert!(
+        !any_suppressed_after_enable,
+        "POST /api/providers/claude-code/enable must drop claude-code from the suppressed list; on-disk content: {still_suppressed:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn enable_provider_unsuppresses_local_provider() {
+    // ollama already has the `set_provider_url` un-suppress path; this
+    // covers the "user wants to re-enable without changing the URL"
+    // shortcut, which is the natural one-click re-enable from a
+    // dashboard list of suppressed providers.
+    let h = boot_with_provider(ProviderInfo {
+        id: "ollama".to_string(),
+        display_name: "Ollama".to_string(),
+        api_key_env: "OLLAMA_API_KEY".to_string(),
+        base_url: "http://127.0.0.1:11434".to_string(),
+        key_required: false,
+        auth_status: AuthStatus::NotRequired,
+        model_count: 1,
+        ..ProviderInfo::default()
+    });
+
+    let suppressed_path = h
+        ._state
+        .kernel
+        .home_dir()
+        .join("data")
+        .join("suppressed_providers.json");
+
+    let (status, _) = json_request(&h, Method::DELETE, "/api/providers/ollama/key", None).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (status, _) = json_request(&h, Method::POST, "/api/providers/ollama/enable", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let still_suppressed: Option<Vec<String>> = std::fs::read_to_string(&suppressed_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok());
+    let any_suppressed_after_enable = still_suppressed
+        .as_ref()
+        .map(|v| v.iter().any(|s| s == "ollama"))
+        .unwrap_or(false);
+    assert!(
+        !any_suppressed_after_enable,
+        "POST /api/providers/ollama/enable must drop ollama from the suppressed list; on-disk content: {still_suppressed:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn enable_provider_is_idempotent_on_already_enabled_row() {
+    // Calling enable on a provider that was never suppressed must not
+    // touch the suppressed_providers.json file (the handler skips the
+    // disk write when nothing is suppressed) and must return 200. This
+    // guards the "dashboard double-clicks Re-enable" UX from spuriously
+    // recreating the file every call.
+    let h = boot_with_provider(ProviderInfo {
+        id: "claude-code".to_string(),
+        display_name: "Claude Code".to_string(),
+        api_key_env: String::new(),
+        base_url: String::new(),
+        key_required: false,
+        auth_status: AuthStatus::Configured,
+        model_count: 1,
+        ..ProviderInfo::default()
+    });
+
+    let suppressed_path = h
+        ._state
+        .kernel
+        .home_dir()
+        .join("data")
+        .join("suppressed_providers.json");
+
+    let (status, _) =
+        json_request(&h, Method::POST, "/api/providers/claude-code/enable", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        !suppressed_path.exists(),
+        "idempotent enable on a never-suppressed provider must not create suppressed_providers.json",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_providers_exposes_suppression_state() {
+    // Dashboard discriminates "user-suppressed CLI provider" from
+    // "missing because never configured" by reading `suppressed: bool`
+    // on each provider entry. Pre-fix this flag was not exposed and the
+    // dashboard could only guess from `auth_status: "missing"`.
+    let h = boot_with_provider(ProviderInfo {
+        id: "claude-code".to_string(),
+        display_name: "Claude Code".to_string(),
+        api_key_env: String::new(),
+        base_url: String::new(),
+        key_required: false,
+        auth_status: AuthStatus::Configured,
+        model_count: 1,
+        ..ProviderInfo::default()
+    });
+
+    let (_, body_before) = json_request(&h, Method::GET, "/api/providers", None).await;
+    let claude_before = find_provider(&body_before, "claude-code");
+    assert_eq!(
+        claude_before["suppressed"].as_bool(),
+        Some(false),
+        "pristine catalog must report `suppressed: false`; got {claude_before}",
+    );
+
+    let (status, _) =
+        json_request(&h, Method::DELETE, "/api/providers/claude-code/key", None).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (_, body_after) = json_request(&h, Method::GET, "/api/providers", None).await;
+    let claude_after = find_provider(&body_after, "claude-code");
+    assert_eq!(
+        claude_after["suppressed"].as_bool(),
+        Some(true),
+        "after DELETE /key, suppressed must flip to true; got {claude_after}",
+    );
+
+    let (status, _) =
+        json_request(&h, Method::POST, "/api/providers/claude-code/enable", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (_, body_final) = json_request(&h, Method::GET, "/api/providers", None).await;
+    let claude_final = find_provider(&body_final, "claude-code");
+    assert_eq!(
+        claude_final["suppressed"].as_bool(),
+        Some(false),
+        "after POST /enable, suppressed must flip back to false; got {claude_final}",
+    );
+}

--- a/crates/librefang-api/tests/providers_routes_test.rs
+++ b/crates/librefang-api/tests/providers_routes_test.rs
@@ -728,6 +728,12 @@ use librefang_types::model_catalog::{
 /// Boot a harness seeded with a single named provider in the given
 /// initial `auth_status`. Lets each test stage the "configured" state
 /// the pre-fix bug failed to leave.
+///
+/// Intentionally single-provider. Multi-provider scenarios (e.g.
+/// "suppressing A does not affect B") should build a custom seed via
+/// `MockKernelBuilder::with_catalog_seed` rather than extending this
+/// helper — keeping it 1-to-1 with the test intent makes the asserts
+/// easy to read.
 fn boot_with_provider(provider: ProviderInfo) -> Harness {
     let id = provider.id.clone();
     let model = ModelCatalogEntry {

--- a/crates/librefang-api/tests/providers_routes_test.rs
+++ b/crates/librefang-api/tests/providers_routes_test.rs
@@ -8,7 +8,6 @@
 //!
 //! Out of scope (not exercised here, by design):
 //!   - `POST /api/providers/{name}/key`             — mutates global `std::env`
-//!   - `DELETE /api/providers/{name}/key`           — mutates global `std::env`
 //!   - `POST /api/providers/github-copilot/oauth/*` — outbound device-flow HTTP
 //!   - `GET  /api/providers/ollama/detect`          — outbound HTTP probe
 //!   - `POST /api/catalog/update`                   — outbound network sync
@@ -18,6 +17,13 @@
 //! These would either flake on CI (real network) or contaminate other test
 //! binaries running in parallel via `std::env::set_var`. Per CLAUDE.md
 //! "no global env mutation, no fs writes outside tempfile."
+//!
+//! `DELETE /api/providers/{name}/key` IS exercised — only for providers
+//! whose env var name (`CLAUDE_CODE_API_KEY`, `OLLAMA_API_KEY`) is not
+//! referenced by any other test in this workspace, so the
+//! `std::env::remove_var` call inside the handler is a no-op on shared
+//! state. The assertion is on the catalog's `auth_status` flip, which is
+//! the regression surface for #4803.
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
@@ -701,4 +707,209 @@ async fn copilot_oauth_poll_unknown_id_returns_404() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
     assert_eq!(body["status"].as_str().unwrap(), "not_found");
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/providers/{name}/key — regression coverage for #4803.
+//
+// Pre-fix, pressing "remove key" on a CLI or local-HTTP provider suppressed
+// it in `suppressed_providers.json` but `detect_auth` ignored suppression
+// for those branches and re-promoted the provider to Configured /
+// NotRequired on the same call, so the provider never left the configured
+// grid. These tests boot a seeded catalog, hit the route, and assert the
+// catalog flips `auth_status` to Missing — the state the dashboard filter
+// (`isProviderAvailable`) treats as unconfigured.
+// ---------------------------------------------------------------------------
+
+use librefang_types::model_catalog::{
+    AuthStatus, Modality, ModelCatalogEntry, ModelTier, ProviderInfo, ReasoningEchoPolicy,
+};
+
+/// Boot a harness seeded with a single named provider in the given
+/// initial `auth_status`. Lets each test stage the "configured" state
+/// the pre-fix bug failed to leave.
+fn boot_with_provider(provider: ProviderInfo) -> Harness {
+    let id = provider.id.clone();
+    let model = ModelCatalogEntry {
+        id: format!("{id}-test-model"),
+        display_name: format!("{id} test model"),
+        provider: id,
+        tier: ModelTier::Custom,
+        modality: Modality::default(),
+        context_window: 8_192,
+        max_output_tokens: 2_048,
+        input_cost_per_m: 0.0,
+        output_cost_per_m: 0.0,
+        image_input_cost_per_m: None,
+        image_output_cost_per_m: None,
+        supports_tools: false,
+        supports_vision: false,
+        supports_streaming: false,
+        supports_thinking: false,
+        aliases: Vec::new(),
+        reasoning_echo_policy: ReasoningEchoPolicy::default(),
+    };
+    let test = TestAppState::with_builder(
+        MockKernelBuilder::new()
+            .with_config(|cfg| {
+                cfg.default_model = librefang_types::config::DefaultModelConfig {
+                    provider: "openai".to_string(),
+                    model: "gpt-4o-mini".to_string(),
+                    api_key_env: "OPENAI_API_KEY".to_string(),
+                    base_url: None,
+                    message_timeout_secs: 300,
+                    extra_params: std::collections::HashMap::new(),
+                    cli_profile_dirs: Vec::new(),
+                };
+            })
+            .with_catalog_seed((vec![provider], vec![model])),
+    );
+
+    let state = test.state.clone();
+    let app = Router::new()
+        .nest("/api", routes::providers::router())
+        .with_state(state.clone());
+
+    Harness {
+        app,
+        _state: state,
+        _test: test,
+    }
+}
+
+fn find_provider<'a>(body: &'a serde_json::Value, id: &str) -> &'a serde_json::Value {
+    body["providers"]
+        .as_array()
+        .expect("providers array")
+        .iter()
+        .find(|p| p["id"].as_str() == Some(id))
+        .unwrap_or_else(|| panic!("provider '{id}' missing from /api/providers"))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_provider_key_flips_cli_provider_to_missing() {
+    // claude-code is a CLI provider (`is_cli_provider("claude-code") = true`,
+    // `key_required = false`, `api_key_env = ""`). Pre-fix `detect_auth`
+    // re-set its status from the cli_provider_available probe, leaving the
+    // provider in the configured grid no matter what the dashboard did.
+    let h = boot_with_provider(ProviderInfo {
+        id: "claude-code".to_string(),
+        display_name: "Claude Code".to_string(),
+        api_key_env: String::new(),
+        base_url: String::new(),
+        key_required: false,
+        auth_status: AuthStatus::Configured,
+        model_count: 1,
+        ..ProviderInfo::default()
+    });
+
+    let (status, _) =
+        json_request(&h, Method::DELETE, "/api/providers/claude-code/key", None).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (_, body) = json_request(&h, Method::GET, "/api/providers", None).await;
+    let claude = find_provider(&body, "claude-code");
+    assert_eq!(
+        claude["auth_status"].as_str(),
+        Some("missing"),
+        "suppressed CLI provider must report `missing` so the dashboard moves it out of the configured grid; got {claude}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_provider_key_flips_local_provider_to_missing() {
+    // ollama is a local HTTP provider (`is_local_provider("ollama") = true`,
+    // `key_required = false`). Pre-fix `detect_auth` re-promoted it from
+    // Missing to NotRequired on the same call that suppressed it.
+    let h = boot_with_provider(ProviderInfo {
+        id: "ollama".to_string(),
+        display_name: "Ollama".to_string(),
+        api_key_env: "OLLAMA_API_KEY".to_string(),
+        base_url: "http://127.0.0.1:11434".to_string(),
+        key_required: false,
+        auth_status: AuthStatus::NotRequired,
+        model_count: 1,
+        ..ProviderInfo::default()
+    });
+
+    let (status, _) = json_request(&h, Method::DELETE, "/api/providers/ollama/key", None).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (_, body) = json_request(&h, Method::GET, "/api/providers", None).await;
+    let ollama = find_provider(&body, "ollama");
+    assert_eq!(
+        ollama["auth_status"].as_str(),
+        Some("missing"),
+        "suppressed local provider must report `missing`; got {ollama}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_provider_url_unsuppresses_after_delete() {
+    // The re-enable counterpart of the above: after suppressing a local
+    // provider, pointing it at a new URL must un-suppress so it appears
+    // in the configured grid again. Without `set_provider_url` clearing
+    // the suppression flag (#4803), the local provider would stay
+    // Missing forever after the user removed and re-configured it.
+    //
+    // We assert against the on-disk `suppressed_providers.json` rather
+    // than `/api/providers` because the list endpoint additionally
+    // overrides `auth_status` to "missing" when a fresh probe finds the
+    // local port closed — that branch fires here (nothing is listening
+    // in the test process), masking the un-suppression we want to
+    // verify. The file is the persistence layer that survives restarts,
+    // so it is the right surface for this regression.
+    let h = boot_with_provider(ProviderInfo {
+        id: "ollama".to_string(),
+        display_name: "Ollama".to_string(),
+        api_key_env: "OLLAMA_API_KEY".to_string(),
+        base_url: "http://127.0.0.1:11434".to_string(),
+        key_required: false,
+        auth_status: AuthStatus::NotRequired,
+        model_count: 1,
+        ..ProviderInfo::default()
+    });
+
+    let suppressed_path = h
+        ._state
+        .kernel
+        .home_dir()
+        .join("data")
+        .join("suppressed_providers.json");
+
+    // Suppress via DELETE first to set up the regression scenario.
+    let (status, _) = json_request(&h, Method::DELETE, "/api/providers/ollama/key", None).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let suppressed_after_delete: Vec<String> =
+        serde_json::from_str(&std::fs::read_to_string(&suppressed_path).unwrap()).unwrap();
+    assert!(
+        suppressed_after_delete.iter().any(|s| s == "ollama"),
+        "DELETE should add ollama to suppressed_providers.json; got {suppressed_after_delete:?}",
+    );
+
+    // PUT a new URL — this must un-suppress (#4803). The probe inside
+    // the handler fires against the new URL; in this test environment
+    // nothing is listening so the probe fails, but that does not block
+    // the suppression flip.
+    let (status, _) = json_request(
+        &h,
+        Method::PUT,
+        "/api/providers/ollama/url",
+        Some(serde_json::json!({ "base_url": "http://127.0.0.1:11999" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // `save_suppressed` removes the file when the set is empty.
+    let still_suppressed: Option<Vec<String>> = std::fs::read_to_string(&suppressed_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok());
+    let any_suppressed_after_put = still_suppressed
+        .as_ref()
+        .map(|v| v.iter().any(|s| s == "ollama"))
+        .unwrap_or(false);
+    assert!(
+        !any_suppressed_after_put,
+        "PUT /api/providers/ollama/url must drop ollama from the suppressed list; on-disk content: {still_suppressed:?}",
+    );
 }

--- a/crates/librefang-kernel/src/kernel/provider_probe.rs
+++ b/crates/librefang-kernel/src/kernel/provider_probe.rs
@@ -70,10 +70,19 @@ pub async fn probe_and_update_local_provider(
                 Some(result.discovered_model_info.clone())
             };
         kernel.model_catalog_update(|catalog| {
-            catalog.set_provider_auth_status(
-                provider_id,
-                librefang_types::model_catalog::AuthStatus::NotRequired,
-            );
+            // Honour suppression — periodic probes are already filtered upstream
+            // via `local_provider_probe_targets`, but user-triggered tests
+            // (POST /api/providers/{name}/test) reach this path on suppressed
+            // providers too; silently flipping auth_status to NotRequired would
+            // un-do `delete_provider_key`. `merge_discovered_models` stays
+            // outside the gate so a Test click still refreshes the model list
+            // the user might want to inspect before re-enabling.
+            if !catalog.is_suppressed(provider_id) {
+                catalog.set_provider_auth_status(
+                    provider_id,
+                    librefang_types::model_catalog::AuthStatus::NotRequired,
+                );
+            }
             if let Some(ref info) = merged_info {
                 catalog.merge_discovered_models(provider_id, info);
             }
@@ -97,11 +106,18 @@ pub async fn probe_and_update_local_provider(
         // Using Missing would cause detect_auth() to reset the status back
         // to NotRequired on the next unrelated auth check, making offline
         // providers reappear in the model switcher.
+        //
+        // Same suppression gate as the reachable branch above — a
+        // user-triggered Test on a suppressed provider must not silently
+        // promote `Missing` to `LocalOffline`, which would re-add the
+        // provider to the dashboard's "configured but offline" bucket.
         kernel.model_catalog_update(|catalog| {
-            catalog.set_provider_auth_status(
-                provider_id,
-                librefang_types::model_catalog::AuthStatus::LocalOffline,
-            );
+            if !catalog.is_suppressed(provider_id) {
+                catalog.set_provider_auth_status(
+                    provider_id,
+                    librefang_types::model_catalog::AuthStatus::LocalOffline,
+                );
+            }
         });
     }
     result
@@ -119,17 +135,14 @@ pub(super) async fn probe_all_local_providers_once(
     kernel: &Arc<LibreFangKernel>,
     relevant_providers: &std::collections::HashSet<String>,
 ) {
+    // Pull the filter through `ModelCatalog::local_provider_probe_targets` so
+    // suppressed providers (set by `delete_provider_key`) are excluded — without
+    // that, the next tick would overwrite `Missing` with `NotRequired` /
+    // `LocalOffline` via `set_provider_auth_status` (#4803) and the provider
+    // would reappear in the configured grid.
     let local_providers: Vec<(String, String)> = {
         let catalog = kernel.llm.model_catalog.load();
-        catalog
-            .list_providers()
-            .iter()
-            .filter(|p| {
-                librefang_runtime::provider_health::is_local_provider(&p.id)
-                    && !p.base_url.is_empty()
-            })
-            .map(|p| (p.id.clone(), p.base_url.clone()))
-            .collect()
+        catalog.local_provider_probe_targets()
     };
     let tasks = local_providers.into_iter().map(|(provider_id, base_url)| {
         let kernel = Arc::clone(kernel);

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -613,6 +613,34 @@ impl ModelCatalog {
         self.suppressed_providers.remove(id);
     }
 
+    /// Whether `id` is currently in the suppressed-providers set.
+    ///
+    /// Background loops that bypass `detect_auth` (notably
+    /// `probe_all_local_providers_once`, which writes `set_provider_auth_status`
+    /// directly) need this check so an unrelated tick does not silently
+    /// un-do a user's "remove key" action.
+    pub fn is_suppressed(&self, id: &str) -> bool {
+        self.suppressed_providers.contains(id)
+    }
+
+    /// Return `(id, base_url)` for every local HTTP provider that the
+    /// periodic probe loop should poll. Filters out providers the user has
+    /// explicitly suppressed — without this, the next probe tick would
+    /// overwrite the `Missing` status set by `delete_provider_key` with
+    /// `NotRequired`/`LocalOffline` and the provider would re-appear in
+    /// the configured grid (#4803).
+    pub fn local_provider_probe_targets(&self) -> Vec<(String, String)> {
+        self.providers
+            .iter()
+            .filter(|p| {
+                crate::provider_health::is_local_provider(&p.id)
+                    && !p.base_url.is_empty()
+                    && !self.suppressed_providers.contains(&p.id)
+            })
+            .map(|p| (p.id.clone(), p.base_url.clone()))
+            .collect()
+    }
+
     /// Load the suppressed-providers list from a JSON file.
     pub fn load_suppressed(&mut self, path: &std::path::Path) {
         if let Ok(data) = std::fs::read_to_string(path) {
@@ -1684,6 +1712,68 @@ id = "acme"
         catalog.detect_auth();
         let ollama = catalog.get_provider("ollama").unwrap();
         assert_eq!(ollama.auth_status, AuthStatus::NotRequired);
+    }
+
+    /// `is_suppressed` reflects `suppress_provider` / `unsuppress_provider`
+    /// without going through `detect_auth`. This is the accessor the
+    /// `probe_and_update_local_provider` gate (#4803 follow-up) reads to
+    /// decide whether a probe write should be skipped, so a regression in
+    /// the lookup primitive would silently re-introduce the bug where
+    /// user-triggered Test on a suppressed provider re-flipped the catalog.
+    #[test]
+    fn is_suppressed_reflects_set_membership() {
+        let mut catalog = test_catalog();
+        assert!(!catalog.is_suppressed("ollama"));
+        catalog.suppress_provider("ollama");
+        assert!(catalog.is_suppressed("ollama"));
+        catalog.unsuppress_provider("ollama");
+        assert!(!catalog.is_suppressed("ollama"));
+        // Unknown id is just not-in-set, not a panic.
+        assert!(!catalog.is_suppressed("__no_such_provider__"));
+    }
+
+    /// Regression for the #4803 follow-up — the periodic probe loop must
+    /// not re-promote a suppressed local provider. Pre-fix the filter in
+    /// `probe_all_local_providers_once` only checked `is_local_provider`
+    /// + non-empty `base_url`, so an ollama row that the user had hidden
+    /// via "remove key" would still be polled every ~60 s and have its
+    /// `auth_status` overwritten with `NotRequired` / `LocalOffline` via
+    /// `set_provider_auth_status` (which bypasses `detect_auth`). The
+    /// fix routes the filter through `local_provider_probe_targets`,
+    /// which excludes suppressed providers up front.
+    #[test]
+    fn local_provider_probe_targets_excludes_suppressed_providers() {
+        let mut catalog = test_catalog();
+        let baseline = catalog.local_provider_probe_targets();
+        assert!(
+            baseline.iter().any(|(id, _)| id == "ollama"),
+            "ollama must be a probe target by default — sanity-check the seed catalog: {baseline:?}"
+        );
+
+        catalog.suppress_provider("ollama");
+        let filtered = catalog.local_provider_probe_targets();
+        assert!(
+            !filtered.iter().any(|(id, _)| id == "ollama"),
+            "suppressed local provider must be excluded from probe targets: {filtered:?}"
+        );
+
+        // Other local providers (e.g. vllm, lmstudio) stay in the list —
+        // suppression is per-provider, not a global kill switch.
+        for (id, _) in &baseline {
+            if id != "ollama" {
+                assert!(
+                    filtered.iter().any(|(fid, _)| fid == id),
+                    "non-suppressed local provider {id} must survive the filter"
+                );
+            }
+        }
+
+        catalog.unsuppress_provider("ollama");
+        let restored = catalog.local_provider_probe_targets();
+        assert!(
+            restored.iter().any(|(id, _)| id == "ollama"),
+            "un-suppressing must restore ollama as a probe target"
+        );
     }
 
     #[test]

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -282,10 +282,20 @@ impl ModelCatalog {
     /// Only checks presence — never reads or stores the actual secret.
     pub fn detect_auth(&mut self) {
         for provider in &mut self.providers {
+            // Suppression — set by `delete_provider_key` when the user
+            // explicitly hides a provider from the configured page (#4803).
+            // For non-key-required providers (CLI, local HTTP) the rest of
+            // this loop would unconditionally re-detect them as available,
+            // defeating the user's intent. Honour suppression up front so
+            // "remove key" works regardless of provider shape.
+            let suppressed = self.suppressed_providers.contains(&provider.id);
+
             // CLI-based providers: no API key needed, but we probe for CLI
             // installation so the dashboard shows "Configured" vs "Not Installed".
             if crate::drivers::is_cli_provider(&provider.id) {
-                provider.auth_status = if crate::drivers::cli_provider_available(&provider.id) {
+                provider.auth_status = if suppressed {
+                    AuthStatus::Missing
+                } else if crate::drivers::cli_provider_available(&provider.id) {
                     AuthStatus::Configured
                 } else {
                     AuthStatus::CliNotInstalled
@@ -294,6 +304,13 @@ impl ModelCatalog {
             }
 
             if !provider.key_required {
+                if suppressed {
+                    // User explicitly hid this provider. Holding it as
+                    // Missing keeps it out of the configured grid until
+                    // `unsuppress_provider` runs (e.g. via `set_provider_url`).
+                    provider.auth_status = AuthStatus::Missing;
+                    continue;
+                }
                 // Local providers (ollama, vllm, etc.) have their status set by
                 // the async probe at startup. Only set NotRequired as a fallback
                 // when the probe hasn't run yet (status still Missing).
@@ -328,10 +345,6 @@ impl ModelCatalog {
             } else {
                 std::env::var(&provider.api_key_env).is_ok_and(|v| !v.trim().is_empty())
             };
-
-            // If the user explicitly removed this provider's key, skip
-            // alias detection — only honour the primary env var.
-            let suppressed = self.suppressed_providers.contains(&provider.id);
 
             // Secondary: recognised alias env var. Only officially documented
             // aliases count (e.g. Google AI Studio docs both `GEMINI_API_KEY`
@@ -1612,6 +1625,65 @@ id = "acme"
                 std::env::remove_var("GOOGLE_API_KEY");
             }
         }
+    }
+
+    /// Regression for #4803: pressing "remove key" on a CLI provider
+    /// (claude-code, codex-cli, gemini-cli, qwen-code) calls
+    /// `suppress_provider` + `detect_auth`. Pre-fix `detect_auth` ignored
+    /// suppression for CLI providers and re-detected them as Configured
+    /// whenever the CLI binary was on PATH, so the provider never left
+    /// the configured grid. The fix routes suppression through the CLI
+    /// branch.
+    #[test]
+    fn detect_auth_respects_suppression_for_cli_providers() {
+        let mut catalog = test_catalog();
+        // Whatever the host machine reports for these CLIs is fine — the
+        // assertion is that suppression dominates the auto-detection.
+        catalog.suppress_provider("claude-code");
+        catalog.suppress_provider("codex-cli");
+        catalog.detect_auth();
+
+        let claude = catalog.get_provider("claude-code").unwrap();
+        assert_eq!(
+            claude.auth_status,
+            AuthStatus::Missing,
+            "suppressed CLI provider must be Missing regardless of binary presence"
+        );
+        let codex = catalog.get_provider("codex-cli").unwrap();
+        assert_eq!(codex.auth_status, AuthStatus::Missing);
+
+        // A non-suppressed CLI provider is unaffected — proves we did not
+        // break the auto-detect path for the unsuppressed case.
+        let gemini_cli = catalog.get_provider("gemini-cli").unwrap();
+        assert!(matches!(
+            gemini_cli.auth_status,
+            AuthStatus::Configured | AuthStatus::CliNotInstalled
+        ));
+    }
+
+    /// Regression for #4803: pressing "remove key" on a local HTTP provider
+    /// (ollama, vllm, lmstudio, lemonade) similarly suppressed it but
+    /// `detect_auth` set it back to NotRequired on the next call, so the
+    /// provider never left the configured grid.
+    #[test]
+    fn detect_auth_respects_suppression_for_local_providers() {
+        let mut catalog = test_catalog();
+        catalog.suppress_provider("ollama");
+        catalog.detect_auth();
+
+        let ollama = catalog.get_provider("ollama").unwrap();
+        assert_eq!(
+            ollama.auth_status,
+            AuthStatus::Missing,
+            "suppressed local provider must be Missing instead of NotRequired"
+        );
+
+        // Un-suppressing restores the local default. This mirrors the
+        // `set_provider_url` re-enable path in the API layer.
+        catalog.unsuppress_provider("ollama");
+        catalog.detect_auth();
+        let ollama = catalog.get_provider("ollama").unwrap();
+        assert_eq!(ollama.auth_status, AuthStatus::NotRequired);
     }
 
     #[test]

--- a/openapi.json
+++ b/openapi.json
@@ -7995,6 +7995,39 @@
         }
       }
     },
+    "/api/providers/{name}/enable": {
+      "post": {
+        "tags": [
+          "models"
+        ],
+        "summary": "POST /api/providers/{name}/enable — Re-enable a previously suppressed\nprovider.",
+        "description": "Pairs with DELETE /api/providers/{name}/key, which writes the provider\nid into `suppressed_providers.json` so `detect_auth` stops promoting\nthe row back to `Configured` / `NotRequired` / `AutoDetected` via\nCLI binary probes, local HTTP probes, or alias env vars. For\nCLI-shape providers (`claude-code`, `codex-cli`, `gemini-cli`,\n`qwen-code`) the existing `set_provider_key` / `set_provider_url`\nun-suppress side-effects don't apply — there's no key or URL to\nset — so without this endpoint a user who clicked \"remove key\" on a\nCLI provider had no UI to revert. This endpoint is the explicit\nre-enable signal and works uniformly for every provider shape.\n\nIdempotent: calling on a non-suppressed provider is a no-op aside\nfrom the `detect_auth` refresh.",
+        "operationId": "enable_provider",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Provider name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Provider re-enabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/providers/{name}/key": {
       "post": {
         "tags": [

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-f1f93e131cc0a113bdf30d0786d082d37adedeb234e24adafad950bcd182bbad  openapi.json
+54c174fad990f4c95f15456f7e59c072441dee62f94dc26e80b143ee597376f5  openapi.json


### PR DESCRIPTION
## Summary

Closes #4803 — the dashboard's "remove key" button confirmed *"This will remove the stored API key and move the provider back to unconfigured"* but the provider stayed in the configured grid for any non-API-key shape (CLI providers, local-HTTP providers).

Root cause: `delete_provider_key` already wrote `suppress_provider(name)` into the catalog, but `ModelCatalog::detect_auth()` only consulted the suppression flag inside the key-required alias branch. The CLI branch (`claude-code` / `codex-cli` / `gemini-cli` / `qwen-code`) ran `cli_provider_available()` on the same call and re-set `auth_status = Configured`; the local-HTTP branch (`ollama` / `vllm` / `lmstudio` / `lemonade`) re-set `auth_status = NotRequired`. Suppression was persisted to `~/.librefang/data/suppressed_providers.json` but immediately ignored.

## Changes

- **`crates/librefang-runtime/src/model_catalog.rs`** — Hoist `let suppressed = self.suppressed_providers.contains(...)` to the top of the `detect_auth` loop and short-circuit both the CLI branch and the `!key_required` branch to `AuthStatus::Missing` when the provider is suppressed. The key-required alias-detection check (existing usage) is unchanged.
- **`crates/librefang-api/src/routes/providers.rs`** — `set_provider_url` now `unsuppress_provider` + `save_suppressed` + `detect_auth` inside the same `model_catalog_update` closure. Reconfiguring a base URL is an explicit "use this provider" signal, so a local provider that was suppressed by a prior `delete_provider_key` re-appears as soon as the user re-points it. RCU closure stays idempotent (string + path captured by move, methods take `&`).
- **CLI re-enable is out of scope.** A suppressed CLI provider (`claude-code` etc.) currently requires deleting `~/.librefang/data/suppressed_providers.json` by hand — adding a dashboard "Re-enable" button is a separate UX change, not part of this bug fix.

## Regression coverage

Three unit tests in `model_catalog.rs` (no env mutation, run on `test_catalog()`):
- `detect_auth_respects_suppression_for_cli_providers` — suppressed CLI provider → Missing regardless of binary presence; unsuppressed peer stays auto-detected.
- `detect_auth_respects_suppression_for_local_providers` — suppressed ollama → Missing; un-suppress + detect_auth restores `NotRequired`.

Three integration tests in `providers_routes_test.rs`:
- `delete_provider_key_flips_cli_provider_to_missing` — seeds `claude-code` as Configured, `DELETE /api/providers/claude-code/key` → `GET /api/providers` reports `auth_status: "missing"`.
- `delete_provider_key_flips_local_provider_to_missing` — same for `ollama`.
- `set_provider_url_unsuppresses_after_delete` — asserts against on-disk `suppressed_providers.json` rather than the list endpoint (the probe inside `list_providers` overrides `auth_status` to `"missing"` for unreachable local hosts and would mask the un-suppression we want to verify).

The integration tests use env-var names (`CLAUDE_CODE_API_KEY`, `OLLAMA_API_KEY`) that no other test in the workspace references, so `std::env::remove_var` inside the handler is a no-op on shared state — the file's existing "no global env mutation" rule is preserved.

## Verification

- `cargo check -p librefang-runtime --lib` — green
- `cargo check -p librefang-api --lib` — green
- `cargo test -p librefang-runtime --lib model_catalog` — 84 pass (3 new)
- `cargo test -p librefang-api --test providers_routes_test` — 25 pass (3 new)
- `cargo clippy -p librefang-runtime -p librefang-api --all-targets -- -D warnings` — zero warnings