### PR TITLE
fix(ci): guard pr-status-labels filter against undefined check_run entries

### DIFF
--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -181,7 +181,15 @@ jobs:
               'Conflict Check', 'CI Status Check', 'PR Size',
               'Docs/CI Check', 'Review State',
             ]);
-            const externalRuns = allCheckRuns.filter(cr => !SELF_JOBS.has(cr.name));
+            // Guard against undefined / partial entries — `github.paginate`
+            // can surface items without a `name` when a transient API hiccup
+            // leaves `response.data.check_runs` shaped unexpectedly on one
+            // page. Without the guard, the next line crashed on main
+            // b7b39ee1 with `TypeError: Cannot read properties of undefined
+            // (reading 'name')` (run 25899402530) and the whole job failed.
+            const externalRuns = allCheckRuns.filter(
+              cr => cr && cr.name && !SELF_JOBS.has(cr.name),
+            );
 
             const hasFailure = externalRuns.some(
               cr => cr.conclusion === 'failure' || cr.conclusion === 'timed_out'


### PR DESCRIPTION
## Summary

The `CI Status Check` job in `.github/workflows/pr-status-labels.yml` crashed on main `b7b39ee1` (run [25899402530](https://github.com/librefang/librefang/actions/runs/25899402530/job/76119363187)) with:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'name')
  at eval ...<anonymous>:55:66
  at Array.filter
\`\`\`

The offending call (current main, line 184):
\`\`\`js
const externalRuns = allCheckRuns.filter(cr => !SELF_JOBS.has(cr.name));
\`\`\`

`github.paginate` of `checks.listForRef` can surface entries lacking a `name` when a transient API hiccup leaves `response.data.check_runs` shaped unexpectedly on one page. The filter then dereferences `undefined` and the whole job dies — which blocks the `ci-failed` / `ready-for-review` label sync for every open PR routed through that commit.

Add a defensive `cr && cr.name &&` predicate to the filter so a single malformed page no longer takes the label sync down with it.

## Test plan

- [ ] Workflow YAML lint passes
- [ ] Job re-runs cleanly on the next push to main / sync event
- [ ] `ci-failed` / `ready-for-review` labels resume updating

🚨 No way to reproduce the transient API condition locally; the fix is defensive and a strict superset of the prior behaviour (anything previously kept by the filter is still kept; only `undefined` / nameless entries are now skipped).