### PR TITLE
fix(channels/telegram): magic-byte sniff outbound audio/ogg to catch mislabeled payloads

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -4239,7 +4239,7 @@ fn detect_image_magic(bytes: &[u8]) -> Option<String> {
 /// Returns `Some("audio/...")` for OGG, MP3, WAV, FLAC, M4A, and WebM/Matroska.
 /// Used to recover a correct MIME type when the HTTP Content-Type header is
 /// the uninformative `application/octet-stream` (common with Telegram CDN).
-fn detect_audio_magic(bytes: &[u8]) -> Option<&'static str> {
+pub(crate) fn detect_audio_magic(bytes: &[u8]) -> Option<&'static str> {
     // OGG container — covers Opus (.oga/.opus), Vorbis, etc.
     if bytes.len() >= 4 && bytes[..4] == [0x4F, 0x67, 0x67, 0x53] {
         return Some("audio/ogg");

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -1681,6 +1681,10 @@ impl TelegramAdapter {
                 // bytes actually start with the OGG container magic before
                 // committing to sendVoice; otherwise fall through to
                 // sendDocument so the file still reaches the user.
+                // 12 = the longest prefix `detect_audio_magic` inspects
+                // (M4A's `ftyp` box). OGG itself only needs the first 4
+                // bytes, but feeding 12 keeps the call site future-proof
+                // for additional container formats added to the helper.
                 let bytes_look_like_ogg =
                     crate::bridge::detect_audio_magic(&data[..data.len().min(12)])
                         == Some("audio/ogg");

--- a/crates/librefang-channels/src/telegram.rs
+++ b/crates/librefang-channels/src/telegram.rs
@@ -1673,7 +1673,18 @@ impl TelegramAdapter {
                 // local-file path is the one users hit via `channel_send`'s
                 // `file_path` parameter and the one called out in the bug
                 // report.
-                if is_telegram_voice_payload(&mime_type, &filename) {
+                //
+                // Magic-byte sniff (#5004): MIME/filename may be wrong (e.g.
+                // an MP3 mislabeled as `voice.ogg` / `audio/ogg`). Telegram's
+                // sendVoice validates the container server-side and 400s,
+                // surfacing as a generic channel-send failure. Verify the
+                // bytes actually start with the OGG container magic before
+                // committing to sendVoice; otherwise fall through to
+                // sendDocument so the file still reaches the user.
+                let bytes_look_like_ogg =
+                    crate::bridge::detect_audio_magic(&data[..data.len().min(12)])
+                        == Some("audio/ogg");
+                if is_telegram_voice_payload(&mime_type, &filename) && bytes_look_like_ogg {
                     self.api_send_voice_upload(chat_id, data, &filename, &mime_type, thread_id)
                         .await?;
                 } else {
@@ -5778,7 +5789,10 @@ mod tests {
             .send(
                 &dummy_user("1"),
                 ChannelContent::FileData {
-                    data: vec![],
+                    // OggS magic — required by the #5004 magic-byte sniff so
+                    // the routing predicate can confirm the payload really is
+                    // an OGG container before committing to sendVoice.
+                    data: vec![0x4F, 0x67, 0x67, 0x53],
                     filename: "memo.oga".into(),
                     // Intentionally generic — extension must still win.
                     mime_type: "application/octet-stream".into(),
@@ -5850,6 +5864,48 @@ mod tests {
             )
             .await
             .expect("PDF must still go via sendDocument");
+    }
+
+    #[tokio::test]
+    async fn telegram_send_file_data_ogg_labeled_but_mp3_bytes_routes_to_send_document() {
+        // #5004: caller-supplied MIME/filename can lie. An MP3 mislabeled as
+        // `voice.ogg` / `audio/ogg` must be downgraded to sendDocument —
+        // Telegram's sendVoice rejects non-OGG containers server-side, and
+        // the resulting 400 would surface as a generic channel-send failure
+        // with no hint that the label was wrong.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(format!("/bot{TEST_TOKEN}/sendDocument")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 1, "date": 0, "chat": { "id": 1, "type": "private" } },
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(format!("/bot{TEST_TOKEN}/sendVoice")))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let adapter = make_send_adapter(server.uri());
+        adapter
+            .send(
+                &dummy_user("1"),
+                ChannelContent::FileData {
+                    // ID3v2 tag header — the standard MP3 magic. MIME and
+                    // filename below claim OGG; the bytes win.
+                    data: vec![
+                        0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    ],
+                    filename: "voice.ogg".into(),
+                    mime_type: "audio/ogg".into(),
+                },
+            )
+            .await
+            .expect("mislabeled MP3 must downgrade to sendDocument");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to PR #4998 (which fixed #4959). Outbound `ChannelContent::FileData`
voice-routing in the Telegram adapter currently classifies on caller-supplied
MIME + filename only. A payload tagged `voice.ogg` / `audio/ogg` but carrying
actual MP3 (or any non-OGG) bytes is routed to `sendVoice`; Telegram validates
the container server-side and 400s, which surfaces as a generic channel-send
failure with no hint that the MIME label was wrong.

This adds the outbound symmetry of the inbound magic-byte sniff added in #4927
(`bridge::detect_audio_magic`). The `FileData` branch now confirms the bytes
actually start with the OGG container magic before committing to `sendVoice`;
otherwise it falls through to `sendDocument` so the file still reaches the
user.

The URL branch (`ChannelContent::File`) is unchanged — it has no cheap way to
peek the bytes without an extra HTTP round-trip.

## Changes

- `crates/librefang-channels/src/bridge.rs`: bump `detect_audio_magic` to
  `pub(crate)` so the telegram adapter can reuse it. No behaviour change for
  the existing inbound caller.
- `crates/librefang-channels/src/telegram.rs`: in `send_content`'s `FileData`
  arm, gate `sendVoice` on
  `is_telegram_voice_payload(&mime_type, &filename) && magic == Some("audio/ogg")`.
  Updated the existing `oga` test to use real `OggS` magic bytes (empty
  payload is no longer a valid voice candidate by construction).
- New test `telegram_send_file_data_ogg_labeled_but_mp3_bytes_routes_to_send_document`
  pins the regression: `audio/ogg` MIME + `voice.ogg` filename + ID3-prefixed
  MP3 bytes routes to `sendDocument`, not `sendVoice`.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-channels --all-targets --features channel-telegram -- -D warnings` — clean.
- `cargo test -p librefang-channels --lib --features channel-telegram` — 520 passed.
- `cargo test -p librefang-channels --lib --features channel-telegram telegram::tests::telegram_send_file_data` — 5 passed (including the new mislabeled case).

Closes #5004.
