### PR TITLE
fix(config): serde/config polish (#5145)

### DIFF
--- a/crates/librefang-types/src/approval.rs
+++ b/crates/librefang-types/src/approval.rs
@@ -647,8 +647,8 @@ pub struct ApprovalPolicy {
     pub timeout_secs: u64,
     /// Auto-approve in autonomous mode. Default: `false`.
     pub auto_approve_autonomous: bool,
-    /// Alias: if `auto_approve = true`, clears the require list at boot.
-    #[serde(default, alias = "auto_approve")]
+    /// If `auto_approve = true`, clears the require list at boot.
+    #[serde(default)]
     pub auto_approve: bool,
     /// User IDs that are trusted and auto-approved for all tools.
     ///
@@ -1270,6 +1270,28 @@ mod tests {
         policy.auto_approve = true;
         policy.apply_shorthands();
         assert!(policy.require_approval.is_empty());
+    }
+
+    #[test]
+    fn policy_auto_approve_canonical_name_deserializes() {
+        // Regression for #5145: the field previously carried a
+        // self-referential `#[serde(alias = "auto_approve")]` no-op.
+        // Removing it must not affect deserialization of the canonical
+        // field name.
+        let policy: ApprovalPolicy = serde_json::from_str(r#"{"auto_approve": true}"#).unwrap();
+        assert!(policy.auto_approve);
+
+        let default: ApprovalPolicy = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(!default.auto_approve);
+
+        // Full roundtrip with the field set still preserves it.
+        let p = ApprovalPolicy {
+            auto_approve: true,
+            ..ApprovalPolicy::default()
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: ApprovalPolicy = serde_json::from_str(&json).unwrap();
+        assert!(back.auto_approve);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses the single sub-item of the [audit] umbrella #5145.

### Sub-item addressed

- **`ApprovalPolicy.auto_approve` self-referential `#[serde(alias)]` no-op** — `crates/librefang-types/src/approval.rs:651`
  - `git log -p --follow -S 'auto_approve'` shows the field `auto_approve` and its identical `#[serde(alias = "auto_approve")]` were introduced together in commit `7ae80b1b` ("batch fixes"), in the same diff hunk. There was **never** a legacy/renamed name (no `auto_accept` / `auto_grant` in history) — the alias is a copy-paste artifact that serde treats as a complete no-op (an alias equal to the field name does nothing).
  - **Fix:** removed the redundant `alias` clause (kept `#[serde(default)]`) and updated the now-inaccurate doc comment (dropped the leading "Alias:").

## Behavior impact

None. An alias matching the field name has zero deserialization effect, so this is dead-attribute removal — wire format and accepted JSON are unchanged.

## Tests

Added `policy_auto_approve_canonical_name_deserializes` (in `approval::tests`) asserting after alias removal:
- `{"auto_approve": true}` still deserializes to `auto_approve = true`
- `{}` defaults `auto_approve` to `false`
- a full serialize → deserialize roundtrip preserves the field

## Verification

- `cargo check -p librefang-types --lib` — clean
- `cargo clippy -p librefang-types --all-targets -- -D warnings` — zero warnings
- `cargo test -p librefang-types --lib approval` — 70 passed, 0 failed (incl. the new test)

## Not changed (with reason)

None — the umbrella enumerates exactly one sub-item and it was a genuine low-risk serde polish; fully addressed here.

Closes #5145