### PR TITLE
fix(kernel): cover ChainExhausted in PooledDriver match (unblock main)

### DIFF
--- a/crates/librefang-kernel/src/kernel/pooled_driver.rs
+++ b/crates/librefang-kernel/src/kernel/pooled_driver.rs
@@ -71,7 +71,8 @@ impl PooledDriver {
     ///   any provider-side error as a reason to rotate.
     /// - `ModelUnavailable` / `Timeout`: don't mark the key — these are
     ///   provider-side issues, not key-specific.
-    /// - `ContextTooLong` / `Unknown`: propagate without marking.
+    /// - `ContextTooLong` / `Unknown` / `ChainExhausted`: propagate without
+    ///   marking — none of these classify the credential itself.
     fn handle_driver_error(&self, api_key: &str, error: &LlmError) {
         use librefang_llm_driver::llm_errors::FailoverReason;
         match error.failover_reason() {
@@ -88,7 +89,14 @@ impl PooledDriver {
                 self.pool.mark_exhausted(api_key);
             }
             FailoverReason::ModelUnavailable | FailoverReason::Timeout => {}
-            FailoverReason::ContextTooLong | FailoverReason::Unknown => {}
+            // ChainExhausted classifies the fallback chain as a whole, not
+            // this credential — leave the key untouched. Reaching this arm
+            // from a PooledDriver should be vanishingly rare (the wrapped
+            // driver is a concrete provider, not a FallbackChain), but the
+            // match must remain exhaustive.
+            FailoverReason::ContextTooLong
+            | FailoverReason::Unknown
+            | FailoverReason::ChainExhausted => {}
         }
     }
 }


### PR DESCRIPTION
## Summary
- Main is red since #5063 merged this morning: `cargo build` fails with `E0004 non-exhaustive patterns: FailoverReason::ChainExhausted not covered` at `crates/librefang-kernel/src/kernel/pooled_driver.rs:77`.
- #4807 (merged 2026-05-16) added `FailoverReason::ChainExhausted` and updated all then-existing matches.
- #5063 (merged 2026-05-18) introduced `PooledDriver::handle_driver_error` with its own `match` on `failover_reason()`, but was written before / rebased without picking up the new variant — so as soon as it landed on top of #4807, every match-completeness check on main broke.

## Fix
Add `FailoverReason::ChainExhausted` to the existing "don't mark the key" arm alongside `ContextTooLong` and `Unknown`. Rationale: `ChainExhausted` classifies the fallback chain as a whole, not the individual credential, so the pool entry should be left untouched. Doc comment updated to reflect this. A `PooledDriver` should rarely (if ever) actually see this variant — its inner driver is a concrete provider, not a `FallbackChain` — but the match must remain exhaustive either way.

## Verification
- `cargo check -p librefang-kernel --lib` → clean (50.55s).
- `cargo check -p librefang-kernel --all-targets` → clean (4m38s).

## Test plan
- [ ] CI green on this branch.
- [ ] After merge: confirm Coverage / Test lanes on main go green again.

## Out-of-scope follow-ups
None — single-line classification fix.