### PR TITLE
fix(runtime): security defense-in-depth — symlink/archive/header/IP edge cases (#5141)

### DIFF
--- a/crates/librefang-runtime/src/agent_loop/message.rs
+++ b/crates/librefang-runtime/src/agent_loop/message.rs
@@ -11,7 +11,7 @@
 
 use crate::context_budget::{truncate_tool_result_dynamic, ContextBudget};
 use crate::silent_response::{ENVELOPE_LINE_PREFIXES, ENVELOPE_STANDALONE_MARKERS};
-use crate::workspace_sandbox::{ERR_PATH_TRAVERSAL, ERR_SANDBOX_ESCAPE};
+use crate::workspace_sandbox::{ERR_PATH_TRAVERSAL, ERR_SANDBOX_ESCAPE, ERR_SYMLINK_LEAF};
 use librefang_types::message::{Message, Role, TokenUsage};
 use tracing::{info, warn};
 
@@ -176,6 +176,7 @@ pub(super) fn is_cascade_leak(text: &str) -> bool {
 pub(super) fn is_soft_error_content(content: &str) -> bool {
     content.contains(ERR_PATH_TRAVERSAL)
         || content.contains(ERR_SANDBOX_ESCAPE)
+        || content.contains(ERR_SYMLINK_LEAF)
         || content.contains("arguments were truncated")
         || is_parameter_error_content(content)
 }

--- a/crates/librefang-runtime/src/host_functions.rs
+++ b/crates/librefang-runtime/src/host_functions.rs
@@ -191,10 +191,22 @@ fn is_ssrf_target(url: &str) -> Result<SsrfResolved, serde_json::Value> {
     match socket_addr.to_socket_addrs() {
         Ok(addrs) => {
             for addr in addrs {
-                // Canonicalise IPv4-mapped IPv6 (::ffff:X.X.X.X) before any
-                // safety check — see canonical_ip below.
-                let ip = canonical_ip(&addr.ip());
-                if ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) {
+                // Canonicalise IPv4-mapped IPv6 (::ffff:X.X.X.X) AND the
+                // NAT64 well-known prefix (64:ff9b::/96) before any safety
+                // check. Delegating to the canonical `web_fetch` helpers
+                // (rather than a local copy) means the WASM guest path and
+                // the runtime web_fetch path enforce identical SSRF policy
+                // and cannot drift: the local copy here previously missed
+                // NAT64 unwrap and CGNAT (100.64.0.0/10), letting a guest
+                // with `NetConnect(*)` reach IMDS via
+                // `http://[64:ff9b::a9fe:a9fe]/` on a NAT64-gateway env
+                // (issue #5141).
+                let ip = crate::web_fetch::canonical_ip(&addr.ip());
+                if ip.is_loopback()
+                    || ip.is_unspecified()
+                    || crate::web_fetch::is_private_ip(&ip)
+                    || crate::web_fetch::is_cloud_metadata_ip(&ip)
+                {
                     return Err(json!({"error": format!(
                         "SSRF blocked: {hostname} resolves to private IP {ip}"
                     )}));
@@ -219,34 +231,15 @@ fn is_ssrf_target(url: &str) -> Result<SsrfResolved, serde_json::Value> {
     })
 }
 
-/// Unwrap IPv4-mapped IPv6 (`::ffff:X.X.X.X`) to its IPv4 form. All other
-/// addresses are returned unchanged. Keeps downstream IP checks operating on
-/// the address the OS will actually connect to.
-fn canonical_ip(ip: &std::net::IpAddr) -> std::net::IpAddr {
-    match ip {
-        std::net::IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
-            Some(v4) => std::net::IpAddr::V4(v4),
-            None => std::net::IpAddr::V6(*v6),
-        },
-        std::net::IpAddr::V4(_) => *ip,
-    }
-}
-
-fn is_private_ip(ip: &std::net::IpAddr) -> bool {
-    match canonical_ip(ip) {
-        std::net::IpAddr::V4(v4) => {
-            let octets = v4.octets();
-            matches!(
-                octets,
-                [10, ..] | [172, 16..=31, ..] | [192, 168, ..] | [169, 254, ..]
-            )
-        }
-        std::net::IpAddr::V6(v6) => {
-            let segments = v6.segments();
-            (segments[0] & 0xfe00) == 0xfc00 || (segments[0] & 0xffc0) == 0xfe80
-        }
-    }
-}
+// NOTE: the SSRF IP-classification helpers (`canonical_ip`,
+// `is_private_ip`, `is_cloud_metadata_ip`, NAT64 unwrap) used to be
+// duplicated here. They are now the single canonical implementation in
+// `crate::web_fetch` (`pub(crate)`), shared by both the runtime web_fetch
+// path and this WASM-guest path. The local copy missed the NAT64
+// well-known prefix unwrap and the CGNAT 100.64.0.0/10 block, so a guest
+// with `NetConnect(*)` could reach IMDS via `http://[64:ff9b::a9fe:a9fe]/`
+// on a NAT64-gateway environment (issue #5141). Sharing one implementation
+// makes that class of drift structurally impossible.
 
 // ---------------------------------------------------------------------------
 // Always-allowed functions
@@ -1658,6 +1651,17 @@ mod tests {
         assert!(is_ssrf_target("https://api.openai.com/?email=me@example.com").is_ok());
     }
 
+    // Helper aliases so the existing WASM-path assertions keep exercising
+    // the IP classification used by `is_ssrf_target` — now the shared
+    // `web_fetch` implementation rather than a drifted local copy.
+    fn is_private_ip(ip: &std::net::IpAddr) -> bool {
+        let c = crate::web_fetch::canonical_ip(ip);
+        c.is_loopback()
+            || c.is_unspecified()
+            || crate::web_fetch::is_private_ip(&c)
+            || crate::web_fetch::is_cloud_metadata_ip(&c)
+    }
+
     #[test]
     fn test_is_private_ip() {
         use std::net::IpAddr;
@@ -1686,6 +1690,23 @@ mod tests {
         ));
         // Real IPv6 still takes the V6 branch.
         assert!(!is_private_ip(&"2001:db8::1".parse::<IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_blocks_nat64_and_cgnat() {
+        use std::net::IpAddr;
+        // NAT64 well-known prefix embedding IMDS / loopback / RFC1918 —
+        // previously missed by the local copy (issue #5141).
+        assert!(is_private_ip(
+            &"64:ff9b::a9fe:a9fe".parse::<IpAddr>().unwrap()
+        ));
+        assert!(is_private_ip(&"64:ff9b::7f00:1".parse::<IpAddr>().unwrap()));
+        assert!(is_private_ip(&"64:ff9b::a00:1".parse::<IpAddr>().unwrap()));
+        // CGNAT 100.64.0.0/10 (incl. Alibaba Cloud IMDS 100.100.100.200).
+        assert!(is_private_ip(&"100.64.0.1".parse::<IpAddr>().unwrap()));
+        assert!(is_private_ip(&"100.100.100.200".parse::<IpAddr>().unwrap()));
+        // A public address that merely shares the leading octet is fine.
+        assert!(!is_private_ip(&"100.128.0.1".parse::<IpAddr>().unwrap()));
     }
 
     #[test]

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -256,6 +256,118 @@ fn apply_mirror(mirror: &str, url: &str) -> String {
     }
 }
 
+/// Extract the entries of a (already-decompressed) tar archive into
+/// `tmp_dir`, stripping the GitHub `librefang-registry-main/` prefix and
+/// enforcing the security invariants:
+///
+/// - Skip every entry that is not a regular file or directory
+///   (`SymbolicLink`, `HardLink`, device, fifo) — `tar::Entry::unpack`
+///   honours symlink/hardlink entries, which an attacker-influenced
+///   tarball (mirror substitution, see `apply_mirror`) could use to
+///   escape the cache or clobber arbitrary files (issue #5141).
+/// - Reject any entry whose path (after the plain-string prefix strip)
+///   still contains a `..` / root / drive-prefix component — the strip
+///   does not normalise, so `…-main/foo/../../../etc/cron.d/owned`
+///   survives it.
+/// - Belt-and-suspenders: re-verify the resolved destination's deepest
+///   existing ancestor canonicalises to inside `tmp_dir`.
+///
+/// Factored out of `download_and_extract` so the security logic is unit
+/// testable without performing a network download.
+pub(crate) fn extract_entries_into<R: std::io::Read>(
+    archive: &mut tar::Archive<R>,
+    tmp_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Canonicalise the extraction root once so the per-entry containment
+    // check below operates on a path with no symlink / `.` / `..` segments.
+    let tmp_canon = tmp_dir.canonicalize()?;
+
+    for entry in archive.entries()? {
+        let mut entry: tar::Entry<_> = entry?;
+        let path = entry.path()?;
+        let path_str = path.to_string_lossy().into_owned();
+
+        // SECURITY: skip symlink / hardlink / device / fifo entries
+        // entirely. `entry.unpack` honours `SymbolicLink`/`HardLink`
+        // entries, so a tarball containing
+        // `librefang-registry-main/x -> /etc/cron.d` followed by a file
+        // entry writing through `x/owned` would escape the cache dir
+        // (or, for a hardlink, clobber an arbitrary existing file).
+        // The registry only ever ships regular files and directories;
+        // anything else is malicious or corrupt input.
+        let etype = entry.header().entry_type();
+        if !etype.is_file() && !etype.is_dir() {
+            tracing::warn!("registry tarball: skipping non-regular entry {path_str:?} ({etype:?})");
+            continue;
+        }
+
+        // Strip the tarball prefix
+        let relative: String = match path_str.strip_prefix(TARBALL_PREFIX) {
+            Some(r) if !r.is_empty() => r.to_string(),
+            _ => continue,
+        };
+
+        // SECURITY: reject any entry whose name contains a `..` (or root /
+        // prefix) component. `strip_prefix(TARBALL_PREFIX)` is a plain
+        // string strip — it does NOT normalise, so a crafted entry like
+        // `librefang-registry-main/foo/../../../../etc/cron.d/owned`
+        // survives the strip with `relative` still holding the traversal.
+        // `tmp_dir.join(relative)` would then resolve outside the cache.
+        // Mirror-substitution (`apply_mirror`) makes the tarball source
+        // attacker-influenceable by operator config, so this is not purely
+        // theoretical.
+        let rel_path = Path::new(&relative);
+        if rel_path.components().any(|c| {
+            matches!(
+                c,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        }) {
+            tracing::warn!(
+                "registry tarball: rejecting entry with traversal/absolute \
+                 component: {path_str:?}"
+            );
+            continue;
+        }
+
+        let dest = tmp_dir.join(&relative);
+
+        // Create parent directories
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // SECURITY: belt-and-suspenders containment check on the resolved
+        // destination. The component scan above already rejects `..`, but
+        // re-verify after `join` against the canonical extraction root so a
+        // symlinked parent dir (created by a *prior* malicious entry that
+        // slipped a different bug) still can't redirect the write. Resolve
+        // the deepest existing ancestor (the leaf doesn't exist yet) and
+        // require it to stay under `tmp_canon`.
+        let containment_anchor = dest.ancestors().find(|a| a.exists()).unwrap_or(tmp_dir);
+        match containment_anchor.canonicalize() {
+            Ok(anchor_canon) if anchor_canon.starts_with(&tmp_canon) => {}
+            _ => {
+                tracing::warn!(
+                    "registry tarball: rejecting entry resolving outside \
+                     extraction root: {path_str:?}"
+                );
+                continue;
+            }
+        }
+
+        // Only extract files and directories
+        if etype.is_dir() {
+            std::fs::create_dir_all(&dest)?;
+        } else if etype.is_file() {
+            entry.unpack(&dest)?;
+        }
+    }
+    Ok(())
+}
+
 /// Download the tarball via HTTP and extract it into `registry_cache`.
 fn download_and_extract(
     registry_cache: &Path,
@@ -286,32 +398,7 @@ fn download_and_extract(
     }
     std::fs::create_dir_all(&tmp_dir)?;
 
-    // Extract, stripping the `librefang-registry-main/` prefix
-    for entry in archive.entries()? {
-        let mut entry: tar::Entry<_> = entry?;
-        let path = entry.path()?;
-        let path_str = path.to_string_lossy();
-
-        // Strip the tarball prefix
-        let relative: String = match path_str.strip_prefix(TARBALL_PREFIX) {
-            Some(r) if !r.is_empty() => r.to_string(),
-            _ => continue,
-        };
-
-        let dest = tmp_dir.join(&relative);
-
-        // Create parent directories
-        if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        // Only extract files and directories
-        if entry.header().entry_type().is_dir() {
-            std::fs::create_dir_all(&dest)?;
-        } else if entry.header().entry_type().is_file() {
-            entry.unpack(&dest)?;
-        }
-    }
+    extract_entries_into(&mut archive, &tmp_dir)?;
 
     // Swap: remove old cache, rename tmp to cache
     if registry_cache.exists() {
@@ -794,5 +881,170 @@ mod tests {
         assert!(!stale.exists(), "stale dir should be removed");
         assert!(valid.exists(), "valid dir should remain");
         assert!(both.exists(), "dir with both files should remain");
+    }
+
+    // ---- #5141: malicious-tarball extraction hardening ----------------
+
+    /// Build a raw (uncompressed) tar archive containing the given
+    /// `(name, contents)` regular-file entries and return its bytes.
+    fn build_tar_with_files(files: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut buf);
+            for (name, contents) in files {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(contents.len() as u64);
+                header.set_mode(0o644);
+                header.set_entry_type(tar::EntryType::Regular);
+                header.set_cksum();
+                b.append_data(&mut header, name, &contents[..]).unwrap();
+            }
+            b.finish().unwrap();
+        }
+        buf
+    }
+
+    /// Append a regular-file entry whose stored name is written DIRECTLY
+    /// into the raw tar header `name[..]` bytes, bypassing the `tar`
+    /// writer's own `..`-rejecting guard. This is exactly the shape a
+    /// hand-crafted malicious tarball takes (the writer guard is a courtesy
+    /// to honest producers; a real attacker emits raw blocks).
+    fn append_raw_named_entry<W: std::io::Write>(
+        builder: &mut tar::Builder<W>,
+        raw_name: &str,
+        contents: &[u8],
+    ) {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_mtime(0);
+        header.set_entry_type(tar::EntryType::Regular);
+        {
+            let name_field = &mut header.as_old_mut().name;
+            name_field.fill(0);
+            let bytes = raw_name.as_bytes();
+            name_field[..bytes.len()].copy_from_slice(bytes);
+        }
+        header.set_cksum();
+        builder.append(&header, contents).unwrap();
+    }
+
+    #[test]
+    fn extract_rejects_dotdot_traversal_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let extract_root = tmp.path().join(".registry_tmp");
+        std::fs::create_dir_all(&extract_root).unwrap();
+        // Sentinel target the attacker tries to clobber, OUTSIDE the root.
+        let outside = tmp.path().join("etc-cron-d-owned");
+
+        let mut buf = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut buf);
+            // Legitimate file — must extract fine.
+            append_raw_named_entry(
+                &mut b,
+                "librefang-registry-main/providers/ok.toml",
+                b"id=\"ok\"",
+            );
+            // ATTACK: traversal escaping the extraction root.
+            append_raw_named_entry(
+                &mut b,
+                "librefang-registry-main/x/../../../etc-cron-d-owned",
+                b"PWNED",
+            );
+            b.finish().unwrap();
+        }
+        let mut archive = tar::Archive::new(&buf[..]);
+        extract_entries_into(&mut archive, &extract_root).unwrap();
+
+        assert!(
+            !outside.exists(),
+            "traversal entry must NOT have written outside the root"
+        );
+        assert!(
+            extract_root.join("providers/ok.toml").exists(),
+            "legitimate entry must still extract"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_skips_symlink_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let extract_root = tmp.path().join(".registry_tmp");
+        std::fs::create_dir_all(&extract_root).unwrap();
+        let outside = tmp.path().join("secret-target");
+        std::fs::write(&outside, b"original").unwrap();
+
+        // Build a tarball whose first entry is a symlink pointing outside,
+        // followed by a file written "through" the symlink name.
+        let mut buf = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut buf);
+            let mut link_hdr = tar::Header::new_gnu();
+            link_hdr.set_entry_type(tar::EntryType::Symlink);
+            link_hdr.set_size(0);
+            link_hdr.set_mode(0o777);
+            b.append_link(&mut link_hdr, "librefang-registry-main/evil", &outside)
+                .unwrap();
+
+            let payload = b"PWNED";
+            let mut f_hdr = tar::Header::new_gnu();
+            f_hdr.set_entry_type(tar::EntryType::Regular);
+            f_hdr.set_size(payload.len() as u64);
+            f_hdr.set_mode(0o644);
+            f_hdr.set_cksum();
+            b.append_data(
+                &mut f_hdr,
+                "librefang-registry-main/evil/owned",
+                &payload[..],
+            )
+            .unwrap();
+            b.finish().unwrap();
+        }
+        let mut archive = tar::Archive::new(&buf[..]);
+        extract_entries_into(&mut archive, &extract_root).unwrap();
+
+        // The symlink entry was skipped, so `evil` is NOT a symlink and the
+        // original outside file is untouched.
+        assert_eq!(
+            std::fs::read(&outside).unwrap(),
+            b"original",
+            "symlink entry must not redirect a write outside the root"
+        );
+        let evil = extract_root.join("evil");
+        if let Ok(meta) = std::fs::symlink_metadata(&evil) {
+            assert!(
+                !meta.file_type().is_symlink(),
+                "symlink entry must have been skipped, not materialised"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_accepts_legitimate_tarball() {
+        // POSITIVE: a normal registry tarball extracts cleanly.
+        let tmp = tempfile::tempdir().unwrap();
+        let extract_root = tmp.path().join(".registry_tmp");
+        std::fs::create_dir_all(&extract_root).unwrap();
+
+        let bytes = build_tar_with_files(&[
+            (
+                "librefang-registry-main/providers/groq.toml",
+                b"id=\"groq\"\nversion=\"1.0.0\"",
+            ),
+            (
+                "librefang-registry-main/hands/clip/HAND.toml",
+                b"id=\"clip\"",
+            ),
+        ]);
+        let mut archive = tar::Archive::new(&bytes[..]);
+        extract_entries_into(&mut archive, &extract_root).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(extract_root.join("providers/groq.toml")).unwrap(),
+            "id=\"groq\"\nversion=\"1.0.0\"",
+        );
+        assert!(extract_root.join("hands/clip/HAND.toml").exists());
     }
 }

--- a/crates/librefang-runtime/src/silent_response.rs
+++ b/crates/librefang-runtime/src/silent_response.rs
@@ -51,6 +51,11 @@ pub(crate) const ENVELOPE_STANDALONE_MARKERS: &[&str] = &["[Stranger]", "[Forwar
 
 /// Prompt section headers that, when paired with a structural marker,
 /// indicate cascade scaffolding regurgitation.
+///
+/// `## Today` / `## Calendar` / `## Tasks` are *ambiguous* — a legitimate
+/// "what does my day look like" help reply produces these freely, so 2+ of
+/// them alone is intentionally NOT a leak (houko-flagged false positive,
+/// guarded by `thematic_headers_alone_are_legitimate`).
 const THEMATIC_HEADERS: &[&str] = &[
     "## Sender",
     "## Today",
@@ -58,6 +63,19 @@ const THEMATIC_HEADERS: &[&str] = &[
     "## Tasks",
     "## Response Style",
 ];
+
+/// Subset of [`THEMATIC_HEADERS`] that describe the *prompt frame itself*,
+/// not reply content. An agent never legitimately emits `## Sender`
+/// (it does not narrate who messaged it back to the user) or
+/// `## Response Style` (a meta-instruction block, never reply prose) in a
+/// genuine reply — these only appear when the model regurgitates the
+/// scaffolding verbatim. They are therefore as diagnostic as a structural
+/// turn-frame marker. This closes the all-thematic bypass
+/// (`## Sender\n…\n## Today\n…\n## Tasks` — three thematic, zero structural)
+/// flagged in issue #5141 without regressing the legitimate day-summary
+/// reply (which only ever uses the ambiguous `## Today`/`## Calendar`/
+/// `## Tasks` subset).
+const SCAFFOLD_ONLY_HEADERS: &[&str] = &["## Sender", "## Response Style"];
 
 /// Structural turn-frame markers that almost never appear in legitimate
 /// agent replies.
@@ -68,7 +86,13 @@ const STRUCTURAL_TURN_FRAMES: &[&str] = &["User asked:", "I responded:", "[Past 
 /// produce.
 ///
 /// Trip condition: **2+ structural** OR **1 structural + 1 thematic**.
-/// `2+ thematic alone` is intentionally NOT a leak.
+/// `2+ *ambiguous* thematic alone` is intentionally NOT a leak (legitimate
+/// day-summary replies). The scaffold-only headers (`## Sender`,
+/// `## Response Style` — see [`SCAFFOLD_ONLY_HEADERS`]) count toward the
+/// structural tally because no genuine reply emits them, so the
+/// all-thematic regurgitation `## Sender\n…\n## Today\n…\n## Tasks`
+/// (issue #5141) now trips: `## Sender` is structural-equivalent, and it
+/// pairs with the `## Today`/`## Tasks` thematic hits.
 ///
 /// Used both by the assembled-response guard (non-streaming and streaming
 /// EndTurn) and by the incremental streaming abort path.
@@ -79,6 +103,7 @@ pub fn is_cascade_leak(text: &str) -> bool {
         .iter()
         .chain(ENVELOPE_LINE_PREFIXES.iter())
         .chain(ENVELOPE_STANDALONE_MARKERS.iter())
+        .chain(SCAFFOLD_ONLY_HEADERS.iter())
     {
         if text.contains(m) {
             structural_hits += 1;
@@ -91,7 +116,17 @@ pub fn is_cascade_leak(text: &str) -> bool {
     if structural_hits == 0 {
         return false;
     }
-    THEMATIC_HEADERS.iter().any(|m| text.contains(m))
+    // Pair the structural hit with an *ambiguous* thematic header only.
+    // Scaffold-only headers are already counted as structural above —
+    // re-counting them here would let a single `## Response Style` (1
+    // structural + itself as "thematic") trip on a legitimate one-section
+    // reply. The ambiguous subset (## Today / ## Calendar / ## Tasks) is
+    // exactly the day-summary content a real reply pairs with scaffolding
+    // when the model regurgitates the frame.
+    THEMATIC_HEADERS
+        .iter()
+        .filter(|h| !SCAFFOLD_ONLY_HEADERS.contains(h))
+        .any(|m| text.contains(m))
 }
 
 /// Env-flag rollback hatch: setting `LIBREFANG_SILENT_V2=off` reverts to
@@ -111,16 +146,44 @@ fn v2_enabled() -> bool {
     })
 }
 
-/// Legacy detector — bit-for-bit equivalent to the pre-Phase-2 `is_no_reply`
-/// helper that lived in `agent_loop.rs`. Used when `LIBREFANG_SILENT_V2=off`.
+/// Legacy detector — used when `LIBREFANG_SILENT_V2=off`. Historically this
+/// was bit-for-bit `t == S || t.ends_with(S)` for each sentinel, but the
+/// unbounded `ends_with` let adversarial sender input coerce the LLM into
+/// appending `NO_REPLY` *directly after a side-effecting tool's output*
+/// (e.g. `...deleted 200 rowsNO_REPLY`) to suppress the user-visible reply
+/// while the tool already ran (issue #5141). The trailing-suffix form now
+/// requires a boundary (the char before the sentinel must not be
+/// alphanumeric / `_`) — mirroring the v2 [`ends_with_canonical`] boundary
+/// rule — so `xNO_REPLY` no longer matches but `x. NO_REPLY` /
+/// `x\nNO_REPLY` (legitimate trailing-token prompts) still do. Exact-match
+/// behaviour is unchanged.
 fn legacy_is_silent(text: &str) -> bool {
     let t = text.trim();
     t == "NO_REPLY"
-        || t.ends_with("NO_REPLY")
+        || legacy_ends_with_boundary(t, "NO_REPLY")
         || t == "[no reply needed]"
-        || t.ends_with("[no reply needed]")
+        || legacy_ends_with_boundary(t, "[no reply needed]")
         || t == "no reply needed"
-        || t.ends_with("no reply needed")
+        || legacy_ends_with_boundary(t, "no reply needed")
+}
+
+/// True iff `t` ends with `needle` AND the character immediately before
+/// `needle` is a non-word boundary (whitespace, punctuation, bracket, …)
+/// or `needle` is at the start. Prevents `...rowsNO_REPLY` /
+/// `NO_REPLYING` from suppressing a reply while preserving the legacy
+/// "context.\nNO_REPLY" trailing-token tolerance.
+fn legacy_ends_with_boundary(t: &str, needle: &str) -> bool {
+    let Some(cut) = t.len().checked_sub(needle.len()) else {
+        return false;
+    };
+    if !t.ends_with(needle) {
+        return false;
+    }
+    if cut == 0 {
+        return true;
+    }
+    let prev = t[..cut].chars().next_back().unwrap();
+    !(prev.is_alphanumeric() || prev == '_')
 }
 
 /// Reason classification for a silent decision. Used in structured logs
@@ -337,6 +400,41 @@ mod tests {
         ));
     }
 
+    // --- #5141: legacy detector trailing-NO_REPLY boundary ---
+    // Tested against `legacy_is_silent` directly: `is_silent_response`
+    // routes here only when `LIBREFANG_SILENT_V2=off`, and `v2_enabled()`
+    // memoises the env read in a process-wide `OnceLock`, so going through
+    // the public entrypoint would be order-dependent / flaky.
+    #[test]
+    fn legacy_rejects_glued_no_reply_after_tool_output() {
+        // ATTACK: adversarial sender input coerces the LLM to append
+        // NO_REPLY directly after a side-effecting tool's output so the
+        // user never sees that the tool ran. No boundary before the
+        // sentinel → must NOT be treated as silent.
+        assert!(!legacy_is_silent("deleted 200 rowsNO_REPLY"));
+        assert!(!legacy_is_silent(
+            "Transferred $5000 to account 12345NO_REPLY"
+        ));
+        assert!(!legacy_is_silent("doneno reply needed"));
+        // Alphanumeric / `_` immediately before sentinel: still not silent.
+        assert!(!legacy_is_silent("xNO_REPLY"));
+        assert!(!legacy_is_silent("foo_NO_REPLY"));
+        assert!(!legacy_is_silent("NO_REPLYING"));
+    }
+
+    #[test]
+    fn legacy_still_accepts_bounded_trailing_no_reply() {
+        // POSITIVE: legitimate trailing-token prompts (the historical
+        // behaviour we cannot regress) must still be silent.
+        assert!(legacy_is_silent("NO_REPLY"));
+        assert!(legacy_is_silent("all good. NO_REPLY"));
+        assert!(legacy_is_silent("Let me think.\nNO_REPLY"));
+        assert!(legacy_is_silent("[no reply needed]"));
+        assert!(legacy_is_silent("Some context. [no reply needed]"));
+        assert!(legacy_is_silent("no reply needed"));
+        assert!(legacy_is_silent("done; no reply needed"));
+    }
+
     // --- SilentReason serialization ---
     #[test]
     fn silent_reason_serializes_snake_case() {
@@ -380,11 +478,17 @@ mod tests {
     }
 
     #[test]
-    fn cascade_leak_thematic_headers_alone_are_legitimate() {
-        // 2+ thematic headers alone must NOT trigger the guard —
-        // legitimate markdown help replies use these freely.
+    fn cascade_leak_ambiguous_thematic_headers_alone_are_legitimate() {
+        // 2+ *ambiguous* thematic headers alone must NOT trigger the guard
+        // — legitimate "what does my day look like" replies use these
+        // freely. NOTE (#5141): the previous version of this test asserted
+        // `"## Sender …\n## Response Style …"` was also legitimate. That
+        // was the vulnerability: `## Sender` / `## Response Style` are
+        // pure scaffolding (a genuine reply never narrates the sender or a
+        // meta response-style block), so that exact shape is now correctly
+        // a leak — see `cascade_leak_scaffold_only_headers_trip_*`.
         assert!(!is_cascade_leak(
-            "## Sender\nAlice\n\n## Today\n2024-01-01\n\n## Response Style\nFormal"
+            "## Today\n2024-01-01\n\n## Calendar\nstandup 9am\n\n## Tasks\nreview"
         ));
         assert!(!is_cascade_leak(
             "## Tasks\n- buy milk\n\n## Calendar\nTuesday"
@@ -398,6 +502,45 @@ mod tests {
         assert!(!is_cascade_leak(
             "Here is a summary:\n\n1. Point one\n2. Point two"
         ));
+    }
+
+    // --- #5141: all-thematic scaffolding-regurgitation bypass ---
+
+    #[test]
+    fn cascade_leak_scaffold_only_headers_trip_without_structural() {
+        // ATTACK: the LLM is coerced into regurgitating the system-prompt
+        // scaffolding with zero structural markers and only thematic
+        // headers — `## Sender` + `## Today` + `## Tasks`. Before the fix
+        // this had 0 structural hits → not a leak → fully delivered to the
+        // user. `## Sender` is a scaffold-only header (no genuine reply
+        // emits it), so it now counts toward the structural tally and the
+        // leak trips.
+        assert!(is_cascade_leak(
+            "## Sender\nAlice (+15551234567)\n\n## Today\n2024-01-01\n\n## Tasks\n- review PR"
+        ));
+        // `## Response Style` is the other scaffold-only header; two
+        // scaffold-only headers alone (2 structural-equiv) also trip.
+        assert!(is_cascade_leak(
+            "## Sender\nBob\n\n## Response Style\nFormal, concise."
+        ));
+    }
+
+    #[test]
+    fn cascade_leak_ambiguous_thematic_alone_still_legitimate() {
+        // REGRESSION GUARD: the houko-flagged false positive must stay
+        // fixed — a legitimate "what does my day look like" reply uses the
+        // *ambiguous* thematic headers (## Today/## Calendar/## Tasks) and
+        // must NOT be classified as a leak. Crucially these contain NO
+        // scaffold-only header.
+        assert!(!is_cascade_leak(
+            "## Today\nWednesday\n\n## Calendar\nno events\n\n## Tasks\npending"
+        ));
+        assert!(!is_cascade_leak(
+            "## Calendar\n- meeting at 5pm\n\n## Tasks\n- send follow-up"
+        ));
+        // Single scaffold-only header alone is not enough (needs a 2nd
+        // structural OR a thematic to pair with).
+        assert!(!is_cascade_leak("## Response Style\nBe brief."));
     }
 
     #[test]

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -257,6 +257,23 @@ pub fn check_ssrf(url: &str, allowed_hosts: &[String]) -> Result<SsrfResolution,
         return Err("Only http:// and https:// URLs are allowed".to_string());
     }
 
+    // Reject userinfo (`user[:pass]@host`) in the authority. Defense in
+    // depth (issue #5141): `extract_host` splits on `://` then `/`, so
+    // `http://allowed.example.com@127.0.0.1/` yields the host
+    // `allowed.example.com@127.0.0.1` and today merely fails DNS — but
+    // that is one parser tweak away from exploitable (the #3527 shape).
+    // `is_ssrf_target` on the WASM path and the MCP-OAuth path both reject
+    // userinfo explicitly; align this path so the policy is uniform and
+    // the URL never reaches reqwest's connection-pool key with credentials
+    // embedded. Scope the `@` scan to the authority only (a `?query=a@b`
+    // or `#frag@x` is legitimate and must not be rejected).
+    if let Some((_, rest)) = url.split_once("://") {
+        let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+        if rest[..authority_end].contains('@') {
+            return Err("SSRF blocked: URLs with userinfo are not permitted".to_string());
+        }
+    }
+
     let host = extract_host(url);
     // For IPv6 bracket notation like [::1]:80, extract [::1] as hostname
     let hostname = if host.starts_with('[') {
@@ -337,7 +354,7 @@ pub fn check_ssrf(url: &str, allowed_hosts: &[String]) -> Result<SsrfResolution,
 /// Covers:
 /// - `169.254.0.0/16` — link-local / AWS EC2 metadata
 /// - `100.64.0.0/10`  — CGNAT (also used by Alibaba Cloud IMDS at 100.100.100.200)
-fn is_cloud_metadata_ip(ip: &IpAddr) -> bool {
+pub(crate) fn is_cloud_metadata_ip(ip: &IpAddr) -> bool {
     match canonical_ip(ip) {
         IpAddr::V4(v4) => {
             let o = v4.octets();
@@ -361,7 +378,7 @@ fn is_cloud_metadata_ip(ip: &IpAddr) -> bool {
 ///
 /// Custom NAT64 prefixes (RFC 6052 §2.2) are NOT handled — those are
 /// per-environment configuration and would need an explicit setting.
-fn canonical_ip(ip: &IpAddr) -> IpAddr {
+pub(crate) fn canonical_ip(ip: &IpAddr) -> IpAddr {
     match ip {
         IpAddr::V6(v6) => {
             if let Some(v4) = v6.to_ipv4_mapped() {
@@ -378,7 +395,7 @@ fn canonical_ip(ip: &IpAddr) -> IpAddr {
 
 /// Extract the embedded IPv4 from an address in the NAT64 well-known
 /// prefix `64:ff9b::/96` (RFC 6052). Returns `None` for any other address.
-fn extract_nat64_well_known(v6: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
+pub(crate) fn extract_nat64_well_known(v6: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
     let segments = v6.segments();
     // 96-bit prefix: 0064:ff9b:0000:0000:0000:0000::/96
     if segments[0] != 0x0064
@@ -485,7 +502,7 @@ fn cidr_contains(cidr: &str, ip: &IpAddr) -> Result<bool, ()> {
 }
 
 /// Check if an IP address is in a private range.
-fn is_private_ip(ip: &IpAddr) -> bool {
+pub(crate) fn is_private_ip(ip: &IpAddr) -> bool {
     match canonical_ip(ip) {
         IpAddr::V4(v4) => {
             let octets = v4.octets();
@@ -592,6 +609,44 @@ mod tests {
         assert!(check_ssrf("file:///etc/passwd", &[]).is_err());
         assert!(check_ssrf("ftp://internal.corp/data", &[]).is_err());
         assert!(check_ssrf("gopher://evil.com", &[]).is_err());
+    }
+
+    // --- #5141: userinfo rejection (defense-in-depth, #3527 shape) ---
+    #[test]
+    fn test_ssrf_rejects_userinfo() {
+        // ATTACK: host-confusion via userinfo. `extract_host` splits on
+        // `://` then `/`, so the host would be
+        // `allowed.example.com@127.0.0.1` — today that merely fails DNS,
+        // but it must be rejected explicitly so a future parser change
+        // can't make it exploitable, and so credentials never reach
+        // reqwest's connection-pool key.
+        let err = match check_ssrf("http://allowed.example.com@127.0.0.1/", &[]) {
+            Err(e) => e,
+            Ok(_) => panic!("userinfo URL must be rejected"),
+        };
+        assert!(err.contains("userinfo"), "got: {err}");
+        assert!(check_ssrf("http://user:pass@169.254.169.254/", &[]).is_err());
+        assert!(check_ssrf("https://a@b@evil.example.com/", &[]).is_err());
+    }
+
+    #[test]
+    fn test_ssrf_userinfo_check_does_not_false_positive_on_query_or_fragment() {
+        // POSITIVE: an `@` in the path / query / fragment is legitimate
+        // and must NOT be treated as userinfo. (DNS for example.com may
+        // fail in CI sandboxes, so only assert it is not the userinfo
+        // rejection.)
+        for u in [
+            "http://example.com/path?email=a@b.com",
+            "http://example.com/#section@2",
+            "http://example.com/users/a@b",
+        ] {
+            if let Err(e) = check_ssrf(u, &[]) {
+                assert!(
+                    !e.contains("userinfo"),
+                    "URL {u} wrongly rejected as userinfo: {e}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/librefang-runtime/src/workspace_sandbox.rs
+++ b/crates/librefang-runtime/src/workspace_sandbox.rs
@@ -13,6 +13,14 @@ pub const ERR_PATH_TRAVERSAL: &str = "Path traversal denied";
 /// Used by `agent_loop` to identify sandbox rejections as soft (recoverable) failures.
 pub const ERR_SANDBOX_ESCAPE: &str = "resolves outside workspace";
 
+/// Error prefix emitted when the final path component is itself a symlink.
+/// A leaf symlink — even a dangling one whose target does not yet exist —
+/// must never be followed by a subsequent write/read: the caller would
+/// resolve the link to an attacker-chosen target outside the sandbox
+/// (`/etc/cron.d/foo`, `~/.ssh/authorized_keys`). Treated as a soft
+/// (recoverable) failure by `agent_loop`, same class as the other two.
+pub const ERR_SYMLINK_LEAF: &str = "Symlink leaf denied";
+
 /// Resolve a user-supplied path within a workspace sandbox.
 ///
 /// - Rejects `..` components outright.
@@ -73,6 +81,30 @@ pub fn resolve_sandbox_path_ext(
             .canonicalize()
             .map_err(|e| format!("Failed to resolve path: {e}"))?
     } else {
+        // SECURITY: a leaf symlink whose target does NOT exist makes
+        // `candidate.exists()` return `false` (it follows the link and
+        // finds nothing), so we land here instead of the canonicalize
+        // branch above. Without this guard the code below would return
+        // `canon_parent.join(filename)` — i.e. the symlink path itself —
+        // and `tool_file_write` / `web_fetch_to_file` would then
+        // `fs::write` *through* the link to an attacker-chosen target
+        // (`/etc/cron.d/foo`, `~/.ssh/authorized_keys`). `symlink_metadata`
+        // does NOT follow the link, so it sees the symlink even when the
+        // target is missing. Reject it outright — mirrors the WASM host
+        // path (`host_functions::host_fs_write`, symlink_metadata + the
+        // O_NOFOLLOW belt-and-suspenders). The legitimate `exists()`
+        // branch above is unaffected: a leaf symlink with a live target
+        // is canonicalized there and the `starts_with` check still
+        // catches escapes.
+        if let Ok(meta) = candidate.symlink_metadata() {
+            if meta.file_type().is_symlink() {
+                return Err(format!(
+                    "{ERR_SYMLINK_LEAF}: '{user_path}' is a symlink; \
+                     refusing to follow it (target may point outside the \
+                     workspace)"
+                ));
+            }
+        }
         // For new files: canonicalize the parent and append the filename
         // If the parent doesn't exist yet, return the joined path and let
         // the caller create the directory structure.
@@ -236,6 +268,73 @@ mod tests {
         let result = resolve_sandbox_path("escape/secret.txt", dir.path());
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Access denied"));
+    }
+
+    // ---- #5141: dangling-leaf-symlink escape ---------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn test_dangling_leaf_symlink_escaping_workspace_is_rejected() {
+        // ATTACK: pre-stage a leaf symlink inside the workspace that points
+        // to a target that does NOT exist outside the workspace
+        // (`/tmp/<unique>/etc-cron-d-foo`). `candidate.exists()` follows the
+        // link, finds nothing, returns false — so before the fix the code
+        // fell through to the parent-canonicalize branch and returned the
+        // symlink path itself; `tool_file_write` would then write THROUGH
+        // it to the attacker target. After the fix the leaf symlink is
+        // rejected outright.
+        let dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let dangling_target = outside.path().join("does-not-exist-yet");
+        assert!(!dangling_target.exists());
+
+        let link_path = dir.path().join("evil_link");
+        std::os::unix::fs::symlink(&dangling_target, &link_path).unwrap();
+
+        let result = resolve_sandbox_path("evil_link", dir.path());
+        assert!(result.is_err(), "dangling leaf symlink must be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains(ERR_SYMLINK_LEAF),
+            "expected symlink-leaf rejection, got: {err}"
+        );
+        // The attacker target must NOT have been created.
+        assert!(!dangling_target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_dangling_leaf_symlink_to_inside_target_still_rejected() {
+        // Even a dangling symlink whose (non-existent) target is *inside*
+        // the workspace is rejected: we cannot trust the link, and the
+        // legitimate path is to write the regular file directly. This keeps
+        // the rule simple and removes the TOCTOU surface.
+        let dir = TempDir::new().unwrap();
+        let inside_missing = dir.path().join("real_file.txt");
+        let link_path = dir.path().join("link_to_real");
+        std::os::unix::fs::symlink(&inside_missing, &link_path).unwrap();
+
+        let result = resolve_sandbox_path("link_to_real", dir.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains(ERR_SYMLINK_LEAF));
+    }
+
+    #[test]
+    fn test_legitimate_new_file_write_still_succeeds() {
+        // POSITIVE: the fix must not break the common case — creating a new
+        // regular file (no symlink anywhere) under an existing dir.
+        let dir = TempDir::new().unwrap();
+        let data = dir.path().join("data");
+        std::fs::create_dir_all(&data).unwrap();
+
+        let result = resolve_sandbox_path("data/report.txt", dir.path());
+        assert!(result.is_ok(), "got: {:?}", result);
+        let resolved = result.unwrap();
+        assert!(resolved.starts_with(dir.path().canonicalize().unwrap()));
+        assert!(resolved.ends_with("report.txt"));
+        // And it is actually writable.
+        std::fs::write(&resolved, b"hello").unwrap();
+        assert_eq!(std::fs::read(&resolved).unwrap(), b"hello");
     }
 
     // ---- additional_roots tests (named-workspace read-side support) ----


### PR DESCRIPTION
## Summary

P1/P2 follow-ups from the security audit (#5141, sibling of #5124). Each
validator handled the easy case but missed an adjacent shape an attacker
would deliberately pick. One cohesive thematic PR; scoped to
`librefang-runtime` only.

## Sub-items addressed

- **`file_write` dangling-leaf-symlink escape** — `crates/librefang-runtime/src/workspace_sandbox.rs:71-89`. For a symlink whose target does not exist, `candidate.exists()` follows the link and returns `false`, so resolution fell through to `canon_parent.join(filename)` and returned the symlink path; `tool_file_write` (`tool_runner/fs.rs:252`) / `web_fetch_to_file.rs:181-185` then `fs::write` THROUGH it. Fix: `symlink_metadata` rejects the leaf in the non-exists branch (it does not follow the link). New `ERR_SYMLINK_LEAF` added to the soft-error allowlist (`agent_loop/message.rs:177`) so the LLM recovers, same class as the existing two.

- **Tarball extraction has no `..`/symlink rejection** — `crates/librefang-runtime/src/registry_sync.rs:290-313`. Loop factored into `extract_entries_into`. Now: skip every non-file/non-dir entry (`SymbolicLink`/`HardLink`/device — `Entry::unpack` honours them); reject any post-strip path with a `..`/root/prefix component (the plain-string prefix strip does not normalise); plus a canonical deepest-existing-ancestor containment re-check. Mirror substitution (`apply_mirror`, :251-256) makes the source operator-influenceable, so this is not theoretical.

- **Cascade-leak bypassed by all-thematic headers** — `crates/librefang-runtime/src/silent_response.rs:54-95`. `THEMATIC_HEADERS` split into a scaffold-only subset (`## Sender`, `## Response Style` — never emitted by a genuine reply) counted as structural-equivalent; the thematic pairing re-scan now uses only the *ambiguous* subset (`## Today`/`## Calendar`/`## Tasks`) so a single scaffold header alone does not trip. Closes the `## Sender / ## Today / ## Tasks` regurgitation while keeping the legitimate day-summary reply non-leaking. Pre-existing test `cascade_leak_thematic_headers_alone_are_legitimate` updated — its `## Sender + ## Response Style` assertion *was* the vulnerability.

- **Legacy `NO_REPLY` unbounded trailing match** — `crates/librefang-runtime/src/silent_response.rs:116-124`. `legacy_ends_with_boundary` requires a non-word char before the trailing sentinel, so `…rowsNO_REPLY` no longer suppresses a user-visible reply after a side-effecting tool ran. Bounded trailing tokens (`x. NO_REPLY`, `x\nNO_REPLY`) and exact match unchanged. (Rollback-flag `LIBREFANG_SILENT_V2=off` path only.)

- **WASM `is_ssrf_target` misses NAT64/CGNAT** — `crates/librefang-runtime/src/host_functions.rs:225-249`. Deleted the drifted local `canonical_ip`/`is_private_ip`; now reuses the canonical `web_fetch` helpers (made `pub(crate)`), which unwrap NAT64 `64:ff9b::/96` and block CGNAT `100.64.0.0/10` + IMDS. Sharing one impl makes this class of drift structurally impossible.

- **`extract_host`/`check_ssrf` doesn't reject userinfo (defense-in-depth, [low])** — `crates/librefang-runtime/src/web_fetch.rs:254`. Explicit authority-scoped userinfo rejection (`http://allowed@127.0.0.1/`), aligning with the WASM (`is_ssrf_target`) and OAuth (`is_ssrf_blocked_url`) paths. `@` in path/query/fragment is not a false positive.

## Not changed (reason)

- **`is_ssrf_blocked_host` in the MCP-OAuth path doesn't resolve DNS** — `crates/librefang-runtime-mcp/src/mcp_oauth.rs:166-258`. The function is *documented* (doc comment :166-171) as deliberately literal-only, with DNS-rebind explicitly out of scope and to be mitigated at the network layer. The audit itself acknowledges this. Adding a resolver to a pure literal-matcher shared by `well_known_url` / `validate_metadata_endpoints` is a separate design decision (different crate + behavioural change) the maintainer already made consciously — surfaced here for the reviewer rather than reversed unilaterally.

## Verification

- `cargo check -p librefang-runtime --lib` — clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` — clean
- `cargo fmt -p librefang-runtime -- --check` — clean (pre-commit hook also ran)
- `cargo test -p librefang-runtime --lib` — **1701 passed, 0 failed**, incl. new attack-shape + positive regression tests:
  - `workspace_sandbox`: `test_dangling_leaf_symlink_escaping_workspace_is_rejected`, `_to_inside_target_still_rejected`, `test_legitimate_new_file_write_still_succeeds`
  - `registry_sync`: `extract_rejects_dotdot_traversal_entry` (raw-header crafted), `extract_skips_symlink_entry`, `extract_accepts_legitimate_tarball`
  - `silent_response`: `cascade_leak_scaffold_only_headers_trip_without_structural`, `cascade_leak_ambiguous_thematic_alone_still_legitimate`, `legacy_rejects_glued_no_reply_after_tool_output`, `legacy_still_accepts_bounded_trailing_no_reply`
  - `host_functions`: `test_is_private_ip_blocks_nat64_and_cgnat`
  - `web_fetch`: `test_ssrf_rejects_userinfo`, `_does_not_false_positive_on_query_or_fragment`
  - Pre-existing `agent_loop::tests::*cascade_leak*` and `thematic_headers_alone_are_legitimate` still green (no regression).

Closes #5141