### PR TITLE
feat(dashboard/agents): show skill descriptions in agent Skills tab

### DIFF
--- a/crates/librefang-api/dashboard/src/components/AgentSkillItem.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/AgentSkillItem.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AgentSkillItem } from "./AgentSkillItem";
+
+// Issue #4925 — assignment UI used to show only the skill name; this
+// component renders the description inline below the name when present
+// and falls back to the previous "installed" hint when the global
+// registry has no description (or it's empty). The test pins both
+// branches so a regression toward "name-only" surfaces immediately.
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>(
+    "react-i18next",
+  );
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, defaultOrOpts?: unknown) => {
+        if (
+          defaultOrOpts &&
+          typeof defaultOrOpts === "object" &&
+          "defaultValue" in (defaultOrOpts as Record<string, unknown>)
+        ) {
+          return String(
+            (defaultOrOpts as { defaultValue: string }).defaultValue,
+          );
+        }
+        return typeof defaultOrOpts === "string" ? defaultOrOpts : key;
+      },
+    }),
+  };
+});
+
+describe("AgentSkillItem", () => {
+  it("shows the description inline below the name when present", () => {
+    render(
+      <AgentSkillItem
+        name="web-search"
+        description="Searches the public web and returns ranked snippets"
+      />,
+    );
+    expect(screen.getByTestId("agent-skill-item-name").textContent).toBe(
+      "web-search",
+    );
+    expect(
+      screen.getByTestId("agent-skill-item-description").textContent,
+    ).toBe("Searches the public web and returns ranked snippets");
+  });
+
+  it("falls back to the 'installed' hint when description is missing", () => {
+    render(<AgentSkillItem name="writing-coach" />);
+    expect(
+      screen.getByTestId("agent-skill-item-description").textContent,
+    ).toBe("installed");
+  });
+
+  it("falls back to the 'installed' hint when description is the empty string", () => {
+    // Empty/whitespace descriptions used to render as a stray blank
+    // second line because the original code unconditionally rendered
+    // the subtitle div. The component now trims and treats empty as
+    // "no description" so the row layout stays stable.
+    render(<AgentSkillItem name="puppeteer" description="   " />);
+    expect(
+      screen.getByTestId("agent-skill-item-description").textContent,
+    ).toBe("installed");
+  });
+
+  it("invokes onClick when the row is clicked", async () => {
+    const onClick = vi.fn();
+    render(
+      <AgentSkillItem
+        name="web-search"
+        description="hi"
+        onClick={onClick}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("agent-skill-item"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/AgentSkillItem.tsx
+++ b/crates/librefang-api/dashboard/src/components/AgentSkillItem.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from "react";
 import { Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -30,9 +31,23 @@ export function AgentSkillItem({ name, description, onClick }: AgentSkillItemPro
   const subtitle = trimmedDescription && trimmedDescription.length > 0
     ? trimmedDescription
     : t("agents.detail.skill_meta", { defaultValue: "installed" });
+  // The row is interactive when an onClick is provided. Mirror that to
+  // keyboard + assistive tech with role/tabIndex/Enter+Space handling so
+  // it isn't a mouse-only target.
+  const handleKeyDown = onClick
+    ? (event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onClick();
+        }
+      }
+    : undefined;
   return (
     <div
       onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
       className="px-3 py-2.5 rounded-md border border-border-subtle bg-main/40 cursor-pointer hover:border-brand/40 transition-colors flex items-start justify-between gap-2"
       data-testid="agent-skill-item"
     >

--- a/crates/librefang-api/dashboard/src/components/AgentSkillItem.tsx
+++ b/crates/librefang-api/dashboard/src/components/AgentSkillItem.tsx
@@ -1,0 +1,57 @@
+import { Sparkles } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Single skill row rendered inside the agent detail panel's Skills tab.
+ *
+ * Issue #4925: the assignment UI used to show only the skill name, so
+ * users with 40+ skills had no clue what `web-search` vs `web-research`
+ * vs `web-fetch` actually do. We cross-reference the global skill
+ * registry (`useSkills()` in AgentsPage) and pass the description in
+ * here so each row shows the human-readable summary inline below the
+ * name. When no description is available (skill not in the global list,
+ * or its `description` field is empty) we fall back to the previous
+ * "installed" hint so the row still has a stable second line and the
+ * grid layout doesn't jump.
+ *
+ * Extracted into its own component so it can be unit-tested without
+ * mounting the entire AgentsPage (which pulls in routing, multiple
+ * queries, the manifest form, etc.).
+ */
+export interface AgentSkillItemProps {
+  name: string;
+  description?: string;
+  onClick?: () => void;
+}
+
+export function AgentSkillItem({ name, description, onClick }: AgentSkillItemProps) {
+  const { t } = useTranslation();
+  const trimmedDescription = description?.trim();
+  const subtitle = trimmedDescription && trimmedDescription.length > 0
+    ? trimmedDescription
+    : t("agents.detail.skill_meta", { defaultValue: "installed" });
+  return (
+    <div
+      onClick={onClick}
+      className="px-3 py-2.5 rounded-md border border-border-subtle bg-main/40 cursor-pointer hover:border-brand/40 transition-colors flex items-start justify-between gap-2"
+      data-testid="agent-skill-item"
+    >
+      <div className="min-w-0 flex-1">
+        <div
+          className="font-mono text-[12.5px] font-medium text-text-main truncate"
+          data-testid="agent-skill-item-name"
+        >
+          {name}
+        </div>
+        <div
+          className="font-mono text-[10.5px] text-text-dim/80 mt-0.5 line-clamp-2"
+          data-testid="agent-skill-item-description"
+          title={trimmedDescription || undefined}
+        >
+          {subtitle}
+        </div>
+      </div>
+      <Sparkles className="w-3.5 h-3.5 text-brand/70 shrink-0 mt-0.5" />
+    </div>
+  );
+}

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -38,7 +38,9 @@ import { useCronJobs } from "../lib/queries/runtime";
 import { useAgentTriggers } from "../lib/queries/schedules";
 import { useProviders } from "../lib/queries/providers";
 import { useModels } from "../lib/queries/models";
+import { useSkills } from "../lib/queries/skills";
 import { AgentManifestForm } from "../components/AgentManifestForm";
+import { AgentSkillItem } from "../components/AgentSkillItem";
 import {
   emptyManifestExtras,
   emptyManifestForm,
@@ -525,6 +527,21 @@ export function AgentsPage() {
   );
 
   const providersQuery = useProviders();
+
+  // Global skill registry — used to cross-reference descriptions for the
+  // names listed in the agent's `skills` allowlist (issue #4925). The
+  // hook is gated on detail-panel selection so the list isn't fetched
+  // when no agent is open. `staleTime` from `useSkills` defaults to
+  // 30s, matching SkillsPage, so opening multiple agents in quick
+  // succession reuses the cache.
+  const skillsQuery = useSkills({ enabled: !!detailAgent });
+  const skillDescriptionByName = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const s of skillsQuery.data ?? []) {
+      if (s.description) map.set(s.name, s.description);
+    }
+    return map;
+  }, [skillsQuery.data]);
 
   const configuredProviders = useMemo(
     () => (providersQuery.data ?? []).filter(p => isProviderAvailable(p.auth_status)),
@@ -1247,19 +1264,12 @@ export function AgentsPage() {
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
             {skills.map((s) => (
-              <div
+              <AgentSkillItem
                 key={s}
+                name={s}
+                description={skillDescriptionByName.get(s)}
                 onClick={() => navigate({ to: "/skills" })}
-                className="px-3 py-2.5 rounded-md border border-border-subtle bg-main/40 cursor-pointer hover:border-brand/40 transition-colors flex items-start justify-between gap-2"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="font-mono text-[12.5px] font-medium text-text-main truncate">{s}</div>
-                  <div className="font-mono text-[10.5px] text-text-dim/80 mt-0.5 truncate">
-                    {t("agents.detail.skill_meta", { defaultValue: "installed" })}
-                  </div>
-                </div>
-                <Sparkles className="w-3.5 h-3.5 text-brand/70 shrink-0 mt-0.5" />
-              </div>
+              />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary

Fixes #4925.

The agent detail Skills tab previously showed only the skill name and a
static "installed" hint, so users with 40+ skills had no context for
deciding which to assign or understanding what an already-assigned
skill does.

This PR cross-references the description from the existing global
`useSkills()` list and renders it inline under the name in the existing
card. When the registry has no description (or it's empty/whitespace)
the row falls back to the previous "installed" hint so the grid layout
stays stable.

## Approach

**Cross-reference from the global skills list — no API change.**

The issue's "OR" wording allows either expanding the per-agent
`/api/agents/{id}/skills` payload, or cross-referencing from
`GET /api/skills` in the dashboard. The dashboard path is strictly
smaller and cheaper:

- `GET /api/skills` already returns `description` on every item.
- `useSkills()` already exists (`src/lib/queries/skills.ts`) with a
  30s `staleTime` matching SkillsPage, so opening multiple agents in
  the same minute reuses the cache.
- Gated on `enabled: !!detailAgent` so the list is only fetched when an
  agent detail panel is actually open.

## MCP scope (deferred — see PR body)

The issue title mentions an MCP tab alongside the Skills tab. PR #4912
was the PR that would have introduced both ("Related: #4917 — skills
tab inline assignment (landed in #4912)" and "#4918 — MCP tab inline
assignment (landed in #4912)") but PR #4912 was closed unmerged.
Today's agent detail panel has no MCP tab — MCP-server assignment lives
in the manifest TagInput in `AgentManifestForm`, which is a free-text
input with no list-of-known-servers UI to attach descriptions to.
Description display for MCP servers properly belongs in the PR that
introduces the assignment UI surface; bolting it onto a free-text input
here would be guesswork. Not in scope for this PR.

## Files changed

- `crates/librefang-api/dashboard/src/components/AgentSkillItem.tsx` —
  new component, extracted from the Skills tab render loop. Renders
  name + description (or the "installed" fallback) per row.
- `crates/librefang-api/dashboard/src/components/AgentSkillItem.test.tsx` —
  Vitest + RTL tests for the four branches (description present /
  missing / empty-string / click handler).
- `crates/librefang-api/dashboard/src/pages/AgentsPage.tsx` — add
  `useSkills()` call gated on detail-panel open, build a
  `Map<name, description>` via `useMemo`, replace the inline JSX in the
  Skills tab with `<AgentSkillItem>`.

No API/backend files changed.

## Verification

- `pnpm typecheck` — clean.
- `pnpm test src/components/AgentSkillItem.test.tsx` — 4/4 pass.
- `pnpm test src/lib/queries/agents.test.tsx
   src/lib/queries/agents-experiments.test.tsx
   src/components/AgentSkillItem.test.tsx` — 21/21 pass (adjacent
  suites unaffected).
- `cargo check --workspace --lib` — clean (~7m on cold cache).
- Pre-existing `ModelsPage.test.tsx` and `TerminalPage.test.tsx`
  failures reproduce on `origin/main` without these changes and are
  not caused by this PR.

## Test plan

- [x] Vitest unit tests for the new component
- [x] `tsc --noEmit` green
- [x] `cargo check --workspace --lib` green
- [ ] Manual: open an agent with installed skills in the dashboard and
      verify descriptions appear; install a skill whose `description`
      field is empty and verify the "installed" fallback shows
