### PR TITLE
fix(kernel,api): restore rustfmt-clean main after #5209 (#5214)

### DIFF
--- a/crates/librefang-api/tests/config_routes_integration.rs
+++ b/crates/librefang-api/tests/config_routes_integration.rs
@@ -1020,9 +1020,7 @@ poll_interval_secs = \"thirty-seconds\"
     // we abort at parse time with the field name and never reach auth.
     let lower = err.to_lowercase();
     assert!(
-        !lower.contains("auth")
-            && !lower.contains("bot token")
-            && !lower.contains("unauthorized"),
+        !lower.contains("auth") && !lower.contains("bot token") && !lower.contains("unauthorized"),
         "boot error must not be misclassified as an auth failure (the \
          pre-#5186 downstream symptom); got: {err}"
     );

--- a/crates/librefang-kernel/src/config.rs
+++ b/crates/librefang-kernel/src/config.rs
@@ -1128,7 +1128,9 @@ mod tests {
         );
         let msg = result.unwrap_err();
         assert!(
-            msg.contains("deserialize") || msg.contains("default_model") || msg.contains("invalid type"),
+            msg.contains("deserialize")
+                || msg.contains("default_model")
+                || msg.contains("invalid type"),
             "error must name the offending field or describe the mismatch; got: {msg}"
         );
     }

--- a/crates/librefang-kernel/src/kernel/agent_runtime.rs
+++ b/crates/librefang-kernel/src/kernel/agent_runtime.rs
@@ -509,7 +509,11 @@ impl LibreFangKernel {
             })
             .or_else(|| {
                 let v = session.context_window_tokens as usize;
-                if v > 0 { Some(v) } else { None }
+                if v > 0 {
+                    Some(v)
+                } else {
+                    None
+                }
             })
             .unwrap_or(librefang_runtime::agent_loop::model::UNKNOWN_MODEL_CONTEXT_WINDOW);
 

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -8787,9 +8787,7 @@ async fn test_compact_gate_passes_when_tokens_above_threshold_but_messages_below
     // Each ~60K-char ASCII message estimates to ~15K tokens (chars/4).
     // 10 such messages → ~150K tokens, which exceeds 140K.
     let big_chunk = "word ".repeat(12_000); // ~60K chars ≈ 15K tokens
-    let messages: Vec<Message> = (0..10)
-        .map(|_| Message::user(big_chunk.clone()))
-        .collect();
+    let messages: Vec<Message> = (0..10).map(|_| Message::user(big_chunk.clone())).collect();
 
     // Sanity: message count is below the default threshold (30).
     assert!(


### PR DESCRIPTION
## Summary

`main` is red (#5214). Root cause: PR #5209 (`49b9bcd`) landed code that
is not `rustfmt`-clean. The `quality` job's `Check formatting` step is
*always full-workspace*, so every open PR inherits the failure on its
next CI run.

This PR is the mechanical `cargo fmt --all` output — pure line-wrap
normalization, **no semantic change**:

- `crates/librefang-api/tests/config_routes_integration.rs`
- `crates/librefang-kernel/src/config.rs`
- `crates/librefang-kernel/src/kernel/agent_runtime.rs`
- `crates/librefang-kernel/src/kernel/tests.rs`

(4 files, +10 / -8.)

## The other failures in run 26013358890 were a cascade, already fixed

That run was on `49b9bcd`, before #5215 landed. `Build tests` /
`Run tests` / `Unit` / `OpenAPI Drift` all failed because
`librefang-kernel` did not compile —
`error[E0004]: FailoverReason::ChainExhausted not covered`. #5215
(`15a7a63d`, an ancestor of current main HEAD `214c60c5`) fixes that
match. No further action needed for those.

## Verification (on `214c60c5` + this commit)

- `cargo fmt --all -- --check` → **0 diffs** (CI's exact command)
- `cargo check --workspace --tests` → clean (covers the Build/Run/Unit
  test jobs; ChainExhausted no longer present)
- `cargo xtask codegen --openapi` + `python3 scripts/codegen-sdks.py` +
  `cargo xtask schema-check gen` → **zero drift** in `openapi.json`,
  `sdk/`, `xtask/baselines/` (OpenAPI Drift job will pass)

## Out-of-scope follow-ups

None.