### PR TITLE
fix(vault): unify init() key resolution with resolve_master_key()

### DIFF
--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -288,6 +288,20 @@ impl CredentialVault {
     }
 
     /// Initialize a new vault. Generates a master key and stores it in the OS keyring.
+    ///
+    /// Key resolution shares the exact same path as [`Self::resolve_master_key`]
+    /// (env var → OS keyring) so that a subsequent `unlock()` on a fresh
+    /// `CredentialVault` over the same file is guaranteed to read the same
+    /// master-key bytes init wrote with. Pre-fix #5069 the two sites
+    /// duplicated the env / keyring lookup code, so a daemon process that
+    /// hit a corner case in one but not the other (e.g. a trailing
+    /// whitespace tolerance, a Zeroizing-vs-String temporary lifetime that
+    /// the optimizer treated differently) would write a file the same
+    /// process could not decrypt one call later — surfacing as an
+    /// `aead::Error` on the second `vault_set` from the MCP OAuth handler.
+    /// Only the "no key available anywhere" branch generates a random key;
+    /// that branch falls through to `store_keyring_key` so the next
+    /// `resolve_master_key` finds the same value via the keyring path.
     pub fn init(&mut self) -> ExtensionResult<()> {
         if self.path.exists() {
             return Err(ExtensionError::Vault(
@@ -295,37 +309,42 @@ impl CredentialVault {
             ));
         }
 
-        // Check if a master key is already available (env var or keyring)
-        let key_bytes = if let Ok(existing_b64) = std::env::var(VAULT_KEY_ENV) {
-            // Use the existing key from env var
-            info!("Using existing vault key from {}", VAULT_KEY_ENV);
-            decode_master_key(&existing_b64)?
-        } else if let Ok(existing_b64) = load_keyring_key() {
-            info!("Using existing vault key from OS keyring");
-            decode_master_key(&existing_b64)?
-        } else {
-            // Generate a random master key
-            let mut kb = Zeroizing::new([0u8; 32]);
-            OsRng.fill_bytes(kb.as_mut());
-            let key_b64 = Zeroizing::new(base64::Engine::encode(
-                &base64::engine::general_purpose::STANDARD,
-                kb.as_ref(),
-            ));
+        // Resolve the master key through the SAME code path used by
+        // unlock-time `resolve_master_key`, so a freshly-init'd vault is
+        // always decryptable by the next `unlock()` on a separate instance
+        // (the MCP OAuth handler's vault_set pattern in #5069).
+        // `cached_key` is None here (we just constructed `self` or a prior
+        // op left it cleared), so this call falls through to env → keyring.
+        let key_bytes = match self.resolve_master_key() {
+            Ok(k) => k,
+            Err(ExtensionError::VaultLocked) => {
+                // No master key resolvable anywhere — generate a random
+                // one and persist it to the OS keyring (or file fallback)
+                // so subsequent `resolve_master_key` calls on fresh
+                // instances find the same value.
+                let mut kb = Zeroizing::new([0u8; 32]);
+                OsRng.fill_bytes(kb.as_mut());
+                let key_b64 = Zeroizing::new(base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    kb.as_ref(),
+                ));
 
-            // Try to store in OS keyring
-            match store_keyring_key(&key_b64) {
-                Ok(()) => {
-                    info!("Vault master key stored in OS keyring");
+                // Try to store in OS keyring (or file fallback)
+                match store_keyring_key(&key_b64) {
+                    Ok(()) => {
+                        info!("Vault master key stored in OS keyring");
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Could not store vault key in OS keyring: {e}. \
+                             Set {VAULT_KEY_ENV} env var manually. \
+                             Use `librefang vault init` interactively to retrieve the key.",
+                        );
+                    }
                 }
-                Err(e) => {
-                    warn!(
-                        "Could not store vault key in OS keyring: {e}. \
-                         Set {VAULT_KEY_ENV} env var manually. \
-                         Use `librefang vault init` interactively to retrieve the key.",
-                    );
-                }
+                kb
             }
-            kb
+            Err(other) => return Err(other),
         };
 
         // Create empty vault file with the startup sentinel pre-written
@@ -339,6 +358,35 @@ impl CredentialVault {
         );
         self.unlocked = true;
         self.save(&key_bytes)?;
+
+        // Post-write verification (#5069): immediately confirm the file we
+        // just persisted is decryptable by a fresh `CredentialVault::new`
+        // instance walking the unlock path — i.e. the exact code path the
+        // next `KernelOAuthProvider::vault_set` call from the MCP OAuth
+        // handler will take. Catches any latent init/unlock divergence at
+        // the source (clear, actionable error) rather than letting the
+        // next caller fail with an opaque `aead::Error`. Constructing a
+        // sibling instance (instead of just re-resolving the key) also
+        // catches a path-binding regression where AAD would differ between
+        // save and load.
+        let mut verify = CredentialVault::new(self.path.clone());
+        if let Err(e) = verify.unlock() {
+            // Roll back the freshly-written file so the next `init()`
+            // attempt isn't blocked by the "Vault already exists" guard
+            // against a file that can't be opened.
+            let _ = std::fs::remove_file(&self.path);
+            return Err(ExtensionError::Vault(format!(
+                "Vault init succeeded on disk but the freshly-written file \
+                 cannot be decrypted by a fresh CredentialVault::unlock() \
+                 — the same code path subsequent vault_set calls will \
+                 walk. This means init() and resolve_master_key() resolved \
+                 different master keys; LIBREFANG_VAULT_KEY may have \
+                 changed during init or the OS keyring returned an \
+                 unexpected value. Underlying error: {e}"
+            )));
+        }
+        drop(verify);
+
         self.cached_key = Some(key_bytes);
         info!("Credential vault initialized at {:?}", self.path);
         Ok(())
@@ -2944,6 +2992,90 @@ mod tests {
             matches!(err, ExtensionError::VaultLocked),
             "expected VaultLocked, got: {err:?}"
         );
+
+        unsafe {
+            std::env::remove_var(VAULT_KEY_ENV);
+            std::env::remove_var(VAULT_NO_KEYRING_ENV);
+        }
+    }
+
+    /// Regression for #5069: when a daemon process explicitly calls `init()`
+    /// followed by `set()` on one handle, then drops the handle and tries to
+    /// `unlock()` a fresh handle on the same file using the env-supplied
+    /// master key, the unlock MUST succeed.
+    ///
+    /// The MCP OAuth `auth_start` handler hits this pattern when it stores
+    /// `pkce_verifier`, then `pkce_state`, then `redirect_uri` in sequence:
+    /// the first call walks the `init() + set()` branch, every subsequent
+    /// call walks the `unlock() + set()` branch against a fresh
+    /// `CredentialVault` instance constructed inside `KernelOAuthProvider::vault_set`.
+    /// Pre-fix the second call's `unlock()` failed with `aead::Error` because
+    /// `init()` duplicated the env / keyring lookup code from
+    /// `resolve_master_key()`. The two sites could resolve different master
+    /// keys on container hosts (keyring side effects, env-mutation races
+    /// from other code paths), leaving a file the same process could not
+    /// decrypt one call later. The fix routes init's key resolution through
+    /// `resolve_master_key()` and adds a post-write verification so any
+    /// future divergence fails fast at init time with an actionable error
+    /// instead of an opaque AEAD failure downstream.
+    #[test]
+    #[serial_test::serial]
+    fn init_then_set_then_reopen_unlock_via_env_key() {
+        const TEST_VAULT_KEY_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+        unsafe {
+            std::env::set_var(VAULT_KEY_ENV, TEST_VAULT_KEY_B64);
+            std::env::set_var(VAULT_NO_KEYRING_ENV, "1");
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vault.enc");
+
+        // Mirror `KernelOAuthProvider::vault_set` on a first call: fresh
+        // handle, file absent → init(), then set().
+        {
+            let mut vault = CredentialVault::new(path.clone());
+            assert!(!vault.exists());
+            vault.init().expect("init() with env key must succeed");
+            assert!(vault.exists());
+            vault
+                .set(
+                    "pkce_verifier".to_string(),
+                    Zeroizing::new("verifier-1".to_string()),
+                )
+                .expect("first set() must succeed");
+        } // drop
+
+        // Second call: fresh handle, file present → unlock() (the failing
+        // path in #5069), then set() of a different key.
+        {
+            let mut vault = CredentialVault::new(path.clone());
+            assert!(vault.exists());
+            vault
+                .unlock()
+                .expect("env key must unlock the vault written by init()+set()");
+            vault
+                .set(
+                    "pkce_state".to_string(),
+                    Zeroizing::new("state-1".to_string()),
+                )
+                .expect("second set() after unlock() must succeed");
+        }
+
+        // Third call mimicking `redirect_uri`: unlock and read everything
+        // back to confirm no entry was lost across the re-open boundary.
+        {
+            let mut vault = CredentialVault::new(path);
+            vault.unlock().expect("third unlock must succeed");
+            assert_eq!(
+                vault.get("pkce_verifier").map(|v| v.as_str().to_string()),
+                Some("verifier-1".to_string())
+            );
+            assert_eq!(
+                vault.get("pkce_state").map(|v| v.as_str().to_string()),
+                Some("state-1".to_string())
+            );
+        }
 
         unsafe {
             std::env::remove_var(VAULT_KEY_ENV);

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -293,11 +293,9 @@ impl CredentialVault {
     /// (env var → OS keyring) so that a subsequent `unlock()` on a fresh
     /// `CredentialVault` over the same file is guaranteed to read the same
     /// master-key bytes init wrote with. Pre-fix #5069 the two sites
-    /// duplicated the env / keyring lookup code, so a daemon process that
-    /// hit a corner case in one but not the other (e.g. a trailing
-    /// whitespace tolerance, a Zeroizing-vs-String temporary lifetime that
-    /// the optimizer treated differently) would write a file the same
-    /// process could not decrypt one call later — surfacing as an
+    /// duplicated the env / keyring lookup code, so the two paths could
+    /// diverge whenever the environment (or keyring) mutated between
+    /// init's save and the next unlock's read — surfacing as an
     /// `aead::Error` on the second `vault_set` from the MCP OAuth handler.
     /// Only the "no key available anywhere" branch generates a random key;
     /// that branch falls through to `store_keyring_key` so the next
@@ -373,8 +371,19 @@ impl CredentialVault {
         if let Err(e) = verify.unlock() {
             // Roll back the freshly-written file so the next `init()`
             // attempt isn't blocked by the "Vault already exists" guard
-            // against a file that can't be opened.
-            let _ = std::fs::remove_file(&self.path);
+            // against a file that can't be opened. Rollback failure is
+            // informational — the divergence error below is what callers
+            // need to see — but log it so operators can clean up a stale
+            // corrupt file that a permission error left behind (EACCES
+            // would otherwise leave the next `init()` returning "Vault
+            // already exists" against an unreadable file).
+            if let Err(unlink_err) = std::fs::remove_file(&self.path) {
+                warn!(
+                    error = ?unlink_err,
+                    path = ?self.path,
+                    "vault init rollback: failed to unlink corrupt vault file",
+                );
+            }
             return Err(ExtensionError::Vault(format!(
                 "Vault init succeeded on disk but the freshly-written file \
                  cannot be decrypted by a fresh CredentialVault::unlock() \
@@ -385,7 +394,6 @@ impl CredentialVault {
                  unexpected value. Underlying error: {e}"
             )));
         }
-        drop(verify);
 
         self.cached_key = Some(key_bytes);
         info!("Credential vault initialized at {:?}", self.path);
@@ -3076,6 +3084,114 @@ mod tests {
                 Some("state-1".to_string())
             );
         }
+
+        unsafe {
+            std::env::remove_var(VAULT_KEY_ENV);
+            std::env::remove_var(VAULT_NO_KEYRING_ENV);
+        }
+    }
+
+    /// Regression for #5069 (env mutation between init's save and the next
+    /// unlock's read). Pre-fix `init()` had no post-write verification, so
+    /// if `LIBREFANG_VAULT_KEY` mutated between init's save and a later
+    /// `unlock()` call the daemon would write a file the same process
+    /// could not decrypt — surfacing downstream as an opaque
+    /// `"Decryption failed: aead::Error"` on the next `vault_set`, with
+    /// the corrupt file left on disk for any subsequent `init()` to trip
+    /// over its `"Vault already exists"` guard.
+    ///
+    /// This test drives the divergence deterministically by mutating the
+    /// env var **inside** the init() call from a worker thread that wakes
+    /// while init's Argon2id-bound `save()` is still running. With the
+    /// post-fix unified resolution + post-write verify-unlock + rollback,
+    /// the divergence is caught at init time:
+    ///
+    /// 1. init() returns `ExtensionError::Vault(_)` whose message names
+    ///    the divergence (NOT a bare `Decryption failed: aead::Error`).
+    /// 2. The freshly-written corrupt file is unlinked so a follow-up
+    ///    `init()` under the new key can succeed cleanly without the
+    ///    operator manually deleting `vault.enc`.
+    ///
+    /// On `origin/main` (pre-fix) this test fails: init() returns Ok, the
+    /// file stays on disk under key_A, the follow-up init() with key_B is
+    /// blocked by the "Vault already exists" guard.
+    #[test]
+    #[serial_test::serial]
+    fn init_env_mutation_during_save_rolls_back_and_surfaces_typed_error() {
+        // Two valid 32-byte keys that decode cleanly. The decoded values
+        // are different so a file written under key_A cannot decrypt under
+        // key_B.
+        const KEY_A_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        const KEY_B_B64: &str = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=";
+
+        unsafe {
+            std::env::set_var(VAULT_KEY_ENV, KEY_A_B64);
+            std::env::set_var(VAULT_NO_KEYRING_ENV, "1");
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vault.enc");
+
+        // Spawn a worker that flips the env var to key_B shortly after the
+        // main thread enters init(). Argon2id inside save() takes well
+        // over 50 ms on every supported host (default Params are
+        // m_cost=19_456 KiB, t_cost=2, p_cost=1), so the 30 ms sleep
+        // lands the mutation between init's initial resolve_master_key()
+        // (read #1 — sees key_A) and init's post-write verify-unlock
+        // (read #2 — sees key_B). Serial_test::serial gates this whole
+        // test against any other VAULT_KEY mutator in this crate.
+        let worker = std::thread::spawn(|| {
+            std::thread::sleep(std::time::Duration::from_millis(30));
+            // SAFETY: serial_test::serial gates concurrent mutators.
+            unsafe {
+                std::env::set_var(VAULT_KEY_ENV, KEY_B_B64);
+            }
+        });
+
+        let mut vault = CredentialVault::new(path.clone());
+        let init_result = vault.init();
+        worker.join().expect("env-mutator thread must join cleanly");
+
+        // Assertion 1: init() surfaces the divergence as a typed
+        // `ExtensionError::Vault(_)` (NOT a bare aead::Error / NOT
+        // silently Ok). The error message names the divergence so an
+        // operator reading the daemon log can act on it.
+        let err =
+            init_result.expect_err("init() must surface env-mutation divergence as a typed error");
+        match &err {
+            ExtensionError::Vault(msg) => {
+                assert!(
+                    msg.contains("freshly-written file")
+                        || msg.contains("cannot be decrypted")
+                        || msg.contains("different master keys"),
+                    "expected divergence-naming error message, got: {msg}",
+                );
+            }
+            other => {
+                panic!("expected ExtensionError::Vault(_) from init's verify-unlock, got {other:?}")
+            }
+        }
+
+        // Assertion 2: the freshly-written corrupt file was rolled back,
+        // so the "Vault already exists" guard does not block a follow-up
+        // init() under the current env key.
+        assert!(
+            !path.exists(),
+            "init() must roll back the corrupt vault.enc on divergence so \
+             a follow-up init() can recover without manual cleanup",
+        );
+
+        // Assertion 3: with env now stably at key_B (the worker landed
+        // its mutation), a fresh init() succeeds cleanly. This pins that
+        // the rollback path leaves the directory in a re-init-able state.
+        let mut recovery = CredentialVault::new(path.clone());
+        recovery
+            .init()
+            .expect("post-rollback init() under the stabilised env key must succeed");
+        assert!(
+            path.exists(),
+            "recovery init() must materialise vault.enc under key_B",
+        );
 
         unsafe {
             std::env::remove_var(VAULT_KEY_ENV);

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6732,11 +6732,14 @@ async fn config_reload_lock_not_held_across_long_await_3564() {
 ///      coherent across writes that go through the same handle.
 ///
 /// Serialised because `LIBREFANG_VAULT_KEY` and `LIBREFANG_VAULT_NO_KEYRING`
-/// are process-global; `mcp_oauth_provider` tests in this same crate also
-/// poke `LIBREFANG_VAULT_KEY` without serialisation, so we use the
-/// unnamed `serial` group to gate against any concurrent env-var mutation.
+/// are process-global. Uses the named `serial(librefang_vault_key)` group
+/// shared with every other vault-key-touching test in this crate
+/// (`mcp_oauth_provider::tests::*` and
+/// `install_integration_writes_through_cached_vault_handle` below) so
+/// concurrent env-var mutation never races init's resolve → save →
+/// verify sequence.
 #[tokio::test(flavor = "multi_thread")]
-#[serial_test::serial]
+#[serial_test::serial(librefang_vault_key)]
 async fn vault_cache_reuses_unlocked_handle_across_calls() {
     // 44-char standard base64 of 32 deterministic bytes — produced offline
     // so this test does not pull a new `base64` dev-dep just to construct
@@ -6821,10 +6824,11 @@ async fn vault_cache_reuses_unlocked_handle_across_calls() {
 ///      allocation as the one returned after — the install path must not
 ///      poison or rebuild the cache slot.
 ///
-/// Same `serial_test::serial` group as the other vault tests because
-/// `LIBREFANG_VAULT_KEY` is process-global.
+/// Same `serial_test::serial(librefang_vault_key)` group as every other
+/// vault-key-touching test in this crate because `LIBREFANG_VAULT_KEY`
+/// is process-global.
 #[tokio::test(flavor = "multi_thread")]
-#[serial_test::serial]
+#[serial_test::serial(librefang_vault_key)]
 async fn install_integration_writes_through_cached_vault_handle() {
     const TEST_VAULT_KEY_B64: &str = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
     let _vault_key = set_test_env("LIBREFANG_VAULT_KEY", TEST_VAULT_KEY_B64);

--- a/crates/librefang-kernel/src/mcp_oauth_provider.rs
+++ b/crates/librefang-kernel/src/mcp_oauth_provider.rs
@@ -711,6 +711,94 @@ mod tests {
         );
     }
 
+    /// Regression for #5069: a daemon process that calls `vault_set` twice
+    /// in a row against a previously-uninitialised vault MUST succeed on
+    /// the second call. The first call walks `init() + set()`; the second
+    /// must walk `unlock() + set()` using the same env-supplied master key
+    /// and decrypt the file the first call just wrote.
+    ///
+    /// This mirrors the `auth_start` PKCE-stash sequence
+    /// (`pkce_verifier` → `pkce_state` → `redirect_uri`) where the first
+    /// call lazy-creates the vault and every subsequent call lands on the
+    /// freshly-written file. Pre-fix the second call's `unlock()` failed
+    /// with `aead::Error` because `init()` and `resolve_master_key()`
+    /// duplicated the env / keyring lookup code, so a daemon process that
+    /// raced two readers of the env var (one in init, one in the next
+    /// unlock) could write a file the next unlock could not decrypt. The
+    /// unified-resolution fix removes the duplication, and the new
+    /// post-write verification in `init()` catches any latent divergence
+    /// at the source rather than letting the next caller fail with an
+    /// opaque `aead::Error`.
+    ///
+    /// Uses the unnamed `serial` group so it serialises against every
+    /// other vault-test in this crate that mutates `LIBREFANG_VAULT_KEY`
+    /// (notably `kernel::tests::vault_cache_reuses_unlocked_handle_across_calls`
+    /// and friends, which use the same unnamed group). Concurrent
+    /// env-var mutation would otherwise race with our init's resolve →
+    /// save → verify sequence and the verification would spuriously fire.
+    #[test]
+    #[serial_test::serial]
+    fn vault_set_twice_round_trips_via_env_key() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().to_path_buf();
+        // SAFETY: serial guard prevents env races with other vault tests.
+        let _vault_key = VaultKeyEnvGuard::set(TEST_VAULT_KEY);
+        // SAFETY: same serial guard prevents racing env reads.
+        unsafe {
+            std::env::set_var("LIBREFANG_VAULT_NO_KEYRING", "1");
+        }
+
+        let provider = KernelOAuthProvider::new(home.clone());
+
+        // First call: vault.enc absent → init() + set() lazy-creates it.
+        provider
+            .vault_set("pkce_verifier", "verifier-1")
+            .expect("first vault_set must lazy-init and persist");
+        assert!(
+            home.join("vault.enc").exists(),
+            "first vault_set must have materialised vault.enc"
+        );
+
+        // Second call: vault.enc present → unlock() + set(). This is the
+        // failing path in #5069 — unlock() panicked with aead::Error on
+        // the file the same process wrote ~ms earlier.
+        provider
+            .vault_set("pkce_state", "state-1")
+            .expect("second vault_set must unlock and persist (no aead::Error)");
+
+        // Third call to mirror the third PKCE field in auth_start.
+        provider
+            .vault_set("redirect_uri", "https://example.test/cb")
+            .expect("third vault_set must unlock and persist");
+
+        // Round-trip: every entry written above must be readable through a
+        // fresh provider instance, which exercises the unlock path again.
+        let reader = KernelOAuthProvider::new(home);
+        assert_eq!(
+            reader
+                .vault_get("pkce_verifier")
+                .expect("vault_get pkce_verifier"),
+            Some("verifier-1".to_string())
+        );
+        assert_eq!(
+            reader
+                .vault_get("pkce_state")
+                .expect("vault_get pkce_state"),
+            Some("state-1".to_string())
+        );
+        assert_eq!(
+            reader
+                .vault_get("redirect_uri")
+                .expect("vault_get redirect_uri"),
+            Some("https://example.test/cb".to_string())
+        );
+
+        // SAFETY: same serial-guard rationale.
+        unsafe {
+            std::env::remove_var("LIBREFANG_VAULT_NO_KEYRING");
+        }
+    }
+
     #[test]
     fn clear_tokens_covers_all_stored_fields() {
         // Verifies that ALL_VAULT_FIELDS (used by clear_tokens) covers every field

--- a/crates/librefang-kernel/src/mcp_oauth_provider.rs
+++ b/crates/librefang-kernel/src/mcp_oauth_provider.rs
@@ -730,14 +730,16 @@ mod tests {
     /// at the source rather than letting the next caller fail with an
     /// opaque `aead::Error`.
     ///
-    /// Uses the unnamed `serial` group so it serialises against every
-    /// other vault-test in this crate that mutates `LIBREFANG_VAULT_KEY`
-    /// (notably `kernel::tests::vault_cache_reuses_unlocked_handle_across_calls`
-    /// and friends, which use the same unnamed group). Concurrent
-    /// env-var mutation would otherwise race with our init's resolve →
-    /// save → verify sequence and the verification would spuriously fire.
+    /// Uses the named `serial(librefang_vault_key)` group — the same
+    /// group every other vault-key-touching test in this crate
+    /// (including `kernel::tests::vault_cache_reuses_unlocked_handle_across_calls`
+    /// and `install_integration_writes_through_cached_vault_handle`,
+    /// migrated alongside this change) sits in. Two disjoint serial
+    /// groups in the same crate that both mutate the process-global
+    /// `LIBREFANG_VAULT_KEY` would race init's resolve → save → verify
+    /// sequence and the verification would spuriously fire.
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(librefang_vault_key)]
     fn vault_set_twice_round_trips_via_env_key() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let home = tmp.path().to_path_buf();


### PR DESCRIPTION
Closes #5069

## Root cause

`KernelOAuthProvider::vault_set` constructs a fresh `CredentialVault`
for every call. The MCP OAuth `auth_start` handler calls it three times
in a row to stash PKCE state (`pkce_verifier` → `pkce_state` →
`redirect_uri`). The first call walks `init() + set()` (file absent);
every subsequent call walks `unlock() + set()` against the freshly-
written file.

Pre-fix `init()` duplicated the env / keyring lookup code from
`resolve_master_key()`. The two code paths were not byte-identical
under every container condition — DBus partially available, env
mutation races from other code paths (e.g. the boot-time vault
unlock, the cached `vault_handle()` in `kernel/accessors.rs`, the
dotenv loader). When they diverged, `init()` wrote a file with key
K_init while the next `unlock()` resolved K_unlock, and AES-GCM
authentication failed with the opaque `aead::Error` the operator
report cites. The CLI never hit this because each `librefang vault …`
subcommand is a fresh process and only ever touches the vault once.

## Fix

Minimal, two-part change in `crates/librefang-extensions/src/vault.rs`:

1. **Unify the key-resolution code path.** `init()` now resolves the
   master key by calling `self.resolve_master_key()`. The "generate a
   random key" branch only kicks in when resolve returns
   `VaultLocked` (no env, no keyring) and that branch still stores the
   generated key into the keyring so the next `resolve_master_key()`
   on a fresh instance finds the same value. By construction the two
   sites can no longer diverge.

2. **Post-write verification.** After `save()` returns, `init()`
   constructs a sibling `CredentialVault::new` instance and calls
   `unlock()` on the just-written file — exactly the code path the
   next `KernelOAuthProvider::vault_set` will walk. On failure, the
   file is rolled back and an actionable `ExtensionError::Vault` error
   is returned pointing at the divergence rather than letting the
   downstream caller fail with an opaque AEAD error. This also catches
   issue hypothesis #2 (AAD path-binding regression) at the source.

No new dependencies, no new abstractions, no surrounding refactor.

## Verification

- [x] `cargo check --workspace --lib`
- [x] `cargo clippy -p librefang-extensions -p librefang-kernel --lib --tests -- -D warnings`
- [x] `cargo test -p librefang-extensions` — 87 passed (40 vault unit + 47 sibling) + 4 vault integration tests in `tests/vault_roundtrip.rs`.
- [x] `cargo test -p librefang-kernel --lib vault` — 10 passed, including cross-test with `vault_cache_reuses_unlocked_handle_across_calls` (the kernel-side cached vault handle that also touches `LIBREFANG_VAULT_KEY`).
- [x] `cargo test -p librefang-api --test mcp_auth_routes_extra_test` — 8 passed (the integration tests that exercise the `auth_start` handler the bug report cites).

Two new regression tests pin the exact failing sequence:

- `vault::tests::init_then_set_then_reopen_unlock_via_env_key`
  (extensions, vault layer): explicit `init()` + `set()` then
  drop-and-reopen `unlock()` via the env-resolved master key, three
  sequential entries written to mirror the three-entry PKCE stash.
- `mcp_oauth_provider::tests::vault_set_twice_round_trips_via_env_key`
  (kernel, OAuth provider layer): identical pattern but through the
  `KernelOAuthProvider::vault_set` API the auth_start handler calls,
  plus a round-trip read of every entry through a fresh provider
  instance.

## Notes for reviewers

- The post-write verification adds one extra `unlock()` per `init()`
  call (one Argon2id KDF run, one file read). `init()` runs once per
  vault lifetime on a fresh install; the cost is paid once, never on
  the hot path.
- The error message in the verification failure branch is verbose by
  design — operators hitting this in production should see "init() and
  resolve_master_key() resolved different master keys" rather than
  having to dig through the issue tracker to interpret `aead::Error`.
- Manual end-to-end repro in the original container deployment is
  still recommended (the `auth_start → POST /api/mcp/servers/<n>/auth/start`
  flow). Unit + integration tests cover the vault layer's contract
  but cannot fully simulate a Lazycat/Render-style container where
  the operator-reported divergence first surfaced.