### PR TITLE
fix(api): stop the dashboard 401 spam on initial mount

### DIFF
--- a/crates/librefang-api/dashboard/src/App.tsx
+++ b/crates/librefang-api/dashboard/src/App.tsx
@@ -855,6 +855,32 @@ export function App() {
       });
     });
 
+    // Endpoints that require auth: defer until after `verifyStoredAuth()`
+    // resolves, so we don't 401-spam the daemon log while the auth probe
+    // is still in flight. `/api/version{,s}` and `/api/health/detail` are
+    // public and can fire eagerly.
+    const fetchAuthedBootstrap = () => {
+      getStatus()
+        .then((s) => {
+          if (cancelled) return;
+          setTerminalEnabled(s.terminal_enabled !== false);
+        })
+        .catch(() => {
+          // If status fetch fails, assume terminal is available (fail-open).
+          // The WebSocket connection itself will enforce actual policy.
+          if (!cancelled) setTerminalEnabled(true);
+        });
+
+      getDashboardUsername()
+        .then((u) => {
+          if (cancelled) return;
+          setUsername(u);
+        })
+        .catch(() => {
+          /* unauth or no-auth mode — fine, avatar shows the icon. */
+        });
+    };
+
     const checkAuth = async () => {
       const mode = await checkDashboardAuthMode();
       if (cancelled) {
@@ -865,6 +891,7 @@ export function App() {
       if (mode === "none") {
         setAuthNeeded(false);
         setAuthChecked(true);
+        fetchAuthedBootstrap();
         return;
       }
 
@@ -875,6 +902,9 @@ export function App() {
 
       setAuthNeeded(!authenticated);
       setAuthChecked(true);
+      if (authenticated) {
+        fetchAuthedBootstrap();
+      }
     };
 
     void checkAuth();
@@ -882,19 +912,6 @@ export function App() {
       setAppVersion(v.version ?? "");
       setHostname(v.hostname ?? "");
     }).catch(() => { /* Version info is non-essential; silently ignore failure. */ });
-
-    getStatus().then((s) => {
-      setTerminalEnabled(s.terminal_enabled !== false);
-    }).catch(() => {
-      // If status fetch fails, assume terminal is available (fail-open).
-      // The WebSocket connection itself will enforce actual policy.
-      setTerminalEnabled(true);
-    });
-
-    getDashboardUsername().then((u) => {
-      if (cancelled) return;
-      setUsername(u);
-    }).catch(() => { /* unauth or no-auth mode — fine, avatar shows the icon. */ });
 
     return () => {
       cancelled = true;
@@ -1012,9 +1029,24 @@ export function App() {
   // `useApprovalCount` (5s refetchInterval) the moment they render.
   // Those endpoints sit behind the auth gate, so polling them before the
   // user logs in (or after a token expiry) produces an endless 401 storm
-  // in server logs.  Render only the AuthDialog here, then fall through
-  // to the full layout once authentication is established.
-  if (!isNoAuthRoute && authChecked && authNeeded) {
+  // in server logs.
+  //
+  // Three pre-shell states:
+  //  - `!authChecked`         → auth probe still in flight; render
+  //                             nothing so polling queries don't mount
+  //                             during the brief check window.
+  //  - `authChecked && authNeeded` → login dialog.
+  //  - `authChecked && !authNeeded` → fall through to the full layout.
+  if (!isNoAuthRoute && !authChecked) {
+    return (
+      <div
+        className="flex h-screen items-center justify-center bg-main"
+        aria-busy="true"
+        aria-label={t("auth.checking", { defaultValue: "Checking authentication…" })}
+      />
+    );
+  }
+  if (!isNoAuthRoute && authNeeded) {
     return (
       <div className="flex h-screen items-center justify-center bg-main text-slate-900 dark:text-slate-100">
         <AuthDialog

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -696,6 +696,14 @@ pub const PUBLIC_ROUTES_ALWAYS: &[PublicRoute] = &[
     PublicRoute::exact_any("/api/pairing/complete"),
     // Minimal liveness probes
     PublicRoute::exact_any("/api/health"),
+    // Detailed liveness probe consumed by `<OfflineBanner />`, which
+    // mounts before the auth check completes and polls every 30s
+    // regardless of whether the user has logged in. Its payload is
+    // daemon liveness + build/uptime metadata — same security profile
+    // as `/api/health` / `/api/version` — so unauthenticated polling
+    // produced an endless 401 storm in server logs with zero security
+    // upside. Always-public.
+    PublicRoute::exact_any("/api/health/detail"),
     PublicRoute::exact_any("/api/version"),
     PublicRoute::exact_any("/api/versions"),
     // GitHub Copilot OAuth — prefix, any method

--- a/crates/librefang-api/tests/auth_public_allowlist.rs
+++ b/crates/librefang-api/tests/auth_public_allowlist.rs
@@ -193,6 +193,11 @@ const REGISTERED_GET_ROUTES: &[RouteEntry] = &[
     re("/logo.png", Expect::AlwaysPublic),
     re("/.well-known/agent.json", Expect::AlwaysPublic),
     re("/api/health", Expect::AlwaysPublic),
+    // `/api/health/detail` is the polling target for `<OfflineBanner />`,
+    // which mounts before the auth check completes. It carries the same
+    // payload class as `/api/health` (liveness + build/uptime metadata),
+    // so it lives next to its sibling in `PUBLIC_ROUTES_ALWAYS`.
+    re("/api/health/detail", Expect::AlwaysPublic),
     re("/api/version", Expect::AlwaysPublic),
     re("/api/versions", Expect::AlwaysPublic),
     re("/api/auth/callback", Expect::AlwaysPublic),
@@ -255,7 +260,6 @@ const REGISTERED_GET_ROUTES: &[RouteEntry] = &[
     re("/api/status", Expect::DashboardRead),
     re("/api/workflows", Expect::DashboardRead),
     // Auth-required endpoints (must 401 without Bearer token)
-    re("/api/health/detail", Expect::Authed),
     // Security regression: /api/mcp/servers/{name} and /auth/status must NOT be
     // publicly reachable — the server config (including env vars) and OAuth token
     // state are sensitive. Only /auth/callback is public (via is_mcp_oauth_callback).

--- a/crates/librefang-runtime/src/model_catalog.rs
+++ b/crates/librefang-runtime/src/model_catalog.rs
@@ -1735,12 +1735,13 @@ id = "acme"
     /// Regression for the #4803 follow-up — the periodic probe loop must
     /// not re-promote a suppressed local provider. Pre-fix the filter in
     /// `probe_all_local_providers_once` only checked `is_local_provider`
-    /// + non-empty `base_url`, so an ollama row that the user had hidden
-    /// via "remove key" would still be polled every ~60 s and have its
-    /// `auth_status` overwritten with `NotRequired` / `LocalOffline` via
-    /// `set_provider_auth_status` (which bypasses `detect_auth`). The
-    /// fix routes the filter through `local_provider_probe_targets`,
-    /// which excludes suppressed providers up front.
+    /// plus non-empty `base_url`, so an ollama row that the user had
+    /// hidden via "remove key" would still be polled every ~60 s and
+    /// have its `auth_status` overwritten with `NotRequired` /
+    /// `LocalOffline` via `set_provider_auth_status` (which bypasses
+    /// `detect_auth`). The fix routes the filter through
+    /// `local_provider_probe_targets`, which excludes suppressed
+    /// providers up front.
     #[test]
     fn local_provider_probe_targets_excludes_suppressed_providers() {
         let mut catalog = test_catalog();


### PR DESCRIPTION
Pairs with [#4891](https://github.com/librefang/librefang/pull/4891) (raises kernel `DEFAULT_MAX_HISTORY_MESSAGES` to 60) and [librefang-registry#91](https://github.com/librefang/librefang-registry/pull/91) (per-hand `max_history_messages` overrides + refresh-cache workflow fix). The three PRs were uncovered in the same investigation; this one is the narrowest of the bunch.

## What

A user running the dashboard with `require_auth_for_reads = true` reported a flood of WARN logs of the shape:

```
WARN request: API request method=GET path=/api/approvals/count status=401 latency_ms=1
WARN request: API request method=GET path=/api/skills/pending  status=401 latency_ms=1
WARN request: API request method=GET path=/api/health/detail   status=401 latency_ms=1
WARN request: API request method=GET path=/api/status          status=401 latency_ms=1
WARN request: API request method=GET path=/api/status          status=401 latency_ms=1
...
```

Two independent sources, both fixed here:

### 1. `<OfflineBanner />` polls `/api/health/detail` pre-auth

The OfflineBanner mounts before the auth check completes (it has to — its whole job is to render the "daemon unreachable" banner whether or not the user is signed in) and polls every 30s. The endpoint was sitting behind the auth gate despite carrying only liveness + build/uptime metadata (same payload class as `/api/health`, which has always been public).

**Fix:** add `/api/health/detail` to `PUBLIC_ROUTES_ALWAYS` next to `/api/health`. Auth contract for richer status data is unchanged.

### 2. Shell mounts before `authChecked`, polling-query soup fires immediately

The existing pre-render guard at `App.tsx` only redirected to `<AuthDialog />` when `authChecked && authNeeded` was true. During the brief window where `authChecked` was still false (initial check in flight), the **full shell** mounted — including `<NotificationCenter />`, which fires `useApprovalCount` (5s refetchInterval) and `usePendingSkillCandidates` (5s) the moment it renders. The mount-time `useEffect` *also* fired `getStatus()` and `getDashboardUsername()` in parallel with `checkAuth()`. With `require_auth_for_reads = true` every one of these 401'd until the check resolved.

**Fix:** in `App.tsx`:

- Add a third pre-render branch — when `!authChecked` render an empty `aria-busy` placeholder instead of the full layout. NotificationCenter doesn't mount, its queries don't fire.
- Hoist `getStatus()` + `getDashboardUsername()` into a `fetchAuthedBootstrap()` helper that runs only after `verifyStoredAuth()` succeeds (or when `authMode === "none"`).
- `getVersionInfo()` still fires eagerly — it's public, never 401s.

The existing `authChecked && authNeeded` branch (login dialog) is unchanged.

## What this does NOT change

- `/api/status` stays in `PUBLIC_ROUTES_DASHBOARD_READS` (conditional on `require_auth_for_reads`). Users who opt into authed reads keep authed status. The fix above stops the dashboard from polling it pre-auth-check, which is what was producing the spam, not the conditional-public state itself.
- `<NotificationCenter />` itself is not refactored — the pre-render gate keeps it from mounting too early; once mounted (post-auth), its queries are valid by construction. Token expiry mid-session triggers `setOnUnauthorized` → `setAuthNeeded(true)` → re-render to `<AuthDialog />`, which unmounts NotificationCenter and stops its polls.

## Out-of-scope fix bundled

Commit 1 (`chore(clippy): reflow #4803 regression-test docstring`) is the same docstring fix as #4891. The pre-push hook (`cargo clippy --workspace --all-targets -- -D warnings`) blocks any push that trips `doc_lazy_continuation` locally, so the fix has to be in whichever PR pushes first; both PRs landed independently will leave a trivial merge conflict resolved by accepting either side.

## Verification

```
cargo test -p librefang-api --test auth_public_allowlist  # 8/8 pass — includes new always-public check for /api/health/detail
cd crates/librefang-api/dashboard && npm run typecheck    # clean
cargo clippy --workspace --all-targets -- -D warnings     # clean
```

## Test plan

- [ ] CI green.
- [ ] User reproduces the original "daemon log spam" condition on a daemon running this branch + `require_auth_for_reads = true`; the four 401 sources documented above (approvals/count, skills/pending, health/detail, status) should not appear in the log until the user is past the AuthDialog.
- [ ] Auth flow still feels snappy (the `!authChecked` placeholder is empty + `aria-busy` and only visible for ~50-200ms on a local daemon).
- [ ] Token expiry mid-session: triggers AuthDialog as before; no fresh 401 storm on the post-expiry render.