### PR TITLE
fix(api,kernel,runtime,acp): task lifecycle / resource-leak follow-ups (#5144)

### DIFF
--- a/crates/librefang-acp/src/events.rs
+++ b/crates/librefang-acp/src/events.rs
@@ -132,8 +132,23 @@ impl EventTranslator {
                 // tool-call card. (#3313 review, PR-3)
                 let pending_before = queue.as_ref().map(|q| q.len()).unwrap_or(0);
                 let tool_call_id = queue
-                    .and_then(|q| q.pop_front())
+                    .map(|q| q.pop_front())
+                    .unwrap_or(None)
                     .unwrap_or_else(|| ToolCallId::new(format!("orphan-{name}")));
+                // Reap the outer entry once its queue drains. Without
+                // this the `(name, empty-VecDeque)` pair lingers for the
+                // life of the translator (this turn / ACP session) and
+                // grows with the count of distinct tool names invoked —
+                // a per-session leak (#5144). Re-borrow and check
+                // emptiness directly so a queue emptied by this pop (or
+                // one already empty from a prior result) is removed.
+                if self
+                    .in_flight_by_name
+                    .get(&name)
+                    .is_some_and(|q| q.is_empty())
+                {
+                    self.in_flight_by_name.remove(&name);
+                }
                 let status = if is_error {
                     ToolCallStatus::Failed
                 } else {
@@ -383,5 +398,79 @@ mod tests {
             }
             _ => panic!(),
         }
+    }
+
+    /// Regression (#5144): once a tool name's in-flight queue drains,
+    /// the outer `in_flight_by_name` entry must be removed, not left as
+    /// a `(name, empty-VecDeque)` pair. Before the fix the map grew with
+    /// the count of distinct tool names invoked in the session/turn even
+    /// though every call had completed.
+    #[test]
+    fn drained_tool_queue_is_reaped_from_map() {
+        let mut t = EventTranslator::new();
+
+        // Two distinct tool names, each a single start→result round-trip.
+        for name in ["read_file", "write_file"] {
+            let _ = t.translate(StreamEvent::ToolUseStart {
+                id: format!("{name}-1"),
+                name: name.to_string(),
+            });
+            // While in flight the entry exists.
+            assert!(
+                t.in_flight_by_name.contains_key(name),
+                "in-flight entry must exist for {name}"
+            );
+            let _ = t.translate(StreamEvent::ToolExecutionResult {
+                name: name.to_string(),
+                result_preview: "done".into(),
+                is_error: false,
+            });
+            // After the result drains the queue the entry must be gone.
+            assert!(
+                !t.in_flight_by_name.contains_key(name),
+                "drained entry for {name} must be reaped"
+            );
+        }
+
+        assert!(
+            t.in_flight_by_name.is_empty(),
+            "map must be empty after all tool calls completed, got {} entries",
+            t.in_flight_by_name.len()
+        );
+    }
+
+    /// A still-pending sibling call must NOT cause premature reaping:
+    /// the entry survives until its queue is fully drained.
+    #[test]
+    fn map_entry_survives_while_siblings_pending() {
+        let mut t = EventTranslator::new();
+        let _ = t.translate(StreamEvent::ToolUseStart {
+            id: "a".into(),
+            name: "fetch".into(),
+        });
+        let _ = t.translate(StreamEvent::ToolUseStart {
+            id: "b".into(),
+            name: "fetch".into(),
+        });
+        // First result pops "a" but "b" is still pending → keep entry.
+        let _ = t.translate(StreamEvent::ToolExecutionResult {
+            name: "fetch".into(),
+            result_preview: "first".into(),
+            is_error: false,
+        });
+        assert!(
+            t.in_flight_by_name.contains_key("fetch"),
+            "entry must survive while a sibling call is still in flight"
+        );
+        // Second result drains the queue → entry reaped.
+        let _ = t.translate(StreamEvent::ToolExecutionResult {
+            name: "fetch".into(),
+            result_preview: "second".into(),
+            is_error: false,
+        });
+        assert!(
+            !t.in_flight_by_name.contains_key("fetch"),
+            "entry must be reaped once all siblings have completed"
+        );
     }
 }

--- a/crates/librefang-api/src/routes/logs.rs
+++ b/crates/librefang-api/src/routes/logs.rs
@@ -41,6 +41,15 @@ pub async fn logs_stream(
         Result<axum::response::sse::Event, std::convert::Infallible>,
     >(256);
 
+    // Subscribe to the kernel shutdown signal so this detached task can
+    // exit promptly on daemon shutdown. Without this the only loop exit
+    // is `tx.send` returning `Err` (client disconnect), so the spawned
+    // task holds the `Arc<AppState>` (and therefore the whole kernel
+    // graph via `state.kernel`) until the OS tears the socket down —
+    // pinning the entire `AppState` for as long as any dashboard tab
+    // keeps an SSE channel open (#5144).
+    let mut shutdown_rx = state.kernel.supervisor_ref().subscribe();
+
     tokio::spawn(async move {
         // Cursor-based polling: `last_seq == 0` triggers the bounded
         // backfill on the very first iteration, then every subsequent
@@ -54,7 +63,15 @@ pub async fn logs_stream(
         let mut first_poll = true;
 
         loop {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        return; // Kernel shutting down — drop Arc<AppState>.
+                    }
+                    continue;
+                }
+            }
 
             let entries = if first_poll {
                 // First connect: cap the backfill so a long-running

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -1925,6 +1925,11 @@ pub async fn comms_events_stream(State(state): State<Arc<AppState>>) -> axum::re
         Result<axum::response::sse::Event, std::convert::Infallible>,
     >(256);
 
+    // Subscribe to kernel shutdown so the detached poll task exits on
+    // daemon shutdown rather than pinning the whole `AppState` graph
+    // (via the moved `state`) until the client socket closes (#5144).
+    let mut shutdown_rx = state.kernel.supervisor_ref().subscribe();
+
     tokio::spawn(async move {
         let mut last_seq: u64 = {
             let entries = state.kernel.audit().recent(1);
@@ -1932,7 +1937,15 @@ pub async fn comms_events_stream(State(state): State<Arc<AppState>>) -> axum::re
         };
 
         loop {
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {}
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        return; // Kernel shutting down — drop Arc<AppState>.
+                    }
+                    continue;
+                }
+            }
 
             let agents = state.kernel.agent_registry().list();
             let entries = state.kernel.audit().recent(50);

--- a/crates/librefang-api/tests/sse_stream_shutdown_test.rs
+++ b/crates/librefang-api/tests/sse_stream_shutdown_test.rs
@@ -1,0 +1,110 @@
+//! Regression (#5144): the SSE log / comms-event stream handlers spawn a
+//! detached polling task that holds an `Arc<AppState>` (and therefore the
+//! whole kernel graph via `state.kernel`). Before the fix the only loop
+//! exit was `tx.send` returning `Err` (client disconnect), so on daemon
+//! shutdown the task kept the entire `AppState` pinned for as long as any
+//! dashboard tab kept an SSE channel open.
+//!
+//! These tests keep the SSE response (and thus the channel receiver)
+//! alive so a client-disconnect exit is impossible, then fire the kernel
+//! shutdown signal and assert the detached task drops its `Arc<AppState>`
+//! clone — i.e. it exited on the shutdown signal, not on disconnect.
+
+use axum::extract::{Query, State};
+use librefang_api::routes::{logs, network, AppState};
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Poll `Arc::strong_count(state)` down to `target` within a bounded
+/// budget. Returns the final observed count.
+async fn wait_for_strong_count(state: &Arc<AppState>, target: usize) -> usize {
+    for _ in 0..200 {
+        let c = Arc::strong_count(state);
+        if c <= target {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    Arc::strong_count(state)
+}
+
+// Multi-thread flavor: `MockKernelBuilder::build` calls `block_in_place`
+// during kernel boot, which panics on the single-thread runtime.
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_stream_task_exits_on_kernel_shutdown() {
+    let test = TestAppState::with_builder(MockKernelBuilder::new());
+    let state = test.state.clone();
+
+    // Baseline: `state` (our handle) + `test.state` (the harness's).
+    let baseline = Arc::strong_count(&state);
+
+    // Invoke the handler directly. It spawns a detached task that moves
+    // a clone of `state` in, so the strong count must rise.
+    let resp = logs::logs_stream(State(state.clone()), Query(HashMap::new())).await;
+
+    // The detached poll task now holds an extra Arc clone.
+    let with_task = wait_for_task_to_hold_ref(&state, baseline).await;
+    assert!(
+        with_task > baseline,
+        "detached SSE task must hold an extra Arc<AppState> (baseline {baseline}, observed {with_task})"
+    );
+
+    // Keep the response (and its channel receiver) ALIVE so the only
+    // possible loop exit is the shutdown signal, never client
+    // disconnect.
+    let _resp_kept_alive = resp;
+
+    // Fire the kernel shutdown signal.
+    state.kernel.supervisor_ref().shutdown();
+
+    // The task must observe `shutdown_rx.changed()` and return, dropping
+    // its Arc clone — strong count returns to baseline even though the
+    // SSE receiver is still held.
+    let after = wait_for_strong_count(&state, baseline).await;
+    assert_eq!(
+        after, baseline,
+        "logs_stream task did not exit on shutdown while the SSE receiver was still alive \
+         (baseline {baseline}, after {after}) — it would have pinned the kernel"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn comms_events_stream_task_exits_on_kernel_shutdown() {
+    let test = TestAppState::with_builder(MockKernelBuilder::new());
+    let state = test.state.clone();
+    let baseline = Arc::strong_count(&state);
+
+    let resp = network::comms_events_stream(State(state.clone())).await;
+
+    let with_task = wait_for_task_to_hold_ref(&state, baseline).await;
+    assert!(
+        with_task > baseline,
+        "detached comms SSE task must hold an extra Arc<AppState> (baseline {baseline}, observed {with_task})"
+    );
+
+    let _resp_kept_alive = resp;
+
+    state.kernel.supervisor_ref().shutdown();
+
+    let after = wait_for_strong_count(&state, baseline).await;
+    assert_eq!(
+        after, baseline,
+        "comms_events_stream task did not exit on shutdown while the SSE receiver was still alive \
+         (baseline {baseline}, after {after}) — it would have pinned the kernel"
+    );
+}
+
+/// Spin until the freshly-spawned detached task has actually started and
+/// captured its `Arc<AppState>` clone (it is spawned, not run inline).
+async fn wait_for_task_to_hold_ref(state: &Arc<AppState>, baseline: usize) -> usize {
+    for _ in 0..200 {
+        let c = Arc::strong_count(state);
+        if c > baseline {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    Arc::strong_count(state)
+}

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -831,7 +831,46 @@ impl ApprovalManager {
             }
         }
 
+        // Piggyback the stale-TOTP-entry sweep on the existing periodic
+        // pending-request expiry pass (driven by `spawn_approval_sweep_task`,
+        // ~every 10s) instead of introducing a second background task
+        // (#5144).
+        self.gc_expired_totp_entries();
+
         (escalated, expired)
+    }
+
+    /// Drop TOTP grace / failure map entries that can no longer affect a
+    /// decision, so the maps stay bounded by *currently-relevant* sender
+    /// IDs rather than every sender ID seen over the daemon's lifetime
+    /// (#5144).
+    ///
+    /// - A grace entry is dead once `last.elapsed() >= totp_grace_period_secs`
+    ///   (it can no longer satisfy `is_within_totp_grace`). When the policy
+    ///   sets `totp_grace_period_secs == 0` grace is never honoured, so all
+    ///   grace entries are dead.
+    /// - A failure entry is dead once its lockout window has elapsed
+    ///   (`lockout_start.elapsed() >= TOTP_LOCKOUT_SECS`). Entries that
+    ///   never reached the lockout threshold (`lockout_start == None`)
+    ///   still gate brute-force counting, so they are kept — they are
+    ///   bounded by the in-flight failing senders and cleared on the
+    ///   next success or on lockout expiry inside `record_totp_failure`.
+    fn gc_expired_totp_entries(&self) {
+        let grace_secs = {
+            let policy = self.policy.read().unwrap_or_else(|e| e.into_inner());
+            policy.totp_grace_period_secs
+        };
+        {
+            let mut grace = self.totp_grace.lock().unwrap_or_else(|e| e.into_inner());
+            grace.retain(|_, last| grace_secs > 0 && last.elapsed().as_secs() < grace_secs);
+        }
+        {
+            let mut failures = self.totp_failures.lock().unwrap_or_else(|e| e.into_inner());
+            failures.retain(|_, (_, lockout_start)| match lockout_start {
+                Some(started) => started.elapsed().as_secs() < TOTP_LOCKOUT_SECS,
+                None => true,
+            });
+        }
     }
 
     /// Resolve a pending request (called by API/UI).
@@ -2949,6 +2988,59 @@ mod tests {
         // Even after recording grace, zero period means no grace
         mgr.record_totp_grace("admin");
         assert!(!mgr.is_within_totp_grace("admin", &policy));
+    }
+
+    /// Regression (#5144): `gc_expired_totp_entries` must drop grace
+    /// entries that can no longer satisfy `is_within_totp_grace` and
+    /// failure entries whose lockout window has elapsed, so the maps
+    /// stay bounded by *currently-relevant* sender IDs instead of every
+    /// sender seen over the daemon's lifetime. Entries that still gate a
+    /// decision (pre-threshold failure counters) must be preserved.
+    #[test]
+    fn gc_drops_only_dead_totp_entries() {
+        // grace_period == 0 → no grace entry can ever be honoured, so a
+        // sweep must drop every grace entry regardless of age. This
+        // exercises the GC deterministically without real-time waits.
+        let policy = ApprovalPolicy {
+            second_factor: SecondFactor::Totp,
+            totp_grace_period_secs: 0,
+            ..Default::default()
+        };
+        let mgr = ApprovalManager::new(policy);
+
+        mgr.record_totp_grace("alice");
+        mgr.record_totp_grace("bob");
+        assert_eq!(
+            mgr.totp_grace.lock().unwrap().len(),
+            2,
+            "grace entries recorded before sweep"
+        );
+
+        // Two pre-threshold failures (count < TOTP_MAX_FAILURES, so
+        // lockout_start stays None) — these must survive the sweep
+        // because they still gate brute-force counting.
+        let _ = mgr.record_totp_failure("charlie");
+        let _ = mgr.record_totp_failure("charlie");
+        assert_eq!(
+            mgr.totp_failures.lock().unwrap().len(),
+            1,
+            "pre-threshold failure entry recorded"
+        );
+
+        mgr.gc_expired_totp_entries();
+
+        assert_eq!(
+            mgr.totp_grace.lock().unwrap().len(),
+            0,
+            "grace entries must be reaped when grace is disabled"
+        );
+        assert_eq!(
+            mgr.totp_failures.lock().unwrap().len(),
+            1,
+            "pre-threshold failure entry must be preserved (still gates counting)"
+        );
+        // Charlie's counter must be intact.
+        assert!(!mgr.is_totp_locked_out("charlie"));
     }
 
     #[test]

--- a/crates/librefang-kernel/src/auto_dream/mod.rs
+++ b/crates/librefang-kernel/src/auto_dream/mod.rs
@@ -802,6 +802,23 @@ pub fn maybe_fire_on_turn_end(kernel: Arc<LibreFangKernel>, agent_id: AgentId) {
         return;
     }
 
+    // Scan throttle (moved ahead of the spawn — #5144): a chatty agent
+    // can push dozens of turns per minute past the three pre-filters.
+    // By design at most one dream fires per `min_hours`, so scanning
+    // more often than every ~10 minutes is pure noise. Evaluating this
+    // synchronously on the hot path means a throttled turn no longer
+    // allocates a short-lived `Arc<LibreFangKernel>`-holding task only
+    // to early-return inside it. The throttle is a pure rate-limit on
+    // `agent_id` (records the scan instant in a global map); it does
+    // not depend on the live kernel/global/opt-in state that the
+    // in-task re-checks below guard against, so it is correct to
+    // resolve before the `spawn_supervised`. Matches libre-code's
+    // `SESSION_SCAN_INTERVAL_MS = 10 min`.
+    if should_throttle_event_scan(agent_id) {
+        tracing::trace!(agent = %agent_id, "auto_dream: turn-end scan throttled (within 10 min of last scan)");
+        return;
+    }
+
     crate::supervised_spawn::spawn_supervised("auto_dream_dispatch", async move {
         // Re-check all three gates inside the task. The operator could have
         // flipped the global switch, toggled this agent off, or started a
@@ -818,17 +835,6 @@ pub fn maybe_fire_on_turn_end(kernel: Arc<LibreFangKernel>, agent_id: AgentId) {
         }
         if !kernel.agent_registry_ref().is_auto_dream_enabled(agent_id) {
             tracing::debug!(agent = %agent_id, "auto_dream: agent toggled off between hook and spawn, skipping");
-            return;
-        }
-        // Scan throttle: a chatty agent can push dozens of turns per minute
-        // past the three pre-filters. Each of those would otherwise run a
-        // full `check_agent_gates` (lock stat + sessions-touched SQL).
-        // Cheap individually but pointless at that rate — by design, at
-        // most one dream fires per `min_hours`, so scanning more often
-        // than every ~10 minutes is pure noise. Matches libre-code's
-        // `SESSION_SCAN_INTERVAL_MS = 10 min`.
-        if should_throttle_event_scan(agent_id) {
-            tracing::trace!(agent = %agent_id, "auto_dream: turn-end scan throttled (within 10 min of last scan)");
             return;
         }
         match check_agent_gates(&kernel, agent_id, false).await {
@@ -928,6 +934,13 @@ pub fn spawn_scheduler(kernel: Arc<LibreFangKernel>) {
             }
         }
 
+        // Subscribe to the supervisor shutdown signal so the scheduler
+        // wakes immediately on daemon shutdown instead of finishing a
+        // pending `sleep(interval_s)` first. `interval_s` is floored at
+        // 60s, so a plain `is_shutting_down()` check between sleeps left
+        // up to a full check-interval of shutdown latency (#5144).
+        let mut shutdown_rx = kernel.agents.supervisor.subscribe();
+
         loop {
             let interval_s = {
                 let cfg = kernel.config_snapshot();
@@ -936,7 +949,16 @@ pub fn spawn_scheduler(kernel: Arc<LibreFangKernel>) {
                 // a shorter cadence past the UI's validation.
                 cfg.auto_dream.check_interval_secs.max(60)
             };
-            tokio::time::sleep(Duration::from_secs(interval_s)).await;
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(interval_s)) => {}
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        tracing::debug!("auto_dream: shutdown signalled, scheduler exiting");
+                        return;
+                    }
+                    continue;
+                }
+            }
 
             if kernel.agents.supervisor.is_shutting_down() {
                 tracing::debug!("auto_dream: shutdown detected, scheduler exiting");

--- a/crates/librefang-runtime/src/process_manager.rs
+++ b/crates/librefang-runtime/src/process_manager.rs
@@ -48,7 +48,13 @@ pub struct ProcessInfo {
 
 /// Manager for persistent agent processes.
 pub struct ProcessManager {
-    processes: DashMap<ProcessId, ManagedProcess>,
+    // `Arc` so a detached reaper task (spawned per process in `start`)
+    // can hold a clone and evict the entry the moment the child exits
+    // on its own — `kill()` only reaps explicitly-killed processes, and
+    // `cleanup()` evicts by uptime, so without this a long-lived daemon
+    // running many short-lived process tools accumulates zombie
+    // `ManagedProcess` records forever (#5144).
+    processes: Arc<DashMap<ProcessId, ManagedProcess>>,
     max_per_agent: usize,
     next_id: std::sync::atomic::AtomicU64,
 }
@@ -57,7 +63,7 @@ impl ProcessManager {
     /// Create a new process manager.
     pub fn new(max_per_agent: usize) -> Self {
         Self {
-            processes: DashMap::new(),
+            processes: Arc::new(DashMap::new()),
             max_per_agent,
             next_id: std::sync::atomic::AtomicU64::new(1),
         }
@@ -111,8 +117,10 @@ impl ProcessManager {
         let stdout_buf = Arc::new(Mutex::new(Vec::<String>::new()));
         let stderr_buf = Arc::new(Mutex::new(Vec::<String>::new()));
 
-        // Spawn background readers for stdout/stderr
-        if let Some(out) = stdout {
+        // Spawn background readers for stdout/stderr. We keep the join
+        // handles so the per-process reaper can await pipe drain before
+        // evicting the registry entry (#5144).
+        let stdout_reader = stdout.map(|out| {
             let buf = stdout_buf.clone();
             tokio::spawn(async move {
                 let reader = BufReader::new(out);
@@ -125,10 +133,10 @@ impl ProcessManager {
                     }
                     b.push(line);
                 }
-            });
-        }
+            })
+        });
 
-        if let Some(err) = stderr {
+        let stderr_reader = stderr.map(|err| {
             let buf = stderr_buf.clone();
             tokio::spawn(async move {
                 let reader = BufReader::new(err);
@@ -140,8 +148,8 @@ impl ProcessManager {
                     }
                     b.push(line);
                 }
-            });
-        }
+            })
+        });
 
         let id = format!(
             "proc_{}",
@@ -169,6 +177,36 @@ impl ProcessManager {
                 started_at: std::time::Instant::now(),
             },
         );
+
+        // Per-process reaper: a child that exits on its own closes both
+        // pipes (the readers above hit EOF and their tasks finish). Once
+        // both readers are done, confirm the child has actually exited
+        // via the registry entry's `child.wait()` and evict it, so
+        // naturally-exited processes don't linger as zombie records
+        // until `cleanup()`'s uptime sweep or an explicit `kill()`
+        // (#5144). If a `kill()` removed the entry first this is a
+        // harmless no-op.
+        let processes = self.processes.clone();
+        let reap_id = id.clone();
+        tokio::spawn(async move {
+            if let Some(h) = stdout_reader {
+                let _ = h.await;
+            }
+            if let Some(h) = stderr_reader {
+                let _ = h.await;
+            }
+            // Both pipes drained → the child has exited. Remove the
+            // registry entry first (releasing the DashMap shard lock
+            // immediately — never hold a `get_mut` guard across the
+            // `child.wait()` await, or a concurrent `kill()` would
+            // block on the same shard), then reap the owned child to
+            // collect its exit status and avoid a zombie. If `kill()`
+            // already removed the entry this is a harmless no-op.
+            if let Some((_, mut proc)) = processes.remove(&reap_id) {
+                let _ = proc.child.wait().await;
+                debug!(process_id = %reap_id, "Reaped naturally-exited process");
+            }
+        });
 
         Ok(id)
     }
@@ -353,5 +391,71 @@ mod tests {
         let pm = ProcessManager::default();
         assert_eq!(pm.max_per_agent, 5);
         assert_eq!(pm.count(), 0);
+    }
+
+    /// A short-lived command that exits on its own (no explicit `kill`).
+    fn short_lived_proc() -> (&'static str, Vec<String>) {
+        if cfg!(windows) {
+            ("cmd", vec!["/C".to_string(), "exit".to_string()])
+        } else {
+            ("true", vec![])
+        }
+    }
+
+    /// Regression (#5144): a managed child that exits on its own must
+    /// have its registry entry reaped automatically by the per-process
+    /// reaper. Before the fix only `kill()` (explicit) or `cleanup()`
+    /// (uptime-based) removed entries, so naturally-exited short-lived
+    /// process tools accumulated as zombie `ManagedProcess` records.
+    #[tokio::test]
+    async fn naturally_exited_process_is_reaped() {
+        let pm = ProcessManager::new(5);
+        let (cmd, args) = short_lived_proc();
+        let id = pm.start("agent1", cmd, &args).await.unwrap();
+        assert_eq!(pm.count(), 1, "entry present right after start");
+
+        // The reaper awaits both pipe readers then `child.wait()`; for a
+        // process that exits immediately this happens quickly. Poll with
+        // a bounded budget rather than a fixed sleep to stay robust on
+        // slow CI without flaking.
+        let mut reaped = false;
+        for _ in 0..100 {
+            if pm.count() == 0 {
+                reaped = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(
+            reaped,
+            "naturally-exited process entry was not reaped (count still {})",
+            pm.count()
+        );
+
+        // A late `kill` of the already-reaped id is a harmless error,
+        // not a panic / double-free.
+        assert!(pm.kill(&id).await.is_err());
+    }
+
+    /// The reaper must not fight an explicit `kill()`: killing a
+    /// long-running process still removes exactly one entry and leaves
+    /// the manager consistent (no double-remove panic, count == 0).
+    #[tokio::test]
+    async fn explicit_kill_still_reaps_exactly_once() {
+        let pm = ProcessManager::new(5);
+        let (cmd, args) = long_running_proc();
+        let id = pm.start("agent1", cmd, &args).await.unwrap();
+        assert_eq!(pm.count(), 1);
+        pm.kill(&id).await.unwrap();
+
+        // After kill the pipes EOF and the reaper runs; either path
+        // converges on count == 0 with no panic.
+        for _ in 0..100 {
+            if pm.count() == 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert_eq!(pm.count(), 0, "manager must be empty after kill + reap");
     }
 }


### PR DESCRIPTION
## Summary

P1/P2 follow-ups from the resource-leak audit (#5144). Each enumerated sub-item read against current `origin/main` and confirmed before fixing: a detached `tokio::spawn` task with no shutdown signal, a raw `tokio::time::sleep` without `select!`, or a map that grows but is never reaped.

## Sub-items fixed

- **SSE log / comms stream tasks never check kernel shutdown** — `crates/librefang-api/src/routes/logs.rs:44` (`logs_stream`) and `crates/librefang-api/src/routes/network.rs:1928` (`comms_events_stream`). The spawned poll loop's only exit was `tx.send` returning `Err` (client disconnect), so on shutdown the task pinned the whole `AppState` graph (`Arc<dyn KernelApi>`, hence the kernel) until the OS closed the socket. Both loops now wrap the sleep in `tokio::select!` on `state.kernel.supervisor_ref().subscribe()` and `return` on shutdown.

- **`auto_dream` raw sleep + per-turn spawn churn** — `crates/librefang-kernel/src/auto_dream/mod.rs`. (a) `spawn_scheduler` now `select!`s on `kernel.agents.supervisor.subscribe()` instead of checking `is_shutting_down()` only *after* a raw `sleep(interval_s)` (interval floored at 60s), removing up to a full check-interval of shutdown latency. (b) `maybe_fire_on_turn_end` moves the `should_throttle_event_scan` check ahead of `spawn_supervised`, so a throttled turn no longer allocates a short-lived `Arc<LibreFangKernel>`-holding task only to early-return inside it. The throttle is a pure per-`agent_id` rate-limit and does not depend on the live kernel/global/opt-in state the in-task re-checks guard.

- **`EventTranslator.in_flight_by_name` HashMap entries never reaped** — `crates/librefang-acp/src/events.rs:49,123`. After `pop_front`, the outer `(name, VecDeque)` entry is removed once its queue is empty (re-borrow + `is_empty()` check), instead of lingering as a `(name, empty-VecDeque)` pair for the life of the translator.

- **`ApprovalManager` TOTP grace / failure HashMaps never GC'd** — `crates/librefang-kernel/src/approval.rs:1463,1495`. New private `gc_expired_totp_entries()` piggybacked on the existing `expire_pending_requests()` sweep (already driven ~every 10s by `spawn_approval_sweep_task`) — no second background task. Drops grace entries that can no longer satisfy `is_within_totp_grace` (including all of them when `totp_grace_period_secs == 0`) and failure entries whose lockout window has elapsed. Pre-threshold failure counters (`lockout_start == None`) are preserved — they still gate brute-force counting.

- **`process_manager` retains entries for naturally-exited processes** — `crates/librefang-runtime/src/process_manager.rs:215-228`. A per-process reaper task awaits both pipe-reader join handles (EOF on child exit), then removes the `DashMap` entry and `child.wait()`s the owned child to avoid a zombie. `processes` is now `Arc<DashMap<..>>` so the detached reaper can hold a clone. The entry is removed **before** the `child.wait()` await, so a concurrent `kill()` never blocks on the same DashMap shard; a late `kill()` of an already-reaped id is a harmless `Err`.

## Verification

- `cargo check -p <crate> --lib` clean: `librefang-acp`, `librefang-api`, `librefang-kernel`, `librefang-runtime`.
- `cargo clippy -p <crate> --all-targets -- -D warnings` clean on all four.
- Scoped tests green: `librefang-acp` 31 lib tests, `librefang-runtime` 7 `process_manager` tests, `librefang-kernel` 78 `approval` + 25 `auto_dream` tests, `librefang-api` `sse_stream_shutdown_test` 2 tests.
- Pre-commit hook (`cargo fmt --check`, CHANGELOG/attribution guards) passed.

### Tests added

- `librefang-acp`: `drained_tool_queue_is_reaped_from_map`, `map_entry_survives_while_siblings_pending`
- `librefang-runtime`: `naturally_exited_process_is_reaped`, `explicit_kill_still_reaps_exactly_once`
- `librefang-kernel`: `approval::tests::gc_drops_only_dead_totp_entries` (the relocated throttle is covered by the existing `scan_throttle_*` tests, which still pass — semantics unchanged, only the call site moved)
- `librefang-api`: `tests/sse_stream_shutdown_test.rs` — keeps the SSE response (channel receiver) alive so a disconnect exit is impossible, fires `supervisor_ref().shutdown()`, and asserts the detached task drops its `Arc<AppState>` clone (strong count returns to baseline). This is the real-behavior proof that the kernel can drop while a dashboard tab still holds an SSE channel.

## Not changed (reason)

- **#5127 (cron per-fire `reqwest::Client` construction)** — the P0 sibling, explicitly out of scope for #5144 and already landed on `main` as commit `864ac1bf` (`fix(cron): reuse reqwest::Client across fan-out fires`). Not touched here.

Closes #5144