### PR TITLE
revert(deps): pin opentelemetry to 0.31 (#4947 broke main)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4321,7 +4321,7 @@ dependencies = [
  "librefang-wire",
  "metrics",
  "metrics-exporter-prometheus",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "portable-pty",
@@ -4436,7 +4436,7 @@ dependencies = [
  "librefang-skills",
  "librefang-types",
  "open",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "ratatui",
  "reqwest",
@@ -5937,27 +5937,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
 name = "opentelemetry-otlp"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
@@ -5972,7 +5958,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
@@ -5988,7 +5974,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.18",
@@ -10205,7 +10191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,13 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 
 # OpenTelemetry
-opentelemetry = "0.32"
+# DO NOT upgrade to 0.32 until `tracing-opentelemetry` releases a version
+# that depends on opentelemetry 0.32 (current latest 0.32.1 still pins
+# opentelemetry = "0.31"). Mixing 0.32 here with tracing-opentelemetry
+# 0.32.1 leaves two copies of `opentelemetry::trace::Tracer` in the
+# tree and breaks `SdkTracer: Tracer` trait bounds in telemetry.rs.
+# dependabot bump #4947 violated this constraint and was reverted.
+opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 # `default-features = false` is critical: opentelemetry-otlp's default feature
 # set enables `http-proto` + `reqwest-blocking-client`, which forces


### PR DESCRIPTION
## Summary

dependabot #4947 bumped \`opentelemetry\` from 0.31 to 0.32, but \`tracing-opentelemetry@0.32.1\` (the latest published version) still pins \`opentelemetry = \"0.31\"\`. The mismatch leaves two copies of \`opentelemetry::trace::Tracer\` in the dependency tree, and \`telemetry.rs:153\` (\`tracing_opentelemetry::layer().with_tracer(tracer)\`) fails to resolve the \`SdkTracer: Tracer\` trait bound.

**Effect:** every PR's CI on top of main was failing with E0599/E0277 across Test/Unit, Test/macOS, Test/Windows, Test/Ubuntu shards, Quality, Live Integration Smoke, OpenAPI Drift, and llvm-cov.

**Why not adapt the API to 0.32?** That doesn't help. Even after migrating \`telemetry.rs\` to 0.32, \`tracing-opentelemetry\` would still import \`opentelemetry 0.31\`, so both versions would coexist and the \`Tracer\` trait bound would still fail to unify. The fix has to wait until \`tokio-rs/tracing-opentelemetry\` publishes an opentelemetry-0.32-compatible release.

## Changes

- \`Cargo.toml\` — revert \`opentelemetry\`, \`opentelemetry_sdk\`, \`opentelemetry-otlp\` to \`\"0.31\"\`. Keep \`tracing-opentelemetry = \"0.32\"\` (still on the 0.31 train).
- Add a doc-comment above the opentelemetry block guarding the next bump on tracing-opentelemetry shipping a follow-up.
- \`Cargo.lock\` — regenerated.

## Verification

- \`cargo check -p librefang-api\` → clean.

## Out-of-scope follow-ups

None.