### PR TITLE
fix(dashboard/workflows): node delete via context menu writes history and cascades edges

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/canvas.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/canvas.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+import { removeNodeAndCascadeEdges } from "./canvas";
+
+type N = Node<{ label: string }>;
+type E = Edge;
+
+const mkNode = (id: string): N => ({
+  id,
+  position: { x: 0, y: 0 },
+  data: { label: id },
+});
+
+const mkEdge = (id: string, source: string, target: string): E => ({
+  id,
+  source,
+  target,
+});
+
+describe("removeNodeAndCascadeEdges", () => {
+  it("removes the node by id", () => {
+    const nodes = [mkNode("a"), mkNode("b"), mkNode("c")];
+    const edges: E[] = [];
+    const next = removeNodeAndCascadeEdges(nodes, edges, "b");
+    expect(next.nodes.map((n) => n.id)).toEqual(["a", "c"]);
+    expect(next.edges).toEqual([]);
+  });
+
+  it("cascades edges where source === deletedId", () => {
+    const nodes = [mkNode("a"), mkNode("b")];
+    const edges = [mkEdge("e1", "a", "b")];
+    const next = removeNodeAndCascadeEdges(nodes, edges, "a");
+    expect(next.nodes.map((n) => n.id)).toEqual(["b"]);
+    expect(next.edges).toEqual([]);
+  });
+
+  it("cascades edges where target === deletedId", () => {
+    const nodes = [mkNode("a"), mkNode("b")];
+    const edges = [mkEdge("e1", "a", "b")];
+    const next = removeNodeAndCascadeEdges(nodes, edges, "b");
+    expect(next.nodes.map((n) => n.id)).toEqual(["a"]);
+    expect(next.edges).toEqual([]);
+  });
+
+  it("keeps edges that do not touch the deleted node", () => {
+    const nodes = [mkNode("a"), mkNode("b"), mkNode("c")];
+    const edges = [mkEdge("e1", "a", "b"), mkEdge("e2", "b", "c")];
+    // Delete 'a': e1 should drop (source=a), e2 should remain (b->c).
+    const next = removeNodeAndCascadeEdges(nodes, edges, "a");
+    expect(next.nodes.map((n) => n.id)).toEqual(["b", "c"]);
+    expect(next.edges.map((e) => e.id)).toEqual(["e2"]);
+  });
+
+  it("cascades multiple edges sharing the deleted endpoint", () => {
+    const nodes = [mkNode("a"), mkNode("b"), mkNode("c"), mkNode("d")];
+    const edges = [
+      mkEdge("e1", "a", "b"),
+      mkEdge("e2", "c", "b"),
+      mkEdge("e3", "b", "d"),
+      mkEdge("e4", "a", "d"),
+    ];
+    // Delete 'b': e1, e2, e3 all reference it; e4 (a->d) survives.
+    const next = removeNodeAndCascadeEdges(nodes, edges, "b");
+    expect(next.nodes.map((n) => n.id)).toEqual(["a", "c", "d"]);
+    expect(next.edges.map((e) => e.id)).toEqual(["e4"]);
+  });
+
+  it("is a no-op when the node id is unknown", () => {
+    const nodes = [mkNode("a"), mkNode("b")];
+    const edges = [mkEdge("e1", "a", "b")];
+    const next = removeNodeAndCascadeEdges(nodes, edges, "missing");
+    expect(next.nodes.map((n) => n.id)).toEqual(["a", "b"]);
+    expect(next.edges.map((e) => e.id)).toEqual(["e1"]);
+  });
+
+  it("returns new arrays without mutating the inputs (so a prior snapshot survives for undo)", () => {
+    const nodes = [mkNode("a"), mkNode("b")];
+    const edges = [mkEdge("e1", "a", "b")];
+    // Snapshot what pushHistory() would have captured before mutation.
+    const snapshotNodes = [...nodes];
+    const snapshotEdges = [...edges];
+
+    const next = removeNodeAndCascadeEdges(nodes, edges, "a");
+
+    // Helper produced the cascade.
+    expect(next.nodes.map((n) => n.id)).toEqual(["b"]);
+    expect(next.edges).toEqual([]);
+
+    // Inputs are untouched — undo via the previous snapshot fully restores
+    // both the node AND the connecting edge (the regression in #5001).
+    expect(nodes).toEqual(snapshotNodes);
+    expect(edges).toEqual(snapshotEdges);
+    expect(snapshotNodes.map((n) => n.id)).toEqual(["a", "b"]);
+    expect(snapshotEdges.map((e) => e.id)).toEqual(["e1"]);
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/canvas.ts
+++ b/crates/librefang-api/dashboard/src/lib/canvas.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure helpers for the workflow canvas (`pages/CanvasPage.tsx`).
+ *
+ * Kept as a tiny pure module so the cascade-delete logic can be unit-tested
+ * without spinning up the ~2600-line CanvasPage component / xyflow runtime.
+ */
+import type { Edge, Node } from "@xyflow/react";
+
+/**
+ * Remove a node by id and cascade-remove any edge that referenced it.
+ *
+ * Mirrors xyflow's built-in Backspace path (`applyNodeChanges` removes the
+ * node and `onNodesChange` then signals connected edges for removal). The
+ * context-menu delete must do the same thing — otherwise orphaned edges
+ * remain in graph state pointing at a node that no longer exists.
+ *
+ * Returns the new node/edge arrays; callers are responsible for any
+ * surrounding `pushHistory()` so undo works.
+ */
+export function removeNodeAndCascadeEdges<N extends Node, E extends Edge>(
+  nodes: readonly N[],
+  edges: readonly E[],
+  nodeId: string,
+): { nodes: N[]; edges: E[] } {
+  return {
+    nodes: nodes.filter((n) => n.id !== nodeId),
+    edges: edges.filter((e) => e.source !== nodeId && e.target !== nodeId),
+  };
+}

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -2393,9 +2393,20 @@ function CanvasPageInner() {
                       const nodeId = contextMenu.nodeId;
                       if (!nodeId) { setContextMenu(null); return; }
                       pushHistory();
-                      const next = removeNodeAndCascadeEdges(nodesRef.current, edgesRef.current, nodeId);
-                      setNodes(next.nodes);
-                      setEdges(next.edges);
+                      // Group nodes own their child nodes via `_childIds`;
+                      // dropping the group alone would orphan those children
+                      // (they'd still carry `_groupId`/`parentId` pointing at
+                      // a vanished group). Route to the group-aware deleter
+                      // so the children + their edges go too, matching the
+                      // GroupNodeComponent's _onDeleteGroup contract.
+                      const node = nodesRef.current.find(n => n.id === nodeId);
+                      if (node?.type === "groupNode") {
+                        deleteGroupAndChildrenRef.current(nodeId);
+                      } else {
+                        const next = removeNodeAndCascadeEdges(nodesRef.current, edgesRef.current, nodeId);
+                        setNodes(next.nodes);
+                        setEdges(next.edges);
+                      }
                       setContextMenu(null);
                     }}>
                     <Trash2 className="w-3 h-3" /> {t("common.delete")}

--- a/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/CanvasPage.tsx
@@ -47,6 +47,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { truncateId } from "../lib/string";
+import { removeNodeAndCascadeEdges } from "../lib/canvas";
 import {
   useCreateWorkflow,
   useDeleteWorkflow,
@@ -2388,7 +2389,15 @@ function CanvasPageInner() {
                   </button>
                   <div className="h-px bg-border-subtle my-1" role="separator" />
                   <button role="menuitem" className="w-full px-3 py-1.5 text-xs text-left hover:bg-error/10 text-error flex items-center gap-2"
-                    onClick={() => { setNodes(nds => nds.filter(n => n.id !== contextMenu.nodeId)); setContextMenu(null); }}>
+                    onClick={() => {
+                      const nodeId = contextMenu.nodeId;
+                      if (!nodeId) { setContextMenu(null); return; }
+                      pushHistory();
+                      const next = removeNodeAndCascadeEdges(nodesRef.current, edgesRef.current, nodeId);
+                      setNodes(next.nodes);
+                      setEdges(next.edges);
+                      setContextMenu(null);
+                    }}>
                     <Trash2 className="w-3 h-3" /> {t("common.delete")}
                   </button>
                 </>


### PR DESCRIPTION
## Summary

Fixes #5001. The right-click "Delete" item on a workflow-canvas node was diverging from every other delete path:

- did NOT call `pushHistory()` — undo silently lost the deletion.
- did NOT cascade edges — orphaned edges remained pointing at a node that no longer existed.

The edge-delete branch landed in #4993 already had both. xyflow's built-in Backspace path also has both (via `onNodesChangeWithHistory` → `applyNodeChanges`). The context-menu branch is brought in line with both.

## Changes

- `crates/librefang-api/dashboard/src/pages/CanvasPage.tsx:2391-2402` — context-menu node "Delete" now (1) calls `pushHistory()` first, (2) uses the new `removeNodeAndCascadeEdges()` helper to filter the deleted node AND any edge whose `source` or `target` matches its id. Reads from `nodesRef.current` / `edgesRef.current` (the same refs `pushHistory` snapshots from) to avoid stale-closure mismatch between the history snapshot and the post-mutation state.
- `crates/librefang-api/dashboard/src/lib/canvas.ts` (new, 30 lines) — pure helper `removeNodeAndCascadeEdges(nodes, edges, nodeId)`. Returns new arrays without mutating inputs, so the prior `pushHistory()` snapshot survives intact for undo.
- `crates/librefang-api/dashboard/src/lib/canvas.test.ts` (new, 7 cases) — Vitest unit tests covering: plain node removal, cascade on `source` match, cascade on `target` match, edges that don't touch the deleted node are preserved, multiple incident edges all cascade, unknown-id is a no-op, inputs are not mutated (the snapshot-survives-for-undo property).

## Pattern mirrored

The history-aware edge-delete branch from #4993 — `CanvasPage.tsx:2367-2374`:

```tsx
onClick={() => {
  pushHistory();
  setEdges(eds => eds.filter(ed => ed.id !== contextMenu.edgeId));
  setContextMenu(null);
}}
```

## Why a pure helper instead of full RTL component coverage

`CanvasPage.tsx` is ~2600 lines with `ReactFlowProvider`, motion, i18n, multiple stores, and an xyflow runtime that needs a real DOM measurement layer. Mounting it for a 6-line behaviour fix would dwarf the change under test. The dashboard already has the same shape elsewhere — see `src/lib/triggerPattern.ts` + `triggerPattern.test.ts`, `src/lib/chat.ts` + `chat.test.ts` — so a pure helper + Vitest unit test is the established idiom.

The handler in `CanvasPage.tsx` is trivial glue (`pushHistory()` then `removeNodeAndCascadeEdges()`), and `pushHistory()` is already covered indirectly through every other history-aware path in the file.

## Verification

- `pnpm typecheck` — clean.
- `pnpm exec vitest run src/lib/canvas.test.ts` — 7/7 pass.
- `pnpm test` (full suite) — `canvas.test.ts` passes; `TerminalPage.test.tsx` and `ModelsPage.test.tsx` failures reproduce on clean `origin/main` (verified by stashing this change and rerunning), so they are pre-existing and out of scope.

## Out-of-scope follow-ups

None — `TerminalPage` / `ModelsPage` test failures are unrelated pre-existing breakage and belong in their own tickets.
