### PR TITLE
fix(kernel): honor token-trigger in inner compaction gate

### DIFF
--- a/crates/librefang-kernel/src/kernel/agent_runtime.rs
+++ b/crates/librefang-kernel/src/kernel/agent_runtime.rs
@@ -300,7 +300,10 @@ impl LibreFangKernel {
         session_id_override: Option<SessionId>,
     ) -> KernelResult<String> {
         let cfg = self.config.load_full();
-        use librefang_runtime::compactor::{compact_session, needs_compaction, CompactionConfig};
+        use librefang_runtime::compactor::{
+            compact_session, estimate_token_count, needs_compaction, needs_compaction_by_tokens,
+            CompactionConfig,
+        };
 
         let entry = self.agents.registry.get(agent_id).ok_or_else(|| {
             KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
@@ -331,7 +334,10 @@ impl LibreFangKernel {
             entry.manifest.compaction.as_ref(),
         );
 
-        if !needs_compaction(&session, &config) {
+        let estimated_tokens = estimate_token_count(&session.messages, None, None);
+        if !needs_compaction(&session, &config)
+            && !needs_compaction_by_tokens(estimated_tokens, &config)
+        {
             return Ok(format!(
                 "No compaction needed ({} messages, threshold {})",
                 session.messages.len(),

--- a/crates/librefang-kernel/src/kernel/agent_runtime.rs
+++ b/crates/librefang-kernel/src/kernel/agent_runtime.rs
@@ -329,12 +329,44 @@ impl LibreFangKernel {
 
         // #4976: merge per-agent [compaction] overrides on top of the
         // global config before deciding thresholds / summary budget.
-        let config = CompactionConfig::from_toml_with_overrides(
+        let mut config = CompactionConfig::from_toml_with_overrides(
             &cfg.compaction,
             entry.manifest.compaction.as_ref(),
         );
 
-        let estimated_tokens = estimate_token_count(&session.messages, None, None);
+        // Strip provider prefix so the model name is valid for the upstream API.
+        let model = librefang_runtime::agent_loop::strip_provider_prefix(
+            &entry.manifest.model.model,
+            &entry.manifest.model.provider,
+        );
+
+        // Resolve the agent's actual context window from the model catalog
+        // BEFORE the gate so the gate's token-trigger comparison uses the
+        // real per-agent window (e.g. 128K GPT-4o, 1M Gemini) instead of
+        // the global 200K default that `CompactionConfig::from_toml_…`
+        // would otherwise hand us. Filter out 0 so image/audio entries
+        // (no context window) fall back to the 200K default instead of
+        // feeding 0 into compaction math.
+        let agent_ctx_window = self
+            .llm
+            .model_catalog
+            .load()
+            .find_model(&entry.manifest.model.model)
+            .map(|m| m.context_window as usize)
+            .filter(|w| *w > 0)
+            .unwrap_or(200_000);
+        config.context_window_tokens = agent_ctx_window;
+
+        // Match the pre-loop caller's estimator inputs in `messaging.rs`
+        // (`send_message_full` passes `Some(&manifest.model.system_prompt)`),
+        // otherwise this inner gate's estimate would skip the system prompt
+        // / tools budget and short-circuit even when the caller has already
+        // concluded compaction is warranted.
+        let estimated_tokens = estimate_token_count(
+            &session.messages,
+            Some(&entry.manifest.model.system_prompt),
+            None,
+        );
         if !needs_compaction(&session, &config)
             && !needs_compaction_by_tokens(estimated_tokens, &config)
         {
@@ -344,24 +376,6 @@ impl LibreFangKernel {
                 config.threshold
             ));
         }
-
-        // Strip provider prefix so the model name is valid for the upstream API.
-        let model = librefang_runtime::agent_loop::strip_provider_prefix(
-            &entry.manifest.model.model,
-            &entry.manifest.model.provider,
-        );
-
-        // Resolve the agent's actual context window from the model catalog.
-        // Filter out 0 so image/audio entries (no context window) fall back
-        // to the 200K default instead of feeding 0 into compaction math.
-        let agent_ctx_window = self
-            .llm
-            .model_catalog
-            .load()
-            .find_model(&entry.manifest.model.model)
-            .map(|m| m.context_window as usize)
-            .filter(|w| *w > 0)
-            .unwrap_or(200_000);
 
         // Compaction is a side task — route through the auxiliary chain when
         // configured (issue #3314) so users with `[llm.auxiliary] compression`

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -8747,3 +8747,103 @@ async fn issue_5126_streaming_spawn_body_mirror_write_is_lockless() {
 
     kernel.shutdown();
 }
+
+// Regression test for #5201: when a session is over the token threshold but
+// under threshold_messages, the inner gate in compact_agent_session_with_id
+// must NOT return "No compaction needed" — it must proceed to the compactor.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_compact_gate_passes_when_tokens_above_threshold_but_messages_below() {
+    use librefang_memory::session::Session as MemSession;
+    use librefang_runtime::compactor::{estimate_token_count, CompactionConfig};
+    use librefang_types::message::Message;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+
+    let manifest = AgentManifest {
+        name: "compact-token-gate-test".to_string(),
+        description: "test".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        ..Default::default()
+    };
+    let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
+    let entry = kernel.agents.registry.get(agent_id).unwrap();
+    let session_id = entry.session_id;
+    drop(entry);
+
+    // Build a session with fewer messages than threshold_messages (default 30)
+    // but enough token volume to exceed token_threshold_ratio × context_window
+    // (default 0.7 × 200_000 = 140_000 tokens).
+    // Each ~60K-char ASCII message estimates to ~15K tokens (chars/4).
+    // 10 such messages → ~150K tokens, which exceeds 140K.
+    let big_chunk = "word ".repeat(12_000); // ~60K chars ≈ 15K tokens
+    let messages: Vec<Message> = (0..10)
+        .map(|_| Message::user(big_chunk.clone()))
+        .collect();
+
+    // Sanity: message count is below the default threshold (30).
+    assert!(
+        messages.len() < CompactionConfig::default().threshold,
+        "test invariant: message count must be below threshold_messages"
+    );
+
+    // Sanity: token estimate exceeds the default token threshold.
+    let estimated = estimate_token_count(&messages, None, None);
+    let token_threshold = (CompactionConfig::default().context_window_tokens as f64
+        * CompactionConfig::default().token_threshold_ratio) as usize;
+    assert!(
+        estimated > token_threshold,
+        "test invariant: estimated tokens ({estimated}) must exceed token threshold ({token_threshold})"
+    );
+
+    // Persist the fat session so compact_agent_session_with_id can load it.
+    let session = MemSession {
+        id: session_id,
+        agent_id,
+        messages,
+        context_window_tokens: 0,
+        label: None,
+        model_override: None,
+        messages_generation: 0,
+        last_repaired_generation: None,
+    };
+    kernel
+        .memory
+        .substrate
+        .save_session(&session)
+        .expect("save_session should succeed");
+
+    // Call the function under test.  Without the fix it returns
+    // Ok("No compaction needed (10 messages, threshold 30)"); with the fix
+    // it proceeds past the gate and either compacts or errors at the LLM
+    // step (no provider configured in test).  Either way the result must
+    // not be the early-return sentinel.
+    let result = kernel
+        .compact_agent_session_with_id(agent_id, Some(session_id))
+        .await;
+
+    match &result {
+        Ok(msg) => {
+            assert!(
+                !msg.starts_with("No compaction needed"),
+                "gate must not short-circuit on token-only trigger; got: {msg}"
+            );
+        }
+        Err(_) => {
+            // An error from the LLM driver (no provider) is the expected
+            // outcome once the gate passes — this is correct behaviour.
+        }
+    }
+
+    kernel.shutdown();
+}


### PR DESCRIPTION
## Summary
Fixes #5201. When a session exceeded `token_threshold_ratio × context_window` but stayed under `threshold_messages`, `compact_agent_session_with_id` short-circuited with "No compaction needed" — its inner gate checked message count only, silently undoing the token-based decision the callers had already made.

## Root cause
`crates/librefang-kernel/src/kernel/agent_runtime.rs:334` — the early-return gate called `needs_compaction(&session, &config)` (message count only). Both auto-compaction callers in `messaging.rs` (pre-loop at `:2503-2521`, post-loop at `:2857-2884`) already check `needs_compaction_by_tokens` before calling in, but the inner gate then bailed on the message-count check.

## Fix
- Before the early-return, compute `estimate_token_count(&session.messages, None, None)`.
- Change the guard from `if !needs_compaction(...)` to `if !needs_compaction(...) && !needs_compaction_by_tokens(estimated_tokens, &config)` so the function returns early only when BOTH triggers indicate no compaction is needed.

## Test plan
- [x] `cargo check -p librefang-kernel` — clean
- [x] `cargo clippy -p librefang-kernel --all-targets -- -D warnings` — clean
- [x] New test: `test_compact_gate_passes_when_tokens_above_threshold_but_messages_below` in `crates/librefang-kernel/src/kernel/tests.rs` — builds a 10-message session estimated at >140K tokens (above the 0.7×200K default threshold) and asserts `compact_agent_session_with_id` does NOT return the "No compaction needed" sentinel.
- [ ] `cargo test -p librefang-kernel` — linker OOM-killed in local environment due to shared `target/` contention; CI will confirm.