### PR TITLE
fix(api): unblock main coverage — /api/health/detail auth + workflow timeout overlay

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -2098,7 +2098,8 @@ pub fn ui_sections_overlay() -> serde_json::Value {
                 // Newly surfaced root-level scalars (#4678).
                 "update_channel", "max_history_messages", "max_upload_size_bytes",
                 "max_concurrent_bg_llm", "max_agent_call_depth", "max_request_body_bytes",
-                "workflow_stale_timeout_minutes", "tool_timeout_secs",
+                "workflow_stale_timeout_minutes", "workflow_default_total_timeout_secs",
+                "tool_timeout_secs",
                 "local_probe_interval_secs", "require_auth_for_reads",
                 "dashboard_user", "log_dir", "data_dir", "home_dir",
                 "cors_origin", "trust_forwarded_for",

--- a/crates/librefang-api/tests/auth_public_allowlist.rs
+++ b/crates/librefang-api/tests/auth_public_allowlist.rs
@@ -193,11 +193,6 @@ const REGISTERED_GET_ROUTES: &[RouteEntry] = &[
     re("/logo.png", Expect::AlwaysPublic),
     re("/.well-known/agent.json", Expect::AlwaysPublic),
     re("/api/health", Expect::AlwaysPublic),
-    // `/api/health/detail` is the polling target for `<OfflineBanner />`,
-    // which mounts before the auth check completes. It carries the same
-    // payload class as `/api/health` (liveness + build/uptime metadata),
-    // so it lives next to its sibling in `PUBLIC_ROUTES_ALWAYS`.
-    re("/api/health/detail", Expect::AlwaysPublic),
     re("/api/version", Expect::AlwaysPublic),
     re("/api/versions", Expect::AlwaysPublic),
     re("/api/auth/callback", Expect::AlwaysPublic),
@@ -260,6 +255,12 @@ const REGISTERED_GET_ROUTES: &[RouteEntry] = &[
     re("/api/status", Expect::DashboardRead),
     re("/api/workflows", Expect::DashboardRead),
     // Auth-required endpoints (must 401 without Bearer token)
+    // `/api/health/detail` is auth-required: the response leaks budget USD
+    // figures, agent counts, panic/restart counters, LLM latency stats, and
+    // memory-provider config — reconnaissance-grade if exposed unauthenticated.
+    // The minimal-payload `/api/health` (above) is what `<OfflineBanner />`
+    // polls pre-auth (see `dashboard/src/lib/queries/runtime.ts`).
+    re("/api/health/detail", Expect::Authed),
     // Security regression: /api/mcp/servers/{name} and /auth/status must NOT be
     // publicly reachable — the server config (including env vars) and OAuth token
     // state are sensitive. Only /auth/callback is public (via is_mcp_oauth_callback).

--- a/crates/librefang-api/tests/config_schema_overlay.rs
+++ b/crates/librefang-api/tests/config_schema_overlay.rs
@@ -253,6 +253,7 @@ fn every_kernel_config_struct_field_is_exposed_via_overlay() {
         "max_agent_call_depth",
         "max_request_body_bytes",
         "workflow_stale_timeout_minutes",
+        "workflow_default_total_timeout_secs",
         "local_probe_interval_secs",
     ];
 


### PR DESCRIPTION
## Summary

Two regressions landed on `main` that fail the **Coverage** workflow on every push. CI sharding intermittently hides them but Coverage (full-workspace nextest) catches both reliably. This PR fixes both.

### 1. `/api/health/detail` test ↔ middleware drift (regression from #4893)

#4893 reclassified `/api/health/detail` as `Expect::AlwaysPublic` in `tests/auth_public_allowlist.rs` so `<OfflineBanner />` could poll pre-auth, but the middleware still — correctly — keeps it auth-required. The handler returns:

- Budget figures (hourly/daily/monthly USD)
- Agent count, panic/restart counters
- LLM call latency (count, mean, max)
- Memory embedding provider + model, proactive_memory extraction model
- Config validation warnings, event bus drop counts

That's reconnaissance-grade data — must not be unauthenticated. The dashboard already polls `/api/health` (minimal-payload, always-public) for `<OfflineBanner />` — see `dashboard/src/lib/queries/runtime.ts:58`. So this is a pure test-table revert; no dashboard change needed.

Failing tests fixed:
- `librefang-api::auth_public_allowlist::always_public_paths_are_in_catalog`
- `librefang-api::auth_public_allowlist::always_public_routes_are_reachable_without_token`

### 2. `workflow_default_total_timeout_secs` not in overlay (regression from #4906)

#4906 added `KernelConfig::workflow_default_total_timeout_secs: Option<u64>` (workflow total-timeout feature, gap #9 of #4844) but never wired it into `ui_sections_overlay()` in `routes/config.rs`. The catalog enforcement test panicked listing the missing field.

Surface it in the `general` section next to its sibling `workflow_stale_timeout_minutes`, and add the matching `EXCLUDED`-list entry the test requires for root-level scalars (the test's `registered` set only collects descriptors with a `struct_field` key, so root-level scalars must be explicitly excused).

Failing test fixed:
- `librefang-api::config_schema_overlay::every_kernel_config_struct_field_is_exposed_via_overlay`

## Files changed

- `crates/librefang-api/tests/auth_public_allowlist.rs` — revert `/api/health/detail` classification `AlwaysPublic` → `Authed`; comment explains the recon-surface rationale and points readers to the `<OfflineBanner />` query that uses `/api/health` instead.
- `crates/librefang-api/src/routes/config.rs` — add `workflow_default_total_timeout_secs` to the general section's `fields` array so it renders on the dashboard ConfigPage.
- `crates/librefang-api/tests/config_schema_overlay.rs` — add `workflow_default_total_timeout_secs` to `EXCLUDED` next to `workflow_stale_timeout_minutes`.

## Verification

- `cargo test -p librefang-api --test auth_public_allowlist --test config_schema_overlay` → 12/12 passed
- `cargo check --workspace --lib` → clean
- `cargo clippy --workspace --all-targets -- -D warnings` → clean

## Test plan

- [x] Both failing integration tests pass locally
- [x] Workspace lib check + clippy clean
- [ ] CI: Coverage workflow turns green on this branch