### PR TITLE
fix(kernel,channels): auto-transcribe inbound channel audio when [media].audio_transcription = true (#4975)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2235,6 +2235,49 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
     fn channels_download_max_bytes(&self) -> Option<u64> {
         Some(self.kernel.config_ref().channels.file_download_max_bytes)
     }
+
+    /// Auto-transcribe inbound channel audio (#4975).
+    ///
+    /// Honors the kernel `[media] audio_transcription` flag (default OFF) —
+    /// returns `Ok(None)` when disabled so the bridge falls back to the
+    /// raw-path block. When enabled, materializes a `MediaAttachment` over the
+    /// already-downloaded file and dispatches to `MediaEngine::transcribe_audio`.
+    /// Errors propagate as `Err(reason)` so the bridge can render a
+    /// `[Transcription failed: …]` note instead of dropping the message.
+    async fn transcribe_inbound_audio(
+        &self,
+        path: &std::path::Path,
+        mime_type: &str,
+    ) -> Result<Option<String>, String> {
+        // Default-OFF respect — exit immediately when the operator hasn't
+        // opted in. Cheap config snapshot, no allocations on the cold path.
+        if !self.kernel.config_ref().media.audio_transcription {
+            return Ok(None);
+        }
+
+        // Probe size + reject unsupported MIME bases at the validation
+        // layer (mirrors `/api/uploads` / `/media/transcribe` semantics).
+        // We use `tokio::fs` rather than blocking `std::fs` because this
+        // method is called from inside the channel dispatch task.
+        let size_bytes = match tokio::fs::metadata(path).await {
+            Ok(m) => m.len(),
+            Err(e) => return Err(format!("stat saved audio failed: {e}")),
+        };
+
+        let attachment = librefang_types::media::MediaAttachment {
+            media_type: librefang_types::media::MediaType::Audio,
+            mime_type: mime_type.to_string(),
+            source: librefang_types::media::MediaSource::FilePath {
+                path: path.to_string_lossy().into_owned(),
+            },
+            size_bytes,
+        };
+
+        match self.kernel.media().transcribe_audio(&attachment).await {
+            Ok(result) => Ok(Some(result.description)),
+            Err(reason) => Err(reason),
+        }
+    }
 }
 
 /// Parse a trigger pattern string from chat into a `TriggerPattern`.

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -577,8 +577,11 @@ pub trait ChannelBridgeHandle: Send + Sync {
     ///   2. On enabled, hand the attachment to the kernel `MediaEngine`
     ///      (`transcribe_audio`), returning `Ok(Some(text))` on success.
     ///   3. On provider error / no credentials / oversize file, return
-    ///      `Err(reason)` so the bridge can surface a `[Transcription failed: …]`
-    ///      note next to the saved path without dropping the message.
+    ///      `Err(reason)` so the bridge can surface an opaque
+    ///      `[Transcription unavailable]` note next to the saved path
+    ///      without dropping the message. The bridge sanitizes the
+    ///      reason out of the user-facing block (see #4999) — operator
+    ///      logs still carry the full error.
     ///
     /// The default impl (used by mocks) is "feature off" — returns `Ok(None)`.
     /// See issue #4975: `MediaEngine::process_attachments` previously had no
@@ -4285,10 +4288,16 @@ fn has_file_saved_block(blocks: &[ContentBlock]) -> bool {
 ///
 /// Returns a `ContentBlock::Text` to insert next to the saved-path block:
 ///   - `Some([Transcription: …])` when transcription succeeded.
-///   - `Some([Transcription failed: …])` when the kernel reported an error
-///     (no provider configured, oversize file, provider 5xx, …) — the raw
+///   - `Some([Transcription unavailable])` when the kernel reported an
+///     error (no provider configured, oversize file, provider 5xx, …) or
+///     the STT call exceeded [`INBOUND_TRANSCRIPTION_TIMEOUT`]. The raw
 ///     path block is still delivered so the agent can fall back to
-///     `media_transcribe` or just acknowledge the voice note.
+///     `media_transcribe` or just acknowledge the voice note. The
+///     opaque text deliberately omits the provider reason — provider
+///     error envelopes can echo API keys / URLs (e.g. Gemini's
+///     `?key=…`); leaking the verbose reason into the message stream
+///     would also leak it into every downstream LLM's prompt cache.
+///     Operators see the full reason in logs.
 ///   - `None` when transcription is disabled (the default) or there is no
 ///     saved file (download failed earlier).
 ///
@@ -4299,11 +4308,50 @@ async fn maybe_transcribe_inbound_audio(
     handle: &Arc<dyn ChannelBridgeHandle>,
     saved: Option<&(std::path::PathBuf, String)>,
 ) -> Option<ContentBlock> {
+    maybe_transcribe_inbound_audio_with_timeout(handle, saved, INBOUND_TRANSCRIPTION_TIMEOUT).await
+}
+
+/// Inner variant of [`maybe_transcribe_inbound_audio`] that takes the
+/// timeout explicitly. Production callers go through the wrapper above,
+/// which pins the timeout to [`INBOUND_TRANSCRIPTION_TIMEOUT`]; tests use
+/// this entry point with a small duration to exercise the timeout branch
+/// without sitting on the wall clock.
+async fn maybe_transcribe_inbound_audio_with_timeout(
+    handle: &Arc<dyn ChannelBridgeHandle>,
+    saved: Option<&(std::path::PathBuf, String)>,
+    timeout_dur: std::time::Duration,
+) -> Option<ContentBlock> {
     let (path, media_type) = saved?;
-    if !media_type.to_ascii_lowercase().starts_with("audio/") {
+    // Cheap ASCII prefix check without allocating a lowercase copy on
+    // every voice message.
+    if !media_type
+        .as_bytes()
+        .get(..6)
+        .is_some_and(|p| p.eq_ignore_ascii_case(b"audio/"))
+    {
         return None;
     }
-    match handle.transcribe_inbound_audio(path, media_type).await {
+    let fut = handle.transcribe_inbound_audio(path, media_type);
+    let result = match tokio::time::timeout(timeout_dur, fut).await {
+        Ok(inner) => inner,
+        Err(_elapsed) => {
+            // STT hung past the budget — dispatch must move on so the
+            // per-(agent,channel) session doesn't pile up behind one
+            // 60s voice note. Treat identically to the provider-error
+            // path: opaque unavailable block + raw saved-path block.
+            warn!(
+                path = %path.display(),
+                mime = %media_type,
+                timeout_secs = timeout_dur.as_secs(),
+                "Inbound audio transcription timed out; passing raw file to agent"
+            );
+            return Some(ContentBlock::Text {
+                text: TRANSCRIPTION_UNAVAILABLE_BLOCK.to_string(),
+                provider_metadata: None,
+            });
+        }
+    };
+    match result {
         Ok(Some(text)) => {
             let trimmed = text.trim();
             if trimmed.is_empty() {
@@ -4318,7 +4366,9 @@ async fn maybe_transcribe_inbound_audio(
         Err(reason) => {
             // Never drop the message — surface the failure as a sibling
             // block so the agent knows transcription was attempted and
-            // failed. Operator sees the same reason in the kernel logs.
+            // failed. Operator log keeps the full reason; the LLM-facing
+            // block is intentionally opaque (see SECURITY note in the
+            // doc-comment above).
             warn!(
                 path = %path.display(),
                 mime = %media_type,
@@ -4326,12 +4376,28 @@ async fn maybe_transcribe_inbound_audio(
                 "Inbound audio transcription failed; passing raw file to agent"
             );
             Some(ContentBlock::Text {
-                text: format!("[Transcription failed: {reason}]"),
+                text: TRANSCRIPTION_UNAVAILABLE_BLOCK.to_string(),
                 provider_metadata: None,
             })
         }
     }
 }
+
+/// Hard deadline for the kernel STT round-trip during channel dispatch.
+///
+/// Whisper / Groq normally return in 2-5s for a 1-minute voice; 30s is
+/// generous but short enough that a hung provider can't pin the
+/// per-(agent,channel) session indefinitely. On expiry the helper
+/// returns the opaque "unavailable" block and the raw saved-path block
+/// continues to the agent.
+const INBOUND_TRANSCRIPTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// User-facing text for an inbound transcription that didn't produce a
+/// usable result — provider error, missing credentials, oversize file,
+/// or [`INBOUND_TRANSCRIPTION_TIMEOUT`] expiry. Deliberately opaque to
+/// avoid leaking provider error envelopes (which can echo API keys /
+/// request URLs) into the LLM prompt and downstream cache.
+const TRANSCRIPTION_UNAVAILABLE_BLOCK: &str = "[Transcription unavailable]";
 
 /// Extract a basename-style filename from the path component of a URL.
 ///
@@ -7905,23 +7971,33 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn provider_failure_surfaces_warn_block_not_drop() {
+        async fn provider_failure_surfaces_opaque_block_not_drop() {
             // Provider 5xx, missing creds, or oversize → `Err(reason)`.
-            // Message MUST still reach the agent: we return a
-            // `[Transcription failed: …]` text block; the raw saved-path
-            // block is preserved by the caller, so the agent can fall
-            // back to `media_transcribe` or just acknowledge the voice
-            // note. Never drop the message.
-            let (h, _rec) = handle_with(Err("groq 500: backend exploded".into()));
+            // Message MUST still reach the agent: we return an opaque
+            // `[Transcription unavailable]` text block (the raw reason
+            // never reaches the LLM prompt because provider error
+            // envelopes can echo API keys — see #4999); the raw
+            // saved-path block is preserved by the caller, so the agent
+            // can fall back to `media_transcribe` or just acknowledge
+            // the voice note. Never drop the message.
+            let leak = "Gemini API error (401): https://generativelanguage.googleapis.com/v1beta/models/foo:generateContent?key=SECRET_KEY_DO_NOT_LEAK";
+            let (h, _rec) = handle_with(Err(leak.into()));
             let s = saved("/tmp/x.ogg", "audio/ogg");
             let block = maybe_transcribe_inbound_audio(&h, s.as_ref()).await;
             match block {
                 Some(ContentBlock::Text { text, .. }) => {
-                    assert!(
-                        text.starts_with("[Transcription failed:"),
-                        "want failure marker, got: {text}"
+                    assert_eq!(
+                        text, "[Transcription unavailable]",
+                        "failure block must be the opaque sentinel"
                     );
-                    assert!(text.contains("groq 500"));
+                    assert!(
+                        !text.contains("SECRET_KEY_DO_NOT_LEAK"),
+                        "provider reason (which may contain credentials) must not leak into the block"
+                    );
+                    assert!(
+                        !text.contains("?key="),
+                        "URL query params from the provider error must not leak into the block"
+                    );
                 }
                 other => panic!("expected failure text block, got {other:?}"),
             }
@@ -7964,6 +8040,143 @@ mod tests {
             let s = saved("/tmp/x.ogg", "audio/ogg");
             let block = maybe_transcribe_inbound_audio(&h, s.as_ref()).await;
             assert!(block.is_none(), "empty transcription must be dropped");
+        }
+
+        /// Mirror the Voice/Audio dispatch sites in `dispatch_message`:
+        /// after `download_file_to_blocks` we have `[Text("[File: …]")]`
+        /// → caller `insert(0, header)` → caller `insert(1, transcription)`.
+        /// The resulting order must be:
+        ///   blocks[0] = "[Voice message …]" header
+        ///   blocks[1] = "[Transcription: …]"
+        ///   blocks[2] = "[File: …]" saved-path block
+        ///
+        /// This pins the position so a future refactor can't silently
+        /// move the transcription after the path block — which would
+        /// change how the model reads the message (transcription serves
+        /// as the *spoken content*; it must precede the file metadata).
+        #[tokio::test]
+        async fn transcription_block_lands_between_header_and_file_path() {
+            let (h, _rec) = handle_with(Ok(Some("hello world".into())));
+            let s = saved("/tmp/voice.ogg", "audio/ogg");
+
+            // Simulate what `download_file_to_blocks` produced on success.
+            let mut blocks = vec![ContentBlock::Text {
+                text: "[File: /tmp/voice.ogg]".into(),
+                provider_metadata: None,
+            }];
+
+            // Same sequence as the Voice/Audio arms of dispatch_message.
+            let transcription = maybe_transcribe_inbound_audio(&h, s.as_ref()).await;
+            blocks.insert(
+                0,
+                ContentBlock::Text {
+                    text: "[Voice message (4s)]".into(),
+                    provider_metadata: None,
+                },
+            );
+            if let Some(t) = transcription {
+                blocks.insert(1, t);
+            }
+
+            assert_eq!(blocks.len(), 3, "want header + transcription + file block");
+            match &blocks[0] {
+                ContentBlock::Text { text, .. } => {
+                    assert!(text.starts_with("[Voice message"), "blocks[0] header");
+                }
+                other => panic!("blocks[0] should be the voice header, got {other:?}"),
+            }
+            match &blocks[1] {
+                ContentBlock::Text { text, .. } => {
+                    assert_eq!(
+                        text, "[Transcription: hello world]",
+                        "blocks[1] must be the transcription, not the file path"
+                    );
+                }
+                other => panic!("blocks[1] should be the transcription, got {other:?}"),
+            }
+            match &blocks[2] {
+                ContentBlock::Text { text, .. } => {
+                    assert!(
+                        text.starts_with("[File:"),
+                        "blocks[2] must be the saved-path block"
+                    );
+                }
+                other => panic!("blocks[2] should be the file path block, got {other:?}"),
+            }
+        }
+
+        /// A hung STT provider must not pin the dispatch task. The
+        /// production helper wraps the kernel call in a 30s
+        /// `tokio::time::timeout`; on expiry it delivers the opaque
+        /// "unavailable" block (same shape as the provider-error path)
+        /// and lets dispatch move on. We exercise the timeout branch
+        /// via `maybe_transcribe_inbound_audio_with_timeout` so the
+        /// test finishes in milliseconds, not 30s. Using `test-util`'s
+        /// paused-time runtime would be cleaner but requires an extra
+        /// dev-dep — the parameterized helper is the cheapest path.
+        #[tokio::test]
+        async fn provider_hang_times_out_and_returns_unavailable_block() {
+            // Custom hand-rolled handle whose `transcribe_inbound_audio`
+            // future never resolves. `RecordingHandle` can't model this
+            // because it returns a cloned response immediately.
+            struct HangHandle;
+            #[async_trait]
+            impl ChannelBridgeHandle for HangHandle {
+                async fn send_message(
+                    &self,
+                    _agent_id: AgentId,
+                    _message: &str,
+                ) -> Result<String, String> {
+                    Ok(String::new())
+                }
+                async fn find_agent_by_name(&self, _name: &str) -> Result<Option<AgentId>, String> {
+                    Ok(None)
+                }
+                async fn list_agents(&self) -> Result<Vec<(AgentId, String)>, String> {
+                    Ok(Vec::new())
+                }
+                async fn spawn_agent_by_name(
+                    &self,
+                    _manifest_name: &str,
+                ) -> Result<AgentId, String> {
+                    Err("unused".into())
+                }
+                fn record_consumer_lag(&self, _n: u64, _ctx: &'static str) {}
+
+                async fn transcribe_inbound_audio(
+                    &self,
+                    _path: &std::path::Path,
+                    _mime_type: &str,
+                ) -> Result<Option<String>, String> {
+                    // Block forever; the helper's timeout must fire.
+                    std::future::pending::<()>().await;
+                    unreachable!("pending future cannot resolve")
+                }
+            }
+
+            let h: Arc<dyn ChannelBridgeHandle> = Arc::new(HangHandle);
+            let s = saved("/tmp/x.ogg", "audio/ogg");
+            let started = std::time::Instant::now();
+            let block = maybe_transcribe_inbound_audio_with_timeout(
+                &h,
+                s.as_ref(),
+                std::time::Duration::from_millis(50),
+            )
+            .await;
+
+            // The timeout must actually have fired — sanity-check the
+            // wall-clock elapsed is on the order of the budget, not 30s.
+            assert!(
+                started.elapsed() < std::time::Duration::from_secs(5),
+                "helper waited too long; timeout did not fire"
+            );
+
+            match block {
+                Some(ContentBlock::Text { text, .. }) => {
+                    assert_eq!(text, "[Transcription unavailable]");
+                }
+                other => panic!("timeout must produce the unavailable block, got {other:?}"),
+            }
         }
     }
 }

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -567,6 +567,30 @@ pub trait ChannelBridgeHandle: Send + Sync {
     fn channels_download_max_bytes(&self) -> Option<u64> {
         None
     }
+
+    /// Transcribe an inbound channel audio attachment that has already been
+    /// downloaded to disk by the bridge.
+    ///
+    /// Implementations should:
+    ///   1. Honor the `[media] audio_transcription` kernel config (default OFF) —
+    ///      return `Ok(None)` when transcription is disabled.
+    ///   2. On enabled, hand the attachment to the kernel `MediaEngine`
+    ///      (`transcribe_audio`), returning `Ok(Some(text))` on success.
+    ///   3. On provider error / no credentials / oversize file, return
+    ///      `Err(reason)` so the bridge can surface a `[Transcription failed: …]`
+    ///      note next to the saved path without dropping the message.
+    ///
+    /// The default impl (used by mocks) is "feature off" — returns `Ok(None)`.
+    /// See issue #4975: `MediaEngine::process_attachments` previously had no
+    /// callers, so inbound voice messages were never auto-transcribed even
+    /// when `[media].audio_transcription = true`.
+    async fn transcribe_inbound_audio(
+        &self,
+        _path: &std::path::Path,
+        _mime_type: &str,
+    ) -> Result<Option<String>, String> {
+        Ok(None)
+    }
 }
 
 struct PendingMessage {
@@ -2939,8 +2963,9 @@ async fn dispatch_message(
             .channels_download_max_bytes()
             .unwrap_or(CHANNEL_FILE_DOWNLOAD_MAX_BYTES);
         let extra_headers = adapter.fetch_headers_for(url);
-        let blocks =
+        let downloaded =
             download_file_to_blocks(url, filename, max_bytes, &download_dir, &extra_headers).await;
+        let blocks = downloaded.blocks;
         if has_file_saved_block(&blocks) {
             dispatch_with_blocks(
                 blocks,
@@ -2975,9 +3000,16 @@ async fn dispatch_message(
             .unwrap_or(CHANNEL_FILE_DOWNLOAD_MAX_BYTES);
         let filename = filename_from_url(url).unwrap_or_else(|| "voice.ogg".to_string());
         let extra_headers = adapter.fetch_headers_for(url);
-        let mut blocks =
+        let downloaded =
             download_file_to_blocks(url, &filename, max_bytes, &download_dir, &extra_headers).await;
+        let mut blocks = downloaded.blocks;
         if has_file_saved_block(&blocks) {
+            // Auto-transcription when `[media] audio_transcription = true` (#4975).
+            // The kernel checks the flag and falls back to `Ok(None)` when disabled,
+            // so the existing default-OFF behaviour is preserved verbatim.
+            let transcription_block =
+                maybe_transcribe_inbound_audio(handle, downloaded.saved.as_ref()).await;
+
             // Prepend a context block carrying duration + caption so the
             // model knows this is voice (not an arbitrary file) and any
             // user-supplied caption survives the save-path replacement.
@@ -2994,6 +3026,9 @@ async fn dispatch_message(
                     provider_metadata: None,
                 },
             );
+            if let Some(t) = transcription_block {
+                blocks.insert(1, t);
+            }
             dispatch_with_blocks(
                 blocks,
                 message,
@@ -3030,9 +3065,14 @@ async fn dispatch_message(
             .unwrap_or(CHANNEL_FILE_DOWNLOAD_MAX_BYTES);
         let filename = filename_from_url(url).unwrap_or_else(|| "audio.mp3".to_string());
         let extra_headers = adapter.fetch_headers_for(url);
-        let mut blocks =
+        let downloaded =
             download_file_to_blocks(url, &filename, max_bytes, &download_dir, &extra_headers).await;
+        let mut blocks = downloaded.blocks;
         if has_file_saved_block(&blocks) {
+            // Auto-transcription when `[media] audio_transcription = true` (#4975).
+            let transcription_block =
+                maybe_transcribe_inbound_audio(handle, downloaded.saved.as_ref()).await;
+
             let mut header = format!("[Audio ({duration_seconds}s)");
             match (title.as_deref(), performer.as_deref()) {
                 (Some(t), Some(p)) if !t.is_empty() && !p.is_empty() => {
@@ -3054,6 +3094,9 @@ async fn dispatch_message(
                     provider_metadata: None,
                 },
             );
+            if let Some(t) = transcription_block {
+                blocks.insert(1, t);
+            }
             dispatch_with_blocks(
                 blocks,
                 message,
@@ -3093,7 +3136,7 @@ async fn dispatch_message(
             .or_else(|| filename_from_url(url))
             .unwrap_or_else(|| "video.mp4".to_string());
         let extra_headers = adapter.fetch_headers_for(url);
-        let mut blocks = download_file_to_blocks(
+        let downloaded = download_file_to_blocks(
             url,
             &resolved_filename,
             max_bytes,
@@ -3101,6 +3144,7 @@ async fn dispatch_message(
             &extra_headers,
         )
         .await;
+        let mut blocks = downloaded.blocks;
         if has_file_saved_block(&blocks) {
             let context = match caption {
                 Some(c) if !c.is_empty() => {
@@ -4194,6 +4238,27 @@ const CHANNEL_FILE_DOWNLOAD_MAX_BYTES: u64 = 50 * 1024 * 1024;
 /// `dispatch_message` to detect success vs failure.
 const FILE_SAVED_BLOCK_PREFIX: &str = "[File: ";
 
+/// Result of downloading a channel attachment to disk.
+///
+/// `blocks` is the content blocks the agent should receive (path block plus
+/// any inline-enriched text). `saved` is `Some((path, media_type))` when the
+/// download produced bytes on disk — callers that need to invoke media
+/// understanding (e.g. inbound audio transcription, #4975) use this to drive
+/// `MediaEngine` without re-parsing the path-block text.
+struct DownloadedFile {
+    blocks: Vec<ContentBlock>,
+    saved: Option<(std::path::PathBuf, String)>,
+}
+
+impl DownloadedFile {
+    fn failed(blocks: Vec<ContentBlock>) -> Self {
+        Self {
+            blocks,
+            saved: None,
+        }
+    }
+}
+
 /// Returns `true` when [`download_file_to_blocks`] produced a block that
 /// represents a successfully saved download — either an inline `ImageFile`
 /// (when the response was image-typed) or a `Text` block whose content
@@ -4213,6 +4278,59 @@ fn has_file_saved_block(blocks: &[ContentBlock]) -> bool {
         ContentBlock::Text { text, .. } => text.starts_with(FILE_SAVED_BLOCK_PREFIX),
         _ => false,
     })
+}
+
+/// Auto-transcribe an inbound channel audio attachment when the kernel's
+/// `[media] audio_transcription` flag is enabled (#4975).
+///
+/// Returns a `ContentBlock::Text` to insert next to the saved-path block:
+///   - `Some([Transcription: …])` when transcription succeeded.
+///   - `Some([Transcription failed: …])` when the kernel reported an error
+///     (no provider configured, oversize file, provider 5xx, …) — the raw
+///     path block is still delivered so the agent can fall back to
+///     `media_transcribe` or just acknowledge the voice note.
+///   - `None` when transcription is disabled (the default) or there is no
+///     saved file (download failed earlier).
+///
+/// Non-audio MIME types (e.g. a `video/mp4` that hit the Voice arm because
+/// of an upstream classification bug) are skipped silently so we never
+/// bill an STT provider for the wrong shape.
+async fn maybe_transcribe_inbound_audio(
+    handle: &Arc<dyn ChannelBridgeHandle>,
+    saved: Option<&(std::path::PathBuf, String)>,
+) -> Option<ContentBlock> {
+    let (path, media_type) = saved?;
+    if !media_type.to_ascii_lowercase().starts_with("audio/") {
+        return None;
+    }
+    match handle.transcribe_inbound_audio(path, media_type).await {
+        Ok(Some(text)) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            Some(ContentBlock::Text {
+                text: format!("[Transcription: {trimmed}]"),
+                provider_metadata: None,
+            })
+        }
+        Ok(None) => None,
+        Err(reason) => {
+            // Never drop the message — surface the failure as a sibling
+            // block so the agent knows transcription was attempted and
+            // failed. Operator sees the same reason in the kernel logs.
+            warn!(
+                path = %path.display(),
+                mime = %media_type,
+                error = %reason,
+                "Inbound audio transcription failed; passing raw file to agent"
+            );
+            Some(ContentBlock::Text {
+                text: format!("[Transcription failed: {reason}]"),
+                provider_metadata: None,
+            })
+        }
+    }
 }
 
 /// Extract a basename-style filename from the path component of a URL.
@@ -4277,14 +4395,14 @@ async fn download_file_to_blocks(
     max_bytes: u64,
     download_dir: &std::path::Path,
     extra_headers: &[(String, String)],
-) -> Vec<ContentBlock> {
+) -> DownloadedFile {
     // Validate URL scheme
     if let Err(reason) = validate_url_scheme(url) {
         warn!("{reason}");
-        return vec![ContentBlock::Text {
+        return DownloadedFile::failed(vec![ContentBlock::Text {
             text: format!("[File download rejected: {reason}]"),
             provider_metadata: None,
-        }];
+        }]);
     }
 
     let client = crate::http_client::new_client();
@@ -4296,10 +4414,10 @@ async fn download_file_to_blocks(
         Ok(r) => r,
         Err(e) => {
             warn!("Failed to download file from channel: {e}");
-            return vec![ContentBlock::Text {
+            return DownloadedFile::failed(vec![ContentBlock::Text {
                 text: format!("[File download failed: {e}]"),
                 provider_metadata: None,
-            }];
+            }]);
         }
     };
 
@@ -4317,10 +4435,10 @@ async fn download_file_to_blocks(
             url = %url,
             "File download returned non-success status"
         );
-        return vec![ContentBlock::Text {
+        return DownloadedFile::failed(vec![ContentBlock::Text {
             text: format!("[File download failed: HTTP {status} ({filename})]"),
             provider_metadata: None,
-        }];
+        }]);
     }
 
     // Fast-reject via Content-Length header when available.
@@ -4330,12 +4448,12 @@ async fn download_file_to_blocks(
                 content_length = cl,
                 max_bytes, "File exceeds size cap (Content-Length), skipping download"
             );
-            return vec![ContentBlock::Text {
+            return DownloadedFile::failed(vec![ContentBlock::Text {
                 text: format!(
                     "[File too large: {cl} bytes exceeds {max_bytes} byte limit ({filename})]"
                 ),
                 provider_metadata: None,
-            }];
+            }]);
         }
     }
 
@@ -4363,10 +4481,10 @@ async fn download_file_to_blocks(
             "Failed to create download dir {}: {e}",
             download_dir.display()
         );
-        return vec![ContentBlock::Text {
+        return DownloadedFile::failed(vec![ContentBlock::Text {
             text: format!("[File download failed: cannot create directory: {e}]"),
             provider_metadata: None,
-        }];
+        }]);
     }
 
     // Stream body to disk chunk by chunk, enforcing size cap.
@@ -4375,10 +4493,10 @@ async fn download_file_to_blocks(
         Ok(f) => f,
         Err(e) => {
             warn!("Failed to create file {}: {e}", file_path.display());
-            return vec![ContentBlock::Text {
+            return DownloadedFile::failed(vec![ContentBlock::Text {
                 text: format!("[File download failed: {e}]"),
                 provider_metadata: None,
-            }];
+            }]);
         }
     };
 
@@ -4399,12 +4517,12 @@ async fn download_file_to_blocks(
                     );
                     drop(file);
                     let _ = tokio::fs::remove_file(&file_path).await;
-                    return vec![ContentBlock::Text {
+                    return DownloadedFile::failed(vec![ContentBlock::Text {
                         text: format!(
                             "[File too large: exceeded {max_bytes} byte limit ({filename})]"
                         ),
                         provider_metadata: None,
-                    }];
+                    }]);
                 }
                 // Fill magic buffer from the very first bytes of the stream.
                 if magic_filled < magic_buf.len() {
@@ -4417,20 +4535,20 @@ async fn download_file_to_blocks(
                     warn!("Failed to write chunk to {}: {e}", file_path.display());
                     drop(file);
                     let _ = tokio::fs::remove_file(&file_path).await;
-                    return vec![ContentBlock::Text {
+                    return DownloadedFile::failed(vec![ContentBlock::Text {
                         text: format!("[File download failed: write error: {e}]"),
                         provider_metadata: None,
-                    }];
+                    }]);
                 }
             }
             Err(e) => {
                 warn!("Stream error downloading file: {e}");
                 drop(file);
                 let _ = tokio::fs::remove_file(&file_path).await;
-                return vec![ContentBlock::Text {
+                return DownloadedFile::failed(vec![ContentBlock::Text {
                     text: format!("[File download failed: {e}]"),
                     provider_metadata: None,
-                }];
+                }]);
             }
         }
     }
@@ -4491,9 +4609,9 @@ async fn download_file_to_blocks(
     );
 
     let path_str = file_path.to_string_lossy().into_owned();
-    if media_type.starts_with("image/") {
+    let blocks = if media_type.starts_with("image/") {
         vec![ContentBlock::ImageFile {
-            media_type,
+            media_type: media_type.clone(),
             path: path_str,
         }]
     } else {
@@ -4509,6 +4627,10 @@ async fn download_file_to_blocks(
             provider_metadata: None,
         });
         blocks
+    };
+    DownloadedFile {
+        blocks,
+        saved: Some((file_path, media_type)),
     }
 }
 
@@ -7517,7 +7639,7 @@ mod tests {
         #[tokio::test]
         async fn test_file_download_rejects_bad_scheme() {
             let dir = std::env::temp_dir().join("librefang_test_download");
-            let blocks = download_file_to_blocks(
+            let result = download_file_to_blocks(
                 "ftp://evil.com/malware.exe",
                 "malware.exe",
                 1024,
@@ -7525,6 +7647,8 @@ mod tests {
                 &[],
             )
             .await;
+            let blocks = result.blocks;
+            assert!(result.saved.is_none());
             assert_eq!(blocks.len(), 1);
             match &blocks[0] {
                 ContentBlock::Text { text, .. } => {
@@ -7668,6 +7792,178 @@ mod tests {
             // Filename fallback also agrees (extension .oga).
             let fname_mime = audio_mime_from_filename("file_136.oga");
             assert_eq!(fname_mime, Some("audio/ogg"));
+        }
+    }
+
+    /// Regression coverage for #4975 — inbound audio attachments must hand
+    /// the saved file off to the kernel's `MediaEngine` (via the
+    /// `transcribe_inbound_audio` trait method) whenever `[media]
+    /// audio_transcription = true`. Before the fix the path-block was
+    /// dispatched as-is and `MediaEngine::process_attachments` was
+    /// orphaned, so a Telegram voice note never reached Whisper / Groq.
+    mod inbound_audio_transcription {
+        use super::*;
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        /// Mock that captures every `transcribe_inbound_audio` call.
+        ///
+        /// The fixed/error response lets us simulate the kernel returning:
+        ///   - `Ok(Some(text))` — transcription succeeded
+        ///   - `Ok(None)`       — config disabled (`audio_transcription = false`)
+        ///   - `Err(reason)`    — provider error / oversize / missing creds
+        struct RecordingHandle {
+            calls: Mutex<Vec<(PathBuf, String)>>,
+            response: Result<Option<String>, String>,
+        }
+
+        #[async_trait]
+        impl ChannelBridgeHandle for RecordingHandle {
+            async fn send_message(
+                &self,
+                _agent_id: AgentId,
+                _message: &str,
+            ) -> Result<String, String> {
+                Ok(String::new())
+            }
+            async fn find_agent_by_name(&self, _name: &str) -> Result<Option<AgentId>, String> {
+                Ok(None)
+            }
+            async fn list_agents(&self) -> Result<Vec<(AgentId, String)>, String> {
+                Ok(Vec::new())
+            }
+            async fn spawn_agent_by_name(&self, _manifest_name: &str) -> Result<AgentId, String> {
+                Err("unused in this test".into())
+            }
+            fn record_consumer_lag(&self, _n: u64, _ctx: &'static str) {}
+
+            async fn transcribe_inbound_audio(
+                &self,
+                path: &std::path::Path,
+                mime_type: &str,
+            ) -> Result<Option<String>, String> {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push((path.to_path_buf(), mime_type.to_string()));
+                self.response.clone()
+            }
+        }
+
+        fn handle_with(
+            response: Result<Option<String>, String>,
+        ) -> (Arc<dyn ChannelBridgeHandle>, Arc<RecordingHandle>) {
+            let inner = Arc::new(RecordingHandle {
+                calls: Mutex::new(Vec::new()),
+                response,
+            });
+            let h: Arc<dyn ChannelBridgeHandle> = inner.clone();
+            (h, inner)
+        }
+
+        fn saved(path: &str, mime: &str) -> Option<(PathBuf, String)> {
+            Some((PathBuf::from(path), mime.to_string()))
+        }
+
+        #[tokio::test]
+        async fn enabled_success_returns_transcription_block() {
+            // Kernel reports `Ok(Some("hello world"))` → bridge appends a
+            // `[Transcription: hello world]` block. This is the path that
+            // was completely broken before #4975 — no caller ever invoked
+            // `MediaEngine::process_attachments` so `Some(...)` was never
+            // produced for inbound audio.
+            let (h, rec) = handle_with(Ok(Some("hello world".into())));
+            let s = saved("/tmp/x.ogg", "audio/ogg");
+            let block = maybe_transcribe_inbound_audio(&h, s.as_ref()).await;
+            match block {
+                Some(ContentBlock::Text { text, .. }) => {
+                    assert_eq!(text, "[Transcription: hello world]");
+                }
+                other => panic!("expected transcription text block, got {other:?}"),
+            }
+            let calls = rec.calls.lock().unwrap();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].0, PathBuf::from("/tmp/x.ogg"));
+            assert_eq!(calls[0].1, "audio/ogg");
+        }
+
+        #[tokio::test]
+        async fn disabled_returns_none_and_preserves_raw_path() {
+            // `audio_transcription = false` → kernel returns Ok(None) → the
+            // bridge does NOT insert a transcription block. The raw saved-
+            // path block continues straight to the agent (verified by
+            // absence of any sibling Text insertion at the call site —
+            // see Voice/Audio branches in dispatch_message).
+            let (h, rec) = handle_with(Ok(None));
+            let s = saved("/tmp/x.ogg", "audio/ogg");
+            let block = maybe_transcribe_inbound_audio(&h, s.as_ref()).await;
+            assert!(block.is_none(), "disabled-config must produce no block");
+            // The trait call still happens — the kernel is the one that
+            // honors the flag. This guarantees mocks/integration tests
+            // can't accidentally hide the dispatch.
+            assert_eq!(rec.calls.lock().unwrap().len(), 1);
+        }
+
+        #[tokio::test]
+        async fn provider_failure_surfaces_warn_block_not_drop() {
+            // Provider 5xx, missing creds, or oversize → `Err(reason)`.
+            // Message MUST still reach the agent: we return a
+            // `[Transcription failed: …]` text block; the raw saved-path
+            // block is preserved by the caller, so the agent can fall
+            // back to `media_transcribe` or just acknowledge the voice
+            // note. Never drop the message.
+            let (h, _rec) = handle_with(Err("groq 500: backend exploded".into()));
+            let s = saved("/tmp/x.ogg", "audio/ogg");
+            let block = maybe_transcribe_inbound_audio(&h, s.as_ref()).await;
+            match block {
+                Some(ContentBlock::Text { text, .. }) => {
+                    assert!(
+                        text.starts_with("[Transcription failed:"),
+                        "want failure marker, got: {text}"
+                    );
+                    assert!(text.contains("groq 500"));
+                }
+                other => panic!("expected failure text block, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn no_saved_file_skips_dispatch() {
+            // Download failed earlier in the pipeline → no path/mime to
+            // send. Helper must return None without touching the trait —
+            // saves a no-op kernel round-trip.
+            let (h, rec) = handle_with(Ok(Some("should never be returned".into())));
+            let block = maybe_transcribe_inbound_audio(&h, None).await;
+            assert!(block.is_none());
+            assert!(rec.calls.lock().unwrap().is_empty());
+        }
+
+        #[tokio::test]
+        async fn non_audio_mime_is_silently_skipped() {
+            // Defense in depth: if upstream classification routes a video
+            // through the Voice/Audio arm (it shouldn't, but #4927 wasn't
+            // shipped yet at the time the bug was reported), don't waste
+            // an STT call on a non-audio file. The agent still gets the
+            // raw path block.
+            let (h, rec) = handle_with(Ok(Some("would have transcribed".into())));
+            let s = saved("/tmp/clip.mp4", "video/mp4");
+            let block = maybe_transcribe_inbound_audio(&h, s.as_ref()).await;
+            assert!(block.is_none());
+            assert!(
+                rec.calls.lock().unwrap().is_empty(),
+                "non-audio MIME must never hit the kernel STT path"
+            );
+        }
+
+        #[tokio::test]
+        async fn empty_transcription_is_discarded() {
+            // Whisper occasionally returns empty/whitespace when the
+            // audio is silence. Don't pollute the agent's prompt with
+            // `[Transcription: ]`.
+            let (h, _rec) = handle_with(Ok(Some("   ".into())));
+            let s = saved("/tmp/x.ogg", "audio/ogg");
+            let block = maybe_transcribe_inbound_audio(&h, s.as_ref()).await;
+            assert!(block.is_none(), "empty transcription must be dropped");
         }
     }
 }

--- a/crates/librefang-runtime/src/media_understanding.rs
+++ b/crates/librefang-runtime/src/media_understanding.rs
@@ -1,6 +1,10 @@
 //! Media understanding engine — image description, audio transcription, video analysis.
 //!
-//! Auto-cascades through available providers based on configured API keys.
+//! Each modality dispatches to a single provider: either the one explicitly
+//! configured in `[media]` (`image_provider` / `audio_provider`), or — when
+//! no explicit provider is set — the first one whose API key env var is
+//! present. There is no runtime cascade across providers; a failure on the
+//! chosen provider surfaces as an `Err` to the caller.
 
 use librefang_types::media::{
     MediaAttachment, MediaConfig, MediaSource, MediaType, MediaUnderstanding,
@@ -27,7 +31,9 @@ impl MediaEngine {
     }
 
     /// Describe an image using a vision-capable LLM.
-    /// Auto-cascade: Anthropic -> OpenAI -> Gemini (based on API key availability).
+    /// Picks a single provider: `[media] image_provider` if set, otherwise
+    /// the first of Anthropic / OpenAI / Gemini whose API key env var is
+    /// present. No runtime fallback if the chosen provider errors.
     pub async fn describe_image(
         &self,
         attachment: &MediaAttachment,
@@ -56,7 +62,10 @@ impl MediaEngine {
     }
 
     /// Transcribe audio using speech-to-text.
-    /// Auto-cascade: Groq (whisper-large-v3-turbo) -> OpenAI (whisper-1).
+    /// Picks a single provider: `[media] audio_provider` if set, otherwise
+    /// the first one detected from env vars (Groq, OpenAI, Gemini,
+    /// ElevenLabs, …). There is no runtime cascade; a provider failure
+    /// surfaces as `Err` to the caller.
     pub async fn transcribe_audio(
         &self,
         attachment: &MediaAttachment,
@@ -343,17 +352,29 @@ async fn whisper_transcribe(
         .timeout(std::time::Duration::from_secs(60))
         .send()
         .await
-        .map_err(|e| format!("Transcription request failed: {}", e))?;
+        .map_err(|e| {
+            // Operator-facing: full error in logs. User-facing Err is
+            // sanitized to drop the underlying reqwest::Error display,
+            // which can echo URLs / request internals. See #4999.
+            tracing::warn!(error = %e, "Whisper transcription request failed");
+            "Transcription request failed".to_string()
+        })?;
 
     if !resp.status().is_success() {
         let status = resp.status();
+        // Operator log keeps the response body for diagnosis; the Err
+        // returned to the bridge / agent prompt only carries the status
+        // code so a misconfigured provider can't leak a key (some
+        // providers echo the request envelope) into the LLM prompt.
         let body = resp.text().await.unwrap_or_default();
-        return Err(format!("Transcription API error ({}): {}", status, body));
+        tracing::warn!(%status, body = %body, "Whisper transcription returned non-2xx");
+        return Err(format!("Transcription API error ({})", status));
     }
 
-    resp.text()
-        .await
-        .map_err(|e| format!("Failed to read transcription response: {}", e))
+    resp.text().await.map_err(|e| {
+        tracing::warn!(error = %e, "Failed to read transcription response");
+        "Failed to read transcription response".to_string()
+    })
 }
 
 /// Transcribe using Gemini's multimodal generateContent API.
@@ -398,18 +419,26 @@ async fn gemini_transcribe(
         .timeout(std::time::Duration::from_secs(60))
         .send()
         .await
-        .map_err(|e| format!("Gemini transcription request failed: {}", e))?;
+        .map_err(|e| {
+            // Critical: Gemini's URL embeds the API key as `?key=…`.
+            // The `reqwest::Error` display can reproduce the URL — never
+            // surface it to the LLM prompt. Log + return a sanitized Err.
+            // See #4999.
+            tracing::warn!(error = %e, "Gemini transcription request failed");
+            "Gemini transcription request failed".to_string()
+        })?;
 
     if !resp.status().is_success() {
         let status = resp.status();
         let err_body = resp.text().await.unwrap_or_default();
-        return Err(format!("Gemini API error ({}): {}", status, err_body));
+        tracing::warn!(%status, body = %err_body, "Gemini transcription returned non-2xx");
+        return Err(format!("Gemini API error ({})", status));
     }
 
-    let json: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse Gemini response: {}", e))?;
+    let json: serde_json::Value = resp.json().await.map_err(|e| {
+        tracing::warn!(error = %e, "Failed to parse Gemini response");
+        "Failed to parse Gemini response".to_string()
+    })?;
 
     json["candidates"][0]["content"]["parts"][0]["text"]
         .as_str()
@@ -442,18 +471,22 @@ async fn elevenlabs_transcribe(
         .timeout(std::time::Duration::from_secs(60))
         .send()
         .await
-        .map_err(|e| format!("ElevenLabs STT request failed: {}", e))?;
+        .map_err(|e| {
+            tracing::warn!(error = %e, "ElevenLabs STT request failed");
+            "ElevenLabs STT request failed".to_string()
+        })?;
 
     if !resp.status().is_success() {
         let status = resp.status();
         let err_body = resp.text().await.unwrap_or_default();
-        return Err(format!("ElevenLabs API error ({}): {}", status, err_body));
+        tracing::warn!(%status, body = %err_body, "ElevenLabs STT returned non-2xx");
+        return Err(format!("ElevenLabs API error ({})", status));
     }
 
-    let json: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse ElevenLabs response: {}", e))?;
+    let json: serde_json::Value = resp.json().await.map_err(|e| {
+        tracing::warn!(error = %e, "Failed to parse ElevenLabs response");
+        "Failed to parse ElevenLabs response".to_string()
+    })?;
 
     json["text"]
         .as_str()


### PR DESCRIPTION
Fixes #4975.

## Root cause

`MediaEngine::process_attachments` in `crates/librefang-runtime/src/media_understanding.rs:219` is the function that honors `[media] audio_transcription` and dispatches each attachment to `transcribe_audio`. A grep across the workspace shows **it has no callers** — the only real consumers of `transcribe_audio` are `/api/uploads/...`, the `media_transcribe` agent tool, and the realtime voice WebSocket. None of these are on the inbound channel path.

The Telegram bridge streamed voice messages to disk, emitted a `[File: voice.ogg] saved to /tmp/librefang_uploads/<uuid>.ogg` block (`crates/librefang-channels/src/bridge.rs:4538`), and handed it straight to the agent. The agent had to invoke `media_transcribe` by hand, which is exactly what the `audio_transcription` flag was meant to obviate.

## Fix

**Option (a): kernel-side wiring via a new `ChannelBridgeHandle` trait method.** A new method `transcribe_inbound_audio(path, mime_type) -> Result<Option<String>, String>` is added to the trait that lives in `librefang-channels`. The kernel impl in `crates/librefang-api/src/channel_bridge.rs` reads `config.media.audio_transcription` (default-OFF preserved — short-circuits to `Ok(None)` when disabled) and otherwise hands a `MediaAttachment` to `kernel.media().transcribe_audio(...)` — the same `MediaEngine` instance `/api/uploads` uses, so cost accounting + provider-cascade behaviour are identical. Mocks inherit `Ok(None)` from the trait default.

The bridge calls the new method from both the **Voice** and **Audio** branches in `dispatch_message` after the download produces a saved file, and inserts a sibling `[Transcription: …]` text block in front of the saved-path block before dispatching. `download_file_to_blocks` now returns a small struct (`blocks` + `Option<(path, media_type)>`) so the wiring point has the on-disk info without re-parsing the path-block text.

Wiring sites:
- `crates/librefang-channels/src/bridge.rs:2978` (Voice — Telegram voice notes / WhatsApp PTT)
- `crates/librefang-channels/src/bridge.rs:3034` (Audio — music / podcast attachments)
- `crates/librefang-channels/src/bridge.rs:4238` (`maybe_transcribe_inbound_audio` helper)
- `crates/librefang-api/src/channel_bridge.rs:2239` (`KernelBridgeAdapter::transcribe_inbound_audio` impl — config gate + `MediaEngine` dispatch)

Because the trait is the channel↔kernel boundary, **every** channel adapter (Telegram, WhatsApp, Discord, Matrix, Slack, Email, …) inherits the fix the moment the operator flips `[media] audio_transcription = true` — no per-adapter edits.

## Failure mode

- Provider error / no credentials / oversize / Whisper rejection → bridge logs `WARN` and inserts a `[Transcription failed: <reason>]` block, then dispatches with the **raw saved-path block intact**. Message never dropped.
- Empty transcript (Whisper sometimes returns whitespace for silence) → no block inserted, raw path delivered.
- Non-audio MIME accidentally routed through the audio branch → `maybe_transcribe_inbound_audio` skips silently rather than billing an STT call for the wrong shape.
- Config disabled (default) → bridge inserts nothing, behaviour identical to pre-fix.

## Budget / cost

The kernel impl calls `kernel.media().transcribe_audio(...)` — the same path `/api/uploads` and `/media/transcribe` use today. Provider auto-cascade (`groq` → `openai` → …) and the `[media] audio_provider` / `audio_model` overrides apply unchanged. The repo does **not** currently have a separate budget gate in front of `transcribe_audio` (that's a global call site decision tracked elsewhere); this fix mirrors the existing endpoint semantics rather than introducing a new policy layer.

## Verification

- New tests in `crates/librefang-channels/src/bridge.rs::tests::inbound_audio_transcription`:
  - `enabled_success_returns_transcription_block` — happy path
  - `disabled_returns_none_and_preserves_raw_path` — default-OFF respected
  - `provider_failure_surfaces_warn_block_not_drop` — message never dropped on STT error
  - `no_saved_file_skips_dispatch` — download-failure short circuit
  - `non_audio_mime_is_silently_skipped` — defense in depth against bad classification
  - `empty_transcription_is_discarded` — Whisper whitespace doesn't pollute the prompt
- `cargo test -p librefang-channels --lib` → 378/378 pass (372 pre-existing + 6 new).
- `cargo test -p librefang-channels --test bridge_integration_test` → 17/17 pass.
- `cargo test -p librefang-api --lib` → 680/680 pass.
- `cargo check --workspace --lib` → clean.
- `cargo clippy --workspace --all-targets -- -D warnings` → clean.

## Cross-links

- #4927 — MIME classification (prerequisite — magic-byte / extension sniff finalizes `audio/ogg` on `application/octet-stream` Telegram downloads).
- #4981 — sandbox fix (landing in parallel).
- #4959 — **outbound** Telegram `audio/ogg` routing (`sendDocument` → `sendVoice`); separate sibling PR, not touched here.

## Out-of-scope / not deferred

None — the bridge is the only place inbound audio attachments are materialized, and all four media-download arms (File, Voice, Audio, Video) already share `download_file_to_blocks`, so the new return struct propagated cleanly without leaking into other layers. Realtime voice WebSocket and `/api/uploads` already had working transcription wiring and were not touched.


---

## Follow-up to review (commits 2085d616, 63a63cde)

Two new commits address findings from an independent review pass.

### 🔴 Credential leak in failure path (`media_understanding.rs` + bridge boundary)

The original failure block placed `[Transcription failed: {reason}]` directly in
the LLM-facing message stream. `{reason}` came from the kernel's
`Err(String)`, which on three provider paths (Whisper / Groq family, Gemini,
ElevenLabs) embedded the raw HTTP response body and a `reqwest::Error` display.
Worst case: Gemini's URL embeds the API key as `?key=…` — a request-level
`reqwest::Error` reproduces that URL, which would then land in the message
stream **and** every downstream provider's prompt cache.

Fixed at **both layers**:

- **Source** (`crates/librefang-runtime/src/media_understanding.rs`, commit
  `2085d616`): the three provider error paths now return a sanitized `Err`
  containing only the HTTP status code. The raw body and `reqwest::Error`
  display still go to operator logs via `tracing::warn!`, so diagnosability
  is preserved.
- **Bridge boundary** (`crates/librefang-channels/src/bridge.rs`, commit
  `63a63cde`): `maybe_transcribe_inbound_audio` now emits an opaque
  `[Transcription unavailable]` block instead of interpolating any portion of
  the kernel's `Err(reason)` into the message text. Defense in depth — even
  if a future provider adds an un-sanitized error path, the bridge will not
  leak it.

Test `provider_failure_surfaces_opaque_block_not_drop` exercises the leak
shape directly: feeds a fake provider error containing `?key=SECRET_KEY_DO_NOT_LEAK`
and asserts the LLM-facing block does not contain it.

### 🟡 Hung-provider stall on the dispatch task (`bridge.rs`)

Original code awaited the kernel STT call with no timeout. A 60s voice note
plus a slow provider could pin the per-`(agent, channel:chat)` session
indefinitely — every subsequent inbound message on that session queued
behind. Commit `63a63cde` wraps the call in a 30s `tokio::time::timeout`
(matches the precedent in `crates/librefang-channels/src/sidecar.rs:562`).
On expiry: same opaque `[Transcription unavailable]` block, raw saved-path
block still delivered, message never dropped. A small refactor extracts
`maybe_transcribe_inbound_audio_with_timeout(_, _, dur)` so tests can drive
the timeout branch in milliseconds.

New test `provider_hang_times_out_and_returns_unavailable_block` uses a
`HangHandle` whose future never resolves and confirms a 50ms budget trips
the timeout and produces the expected opaque block.

### 🟡 Missing index-position test (`bridge.rs`)

The original 6 tests covered the helper's outputs but never pinned the final
block ordering inside the caller. Added
`transcription_block_lands_between_header_and_file_path` — builds the same
sequence `dispatch_message` does (`[Voice header]` at index 0,
transcription at index 1, `[File: …]` at index 2) and asserts each
position. A future refactor that moves the transcription after the saved
path block now fails this test loudly.

### Doc-comment correction

The module / function docs in `media_understanding.rs` previously described a
"Auto-cascade: Groq → OpenAI" but `transcribe_audio` actually dispatches to a
single provider (explicit `[media] audio_provider`, else first detected from
env). Doc-comments now state the single-provider behavior plainly. Same
correction applied to `describe_image` and the module-level doc.

### Perf nit

`media_type.to_ascii_lowercase()` allocated a `String` on every voice message
just to prefix-match six bytes. Replaced with
`as_bytes().get(..6).is_some_and(|p| p.eq_ignore_ascii_case(b"audio/"))` — no
allocation, identical semantics.

### Verification (this follow-up)

- `cargo test -p librefang-channels --lib bridge::tests::inbound_audio_transcription`
  → 8/8 pass (was 6; added 2).
- `cargo test -p librefang-channels --lib` → 380/380 pass.
- `cargo test -p librefang-runtime --lib` → 1663/1663 pass.
- `cargo check --workspace --lib` → clean.
- `cargo clippy --workspace --all-targets -- -D warnings` → clean.
