### PR TITLE
release: v2026.5.17-beta.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,115 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.5.17] - 2026-05-17
+
+_76 PRs from 5 contributors since v2026.5.12-beta.11._
+
+### Highlights
+
+- **Workflow operator nodes** — Wait, Gate, Transform, Branch, and human-in-the-loop pause/resume steps bring full orchestration control to multi-step workflows, with inline image display and rich invocation support
+- **Per-agent compaction & prompt-cache tuning** — agents can now configure context compaction thresholds and Anthropic prompt-cache breakpoint strategy directly in `agent.toml`, reducing token costs on long sessions
+- **On-demand tool/skill loading and declarative triggers** — tools and skills load only when needed, and `[[triggers]]` can now be declared directly in `agent.toml`, cutting startup overhead and simplifying agent configuration
+- **Async task tracker and training exporters** — a kernel-level async task registry with W&B, Tinker, and Atropos trajectory exporters enables continuous learning pipelines from agent runs
+- **Audio transcription and voice routing fixes** — inbound channel audio auto-transcribes when enabled, outbound OGG/Opus correctly routes via `sendVoice`, and per-channel proxy configuration is now supported
+
+### Added
+
+- Show skill descriptions in agent Skills tab (#5013) (@houko)
+- Display generated images inline in workflow run view (#5015) (@houko)
+- File_read deduplication — stub repeated reads of unchanged files (#5016) (@houko)
+- Per-channel proxy configuration (#4795) (#5019) (@houko)
+- Per-agent compaction settings in agent.toml (#4976) (#5020) (@houko)
+- Prompt-cache breakpoint strategy for Anthropic (#5021) (@houko)
+- Dual-layer compression — gateway safety net before agent loop (#4972) (#5022) (@houko)
+- Reference existing registry agents in workflow steps (#5023) (@houko)
+- Async task tracker — kernel registry + event injection + wake-idle (#4983) (#5033) (@houko)
+- New crate + W&B + Tinker + Atropos exporters (#3331) (#5034) (@houko)
+- Non-agent operator nodes — Wait, Gate, Transform, Branch (#4980) (#5035) (@houko)
+- Skill/tool finder in agent creation dialog (#5049) (#5066) (@houko)
+- ProviderExhaustionStore substrate + AuxClient consumer (#4807) (#5067) (@houko)
+- Declarative [[triggers]] in agent.toml (#5014) (#5068) (@houko)
+- On-demand tool/skill loading (#5073) (@houko)
+- Rich workflow invocation (#4982) (#5075) (@houko)
+- Document ElevenLabs and validate voice_id at driver boundary (#5078) (@houko)
+- Operator step mode — human-in-the-loop pause + resume (#4977 step 1/N) (#5108) (@houko)
+
+### Fixed
+
+- Keep ANTHROPIC_API_KEY in subprocess env (#4967) (@f-liva)
+- Surface CLI stderr on stdin write failure (#4974) (@f-liva)
+- Add schedule field to PATCH partial update path (#4986) (@DaBlitzStein)
+- Allow deleting connection arrows between steps (#4978) (#4993) (@houko)
+- Scope ApprovalRequested delivery to requesting agent's adapters/recipients (#4985) (#4994) (@houko)
+- Allow media read tools to access kernel staging dir (#4981) (#4995) (@houko)
+- Accept absolute workspace paths under workspaces_root (#4991) (#4996) (@houko)
+- Route audio/ogg outbound via sendVoice (#4959) (#4998) (@houko)
+- Auto-transcribe inbound channel audio when [media].audio_transcription = true (#4975) (#4999) (@houko)
+- Node delete via context menu writes history and cascades edges (#5007) (@houko)
+- Keep ANTHROPIC_* env vars when spawning CLI (#5008) (@houko)
+- Override account_id() in non-Telegram multi-bot adapters (#5009) (@houko)
+- Magic-byte sniff outbound audio/ogg to catch mislabeled payloads (#5010) (@houko)
+- Route approvals to bound chats when default_agent is None (#5002) (#5011) (@houko)
+- Downgrade OGG Vorbis to sendDocument; only Opus is valid for sendVoice (#5012) (@houko)
+- Unblock Windows test lane (7 assertions / platform divergences) (#5024) (@houko)
+- Stabilise diagnose_stdin macOS test (#5024 follow-up) (#5026) (@houko)
+- Resolve ioreg / reg.exe by absolute path (#5025) (#5031) (@houko)
+- Schedule field PATCH + actual_provider wiring + warn_ws_proxy_bypass gating (supersedes #4986) (#5036) (@houko)
+- Unblock main — docs TS 6 + lettre RUSTSEC-2026-0141 (#5056) (@houko)
+- Guard pr-status-labels filter against undefined check_run entries (#5057) (@houko)
+- Unify init() key resolution with resolve_master_key() (#5074) (@houko)
+- Add input_schema: None to Workflow literals after #5075 (#5105) (@houko)
+- Add input_schema: None to workflow_with_single_op_step test helper (#5107) (@houko)
+- Apply per-agent tool_allowlist/blocklist on tools/list (#5101) (#5109) (@houko)
+- Invalidate budget/usage on send and snapshot-prefix on session override (#5147) (@houko)
+- Raise persisted-session message cap from 200 to 2000 (#5148) (@houko)
+- Preserve other config sections during default-model write (#5150) (@houko)
+- Deny unknown fields in request DTOs to catch body typos (#5131) (#5151) (@houko)
+- Reuse reqwest::Client across fan-out fires; skip engine on empty targets (#5152) (@houko)
+- Preserve nested serde aliases + deny unknown fields on repeated tables (#5129, #5130) (#5154) (@houko)
+- Clamp negative age in stale-run recovery to survive NTP backstep (#5155) (@houko)
+- Replace SSRF substring stub with parsed-URL allowlist (#5156) (@houko)
+- Require non-empty sub claim on IdTokenClaims (#5128) (#5157) (@houko)
+- Refuse to run hook when concurrency semaphore is closed (#5158) (@houko)
+- Block Azure IMDS alternative 192.0.0.192 in MCP SSRF helper (#5159) (@houko)
+- Reject peer: key prefix and colon-bearing peer_id at substrate boundary (#5161) (@houko)
+- Propagate DB error from agent deletion (#5117) (#5163) (@houko)
+- Bind named params at run time (#5170) (@houko)
+- Give the root route an explicit notFoundComponent (#5171) (@houko)
+- Cap sysinfo at 0.38 to honor 1.94.1 MSRV (#5183) (@houko)
+
+### Changed
+
+- #3710 god-crate split — 5 standalone crates + oauth/wasm collapse (#5053) (@houko)
+- Typed SandboxError replaces anyhow (#3576) (#5077) (@houko)
+- Drop pass-through KernelError wrapper (#3576 wedge) (#5110) (@houko)
+
+<details>
+<summary>Documentation, maintenance, and other internal changes</summary>
+
+### Documentation
+
+- Add Auto-Evolution Mode page (companion to registry#94) (#5029) (@houko)
+- Trajectory format RFC (#3330) (#5032) (@houko)
+- Clarify extraction_model provider/model format (#5059) (#5062) (@leszek3737)
+- Correct historical attribution in README (#3710 follow-up) (#5100) (@houko)
+- Sync DEFAULT_MAX_HISTORY_MESSAGES default (60, not 40) (#5153) (@houko)
+
+### Maintenance
+
+- Bump the actions-minor-patch group with 4 updates (#4988) (@app/dependabot)
+- Bump apple-actions/import-codesign-certs from b2e261033a9e248f91a9b57201e8d1e12b15a24e to 5142e029c445c10ffc7149d172e540235a065466 (#4989) (@app/dependabot)
+- Bump actions/setup-python from 5 to 6 (#4990) (@app/dependabot)
+- Install rustc on cli_npm/cli_pypi to fix sysinfo MSRV (#4992) (@houko)
+- Bump the dashboard-minor-patch group in /crates/librefang-api/dashboard with 9 updates (#5027) (@app/dependabot)
+- Bump the web-minor-patch group in /web with 7 updates (#5028) (@app/dependabot)
+- Bump typescript from 5.9.3 to 6.0.3 in /docs (#5052) (@app/dependabot)
+- Update IGNORE path after #5053 god-crate split (#5102) (@houko)
+- Rustfmt mcp_tools_list_allowlist_test.rs (fix main CI) (#5146) (@houko)
+
+</details>
+
+
 ## [2026.5.12] - 2026-05-12
 
 _95 PRs from 5 contributors since v2026.5.8-beta.10._

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-acp"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-tokio",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "aes 0.9.0",
  "async-trait",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "axum",
  "clap",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "librefang-types",
  "reqwest",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "librefang-llm-driver",
  "librefang-memory",
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4720,7 +4720,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory-wiki"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "chrono",
  "librefang-kernel-handle",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-migrate"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-rl-export"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4824,7 +4824,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-audit"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "chrono",
  "hex",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-media"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-sandbox-docker"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5025,7 +5025,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5051,7 +5051,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -12289,7 +12289,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.5.32131",
+  "version": "26.5.32182",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
     },
-    "version": "2026.5.12-beta.11"
+    "version": "2026.5.17-beta.12"
   },
   "paths": {
     "/.well-known/agent.json": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.5.12-beta.11",
+  "version": "2026.5.17-beta.12",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.5.12-beta.11",
+  "version": "2026.5.17-beta.12",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.5.12b11",
+    version="2026.5.17b12",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.5.12-beta.11"
+version = "2026.5.17-beta.12"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.5.17-beta.12 -->
## Release v2026.5.17-beta.12

_76 PRs from 5 contributors since v2026.5.12-beta.11._

### Highlights

- **Workflow operator nodes** — Wait, Gate, Transform, Branch, and human-in-the-loop pause/resume steps bring full orchestration control to multi-step workflows, with inline image display and rich invocation support
- **Per-agent compaction & prompt-cache tuning** — agents can now configure context compaction thresholds and Anthropic prompt-cache breakpoint strategy directly in `agent.toml`, reducing token costs on long sessions
- **On-demand tool/skill loading and declarative triggers** — tools and skills load only when needed, and `[[triggers]]` can now be declared directly in `agent.toml`, cutting startup overhead and simplifying agent configuration
- **Async task tracker and training exporters** — a kernel-level async task registry with W&B, Tinker, and Atropos trajectory exporters enables continuous learning pipelines from agent runs
- **Audio transcription and voice routing fixes** — inbound channel audio auto-transcribes when enabled, outbound OGG/Opus correctly routes via `sendVoice`, and per-channel proxy configuration is now supported

### Added

- Show skill descriptions in agent Skills tab (#5013) (@houko)
- Display generated images inline in workflow run view (#5015) (@houko)
- File_read deduplication — stub repeated reads of unchanged files (#5016) (@houko)
- Per-channel proxy configuration (#4795) (#5019) (@houko)
- Per-agent compaction settings in agent.toml (#4976) (#5020) (@houko)
- Prompt-cache breakpoint strategy for Anthropic (#5021) (@houko)
- Dual-layer compression — gateway safety net before agent loop (#4972) (#5022) (@houko)
- Reference existing registry agents in workflow steps (#5023) (@houko)
- Async task tracker — kernel registry + event injection + wake-idle (#4983) (#5033) (@houko)
- New crate + W&B + Tinker + Atropos exporters (#3331) (#5034) (@houko)
- Non-agent operator nodes — Wait, Gate, Transform, Branch (#4980) (#5035) (@houko)
- Skill/tool finder in agent creation dialog (#5049) (#5066) (@houko)
- ProviderExhaustionStore substrate + AuxClient consumer (#4807) (#5067) (@houko)
- Declarative [[triggers]] in agent.toml (#5014) (#5068) (@houko)
- On-demand tool/skill loading (#5073) (@houko)
- Rich workflow invocation (#4982) (#5075) (@houko)
- Document ElevenLabs and validate voice_id at driver boundary (#5078) (@houko)
- Operator step mode — human-in-the-loop pause + resume (#4977 step 1/N) (#5108) (@houko)

### Fixed

- Keep ANTHROPIC_API_KEY in subprocess env (#4967) (@f-liva)
- Surface CLI stderr on stdin write failure (#4974) (@f-liva)
- Add schedule field to PATCH partial update path (#4986) (@DaBlitzStein)
- Allow deleting connection arrows between steps (#4978) (#4993) (@houko)
- Scope ApprovalRequested delivery to requesting agent's adapters/recipients (#4985) (#4994) (@houko)
- Allow media read tools to access kernel staging dir (#4981) (#4995) (@houko)
- Accept absolute workspace paths under workspaces_root (#4991) (#4996) (@houko)
- Route audio/ogg outbound via sendVoice (#4959) (#4998) (@houko)
- Auto-transcribe inbound channel audio when [media].audio_transcription = true (#4975) (#4999) (@houko)
- Node delete via context menu writes history and cascades edges (#5007) (@houko)
- Keep ANTHROPIC_* env vars when spawning CLI (#5008) (@houko)
- Override account_id() in non-Telegram multi-bot adapters (#5009) (@houko)
- Magic-byte sniff outbound audio/ogg to catch mislabeled payloads (#5010) (@houko)
- Route approvals to bound chats when default_agent is None (#5002) (#5011) (@houko)
- Downgrade OGG Vorbis to sendDocument; only Opus is valid for sendVoice (#5012) (@houko)
- Unblock Windows test lane (7 assertions / platform divergences) (#5024) (@houko)
- Stabilise diagnose_stdin macOS test (#5024 follow-up) (#5026) (@houko)
- Resolve ioreg / reg.exe by absolute path (#5025) (#5031) (@houko)
- Schedule field PATCH + actual_provider wiring + warn_ws_proxy_bypass gating (supersedes #4986) (#5036) (@houko)
- Unblock main — docs TS 6 + lettre RUSTSEC-2026-0141 (#5056) (@houko)
- Guard pr-status-labels filter against undefined check_run entries (#5057) (@houko)
- Unify init() key resolution with resolve_master_key() (#5074) (@houko)
- Add input_schema: None to Workflow literals after #5075 (#5105) (@houko)
- Add input_schema: None to workflow_with_single_op_step test helper (#5107) (@houko)
- Apply per-agent tool_allowlist/blocklist on tools/list (#5101) (#5109) (@houko)
- Invalidate budget/usage on send and snapshot-prefix on session override (#5147) (@houko)
- Raise persisted-session message cap from 200 to 2000 (#5148) (@houko)
- Preserve other config sections during default-model write (#5150) (@houko)
- Deny unknown fields in request DTOs to catch body typos (#5131) (#5151) (@houko)
- Reuse reqwest::Client across fan-out fires; skip engine on empty targets (#5152) (@houko)
- Preserve nested serde aliases + deny unknown fields on repeated tables (#5129, #5130) (#5154) (@houko)
- Clamp negative age in stale-run recovery to survive NTP backstep (#5155) (@houko)
- Replace SSRF substring stub with parsed-URL allowlist (#5156) (@houko)
- Require non-empty sub claim on IdTokenClaims (#5128) (#5157) (@houko)
- Refuse to run hook when concurrency semaphore is closed (#5158) (@houko)
- Block Azure IMDS alternative 192.0.0.192 in MCP SSRF helper (#5159) (@houko)
- Reject peer: key prefix and colon-bearing peer_id at substrate boundary (#5161) (@houko)
- Propagate DB error from agent deletion (#5117) (#5163) (@houko)
- Bind named params at run time (#5170) (@houko)
- Give the root route an explicit notFoundComponent (#5171) (@houko)
- Cap sysinfo at 0.38 to honor 1.94.1 MSRV (#5183) (@houko)

### Changed

- #3710 god-crate split — 5 standalone crates + oauth/wasm collapse (#5053) (@houko)
- Typed SandboxError replaces anyhow (#3576) (#5077) (@houko)
- Drop pass-through KernelError wrapper (#3576 wedge) (#5110) (@houko)

<details>
<summary>Documentation, maintenance, and other internal changes</summary>

### Documentation

- Add Auto-Evolution Mode page (companion to registry#94) (#5029) (@houko)
- Trajectory format RFC (#3330) (#5032) (@houko)
- Clarify extraction_model provider/model format (#5059) (#5062) (@leszek3737)
- Correct historical attribution in README (#3710 follow-up) (#5100) (@houko)
- Sync DEFAULT_MAX_HISTORY_MESSAGES default (60, not 40) (#5153) (@houko)

### Maintenance

- Bump the actions-minor-patch group with 4 updates (#4988) (@app/dependabot)
- Bump apple-actions/import-codesign-certs from b2e261033a9e248f91a9b57201e8d1e12b15a24e to 5142e029c445c10ffc7149d172e540235a065466 (#4989) (@app/dependabot)
- Bump actions/setup-python from 5 to 6 (#4990) (@app/dependabot)
- Install rustc on cli_npm/cli_pypi to fix sysinfo MSRV (#4992) (@houko)
- Bump the dashboard-minor-patch group in /crates/librefang-api/dashboard with 9 updates (#5027) (@app/dependabot)
- Bump the web-minor-patch group in /web with 7 updates (#5028) (@app/dependabot)
- Bump typescript from 5.9.3 to 6.0.3 in /docs (#5052) (@app/dependabot)
- Update IGNORE path after #5053 god-crate split (#5102) (@houko)
- Rustfmt mcp_tools_list_allowlist_test.rs (fix main CI) (#5146) (@houko)

</details>

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.5.12-beta.11...v2026.5.17-beta.12