### PR TITLE
fix(dashboard): give the root route an explicit notFoundComponent

### DIFF
--- a/crates/librefang-api/dashboard/src/router.tsx
+++ b/crates/librefang-api/dashboard/src/router.tsx
@@ -108,7 +108,13 @@ function LazyRouteBoundary({ children }: { children: React.ReactNode }) {
 }
 
 const rootRoute = createRootRoute({
-  component: App
+  component: App,
+  // Explicit handler for notFound() bubbling to `__root__` (unmatched
+  // URLs, or notFound thrown in a loader/beforeLoad). Without this the
+  // router falls back to its generic `<p>Not Found</p>` and logs a dev
+  // warning; `defaultNotFoundComponent` below is the global fallback,
+  // this is the root-route-level handler the warning asks for.
+  notFoundComponent: NotFound,
 });
 
 const indexRoute = createRoute({


### PR DESCRIPTION
## Problem

The dashboard dev server logged repeatedly:

> A notFoundError was encountered on the route with ID `__root__`, but a notFoundComponent option was not configured, nor was a router level defaultNotFoundComponent configured.

`createRootRoute` only set `component: App` — no `notFoundComponent`. A `notFound()` that bubbles to `__root__` (unmatched URL, or thrown in a loader/`beforeLoad`) had no route-level handler; only the router-wide `defaultNotFoundComponent` fallback existed, and TanStack Router still emits the dev warning for the root route itself (and renders its generic `<p>Not Found</p>` on any build lacking the fallback).

## Change

`router.tsx` — add `notFoundComponent: NotFound` to `createRootRoute`. `NotFound` is the same hoisted component already wired as `defaultNotFoundComponent` (kept as the global fallback), so matched-route behavior is unchanged; unmatched routes now render the proper `NotFound` UI and the dev warning no longer fires.

## Verification

- `pnpm typecheck` — clean
- `pnpm build` — succeeds
- Router-only config change; no Rust/API surface touched. Not browser-repro'd here (1-line framework-config change with well-defined TanStack Router behavior); the warning's own text ("a notFoundComponent option was not configured") is exactly what this configures.

## Notes

The warning was originally observed from a dev server running inside a worktree that was deleted out from under it; current `main` already has `defaultNotFoundComponent`, so the warning would not reproduce on a healthy checkout. This change still hardens the root route with the explicit handler the warning asks for.