### PR TITLE
fix(kernel): accept absolute workspace paths under workspaces_root (#4991)

### DIFF
--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -448,6 +448,180 @@ async fn test_delete_agent_unknown_uuid_is_idempotent_200() {
 }
 
 // ---------------------------------------------------------------------------
+// POST /api/agents — re-create an agent with a previously-used name (#4991)
+// ---------------------------------------------------------------------------
+
+/// Refs #4991: deleting an agent and immediately re-creating one with the
+/// same name used to fail with `500 Internal error: Invalid workspace path`.
+///
+/// Root cause: `spawn_agent_inner` rewrites `manifest.workspace` to the
+/// resolved absolute directory (`<workspaces>/agents/<name>`). The manifest
+/// is round-tripped to `agent.toml` on disk; subsequent re-creation feeds
+/// that absolute path back into `resolve_workspace_dir`, which blanket-
+/// rejected anything `is_absolute()` — even when it pointed inside the
+/// workspaces root the helper would have produced itself.
+///
+/// The fix accepts absolute paths under `workspaces_root` while still
+/// rejecting paths outside it (and any `..` / Windows-prefix traversal).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_spawn_agent_with_absolute_workspace_inside_root_succeeds() {
+    let h = boot(TEST_TOKEN).await;
+
+    // Compute the absolute workspace path the kernel itself would assign
+    // to an agent named "recreate-me". This mirrors what
+    // `persist_manifest_to_disk` writes back into `agent.toml` after a
+    // successful spawn — and what gets fed into a subsequent re-spawn.
+    let cfg = h.state.kernel.config_ref();
+    let abs_workspace = cfg.effective_agent_workspaces_dir().join("recreate-me");
+
+    let manifest_toml = format!(
+        r#"
+name = "recreate-me"
+description = "agent with absolute workspace path"
+workspace = "{}"
+
+[model]
+provider = "ollama"
+model = "test-model"
+"#,
+        // TOML basic-string escape: backslashes (Windows paths) must be
+        // doubled so the parser sees a literal path component.
+        abs_workspace.display().to_string().replace('\\', "\\\\"),
+    );
+
+    let (status, body) = send(
+        h.app.clone(),
+        post_json(
+            "/api/agents",
+            serde_json::json!({ "manifest_toml": manifest_toml }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "spawn with absolute workspace inside root must succeed; body={body:?}"
+    );
+    assert_eq!(body["name"], "recreate-me", "body={body:?}");
+}
+
+/// Refs #4991: the full delete-then-recreate flow the issue reporter hit.
+/// Spawn → confirmed DELETE → spawn again under the same name with the
+/// manifest the kernel persisted on the first spawn (i.e. carrying the
+/// resolved absolute workspace path). Without the fix the second spawn
+/// returns `500 spawn_failed / api-error-agent-error`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_recreate_agent_same_name_after_delete_succeeds() {
+    let h = boot(TEST_TOKEN).await;
+
+    // First spawn — let the kernel synthesize the absolute workspace dir,
+    // then read it back from the registry exactly as
+    // `persist_manifest_to_disk` would serialize it.
+    let id1 = spawn_named(&h.state, "recreated");
+    let resolved_workspace = h
+        .state
+        .kernel
+        .agent_registry()
+        .get(id1)
+        .and_then(|e| e.manifest.workspace.clone())
+        .expect("spawn must have set manifest.workspace to an absolute path");
+    assert!(
+        resolved_workspace.is_absolute(),
+        "first spawn should resolve workspace to an absolute path; got {}",
+        resolved_workspace.display()
+    );
+
+    // Confirmed DELETE — purges canonical UUID, drops registry entry,
+    // but leaves the workspace directory on disk (kill_agent does NOT
+    // remove the workspace; the reporter's repro relies on this).
+    let (del_status, del_body) = send(
+        h.app.clone(),
+        delete_confirmed(&format!("/api/agents/{}", id1), Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(
+        del_status,
+        StatusCode::OK,
+        "DELETE must succeed; body={del_body:?}"
+    );
+    assert_eq!(del_body["status"], "killed", "body={del_body:?}");
+
+    // Second spawn — same name, carrying the absolute workspace that the
+    // first spawn would have written back to agent.toml. This is exactly
+    // what the dashboard form (or template instantiation) replays.
+    let manifest_toml = format!(
+        r#"
+name = "recreated"
+workspace = "{}"
+
+[model]
+provider = "ollama"
+model = "test-model"
+"#,
+        resolved_workspace
+            .display()
+            .to_string()
+            .replace('\\', "\\\\"),
+    );
+    let (status, body) = send(
+        h.app.clone(),
+        post_json(
+            "/api/agents",
+            serde_json::json!({ "manifest_toml": manifest_toml }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "recreate after delete must succeed; got {status} body={body:?}"
+    );
+    assert_eq!(body["name"], "recreated", "body={body:?}");
+}
+
+/// Refs #4991: the security boundary the original blanket `is_absolute()`
+/// reject was protecting must stay closed. An absolute path pointing
+/// **outside** `workspaces_root` is still rejected.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_spawn_agent_with_absolute_workspace_outside_root_rejected() {
+    let h = boot(TEST_TOKEN).await;
+
+    // `/tmp/...` (or `C:\...` on Windows) is always outside the per-test
+    // tempdir workspaces root. Use a platform-appropriate absolute path
+    // so the test is meaningful on both Unix and Windows runners.
+    #[cfg(unix)]
+    let outside = "/tmp/librefang-4991-outside";
+    #[cfg(windows)]
+    let outside = "C:\\librefang-4991-outside";
+
+    let manifest_toml = format!(
+        r#"
+name = "escape-me"
+workspace = "{}"
+
+[model]
+provider = "ollama"
+model = "test-model"
+"#,
+        outside.replace('\\', "\\\\"),
+    );
+
+    let (status, _body) = send(
+        h.app.clone(),
+        post_json(
+            "/api/agents",
+            serde_json::json!({ "manifest_toml": manifest_toml }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "absolute workspace outside the workspaces root must still be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // GET /api/agents/{id}/session — thinking blocks reach the dashboard
 // ---------------------------------------------------------------------------
 

--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -577,6 +577,20 @@ model = "test-model"
         "recreate after delete must succeed; got {status} body={body:?}"
     );
     assert_eq!(body["name"], "recreated", "body={body:?}");
+    // AgentId is a deterministic UUIDv5 derived from the agent name
+    // (`AgentId::new_for_name`), so the recreated agent intentionally
+    // shares its UUID with the deleted one. We only assert the response
+    // carries an agent_id at all — confirming the second spawn went
+    // through the full code path rather than returning a stale 200 from
+    // the idempotency cache.
+    let id2 = body["agent_id"]
+        .as_str()
+        .expect("recreate response must carry the new agent id");
+    assert_eq!(
+        id2,
+        id1.to_string(),
+        "AgentId is name-deterministic; recreated UUID must match the original"
+    );
 }
 
 /// Refs #4991: the security boundary the original blanket `is_absolute()`
@@ -618,6 +632,51 @@ model = "test-model"
         status,
         StatusCode::INTERNAL_SERVER_ERROR,
         "absolute workspace outside the workspaces root must still be rejected"
+    );
+}
+
+/// Refs #4991: even when the absolute path's prefix matches `workspaces_root`,
+/// a `..` component anywhere in the path must still be rejected. Without this
+/// guard, `<workspaces_root>/x/../../escape` would syntactically `starts_with`
+/// the root yet resolve outside it once the OS canonicalizes the path.
+/// `has_unsafe_relative_components` runs *before* the `is_absolute()` branch
+/// in `resolve_workspace_dir`, so any `ParentDir` component fails closed
+/// regardless of which branch would otherwise accept the input.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_spawn_agent_with_absolute_workspace_dotdot_traversal_rejected() {
+    let h = boot(TEST_TOKEN).await;
+
+    // Build an absolute path that starts with the real workspaces root but
+    // contains a `..` segment further down. Without the unsafe-component
+    // check this would slip past the `starts_with(&root)` branch.
+    let cfg = h.state.kernel.config_ref();
+    let root = cfg.effective_agent_workspaces_dir();
+    let traversal = root.join("x").join("..").join("escape");
+
+    let manifest_toml = format!(
+        r#"
+name = "dotdot-escape"
+workspace = "{}"
+
+[model]
+provider = "ollama"
+model = "test-model"
+"#,
+        traversal.display().to_string().replace('\\', "\\\\"),
+    );
+
+    let (status, _body) = send(
+        h.app.clone(),
+        post_json(
+            "/api/agents",
+            serde_json::json!({ "manifest_toml": manifest_toml }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "absolute workspace with `..` traversal must be rejected even when the prefix matches workspaces_root"
     );
 }
 

--- a/crates/librefang-kernel/src/kernel/workspace_setup.rs
+++ b/crates/librefang-kernel/src/kernel/workspace_setup.rs
@@ -298,7 +298,28 @@ pub(super) fn resolve_workspace_dir(
     let root = workspaces_root.to_path_buf();
 
     if let Some(path) = requested {
-        if path.is_absolute() || has_unsafe_relative_components(&path) {
+        // Reject `..` traversal or Windows drive prefixes anywhere in the
+        // requested path — these can escape `workspaces_root` even after
+        // joining and must never be honoured.
+        if has_unsafe_relative_components(&path) {
+            return Err(KernelError::LibreFang(LibreFangError::Internal(
+                "Invalid workspace path".to_string(),
+            )));
+        }
+        // Refs #4991: an absolute path is acceptable iff it lies inside
+        // `workspaces_root`. Spawn previously rewrote `manifest.workspace`
+        // to the resolved absolute directory and `persist_manifest_to_disk`
+        // round-tripped it back into `agent.toml`. Re-spawning the agent
+        // (recreate after delete, template instantiation, daemon restart)
+        // would then feed that absolute path back through this helper and
+        // hit the blanket `is_absolute()` reject below — hence the
+        // user-visible `Internal error: Invalid workspace path` 500 on
+        // recreate with a previously-used name. Accept absolute paths
+        // under the root; everything outside still fails closed.
+        if path.is_absolute() {
+            if path.starts_with(&root) {
+                return Ok(path);
+            }
             return Err(KernelError::LibreFang(LibreFangError::Internal(
                 "Invalid workspace path".to_string(),
             )));

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-5dc1c3c57a2e6fc95085bf46f85e6aae116eb90dfd2fa608fc1585672d73f825  openapi.json
+f2c10b56e0d615e2870aa5d29eb859c2e4a7a3eb649f54a5e9fcc720202ec7ef  openapi.json


### PR DESCRIPTION
Fixes #4991

## Root cause

`resolve_workspace_dir` in `crates/librefang-kernel/src/kernel/workspace_setup.rs:300-306` blanket-rejected any `manifest.workspace` that was absolute, even when the path pointed inside the workspaces root the helper would have produced itself. The original spawn (`crates/librefang-kernel/src/kernel/spawn.rs:253-269`) rewrites `manifest.workspace = Some(workspace_dir)` to the resolved absolute path, and `persist_manifest_to_disk` (`crates/librefang-kernel/src/kernel/agent_state.rs:35-73`) round-trips that absolute path back into the on-disk `agent.toml`. Any later code that re-feeds the persisted manifest into spawn — POST `/api/agents` from the dashboard recreate flow, `load_template_manifest` from assistant routing (`crates/librefang-kernel/src/kernel/assistant_routing.rs:146-148`), or daemon restart restore — then hit the `is_absolute()` reject and surfaced as `WARN Spawn failed: Internal error: Invalid workspace path` followed by `500 api-error-agent-error`. `kill_agent` does not remove the workspace directory or `agent.toml` from disk, which is why the failure only reproduces after a prior delete under the same name.

## Fix

In `resolve_workspace_dir`, accept absolute paths iff `path.starts_with(workspaces_root)`. Reject any absolute path outside the root, and keep rejecting `..` traversal / Windows `Prefix` components (`has_unsafe_relative_components`) regardless. This is minimal — no callers changed, no contract change for relative paths, the security boundary (no escape from the workspaces root) is preserved by the `starts_with` check.

## Verification

- `cargo check --workspace --lib` clean (8m 21s).
- `cargo clippy --workspace --all-targets -- -D warnings` clean (5m 31s).
- `cargo test -p librefang-api --test agents_routes_integration` — 22 passed, 0 failed. Three new tests cover the fix:
  - `test_spawn_agent_with_absolute_workspace_inside_root_succeeds` — happy path: POST `/api/agents` with `manifest_toml` carrying an absolute path inside the workspaces root returns 201.
  - `test_recreate_agent_same_name_after_delete_succeeds` — full repro: spawn, read back the kernel-assigned absolute `manifest.workspace`, confirmed DELETE, re-spawn with that exact absolute path. Without the fix the second spawn returned 500.
  - `test_spawn_agent_with_absolute_workspace_outside_root_rejected` — security boundary: absolute path outside the workspaces root (`/tmp/...` on Unix, `C:\\...` on Windows) is still rejected with 500.
- `cargo test -p librefang-kernel --lib spawn` — 18 passed, 0 failed (no regressions in spawn-related kernel unit tests).

## Out-of-scope

None — the fix is one file, one helper, and the test additions are colocated with the affected route.

## Follow-up to review

Addresses reviewer findings on the initial revision (commit `c0c1e1e3`):

- **Fix 1 — pin `..` traversal rejection on the new absolute-path branch.** Added `test_spawn_agent_with_absolute_workspace_dotdot_traversal_rejected` next to the existing three tests. Builds an absolute path of the form `<workspaces_root>/x/../escape` so the `starts_with(&root)` check would syntactically match, then asserts the spawn is rejected with 500. This exercises the fact that `has_unsafe_relative_components` runs *before* the `is_absolute()` branch in `resolve_workspace_dir`, so any `ParentDir` component fails closed regardless of which branch would otherwise accept the input.
- **Fix 2 — `clippy::collapsible_if` on `workspace_setup.rs:319-322`.** Ran `cargo clippy -p librefang-kernel --all-targets -- -D warnings` and `cargo clippy --workspace --all-targets -- -D warnings`; both clean. clippy did NOT flag the nested `if path.is_absolute() { if path.starts_with(...) {...} return Err }` form — the early-return inside the inner block keeps it out of the `collapsible_if` lint. No code change required; original shape preserved.
- **Fix 3 — strengthen the recreate assertion.** Investigated: `AgentId::new_for_name` is a deterministic `Uuid::new_v5(&LIBREFANG_USER_NAMESPACE, name.as_bytes())` (`crates/librefang-types/src/agent.rs:41`). Recreating an agent with the same name intentionally produces the same UUID. The original "different UUID" suggestion was based on a wrong assumption — instead the test now asserts the response carries `agent_id` and that it equals `id1`, documenting the name-deterministic contract so any future change to ID derivation surfaces here.

### Verification (this commit)

- `cargo check --workspace --lib` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test -p librefang-api --test agents_routes_integration -- test_spawn_agent_with_absolute_workspace_dotdot_traversal_rejected test_recreate_agent_same_name_after_delete_succeeds test_spawn_agent_with_absolute_workspace_inside_root_succeeds test_spawn_agent_with_absolute_workspace_outside_root_rejected` — 4 passed, 0 failed.
