### PR TITLE
fix(workflows,kernel): close gaps from #4907-#4910/#4920 audit

### DIFF
--- a/crates/librefang-api/tests/trigger_workflow_test.rs
+++ b/crates/librefang-api/tests/trigger_workflow_test.rs
@@ -373,6 +373,98 @@ async fn trigger_workflow_id_too_long_returns_400() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 6b: trigger workflow_id resolves by name case-insensitively, matching
+// WorkflowRunner::run_workflow / start_workflow_async and the cron path.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trigger_workflow_id_resolves_name_case_insensitively() {
+    use librefang_kernel::triggers::TriggerPattern;
+    use librefang_kernel::workflow::WorkflowId;
+    use librefang_types::event::{Event, EventPayload, EventTarget};
+
+    let h = boot().await;
+    let agent_id = spawn_agent(&h.state);
+
+    // Register a workflow with a MIXED-case name via the HTTP API.
+    let mixed_name = format!("MixedDeploy-{}", uuid::Uuid::new_v4().simple());
+    let agent_ref = uuid::Uuid::new_v4().to_string();
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/workflows",
+        Some(serde_json::json!({
+            "name": mixed_name.clone(),
+            "description": "case-insensitive lookup probe",
+            "steps": [{"name": "s1", "agent_id": agent_ref, "prompt": "hello"}]
+        })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "create_workflow failed: {body:?}"
+    );
+    let wf_uuid: WorkflowId = WorkflowId(
+        body["workflow_id"]
+            .as_str()
+            .unwrap()
+            .parse()
+            .expect("workflow_id must be a UUID"),
+    );
+
+    // Register a trigger with the workflow_id set to the LOWERCASE form of
+    // the workflow name. UUID parsing must fail (so the trigger falls into
+    // the name-lookup branch) and the case-insensitive comparison must match.
+    let lowercase_form = mixed_name.to_lowercase();
+    let trigger_id = h
+        .state
+        .kernel
+        .register_trigger_with_target(
+            agent_id,
+            TriggerPattern::ContentMatch {
+                substring: "deploy".to_string(),
+            },
+            "input is: {{event}}".to_string(),
+            0,
+            None,
+            Some(0),
+            None,
+            Some(lowercase_form.clone()),
+        )
+        .expect("register_trigger_with_target must succeed");
+
+    let stored = h
+        .state
+        .kernel
+        .get_trigger(trigger_id)
+        .expect("trigger must exist");
+    assert_eq!(stored.workflow_id.as_deref(), Some(lowercase_form.as_str()));
+
+    let payload_bytes = serde_json::to_vec(&serde_json::json!({
+        "type": "custom",
+        "text": "deploy this thing",
+    }))
+    .unwrap();
+    let event = Event::new(
+        AgentId::new(),
+        EventTarget::Broadcast,
+        EventPayload::Custom(payload_bytes),
+    );
+    h.state.kernel.publish_typed_event(event).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let engine = h.state.kernel.workflow_engine();
+    let runs = engine.list_runs(None).await;
+    let wf_run = runs.iter().find(|r| r.workflow_id == wf_uuid);
+    assert!(
+        wf_run.is_some(),
+        "case-insensitive name lookup must resolve `{lowercase_form}` to workflow `{mixed_name}` (id {wf_uuid:?}); got runs: {runs:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Test 6: old-format trigger JSON (without workflow_id) deserialises cleanly
 // ---------------------------------------------------------------------------
 

--- a/crates/librefang-kernel/src/kernel/cron_tick.rs
+++ b/crates/librefang-kernel/src/kernel/cron_tick.rs
@@ -597,16 +597,18 @@ pub(super) async fn run_cron_scheduler_loop(kernel: Arc<LibreFangKernel>) {
                             }
                         };
 
-                        // Resolve workflow by UUID first, then by name
+                        // Resolve workflow by UUID first, then by name (case-insensitive,
+                        // matching WorkflowRunner::run_workflow and the trigger-workflow
+                        // dispatch path so cron/tool/trigger all agree on the same name).
                         let resolved_id =
                             if let Ok(uuid) = uuid::Uuid::parse_str(&workflow_id_owned) {
                                 Some(crate::workflow::WorkflowId(uuid))
                             } else {
-                                // Search by name
+                                let name_lower = workflow_id_owned.to_lowercase();
                                 let workflows = kernel_job.workflows.engine.list_workflows().await;
                                 workflows
                                     .iter()
-                                    .find(|w| w.name == workflow_id_owned)
+                                    .find(|w| w.name.to_lowercase() == name_lower)
                                     .map(|w| w.id)
                             };
 

--- a/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
+++ b/crates/librefang-kernel/src/kernel/handles/workflow_runner.rs
@@ -173,11 +173,20 @@ impl kernel_handle::WorkflowRunner for LibreFangKernel {
                         .map_err(|e| format!("{e}"))
                 }
             };
-            let _ = kernel_arc
+            // Don't swallow the result — without a log the agent that
+            // called workflow_start has no way to learn the run failed
+            // except by polling get_workflow_run for the Failed state.
+            if let Err(e) = kernel_arc
                 .workflows
                 .engine
                 .execute_run(run_id, resolver, send_message)
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    run_id = %run_id,
+                    "Async workflow execution failed: {e}"
+                );
+            }
         });
 
         Ok(run_id.0.to_string())

--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -426,17 +426,20 @@ impl LibreFangKernel {
                             };
 
                             if let Some(ref wid_str) = workflow_id {
-                                // Workflow dispatch path: resolve workflow by UUID then name,
-                                // create a run, and execute it in a separate task so it does
-                                // not block other trigger dispatches from the same event.
+                                // Workflow dispatch path: resolve workflow by UUID, then by
+                                // name (case-insensitive — matches WorkflowRunner::run_workflow
+                                // and start_workflow_async so `daily report` and `Daily Report`
+                                // resolve to the same workflow whether the entry point is a
+                                // tool call or a trigger).
                                 let wid_str = wid_str.clone();
+                                let wid_lower = wid_str.to_lowercase();
                                 let resolved_id = if let Ok(uuid) = wid_str.parse::<uuid::Uuid>() {
                                     Some(crate::workflow::WorkflowId(uuid))
                                 } else {
                                     let workflows = kernel.workflows.engine.list_workflows().await;
                                     workflows
                                         .iter()
-                                        .find(|w| w.name == wid_str)
+                                        .find(|w| w.name.to_lowercase() == wid_lower)
                                         .map(|w| w.id)
                                 };
                                 match resolved_id {
@@ -444,38 +447,50 @@ impl LibreFangKernel {
                                         info!(
                                             trigger_id = %trigger_id,
                                             workflow_id = %wid_str,
-                                            "Trigger fired workflow"
+                                            "Trigger fired workflow (async)"
                                         );
-                                        match tokio::time::timeout(
-                                            fire_timeout,
-                                            kernel.run_workflow(wf_id, msg),
-                                        )
-                                        .await
-                                        {
-                                            Ok(Ok((run_id, _output))) => {
-                                                info!(
-                                                    trigger_id = %trigger_id,
-                                                    run_id = %run_id,
-                                                    workflow_id = %wid_str,
-                                                    "Trigger workflow run completed"
-                                                );
+                                        // Spawn the run so the Lane::Trigger permit drops as
+                                        // soon as this iteration yields. A slow workflow must
+                                        // not pin Lane::Trigger kernel-wide (default lane cap
+                                        // is 8 per CLAUDE.md), starving agent-path triggers.
+                                        // Mirrors the fire-and-forget shape of
+                                        // WorkflowRunner::start_workflow_async (#4910).
+                                        let kernel_for_spawn = std::sync::Arc::clone(&kernel);
+                                        let wid_for_spawn = wid_str.clone();
+                                        let trigger_id_for_spawn = trigger_id;
+                                        let timeout_for_spawn = fire_timeout;
+                                        tokio::spawn(async move {
+                                            match tokio::time::timeout(
+                                                timeout_for_spawn,
+                                                kernel_for_spawn.run_workflow(wf_id, msg),
+                                            )
+                                            .await
+                                            {
+                                                Ok(Ok((run_id, _output))) => {
+                                                    info!(
+                                                        trigger_id = %trigger_id_for_spawn,
+                                                        run_id = %run_id,
+                                                        workflow_id = %wid_for_spawn,
+                                                        "Trigger workflow run completed"
+                                                    );
+                                                }
+                                                Ok(Err(e)) => {
+                                                    warn!(
+                                                        trigger_id = %trigger_id_for_spawn,
+                                                        workflow_id = %wid_for_spawn,
+                                                        "Trigger workflow run failed: {e}"
+                                                    );
+                                                }
+                                                Err(_) => {
+                                                    warn!(
+                                                        trigger_id = %trigger_id_for_spawn,
+                                                        workflow_id = %wid_for_spawn,
+                                                        timeout_secs = timeout_for_spawn.as_secs(),
+                                                        "Trigger workflow run timed out"
+                                                    );
+                                                }
                                             }
-                                            Ok(Err(e)) => {
-                                                warn!(
-                                                    trigger_id = %trigger_id,
-                                                    workflow_id = %wid_str,
-                                                    "Trigger workflow run failed: {e}"
-                                                );
-                                            }
-                                            Err(_) => {
-                                                warn!(
-                                                    trigger_id = %trigger_id,
-                                                    workflow_id = %wid_str,
-                                                    timeout_secs = fire_timeout.as_secs(),
-                                                    "Trigger workflow run timed out; releasing lane permit"
-                                                );
-                                            }
-                                        }
+                                        });
                                     }
                                     None => {
                                         warn!(

--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -903,16 +903,28 @@ impl WorkflowEngine {
     }
 
     /// Register a new workflow definition and persist it to disk.
+    ///
+    /// Persistence is atomic: serialise → write `<id>.workflow.json.tmp` →
+    /// rename to `<id>.workflow.json`. A crash mid-write leaves the `.tmp`
+    /// side-file (ignored by `load_from_dir_sync`'s extension filter) but
+    /// never a half-written `<id>.workflow.json` that would later refuse to
+    /// parse and stall startup.
     pub async fn register(&self, workflow: Workflow) -> WorkflowId {
         let id = workflow.id;
         if let Some(ref dir) = self.workflows_dir {
             let path = dir.join(format!("{id}.workflow.json"));
+            let tmp_path = dir.join(format!("{id}.workflow.json.tmp"));
             match serde_json::to_string_pretty(&workflow) {
                 Ok(json) => {
                     if let Err(e) = tokio::fs::create_dir_all(dir).await {
                         warn!(workflow_id = %id, error = %e, "Failed to create workflows dir");
-                    } else if let Err(e) = tokio::fs::write(&path, &json).await {
-                        warn!(workflow_id = %id, error = %e, "Failed to persist workflow definition");
+                    } else if let Err(e) = tokio::fs::write(&tmp_path, &json).await {
+                        warn!(workflow_id = %id, error = %e, "Failed to persist workflow definition (tmp write)");
+                    } else if let Err(e) = tokio::fs::rename(&tmp_path, &path).await {
+                        warn!(workflow_id = %id, error = %e, "Failed to persist workflow definition (atomic rename)");
+                        // Best-effort cleanup so the next register attempt isn't
+                        // blocked by a stale tmp file.
+                        let _ = tokio::fs::remove_file(&tmp_path).await;
                     } else {
                         debug!(workflow_id = %id, path = %path.display(), "Persisted workflow definition");
                     }
@@ -3654,6 +3666,60 @@ mod tests {
         let retrieved = engine.get_workflow(id).await;
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().name, "test-pipeline");
+    }
+
+    // Multi-thread flavor because `load_from_dir_sync` uses
+    // `blocking_write` on the workflows RwLock, which panics on the default
+    // current-thread runtime ("Cannot block the current thread from within
+    // a runtime").
+    #[tokio::test(flavor = "multi_thread")]
+    async fn register_writes_atomically_and_cleans_tmp() {
+        // Atomic-write invariant: after a successful register, the persisted
+        // file exists at <id>.workflow.json and the staging path
+        // <id>.workflow.json.tmp must NOT exist — otherwise the loader on
+        // the next boot would happily skip the .tmp file (extension filter)
+        // and the rename clearly didn't fire.
+        let tmp = tempfile::tempdir().unwrap();
+        let engine = WorkflowEngine::new_with_persistence(tmp.path());
+        let wf = test_workflow();
+        let id = engine.register(wf.clone()).await;
+
+        let final_path = tmp
+            .path()
+            .join("workflows")
+            .join(format!("{id}.workflow.json"));
+        let tmp_path = tmp
+            .path()
+            .join("workflows")
+            .join(format!("{id}.workflow.json.tmp"));
+        assert!(
+            final_path.exists(),
+            "final file must exist after register: {}",
+            final_path.display()
+        );
+        assert!(
+            !tmp_path.exists(),
+            "tmp staging file must be cleaned after successful rename: {}",
+            tmp_path.display()
+        );
+
+        // The file must round-trip: load_from_dir_sync picks it up and the
+        // engine recognises the registered workflow by id. Drive
+        // `load_from_dir_sync` via `block_in_place` because it acquires
+        // `blocking_write` internally.
+        let engine2 = WorkflowEngine::new_with_persistence(tmp.path());
+        let loaded = tokio::task::block_in_place(|| {
+            engine2.load_from_dir_sync(&tmp.path().join("workflows"))
+        });
+        assert_eq!(loaded, 1, "expected exactly one workflow loaded back");
+        assert!(engine2.get_workflow(id).await.is_some());
+
+        // remove_workflow deletes the file too.
+        assert!(engine.remove_workflow(id).await);
+        assert!(
+            !final_path.exists(),
+            "persisted file must be gone after remove_workflow"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Post-merge audit of the workflow / trigger batch (#4907 / #4909 / #4910 / #4920) surfaced four small but real issues. Bundling them together because they all cluster around the same trigger ↔ workflow ↔ persistence surface area touched by that batch.

- **`#4909` trigger workflow dispatch was blocking, not fire-and-forget.** The original code awaited `kernel.run_workflow(wf_id, msg)` inside the dispatch worker, holding the `Lane::Trigger` permit for the entire workflow duration. A burst of slow workflow triggers could starve every other trigger (agent-path included) — default lane cap is 8 per CLAUDE.md. Now wraps the run in a nested `tokio::spawn`, mirroring `WorkflowRunner::start_workflow_async` from #4910 so the same logical operation has the same execution shape regardless of entry point.

- **`#4909` resolved workflow names case-sensitively, `#4910` resolved them case-insensitively.** Same workflow `Daily Report` was reachable from a tool call (`workflow_start("daily report")`) but not from a trigger configured with `daily report`. Cron (`CronAction::Workflow`) had the same case-sensitive bug. Both paths are now case-insensitive — agrees with the existing `WorkflowRunner::run_workflow` / `start_workflow_async` rule.

- **`#4920` persisted workflow defs with non-atomic `tokio::fs::write`.** A crash mid-write produced a half-written `<id>.workflow.json` that the loader (`load_from_dir_sync`) would barf on at next boot. Now writes `<id>.workflow.json.tmp` first and renames atomically. A crash leaves only the `.tmp` side-file (ignored by the loader's extension filter), never a corrupt final.

- **`#4910` swallowed `execute_run` errors from the spawned task.** `let _ = ...execute_run(...).await` meant a workflow that failed inside the spawn was invisible to the agent that called `workflow_start` — only an eventual `state=Failed` from polling `get_workflow_run` would surface it. Now logs via `tracing::warn!` with the `run_id` on failure.

## Files

| File | Change |
|------|--------|
| `crates/librefang-kernel/src/kernel/triggers_and_workflow.rs` | Nested `tokio::spawn` for trigger workflow dispatch + case-insensitive name match |
| `crates/librefang-kernel/src/kernel/cron_tick.rs` | Case-insensitive name match in `CronAction::Workflow` path |
| `crates/librefang-kernel/src/workflow.rs` | Atomic rename in `register()` + new `register_writes_atomically_and_cleans_tmp` test |
| `crates/librefang-kernel/src/kernel/handles/workflow_runner.rs` | Log `execute_run` errors in `start_workflow_async` spawn |
| `crates/librefang-api/tests/trigger_workflow_test.rs` | New `trigger_workflow_id_resolves_name_case_insensitively` test |

## Verification

```
cargo check --workspace --lib                          → clean
cargo clippy --workspace --all-targets -- -D warnings  → clean
cargo fmt --check                                      → clean
cargo test -p librefang-kernel --lib workflow::        → 88 pass, 0 fail
cargo test -p librefang-api --test trigger_workflow_test → 7 pass, 0 fail
cargo test -p librefang-runtime --test tool_runner_workflow_write → 12 pass, 0 fail (regression)
```

## Out of scope (intentionally deferred)

- `CancelRunError::NotFound` / `AlreadyTerminal` both still map to `KernelOpError::Internal` in `WorkflowRunner::cancel_workflow_run`. Tests downstream key off the error *message* (which is informative on both paths) rather than the variant, so this is purely an ergonomics nit rather than a correctness one. Cleanest fix is a new `KernelOpError` variant; out of scope for this batch.
- `register()`'s disk-write failure is still `warn!` + insert-to-memory rather than aborting. This is the existing graceful-degradation choice and reverting it would change API behaviour from "register succeeds" to "register might fail" — a deliberate design decision better debated separately.
- #4921 (`burst_ratio`) effectively no-op'd because the infrastructure was already in main; nothing to fix.

## Test plan

- [x] Atomic-write invariant test
- [x] Case-insensitive trigger workflow lookup test
- [x] Regression: existing 12 `tool_runner_workflow_write` tests still pass
- [x] Regression: existing 7 `trigger_workflow_test` tests still pass
- [x] Workspace check / clippy / fmt clean