### PR TITLE
fix(kernel): surface config deserialize errors and fail closed on hard parse failure

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -4059,7 +4059,16 @@ pub async fn reload_channels_from_disk(
 
     // Re-read config from disk
     let config_path = state.kernel.home_dir().join("config.toml");
-    let fresh_config = kernel_load_config(Some(&config_path));
+    let fresh_config = match kernel_load_config(Some(&config_path)) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Channel hot-reload: config file cannot be loaded; keeping current channel config"
+            );
+            return Err(e);
+        }
+    };
 
     // Update the live channels config so list_channels() reflects reality
     *state.channels_config.write().await = fresh_config.channels.clone();

--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -946,3 +946,84 @@ async fn health_detail_daily_spend_percent_reflects_configured_cap() {
         "monthly_spend_percent must stay null when no monthly cap is set: {budget}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #5186 boot-path golden — stale renamed channel key fails boot loudly.
+//
+// Issue #5186 asked for an end-to-end guard that this class can't regress:
+// when an operator's `config.toml` carries a channel-scoped field whose
+// shape no longer matches the schema (the prototypical "stale renamed
+// channel key" — old release accepted one shape, new release expects
+// another), boot must abort with the field path in the error so the
+// operator can pinpoint the offending line. The pre-#5186 behaviour
+// silently substituted `KernelConfig::default()`, after which the
+// daemon's downstream auth / token-resolve step would fail with a
+// confusing "missing bot token" message that hid the real cause.
+//
+// The test goes through `librefang_kernel::config::load_config` — the
+// exact entry point `LibreFangKernel::boot` uses to read `config.toml`
+// from disk — and asserts:
+//   1. it returns `Err` (fail-closed),
+//   2. the error names the offending channel field,
+//   3. the error does NOT mention authentication.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn boot_fails_on_stale_channel_output_format_key() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+
+    // A `[channels.telegram]` block where `poll_interval_secs` has the
+    // wrong shape (string instead of u64) — the canonical "stale renamed
+    // channel key" scenario the issue tracks: an older release tolerated
+    // a string here (e.g. "30s"), the current schema is `u64` seconds,
+    // and the operator's config still carries the old value.
+    //
+    // We use `poll_interval_secs` rather than the literal `output_format`
+    // from the issue write-up because `output_format` was never a real
+    // schema field — making the test trip the unknown-field tolerance
+    // path (warn-and-proceed by design, see #5130) instead of the
+    // hard-fail path #5186 actually closes. The behavioural assertion
+    // (boot fails, message names the channel field, no "auth" leakage)
+    // is identical either way and is the real regression contract.
+    let bad_toml = "\
+[channels.telegram]
+bot_token_env = \"TELEGRAM_BOT_TOKEN\"
+poll_interval_secs = \"thirty-seconds\"
+";
+    std::fs::write(&config_path, bad_toml).expect("write bad config.toml");
+
+    let result = librefang_kernel::config::load_config(Some(&config_path));
+    let err = result.expect_err(
+        "stale-shape channel field must fail-close at load_config, \
+         not silently substitute KernelConfig::default()",
+    );
+
+    // The error must name the offending field so the operator can fix
+    // their config without guessing. The exact wording is owned by the
+    // TOML deserializer; we lock the substring contract on the field
+    // name and the section path.
+    assert!(
+        err.contains("poll_interval_secs"),
+        "boot error must name the offending channel field; got: {err}"
+    );
+    assert!(
+        err.contains("channels") && err.contains("telegram"),
+        "boot error must locate the field under [channels.telegram]; got: {err}"
+    );
+
+    // The critical regression guard from the issue: the failure must NOT
+    // be misclassified as an auth / token error downstream. Pre-#5186,
+    // the load tolerated the bad value, defaults wiped the operator's
+    // `[channels.telegram] bot_token_env`, and the next layer surfaced
+    // it as "telegram bot token missing — authentication failed". Now
+    // we abort at parse time with the field name and never reach auth.
+    let lower = err.to_lowercase();
+    assert!(
+        !lower.contains("auth")
+            && !lower.contains("bot token")
+            && !lower.contains("unauthorized"),
+        "boot error must not be misclassified as an auth failure (the \
+         pre-#5186 downstream symptom); got: {err}"
+    );
+}

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -1920,7 +1920,10 @@ struct DaemonConfigContext {
 }
 
 fn daemon_config_context(config: Option<&std::path::Path>) -> DaemonConfigContext {
-    let config = load_config(config);
+    let config = load_config(config).unwrap_or_else(|e| {
+        eprintln!("warning: {e}; using default config values for this command");
+        librefang_types::config::KernelConfig::default()
+    });
     let api_key = {
         let trimmed = config.api_key.trim();
         if trimmed.is_empty() {
@@ -4633,7 +4636,10 @@ fn render_status_daemon(
         .api_key
         .as_deref()
         .and_then(|k| fetch_status_detail(base, k));
-    let cfg = load_config(config);
+    let cfg = load_config(config).unwrap_or_else(|e| {
+        eprintln!("warning: {e}; using default config values for status display");
+        librefang_types::config::KernelConfig::default()
+    });
 
     let exit_code = classify_exit(health.as_ref());
     let is_public_bind = info
@@ -5152,7 +5158,10 @@ fn render_status_inprocess(config: Option<PathBuf>, json: bool, quiet: bool) -> 
     // workflow templates just to print "daemon down". Pull what we can from
     // the config file alone.
     if quiet {
-        let cfg = load_config(config.as_deref());
+        let cfg = load_config(config.as_deref()).unwrap_or_else(|e| {
+            eprintln!("warning: {e}; using default config values for status display");
+            librefang_types::config::KernelConfig::default()
+        });
         println!(
             "librefang down home={} default={}/{}",
             cfg.home_dir.display(),
@@ -11161,7 +11170,13 @@ fn cmd_security_verify() {
 /// `--confirm`.
 fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
     let daemon = daemon_config_context(config.as_deref());
-    let kernel_config = load_config(config.as_deref());
+    let kernel_config = match load_config(config.as_deref()) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    };
 
     let db_path = kernel_config
         .memory

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -3510,6 +3510,21 @@ fn ensure_initialized(config: &Option<PathBuf>) {
 fn cmd_start(config: Option<PathBuf>, tail: bool, spawned: bool, foreground: bool) {
     ensure_initialized(&config);
 
+    // Issue #5186 follow-up: `cmd_start` boots a real daemon, so a bad
+    // `config.toml` must abort here BEFORE `daemon_config_context` swallows
+    // the load error and substitutes `KernelConfig::default()`. The
+    // tolerant default would silently change `home_dir` (used a few lines
+    // below to detect an already-running daemon) and the spawned child
+    // would only fail-closed during its own boot — losing the field-name
+    // diagnostic from the parent's stderr in the process.
+    //
+    // `load_config` already prints the underlying error to stderr (so
+    // operators see the field name even before the tracing subscriber is
+    // wired up); we only need to short-circuit with a non-zero exit.
+    if load_config(config.as_deref()).is_err() {
+        std::process::exit(1);
+    }
+
     let daemon = daemon_config_context(config.as_deref());
     if let Some(base) = find_daemon_in_home(&daemon.home_dir) {
         ui::error_with_fix(
@@ -3798,6 +3813,15 @@ fn cmd_stop(config: Option<PathBuf>) {
 }
 
 fn cmd_restart(config: Option<PathBuf>, tail: bool, foreground: bool) {
+    // Same fail-closed rule as `cmd_start` (#5186 follow-up): a bad config
+    // must abort before we read `home_dir` to look up a running daemon, or
+    // we'd `find_daemon_in_home` on `~/.librefang` (the default) and either
+    // miss a real daemon at a user-configured `home_dir` or "stop" the
+    // wrong one. `load_config` already eprintln!s the underlying error.
+    if load_config(config.as_deref()).is_err() {
+        std::process::exit(1);
+    }
+
     let daemon = daemon_config_context(config.as_deref());
     if find_daemon_in_home(&daemon.home_dir).is_some() {
         ui::hint(&i18n::t("daemon-restarting"));
@@ -11170,12 +11194,11 @@ fn cmd_security_verify() {
 /// `--confirm`.
 fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
     let daemon = daemon_config_context(config.as_deref());
+    // `load_config` already eprintln!s the underlying parse / deserialize
+    // error (see #5186); printing it again here would double the message.
     let kernel_config = match load_config(config.as_deref()) {
         Ok(cfg) => cfg,
-        Err(e) => {
-            eprintln!("error: {e}");
-            std::process::exit(1);
-        }
+        Err(_) => std::process::exit(1),
     };
 
     let db_path = kernel_config

--- a/crates/librefang-kernel/src/config.rs
+++ b/crates/librefang-kernel/src/config.rs
@@ -15,9 +15,19 @@ const MAX_INCLUDE_DEPTH: u32 = 10;
 
 /// Load kernel configuration from a TOML file, with defaults.
 ///
+/// Returns `Err` when the config file exists but cannot be parsed as valid TOML
+/// or cannot be deserialized into `KernelConfig` — a content failure that means
+/// the operator's settings have been silently discarded. The caller must not
+/// substitute `KernelConfig::default()` on `Err`; doing so would hide the
+/// real problem and produce a misleading downstream error (see issue #5186).
+///
+/// Returns `Ok(KernelConfig::default())` when the config file is absent or
+/// unreadable due to an I/O error (file not found, permission denied), because
+/// that is a deployment-time condition where defaults are a safe starting point.
+///
 /// If the config contains an `include` field, included files are loaded
 /// and deep-merged first, then the root config overrides them.
-pub fn load_config(path: Option<&Path>) -> KernelConfig {
+pub fn load_config(path: Option<&Path>) -> Result<KernelConfig, String> {
     let config_path = path
         .map(|p| p.to_path_buf())
         .unwrap_or_else(default_config_path);
@@ -118,10 +128,10 @@ pub fn load_config(path: Option<&Path>) -> KernelConfig {
                                 fields = %all_unknown.join(", "),
                                 "strict_config is enabled and config contains unknown fields, using defaults"
                             );
-                            return KernelConfig {
+                            return Ok(KernelConfig {
                                 strict_config: true,
                                 ..KernelConfig::default()
-                            };
+                            });
                         }
                         for field in &all_unknown {
                             tracing::warn!(field, "Unknown config field (ignored)");
@@ -157,23 +167,25 @@ pub fn load_config(path: Option<&Path>) -> KernelConfig {
                                 }
                             }
                             info!(path = %config_path.display(), "Loaded configuration");
-                            return config;
+                            return Ok(config);
                         }
                         Err(e) => {
-                            tracing::warn!(
-                                error = %e,
-                                path = %config_path.display(),
-                                "Failed to deserialize merged config, using defaults"
+                            let msg = format!(
+                                "Config file cannot be deserialized (path={}): {e}",
+                                config_path.display()
                             );
+                            eprintln!("error: {msg}");
+                            return Err(msg);
                         }
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        path = %config_path.display(),
-                        "Failed to parse config, using defaults"
+                    let msg = format!(
+                        "Config file has invalid TOML and cannot be loaded (path={}): {e}",
+                        config_path.display()
                     );
+                    eprintln!("error: {msg}");
+                    return Err(msg);
                 }
             },
             Err(e) => {
@@ -191,7 +203,7 @@ pub fn load_config(path: Option<&Path>) -> KernelConfig {
         );
     }
 
-    KernelConfig::default()
+    Ok(KernelConfig::default())
 }
 
 /// Strict counterpart of [`load_config`] that returns `Err` on every failure
@@ -444,13 +456,13 @@ mod tests {
 
     #[test]
     fn test_load_config_defaults() {
-        let config = load_config(None);
+        let config = load_config(None).unwrap();
         assert_eq!(config.log_level, "info");
     }
 
     #[test]
     fn test_load_config_missing_file() {
-        let config = load_config(Some(Path::new("/nonexistent/config.toml")));
+        let config = load_config(Some(Path::new("/nonexistent/config.toml"))).unwrap();
         assert_eq!(config.log_level, "info");
     }
 
@@ -517,7 +529,7 @@ mod tests {
         writeln!(f, "log_level = \"warn\"").unwrap();
         drop(f);
 
-        let config = load_config(Some(&root_path));
+        let config = load_config(Some(&root_path)).unwrap();
         assert_eq!(config.log_level, "warn"); // root overrides
         assert_eq!(config.api_listen, "0.0.0.0:9999"); // from base
     }
@@ -543,7 +555,7 @@ mod tests {
         writeln!(f, "log_level = \"info\"").unwrap();
         drop(f);
 
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.log_level, "info"); // root wins
     }
 
@@ -562,9 +574,8 @@ mod tests {
         writeln!(f, "include = [\"a.toml\"]").unwrap();
         drop(f);
 
-        // Should not panic — circular detection triggers, falls back gracefully
-        let config = load_config(Some(&a_path));
-        // Falls back to defaults due to the circular error
+        // Include errors are tolerated — the root file still loads with its own fields.
+        let config = load_config(Some(&a_path)).unwrap();
         assert!(!config.log_level.is_empty());
     }
 
@@ -577,9 +588,9 @@ mod tests {
         writeln!(f, "include = [\"../etc/passwd\"]").unwrap();
         drop(f);
 
-        // Should not panic — path traversal triggers error, falls back
-        let config = load_config(Some(&root));
-        assert_eq!(config.log_level, "info"); // defaults
+        // Include-chain security errors are tolerated; root-only config still loads.
+        let config = load_config(Some(&root)).unwrap();
+        assert_eq!(config.log_level, "info"); // defaults (root was just an include directive)
     }
 
     #[test]
@@ -600,8 +611,8 @@ mod tests {
         }
 
         let root = dir.path().join("level0.toml");
-        let config = load_config(Some(&root));
-        // Falls back due to depth limit — but should not panic
+        // Include depth overflow is tolerated; the root file still loads.
+        let config = load_config(Some(&root)).unwrap();
         assert!(!config.log_level.is_empty());
     }
 
@@ -614,7 +625,8 @@ mod tests {
         writeln!(f, "include = [\"/etc/shadow\"]").unwrap();
         drop(f);
 
-        let config = load_config(Some(&root));
+        // Include-chain security errors are tolerated; root-only config still loads.
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.log_level, "info"); // defaults
     }
 
@@ -627,7 +639,7 @@ mod tests {
         writeln!(f, "log_level = \"trace\"").unwrap();
         drop(f);
 
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.log_level, "trace");
     }
 
@@ -645,7 +657,7 @@ mod tests {
         drop(f);
 
         // Tolerant mode (default): should still load successfully
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.log_level, "debug");
         assert!(!config.strict_config);
     }
@@ -662,7 +674,7 @@ mod tests {
         drop(f);
 
         // Strict mode: should reject and return defaults (with strict_config=true)
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         // Falls back to defaults because strict mode rejected unknown fields
         assert_eq!(config.log_level, "info"); // default, not "debug"
         assert!(config.strict_config);
@@ -679,7 +691,7 @@ mod tests {
         drop(f);
 
         // Strict mode with no unknown fields: should load normally
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.log_level, "warn");
         assert!(config.strict_config);
     }
@@ -696,7 +708,7 @@ mod tests {
         drop(f);
 
         // Explicitly tolerant: should load despite unknown field
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.log_level, "error");
         assert!(!config.strict_config);
     }
@@ -713,7 +725,7 @@ mod tests {
         writeln!(f, "api_listen = \"0.0.0.0:9999\"").unwrap();
         drop(f);
 
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.api_key, "my-secret");
         assert_eq!(config.api_listen, "0.0.0.0:9999");
         assert_eq!(config.config_version, CONFIG_VERSION);
@@ -740,7 +752,7 @@ mod tests {
         writeln!(f, "log_level = \"debug\"").unwrap();
         drop(f);
 
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.log_level, "debug");
         assert_eq!(config.config_version, 2);
     }
@@ -762,7 +774,7 @@ mod tests {
         writeln!(f, "role = \"owner\"").unwrap();
         drop(f);
 
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.users.len(), 1);
         assert_eq!(config.users[0].name, "Alice");
         assert_eq!(config.users[0].role, "owner");
@@ -783,7 +795,7 @@ mod tests {
         writeln!(f, "telegram = \"123456\"").unwrap();
         drop(f);
 
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.users.len(), 1);
         assert_eq!(config.users[0].name, "Alice");
         assert_eq!(
@@ -807,14 +819,14 @@ mod tests {
         drop(f);
 
         // First load: triggers migration (v1 → v2), writes back
-        let config1 = load_config(Some(&root));
+        let config1 = load_config(Some(&root)).unwrap();
         assert_eq!(config1.log_level, "debug");
         assert_eq!(config1.users.len(), 1);
         assert_eq!(config1.users[0].name, "Alice");
         assert_eq!(config1.config_version, CONFIG_VERSION);
 
         // Second load: reads migrated file, no migration needed
-        let config2 = load_config(Some(&root));
+        let config2 = load_config(Some(&root)).unwrap();
         assert_eq!(config2.log_level, "debug");
         assert_eq!(config2.users.len(), 1);
         assert_eq!(config2.users[0].name, "Alice");
@@ -835,7 +847,7 @@ mod tests {
         // No [[users]] section — migration should not add users = []
         drop(f);
 
-        let _config = load_config(Some(&root));
+        let _config = load_config(Some(&root)).unwrap();
         let contents = std::fs::read_to_string(&root).unwrap();
 
         // The migrated file should not have a `users = []` line that would
@@ -849,8 +861,8 @@ mod tests {
     #[test]
     fn test_users_array_key_conflicts_with_array_of_tables() {
         // Verify that if a config has BOTH `users = []` and `[[users]]`,
-        // the TOML parser rejects it (duplicate key). The kernel should
-        // fall back to defaults gracefully rather than panic.
+        // the TOML parser rejects it (duplicate key). The kernel must surface
+        // the error rather than silently substituting defaults.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("config.toml");
 
@@ -862,10 +874,17 @@ mod tests {
         writeln!(f, "role = \"owner\"").unwrap();
         drop(f);
 
-        // Should fall back to defaults (TOML parse error: duplicate key)
-        let config = load_config(Some(&root));
-        assert_eq!(config.log_level, "info"); // default, not "warn"
-        assert!(config.users.is_empty());
+        // TOML parse error (duplicate key) → Err, not silent defaults.
+        let result = load_config(Some(&root));
+        assert!(
+            result.is_err(),
+            "duplicate TOML key must surface as Err, not silent defaults"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("invalid TOML") || msg.contains("duplicate"),
+            "error must be actionable; got: {msg}"
+        );
     }
 
     /// Regression for #3460: nested typos like `[memory] decay_ratee` were
@@ -886,7 +905,7 @@ mod tests {
         drop(f);
 
         // Tolerant: still loads with defaults for the typo'd fields.
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         assert_eq!(config.log_level, "debug");
         // Defaults preserved (the typos didn't take effect).
         assert!(
@@ -911,16 +930,17 @@ mod tests {
         writeln!(f, "max_hourly_usdd = 5.0").unwrap(); // typo
         drop(f);
 
-        let config = load_config(Some(&root));
+        let config = load_config(Some(&root)).unwrap();
         // Falls back to defaults because strict mode rejected the typo.
         assert_eq!(config.log_level, "info");
         assert!(config.strict_config);
     }
 
     #[test]
-    fn test_load_config_users_missing_name_falls_back_to_defaults() {
-        // A [[users]] block without a required `name` field should fail deserialization
-        // and fall back to defaults rather than panicking.
+    fn test_load_config_users_missing_name_fails_closed() {
+        // A [[users]] block without a required `name` field fails deserialization.
+        // The kernel must surface the error rather than silently substituting
+        // defaults (which would discard the operator's full user list).
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("config.toml");
 
@@ -930,10 +950,16 @@ mod tests {
         writeln!(f, "role = \"owner\"").unwrap(); // no name — invalid
         drop(f);
 
-        let config = load_config(Some(&root));
-        // Should fall back to defaults (users deserialization fails)
-        assert_eq!(config.log_level, "info"); // default, not "warn"
-        assert!(config.users.is_empty());
+        let result = load_config(Some(&root));
+        assert!(
+            result.is_err(),
+            "deserialization failure must surface as Err, not silent defaults"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("deserialize") || msg.contains("missing field"),
+            "error must be actionable; got: {msg}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1021,9 +1047,8 @@ mod tests {
     #[test]
     fn test_try_load_config_deserialize_shape_mismatch_is_error() {
         // TOML parses cleanly but a field has the wrong shape — `default_model`
-        // is a struct, not a scalar. Tolerant `load_config` warns and returns
-        // defaults; strict variant must refuse so the reload caller cannot
-        // accidentally apply defaults as the diff target.
+        // is a struct, not a scalar. Both `load_config` and `try_load_config`
+        // now return `Err` on a hard deserialize failure (see #5186).
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("config.toml");
 
@@ -1076,5 +1101,85 @@ mod tests {
         let cfg =
             try_load_config(&root).expect("tolerant unknown fields must not fail strict load");
         assert_eq!(cfg.log_level, "warn");
+    }
+
+    // -----------------------------------------------------------------------
+    // #5186 — hard deserialize failures fail closed; unknown fields stay tolerant
+    // -----------------------------------------------------------------------
+
+    /// A config with a wrong-type field (not a structurally unknown field) must
+    /// cause `load_config` to return `Err` containing the field path, not
+    /// silently substitute `KernelConfig::default()`.
+    #[test]
+    fn test_load_config_hard_deserialize_failure_returns_err_with_field_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+
+        // `default_model` expects a table, not a plain string.
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "log_level = \"warn\"").unwrap();
+        writeln!(f, "default_model = \"not-a-table\"").unwrap();
+        drop(f);
+
+        let result = load_config(Some(&root));
+        assert!(
+            result.is_err(),
+            "wrong-type field must surface as Err, not silent defaults"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("deserialize") || msg.contains("default_model") || msg.contains("invalid type"),
+            "error must name the offending field or describe the mismatch; got: {msg}"
+        );
+    }
+
+    /// A config with TOML syntax that the parser outright rejects must cause
+    /// `load_config` to return `Err`, not silently substitute defaults.
+    #[test]
+    fn test_load_config_invalid_toml_returns_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+
+        // Duplicate section key — valid TOML rejects this at parse time.
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "[memory]").unwrap();
+        writeln!(f, "decay_rate = 0.1").unwrap();
+        writeln!(f, "[memory]").unwrap();
+        writeln!(f, "decay_rate = 0.2").unwrap();
+        drop(f);
+
+        let result = load_config(Some(&root));
+        assert!(
+            result.is_err(),
+            "invalid TOML must surface as Err, not silent defaults"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("invalid TOML") || msg.contains("duplicate"),
+            "error must be actionable; got: {msg}"
+        );
+    }
+
+    /// Unknown/extra fields in the config must NOT cause `load_config` to fail —
+    /// the forward-compat (unknown-field tolerance) path introduced in #5130
+    /// must remain intact even after the #5186 fail-closed change.
+    #[test]
+    fn test_load_config_unknown_field_forward_compat_still_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+
+        // A field that did not exist in the schema — simulates a stale key
+        // from a prior release that has since been removed or renamed.
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "log_level = \"debug\"").unwrap();
+        writeln!(f, "api_key = \"secret\"").unwrap();
+        writeln!(f, "output_format_legacy = \"markdown\"").unwrap(); // stale field
+        drop(f);
+
+        // Must succeed: unknown fields are tolerated and warned, not fatal.
+        let config = load_config(Some(&root))
+            .expect("unknown-field forward-compat path must still load successfully");
+        assert_eq!(config.log_level, "debug");
+        assert_eq!(config.api_key, "secret");
     }
 }

--- a/crates/librefang-kernel/src/kernel/boot.rs
+++ b/crates/librefang-kernel/src/kernel/boot.rs
@@ -27,7 +27,8 @@ impl LibreFangKernel {
 
     /// Boot the kernel with configuration from the given path.
     pub fn boot(config_path: Option<&Path>) -> KernelResult<Self> {
-        let config = load_config(config_path);
+        let config = load_config(config_path)
+            .map_err(|e| crate::error::KernelError::LibreFang(LibreFangError::Config(e)))?;
         Self::boot_with_config(config)
     }
 
@@ -814,13 +815,23 @@ impl LibreFangKernel {
         let config = if migrated {
             let cfg_path = config.home_dir.join("config.toml");
             if cfg_path.is_file() {
-                let reloaded = load_config(Some(&cfg_path));
-                // Defensive: only accept the reloaded view if it didn't drop
-                // any `[[mcp_servers]]` entries the caller already had.
-                if reloaded.mcp_servers.len() >= config.mcp_servers.len() {
-                    reloaded
-                } else {
-                    config
+                match load_config(Some(&cfg_path)) {
+                    Ok(reloaded) => {
+                        // Defensive: only accept the reloaded view if it didn't drop
+                        // any `[[mcp_servers]]` entries the caller already had.
+                        if reloaded.mcp_servers.len() >= config.mcp_servers.len() {
+                            reloaded
+                        } else {
+                            config
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "Failed to re-read migrated config; using in-memory copy"
+                        );
+                        config
+                    }
                 }
             } else {
                 config


### PR DESCRIPTION
## Summary

Fixes #5186.

- `load_config` now returns `Result<KernelConfig, String>` and fails closed on hard content failures (invalid TOML / shape-mismatch deserialization), ending the silent substitution of `KernelConfig::default()` that produced misleading downstream boot errors.
- Both hard-failure arms `eprintln!` the real error to stderr before returning `Err`, so operators see the actionable message regardless of whether the tracing subscriber is up.
- I/O errors (file not found, permission denied) and unknown-field forward-compat (#5130) remain tolerant — only a whole-struct parse or deserialize failure is fatal.

## Root cause

`crates/librefang-kernel/src/config.rs:162-168` — `try_into::<KernelConfig>()` Err arm used `tracing::warn!` and returned `KernelConfig::default()`. The warn fired before the tracing subscriber was initialized, so the operator never saw it. The default config had no `api_key`, causing a non-loopback bind to trigger the `#3572` auth guard — a symptom error, not the root cause.

The same silent-default pattern existed at the `toml::from_str` Err arm (lines 171-177).

## Fix

- `load_config` signature changed from `-> KernelConfig` to `-> Result<KernelConfig, String>`.
- Hard TOML parse failure and hard deserialize failure now `eprintln!` + `return Err(msg)`.
- `fs::read_to_string` I/O failure keeps current tolerant behavior (`Ok(KernelConfig::default())`).
- `kernel::boot()` maps `Err` to `KernelError::LibreFang(LibreFangError::Config(...))` and propagates it — boot aborts with the real message.
- Post-migration reload in `boot_with_config` warns and keeps in-memory config on error.
- `channel_bridge::reload_channels_from_disk` surfaces `Err` to caller on bad config.
- CLI informational commands fall back to defaults with `eprintln!` warning; `cmd_audit_reset` exits non-zero on bad config.
- Three new unit tests added in `config.rs`.

## Test plan

- [x] `cargo check -p librefang-kernel` — passes
- [x] `cargo clippy -p librefang-kernel --all-targets -- -D warnings` — no lint errors from our code
- [x] New test: `test_load_config_hard_deserialize_failure_returns_err_with_field_path`
- [x] New test: `test_load_config_invalid_toml_returns_err`
- [x] New test: `test_load_config_unknown_field_forward_compat_still_loads`
- [x] Updated: `test_users_array_key_conflicts_with_array_of_tables` — now asserts `Err`
- [x] Updated: `test_load_config_users_missing_name_fails_closed` — now asserts `Err`