### PR TITLE
fix(runtime): batch history_fold LLM call + persist rewrites to session (#4866)

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -3302,12 +3302,24 @@ async fn finalize_successful_end_turn(
 /// helper prevents the two paths from drifting (e.g. one branch picking
 /// up a new `min_batch_size` knob and the other lagging).
 ///
-/// Returns the (possibly modified) message list — same semantics as
-/// [`crate::history_fold::fold_stale_tool_results`] but with the fast-path
-/// and call-site logging baked in.  `streaming` flips the log target so
-/// operators can grep `"streaming"` vs `"non-streaming"` in production.
+/// Returns the (possibly modified) working-copy message list — same
+/// semantics as [`crate::history_fold::fold_stale_tool_results`] but with
+/// the fast-path, call-site logging, and durable-session replay baked in.
+/// The durable replay (issue #4866 axis 2) walks `session.messages` and
+/// rewrites every matching `ToolResult.content` by `tool_use_id`, then
+/// calls `session.mark_messages_mutated()`.  Without that step the fold
+/// runs from scratch every turn — see `history_fold.rs` module doc.
+/// `streaming` flips the log target so operators can grep `"streaming"`
+/// vs `"non-streaming"` in production.
+// Eight args because every parameter is genuinely distinct (working
+// messages, durable session, knobs, model, aux+primary driver chain,
+// streaming flag, reasoning policy) and bundling them into a context
+// struct would just be a positional alias.  FoldConfig already pulls the
+// two knobs out; further bundling would obscure the call sites.
+#[allow(clippy::too_many_arguments)]
 async fn maybe_fold_stale_tool_results(
     messages: Vec<Message>,
+    session: &mut Session,
     fold_cfg: crate::history_fold::FoldConfig,
     model: &str,
     aux_client: Option<&crate::aux_client::AuxClient>,
@@ -3334,6 +3346,18 @@ async fn maybe_fold_stale_tool_results(
         reasoning_echo_policy,
     )
     .await;
+    // Replay the fold onto `session.messages` so the rewrite is persisted
+    // on the next `save_session_async` and subsequent turns short-circuit
+    // via `is_already_folded` instead of re-summarising from scratch.
+    // Matching by `tool_use_id` lets the working copy and durable list
+    // drift in length/ordering without breaking the projection.
+    if !fold_result.rewrites.is_empty() {
+        let durable_changed =
+            crate::history_fold::apply_fold_rewrites(&mut session.messages, &fold_result.rewrites);
+        if durable_changed {
+            session.mark_messages_mutated();
+        }
+    }
     if fold_result.groups_folded > 0 {
         let label = if streaming {
             "streaming"
@@ -3344,6 +3368,7 @@ async fn maybe_fold_stale_tool_results(
             groups = fold_result.groups_folded,
             replaced = fold_result.messages_replaced,
             groups_used_fallback = fold_result.groups_used_fallback,
+            durable_rewrites = fold_result.rewrites.len(),
             "history_fold: fold pass complete ({label})"
         );
     }
@@ -3870,6 +3895,7 @@ pub async fn run_agent_loop(
             .unwrap_or_default();
         messages = maybe_fold_stale_tool_results(
             messages,
+            session,
             crate::history_fold::FoldConfig {
                 fold_after_turns: tr_fold_after_turns,
                 min_batch_size: tr_fold_min_batch_size,
@@ -5367,6 +5393,7 @@ pub async fn run_agent_loop_streaming(
             .unwrap_or_default();
         messages = maybe_fold_stale_tool_results(
             messages,
+            session,
             crate::history_fold::FoldConfig {
                 fold_after_turns: tr_fold_after_turns,
                 min_batch_size: tr_fold_min_batch_size,

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -10040,6 +10040,41 @@ mod tests {
                  missing {expected}"
             );
         }
+
+        // (5) Second-call no-op: now that session.messages carries fold
+        // stubs, calling the wrapper again on a fresh working clone must
+        // NOT rewrite session.messages a second time — the
+        // `is_already_folded` short-circuit fires inside
+        // `collect_stale_indices`, no aux-LLM call, no new rewrites, and
+        // `messages_generation` MUST stay where it is.  Without this
+        // invariant the persistence fix only saves one round-trip per
+        // session lifetime instead of all subsequent ones.
+        let gen_after_first = session.messages_generation;
+        let working_after_first = session.messages.clone();
+        let aux_driver_2: Arc<dyn LlmDriver> = Arc::new(FoldSummaryDriver);
+        let aux_client_2 =
+            crate::aux_client::AuxClient::with_primary_only(Arc::clone(&aux_driver_2));
+        let _ = maybe_fold_stale_tool_results(
+            working_after_first,
+            &mut session,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            Some(&aux_client_2),
+            aux_driver_2,
+            false,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+        assert_eq!(
+            session.messages_generation,
+            gen_after_first,
+            "second fold pass on already-folded session must NOT advance \
+             messages_generation; pre={gen_after_first} post={post}",
+            post = session.messages_generation,
+        );
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -3311,6 +3311,15 @@ async fn finalize_successful_end_turn(
 /// runs from scratch every turn — see `history_fold.rs` module doc.
 /// `streaming` flips the log target so operators can grep `"streaming"`
 /// vs `"non-streaming"` in production.
+///
+/// **Ordering note** — when soft-compression later in this same loop
+/// iteration fires `session.set_messages(messages.clone())`, it writes
+/// the (already-folded) working copy back over `session.messages`, so
+/// the explicit replay above is redundant on that path.  The replay is
+/// load-bearing only on the no-compression path; keeping it on both
+/// paths keeps session-mutation semantics uniform and removes a foot-gun
+/// for future refactors that move the fold call out from under the
+/// compression step.
 // Eight args because every parameter is genuinely distinct (working
 // messages, durable session, knobs, model, aux+primary driver chain,
 // streaming flag, reasoning policy) and bundling them into a context
@@ -9876,6 +9885,161 @@ mod tests {
                 .map(|m| format!("{:?}: {:?}", m.role, m.content))
                 .collect::<Vec<_>>()
         );
+    }
+
+    /// Axis-2 wiring regression for #4866: `maybe_fold_stale_tool_results`
+    /// must replay the fold rewrites onto `session.messages` (not just the
+    /// working clone) AND advance `messages_generation` via
+    /// `mark_messages_mutated()` so `save_session_async` persists the
+    /// rewrite.  A future refactor in this wrapper could silently drop
+    /// either of those steps; the unit tests inside `history_fold` cover
+    /// the function in isolation and would not catch that.
+    #[tokio::test]
+    async fn maybe_fold_stale_tool_results_persists_rewrites_to_session_messages() {
+        use crate::history_fold::FoldConfig;
+        use librefang_types::tool::ToolExecutionStatus;
+
+        let agent_id = librefang_types::agent::AgentId::new();
+        let mut session = librefang_memory::session::Session {
+            id: librefang_types::agent::SessionId::new(),
+            agent_id,
+            messages: Vec::new(),
+            context_window_tokens: 0,
+            label: None,
+            messages_generation: 0,
+            last_repaired_generation: None,
+        };
+        // 10 turns of (assistant, tool_result) — under fold_after=2 every
+        // tool_result older than the last two assistant turns is stale.
+        session
+            .messages
+            .push(librefang_types::message::Message::user("start"));
+        for i in 0..10 {
+            session
+                .messages
+                .push(librefang_types::message::Message::assistant(format!(
+                    "asst {i}"
+                )));
+            session.messages.push(librefang_types::message::Message {
+                role: librefang_types::message::Role::User,
+                content: librefang_types::message::MessageContent::Blocks(vec![
+                    librefang_types::message::ContentBlock::ToolResult {
+                        tool_use_id: format!("tid_{i}"),
+                        tool_name: "shell".to_string(),
+                        content: format!("output {i}"),
+                        is_error: false,
+                        status: ToolExecutionStatus::Completed,
+                        approval_request_id: None,
+                    },
+                ]),
+                pinned: false,
+                timestamp: None,
+            });
+        }
+        let pre_generation = session.messages_generation;
+        let working = session.messages.clone();
+
+        // Aux driver returns plain prose — fold falls back to bulk
+        // summary across every block.  The persistence wiring is what
+        // we are testing, NOT the JSON path; using the prose driver
+        // makes the assertion shape independent of JSON formatting.
+        let aux_driver: Arc<dyn LlmDriver> = Arc::new(FoldSummaryDriver);
+        let aux_client = crate::aux_client::AuxClient::with_primary_only(Arc::clone(&aux_driver));
+
+        let folded = maybe_fold_stale_tool_results(
+            working,
+            &mut session,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            Some(&aux_client),
+            aux_driver,
+            false,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+
+        // (1) The working clone must carry the stubs (sanity).
+        let working_stubs = folded
+            .iter()
+            .filter(|m| match &m.content {
+                librefang_types::message::MessageContent::Blocks(blocks) => {
+                    blocks.iter().any(|b| {
+                        matches!(
+                            b,
+                            librefang_types::message::ContentBlock::ToolResult { content, .. }
+                                if content.starts_with("[history-fold]")
+                        )
+                    })
+                }
+                _ => false,
+            })
+            .count();
+        assert!(working_stubs >= 8, "expected working copy to be folded");
+
+        // (2) `session.messages` must ALSO carry the stubs — without
+        // this, every subsequent turn refolds from scratch (the bug).
+        let durable_stubs = session
+            .messages
+            .iter()
+            .filter(|m| match &m.content {
+                librefang_types::message::MessageContent::Blocks(blocks) => {
+                    blocks.iter().any(|b| {
+                        matches!(
+                            b,
+                            librefang_types::message::ContentBlock::ToolResult { content, .. }
+                                if content.starts_with("[history-fold]")
+                        )
+                    })
+                }
+                _ => false,
+            })
+            .count();
+        assert!(
+            durable_stubs >= 8,
+            "fold must replay rewrites onto session.messages — without this the \
+             durable record stays raw and every subsequent turn refolds from scratch \
+             (issue #4866 axis 2). durable_stubs={durable_stubs}"
+        );
+
+        // (3) `messages_generation` must have advanced — without this
+        // `save_session_async` would NOT detect the mutation and the
+        // rewrite would be lost across save / reload.
+        assert!(
+            session.messages_generation > pre_generation,
+            "mark_messages_mutated must fire when fold rewrites are replayed; \
+             pre={pre_generation} post={post}",
+            post = session.messages_generation,
+        );
+
+        // (4) Every original `tool_use_id` must still be present in
+        // `session.messages` — pairing invariant.
+        let durable_ids: std::collections::BTreeSet<String> = session
+            .messages
+            .iter()
+            .flat_map(|m| match &m.content {
+                librefang_types::message::MessageContent::Blocks(blocks) => blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        librefang_types::message::ContentBlock::ToolResult {
+                            tool_use_id, ..
+                        } => Some(tool_use_id.clone()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>(),
+                _ => Vec::new(),
+            })
+            .collect();
+        for i in 0..10 {
+            let expected = format!("tid_{i}");
+            assert!(
+                durable_ids.contains(&expected),
+                "fold must preserve every original tool_use_id in session.messages, \
+                 missing {expected}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -220,6 +220,27 @@ pub async fn fold_stale_tool_results(
                 count = stale_count,
                 "history_fold: summarised tool-result(s) in 1 batched call"
             );
+            // Surface model-returned ids that do not match any stale
+            // tool_use_id.  Common failure modes: trailing whitespace,
+            // double-quoting (`"\"tid_3\""`), Unicode-normalised dash
+            // variants.  Without this warn the affected blocks silently
+            // fall back to `FALLBACK_SUMMARY` and operators have no way
+            // to spot the drift.
+            let stale_id_set: std::collections::BTreeSet<&str> = stale_blocks
+                .iter()
+                .map(|b| b.tool_use_id.as_str())
+                .collect();
+            let unmatched: Vec<&str> = map
+                .keys()
+                .map(String::as_str)
+                .filter(|id| !stale_id_set.contains(id))
+                .collect();
+            if !unmatched.is_empty() {
+                warn!(
+                    unmatched_ids = ?unmatched,
+                    "history_fold: model returned ids that did not match any stale tool_use_id — those blocks fall back to the static stub"
+                );
+            }
             (map, None)
         }
         Err(BatchSummariseFailure::Parse { raw, error }) => {
@@ -480,7 +501,13 @@ async fn summarise_batch(
     // Headroom for N short summaries plus the JSON wrapping.  256 was the
     // pre-#4866 per-group cap; with N blocks per call we need linear
     // headroom — 64 tokens per block is generous for 1-2 sentence outputs.
-    let max_tokens = std::cmp::max(256_usize, 64usize.saturating_mul(blocks.len())) as u32;
+    // Cap at 8192 because several providers (Groq Llama-3.1, Cerebras,
+    // older Anthropic SKUs) reject `max_tokens` above that with a 400 —
+    // and 1-2 sentences × ~125 blocks already saturates ~8k completion
+    // tokens, beyond which the per-block summary stops fitting anyway.
+    const MAX_FOLD_OUTPUT_TOKENS: usize = 8_192;
+    let max_tokens = std::cmp::max(256_usize, 64usize.saturating_mul(blocks.len()))
+        .min(MAX_FOLD_OUTPUT_TOKENS) as u32;
 
     let request = CompletionRequest {
         model: model.to_string(),
@@ -537,10 +564,21 @@ async fn summarise_batch(
 /// fenced output even when told not to.
 fn parse_labeled_summaries(text: &str) -> Result<BTreeMap<String, String>, String> {
     let body = strip_code_fence(text.trim()).unwrap_or_else(|| text.trim().to_string());
-    let parsed: Vec<serde_json::Value> =
+    let value: serde_json::Value =
         serde_json::from_str(&body).map_err(|e| format!("JSON parse failed: {e}"))?;
+    // Accept both the documented JSON-array shape AND a bare single
+    // object — providers routinely emit `{...}` instead of `[{...}]`
+    // when only one stale block was supplied (after #4866 persistence
+    // most fold passes are exactly that case).  Lifting the object into
+    // a one-element vec preserves per-id granularity instead of
+    // degrading to bulk-summary on every size-1 pass.
+    let entries: Vec<serde_json::Value> = match value {
+        serde_json::Value::Array(arr) => arr,
+        serde_json::Value::Object(_) => vec![value],
+        _ => return Err("expected JSON array or object".into()),
+    };
     let mut out: BTreeMap<String, String> = BTreeMap::new();
-    for entry in parsed {
+    for entry in entries {
         if let (Some(id), Some(summary)) = (
             entry.get("id").and_then(|x| x.as_str()),
             entry.get("summary").and_then(|x| x.as_str()),
@@ -1147,6 +1185,52 @@ mod tests {
             Some("[history-fold] fenced ok"),
             "fenced JSON response should parse identically to bare JSON"
         );
+    }
+
+    /// Single-object JSON response (no surrounding `[]`) must still
+    /// produce a per-id summary.  Providers commonly emit a bare object
+    /// when only one stale block was supplied — which is the common
+    /// case after the #4866 persistence fix, since each subsequent fold
+    /// pass tends to carry exactly one newly-stale block.
+    #[tokio::test]
+    async fn json_response_single_object_is_lifted_to_one_element() {
+        let messages = build_history(5);
+        let single = r#"{"id":"tid_0","summary":"single-object reply"}"#;
+        let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(single.to_string()));
+        let (out, result) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+        assert_eq!(
+            result.groups_used_fallback, 0,
+            "single-object happy path must NOT fall back to the static stub"
+        );
+        let tid_0_content = out.iter().find_map(|m| match &m.content {
+            MessageContent::Blocks(blocks) => blocks.iter().find_map(|b| match b {
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } if tool_use_id == "tid_0" => Some(content.clone()),
+                _ => None,
+            }),
+            _ => None,
+        });
+        assert_eq!(
+            tid_0_content.as_deref(),
+            Some("[history-fold] single-object reply"),
+            "bare-object JSON response must be lifted into a single-element array \
+             so per-id granularity is preserved on size-1 fold passes"
+        );
+        assert!(result.rewrites.contains_key("tid_0"));
     }
 
     /// Non-JSON response should NOT crash the fold — degrade to Option-1

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -85,6 +85,15 @@ const FOLD_PREVIEW_CHARS: usize = 500;
 /// Static-stub text used when the aux-LLM summarisation call fails outright.
 const FALLBACK_SUMMARY: &str = "[summarisation unavailable]";
 
+/// Hard cap on `max_tokens` requested from the summariser.  Several
+/// providers (Groq Llama-3.1, Cerebras, older Anthropic SKUs) reject
+/// `max_tokens` above 8192 with a 400; 1-2 sentence summaries × ~125
+/// blocks already saturates ~8k completion tokens, so the cap is
+/// generous in practice.  A catalog-driven per-model cap would be the
+/// long-term shape but bridges into the model catalog crate; static 8k
+/// is the simplest safe default until a fold pass actually exceeds it.
+const MAX_FOLD_OUTPUT_TOKENS: usize = 8_192;
+
 /// Result of a single fold pass.
 #[derive(Debug, Default)]
 pub struct FoldResult {
@@ -141,7 +150,8 @@ pub struct FoldConfig {
 /// Returns the (possibly modified) message list and a [`FoldResult`]
 /// summary.  Callers MUST also replay `result.rewrites` onto the durable
 /// `session.messages` and mark the session mutated — otherwise the fold
-/// is performed again from scratch on the next turn.
+/// is performed again from scratch on the next turn.  See
+/// [`apply_fold_rewrites`] for the recommended replay helper.
 pub async fn fold_stale_tool_results(
     mut messages: Vec<Message>,
     cfg: FoldConfig,
@@ -221,11 +231,13 @@ pub async fn fold_stale_tool_results(
                 "history_fold: summarised tool-result(s) in 1 batched call"
             );
             // Surface model-returned ids that do not match any stale
-            // tool_use_id.  Common failure modes: trailing whitespace,
-            // double-quoting (`"\"tid_3\""`), Unicode-normalised dash
-            // variants.  Without this warn the affected blocks silently
-            // fall back to `FALLBACK_SUMMARY` and operators have no way
-            // to spot the drift.
+            // tool_use_id AND stale ids that the model silently omitted.
+            // Common failure modes: trailing whitespace, double-quoting
+            // (`"\"tid_3\""`), Unicode-normalised dash variants, model
+            // under-delivery (returns summaries for K of N stale blocks).
+            // Without these warns the affected blocks silently fall back
+            // to `FALLBACK_SUMMARY` and operators have no way to spot
+            // the drift.
             let stale_id_set: std::collections::BTreeSet<&str> = stale_blocks
                 .iter()
                 .map(|b| b.tool_use_id.as_str())
@@ -239,6 +251,17 @@ pub async fn fold_stale_tool_results(
                 warn!(
                     unmatched_ids = ?unmatched,
                     "history_fold: model returned ids that did not match any stale tool_use_id — those blocks fall back to the static stub"
+                );
+            }
+            let missing: Vec<&str> = stale_id_set
+                .iter()
+                .copied()
+                .filter(|id| !map.contains_key(*id))
+                .collect();
+            if !missing.is_empty() {
+                warn!(
+                    missing_ids = ?missing,
+                    "history_fold: model omitted summaries for some stale tool_use_ids — those blocks fall back to the static stub"
                 );
             }
             (map, None)
@@ -306,9 +329,10 @@ pub async fn fold_stale_tool_results(
 /// caller is responsible for invoking `session.mark_messages_mutated()`
 /// in that case.
 ///
-/// This is the companion to the `rewrites` field added in #4866 to fix
-/// axis 2 (fold was previously applied only to a working clone, leaving
-/// `session.messages` to be re-folded from scratch every turn).
+/// This is the companion to [`fold_stale_tool_results`] and the
+/// [`FoldResult::rewrites`] field added in #4866 to fix axis 2 (fold was
+/// previously applied only to a working clone, leaving `session.messages`
+/// to be re-folded from scratch every turn).
 pub fn apply_fold_rewrites(messages: &mut [Message], rewrites: &BTreeMap<String, String>) -> bool {
     if rewrites.is_empty() {
         return false;
@@ -501,11 +525,8 @@ async fn summarise_batch(
     // Headroom for N short summaries plus the JSON wrapping.  256 was the
     // pre-#4866 per-group cap; with N blocks per call we need linear
     // headroom — 64 tokens per block is generous for 1-2 sentence outputs.
-    // Cap at 8192 because several providers (Groq Llama-3.1, Cerebras,
-    // older Anthropic SKUs) reject `max_tokens` above that with a 400 —
-    // and 1-2 sentences × ~125 blocks already saturates ~8k completion
-    // tokens, beyond which the per-block summary stops fitting anyway.
-    const MAX_FOLD_OUTPUT_TOKENS: usize = 8_192;
+    // Capped at MAX_FOLD_OUTPUT_TOKENS (see module-level const for the
+    // rationale).
     let max_tokens = std::cmp::max(256_usize, 64usize.saturating_mul(blocks.len()))
         .min(MAX_FOLD_OUTPUT_TOKENS) as u32;
 
@@ -577,6 +598,13 @@ fn parse_labeled_summaries(text: &str) -> Result<BTreeMap<String, String>, Strin
         serde_json::Value::Object(_) => vec![value],
         _ => return Err("expected JSON array or object".into()),
     };
+    // Distinguish "model returned an empty array" from "model returned
+    // entries but none had the {id,summary} shape" — the two failure
+    // modes need different operator interventions and squashing them
+    // into one error string costs debugging time.
+    if entries.is_empty() {
+        return Err("JSON array was empty — model returned no summaries".into());
+    }
     let mut out: BTreeMap<String, String> = BTreeMap::new();
     for entry in entries {
         if let (Some(id), Some(summary)) = (
@@ -587,7 +615,7 @@ fn parse_labeled_summaries(text: &str) -> Result<BTreeMap<String, String>, Strin
         }
     }
     if out.is_empty() {
-        return Err("JSON parsed but contained no {id,summary} entries".into());
+        return Err("JSON entries did not contain any {id,summary} pairs".into());
     }
     Ok(out)
 }
@@ -1278,6 +1306,56 @@ mod tests {
         assert!(
             all_stale_carry_raw_prose,
             "parse failure must apply the raw response as bulk summary, not the static stub"
+        );
+    }
+
+    /// JSON parse succeeds but every returned `id` is bogus (no overlap
+    /// with stale `tool_use_id`s).  The Ok-path runs, the per-block
+    /// apply loop finds no matching summary, every block falls back to
+    /// the static stub.  `groups_used_fallback` stays 0 (the aux-LLM
+    /// call itself succeeded — the operator-visible drift is surfaced
+    /// via the unmatched-ids warn, not this counter).
+    #[tokio::test]
+    async fn parse_succeeds_but_all_ids_bogus_falls_back_per_block() {
+        let messages = build_history(10); // tid_0..tid_9
+        let bogus = r#"[{"id":"not_a_real_id","summary":"won't match anything"}]"#;
+        let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(bogus.to_string()));
+
+        let (out, result) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+
+        // Ok-path → aux-call-failure counter stays 0 even though every
+        // block ended up on the static stub.
+        assert_eq!(result.groups_used_fallback, 0);
+        // But every folded block should carry the static FALLBACK_SUMMARY
+        // marker, not arbitrary text.
+        let stale_count = out
+            .iter()
+            .filter(|m| match &m.content {
+                MessageContent::Blocks(blocks) => blocks.iter().any(|b| match b {
+                    ContentBlock::ToolResult { content, .. } => {
+                        content.starts_with(FOLD_PREFIX)
+                            && content.contains("summarisation unavailable")
+                    }
+                    _ => false,
+                }),
+                _ => false,
+            })
+            .count();
+        assert!(
+            stale_count >= 8,
+            "every stale block must carry the static fallback stub when no \
+             returned id matches; saw {stale_count}"
         );
     }
 

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -6,24 +6,39 @@
 //! them into compact summaries so the LLM sees the history without the raw
 //! payload bulk.
 //!
-//! # Algorithm
+//! # Algorithm (#4866 — batched-call + persistence)
 //!
 //! 1. Walk `messages` and count assistant turns.  Any tool-result user message
 //!    that was answered before the most recent `history_fold_after_turns`
 //!    assistant turns is marked stale.
-//! 2. Group consecutive stale tool-result messages and ask the aux-LLM (or the
-//!    primary driver when no aux chain is configured) to produce a 1–2 sentence
-//!    summary per group.
-//! 3. Rewrite **each `ContentBlock::ToolResult` in the stale group in place**:
-//!    `tool_use_id` / `tool_name` / `is_error` / `status` are preserved, only
-//!    `content` is replaced with `"[history-fold] <summary>"`.
-//! 4. Pinned messages are never folded (they are protected work product).
+//! 2. Collect every stale `ContentBlock::ToolResult` across those messages
+//!    and ask the aux-LLM (or the primary driver when no aux chain is
+//!    configured) for **one** batched call that returns a JSON array of
+//!    per-`tool_use_id` summaries.
+//! 3. Rewrite each stale `ContentBlock::ToolResult.content` in place using
+//!    the matching per-id summary.  `tool_use_id` / `tool_name` / `is_error`
+//!    / `status` are preserved, only `content` is replaced with
+//!    `"[history-fold] <summary>"`.
+//! 4. Return a `FoldResult.rewrites` map (`tool_use_id → "[history-fold] …"`)
+//!    so the caller can replay the same rewrite onto the durable
+//!    `session.messages` and call `session.mark_messages_mutated()` — without
+//!    that step the fold runs from scratch every turn (axis 2 of #4866).
+//! 5. Pinned messages are never folded (they are protected work product).
+//!
+//! Earlier drafts of this module (pre-#4866) made one aux-LLM call per
+//! `group_consecutive` run of stale indices.  In practice
+//! `collect_stale_indices` always returned indices interleaved with
+//! assistant turns (e.g. `[2, 4, 6, …]`), so every group was size 1 and
+//! the cost-amortiser knob (`min_batch_size`) gated the *pass* but not the
+//! per-block calls — yielding `O(stale_count × turns)` aux-LLM round-trips.
+//! The batched call collapses the pass to one round-trip; the persistence
+//! step collapses the lifetime cost to `O(stale_count)` overall.
 //!
 //! # tool_use ↔ tool_result pairing — why we don't replace messages
 //!
-//! Earlier drafts of this module replaced each stale tool-result message with
-//! a single `Message::user(Text("[history-fold] ..."))` plain-text message.
-//! That broke conversation invariants: provider APIs (Anthropic Messages,
+//! Earlier drafts replaced each stale tool-result message with a single
+//! `Message::user(Text("[history-fold] ..."))` plain-text message.  That
+//! broke conversation invariants: provider APIs (Anthropic Messages,
 //! OpenAI Responses, Gemini function_call) require every assistant
 //! `tool_use` block to be answered by a `tool_result` block carrying the
 //! same `tool_use_id`.  Replacing the user message with free-form text
@@ -45,15 +60,18 @@
 //! # Fallback
 //!
 //! When the aux-LLM call fails (no key configured, network error, empty
-//! response), the fold falls back to a static stub:
-//! `[history-fold: <count> tool result(s) summarisation unavailable]`
-//! This ensures the stale payload is still removed from context even when the
-//! LLM is unavailable.
+//! response) the fold falls back to a static stub:
+//! `[history-fold: summarisation unavailable]`.  When the call succeeds but
+//! the response is not valid JSON the raw response text is applied to every
+//! stale block instead (degrading to Option-1 bulk-summary semantics rather
+//! than wasting the round-trip).  Either way the stale payload is removed
+//! from context.
 
 use crate::aux_client::AuxClient;
 use crate::llm_driver::{CompletionRequest, LlmDriver};
 use librefang_types::config::AuxTask;
 use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
@@ -64,18 +82,28 @@ const FOLD_PREFIX: &str = "[history-fold]";
 /// Number of characters shown in the per-tool preview inside the fold prompt.
 const FOLD_PREVIEW_CHARS: usize = 500;
 
+/// Static-stub text used when the aux-LLM summarisation call fails outright.
+const FALLBACK_SUMMARY: &str = "[summarisation unavailable]";
+
 /// Result of a single fold pass.
 #[derive(Debug, Default)]
 pub struct FoldResult {
-    /// Number of groups that were folded.
+    /// `1` when a fold pass actually rewrote at least one stale block; `0`
+    /// otherwise.  Retained as a `usize` for backward compatibility with
+    /// pre-#4866 call sites that branch on `groups_folded > 0`.
     pub groups_folded: usize,
     /// Total tool-result messages that were replaced.
     pub messages_replaced: usize,
-    /// Number of groups that fell back to the static stub because the
-    /// aux-LLM summarisation failed (#7 review follow-up: was previously a
-    /// single-bit `used_fallback`, which lost fidelity when one group in
-    /// the pass failed and others succeeded).
+    /// `1` when the aux-LLM batched call failed (network/empty) and the
+    /// pass fell back to [`FALLBACK_SUMMARY`]; `0` otherwise.  Kept as a
+    /// counter (rather than a bool) so future per-chunk batching can
+    /// surface partial failures.
     pub groups_used_fallback: usize,
+    /// Map of `tool_use_id → "[history-fold] <summary>"` content.  The
+    /// agent loop replays this onto the durable `session.messages` (and
+    /// calls `mark_messages_mutated()`) so subsequent turns don't refold
+    /// the same blocks — addressing axis 2 of #4866.
+    pub rewrites: BTreeMap<String, String>,
 }
 
 /// Tuning knobs for a single [`fold_stale_tool_results`] pass.
@@ -102,12 +130,18 @@ pub struct FoldConfig {
 ///
 /// `cfg` carries the fold-tuning knobs (see [`FoldConfig`]).
 /// `model` — model slug forwarded to the summariser.
-/// `aux_client` — optional aux-LLM client; when `None`, fallback text is used.
+/// `aux_client` — optional aux-LLM client; when `None`, the primary driver
+///   is used.  With the persistence fix the cost is `O(1)` per stale block
+///   over the session lifetime, so the primary-driver fallback is no longer
+///   the silent financial-DoS it was before #4866.
 /// `driver` — primary driver (used when aux chain resolves to primary).
 /// `reasoning_echo_policy` — catalog-driven dispatch hint for the
 /// OpenAI-compatible driver (#4842).
 ///
-/// Returns the (possibly modified) message list and a [`FoldResult`] summary.
+/// Returns the (possibly modified) message list and a [`FoldResult`]
+/// summary.  Callers MUST also replay `result.rewrites` onto the durable
+/// `session.messages` and mark the session mutated — otherwise the fold
+/// is performed again from scratch on the next turn.
 pub async fn fold_stale_tool_results(
     mut messages: Vec<Message>,
     cfg: FoldConfig,
@@ -133,11 +167,11 @@ pub async fn fold_stale_tool_results(
         return (messages, FoldResult::default());
     }
 
-    // Cost amortiser (#3 review follow-up): on a long-running session every
-    // new turn pushes exactly one fresh message across the staleness
-    // boundary, which would trigger an aux-LLM call per turn just to fold a
-    // single message. Skip the pass until at least `min_batch_size`
-    // newly-stale messages have accumulated.
+    // Cost amortiser: on a long-running session every new turn pushes
+    // exactly one fresh message across the staleness boundary, which would
+    // trigger an aux-LLM call per turn just to fold a single message.  Skip
+    // the pass until at least `min_batch_size` newly-stale messages have
+    // accumulated.
     let batch_size = std::cmp::max(min_batch_size, 1) as usize;
     if stale_indices.len() < batch_size {
         debug!(
@@ -158,79 +192,166 @@ pub async fn fold_stale_tool_results(
         .map(|c| c.driver_for(AuxTask::Fold))
         .unwrap_or_else(|| Arc::clone(&driver));
 
-    // Group consecutive stale indices so we produce one summary call per
-    // contiguous run; the summary text is then assigned to the `content`
-    // field of every `ToolResult` block in the group.
-    let groups = group_consecutive(stale_indices);
+    // Collect every stale tool-result block, in message+block order, with
+    // its `tool_use_id` / `tool_name` / preview-bounded content.  This is
+    // the payload of the batched summariser call.
+    let stale_blocks = collect_stale_blocks(&messages, &stale_indices);
 
     let mut result = FoldResult::default();
 
-    // Compute a summary string for each group.
-    let mut group_summaries: Vec<(Vec<usize>, String)> = Vec::with_capacity(groups.len());
-    for (g_idx, group) in groups.iter().enumerate() {
-        let count = group.len();
-        let group_msgs: Vec<&Message> = group.iter().map(|&i| &messages[i]).collect();
-        let summary = summarise_group(
-            group_msgs.as_slice(),
-            model,
-            &*summary_driver,
-            g_idx,
-            reasoning_echo_policy,
-        )
-        .await;
-        let text = match summary {
-            Ok(text) => {
-                info!(
-                    count,
-                    "history_fold: summarised group of {count} tool-result(s)"
-                );
-                text
-            }
-            Err(e) => {
-                warn!(
-                    count,
-                    error = %e,
-                    "history_fold: summarisation failed, using fallback stub"
-                );
-                result.groups_used_fallback += 1;
-                FALLBACK_SUMMARY.to_string()
-            }
-        };
-        result.groups_folded += 1;
-        result.messages_replaced += count;
-        group_summaries.push((group.clone(), text));
-    }
+    // One batched LLM call returns either:
+    //   - `Ok(per-id map)` on a happy-path JSON response,
+    //   - `Err(Parse{raw,…})` when the model produced a non-JSON string —
+    //     we still apply `raw` as a bulk summary to every block (Option-1
+    //     fallback) rather than waste the round-trip,
+    //   - `Err(Call|Empty)` when the aux-LLM is unreachable / returned
+    //     nothing — we apply [`FALLBACK_SUMMARY`] to every block.
+    let stale_count = stale_blocks.len();
+    let (summaries_by_id, bulk_fallback) = match summarise_batch(
+        &stale_blocks,
+        model,
+        &*summary_driver,
+        reasoning_echo_policy,
+    )
+    .await
+    {
+        Ok(map) => {
+            info!(
+                count = stale_count,
+                "history_fold: summarised tool-result(s) in 1 batched call"
+            );
+            (map, None)
+        }
+        Err(BatchSummariseFailure::Parse { raw, error }) => {
+            warn!(
+                count = stale_count,
+                error = %error,
+                "history_fold: JSON parse failed — applying raw response as bulk summary"
+            );
+            (BTreeMap::new(), Some(raw))
+        }
+        Err(err) => {
+            warn!(
+                count = stale_count,
+                error = %err,
+                "history_fold: aux-LLM batched call failed — using fallback stub"
+            );
+            result.groups_used_fallback = 1;
+            (BTreeMap::new(), Some(FALLBACK_SUMMARY.to_string()))
+        }
+    };
 
-    // Apply the summary by rewriting `ContentBlock::ToolResult.content` in
-    // place — preserving `tool_use_id` / `tool_name` / `is_error` / `status`
-    // so every original assistant `tool_use` block keeps its matching
-    // `tool_result` block.  This is the difference vs. the earlier draft
-    // that emitted a free-text stub: provider APIs reject mismatched
-    // tool_use_ids with `400 invalid_request_error`. (Pairing-preservation
+    // Apply per-block.  Preserve `tool_use_id` / `tool_name` / `is_error`
+    // / `status` so every original assistant `tool_use` block keeps its
+    // matching `tool_result` block — provider APIs reject mismatched
+    // tool_use_ids with `400 invalid_request_error`.  (Pairing-preservation
     // is module-doc invariant; see the test suite below.)
-    for (group, summary) in &group_summaries {
-        let stub_content = format!("{FOLD_PREFIX} {summary}");
-        for &i in group {
-            if let MessageContent::Blocks(blocks) = &mut messages[i].content {
-                for block in blocks.iter_mut() {
-                    if let ContentBlock::ToolResult { content, .. } = block {
-                        *content = stub_content.clone();
+    for &i in &stale_indices {
+        if let MessageContent::Blocks(blocks) = &mut messages[i].content {
+            for block in blocks.iter_mut() {
+                if let ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } = block
+                {
+                    let summary = summaries_by_id
+                        .get(tool_use_id)
+                        .cloned()
+                        .or_else(|| bulk_fallback.clone())
+                        .unwrap_or_else(|| FALLBACK_SUMMARY.to_string());
+                    let new_content = format!("{FOLD_PREFIX} {summary}");
+                    if *content != new_content {
+                        *content = new_content.clone();
+                        result.rewrites.insert(tool_use_id.clone(), new_content);
                     }
                 }
             }
         }
     }
 
+    if !result.rewrites.is_empty() {
+        result.groups_folded = 1;
+    }
+    result.messages_replaced = stale_indices.len();
+
     (messages, result)
 }
 
-/// Static-stub text used when the aux-LLM summarisation call fails.  Kept as
-/// a const so tests and call sites can spot it without string-matching.
-const FALLBACK_SUMMARY: &str = "[summarisation unavailable]";
+/// Replay a fold pass's [`FoldResult::rewrites`] onto a durable message
+/// list (typically `session.messages`).  Matches by `tool_use_id` so the
+/// caller does not have to keep the working-copy and durable lists in
+/// lock-step.  Returns `true` when at least one block was rewritten — the
+/// caller is responsible for invoking `session.mark_messages_mutated()`
+/// in that case.
+///
+/// This is the companion to the `rewrites` field added in #4866 to fix
+/// axis 2 (fold was previously applied only to a working clone, leaving
+/// `session.messages` to be re-folded from scratch every turn).
+pub fn apply_fold_rewrites(messages: &mut [Message], rewrites: &BTreeMap<String, String>) -> bool {
+    if rewrites.is_empty() {
+        return false;
+    }
+    let mut changed = false;
+    for msg in messages.iter_mut() {
+        if let MessageContent::Blocks(blocks) = &mut msg.content {
+            for block in blocks.iter_mut() {
+                if let ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } = block
+                {
+                    if let Some(new_content) = rewrites.get(tool_use_id) {
+                        if content != new_content {
+                            *content = new_content.clone();
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    changed
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Internal helpers
 // ─────────────────────────────────────────────────────────────────────────────
+
+/// One stale tool-result block flattened for the batched summariser
+/// prompt.  Kept as a struct (not a tuple) so each call site is
+/// self-documenting and the test mock can construct fixtures without
+/// positional confusion.
+struct StaleBlock {
+    tool_use_id: String,
+    tool_name: String,
+    content: String,
+}
+
+fn collect_stale_blocks(messages: &[Message], stale_indices: &[usize]) -> Vec<StaleBlock> {
+    let mut out: Vec<StaleBlock> = Vec::new();
+    for &i in stale_indices {
+        if let MessageContent::Blocks(blocks) = &messages[i].content {
+            for b in blocks {
+                if let ContentBlock::ToolResult {
+                    tool_use_id,
+                    tool_name,
+                    content,
+                    ..
+                } = b
+                {
+                    out.push(StaleBlock {
+                        tool_use_id: tool_use_id.clone(),
+                        tool_name: tool_name.clone(),
+                        content: content.clone(),
+                    });
+                }
+            }
+        }
+    }
+    out
+}
 
 /// Return the indices (into `messages`) of tool-result user messages that are
 /// older than `fold_after_turns` assistant turns from the end.
@@ -306,66 +427,60 @@ fn is_already_folded(msg: &Message) -> bool {
     }
 }
 
-/// Group a sorted list of indices into consecutive runs.
-fn group_consecutive(mut indices: Vec<usize>) -> Vec<Vec<usize>> {
-    indices.sort_unstable();
-    let mut groups: Vec<Vec<usize>> = Vec::new();
-    let mut current: Vec<usize> = Vec::new();
-
-    for idx in indices {
-        if current.is_empty() || idx == *current.last().unwrap() + 1 {
-            current.push(idx);
-        } else {
-            groups.push(current);
-            current = vec![idx];
-        }
-    }
-    if !current.is_empty() {
-        groups.push(current);
-    }
-    groups
+/// Failure modes for the batched summariser.  `Parse` retains the raw
+/// model response so the caller can fall back to Option-1 bulk-summary
+/// semantics instead of wasting the round-trip.
+enum BatchSummariseFailure {
+    Call(String),
+    Empty,
+    Parse { raw: String, error: String },
 }
 
-/// Ask the LLM to summarise a group of tool-result messages.
-async fn summarise_group(
-    group: &[&Message],
-    model: &str,
-    driver: &dyn LlmDriver,
-    group_idx: usize,
-    reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy,
-) -> Result<String, String> {
-    // Render the group to a compact text block.
-    let mut text = format!("Tool results group {}:\n", group_idx + 1);
-    for msg in group {
-        match &msg.content {
-            MessageContent::Blocks(blocks) => {
-                for block in blocks {
-                    if let ContentBlock::ToolResult {
-                        tool_name, content, ..
-                    } = block
-                    {
-                        let preview: String = content.chars().take(FOLD_PREVIEW_CHARS).collect();
-                        let has_more = content.len() > FOLD_PREVIEW_CHARS;
-                        text.push_str(&format!("- {tool_name}: {preview}"));
-                        if has_more {
-                            text.push_str(" ...[truncated]");
-                        }
-                        text.push('\n');
-                    }
-                }
-            }
-            MessageContent::Text(t) => {
-                let preview: String = t.chars().take(FOLD_PREVIEW_CHARS).collect();
-                text.push_str(&format!("- {preview}\n"));
-            }
+impl std::fmt::Display for BatchSummariseFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BatchSummariseFailure::Call(e) => write!(f, "LLM call failed: {e}"),
+            BatchSummariseFailure::Empty => write!(f, "LLM returned empty response"),
+            BatchSummariseFailure::Parse { error, .. } => write!(f, "{error}"),
         }
     }
+}
 
-    let prompt = format!(
-        "Summarise the following tool execution results in 1–2 sentences. \
-         Capture what each tool did and what it returned, omitting raw data. \
-         Output only the summary, no preamble.\n\n{text}"
+/// Ask the LLM to summarise every stale tool-result block in one batched
+/// call, returning a `tool_use_id → summary` map.  See module-doc for the
+/// algorithm rationale and the `BatchSummariseFailure` variants for the
+/// fall-back paths the caller must handle.
+async fn summarise_batch(
+    blocks: &[StaleBlock],
+    model: &str,
+    driver: &dyn LlmDriver,
+    reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy,
+) -> Result<BTreeMap<String, String>, BatchSummariseFailure> {
+    // Build the batched prompt: a JSON-array contract, one labelled line
+    // per stale block.  The `[id]` prefix is the round-trip key the model
+    // must echo back in its JSON output.
+    let mut prompt = String::from(
+        "Summarise each tool execution result below in 1-2 sentences. \
+         Capture what the tool did and what it returned, omitting raw data. \
+         Output ONLY a JSON array of objects with this shape: \
+         [{\"id\":\"<tool_use_id>\",\"summary\":\"...\"}]. \
+         Echo every id verbatim. No preamble, no markdown fences.\n\n\
+         Results:\n",
     );
+    for b in blocks {
+        let preview: String = b.content.chars().take(FOLD_PREVIEW_CHARS).collect();
+        let has_more = b.content.len() > FOLD_PREVIEW_CHARS;
+        prompt.push_str(&format!("[{}] {}: {}", b.tool_use_id, b.tool_name, preview));
+        if has_more {
+            prompt.push_str(" ...[truncated]");
+        }
+        prompt.push('\n');
+    }
+
+    // Headroom for N short summaries plus the JSON wrapping.  256 was the
+    // pre-#4866 per-group cap; with N blocks per call we need linear
+    // headroom — 64 tokens per block is generous for 1-2 sentence outputs.
+    let max_tokens = std::cmp::max(256_usize, 64usize.saturating_mul(blocks.len())) as u32;
 
     let request = CompletionRequest {
         model: model.to_string(),
@@ -379,17 +494,17 @@ async fn summarise_group(
             timestamp: None,
         }]),
         tools: Arc::new(vec![]),
-        max_tokens: 256,
+        max_tokens,
         temperature: 0.3,
         system: Some(
-            "You are a concise summariser. Produce short factual summaries of tool outputs."
+            "You are a concise summariser. Produce short factual summaries of tool outputs \
+             as a JSON array, echoing the supplied ids verbatim."
                 .to_string(),
         ),
         thinking: None,
-        // Each summary prompt embeds distinct tool-result previews, so
-        // there is no shared prefix to amortise. Caching only adds the
-        // cache-write latency / token cost without any subsequent hit.
-        // (#5 review follow-up.)
+        // Each fold call embeds distinct previews, so there is no shared
+        // prefix to amortise.  Caching only adds the cache-write cost
+        // without any subsequent hit.
         prompt_caching: false,
         cache_ttl: None,
         response_format: None,
@@ -401,17 +516,56 @@ async fn summarise_group(
         reasoning_echo_policy,
     };
 
-    match driver.complete(request).await {
-        Ok(resp) => {
-            let summary = resp.text();
-            if summary.is_empty() {
-                Err("LLM returned empty summary".to_string())
-            } else {
-                Ok(summary)
-            }
-        }
-        Err(e) => Err(format!("LLM call failed: {e}")),
+    let response = driver
+        .complete(request)
+        .await
+        .map_err(|e| BatchSummariseFailure::Call(format!("{e}")))?;
+    let raw = response.text();
+    if raw.is_empty() {
+        return Err(BatchSummariseFailure::Empty);
     }
+
+    parse_labeled_summaries(&raw).map_err(|error| BatchSummariseFailure::Parse {
+        raw: raw.clone(),
+        error,
+    })
+}
+
+/// Parse the batched-call response into a `tool_use_id → summary` map.
+/// Tolerates a single markdown code-fence wrapper around the JSON array
+/// because some providers (notably reasoning-tier models) still emit
+/// fenced output even when told not to.
+fn parse_labeled_summaries(text: &str) -> Result<BTreeMap<String, String>, String> {
+    let body = strip_code_fence(text.trim()).unwrap_or_else(|| text.trim().to_string());
+    let parsed: Vec<serde_json::Value> =
+        serde_json::from_str(&body).map_err(|e| format!("JSON parse failed: {e}"))?;
+    let mut out: BTreeMap<String, String> = BTreeMap::new();
+    for entry in parsed {
+        if let (Some(id), Some(summary)) = (
+            entry.get("id").and_then(|x| x.as_str()),
+            entry.get("summary").and_then(|x| x.as_str()),
+        ) {
+            out.insert(id.to_string(), summary.to_string());
+        }
+    }
+    if out.is_empty() {
+        return Err("JSON parsed but contained no {id,summary} entries".into());
+    }
+    Ok(out)
+}
+
+/// Strip a leading ` ```json ` / ` ``` ` and trailing ` ``` ` fence if
+/// present.  Returns `None` when there is no fence so the caller can fall
+/// back to the unfenced body.
+fn strip_code_fence(s: &str) -> Option<String> {
+    let s = s.trim();
+    let after_open = s
+        .strip_prefix("```json")
+        .or_else(|| s.strip_prefix("```JSON"))
+        .or_else(|| s.strip_prefix("```"))?;
+    let inner = after_open.trim_start_matches(['\n', '\r', ' ']);
+    let body = inner.strip_suffix("```").unwrap_or(inner);
+    Some(body.trim().to_string())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -423,6 +577,7 @@ mod tests {
     use super::*;
     use crate::llm_driver::{CompletionRequest, CompletionResponse, LlmError};
     use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -436,10 +591,14 @@ mod tests {
     }
 
     fn tool_result_msg(tool_name: &str, content: &str) -> Message {
+        tool_result_msg_with_id("id-1", tool_name, content)
+    }
+
+    fn tool_result_msg_with_id(tool_use_id: &str, tool_name: &str, content: &str) -> Message {
         Message {
             role: Role::User,
             content: MessageContent::Blocks(vec![ContentBlock::ToolResult {
-                tool_use_id: "id-1".to_string(),
+                tool_use_id: tool_use_id.to_string(),
                 tool_name: tool_name.to_string(),
                 content: content.to_string(),
                 is_error: false,
@@ -462,7 +621,46 @@ mod tests {
 
     // ── Mock drivers ─────────────────────────────────────────────────────────
 
-    /// Driver that always returns a fixed summary string.
+    /// Driver that always returns a fixed text body (NOT JSON) and counts
+    /// the number of `complete()` invocations.  Lets tests assert both
+    /// "batched-call ran exactly once" (#4866 axis 1) and "second pass
+    /// is a no-op when fold was persisted" (axis 2).
+    struct CountingTextDriver {
+        text: String,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl CountingTextDriver {
+        fn new(text: &str) -> (Self, Arc<AtomicUsize>) {
+            let calls = Arc::new(AtomicUsize::new(0));
+            (
+                CountingTextDriver {
+                    text: text.to_string(),
+                    calls: Arc::clone(&calls),
+                },
+                calls,
+            )
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LlmDriver for CountingTextDriver {
+        async fn complete(&self, _req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(CompletionResponse {
+                content: vec![ContentBlock::Text {
+                    text: self.text.clone(),
+                    provider_metadata: None,
+                }],
+                tool_calls: vec![],
+                stop_reason: librefang_types::message::StopReason::EndTurn,
+                usage: librefang_types::message::TokenUsage::default(),
+            })
+        }
+    }
+
+    /// Driver that always returns a fixed text body (no call counter).
+    /// Kept as the `OkDriver` shorthand the legacy tests reach for.
     struct OkDriver(String);
 
     #[async_trait::async_trait]
@@ -493,12 +691,15 @@ mod tests {
     // ── Tests ─────────────────────────────────────────────────────────────
 
     /// Build a message list that simulates `n_turns` turns, each containing
-    /// one user message, one assistant message, and one tool-result message.
+    /// one user message, one assistant message, and one tool-result
+    /// message.  Each tool result gets a unique `tool_use_id` so the
+    /// batched-call labelled-summary tests can match per-id.
     fn build_history(n_turns: usize) -> Vec<Message> {
         let mut msgs = vec![user_msg("initial question")];
         for i in 0..n_turns {
             msgs.push(assistant_msg(&format!("assistant response {i}")));
-            msgs.push(tool_result_msg(
+            msgs.push(tool_result_msg_with_id(
+                &format!("tid_{i}"),
                 "shell_exec",
                 &format!("output of turn {i}"),
             ));
@@ -551,13 +752,18 @@ mod tests {
         )
         .await;
 
-        assert!(
-            result.groups_folded >= 1,
-            "expected at least one group folded"
+        assert_eq!(
+            result.groups_folded, 1,
+            "expected a single batched fold pass to have run"
         );
         assert!(
             result.messages_replaced >= 1,
             "expected at least one message replaced"
+        );
+        assert!(
+            !result.rewrites.is_empty(),
+            "expected the rewrites map to capture per-tool_use_id stubs for the caller \
+             to replay onto session.messages"
         );
         // tool_use_ids must survive — pairing invariant.
         let post_ids: Vec<Vec<String>> = out.iter().map(tool_use_ids_in).collect();
@@ -594,6 +800,7 @@ mod tests {
 
         assert_eq!(result.groups_folded, 0);
         assert_eq!(result.messages_replaced, 0);
+        assert!(result.rewrites.is_empty());
         assert_eq!(out.len(), original_len, "history unchanged");
     }
 
@@ -617,11 +824,11 @@ mod tests {
         .await;
 
         // Should still fold (with fallback stubs).
-        assert!(
-            result.groups_used_fallback >= 1,
-            "expected at least one group to use the fallback stub"
+        assert_eq!(
+            result.groups_used_fallback, 1,
+            "single batched call → exactly one fallback recorded"
         );
-        assert!(result.groups_folded >= 1);
+        assert_eq!(result.groups_folded, 1);
         let fallback_present = out.iter().any(|m| match &m.content {
             MessageContent::Blocks(blocks) => blocks.iter().any(|b| match b {
                 ContentBlock::ToolResult { content, .. } => {
@@ -714,8 +921,8 @@ mod tests {
         );
     }
 
-    /// Cost amortiser (#3): when `min_batch_size > stale_count` the fold
-    /// pass exits early without calling the aux-LLM.
+    /// Cost amortiser: when `min_batch_size > stale_count` the fold pass
+    /// exits early without calling the aux-LLM.
     #[tokio::test]
     async fn min_batch_size_skips_fold_when_below_threshold() {
         // 3 stale turns; min_batch_size=4 → no fold, no aux call.
@@ -723,9 +930,9 @@ mod tests {
         let stale = collect_stale_indices(&messages, 8);
         assert_eq!(stale.len(), 3, "test setup: expected 3 stale tool results");
 
-        let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(
-            "should never be called — fold should skip below batch threshold".to_string(),
-        ));
+        let (driver_inner, calls) =
+            CountingTextDriver::new("should never be called — fold should skip below threshold");
+        let driver: Arc<dyn LlmDriver> = Arc::new(driver_inner);
         let (out, result) = fold_stale_tool_results(
             messages.clone(),
             FoldConfig {
@@ -744,8 +951,292 @@ mod tests {
             "fold must skip when stale_count < min_batch_size"
         );
         assert_eq!(result.messages_replaced, 0);
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "no aux call expected");
         // History returns unchanged.
         assert_eq!(out.len(), messages.len());
+    }
+
+    /// Axis 1 regression: every stale tool-result must be summarised by
+    /// **one** batched LLM call, not N per-block calls.
+    #[tokio::test]
+    async fn batched_call_invokes_llm_once_per_pass() {
+        let messages = build_history(10); // 8 stale, fold_after=2
+        let (driver_inner, calls) = CountingTextDriver::new("bulk summary");
+        let driver: Arc<dyn LlmDriver> = Arc::new(driver_inner);
+
+        let (_, result) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "fold must produce exactly one aux-LLM call per pass — previously \
+             every stale tool-result triggered its own call (issue #4866 axis 1)"
+        );
+        assert!(result.messages_replaced >= 8);
+    }
+
+    /// Axis 2 regression: once `rewrites` is replayed onto a durable
+    /// message list, a second fold pass on the SAME list must be a no-op
+    /// (zero aux-LLM calls, zero rewrites).  Without the persistence fix
+    /// every subsequent turn re-folded the same stale payloads from
+    /// scratch.
+    #[tokio::test]
+    async fn second_pass_is_no_op_after_rewrites_applied() {
+        let messages = build_history(10);
+        let (driver_inner, calls) = CountingTextDriver::new("bulk summary");
+        let driver: Arc<dyn LlmDriver> = Arc::new(driver_inner);
+
+        // First pass: should call the aux-LLM once and produce rewrites.
+        let (mut durable, first) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            Arc::clone(&driver),
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(!first.rewrites.is_empty());
+
+        // Simulate the agent_loop replay step: caller would apply the
+        // rewrites onto session.messages.  `durable` here already has
+        // the stubs (it is the returned working copy), so `apply_fold_rewrites`
+        // is just a no-op safety check.
+        let _ = apply_fold_rewrites(&mut durable, &first.rewrites);
+
+        // Second pass: stubs are present, fold should bail out before
+        // ever calling the aux-LLM.
+        let (_, second) = fold_stale_tool_results(
+            durable,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "second pass must NOT call the aux-LLM — previously fold re-ran \
+             from scratch every turn (issue #4866 axis 2)"
+        );
+        assert_eq!(second.groups_folded, 0);
+        assert_eq!(second.messages_replaced, 0);
+        assert!(second.rewrites.is_empty());
+    }
+
+    /// JSON happy-path: when the model returns a proper `[{id,summary}…]`
+    /// array each stale block receives its own per-id summary (Option 2
+    /// per-tool granularity preserved).
+    #[tokio::test]
+    async fn json_response_assigns_per_tool_use_id_summary() {
+        let messages = build_history(10); // tid_0..tid_9
+                                          // Hand-craft a JSON response that names a subset of stale ids.
+                                          // Anything not named falls back to FALLBACK_SUMMARY because
+                                          // `bulk_fallback` is None on the happy path.
+        let json = r#"[
+            {"id":"tid_0","summary":"listed files"},
+            {"id":"tid_1","summary":"read config"},
+            {"id":"tid_2","summary":"ran tests"},
+            {"id":"tid_3","summary":"committed change"},
+            {"id":"tid_4","summary":"pushed branch"},
+            {"id":"tid_5","summary":"opened PR"},
+            {"id":"tid_6","summary":"merged PR"},
+            {"id":"tid_7","summary":"deployed staging"}
+        ]"#;
+        let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(json.to_string()));
+
+        let (out, result) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+
+        // Every named id should now carry its specific summary.
+        let by_id: BTreeMap<String, String> = out
+            .iter()
+            .flat_map(|m| match &m.content {
+                MessageContent::Blocks(blocks) => blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                            ..
+                        } => Some((tool_use_id.clone(), content.clone())),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>(),
+                _ => Vec::new(),
+            })
+            .collect();
+        assert_eq!(
+            by_id.get("tid_0").map(String::as_str),
+            Some("[history-fold] listed files")
+        );
+        assert_eq!(
+            by_id.get("tid_3").map(String::as_str),
+            Some("[history-fold] committed change")
+        );
+        // groups_used_fallback must stay 0 on the happy path.
+        assert_eq!(result.groups_used_fallback, 0);
+        // rewrites must contain at least one entry per stale id we named.
+        assert!(result.rewrites.contains_key("tid_0"));
+        assert!(result.rewrites.contains_key("tid_7"));
+    }
+
+    /// Tolerate ```json … ``` fences around the JSON body — common with
+    /// reasoning-tier models that ignore "no markdown" instructions.
+    #[tokio::test]
+    async fn json_response_with_markdown_fence_is_accepted() {
+        let messages = build_history(5);
+        let fenced = "```json\n[{\"id\":\"tid_0\",\"summary\":\"fenced ok\"}]\n```";
+        let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(fenced.to_string()));
+        let (out, result) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+        assert_eq!(result.groups_used_fallback, 0);
+        let tid_0_content = out.iter().find_map(|m| match &m.content {
+            MessageContent::Blocks(blocks) => blocks.iter().find_map(|b| match b {
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } if tool_use_id == "tid_0" => Some(content.clone()),
+                _ => None,
+            }),
+            _ => None,
+        });
+        assert_eq!(
+            tid_0_content.as_deref(),
+            Some("[history-fold] fenced ok"),
+            "fenced JSON response should parse identically to bare JSON"
+        );
+    }
+
+    /// Non-JSON response should NOT crash the fold — degrade to Option-1
+    /// bulk summary applied to every block.  This keeps user-facing
+    /// behaviour identical to the pre-#4866 single-group fast-path so
+    /// existing call sites that rely on `messages_replaced > 0` still
+    /// signal correctly.
+    #[tokio::test]
+    async fn parse_failure_falls_back_to_raw_response_as_bulk_summary() {
+        let messages = build_history(10);
+        let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(
+            "not json at all — just prose the model produced".to_string(),
+        ));
+
+        let (out, result) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+
+        assert!(result.messages_replaced >= 8);
+        // groups_used_fallback stays 0 because the LLM call itself
+        // succeeded — only the JSON parse failed.  This matters for
+        // observability: an operator chasing "why is fold falling back"
+        // can distinguish "aux unreachable" from "model produced prose".
+        assert_eq!(result.groups_used_fallback, 0);
+        // Every stale block should carry the raw response prose.
+        let all_stale_carry_raw_prose =
+            out.iter()
+                .filter(|m| has_folded_tool_result(m))
+                .all(|m| match &m.content {
+                    MessageContent::Blocks(blocks) => blocks.iter().all(|b| match b {
+                        ContentBlock::ToolResult { content, .. } => content.contains("just prose"),
+                        _ => true,
+                    }),
+                    _ => false,
+                });
+        assert!(
+            all_stale_carry_raw_prose,
+            "parse failure must apply the raw response as bulk summary, not the static stub"
+        );
+    }
+
+    /// `apply_fold_rewrites` must walk a separate message list (typically
+    /// `session.messages`) and replay the rewrites by `tool_use_id`.
+    /// Crucial for axis 2: the working clone and the durable list can
+    /// drift in length / ordering, so id-matching is the only reliable
+    /// way to project fold onto the durable record.
+    #[test]
+    fn apply_fold_rewrites_matches_by_tool_use_id_across_lists() {
+        let mut durable = vec![
+            user_msg("q"),
+            assistant_msg("a"),
+            tool_result_msg_with_id("tid_A", "shell", "raw output A"),
+            assistant_msg("a2"),
+            tool_result_msg_with_id("tid_B", "shell", "raw output B"),
+        ];
+        let mut rewrites = BTreeMap::new();
+        rewrites.insert("tid_A".to_string(), "[history-fold] A summary".to_string());
+        // tid_C does not exist in `durable` — must be silently skipped.
+        rewrites.insert("tid_C".to_string(), "[history-fold] dangling".to_string());
+
+        let changed = apply_fold_rewrites(&mut durable, &rewrites);
+        assert!(changed, "expected at least one match (tid_A)");
+
+        let a_content = match &durable[2].content {
+            MessageContent::Blocks(blocks) => match &blocks[0] {
+                ContentBlock::ToolResult { content, .. } => content.clone(),
+                _ => String::new(),
+            },
+            _ => String::new(),
+        };
+        assert_eq!(a_content, "[history-fold] A summary");
+
+        // tid_B was not in the rewrites map — must remain untouched.
+        let b_content = match &durable[4].content {
+            MessageContent::Blocks(blocks) => match &blocks[0] {
+                ContentBlock::ToolResult { content, .. } => content.clone(),
+                _ => String::new(),
+            },
+            _ => String::new(),
+        };
+        assert_eq!(b_content, "raw output B");
     }
 
     #[test]
@@ -769,12 +1260,6 @@ mod tests {
             !stale.contains(&4),
             "index 4 should not be stale, got {stale:?}"
         );
-    }
-
-    #[test]
-    fn group_consecutive_basic() {
-        let g = group_consecutive(vec![0, 1, 2, 5, 6, 9]);
-        assert_eq!(g, vec![vec![0, 1, 2], vec![5, 6], vec![9]]);
     }
 
     #[tokio::test]
@@ -849,5 +1334,26 @@ mod tests {
             !stale.contains(&2),
             "pinned message should never be stale: {stale:?}"
         );
+    }
+
+    #[test]
+    fn strip_code_fence_handles_json_label() {
+        let fenced = "```json\n[{\"id\":\"x\",\"summary\":\"y\"}]\n```";
+        let body = strip_code_fence(fenced).expect("should strip ```json fence");
+        assert!(body.starts_with('['));
+        assert!(body.ends_with(']'));
+    }
+
+    #[test]
+    fn strip_code_fence_handles_bare_triple_backtick() {
+        let fenced = "```\n[1,2,3]\n```";
+        let body = strip_code_fence(fenced).expect("should strip ``` fence");
+        assert_eq!(body, "[1,2,3]");
+    }
+
+    #[test]
+    fn strip_code_fence_returns_none_when_unfenced() {
+        assert!(strip_code_fence("plain text").is_none());
+        assert!(strip_code_fence("[1,2,3]").is_none());
     }
 }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -2344,14 +2344,6 @@ impl ModelsResource {
         .await
     }
 
-    pub async fn enable_provider(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/providers/{}/enable", name), None, &[]).await
-    }
-
-    pub async fn enable_provider(&self, name: &str) -> Result<Value> {
-        do_req(&self.client, &self.base_url, reqwest::Method::POST, &format!("/api/providers/{}/enable", name), None, &[]).await
-    }
-
     pub async fn set_provider_key(&self, name: &str, data: Value) -> Result<Value> {
         do_req(
             &self.client,


### PR DESCRIPTION
## Summary

Closes #4866 — fold was burning `O(stale_count × turns)` aux-LLM round-trips and refolding the same payloads on every turn.

* **Axis 1 (size-1 groups):** old `group_consecutive` over `[2, 4, 6, …]` always split stale indices into size-1 runs → one aux-LLM call per stale tool-result + one info log per call. Replaced with **one batched LLM call** per pass that returns a JSON array of `{id, summary}` entries — per-`tool_use_id` granularity preserved (Option 2 from the issue).
* **Axis 2 (no persistence):** fold rewrote `prepare_llm_messages`' working clone, never `session.messages`, so the `is_already_folded` guard was dead on the live path and every subsequent turn refolded the same blocks. `FoldResult.rewrites` now exposes the per-id stub map; `agent_loop::maybe_fold_stale_tool_results` replays it onto `session.messages` and calls `mark_messages_mutated()`. Lifetime cost is now `O(stale_count)` — each block folded once per session, then short-circuited by `is_already_folded` forever after.

Fallback behaviour:

* Aux-LLM call fails / empty response → static `FALLBACK_SUMMARY` stub applied to every stale block (pre-existing behaviour, kept).
* LLM call succeeds but the response isn't valid JSON → raw response text applied as a single bulk summary across every block. This degrades cleanly to Option-1 semantics for models that ignore the format contract, rather than wasting the round-trip.
* Markdown ` ```json ` fences around the JSON array are stripped before parsing.

The old `group_consecutive` helper and its per-group LLM call are deleted — they were the source of the bug, not a useful seam.

## Verification

* `cargo check --workspace --lib` — clean.
* `cargo clippy -p librefang-runtime --all-targets -- -D warnings` — clean.
* `cargo test -p librefang-runtime --lib` — **1578 passed**, 0 failed.
* New regression tests in `crates/librefang-runtime/src/history_fold.rs`:
  * `batched_call_invokes_llm_once_per_pass` — axis 1.
  * `second_pass_is_no_op_after_rewrites_applied` — axis 2.
  * `json_response_assigns_per_tool_use_id_summary` — Option 2 happy path.
  * `json_response_with_markdown_fence_is_accepted` — fenced JSON tolerated.
  * `parse_failure_falls_back_to_raw_response_as_bulk_summary` — Option-1 degradation.
  * `apply_fold_rewrites_matches_by_tool_use_id_across_lists` — id-match projection across separate lists.
* Existing integration test `agent_loop::tests::test_history_fold_stub_appears_in_llm_request_after_enough_tool_cycles` still passes.

## Test plan

- [ ] CI: Unit (lib+bin) green.
- [ ] CI: Ubuntu shards 1–4 green (integration tests, especially `librefang-api` — fold path is upstream of every LLM call).
- [ ] CI: macOS / Windows green.
- [ ] CI: clippy `-D warnings` green.
- [ ] Maintainer live-daemon smoke (optional, only if changing LLM call shape needs eyes-on): hit a long-session agent with ≥ `history_fold_after_turns + min_batch_size` stale tool-results, confirm the log line now reads `summarised N tool-result(s) in 1 batched call` exactly once instead of N `summarised group of 1` lines per turn, and that the same session reloaded shows zero fold log lines on the next turn (persistence).

## Notes for reviewers

* The wrapper `maybe_fold_stale_tool_results` now takes `&mut Session`. Both call sites (non-streaming + streaming) updated.
* I considered moving the fold call from inside the loop to before `prepare_llm_messages`, but the inside-loop position is correct: each loop iteration appends new assistant turns which can push older tool-results across the staleness boundary mid-flight. The persistence step makes the repeat cost zero, so the inside-loop placement is now free.
* `groups_folded` and `groups_used_fallback` remain `usize` for backward compatibility with existing call-site branches; semantics are now `0 | 1` per pass since there is exactly one batched call.