### PR TITLE
feat(runtime): file_read deduplication — stub repeated reads of unchanged files

### DIFF
--- a/crates/librefang-kernel-handle/src/lib.rs
+++ b/crates/librefang-kernel-handle/src/lib.rs
@@ -1033,6 +1033,16 @@ pub trait ToolPolicy: Send + Sync {
         None
     }
 
+    /// Whether the runtime should collapse repeated `file_read` calls on the
+    /// same path within a session into a short stub (#4971). Backed by
+    /// `[context_engine] deduplicate_file_reads` — default `true`. Stub
+    /// implementations leave the legacy "always full content" behaviour by
+    /// returning `false` so they don't have to think about session-scoped
+    /// state.
+    fn deduplicate_file_reads(&self) -> bool {
+        false
+    }
+
     /// Return the effective directory for storing runtime-generated uploads
     /// (image_generate, browser_screenshot, etc.). Honors operator-configured
     /// `[channels].file_download_dir` when set, otherwise falls back to the

--- a/crates/librefang-kernel/src/kernel/handles/tool_policy.rs
+++ b/crates/librefang-kernel/src/kernel/handles/tool_policy.rs
@@ -46,6 +46,10 @@ impl kernel_handle::ToolPolicy for LibreFangKernel {
         Some(self.config.load().channels.effective_file_download_dir())
     }
 
+    fn deduplicate_file_reads(&self) -> bool {
+        self.config.load().context_engine.deduplicate_file_reads
+    }
+
     fn effective_upload_dir(&self) -> std::path::PathBuf {
         self.config_ref().channels.effective_file_download_dir()
     }

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -4160,6 +4160,9 @@ pub async fn run_agent_loop(
                 messages = compressed;
                 messages = crate::session_repair::validate_and_repair(&messages);
                 messages = crate::session_repair::ensure_starts_with_user(messages);
+                // #4971: drop file_read dedup state — the bodies its stubs
+                // referenced have been summarised away.
+                crate::context_compressor::reset_post_compression_side_state(session.id);
             }
 
             // Hard-trim only if still above threshold after soft compression
@@ -5793,6 +5796,9 @@ pub async fn run_agent_loop_streaming(
                 messages = compressed;
                 messages = crate::session_repair::validate_and_repair(&messages);
                 messages = crate::session_repair::ensure_starts_with_user(messages);
+                // #4971: drop file_read dedup state — the bodies its stubs
+                // referenced have been summarised away.
+                crate::context_compressor::reset_post_compression_side_state(session.id);
             }
 
             let remaining_tokens = crate::compactor::estimate_token_count(

--- a/crates/librefang-runtime/src/context_compressor.rs
+++ b/crates/librefang-runtime/src/context_compressor.rs
@@ -95,6 +95,22 @@ pub struct CompressionEvent {
     pub used_fallback: bool,
 }
 
+/// Reset side-state that depends on the pre-compression message history
+/// surviving in the prompt (#4971).
+///
+/// Currently this clears the per-session `file_read` deduplication tracker:
+/// the tracker's stubs refer to "see above for full content", and once the
+/// compressor has summarised those bodies away there is nothing above for the
+/// model to look at. Call sites should invoke this immediately after
+/// `compress_if_needed_with_aux` reports a successful compression.
+///
+/// Kept as a thin module-level function rather than a method on
+/// [`ContextCompressor`] so that future side-state resets can plug in without
+/// requiring callers to hold a compressor instance (e.g. manual `/compact`).
+pub fn reset_post_compression_side_state(session_id: librefang_types::agent::SessionId) {
+    crate::file_read_tracker::reset_session(session_id);
+}
+
 /// Context compressor — wraps `compactor::compact_session` with automatic
 /// threshold detection and iterative refinement.
 #[derive(Debug, Clone)]

--- a/crates/librefang-runtime/src/file_read_tracker.rs
+++ b/crates/librefang-runtime/src/file_read_tracker.rs
@@ -113,13 +113,20 @@ impl FileReadTracker {
             None => ReadOutcome::First,
         };
 
-        self.entries.insert(
-            key,
-            FileReadEntry {
-                content_hash: hash,
-                turn_id: turn,
-            },
-        );
+        // Only First and Changed write a new entry. Unchanged must leave the
+        // recorded turn_id anchored to the turn that actually carried the
+        // file body — otherwise the stub on call N points at call N-1, which
+        // is itself a stub, and the "see above for full content" trail
+        // drifts forward away from the real content.
+        if !matches!(outcome, ReadOutcome::Unchanged { .. }) {
+            self.entries.insert(
+                key,
+                FileReadEntry {
+                    content_hash: hash,
+                    turn_id: turn,
+                },
+            );
+        }
 
         // Bound memory growth: when above the cap, drop the lowest-turn (i.e.
         // oldest-recorded) entry. BTreeMap iteration is by key, not insertion
@@ -214,6 +221,28 @@ mod tests {
         let second = t.observe(&PathBuf::from("/tmp/a"), "hello");
         // First call recorded turn=1; second call sees that entry.
         assert_eq!(second, ReadOutcome::Unchanged { first_turn: 1 });
+    }
+
+    #[test]
+    fn unchanged_anchor_does_not_drift_forward() {
+        // Repeated unchanged reads must all point back to the FIRST turn
+        // that actually stored the file body. If the anchor advanced on each
+        // unchanged observation, the stub on call N would reference call N-1
+        // (itself a stub), losing the trail to the turn that carries the
+        // real content.
+        let mut t = FileReadTracker::new();
+        let r1 = t.observe(&PathBuf::from("/tmp/a"), "hello");
+        assert_eq!(r1, ReadOutcome::First);
+        let r2 = t.observe(&PathBuf::from("/tmp/a"), "hello");
+        assert_eq!(r2, ReadOutcome::Unchanged { first_turn: 1 });
+        let r3 = t.observe(&PathBuf::from("/tmp/a"), "hello");
+        assert_eq!(
+            r3,
+            ReadOutcome::Unchanged { first_turn: 1 },
+            "anchor must stay on turn 1 — the only turn carrying full content"
+        );
+        let r4 = t.observe(&PathBuf::from("/tmp/a"), "hello");
+        assert_eq!(r4, ReadOutcome::Unchanged { first_turn: 1 });
     }
 
     #[test]

--- a/crates/librefang-runtime/src/file_read_tracker.rs
+++ b/crates/librefang-runtime/src/file_read_tracker.rs
@@ -1,0 +1,325 @@
+//! Per-session `file_read` deduplication tracker (#4971).
+//!
+//! Agents frequently re-read the same config / source file across multiple
+//! turns. Each `file_read` tool result stores the full body in history, so a
+//! 10 KB file read four times consumes ~40 KB of context. This module tracks
+//! `(path, sha256, turn_id)` per session and rewrites repeat reads into short
+//! stubs:
+//!
+//! - Same path, same hash → `[File already read — content unchanged since
+//!   turn N. See above for full content.]`
+//! - Same path, different hash → original content prefixed with
+//!   `[File updated since last read at turn N]\n\n`
+//! - New path → return content unchanged and record.
+//!
+//! State is keyed by [`SessionId`] and cleared when the context compressor
+//! summarises history (the prior bodies are gone, so the stub would point at
+//! nothing). Insertion / eviction also keep a small recency-driven cap to
+//! bound memory for long-lived sessions.
+//!
+//! # Determinism
+//!
+//! Tracker maps use `BTreeMap` so iteration is stable across processes — this
+//! aligns with the prompt-cache invariants documented in `CLAUDE.md`.
+
+use librefang_types::agent::SessionId;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+/// Hard cap on tracked paths per session. Bounded purely for memory safety on
+/// pathological agents that touch tens of thousands of unique files; under
+/// the cap older entries are evicted by `turn_id` so the freshest reads win.
+const MAX_TRACKED_PATHS: usize = 512;
+
+/// One recorded read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileReadEntry {
+    /// sha256 of the file content at the time of the recorded read.
+    content_hash: [u8; 32],
+    /// 1-based turn / read counter at the time of the recorded read.
+    turn_id: u64,
+}
+
+/// What [`FileReadTracker::observe`] decided to do with this read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadOutcome {
+    /// First time we have seen this path in this session (or dedup disabled,
+    /// or after a reset). Caller returns the full content unchanged.
+    First,
+    /// Same path, identical content hash. Caller returns the
+    /// `[File already read — content unchanged since turn N. See above for
+    /// full content.]` stub.
+    Unchanged { first_turn: u64 },
+    /// Same path, content changed since the previous read. Caller returns the
+    /// full content prefixed with `[File updated since last read at turn N]`.
+    Changed { previous_turn: u64 },
+}
+
+/// Per-session tracker — see module docs.
+#[derive(Debug)]
+pub struct FileReadTracker {
+    entries: BTreeMap<PathBuf, FileReadEntry>,
+    /// Monotonic counter — incremented on every `observe` call regardless of
+    /// outcome so each recorded `turn_id` is unique within the session and the
+    /// human-readable "turn N" stub stays meaningful even across re-reads.
+    next_turn: u64,
+}
+
+impl Default for FileReadTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FileReadTracker {
+    /// Empty tracker.
+    pub fn new() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            next_turn: 1,
+        }
+    }
+
+    /// Wipe all state. Called when context compression fires (#4971: prior
+    /// bodies are no longer in history so stubs would dangle).
+    pub fn reset(&mut self) {
+        self.entries.clear();
+        self.next_turn = 1;
+    }
+
+    /// Number of paths currently tracked. Test helper.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Record a read of `path` containing `content`, returning what the caller
+    /// should send back to the model.
+    pub fn observe(&mut self, path: &Path, content: &str) -> ReadOutcome {
+        let hash = Self::hash(content);
+        let turn = self.next_turn;
+        self.next_turn = self.next_turn.saturating_add(1);
+
+        let key = path.to_path_buf();
+        let outcome = match self.entries.get(&key) {
+            Some(prev) if prev.content_hash == hash => ReadOutcome::Unchanged {
+                first_turn: prev.turn_id,
+            },
+            Some(prev) => ReadOutcome::Changed {
+                previous_turn: prev.turn_id,
+            },
+            None => ReadOutcome::First,
+        };
+
+        self.entries.insert(
+            key,
+            FileReadEntry {
+                content_hash: hash,
+                turn_id: turn,
+            },
+        );
+
+        // Bound memory growth: when above the cap, drop the lowest-turn (i.e.
+        // oldest-recorded) entry. BTreeMap iteration is by key, not insertion
+        // order, so we have to scan to find the oldest — fine at this size.
+        while self.entries.len() > MAX_TRACKED_PATHS {
+            if let Some(oldest_key) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, e)| e.turn_id)
+                .map(|(k, _)| k.clone())
+            {
+                self.entries.remove(&oldest_key);
+            } else {
+                break;
+            }
+        }
+
+        outcome
+    }
+
+    fn hash(content: &str) -> [u8; 32] {
+        let mut h = Sha256::new();
+        h.update(content.as_bytes());
+        h.finalize().into()
+    }
+}
+
+/// Render the "unchanged" stub message that the caller substitutes for the
+/// full file body.
+pub fn unchanged_stub(first_turn: u64) -> String {
+    format!(
+        "[File already read — content unchanged since turn {first_turn}. See above for full content.]"
+    )
+}
+
+/// Prefix prepended to the full body when the file changed since the previous
+/// read in this session.
+pub fn changed_header(previous_turn: u64) -> String {
+    format!("[File updated since last read at turn {previous_turn}]")
+}
+
+// ─── Process-wide registry ───────────────────────────────────────────────
+
+// The per-session registry is keyed by [`SessionId`] (a UUID newtype that is
+// `Hash + Eq` but not `Ord`). Iteration order doesn't influence prompts —
+// callers always look up a single session — so `HashMap` is fine here. The
+// inner `FileReadTracker` keeps its own `BTreeMap` for prompt-stable behaviour.
+fn registry() -> &'static Mutex<HashMap<SessionId, FileReadTracker>> {
+    static REG: OnceLock<Mutex<HashMap<SessionId, FileReadTracker>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Run `f` against the tracker for `session_id`, creating an empty tracker on
+/// first access. The mutex is held across `f` so callers should keep the
+/// closure short.
+pub fn with_session<R>(session_id: SessionId, f: impl FnOnce(&mut FileReadTracker) -> R) -> R {
+    let mut guard = registry().lock().unwrap_or_else(|p| p.into_inner());
+    let tracker = guard.entry(session_id).or_default();
+    f(tracker)
+}
+
+/// Clear the tracker for `session_id`. No-op if it doesn't exist.
+///
+/// Called from the context compressor (#4971) after a successful compression
+/// pass: the prior full file bodies have been summarised away, so the
+/// "see above for full content" stub would dangle if we kept the state.
+pub fn reset_session(session_id: SessionId) {
+    let mut guard = registry().lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(t) = guard.get_mut(&session_id) {
+        t.reset();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn first_read_is_first_outcome() {
+        let mut t = FileReadTracker::new();
+        let outcome = t.observe(&PathBuf::from("/tmp/a"), "hello");
+        assert_eq!(outcome, ReadOutcome::First);
+        assert_eq!(t.len(), 1);
+    }
+
+    #[test]
+    fn unchanged_read_returns_unchanged_with_first_turn() {
+        let mut t = FileReadTracker::new();
+        let first = t.observe(&PathBuf::from("/tmp/a"), "hello");
+        assert_eq!(first, ReadOutcome::First);
+        let second = t.observe(&PathBuf::from("/tmp/a"), "hello");
+        // First call recorded turn=1; second call sees that entry.
+        assert_eq!(second, ReadOutcome::Unchanged { first_turn: 1 });
+    }
+
+    #[test]
+    fn changed_read_returns_changed_with_previous_turn() {
+        let mut t = FileReadTracker::new();
+        t.observe(&PathBuf::from("/tmp/a"), "hello");
+        let second = t.observe(&PathBuf::from("/tmp/a"), "world");
+        assert_eq!(second, ReadOutcome::Changed { previous_turn: 1 });
+        // Third read with the new content is now "unchanged since turn 2",
+        // proving the entry was overwritten on the previous call.
+        let third = t.observe(&PathBuf::from("/tmp/a"), "world");
+        assert_eq!(third, ReadOutcome::Unchanged { first_turn: 2 });
+    }
+
+    #[test]
+    fn different_paths_tracked_separately() {
+        let mut t = FileReadTracker::new();
+        assert_eq!(
+            t.observe(&PathBuf::from("/tmp/a"), "aaa"),
+            ReadOutcome::First
+        );
+        assert_eq!(
+            t.observe(&PathBuf::from("/tmp/b"), "aaa"),
+            ReadOutcome::First
+        );
+        assert_eq!(
+            t.observe(&PathBuf::from("/tmp/a"), "aaa"),
+            ReadOutcome::Unchanged { first_turn: 1 }
+        );
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut t = FileReadTracker::new();
+        t.observe(&PathBuf::from("/tmp/a"), "hello");
+        t.reset();
+        assert_eq!(t.len(), 0);
+        // After reset the next read is treated as first.
+        assert_eq!(
+            t.observe(&PathBuf::from("/tmp/a"), "hello"),
+            ReadOutcome::First
+        );
+    }
+
+    #[test]
+    fn cap_evicts_oldest_entries() {
+        let mut t = FileReadTracker::new();
+        for i in 0..MAX_TRACKED_PATHS + 5 {
+            t.observe(&PathBuf::from(format!("/tmp/{i}")), "x");
+        }
+        assert_eq!(t.len(), MAX_TRACKED_PATHS);
+        // Oldest entries (low i) should have been evicted; newest survives.
+        let last = format!("/tmp/{}", MAX_TRACKED_PATHS + 4);
+        assert_eq!(
+            t.observe(&PathBuf::from(last), "x"),
+            ReadOutcome::Unchanged {
+                first_turn: (MAX_TRACKED_PATHS + 5) as u64
+            }
+        );
+    }
+
+    #[test]
+    fn stub_text_includes_turn_number() {
+        let s = unchanged_stub(7);
+        assert!(s.contains("turn 7"));
+        assert!(s.contains("unchanged"));
+    }
+
+    #[test]
+    fn changed_header_includes_turn_number() {
+        let h = changed_header(3);
+        assert!(h.contains("turn 3"));
+        assert!(h.contains("updated"));
+    }
+
+    #[test]
+    fn session_registry_isolates_sessions() {
+        let s1 = SessionId::new();
+        let s2 = SessionId::new();
+        with_session(s1, |t| {
+            t.observe(&PathBuf::from("/tmp/x"), "v1");
+        });
+        // s2's first read is unaffected by s1's history.
+        let outcome = with_session(s2, |t| t.observe(&PathBuf::from("/tmp/x"), "v1"));
+        assert_eq!(outcome, ReadOutcome::First);
+        // s1 still remembers.
+        let outcome = with_session(s1, |t| t.observe(&PathBuf::from("/tmp/x"), "v1"));
+        assert_eq!(outcome, ReadOutcome::Unchanged { first_turn: 1 });
+    }
+
+    #[test]
+    fn reset_session_clears_only_target() {
+        let s1 = SessionId::new();
+        let s2 = SessionId::new();
+        with_session(s1, |t| {
+            t.observe(&PathBuf::from("/tmp/x"), "v1");
+        });
+        with_session(s2, |t| {
+            t.observe(&PathBuf::from("/tmp/x"), "v1");
+        });
+        reset_session(s1);
+        // s1 is cleared.
+        let after = with_session(s1, |t| t.observe(&PathBuf::from("/tmp/x"), "v1"));
+        assert_eq!(after, ReadOutcome::First);
+        // s2 untouched.
+        let after = with_session(s2, |t| t.observe(&PathBuf::from("/tmp/x"), "v1"));
+        assert_eq!(after, ReadOutcome::Unchanged { first_turn: 1 });
+    }
+}

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -31,6 +31,7 @@ pub use librefang_runtime_oauth::copilot_oauth;
 pub mod docker_sandbox;
 pub use librefang_llm_drivers::drivers;
 pub mod embedding;
+pub mod file_read_tracker;
 pub mod graceful_shutdown;
 pub mod history_fold;
 pub mod hooks;

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -1041,8 +1041,20 @@ pub async fn execute_tool_raw(
                     let path = std::path::PathBuf::from(path_str);
                     let line = input["line"].as_u64().map(|v| v as u32);
                     let limit = input["limit"].as_u64().map(|v| v as u32);
-                    return match client.read_text_file(path, line, limit).await {
-                        Ok(content) => ToolResult::ok(tool_use_id.to_string(), content),
+                    return match client.read_text_file(path.clone(), line, limit).await {
+                        Ok(content) => {
+                            // #4971: dedup repeated reads of the same buffer.
+                            // Only applies when no slicing args were supplied —
+                            // a partial read (`line` / `limit`) returns a
+                            // window, not the full content, so hashing would
+                            // be lossy.
+                            let final_content = if line.is_none() && limit.is_none() {
+                                maybe_dedup_file_read(*kernel, *session_id, &path, content)
+                            } else {
+                                content
+                            };
+                            ToolResult::ok(tool_use_id.to_string(), final_content)
+                        }
                         Err(e) => ToolResult::error(
                             tool_use_id.to_string(),
                             format!("ACP fs/read_text_file failed: {e}"),
@@ -1051,7 +1063,17 @@ pub async fn execute_tool_raw(
                 }
             }
             let extra_refs: Vec<&Path> = allowed.iter().map(|p| p.as_path()).collect();
-            tool_file_read(input, *workspace_root, &extra_refs).await
+            let raw_input_path = input.get("path").and_then(|v| v.as_str());
+            let resolved_for_dedup = raw_input_path
+                .and_then(|p| resolve_file_path_ext(p, *workspace_root, &extra_refs).ok());
+            tool_file_read(input, *workspace_root, &extra_refs)
+                .await
+                .map(|content| match resolved_for_dedup {
+                    Some(resolved) => {
+                        maybe_dedup_file_read(*kernel, *session_id, &resolved, content)
+                    }
+                    None => content,
+                })
         }
         "file_write" => {
             // Enforce named workspace read-only restrictions before the sandbox resolves the path.
@@ -3817,6 +3839,44 @@ async fn tool_file_read(
     tokio::fs::read_to_string(&resolved)
         .await
         .map_err(|e| format!("Failed to read file: {e}"))
+}
+
+/// `file_read` deduplication shim (#4971).
+///
+/// Returns the content the model should see — either the original content
+/// unchanged, a short "already read" stub, or the original content prefixed
+/// with a "file updated" header. The transformation is bypassed (i.e. always
+/// returns `content` unchanged) when any of the gating conditions don't hold:
+///
+/// - no kernel handle (legacy / test call sites),
+/// - no session id (can't isolate state across concurrent sessions),
+/// - `[context_engine] deduplicate_file_reads = false`.
+fn maybe_dedup_file_read(
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    session_id: Option<librefang_types::agent::SessionId>,
+    path: &Path,
+    content: String,
+) -> String {
+    let Some(k) = kernel else { return content };
+    let Some(sid) = session_id else {
+        return content;
+    };
+    if !k.deduplicate_file_reads() {
+        return content;
+    }
+    match crate::file_read_tracker::with_session(sid, |t| t.observe(path, &content)) {
+        crate::file_read_tracker::ReadOutcome::First => content,
+        crate::file_read_tracker::ReadOutcome::Unchanged { first_turn } => {
+            crate::file_read_tracker::unchanged_stub(first_turn)
+        }
+        crate::file_read_tracker::ReadOutcome::Changed { previous_turn } => {
+            format!(
+                "{}\n\n{}",
+                crate::file_read_tracker::changed_header(previous_turn),
+                content
+            )
+        }
+    }
 }
 
 async fn tool_file_write(
@@ -9472,6 +9532,9 @@ mod tests {
         /// `KernelHandle::channel_file_download_dir` (#4434 regression test
         /// hook). `None` matches the default trait behaviour.
         download_dir: Option<std::path::PathBuf>,
+        /// Whether `ToolPolicy::deduplicate_file_reads()` should return `true`
+        /// (#4971 regression test hook). The stub trait default is `false`.
+        dedup_enabled: bool,
     }
 
     // ---- BEGIN role-trait impls (split from former `impl KernelHandle for NamedWsKernel`, #3746) ----
@@ -9657,6 +9720,9 @@ mod tests {
         fn channel_file_download_dir(&self) -> Option<std::path::PathBuf> {
             self.download_dir.clone()
         }
+        fn deduplicate_file_reads(&self) -> bool {
+            self.dedup_enabled
+        }
     }
 
     // No-op role-trait impls (#3746) — mock relies on default bodies.
@@ -9693,6 +9759,7 @@ mod tests {
         Arc::new(NamedWsKernel {
             named,
             download_dir: None,
+            dedup_enabled: false,
         })
     }
 
@@ -9700,6 +9767,7 @@ mod tests {
         Arc::new(NamedWsKernel {
             named: vec![],
             download_dir: Some(download_dir),
+            dedup_enabled: false,
         })
     }
 
@@ -13936,6 +14004,143 @@ description = "test"
             r_none.loaded_tool.map(|d| d.name).as_deref(),
             Some("file_write")
         );
+    }
+
+    // ── file_read deduplication (#4971) ───────────────────────────────
+
+    fn make_dedup_kernel(enabled: bool) -> Arc<dyn KernelHandle> {
+        // `NamedWsKernel`'s `ToolPolicy::deduplicate_file_reads` reads the
+        // `dedup_enabled` field below — see its impl in this module.
+        Arc::new(NamedWsKernel {
+            named: vec![],
+            download_dir: None,
+            dedup_enabled: enabled,
+        })
+    }
+
+    async fn run_file_read_for_dedup(
+        kernel: &Arc<dyn KernelHandle>,
+        workspace: &Path,
+        rel_path: &str,
+        session_id: &str,
+    ) -> librefang_types::tool::ToolResult {
+        execute_tool(
+            "test-id",
+            "file_read",
+            &serde_json::json!({"path": rel_path}),
+            Some(kernel),
+            None,
+            Some("00000000-0000-0000-0000-000000000099"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(workspace),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(session_id),
+            None,
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn file_read_dedup_second_unchanged_read_returns_stub() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        std::fs::write(workspace.path().join("a.txt"), "hello world").unwrap();
+        let kernel = make_dedup_kernel(true);
+        // Unique session id so the global tracker doesn't bleed between tests.
+        let sid = uuid::Uuid::new_v4().to_string();
+
+        let first = run_file_read_for_dedup(&kernel, workspace.path(), "a.txt", &sid).await;
+        assert!(!first.is_error, "first read errored: {}", first.content);
+        assert_eq!(first.content, "hello world");
+
+        let second = run_file_read_for_dedup(&kernel, workspace.path(), "a.txt", &sid).await;
+        assert!(!second.is_error, "second read errored: {}", second.content);
+        assert!(
+            second.content.contains("already read"),
+            "expected stub, got: {}",
+            second.content
+        );
+        assert!(
+            second.content.contains("turn 1"),
+            "stub must reference the first turn, got: {}",
+            second.content
+        );
+        assert!(
+            !second.content.contains("hello world"),
+            "stub must not leak full content, got: {}",
+            second.content
+        );
+    }
+
+    #[tokio::test]
+    async fn file_read_dedup_changed_content_returns_updated_header() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let target = workspace.path().join("a.txt");
+        std::fs::write(&target, "v1").unwrap();
+        let kernel = make_dedup_kernel(true);
+        let sid = uuid::Uuid::new_v4().to_string();
+
+        let first = run_file_read_for_dedup(&kernel, workspace.path(), "a.txt", &sid).await;
+        assert_eq!(first.content, "v1");
+
+        std::fs::write(&target, "v2-updated").unwrap();
+        let second = run_file_read_for_dedup(&kernel, workspace.path(), "a.txt", &sid).await;
+        assert!(
+            second.content.contains("updated since last read"),
+            "expected updated header, got: {}",
+            second.content
+        );
+        assert!(
+            second.content.contains("v2-updated"),
+            "full new content must follow the header, got: {}",
+            second.content
+        );
+    }
+
+    #[tokio::test]
+    async fn file_read_dedup_disabled_returns_full_content_each_time() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        std::fs::write(workspace.path().join("a.txt"), "hello world").unwrap();
+        let kernel = make_dedup_kernel(false);
+        let sid = uuid::Uuid::new_v4().to_string();
+
+        let first = run_file_read_for_dedup(&kernel, workspace.path(), "a.txt", &sid).await;
+        assert_eq!(first.content, "hello world");
+        let second = run_file_read_for_dedup(&kernel, workspace.path(), "a.txt", &sid).await;
+        // No stub, no header — verbatim.
+        assert_eq!(second.content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn file_read_dedup_reset_after_compression_clears_state() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        std::fs::write(workspace.path().join("a.txt"), "hello").unwrap();
+        let kernel = make_dedup_kernel(true);
+        let sid_str = uuid::Uuid::new_v4().to_string();
+        let sid = librefang_types::agent::SessionId(uuid::Uuid::parse_str(&sid_str).unwrap());
+
+        let _ = run_file_read_for_dedup(&kernel, workspace.path(), "a.txt", &sid_str).await;
+        // Simulate the compressor's reset hook.
+        crate::context_compressor::reset_post_compression_side_state(sid);
+        // After reset, the next read is treated as the first read again —
+        // the agent sees full content rather than a stub.
+        let after = run_file_read_for_dedup(&kernel, workspace.path(), "a.txt", &sid_str).await;
+        assert_eq!(after.content, "hello");
     }
 
     #[test]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3404,6 +3404,23 @@ pub struct ContextEngineTomlConfig {
     /// Defaults to the official `librefang/librefang-registry`.
     #[serde(default = "default_plugin_registries")]
     pub plugin_registries: Vec<PluginRegistrySource>,
+    /// When `true` (default), repeated `file_read` calls on the same path in a
+    /// session are collapsed: if the on-disk content's hash matches a prior
+    /// read in the same session, the tool returns a short
+    /// `[File already read — content unchanged since turn N. See above for
+    /// full content.]` stub instead of the full body. If the hash differs,
+    /// the result is prefixed with
+    /// `[File updated since last read at turn N]`. Set to `false` to send the
+    /// full file content every time (legacy behaviour). The tracker is reset
+    /// whenever automatic context compression fires, because the prior full
+    /// content is no longer present in the history (#4971).
+    #[serde(default = "default_deduplicate_file_reads")]
+    pub deduplicate_file_reads: bool,
+}
+
+/// Default for [`ContextEngineTomlConfig::deduplicate_file_reads`]: enabled.
+fn default_deduplicate_file_reads() -> bool {
+    true
 }
 
 impl Default for ContextEngineTomlConfig {
@@ -3415,6 +3432,7 @@ impl Default for ContextEngineTomlConfig {
             plugin_stack_weights: Vec::new(),
             hooks: ContextEngineHooks::default(),
             plugin_registries: default_plugin_registries(),
+            deduplicate_file_reads: default_deduplicate_file_reads(),
         }
     }
 }


### PR DESCRIPTION
Closes #4971.

## Summary

Agents frequently re-read the same configuration / source file across
multiple turns. Each `file_read` tool result stores the full body in
session history, so a 10 KB file read four times consumes ~40 KB of
context. This PR tracks `(path, sha256, turn_id)` per session and
rewrites repeat reads into compact stubs.

## What changed

- **`crates/librefang-runtime/src/file_read_tracker.rs`** (new) —
  `FileReadTracker` over `BTreeMap<PathBuf, FileReadEntry>` plus a
  process-wide `OnceLock<Mutex<HashMap<SessionId, FileReadTracker>>>`
  registry with `with_session` / `reset_session` helpers. `BTreeMap` is
  used inside the tracker for deterministic iteration (CLAUDE.md prompt
  cache invariant); the outer registry is `HashMap` because callers
  only look up a single key and `SessionId` is not `Ord`. A hard cap
  (`MAX_TRACKED_PATHS = 512`, oldest-turn eviction) bounds memory for
  pathological agents that touch tens of thousands of unique files.
- **`crates/librefang-runtime/src/tool_runner.rs`** — `"file_read"`
  branch now passes successful read results through
  `maybe_dedup_file_read`. Three early-exit gates: no kernel handle,
  no session id, or `[context_engine] deduplicate_file_reads = false`
  → behaviour unchanged. Outcomes:
  - **First read** → full content, recorded.
  - **Repeat, hash matches** →
    `[File already read — content unchanged since turn N. See above for
    full content.]`.
  - **Repeat, hash differs** → original content prefixed with
    `[File updated since last read at turn N]\n\n`.
  Applies to both the local-fs path and the ACP `fs/read_text_file`
  routing (#3313). ACP partial reads with `line`/`limit` skip dedup
  because hashing a window would be lossy.
- **`crates/librefang-runtime/src/context_compressor.rs`** — adds
  `reset_post_compression_side_state(SessionId)`, a single-line module
  hook the agent loop invokes after a successful compression pass.
  Kept as a module function (not a method on `ContextCompressor`) so
  future side-state resets can plug in without forcing every caller to
  hold a compressor instance. Edit is intentionally small to stay clear
  of #4976's parallel work on the same file.
- **`crates/librefang-runtime/src/agent_loop.rs`** — calls the new
  reset hook from both the normal and streaming compression sites
  whenever `had_soft_compression` is true. Once the compressor has
  summarised the prior bodies away, the stubs would dangle ("see above
  for full content" with nothing above), so dropping the state matches
  the human-mental-model of the new turn boundary.
- **`crates/librefang-types/src/config/types.rs`** — adds
  `deduplicate_file_reads: bool` to `ContextEngineTomlConfig`, default
  `true` via `default_deduplicate_file_reads()` (`#[serde(default = ...)]`
  so existing config.toml files keep working). Updated the `Default`
  impl in lockstep so the build doesn't silently disable the feature.
- **`crates/librefang-kernel-handle/src/lib.rs`** — adds
  `ToolPolicy::deduplicate_file_reads()` with default `false` (stub
  kernels keep legacy behaviour without needing to think about
  session-scoped state).
- **`crates/librefang-kernel/src/kernel/handles/tool_policy.rs`** —
  real kernel reads from
  `self.config.load().context_engine.deduplicate_file_reads`.

No new top-level crate dependencies. Hashing uses `sha2` which is
already a runtime workspace dep (`crates/librefang-runtime/Cargo.toml`
line 35 → `sha2 = { workspace = true }`); sha256 is sufficient (we only
need collision resistance against incidental edits, not adversarial
inputs) and avoids pulling in `blake3`.

## Tests

Unit (`file_read_tracker::tests`, 10 tests):
- `first_read_is_first_outcome`
- `unchanged_read_returns_unchanged_with_first_turn`
- `changed_read_returns_changed_with_previous_turn` (also asserts the
  third read sees the updated turn id — proves the entry was
  overwritten)
- `different_paths_tracked_separately`
- `reset_clears_state`
- `cap_evicts_oldest_entries` (overflows `MAX_TRACKED_PATHS` by 5 and
  checks eviction policy)
- `stub_text_includes_turn_number` / `changed_header_includes_turn_number`
- `session_registry_isolates_sessions`
- `reset_session_clears_only_target`

Integration (`tool_runner::tests`, 4 tests, drive `execute_tool` end to
end with a `KernelHandle` that overrides `deduplicate_file_reads`):
- `file_read_dedup_second_unchanged_read_returns_stub`
- `file_read_dedup_changed_content_returns_updated_header`
- `file_read_dedup_disabled_returns_full_content_each_time`
- `file_read_dedup_reset_after_compression_clears_state`

## Verification

- `cargo check --workspace --lib`: clean.
- `cargo clippy -p librefang-runtime -p librefang-types
  -p librefang-kernel-handle -p librefang-kernel --all-targets --
  -D warnings`: zero warnings.
- `cargo test -p librefang-runtime --lib`: 1689 passed, 0 failed.
- `cargo test -p librefang-types --lib`: 809 passed, 0 failed.
- `cargo test -p librefang-kernel-handle --lib`: 4 passed, 0 failed.

## Out of scope (per issue)

- Per-agent override (`agent.toml`) for `deduplicate_file_reads` —
  trivial follow-up if #4976's per-agent compaction-config plumbing
  lands first; would slot in next to its resolver.
- `skill_read_file` / other read-shaped tools — issue explicitly scopes
  to `file_read`, and the stub mechanism would need re-validation
  against each tool's distinct path/content contract.
