### PR TITLE
fix(xtask): cap sysinfo at 0.38 to honor 1.94.1 MSRV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -239,7 +239,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1154,7 +1154,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1972,7 +1972,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2302,7 +2302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2875,7 +2875,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -5467,7 +5467,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5628,7 +5628,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6119,7 +6119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7990,7 +7990,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8073,7 +8073,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8817,7 +8817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9153,9 +9153,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.1"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
@@ -9680,7 +9680,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10349,7 +10349,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10432,7 +10432,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11513,7 +11513,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,7 +17,10 @@ sha2 = { workspace = true }
 # Kept xtask-local; not promoted to workspace.dependencies because no
 # production crate consumes it. Default features are disabled — we only need
 # the system probe, not disks/networks/processes.
-sysinfo = { version = "0.39", default-features = false, features = ["system"] }
+# Capped at 0.38: the entire sysinfo 0.39.x line requires rustc 1.95, which
+# exceeds this workspace's pinned MSRV (Cargo.toml rust-version = 1.94.1).
+# 0.38.4 needs only rustc 1.88 and exposes the same probe API we use.
+sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 librefang-migrate = { path = "../crates/librefang-migrate" }
 
 [lints]


### PR DESCRIPTION
## Problem

`cargo xtask release` (and `just release`) fails on stable rustc 1.94.1:

```
error: rustc 1.94.1 is not supported by the following package:
  sysinfo@0.39.1 requires rustc 1.95
```

`xtask/Cargo.toml` declared `sysinfo = "0.39"`. The **entire 0.39.x line**
(0.39.0 / 0.39.1 / 0.39.2) requires rustc 1.95, which exceeds this
workspace's deliberately pinned MSRV — `Cargo.toml` `rust-version = "1.94.1"`,
reinforced by the comment in `rust-toolchain.toml` requiring new code to
respect the declared MSRV. cargo resolved to 0.39.1 and broke the build.

## Change

- `xtask/Cargo.toml`: `sysinfo` version requirement `"0.39"` → `"0.38"`,
  with a comment explaining the MSRV cap.
- `Cargo.lock`: `sysinfo` `0.39.1` → `0.38.4` (needs only rustc 1.88).

0.38.4 exposes the identical API surface xtask consumes in
`xtask/src/local_check_mode.rs:75-83` (`System::new_with_specifics`,
`RefreshKind::nothing()`, `MemoryRefreshKind::nothing().with_ram()`,
`total_memory()`), so the downgrade is API-safe.

### About the Cargo.lock diff size

Only the **sysinfo** package entry changes version. No other package is
added, removed, or version-bumped. The remaining ~17 changed lines
normalize pre-existing stale `windows-sys` / `windows-link` dependency
*edges* (those package versions already existed in the committed lock);
cargo rewrites these on any lock regeneration regardless of this change.
Verified: `git diff Cargo.lock | grep -E '^[+-]\[\[package\]\]|^[+-]name = '`
returns nothing.

## Verification

- `cargo update sysinfo --precise 0.38.4 --dry-run` → reports only the
  sysinfo downgrade.
- `cargo check -p xtask` → `Finished` in 29.57s, zero warnings, against
  sysinfo 0.38.4.

## Out-of-scope follow-ups

None.