### PR TITLE
fix(dashboard/memory): make embedding & extraction model fields suggest options instead of being raw text inputs

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "../lib/queries/memory";
 import { useAgents } from "../lib/queries/agents";
 import { useAutoDreamStatus } from "../lib/queries/autoDream";
+import { useModels } from "../lib/queries/models";
 import { useAddMemory, useUpdateMemory, useDeleteMemory, useCleanupMemories, useUpdateMemoryConfig } from "../lib/mutations/memory";
 import { useTriggerAutoDream, useAbortAutoDream, useSetAutoDreamEnabled } from "../lib/mutations/autoDream";
 import type { AgentItem, AgentKvPair, AutoDreamAgentStatus } from "../api";
@@ -184,14 +185,35 @@ interface MemoryConfigForm {
   pm_max_retrieve: string;
 }
 
+// Known embedding model names per provider. Used to populate the embedding
+// model `<datalist>` suggestions. Local providers (ollama/vllm/lmstudio) load
+// arbitrary user-pulled models, so the suggestions there are just common
+// defaults — the input remains free-form for everyone.
+const KNOWN_EMBEDDING_MODELS: Record<string, string[]> = {
+  openai: ["text-embedding-3-small", "text-embedding-3-large", "text-embedding-ada-002"],
+  gemini: ["text-embedding-004", "embedding-001"],
+  minimax: ["embo-01"],
+  ollama: ["nomic-embed-text", "mxbai-embed-large", "all-minilm"],
+  vllm: ["nomic-embed-text", "BAAI/bge-large-en-v1.5"],
+  lmstudio: ["nomic-embed-text", "text-embedding-nomic-embed-text-v1.5"],
+};
+
 function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
 
   const configQuery = useMemoryConfig();
   const updateConfig = useUpdateMemoryConfig();
+  // Chat-model catalog for the Extraction Model suggestions. Unfiltered so
+  // configured-but-not-yet-probed providers still appear; the user is free to
+  // type any id the dropdown doesn't list.
+  const modelsQuery = useModels();
+  const chatModels = modelsQuery.data?.models ?? [];
 
   const [form, setForm] = useState<MemoryConfigForm | null>(null);
+
+  const embeddingProviderSuggestions =
+    KNOWN_EMBEDDING_MODELS[form?.embedding_provider ?? ""] ?? [];
 
   useEffect(() => {
     if (!configQuery.data || form) return;
@@ -263,8 +285,18 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
               </div>
               <div>
                 <span className={labelCls}>{t("memory.model", { defaultValue: "Model" })}</span>
-                <input value={form.embedding_model ?? ""} onChange={e => setForm({ ...form, embedding_model: e.target.value })}
-                  placeholder="text-embedding-3-small" className={inputCls} />
+                <input
+                  list="memory-embedding-model-options"
+                  value={form.embedding_model ?? ""}
+                  onChange={e => setForm({ ...form, embedding_model: e.target.value })}
+                  placeholder="text-embedding-3-small"
+                  className={inputCls}
+                />
+                <datalist id="memory-embedding-model-options">
+                  {embeddingProviderSuggestions.map(name => (
+                    <option key={name} value={name} />
+                  ))}
+                </datalist>
               </div>
             </div>
             <div className="mt-2">
@@ -300,8 +332,20 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
               <div>
                 <span className={labelCls}>{t("memory.extraction_model_label", { defaultValue: "Extraction Model" })}</span>
-                <input value={form.pm_extraction_model ?? ""} onChange={e => setForm({ ...form, pm_extraction_model: e.target.value })}
-                  placeholder="MiniMax-M2.7-highspeed" className={inputCls} />
+                <input
+                  list="memory-extraction-model-options"
+                  value={form.pm_extraction_model ?? ""}
+                  onChange={e => setForm({ ...form, pm_extraction_model: e.target.value })}
+                  placeholder={t("memory.extraction_model_placeholder", { defaultValue: "Leave empty to use default" })}
+                  className={inputCls}
+                />
+                <datalist id="memory-extraction-model-options">
+                  {chatModels.map(m => (
+                    <option key={m.id} value={m.id}>
+                      {m.display_name && m.display_name !== m.id ? `${m.display_name} (${m.provider})` : m.provider}
+                    </option>
+                  ))}
+                </datalist>
               </div>
               <div>
                 <span className={labelCls}>{t("memory.max_retrieve", { defaultValue: "Max Retrieve" })}</span>

--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -261,12 +261,13 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
 
   return (
     <DrawerPanel isOpen={true} onClose={onClose} title={t("memory.config_title", { defaultValue: "Memory Configuration" })} size="lg">
-      <p className="text-xs text-text-dim -mt-2 mb-4">{t("memory.config_desc", { defaultValue: "Changes are written to config.toml. Restart required for full effect." })}</p>
+      <div className="p-4 sm:p-6">
+      <p className="text-xs text-text-dim mb-4">{t("memory.config_desc", { defaultValue: "Changes are written to config.toml. Restart required for full effect." })}</p>
 
       {configQuery.isLoading || !form ? (
         <div className="p-6 text-center"><Loader2 className="w-5 h-5 animate-spin mx-auto" /></div>
       ) : (
-        <div className="space-y-4 max-h-[60vh] overflow-y-auto">
+        <div className="space-y-4">
           {/* Embedding */}
           <div>
             <h4 className="text-xs font-bold mb-3">{t("memory.embedding_section", { defaultValue: "Embedding" })}</h4>
@@ -369,6 +370,7 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
           {updateConfig.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : t("common.save")}
         </Button>
         <Button variant="secondary" className="flex-1" onClick={onClose}>{t("common.cancel")}</Button>
+      </div>
       </div>
     </DrawerPanel>
   );


### PR DESCRIPTION
## Summary

The Memory Configuration drawer (`/dashboard/memory` → settings cog) rendered both **Embedding Model** and **Extraction Model** as plain `<input>` text boxes — even though Provider above them was already a `<select>` and the dashboard already has `useModels()` available for the chat-model catalog. The two model fields offered no help while clearly being pickable choices.

This PR switches both to `<input list="…">` + `<datalist>` so the user gets a dropdown of sensible suggestions while keeping free input for custom / local-provider models.

### Changes

- **Embedding Model** — suggestions come from a small per-provider catalog (`KNOWN_EMBEDDING_MODELS`):
  - `openai`: `text-embedding-3-small`, `text-embedding-3-large`, `text-embedding-ada-002`
  - `gemini`: `text-embedding-004`, `embedding-001`
  - `minimax`: `embo-01`
  - `ollama` / `vllm` / `lmstudio`: common pulled defaults (`nomic-embed-text`, …)

  Local-provider users still get a free-form text input because their loaded model names are arbitrary.
- **Extraction Model** — suggestions come from `useModels()` (the same catalog the Models page uses). Placeholder now reads "Leave empty to use default" so the implicit fallback is visible at a glance.
- No new locale keys (label keys already existed); kept the placeholder copy under `t(..., { defaultValue })`.

### Verification

- `tsc --noEmit` clean
- `vitest run src/pages/MemoryPage.test.tsx` — 10/10 pass
- `vitest run src/lib/queries/keys.test.ts src/lib/queries/channels-models.test.tsx` — 46/46 pass

## Test plan

- [ ] Open `/dashboard/memory`, click the settings cog.
- [ ] Embedding Model: switch Provider to `openai` → focusing the Model field shows a dropdown with the three OpenAI embedding models.
- [ ] Switch Provider to `ollama` → suggestions become `nomic-embed-text` etc.; typing a custom name still works.
- [ ] Extraction Model: focusing the field shows your configured chat models. Typing a custom id still works. Leaving it empty still saves as "use default".