### PR TITLE
fix(kernel/workflow): add input_schema: None to workflow_with_single_op_step test helper

### DIFF
--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -6680,6 +6680,7 @@ mod tests {
             created_at: Utc::now(),
             layout: None,
             total_timeout_secs: None,
+            input_schema: None,
         }
     }
 


### PR DESCRIPTION
## Problem

Companion to #5105. After #5075 added `input_schema: Option<Vec<WorkflowInputParam>>` to `Workflow`, one missed literal in `crates/librefang-kernel/src/workflow.rs:6662` (test helper `workflow_with_single_op_step`) still fails to compile:

```
error[E0063]: missing field `input_schema` in initializer of `workflow::Workflow`
    --> crates/librefang-kernel/src/workflow.rs:6662:9
```

Every `Test/*` shard fails at the build-tests step on this single error.

## Fix

Add `input_schema: None` as the last field of the `Workflow { ... }` literal inside `fn workflow_with_single_op_step`. Pure additive — no semantic change.

## Verification

- Locally-rebuilt diff: 1 insertion, 0 deletions, scoped to lines 6662-6685.
- After this lands, the 9 post-#5102 red CI lanes should clear (Quality + 7 Test shards).