### PR TITLE
ci(release): install rustc on cli_npm/cli_pypi to fix sysinfo MSRV

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1082,6 +1082,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.RELEASE_REF }}
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
@@ -1111,6 +1112,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.RELEASE_REF }}
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-5dc1c3c57a2e6fc95085bf46f85e6aae116eb90dfd2fa608fc1585672d73f825  openapi.json
+f2c10b56e0d615e2870aa5d29eb859c2e4a7a3eb649f54a5e9fcc720202ec7ef  openapi.json


### PR DESCRIPTION
## Summary

Fixes the three failing checks on the latest `main` (HEAD `9a4aadee`, the
v2026.5.12-beta.11 version-bump commit):

1. **Release / CLI / PyPI** and **Release / CLI / npm** — both jobs were
   missing `dtolnay/rust-toolchain@stable` and used the `ubuntu-latest`
   preinstalled rustc (1.94.1). After #4952 raised sysinfo to 0.39.1
   (which requires rustc 1.95), the post-merge Release runs on tag
   `v2026.5.12-beta.11` fail with:
   ```
   error: rustc 1.94.1 is not supported by the following package:
     sysinfo@0.39.1 requires rustc 1.95
   ```
   Every other `cli_*` job in `release.yml` already installs dtolnay
   stable (which on the runner resolves to 1.95). This PR aligns
   `cli_npm` and `cli_pypi` with the rest — two-line yaml addition.

2. **CI / OpenAPI Drift** — the version-bump commit updated
   `openapi.json`'s `"version"` field to `2026.5.12-beta.11` but did not
   regenerate `xtask/baselines/openapi.sha256`, so `cargo xtask
   schema-check gen` now produces a different hash than what's checked
   in. The drift job auto-commits the regen on internal PRs
   (`IS_INTERNAL_PR=true`, see `.github/workflows/ci.yml:365`), so this
   PR's first CI run should push a `chore(codegen): auto-regenerate ...`
   commit back to this branch and turn the check green. No manual codegen
   needed in this commit; local rustc here is also 1.94.0 and can't
   compile the regen.

## Out-of-scope follow-up considered

Pinning sysinfo back to 0.38.x (the root cause for the rustc-version
mismatch) was the alternative. Rejected because the actual bug is that
`cli_npm` / `cli_pypi` drifted from the rest of the workflow on toolchain
setup — the next dependency to raise MSRV would re-trigger the same
failure even with sysinfo pinned. Fixing the toolchain pin in CI is the
real fix; the sysinfo upgrade can stay.

## Test plan

- [ ] CI's OpenAPI Drift job auto-commits regenerated baselines (look for
      a `chore(codegen): auto-regenerate ...` follow-up commit on this
      branch).
- [ ] All other required CI lanes (Test, Quality, Security) pass.
- [ ] On next release tag (post-merge), `Release / CLI / npm` and
      `Release / CLI / PyPI` jobs succeed. Cannot validate pre-merge —
      both gated on `startsWith(github.ref, 'refs/tags/v')`.
