### PR TITLE
docs(hands): add Auto-Evolution Mode page (companion to registry#94)

### DIFF
--- a/docs/src/app/agent/auto-evolution/page.mdx
+++ b/docs/src/app/agent/auto-evolution/page.mdx
@@ -1,0 +1,219 @@
+# Auto-Evolution Mode
+
+Auto-Evolution Mode is an opt-in capability of the **DevOps Hand** that lets the daemon watch GitHub repositories on a schedule and act on what it finds without human prompting: review open pull requests, triage open issues, and produce draft pull requests that implement triaged bug fixes or feature requests via a Brainstorm → Architect → PRD → Implement (BMAD) pipeline.
+
+<Note>
+**Auto-evolution is not a separate Hand.** It is a Phase-7 extension of the existing DevOps Hand, sharing the same agents (coordinator, engineer, ops, code-reviewer) plus one new sub-agent (implementer). Activate it by flipping the DevOps Hand's `auto_evolve` setting to `true` — no extra install required once `librefang hand install devops` is done.
+</Note>
+
+## Table of Contents
+
+- [What it does](#what-it-does)
+- [Where it fits in the platform](#where-it-fits-in-the-platform)
+- [Setup](#setup)
+- [Required GitHub token scopes](#required-github-token-scopes)
+- [Configuration reference](#configuration-reference)
+- [Safety model](#safety-model)
+- [BMAD pipeline phases](#bmad-pipeline-phases)
+- [Observability](#observability)
+- [Troubleshooting](#troubleshooting)
+- [What it does NOT do](#what-it-does-not-do)
+
+---
+
+## What it does
+
+Every `evolution_check_interval` (default 15 min) the Hand wakes up and, for each `owner/repo` in `evolution_repos`:
+
+1. **Reviews open PRs** — pulls each PR's diff, asks the existing `code-reviewer` sub-agent for a structured verdict, posts a single `COMMENT` review (or `REQUEST_CHANGES` on blocking findings — never auto-`APPROVE`). PRs already reviewed at their current `head_sha` are skipped.
+2. **Triages open issues** — labels first (`bug` / `feature` / `question` / `wontfix`), single-prompt LLM fallback when labels are absent. Outcomes: `bug-fix | feature | needs-info | skip`.
+3. **Implements actionable issues** — dispatches `bug-fix` and `feature` issues to the `implementer` sub-agent, which runs the BMAD pipeline scaled by `bmad_strictness` and opens a **draft PR**.
+
+Bot-authored PRs (dependabot, renovate, etc.) get a token-cheap pass: recorded but not deeply reviewed. PRs with `> 200` changed files are surfaced for human review rather than spending tokens on a diff the reviewer can't usefully ground.
+
+---
+
+## Where it fits in the platform
+
+LibreFang ships three autonomous self-improvement subsystems. They are designed to complement each other, not duplicate:
+
+| Subsystem | Scope | Trigger | Output |
+|---|---|---|---|
+| **`auto_dream`** | Agent's own memory | Time + session-count gate, per-agent opt-in | Consolidated memory entries |
+| **`skill_workshop`** | Reusable workflows captured from agent turns | Post-turn hook, opt-in per agent | Candidate skill drafts in `~/.librefang/skills/pending/` |
+| **`auto_evolve`** (this page) | Source code in upstream repos | Cron gate inside DevOps Hand, opt-in per Hand instance | PR review comments + draft PRs |
+
+Together they form the platform's "code evolves" / "memory consolidates" / "workflows distill" triad. Each is independently gated and independently safe to disable. See `docs/architecture/skill-workshop.md` in the repo for the same pattern applied to skill capture.
+
+---
+
+## Setup
+
+The Hand definition lives in [`librefang/librefang-registry`](https://github.com/librefang/librefang-registry) under `hands/devops/`. Install, configure, and activate:
+
+```bash
+# 1. Install or update the DevOps Hand
+librefang hand install devops
+# or, if already installed:
+librefang hand update devops
+
+# 2. Provide a GitHub Personal Access Token (see scopes below)
+export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+# (Or write GITHUB_TOKEN=... to ~/.librefang/.env)
+
+# 3. Configure the four evolution settings
+librefang hand config devops auto_evolve=true
+librefang hand config devops evolution_repos=librefang/librefang,librefang/librefang-registry
+librefang hand config devops evolution_check_interval=15min
+librefang hand config devops bmad_strictness=standard
+# Optional: tighten or relax the per-PR file-touch budget
+librefang hand config devops max_changed_files=30
+
+# 4. Activate (or restart if already active)
+librefang hand activate devops
+```
+
+The full Hand-side config matrix (with each option's effect and default) is in the [`hands/devops/README.md`](https://github.com/librefang/librefang-registry/blob/main/hands/devops/README.md) of the registry. This page focuses on platform behaviour, not the Hand itself.
+
+---
+
+## Required GitHub token scopes
+
+For **public-repo evolution**, a fine-grained token needs:
+
+- **Pull requests** — read & write (posting reviews, opening draft PRs)
+- **Issues** — read & write (triage comments, cross-link comments on the source issue)
+- **Contents** — read & write (pushing the implementation branch)
+- **Metadata** — read (resolving `default_branch` for PR creation)
+
+For **private-repo evolution**, add the classic `repo` scope and ensure each target repo is listed in `evolution_repos`. Forks of public repos still count as private for token purposes if the fork is private.
+
+<Note>
+**Never store the PAT in `librefang.toml` or in a Hand setting.** Keep it in the `GITHUB_TOKEN` environment variable read at daemon start, or in `~/.librefang/.env`. The Hand's `shell_exec` calls reference `$GITHUB_TOKEN` directly so the token never lands in agent message history or memory.
+</Note>
+
+---
+
+## Configuration reference
+
+| Setting | Type | Default | Effect |
+|---|---|---|---|
+| `auto_evolve` | toggle | `false` | Master switch. When `false`, Phase 7 is skipped entirely on every tick. |
+| `evolution_repos` | text | `""` | Comma-separated `owner/repo` pairs. Empty disables the loop without needing to flip `auto_evolve`. |
+| `evolution_check_interval` | select | `15min` | Per-repo cadence. Values: `5min` / `15min` / `1hour` / `6hour` / `1day`. |
+| `bmad_strictness` | select | `standard` | Depth of the BMAD pipeline (see below). Values: `light` / `standard` / `strict`. |
+| `max_changed_files` | select | `30` | Hard cap on files touched by a single auto-generated draft PR. Larger work is split into multiple PRs. |
+| `approval_mode` | toggle (inherited) | `true` | When `true`, deployment-style and destructive actions go through `devops_queue.json` for human approval — this applies to evolution work too. |
+
+---
+
+## Safety model
+
+Auto-evolution operates under three layered guarantees that the operator cannot accidentally turn off:
+
+**1. Draft-only PRs.** Every PR the implementer creates is `draft: true`. The Hand never marks a PR ready-for-review and never merges. A human is always the one to flip the readiness flag and click merge.
+
+**2. No protected-branch writes.** The implementer never pushes to `main`, `master`, `trunk`, or any branch protected by a GitHub ruleset. It never uses `--force`, `--no-verify`, `--no-gpg-sign`, or `--amend` against a remote branch. Upstream pre-commit / pre-push / commit-msg hooks are discovered via `git config core.hooksPath` and honored — hook failure aborts the task rather than triggering a retry.
+
+**3. Path safety floor.** The implementer stops and writes to `devops_queue.json` (for human triage) rather than committing if the change would touch:
+
+- `Cargo.toml` workspace `members = [...]` entries
+- migration files (any `*/migrations/*`, `*/migrate/*`, or `*.sql`)
+- secrets (`.env*`, `*.pem`, `*.p12`, `id_rsa`, `id_ed25519`, `credentials*`, `secrets*`, `vault_*.key`)
+- more files than the `max_changed_files` setting allows (default 30)
+
+In addition, each evolution tick self-paces against ~70% of the per-turn token budget so subsequent ticks have headroom and a runaway pipeline can't starve the rest of the Hand.
+
+---
+
+## BMAD pipeline phases
+
+When the implementer is dispatched to an actionable issue (`bug-fix` or `feature`), it runs a four-phase pipeline whose depth scales with `bmad_strictness`:
+
+| Phase | `light` | `standard` | `strict` |
+|---|---|---|---|
+| **B**rainstorm | skip | inline (≤200 words) | inline + queue gate |
+| **A**rchitect | always | always | always + queue gate |
+| **P**RD | skip | required | required + queue gate |
+| **I**mplement | always | always | always |
+
+Each phase's output is appended to a `BMAD.md` file committed alongside the implementation so reviewers can see the reasoning that led to the diff.
+
+For bug fixes, the implement phase is **strictly test-first**: the failing reproduction test is committed *before* the fix, in the same PR. For features, tests land alongside the code.
+
+**Strict mode queue gate.** Between every phase, the implementer writes the produced artifact to `devops_queue.json` with `status: "pending"` and ends the current turn. The next continuous tick re-reads the queue; if the user (out-of-band) has flipped `status` to `approved`, the implementer resumes from the next phase. There is no in-turn polling or sleep — the queue persists across turns by design.
+
+---
+
+## Observability
+
+Three new metrics surface on the agent dashboard at `http://127.0.0.1:4545`:
+
+- **PRs Reviewed** — total successful review postings (`devops_hand_prs_reviewed`)
+- **Issues Processed** — total triaged issues, regardless of outcome (`devops_hand_issues_processed`)
+- **Draft PRs Opened** — total auto-generated draft PRs (`devops_hand_draft_prs_opened`)
+
+The Hand also publishes four advisory events that subscribers (dashboard, audit log, downstream Hands) can consume:
+
+| Event | Payload | When |
+|---|---|---|
+| `devops_evolution_pr_reviewed` | `{ pr_url, verdict, head_sha }` | After a PR review is posted |
+| `devops_evolution_pr_opened` | `{ pr_url, issue_url, classification }` | After a draft PR is created from an issue |
+| `devops_evolution_blocked` | `{ reason, pr_or_issue_url, retry_after }` | When a tick aborts (safety floor / API / hook) |
+| `devops_evolution_skipped` | `{ pr_or_issue_url, reason }` | When the cadence gate or filters skip an item |
+
+Per-PR / per-issue state lives in memory under keys like `devops_pr_review_<owner>_<repo>_<num>` and `devops_issue_state_<owner>_<repo>_<num>` so progress survives daemon restarts.
+
+---
+
+## Troubleshooting
+
+### "Nothing seems to be happening"
+
+Check, in order:
+
+1. **`auto_evolve` is actually on**: `librefang hand config devops` and confirm the setting reads `true`.
+2. **`evolution_repos` is non-empty** and the pairs are `owner/repo` (no leading `https://`, no trailing slash).
+3. **`GITHUB_TOKEN` is set in the daemon's environment**, not just your interactive shell. If you started the daemon before exporting the token, restart it.
+4. **The cadence gate hasn't fired yet** — check `devops_evolution_cursor_<owner>_<repo>` in memory; if `last_tick_at` is recent (`< evolution_check_interval` ago), the next tick is still in the future.
+
+### "Reviews are posted but with weird verdicts"
+
+The reviewer sub-agent returns one of `approve | request_changes | block | comment_only`. The mapping to GitHub review events is:
+
+- `approve` → posted as `COMMENT` (the Hand never auto-`APPROVE`s; a human still has to)
+- `request_changes` → `REQUEST_CHANGES`
+- `block` → `REQUEST_CHANGES` with a `**Reviewer flagged as BLOCKING — escalate to a maintainer**` prefix in the body
+- `comment_only` / anything unexpected → `COMMENT`
+
+If you're seeing `REQUEST_CHANGES` more often than expected, inspect the reviewer's `summary` in the GitHub review body or in memory under `devops_pr_review_<owner>_<repo>_<num>`.
+
+### "Draft PRs land but `cargo` checks fail in CI"
+
+The implementer runs the project's own lint/test gate locally before pushing (typically `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test -p <crate>`). A CI-only failure usually means:
+
+- the project gates CI on commands the implementer didn't run (custom integration tests, `xtask` jobs) — add them to the implementer's lint/test invocations via the project's `justfile` or a `CONTRIBUTING.md` runbook the agent can pick up
+- the implementer-local cache differs from CI's clean build — usually surfaces as a `Cargo.lock` regeneration the implementer didn't commit; the BMAD pipeline should always re-stage `Cargo.lock` after a dependency-affecting change
+
+### "The Hand wants to touch `Cargo.toml` / migrations / secrets and stops"
+
+That's the path safety floor doing its job. Inspect `devops_queue.json`; if the change is legitimately needed, manually take it from the queue, perform the edit out-of-band, and the implementer will pick up the next tick on a clean tree.
+
+### "Hooks reject the implementer's push"
+
+Most often the upstream repo enforces `Co-Authored-By: Claude` rejection or similar AI-attribution bans. The implementer's prompt forbids LLM-vendor attribution in commit messages, but process attribution (`Generated by DevOps Hand → implementer`) is fine and encouraged. If the upstream rejects the latter too, customize the implementer's commit-message template in the Hand definition — do not add `--no-verify` (the Hand's safety floor blocks it anyway).
+
+---
+
+## What it does NOT do
+
+To set realistic expectations:
+
+- It does **not** merge PRs. A human always merges.
+- It does **not** mark draft PRs as ready-for-review.
+- It does **not** push to `main` / `master` / protected branches.
+- It does **not** operate on private repos unless the configured PAT has `repo` scope and the repo is listed in `evolution_repos`.
+- It does **not** modify `Cargo.toml` workspace members, migration files, secrets, or > `max_changed_files` files in a single PR.
+- It does **not** consume more than ~70% of the per-turn token budget in a single tick.
+
+For the full Hand-level specification and the prompts each sub-agent runs, see the source: [`hands/devops/HAND.toml`](https://github.com/librefang/librefang-registry/blob/main/hands/devops/HAND.toml) and [`hands/devops/SKILL.md`](https://github.com/librefang/librefang-registry/blob/main/hands/devops/SKILL.md) in the registry.

--- a/docs/src/app/agent/hands/page.mdx
+++ b/docs/src/app/agent/hands/page.mdx
@@ -32,7 +32,7 @@ Hands are LibreFang's unique feature — they are autonomous agents that can:
 | **Browser** | Web automation via Playwright, mandatory purchase approval gate | Single-agent |
 | **Analytics** | Business analytics, KPI tracking, automated reporting | Multi-agent |
 | **ApiTester** | Automated API testing, contract validation, regression detection | Single-agent |
-| **DevOps** | CI/CD monitoring, deployment automation, infrastructure alerts | Multi-agent |
+| **DevOps** | CI/CD monitoring, deployment automation, infrastructure alerts, [auto-evolution](/agent/auto-evolution) (PR review + BMAD bug/feature pipeline) | Multi-agent |
 | **LinkedIn** | LinkedIn profile monitoring, outreach automation | Multi-agent |
 | **Reddit** | Reddit community monitoring, post scheduling, sentiment tracking | Multi-agent |
 | **Strategist** | Strategic analysis, competitive intelligence, scenario planning | Multi-agent |

--- a/docs/src/app/zh/agent/auto-evolution/page.mdx
+++ b/docs/src/app/zh/agent/auto-evolution/page.mdx
@@ -1,0 +1,219 @@
+# 自动进化模式
+
+自动进化模式（Auto-Evolution Mode）是 **DevOps Hand** 的可选能力：让 daemon 周期性地监视 GitHub 仓库并自主行动——review 打开的 PR、triage 打开的 issue，并通过 Brainstorm → Architect → PRD → Implement（BMAD）流水线，把已归类的 bug 修复或功能需求产出为草稿 PR。
+
+<Note>
+**它不是独立的 Hand。** 它是现有 DevOps Hand 的 Phase 7 扩展，共用同一套 sub-agent（coordinator、engineer、ops、code-reviewer），仅新增一个 implementer。激活方式：把 DevOps Hand 的 `auto_evolve` 设置改成 `true`——只要执行过 `librefang hand install devops`，就无需额外安装。
+</Note>
+
+## 目录
+
+- [它做什么](#它做什么)
+- [它在平台中的定位](#它在平台中的定位)
+- [安装与配置](#安装与配置)
+- [GitHub Token 权限](#github-token-权限)
+- [配置项参考](#配置项参考)
+- [安全模型](#安全模型)
+- [BMAD 流水线四阶段](#bmad-流水线四阶段)
+- [可观察性](#可观察性)
+- [故障排查](#故障排查)
+- [它不做什么](#它不做什么)
+
+---
+
+## 它做什么
+
+每过 `evolution_check_interval`（默认 15 分钟），Hand 进入 Phase 7，对 `evolution_repos` 里每个 `owner/repo` 对：
+
+1. **Review 打开的 PR** —— 拉 diff，调用现有的 `code-reviewer` sub-agent 生成结构化判定，把单条 `COMMENT` review（或对阻塞性问题用 `REQUEST_CHANGES`，绝不自动 `APPROVE`）发回 GitHub。当前 `head_sha` 已 review 过的 PR 自动跳过。
+2. **Triage 打开的 issue** —— 优先用 label（`bug` / `feature` / `question` / `wontfix`），label 缺失时回退到一次性单轮 LLM 分类。结果限定为 `bug-fix | feature | needs-info | skip`。
+3. **实现可行动的 issue** —— 把 `bug-fix` 与 `feature` 分发给 implementer sub-agent，跑 BMAD 流水线（深度由 `bmad_strictness` 决定）并提一个 **draft PR**。
+
+机器人作者（dependabot、renovate 等）的 PR 走 token-cheap 短路：记录但不做深度 review。变更超过 200 个文件的 PR 直接交人审，不浪费 token 去 review 一个 reviewer agent 根本 ground 不住的 diff。
+
+---
+
+## 它在平台中的定位
+
+LibreFang 内置三套自治型自我改进子系统，设计上互补不重复：
+
+| 子系统 | 作用域 | 触发 | 产出 |
+|---|---|---|---|
+| **`auto_dream`** | agent 自己的 memory | 时间 + 会话计数 gate，agent 级 opt-in | 整合后的 memory 条目 |
+| **`skill_workshop`** | 从 agent turn 里捕获可复用工作流 | turn 结束钩子，agent 级 opt-in | `~/.librefang/skills/pending/` 下的候选 skill |
+| **`auto_evolve`**（本页） | 上游 repo 的源代码 | DevOps Hand 内的 cron gate，Hand 实例级 opt-in | PR review 评论 + draft PR |
+
+三者构成平台「代码进化 / memory 整合 / 工作流提炼」三件套。每一个都可独立 gate、独立关闭。同样的设计模式可参考 `docs/architecture/skill-workshop.md`（应用在 skill 捕获上）。
+
+---
+
+## 安装与配置
+
+Hand 定义托管在 [`librefang/librefang-registry`](https://github.com/librefang/librefang-registry) 的 `hands/devops/` 目录。安装、配置、激活：
+
+```bash
+# 1. 安装或更新 DevOps Hand
+librefang hand install devops
+# 或，已安装时：
+librefang hand update devops
+
+# 2. 提供 GitHub Personal Access Token（权限见下节）
+export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+# 或在 ~/.librefang/.env 中写 GITHUB_TOKEN=...
+
+# 3. 配置 4 个进化相关设置
+librefang hand config devops auto_evolve=true
+librefang hand config devops evolution_repos=librefang/librefang,librefang/librefang-registry
+librefang hand config devops evolution_check_interval=15min
+librefang hand config devops bmad_strictness=standard
+# 可选：调整单 PR 文件改动上限
+librefang hand config devops max_changed_files=30
+
+# 4. 激活（已激活则重启）
+librefang hand activate devops
+```
+
+Hand 层面完整的配置矩阵（每个选项的作用与默认值）见 registry 的 [`hands/devops/README.md`](https://github.com/librefang/librefang-registry/blob/main/hands/devops/README.md)。本页聚焦平台行为，不重复 Hand 文档。
+
+---
+
+## GitHub Token 权限
+
+**公共仓库** —— fine-grained token 需要：
+
+- **Pull requests** —— read & write（发 review、开 draft PR）
+- **Issues** —— read & write（triage 评论、在原 issue 上交叉链接）
+- **Contents** —— read & write（推送实现分支）
+- **Metadata** —— read（解析 `default_branch` 用于建 PR）
+
+**私有仓库** —— 追加 classic `repo` 作用域，并确保目标 repo 在 `evolution_repos` 中显式列出。私有 fork 仍按私有仓库对待。
+
+<Note>
+**不要把 PAT 写进 `librefang.toml` 或 Hand 的 setting 字段。** 放在 daemon 启动时读取的 `GITHUB_TOKEN` 环境变量中，或写进 `~/.librefang/.env`。Hand 的 `shell_exec` 调用直接引用 `$GITHUB_TOKEN`，token 不会落到 agent 消息历史或 memory 里。
+</Note>
+
+---
+
+## 配置项参考
+
+| 设置 | 类型 | 默认 | 作用 |
+|---|---|---|---|
+| `auto_evolve` | toggle | `false` | 总开关。`false` 时 Phase 7 在每一 tick 完全跳过。 |
+| `evolution_repos` | text | `""` | 逗号分隔的 `owner/repo` 对。留空也能在不动 `auto_evolve` 的情况下停止循环。 |
+| `evolution_check_interval` | select | `15min` | 每个 repo 的扫描频率。可选 `5min` / `15min` / `1hour` / `6hour` / `1day`。 |
+| `bmad_strictness` | select | `standard` | BMAD 流水线深度（见下）。可选 `light` / `standard` / `strict`。 |
+| `max_changed_files` | select | `30` | 单个自动生成 draft PR 的文件改动上限。更大的工作量拆成多个 PR。 |
+| `approval_mode` | toggle（继承） | `true` | `true` 时部署性 / 破坏性动作进 `devops_queue.json` 待人审；同样作用于进化工作。 |
+
+---
+
+## 安全模型
+
+自动进化运行在三道无法被运维人员误关的护栏下：
+
+**1. 仅 draft PR。** implementer 创建的 PR 都是 `draft: true`。Hand 永不把 PR 标 ready-for-review，永不 merge。人始终是 ready 标识与合并按钮的唯一执行者。
+
+**2. 绝不写保护分支。** implementer 不向 `main`、`master`、`trunk` 或任何受 GitHub ruleset 保护的分支推送；不使用 `--force`、`--no-verify`、`--no-gpg-sign`、`--amend` 对远程分支操作。上游的 pre-commit / pre-push / commit-msg 钩子通过 `git config core.hooksPath` 发现并执行，钩子失败直接 abort 任务，不重试。
+
+**3. 路径安全底线。** 以下情况 implementer 不提交，而是写入 `devops_queue.json` 交人审：
+
+- `Cargo.toml` 中的 workspace `members = [...]` 改动
+- 迁移文件（任何 `*/migrations/*`、`*/migrate/*` 或 `*.sql`）
+- 秘密相关路径（`.env*`、`*.pem`、`*.p12`、`id_rsa`、`id_ed25519`、`credentials*`、`secrets*`、`vault_*.key`）
+- 超过 `max_changed_files`（默认 30）个文件
+
+此外每个进化 tick 主动控制在每 turn token 预算的约 70% 内，给后续 tick 留出 headroom，避免某次流水线狂飙拖死 Hand 其余工作。
+
+---
+
+## BMAD 流水线四阶段
+
+implementer 被分发到可行动 issue（`bug-fix` 或 `feature`）时，跑 4 阶段流水线，深度随 `bmad_strictness` 变化：
+
+| 阶段 | `light` | `standard` | `strict` |
+|---|---|---|---|
+| **B**rainstorm（构思） | 跳过 | 不超过 200 字 inline | inline + queue 卡口 |
+| **A**rchitect（架构） | 一直执行 | 一直执行 | 一直执行 + queue 卡口 |
+| **P**RD（验收标准） | 跳过 | 必须 | 必须 + queue 卡口 |
+| **I**mplement（实现） | 一直执行 | 一直执行 | 一直执行 |
+
+每阶段的产物追加到与实现一同提交的 `BMAD.md`，让 reviewer 看到推导出 diff 的过程。
+
+修 bug 时实现阶段 **严格 test-first**：可复现的失败测试在修复之前先 commit（在同一个 PR 内）。新功能时测试与代码同提。
+
+**strict 模式 queue 卡口。** 每阶段之间，implementer 把产物写进 `devops_queue.json`（`status: "pending"`），然后**结束当前 turn**。下一个 continuous tick 会重新读取 queue：若用户已 out-of-band 把 `status` 翻成 `approved`，从下一阶段继续；否则跳过这个 issue，下一 tick 再查。turn 内没有任何 polling 或 sleep——queue 设计上跨 turn 持久化。
+
+---
+
+## 可观察性
+
+dashboard（`http://127.0.0.1:4545`）新增三个指标：
+
+- **PRs Reviewed** —— 成功发出的 review 总数（`devops_hand_prs_reviewed`）
+- **Issues Processed** —— triage 过的 issue 总数，不论结果（`devops_hand_issues_processed`）
+- **Draft PRs Opened** —— 自动生成的 draft PR 总数（`devops_hand_draft_prs_opened`）
+
+Hand 同时发布 4 个 advisory 事件，订阅方（dashboard、审计日志、下游 Hand）可按需消费：
+
+| 事件名 | Payload | 触发时机 |
+|---|---|---|
+| `devops_evolution_pr_reviewed` | `{ pr_url, verdict, head_sha }` | review 发布之后 |
+| `devops_evolution_pr_opened` | `{ pr_url, issue_url, classification }` | 由 issue 产生的 draft PR 创建后 |
+| `devops_evolution_blocked` | `{ reason, pr_or_issue_url, retry_after }` | tick 被安全底线 / API / 钩子打断 |
+| `devops_evolution_skipped` | `{ pr_or_issue_url, reason }` | 频率 gate 或过滤器跳过条目 |
+
+每个 PR / issue 的状态存在 memory 中（`devops_pr_review_<owner>_<repo>_<num>` 与 `devops_issue_state_<owner>_<repo>_<num>` 等键），daemon 重启后进度仍在。
+
+---
+
+## 故障排查
+
+### 「没动静」
+
+按顺序查：
+
+1. **`auto_evolve` 真的开了吗** —— `librefang hand config devops` 看 setting 是否为 `true`。
+2. **`evolution_repos` 非空且格式正确** —— `owner/repo` 对，不带 `https://`，不带末尾斜杠。
+3. **`GITHUB_TOKEN` 在 daemon 的环境里**，不只是当前交互 shell。若 daemon 启动早于 export，重启 daemon。
+4. **频率 gate 还没到** —— 看 memory 中的 `devops_evolution_cursor_<owner>_<repo>`，若 `last_tick_at` 距现在还不到 `evolution_check_interval`，下一 tick 尚未到。
+
+### 「review 发出去了但 verdict 怪怪的」
+
+reviewer sub-agent 返回 `approve | request_changes | block | comment_only` 之一。GitHub 事件映射：
+
+- `approve` → 发为 `COMMENT`（Hand 永不自动 `APPROVE`，得由人来）
+- `request_changes` → `REQUEST_CHANGES`
+- `block` → `REQUEST_CHANGES`，body 前置 `**Reviewer flagged as BLOCKING — escalate to a maintainer**`
+- `comment_only` / 未知值 → `COMMENT`
+
+如果 `REQUEST_CHANGES` 比预期多，查 review body 里的 `summary` 字段或 memory 中的 `devops_pr_review_<owner>_<repo>_<num>`。
+
+### 「draft PR 提了但 CI 里 cargo 失败」
+
+implementer 推送前会跑本地 lint/test gate（通常是 `cargo clippy --workspace --all-targets -- -D warnings` 与 `cargo test -p <crate>`）。仅 CI 失败通常是：
+
+- 项目 CI 跑了 implementer 没跑的命令（自定义 integration、`xtask` 任务）—— 通过 `justfile` 或 `CONTRIBUTING.md` runbook 给 agent 看到这些命令
+- implementer 本地缓存与 CI 干净构建不同 —— 多半是 implementer 没 commit `Cargo.lock` 的再生成；BMAD 流水线在依赖相关改动后应重新 stage `Cargo.lock`
+
+### 「Hand 想动 `Cargo.toml` / migration / secrets 然后停下来了」
+
+是路径安全底线在工作。查 `devops_queue.json`；如果改动确实必要，手动从队列取出、out-of-band 完成编辑，implementer 下次 tick 会基于干净 tree 继续。
+
+### 「钩子拒绝 implementer 的 push」
+
+最常见的是上游禁止 `Co-Authored-By: Claude` 之类的 AI 归属。implementer 的 prompt 禁止 LLM 厂商归属（Claude / GPT / 🤖 等），但流程归属（`Generated by DevOps Hand → implementer`）允许，用于可追溯性。如果上游连后者也拒绝，定制 Hand 定义里的 commit-message 模板——**不要**加 `--no-verify`（Hand 的安全底线本身会拒绝）。
+
+---
+
+## 它不做什么
+
+为了设定合理预期：
+
+- **不** merge PR。永远人来 merge。
+- **不** 把 draft PR 标 ready-for-review。
+- **不** 推送 `main` / `master` / 保护分支。
+- **不** 处理私有 repo —— 除非 PAT 有 `repo` 作用域且 repo 在 `evolution_repos` 中。
+- **不** 改 `Cargo.toml` workspace members、迁移文件、秘密路径，或单 PR 改动超过 `max_changed_files`。
+- **不** 在单 tick 内消耗超过约 70% 每 turn token 预算。
+
+Hand 级完整规范与每个 sub-agent 的提示词源码：[`hands/devops/HAND.toml`](https://github.com/librefang/librefang-registry/blob/main/hands/devops/HAND.toml) 与 [`hands/devops/SKILL.md`](https://github.com/librefang/librefang-registry/blob/main/hands/devops/SKILL.md)，均在 registry 仓库里。

--- a/docs/src/app/zh/agent/hands/page.mdx
+++ b/docs/src/app/zh/agent/hands/page.mdx
@@ -32,7 +32,7 @@ Hands 是 LibreFang 的独特功能，它们是自主工作的 Agent，可以：
 | **Browser** | Web 自动化、Playwright、强制购买审批 | 单 Agent |
 | **Analytics** | 业务分析、KPI 追踪、自动化报告 | 多 Agent |
 | **ApiTester** | 自动化 API 测试、合约验证、回归检测 | 单 Agent |
-| **DevOps** | CI/CD 监控、部署自动化、基础设施告警 | 多 Agent |
+| **DevOps** | CI/CD 监控、部署自动化、基础设施告警、[自动进化](/zh/agent/auto-evolution)（PR review + BMAD bug/feature 流水线） | 多 Agent |
 | **LinkedIn** | LinkedIn 档案监控、外展自动化 | 多 Agent |
 | **Reddit** | Reddit 社区监控、帖子排期、情感追踪 | 多 Agent |
 | **Strategist** | 战略分析、竞争情报、场景规划 | 多 Agent |

--- a/docs/src/components/Navigation.tsx
+++ b/docs/src/components/Navigation.tsx
@@ -373,6 +373,7 @@ const zhNavigation: Array<NavGroup> = [
 		links: [
 			{ title: "Agent 模板", href: withPrefix("/zh/agent/templates") },
 			{ title: "自主 Hands", href: withPrefix("/zh/agent/hands") },
+			{ title: "自动进化模式", href: withPrefix("/zh/agent/auto-evolution") },
 			{ title: "内存系统", href: withPrefix("/zh/agent/memory") },
 			{ title: "技能开发", href: withPrefix("/zh/agent/skills") },
 			{ title: "插件开发", href: withPrefix("/zh/agent/plugins") },
@@ -475,6 +476,7 @@ export const enNavigation: Array<NavGroup> = [
 		links: [
 			{ title: "Agent Templates", href: withPrefix("/agent/templates") },
 			{ title: "Autonomous Hands", href: withPrefix("/agent/hands") },
+			{ title: "Auto-Evolution Mode", href: withPrefix("/agent/auto-evolution") },
 			{ title: "Memory System", href: withPrefix("/agent/memory") },
 			{ title: "Skills", href: withPrefix("/agent/skills") },
 			{ title: "Plugins", href: withPrefix("/agent/plugins") },


### PR DESCRIPTION
## Summary

Documents the new **Auto-Evolution Mode** capability that is being added to the DevOps Hand in [`librefang/librefang-registry#94`](https://github.com/librefang/librefang-registry/pull/94). The Hand-side definition (HAND.toml, SKILL.md, README) lives in the registry repo; this PR is the platform-side documentation that frames the feature alongside the existing self-improvement subsystems (`auto_dream`, `skill_workshop`) and provides setup, configuration, and troubleshooting guidance.

## New pages

- `docs/src/app/agent/auto-evolution/page.mdx` (EN)
- `docs/src/app/zh/agent/auto-evolution/page.mdx` (ZH)

Both pages cover:
- What auto-evolution does — PR review, issue triage, BMAD-style draft PR creation
- Platform positioning — the third "self-improvement triad" leg next to `auto_dream` (memory consolidation) and `skill_workshop` (workflow distillation)
- Setup walkthrough (`librefang hand install/config/activate`) with cross-links to the registry Hand README rather than duplication
- Required GitHub PAT scopes (Pull requests / Issues / Contents / Metadata; `repo` for private)
- Configuration matrix with effects and defaults
- Three-layer safety model (draft-only PRs / no protected-branch writes / path safety floor) with rationale
- BMAD phase scaling table (`light` / `standard` / `strict`)
- Strict-mode queue-gate semantics (turn-end then resume, no in-turn poll)
- Observability: 3 new dashboard metrics + 4 new advisory events
- 5 troubleshooting scenarios

## Nav + cross-link updates

- `docs/src/components/Navigation.tsx` — added "Auto-Evolution Mode" / "自动进化模式" entry to both EN and ZH Agent groups
- `docs/src/app/agent/hands/page.mdx` + `docs/src/app/zh/agent/hands/page.mdx` — the DevOps row in the Built-in Hands table now mentions auto-evolution and links to the new page

## Verification

- `pnpm typecheck` (tsc --noEmit) — **passed**
- `pnpm lint` (biome) — biome binary is not present in my local sandbox; will rely on CI. The Navigation.tsx change is two new array entries in the exact shape of the surrounding code, so any biome finding would be a style nit on existing patterns.
- The new MDX pages only use `<Note>` (existing component imported via `src/components/mdx.tsx`); no new component imports.

## Out of scope / deferred

- No actual end-to-end smoke test in a sandbox daemon — the Hand-side PR (registry#94) carries that. This PR is documentation only.
- No additional language translations beyond EN + ZH. The convention I'm following matches the rest of `docs/src/app/agent/*` which is EN+ZH only.

## Dependencies

- Should land **after** [`librefang/librefang-registry#94`](https://github.com/librefang/librefang-registry/pull/94) so the external links to `HAND.toml` / `SKILL.md` resolve on `main`. If that PR lands first, this one can be merged anytime. If reviewers want to merge this first, the external links will 404 briefly until registry#94 lands.