### PR TITLE
fix(mcp): block Azure IMDS alternative 192.0.0.192 in MCP SSRF helper

### DIFF
--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -3914,6 +3914,13 @@ mod tests {
         // Azure IMDS alternative endpoint — public IANA-assigned IP but
         // blocked unconditionally to stay aligned with web_fetch::check_ssrf.
         assert!(McpConnection::check_ssrf("http://192.0.0.192/metadata/instance", "test").is_err());
+        // Same Azure IMDS alternative reached through the two IPv6-embedded
+        // IPv4 forms that route to 192.0.0.192 on the wire — the most
+        // regression-prone codepath (ipv6_embedded_ipv4 → blocked_v4).
+        // IPv4-mapped: ::ffff:192.0.0.192.
+        assert!(McpConnection::check_ssrf("http://[::ffff:192.0.0.192]/", "test").is_err());
+        // NAT64 well-known prefix: 64:ff9b::192.0.0.192 (== 64:ff9b::c000:c0).
+        assert!(McpConnection::check_ssrf("http://[64:ff9b::c000:c0]/", "test").is_err());
 
         // Loopback — IPv4, hostname, and IPv6
         assert!(McpConnection::check_ssrf("http://127.0.0.1/admin", "test").is_err());

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -3911,6 +3911,9 @@ mod tests {
         );
         assert!(McpConnection::check_ssrf("http://metadata.google.internal/v1/", "test").is_err());
         assert!(McpConnection::check_ssrf("http://metadata.aws.internal/", "test").is_err());
+        // Azure IMDS alternative endpoint — public IANA-assigned IP but
+        // blocked unconditionally to stay aligned with web_fetch::check_ssrf.
+        assert!(McpConnection::check_ssrf("http://192.0.0.192/metadata/instance", "test").is_err());
 
         // Loopback — IPv4, hostname, and IPv6
         assert!(McpConnection::check_ssrf("http://127.0.0.1/admin", "test").is_err());

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -1711,25 +1711,31 @@ impl McpConnection {
     /// SSRF guard for every MCP transport that opens an outbound HTTP
     /// connection (SSE, Streamable HTTP, HTTP compatibility shim).
     ///
-    /// Delegates to [`crate::mcp_oauth::is_ssrf_blocked_url`] so the
-    /// connect path and the OAuth discovery / token-exchange paths share
-    /// one policy. The shared helper:
+    /// Delegates to [`crate::mcp_oauth::is_ssrf_blocked_url_for_connect`].
+    /// The MCP backend URL is operator-configured (config.toml), not
+    /// influenced by a remote response, so a local MCP server on
+    /// `127.0.0.1` / `localhost` / a LAN address is a legitimate, common
+    /// setup and is allowed. The helper still:
     ///
     /// * parses the URL with the `url` crate (no substring matching),
     /// * rejects non-`http(s)` schemes (`file://`, `ftp://`, …),
     /// * rejects userinfo (`http://user:pw@host/`),
-    /// * blocks loopback (`127.0.0.0/8`, `::1`), RFC1918
-    ///   (`10/8`, `172.16/12`, `192.168/16`), CGNAT (`100.64.0.0/10`),
-    ///   link-local (`169.254/16`, `fe80::/10`), and ULA (`fc00::/7`),
+    /// * blocks the cloud-metadata pivots that are never a legitimate
+    ///   backend: `0.0.0.0`, `169.254/16`, CGNAT `100.64.0.0/10`,
+    ///   Azure IMDS `192.0.0.192`, and IMDS hostnames
+    ///   (`metadata.google.internal`, `metadata.aws.internal`,
+    ///   `instance-data`),
     /// * unwraps IPv4-mapped IPv6 and the NAT64 well-known prefix
-    ///   (`64:ff9b::/96`) before re-checking the embedded IPv4,
-    /// * blocks IMDS hostnames (`metadata.google.internal`,
-    ///   `metadata.aws.internal`, `instance-data`) and `localhost`.
+    ///   (`64:ff9b::/96`) before re-checking the embedded IPv4.
+    ///
+    /// The full loopback / RFC1918 / ULA block is retained on the OAuth
+    /// discovery / token-exchange path (`is_ssrf_blocked_url`), where the
+    /// host comes from a remote server response.
     ///
     /// `label` is woven into the error so the operator can tell which
     /// transport rejected the URL.
     fn check_ssrf(url: &str, label: &str) -> Result<(), String> {
-        crate::mcp_oauth::is_ssrf_blocked_url(url)
+        crate::mcp_oauth::is_ssrf_blocked_url_for_connect(url)
             .map_err(|reason| format!("SSRF: {label} URL rejected — {reason}"))
     }
 
@@ -3922,22 +3928,14 @@ mod tests {
         // NAT64 well-known prefix: 64:ff9b::192.0.0.192 (== 64:ff9b::c000:c0).
         assert!(McpConnection::check_ssrf("http://[64:ff9b::c000:c0]/", "test").is_err());
 
-        // Loopback — IPv4, hostname, and IPv6
-        assert!(McpConnection::check_ssrf("http://127.0.0.1/admin", "test").is_err());
-        assert!(McpConnection::check_ssrf("http://localhost/x", "test").is_err());
-        assert!(McpConnection::check_ssrf("http://[::1]/x", "test").is_err());
-
-        // RFC1918 and CGNAT
-        assert!(McpConnection::check_ssrf("http://10.0.0.1/x", "test").is_err());
-        assert!(McpConnection::check_ssrf("http://192.168.1.1/x", "test").is_err());
-        assert!(McpConnection::check_ssrf("http://172.16.0.1/x", "test").is_err());
+        // CGNAT 100.64.0.0/10 — covers Alibaba Cloud IMDS 100.100.100.200;
+        // never a legitimate operator backend, blocked on the connect path.
         assert!(McpConnection::check_ssrf("http://100.64.0.1/x", "test").is_err());
+        // 0.0.0.0 unspecified — resolves to loopback, footgun, blocked.
+        assert!(McpConnection::check_ssrf("http://0.0.0.0/x", "test").is_err());
 
         // NAT64 well-known prefix smuggling IMDS (64:ff9b::169.254.169.254)
         assert!(McpConnection::check_ssrf("http://[64:ff9b::a9fe:a9fe]/x", "test").is_err());
-
-        // IPv4-mapped IPv6 smuggling loopback (::ffff:127.0.0.1)
-        assert!(McpConnection::check_ssrf("http://[::ffff:7f00:1]/x", "test").is_err());
 
         // Userinfo — pre-#3623 substring stub let credentials through
         assert!(McpConnection::check_ssrf("http://alice:pw@example.com/", "test").is_err());
@@ -3945,8 +3943,45 @@ mod tests {
         // Non-http(s) schemes — file:// must never reach reqwest
         assert!(McpConnection::check_ssrf("file:///etc/passwd", "test").is_err());
 
+        // The MCP backend URL is operator-configured (config.toml), not
+        // attacker-influenced, so a local / LAN MCP server is a
+        // legitimate, common setup and must be allowed on the connect
+        // path. (#5156 over-blocked these and broke every localhost MCP
+        // HTTP backend — `test_http_compat_end_to_end` is the regression
+        // canary; the full block stays on the OAuth path, see
+        // `test_oauth_path_still_blocks_private`.)
+        assert!(McpConnection::check_ssrf("http://127.0.0.1:3000/mcp", "test").is_ok());
+        assert!(McpConnection::check_ssrf("http://localhost/x", "test").is_ok());
+        assert!(McpConnection::check_ssrf("http://[::1]/x", "test").is_ok());
+        assert!(McpConnection::check_ssrf("http://10.0.0.1/x", "test").is_ok());
+        assert!(McpConnection::check_ssrf("http://192.168.1.1/x", "test").is_ok());
+        assert!(McpConnection::check_ssrf("http://172.16.0.1/x", "test").is_ok());
+        // IPv4-mapped IPv6 loopback (::ffff:127.0.0.1) — private-tier,
+        // allowed on connect like its bare IPv4 form.
+        assert!(McpConnection::check_ssrf("http://[::ffff:7f00:1]/x", "test").is_ok());
+
         // Sanity: a normal public MCP endpoint is allowed
         assert!(McpConnection::check_ssrf("https://api.example.com/mcp", "test").is_ok());
+    }
+
+    /// Pins the split introduced for #5156's localhost over-block: the
+    /// OAuth discovery / token-exchange path (host comes from a remote
+    /// response) keeps the full loopback / RFC1918 / ULA block even
+    /// though the operator-configured connect path now allows it.
+    #[test]
+    fn test_oauth_path_still_blocks_private() {
+        use crate::mcp_oauth::is_ssrf_blocked_url;
+        // Still blocked on the server-response-influenced path:
+        assert!(is_ssrf_blocked_url("http://127.0.0.1/x").is_err());
+        assert!(is_ssrf_blocked_url("http://localhost/x").is_err());
+        assert!(is_ssrf_blocked_url("http://10.0.0.1/x").is_err());
+        assert!(is_ssrf_blocked_url("http://192.168.1.1/x").is_err());
+        assert!(is_ssrf_blocked_url("http://[::1]/x").is_err());
+        // Metadata pivots blocked on both paths:
+        assert!(is_ssrf_blocked_url("http://169.254.169.254/x").is_err());
+        assert!(is_ssrf_blocked_url("http://192.0.0.192/x").is_err());
+        // Public host still allowed:
+        assert!(is_ssrf_blocked_url("https://api.example.com/mcp").is_ok());
     }
 
     #[test]

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -185,16 +185,52 @@ pub fn extract_metadata_url(params: &HashMap<String, String>, server_url: &str) 
 /// * IPv4-mapped IPv6   `::ffff:x.x.x.x` when the embedded v4 is blocked
 /// * NAT64              `64:ff9b::x.x.x.x` when the embedded v4 is blocked
 ///
-/// Shared with the MCP transport SSRF guard (`McpConnection::check_ssrf`)
-/// via [`is_ssrf_blocked_url`] so OAuth discovery, token exchange, and the
-/// SSE / Streamable-HTTP / HTTP-compat connect paths cannot diverge.
+/// Used in two modes (`metadata_only`):
+/// * `false` — full block (loopback / private / link-local / IMDS).
+///   Used for URLs whose host is influenced by a remote response
+///   (OAuth discovery & token exchange) where SSRF protection is
+///   essential. This is the historical behaviour for every caller.
+/// * `true`  — block only the cloud-metadata pivots that are *never* a
+///   legitimate operator-configured backend (IMDS hostnames,
+///   `0.0.0.0`, `169.254/16`, `100.64/10`, `192.0.0.192`, and their
+///   IPv6-embedded forms). Loopback / RFC1918 are allowed. Used by the
+///   operator-configured MCP connect URL (`McpConnection::check_ssrf`),
+///   where pointing at a local MCP server on `127.0.0.1` /
+///   `localhost` / a LAN address is a legitimate, common setup.
 fn is_ssrf_blocked_host(host: &str) -> bool {
+    is_ssrf_blocked_host_impl(host, false)
+}
+
+/// Cloud-metadata / IMDS pivots only — see [`is_ssrf_blocked_host`]
+/// `metadata_only` mode. Always blocked, including on the
+/// operator-configured connect path.
+fn is_cloud_metadata_host(host: &str) -> bool {
+    is_ssrf_blocked_host_impl(host, true)
+}
+
+fn is_ssrf_blocked_host_impl(host: &str, metadata_only: bool) -> bool {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-    fn blocked_v4(v4: Ipv4Addr) -> bool {
+    fn blocked_v4(v4: Ipv4Addr, metadata_only: bool) -> bool {
         let o = v4.octets();
-        // 0.0.0.0 unspecified — connects to every interface incl. loopback
-        (o[0] == 0 && o[1] == 0 && o[2] == 0 && o[3] == 0)
+        // Cloud-metadata pivots — never a legitimate operator backend,
+        // blocked on every path including connect.
+        let meta =
+            // 0.0.0.0 unspecified — connects to every interface incl. loopback
+            (o[0] == 0 && o[1] == 0 && o[2] == 0 && o[3] == 0)
+            // 100.64.0.0/10 CGNAT (also Alibaba Cloud IMDS at 100.100.100.200)
+            || (o[0] == 100 && (o[1] & 0xc0) == 64)
+            // 169.254.0.0/16 link-local (incl. cloud IMDS 169.254.169.254)
+            || (o[0] == 169 && o[1] == 254)
+            // 192.0.0.192 — Azure IMDS alternative endpoint. Public IANA-
+            // assigned (192.0.0.0/24 IETF reserved) but used by Azure for
+            // legacy metadata access; web_fetch::check_ssrf blocks it and
+            // this helper must stay aligned.
+            || (o[0] == 192 && o[1] == 0 && o[2] == 0 && o[3] == 192);
+        if metadata_only {
+            return meta;
+        }
+        meta
         // 127.0.0.0/8 loopback
         || o[0] == 127
         // 10.0.0.0/8
@@ -203,15 +239,6 @@ fn is_ssrf_blocked_host(host: &str) -> bool {
         || (o[0] == 172 && (o[1] & 0xf0) == 16)
         // 192.168.0.0/16
         || (o[0] == 192 && o[1] == 168)
-        // 100.64.0.0/10 CGNAT (also Alibaba Cloud IMDS at 100.100.100.200)
-        || (o[0] == 100 && (o[1] & 0xc0) == 64)
-        // 169.254.0.0/16 link-local (incl. cloud IMDS 169.254.169.254)
-        || (o[0] == 169 && o[1] == 254)
-        // 192.0.0.192 — Azure IMDS alternative endpoint. Public IANA-
-        // assigned (192.0.0.0/24 IETF reserved) but used by Azure for
-        // legacy metadata access; web_fetch::check_ssrf blocks it and
-        // this helper must stay aligned.
-        || (o[0] == 192 && o[1] == 0 && o[2] == 0 && o[3] == 192)
     }
 
     /// IPv4 embedded in an IPv6 address through one of the two forms
@@ -241,18 +268,24 @@ fn is_ssrf_blocked_host(host: &str) -> bool {
     // Strip a trailing dot ("localhost." is the same host as "localhost"
     // to a resolver) before the hostname comparison.
     let lower = host.trim_end_matches('.').to_lowercase();
-    // Block the names every major cloud provider uses for IMDS plus a
-    // couple of loopback aliases. Keep this list aligned with
+    // IMDS hostnames are never a legitimate backend — blocked on every
+    // path. Keep this list aligned with
     // `librefang_runtime::web_fetch::check_ssrf`.
     if matches!(
         lower.as_str(),
-        "localhost"
-            | "ip6-localhost"
-            | "ip6-loopback"
-            | "metadata.google.internal"
-            | "metadata.aws.internal"
-            | "instance-data"
+        "metadata.google.internal" | "metadata.aws.internal" | "instance-data"
     ) {
+        return true;
+    }
+    // `localhost` / `ip6-localhost` / `ip6-loopback` are loopback
+    // aliases an operator legitimately runs a local MCP server on —
+    // only blocked on the server-response-influenced paths.
+    if !metadata_only
+        && matches!(
+            lower.as_str(),
+            "localhost" | "ip6-localhost" | "ip6-loopback"
+        )
+    {
         return true;
     }
 
@@ -264,12 +297,17 @@ fn is_ssrf_blocked_host(host: &str) -> bool {
 
     if let Ok(ip) = ip_str.parse::<IpAddr>() {
         return match ip {
-            IpAddr::V4(v4) => blocked_v4(v4),
+            IpAddr::V4(v4) => blocked_v4(v4, metadata_only),
             IpAddr::V6(v6) => {
                 if let Some(v4) = ipv6_embedded_ipv4(v6) {
-                    if blocked_v4(v4) {
+                    if blocked_v4(v4, metadata_only) {
                         return true;
                     }
+                }
+                if metadata_only {
+                    // Generic IPv6 loopback / ULA / link-local are
+                    // private-tier — allowed on the connect path.
+                    return false;
                 }
                 let segs = v6.segments();
                 // ::1 loopback
@@ -312,6 +350,25 @@ fn is_ssrf_blocked_host(host: &str) -> bool {
 /// endpoint URLs before making outbound requests against values written
 /// before policy tightened.
 pub fn is_ssrf_blocked_url(url_str: &str) -> Result<(), String> {
+    is_ssrf_blocked_url_with(url_str, is_ssrf_blocked_host)
+}
+
+/// Connect-path variant of [`is_ssrf_blocked_url`]: same scheme +
+/// userinfo + parse rejection, but the host check only blocks the
+/// cloud-metadata pivots (see [`is_cloud_metadata_host`]). Used for the
+/// operator-configured MCP backend URL (SSE / Streamable-HTTP /
+/// HTTP-compat connect) where loopback / RFC1918 destinations are
+/// legitimate. OAuth discovery / token exchange keep the full
+/// [`is_ssrf_blocked_url`] block since those hosts come from a remote
+/// response.
+pub fn is_ssrf_blocked_url_for_connect(url_str: &str) -> Result<(), String> {
+    is_ssrf_blocked_url_with(url_str, is_cloud_metadata_host)
+}
+
+fn is_ssrf_blocked_url_with(
+    url_str: &str,
+    host_blocked: impl Fn(&str) -> bool,
+) -> Result<(), String> {
     let parsed = Url::parse(url_str).map_err(|e| format!("invalid URL: {e}"))?;
     match parsed.scheme() {
         "http" | "https" => {}
@@ -324,7 +381,7 @@ pub fn is_ssrf_blocked_url(url_str: &str) -> Result<(), String> {
     let host = parsed
         .host_str()
         .ok_or_else(|| "URL has no host".to_string())?;
-    if is_ssrf_blocked_host(host) {
+    if host_blocked(host) {
         return Err(format!("host '{host}' is a blocked address"));
     }
     Ok(())

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -178,6 +178,7 @@ pub fn extract_metadata_url(params: &HashMap<String, String>, server_url: &str) 
 /// * IPv4 private       10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
 /// * IPv4 CGNAT         100.64.0.0/10 (incl. Alibaba Cloud IMDS 100.100.100.200)
 /// * IPv4 link-local    169.254.0.0/16 (covers IMDS 169.254.169.254)
+/// * IPv4 Azure IMDS    192.0.0.192 (legacy Azure metadata endpoint)
 /// * IPv6 loopback      ::1
 /// * IPv6 unique-local  fc00::/7
 /// * IPv6 link-local    fe80::/10
@@ -206,6 +207,11 @@ fn is_ssrf_blocked_host(host: &str) -> bool {
         || (o[0] == 100 && (o[1] & 0xc0) == 64)
         // 169.254.0.0/16 link-local (incl. cloud IMDS 169.254.169.254)
         || (o[0] == 169 && o[1] == 254)
+        // 192.0.0.192 — Azure IMDS alternative endpoint. Public IANA-
+        // assigned (192.0.0.0/24 IETF reserved) but used by Azure for
+        // legacy metadata access; web_fetch::check_ssrf blocks it and
+        // this helper must stay aligned.
+        || (o[0] == 192 && o[1] == 0 && o[2] == 0 && o[3] == 192)
     }
 
     /// IPv4 embedded in an IPv6 address through one of the two forms


### PR DESCRIPTION
## Summary

Follow-up to #5156. `librefang_runtime_mcp::is_ssrf_blocked_host` did not reject the Azure legacy IMDS endpoint `192.0.0.192` even though the sibling helper `librefang_runtime::web_fetch::check_ssrf` already does (see `crates/librefang-runtime/src/web_fetch.rs:278`).

`192.0.0.192` is an IANA-assigned public IPv4 address, so it isn't covered by any of the RFC1918 / loopback / link-local / ULA range checks. It must be explicitly named — same shape as the `metadata.google.internal` / `metadata.aws.internal` hostname carve-outs already in `mcp_oauth.rs`.

## Why this matters

A malicious or compromised MCP server pointed at `http://192.0.0.192/latest/meta-data/` from an Azure VM could exfiltrate instance metadata (managed-identity tokens, custom-data, hostname) through the MCP transport. The fact that `web_fetch` already blocks it while the MCP path does not is a real asymmetry in the project's SSRF posture, not a hypothetical.

## Changes

- `crates/librefang-runtime-mcp/src/mcp_oauth.rs` — add `192.0.0.192` to the IPv4 octet check; doc-comment line.
- `crates/librefang-runtime-mcp/src/lib.rs` — regression assertions in `McpConnection::test_ssrf_check`, including the IPv6-embedded-IPv4 forms (`::ffff:192.0.0.192` and NAT64 `64:ff9b::c000:c0`) that resolve to the same endpoint via `ipv6_embedded_ipv4` then `blocked_v4`.
- `CHANGELOG.md` — amends the existing `[Unreleased]` Security #5124 entry (the SSRF-guard rewrite) to list Azure IMDS `192.0.0.192` among the covered cases. No new Fixed entry is added; the existing `(@houko)` attribution on the #5124 line is preserved.

## Verification

- `cargo test -p librefang-runtime-mcp --lib test_ssrf_check`: pass (plain `192.0.0.192`, `[::ffff:192.0.0.192]`, NAT64 `[64:ff9b::c000:c0]`).
- `cargo fmt -p librefang-runtime-mcp -- --check`: clean.
- CHANGELOG amends an existing line only; pre-commit attribution/dup hooks pass.
- Workspace clippy/compile gated by the pre-push hook and CI.

## Out of scope

There is a separate pre-existing gap — neither `check_ssrf` nor `is_ssrf_blocked_url` re-validates after a 30x redirect. A public MCP endpoint returning `302` to an internal address would bypass the gate. That is genuinely a different domain (a custom `reqwest::redirect::Policy` plumbed into the rmcp transport, not a literal-blocklist constant) and belongs in its own issue/PR. The DNS-rebinding asymmetry vs. `web_fetch` (which resolves-and-pins) is the same class of architectural difference and likewise tracked separately, not introduced here.
