### PR TITLE
feat(runtime,skills): on-demand tool/skill loading

### DIFF
--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -555,6 +555,12 @@ impl LibreFangKernel {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             let agent_id_str = agent_id.0.to_string();
+            // One pass over `tools` produces both the name list (for the
+            // hook payload + `PromptContext::granted_tools`) and the
+            // description hint map (for `PromptContext::granted_tool_hints`).
+            // Avoids three separate walks per send (#4805 review).
+            let (granted_tool_names, granted_tool_hints) =
+                librefang_runtime::prompt_builder::collect_granted_tool_names_and_hints(&tools);
             let hook_ctx = librefang_runtime::hooks::HookContext {
                 agent_name: &manifest.name,
                 agent_id: agent_id_str.as_str(),
@@ -567,7 +573,7 @@ impl LibreFangKernel {
                     "channel_type": sender_context.map(|s| s.channel.clone()),
                     "is_group": sender_context.map(|s| s.is_group).unwrap_or(false),
                     "is_subagent": is_subagent_flag,
-                    "granted_tools": tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+                    "granted_tools": granted_tool_names,
                 }),
             };
             let dynamic_sections = self.governance.hooks.collect_prompt_sections(&hook_ctx);
@@ -589,10 +595,8 @@ impl LibreFangKernel {
                 agent_name: manifest.name.clone(),
                 agent_description: manifest.description.clone(),
                 base_system_prompt: manifest.model.system_prompt.clone(),
-                granted_tools: tools.iter().map(|t| t.name.clone()).collect(),
-                granted_tool_hints: librefang_runtime::prompt_builder::build_granted_tool_hints(
-                    &tools,
-                ),
+                granted_tools: granted_tool_names,
+                granted_tool_hints,
                 recalled_memories: vec![], // Recalled in agent_loop, not here
                 skill_summary: skill_meta
                     .as_ref()

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -590,6 +590,9 @@ impl LibreFangKernel {
                 agent_description: manifest.description.clone(),
                 base_system_prompt: manifest.model.system_prompt.clone(),
                 granted_tools: tools.iter().map(|t| t.name.clone()).collect(),
+                granted_tool_hints: librefang_runtime::prompt_builder::build_granted_tool_hints(
+                    &tools,
+                ),
                 recalled_memories: vec![], // Recalled in agent_loop, not here
                 skill_summary: skill_meta
                     .as_ref()

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -456,6 +456,12 @@ impl LibreFangKernel {
                 .map(|w| self.cached_workspace_metadata(w, manifest.autonomous.is_some()));
 
             let agent_id_str = agent_id.0.to_string();
+            // One pass over `tools` produces both the name list (for the
+            // hook payload + `PromptContext::granted_tools`) and the
+            // description hint map (for `PromptContext::granted_tool_hints`).
+            // Avoids three separate walks per send (#4805 review).
+            let (granted_tool_names, granted_tool_hints) =
+                librefang_runtime::prompt_builder::collect_granted_tool_names_and_hints(&tools);
             let hook_ctx = librefang_runtime::hooks::HookContext {
                 agent_name: &manifest.name,
                 agent_id: agent_id_str.as_str(),
@@ -465,7 +471,7 @@ impl LibreFangKernel {
                     "call_site": "ephemeral",
                     "user_message": message,
                     "is_subagent": false,
-                    "granted_tools": tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+                    "granted_tools": granted_tool_names,
                 }),
             };
             let dynamic_sections = self.governance.hooks.collect_prompt_sections(&hook_ctx);
@@ -490,10 +496,8 @@ impl LibreFangKernel {
                 agent_name: manifest.name.clone(),
                 agent_description: manifest.description.clone(),
                 base_system_prompt: manifest.model.system_prompt.clone(),
-                granted_tools: tools.iter().map(|t| t.name.clone()).collect(),
-                granted_tool_hints: librefang_runtime::prompt_builder::build_granted_tool_hints(
-                    &tools,
-                ),
+                granted_tools: granted_tool_names,
+                granted_tool_hints,
                 recalled_memories: vec![],
                 skill_summary: String::new(),
                 skill_count: 0,
@@ -2081,6 +2085,12 @@ impl LibreFangKernel {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             let agent_id_str = agent_id.0.to_string();
+            // One pass over `tools` produces both the name list (for the
+            // hook payload + `PromptContext::granted_tools`) and the
+            // description hint map (for `PromptContext::granted_tool_hints`).
+            // Avoids three separate walks per send (#4805 review).
+            let (granted_tool_names, granted_tool_hints) =
+                librefang_runtime::prompt_builder::collect_granted_tool_names_and_hints(&tools);
             let hook_ctx = librefang_runtime::hooks::HookContext {
                 agent_name: &manifest.name,
                 agent_id: agent_id_str.as_str(),
@@ -2093,7 +2103,7 @@ impl LibreFangKernel {
                     "channel_type": sender_context.map(|s| s.channel.clone()),
                     "is_group": sender_context.map(|s| s.is_group).unwrap_or(false),
                     "is_subagent": is_subagent_flag,
-                    "granted_tools": tools.iter().map(|t| t.name.clone()).collect::<Vec<_>>(),
+                    "granted_tools": granted_tool_names,
                 }),
             };
             let dynamic_sections = self.governance.hooks.collect_prompt_sections(&hook_ctx);
@@ -2113,10 +2123,8 @@ impl LibreFangKernel {
                 agent_name: manifest.name.clone(),
                 agent_description: manifest.description.clone(),
                 base_system_prompt: manifest.model.system_prompt.clone(),
-                granted_tools: tools.iter().map(|t| t.name.clone()).collect(),
-                granted_tool_hints: librefang_runtime::prompt_builder::build_granted_tool_hints(
-                    &tools,
-                ),
+                granted_tools: granted_tool_names,
+                granted_tool_hints,
                 recalled_memories: vec![],
                 skill_summary: skill_meta
                     .as_ref()

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -491,6 +491,9 @@ impl LibreFangKernel {
                 agent_description: manifest.description.clone(),
                 base_system_prompt: manifest.model.system_prompt.clone(),
                 granted_tools: tools.iter().map(|t| t.name.clone()).collect(),
+                granted_tool_hints: librefang_runtime::prompt_builder::build_granted_tool_hints(
+                    &tools,
+                ),
                 recalled_memories: vec![],
                 skill_summary: String::new(),
                 skill_count: 0,
@@ -2111,6 +2114,9 @@ impl LibreFangKernel {
                 agent_description: manifest.description.clone(),
                 base_system_prompt: manifest.model.system_prompt.clone(),
                 granted_tools: tools.iter().map(|t| t.name.clone()).collect(),
+                granted_tool_hints: librefang_runtime::prompt_builder::build_granted_tool_hints(
+                    &tools,
+                ),
                 recalled_memories: vec![],
                 skill_summary: skill_meta
                     .as_ref()

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -115,6 +115,20 @@ pub struct PromptContext {
     pub base_system_prompt: String,
     /// Tool names this agent has access to.
     pub granted_tools: Vec<String>,
+    /// Per-tool short description hint, keyed by tool name. Populated by the
+    /// kernel from each `ToolDefinition.description` so the lazy-mode catalog
+    /// (#4805) can surface MCP and skill tools with their own descriptions
+    /// instead of bare names. Builtin tools fall back to the curated
+    /// [`tool_hint`] table — that table is the source of truth for builtins
+    /// because their descriptions are tuned for the catalog's compact format.
+    /// Empty by default for backwards compatibility with the legacy
+    /// names-only catalog.
+    ///
+    /// `BTreeMap` because anything that reaches the LLM prompt must iterate
+    /// deterministically (#3298). Today the catalog iterates `granted_tools`
+    /// directly, but using a `BTreeMap` here keeps the map's own iteration
+    /// order stable in case future call sites surface it directly.
+    pub granted_tool_hints: std::collections::BTreeMap<String, String>,
     /// Recalled memories as (key, content) pairs.
     pub recalled_memories: Vec<(String, String)>,
     /// Skill summary text (from kernel.build_skill_summary()).
@@ -221,7 +235,7 @@ pub fn build_system_prompt(ctx: &PromptContext) -> String {
     }
 
     // Section 3 — Available Tools (always present if tools exist)
-    let tools_section = build_tools_section(&ctx.granted_tools);
+    let tools_section = build_tools_section_with_hints(&ctx.granted_tools, &ctx.granted_tool_hints);
     if !tools_section.is_empty() {
         sections.push(tools_section);
     }
@@ -470,25 +484,50 @@ code blocks — always call the tool instead.";
 
 /// Build the grouped tools section (Section 3).
 ///
+/// Backwards-compatible shim around [`build_tools_section_with_hints`]
+/// that supplies an empty hint map. Builtin tools still get their hints
+/// from the curated [`tool_hint`] table; MCP and skill tools render as
+/// bare names. Prefer the `_with_hints` variant when descriptions are
+/// available — see #4805.
+pub fn build_tools_section(granted_tools: &[String]) -> String {
+    build_tools_section_with_hints(granted_tools, &std::collections::BTreeMap::new())
+}
+
+/// Build the grouped tools section (Section 3) with per-tool description hints.
+///
+/// `granted_tool_hints` maps tool name → short description (typically
+/// `ToolDefinition.description` truncated to one line). Used as a fallback
+/// hint source for tools the builtin [`tool_hint`] table doesn't know about
+/// (MCP servers, skill-provided tools). Builtin hints take priority because
+/// they're already tuned for the compact catalog format.
+///
 /// When `tool_load` appears in `granted_tools`, the section is framed as a
 /// lazy-load catalog: only a handful of tools carry full JSON schemas in the
 /// request (see [`tool_runner::ALWAYS_NATIVE_TOOLS`]) and the rest are
-/// listed by name so the LLM can call `tool_load(name)` before using them.
-/// This keeps per-turn request payload ~1.5k tokens instead of ~6k when the
-/// agent has access to the full builtin catalog (issue #3044).
-pub fn build_tools_section(granted_tools: &[String]) -> String {
+/// listed by name + short hint so the LLM can call `tool_load(name)` before
+/// using them. Issue #4805 extends this to MCP and skill tools, which
+/// previously appeared as bare names with no description for the LLM to
+/// pick from.
+pub fn build_tools_section_with_hints(
+    granted_tools: &[String],
+    granted_tool_hints: &std::collections::BTreeMap<String, String>,
+) -> String {
     if granted_tools.is_empty() {
         return String::new();
     }
 
     let lazy_mode = granted_tools.iter().any(|t| t == "tool_load");
 
-    // Group tools by category
-    let mut groups: std::collections::BTreeMap<&str, Vec<(&str, &str)>> =
+    // Group tools by category. Owned `String` for the hint so we can carry
+    // either the static curated hint or a sanitised one from the hint map
+    // without lifetime gymnastics — `granted_tools` is on the small side
+    // (median ~30) so the per-name allocation is dwarfed by the prompt
+    // build's other allocations.
+    let mut groups: std::collections::BTreeMap<&str, Vec<(&str, String)>> =
         std::collections::BTreeMap::new();
     for name in granted_tools {
         let cat = tool_category(name);
-        let hint = tool_hint(name);
+        let hint = resolve_tool_hint(name, granted_tool_hints);
         groups.entry(cat).or_default().push((name.as_str(), hint));
     }
 
@@ -1179,6 +1218,72 @@ pub fn tool_hint(name: &str) -> &'static str {
 
         _ => "",
     }
+}
+
+/// Build a [`PromptContext::granted_tool_hints`] map from a slice of
+/// `ToolDefinition`s, indexing each tool's description by its name. Used by
+/// the kernel to populate the lazy-mode catalog hints for MCP and skill
+/// tools (#4805); builtins fall back to the curated [`tool_hint`] table at
+/// render time so this map's values for them are ignored.
+///
+/// Skips tools whose description is empty so the map stays cheap to clone.
+pub fn build_granted_tool_hints(
+    tools: &[librefang_types::tool::ToolDefinition],
+) -> std::collections::BTreeMap<String, String> {
+    let mut out = std::collections::BTreeMap::new();
+    for t in tools {
+        if t.description.is_empty() {
+            continue;
+        }
+        out.insert(t.name.clone(), t.description.clone());
+    }
+    out
+}
+
+/// Maximum length of a description hint pulled from `granted_tool_hints`
+/// in the system prompt's tool catalog (#4805).
+///
+/// 80 chars is roughly one console line and matches the longest hand-written
+/// hints in [`tool_hint`]. Anything longer would either wrap awkwardly in
+/// the rendered prompt or burn tokens on detail the LLM can fetch with
+/// `tool_load` once it actually wants the tool.
+const TOOL_HINT_MAX_CHARS: usize = 80;
+
+/// Look up a per-tool catalog hint, preferring the curated builtin table.
+///
+/// Resolution order:
+/// 1. [`tool_hint`] — hand-tuned one-liners for builtin tools.
+/// 2. `granted_tool_hints[name]` — typically `ToolDefinition.description`
+///    surfaced by the kernel for MCP and skill tools (#4805). The first
+///    sentence is extracted and truncated to [`TOOL_HINT_MAX_CHARS`] so
+///    long marketplace-style descriptions don't bloat the prompt.
+///
+/// Returns an empty `String` when neither source has anything — the
+/// catalog renderer treats that as "name only".
+fn resolve_tool_hint(
+    name: &str,
+    granted_tool_hints: &std::collections::BTreeMap<String, String>,
+) -> String {
+    let curated = tool_hint(name);
+    if !curated.is_empty() {
+        return curated.to_string();
+    }
+    let Some(desc) = granted_tool_hints.get(name) else {
+        return String::new();
+    };
+    // Take the first sentence-ish unit so we get the headline, not the API
+    // contract. Split on `. ` rather than `.` to keep file extensions and
+    // version numbers intact in the snippet.
+    let first_clause = desc
+        .split_once(". ")
+        .map(|(head, _)| head)
+        .unwrap_or(desc.as_str())
+        .trim()
+        .trim_end_matches('.');
+    if first_clause.is_empty() {
+        return String::new();
+    }
+    cap_str(first_clause, TOOL_HINT_MAX_CHARS)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -124,10 +124,7 @@ pub struct PromptContext {
     /// Empty by default for backwards compatibility with the legacy
     /// names-only catalog.
     ///
-    /// `BTreeMap` because anything that reaches the LLM prompt must iterate
-    /// deterministically (#3298). Today the catalog iterates `granted_tools`
-    /// directly, but using a `BTreeMap` here keeps the map's own iteration
-    /// order stable in case future call sites surface it directly.
+    /// `BTreeMap` so future direct iterations stay deterministic (#3298).
     pub granted_tool_hints: std::collections::BTreeMap<String, String>,
     /// Recalled memories as (key, content) pairs.
     pub recalled_memories: Vec<(String, String)>,
@@ -1227,6 +1224,11 @@ pub fn tool_hint(name: &str) -> &'static str {
 /// render time so this map's values for them are ignored.
 ///
 /// Skips tools whose description is empty so the map stays cheap to clone.
+///
+/// Duplicate `name` entries: `BTreeMap::insert` is last-write-wins, so when
+/// two `ToolDefinition`s share a name the latter's description survives. The
+/// names `Vec` returned by [`collect_granted_tool_names_and_hints`] still
+/// preserves both occurrences in input order — only the hint map dedupes.
 pub fn build_granted_tool_hints(
     tools: &[librefang_types::tool::ToolDefinition],
 ) -> std::collections::BTreeMap<String, String> {
@@ -1238,6 +1240,31 @@ pub fn build_granted_tool_hints(
         out.insert(t.name.clone(), t.description.clone());
     }
     out
+}
+
+/// Single-pass companion to [`build_granted_tool_hints`] that produces both
+/// the `granted_tools` name list and the `granted_tool_hints` map in one
+/// walk over `tools`. Kernel call sites use this to avoid walking the slice
+/// twice per send (once for the `PromptContext::granted_tools` `Vec`, once
+/// for the description map).
+///
+/// The returned `Vec<String>` preserves the input order of `tools` (including
+/// duplicates); the `BTreeMap` is last-write-wins on duplicate names, matching
+/// [`build_granted_tool_hints`] semantics. Tools with an empty description
+/// are still listed in the names `Vec` but skipped in the hints map so the
+/// catalog renderer falls through to bare-name rendering for them.
+pub fn collect_granted_tool_names_and_hints(
+    tools: &[librefang_types::tool::ToolDefinition],
+) -> (Vec<String>, std::collections::BTreeMap<String, String>) {
+    let mut names = Vec::with_capacity(tools.len());
+    let mut hints = std::collections::BTreeMap::new();
+    for t in tools {
+        names.push(t.name.clone());
+        if !t.description.is_empty() {
+            hints.insert(t.name.clone(), t.description.clone());
+        }
+    }
+    (names, hints)
 }
 
 /// Maximum length of a description hint pulled from `granted_tool_hints`
@@ -1283,7 +1310,12 @@ fn resolve_tool_hint(
     if first_clause.is_empty() {
         return String::new();
     }
-    cap_str(first_clause, TOOL_HINT_MAX_CHARS)
+    // Collapse embedded `\n` / `\r` into spaces so a multi-line marketplace
+    // description renders as a single-line catalog hint. Without this, a CR
+    // or LF inside the first clause would break the `name (hint)` row visual
+    // grouping and inflate the prompt's effective line count.
+    let single_line = first_clause.replace(['\n', '\r'], " ");
+    cap_str(&single_line, TOOL_HINT_MAX_CHARS)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4805

## Problem

Issue #4805 calls out 167 tool definitions / ~50k tokens per LLM call when an instance has many MCP servers and skills installed. The lazy-loading skeleton from #3044 already trims the eager schema list to a small always-native subset (`ALWAYS_NATIVE_TOOLS`, ~20 tools) and exposes `tool_search` / `tool_load` so the LLM can pull a tool's full schema on demand — but the catalog rendered in the system prompt was missing one-line descriptions for MCP and skill tools, leaving the LLM with bare names like `mcp_github_search_repositories` and no clue what each one does. That defeats the catalog's purpose: the LLM can't pick the right tool to `tool_load` from names alone.

## Approach

Surface each granted tool's `ToolDefinition.description` into the lazy-mode catalog by plumbing a `BTreeMap<String, String>` of name → description through `PromptContext`. The catalog renderer consults this map only when the curated builtin `tool_hint` table has nothing, so builtins keep their hand-tuned compact one-liners and MCP / skill tools finally get their own descriptions. Descriptions are clipped to the first sentence and 80 chars so a verbose marketplace description doesn't bloat the system prompt.

No agent-loop / tool-runner changes — the `tool_search` / `tool_load` meta-tools and the per-session `session_loaded_tools` cache already work for MCP and skill tools (verified by existing `test_tool_meta_load_resolves_non_builtin_from_available_tools`).

## Surface change

- `librefang_runtime::prompt_builder::PromptContext` gains
  `granted_tool_hints: BTreeMap<String, String>`. `Default` initialises it
  empty so existing callers compile unchanged but render the legacy
  bare-name catalog for MCP / skill tools.
- New public helpers:
  - `build_granted_tool_hints(&[ToolDefinition])` — kernel-side constructor.
  - `build_tools_section_with_hints(&[String], &BTreeMap<...>)` — the
    renderer the system prompt builder now uses. Old
    `build_tools_section(&[String])` remains as a backwards-compatible
    shim that forwards an empty map.
- Kernel call sites (`messaging.rs` × 2, `agent_execution.rs` × 1) populate
  the new field from each call's `tools` slice.

## Verification

- [x] `LIBREFANG_MOUNT_BASE=/Volumes/Lexar LIBREFANG_RUST_IMAGE=librefang-rust-dev:latest cargo check --workspace --lib` — clean
- [x] `cargo clippy -p librefang-runtime -p librefang-kernel --lib -- -D warnings` — clean
  (workspace-wide `cargo clippy --all-targets` fails on pre-existing breakage in
  `librefang-llm-drivers/tests/common/mod.rs` and `librefang-runtime/tests/mcp_oauth_integration.rs`
  on `origin/main` — verified unrelated by re-running with the changes stashed.)
- [x] `cargo test -p librefang-runtime --lib` — 1714 passed, 0 failed (including 6 new prompt_builder tests)
- [x] `cargo test -p librefang-kernel --lib` — 954 passed, 0 failed
- [x] `cargo fmt --check` — clean on the three modified files

New tests in `crates/librefang-runtime/src/prompt_builder.rs`:

- `test_catalog_surfaces_mcp_and_skill_hints_from_descriptions`
- `test_catalog_curated_hint_wins_over_description`
- `test_catalog_truncates_long_hints`
- `test_legacy_build_tools_section_renders_bare_names_for_mcp`
- `test_build_granted_tool_hints_indexes_descriptions`
- `test_full_prompt_renders_mcp_hint_in_catalog`

## Deferred to follow-up

- Counting only non-builtin tools for the lazy-mode threshold so an agent with 30 builtins + 100 MCP tools doesn't fall under the cutoff. The current `LAZY_TOOLS_THRESHOLD = 30` triggers on total count, which the #3044 doc-comment justifies for the original use case. Changing the trigger metric is a behaviour change worth its own PR with cache-impact analysis. The catalog improvements in this PR are independent of that knob.
- Per-tool `mcp_*_summary` carved out of MCP server `instructions` so MCP descriptions in the catalog can be more aggressive than just the first sentence. Today's MCP descriptions are usually fine; if not, the right fix is upstream at the MCP server, not in the catalog renderer.