### PR TITLE
feat(dashboard/workflows): display generated images inline in workflow run view

### DIFF
--- a/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WorkflowStepImageGallery } from "./WorkflowStepImageGallery";
+import { extractImageRefs } from "../lib/workflowOutputImages";
+
+describe("WorkflowStepImageGallery", () => {
+  it("renders nothing when refs is empty", () => {
+    const { container } = render(<WorkflowStepImageGallery refs={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a single <img> for one image ref", () => {
+    const refs = extractImageRefs(
+      JSON.stringify({ image_urls: ["/api/uploads/abc-1"] }),
+    );
+    render(<WorkflowStepImageGallery refs={refs} />);
+    const imgs = screen.getAllByRole("img");
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0]).toHaveAttribute("src", "/api/uploads/abc-1");
+  });
+
+  it("renders multiple <img>s as a gallery", () => {
+    const refs = extractImageRefs(
+      JSON.stringify({
+        image_urls: ["/api/uploads/a", "/api/uploads/b"],
+      }),
+    );
+    render(<WorkflowStepImageGallery refs={refs} />);
+    const imgs = screen.getAllByRole("img");
+    expect(imgs).toHaveLength(2);
+    expect(imgs.map((i) => i.getAttribute("src"))).toEqual([
+      "/api/uploads/a",
+      "/api/uploads/b",
+    ]);
+  });
+
+  it("uses revised_prompt as alt text when present", () => {
+    const refs = extractImageRefs(
+      JSON.stringify({
+        revised_prompt: "a watercolor sunset",
+        image_urls: ["/api/uploads/sunset"],
+      }),
+    );
+    render(<WorkflowStepImageGallery refs={refs} />);
+    expect(screen.getByAltText("a watercolor sunset")).toBeInTheDocument();
+  });
+
+  it("does NOT render anything for plain text (falls back to caller)", () => {
+    const refs = extractImageRefs("Just a regular workflow result, no image.");
+    const { container } = render(<WorkflowStepImageGallery refs={refs} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.tsx
+++ b/crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.tsx
@@ -1,0 +1,43 @@
+// Renders the images detected in a workflow step's output as a gallery.
+// Pure presentation — no fetch, no data access; the helper that produces
+// `refs` is in src/lib/workflowOutputImages.ts and is already URL-safety
+// checked, so we render `<img src={ref.src}>` directly.
+
+import type { ImageRef } from "../lib/workflowOutputImages";
+
+interface Props {
+  refs: ImageRef[];
+  /** Optional label rendered above the gallery (i18n string from caller). */
+  label?: string;
+}
+
+export function WorkflowStepImageGallery({ refs, label }: Props) {
+  if (refs.length === 0) return null;
+
+  return (
+    <div data-testid="workflow-step-image-gallery" className="space-y-1.5">
+      {label && (
+        <p className="text-[9px] font-bold text-text-dim/50">{label}</p>
+      )}
+      <div className="flex flex-wrap gap-2">
+        {refs.map((ref) => (
+          <a
+            key={ref.src}
+            href={ref.src}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="block rounded-lg overflow-hidden border border-border-subtle hover:border-brand/40 transition-colors max-w-[200px]"
+            title={ref.alt}
+          >
+            <img
+              src={ref.src}
+              alt={ref.alt || "generated image"}
+              loading="lazy"
+              className="block max-h-[200px] w-auto object-contain bg-main/30"
+            />
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/crates/librefang-api/dashboard/src/lib/workflowOutputImages.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/workflowOutputImages.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest";
+import { classifyImageRef, extractImageRefs } from "./workflowOutputImages";
+
+describe("classifyImageRef", () => {
+  it("accepts http(s) URLs with known image extensions", () => {
+    expect(classifyImageRef("https://example.com/foo.png")?.kind).toBe("url");
+    expect(classifyImageRef("https://example.com/foo.jpg")?.kind).toBe("url");
+    expect(classifyImageRef("https://example.com/foo.jpeg")?.kind).toBe("url");
+    expect(classifyImageRef("https://example.com/foo.webp")?.kind).toBe("url");
+    expect(classifyImageRef("https://example.com/foo.gif")?.kind).toBe("url");
+    expect(classifyImageRef("http://example.com/x.svg?v=1")?.kind).toBe("url");
+  });
+
+  it("accepts data:image URIs", () => {
+    const ref = classifyImageRef("data:image/png;base64,iVBORw0KGgo=");
+    expect(ref?.kind).toBe("data-uri");
+    expect(ref?.src).toBe("data:image/png;base64,iVBORw0KGgo=");
+  });
+
+  it("accepts /api/media/artifacts/<id> paths", () => {
+    const ref = classifyImageRef("/api/media/artifacts/abc123");
+    expect(ref?.kind).toBe("artifact");
+    expect(ref?.src).toBe("/api/media/artifacts/abc123");
+  });
+
+  it("accepts /api/uploads/<id> paths (image_generate tool output)", () => {
+    const ref = classifyImageRef("/api/uploads/9d8e7c0a-1111-2222-3333-444455556666");
+    expect(ref?.kind).toBe("url");
+  });
+
+  it("rejects javascript: scheme", () => {
+    expect(classifyImageRef("javascript:alert(1)")).toBeNull();
+    expect(classifyImageRef("JavaScript:alert(1)")).toBeNull();
+  });
+
+  it("rejects file: scheme", () => {
+    expect(classifyImageRef("file:///etc/passwd")).toBeNull();
+  });
+
+  it("rejects about: scheme", () => {
+    expect(classifyImageRef("about:blank")).toBeNull();
+  });
+
+  it("rejects vbscript: scheme", () => {
+    expect(classifyImageRef("vbscript:msgbox(1)")).toBeNull();
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(classifyImageRef("//evil.com/pwn.png")).toBeNull();
+  });
+
+  it("rejects non-image data: URIs", () => {
+    expect(classifyImageRef("data:text/html,<script>alert(1)</script>")).toBeNull();
+    expect(classifyImageRef("data:application/json;base64,e30=")).toBeNull();
+  });
+
+  it("rejects http(s) URLs that don't look like images", () => {
+    // Non-image extensions and bare hosts: caller should fall back to text.
+    expect(classifyImageRef("https://example.com/article.html")).toBeNull();
+    expect(classifyImageRef("https://example.com/")).toBeNull();
+  });
+
+  it("rejects empty / whitespace", () => {
+    expect(classifyImageRef("")).toBeNull();
+    expect(classifyImageRef("   ")).toBeNull();
+  });
+});
+
+describe("extractImageRefs", () => {
+  it("returns [] for plain non-image text", () => {
+    expect(extractImageRefs("Hello, world!")).toEqual([]);
+    expect(extractImageRefs("")).toEqual([]);
+    expect(extractImageRefs(null)).toEqual([]);
+    expect(extractImageRefs(undefined)).toEqual([]);
+  });
+
+  it("returns [] for non-image JSON", () => {
+    expect(extractImageRefs(JSON.stringify({ ok: true, count: 3 }))).toEqual([]);
+  });
+
+  it("extracts a single URL from { url: ... }", () => {
+    const out = extractImageRefs(JSON.stringify({ url: "https://cdn.example/x.png" }));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ kind: "url", src: "https://cdn.example/x.png" });
+  });
+
+  it("extracts the image_generate tool's image_urls array", () => {
+    // Matches the shape produced by tool_image_generate in
+    // crates/librefang-runtime/src/tool_runner.rs:6592 — keys are
+    // images_generated, saved_to, revised_prompt, image_urls.
+    const toolJson = JSON.stringify({
+      model: "dall-e-3",
+      provider: "openai",
+      images_generated: 2,
+      saved_to: ["/tmp/a.png", "/tmp/b.png"],
+      revised_prompt: "a cat in sunglasses",
+      image_urls: ["/api/uploads/aaa-111", "/api/uploads/bbb-222"],
+    });
+    const out = extractImageRefs(toolJson);
+    expect(out).toHaveLength(2);
+    expect(out.map((r) => r.src)).toEqual([
+      "/api/uploads/aaa-111",
+      "/api/uploads/bbb-222",
+    ]);
+    expect(out[0].alt).toBe("a cat in sunglasses");
+  });
+
+  it("extracts from the OpenAI generate_image legacy shape { images: [{ url, data_base64 }] }", () => {
+    // Matches /api/media/image route handler in
+    // crates/librefang-api/src/routes/media.rs:175.
+    const json = JSON.stringify({
+      images: [
+        { url: "/api/uploads/img-1" },
+        { url: "https://cdn.openai.com/foo.png", revised_prompt: "x" },
+      ],
+    });
+    const out = extractImageRefs(json);
+    expect(out.map((r) => r.src)).toEqual([
+      "/api/uploads/img-1",
+      "https://cdn.openai.com/foo.png",
+    ]);
+  });
+
+  it("extracts artifact references ({ artifact } and { artifact_id })", () => {
+    const out1 = extractImageRefs(JSON.stringify({ artifact: "/api/media/artifacts/x1" }));
+    expect(out1).toEqual([{ kind: "artifact", src: "/api/media/artifacts/x1", alt: undefined }]);
+
+    const out2 = extractImageRefs(JSON.stringify({ artifact_id: "abc-123" }));
+    expect(out2).toHaveLength(1);
+    expect(out2[0].kind).toBe("artifact");
+    expect(out2[0].src).toBe("/api/media/artifacts/abc-123");
+  });
+
+  it("extracts data URIs from a nested data_base64 field", () => {
+    const out = extractImageRefs(
+      JSON.stringify({ images: [{ data_base64: "AAAA", mime: "image/png" }] }),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("data-uri");
+    expect(out[0].src).toBe("data:image/png;base64,AAAA");
+  });
+
+  it("extracts bare URLs embedded in agent prose", () => {
+    const text =
+      "I generated the cover. Here you go: https://cdn.example/cover.png — enjoy!";
+    const out = extractImageRefs(text);
+    expect(out).toHaveLength(1);
+    expect(out[0].src).toBe("https://cdn.example/cover.png");
+  });
+
+  it("extracts /api/uploads paths embedded in prose", () => {
+    const text = "Saved to /api/uploads/9d8e-img — let me know.";
+    const out = extractImageRefs(text);
+    expect(out.map((r) => r.src)).toContain("/api/uploads/9d8e-img");
+  });
+
+  it("extracts data:image URIs from prose", () => {
+    const text =
+      "preview: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=";
+    const out = extractImageRefs(text);
+    expect(out.some((r) => r.kind === "data-uri")).toBe(true);
+  });
+
+  it("handles arrays at the root", () => {
+    const out = extractImageRefs(
+      JSON.stringify([
+        { url: "https://example.com/a.png" },
+        { url: "https://example.com/b.jpg" },
+      ]),
+    );
+    expect(out).toHaveLength(2);
+  });
+
+  it("handles deeply nested arrays", () => {
+    const out = extractImageRefs(
+      JSON.stringify({
+        results: { gallery: { items: [{ url: "https://example.com/x.webp" }] } },
+      }),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].src).toBe("https://example.com/x.webp");
+  });
+
+  it("dedupes repeated URLs", () => {
+    const out = extractImageRefs(
+      JSON.stringify({
+        image_urls: ["/api/uploads/x", "/api/uploads/x", "/api/uploads/x"],
+      }),
+    );
+    expect(out).toHaveLength(1);
+  });
+
+  it("rejects dangerous schemes embedded as a URL field", () => {
+    // The classifier short-circuits even when the JSON is otherwise valid.
+    const out = extractImageRefs(
+      JSON.stringify({
+        url: "javascript:alert(1)",
+        also: "data:text/html,<script>",
+      }),
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("rejects protocol-relative URLs in JSON fields", () => {
+    const out = extractImageRefs(JSON.stringify({ url: "//evil.com/pwn.png" }));
+    expect(out).toEqual([]);
+  });
+
+  it("rejects file: scheme in JSON fields", () => {
+    const out = extractImageRefs(JSON.stringify({ url: "file:///etc/passwd" }));
+    expect(out).toEqual([]);
+  });
+
+  it("recovers an image URL even when prose contains a malformed JSON block", () => {
+    // The agent sometimes writes broken JSON. Bare-URL scan still works.
+    const text =
+      "Here's the result: { not really json } but the image is at https://example.com/result.png";
+    const out = extractImageRefs(text);
+    expect(out.map((r) => r.src)).toContain("https://example.com/result.png");
+  });
+
+  it("strips trailing punctuation from bare URLs in prose", () => {
+    const out = extractImageRefs(
+      "see https://example.com/foo.png, also https://example.com/bar.jpg.",
+    );
+    expect(out.map((r) => r.src)).toEqual([
+      "https://example.com/foo.png",
+      "https://example.com/bar.jpg",
+    ]);
+  });
+
+  it("accepts a pre-parsed object input", () => {
+    const out = extractImageRefs({ url: "https://example.com/parsed.png" });
+    expect(out).toHaveLength(1);
+    expect(out[0].src).toBe("https://example.com/parsed.png");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/workflowOutputImages.ts
+++ b/crates/librefang-api/dashboard/src/lib/workflowOutputImages.ts
@@ -1,0 +1,324 @@
+// Extracts image references from a workflow step's free-form output string.
+//
+// Step outputs are plain strings (see WorkflowStepResult.output in src/api.ts
+// and StepResult in crates/librefang-kernel/src/workflow.rs). When a step
+// calls the `image_generate` tool the agent typically includes the tool's
+// JSON result (or its `image_urls` array) verbatim in its reply. We scan the
+// text for:
+//
+//   * Embedded JSON objects/arrays containing image shapes:
+//       { url: "https://.../foo.png" }
+//       { url: "data:image/png;base64,..." }
+//       { image_urls: ["/api/uploads/<id>", ...] }
+//       { images: [ { url, data_base64 } ] }
+//       { artifact: "/api/media/artifacts/<id>" } | { artifact_id: "<id>" }
+//
+//   * Bare URLs in prose: `https://example.com/foo.png`,
+//     `/api/uploads/<id>`, `/api/media/artifacts/<id>`, `data:image/...`.
+//
+// Only safe URL schemes are returned. `javascript:`, `file:`, `about:`,
+// `vbscript:`, `data:` with a non-image MIME, and protocol-relative
+// (`//evil.com/foo.png`) refs are rejected — those would otherwise render
+// as `<img src>` and either no-op or, worse, leak credentials. The fallback
+// is to display the raw string; nothing is dropped silently.
+
+export type ImageRefKind = "url" | "data-uri" | "artifact";
+
+export interface ImageRef {
+  kind: ImageRefKind;
+  src: string;
+  alt?: string;
+}
+
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|svg|avif|bmp|ico)(\?[^\s"'<>)]*)?$/i;
+const ARTIFACT_PATH_RE = /^\/api\/media\/artifacts\/[A-Za-z0-9_-]+/;
+const UPLOAD_PATH_RE = /^\/api\/uploads\/[A-Za-z0-9_.-]+/;
+const DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;[^,]*,/i;
+
+const HTTP_URL_RE = /https?:\/\/[^\s"'<>)]+/gi;
+const DATA_URI_RE = /data:image\/[a-z0-9.+-]+;[^,]*,[A-Za-z0-9+/=_-]+/gi;
+const APIPATH_RE = /\/api\/(?:uploads|media\/artifacts)\/[A-Za-z0-9_.-]+/gi;
+
+/**
+ * Validate a string is a safe image source we'll render as `<img src>`.
+ * Returns the matching ImageRef or `null` if the value is not a safe image.
+ */
+export function classifyImageRef(raw: string, alt?: string): ImageRef | null {
+  if (typeof raw !== "string") return null;
+  const s = raw.trim();
+  if (!s) return null;
+
+  // Reject protocol-relative URLs — even if the path ends in .png, the
+  // browser resolves the host from the current origin, which is a vector
+  // for hijacking once the dashboard is served from a custom domain.
+  if (s.startsWith("//")) return null;
+
+  if (DATA_IMAGE_RE.test(s)) {
+    return { kind: "data-uri", src: s, alt };
+  }
+
+  // Reject any other data:/javascript:/file:/about:/vbscript: scheme.
+  const lower = s.toLowerCase();
+  if (
+    lower.startsWith("javascript:") ||
+    lower.startsWith("file:") ||
+    lower.startsWith("about:") ||
+    lower.startsWith("vbscript:") ||
+    lower.startsWith("data:")
+  ) {
+    return null;
+  }
+
+  if (s.startsWith("http://") || s.startsWith("https://")) {
+    // Strip query/fragment when checking extension.
+    const path = s.split(/[?#]/, 1)[0];
+    if (IMAGE_EXT_RE.test(path)) return { kind: "url", src: s, alt };
+    // http(s) without image extension is not assumed to be an image —
+    // could be an HTML page link.
+    return null;
+  }
+
+  if (ARTIFACT_PATH_RE.test(s)) return { kind: "artifact", src: s, alt };
+  if (UPLOAD_PATH_RE.test(s)) {
+    // Uploads dir holds generated images (and other media); without an
+    // extension we can't be 100% sure, but the image_generate tool
+    // writes here and we treat it as image. Caller renders <img>;
+    // browser falls back to broken-image icon if MIME is wrong, which
+    // is acceptable.
+    return { kind: "url", src: s, alt };
+  }
+
+  return null;
+}
+
+interface CandidateNode {
+  value: unknown;
+  alt?: string;
+}
+
+/**
+ * Walk a parsed JSON value collecting image-shaped fields. Recognizes:
+ *   - { url: "..." }
+ *   - { artifact: "..." } / { artifact_id: "..." }
+ *   - { data_base64: "...", mime?: "image/png" }
+ *   - { image_urls: [...] }
+ *   - { images: [ ... ] }
+ *   - Arrays of any of the above.
+ */
+function harvestFromJson(root: unknown, out: ImageRef[], seen: Set<string>): void {
+  // FIFO queue so iteration order matches document order — galleries
+  // should render images in the same sequence the agent produced them.
+  const queue: CandidateNode[] = [{ value: root }];
+  let head = 0;
+
+  while (head < queue.length) {
+    const { value, alt } = queue[head++];
+
+    if (value == null) continue;
+
+    if (typeof value === "string") {
+      const ref = classifyImageRef(value, alt);
+      if (ref && !seen.has(ref.src)) {
+        seen.add(ref.src);
+        out.push(ref);
+      }
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) queue.push({ value: item, alt });
+      continue;
+    }
+
+    if (typeof value === "object") {
+      const obj = value as Record<string, unknown>;
+
+      // Common alt-text fields produced by image tools.
+      const altText =
+        (typeof obj.alt === "string" && obj.alt) ||
+        (typeof obj.revised_prompt === "string" && obj.revised_prompt) ||
+        (typeof obj.prompt === "string" && obj.prompt) ||
+        alt;
+
+      // Image-shaped scalar fields, checked in priority order.
+      for (const key of ["url", "image_url", "src", "file_url"]) {
+        const v = obj[key];
+        if (typeof v === "string") {
+          const ref = classifyImageRef(v, altText);
+          if (ref && !seen.has(ref.src)) {
+            seen.add(ref.src);
+            out.push(ref);
+          }
+        }
+      }
+
+      // Artifact references.
+      for (const key of ["artifact", "artifact_path"]) {
+        const v = obj[key];
+        if (typeof v === "string") {
+          const ref = classifyImageRef(v, altText);
+          if (ref && !seen.has(ref.src)) {
+            seen.add(ref.src);
+            out.push(ref);
+          }
+        }
+      }
+      if (typeof obj.artifact_id === "string" && obj.artifact_id) {
+        const src = `/api/media/artifacts/${obj.artifact_id}`;
+        const ref = classifyImageRef(src, altText);
+        if (ref && !seen.has(ref.src)) {
+          seen.add(ref.src);
+          out.push(ref);
+        }
+      }
+
+      // base64 blob directly on the object — synthesize a data URI.
+      if (typeof obj.data_base64 === "string" && obj.data_base64) {
+        const mime = typeof obj.mime === "string" && obj.mime.startsWith("image/")
+          ? obj.mime
+          : "image/png";
+        const src = `data:${mime};base64,${obj.data_base64}`;
+        if (!seen.has(src)) {
+          seen.add(src);
+          out.push({ kind: "data-uri", src, alt: altText });
+        }
+      }
+
+      // Recurse into known container fields and any unknown nested values.
+      for (const v of Object.values(obj)) {
+        if (v !== null && (typeof v === "object")) {
+          queue.push({ value: v, alt: altText });
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Find every parseable JSON object/array embedded in `text` and feed
+ * each one through `harvestFromJson`. We scan for balanced `{...}` and
+ * `[...]` regions — bracket counting is enough for the well-formed JSON
+ * blocks that `serde_json::to_string_pretty` emits in tool results.
+ */
+function harvestFromText(text: string, out: ImageRef[], seen: Set<string>): void {
+  const len = text.length;
+  let i = 0;
+  while (i < len) {
+    const ch = text[i];
+    if (ch === "{" || ch === "[") {
+      const end = scanBalanced(text, i);
+      if (end > i) {
+        const slice = text.slice(i, end + 1);
+        try {
+          const parsed: unknown = JSON.parse(slice);
+          harvestFromJson(parsed, out, seen);
+        } catch {
+          // Not valid JSON — keep going.
+        }
+        i = end + 1;
+        continue;
+      }
+    }
+    i += 1;
+  }
+}
+
+/** Returns the index of the matching closing bracket, or -1 if unbalanced. */
+function scanBalanced(s: string, start: number): number {
+  const open = s[start];
+  const close = open === "{" ? "}" : open === "[" ? "]" : "";
+  if (!close) return -1;
+  let depth = 0;
+  let inStr = false;
+  let escape = false;
+  for (let i = start; i < s.length; i += 1) {
+    const c = s[i];
+    if (inStr) {
+      if (escape) {
+        escape = false;
+      } else if (c === "\\") {
+        escape = true;
+      } else if (c === '"') {
+        inStr = false;
+      }
+      continue;
+    }
+    if (c === '"') {
+      inStr = true;
+      continue;
+    }
+    if (c === open) depth += 1;
+    else if (c === close) {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** Fallback: pull bare image-shaped URLs out of prose. */
+function harvestBareUrls(text: string, out: ImageRef[], seen: Set<string>): void {
+  const collect = (re: RegExp) => {
+    let m: RegExpExecArray | null;
+    // Reset lastIndex to be safe — these regexes are module-scope.
+    re.lastIndex = 0;
+    while ((m = re.exec(text)) !== null) {
+      // Trim trailing punctuation that often glues onto URLs in prose.
+      const raw = m[0].replace(/[)\].,;:!?"']+$/, "");
+      const ref = classifyImageRef(raw);
+      if (ref && !seen.has(ref.src)) {
+        seen.add(ref.src);
+        out.push(ref);
+      }
+    }
+  };
+  collect(DATA_URI_RE);
+  collect(HTTP_URL_RE);
+  collect(APIPATH_RE);
+}
+
+/**
+ * Extract every image reference from a workflow step's output. Returns
+ * an empty array when nothing image-shaped is found — callers fall back
+ * to plain-text rendering.
+ *
+ * Accepts `unknown` so callers don't need to narrow first; non-strings
+ * are treated as empty.
+ */
+export function extractImageRefs(output: unknown): ImageRef[] {
+  if (output == null) return [];
+
+  // If the caller hands us a parsed value directly, walk it.
+  if (typeof output !== "string") {
+    const out: ImageRef[] = [];
+    const seen = new Set<string>();
+    harvestFromJson(output, out, seen);
+    return out;
+  }
+
+  const text = output;
+  if (!text) return [];
+
+  const out: ImageRef[] = [];
+  const seen = new Set<string>();
+
+  // 1. Try parsing the whole string as JSON first — the cleanest case
+  //    (a step that returns nothing but the tool's JSON result).
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      harvestFromJson(parsed, out, seen);
+    } catch {
+      // Fall through to embedded-block scan.
+    }
+  }
+
+  // 2. Scan for embedded JSON blocks (agent prose + a tool result blob).
+  harvestFromText(text, out, seen);
+
+  // 3. Bare URLs in prose (no surrounding JSON).
+  harvestBareUrls(text, out, seen);
+
+  return out;
+}

--- a/crates/librefang-api/dashboard/src/lib/workflowOutputImages.ts
+++ b/crates/librefang-api/dashboard/src/lib/workflowOutputImages.ts
@@ -32,12 +32,17 @@ export interface ImageRef {
 
 const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|svg|avif|bmp|ico)(\?[^\s"'<>)]*)?$/i;
 const ARTIFACT_PATH_RE = /^\/api\/media\/artifacts\/[A-Za-z0-9_-]+/;
-const UPLOAD_PATH_RE = /^\/api\/uploads\/[A-Za-z0-9_.-]+/;
+// `save_upload` mints `file_id = uuid::Uuid::new_v4().to_string()` (hex +
+// hyphen, never a dot — see crates/librefang-api/src/routes/media.rs). Disallow
+// `.` so a hostile / mistaken path like `/api/uploads/foo.html` is not
+// classified as an image and rendered as `<img src>`.
+const UPLOAD_PATH_RE = /^\/api\/uploads\/[A-Za-z0-9_-]+$/;
 const DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;[^,]*,/i;
 
 const HTTP_URL_RE = /https?:\/\/[^\s"'<>)]+/gi;
 const DATA_URI_RE = /data:image\/[a-z0-9.+-]+;[^,]*,[A-Za-z0-9+/=_-]+/gi;
-const APIPATH_RE = /\/api\/(?:uploads|media\/artifacts)\/[A-Za-z0-9_.-]+/gi;
+// Same UUID constraint as UPLOAD_PATH_RE; artifacts already follow it.
+const APIPATH_RE = /\/api\/(?:uploads|media\/artifacts)\/[A-Za-z0-9_-]+/gi;
 
 /**
  * Validate a string is a safe image source we'll render as `<img src>`.
@@ -105,14 +110,21 @@ interface CandidateNode {
  *   - { images: [ ... ] }
  *   - Arrays of any of the above.
  */
+// Cap traversal depth so deeply self-similar tool blobs (e.g. nested
+// debug payloads echoing the same fields) can't make harvest cost
+// super-linear. 32 covers every realistic image-tool result; anything
+// deeper is almost certainly a non-image payload that just happens to
+// contain `{` characters.
+const MAX_HARVEST_DEPTH = 32;
+
 function harvestFromJson(root: unknown, out: ImageRef[], seen: Set<string>): void {
   // FIFO queue so iteration order matches document order — galleries
   // should render images in the same sequence the agent produced them.
-  const queue: CandidateNode[] = [{ value: root }];
+  const queue: (CandidateNode & { depth: number })[] = [{ value: root, depth: 0 }];
   let head = 0;
 
   while (head < queue.length) {
-    const { value, alt } = queue[head++];
+    const { value, alt, depth } = queue[head++];
 
     if (value == null) continue;
 
@@ -125,8 +137,10 @@ function harvestFromJson(root: unknown, out: ImageRef[], seen: Set<string>): voi
       continue;
     }
 
+    if (depth >= MAX_HARVEST_DEPTH) continue;
+
     if (Array.isArray(value)) {
-      for (const item of value) queue.push({ value: item, alt });
+      for (const item of value) queue.push({ value: item, alt, depth: depth + 1 });
       continue;
     }
 
@@ -187,7 +201,7 @@ function harvestFromJson(root: unknown, out: ImageRef[], seen: Set<string>): voi
       // Recurse into known container fields and any unknown nested values.
       for (const v of Object.values(obj)) {
         if (v !== null && (typeof v === "object")) {
-          queue.push({ value: v, alt: altText });
+          queue.push({ value: v, alt: altText, depth: depth + 1 });
         }
       }
     }

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -1500,6 +1500,7 @@
     "run_history": "Run History",
     "prompt_sent": "Prompt sent:",
     "output": "Output:",
+    "generated_images": "Generated images:",
     "loading_details": "Loading details…"
   },
   "scheduler": {

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -1500,6 +1500,7 @@
     "run_history": "运行历史",
     "prompt_sent": "发送的提示词：",
     "output": "输出：",
+    "generated_images": "生成的图片：",
     "loading_details": "正在加载详情…"
   },
   "scheduler": {

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -160,6 +160,40 @@ const getErrorMessage = (error: unknown): string =>
 
 const isRunState = (state: WorkflowRunItem["state"]): state is string => typeof state === "string";
 
+// Image detection is `O(n²)` worst-case on malformed JSON-ish output (a
+// run of unmatched `{` triggers a fresh scan from each one). Memoize so
+// unrelated re-renders of the parent (poll ticks, prop bag churn) don't
+// re-pay the cost on long step outputs.
+function StepResultContent({ step }: { step: WorkflowStepResult }) {
+  const { t } = useTranslation();
+  const imageRefs = useMemo(() => extractImageRefs(step.output), [step.output]);
+  return (
+    <div className="px-3 pb-3 space-y-2 border-t border-border-subtle">
+      <div>
+        <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("workflows.prompt_sent", { defaultValue: "Prompt sent:" })}</p>
+        <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
+          {step.prompt || "(empty)"}
+        </pre>
+      </div>
+      {imageRefs.length > 0 && (
+        <WorkflowStepImageGallery
+          refs={imageRefs}
+          label={t("workflows.generated_images", { defaultValue: "Generated images:" })}
+        />
+      )}
+      <div>
+        <p className="text-[9px] font-bold text-text-dim/50">{t("workflows.output", { defaultValue: "Output:" })}</p>
+        <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
+          {step.output || "(empty)"}
+        </pre>
+      </div>
+      <p className="text-[9px] text-text-dim/40">
+        {step.agent_name} · {step.input_tokens} in / {step.output_tokens} out tokens
+      </p>
+    </div>
+  );
+}
+
 function StepAccordion<T>({
   steps,
   getKey,
@@ -587,38 +621,9 @@ export function WorkflowsPage() {
     </button>
   );
 
-  const stepResultContent = (step: WorkflowStepResult, _idx: number) => {
-    // Detect images embedded in the step output (image_generate tool
-    // results, bare URLs in agent prose, etc.) and render them above
-    // the raw text — operators still need the raw output for debugging
-    // and for the human-in-the-loop approval flow (#4977).
-    const imageRefs = extractImageRefs(step.output);
-    return (
-      <div className="px-3 pb-3 space-y-2 border-t border-border-subtle">
-        <div>
-          <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("workflows.prompt_sent", { defaultValue: "Prompt sent:" })}</p>
-          <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
-            {step.prompt || "(empty)"}
-          </pre>
-        </div>
-        {imageRefs.length > 0 && (
-          <WorkflowStepImageGallery
-            refs={imageRefs}
-            label={t("workflows.generated_images", { defaultValue: "Generated images:" })}
-          />
-        )}
-        <div>
-          <p className="text-[9px] font-bold text-text-dim/50">{t("workflows.output", { defaultValue: "Output:" })}</p>
-          <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
-            {step.output || "(empty)"}
-          </pre>
-        </div>
-        <p className="text-[9px] text-text-dim/40">
-          {step.agent_name} · {step.input_tokens} in / {step.output_tokens} out tokens
-        </p>
-      </div>
-    );
-  };
+  const stepResultContent = (step: WorkflowStepResult, _idx: number) => (
+    <StepResultContent step={step} />
+  );
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">

--- a/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx
@@ -42,6 +42,8 @@ import {
 } from "../lib/mutations/workflows";
 import { useCreateSchedule } from "../lib/mutations/schedules";
 import { useUIStore } from "../lib/store";
+import { extractImageRefs } from "../lib/workflowOutputImages";
+import { WorkflowStepImageGallery } from "../components/WorkflowStepImageGallery";
 
 const categoryIconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   creation: FileText, language: Bot, thinking: Activity, business: Calendar,
@@ -585,25 +587,38 @@ export function WorkflowsPage() {
     </button>
   );
 
-  const stepResultContent = (step: WorkflowStepResult, _idx: number) => (
-    <div className="px-3 pb-3 space-y-2 border-t border-border-subtle">
-      <div>
-        <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("workflows.prompt_sent", { defaultValue: "Prompt sent:" })}</p>
-        <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
-          {step.prompt || "(empty)"}
-        </pre>
+  const stepResultContent = (step: WorkflowStepResult, _idx: number) => {
+    // Detect images embedded in the step output (image_generate tool
+    // results, bare URLs in agent prose, etc.) and render them above
+    // the raw text — operators still need the raw output for debugging
+    // and for the human-in-the-loop approval flow (#4977).
+    const imageRefs = extractImageRefs(step.output);
+    return (
+      <div className="px-3 pb-3 space-y-2 border-t border-border-subtle">
+        <div>
+          <p className="text-[9px] font-bold text-text-dim/50 mt-2">{t("workflows.prompt_sent", { defaultValue: "Prompt sent:" })}</p>
+          <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
+            {step.prompt || "(empty)"}
+          </pre>
+        </div>
+        {imageRefs.length > 0 && (
+          <WorkflowStepImageGallery
+            refs={imageRefs}
+            label={t("workflows.generated_images", { defaultValue: "Generated images:" })}
+          />
+        )}
+        <div>
+          <p className="text-[9px] font-bold text-text-dim/50">{t("workflows.output", { defaultValue: "Output:" })}</p>
+          <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
+            {step.output || "(empty)"}
+          </pre>
+        </div>
+        <p className="text-[9px] text-text-dim/40">
+          {step.agent_name} · {step.input_tokens} in / {step.output_tokens} out tokens
+        </p>
       </div>
-      <div>
-        <p className="text-[9px] font-bold text-text-dim/50">{t("workflows.output", { defaultValue: "Output:" })}</p>
-        <pre className="text-[10px] text-text whitespace-pre-wrap max-h-24 overflow-y-auto bg-surface rounded-lg p-2 mt-1">
-          {step.output || "(empty)"}
-        </pre>
-      </div>
-      <p className="text-[9px] text-text-dim/40">
-        {step.agent_name} · {step.input_tokens} in / {step.output_tokens} out tokens
-      </p>
-    </div>
-  );
+    );
+  };
 
   return (
     <div className="flex flex-col gap-6 transition-colors duration-300">


### PR DESCRIPTION
Closes #4979.

## What changes

Workflow steps that emit image URLs / data URIs / artifact references now render those images inline in the workflow run view (both the post-run result panel and the run-history accordion). The raw text output is preserved below the gallery — operators still need it for debugging and for the upcoming human-in-the-loop approval flow (#4977).

The wiring is small: one pure helper, one presentation component, two locale strings. The detection lives entirely on the client; no backend change is needed.

## Files

- `crates/librefang-api/dashboard/src/lib/workflowOutputImages.ts` — pure helper `extractImageRefs(output: unknown): ImageRef[]`. URL-safety classifier `classifyImageRef`.
- `crates/librefang-api/dashboard/src/lib/workflowOutputImages.test.ts` — 31 unit cases.
- `crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.tsx` — gallery component (click-to-open thumbnails, mirrors `ChatPage.tsx:1255`).
- `crates/librefang-api/dashboard/src/components/WorkflowStepImageGallery.test.tsx` — 5 RTL cases.
- `crates/librefang-api/dashboard/src/pages/WorkflowsPage.tsx` — gallery wired above the existing `<pre>{step.output}</pre>` block in `stepResultContent`, used by both the run result and run detail accordions.
- `crates/librefang-api/dashboard/src/locales/{en,zh}.json` — new `workflows.generated_images` key.

## Image-ref shapes detected (with backend evidence)

The `image_generate` tool blob the agent writes into `step.output`:

```json
{
  "model": "dall-e-3",
  "provider": "openai",
  "images_generated": 2,
  "saved_to": ["/Users/x/output/img_0.png"],
  "revised_prompt": "…",
  "image_urls": ["/api/uploads/<id>", "/api/uploads/<id>"]
}
```

— produced by `tool_image_generate` in `crates/librefang-runtime/src/tool_runner.rs:6592-6602`, with URLs minted by `save_media_images_to_uploads` at `crates/librefang-runtime/src/tool_runner.rs:6699-6725` (format string `"/api/uploads/{file_id}"` at line 6719).

The `/api/media/image` HTTP route's legacy response shape:

```json
{ "images": [ { "url": "/api/uploads/…", "data_base64": "…" }, … ] }
```

— produced in `crates/librefang-api/src/routes/media.rs:175` (`{ "images": image_urls, … }`), where `image_urls` entries are emitted at lines 149-172. Upload URLs come from `save_upload` at `crates/librefang-api/src/routes/media.rs:81-110` (returns `format!("/api/uploads/{file_id}")` at line 110).

The artifact reference shape (`{artifact}`, `{artifact_path}`, `{artifact_id}`) is supported defensively — the current backend does not emit it under that exact key, but the issue explicitly calls it out as the third supported shape and other media routes will likely move toward an artifact addressing scheme. The helper synthesizes `/api/media/artifacts/<id>` from `{artifact_id}` and accepts pre-formed paths too. If the backend ends up using a different key, this is a one-line addition to the helper.

In addition the helper picks up bare image URLs and `data:image/…` URIs from agent prose, so freeform `"Here's the cover: https://cdn.example/cover.png"` replies also render inline.

## URL whitelist scheme

`classifyImageRef` accepts and returns these and only these:

| Input pattern | `kind` | Rationale |
|---|---|---|
| `https?://*.{png,jpg,jpeg,gif,webp,svg,avif,bmp,ico}[?…]` | `url` | Known image extensions only — http(s) URLs without an image extension are not assumed to be images. |
| `data:image/<mime>;<params>,<payload>` | `data-uri` | Inline image content (DALL-E b64 returns, small previews). |
| `/api/media/artifacts/<id>` | `artifact` | Same-origin artifact path. |
| `/api/uploads/<id>` | `url` | The path the `image_generate` tool writes to. |

Everything else is rejected (returns `null`) and the caller falls back to plain text rendering. Tests explicitly cover rejection of: `javascript:`, `file:`, `about:`, `vbscript:`, non-image `data:` MIMEs (`data:text/html`, `data:application/json`), protocol-relative `//evil.com/…`, and `http(s)://…` without a known image extension.

## Backend change required?

**No.** `WorkflowStepResult.output` (defined in `crates/librefang-kernel/src/workflow.rs:440`, exposed through `WorkflowStepResult` in `crates/librefang-api/dashboard/src/api.ts:2192-2202`) is already a plain `String` that contains the agent's reply. The agent already includes the `image_generate` tool's JSON blob in its response when the step produces images. The dashboard detects them client-side.

## Verification

- `pnpm typecheck` — clean.
- `pnpm vitest run src/lib/workflowOutputImages.test.ts src/components/WorkflowStepImageGallery.test.tsx src/pages/WorkflowsPage.test.tsx src/lib/__tests__/locale-parity.test.ts src/lib/__tests__/no-inline-fetch.test.ts` — 52 tests passed (5 files).
- `pnpm build` — clean (Vite).
- `cargo check --workspace --lib` — clean.
- Two pre-existing test files unrelated to this change (`ModelsPage.test.tsx`, `TerminalTabs.test.tsx`) fail with the same `storage.setItem is not a function` zustand error on `origin/main` — verified by re-running with my changes stashed. Not introduced here.

## Out of scope

- Inline image previews in chat tool results / canvas — same helper could be reused later, but kept this PR scoped to the workflow run view per the issue.
- Authenticated artifact fetch — if `/api/media/artifacts/<id>` ever requires auth headers, an existing image-fetch utility (not present today) would be the right place to handle it; deferring until the artifact route actually exists.
