### PR TITLE
fix(channels,kernel): scope `/new` to the calling channel + purge JSONL on delete (#4868)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -332,7 +332,7 @@ use librefang_kernel::config::load_config as kernel_load_config;
 use librefang_kernel::llm_driver::StreamEvent;
 use librefang_kernel::DeliveryTracker;
 use librefang_kernel::KernelApi;
-use librefang_types::agent::AgentId;
+use librefang_types::agent::{AgentId, ResetScope, SessionId};
 use std::sync::Arc;
 #[cfg(feature = "channel-telegram")]
 use std::time::Duration;
@@ -1659,14 +1659,16 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
 
     async fn reset_session(&self, agent_id: AgentId) -> Result<String, String> {
         self.kernel
-            .reset_session(agent_id)
+            .reset_session(agent_id, ResetScope::Agent)
+            .await
             .map_err(|e| format!("{e}"))?;
         Ok("Session reset. Chat history cleared.".to_string())
     }
 
     async fn reboot_session(&self, agent_id: AgentId) -> Result<String, String> {
         self.kernel
-            .reboot_session(agent_id)
+            .reboot_session(agent_id, ResetScope::Agent)
+            .await
             .map_err(|e| format!("{e}"))?;
         Ok("Session rebooted. Context cleared.".to_string())
     }
@@ -1674,6 +1676,51 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
     async fn compact_session(&self, agent_id: AgentId) -> Result<String, String> {
         self.kernel
             .compact_agent_session(agent_id)
+            .await
+            .map_err(|e| format!("{e}"))
+    }
+
+    async fn reset_channel_session(
+        &self,
+        agent_id: AgentId,
+        channel: &str,
+        chat_id: Option<&str>,
+    ) -> Result<String, String> {
+        let sid = SessionId::for_sender_scope(agent_id, channel, chat_id);
+        self.kernel
+            .reset_session(agent_id, ResetScope::Session(sid))
+            .await
+            .map_err(|e| format!("{e}"))?;
+        Ok(format!(
+            "Session reset for this {channel} chat. Other surfaces untouched."
+        ))
+    }
+
+    async fn reboot_channel_session(
+        &self,
+        agent_id: AgentId,
+        channel: &str,
+        chat_id: Option<&str>,
+    ) -> Result<String, String> {
+        let sid = SessionId::for_sender_scope(agent_id, channel, chat_id);
+        self.kernel
+            .reboot_session(agent_id, ResetScope::Session(sid))
+            .await
+            .map_err(|e| format!("{e}"))?;
+        Ok(format!(
+            "Session rebooted for this {channel} chat. Other surfaces untouched."
+        ))
+    }
+
+    async fn compact_channel_session(
+        &self,
+        agent_id: AgentId,
+        channel: &str,
+        chat_id: Option<&str>,
+    ) -> Result<String, String> {
+        let sid = SessionId::for_sender_scope(agent_id, channel, chat_id);
+        self.kernel
+            .compact_agent_session_with_id(agent_id, Some(sid))
             .await
             .map_err(|e| format!("{e}"))
     }
@@ -4769,6 +4816,46 @@ mod tests {
             lookups.get(),
             1,
             "SMTP-side lookup must NOT run after IMAP fails — short-circuit via the `?` operator on the first read_env call"
+        );
+    }
+
+    /// `SessionId::for_sender_scope` is the SINGLE source of truth for the
+    /// channel-scope formula and is called by both ends of the round-trip
+    /// (the channel-bridge reset helpers and the four kernel inbound
+    /// resolvers — `kernel/messaging.rs::send_message_full`,
+    /// `kernel/agent_execution.rs`, `kernel/mod.rs::resolve_dispatch_session_id`).
+    /// This test pins its output: empty `chat_id` collapses to channel-only
+    /// (matching `build_sender_context`'s empty-platform-id case), and the
+    /// `format!("{ch}:{cid}")` joiner matches what the inline formulas
+    /// produced before extraction. If these inputs ever produce different
+    /// sids than the legacy formula did, channel `/new` will delete a
+    /// different sid than the one the next inbound message resolves to,
+    /// silently regressing #4868.
+    #[test]
+    fn for_sender_scope_matches_legacy_inline_formula() {
+        use librefang_types::agent::SessionId;
+        let agent = AgentId(uuid::Uuid::new_v4());
+
+        // Channel + chat — the most common case (Telegram, Slack, Discord).
+        let with_chat = SessionId::for_sender_scope(agent, "telegram", Some("chat-1"));
+        let legacy_with_chat = SessionId::for_channel(agent, "telegram:chat-1");
+        assert_eq!(
+            with_chat, legacy_with_chat,
+            "channel + chat sid must match the legacy inline scope formula (#4868)"
+        );
+
+        // Channel without chat (DM-style adapter that doesn't disambiguate).
+        let dm = SessionId::for_sender_scope(agent, "webhook", None);
+        let legacy_dm = SessionId::for_channel(agent, "webhook");
+        assert_eq!(dm, legacy_dm, "channel-only sid must match (#4868)");
+
+        // Empty chat_id is treated identically to None — same path the
+        // resolver hits when ctx.chat_id is Some("").
+        let empty = SessionId::for_sender_scope(agent, "discord", Some(""));
+        let legacy_empty = SessionId::for_channel(agent, "discord");
+        assert_eq!(
+            empty, legacy_empty,
+            "empty chat_id collapses to channel-only (#4868)"
         );
     }
 

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -201,7 +201,7 @@ use dashmap::DashMap;
 use librefang_channels::types::SenderContext;
 use librefang_kernel::kernel_handle::prelude::*;
 use librefang_kernel::kernel_handle::SessionWriter;
-use librefang_types::agent::{AgentId, AgentIdentity, AgentManifest};
+use librefang_types::agent::{AgentId, AgentIdentity, AgentManifest, ResetScope};
 use librefang_types::i18n::ErrorTranslator;
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
@@ -3420,27 +3420,41 @@ pub async fn reset_session(
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
-    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    // `ErrorTranslator` is `!Send` (per repo CLAUDE.md) — never hold it
+    // across an `.await`, or axum's `Handler` trait bound fails with a
+    // cryptic message. Same shape as `compact_session` below.
+    let l = super::resolve_lang(lang.as_ref());
+    let err_invalid_id = {
+        let t = ErrorTranslator::new(l);
+        t.t("api-error-agent-invalid-id")
+    };
     let agent_id: AgentId = match id.parse() {
         Ok(id) => id,
         Err(_) => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": t.t("api-error-agent-invalid-id")})),
+                Json(serde_json::json!({"error": err_invalid_id})),
             )
         }
     };
-    match state.kernel.reset_session(agent_id) {
+    match state
+        .kernel
+        .reset_session(agent_id, ResetScope::Agent)
+        .await
+    {
         Ok(()) => (
             StatusCode::OK,
             Json(serde_json::json!({"status": "ok", "message": "Session reset"})),
         ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(
-                serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
-            ),
-        ),
+        Err(e) => {
+            let t = ErrorTranslator::new(l);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
+                ),
+            )
+        }
     }
 }
 
@@ -3459,29 +3473,41 @@ pub async fn reboot_session(
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
-    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    // `ErrorTranslator` is `!Send` — see note in `reset_session` above.
+    let l = super::resolve_lang(lang.as_ref());
+    let err_invalid_id = {
+        let t = ErrorTranslator::new(l);
+        t.t("api-error-agent-invalid-id")
+    };
     let agent_id: AgentId = match id.parse() {
         Ok(id) => id,
         Err(_) => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": t.t("api-error-agent-invalid-id")})),
+                Json(serde_json::json!({"error": err_invalid_id})),
             )
         }
     };
-    match state.kernel.reboot_session(agent_id) {
+    match state
+        .kernel
+        .reboot_session(agent_id, ResetScope::Agent)
+        .await
+    {
         Ok(()) => (
             StatusCode::OK,
             Json(
                 serde_json::json!({"status": "ok", "message": "Session rebooted. Context cleared."}),
             ),
         ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(
-                serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
-            ),
-        ),
+        Err(e) => {
+            let t = ErrorTranslator::new(l);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
+                ),
+            )
+        }
     }
 }
 
@@ -3500,33 +3526,44 @@ pub async fn clear_agent_history(
     Path(id): Path<String>,
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
-    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    // `ErrorTranslator` is `!Send` — see note in `reset_session` above.
+    let l = super::resolve_lang(lang.as_ref());
+    let (err_invalid_id, err_not_found) = {
+        let t = ErrorTranslator::new(l);
+        (
+            t.t("api-error-agent-invalid-id"),
+            t.t("api-error-agent-not-found"),
+        )
+    };
     let agent_id: AgentId = match id.parse() {
         Ok(id) => id,
         Err(_) => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": t.t("api-error-agent-invalid-id")})),
+                Json(serde_json::json!({"error": err_invalid_id})),
             )
         }
     };
     if state.kernel.agent_registry().get(agent_id).is_none() {
         return (
             StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
+            Json(serde_json::json!({"error": err_not_found})),
         );
     }
-    match state.kernel.clear_agent_history(agent_id) {
+    match state.kernel.clear_agent_history(agent_id).await {
         Ok(()) => (
             StatusCode::OK,
             Json(serde_json::json!({"status": "ok", "message": "All history cleared"})),
         ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(
-                serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
-            ),
-        ),
+        Err(e) => {
+            let t = ErrorTranslator::new(l);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
+                ),
+            )
+        }
     }
 }
 

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -3446,6 +3446,17 @@ pub async fn reset_session(
             StatusCode::OK,
             Json(serde_json::json!({"status": "ok", "message": "Session reset"})),
         ),
+        Err(crate::error::KernelError::LibreFang(
+            librefang_types::error::LibreFangError::InvalidInput(msg),
+        )) => {
+            let t = ErrorTranslator::new(l);
+            (
+                StatusCode::BAD_REQUEST,
+                Json(
+                    serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &msg)])}),
+                ),
+            )
+        }
         Err(e) => {
             let t = ErrorTranslator::new(l);
             (
@@ -3499,6 +3510,17 @@ pub async fn reboot_session(
                 serde_json::json!({"status": "ok", "message": "Session rebooted. Context cleared."}),
             ),
         ),
+        Err(crate::error::KernelError::LibreFang(
+            librefang_types::error::LibreFangError::InvalidInput(msg),
+        )) => {
+            let t = ErrorTranslator::new(l);
+            (
+                StatusCode::BAD_REQUEST,
+                Json(
+                    serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &msg)])}),
+                ),
+            )
+        }
         Err(e) => {
             let t = ErrorTranslator::new(l);
             (

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -24,7 +24,7 @@ use librefang_channels::types::SenderContext;
 use librefang_kernel::kernel_handle::prelude::*;
 use librefang_kernel::llm_driver::{StreamEvent, PHASE_RESPONSE_COMPLETE};
 use librefang_kernel::llm_errors;
-use librefang_types::agent::{AgentId, SessionId};
+use librefang_types::agent::{AgentId, ResetScope, SessionId};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, SocketAddr};
@@ -1426,13 +1426,21 @@ async fn handle_command(
                 serde_json::json!({"type": "error", "content": format!("New session failed: {e}")})
             }
         },
-        "reset" => match state.kernel.reset_session(agent_id) {
+        "reset" => match state
+            .kernel
+            .reset_session(agent_id, ResetScope::Agent)
+            .await
+        {
             Ok(()) => {
                 serde_json::json!({"type": "command_result", "command": "reset", "message": "Session reset. Chat history cleared."})
             }
             Err(e) => serde_json::json!({"type": "error", "content": format!("Reset failed: {e}")}),
         },
-        "reboot" => match state.kernel.reboot_session(agent_id) {
+        "reboot" => match state
+            .kernel
+            .reboot_session(agent_id, ResetScope::Agent)
+            .await
+        {
             Ok(()) => {
                 serde_json::json!({"type": "command_result", "command": "reboot", "message": "Session rebooted. Context cleared."})
             }

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -165,18 +165,67 @@ pub trait ChannelBridgeHandle: Send + Sync {
         Err("Not implemented".to_string())
     }
 
-    /// Reset an agent's session (clear messages, fresh session ID).
+    /// Reset every session for an agent (default + per-channel + cron).
+    /// Used by surfaces that mean "wipe this agent" — dashboard / explicit
+    /// admin reset. Channel `/new` should call [`Self::reset_channel_session`]
+    /// instead so other surfaces are not collateral damage (#4868).
     async fn reset_session(&self, _agent_id: AgentId) -> Result<String, String> {
         Err("Not implemented".to_string())
     }
 
-    /// Hard-reboot an agent's session — full context clear without saving summary.
+    /// Hard-reboot every session for an agent — full context clear without
+    /// saving summaries. Channel `/reboot` should call
+    /// [`Self::reboot_channel_session`] instead (#4868).
     async fn reboot_session(&self, _agent_id: AgentId) -> Result<String, String> {
         Err("Not implemented".to_string())
     }
 
-    /// Trigger LLM-based session compaction for an agent.
+    /// Trigger LLM-based session compaction for an agent's registry-pointer
+    /// session. Channel `/compact` should call
+    /// [`Self::compact_channel_session`] instead so it operates on the
+    /// per-channel session the user is actually chatting in (#4868).
     async fn compact_session(&self, _agent_id: AgentId) -> Result<String, String> {
+        Err("Not implemented".to_string())
+    }
+
+    /// Reset only the session derived from `(channel, chat_id)` — the
+    /// per-channel session that channel `/new` actually means to clear
+    /// (#4868). Sibling sessions (other channels, dashboard) stay intact.
+    ///
+    /// `chat_id` follows the inbound-message convention: `None` for an
+    /// adapter that doesn't disambiguate by chat (the channel name itself
+    /// becomes the scope), `Some(<sender.platform_id>)` otherwise — the same
+    /// pair the channel resolver uses to derive
+    /// [`librefang_types::agent::SessionId::for_channel`] for inbound traffic.
+    async fn reset_channel_session(
+        &self,
+        _agent_id: AgentId,
+        _channel: &str,
+        _chat_id: Option<&str>,
+    ) -> Result<String, String> {
+        Err("Not implemented".to_string())
+    }
+
+    /// Hard-reboot only the per-channel session derived from
+    /// `(channel, chat_id)` — no summary saved (#4868).
+    async fn reboot_channel_session(
+        &self,
+        _agent_id: AgentId,
+        _channel: &str,
+        _chat_id: Option<&str>,
+    ) -> Result<String, String> {
+        Err("Not implemented".to_string())
+    }
+
+    /// Compact only the per-channel session derived from
+    /// `(channel, chat_id)` — operates on the session the channel user is
+    /// chatting in, not the agent's registry-pointer session (#4868).
+    async fn compact_channel_session(
+        &self,
+        _agent_id: AgentId,
+        _channel: &str,
+        _chat_id: Option<&str>,
+    ) -> Result<String, String> {
         Err("Not implemented".to_string())
     }
 
@@ -4837,17 +4886,29 @@ async fn handle_command(
             }
         }
         "new" => {
-            // Need to resolve the user's current agent
+            // Resolve the user's current agent and the channel-derived sid
+            // so /new only resets THIS chat (#4868). The (channel, chat_id)
+            // pair must match `build_sender_context` exactly so the sid we
+            // delete here equals the sid the next inbound message will
+            // resolve via `SessionId::for_channel`.
             let agent_id = router.resolve(
                 channel_type,
                 &sender.platform_id,
                 sender.librefang_user.as_deref(),
             );
             match agent_id {
-                Some(aid) => handle
-                    .reset_session(aid)
-                    .await
-                    .unwrap_or_else(|e| format!("Error: {e}")),
+                Some(aid) => {
+                    let ch = channel_type_str(channel_type);
+                    let chat = if sender.platform_id.is_empty() {
+                        None
+                    } else {
+                        Some(sender.platform_id.as_str())
+                    };
+                    handle
+                        .reset_channel_session(aid, ch, chat)
+                        .await
+                        .unwrap_or_else(|e| format!("Error: {e}"))
+                }
                 None => "No agent selected. Use /agent <name> first.".to_string(),
             }
         }
@@ -4858,10 +4919,18 @@ async fn handle_command(
                 sender.librefang_user.as_deref(),
             );
             match agent_id {
-                Some(aid) => handle
-                    .reboot_session(aid)
-                    .await
-                    .unwrap_or_else(|e| format!("Error: {e}")),
+                Some(aid) => {
+                    let ch = channel_type_str(channel_type);
+                    let chat = if sender.platform_id.is_empty() {
+                        None
+                    } else {
+                        Some(sender.platform_id.as_str())
+                    };
+                    handle
+                        .reboot_channel_session(aid, ch, chat)
+                        .await
+                        .unwrap_or_else(|e| format!("Error: {e}"))
+                }
                 None => "No agent selected. Use /agent <name> first.".to_string(),
             }
         }
@@ -4872,10 +4941,18 @@ async fn handle_command(
                 sender.librefang_user.as_deref(),
             );
             match agent_id {
-                Some(aid) => handle
-                    .compact_session(aid)
-                    .await
-                    .unwrap_or_else(|e| format!("Error: {e}")),
+                Some(aid) => {
+                    let ch = channel_type_str(channel_type);
+                    let chat = if sender.platform_id.is_empty() {
+                        None
+                    } else {
+                        Some(sender.platform_id.as_str())
+                    };
+                    handle
+                        .compact_channel_session(aid, ch, chat)
+                        .await
+                        .unwrap_or_else(|e| format!("Error: {e}"))
+                }
                 None => "No agent selected. Use /agent <name> first.".to_string(),
             }
         }

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -284,11 +284,8 @@ impl LibreFangKernel {
         } else {
             match sender_context {
                 Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
-                    let scope = match &ctx.chat_id {
-                        Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
-                        _ => ctx.channel.clone(),
-                    };
-                    let derived = SessionId::for_channel(agent_id, &scope);
+                    let derived =
+                        SessionId::for_sender_scope(agent_id, &ctx.channel, ctx.chat_id.as_deref());
                     // #3692: surface when the channel branch silently
                     // overrides a non-default manifest `session_mode`.
                     // The `execute_llm_agent` path is reached by

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -1795,11 +1795,8 @@ impl LibreFangKernel {
         } else {
             match sender_context {
                 Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
-                    let scope = match &ctx.chat_id {
-                        Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
-                        _ => ctx.channel.clone(),
-                    };
-                    let derived = SessionId::for_channel(agent_id, &scope);
+                    let derived =
+                        SessionId::for_sender_scope(agent_id, &ctx.channel, ctx.chat_id.as_deref());
                     // #3692: surface when the channel branch silently
                     // overrides a non-default manifest `session_mode`.
                     // Operators previously had no way to tell from logs

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -614,11 +614,7 @@ fn resolve_dispatch_session_id(
     }
     Some(match sender_context {
         Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
-            let scope = match &ctx.chat_id {
-                Some(cid) if !cid.is_empty() => format!("{}:{}", ctx.channel, cid),
-                _ => ctx.channel.clone(),
-            };
-            SessionId::for_channel(agent_id, &scope)
+            SessionId::for_sender_scope(agent_id, &ctx.channel, ctx.chat_id.as_deref())
         }
         _ => {
             let mode = session_mode_override.unwrap_or(manifest_session_mode);

--- a/crates/librefang-kernel/src/kernel/session_ops.rs
+++ b/crates/librefang-kernel/src/kernel/session_ops.rs
@@ -212,32 +212,54 @@ impl LibreFangKernel {
     /// Implementation of [`ResetScope::Agent`] — wipe every session for this
     /// agent. `save_summary` distinguishes reset (true) vs. reboot (false).
     ///
-    /// Acquires `agents.agent_msg_locks[agent_id]` before deleting so an
-    /// in-flight inbound turn (which holds the same lock — see
-    /// `messaging.rs::send_message_full`) cannot resurrect the session
-    /// with stale history after the reset completes (#4868 review).
+    /// Lock discipline (#4868 review): `send_message_full` and the streaming
+    /// path acquire EITHER `agent_msg_locks[agent_id]` OR
+    /// `session_msg_locks[sid]` depending on whether the caller supplied a
+    /// `session_id_override` (multi-tab WS / scoped HTTP — #2959). Holding
+    /// just the agent lock would leave a revive-after-delete window for
+    /// any concurrent override-using turn: it could finish its work and
+    /// UPSERT a deleted session row back into existence. So we acquire the
+    /// agent lock, snapshot the live sids under it, then take every
+    /// per-session lock (sorted to keep a deterministic order across
+    /// callers). All guards are held through the delete + recreate.
     async fn reset_all_sessions(
         &self,
         agent_id: AgentId,
         entry: &AgentEntry,
         save_summary: bool,
     ) -> KernelResult<()> {
-        let lock = self
+        let agent_lock = self
             .agents
             .agent_msg_locks
             .entry(agent_id)
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone();
-        let _guard = lock.lock().await;
+        let _agent_guard = agent_lock.lock_owned().await;
 
         // Auto-save session summaries for ALL sessions (default + per-channel)
         // before clearing, so no channel's conversation history is silently lost.
         // Also emit session:end for each active session before deletion.
-        let pre_delete_sids = self
+        let mut pre_delete_sids = self
             .memory
             .substrate
             .get_agent_session_ids(agent_id)
             .unwrap_or_default();
+        // Sort so two concurrent agent-wide resets on different agents that
+        // somehow shared a sid (impossible today — sids hash in agent_id —
+        // but cheap insurance) can never form a deadlock cycle on the
+        // session locks.
+        pre_delete_sids.sort_by_key(|s| s.0);
+        let mut _session_guards: Vec<tokio::sync::OwnedMutexGuard<()>> =
+            Vec::with_capacity(pre_delete_sids.len());
+        for sid in &pre_delete_sids {
+            let lock = self
+                .agents
+                .session_msg_locks
+                .entry(*sid)
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone();
+            _session_guards.push(lock.lock_owned().await);
+        }
         for sid in &pre_delete_sids {
             if let Ok(Some(old_session)) = self.memory.substrate.get_session(*sid) {
                 // Fire session:end before removing the old session.
@@ -308,7 +330,8 @@ impl LibreFangKernel {
         info!(
             agent_id = %agent_id,
             save_summary,
-            "Agent-wide session reset"
+            op = if save_summary { "reset" } else { "reboot" },
+            "Agent-wide session wipe complete"
         );
         Ok(())
     }
@@ -322,14 +345,14 @@ impl LibreFangKernel {
     /// — the next inbound message on that channel will resolve back to the
     /// same id and we want it to land on a fresh empty session, not a 404.
     ///
-    /// Lock discipline (#4868 review, lock-race fix): an in-flight turn on
-    /// this agent holds either `agent_msg_locks[agent_id]` (the common
-    /// channel-inbound path with no explicit session_id_override) or
-    /// `session_msg_locks[sid]` (the multi-tab HTTP path with an explicit
-    /// override). Without acquiring both, the in-flight turn's later
-    /// `save_session` UPSERT would silently revive the just-deleted row.
-    /// We acquire both in the same agent-then-session order
-    /// `send_message_full` uses, so no deadlock can form.
+    /// Lock discipline (#4868 review, lock-race fix): `send_message_full`
+    /// acquires EITHER `agent_msg_locks[agent_id]` OR `session_msg_locks[sid]`
+    /// — never both, branching on `session_id_override`. Without acquiring
+    /// both here, an in-flight turn on either path could finish after the
+    /// delete and UPSERT the row back via `save_session`. We take agent
+    /// then session; no deadlock cycle is possible because
+    /// `send_message_full` only ever holds one of the two, so the second
+    /// lock here is never blocked by a caller already holding the first.
     ///
     /// JSONL asymmetry: the recreated empty session is persisted to SQL
     /// but its `<workspace>/sessions/{sid}.jsonl` mirror is intentionally
@@ -468,7 +491,8 @@ impl LibreFangKernel {
             session_id = %sid,
             existed = old_session.is_some(),
             save_summary,
-            "Per-session reset complete (sibling sessions untouched)"
+            op = if save_summary { "reset" } else { "reboot" },
+            "Per-session wipe complete (sibling sessions untouched)"
         );
         Ok(())
     }

--- a/crates/librefang-kernel/src/kernel/session_ops.rs
+++ b/crates/librefang-kernel/src/kernel/session_ops.rs
@@ -163,30 +163,93 @@ impl LibreFangKernel {
         }
     }
 
-    /// Reset an agent's session — auto-saves a summary to memory, then clears messages
-    /// and creates a fresh session ID.
-    pub fn reset_session(&self, agent_id: AgentId) -> KernelResult<()> {
+    /// Reset an agent's session(s) — auto-saves a summary to memory, then
+    /// clears messages and prepares a fresh session.
+    ///
+    /// `scope` chooses between agent-wide and per-session semantics (#4868):
+    ///
+    /// - [`ResetScope::Agent`] — historical behaviour. Saves a summary for
+    ///   every session (default + per-channel + cron-spawned), deletes all
+    ///   rows, creates one fresh registry-pointer session, resets quota.
+    ///   Used by the dashboard / explicit `POST /api/agents/{id}/session/reset`.
+    /// - [`ResetScope::Session(sid)`] — scoped delete. Saves the summary for
+    ///   that one session, deletes only that row + its FTS index + its JSONL
+    ///   mirror, eagerly recreates an empty session at the same deterministic
+    ///   sid (so the channel resolver lands on it on the next inbound
+    ///   message), and leaves all other sessions untouched. Quota is **not**
+    ///   reset (per-channel resets must not give one user a way to clear an
+    ///   agent-wide token-quota state). Used by channel `/new`.
+    pub async fn reset_session(&self, agent_id: AgentId, scope: ResetScope) -> KernelResult<()> {
         let entry = self.agents.registry.get(agent_id).ok_or_else(|| {
             KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
         })?;
 
+        match scope {
+            ResetScope::Session(sid) => self.reset_one_session(agent_id, sid, &entry, true).await,
+            ResetScope::Agent => self.reset_all_sessions(agent_id, &entry, true).await,
+        }
+    }
+
+    /// Hard-reboot an agent's session(s) — clears conversation history WITHOUT
+    /// saving a summary to memory. Keeps agent config, system prompt, and
+    /// tools intact. More aggressive than `reset_session` (which auto-saves a
+    /// summary) but less destructive than `clear_agent_history` (which wipes
+    /// the canonical session as well).
+    ///
+    /// `scope` follows the same agent-wide vs. per-session split as
+    /// [`Self::reset_session`] (#4868).
+    pub async fn reboot_session(&self, agent_id: AgentId, scope: ResetScope) -> KernelResult<()> {
+        let entry = self.agents.registry.get(agent_id).ok_or_else(|| {
+            KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
+        })?;
+
+        match scope {
+            ResetScope::Session(sid) => self.reset_one_session(agent_id, sid, &entry, false).await,
+            ResetScope::Agent => self.reset_all_sessions(agent_id, &entry, false).await,
+        }
+    }
+
+    /// Implementation of [`ResetScope::Agent`] — wipe every session for this
+    /// agent. `save_summary` distinguishes reset (true) vs. reboot (false).
+    ///
+    /// Acquires `agents.agent_msg_locks[agent_id]` before deleting so an
+    /// in-flight inbound turn (which holds the same lock — see
+    /// `messaging.rs::send_message_full`) cannot resurrect the session
+    /// with stale history after the reset completes (#4868 review).
+    async fn reset_all_sessions(
+        &self,
+        agent_id: AgentId,
+        entry: &AgentEntry,
+        save_summary: bool,
+    ) -> KernelResult<()> {
+        let lock = self
+            .agents
+            .agent_msg_locks
+            .entry(agent_id)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        let _guard = lock.lock().await;
+
         // Auto-save session summaries for ALL sessions (default + per-channel)
         // before clearing, so no channel's conversation history is silently lost.
         // Also emit session:end for each active session before deletion.
-        if let Ok(session_ids) = self.memory.substrate.get_agent_session_ids(agent_id) {
-            for sid in session_ids {
-                if let Ok(Some(old_session)) = self.memory.substrate.get_session(sid) {
-                    // Fire session:end before removing the old session.
-                    self.governance.external_hooks.fire(
-                        crate::hooks::ExternalHookEvent::SessionEnd,
-                        serde_json::json!({
-                            "agent_id": agent_id.to_string(),
-                            "session_id": old_session.id.0.to_string(),
-                        }),
-                    );
-                    if old_session.messages.len() >= 2 {
-                        self.save_session_summary(agent_id, &entry, &old_session);
-                    }
+        let pre_delete_sids = self
+            .memory
+            .substrate
+            .get_agent_session_ids(agent_id)
+            .unwrap_or_default();
+        for sid in &pre_delete_sids {
+            if let Ok(Some(old_session)) = self.memory.substrate.get_session(*sid) {
+                // Fire session:end before removing the old session.
+                self.governance.external_hooks.fire(
+                    crate::hooks::ExternalHookEvent::SessionEnd,
+                    serde_json::json!({
+                        "agent_id": agent_id.to_string(),
+                        "session_id": old_session.id.0.to_string(),
+                    }),
+                );
+                if save_summary && old_session.messages.len() >= 2 {
+                    self.save_session_summary(agent_id, entry, &old_session);
                 }
             }
         }
@@ -200,6 +263,12 @@ impl LibreFangKernel {
             .substrate
             .delete_agent_sessions(agent_id)
             .map_err(KernelError::LibreFang)?;
+
+        // JSONL mirrors live outside the SQLite transaction (#4868 follow-up).
+        // Best-effort cleanup so deleted sessions don't accumulate as orphan
+        // transcripts on disk. SQLite is the source of truth for the API
+        // surface; a file-system failure here is logged but not fatal.
+        Self::purge_jsonl_files(entry, &pre_delete_sids);
 
         // Create a fresh session and inject reset prompt if configured
         let mut new_session = self
@@ -236,98 +305,242 @@ impl LibreFangKernel {
             }),
         );
 
-        info!(agent_id = %agent_id, "Session reset (summary saved to memory)");
+        info!(
+            agent_id = %agent_id,
+            save_summary,
+            "Agent-wide session reset"
+        );
         Ok(())
     }
 
-    /// Hard-reboot an agent's session — clears conversation history WITHOUT saving
-    /// a summary to memory.  Keeps agent config, system prompt, and tools intact.
-    /// More aggressive than `reset_session` (which auto-saves a summary) but less
-    /// destructive than `clear_agent_history` (which wipes ALL sessions).
-    pub fn reboot_session(&self, agent_id: AgentId) -> KernelResult<()> {
-        let _entry = self.agents.registry.get(agent_id).ok_or_else(|| {
-            KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
-        })?;
+    /// Implementation of [`ResetScope::Session`] — wipe exactly one session
+    /// (sibling sessions untouched). `save_summary` distinguishes reset
+    /// (true) vs. reboot (false).
+    ///
+    /// The recreated session reuses the same deterministic sid because
+    /// channel session ids are derived via [`SessionId::for_sender_scope`]
+    /// — the next inbound message on that channel will resolve back to the
+    /// same id and we want it to land on a fresh empty session, not a 404.
+    ///
+    /// Lock discipline (#4868 review, lock-race fix): an in-flight turn on
+    /// this agent holds either `agent_msg_locks[agent_id]` (the common
+    /// channel-inbound path with no explicit session_id_override) or
+    /// `session_msg_locks[sid]` (the multi-tab HTTP path with an explicit
+    /// override). Without acquiring both, the in-flight turn's later
+    /// `save_session` UPSERT would silently revive the just-deleted row.
+    /// We acquire both in the same agent-then-session order
+    /// `send_message_full` uses, so no deadlock can form.
+    ///
+    /// JSONL asymmetry: the recreated empty session is persisted to SQL
+    /// but its `<workspace>/sessions/{sid}.jsonl` mirror is intentionally
+    /// NOT created at reset time — the next inbound turn's
+    /// `write_jsonl_mirror` does it under truncate-create semantics. So
+    /// in the brief gap between reset and the next turn, the directory
+    /// shows the row in SQL with no file; this is the same shape lazy
+    /// session creation produces and is harmless.
+    async fn reset_one_session(
+        &self,
+        agent_id: AgentId,
+        sid: SessionId,
+        entry: &AgentEntry,
+        save_summary: bool,
+    ) -> KernelResult<()> {
+        let agent_lock = self
+            .agents
+            .agent_msg_locks
+            .entry(agent_id)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        let _agent_guard = agent_lock.lock().await;
+        let session_lock = self
+            .agents
+            .session_msg_locks
+            .entry(sid)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        let _session_guard = session_lock.lock().await;
 
-        // Emit session:end for each active session before deletion.
-        if let Ok(session_ids) = self.memory.substrate.get_agent_session_ids(agent_id) {
-            for sid in session_ids {
-                self.governance.external_hooks.fire(
-                    crate::hooks::ExternalHookEvent::SessionEnd,
-                    serde_json::json!({
-                        "agent_id": agent_id.to_string(),
-                        "session_id": sid.0.to_string(),
-                    }),
-                );
+        // Validate ownership: prevent cross-agent reset (callers compute the
+        // sid from a (channel, chat) pair which is trusted but the typed
+        // `SessionId` argument itself isn't — better to fail loudly than to
+        // delete another agent's session because of a wiring bug.
+        let old_session = self
+            .memory
+            .substrate
+            .get_session(sid)
+            .map_err(KernelError::LibreFang)?;
+        if let Some(ref s) = old_session {
+            if s.agent_id != agent_id {
+                return Err(KernelError::LibreFang(LibreFangError::InvalidInput(
+                    format!("session {sid} does not belong to agent {agent_id}"),
+                )));
             }
         }
 
-        // Delete ALL sessions for this agent (default + per-channel).
-        // Propagate so a failed reboot is visible instead of silently
-        // leaving the old history in place (#3470).
-        self.memory
-            .substrate
-            .delete_agent_sessions(agent_id)
-            .map_err(KernelError::LibreFang)?;
+        // Fire SessionEnd + save summary only when the session actually
+        // existed (no point summarising a never-touched per-channel sid).
+        if let Some(ref s) = old_session {
+            self.governance.external_hooks.fire(
+                crate::hooks::ExternalHookEvent::SessionEnd,
+                serde_json::json!({
+                    "agent_id": agent_id.to_string(),
+                    "session_id": s.id.0.to_string(),
+                }),
+            );
+            if save_summary && s.messages.len() >= 2 {
+                self.save_session_summary(agent_id, entry, s);
+            }
 
-        // Create a fresh session
-        let new_session = self
-            .memory
-            .substrate
-            .create_session(agent_id)
-            .map_err(KernelError::LibreFang)?;
+            // Delete the SQL row + FTS index transactionally. Skip when the
+            // session never existed — `delete_session` would just no-op.
+            self.memory
+                .substrate
+                .delete_session(sid)
+                .map_err(KernelError::LibreFang)?;
 
-        // Update registry with new session ID
-        self.agents
-            .registry
-            .update_session_id(agent_id, new_session.id)
-            .map_err(KernelError::LibreFang)?;
+            // Best-effort JSONL cleanup (see `reset_all_sessions` for rationale).
+            Self::purge_jsonl_files(entry, std::slice::from_ref(&sid));
+        }
 
-        // Reset quota tracking
-        self.agents.scheduler.reset_usage(agent_id);
+        // Eagerly recreate an empty session at the SAME deterministic sid.
+        // Without this, the next channel inbound would lazily materialise an
+        // empty session inside the agent loop — but external SessionStart /
+        // SessionReset hooks would never fire for that lazy creation, so
+        // hook subscribers would see an asymmetric "End without Start".
+        let mut new_session = librefang_memory::session::Session {
+            id: sid,
+            agent_id,
+            messages: Vec::new(),
+            context_window_tokens: 0,
+            label: None,
+            messages_generation: 0,
+            last_repaired_generation: None,
+        };
+        self.inject_reset_prompt(&mut new_session, agent_id);
+        // `inject_reset_prompt` only persists when it actually pushed messages
+        // — explicitly save the empty case so the row exists for the next
+        // inbound message instead of round-tripping back through lazy
+        // creation.
+        if new_session.messages.is_empty() {
+            self.memory
+                .substrate
+                .save_session(&new_session)
+                .map_err(KernelError::LibreFang)?;
+        }
 
-        // Fire external session:reset hook (fire-and-forget).
+        // Update the registry pointer only when it was pointing at the
+        // session we just reset. For channel-derived sids (the common case)
+        // the pointer is a different sid and stays untouched — that's the
+        // whole point of per-session reset.
+        if entry.session_id == sid {
+            self.agents
+                .registry
+                .update_session_id(agent_id, sid)
+                .map_err(KernelError::LibreFang)?;
+        }
+
+        // Quota is intentionally NOT reset here. Token quota is agent-wide;
+        // letting any one channel reset it would give a per-channel user a
+        // way to clear an agent-wide quota-exceeded state by typing /new.
+        // The dashboard "Reset agent" path (ResetScope::Agent) keeps the
+        // quota-clearing semantic.
+
+        // Fire session:reset + session:start so external hooks see the
+        // standard "fresh session" lifecycle pair, mirroring the agent-wide
+        // path.
         self.governance.external_hooks.fire(
             crate::hooks::ExternalHookEvent::SessionReset,
             serde_json::json!({
                 "agent_id": agent_id.to_string(),
-                "session_id": new_session.id.0.to_string(),
+                "session_id": sid.0.to_string(),
             }),
         );
-
-        // Fire session:start for the newly created session to match the
-        // behaviour of other new-session flows.
         self.governance.external_hooks.fire(
             crate::hooks::ExternalHookEvent::SessionStart,
             serde_json::json!({
                 "agent_id": agent_id.to_string(),
-                "session_id": new_session.id.0.to_string(),
+                "session_id": sid.0.to_string(),
             }),
         );
 
-        info!(agent_id = %agent_id, "Session rebooted (no summary saved)");
+        info!(
+            agent_id = %agent_id,
+            session_id = %sid,
+            existed = old_session.is_some(),
+            save_summary,
+            "Per-session reset complete (sibling sessions untouched)"
+        );
         Ok(())
+    }
+
+    /// Best-effort removal of `<workspace>/sessions/{sid}.jsonl` mirrors after
+    /// a session row is deleted from SQLite. Without this, `/new`, `/reboot`,
+    /// and `clear_agent_history` accumulate orphan transcripts indefinitely
+    /// (#4868 follow-up).
+    ///
+    /// Failures are logged but not propagated: the SQL row is gone, so the
+    /// API surface and FTS search no longer expose the deleted session. A
+    /// leftover JSONL is a hygiene issue, not a privacy regression — the
+    /// data was already on disk and removing the index is the user-visible
+    /// "delete" guarantee.
+    fn purge_jsonl_files(entry: &AgentEntry, sids: &[SessionId]) {
+        let Some(ref workspace) = entry.manifest.workspace else {
+            return;
+        };
+        let sessions_dir = workspace.join("sessions");
+        for sid in sids {
+            let path = sessions_dir.join(format!("{}.jsonl", sid.0));
+            if !path.exists() {
+                continue;
+            }
+            if let Err(e) = std::fs::remove_file(&path) {
+                tracing::warn!(
+                    session_id = %sid,
+                    path = %path.display(),
+                    error = %e,
+                    "Failed to remove orphan session JSONL after delete; \
+                     manual cleanup required (DB row already gone)"
+                );
+            }
+        }
     }
 
     /// Clear ALL conversation history for an agent (sessions + canonical).
     ///
     /// Creates a fresh empty session afterward so the agent is still usable.
-    pub fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()> {
-        let _entry = self.agents.registry.get(agent_id).ok_or_else(|| {
+    ///
+    /// Acquires `agents.agent_msg_locks[agent_id]` so an in-flight inbound
+    /// turn cannot save its appended history back over the cleared session
+    /// rows (#4868 review).
+    pub async fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()> {
+        let entry = self.agents.registry.get(agent_id).ok_or_else(|| {
             KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
         })?;
 
-        // Emit session:end for each active session before deletion.
-        if let Ok(session_ids) = self.memory.substrate.get_agent_session_ids(agent_id) {
-            for sid in session_ids {
-                self.governance.external_hooks.fire(
-                    crate::hooks::ExternalHookEvent::SessionEnd,
-                    serde_json::json!({
-                        "agent_id": agent_id.to_string(),
-                        "session_id": sid.0.to_string(),
-                    }),
-                );
-            }
+        let lock = self
+            .agents
+            .agent_msg_locks
+            .entry(agent_id)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        let _guard = lock.lock().await;
+
+        // Emit session:end for each active session before deletion. Capture
+        // the sids list once so we can both fire hooks here and purge JSONL
+        // mirrors after the SQL delete (#4868 follow-up).
+        let pre_delete_sids = self
+            .memory
+            .substrate
+            .get_agent_session_ids(agent_id)
+            .unwrap_or_default();
+        for sid in &pre_delete_sids {
+            self.governance.external_hooks.fire(
+                crate::hooks::ExternalHookEvent::SessionEnd,
+                serde_json::json!({
+                    "agent_id": agent_id.to_string(),
+                    "session_id": sid.0.to_string(),
+                }),
+            );
         }
 
         // Delete all regular sessions then the canonical (cross-channel)
@@ -342,6 +555,11 @@ impl LibreFangKernel {
             .substrate
             .delete_canonical_session(agent_id)
             .map_err(KernelError::LibreFang)?;
+
+        // Best-effort JSONL cleanup. Without this, every history-clear leaks
+        // an orphan transcript file the API surface no longer indexes
+        // (#4868 follow-up).
+        Self::purge_jsonl_files(&entry, &pre_delete_sids);
 
         // Create a fresh session and inject reset prompt if configured
         let mut new_session = self

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -36,7 +36,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use librefang_types::agent::{AgentId, AgentManifest, RunningSessionSnapshot, SessionId};
+use librefang_types::agent::{
+    AgentId, AgentManifest, ResetScope, RunningSessionSnapshot, SessionId,
+};
 use librefang_types::error::LibreFangResult;
 
 use crate::approval::ApprovalManager;
@@ -200,9 +202,23 @@ pub trait KernelApi: KernelHandle + Send + Sync {
     fn suspend_agent(&self, agent_id: AgentId) -> KernelResult<()>;
     fn resume_agent(&self, agent_id: AgentId) -> KernelResult<()>;
     async fn compact_agent_session(&self, agent_id: AgentId) -> KernelResult<String>;
-    fn reset_session(&self, agent_id: AgentId) -> KernelResult<()>;
-    fn reboot_session(&self, agent_id: AgentId) -> KernelResult<()>;
-    fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()>;
+    /// Compact a specific session id; channel `/compact` calls this with the
+    /// per-channel session so it doesn't accidentally summarise the agent's
+    /// registry-pointer session (#4868).
+    async fn compact_agent_session_with_id(
+        &self,
+        agent_id: AgentId,
+        session_id: Option<SessionId>,
+    ) -> KernelResult<String>;
+    /// Reset an agent's session(s). See [`ResetScope`] for the agent-wide vs.
+    /// per-session split (#4868). Async because it acquires the same
+    /// per-agent / per-session message lock that `send_message_full` holds,
+    /// to serialize against in-flight turns.
+    async fn reset_session(&self, agent_id: AgentId, scope: ResetScope) -> KernelResult<()>;
+    /// Hard-reboot an agent's session(s) — no summary saved. See
+    /// [`ResetScope`] for the agent-wide vs. per-session split (#4868).
+    async fn reboot_session(&self, agent_id: AgentId, scope: ResetScope) -> KernelResult<()>;
+    async fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()>;
     fn list_agent_sessions(&self, agent_id: AgentId) -> KernelResult<Vec<serde_json::Value>>;
     fn create_agent_session(
         &self,
@@ -762,14 +778,21 @@ impl KernelApi for LibreFangKernel {
     async fn compact_agent_session(&self, agent_id: AgentId) -> KernelResult<String> {
         Self::compact_agent_session(self, agent_id).await
     }
-    fn reset_session(&self, agent_id: AgentId) -> KernelResult<()> {
-        Self::reset_session(self, agent_id)
+    async fn compact_agent_session_with_id(
+        &self,
+        agent_id: AgentId,
+        session_id: Option<SessionId>,
+    ) -> KernelResult<String> {
+        Self::compact_agent_session_with_id(self, agent_id, session_id).await
     }
-    fn reboot_session(&self, agent_id: AgentId) -> KernelResult<()> {
-        Self::reboot_session(self, agent_id)
+    async fn reset_session(&self, agent_id: AgentId, scope: ResetScope) -> KernelResult<()> {
+        Self::reset_session(self, agent_id, scope).await
     }
-    fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()> {
-        Self::clear_agent_history(self, agent_id)
+    async fn reboot_session(&self, agent_id: AgentId, scope: ResetScope) -> KernelResult<()> {
+        Self::reboot_session(self, agent_id, scope).await
+    }
+    async fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()> {
+        Self::clear_agent_history(self, agent_id).await
     }
     fn list_agent_sessions(&self, agent_id: AgentId) -> KernelResult<Vec<serde_json::Value>> {
         Self::list_agent_sessions(self, agent_id)

--- a/crates/librefang-kernel/tests/session_reset_scope_test.rs
+++ b/crates/librefang-kernel/tests/session_reset_scope_test.rs
@@ -1,0 +1,511 @@
+//! Integration tests for the per-session vs. per-agent reset split (#4868).
+//!
+//! The bug: `/new` typed in any channel called `kernel.reset_session(agent)`
+//! which deleted EVERY session for that agent — wiping the dashboard's
+//! transcript, every other channel's transcript, and any cron-spawned
+//! sessions. The fix is a `ResetScope` argument that distinguishes
+//! `Agent` (existing semantics) from `Session(sid)` (new, scoped) so the
+//! channel side can ask the kernel to delete just one sid.
+//!
+//! Tests here exercise the kernel API directly (the channel layer is a
+//! thin wrapper that derives `SessionId::for_channel(agent, channel:chat)`
+//! and calls `kernel.reset_session(agent, ResetScope::Session(sid))` — the
+//! sid-derivation formula is covered by a unit test in
+//! `librefang-api/src/channel_bridge.rs`).
+//!
+//! What we assert:
+//!   - `ResetScope::Session(sid)` deletes exactly that row + its FTS index.
+//!   - Sibling sids (other channels, dashboard) survive the per-session reset.
+//!   - JSONL mirrors under `<workspace>/sessions/{sid}.jsonl` are removed
+//!     for the deleted sid (#4868 follow-up: orphan transcripts).
+//!   - `ResetScope::Agent` keeps the historical full-wipe semantics AND
+//!     purges every JSONL mirror.
+//!   - A sid belonging to a different agent is rejected with `InvalidInput`
+//!     (defence-in-depth — callers compute the sid from a trusted
+//!     (channel, chat) pair, but the typed argument itself isn't).
+//!   - Per-session reset does NOT touch agent-wide quota state (channel
+//!     users must not be able to clear an agent-wide token-quota by
+//!     typing /new).
+
+use librefang_kernel::KernelApi;
+use librefang_memory::session::Session;
+use librefang_testing::MockKernelBuilder;
+use librefang_types::agent::{AgentManifest, ResetScope, SessionId};
+use librefang_types::message::{Message, MessageContent, Role};
+
+/// Build a session row with `n` user/assistant turns so summary save logic
+/// (gated on `messages.len() >= 2`) is exercised.
+fn populated_session(
+    sid: SessionId,
+    agent_id: librefang_types::agent::AgentId,
+    n: usize,
+) -> Session {
+    let mut messages = Vec::with_capacity(n * 2);
+    for i in 0..n {
+        messages.push(Message {
+            role: Role::User,
+            content: MessageContent::Text(format!("u{i}")),
+            pinned: false,
+            timestamp: None,
+        });
+        messages.push(Message {
+            role: Role::Assistant,
+            content: MessageContent::Text(format!("a{i}")),
+            pinned: false,
+            timestamp: None,
+        });
+    }
+    Session {
+        id: sid,
+        agent_id,
+        messages,
+        context_window_tokens: 0,
+        label: None,
+        messages_generation: 0,
+        last_repaired_generation: None,
+    }
+}
+
+fn spawn_test_agent(
+    kernel: &librefang_kernel::LibreFangKernel,
+    name: &str,
+) -> librefang_types::agent::AgentId {
+    let manifest: AgentManifest = toml::from_str(&format!(
+        r#"
+name = "{name}"
+version = "0.1.0"
+description = "test"
+author = "test"
+module = "builtin:chat"
+
+[model]
+provider = "ollama"
+model = "test"
+system_prompt = "."
+"#
+    ))
+    .unwrap();
+    kernel.spawn_agent(manifest).expect("spawn_agent")
+}
+
+/// Materialise the session in SQLite AND lay down a JSONL mirror at the
+/// path the kernel uses (`<workspace>/sessions/{sid}.jsonl`). Both must
+/// disappear when the session is reset.
+fn save_session_with_jsonl(
+    kernel: &librefang_kernel::LibreFangKernel,
+    agent_id: librefang_types::agent::AgentId,
+    sid: SessionId,
+    n_turns: usize,
+) -> std::path::PathBuf {
+    let session = populated_session(sid, agent_id, n_turns);
+    kernel
+        .memory_substrate()
+        .save_session(&session)
+        .expect("save_session");
+
+    let entry = kernel
+        .agent_registry()
+        .get(agent_id)
+        .expect("agent should be registered");
+    let workspace = entry
+        .manifest
+        .workspace
+        .clone()
+        .expect("spawn_agent must populate workspace");
+    let sessions_dir = workspace.join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+    let jsonl_path = sessions_dir.join(format!("{}.jsonl", sid.0));
+    std::fs::write(&jsonl_path, b"{\"placeholder\":\"transcript\"}\n").expect("write jsonl");
+    jsonl_path
+}
+
+/// Per-channel `/new` (kernel layer): only the targeted sid disappears,
+/// sibling sessions are untouched in BOTH SQLite and on disk.
+#[tokio::test(flavor = "multi_thread")]
+async fn per_session_reset_only_deletes_targeted_sid() {
+    let (kernel, _tmp) = MockKernelBuilder::new()
+        .with_config(|c| {
+            c.default_model.provider = "ollama".to_string();
+            c.default_model.model = "test".to_string();
+            c.default_model.api_key_env = "OLLAMA_API_KEY".to_string();
+        })
+        .build();
+
+    let agent_id = spawn_test_agent(&kernel, "multi-channel-agent");
+
+    // Three sessions on the same agent: dashboard (the registry-pointer
+    // sid), telegram, slack.
+    let dashboard_sid = kernel.agent_registry().get(agent_id).unwrap().session_id;
+    let telegram_sid = SessionId::for_channel(agent_id, "telegram:chat-1");
+    let slack_sid = SessionId::for_channel(agent_id, "slack:chat-2");
+
+    let dashboard_jsonl = save_session_with_jsonl(&kernel, agent_id, dashboard_sid, 3);
+    let telegram_jsonl = save_session_with_jsonl(&kernel, agent_id, telegram_sid, 5);
+    let slack_jsonl = save_session_with_jsonl(&kernel, agent_id, slack_sid, 2);
+
+    // /new in Telegram → only telegram session resets.
+    kernel
+        .reset_session(agent_id, ResetScope::Session(telegram_sid))
+        .await
+        .expect("reset_session(Session) succeeds");
+
+    // SQLite: dashboard + slack still have their original turn counts;
+    // telegram is recreated empty at the same deterministic sid.
+    let dash = kernel
+        .memory_substrate()
+        .get_session(dashboard_sid)
+        .unwrap()
+        .expect("dashboard session must survive per-channel reset");
+    assert_eq!(
+        dash.messages.len(),
+        6,
+        "dashboard turn count must be intact after per-channel /new (#4868)"
+    );
+
+    let slack = kernel
+        .memory_substrate()
+        .get_session(slack_sid)
+        .unwrap()
+        .expect("slack session must survive per-channel reset");
+    assert_eq!(
+        slack.messages.len(),
+        4,
+        "slack turn count must be intact after per-channel /new (#4868)"
+    );
+
+    let telegram = kernel
+        .memory_substrate()
+        .get_session(telegram_sid)
+        .unwrap()
+        .expect(
+            "telegram session must be recreated at the same deterministic sid (eager \
+             reset semantics — next inbound message lands on it)",
+        );
+    assert!(
+        telegram.messages.is_empty(),
+        "telegram session must be empty after reset"
+    );
+    assert_eq!(
+        telegram.id, telegram_sid,
+        "recreated session must reuse the deterministic for_channel sid \
+         so the next inbound message resolves to the same row"
+    );
+
+    // JSONL mirror cleanup: only the targeted sid's file is gone.
+    assert!(
+        !telegram_jsonl.exists(),
+        "telegram JSONL must be purged on per-channel reset (#4868 follow-up: \
+         orphan transcripts on disk)"
+    );
+    assert!(
+        dashboard_jsonl.exists(),
+        "dashboard JSONL must NOT be touched by a per-channel reset"
+    );
+    assert!(
+        slack_jsonl.exists(),
+        "slack JSONL must NOT be touched by a per-channel reset"
+    );
+}
+
+/// `ResetScope::Agent` — historical wipe-everything semantics PLUS the
+/// new JSONL mirror cleanup so we don't accumulate orphan transcripts.
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_wide_reset_purges_all_sessions_and_jsonl() {
+    let (kernel, _tmp) = MockKernelBuilder::new()
+        .with_config(|c| {
+            c.default_model.provider = "ollama".to_string();
+            c.default_model.model = "test".to_string();
+            c.default_model.api_key_env = "OLLAMA_API_KEY".to_string();
+        })
+        .build();
+
+    let agent_id = spawn_test_agent(&kernel, "wipe-target");
+
+    let dashboard_sid = kernel.agent_registry().get(agent_id).unwrap().session_id;
+    let telegram_sid = SessionId::for_channel(agent_id, "telegram:chat-x");
+    let slack_sid = SessionId::for_channel(agent_id, "slack:chat-y");
+
+    let dashboard_jsonl = save_session_with_jsonl(&kernel, agent_id, dashboard_sid, 3);
+    let telegram_jsonl = save_session_with_jsonl(&kernel, agent_id, telegram_sid, 4);
+    let slack_jsonl = save_session_with_jsonl(&kernel, agent_id, slack_sid, 2);
+
+    kernel
+        .reset_session(agent_id, ResetScope::Agent)
+        .await
+        .expect("reset_session(Agent) succeeds");
+
+    // The pre-existing sids are gone — each one would 404 if a caller
+    // looked them up by id.
+    for sid in [dashboard_sid, telegram_sid, slack_sid] {
+        assert!(
+            kernel
+                .memory_substrate()
+                .get_session(sid)
+                .unwrap()
+                .is_none(),
+            "agent-wide reset must delete every pre-existing sid: {sid}"
+        );
+    }
+
+    // JSONL mirrors gone for ALL three.
+    for path in [&dashboard_jsonl, &telegram_jsonl, &slack_jsonl] {
+        assert!(
+            !path.exists(),
+            "agent-wide reset must purge every JSONL mirror (orphan-transcript \
+             leak fix, #4868 follow-up): {}",
+            path.display()
+        );
+    }
+
+    // The agent gets exactly one fresh registry-pointer session afterwards
+    // — that's the historical "create_session" tail of reset_session.
+    let post_reset_sids = kernel
+        .memory_substrate()
+        .get_agent_session_ids(agent_id)
+        .unwrap();
+    assert_eq!(
+        post_reset_sids.len(),
+        1,
+        "agent-wide reset leaves exactly one fresh session"
+    );
+}
+
+/// Defence-in-depth: callers compute the sid from a trusted
+/// `(channel, chat)` pair, but the typed `SessionId` argument itself
+/// isn't trusted. Pointing the kernel at another agent's sid must fail
+/// with `InvalidInput`, NOT silently delete that other agent's data.
+#[tokio::test(flavor = "multi_thread")]
+async fn per_session_reset_rejects_cross_agent_sid() {
+    let (kernel, _tmp) = MockKernelBuilder::new()
+        .with_config(|c| {
+            c.default_model.provider = "ollama".to_string();
+            c.default_model.model = "test".to_string();
+            c.default_model.api_key_env = "OLLAMA_API_KEY".to_string();
+        })
+        .build();
+
+    let agent_a = spawn_test_agent(&kernel, "owner");
+    let agent_b = spawn_test_agent(&kernel, "intruder");
+
+    // Agent B owns this sid via for_channel — even though the channel name
+    // looks innocuous, the sid hashes in agent_b's id.
+    let b_sid = SessionId::for_channel(agent_b, "telegram:secret");
+    let _b_jsonl = save_session_with_jsonl(&kernel, agent_b, b_sid, 5);
+
+    // Agent A asks the kernel to reset agent B's sid. Must fail loudly,
+    // not silently delete.
+    let err = kernel
+        .reset_session(agent_a, ResetScope::Session(b_sid))
+        .await
+        .expect_err("cross-agent reset must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("does not belong to agent"),
+        "error must surface the cross-agent rejection (got: {msg})"
+    );
+
+    // Agent B's session is untouched.
+    let surviving = kernel
+        .memory_substrate()
+        .get_session(b_sid)
+        .unwrap()
+        .expect("agent B's session must survive a cross-agent reset attempt");
+    assert_eq!(
+        surviving.messages.len(),
+        10,
+        "agent B's turn count must be intact"
+    );
+}
+
+/// A per-session reset of an sid that never existed (channel /new typed
+/// before any message) must still succeed and leave the agent's other
+/// sessions untouched. This is the common first-/new case in a fresh chat.
+#[tokio::test(flavor = "multi_thread")]
+async fn per_session_reset_on_unmaterialised_sid_is_ok() {
+    let (kernel, _tmp) = MockKernelBuilder::new()
+        .with_config(|c| {
+            c.default_model.provider = "ollama".to_string();
+            c.default_model.model = "test".to_string();
+            c.default_model.api_key_env = "OLLAMA_API_KEY".to_string();
+        })
+        .build();
+
+    let agent_id = spawn_test_agent(&kernel, "fresh-chat-agent");
+    let dashboard_sid = kernel.agent_registry().get(agent_id).unwrap().session_id;
+    let dashboard_jsonl = save_session_with_jsonl(&kernel, agent_id, dashboard_sid, 2);
+
+    // Telegram sid has never been written to.
+    let telegram_sid = SessionId::for_channel(agent_id, "telegram:never-chatted");
+    assert!(kernel
+        .memory_substrate()
+        .get_session(telegram_sid)
+        .unwrap()
+        .is_none());
+
+    kernel
+        .reset_session(agent_id, ResetScope::Session(telegram_sid))
+        .await
+        .expect("reset of unmaterialised sid must succeed");
+
+    // Dashboard sid + JSONL untouched.
+    assert!(
+        dashboard_jsonl.exists(),
+        "dashboard JSONL must NOT be touched by a no-op per-channel reset"
+    );
+    let dash = kernel
+        .memory_substrate()
+        .get_session(dashboard_sid)
+        .unwrap()
+        .expect("dashboard session must survive");
+    assert_eq!(dash.messages.len(), 4);
+
+    // Telegram sid is now materialised (eager recreation), empty.
+    let tg = kernel
+        .memory_substrate()
+        .get_session(telegram_sid)
+        .unwrap()
+        .expect("eager recreation must materialise the sid");
+    assert!(tg.messages.is_empty());
+}
+
+/// `reboot_session(Session)` deletes exactly one sid like `reset_session`
+/// but does NOT save a memory summary (no `session_<date>_<slug>` entry
+/// in structured kv). Same scope semantics, different summary-handling
+/// contract — pin it so the contract can't drift (#4868 review MINOR #3).
+#[tokio::test(flavor = "multi_thread")]
+async fn per_session_reboot_skips_summary_save() {
+    let (kernel, _tmp) = MockKernelBuilder::new()
+        .with_config(|c| {
+            c.default_model.provider = "ollama".to_string();
+            c.default_model.model = "test".to_string();
+            c.default_model.api_key_env = "OLLAMA_API_KEY".to_string();
+        })
+        .build();
+
+    let agent_id = spawn_test_agent(&kernel, "reboot-target");
+    let telegram_sid = SessionId::for_channel(agent_id, "telegram:reboot-chat");
+    save_session_with_jsonl(&kernel, agent_id, telegram_sid, 5);
+
+    // Snapshot the structured kv keys before reboot — there should be
+    // exactly zero `session_*` keys (no prior reset summaries).
+    let pre_keys: Vec<String> = kernel
+        .memory_substrate()
+        .list_keys(agent_id)
+        .unwrap()
+        .into_iter()
+        .filter(|k| k.starts_with("session_"))
+        .collect();
+
+    kernel
+        .reboot_session(agent_id, ResetScope::Session(telegram_sid))
+        .await
+        .expect("reboot_session(Session) succeeds");
+
+    // Telegram sid is reset to empty same as the reset_session path.
+    let tg = kernel
+        .memory_substrate()
+        .get_session(telegram_sid)
+        .unwrap()
+        .expect("reboot must eagerly recreate the sid");
+    assert!(tg.messages.is_empty());
+
+    // Critical: no summary saved. Pre-list set is unchanged.
+    let post_keys: Vec<String> = kernel
+        .memory_substrate()
+        .list_keys(agent_id)
+        .unwrap()
+        .into_iter()
+        .filter(|k| k.starts_with("session_"))
+        .collect();
+    assert_eq!(
+        pre_keys, post_keys,
+        "reboot must NOT save a session_<date>_<slug> summary — that's \
+         exclusively the reset path's contract (#4868 review)"
+    );
+}
+
+/// `clear_agent_history` also leaks JSONL mirrors pre-fix. The PR added
+/// the same purge call; pin it (#4868 review MINOR #2).
+#[tokio::test(flavor = "multi_thread")]
+async fn clear_agent_history_purges_jsonl_too() {
+    let (kernel, _tmp) = MockKernelBuilder::new()
+        .with_config(|c| {
+            c.default_model.provider = "ollama".to_string();
+            c.default_model.model = "test".to_string();
+            c.default_model.api_key_env = "OLLAMA_API_KEY".to_string();
+        })
+        .build();
+
+    let agent_id = spawn_test_agent(&kernel, "clear-history-target");
+
+    let dashboard_sid = kernel.agent_registry().get(agent_id).unwrap().session_id;
+    let telegram_sid = SessionId::for_channel(agent_id, "telegram:clear-chat");
+
+    let dashboard_jsonl = save_session_with_jsonl(&kernel, agent_id, dashboard_sid, 2);
+    let telegram_jsonl = save_session_with_jsonl(&kernel, agent_id, telegram_sid, 3);
+
+    kernel
+        .clear_agent_history(agent_id)
+        .await
+        .expect("clear_agent_history succeeds");
+
+    // Every JSONL mirror is gone — clear_agent_history is the hardest
+    // wipe and previously left every transcript on disk forever (#4868
+    // follow-up).
+    assert!(
+        !dashboard_jsonl.exists(),
+        "clear_agent_history must purge dashboard JSONL: {}",
+        dashboard_jsonl.display()
+    );
+    assert!(
+        !telegram_jsonl.exists(),
+        "clear_agent_history must purge telegram JSONL: {}",
+        telegram_jsonl.display()
+    );
+}
+
+/// `compact_agent_session_with_id(agent, Some(sid))` operates on the
+/// session it's pointed at, not `entry.session_id`. The channel-bridge
+/// `compact_channel_session` relies on this — without it, a Telegram
+/// `/compact` would summarise the agent's dashboard session instead
+/// of the telegram chat. Pre-#4868 the bridge called the agent-wide
+/// `compact_session` and hit exactly this footgun.
+#[tokio::test(flavor = "multi_thread")]
+async fn compact_with_id_targets_the_requested_session() {
+    let (kernel, _tmp) = MockKernelBuilder::new()
+        .with_config(|c| {
+            c.default_model.provider = "ollama".to_string();
+            c.default_model.model = "test".to_string();
+            c.default_model.api_key_env = "OLLAMA_API_KEY".to_string();
+        })
+        .build();
+
+    let agent_id = spawn_test_agent(&kernel, "compact-scope-target");
+    let dashboard_sid = kernel.agent_registry().get(agent_id).unwrap().session_id;
+    let telegram_sid = SessionId::for_channel(agent_id, "telegram:compact-chat");
+
+    // Two distinct turn counts so the "No compaction needed (N messages, …)"
+    // message tells us which session the call actually loaded.
+    save_session_with_jsonl(&kernel, agent_id, dashboard_sid, 2);
+    save_session_with_jsonl(&kernel, agent_id, telegram_sid, 7);
+
+    let dash_report = kernel
+        .compact_agent_session_with_id(agent_id, Some(dashboard_sid))
+        .await
+        .expect("compact_agent_session_with_id(dashboard) succeeds");
+    assert!(
+        dash_report.contains("4 messages"),
+        "compact must have loaded the dashboard session (4 = 2 turns × 2 \
+         user/assistant pairs): {dash_report}"
+    );
+
+    let tg_report = kernel
+        .compact_agent_session_with_id(agent_id, Some(telegram_sid))
+        .await
+        .expect("compact_agent_session_with_id(telegram) succeeds");
+    assert!(
+        tg_report.contains("14 messages"),
+        "compact must have loaded the telegram session (14 = 7 turns × 2): \
+         {tg_report}"
+    );
+}

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -266,6 +266,29 @@ impl SessionId {
         ))
     }
 
+    /// Derive the per-channel `SessionId` for a `(channel, chat_id)` pair
+    /// using the canonical scope construction shared by the kernel's inbound
+    /// resolver and the channel-bridge `/new` / `/reboot` / `/compact`
+    /// commands. Empty `chat_id` collapses to channel-only — matching what
+    /// `build_sender_context` does when `sender.platform_id` is empty.
+    ///
+    /// This is the single source of truth for the scope formula. The
+    /// inbound message resolver (`kernel/messaging.rs::send_message_full`,
+    /// the dispatch resolver in `kernel/mod.rs::resolve_dispatch_session_id`,
+    /// and the agent-execution path in `kernel/agent_execution.rs`) plus
+    /// the channel-bridge reset helper in `librefang-api::channel_bridge`
+    /// all call this so they cannot drift. Without this helper, the
+    /// scope-derivation literal lived inline in 4 places — any one of
+    /// them silently disagreeing would re-introduce #4868 (channel `/new`
+    /// deleting the wrong sid).
+    pub fn for_sender_scope(agent_id: AgentId, channel: &str, chat_id: Option<&str>) -> Self {
+        let scope = match chat_id {
+            Some(cid) if !cid.is_empty() => format!("{channel}:{cid}"),
+            _ => channel.to_string(),
+        };
+        Self::for_channel(agent_id, &scope)
+    }
+
     /// Derive a per-fire cron session id keyed by `(agent, run_key)`.
     ///
     /// Used when a cron job is configured with `session_mode = "new"` and
@@ -342,6 +365,21 @@ impl std::fmt::Display for SessionId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+/// Scope passed to `reset_session` / `reboot_session` so callers can choose
+/// between agent-wide nuke and single-session reset (#4868).
+///
+/// Channel `/new` / `/reboot` use `Session(for_channel(agent, channel:chat))`
+/// so resetting in one chat does not wipe transcripts on every other surface
+/// the same agent serves. Dashboard / explicit "reset agent" surfaces use
+/// `Agent` to preserve the historical full-wipe semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResetScope {
+    /// Reset every session belonging to this agent (default + per-channel).
+    Agent,
+    /// Reset exactly one session id; sibling sessions are untouched.
+    Session(SessionId),
 }
 
 /// Snapshot of a single in-flight (agent, session) loop, returned by


### PR DESCRIPTION
Closes #4868.

## Summary
- Channel `/new`, `/reboot`, `/compact` previously deleted **every** session for the agent (default + every per-channel sid + cron-spawned). Typing `/new` in Telegram silently nuked the dashboard transcript and every other channel's transcript.
- Same path also leaked the on-disk JSONL mirror — `delete_agent_sessions` clears SQL rows but never touched `<workspace>/sessions/{sid}.jsonl`, so every reset accumulated orphan transcripts indefinitely.
- This PR scopes channel resets to the per-channel sid via a new `ResetScope { Agent, Session(SessionId) }` arg on `reset_session` / `reboot_session`, and adds best-effort JSONL cleanup to **all three** session-delete paths (`reset_session`, `reboot_session`, `clear_agent_history`).

## Behaviour change matrix
| Surface | Before | After |
|---|---|---|
| Channel `/new`, `/reboot`, `/compact` | Wiped every session for the agent | Resets only `SessionId::for_channel(agent, "<ch>:<chat>")`; siblings untouched |
| `POST /api/agents/{id}/session/reset`, `…/reboot` | Agent-wide wipe | Agent-wide wipe (passes `ResetScope::Agent`) — preserved |
| Dashboard WS `reset` / `reboot` commands | Agent-wide wipe | Agent-wide wipe — preserved |
| `DELETE /api/agents/{id}/history` (`clear_agent_history`) | Agent-wide wipe of sessions + canonical | Same + JSONL cleanup |

## Subtleties
- Per-session reset **eagerly recreates** an empty session at the same deterministic sid so external `SessionStart` / `SessionReset` hooks fire symmetrically (lazy creation in the agent loop only fires the internal `SessionLifecycleEvent`, not the external hook).
- Per-session reset **does NOT** clear agent-wide token quota (no grief vector for one channel user to clear an agent-wide quota-exceeded state by typing `/new`).
- Cross-agent sids are rejected with `InvalidInput` instead of silently deleted (defence-in-depth — callers compute the sid from a trusted `(channel, chat)` pair, but the typed argument itself isn't).
- JSONL cleanup is best-effort: SQL is the source of truth, a leftover file is hygiene not privacy. Failures log the orphan path with a `warn!` so admins can clean up.

## API changes
- New: `librefang_types::agent::ResetScope { Agent, Session(SessionId) }`.
- New: `KernelHandle::compact_agent_session_with_id(agent, Option<SessionId>)` — promoted from inherent method.
- New: `ChannelBridgeHandle::{reset,reboot,compact}_channel_session(agent, channel, chat_id)`. Default impls return `Err("Not implemented")` matching the trait's existing pattern.
- Changed: `KernelHandle::{reset,reboot}_session` now takes a `ResetScope` arg.

## Verification
- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-types -p librefang-kernel -p librefang-channels -p librefang-api --all-targets -- -D warnings` — clean.
- `cargo test -p librefang-kernel --test session_reset_scope_test` — 4 new tests:
  - `per_session_reset_only_deletes_targeted_sid` — telegram sid wiped, dashboard + slack survive (SQL + JSONL).
  - `agent_wide_reset_purges_all_sessions_and_jsonl` — every sid + every JSONL gone.
  - `per_session_reset_rejects_cross_agent_sid` — defence-in-depth.
  - `per_session_reset_on_unmaterialised_sid_is_ok` — `/new` typed in a fresh chat that has never received a message.
- `cargo test -p librefang-api --lib channel_session_id_matches_inbound_resolver_formula` — pins the channel-side sid derivation to the inbound resolver's formula so they cannot drift.
- `cargo test -p librefang-api --test agents_routes_integration` — 19 existing agent-route tests still pass.
- `cargo test -p librefang-types -p librefang-kernel -p librefang-channels --lib` — 2086 existing lib tests still pass.

## Out of scope
Per the issue's own #3 follow-up: a `librefang sessions gc` admin tool to reconcile already-orphaned JSONL files on existing deployments. The new code stops accumulating orphans going forward; the historical backfill is a separate environmental cleanup that would expand scope into `librefang-cli` and is best tracked separately.

## Test plan
- [x] Per-channel `/new` deletes only the targeted sid (kernel test)
- [x] JSONL mirror is purged for the deleted sid (kernel test)
- [x] Agent-wide reset still purges everything + every JSONL (kernel test)
- [x] Cross-agent sid rejected (kernel test)
- [x] Unmaterialised sid `/new` works (kernel test)
- [x] Channel-side sid derivation matches inbound resolver formula (api unit test)
- [x] Existing agent-routes integration tests still green