### PR TITLE
fix(dashboard): re-enable send button on typing:stop

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChatPage.tsx
@@ -1801,11 +1801,11 @@ function ChatInput({ agentId, onSend, onStop, isStreaming, disabled, inputDisabl
   }, [message]);
 
   const effectiveDisabled = disabled || !!authMissing;
-  // Textarea only locked while the agent is actively streaming text. Once the
-  // model emits `typing:stop` the user can start composing the next message
-  // even while background post-processing (memory save) is still running —
-  // the send button stays gated on `effectiveDisabled` until the `response`
-  // event arrives with final tokens/cost.
+  // Both the textarea and the send button unlock on `typing:stop` (`disabled`
+  // and `inputDisabled` both track `isStreaming`). The `response` frame still
+  // arrives later and attaches `memories_saved` to the correct message via its
+  // keyed `updateAgentMessages` call — the send-button gate does not need to
+  // wait for it.
   const textareaDisabled = (inputDisabled ?? disabled) || !!authMissing;
 
   return (
@@ -3248,7 +3248,7 @@ export function ChatPage() {
               onSend={sendMessage}
               onStop={stopMessage}
               isStreaming={isStreaming}
-              disabled={isLoading}
+              disabled={isStreaming}
               inputDisabled={isStreaming}
               placeholder={isStreaming ? t("chat.generating") : selectedAgentId ? t("chat.input_placeholder_with_agent", { name: selectedAgent?.name }) : t("chat.transmit_command")}
               authMissing={isAuthUnavailable(selectedAgent?.auth_status)}


### PR DESCRIPTION
## Summary

Fixes #5204. Gates the Send button on `isStreaming` (cleared on `typing:stop`) instead of `isLoading` (cleared only on the `response` WS frame), so the Send button unblocks at the same point as the textarea.

## Root cause

`ChatPage.tsx:3251` passed `disabled={isLoading}` to `ChatInput`. `isLoading` is only cleared by `finishTurnIfCurrent` when the `response` event arrives — which fires server-side only after `auto_memorize` completes (an inline LLM round-trip). The textarea already used `inputDisabled={isStreaming}`, which clears on `typing:stop`, creating the visible asymmetry.

## Fix (Option B — frontend-only stopgap)

- Changed `disabled={isLoading}` → `disabled={isStreaming}` at the `ChatInput` callsite (`ChatPage.tsx:3251`).
- Updated the now-stale comment at `~:1803-1807` to reflect that both controls unlock on `typing:stop`.
- Verified the newer-turn-in-flight guard (`finishTurnIfCurrent` keyed by `botMsg.id` vs `latestTurnRef.current[agent]`) still works correctly: if a fast user submits a new turn while the prior `response` frame is pending, the old turn's `finishTurnIfCurrent` is a no-op (ids differ), and `memories_saved` is still applied to the right prior message via the keyed `updateAgentMessages` map.

## Follow-up (Option A, NOT in this PR)

Server-side detach of `auto_memorize` so the `response` frame fires immediately for all surfaces (channels, API consumers, dashboard). Requires a separate decision on how `memories_saved` is delivered (late WS event vs accepting omission). Tracked as follow-up.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 67 test files, 646 tests, all passing
- [x] `pnpm build` — succeeds
- [x] newer-turn guard: `finishTurnIfCurrent` checks `latestTurnRef.current[agent] === botId` before clearing loading; `memories_saved` attaches via `botMsg.id`-keyed map, unaffected by new turns