### PR TITLE
fix(dashboard/memory): recognise known embedding models when provider is Auto-detect

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MemoryPage.tsx
@@ -199,6 +199,17 @@ const KNOWN_EMBEDDING_MODELS: Record<string, string[]> = {
   lmstudio: ["nomic-embed-text", "text-embedding-nomic-embed-text-v1.5"],
 };
 
+// Display labels for the embedding-provider optgroups shown when the
+// Provider field is "Auto-detect". Keys mirror KNOWN_EMBEDDING_MODELS.
+const EMBEDDING_PROVIDER_LABELS: Record<string, string> = {
+  openai: "OpenAI",
+  gemini: "Gemini",
+  minimax: "MiniMax",
+  ollama: "Ollama",
+  vllm: "vLLM",
+  lmstudio: "LM Studio",
+};
+
 function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
@@ -213,8 +224,17 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
 
   const [form, setForm] = useState<MemoryConfigForm | null>(null);
 
-  const embeddingProviderSuggestions =
-    KNOWN_EMBEDDING_MODELS[form?.embedding_provider ?? ""] ?? [];
+  // Suggestion list for the Embedding Model dropdown. When the provider is
+  // pinned and known, surface only that provider's catalog. When the
+  // provider is "Auto-detect" (empty) or a not-yet-known string, fall back
+  // to the union of every provider's catalog — otherwise a stored value
+  // like `text-embedding-3-small` would be flagged Custom whenever the user
+  // hasn't explicitly pinned `openai`, which is wrong and surprising.
+  const embeddingProvider = form?.embedding_provider ?? "";
+  const embeddingProviderKnown = embeddingProvider in KNOWN_EMBEDDING_MODELS;
+  const embeddingProviderSuggestions = embeddingProviderKnown
+    ? KNOWN_EMBEDDING_MODELS[embeddingProvider]
+    : Array.from(new Set(Object.values(KNOWN_EMBEDDING_MODELS).flat()));
   // Sentinel value for the "Custom…" option in the model `<select>`s. Picking
   // it switches the field into a free-text input rendered alongside the
   // select; an existing stored value that isn't in the catalog is also
@@ -224,8 +244,14 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
   const embeddingIsCustom =
     !!form?.embedding_model && !embeddingKnownSet.has(form.embedding_model);
   const chatModelIdSet = new Set(chatModels.map((m) => m.id));
+  // Guard on `isSuccess` so that the stored value doesn't flicker through
+  // Custom during the initial `useModels` fetch (chatModels is `[]` while
+  // loading, which would otherwise classify every saved model as custom
+  // for a frame).
   const extractionIsCustom =
-    !!form?.pm_extraction_model && !chatModelIdSet.has(form.pm_extraction_model);
+    modelsQuery.isSuccess &&
+    !!form?.pm_extraction_model &&
+    !chatModelIdSet.has(form.pm_extraction_model);
 
   useEffect(() => {
     if (!configQuery.data || form) return;
@@ -314,9 +340,19 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
                   className={inputCls}
                 >
                   <option value="">{t("memory.embedding_model_default", { defaultValue: "Auto / provider default" })}</option>
-                  {embeddingProviderSuggestions.map(name => (
-                    <option key={name} value={name}>{name}</option>
-                  ))}
+                  {embeddingProviderKnown ? (
+                    embeddingProviderSuggestions.map(name => (
+                      <option key={name} value={name}>{name}</option>
+                    ))
+                  ) : (
+                    Object.entries(KNOWN_EMBEDDING_MODELS).map(([prov, names]) => (
+                      <optgroup key={prov} label={EMBEDDING_PROVIDER_LABELS[prov] ?? prov}>
+                        {names.map(name => (
+                          <option key={`${prov}:${name}`} value={name}>{name}</option>
+                        ))}
+                      </optgroup>
+                    ))
+                  )}
                   <option value={CUSTOM_OPTION}>{t("memory.custom_model_option", { defaultValue: "Custom…" })}</option>
                 </select>
                 {embeddingIsCustom && (
@@ -383,6 +419,15 @@ function MemoryConfigDialog({ onClose }: { onClose: () => void }) {
                         : `${m.id} (${m.provider})`}
                     </option>
                   ))}
+                  {/* While useModels() is still loading the catalog is empty;
+                      render the stored value as a transient option so the
+                      select's `value=` has something to match (otherwise
+                      React warns about an unmatched controlled value). */}
+                  {!modelsQuery.isSuccess &&
+                    form.pm_extraction_model &&
+                    !chatModelIdSet.has(form.pm_extraction_model) && (
+                      <option value={form.pm_extraction_model}>{form.pm_extraction_model}</option>
+                    )}
                   <option value={CUSTOM_OPTION}>{t("memory.custom_model_option", { defaultValue: "Custom…" })}</option>
                 </select>
                 {extractionIsCustom && (


### PR DESCRIPTION
## Bug

In the Memory Configuration drawer, with **Provider = "Auto-detect"** and a stored `embedding_model = "text-embedding-3-small"`, the Model dropdown showed **"Custom…"** with the value pre-filled in the free-text input — even though `text-embedding-3-small` is a well-known OpenAI embedding model and should be a recognised option, not a custom one.

## Root cause

`KNOWN_EMBEDDING_MODELS[""]` is `undefined`, so when Provider is Auto-detect the `embeddingProviderSuggestions` array degenerated to `[]`. The known-set check then failed for every stored value, classifying anything non-empty as Custom.

## Fix

When the Provider field is empty (Auto-detect) or holds a string that isn't in our catalog, fall back to **the union of every provider's catalog** for the known-set check, and render the `<select>` with one `<optgroup>` per provider so the user can still see which provider each model belongs to.

When the Provider IS pinned to a known value, behaviour is unchanged — only that provider's list is shown (so e.g. picking Provider = `ollama` while having an old `text-embedding-3-small` stored will still correctly read as Custom for that provider).

## Bundled with this fix

While re-reading the same block I also closed a related flicker on the **Extraction Model** field — refs #4894 / #4897.

While `useModels()` is still loading on first mount, `chatModels` is `[]`, which means every saved model id misses the known set and the select would have flipped through "Custom…" for one frame before the catalog arrived. Gate `extractionIsCustom` on `modelsQuery.isSuccess` so the field is never classified Custom during the load window, and render the stored value as a transient `<option>` while loading so the controlled `<select value=…>` always has something to match (avoids React's controlled-component warning).

## Verification

- `tsc --noEmit` clean
- `vitest run src/pages/MemoryPage.test.tsx` — 10/10 pass

## Test plan

- [ ] Memory Configuration drawer with stored `embedding_provider = ""` and `embedding_model = "text-embedding-3-small"` → Model field shows `text-embedding-3-small` selected (under an "OpenAI" optgroup), NOT "Custom…".
- [ ] Switch Provider to `ollama` → the Model dropdown collapses to Ollama's list; if the stored model isn't in that list, it now reads as "Custom…" (correct behaviour, the model doesn't fit the provider).
- [ ] Hard refresh `/dashboard/memory` with the drawer auto-open → Extraction Model field shows the stored value, no momentary "Custom…" flash before `useModels()` resolves.