### PR TITLE
fix(llm-drivers,runtime,skills): enforce prompt-cache key determinism (#5143)

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -473,6 +473,37 @@ struct OaiRequest {
     extra_body: Option<HashMap<String, serde_json::Value>>,
 }
 
+/// Merge `extra_body` provider-extension params into a serialized request
+/// body so they override any standard field with the same name.
+///
+/// Prompt-cache determinism (#3298, #5143): the body is sent on every LLM
+/// request, so its byte layout is part of the Anthropic/OpenAI prompt-cache
+/// key. `extra_body` is a `HashMap`, whose iteration order varies across
+/// processes. Today the merged result is still byte-stable *only* because
+/// the workspace `Cargo.toml` does not enable `serde_json`'s
+/// `preserve_order` feature, so `serde_json::Map` is a `BTreeMap` and
+/// re-sorts on insert. That is an implicit, fragile invariant — enabling
+/// `preserve_order` (e.g. for nicer dashboard JSON dumps) would silently
+/// re-introduce HashMap-order leakage into every request body with ≥2
+/// `extra_body` keys and invalidate the prompt cache.
+///
+/// This helper makes the invariant explicit and `preserve_order`-proof:
+/// the keys are collected and sorted before insertion, so the merge order
+/// is deterministic regardless of which `serde_json::Map` backend is
+/// active. See `tests::extra_body_merge_is_byte_identical_across_insertion_orders`.
+fn merge_extra_body(
+    extra: &Option<HashMap<String, serde_json::Value>>,
+    body: &mut serde_json::Value,
+) {
+    if let (Some(extra), Some(obj)) = (extra, body.as_object_mut()) {
+        let mut keys: Vec<&String> = extra.keys().collect();
+        keys.sort();
+        for k in keys {
+            obj.insert(k.clone(), extra[k].clone());
+        }
+    }
+}
+
 /// Convert a [`ResponseFormat`] into the OpenAI `response_format` JSON value.
 fn oai_response_format(rf: &ResponseFormat) -> Option<serde_json::Value> {
     match rf {
@@ -1080,11 +1111,7 @@ impl LlmDriver for OpenAIDriver {
             // override any standard field with the same name.
             let mut body =
                 serde_json::to_value(&oai_request).map_err(|e| LlmError::Http(e.to_string()))?;
-            if let (Some(extra), Some(obj)) = (&oai_request.extra_body, body.as_object_mut()) {
-                for (k, v) in extra {
-                    obj.insert(k.clone(), v.clone());
-                }
-            }
+            merge_extra_body(&oai_request.extra_body, &mut body);
 
             let mut req_builder = self
                 .client
@@ -1504,11 +1531,7 @@ impl LlmDriver for OpenAIDriver {
             // override any standard field with the same name.
             let mut body =
                 serde_json::to_value(&oai_request).map_err(|e| LlmError::Http(e.to_string()))?;
-            if let (Some(extra), Some(obj)) = (&oai_request.extra_body, body.as_object_mut()) {
-                for (k, v) in extra {
-                    obj.insert(k.clone(), v.clone());
-                }
-            }
+            merge_extra_body(&oai_request.extra_body, &mut body);
 
             let mut req_builder = self
                 .client
@@ -3449,13 +3472,9 @@ mod tests {
             extra_body: Some(extra),
         };
 
-        // Simulate the merge logic used in complete() / stream()
+        // Use the exact merge logic used in complete() / stream().
         let mut body = serde_json::to_value(&req).unwrap();
-        if let (Some(extra), Some(obj)) = (&req.extra_body, body.as_object_mut()) {
-            for (k, v) in extra {
-                obj.insert(k.clone(), v.clone());
-            }
-        }
+        merge_extra_body(&req.extra_body, &mut body);
 
         // extra_body values should override standard fields
         assert_eq!(body.get("temperature").unwrap(), &serde_json::json!(1.0));
@@ -3466,6 +3485,71 @@ mod tests {
             raw.matches("temperature").count(),
             1,
             "There should be exactly ONE temperature key after merge. Raw: {raw}"
+        );
+    }
+
+    // Issue #5143 — `extra_body` is a HashMap merged into the wire request
+    // body, which is part of the provider prompt-cache key. The merge MUST
+    // produce a byte-identical body regardless of HashMap insertion order,
+    // and MUST stay deterministic even if `serde_json/preserve_order` is
+    // ever enabled workspace-wide. `merge_extra_body` sorts keys before
+    // insertion to enforce this. This pins byte equality across two
+    // different insertion orders, mirroring
+    // `mcp_summary_is_byte_identical_across_input_orders`.
+    #[test]
+    fn extra_body_merge_is_byte_identical_across_insertion_orders() {
+        fn build(order: &[(&str, serde_json::Value)]) -> String {
+            let mut extra = HashMap::new();
+            for (k, v) in order {
+                extra.insert((*k).to_string(), v.clone());
+            }
+            let req = OaiRequest {
+                model: "qwen3.6".to_string(),
+                messages: vec![OaiMessage {
+                    role: "user".to_string(),
+                    content: Some(OaiMessageContent::Text("hello".to_string())),
+                    tool_calls: None,
+                    tool_call_id: None,
+                    reasoning_content: None,
+                }],
+                max_tokens: Some(4096),
+                max_completion_tokens: None,
+                temperature: Some(0.7),
+                tools: vec![],
+                tool_choice: None,
+                stream: false,
+                stream_options: None,
+                thinking: None,
+                response_format: None,
+                extra_body: Some(extra),
+            };
+            let mut body = serde_json::to_value(&req).unwrap();
+            merge_extra_body(&req.extra_body, &mut body);
+            serde_json::to_string(&body).unwrap()
+        }
+
+        // Same three keys, two different HashMap insertion orders.
+        let a = build(&[
+            ("aaa_param", serde_json::json!(1)),
+            ("mmm_param", serde_json::json!("two")),
+            ("zzz_param", serde_json::json!([3, 4])),
+        ]);
+        let b = build(&[
+            ("zzz_param", serde_json::json!([3, 4])),
+            ("aaa_param", serde_json::json!(1)),
+            ("mmm_param", serde_json::json!("two")),
+        ]);
+        assert_eq!(
+            a, b,
+            "extra_body merge must yield a byte-identical request body across insertion orders (#5143)"
+        );
+        // And the merged keys must appear in sorted order in the body.
+        let ai = a.find("aaa_param").unwrap();
+        let mi = a.find("mmm_param").unwrap();
+        let zi = a.find("zzz_param").unwrap();
+        assert!(
+            ai < mi && mi < zi,
+            "merged extra_body keys must be in sorted order: {a}"
         );
     }
 

--- a/crates/librefang-runtime/src/hooks.rs
+++ b/crates/librefang-runtime/src/hooks.rs
@@ -274,6 +274,26 @@ impl HookRegistry {
             }
         }
 
+        // Prompt-cache determinism (#3298, #5143). These sections render
+        // into Section 16 of the system prompt
+        // (`prompt_builder.rs`), which is part of the Anthropic/OpenAI
+        // prompt-cache key. `self.handlers` is a `Vec` inside a `DashMap`
+        // whose contents are appended in *registration* order. No
+        // production code registers a `BeforePromptBuild` handler today,
+        // but a future handler wired in via filesystem walk or plugin
+        // manifest discovery would otherwise carry its non-deterministic
+        // registration order straight into the prompt and silently
+        // invalidate the cache. Sort by the stable `(provider, heading)`
+        // key here — the boundary that produces the order — so the
+        // invariant is enforced regardless of how/when handlers register.
+        // `provider` is a stable slug identifier; `heading` is the
+        // tiebreaker (it may be empty or duplicated across providers).
+        sections.sort_by(|a, b| {
+            a.provider
+                .cmp(&b.provider)
+                .then_with(|| a.heading.cmp(&b.heading))
+        });
+
         sections
     }
 
@@ -485,7 +505,7 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_prompt_sections_returns_in_registration_order() {
+    fn test_collect_prompt_sections_returns_sorted_by_provider() {
         let registry = HookRegistry::new();
         registry.register(
             HookEvent::BeforePromptBuild,
@@ -508,6 +528,59 @@ mod tests {
         assert_eq!(sections.len(), 2);
         assert_eq!(sections[0].provider, "alpha");
         assert_eq!(sections[1].provider, "beta");
+    }
+
+    // Issue #5143 — `BeforePromptBuild` handlers feed Section 16 of the
+    // system prompt, which is part of the provider prompt-cache key.
+    // Handlers register into a `Vec` inside a `DashMap` in registration
+    // order; a future handler wired in via filesystem/plugin discovery
+    // would otherwise leak that non-deterministic order into the prompt.
+    // `collect_prompt_sections` sorts by `(provider, heading)` to enforce
+    // determinism. This pins byte-identical output across two different
+    // registration orders, mirroring
+    // `mcp_summary_is_byte_identical_across_input_orders`.
+    #[test]
+    fn collect_prompt_sections_is_deterministic_across_registration_orders() {
+        fn collected(order: &[(&str, &str, &str)]) -> Vec<(String, String, String)> {
+            let registry = HookRegistry::new();
+            for (provider, heading, body) in order {
+                registry.register(
+                    HookEvent::BeforePromptBuild,
+                    Arc::new(SectionHandler {
+                        provider: (*provider).into(),
+                        heading: (*heading).into(),
+                        body: (*body).into(),
+                    }),
+                );
+            }
+            let ctx = make_ctx(HookEvent::BeforePromptBuild);
+            registry
+                .collect_prompt_sections(&ctx)
+                .into_iter()
+                .map(|s| (s.provider, s.heading, s.body))
+                .collect()
+        }
+
+        let forward = collected(&[
+            ("active-memory", "Recalled", "m"),
+            ("diffs-guidance", "Diffs", "d"),
+            ("zeta-provider", "Zeta", "z"),
+        ]);
+        let reversed = collected(&[
+            ("zeta-provider", "Zeta", "z"),
+            ("diffs-guidance", "Diffs", "d"),
+            ("active-memory", "Recalled", "m"),
+        ]);
+        assert_eq!(
+            forward, reversed,
+            "collect_prompt_sections must yield byte-identical output across registration orders (#5143)"
+        );
+        let providers: Vec<&str> = forward.iter().map(|(p, _, _)| p.as_str()).collect();
+        assert_eq!(
+            providers,
+            vec!["active-memory", "diffs-guidance", "zeta-provider"],
+            "sections must be sorted by provider"
+        );
     }
 
     #[test]

--- a/crates/librefang-skills/src/registry.rs
+++ b/crates/librefang-skills/src/registry.rs
@@ -356,9 +356,23 @@ impl SkillRegistry {
         self.skills.get(name)
     }
 
-    /// List all installed skills.
+    /// List all installed skills, sorted by skill name.
+    ///
+    /// The sort is load-bearing for prompt-cache determinism (#3298,
+    /// #5143). `self.skills` is a `HashMap`, whose iteration order varies
+    /// across processes. Every current prompt-bound caller
+    /// (`sorted_enabled_skills`, `all_tool_definitions`) already sorts
+    /// downstream, but the bare `list()` is also reachable from the API
+    /// (`routes/commands.rs`) and CLI (`main.rs`). Sorting here makes the
+    /// determinism invariant enforced at the source rather than
+    /// sustained-by-convention at every callsite, so a future prompt-side
+    /// caller that picks up `.list()` directly cannot silently reorder the
+    /// tool/skill list sent to the LLM. The API/CLI consumers are
+    /// order-insensitive, so the sort is a no-op for them.
     pub fn list(&self) -> Vec<&InstalledSkill> {
-        self.skills.values().collect()
+        let mut skills: Vec<&InstalledSkill> = self.skills.values().collect();
+        skills.sort_by(|a, b| a.manifest.skill.name.cmp(&b.manifest.skill.name));
+        skills
     }
 
     /// Remove a skill by name.
@@ -964,6 +978,49 @@ input_schema = {{ type = "object" }}
         assert_eq!(
             tools_a,
             vec!["alpha_tool".to_string(), "gamma_tool".to_string()]
+        );
+    }
+
+    // Issue #5143 — `list()` is the source-of-truth ordering for skills.
+    // It backs prompt-bound callers (via `sorted_enabled_skills`) as well
+    // as the API/CLI. Sorting must happen inside `list()` so a future
+    // prompt-side caller picking up `.list()` directly cannot silently
+    // reorder the skill/tool list and invalidate the provider prompt
+    // cache. This pins byte-identical output across insertion orders,
+    // mirroring `all_tool_definitions_is_deterministic_across_insertion_orders`.
+    #[test]
+    fn list_is_deterministic_across_insertion_orders() {
+        let dir_a = TempDir::new().unwrap();
+        let mut reg_a = SkillRegistry::new(dir_a.path().to_path_buf());
+        install_with_tool(&mut reg_a, "alpha", "alpha_tool");
+        install_with_tool(&mut reg_a, "beta", "beta_tool");
+        install_with_tool(&mut reg_a, "gamma", "gamma_tool");
+
+        let dir_b = TempDir::new().unwrap();
+        let mut reg_b = SkillRegistry::new(dir_b.path().to_path_buf());
+        // Reverse insertion order — `list()` output MUST still match.
+        install_with_tool(&mut reg_b, "gamma", "gamma_tool");
+        install_with_tool(&mut reg_b, "beta", "beta_tool");
+        install_with_tool(&mut reg_b, "alpha", "alpha_tool");
+
+        let names_a: Vec<String> = reg_a
+            .list()
+            .into_iter()
+            .map(|s| s.manifest.skill.name.clone())
+            .collect();
+        let names_b: Vec<String> = reg_b
+            .list()
+            .into_iter()
+            .map(|s| s.manifest.skill.name.clone())
+            .collect();
+        assert_eq!(
+            names_a, names_b,
+            "list() must yield byte-identical output across insertion orders (#5143)"
+        );
+        assert_eq!(
+            names_a,
+            vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()],
+            "list() must be sorted by skill name"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #5143. Audit follow-up to #3298: the three remaining prompt-cache
determinism soft spots were sustained-by-convention rather than
enforced-by-type. None exploitable today, but each was one careless
change from silently invalidating the Anthropic/OpenAI prompt cache
(~75% input-token savings). Each is now enforced at its boundary with a
determinism regression test mirroring
`mcp_summary_is_byte_identical_across_input_orders`.

## Soft-spots addressed

- **`serde_json/preserve_order` implicitly load-bearing for openai
  request bodies** — `crates/librefang-llm-drivers/src/drivers/openai.rs`
  (non-streaming `1083-1087`, streaming `1502-1509`). The
  `extra_body: HashMap` was merged into the wire body via `obj.insert`,
  byte-stable ONLY because the workspace does not enable
  `serde_json/preserve_order` (so `serde_json::Map` is `BTreeMap`).
  Extracted `merge_extra_body()` which collects + sorts keys before
  insertion, so the merged body is deterministic regardless of which
  `serde_json::Map` backend is active. The existing
  `test_oai_request_extra_body_merged_overrides_standard_field` now
  calls the production helper instead of a hand-copied merge loop.

- **`HookRegistry::collect_prompt_sections` ordering depends on
  registration order** — `crates/librefang-runtime/src/hooks.rs`
  (`200-205`). `BeforePromptBuild` handlers feed Section 16 of the
  system prompt; they live in a `Vec` inside a `DashMap`, appended in
  registration order. No production handler registers `BeforePromptBuild`
  today, but a future filesystem/plugin-discovered handler would leak
  its order into the prompt. Now sorts the collected sections by the
  stable `(provider, heading)` key at the boundary before returning.
  Renamed `test_collect_prompt_sections_returns_in_registration_order`
  → `_returns_sorted_by_provider` to match the new contract.

- **`SkillRegistry::list()` returned unsorted (HashMap order)** —
  `crates/librefang-skills/src/registry.rs` (`360-362`). Prompt-bound
  callers (`sorted_enabled_skills`, `all_tool_definitions`) sorted
  downstream, but the bare `list()` is also called from the API
  (`routes/commands.rs:63,102`) and CLI (`main.rs:7157`), and any future
  prompt-side caller picking up `.list()` directly would silently
  reorder. `list()` now sorts by `manifest.skill.name`; the existing
  downstream sorts remain (defense-in-depth; `all_tool_definitions`
  reads `self.skills.values()` directly, not via `list()`).
  Order-insensitive API/CLI consumers are unaffected.

## Not changed

- Anthropic / Gemini drivers: confirmed they have NO HashMap-merge-into-
  wire-body pattern (`grep` for `as_object_mut` / `obj.insert` over a
  `HashMap` returns nothing; only `OaiRequest` in `openai.rs` does this).
  Scope is correctly limited to `openai.rs`.
- `deny.toml` rule pinning the `serde_json` feature set: optional per the
  issue. The explicit sort makes the merge correct *regardless* of the
  feature, which is a stronger guarantee than a lint that only fires if
  someone touches `Cargo.toml`; a `deny.toml` rule would be a separate
  tooling-domain change and is not required to close the issue.

## Tests (real assertions, byte-equality across two input orders)

- `librefang_skills::registry::tests::list_is_deterministic_across_insertion_orders`
- `drivers::openai::tests::extra_body_merge_is_byte_identical_across_insertion_orders`
- `hooks::tests::collect_prompt_sections_is_deterministic_across_registration_orders`

## Verification

- `cargo check --lib`: `librefang-skills`, `librefang-llm-drivers`,
  `librefang-runtime`, plus downstream `librefang-kernel`,
  `librefang-api`, `librefang-cli` — all clean.
- `cargo clippy --all-targets -- -D warnings`: skills, llm-drivers,
  runtime — zero warnings.
- `cargo test`: skills (1 new), llm-drivers (3, incl. 1 new), runtime
  hooks (7, incl. 1 new + 1 renamed), kernel skill regression suite
  (80 passed) — all green.