### PR TITLE
fix(claude-code): stabilise diagnose_stdin macOS test (#5024 follow-up)

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -1433,10 +1433,18 @@ mod tests {
     fn spawn_dying_child(stderr_payload: Option<&str>) -> tokio::process::Child {
         let script = match stderr_payload {
             Some(msg) => {
+                // Explicit `flush()` before `sys.exit` because Python's
+                // text-IO layer over stderr is line-buffered: a no-newline
+                // payload sits in the wrapper buffer until interpreter
+                // shutdown flushes it. On loaded macOS GHA runners the
+                // diagnostic helper's `child.kill()` (SIGKILL) has been
+                // observed to land before that shutdown flush completes,
+                // dropping the payload before the OS pipe sees it and
+                // tripping the silent-fallback branch under test.
                 // `{msg:?}` writes the payload as a Rust-debug quoted
                 // string, which is also a valid Python string literal for
                 // the ASCII payloads these tests use.
-                format!("import sys; sys.stderr.write({msg:?}); sys.exit(7)")
+                format!("import sys; sys.stderr.write({msg:?}); sys.stderr.flush(); sys.exit(7)")
             }
             None => "import sys; sys.exit(0)".to_string(),
         };
@@ -1447,7 +1455,9 @@ mod tests {
         // silently dropped piped stderr on the Test / Windows lane.
         let build_cmd = |exe: &str| -> tokio::process::Command {
             let mut cmd = tokio::process::Command::new(exe);
-            cmd.arg("-c").arg(&script);
+            // `-u` forces Python's stdio binary layer unbuffered, defence
+            // in depth alongside the explicit flush in the script body.
+            cmd.arg("-u").arg("-c").arg(&script);
             cmd.stdin(std::process::Stdio::piped());
             cmd.stdout(std::process::Stdio::piped());
             cmd.stderr(std::process::Stdio::piped());
@@ -1458,6 +1468,30 @@ mod tests {
             Err(_) => build_cmd("python")
                 .spawn()
                 .expect("neither python3 nor python is on PATH; install Python 3 to run this test"),
+        }
+    }
+
+    /// Wait deterministically for `child` to exit, polling `try_wait`
+    /// with a 2 s budget. Replaces fixed `tokio::time::sleep` guesses
+    /// (150 ms / 100 ms in earlier revisions of these tests) that left a
+    /// race window: on a loaded macOS GHA runner the Python interpreter's
+    /// startup + shutdown can exceed the budget, so the subsequent
+    /// `child.kill()` inside `diagnose_stdin_write_failure` lands during
+    /// interpreter teardown and steals the stderr that hadn't yet
+    /// reached the OS pipe. Polling until exit removes the guess.
+    async fn await_child_exit(child: &mut tokio::process::Child) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => {
+                    if tokio::time::Instant::now() >= deadline {
+                        return;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+                Err(_) => return,
+            }
         }
     }
 
@@ -1472,8 +1506,10 @@ mod tests {
         // just like a real claude-code init failure.
         let mut child = spawn_dying_child(Some("mock cli: auth profile invalid"));
 
-        // Give the child a moment to exit so its stdin pipe is closed.
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        // Wait until the child has actually exited so its stdio is fully
+        // flushed and its stdin pipe is closed before we ask the
+        // diagnostic helper to read stderr.
+        await_child_exit(&mut child).await;
 
         let write_err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Broken pipe");
         let diag = ClaudeCodeDriver::diagnose_stdin_write_failure(&mut child, &write_err).await;
@@ -1494,7 +1530,7 @@ mod tests {
     #[tokio::test]
     async fn diagnose_stdin_write_failure_falls_back_to_hint_when_silent() {
         let mut child = spawn_dying_child(None);
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        await_child_exit(&mut child).await;
 
         let write_err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Broken pipe");
         let diag = ClaudeCodeDriver::diagnose_stdin_write_failure(&mut child, &write_err).await;


### PR DESCRIPTION
## Summary

`Test / macOS` on `origin/main` (run [25806482593](https://github.com/librefang/librefang/actions/runs/25806482593)) is red on a single case after #5024:

- `librefang-llm-drivers::drivers::claude_code::tests::diagnose_stdin_write_failure_includes_child_stderr`

#5024 switched the test's spawned-child shim from `/bin/sh -c 'echo X >&2; exit 7'` to a Python `-c` payload to unblock the Windows lane. The POSIX sh form was an atomic builtin `write(2)` + `_exit(2)`; the Python form has three time-coupled steps (interpreter start, write, interpreter shutdown flush) that the test's fixed `tokio::time::sleep(150ms)` + the diagnostic helper's `child.kill()` race against.

On loaded macOS GHA runners SIGKILL has been observed landing during Python's interpreter teardown, before the text-IO layer's buffered stderr has flushed to the OS pipe. `diagnose_stdin_write_failure` then reads an empty stderr, trips the silent-fallback branch, and the captured-stderr assertion fails. Linux runners (4 Ubuntu shards) never reproduced this — Python startup/shutdown there is fast enough that the 150 ms slack window holds.

## Changes (test module only)

1. **`spawn_dying_child`**: `python -u -c 'import sys; sys.stderr.write(msg); sys.stderr.flush(); sys.exit(7)'`. Explicit `flush()` is the structural fix — Python's stderr text wrapper is line-buffered, so a no-newline payload sits in the wrapper until shutdown. `-u` is defence in depth on the binary layer.

2. **`await_child_exit` (new helper)**: replaces `tokio::time::sleep(150ms)` / `sleep(100ms)` with a `try_wait` poll loop on a 2 s budget. The sleep was guessing how long Python's startup + shutdown would take; polling until exit removes the guess instead of widening it.

Both tests (`..._includes_child_stderr` and `..._falls_back_to_hint_when_silent`) now use the deterministic waiter.

## Verification

- `rustfmt --check --edition 2021` clean on the touched file.
- Local `cargo test -p librefang-llm-drivers --lib diagnose_stdin` **was not run**: the host's cargo wrapper requires Docker (currently down on the contributor's machine), and even when up it executes inside `rust:latest` on Linux — where this bug never reproduced. The real verdict is the Test / macOS CI lane on this PR.

## Out-of-scope follow-ups

None. The change is fully scoped to the regression introduced by #5024 in the same test module.

Refs #5024.