### PR TITLE
style(api/tests): rustfmt mcp_tools_list_allowlist_test.rs (fix main CI)

### DIFF
--- a/crates/librefang-api/tests/mcp_tools_list_allowlist_test.rs
+++ b/crates/librefang-api/tests/mcp_tools_list_allowlist_test.rs
@@ -210,7 +210,9 @@ async fn tools_list_honours_agent_allowlist() {
         "allowlisted tool must be visible; got {names:?}"
     );
     assert!(
-        !names.iter().any(|n| n == BIG_TOOL_KEEP || n == BIG_TOOL_DROP),
+        !names
+            .iter()
+            .any(|n| n == BIG_TOOL_KEEP || n == BIG_TOOL_DROP),
         "non-allowlisted MCP tools must be hidden from tools/list; got {names:?}"
     );
 }


### PR DESCRIPTION
## Summary

- `main` CI Quality job is failing (run [25960995245](https://github.com/librefang/librefang/actions/runs/25960995245)) because `cargo xtask fmt` flagged an over-long `assert!` line in `mcp_tools_list_allowlist_test.rs:213`, introduced by #5101.
- The fix is a pure `cargo fmt -p librefang-api` reformat — wraps `!names.iter().any(...)` across three lines so it fits the rustfmt budget. No behavior change.

## Verification

- `cargo fmt -p librefang-api -- --check` → exit 0 on the branch
- Diff exactly matches the patch CI suggested in the failed log (the `Diff in ...` block at L210)

## Out of scope

- The local `cargo xtask fmt` invocation can't fully bootstrap on the dev box right now (`sysinfo@0.39.1` needs rustc 1.95; local toolchain is 1.94). This is independent of the fmt fix and CI doesn't hit it because runners use the pinned toolchain. Not addressed here.