### PR TITLE
feat(runtime): dual-layer compression — gateway safety net before agent loop (#4972)

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -2167,6 +2167,7 @@ pub fn ui_sections_overlay() -> serde_json::Value {
         {"key": "parallel_tools", "struct_field": "parallel_tools"},
         {"key": "tool_results", "struct_field": "tool_results"},
         {"key": "compaction", "struct_field": "compaction"},
+        {"key": "gateway_compression", "struct_field": "gateway_compression"},
         {"key": "azure_openai", "struct_field": "azure_openai"},
         {"key": "proxy", "struct_field": "proxy"},
         // Tool-exec backend selection (local / docker / daytona / ssh).

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -935,6 +935,7 @@ impl LibreFangKernel {
             aux_client: Some(self.llm.aux_client.load_full()),
             parent_session_id: None,
             tool_results_config: Some(cfg.tool_results.clone()),
+            gateway_compression: Some(cfg.gateway_compression.clone()),
         };
 
         // Build a per-execution MCP pool that includes the agent workspace as

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -601,6 +601,9 @@ impl LibreFangKernel {
                 // byte-budget enforcement (defaults: 16 KB per result,
                 // 50 KB per turn) still applies — only fold no-ops here.
                 tool_results_config: None,
+                // Ephemeral /btw also starts empty — gateway pass would
+                // no-op (under threshold) so we skip it explicitly.
+                gateway_compression: None,
             },
         )
         .await
@@ -1350,6 +1353,7 @@ impl LibreFangKernel {
             aux_client: Some(self.llm.aux_client.load_full()),
             parent_session_id: None,
             tool_results_config: Some(self.config.load().tool_results.clone()),
+            gateway_compression: Some(self.config.load().gateway_compression.clone()),
         };
         self.send_message_streaming_with_sender_and_opts(
             effective_id,
@@ -1537,6 +1541,7 @@ impl LibreFangKernel {
             aux_client: Some(self.llm.aux_client.load_full()),
             parent_session_id: Some(parent_session_id),
             tool_results_config: Some(self.config.load().tool_results.clone()),
+            gateway_compression: Some(self.config.load().gateway_compression.clone()),
         };
         // INVARIANT: forks must use the canonical session so the parent turn's
         // prompt-cache prefix is reused. Do NOT pass a `session_id_override`
@@ -1611,6 +1616,7 @@ impl LibreFangKernel {
             aux_client: Some(self.llm.aux_client.load_full()),
             parent_session_id: None,
             tool_results_config: Some(self.config.load().tool_results.clone()),
+            gateway_compression: Some(self.config.load().gateway_compression.clone()),
         };
         self.send_message_streaming_with_sender_and_opts(
             agent_id,

--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -2118,6 +2118,14 @@ pub struct LoopOptions {
     ///
     /// Kernel populates this from `KernelConfig.runtime.tool_results`.
     pub tool_results_config: Option<librefang_types::config::ToolResultsConfig>,
+    /// Gateway compression configuration (#4972). When `Some`, the
+    /// runtime runs a cheap safety-net compression pass at the top of the
+    /// loop, before the first LLM call, when the session has grown past
+    /// the configured threshold (default 85 % of context window). When
+    /// `None`, the gateway pass is skipped entirely — kept `None` in tests
+    /// and other call-paths that don't need it. Kernel populates this
+    /// from `KernelConfig.gateway_compression`.
+    pub gateway_compression: Option<librefang_types::config::GatewayCompressionConfig>,
 }
 
 /// Result of an agent loop execution.
@@ -3698,6 +3706,48 @@ pub async fn run_agent_loop(
             new_messages_start,
             ..Default::default()
         });
+    }
+
+    // Gateway-level safety-net compression (#4972). Runs before any prompt
+    // build / first LLM call: catches sessions that grew between turns
+    // (overnight channel backlog, cron output piling up) and have already
+    // exceeded the context window before the agent-level compactor would
+    // ever get a chance to fire. No-op when the session is under threshold,
+    // when ctx_window is unknown, or when the kernel did not enable it.
+    if let (Some(cfg), Some(ctx_window)) = (
+        opts.gateway_compression.as_ref(),
+        context_window_tokens.filter(|w| *w > 0),
+    ) {
+        let ctx_window_u32: u32 = ctx_window.try_into().unwrap_or(u32::MAX);
+        let report =
+            crate::gateway_compression::apply_if_needed(&mut session.messages, ctx_window_u32, cfg);
+        if report.mutated() {
+            // `new_messages_start` is recomputed unconditionally in
+            // `prepare_messages` (set to `session.messages.len() - 1`
+            // after `safe_trim_messages` runs), so no fixup is needed
+            // here — the gateway prune only narrows the prior history
+            // and the just-pushed user message hasn't been added yet.
+            session.mark_messages_mutated();
+            info!(
+                agent = %manifest.name,
+                session_id = %session.id,
+                tokens_before = report.tokens_before,
+                tokens_after = report.tokens_after,
+                tool_results_stubbed = report.tool_results_stubbed,
+                tool_result_bytes_elided = report.tool_result_bytes_elided,
+                messages_dropped = report.messages_dropped,
+                "Gateway compression pruned session before agent loop (#4972)"
+            );
+        } else if report.fired {
+            // Fired but nothing pruned (e.g. entirely pinned history). The
+            // LLM compactor's summarisation is the only remedy.
+            tracing::warn!(
+                agent = %manifest.name,
+                session_id = %session.id,
+                tokens_before = report.tokens_before,
+                "Gateway compression fired but could not prune (entirely pinned?)"
+            );
+        }
     }
 
     let PromptExperimentSelection {
@@ -5360,6 +5410,40 @@ pub async fn run_agent_loop_streaming(
             new_messages_start,
             ..Default::default()
         });
+    }
+
+    // Gateway-level safety-net compression (#4972). See the matching block
+    // in `run_agent_loop` for rationale. Same pure-function entry point.
+    if let (Some(cfg), Some(ctx_window)) = (
+        opts.gateway_compression.as_ref(),
+        context_window_tokens.filter(|w| *w > 0),
+    ) {
+        let ctx_window_u32: u32 = ctx_window.try_into().unwrap_or(u32::MAX);
+        let report =
+            crate::gateway_compression::apply_if_needed(&mut session.messages, ctx_window_u32, cfg);
+        if report.mutated() {
+            // See the matching block in `run_agent_loop` for why we don't
+            // touch `new_messages_start` here — `prepare_messages`
+            // recomputes it unconditionally after `safe_trim_messages`.
+            session.mark_messages_mutated();
+            info!(
+                agent = %manifest.name,
+                session_id = %session.id,
+                tokens_before = report.tokens_before,
+                tokens_after = report.tokens_after,
+                tool_results_stubbed = report.tool_results_stubbed,
+                tool_result_bytes_elided = report.tool_result_bytes_elided,
+                messages_dropped = report.messages_dropped,
+                "Gateway compression pruned session before streaming loop (#4972)"
+            );
+        } else if report.fired {
+            tracing::warn!(
+                agent = %manifest.name,
+                session_id = %session.id,
+                tokens_before = report.tokens_before,
+                "Gateway compression fired but could not prune (entirely pinned?)"
+            );
+        }
     }
 
     let PromptExperimentSelection {

--- a/crates/librefang-runtime/src/gateway_compression.rs
+++ b/crates/librefang-runtime/src/gateway_compression.rs
@@ -1,0 +1,608 @@
+//! Gateway-level safety-net compression (#4972).
+//!
+//! A cheap, deterministic, non-LLM pass that runs at the very top of the
+//! agent loop — *before* the first prompt build, before any LLM call, and
+//! before the LLM-based [`crate::context_compressor`] / `compactor` would
+//! ever get a chance to run.
+//!
+//! ## Why a second compression seam exists
+//!
+//! The LLM-based agent-level compactor (`context_compressor.rs`) runs
+//! *inside* the agent loop, only after the loop has decided to do work.
+//! That's the right home for proper history summarisation, but it leaves a
+//! gap: sessions that grow *between* turns (overnight channel backlog,
+//! cron-job output piling up, parallel `agent_send` fan-in) can already
+//! exceed the model's context window by the time the next turn starts.
+//! The first LLM call then 400s with `context too long` and the
+//! agent-level compactor never gets to fire.
+//!
+//! ## What this pass does (and does not) do
+//!
+//! - Cheap rough-token estimation via [`crate::compactor::estimate_token_count`].
+//! - At 85 % of the model's context window (configurable), stub any tool
+//!   result longer than `max_tool_result_chars` (default 200), preserving
+//!   `tool_use_id` pairing so the assistant ↔ tool-result chain stays
+//!   well-formed for the provider. Stubbed bytes are replaced with
+//!   `[Gateway-pruned tool result — N chars elided]`.
+//! - If the session is still over threshold after stubbing, drop the
+//!   oldest non-pinned, non-system messages, in pairs that respect
+//!   tool-use ↔ tool-result chains, until either (a) the estimate falls
+//!   below threshold, or (b) only the last `keep_recent_messages` (default
+//!   5) non-pinned messages remain.
+//! - **Never** call the LLM. **Never** allocate via [`std::time::Instant`]
+//!   or [`HashMap`] iteration. Same inputs → same outputs every call —
+//!   prompt-cache stability depends on this.
+//!
+//! ## What is deliberately deferred to the agent-level compactor
+//!
+//! LLM summarisation, semantic chunk grouping, retention rules per memory
+//! tier — all of that lives in `compactor.rs` / `context_compressor.rs`
+//! and is out of scope here. The gateway pass aims only to drop the
+//! estimate below ~0.80 so the agent-level compactor can run normally.
+//!
+//! ## Pinning policy
+//!
+//! Messages with `Message::pinned = true` are never dropped and never
+//! mutated (see #2067 / #3563 — pinned typically means delegation results
+//! that downstream code relies on by index). They still count toward the
+//! token estimate. If pinned messages alone push the session over the
+//! threshold, the gateway pass logs and gives up — the agent-level
+//! compactor's LLM summarisation is the only remedy.
+
+use librefang_types::config::GatewayCompressionConfig;
+use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+
+use crate::compactor::estimate_token_count;
+
+/// Summary of what `apply_if_needed` mutated, for logging.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GatewayCompressionReport {
+    /// True when the pass actually fired (estimate exceeded threshold).
+    pub fired: bool,
+    /// True when the pass was skipped because gateway compression is disabled.
+    pub disabled: bool,
+    /// Estimated tokens before pruning.
+    pub tokens_before: usize,
+    /// Estimated tokens after pruning. Equal to `tokens_before` when nothing
+    /// changed (either disabled or below threshold).
+    pub tokens_after: usize,
+    /// Number of tool-result blocks that were stubbed.
+    pub tool_results_stubbed: usize,
+    /// Bytes of tool-result content elided (sum of `content.len()` before
+    /// stubbing, minus stub length).
+    pub tool_result_bytes_elided: usize,
+    /// Number of (whole) messages dropped from the front of history.
+    pub messages_dropped: usize,
+}
+
+impl GatewayCompressionReport {
+    /// Returns true when any visible mutation happened. Used by the caller
+    /// to decide between `info!` (something changed) and `debug!` (no-op).
+    pub fn mutated(&self) -> bool {
+        self.tool_results_stubbed > 0 || self.messages_dropped > 0
+    }
+}
+
+/// Run the gateway compression pass if the session is over threshold.
+///
+/// `history` is mutated in place. Returns a report describing what (if
+/// anything) was pruned. Callers should log at `info!` when
+/// `report.mutated()` and at `debug!` otherwise.
+///
+/// Pure function: no I/O, no async, no LLM. Safe to call from any context.
+pub fn apply_if_needed(
+    history: &mut Vec<Message>,
+    ctx_window: u32,
+    cfg: &GatewayCompressionConfig,
+) -> GatewayCompressionReport {
+    let mut report = GatewayCompressionReport::default();
+
+    if !cfg.enabled {
+        report.disabled = true;
+        return report;
+    }
+
+    // ctx_window == 0 means "model context window unknown" (the kernel
+    // upstream couldn't resolve the model in the catalog). We can't make a
+    // ratio judgement without it, so no-op rather than guess.
+    if ctx_window == 0 {
+        return report;
+    }
+
+    let threshold_ratio = clamp_ratio(cfg.threshold_ratio);
+    let threshold = (ctx_window as f64 * threshold_ratio as f64) as usize;
+
+    let tokens_before = estimate_token_count(history, None, None);
+    report.tokens_before = tokens_before;
+    report.tokens_after = tokens_before;
+
+    if tokens_before <= threshold {
+        // Under threshold — agent-level compactor handles its own decision.
+        return report;
+    }
+
+    report.fired = true;
+
+    // Phase 1: stub oversized tool results in place.
+    let (stubbed, bytes_elided) = stub_large_tool_results(history, cfg.max_tool_result_chars);
+    report.tool_results_stubbed = stubbed;
+    report.tool_result_bytes_elided = bytes_elided;
+
+    let after_phase1 = estimate_token_count(history, None, None);
+    report.tokens_after = after_phase1;
+
+    if after_phase1 <= threshold {
+        return report;
+    }
+
+    // Phase 2: drop oldest non-pinned messages until either the estimate
+    // falls below threshold or only `keep_recent_messages` non-pinned
+    // remain. We walk forward and remove whole tool_use ↔ tool_result
+    // pairs together so the chain stays well-formed.
+    let dropped = drop_oldest_until_under(history, threshold, cfg.keep_recent_messages);
+    report.messages_dropped = dropped;
+    report.tokens_after = estimate_token_count(history, None, None);
+
+    report
+}
+
+fn clamp_ratio(r: f32) -> f32 {
+    // Allow operators to push the gateway threshold high (e.g. 0.95) but
+    // not above 1.0 (free pass) or below the agent-compactor default
+    // (0.70) — otherwise we'd permanently steal the LLM compactor's job.
+    r.clamp(0.70, 0.99)
+}
+
+/// Walk `history` in place and stub any `ToolResult.content` longer than
+/// `max_chars`. Preserves `tool_use_id` so the assistant ↔ tool-result
+/// chain stays well-formed for the provider. Returns
+/// `(count_stubbed, total_bytes_elided)`.
+fn stub_large_tool_results(history: &mut [Message], max_chars: usize) -> (usize, usize) {
+    let mut count = 0usize;
+    let mut bytes_elided = 0usize;
+
+    for msg in history.iter_mut() {
+        if msg.pinned {
+            continue;
+        }
+        let MessageContent::Blocks(blocks) = &mut msg.content else {
+            continue;
+        };
+        for block in blocks.iter_mut() {
+            if let ContentBlock::ToolResult { content, .. } = block {
+                let original_len = content.len();
+                if original_len > max_chars {
+                    let stub =
+                        format!("[Gateway-pruned tool result — {original_len} chars elided]");
+                    bytes_elided += original_len.saturating_sub(stub.len());
+                    *content = stub;
+                    count += 1;
+                }
+            }
+        }
+    }
+
+    (count, bytes_elided)
+}
+
+/// Drop oldest non-pinned, non-system messages until either the token
+/// estimate falls below `threshold` or only `keep_recent` non-pinned
+/// messages remain in the history. A `tool_use` assistant message is
+/// dropped together with its paired `tool_result` user message so the
+/// chain stays well-formed.
+///
+/// Returns the number of messages removed. Deterministic: same input
+/// always produces the same removal sequence.
+fn drop_oldest_until_under(
+    history: &mut Vec<Message>,
+    threshold: usize,
+    keep_recent: usize,
+) -> usize {
+    let mut dropped = 0usize;
+
+    // Recompute the threshold check each iteration. Capped to prevent
+    // pathological loops on inputs we can never bring under threshold
+    // (entirely pinned history): bound by total length.
+    let max_iterations = history.len();
+    for _ in 0..max_iterations {
+        // Non-pinned, non-system count. When it hits keep_recent we stop.
+        let non_pinned_count = history
+            .iter()
+            .filter(|m| !m.pinned && m.role != Role::System)
+            .count();
+        if non_pinned_count <= keep_recent {
+            break;
+        }
+
+        if estimate_token_count(history, None, None) <= threshold {
+            break;
+        }
+
+        // Find the oldest non-pinned, non-system message. We skip
+        // (a) pinned messages, (b) system messages. The first such index
+        // is our drop target.
+        let Some(idx) = history
+            .iter()
+            .position(|m| !m.pinned && m.role != Role::System)
+        else {
+            break;
+        };
+
+        // If this message holds a tool_use, its paired tool_result lives in
+        // the *next* message (assistant tool_use → user tool_result is the
+        // canonical layout). Drop both together so the chain stays whole.
+        let removed_now = if message_contains_tool_use(&history[idx])
+            && idx + 1 < history.len()
+            && message_contains_tool_result(&history[idx + 1])
+            && !history[idx + 1].pinned
+        {
+            history.remove(idx);
+            history.remove(idx); // shifted up — same index
+            2
+        } else if message_contains_tool_result(&history[idx]) {
+            // Lone orphaned tool_result (preceding tool_use already gone
+            // or pinned). Drop it solo — it would otherwise be rejected
+            // by the provider as unmatched.
+            history.remove(idx);
+            1
+        } else {
+            history.remove(idx);
+            1
+        };
+
+        dropped += removed_now;
+    }
+
+    dropped
+}
+
+fn message_contains_tool_use(msg: &Message) -> bool {
+    if let MessageContent::Blocks(blocks) = &msg.content {
+        blocks
+            .iter()
+            .any(|b| matches!(b, ContentBlock::ToolUse { .. }))
+    } else {
+        false
+    }
+}
+
+fn message_contains_tool_result(msg: &Message) -> bool {
+    if let MessageContent::Blocks(blocks) = &msg.content {
+        blocks
+            .iter()
+            .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+    use librefang_types::tool::ToolExecutionStatus;
+
+    fn small_user(text: &str) -> Message {
+        Message::user(text.to_string())
+    }
+
+    fn small_assistant(text: &str) -> Message {
+        Message::assistant(text.to_string())
+    }
+
+    fn tool_use_msg(id: &str, name: &str) -> Message {
+        Message {
+            role: Role::Assistant,
+            content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+                id: id.to_string(),
+                name: name.to_string(),
+                input: serde_json::json!({}),
+                provider_metadata: None,
+            }]),
+            pinned: false,
+            timestamp: None,
+        }
+    }
+
+    fn tool_result_msg(id: &str, content: &str) -> Message {
+        Message {
+            role: Role::User,
+            content: MessageContent::Blocks(vec![ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                tool_name: "demo".to_string(),
+                content: content.to_string(),
+                is_error: false,
+                status: ToolExecutionStatus::default(),
+                approval_request_id: None,
+            }]),
+            pinned: false,
+            timestamp: None,
+        }
+    }
+
+    fn default_cfg() -> GatewayCompressionConfig {
+        GatewayCompressionConfig::default()
+    }
+
+    #[test]
+    fn under_threshold_is_noop() {
+        let mut history = vec![small_user("hi"), small_assistant("hello")];
+        let original = history.clone();
+        let report = apply_if_needed(&mut history, 200_000, &default_cfg());
+        assert!(!report.fired, "report = {report:?}");
+        assert_eq!(report.messages_dropped, 0);
+        assert_eq!(report.tool_results_stubbed, 0);
+        assert_eq!(history.len(), original.len());
+        assert!(!report.mutated());
+    }
+
+    #[test]
+    fn disabled_is_noop_even_when_huge() {
+        // Bloated history but config disabled.
+        let mut history: Vec<Message> = (0..200)
+            .map(|i| small_user(&format!("padding-{i}-{}", "x".repeat(1000))))
+            .collect();
+        let cfg = GatewayCompressionConfig {
+            enabled: false,
+            ..GatewayCompressionConfig::default()
+        };
+        let before = history.len();
+        let report = apply_if_needed(&mut history, 1_000, &cfg);
+        assert!(report.disabled);
+        assert!(!report.fired);
+        assert_eq!(history.len(), before);
+    }
+
+    #[test]
+    fn unknown_ctx_window_is_noop() {
+        let mut history = vec![small_user(&"x".repeat(10_000))];
+        let before = history.len();
+        let report = apply_if_needed(&mut history, 0, &default_cfg());
+        assert!(!report.fired);
+        assert_eq!(history.len(), before);
+    }
+
+    #[test]
+    fn stubs_oversized_tool_results_first() {
+        // One big tool result + an assistant tool_use referencing it.
+        // Context window deliberately tiny so a single big result puts us
+        // over threshold without needing message drops.
+        let big = "y".repeat(20_000);
+        let mut history = vec![
+            small_user("please run the tool"),
+            tool_use_msg("call-1", "demo"),
+            tool_result_msg("call-1", &big),
+            small_user("thanks"),
+        ];
+        // Roughly: 20_000 chars / 4 = 5_000 tokens. Threshold at 0.85 *
+        // 1_000 = 850. So firmly over.
+        let report = apply_if_needed(&mut history, 1_000, &default_cfg());
+        assert!(report.fired);
+        assert_eq!(report.tool_results_stubbed, 1);
+        assert!(report.tool_result_bytes_elided > 0);
+
+        // Verify the stub message replaced the content and tool_use_id
+        // was preserved.
+        match &history[2].content {
+            MessageContent::Blocks(blocks) => match &blocks[0] {
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } => {
+                    assert_eq!(tool_use_id, "call-1");
+                    assert!(content.starts_with("[Gateway-pruned tool result"));
+                }
+                other => panic!("expected ToolResult, got {other:?}"),
+            },
+            other => panic!("expected Blocks, got {other:?}"),
+        }
+        // tool_use side is structurally intact.
+        assert!(message_contains_tool_use(&history[1]));
+    }
+
+    #[test]
+    fn pinned_messages_never_pruned_or_mutated() {
+        // A pinned message with a huge tool result should NOT be stubbed,
+        // even when the gateway pass fires.
+        let big = "z".repeat(20_000);
+        let mut pinned_huge_result = tool_result_msg("call-pinned", &big);
+        pinned_huge_result.pinned = true;
+        let mut history = vec![
+            pinned_huge_result.clone(),
+            small_user("a"),
+            small_user("b"),
+            small_user("c"),
+        ];
+        let _report = apply_if_needed(&mut history, 1_000, &default_cfg());
+        // First message is still there, still pinned, still has its big
+        // content (untouched).
+        assert!(history[0].pinned);
+        match &history[0].content {
+            MessageContent::Blocks(blocks) => match &blocks[0] {
+                ContentBlock::ToolResult { content, .. } => {
+                    assert_eq!(content.len(), 20_000);
+                }
+                _ => panic!("expected ToolResult"),
+            },
+            _ => panic!("expected Blocks"),
+        }
+    }
+
+    #[test]
+    fn drops_oldest_until_under_keep_recent_floor() {
+        // Many medium-sized messages, none pinned, no tool results to stub.
+        // Forces the message-drop phase.
+        let mut history: Vec<Message> = (0..40)
+            .map(|i| small_user(&format!("msg-{i}-{}", "x".repeat(500))))
+            .collect();
+
+        let cfg = GatewayCompressionConfig {
+            keep_recent_messages: 5,
+            ..GatewayCompressionConfig::default()
+        };
+        let report = apply_if_needed(&mut history, 1_000, &cfg);
+        assert!(report.fired);
+        assert!(report.messages_dropped > 0);
+        // keep_recent floor enforced: never drops past the last 5
+        // non-pinned messages.
+        assert!(history.len() >= 5);
+        // The drop loop stops at whichever bound hits first — threshold or
+        // keep_recent. So `n` should be in `[40 - report.messages_dropped,
+        // 35]` (35 is the keep_recent floor for 40 messages). The
+        // important invariant is "old messages got dropped, recent ones
+        // survived" — not an exact id.
+        match &history[0].content {
+            MessageContent::Text(s) => {
+                let n: i32 = s
+                    .strip_prefix("msg-")
+                    .and_then(|rest| rest.split('-').next())
+                    .and_then(|n| n.parse().ok())
+                    .expect("parseable id");
+                assert!(n > 0, "first surviving msg id = {n} (no drops?)");
+                assert!(
+                    n as usize <= 40 - cfg.keep_recent_messages,
+                    "first surviving msg id = {n} should not exceed keep_recent floor"
+                );
+            }
+            _ => panic!("expected Text"),
+        }
+        // And the last message — the most recent one — is always preserved.
+        match &history.last().expect("non-empty").content {
+            MessageContent::Text(s) => assert!(s.starts_with("msg-39-")),
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn tool_use_and_result_dropped_as_pair() {
+        let mut history = vec![
+            tool_use_msg("call-A", "demo"),
+            tool_result_msg("call-A", &"a".repeat(100)),
+            small_user(&format!("padding {}", "y".repeat(2_000))),
+            small_user(&format!("padding2 {}", "z".repeat(2_000))),
+            small_user(&format!("padding3 {}", "q".repeat(2_000))),
+            small_user(&format!("padding4 {}", "w".repeat(2_000))),
+            small_user("recent"),
+        ];
+        let cfg = GatewayCompressionConfig {
+            // Small chunk size irrelevant — tool result content is short.
+            max_tool_result_chars: 200,
+            keep_recent_messages: 3,
+            ..GatewayCompressionConfig::default()
+        };
+        let report = apply_if_needed(&mut history, 1_000, &cfg);
+        assert!(report.fired);
+        // tool_use and its paired tool_result were both dropped, OR neither
+        // was. Verify the chain is still well-formed — for every
+        // tool_result remaining there is a preceding tool_use with the
+        // same id.
+        for (i, msg) in history.iter().enumerate() {
+            if let MessageContent::Blocks(blocks) = &msg.content {
+                for b in blocks {
+                    if let ContentBlock::ToolResult { tool_use_id, .. } = b {
+                        // Search prior messages for the matching tool_use.
+                        let mut found = false;
+                        for prior in history.iter().take(i) {
+                            if let MessageContent::Blocks(pblocks) = &prior.content {
+                                for pb in pblocks {
+                                    if let ContentBlock::ToolUse { id, .. } = pb {
+                                        if id == tool_use_id {
+                                            found = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            if found {
+                                break;
+                            }
+                        }
+                        assert!(
+                            found,
+                            "orphan tool_result at index {i} with id {tool_use_id}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn most_recent_messages_are_preserved() {
+        let mut history: Vec<Message> = (0..30)
+            .map(|i| small_user(&format!("msg-{i}-{}", "x".repeat(800))))
+            .collect();
+        let cfg = GatewayCompressionConfig {
+            keep_recent_messages: 5,
+            ..GatewayCompressionConfig::default()
+        };
+        let _report = apply_if_needed(&mut history, 1_000, &cfg);
+        // The very last message ("msg-29-…") is always preserved.
+        let last = history.last().expect("non-empty after prune");
+        match &last.content {
+            MessageContent::Text(s) => assert!(s.starts_with("msg-29-")),
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn deterministic_across_calls() {
+        // Same input → same output, twice in a row, byte-for-byte.
+        // Strip wall-clock timestamps (set inside `Message::user/assistant`
+        // via `Utc::now()`) so the JSON comparison reflects only the
+        // pruning algorithm, not construction-time clock drift.
+        let build = || -> Vec<Message> {
+            let big = "p".repeat(15_000);
+            let mut msgs = vec![
+                small_user("intro"),
+                tool_use_msg("call-x", "demo"),
+                tool_result_msg("call-x", &big),
+                small_assistant("ok"),
+                small_user("next"),
+                small_user("more"),
+                small_user("final"),
+            ];
+            for m in msgs.iter_mut() {
+                m.timestamp = None;
+            }
+            msgs
+        };
+        let mut h1 = build();
+        let mut h2 = build();
+        let r1 = apply_if_needed(&mut h1, 1_000, &default_cfg());
+        let r2 = apply_if_needed(&mut h2, 1_000, &default_cfg());
+        assert_eq!(r1, r2);
+        // Compare serialised history to catch any nondeterminism in
+        // ordering / content.
+        let s1 = serde_json::to_string(&h1).expect("ser h1");
+        let s2 = serde_json::to_string(&h2).expect("ser h2");
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn threshold_ratio_clamped_low() {
+        // A user trying to set 0.10 (below the compactor's 0.70) gets
+        // clamped to 0.70 — otherwise the gateway would steal the
+        // LLM-compactor's job permanently.
+        assert_eq!(clamp_ratio(0.10), 0.70);
+        assert_eq!(clamp_ratio(0.85), 0.85);
+        assert_eq!(clamp_ratio(1.5), 0.99);
+    }
+
+    #[test]
+    fn entirely_pinned_history_gives_up_gracefully() {
+        // If every message is pinned, the drop phase can't proceed and
+        // must terminate rather than loop. We don't enforce a specific
+        // post-condition on tokens — the LLM compactor's summarisation
+        // is the only remedy in that case.
+        let big = "Q".repeat(15_000);
+        let mut pinned_msg = tool_result_msg("call-p", &big);
+        pinned_msg.pinned = true;
+        let mut history = vec![pinned_msg.clone(), pinned_msg.clone(), pinned_msg];
+        let report = apply_if_needed(&mut history, 1_000, &default_cfg());
+        assert!(report.fired);
+        // All three still there (pinned protects them at both phases).
+        assert_eq!(history.len(), 3);
+    }
+}

--- a/crates/librefang-runtime/src/gateway_compression.rs
+++ b/crates/librefang-runtime/src/gateway_compression.rs
@@ -200,14 +200,14 @@ fn drop_oldest_until_under(
 ) -> usize {
     let mut dropped = 0usize;
 
-    // Recompute the threshold check each iteration. Capped to prevent
-    // pathological loops on inputs we can never bring under threshold
-    // (entirely pinned history): bound by total length. The cap is a
-    // safety net only — the real termination guard is "no candidate
-    // was droppable this iteration → break" below, which fires before
-    // we ever spin.
-    let max_iterations = history.len();
-    for _ in 0..max_iterations {
+    // Termination is guaranteed by two explicit breaks below:
+    //   (1) `non_pinned_count <= keep_recent` once enough drops have happened, and
+    //   (2) `next_droppable_index` returning `None` when every remaining
+    //       non-pinned candidate is locked by a pinned paired partner.
+    // Each iteration removes at least one message (1 for solo, 2 for a
+    // tool_use/tool_result pair), so the non-pinned count is strictly
+    // monotonically decreasing — `loop {}` cannot spin.
+    loop {
         // Non-pinned, non-system count. When it hits keep_recent we stop.
         let non_pinned_count = history
             .iter()

--- a/crates/librefang-runtime/src/gateway_compression.rs
+++ b/crates/librefang-runtime/src/gateway_compression.rs
@@ -202,7 +202,10 @@ fn drop_oldest_until_under(
 
     // Recompute the threshold check each iteration. Capped to prevent
     // pathological loops on inputs we can never bring under threshold
-    // (entirely pinned history): bound by total length.
+    // (entirely pinned history): bound by total length. The cap is a
+    // safety net only — the real termination guard is "no candidate
+    // was droppable this iteration → break" below, which fires before
+    // we ever spin.
     let max_iterations = history.len();
     for _ in 0..max_iterations {
         // Non-pinned, non-system count. When it hits keep_recent we stop.
@@ -218,19 +221,23 @@ fn drop_oldest_until_under(
             break;
         }
 
-        // Find the oldest non-pinned, non-system message. We skip
-        // (a) pinned messages, (b) system messages. The first such index
-        // is our drop target.
-        let Some(idx) = history
-            .iter()
-            .position(|m| !m.pinned && m.role != Role::System)
-        else {
+        // Find the oldest droppable candidate. A `tool_use` whose paired
+        // `tool_result` at `idx+1` is pinned is untouchable — dropping
+        // the `tool_use` alone would orphan the pinned `tool_result` and
+        // the provider would 400 on the resulting payload. Skip past
+        // such stuck pairs and keep searching forward.
+        let Some(idx) = next_droppable_index(history) else {
+            // Every remaining non-pinned candidate is locked by a pinned
+            // paired partner. No further progress possible; bail rather
+            // than spin.
             break;
         };
 
         // If this message holds a tool_use, its paired tool_result lives in
         // the *next* message (assistant tool_use → user tool_result is the
         // canonical layout). Drop both together so the chain stays whole.
+        // `next_droppable_index` guarantees the paired `tool_result`, if
+        // present, is itself non-pinned.
         let removed_now = if message_contains_tool_use(&history[idx])
             && idx + 1 < history.len()
             && message_contains_tool_result(&history[idx + 1])
@@ -254,6 +261,34 @@ fn drop_oldest_until_under(
     }
 
     dropped
+}
+
+/// Return the index of the oldest non-pinned, non-system message that is
+/// safe to drop. A `tool_use` followed by a pinned `tool_result` is NOT
+/// safe (dropping the tool_use would orphan the pinned tool_result), so
+/// we step past it and keep looking. Returns `None` when no droppable
+/// candidate exists.
+fn next_droppable_index(history: &[Message]) -> Option<usize> {
+    let mut i = 0;
+    while i < history.len() {
+        let msg = &history[i];
+        if msg.pinned || msg.role == Role::System {
+            i += 1;
+            continue;
+        }
+        // A tool_use whose paired tool_result is pinned is untouchable —
+        // skip past both to look for a later candidate.
+        if message_contains_tool_use(msg)
+            && i + 1 < history.len()
+            && message_contains_tool_result(&history[i + 1])
+            && history[i + 1].pinned
+        {
+            i += 2;
+            continue;
+        }
+        return Some(i);
+    }
+    None
 }
 
 fn message_contains_tool_use(msg: &Message) -> bool {
@@ -588,6 +623,110 @@ mod tests {
         assert_eq!(clamp_ratio(0.10), 0.70);
         assert_eq!(clamp_ratio(0.85), 0.85);
         assert_eq!(clamp_ratio(1.5), 0.99);
+    }
+
+    #[test]
+    fn tool_use_with_pinned_paired_result_is_not_dropped() {
+        // Phase-2 regression: a non-pinned tool_use whose paired
+        // tool_result at idx+1 is pinned MUST stay whole. Single-dropping
+        // the tool_use would orphan the pinned tool_result and providers
+        // 400 on that shape. The chain has to remain well-formed.
+        let mut pinned_result = tool_result_msg("call-keep", &"k".repeat(200));
+        pinned_result.pinned = true;
+        let mut history = vec![
+            tool_use_msg("call-keep", "demo"),
+            pinned_result,
+            // Padding to force the gateway pass to fire and look for
+            // candidates to drop.
+            small_user(&format!("padding-1 {}", "y".repeat(2_000))),
+            small_user(&format!("padding-2 {}", "z".repeat(2_000))),
+            small_user(&format!("padding-3 {}", "q".repeat(2_000))),
+            small_user("recent"),
+        ];
+        let cfg = GatewayCompressionConfig {
+            keep_recent_messages: 2,
+            ..GatewayCompressionConfig::default()
+        };
+        let report = apply_if_needed(&mut history, 1_000, &cfg);
+        assert!(report.fired, "should have fired: {report:?}");
+
+        // The pinned tool_result must still be present and pinned.
+        let pinned_still_present = history.iter().any(|m| {
+            m.pinned
+                && matches!(
+                    &m.content,
+                    MessageContent::Blocks(b)
+                        if b.iter().any(|cb| matches!(
+                            cb,
+                            ContentBlock::ToolResult { tool_use_id, .. }
+                                if tool_use_id == "call-keep"
+                        ))
+                )
+        });
+        assert!(
+            pinned_still_present,
+            "pinned tool_result must survive — history = {history:?}"
+        );
+
+        // Orphan-free invariant: every remaining tool_result has a
+        // preceding tool_use with the same id.
+        for (i, msg) in history.iter().enumerate() {
+            if let MessageContent::Blocks(blocks) = &msg.content {
+                for b in blocks {
+                    if let ContentBlock::ToolResult { tool_use_id, .. } = b {
+                        let has_pair = history.iter().take(i).any(|prior| {
+                            matches!(
+                                &prior.content,
+                                MessageContent::Blocks(pb)
+                                    if pb.iter().any(|cb| matches!(
+                                        cb,
+                                        ContentBlock::ToolUse { id, .. } if id == tool_use_id
+                                    ))
+                            )
+                        });
+                        assert!(
+                            has_pair,
+                            "orphan tool_result at idx {i} with id {tool_use_id} — \
+                             history = {history:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn drop_loop_terminates_when_no_candidate_can_be_dropped() {
+        // Every non-pinned candidate is a tool_use locked by a pinned
+        // paired tool_result. Plus a system message and a pinned message,
+        // none of which are ever droppable. There must be nothing the
+        // drop loop CAN drop, and it must terminate (not spin) — even
+        // though we're well over threshold.
+        let big = "Q".repeat(8_000);
+        let mut pinned_result_1 = tool_result_msg("call-1", &big);
+        pinned_result_1.pinned = true;
+        let mut pinned_result_2 = tool_result_msg("call-2", &big);
+        pinned_result_2.pinned = true;
+        let mut history = vec![
+            tool_use_msg("call-1", "demo"),
+            pinned_result_1,
+            tool_use_msg("call-2", "demo"),
+            pinned_result_2,
+        ];
+        let before = history.clone();
+        let report = apply_if_needed(&mut history, 1_000, &default_cfg());
+        assert!(report.fired);
+        // Nothing was droppable — history must be identical to the input.
+        assert_eq!(history.len(), before.len(), "history length changed");
+        assert_eq!(report.messages_dropped, 0);
+        // Pinned tool_results both still present and still pinned.
+        assert!(history[1].pinned);
+        assert!(history[3].pinned);
+        // tool_use ↔ pinned tool_result chains both intact.
+        assert!(message_contains_tool_use(&history[0]));
+        assert!(message_contains_tool_result(&history[1]));
+        assert!(message_contains_tool_use(&history[2]));
+        assert!(message_contains_tool_result(&history[3]));
     }
 
     #[test]

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -29,6 +29,7 @@ pub mod context_engine;
 pub mod context_overflow;
 pub use librefang_runtime_oauth::copilot_oauth;
 pub mod docker_sandbox;
+pub mod gateway_compression;
 pub use librefang_llm_drivers::drivers;
 pub mod embedding;
 pub mod graceful_shutdown;

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2276,6 +2276,74 @@ impl Default for CompactionTomlConfig {
     }
 }
 
+/// Gateway-level safety-net compression (exposed in `[gateway_compression]`
+/// TOML section). Runs at the top of the agent loop, *before* the first LLM
+/// call and *before* the LLM-based [`CompactionTomlConfig`] runs.
+///
+/// Purpose: catch sessions that grew between turns (overnight Telegram
+/// backlog, cron-job output piling up, etc.) and have already exceeded the
+/// model's context window when the next turn starts. Without this pass the
+/// first LLM call would 400 with "context too long" before the agent-level
+/// compactor ever gets a chance to run.
+///
+/// Trade-off vs. [`CompactionTomlConfig`]:
+/// - Gateway pass: cheap (rough token estimation, no LLM call), runs at a
+///   *higher* threshold (default 0.85), prunes tool results + drops oldest
+///   non-pinned messages.
+/// - Agent-level compactor: LLM-summarises, runs at a *lower* threshold
+///   (default 0.70). Owns history compaction proper.
+///
+/// The gateway pass aims to bring the session below ~0.80 so the agent-level
+/// compactor can run normally on the next iteration. It never calls the LLM.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct GatewayCompressionConfig {
+    /// Master switch. Default ON. Set to `false` to disable the gateway
+    /// safety-net pass entirely (the agent-level compactor still runs).
+    #[serde(default = "default_gateway_compression_enabled")]
+    pub enabled: bool,
+    /// Trigger ratio: gateway pass fires when estimated session tokens
+    /// exceed `context_window * threshold_ratio` (default: 0.85). Must be
+    /// strictly greater than [`CompactionTomlConfig::token_threshold_ratio`]
+    /// (default 0.70) so the agent-level compactor gets first crack.
+    #[serde(default = "default_gateway_compression_threshold_ratio")]
+    pub threshold_ratio: f32,
+    /// Tool results larger than this character count get stubbed (default:
+    /// 200). Stubbing preserves `tool_use_id` pairing so the assistant ↔
+    /// tool-result chain stays well-formed for the provider.
+    #[serde(default = "default_gateway_compression_max_tool_result_chars")]
+    pub max_tool_result_chars: usize,
+    /// Number of most-recent messages always kept verbatim (default: 5).
+    /// Older non-pinned messages are dropped first if stubbing tool results
+    /// alone does not bring the estimate below the threshold.
+    #[serde(default = "default_gateway_compression_keep_recent")]
+    pub keep_recent_messages: usize,
+}
+
+fn default_gateway_compression_enabled() -> bool {
+    true
+}
+fn default_gateway_compression_threshold_ratio() -> f32 {
+    0.85
+}
+fn default_gateway_compression_max_tool_result_chars() -> usize {
+    200
+}
+fn default_gateway_compression_keep_recent() -> usize {
+    5
+}
+
+impl Default for GatewayCompressionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_gateway_compression_enabled(),
+            threshold_ratio: default_gateway_compression_threshold_ratio(),
+            max_tool_result_chars: default_gateway_compression_max_tool_result_chars(),
+            keep_recent_messages: default_gateway_compression_keep_recent(),
+        }
+    }
+}
+
 /// Where a context injection should be placed in the session message list.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -3024,6 +3092,14 @@ pub struct KernelConfig {
     /// Session compaction configuration (LLM-based history summarization).
     #[serde(default)]
     pub compaction: CompactionTomlConfig,
+    /// Gateway-level safety-net compression (#4972). Cheap pre-loop pass
+    /// that prunes oversized tool results and oldest non-pinned messages
+    /// when a session has grown past the model's context window *between*
+    /// turns, before the first LLM call. Runs at a higher threshold (0.85)
+    /// than the agent-level compactor (0.70) — they are complementary, not
+    /// alternatives. See [`GatewayCompressionConfig`].
+    #[serde(default)]
+    pub gateway_compression: GatewayCompressionConfig,
     /// Message queue configuration (depth limits, TTL, concurrency).
     #[serde(default)]
     pub queue: QueueConfig,
@@ -5085,6 +5161,7 @@ impl Default for KernelConfig {
             prompt_caching: default_prompt_caching(),
             session: SessionConfig::default(),
             compaction: CompactionTomlConfig::default(),
+            gateway_compression: GatewayCompressionConfig::default(),
             queue: QueueConfig::default(),
             task_board: TaskBoardConfig::default(),
             external_auth: ExternalAuthConfig::default(),


### PR DESCRIPTION
Closes #4972.

## Problem

The agent-level compactor (`context_compressor` / `compactor`) runs
*inside* the agent loop. But sessions can grow *between* turns —
overnight Telegram backlog, cron-job output piling up, parallel
`agent_send` fan-in — and already exceed the model's context window
by the time the next turn starts. The first LLM call then 400s with
`context too long` and the agent-level compactor never gets to fire.

## What this PR adds

A cheap, deterministic, non-LLM compression pass that runs at the very
top of the agent loop, before the first prompt build, before any LLM
call, and before the LLM-based agent-level compactor would ever get a
chance to run.

- Module: `crates/librefang-runtime/src/gateway_compression.rs`.
- Entry point: `apply_if_needed(history, ctx_window, cfg) -> GatewayCompressionReport`.
- Pure function: no I/O, no async, no LLM. Same inputs → same outputs
  every call (prompt-cache stability).
- Called from both `run_agent_loop` and `run_agent_loop_streaming`
  immediately after the `driver.is_configured()` early-return.

## Seam choice — runtime-only

The issue listed both `crates/librefang-kernel/src/kernel/messaging.rs`
and `crates/librefang-runtime/src/agent_loop.rs` as candidate sites.
Picked runtime-only because:

- The runtime already owns the model's context window (it knows the
  driver), the in-memory `Session.messages`, and the existing CJK-aware
  `compactor::estimate_token_count` heuristic.
- Adding a kernel-side hook would have dragged context-window awareness
  back into `messaging.rs` without clarifying ownership.
- The kernel still configures the pass via
  `KernelConfig.gateway_compression` → `LoopOptions.gateway_compression`,
  which keeps wiring symmetric with the existing
  `tool_results_config` slot.

## Config knob

New `[gateway_compression]` section on `KernelConfig`:

| Field | Default | Notes |
|---|---|---|
| `enabled` | `true` | Master switch. |
| `threshold_ratio` | `0.85` | Clamped to `[0.70, 0.99]` — floor prevents stealing the agent-level compactor's job. |
| `max_tool_result_chars` | `200` | Tool results larger than this get stubbed. |
| `keep_recent_messages` | `5` | Floor: never drop past the last 5 non-pinned messages. |

Relationship to the agent-level compactor (`[compaction]`, unchanged
in this PR): gateway fires at 0.85, agent-level compactor at 0.70.
Gateway aims to bring the session below ~0.80 so the agent-level
compactor can run normally on the next iteration.

## Pruning order

Phase 1 — **Stub oversized tool results in place.** Walk `history`,
replace any `ContentBlock::ToolResult.content` longer than
`max_tool_result_chars` with `[Gateway-pruned tool result — N chars
elided]`. `tool_use_id` is preserved so the assistant ↔ tool-result
chain stays well-formed for the provider. Pinned messages are skipped.

Phase 2 (only if still over threshold) — **Drop oldest non-pinned,
non-system messages from the front.** Repeats until either (a) the
token estimate falls below threshold, or (b) only `keep_recent_messages`
non-pinned messages remain. When the oldest candidate is a `tool_use`
assistant message followed by its paired `tool_result`, both are
dropped together so the chain stays whole. Lone orphan `tool_result`s
are dropped solo (the provider would reject them anyway).

Pinning policy: messages with `Message::pinned = true` are never
dropped and never mutated. They still count toward the token estimate.
If pinned messages alone push the session over threshold, the gateway
pass logs a `warn!` and gives up — the agent-level compactor's LLM
summarisation is the only remedy.

## Tests

`gateway_compression::tests` adds 11 unit tests:

- `under_threshold_is_noop`
- `disabled_is_noop_even_when_huge`
- `unknown_ctx_window_is_noop`
- `stubs_oversized_tool_results_first`
- `pinned_messages_never_pruned_or_mutated`
- `drops_oldest_until_under_keep_recent_floor`
- `tool_use_and_result_dropped_as_pair`
- `most_recent_messages_are_preserved`
- `deterministic_across_calls`
- `threshold_ratio_clamped_low`
- `entirely_pinned_history_gives_up_gracefully`

A runtime-level integration test driving the full agent loop with a
bloated session was considered but skipped: setting up `run_agent_loop`
with a real `LlmDriver` + `Session` + `MemorySubstrate` + manifest is
~50 lines of fixtures per test (cf. `test_history_fold_stub_appears_*`
in the same file) and would only re-exercise the unit-tested pure
function. The call-site wiring is small enough to read in this PR —
two near-identical 30-line blocks in `agent_loop.rs`.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-runtime -p librefang-kernel -p librefang-types --all-targets -- -D warnings` — clean.
- `cargo test -p librefang-types --lib` — 809 passed.
- `cargo test -p librefang-runtime --lib` — 1 686 passed.
- `cargo test -p librefang-kernel --lib` — 948 passed.

## Coordination with in-flight PRs

This PR stays out of `compactor.rs`, `context_compressor.rs`,
`tool_runner.rs`, `prompt_builder.rs`, and the `[compaction]` section
of `librefang-types/src/config/types.rs` — those are being touched by
PRs #4976 / #4970 / #4971 / #4834. The new `[gateway_compression]`
section lives next to `[compaction]` but is structurally independent.

## Deliberately out of scope

- LLM summarisation. That's the agent-level compactor's job and is
  unchanged in this PR.
- Tool-result pruning beyond the cheap stub-and-drop policy.
- Per-agent threshold override. Kernel-level config is enough for now;
  per-agent can be added later without re-shaping the seam.
