### PR TITLE
fix(kernel,runtime): /context reports real model context window

### DIFF
--- a/crates/librefang-kernel/src/kernel/agent_runtime.rs
+++ b/crates/librefang-kernel/src/kernel/agent_runtime.rs
@@ -467,18 +467,37 @@ impl LibreFangKernel {
         let system_prompt = &entry.manifest.model.system_prompt;
         // Use the agent's actual filtered tools instead of all builtins
         let tools = self.available_tools(agent_id);
-        // Use 200K default or the model's known context window
-        let context_window = if session.context_window_tokens > 0 {
-            session.context_window_tokens
-        } else {
-            200_000
-        };
+
+        // Resolve context window with the same precedence chain the agent loop uses:
+        // 1. agent.toml `model.context_window` explicit override
+        // 2. ModelCatalog lookup (provider-aware, filters out 0)
+        // 3. Persisted session value (authoritative only when catalog has no entry)
+        // 4. Conservative fallback (8192) — matches UNKNOWN_MODEL_CONTEXT_WINDOW (#3349)
+        let context_window: usize = entry
+            .manifest
+            .model
+            .context_window
+            .filter(|v| *v > 0)
+            .map(|v| v as usize)
+            .or_else(|| {
+                self.llm
+                    .model_catalog
+                    .load()
+                    .find_model(&entry.manifest.model.model)
+                    .map(|m| m.context_window as usize)
+                    .filter(|w| *w > 0)
+            })
+            .or_else(|| {
+                let v = session.context_window_tokens as usize;
+                if v > 0 { Some(v) } else { None }
+            })
+            .unwrap_or(librefang_runtime::agent_loop::model::UNKNOWN_MODEL_CONTEXT_WINDOW);
 
         Ok(generate_context_report(
             &session.messages,
             Some(system_prompt),
             Some(&tools),
-            context_window as usize,
+            context_window,
         ))
     }
 

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -8747,3 +8747,111 @@ async fn issue_5126_streaming_spawn_body_mirror_write_is_lockless() {
 
     kernel.shutdown();
 }
+
+/// Regression: `context_report` must resolve the context window from the
+/// model catalog rather than falling back to the 200K hardcoded placeholder
+/// (#5200). An agent on a 1M-window model must report a 1M denominator, not
+/// 200K.
+#[test]
+fn test_context_report_uses_catalog_context_window_not_200k() {
+    use librefang_types::model_catalog::{ModelCatalogEntry, ModelTier};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().join("librefang-kernel-ctx-report-test");
+    std::fs::create_dir_all(&home_dir).unwrap();
+
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("kernel boot");
+
+    // Insert a catalog entry for a fictional 1M-window model so the
+    // resolver finds it via L2 (registry lookup) without needing real
+    // provider files on disk.
+    kernel.model_catalog_update(|cat| {
+        cat.add_custom_model(ModelCatalogEntry {
+            id: "fake-1m-model".to_string(),
+            display_name: "Fake 1M Model".to_string(),
+            provider: "fake-provider".to_string(),
+            tier: ModelTier::Custom,
+            context_window: 1_000_000,
+            ..Default::default()
+        });
+    });
+
+    let manifest = AgentManifest {
+        name: "ctx-report-test-agent".to_string(),
+        description: "agent for context_report regression test".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        model: ModelConfig {
+            provider: "fake-provider".to_string(),
+            model: "fake-1m-model".to_string(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let agent_id = kernel.spawn_agent(manifest).expect("agent spawn");
+    let report = kernel
+        .context_report(agent_id)
+        .expect("context_report must succeed");
+
+    assert_ne!(
+        report.context_window, 200_000,
+        "context_report must not use the 200K hardcoded placeholder (#5200)"
+    );
+    assert_eq!(
+        report.context_window, 1_000_000,
+        "context_report must resolve the catalog's 1M window for fake-1m-model"
+    );
+
+    kernel.shutdown();
+}
+
+/// `context_report` must honour the agent manifest's explicit
+/// `model.context_window` override (L1 in the resolution chain) over the
+/// catalog value (#5200).
+#[test]
+fn test_context_report_honours_manifest_context_window_override() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().join("librefang-kernel-ctx-override-test");
+    std::fs::create_dir_all(&home_dir).unwrap();
+
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("kernel boot");
+
+    let manifest = AgentManifest {
+        name: "ctx-override-test-agent".to_string(),
+        description: "agent with explicit context_window in manifest".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        model: ModelConfig {
+            provider: "ollama".to_string(),
+            model: "some-local-model".to_string(),
+            context_window: Some(262_144),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let agent_id = kernel.spawn_agent(manifest).expect("agent spawn");
+    let report = kernel
+        .context_report(agent_id)
+        .expect("context_report must succeed");
+
+    assert_eq!(
+        report.context_window, 262_144,
+        "manifest model.context_window override must be used as the denominator"
+    );
+
+    kernel.shutdown();
+}

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -36,7 +36,7 @@ use tracing::{debug, info, instrument, warn};
 mod end_turn;
 mod history;
 mod message;
-mod model;
+pub mod model;
 mod prompt;
 mod retry;
 mod run_streaming;

--- a/crates/librefang-runtime/src/agent_loop/model.rs
+++ b/crates/librefang-runtime/src/agent_loop/model.rs
@@ -180,7 +180,7 @@ pub(super) const DEFAULT_CONTEXT_WINDOW: usize = 200_000;
 /// rather than burning tokens (#3349). Operators with larger windows must
 /// set `agent.toml: model.context_window` (or the equivalent provider
 /// catalog entry) explicitly.
-pub(super) const UNKNOWN_MODEL_CONTEXT_WINDOW: usize = 8192;
+pub const UNKNOWN_MODEL_CONTEXT_WINDOW: usize = 8192;
 
 /// Check if stable_prefix_mode is enabled via manifest metadata.
 pub(super) fn stable_prefix_mode_enabled(manifest: &AgentManifest) -> bool {

--- a/crates/librefang-runtime/src/compactor.rs
+++ b/crates/librefang-runtime/src/compactor.rs
@@ -381,7 +381,7 @@ pub fn format_context_report(report: &ContextReport) -> String {
         "**Context Usage:** {bar} {:.1}% ({} / {} tokens)\n\n\
          **Breakdown:**\n\
          - System prompt: ~{} tokens\n\
-         - Messages ({}): ~{} tokens\n\
+         - Messages ({}, estimated, retained messages only): ~{} tokens\n\
          - Tool definitions: ~{} tokens\n\n\
          **Pressure:** {:?}\n\
          **Recommendation:** {}",


### PR DESCRIPTION
## Summary

Fixes #5200. `/context` now resolves the denominator from the ModelCatalog and agent manifest override instead of falling back to a hardcoded 200K placeholder.

## Root cause

Two unrelated context-window resolvers existed in the codebase:

- **Agent loop** (`crates/librefang-runtime/src/agent_loop/mod.rs:655`): correct — reads from ModelCatalog, honours `agent.toml model.context_window`, falls back to `UNKNOWN_MODEL_CONTEXT_WINDOW = 8192`.
- **`/context` reporter** (`crates/librefang-kernel/src/kernel/agent_runtime.rs:471`): wrong — only read `session.context_window_tokens` and fell back to `200_000` when that field was `0` (common for custom/ollama models whose session row was never updated).

## Fix

- **`kernel/agent_runtime.rs` — `Kernel::context_report()`**: replace `200_000` literal with a four-step chain matching the agent loop: (1) `manifest.model.context_window` override, (2) ModelCatalog `find_model` lookup (filter zero), (3) persisted `session.context_window_tokens`, (4) `UNKNOWN_MODEL_CONTEXT_WINDOW = 8192`.
- **`runtime/agent_loop/model.rs`**: promote `UNKNOWN_MODEL_CONTEXT_WINDOW` from `pub(super)` to `pub`; expose `agent_loop::model` as `pub mod` so the kernel can reference the constant without duplication.
- **`runtime/compactor.rs` — `format_context_report()`**: add "(estimated, retained messages only)" qualifier to the message-count breakdown line so users understand the numerator covers only the post-trim persisted session, not cumulative provider tokens.
- **`kernel/tests.rs`**: two regression tests — one inserts a 1M-window model in the catalog and asserts the report denominator is 1_000_000; one sets `manifest.model.context_window = 262_144` and asserts the L1 override wins.

## Test plan

- [x] `cargo check -p librefang-kernel -p librefang-runtime` — clean
- [x] `cargo clippy -p librefang-kernel -- -D warnings` — clean
- [x] `cargo clippy -p librefang-runtime -- -D warnings` — clean
- [x] New tests: `test_context_report_uses_catalog_context_window_not_200k`, `test_context_report_honours_manifest_context_window_override`