### PR TITLE
fix(dashboard/workflows): allow deleting connection arrows between steps (#4978)

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1300,6 +1300,7 @@
     "ctx_paste": "Paste",
     "ctx_select_all": "Select All",
     "ctx_auto_layout": "Auto Layout",
+    "ctx_delete_connection": "Delete Connection",
     "click_to_assign": "Click to assign agent",
     "saved": "Saved",
     "exported": "Exported",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1300,6 +1300,7 @@
     "ctx_paste": "粘贴",
     "ctx_select_all": "全选",
     "ctx_auto_layout": "自动排列",
+    "ctx_delete_connection": "删除连接",
     "click_to_assign": "点击绑定智能体",
     "saved": "已保存",
     "exported": "已导出",

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -864,7 +864,7 @@ function CanvasPageInner() {
 
   const [selectedNodeIds, setSelectedNodeIds] = useState<Set<string>>(new Set());
   const [spacePressed, setSpacePressed] = useState(false);
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId?: string } | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId?: string; edgeId?: string } | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [showHelp, setShowHelp] = useState(false);
   const [showTemplateBrowser, setShowTemplateBrowser] = useState(false);
@@ -2302,8 +2302,17 @@ function CanvasPageInner() {
               e.preventDefault();
               setContextMenu({ x: e.clientX, y: e.clientY, nodeId: node.id });
             }}
+            onEdgeContextMenu={(e, edge) => {
+              e.preventDefault();
+              setContextMenu({ x: e.clientX, y: e.clientY, edgeId: edge.id });
+            }}
+            onEdgeClick={() => { setContextMenu(null); setEditingNode(null); }}
             nodeTypes={nodeTypes} colorMode={theme}
             defaultEdgeOptions={defaultEdgeOptions}
+            // Both Backspace (xyflow default) and Delete — Windows / external
+            // keyboards expose Delete as a separate key from Backspace, and
+            // the shortcut help advertises "Delete" already (#4978).
+            deleteKeyCode={["Backspace", "Delete"]}
             defaultViewport={{ x: 50, y: 80, zoom: 1 }}
             minZoom={0.1} maxZoom={2}
             snapToGrid snapGrid={[12, 12]}
@@ -2354,7 +2363,16 @@ function CanvasPageInner() {
               className="fixed z-50 rounded-xl border border-border-subtle bg-surface shadow-2xl py-1 min-w-[160px]"
               style={{ left: contextMenu.x, top: contextMenu.y }}
               onKeyDown={e => { if (e.key === "Escape") setContextMenu(null); }}>
-              {contextMenu.nodeId ? (
+              {contextMenu.edgeId ? (
+                <button role="menuitem" className="w-full px-3 py-1.5 text-xs text-left hover:bg-error/10 text-error flex items-center gap-2"
+                  onClick={() => {
+                    pushHistory();
+                    setEdges(eds => eds.filter(ed => ed.id !== contextMenu.edgeId));
+                    setContextMenu(null);
+                  }}>
+                  <Trash2 className="w-3 h-3" /> {t("canvas.ctx_delete_connection")}
+                </button>
+              ) : contextMenu.nodeId ? (
                 <>
                   <button role="menuitem" className="w-full px-3 py-1.5 text-xs text-left hover:bg-main flex items-center gap-2"
                     onClick={() => { setEditingNode(nodes.find(n => n.id === contextMenu.nodeId) || null); setContextMenu(null); }}>


### PR DESCRIPTION
Fixes #4978

## What changed

`crates/librefang-api/dashboard/src/pages/CanvasPage.tsx` — the workflow canvas (`@xyflow/react` v12) had no way to remove a connection between two step nodes:

- **Right-click on an arrow** → context menu now offers "Delete Connection". Wired via `onEdgeContextMenu` on the `<ReactFlow>` component; the existing `contextMenu` state was extended with an optional `edgeId` field and a third menu branch renders only the delete item for that case. Uses the same `pushHistory()` + `setEdges(...)` pattern as the node-delete menu item, so the change is undoable with Cmd/Ctrl+Z.
- **Keyboard delete** → `deleteKeyCode={["Backspace", "Delete"]}`. xyflow's default is `Backspace` only, but the shortcut-help dialog already advertised the `Delete` key (line ~2563), so Windows / external-keyboard users were getting a no-op. The combined binding lets xyflow's built-in delete remove whatever is currently selected (nodes **or** edges).
- **`onEdgeClick`** clears any open editing panel / pane context menu, matching `onNodeClick` / `onPaneClick` so state is consistent when the user clicks between elements.

New locale strings: `canvas.ctx_delete_connection` in `locales/en.json` ("Delete Connection") and `locales/zh.json` ("删除连接").

`WorkflowEditor.tsx` (a standalone unused component under `src/components/`) was left untouched — it has no callers in the codebase and the live workflow editor is `CanvasPage.tsx`.

## Verification

- `npm run typecheck` — clean.
- `npm run build` — clean (Vite build succeeds, no new warnings).
- No new dashboard test files added; there are no existing `CanvasPage.test.*` files to extend, and the workflow graph is held in local React state (no API mutation involved in arrow deletion).
- **Manual verification deferred** — please test in the dashboard that: (1) right-clicking an arrow shows "Delete Connection" and deletes it, (2) clicking an arrow + Backspace removes it, (3) clicking an arrow + Delete removes it, (4) undo (Cmd/Ctrl+Z) brings the arrow back.

## Out of scope

The unused `crates/librefang-api/dashboard/src/components/WorkflowEditor.tsx` could be deleted as dead code, but that's an unrelated cleanup.
