### PR TITLE
fix(runtime/tests): add missing model_override in Session literal

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -10882,6 +10882,7 @@ mod tests {
             messages: Vec::new(),
             context_window_tokens: 0,
             label: None,
+            model_override: None,
             messages_generation: 0,
             last_repaired_generation: None,
         };


### PR DESCRIPTION
## Summary
- Coverage CI lane has been failing on main since the `model_override` field was added to `librefang_memory::session::Session` (issue #4898) — `cascade_leak_guard_aborts_tool_use_stop_reason_in_streaming_path` in `crates/librefang-runtime/src/agent_loop.rs` was the lone Session struct literal that wasn't updated, breaking the `--deny=warnings --test` build with `error[E0063]: missing field` model_override` `.
- The other 38 Session literals in the same file already set `model_override: None`; this PR brings the last one in line.

Failing run: https://github.com/librefang/librefang/actions/runs/25716928790

## Test plan
- [x] `cargo check -p librefang-runtime --tests` — clean
- [x] `cargo clippy -p librefang-runtime --all-targets -- -D warnings` — clean
- [x] `cargo test -p librefang-runtime --lib cascade_leak_guard_aborts_tool_use_stop_reason_in_streaming_path` — 1 passed
- [ ] CI: Coverage lane green