### PR TITLE
fix(kernel,runtime): reject same-task re-entrant agent_msg_lock acquisition (#5125, #5126)

### DIFF
--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -3,6 +3,13 @@
 //! When a daemon is running (`librefang start`), the CLI talks to it over HTTP.
 //! Otherwise, commands boot an in-process kernel (single-shot mode).
 
+// The in-process agent loop's deeply-nested async future chain — now
+// carrying the per-task held-agent-lock `scope` layer (#5125/#5126) —
+// exceeds the default type-recursion limit when this binary crate is
+// monomorphised. Matches the `librefang-kernel` / `librefang-api` crate
+// roots.
+#![recursion_limit = "256"]
+
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/crates/librefang-kernel/src/kernel/handles/session_writer.rs
+++ b/crates/librefang-kernel/src/kernel/handles/session_writer.rs
@@ -28,15 +28,48 @@ impl kernel_handle::SessionWriter for LibreFangKernel {
         agent_id: librefang_types::agent::AgentId,
         message: librefang_types::message::Message,
     ) {
-        // Acquire the per-agent lock using block_in_place so this is safe
-        // from both async contexts and spawn_blocking threads.
-        let lock = self
-            .agents
-            .agent_msg_locks
-            .entry(agent_id)
-            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
-            .clone();
-        let _guard = tokio::task::block_in_place(|| lock.blocking_lock());
+        // #5126: this path runs from inside `channel_send`'s mirror
+        // (`mirror_channel_send_to_session`). When the resolved channel
+        // `owner` is the *same* agent whose turn is currently executing,
+        // the outer `send_message_full(owner)` already holds
+        // `agent_msg_locks[owner]` on THIS task. Re-acquiring it here via
+        // `block_in_place(|| lock.blocking_lock())` would self-deadlock —
+        // `block_in_place` runs on the same task and does not release the
+        // held async mutex; no other task exists to wake the blocking
+        // waiter.
+        //
+        // Correctness of the lockless path (chosen over "skip the write"):
+        // the mirror writes `SessionId::for_sender_scope(owner, channel,
+        // recipient)` — a uuid_v5-derived session id *distinct* from the
+        // agent loop's own `entry.session_id`. The outer
+        // `send_message_full` never writes this mirror session on its own
+        // path, so skipping here would silently lose the mirror message
+        // (#4824's whole point). The `agent_msg_locks[owner]` mutex exists
+        // *only* to serialize concurrent cross-task writers to this agent's
+        // sessions; if this task already holds it, mutual exclusion
+        // guarantees there is no other writer for the duration, so this
+        // task has exclusive access and can perform the read-modify-write
+        // directly. We therefore proceed WITHOUT re-locking instead of
+        // skipping. The held-set is populated at the single agent-scoped
+        // acquisition site in `send_message_full_inner`, and the task-local
+        // is visible inside `block_in_place` (same task).
+        let already_held = librefang_runtime::held_agent_locks::is_held(agent_id);
+        let _guard: Option<tokio::sync::OwnedMutexGuard<()>> = if already_held {
+            None
+        } else {
+            // Acquire the per-agent lock using block_in_place so this is safe
+            // from both async contexts and spawn_blocking threads.
+            // `blocking_lock_owned` (vs `blocking_lock`) yields an owned
+            // guard so it can be held in this `Option` past the lock
+            // `Arc`'s local scope.
+            let lock = self
+                .agents
+                .agent_msg_locks
+                .entry(agent_id)
+                .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+                .clone();
+            Some(tokio::task::block_in_place(|| lock.blocking_lock_owned()))
+        };
 
         // Load existing session or create a fresh one for this (agent, session) pair.
         let mut session = match self.memory.substrate.get_session(session_id) {
@@ -95,13 +128,29 @@ impl kernel_handle::SessionWriter for LibreFangKernel {
         // Serialize with any concurrent write to the same agent's session.
         // block_in_place is safe from both async worker threads and
         // spawn_blocking threads (unlike blocking_lock which panics in async).
-        let lock = self
-            .agents
-            .agent_msg_locks
-            .entry(agent_id)
-            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
-            .clone();
-        let _guard = tokio::task::block_in_place(|| lock.blocking_lock());
+        //
+        // Same #5126 self-re-entry guard as `append_to_session`: if THIS
+        // task already holds `agent_msg_locks[agent_id]` (an outer
+        // `send_message_full` frame), re-acquiring would self-deadlock.
+        // Today this method is only reached from the HTTP attachment-upload
+        // path (a fresh task that holds no agent lock, so `is_held` is
+        // `false` and behaviour is unchanged) — the guard is defensive
+        // against any future in-turn caller and keeps both writer methods
+        // consistent. Lockless rationale identical to `append_to_session`:
+        // holding the lock already implies exclusive access, so the
+        // read-modify-write is safe without re-locking.
+        let already_held = librefang_runtime::held_agent_locks::is_held(agent_id);
+        let _guard: Option<tokio::sync::OwnedMutexGuard<()>> = if already_held {
+            None
+        } else {
+            let lock = self
+                .agents
+                .agent_msg_locks
+                .entry(agent_id)
+                .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+                .clone();
+            Some(tokio::task::block_in_place(|| lock.blocking_lock_owned()))
+        };
 
         let mut session = match self.memory.substrate.get_session(entry.session_id) {
             Ok(Some(s)) => s,

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -759,8 +759,48 @@ impl LibreFangKernel {
     /// [`SessionInterrupt`] so a parent session's `/stop` can cascade into
     /// this subagent's loop (issue #3044). Used by `tool_agent_send` when
     /// the caller agent's own interrupt should gate the callee.
+    ///
+    /// Thin wrapper that establishes the task-local held-`agent_msg_locks`
+    /// registry (`held_agent_locks::scope`) around the real work in
+    /// [`Self::send_message_full_inner`]. The registry must span the whole
+    /// body — the per-agent lock is held across the entire agent loop, and
+    /// the re-entrant `agent_send` (#5125) / `channel_send` mirror (#5126)
+    /// tool paths run *inside* that loop on the same task. `scope` is
+    /// idempotent, so a transitively re-entered inner frame shares the
+    /// outer frame's set rather than masking it with a fresh one.
     #[allow(clippy::too_many_arguments)]
     async fn send_message_full_with_upstream(
+        &self,
+        agent_id: AgentId,
+        message: &str,
+        kernel_handle: Arc<dyn KernelHandle>,
+        content_blocks: Option<Vec<librefang_types::message::ContentBlock>>,
+        sender_context: Option<&SenderContext>,
+        session_mode_override: Option<librefang_types::agent::SessionMode>,
+        thinking_override: Option<bool>,
+        session_id_override: Option<SessionId>,
+        upstream_interrupt: Option<librefang_runtime::interrupt::SessionInterrupt>,
+        incognito: bool,
+    ) -> KernelResult<AgentLoopResult> {
+        librefang_runtime::held_agent_locks::scope(self.send_message_full_inner(
+            agent_id,
+            message,
+            kernel_handle,
+            content_blocks,
+            sender_context,
+            session_mode_override,
+            thinking_override,
+            session_id_override,
+            upstream_interrupt,
+            incognito,
+        ))
+        .await
+    }
+
+    /// Real implementation of [`Self::send_message_full_with_upstream`].
+    /// Always invoked under `held_agent_locks::scope`; do not call directly.
+    #[allow(clippy::too_many_arguments)]
+    async fn send_message_full_inner(
         &self,
         agent_id: AgentId,
         message: &str,
@@ -790,25 +830,80 @@ impl LibreFangKernel {
             .resolve_assistant_target(agent_id, message, sender_context)
             .await?;
 
+        // Reject same-task re-entrant acquisition of `agent_msg_locks[agent_id]`
+        // (#5125). When this resolves to the agent-scoped lock (no
+        // `session_id_override`) and the current task *already* holds that
+        // agent's lock, acquiring `lock.lock().await` below would block the
+        // task on itself forever — `tokio::sync::Mutex` is not reentrant and
+        // there is no other task to release it. This is exactly the
+        // transitive `A -> B -> A` `agent_send` cycle: the depth limiter
+        // (`max_agent_call_depth`) permits it, and the direct
+        // `caller == agent_id` guard in `tool_agent_send` only catches the
+        // 1-hop case. Detect it *before* the lock acquisition (the only
+        // place that cannot itself deadlock) and fail loudly with the held
+        // chain so operators can see which agents form the cycle, instead
+        // of silently parking the worker thread. The session-scoped
+        // (`session_id_override`) path is a different key space that the
+        // re-entrant tool paths never take, so it is exempt.
+        if session_id_override.is_none() && librefang_runtime::held_agent_locks::is_held(agent_id) {
+            let mut chain: Vec<String> = librefang_runtime::held_agent_locks::held_snapshot()
+                .into_iter()
+                .map(|a| a.to_string())
+                .collect();
+            chain.push(agent_id.to_string());
+            return Err(KernelError::LibreFang(LibreFangError::InvalidInput(
+                format!(
+                    "agent_send: re-entrant message to agent {} would deadlock its \
+                     per-agent message lock (transitive A->B->A cycle). Currently-held \
+                     agent locks on this task: [{}]. Break the cycle or use the task \
+                     queue for the callback.",
+                    agent_id,
+                    chain.join(" -> "),
+                ),
+            )));
+        }
+
         // When the caller supplies an explicit session_id, scope the lock to that
         // session so concurrent messages to *different* sessions of the same agent
         // are not serialized against each other (multi-tab / multi-session UIs).
         // Without an override, fall back to the per-agent lock to preserve the
         // existing serialization guarantee for single-session agents.
-        let lock = if let Some(sid) = session_id_override {
-            self.agents
-                .session_msg_locks
-                .entry(sid)
-                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-                .clone()
+        let (lock, agent_scoped) = if let Some(sid) = session_id_override {
+            (
+                self.agents
+                    .session_msg_locks
+                    .entry(sid)
+                    .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                    .clone(),
+                false,
+            )
         } else {
-            self.agents
-                .agent_msg_locks
-                .entry(agent_id)
-                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-                .clone()
+            (
+                self.agents
+                    .agent_msg_locks
+                    .entry(agent_id)
+                    .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                    .clone(),
+                true,
+            )
         };
         let _guard = lock.lock().await;
+        // Record that this task now holds `agent_msg_locks[agent_id]` so the
+        // re-entrant `agent_send` (#5125) and `channel_send`-mirror (#5126)
+        // tool paths — which run inside the agent loop below on this same
+        // task — can detect the self-re-entry instead of deadlocking on a
+        // non-reentrant `tokio::sync::Mutex`. Only the agent-scoped lock is
+        // tracked: the session-scoped (`session_id_override`) lock is a
+        // different key space that those two paths never re-acquire, and
+        // tracking it by `agent_id` would risk a false-positive rejection.
+        // Declared *after* `_guard` so drop order is registry-then-mutex:
+        // while the entry is registered the mutex is provably still held,
+        // never the inverse. Drop is panic-safe (RAII unwinds destructors).
+        let _held_guard = if agent_scoped {
+            Some(librefang_runtime::held_agent_locks::HeldLockGuard::register(agent_id))
+        } else {
+            None
+        };
 
         // Pre-call global budget reservation (#3616). Estimate cost from
         // the model's max output tokens and reserve it on the in-memory

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -2409,18 +2409,31 @@ impl LibreFangKernel {
 
         // Acquire the same session/agent lock as the non-streaming path so concurrent
         // turns are serialized. Clone the Arc here (sync fn); lock inside the spawn.
-        let session_lock = if session_id_override.is_some() {
-            self.agents
-                .session_msg_locks
-                .entry(effective_session_id)
-                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-                .clone()
+        // `agent_scoped` tracks whether we are taking the per-agent lock (vs. a
+        // per-session lock for session_id_override callers): only the agent-scoped
+        // branch needs the task-local `held_agent_locks` registration so the
+        // re-entrant `agent_send` (#5125) / `channel_send` mirror (#5126) tool
+        // paths can observe this streaming turn's holding of agent_msg_locks
+        // and skip / reject as appropriate. Mirrors the non-streaming site at
+        // `send_message_full_inner` (~L871-906).
+        let (session_lock, agent_scoped) = if session_id_override.is_some() {
+            (
+                self.agents
+                    .session_msg_locks
+                    .entry(effective_session_id)
+                    .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                    .clone(),
+                false,
+            )
         } else {
-            self.agents
-                .agent_msg_locks
-                .entry(agent_id)
-                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-                .clone()
+            (
+                self.agents
+                    .agent_msg_locks
+                    .entry(agent_id)
+                    .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                    .clone(),
+                true,
+            )
         };
 
         // Lifecycle: emit TurnStarted right before the spawn. Cloning the bus
@@ -2439,12 +2452,27 @@ impl LibreFangKernel {
 
         // Reload session after acquiring the lock so we never act on a stale
         // snapshot captured before a concurrent turn's writes landed.
-        let handle = tokio::spawn(async move {
+        let handle = tokio::spawn(librefang_runtime::held_agent_locks::scope(async move {
             // Acquire the session/agent serialization lock for the duration of
             // this streaming turn.  This matches the non-streaming path and
             // prevents concurrent streaming + non-streaming writes from
             // producing last-write-wins data loss on session history.
             let _session_guard = session_lock.lock().await;
+            // Record that this task now holds `agent_msg_locks[agent_id]` so the
+            // re-entrant `agent_send` (#5125) and `channel_send`-mirror (#5126)
+            // tool paths — which run inside `run_agent_loop_streaming` below on
+            // this same task — can detect the self-re-entry instead of
+            // deadlocking on the non-reentrant `tokio::sync::Mutex`. Only the
+            // agent-scoped lock is tracked: the session-scoped
+            // (`session_id_override`) lock is a different key space those two
+            // paths never re-acquire. Mirrors the non-streaming site at
+            // `send_message_full_inner` (~L890-906); declared *after*
+            // `_session_guard` so drop order is registry-then-mutex.
+            let _held_guard = if agent_scoped {
+                Some(librefang_runtime::held_agent_locks::HeldLockGuard::register(agent_id))
+            } else {
+                None
+            };
 
             // Reload session under the lock; keep the placeholder on miss.
             match memory.get_session(effective_session_id) {
@@ -2936,7 +2964,7 @@ impl LibreFangKernel {
                     Err(KernelError::LibreFang(e))
                 }
             }
-        });
+        }));
 
         // Store abort handle for cancellation support. Fork turns skip —
         // registering the fork's handle under the parent's `(agent, session)`

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -8039,3 +8039,279 @@ fn kill_agent_with_purge_removes_agent_row_from_sqlite() {
 
     kernel.shutdown();
 }
+
+// ---------------------------------------------------------------------------
+// #5125 / #5126: same-task re-entrant `agent_msg_locks` acquisition.
+//
+// Both issues are the same root cause — the same async task re-acquires
+// `agent_msg_locks[agent_id]` (a non-reentrant `tokio::sync::Mutex`) that an
+// outer `send_message_full` frame already holds, silently parking the worker
+// thread. The fix tracks held locks in a task-local registry
+// (`librefang_runtime::held_agent_locks`) populated at the single agent-scoped
+// acquisition site in `send_message_full_inner`, so:
+//   - #5125: the transitive `A -> B -> A` `agent_send` cycle is rejected with
+//     an error *before* the second `lock.lock().await`, instead of hanging.
+//   - #5126: `append_to_session`'s `block_in_place(blocking_lock)` is skipped
+//     in favour of a lockless write when this task already holds the lock,
+//     instead of self-deadlocking; the mirror write still lands.
+// The fix must NOT relax cross-task mutual exclusion (third test).
+//
+// Each test runs the deadlock-prone work under `tokio::time::timeout`: without
+// the fix the future never resolves and the timeout fires (test fails); with
+// the fix it resolves promptly.
+// ---------------------------------------------------------------------------
+
+/// Build a kernel + one spawned agent for the re-entrancy tests.
+fn reentrant_test_kernel() -> (Arc<LibreFangKernel>, AgentId) {
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+    std::mem::forget(dir); // keep tempdir alive until process exit
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = Arc::new(LibreFangKernel::boot_with_config(config).expect("kernel should boot"));
+    // `send_message_full` builds its kernel-handle arg via `kernel_handle()`,
+    // which panics if the self-handle weak ref was never installed.
+    kernel.set_self_handle();
+    let agent_id = kernel
+        .spawn_agent(test_manifest("reentrant-a", "agent A", vec![]))
+        .expect("spawn A should succeed");
+    (kernel, agent_id)
+}
+
+/// #5125: a transitive `A -> B -> A` cycle must be rejected, not deadlock.
+///
+/// We simulate the outer turn for A exactly as `send_message_full_inner` does:
+/// inside `held_agent_locks::scope`, acquire the real `agent_msg_locks[A]`
+/// guard and register A in the task-local held set. Then call
+/// `send_message_full(A, ...)` on the *same task* — the inner re-entrant
+/// acquisition. With the fix it returns the cycle-rejection error before the
+/// (would-be deadlocking) `lock.lock().await`. Without the fix the inner call
+/// blocks forever on the held mutex and the timeout fires.
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_5125_transitive_cycle_is_rejected_not_deadlocked() {
+    let (kernel, agent_a) = reentrant_test_kernel();
+    let lock_a = kernel
+        .agents
+        .agent_msg_locks
+        .entry(agent_a)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone();
+
+    let kernel_clone = Arc::clone(&kernel);
+    let fut = librefang_runtime::held_agent_locks::scope(async move {
+        // Outer turn for A: hold the lock + register, like the real site.
+        let _outer_guard = lock_a.lock().await;
+        let _held = librefang_runtime::held_agent_locks::HeldLockGuard::register(agent_a);
+        assert!(
+            librefang_runtime::held_agent_locks::is_held(agent_a),
+            "A's lock must be registered as held on this task"
+        );
+
+        // Inner re-entrant send to A (the B->A leg of A->B->A), same task.
+        kernel_clone
+            .send_message_full(
+                agent_a,
+                "callback into A",
+                kernel_clone.kernel_handle(),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+    });
+
+    let res = tokio::time::timeout(std::time::Duration::from_secs(10), fut).await;
+    let inner = res.expect(
+        "re-entrant send_message_full(A) must NOT hang — without the fix this \
+         times out because the task self-deadlocks on agent_msg_locks[A]",
+    );
+    let err = inner.expect_err("re-entrant send must be rejected, not succeed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("re-entrant") && msg.contains("deadlock"),
+        "rejection must name the re-entrant deadlock; got: {msg}"
+    );
+    assert!(
+        msg.contains(&agent_a.to_string()),
+        "rejection must name the cycle agent {agent_a}; got: {msg}"
+    );
+
+    kernel.shutdown();
+}
+
+/// #5126: `channel_send`'s mirror (`append_to_session`) from inside the
+/// channel owner's own turn must complete (lockless write) and persist the
+/// message, not deadlock on the already-held `agent_msg_locks[owner]`.
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_5126_owner_caller_mirror_write_is_lockless_not_deadlocked() {
+    use librefang_runtime::kernel_handle::SessionWriter;
+    use librefang_types::message::{Message, MessageContent, Role};
+
+    let (kernel, owner) = reentrant_test_kernel();
+    let lock_owner = kernel
+        .agents
+        .agent_msg_locks
+        .entry(owner)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone();
+
+    // Mirror session id, derived exactly like mirror_channel_send_to_session.
+    let channel_sid = SessionId::for_sender_scope(owner, "telegram", Some("chat-42"));
+    let mirror_msg = Message {
+        role: Role::User,
+        content: MessageContent::Text("{\"mirror_from\":\"owner\",\"body\":\"reply\"}".to_string()),
+        pinned: false,
+        timestamp: Some(chrono::Utc::now()),
+    };
+
+    let kernel_clone = Arc::clone(&kernel);
+    let owner_copy = owner;
+    let sid_copy = channel_sid;
+    let msg_copy = mirror_msg.clone();
+    let fut = librefang_runtime::held_agent_locks::scope(async move {
+        // Outer turn for `owner` holds agent_msg_locks[owner] + registered.
+        let _outer_guard = lock_owner.lock().await;
+        let _held = librefang_runtime::held_agent_locks::HeldLockGuard::register(owner_copy);
+
+        // Mirror path resolves owner == caller -> append_to_session. Without
+        // the fix this block_in_place(blocking_lock)s the held mutex on this
+        // same task and never returns. `append_to_session` is sync; running
+        // it on a blocking thread keeps the runtime healthy while still
+        // exercising the same task-local (block_in_place stays on-task).
+        tokio::task::block_in_place(|| {
+            SessionWriter::append_to_session(&*kernel_clone, sid_copy, owner_copy, msg_copy);
+        });
+    });
+
+    tokio::time::timeout(std::time::Duration::from_secs(10), fut)
+        .await
+        .expect(
+            "owner-caller mirror append must NOT hang — without the fix this \
+             times out because block_in_place re-locks the held agent_msg_lock",
+        );
+
+    // The mirror write must actually be present (lockless-write, not skip).
+    let session = kernel
+        .memory
+        .substrate
+        .get_session(channel_sid)
+        .expect("get_session must not error")
+        .expect("mirror session row must exist after append_to_session");
+    assert_eq!(
+        session.messages.len(),
+        1,
+        "the mirrored channel_send message must be persisted, not silently dropped"
+    );
+
+    kernel.shutdown();
+}
+
+/// The fix must ONLY relax SAME-task re-entry. Two DIFFERENT tasks must still
+/// serialize on the same agent's `agent_msg_locks` entry. Task 1 holds the
+/// real lock (with no held-set scope — it is a plain cross-task holder); Task 2
+/// calls `append_to_session` for the same agent. Task 2 must block until Task 1
+/// releases (proving the `block_in_place(blocking_lock)` path is still taken
+/// across tasks), then complete.
+#[tokio::test(flavor = "multi_thread")]
+async fn cross_task_serialization_on_agent_msg_lock_is_preserved() {
+    use librefang_runtime::kernel_handle::SessionWriter;
+    use librefang_types::message::{Message, MessageContent, Role};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let (kernel, agent) = reentrant_test_kernel();
+
+    // Sanity: `is_held` is false outside any scope and across tasks — the
+    // task-local never bleeds between tasks, so the cross-task path always
+    // takes the real lock.
+    assert!(
+        !librefang_runtime::held_agent_locks::is_held(agent),
+        "is_held must be false outside any held_agent_locks::scope"
+    );
+
+    let lock = kernel
+        .agents
+        .agent_msg_locks
+        .entry(agent)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone();
+
+    let holder_released = Arc::new(AtomicBool::new(false));
+    let writer_started = Arc::new(AtomicBool::new(false));
+
+    // Task 1: hold the real lock for 400ms (NOT in a held-set scope, so this
+    // is a genuine cross-task holder the writer must wait behind).
+    let lock_t1 = Arc::clone(&lock);
+    let released_t1 = Arc::clone(&holder_released);
+    let writer_started_t1 = Arc::clone(&writer_started);
+    let holder = tokio::spawn(async move {
+        let _g = lock_t1.lock().await;
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+        // The writer must NOT have completed while we still hold the lock; it
+        // may have *started* (spawned) but its blocking_lock must be parked.
+        assert!(
+            writer_started_t1.load(Ordering::SeqCst),
+            "writer task should have started while holder held the lock"
+        );
+        released_t1.store(true, Ordering::SeqCst);
+    });
+
+    // Give the holder time to acquire the lock first.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Task 2: a different task calls append_to_session for the SAME agent. It
+    // must block on the real mutex until Task 1 releases.
+    let kernel_w = Arc::clone(&kernel);
+    let sid = SessionId::for_sender_scope(agent, "telegram", Some("c1"));
+    let released_w = Arc::clone(&holder_released);
+    let writer_started_w = Arc::clone(&writer_started);
+    let writer = tokio::spawn(async move {
+        writer_started_w.store(true, Ordering::SeqCst);
+        tokio::task::block_in_place(|| {
+            SessionWriter::append_to_session(
+                &*kernel_w,
+                sid,
+                agent,
+                Message {
+                    role: Role::User,
+                    content: MessageContent::Text("cross-task".to_string()),
+                    pinned: false,
+                    timestamp: Some(chrono::Utc::now()),
+                },
+            );
+        });
+        // By the time the writer acquires the lock, the holder must have
+        // already released it — proving mutual exclusion held.
+        assert!(
+            released_w.load(Ordering::SeqCst),
+            "cross-task writer acquired agent_msg_lock before holder released \
+             it — cross-task mutual exclusion was wrongly relaxed"
+        );
+    });
+
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        holder.await.expect("holder task");
+        writer.await.expect("writer task");
+    })
+    .await
+    .expect("cross-task path must complete once the holder releases");
+
+    let session = kernel
+        .memory
+        .substrate
+        .get_session(sid)
+        .expect("get_session")
+        .expect("session row must exist");
+    assert_eq!(
+        session.messages.len(),
+        1,
+        "cross-task write must still land after serialized acquisition"
+    );
+
+    kernel.shutdown();
+}

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -8315,3 +8315,160 @@ async fn cross_task_serialization_on_agent_msg_lock_is_preserved() {
 
     kernel.shutdown();
 }
+
+/// #5125 (streaming path): the re-entrancy fix must cover the streaming send
+/// path too. The streaming entry (`send_message_streaming_with_sender_and_opts`)
+/// acquires `agent_msg_locks[A]` *inside its spawned task*, not on the caller's
+/// task. Without wrapping that spawn body in `held_agent_locks::scope` and
+/// registering a `HeldLockGuard`, an `agent_send` tool call back to A from
+/// inside the streaming agent loop would re-acquire the same per-agent mutex
+/// on the spawned task and silently deadlock — identical to the non-streaming
+/// failure mode of #5125, just routed through the streaming entry that
+/// dashboards / WS / SSE actually use.
+///
+/// This test simulates the streaming spawn body's exact lock state — fresh
+/// task, `scope` established, agent-scoped `agent_msg_locks[A]` held, A
+/// registered in the held set — and verifies that an inner `send_message_full`
+/// re-entrant call rejects the cycle instead of hanging. The pattern mirrors
+/// `issue_5125_transitive_cycle_is_rejected_not_deadlocked` (the non-streaming
+/// dimension), but the work runs on a `tokio::spawn`ed task to model that the
+/// streaming-entry's spawned task is the one doing the re-acquisition.
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_5125_streaming_spawn_body_rejects_reentrant_cycle() {
+    let (kernel, agent_a) = reentrant_test_kernel();
+    let lock_a = kernel
+        .agents
+        .agent_msg_locks
+        .entry(agent_a)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone();
+
+    let kernel_clone = Arc::clone(&kernel);
+    // Mirror exactly what the patched streaming spawn body does: a fresh task,
+    // wrap in `held_agent_locks::scope`, take the per-agent lock, register the
+    // held guard, then drive the agent-loop body (here represented by an inner
+    // `send_message_full(A)` standing in for an `agent_send` tool call). The
+    // streaming entry is a sync fn returning a `JoinHandle`, so the spawned
+    // task — not the caller — is where re-entrancy detection has to work.
+    let inner = tokio::spawn(librefang_runtime::held_agent_locks::scope(async move {
+        let _session_guard = lock_a.lock().await;
+        let _held = librefang_runtime::held_agent_locks::HeldLockGuard::register(agent_a);
+        assert!(
+            librefang_runtime::held_agent_locks::is_held(agent_a),
+            "A's lock must be registered as held on this spawned task — without \
+             the streaming-path fix, the spawn body never calls `scope` so this \
+             would fail and the inner send below would silently deadlock"
+        );
+
+        // Inner re-entrant send to A from inside the streaming spawn body —
+        // the streaming-turn analogue of an `agent_send(A)` tool call.
+        kernel_clone
+            .send_message_full(
+                agent_a,
+                "callback into A from streaming turn",
+                kernel_clone.kernel_handle(),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+    }));
+
+    let res = tokio::time::timeout(std::time::Duration::from_secs(10), inner).await;
+    let join_result = res.expect(
+        "spawned streaming-turn simulation must NOT hang — without the \
+         streaming-path fix the inner re-entrant send blocks forever on the \
+         held agent_msg_lock and this timeout fires",
+    );
+    let inner_result = join_result.expect("spawned task panicked");
+    let err = inner_result.expect_err(
+        "re-entrant send from inside the streaming spawn body must be rejected, \
+         not succeed",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("re-entrant") && msg.contains("deadlock"),
+        "rejection must name the re-entrant deadlock; got: {msg}"
+    );
+    assert!(
+        msg.contains(&agent_a.to_string()),
+        "rejection must name the cycle agent {agent_a}; got: {msg}"
+    );
+
+    kernel.shutdown();
+}
+
+/// #5126 (streaming path): the `channel_send` mirror (`append_to_session`)
+/// fired from inside a streaming turn must complete via the lockless-write
+/// path, not deadlock on the already-held `agent_msg_locks[owner]`. Same
+/// signal as `issue_5126_owner_caller_mirror_write_is_lockless_not_deadlocked`,
+/// but the work runs on a `tokio::spawn`ed task to model the streaming entry's
+/// own spawn — confirming the held-set registration is set up *inside* that
+/// spawned task (which the streaming-path fix is exactly what installs).
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_5126_streaming_spawn_body_mirror_write_is_lockless() {
+    use librefang_runtime::kernel_handle::SessionWriter;
+    use librefang_types::message::{Message, MessageContent, Role};
+
+    let (kernel, owner) = reentrant_test_kernel();
+    let lock_owner = kernel
+        .agents
+        .agent_msg_locks
+        .entry(owner)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone();
+
+    let channel_sid = SessionId::for_sender_scope(owner, "telegram", Some("chat-stream"));
+    let mirror_msg = Message {
+        role: Role::User,
+        content: MessageContent::Text(
+            "{\"mirror_from\":\"owner-stream\",\"body\":\"reply\"}".to_string(),
+        ),
+        pinned: false,
+        timestamp: Some(chrono::Utc::now()),
+    };
+
+    let kernel_clone = Arc::clone(&kernel);
+    let owner_copy = owner;
+    let sid_copy = channel_sid;
+    let msg_copy = mirror_msg.clone();
+    // Replicate the streaming spawn body's lock-and-scope setup on a fresh
+    // task. The `channel_send` mirror inside the agent loop resolves
+    // owner == caller and falls through to `append_to_session`; without the
+    // streaming-path fix that block_in_place(blocking_lock)s the held
+    // `agent_msg_locks[owner]` on this same task and never returns.
+    let inner = tokio::spawn(librefang_runtime::held_agent_locks::scope(async move {
+        let _session_guard = lock_owner.lock().await;
+        let _held = librefang_runtime::held_agent_locks::HeldLockGuard::register(owner_copy);
+
+        tokio::task::block_in_place(|| {
+            SessionWriter::append_to_session(&*kernel_clone, sid_copy, owner_copy, msg_copy);
+        });
+    }));
+
+    tokio::time::timeout(std::time::Duration::from_secs(10), inner)
+        .await
+        .expect(
+            "streaming-turn mirror append must NOT hang — without the \
+             streaming-path fix this times out because block_in_place re-locks \
+             the held agent_msg_lock from the streaming spawn body",
+        )
+        .expect("spawned task panicked");
+
+    let session = kernel
+        .memory
+        .substrate
+        .get_session(channel_sid)
+        .expect("get_session must not error")
+        .expect("mirror session row must exist after append_to_session");
+    assert_eq!(
+        session.messages.len(),
+        1,
+        "the mirrored channel_send message from the streaming turn must be \
+         persisted, not silently dropped"
+    );
+
+    kernel.shutdown();
+}

--- a/crates/librefang-kernel/tests/integration_test.rs
+++ b/crates/librefang-kernel/tests/integration_test.rs
@@ -2,6 +2,12 @@
 //!
 //! Run with: GROQ_API_KEY=gsk_... cargo test -p librefang-kernel --test integration_test -- --nocapture
 
+// `send_message_full` now nests its body inside `held_agent_locks::scope`
+// (#5125/#5126), deepening the monomorphized future-type layout. Match the
+// crate-root limit (`librefang-kernel/src/lib.rs:3`) and the other heavy
+// integration-test binaries (`audit_retention_test`, `workflow_integration_test`).
+#![recursion_limit = "256"]
+
 use librefang_kernel::LibreFangKernel;
 use librefang_types::agent::AgentManifest;
 use librefang_types::config::{DefaultModelConfig, KernelConfig};

--- a/crates/librefang-kernel/tests/multi_agent_test.rs
+++ b/crates/librefang-kernel/tests/multi_agent_test.rs
@@ -4,6 +4,12 @@
 //! The last test (`test_six_agent_fleet`) is a live LLM integration test
 //! that only runs when GROQ_API_KEY is set.
 
+// `send_message_full` now nests its body inside `held_agent_locks::scope`
+// (#5125/#5126), deepening the monomorphized future-type layout. Match the
+// crate-root limit (`librefang-kernel/src/lib.rs:3`) and the other heavy
+// integration-test binaries (`audit_retention_test`, `workflow_integration_test`).
+#![recursion_limit = "256"]
+
 use librefang_kernel::triggers::TriggerPattern;
 use librefang_kernel::AgentSubsystemApi;
 use librefang_kernel::LibreFangKernel;

--- a/crates/librefang-kernel/tests/wasm_agent_integration_test.rs
+++ b/crates/librefang-kernel/tests/wasm_agent_integration_test.rs
@@ -5,6 +5,12 @@
 //!
 //! These tests use real WASM execution — no mocks.
 
+// `send_message_full` now nests its body inside `held_agent_locks::scope`
+// (#5125/#5126), deepening the monomorphized future-type layout. Match the
+// crate-root limit (`librefang-kernel/src/lib.rs:3`) and the other heavy
+// integration-test binaries (`audit_retention_test`, `workflow_integration_test`).
+#![recursion_limit = "256"]
+
 use librefang_kernel::AgentSubsystemApi;
 use librefang_testing::MockKernelBuilder;
 use librefang_types::agent::AgentManifest;

--- a/crates/librefang-runtime/src/held_agent_locks.rs
+++ b/crates/librefang-runtime/src/held_agent_locks.rs
@@ -1,0 +1,232 @@
+//! Task-local registry of `agent_msg_locks` entries the current task holds.
+//!
+//! `agent_msg_locks[agent_id]` (a non-reentrant `tokio::sync::Mutex`) is
+//! acquired by `send_message_full` for the duration of an agent's turn. The
+//! same async task can then re-enter the lock through two tool paths:
+//!
+//! - `agent_send` with a transitive `A -> B -> A` topology (issue #5125):
+//!   the inner `send_message_full(A)` re-acquires `agent_msg_locks[A]` that
+//!   the outer turn for A still holds — a silent self-deadlock.
+//! - `channel_send` whose channel owner resolves back to the caller
+//!   (issue #5126): `SessionWriter::append_to_session` does
+//!   `block_in_place(|| lock.blocking_lock())` on the same
+//!   `agent_msg_locks[A]` — `block_in_place` does **not** release the held
+//!   async mutex, so the worker thread parks forever.
+//!
+//! Both are *same-task* re-entries. This module records which `AgentId`
+//! locks the current task currently holds so the two consumer paths can
+//! detect the re-entry and act (reject the cycle for #5125; perform the
+//! mirror write without re-locking for #5126) **without** relaxing
+//! cross-task mutual exclusion: a *different* task that wants the same
+//! agent's lock still blocks on the real `tokio::sync::Mutex`.
+//!
+//! ## Why a `tokio::task_local!`, not a `std::thread_local!`
+//!
+//! The tokio multi-thread runtime can migrate a future across worker
+//! threads at every `.await` point, so a `thread_local!` would observe the
+//! wrong set after a yield. A `task_local!` is bound to the *task*, which
+//! is exactly the unit across which the lock is held (the whole agent loop
+//! runs inside one task on the non-streaming `send_message_full` path).
+//!
+//! `tokio::task::block_in_place` runs its closure on the **same task**
+//! (it only signals the runtime to migrate *other* tasks off this worker),
+//! so the task-local is fully visible inside `append_to_session`'s
+//! `block_in_place` — which is the #5126 detection point.
+
+use librefang_types::agent::AgentId;
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+tokio::task_local! {
+    /// Set of `AgentId`s whose `agent_msg_locks` entry the current task
+    /// currently holds. Established once at the outermost
+    /// `send_message_full` entry via [`scope`]; inner re-entrant calls in
+    /// the same task observe and mutate the same cell.
+    ///
+    /// `HashSet` (not `BTreeSet`): `AgentId` is `Hash + Eq` but not `Ord`,
+    /// and this set is used for O(1) membership testing, not for any
+    /// LLM-prompt ordering boundary (the #3298 determinism rule does not
+    /// apply here). The diagnostic cycle-path snapshot is sorted by the
+    /// inner `Uuid` in [`held_snapshot`] for a stable error message.
+    static HELD_AGENT_LOCKS: RefCell<HashSet<AgentId>>;
+}
+
+/// Run `fut` with the held-locks registry available for the current task.
+///
+/// Idempotent: if a registry is already established for this task (an
+/// outer `send_message_full` frame set it up), the future is awaited
+/// directly so the *same* cell is shared with the outer frame — that
+/// sharing is what makes same-task re-entry observable. Only the
+/// outermost frame allocates the `BTreeSet`.
+pub async fn scope<F>(fut: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    if HELD_AGENT_LOCKS.try_with(|_| ()).is_ok() {
+        // Registry already established by an outer frame on this task.
+        fut.await
+    } else {
+        HELD_AGENT_LOCKS
+            .scope(RefCell::new(HashSet::new()), fut)
+            .await
+    }
+}
+
+/// Is `agent_id`'s `agent_msg_locks` entry already held by the current
+/// task? Returns `false` when called outside any [`scope`] (no agent turn
+/// in flight on this task) — the safe default that preserves all existing
+/// behaviour for non-agent-loop callers.
+pub fn is_held(agent_id: AgentId) -> bool {
+    HELD_AGENT_LOCKS
+        .try_with(|set| set.borrow().contains(&agent_id))
+        .unwrap_or(false)
+}
+
+/// Snapshot the currently-held set for diagnostics — used to render the
+/// cycle path in the #5125 rejection message. Sorted by the inner `Uuid`
+/// so the error string is stable across runs (the set itself is a
+/// `HashSet`). Empty when called outside a [`scope`].
+pub fn held_snapshot() -> Vec<AgentId> {
+    let mut v: Vec<AgentId> = HELD_AGENT_LOCKS
+        .try_with(|set| set.borrow().iter().copied().collect())
+        .unwrap_or_default();
+    v.sort_by_key(|a| a.0);
+    v
+}
+
+/// RAII guard: records that the current task holds `agent_msg_locks[agent_id]`
+/// for its lifetime, and removes the entry on drop.
+///
+/// Drop runs on normal return, on early `?`, **and** on panic (Rust unwinds
+/// run destructors), so the registry can never leak a stale entry that would
+/// spuriously reject a later, legitimate, non-re-entrant acquisition.
+///
+/// Constructed only *after* the real `tokio::sync::Mutex` guard is acquired,
+/// and dropped *before* it (declare the registry guard after the lock guard
+/// so drop order is registry-then-lock — reverse of declaration). The
+/// registry therefore reflects "this task is inside the locked region",
+/// never a window where the entry is registered but the mutex is free.
+#[must_use = "dropping the guard immediately would clear the held-lock record before the locked region ends"]
+pub struct HeldLockGuard {
+    agent_id: AgentId,
+    /// `true` when this guard inserted the entry (vs. it was already
+    /// present because a *different* code path on the same task registered
+    /// it). Only the inserter removes it on drop, so re-entrant frames that
+    /// observe an already-held lock do not erase the outer frame's record.
+    inserted: bool,
+}
+
+impl HeldLockGuard {
+    /// Register `agent_id` as held by the current task. No-op-safe when
+    /// called outside a [`scope`] (returns a guard whose drop is inert),
+    /// so existing non-agent-loop lock acquirers keep working unchanged.
+    pub fn register(agent_id: AgentId) -> Self {
+        let inserted = HELD_AGENT_LOCKS
+            .try_with(|set| set.borrow_mut().insert(agent_id))
+            .unwrap_or(false);
+        Self { agent_id, inserted }
+    }
+}
+
+impl Drop for HeldLockGuard {
+    fn drop(&mut self) {
+        if self.inserted {
+            // `try_with` can only fail if the scope was already torn down,
+            // which cannot happen while this guard (a stack value inside
+            // the scoped future) is alive. The `let _ =` is defensive.
+            let _ = HELD_AGENT_LOCKS.try_with(|set| {
+                set.borrow_mut().remove(&self.agent_id);
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_held_is_false_outside_any_scope() {
+        // Non-agent-loop callers (HTTP attachment path, etc.) must see the
+        // safe default so their behaviour is unchanged.
+        assert!(!is_held(AgentId::new()));
+        assert!(held_snapshot().is_empty());
+    }
+
+    #[tokio::test]
+    async fn register_then_drop_clears_the_entry() {
+        let a = AgentId::new();
+        scope(async move {
+            assert!(!is_held(a));
+            {
+                let _g = HeldLockGuard::register(a);
+                assert!(is_held(a), "registered while guard alive");
+                assert_eq!(held_snapshot(), vec![a]);
+            }
+            // RAII drop on normal scope exit must clear the entry, otherwise a
+            // later legitimate non-re-entrant acquisition would be wrongly
+            // rejected.
+            assert!(!is_held(a), "entry must be cleared after guard drop");
+            assert!(held_snapshot().is_empty());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn drop_is_panic_safe() {
+        let a = AgentId::new();
+        let r = scope(async move {
+            let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _g = HeldLockGuard::register(a);
+                assert!(is_held(a));
+                panic!("boom");
+            }));
+            assert!(res.is_err(), "inner closure must have panicked");
+            // Unwinding ran the guard's destructor — the entry must be gone so
+            // a subsequent acquisition is not spuriously rejected.
+            is_held(a)
+        })
+        .await;
+        assert!(!r, "panic unwind must still clear the held entry (RAII)");
+    }
+
+    #[tokio::test]
+    async fn scope_is_idempotent_inner_shares_outer_set() {
+        // A transitively re-entered inner frame must observe the outer
+        // frame's registrations, not a fresh empty set — that sharing is
+        // exactly what makes same-task re-entry detectable.
+        let a = AgentId::new();
+        scope(async move {
+            let _outer = HeldLockGuard::register(a);
+            assert!(is_held(a));
+            scope(async move {
+                assert!(
+                    is_held(a),
+                    "inner scope must see the outer frame's held set"
+                );
+            })
+            .await;
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn task_local_does_not_bleed_across_tasks() {
+        // The whole correctness argument for #5125/#5126 rests on this: the
+        // registry is per-TASK. A different task must NOT observe another
+        // task's held set, so cross-task acquisitions always take the real
+        // mutex.
+        let a = AgentId::new();
+        let handle = tokio::spawn(scope(async move {
+            let _g = HeldLockGuard::register(a);
+            assert!(is_held(a), "holder task sees its own registration");
+            // A freshly spawned task is a new task → no scope, is_held false.
+            tokio::spawn(async move { is_held(a) }).await.unwrap()
+        }));
+        let other_task_saw_held = handle.await.unwrap();
+        assert!(
+            !other_task_saw_held,
+            "a different task must never observe the holder task's held set"
+        );
+    }
+}

--- a/crates/librefang-runtime/src/lib.rs
+++ b/crates/librefang-runtime/src/lib.rs
@@ -44,6 +44,7 @@ pub use librefang_llm_drivers::drivers;
 pub mod embedding;
 pub mod file_read_tracker;
 pub mod graceful_shutdown;
+pub mod held_agent_locks;
 pub mod history_fold;
 pub mod hooks;
 pub use librefang_http as http_client;


### PR DESCRIPTION
## Summary

Two severity/critical concurrency deadlocks with one shared root cause: the
same async task re-acquires `agent_msg_locks[agent_id]` (a non-reentrant
`tokio::sync::Mutex`) that an outer `send_message_full` frame already holds,
silently parking the multi-thread-runtime worker (no panic, no timeout).

## Lock / await graph (non-streaming path)

`send_message_full(A)` acquires `agent_msg_locks[A]` at the single
agent-scoped site, then `.await`s `execute_llm_agent` → `run_agent_loop` →
tool dispatch — all on the **same task** while the guard is held (RAII to
end of function).

- **#5125**: tool `agent_send` → `kh.send_to_agent_as` → `send_message_as`
  → `send_message_full(... A ...)` via `AGENT_CALL_DEPTH.scope` on the same
  task. A transitive `A→B→A` within `max_agent_call_depth` re-locks
  `agent_msg_locks[A]`. The direct `caller == agent_id` guard in
  `tool_agent_send` only catches the 1-hop case.
- **#5126**: tool `channel_send` → `mirror_channel_send_to_session` →
  `resolve_channel_owner` == A → `SessionWriter::append_to_session` does
  `block_in_place(|| lock.blocking_lock())` on `agent_msg_locks[A]`.
  `block_in_place` runs on the same task and does **not** release the held
  async mutex, so the blocking waiter never wakes (uninterruptible even by
  `tokio::time::timeout`).

## Shared task-local design

New `librefang_runtime::held_agent_locks`: a `tokio::task_local!`
`RefCell<HashSet<AgentId>>` registry.

- **task-local, not thread-local**: the multi-thread runtime migrates
  futures across worker threads at await points; a thread-local would
  observe the wrong set after a yield. Fully visible inside `block_in_place`
  (same task), which is the #5126 detection point.
- **`scope()` is idempotent**: the outermost `send_message_full` frame
  allocates the set; transitively re-entered inner frames share it, so
  re-entry is observable rather than masked by a fresh empty set.
- **`HeldLockGuard`** RAII: register-on-construct, remove-on-drop,
  panic-safe (unwind runs destructors), only-the-inserter-removes. Declared
  *after* the real mutex guard so drop order is registry→mutex (the entry
  is registered only while the mutex is provably held — never the inverse).
- Only the agent-scoped lock is tracked; the session-scoped
  (`session_id_override`) key space — which the re-entrant tool paths never
  take — is exempt to avoid false-positive rejections.
- Registration happens at the single agent-scoped acquisition in the
  renamed `send_message_full_inner`; `send_message_full_with_upstream` is
  now a thin wrapper that establishes the scope around the whole body.

## #5126 write-correctness: lockless-write, NOT skip

`append_to_session` writes `SessionId::for_sender_scope(owner, channel,
recipient)` — a uuid_v5-derived id **distinct** from the agent loop's own
`entry.session_id` (`crates/librefang-types/src/agent.rs`
`for_sender_scope`/`for_channel`;
`crates/librefang-runtime/src/tool_runner/channel.rs:93`). The outer
`send_message_full` never writes that mirror session on its own path, so
the issue's suggested "skip" would **silently lose the mirror message**
(defeats #4824). The `agent_msg_locks` mutex only serializes concurrent
*cross-task* writers; if this task already holds it, mutual exclusion
guarantees no other writer exists for the duration, so the
read-modify-write is performed **without re-locking** instead of skipped.
The identical guard is mirrored into `inject_attachment_blocks` (same
file/domain) for consistency and future-proofing — today it is only
reached from the HTTP attachment path where `is_held` is `false`, so
behaviour there is unchanged.

## Tests

- `issue_5125_transitive_cycle_is_rejected_not_deadlocked` — simulates the
  outer A turn (held lock + registered) then re-enters
  `send_message_full(A)`; asserts the cycle-rejection error within a 10s
  timeout.
- `issue_5126_owner_caller_mirror_write_is_lockless_not_deadlocked` — holds
  `agent_msg_locks[owner]` then calls `append_to_session` for the
  owner-derived mirror session; asserts completion within timeout **and**
  that the mirror message is persisted.
- `cross_task_serialization_on_agent_msg_lock_is_preserved` — a *different*
  task holding the real lock must still block a concurrent
  `append_to_session` until release; proves only same-task re-entry is
  relaxed, never cross-task mutual exclusion.
- 5 `held_agent_locks` unit tests: RAII clear, panic-safe drop, scope
  idempotency, cross-task non-bleed, safe default outside scope.

Empirically verified the integration tests **hang/fail without the fix**
(the #5126 `block_in_place` deadlock is uninterruptible by the in-test
`tokio::time::timeout`, confirming the silent worker park) and **pass with
it**.

`recursion_limit` bumped to 256 on `integration_test` / `multi_agent_test`
/ `wasm_agent_integration_test`: the extra `held_agent_locks::scope` future
layer deepens the monomorphized future-type layout past the default 128 in
those heavy test binaries. Matches the crate-root limit and the existing
`audit_retention_test` / `workflow_integration_test` precedent.

## Verification

Isolated `CARGO_TARGET_DIR`, rustc stable (1.95, matches CI):

- [x] `cargo check --workspace --lib` — clean
- [x] `cargo clippy -p librefang-kernel -p librefang-runtime --all-targets -- -D warnings` — clean
- [x] `cargo test -p librefang-runtime --lib` (held_agent_locks + channel_send) — 8 passed
- [x] `cargo test -p librefang-kernel --lib` (3 new + messaging/cascade/send regression) — 9 passed
- [x] `cargo test -p librefang-kernel --test session_reset_scope_test --test multi_agent_test` — 33 passed

## Test plan

- [ ] CI Unit-fast + Integration lanes green
- [ ] Live: confirm a multi-hand `A→B→A` workflow now errors with the cycle
      message instead of wedging the daemon
- [ ] Live: confirm a channel-owning agent replying to its own channel from
      within its turn persists the mirror and does not deadlock

Closes #5125
Closes #5126