### PR TITLE
docs(runtime-media): correct historical attribution in README (#3710 follow-up)

### DIFF
--- a/crates/librefang-runtime-media/README.md
+++ b/crates/librefang-runtime-media/README.md
@@ -11,10 +11,10 @@ Provider-agnostic abstraction mirroring `librefang-llm-drivers`:
 
 ## Where this fits
 
-Extracted from `librefang-runtime` as part of the #3710 god-crate split
-(renamed from the deleted `librefang-runtime-oauth`, whose OAuth code
-collapsed back into the parent runtime crate). `librefang-runtime`
-re-exports this crate at its historical path (`runtime::media`,
+Extracted from `librefang-runtime` as part of the #3710 god-crate split.
+The unrelated `librefang-runtime-oauth` crate was collapsed back into
+the parent runtime in a separate step. `librefang-runtime` re-exports
+this crate at its historical path (`runtime::media`,
 `runtime::media_understanding`), so downstream call sites do not need to
 switch imports. Behind the parent crate's default-on `media` feature.
 


### PR DESCRIPTION
## Summary

Follow-up to #5053. The README I added for `librefang-runtime-media` in the round-2 review pass conflated two unrelated operations from the #3710 god-crate split:

- **`runtime-media`** was extracted from `librefang-runtime`'s `media` module. `git log --follow crates/librefang-runtime-media/src/lib.rs` traces back to commit `a9c8f010` (\"feat(media): generic media generation drivers\").
- **`runtime-oauth`** was a *separate* crate that was collapsed back into `librefang-runtime` (its OAuth modules now live in `crates/librefang-runtime/src/{chatgpt_oauth,copilot_oauth,mcp_oauth}.rs`).

The git rename detection (R061) on Cargo.toml made these look like a single rename in `git log --name-status`, which is what produced the wording \"renamed from the deleted librefang-runtime-oauth\" in the original README. The source content origins are distinct; this PR corrects the attribution.

## Changes

- `crates/librefang-runtime-media/README.md`: replace the conflated rename claim with two sentences making it clear the two operations are independent.

## Verification

- Pure docs change, 4 insertions / 4 deletions.
- No build / test impact.

## Out of scope

Other findings from the third-pass review of #5053 (CHANGELOG entry for #3710, missing `#[tracing::instrument]` on `librefang-runtime-{sandbox-docker,media}` async fns) are pre-existing patterns or judgment calls and are not addressed here.