### PR TITLE
fix(api/tests): add input_schema: None to Workflow literals after #5075

### DIFF
--- a/crates/librefang-api/tests/workflow_operator_nodes_test.rs
+++ b/crates/librefang-api/tests/workflow_operator_nodes_test.rs
@@ -92,6 +92,7 @@ fn workflow_with_op_step(name: &str, mode: StepMode) -> Workflow {
         created_at: chrono::Utc::now(),
         layout: None,
         total_timeout_secs: None,
+        input_schema: None,
     }
 }
 
@@ -756,6 +757,7 @@ fn branch_skip_workflow(literal: &str, target_name: &str, target_template: &str)
         created_at: chrono::Utc::now(),
         layout: None,
         total_timeout_secs: None,
+        input_schema: None,
     }
 }
 
@@ -1040,6 +1042,7 @@ async fn branch_step_ambiguous_target_halts_with_recorded_reason() {
         created_at: chrono::Utc::now(),
         layout: None,
         total_timeout_secs: None,
+        input_schema: None,
     };
     let wf_id = workflow.id;
     engine.register(workflow).await;
@@ -1152,6 +1155,7 @@ async fn validate_rejects_dag_workflow_with_operator_node_step() {
         created_at: chrono::Utc::now(),
         layout: None,
         total_timeout_secs: None,
+        input_schema: None,
     };
     let errs = wf.validate();
     assert!(
@@ -1238,6 +1242,7 @@ async fn dry_run_reports_operator_nodes_as_found_with_synthetic_agent_names() {
         created_at: chrono::Utc::now(),
         layout: None,
         total_timeout_secs: None,
+        input_schema: None,
     };
     let wf_id = wf.id;
     engine.register(wf).await;
@@ -1322,6 +1327,7 @@ async fn dry_run_marks_unparseable_transform_template_as_skipped() {
         created_at: chrono::Utc::now(),
         layout: None,
         total_timeout_secs: None,
+        input_schema: None,
     };
     let wf_id = wf.id;
     engine.register(wf).await;
@@ -1419,6 +1425,7 @@ async fn dry_run_transform_advances_current_input_for_downstream_previews() {
         created_at: chrono::Utc::now(),
         layout: None,
         total_timeout_secs: None,
+        input_schema: None,
     };
     let wf_id = wf.id;
     engine.register(wf).await;


### PR DESCRIPTION
## Problem

`crates/librefang-api/tests/workflow_operator_nodes_test.rs` (added by #5035) fails to compile against current main:

```
error[E0063]: missing field `input_schema` in initializer of `librefang_kernel::workflow::Workflow`
  --> crates/librefang-api/tests/workflow_operator_nodes_test.rs:74:5
   (and 6 more occurrences)
```

The Quality CI lane has been red since #5075 merged.

## Root cause

#5075 added `pub input_schema: Option<Vec<WorkflowInputParam>>` to the `Workflow` struct. The 7 `Workflow { ... }` literals in this test file weren't updated as part of that PR — they were added by #5035 which landed on main between #5075's rebase passes, and the rebase didn't catch the new test file.

## Fix

Add `input_schema: None` as the last field in each of the 7 `Workflow { ... }` literals. Pure additive — no semantic change to test behaviour.

## Verification

- File now compiles against the post-#5075 `Workflow` struct shape.
- 7 occurrences of `input_schema: None,` added (one per literal).
- No production code touched.

Closes the Quality CI breakage; allows #5102 (workflow IGNORE path fix) and any future PR's CI to go green.