### PR TITLE
fix(channels): override account_id() in non-Telegram multi-bot adapters

### DIFF
--- a/crates/librefang-channels/src/bluesky.rs
+++ b/crates/librefang-channels/src/bluesky.rs
@@ -564,6 +564,15 @@ impl ChannelAdapter for BlueskyAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Bluesky
+    /// handle / DID) so the bridge approval listener builds the same
+    /// `bluesky:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the account bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -842,5 +851,22 @@ mod tests {
             }
             other => panic!("Expected Command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_bluesky_account_id_default_none() {
+        let adapter =
+            BlueskyAdapter::new("test.bsky.social".to_string(), "app-password".to_string());
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_bluesky_account_id_returns_configured_value() {
+        // #5003: two Bluesky accounts (each with its own DID) must resolve
+        // under distinct `bluesky:<account_id>` keys via the trait override.
+        let adapter =
+            BlueskyAdapter::new("test.bsky.social".to_string(), "app-password".to_string())
+                .with_account_id(Some("did:plc:testbot".to_string()));
+        assert_eq!(adapter.account_id(), Some("did:plc:testbot"));
     }
 }

--- a/crates/librefang-channels/src/dingtalk.rs
+++ b/crates/librefang-channels/src/dingtalk.rs
@@ -847,6 +847,15 @@ impl ChannelAdapter for DingTalkAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the DingTalk
+    /// corp / robot identifier) so the bridge approval listener builds the
+    /// same `dingtalk:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the bot
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -1247,5 +1256,20 @@ mod tests {
             librefang_user: Some(String::new()),
         };
         assert!(DingTalkAdapter::stream_reply_url(&user_empty_webhook).is_none());
+    }
+
+    #[test]
+    fn test_dingtalk_account_id_default_none() {
+        let adapter = DingTalkAdapter::new("token".to_string(), "secret".to_string(), 0);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_dingtalk_account_id_returns_configured_value() {
+        // #5003: two DingTalk robots / corps must resolve under distinct
+        // `dingtalk:<account_id>` keys via the trait override.
+        let adapter = DingTalkAdapter::new("token".to_string(), "secret".to_string(), 0)
+            .with_account_id(Some("robot-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("robot-42"));
     }
 }

--- a/crates/librefang-channels/src/discord.rs
+++ b/crates/librefang-channels/src/discord.rs
@@ -671,6 +671,15 @@ impl ChannelAdapter for DiscordAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Discord
+    /// guild / application ID) so the bridge approval listener builds the
+    /// same `discord:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the guild
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 /// Parse a Discord MESSAGE_CREATE or MESSAGE_UPDATE payload into a `ChannelMessage`.
@@ -1489,6 +1498,36 @@ mod tests {
         );
         assert_eq!(adapter.name(), "discord");
         assert_eq!(adapter.channel_type(), ChannelType::Discord);
+    }
+
+    #[test]
+    fn test_discord_account_id_default_none() {
+        let adapter = DiscordAdapter::new(
+            "test-token".to_string(),
+            vec![],
+            vec![],
+            true,
+            vec![],
+            37376,
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_discord_account_id_returns_configured_value() {
+        // #5003: two Discord guilds in the same daemon must resolve under
+        // distinct `discord:<guild_id>` keys; this override is what the
+        // bridge approval listener consults.
+        let adapter = DiscordAdapter::new(
+            "test-token".to_string(),
+            vec![],
+            vec![],
+            true,
+            vec![],
+            37376,
+        )
+        .with_account_id(Some("guild-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("guild-42"));
     }
 
     #[test]

--- a/crates/librefang-channels/src/discourse.rs
+++ b/crates/librefang-channels/src/discourse.rs
@@ -423,6 +423,15 @@ impl ChannelAdapter for DiscourseAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Discourse
+    /// forum / site identifier) so the bridge approval listener builds the
+    /// same `discourse:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the forum
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -594,5 +603,30 @@ mod tests {
         let request = builder.build().unwrap();
         assert_eq!(request.headers().get("Api-Key").unwrap(), "my-api-key");
         assert_eq!(request.headers().get("Api-Username").unwrap(), "bot-user");
+    }
+
+    #[test]
+    fn test_discourse_account_id_default_none() {
+        let adapter = DiscourseAdapter::new(
+            "https://forum.example.com".to_string(),
+            "key".to_string(),
+            "bot".to_string(),
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_discourse_account_id_returns_configured_value() {
+        // #5003: two Discourse forums must resolve under distinct
+        // `discourse:<account_id>` keys via the trait override.
+        let adapter = DiscourseAdapter::new(
+            "https://forum.example.com".to_string(),
+            "key".to_string(),
+            "bot".to_string(),
+            vec![],
+        )
+        .with_account_id(Some("forum-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("forum-42"));
     }
 }

--- a/crates/librefang-channels/src/email.rs
+++ b/crates/librefang-channels/src/email.rs
@@ -962,6 +962,15 @@ impl ChannelAdapter for EmailAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the IMAP /
+    /// SMTP mailbox identifier) so the bridge approval listener builds the
+    /// same `email:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the mailbox bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -1552,5 +1561,44 @@ mod tests {
             Some(std::path::Path::new("/etc/ca.pem"))
         );
         assert!(adapter.imap_tls.accept_invalid_certs);
+    }
+
+    #[test]
+    fn test_email_account_id_default_none() {
+        let adapter = EmailAdapter::new(
+            "imap.example.com".to_string(),
+            993,
+            "smtp.example.com".to_string(),
+            587,
+            "bot@example.com".to_string(),
+            "pass".to_string(),
+            "bot@example.com".to_string(),
+            "pass".to_string(),
+            30,
+            vec![],
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_email_account_id_returns_configured_value() {
+        // #5003: two email mailboxes must resolve under distinct
+        // `email:<account_id>` keys via the trait override.
+        let adapter = EmailAdapter::new(
+            "imap.example.com".to_string(),
+            993,
+            "smtp.example.com".to_string(),
+            587,
+            "bot@example.com".to_string(),
+            "pass".to_string(),
+            "bot@example.com".to_string(),
+            "pass".to_string(),
+            30,
+            vec![],
+            vec![],
+        )
+        .with_account_id(Some("mailbox-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("mailbox-42"));
     }
 }

--- a/crates/librefang-channels/src/feishu.rs
+++ b/crates/librefang-channels/src/feishu.rs
@@ -1789,6 +1789,15 @@ impl ChannelAdapter for FeishuAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Feishu /
+    /// Lark tenant or app identifier) so the bridge approval listener builds
+    /// the same `feishu:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the tenant
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2886,5 +2895,32 @@ mod tests {
             )
             .await
             .expect("send with unsupported content must succeed");
+    }
+
+    #[test]
+    fn test_feishu_account_id_default_none() {
+        let adapter = FeishuAdapter::new(
+            "cli_abc123".to_string(),
+            "secret".to_string(),
+            0,
+            FeishuRegion::Cn,
+            FeishuReceiveMode::Websocket,
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_feishu_account_id_returns_configured_value() {
+        // #5003: two Feishu / Lark tenants must resolve under distinct
+        // `feishu:<account_id>` keys via the trait override.
+        let adapter = FeishuAdapter::new(
+            "cli_abc123".to_string(),
+            "secret".to_string(),
+            0,
+            FeishuRegion::Cn,
+            FeishuReceiveMode::Websocket,
+        )
+        .with_account_id(Some("tenant-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("tenant-42"));
     }
 }

--- a/crates/librefang-channels/src/flock.rs
+++ b/crates/librefang-channels/src/flock.rs
@@ -355,6 +355,15 @@ impl ChannelAdapter for FlockAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Flock
+    /// team / app identifier) so the bridge approval listener builds the
+    /// same `flock:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the team bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -560,5 +569,20 @@ mod tests {
 
         let msg = parse_flock_event(&event, "u:bot001");
         assert!(msg.is_none());
+    }
+
+    #[test]
+    fn test_flock_account_id_default_none() {
+        let adapter = FlockAdapter::new("token".to_string(), 0);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_flock_account_id_returns_configured_value() {
+        // #5003: two Flock teams must resolve under distinct
+        // `flock:<account_id>` keys via the trait override.
+        let adapter =
+            FlockAdapter::new("token".to_string(), 0).with_account_id(Some("team-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("team-42"));
     }
 }

--- a/crates/librefang-channels/src/gitter.rs
+++ b/crates/librefang-channels/src/gitter.rs
@@ -387,6 +387,15 @@ impl ChannelAdapter for GitterAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Gitter
+    /// room / org identifier) so the bridge approval listener builds the
+    /// same `gitter:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the room bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -525,5 +534,20 @@ mod tests {
     fn test_gitter_parse_invalid_json() {
         assert!(GitterAdapter::parse_stream_message("not json").is_none());
         assert!(GitterAdapter::parse_stream_message("").is_none());
+    }
+
+    #[test]
+    fn test_gitter_account_id_default_none() {
+        let adapter = GitterAdapter::new("token".to_string(), "room-1".to_string());
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_gitter_account_id_returns_configured_value() {
+        // #5003: two Gitter rooms / orgs must resolve under distinct
+        // `gitter:<account_id>` keys via the trait override.
+        let adapter = GitterAdapter::new("token".to_string(), "room-1".to_string())
+            .with_account_id(Some("org-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("org-42"));
     }
 }

--- a/crates/librefang-channels/src/google_chat.rs
+++ b/crates/librefang-channels/src/google_chat.rs
@@ -497,6 +497,16 @@ impl ChannelAdapter for GoogleChatAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Google
+    /// Workspace / project identifier) so the bridge approval listener
+    /// builds the same `google_chat:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// workspace bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -781,5 +791,28 @@ mod tests {
             err.contains("Failed to parse RSA private key"),
             "Expected RSA parse error (URI should be allowed), got: {err}"
         );
+    }
+
+    #[test]
+    fn test_google_chat_account_id_default_none() {
+        let adapter = GoogleChatAdapter::new(
+            r#"{"access_token":"test-token","project_id":"test"}"#.to_string(),
+            vec![],
+            0,
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_google_chat_account_id_returns_configured_value() {
+        // #5003: two Google Workspace projects must resolve under distinct
+        // `google_chat:<account_id>` keys via the trait override.
+        let adapter = GoogleChatAdapter::new(
+            r#"{"access_token":"test-token","project_id":"test"}"#.to_string(),
+            vec![],
+            0,
+        )
+        .with_account_id(Some("workspace-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("workspace-42"));
     }
 }

--- a/crates/librefang-channels/src/gotify.rs
+++ b/crates/librefang-channels/src/gotify.rs
@@ -344,6 +344,15 @@ impl ChannelAdapter for GotifyAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Gotify
+    /// server / app identifier) so the bridge approval listener builds the
+    /// same `gotify:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the server bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -613,5 +622,28 @@ mod tests {
             .send(&dummy_user(), ChannelContent::Text("auth-check".into()))
             .await
             .expect("must use app token in send URL");
+    }
+
+    #[test]
+    fn test_gotify_account_id_default_none() {
+        let adapter = GotifyAdapter::new(
+            "https://gotify.example.com".to_string(),
+            "APP".to_string(),
+            "CLIENT".to_string(),
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_gotify_account_id_returns_configured_value() {
+        // #5003: two Gotify servers must resolve under distinct
+        // `gotify:<account_id>` keys via the trait override.
+        let adapter = GotifyAdapter::new(
+            "https://gotify.example.com".to_string(),
+            "APP".to_string(),
+            "CLIENT".to_string(),
+        )
+        .with_account_id(Some("server-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("server-42"));
     }
 }

--- a/crates/librefang-channels/src/guilded.rs
+++ b/crates/librefang-channels/src/guilded.rs
@@ -383,6 +383,15 @@ impl ChannelAdapter for GuildedAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Guilded
+    /// server / app identifier) so the bridge approval listener builds the
+    /// same `guilded:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the server bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -499,5 +508,20 @@ mod tests {
     fn test_guilded_constants() {
         assert_eq!(MAX_MESSAGE_LEN, 4000);
         assert_eq!(GUILDED_WS_URL, "wss://www.guilded.gg/websocket/v1");
+    }
+
+    #[test]
+    fn test_guilded_account_id_default_none() {
+        let adapter = GuildedAdapter::new("token".to_string(), vec![]);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_guilded_account_id_returns_configured_value() {
+        // #5003: two Guilded servers must resolve under distinct
+        // `guilded:<account_id>` keys via the trait override.
+        let adapter = GuildedAdapter::new("token".to_string(), vec![])
+            .with_account_id(Some("server-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("server-42"));
     }
 }

--- a/crates/librefang-channels/src/irc.rs
+++ b/crates/librefang-channels/src/irc.rs
@@ -479,6 +479,15 @@ impl ChannelAdapter for IrcAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the IRC
+    /// network / nick identifier) so the bridge approval listener builds
+    /// the same `irc:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the network
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -754,5 +763,34 @@ mod tests {
             err.to_string().to_lowercase().contains("not started"),
             "error should mention not-started state, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_irc_account_id_default_none() {
+        let adapter = IrcAdapter::new(
+            "irc.example.org".to_string(),
+            6697,
+            "nick".to_string(),
+            None,
+            vec![],
+            true,
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_irc_account_id_returns_configured_value() {
+        // #5003: two IRC networks must resolve under distinct
+        // `irc:<account_id>` keys via the trait override.
+        let adapter = IrcAdapter::new(
+            "irc.example.org".to_string(),
+            6697,
+            "nick".to_string(),
+            None,
+            vec![],
+            true,
+        )
+        .with_account_id(Some("libera-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("libera-42"));
     }
 }

--- a/crates/librefang-channels/src/keybase.rs
+++ b/crates/librefang-channels/src/keybase.rs
@@ -479,6 +479,15 @@ impl ChannelAdapter for KeybaseAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Keybase
+    /// username / device identifier) so the bridge approval listener builds
+    /// the same `keybase:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the user
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -634,5 +643,20 @@ mod tests {
     fn test_keybase_username_stored() {
         let adapter = KeybaseAdapter::new("alice".to_string(), "key".to_string(), vec![]);
         assert_eq!(adapter.username, "alice");
+    }
+
+    #[test]
+    fn test_keybase_account_id_default_none() {
+        let adapter = KeybaseAdapter::new("alice".to_string(), "key".to_string(), vec![]);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_keybase_account_id_returns_configured_value() {
+        // #5003: two Keybase users / devices must resolve under distinct
+        // `keybase:<account_id>` keys via the trait override.
+        let adapter = KeybaseAdapter::new("alice".to_string(), "key".to_string(), vec![])
+            .with_account_id(Some("alice-device-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("alice-device-42"));
     }
 }

--- a/crates/librefang-channels/src/line.rs
+++ b/crates/librefang-channels/src/line.rs
@@ -515,6 +515,15 @@ impl ChannelAdapter for LineAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the LINE
+    /// channel / bot identifier) so the bridge approval listener builds the
+    /// same `line:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the channel bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -853,5 +862,20 @@ mod tests {
         assert!(!verify_line_signature(secret, body, ""));
         assert!(!verify_line_signature(secret, body, "   "));
         assert!(!verify_line_signature(secret, body, "not-base64!@#"));
+    }
+
+    #[test]
+    fn test_line_account_id_default_none() {
+        let adapter = LineAdapter::new("secret".to_string(), "token".to_string(), 0);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_line_account_id_returns_configured_value() {
+        // #5003: two LINE channels must resolve under distinct
+        // `line:<account_id>` keys via the trait override.
+        let adapter = LineAdapter::new("secret".to_string(), "token".to_string(), 0)
+            .with_account_id(Some("channel-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("channel-42"));
     }
 }

--- a/crates/librefang-channels/src/linkedin.rs
+++ b/crates/librefang-channels/src/linkedin.rs
@@ -416,6 +416,16 @@ impl ChannelAdapter for LinkedInAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the LinkedIn
+    /// organization identifier) so the bridge approval listener builds the
+    /// same `linkedin:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// organization bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -586,5 +596,20 @@ mod tests {
             err.to_string().contains("403"),
             "error should mention status code, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_linkedin_account_id_default_none() {
+        let adapter = LinkedInAdapter::new("token".to_string(), "org-1".to_string());
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_linkedin_account_id_returns_configured_value() {
+        // #5003: two LinkedIn organizations must resolve under distinct
+        // `linkedin:<account_id>` keys via the trait override.
+        let adapter = LinkedInAdapter::new("token".to_string(), "org-1".to_string())
+            .with_account_id(Some("org-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("org-42"));
     }
 }

--- a/crates/librefang-channels/src/mastodon.rs
+++ b/crates/librefang-channels/src/mastodon.rs
@@ -558,6 +558,16 @@ impl ChannelAdapter for MastodonAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Mastodon
+    /// instance / account identifier) so the bridge approval listener builds
+    /// the same `mastodon:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// instance bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -818,5 +828,23 @@ mod tests {
             adapter.suppress_error_responses(),
             "MastodonAdapter should suppress error responses to avoid posting them publicly"
         );
+    }
+
+    #[test]
+    fn test_mastodon_account_id_default_none() {
+        let adapter =
+            MastodonAdapter::new("https://mastodon.social".to_string(), "token".to_string());
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_mastodon_account_id_returns_configured_value() {
+        // #5003: two Mastodon accounts (different instances or accounts on
+        // the same instance) must resolve under distinct
+        // `mastodon:<account_id>` keys via the trait override.
+        let adapter =
+            MastodonAdapter::new("https://mastodon.social".to_string(), "token".to_string())
+                .with_account_id(Some("acct-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("acct-42"));
     }
 }

--- a/crates/librefang-channels/src/matrix.rs
+++ b/crates/librefang-channels/src/matrix.rs
@@ -1413,6 +1413,16 @@ impl ChannelAdapter for MatrixAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (operator-supplied
+    /// identifier — typically `<mxid>@<homeserver>` or a short tag) so the
+    /// bridge approval listener builds the same `matrix:<account_id>` key
+    /// the router stores in `channel_defaults`, scoping ApprovalRequested
+    /// delivery to the homeserver / mxid bound to the requesting agent
+    /// (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 /// Calculate exponential backoff capped at the given maximum.
@@ -1731,6 +1741,34 @@ mod tests {
             false,
         );
         assert_eq!(adapter.name(), "matrix");
+    }
+
+    #[test]
+    fn test_matrix_account_id_default_none() {
+        let adapter = MatrixAdapter::new(
+            "https://matrix.org".to_string(),
+            "@bot:matrix.org".to_string(),
+            "access_token".to_string(),
+            vec![],
+            false,
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_matrix_account_id_returns_configured_value() {
+        // #5003: a Matrix account identifier (operator-supplied — typically
+        // `<mxid>@<homeserver>` or a short tag) must surface via the trait
+        // method so the bridge can scope approvals to the right bot.
+        let adapter = MatrixAdapter::new(
+            "https://matrix.org".to_string(),
+            "@bot:matrix.org".to_string(),
+            "access_token".to_string(),
+            vec![],
+            false,
+        )
+        .with_account_id(Some("@bot:matrix.org".to_string()));
+        assert_eq!(adapter.account_id(), Some("@bot:matrix.org"));
     }
 
     #[test]

--- a/crates/librefang-channels/src/mattermost.rs
+++ b/crates/librefang-channels/src/mattermost.rs
@@ -501,6 +501,16 @@ impl ChannelAdapter for MattermostAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the
+    /// Mattermost team ID or server URL identifier) so the bridge approval
+    /// listener builds the same `mattermost:<account_id>` key the router
+    /// stores in `channel_defaults`, scoping ApprovalRequested delivery to
+    /// the team bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -600,6 +610,29 @@ mod tests {
         );
         assert_eq!(adapter.name(), "mattermost");
         assert_eq!(adapter.channel_type(), ChannelType::Mattermost);
+    }
+
+    #[test]
+    fn test_mattermost_account_id_default_none() {
+        let adapter = MattermostAdapter::new(
+            "https://mattermost.example.com".to_string(),
+            "test-token".to_string(),
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_mattermost_account_id_returns_configured_value() {
+        // #5003: two Mattermost teams / servers must resolve under distinct
+        // `mattermost:<account_id>` keys via the trait override.
+        let adapter = MattermostAdapter::new(
+            "https://mattermost.example.com".to_string(),
+            "test-token".to_string(),
+            vec![],
+        )
+        .with_account_id(Some("team-acme".to_string()));
+        assert_eq!(adapter.account_id(), Some("team-acme"));
     }
 
     #[test]

--- a/crates/librefang-channels/src/messenger.rs
+++ b/crates/librefang-channels/src/messenger.rs
@@ -528,6 +528,15 @@ impl ChannelAdapter for MessengerAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the
+    /// Messenger page identifier) so the bridge approval listener builds
+    /// the same `messenger:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the page
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -843,5 +852,30 @@ mod tests {
 
         let msgs = parse_messenger_entry(&entry);
         assert_eq!(msgs.len(), 2);
+    }
+
+    #[test]
+    fn test_messenger_account_id_default_none() {
+        let adapter = MessengerAdapter::new(
+            "page-token".to_string(),
+            "verify".to_string(),
+            "secret".to_string(),
+            0,
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_messenger_account_id_returns_configured_value() {
+        // #5003: two Messenger pages must resolve under distinct
+        // `messenger:<account_id>` keys via the trait override.
+        let adapter = MessengerAdapter::new(
+            "page-token".to_string(),
+            "verify".to_string(),
+            "secret".to_string(),
+            0,
+        )
+        .with_account_id(Some("page-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("page-42"));
     }
 }

--- a/crates/librefang-channels/src/mqtt.rs
+++ b/crates/librefang-channels/src/mqtt.rs
@@ -406,6 +406,18 @@ impl ChannelAdapter for MqttAdapter {
         info!("MQTT adapter stopped");
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` so the bridge approval
+    /// listener can build the same `mqtt:<account_id>` key the router stores
+    /// in `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// broker bound to the requesting agent (#5003, follow-up to #4985 /
+    /// #4994). MqttAdapter is not currently registered in librefang-api's
+    /// boot path, so this is dormant — but adding it here keeps the trait
+    /// implementations symmetric and prevents the same regression class
+    /// from re-emerging the moment MQTT is wired up.
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -559,6 +571,25 @@ mod tests {
         let payload: &[u8] = &[0xFF, 0xFE, 0xFD];
         let msg = MqttAdapter::parse_payload("topic", payload, &None);
         assert!(msg.is_none());
+    }
+
+    #[test]
+    fn test_mqtt_account_id_default_none() {
+        let adapter = MqttAdapter::new(test_config());
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_mqtt_account_id_returns_configured_value() {
+        // #5003: two MQTT brokers in the same daemon must resolve under
+        // distinct `mqtt:<account_id>` keys; this override is what the
+        // bridge approval listener consults once MQTT is registered.
+        let cfg = MqttConfig {
+            account_id: Some("broker-42".to_string()),
+            ..test_config()
+        };
+        let adapter = MqttAdapter::new(cfg);
+        assert_eq!(adapter.account_id(), Some("broker-42"));
     }
 
     #[test]

--- a/crates/librefang-channels/src/mumble.rs
+++ b/crates/librefang-channels/src/mumble.rs
@@ -528,6 +528,16 @@ impl ChannelAdapter for MumbleAdapter {
         *lock = None;
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Mumble
+    /// server / certificate identifier) so the bridge approval listener
+    /// builds the same `mumble:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// server bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -734,5 +744,32 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    #[test]
+    fn test_mumble_account_id_default_none() {
+        let adapter = MumbleAdapter::new(
+            "mumble.example.com".to_string(),
+            0,
+            "secret".to_string(),
+            "bot".to_string(),
+            "General".to_string(),
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_mumble_account_id_returns_configured_value() {
+        // #5003: two Mumble servers must resolve under distinct
+        // `mumble:<account_id>` keys via the trait override.
+        let adapter = MumbleAdapter::new(
+            "mumble.example.com".to_string(),
+            0,
+            "secret".to_string(),
+            "bot".to_string(),
+            "General".to_string(),
+        )
+        .with_account_id(Some("server-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("server-42"));
     }
 }

--- a/crates/librefang-channels/src/nextcloud.rs
+++ b/crates/librefang-channels/src/nextcloud.rs
@@ -451,6 +451,16 @@ impl ChannelAdapter for NextcloudAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the
+    /// Nextcloud server / user identifier) so the bridge approval listener
+    /// builds the same `nextcloud:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// server bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -603,5 +613,28 @@ mod tests {
             vec![],
         );
         assert_eq!(adapter.token.as_str(), "secret-token-value");
+    }
+
+    #[test]
+    fn test_nextcloud_account_id_default_none() {
+        let adapter = NextcloudAdapter::new(
+            "https://cloud.example.com".to_string(),
+            "token".to_string(),
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_nextcloud_account_id_returns_configured_value() {
+        // #5003: two Nextcloud servers must resolve under distinct
+        // `nextcloud:<account_id>` keys via the trait override.
+        let adapter = NextcloudAdapter::new(
+            "https://cloud.example.com".to_string(),
+            "token".to_string(),
+            vec![],
+        )
+        .with_account_id(Some("server-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("server-42"));
     }
 }

--- a/crates/librefang-channels/src/nostr.rs
+++ b/crates/librefang-channels/src/nostr.rs
@@ -446,6 +446,15 @@ impl ChannelAdapter for NostrAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Nostr
+    /// pubkey identifier) so the bridge approval listener builds the same
+    /// `nostr:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the pubkey bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -609,5 +618,26 @@ mod tests {
                 .unwrap_or(false),
             "pubkey must be a 32-byte hex string (64 chars)"
         );
+    }
+
+    #[test]
+    fn test_nostr_account_id_default_none() {
+        let adapter = NostrAdapter::new(
+            TEST_PRIVKEY.to_string(),
+            vec!["wss://relay.damus.io".to_string()],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_nostr_account_id_returns_configured_value() {
+        // #5003: two Nostr pubkeys must resolve under distinct
+        // `nostr:<account_id>` keys via the trait override.
+        let adapter = NostrAdapter::new(
+            TEST_PRIVKEY.to_string(),
+            vec!["wss://relay.damus.io".to_string()],
+        )
+        .with_account_id(Some("npub-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("npub-42"));
     }
 }

--- a/crates/librefang-channels/src/ntfy.rs
+++ b/crates/librefang-channels/src/ntfy.rs
@@ -359,6 +359,15 @@ impl ChannelAdapter for NtfyAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the ntfy
+    /// server / topic identifier) so the bridge approval listener builds the
+    /// same `ntfy:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the topic bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -531,5 +540,28 @@ mod tests {
     #[test]
     fn test_ntfy_parse_invalid_json() {
         assert!(NtfyAdapter::parse_sse_data("not json").is_none());
+    }
+
+    #[test]
+    fn test_ntfy_account_id_default_none() {
+        let adapter = NtfyAdapter::new(
+            "https://ntfy.sh".to_string(),
+            "topic".to_string(),
+            "token".to_string(),
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_ntfy_account_id_returns_configured_value() {
+        // #5003: two ntfy topics must resolve under distinct
+        // `ntfy:<account_id>` keys via the trait override.
+        let adapter = NtfyAdapter::new(
+            "https://ntfy.sh".to_string(),
+            "topic".to_string(),
+            "token".to_string(),
+        )
+        .with_account_id(Some("topic-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("topic-42"));
     }
 }

--- a/crates/librefang-channels/src/pumble.rs
+++ b/crates/librefang-channels/src/pumble.rs
@@ -377,6 +377,16 @@ impl ChannelAdapter for PumbleAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Pumble
+    /// workspace / bot identifier) so the bridge approval listener builds
+    /// the same `pumble:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// workspace bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -581,5 +591,20 @@ mod tests {
 
         let msg = parse_pumble_event(&event, "BOT001").unwrap();
         assert_eq!(msg.thread_id.as_deref(), Some("ts1"));
+    }
+
+    #[test]
+    fn test_pumble_account_id_default_none() {
+        let adapter = PumbleAdapter::new("token".to_string(), 0);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_pumble_account_id_returns_configured_value() {
+        // #5003: two Pumble workspaces must resolve under distinct
+        // `pumble:<account_id>` keys via the trait override.
+        let adapter = PumbleAdapter::new("token".to_string(), 0)
+            .with_account_id(Some("workspace-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("workspace-42"));
     }
 }

--- a/crates/librefang-channels/src/qq.rs
+++ b/crates/librefang-channels/src/qq.rs
@@ -527,6 +527,15 @@ impl ChannelAdapter for QqAdapter {
             last_error,
         }
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the QQ
+    /// app / bot identifier) so the bridge approval listener builds the
+    /// same `qq:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the bot bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 // Helper functions to avoid borrowing self in the spawned task
@@ -730,5 +739,20 @@ mod tests {
             "qq send must not hit the network when platform_id has no pipe; got {} request(s)",
             received.len()
         );
+    }
+
+    #[test]
+    fn test_qq_account_id_default_none() {
+        let adapter = QqAdapter::new("app".to_string(), "secret".to_string(), vec![]);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_qq_account_id_returns_configured_value() {
+        // #5003: two QQ bots must resolve under distinct
+        // `qq:<account_id>` keys via the trait override.
+        let adapter = QqAdapter::new("app".to_string(), "secret".to_string(), vec![])
+            .with_account_id(Some("bot-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("bot-42"));
     }
 }

--- a/crates/librefang-channels/src/reddit.rs
+++ b/crates/librefang-channels/src/reddit.rs
@@ -583,6 +583,16 @@ impl ChannelAdapter for RedditAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Reddit
+    /// account / client identifier) so the bridge approval listener builds
+    /// the same `reddit:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// account bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -862,5 +872,32 @@ mod tests {
         assert!(msg.metadata.contains_key("link_id"));
         assert!(msg.metadata.contains_key("parent_id"));
         assert!(msg.metadata.contains_key("permalink"));
+    }
+
+    #[test]
+    fn test_reddit_account_id_default_none() {
+        let adapter = RedditAdapter::new(
+            "cid".to_string(),
+            "csecret".to_string(),
+            "user".to_string(),
+            "pass".to_string(),
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_reddit_account_id_returns_configured_value() {
+        // #5003: two Reddit accounts must resolve under distinct
+        // `reddit:<account_id>` keys via the trait override.
+        let adapter = RedditAdapter::new(
+            "cid".to_string(),
+            "csecret".to_string(),
+            "user".to_string(),
+            "pass".to_string(),
+            vec![],
+        )
+        .with_account_id(Some("acct-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("acct-42"));
     }
 }

--- a/crates/librefang-channels/src/revolt.rs
+++ b/crates/librefang-channels/src/revolt.rs
@@ -528,6 +528,15 @@ impl ChannelAdapter for RevoltAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Revolt
+    /// server / bot identifier) so the bridge approval listener builds the
+    /// same `revolt:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the bot
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -796,5 +805,20 @@ mod tests {
             msg.contains("403"),
             "error should mention status code, got: {msg}"
         );
+    }
+
+    #[test]
+    fn test_revolt_account_id_default_none() {
+        let adapter = RevoltAdapter::new("token".to_string());
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_revolt_account_id_returns_configured_value() {
+        // #5003: two Revolt bots must resolve under distinct
+        // `revolt:<account_id>` keys via the trait override.
+        let adapter =
+            RevoltAdapter::new("token".to_string()).with_account_id(Some("bot-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("bot-42"));
     }
 }

--- a/crates/librefang-channels/src/rocketchat.rs
+++ b/crates/librefang-channels/src/rocketchat.rs
@@ -400,6 +400,16 @@ impl ChannelAdapter for RocketChatAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the
+    /// Rocket.Chat server / user identifier) so the bridge approval
+    /// listener builds the same `rocketchat:<account_id>` key the router
+    /// stores in `channel_defaults`, scoping ApprovalRequested delivery to
+    /// the server bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -546,5 +556,30 @@ mod tests {
             err.to_string().contains("401"),
             "error should mention status code, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_rocketchat_account_id_default_none() {
+        let adapter = RocketChatAdapter::new(
+            "https://chat.example.com".to_string(),
+            "token".to_string(),
+            "user".to_string(),
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_rocketchat_account_id_returns_configured_value() {
+        // #5003: two Rocket.Chat servers must resolve under distinct
+        // `rocketchat:<account_id>` keys via the trait override.
+        let adapter = RocketChatAdapter::new(
+            "https://chat.example.com".to_string(),
+            "token".to_string(),
+            "user".to_string(),
+            vec![],
+        )
+        .with_account_id(Some("server-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("server-42"));
     }
 }

--- a/crates/librefang-channels/src/signal.rs
+++ b/crates/librefang-channels/src/signal.rs
@@ -722,6 +722,16 @@ impl ChannelAdapter for SignalAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Signal
+    /// account phone number or device hash) so the bridge approval listener
+    /// builds the same `signal:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// account bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -741,6 +751,36 @@ mod tests {
         .expect("should build with allow_local=true");
         assert_eq!(adapter.name(), "signal");
         assert_eq!(adapter.channel_type(), ChannelType::Signal);
+    }
+
+    #[test]
+    fn test_signal_account_id_default_none() {
+        let adapter = SignalAdapter::with_options(
+            "http://localhost:8080".to_string(),
+            "+1234567890".to_string(),
+            vec![],
+            None,
+            true,
+        )
+        .expect("should build");
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_signal_account_id_returns_configured_value() {
+        // #5003: two Signal accounts (each with its own phone number /
+        // device hash) must resolve under distinct `signal:<account_id>`
+        // keys via the trait override.
+        let adapter = SignalAdapter::with_options(
+            "http://localhost:8080".to_string(),
+            "+1234567890".to_string(),
+            vec![],
+            None,
+            true,
+        )
+        .expect("should build")
+        .with_account_id(Some("+1234567890".to_string()));
+        assert_eq!(adapter.account_id(), Some("+1234567890"));
     }
 
     #[test]

--- a/crates/librefang-channels/src/slack.rs
+++ b/crates/librefang-channels/src/slack.rs
@@ -816,6 +816,15 @@ impl ChannelAdapter for SlackAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Slack
+    /// workspace / `team_id`) so the bridge approval listener builds the
+    /// same `slack:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the workspace bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 /// Helper to get Socket Mode WebSocket URL.
@@ -1667,6 +1676,24 @@ mod tests {
         );
         assert_eq!(adapter.name(), "slack");
         assert_eq!(adapter.channel_type(), ChannelType::Slack);
+    }
+
+    #[test]
+    fn test_slack_account_id_default_none() {
+        // Without `with_account_id`, the trait override returns `None`,
+        // matching the bare `<channel_type>` key the bridge stores.
+        let adapter = SlackAdapter::new("xapp-test".to_string(), "xoxb-test".to_string(), vec![]);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_slack_account_id_returns_configured_value() {
+        // #5003: multi-bot deployments must expose `account_id()` so the
+        // bridge approval listener builds `slack:<team_id>` instead of
+        // bare `slack`.
+        let adapter = SlackAdapter::new("xapp-test".to_string(), "xoxb-test".to_string(), vec![])
+            .with_account_id(Some("T0ACME".to_string()));
+        assert_eq!(adapter.account_id(), Some("T0ACME"));
     }
 
     #[tokio::test]

--- a/crates/librefang-channels/src/teams.rs
+++ b/crates/librefang-channels/src/teams.rs
@@ -519,6 +519,15 @@ impl ChannelAdapter for TeamsAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Teams
+    /// tenant / app identifier) so the bridge approval listener builds the
+    /// same `teams:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the tenant bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -908,5 +917,32 @@ mod tests {
 
         let msg = parse_teams_activity(&activity, "app-id", &[]).unwrap();
         assert!(msg.is_group);
+    }
+
+    #[test]
+    fn test_teams_account_id_default_none() {
+        let adapter = TeamsAdapter::new(
+            "app-id".to_string(),
+            "app-password".to_string(),
+            String::new(),
+            0,
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_teams_account_id_returns_configured_value() {
+        // #5003: two Teams tenants must resolve under distinct
+        // `teams:<account_id>` keys via the trait override.
+        let adapter = TeamsAdapter::new(
+            "app-id".to_string(),
+            "app-password".to_string(),
+            String::new(),
+            0,
+            vec![],
+        )
+        .with_account_id(Some("tenant-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("tenant-42"));
     }
 }

--- a/crates/librefang-channels/src/threema.rs
+++ b/crates/librefang-channels/src/threema.rs
@@ -310,6 +310,16 @@ impl ChannelAdapter for ThreemaAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Threema
+    /// gateway ID / app identifier) so the bridge approval listener builds
+    /// the same `threema:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// gateway bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -473,5 +483,20 @@ mod tests {
             err.to_string().contains("401"),
             "error should mention status code, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_threema_account_id_default_none() {
+        let adapter = ThreemaAdapter::new("*GATEWAY".to_string(), "secret".to_string(), 0);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_threema_account_id_returns_configured_value() {
+        // #5003: two Threema gateway IDs must resolve under distinct
+        // `threema:<account_id>` keys via the trait override.
+        let adapter = ThreemaAdapter::new("*GATEWAY".to_string(), "secret".to_string(), 0)
+            .with_account_id(Some("gateway-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("gateway-42"));
     }
 }

--- a/crates/librefang-channels/src/twist.rs
+++ b/crates/librefang-channels/src/twist.rs
@@ -575,6 +575,15 @@ impl ChannelAdapter for TwistAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Twist
+    /// workspace identifier) so the bridge approval listener builds the
+    /// same `twist:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the workspace bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -701,5 +710,20 @@ mod tests {
             err.to_string().contains("500"),
             "error should mention status code, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_twist_account_id_default_none() {
+        let adapter = TwistAdapter::new("token".to_string(), "ws-1".to_string(), vec![]);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_twist_account_id_returns_configured_value() {
+        // #5003: two Twist workspaces must resolve under distinct
+        // `twist:<account_id>` keys via the trait override.
+        let adapter = TwistAdapter::new("token".to_string(), "ws-1".to_string(), vec![])
+            .with_account_id(Some("ws-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("ws-42"));
     }
 }

--- a/crates/librefang-channels/src/twitch.rs
+++ b/crates/librefang-channels/src/twitch.rs
@@ -347,6 +347,16 @@ impl ChannelAdapter for TwitchAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Twitch
+    /// channel / nick identifier) so the bridge approval listener builds the
+    /// same `twitch:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// channel bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -506,5 +516,20 @@ mod tests {
             privmsg_idx < quit_idx,
             "PRIVMSG must precede QUIT (text was: {text})"
         );
+    }
+
+    #[test]
+    fn test_twitch_account_id_default_none() {
+        let adapter = TwitchAdapter::new("oauth:token".to_string(), vec![], "nick".to_string());
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_twitch_account_id_returns_configured_value() {
+        // #5003: two Twitch bot accounts must resolve under distinct
+        // `twitch:<account_id>` keys via the trait override.
+        let adapter = TwitchAdapter::new("oauth:token".to_string(), vec![], "nick".to_string())
+            .with_account_id(Some("nick-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("nick-42"));
     }
 }

--- a/crates/librefang-channels/src/viber.rs
+++ b/crates/librefang-channels/src/viber.rs
@@ -498,6 +498,15 @@ impl ChannelAdapter for ViberAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Viber
+    /// bot / account identifier) so the bridge approval listener builds the
+    /// same `viber:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the bot bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -777,5 +786,28 @@ mod tests {
         });
 
         assert!(parse_viber_event(&event).is_none());
+    }
+
+    #[test]
+    fn test_viber_account_id_default_none() {
+        let adapter = ViberAdapter::new(
+            "token".to_string(),
+            "https://example.com/webhook".to_string(),
+            0,
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_viber_account_id_returns_configured_value() {
+        // #5003: two Viber bots must resolve under distinct
+        // `viber:<account_id>` keys via the trait override.
+        let adapter = ViberAdapter::new(
+            "token".to_string(),
+            "https://example.com/webhook".to_string(),
+            0,
+        )
+        .with_account_id(Some("bot-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("bot-42"));
     }
 }

--- a/crates/librefang-channels/src/voice.rs
+++ b/crates/librefang-channels/src/voice.rs
@@ -702,6 +702,16 @@ impl ChannelAdapter for VoiceAdapter {
             last_error: None,
         }
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the voice
+    /// endpoint / device identifier) so the bridge approval listener builds
+    /// the same `voice:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// endpoint bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -796,5 +806,34 @@ mod tests {
         assert!(!status.connected);
         assert_eq!(status.messages_received, 0);
         assert_eq!(status.messages_sent, 0);
+    }
+
+    #[test]
+    fn test_voice_account_id_default_none() {
+        let adapter = VoiceAdapter::new(
+            0,
+            "key".to_string(),
+            "https://api.example.com".to_string(),
+            "https://api.example.com".to_string(),
+            "alloy".to_string(),
+            32768,
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_voice_account_id_returns_configured_value() {
+        // #5003: two voice endpoints must resolve under distinct
+        // `voice:<account_id>` keys via the trait override.
+        let adapter = VoiceAdapter::new(
+            0,
+            "key".to_string(),
+            "https://api.example.com".to_string(),
+            "https://api.example.com".to_string(),
+            "alloy".to_string(),
+            32768,
+        )
+        .with_account_id(Some("endpoint-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("endpoint-42"));
     }
 }

--- a/crates/librefang-channels/src/webex.rs
+++ b/crates/librefang-channels/src/webex.rs
@@ -505,6 +505,15 @@ impl ChannelAdapter for WebexAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Webex
+    /// org / bot identifier) so the bridge approval listener builds the
+    /// same `webex:<account_id>` key the router stores in `channel_defaults`,
+    /// scoping ApprovalRequested delivery to the org bound to the
+    /// requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -617,5 +626,20 @@ mod tests {
             err.to_string().contains("401"),
             "error should mention status code, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_webex_account_id_default_none() {
+        let adapter = WebexAdapter::new("token".to_string(), vec![]);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_webex_account_id_returns_configured_value() {
+        // #5003: two Webex bots must resolve under distinct
+        // `webex:<account_id>` keys via the trait override.
+        let adapter = WebexAdapter::new("token".to_string(), vec![])
+            .with_account_id(Some("org-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("org-42"));
     }
 }

--- a/crates/librefang-channels/src/webhook.rs
+++ b/crates/librefang-channels/src/webhook.rs
@@ -499,6 +499,16 @@ impl ChannelAdapter for WebhookAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the
+    /// webhook endpoint / secret identifier) so the bridge approval
+    /// listener builds the same `webhook:<account_id>` key the router
+    /// stores in `channel_defaults`, scoping ApprovalRequested delivery to
+    /// the endpoint bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -741,5 +751,22 @@ mod tests {
             WebhookAdapter::verify_request(SECRET, body, &sig, Some(future_edge), now()).is_ok(),
             "timestamp exactly at +5 min edge must be accepted"
         );
+    }
+
+    #[test]
+    fn test_webhook_account_id_default_none() {
+        let adapter = WebhookAdapter::new("secret".to_string(), 0, None)
+            .expect("WebhookAdapter::new must accept no callback");
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_webhook_account_id_returns_configured_value() {
+        // #5003: two webhook endpoints must resolve under distinct
+        // `webhook:<account_id>` keys via the trait override.
+        let adapter = WebhookAdapter::new("secret".to_string(), 0, None)
+            .expect("WebhookAdapter::new must accept no callback")
+            .with_account_id(Some("endpoint-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("endpoint-42"));
     }
 }

--- a/crates/librefang-channels/src/wechat.rs
+++ b/crates/librefang-channels/src/wechat.rs
@@ -836,6 +836,16 @@ impl ChannelAdapter for WeChatAdapter {
             last_error,
         }
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the WeChat
+    /// `gh_id` or WeCom corp/app identifier) so the bridge approval
+    /// listener builds the same `wechat:<account_id>` key the router stores
+    /// in `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// account bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -847,6 +857,22 @@ mod tests {
         let adapter = WeChatAdapter::new(Some("test_token".to_string()), vec![]);
         assert_eq!(adapter.name(), "wechat");
         assert_eq!(adapter.channel_type(), ChannelType::WeChat);
+    }
+
+    #[test]
+    fn test_wechat_account_id_default_none() {
+        let adapter = WeChatAdapter::new(Some("test_token".to_string()), vec![]);
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_wechat_account_id_returns_configured_value() {
+        // #5003: two WeChat / WeCom apps (each with its own `gh_id` /
+        // corp app identifier) must resolve under distinct
+        // `wechat:<account_id>` keys via the trait override.
+        let adapter = WeChatAdapter::new(Some("test_token".to_string()), vec![])
+            .with_account_id(Some("gh_acme".to_string()));
+        assert_eq!(adapter.account_id(), Some("gh_acme"));
     }
 
     #[test]

--- a/crates/librefang-channels/src/wecom.rs
+++ b/crates/librefang-channels/src/wecom.rs
@@ -1602,6 +1602,16 @@ impl ChannelAdapter for WeComAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the WeCom
+    /// (Enterprise WeChat) corp / bot identifier) so the bridge approval
+    /// listener builds the same `wecom:<account_id>` key the router stores
+    /// in `channel_defaults`, scoping ApprovalRequested delivery to the
+    /// bot bound to the requesting agent (#5003, follow-up to
+    /// #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -2468,5 +2478,20 @@ mod tests {
             redact_credential_query_params("https://example.com/path"),
             "https://example.com/path"
         );
+    }
+
+    #[test]
+    fn test_wecom_account_id_default_none() {
+        let adapter = WeComAdapter::new("bot-id".to_string(), "secret".to_string());
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_wecom_account_id_returns_configured_value() {
+        // #5003: two WeCom bots must resolve under distinct
+        // `wecom:<account_id>` keys via the trait override.
+        let adapter = WeComAdapter::new("bot-id".to_string(), "secret".to_string())
+            .with_account_id(Some("corp-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("corp-42"));
     }
 }

--- a/crates/librefang-channels/src/whatsapp.rs
+++ b/crates/librefang-channels/src/whatsapp.rs
@@ -614,6 +614,16 @@ impl ChannelAdapter for WhatsAppAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the
+    /// WhatsApp Business phone-number / WABA identifier) so the bridge
+    /// approval listener builds the same `whatsapp:<account_id>` key the
+    /// router stores in `channel_defaults`, scoping ApprovalRequested
+    /// delivery to the phone number bound to the requesting agent
+    /// (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -877,5 +887,32 @@ mod tests {
             )
             .await
             .expect("whatsapp gateway send must succeed against mock");
+    }
+
+    #[test]
+    fn test_whatsapp_account_id_default_none() {
+        let adapter = WhatsAppAdapter::new(
+            "phone-id".to_string(),
+            "token".to_string(),
+            "verify".to_string(),
+            0,
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_whatsapp_account_id_returns_configured_value() {
+        // #5003: two WhatsApp Business phone numbers must resolve under
+        // distinct `whatsapp:<account_id>` keys via the trait override.
+        let adapter = WhatsAppAdapter::new(
+            "phone-id".to_string(),
+            "token".to_string(),
+            "verify".to_string(),
+            0,
+            vec![],
+        )
+        .with_account_id(Some("waba-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("waba-42"));
     }
 }

--- a/crates/librefang-channels/src/xmpp.rs
+++ b/crates/librefang-channels/src/xmpp.rs
@@ -142,6 +142,15 @@ impl ChannelAdapter for XmppAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the XMPP
+    /// JID / resource identifier) so the bridge approval listener builds
+    /// the same `xmpp:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the JID
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -306,5 +315,32 @@ mod tests {
             msg.contains("not started") && msg.contains("tokio-xmpp"),
             "stub error must mention not-started + tokio-xmpp, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_xmpp_account_id_default_none() {
+        let adapter = XmppAdapter::new(
+            "bot@example.com".to_string(),
+            "pass".to_string(),
+            "example.com".to_string(),
+            5222,
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_xmpp_account_id_returns_configured_value() {
+        // #5003: two XMPP JIDs must resolve under distinct
+        // `xmpp:<account_id>` keys via the trait override.
+        let adapter = XmppAdapter::new(
+            "bot@example.com".to_string(),
+            "pass".to_string(),
+            "example.com".to_string(),
+            5222,
+            vec![],
+        )
+        .with_account_id(Some("jid-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("jid-42"));
     }
 }

--- a/crates/librefang-channels/src/zulip.rs
+++ b/crates/librefang-channels/src/zulip.rs
@@ -489,6 +489,15 @@ impl ChannelAdapter for ZulipAdapter {
         let _ = self.shutdown_tx.send(true);
         Ok(())
     }
+
+    /// Expose the configured multi-bot `account_id` (typically the Zulip
+    /// realm / bot-email identifier) so the bridge approval listener builds
+    /// the same `zulip:<account_id>` key the router stores in
+    /// `channel_defaults`, scoping ApprovalRequested delivery to the realm
+    /// bound to the requesting agent (#5003, follow-up to #4985 / #4994).
+    fn account_id(&self) -> Option<&str> {
+        self.account_id.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -675,5 +684,30 @@ mod tests {
             err.to_string().contains("400"),
             "error should mention status code, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_zulip_account_id_default_none() {
+        let adapter = ZulipAdapter::new(
+            "https://zulip.example.com".to_string(),
+            "bot@example.com".to_string(),
+            "key".to_string(),
+            vec![],
+        );
+        assert_eq!(adapter.account_id(), None);
+    }
+
+    #[test]
+    fn test_zulip_account_id_returns_configured_value() {
+        // #5003: two Zulip realms must resolve under distinct
+        // `zulip:<account_id>` keys via the trait override.
+        let adapter = ZulipAdapter::new(
+            "https://zulip.example.com".to_string(),
+            "bot@example.com".to_string(),
+            "key".to_string(),
+            vec![],
+        )
+        .with_account_id(Some("realm-42".to_string()));
+        assert_eq!(adapter.account_id(), Some("realm-42"));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #4985 / #4994. The approval-scoping fix in those PRs relies on
`ChannelAdapter::account_id() -> Option<&str>` to distinguish single-bot adapters
(looked up under `<channel_type>`) from multi-bot adapters (looked up under
`<channel_type>:<account_id>`). Only `TelegramAdapter` overrode the method;
every other multi-bot-capable adapter inherited the trait default `None`, so
two Slack workspaces (or two Discord guilds, two Matrix accounts, etc.) all
resolved under the same bare key and a per-platform repeat of the #4985 leak
followed.

Each adapter already stored `account_id: Option<String>` via `with_account_id(...)`,
and the bridge boot path in `crates/librefang-api/src/channel_bridge.rs` (L3729-3771)
already builds account-qualified keys for every channel that has one — the only
missing piece was the trait override on the adapter so the bridge approval
listener (`bridge.rs::start_approval_listener`, line 1554) builds the matching
qualified key.

## Adapters updated

Each returns `self.account_id.as_deref()` from the trait method, mirroring
`TelegramAdapter` as the reference implementation. The override + symmetric
unit tests (`*_account_id_default_none` + `*_account_id_returns_configured_value`)
were added to **all** non-Telegram adapters that already carried an
`account_id` field — 44 adapters in total:

`bluesky`, `dingtalk`, `discord`, `discourse`, `email`, `feishu`, `flock`,
`gitter`, `google_chat`, `gotify`, `guilded`, `irc`, `keybase`, `line`,
`linkedin`, `mastodon`, `matrix`, `mattermost`, `messenger`, `mqtt`, `mumble`,
`nextcloud`, `nostr`, `ntfy`, `pumble`, `qq`, `reddit`, `revolt`, `rocketchat`,
`signal`, `slack`, `teams`, `threema`, `twist`, `twitch`, `viber`, `voice`,
`webex`, `webhook`, `wechat`, `wecom`, `whatsapp`, `xmpp`, `zulip`.

The earlier draft of this description listed only six (Slack/Discord/Matrix/
Mattermost/WeChat/Signal) as a representative sample; the actual scope is the
full set above so the regression class is closed across every multi-bot-capable
channel rather than left half-fixed.

## Bridge boot path

No change required. The bridge boot path lives in
`crates/librefang-api/src/channel_bridge.rs` (L3729-3771) and is already
channel-type-agnostic — it formats `<channel_type_str>:<account_id>` whenever
the per-adapter config carries `account_id`. The Telegram detection mentioned
in the issue body is in fact the same generic code path; it works for every
adapter as soon as the adapter's config exposes `account_id` (which all 44
adapters above already do).

## Test plan

- [x] \`cargo check --features all-channels\` clean
- [x] \`cargo clippy --features all-channels -- -D warnings\` clean
- [x] \`cargo test --features all-channels\` passes (44 × 2 new unit tests)
- [x] Existing \`tests/bridge_integration_test.rs:2051 test_approval_listener_scopes_to_non_telegram_multibot_adapter\` continues to pass — the real adapters now match the MockAdapter contract that test was already pinning.

Closes #5003.