### PR TITLE
fix(api,dashboard): expose background section + drop stale /api/cron/list allowlist row

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConfigPage.tsx
@@ -58,7 +58,7 @@ const CATEGORY_SECTIONS: Record<string, string[]> = {
     "docker", "extensions", "session", "queue",
     "compaction", "registry", "context_engine", "prompt_intelligence",
     "task_board", "rate_limit", "health_check", "heartbeat",
-    "telemetry", "notification",
+    "telemetry", "notification", "background",
   ],
 };
 

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -2182,7 +2182,9 @@ pub fn ui_sections_overlay() -> serde_json::Value {
         {"key": "provider_proxy_urls", "struct_field": "provider_proxy_urls"},
         {"key": "provider_regions", "struct_field": "provider_regions"},
         {"key": "provider_request_timeout_secs", "struct_field": "provider_request_timeout_secs"},
-        {"key": "tool_timeouts", "struct_field": "tool_timeouts"}
+        {"key": "tool_timeouts", "struct_field": "tool_timeouts"},
+        // Background autonomous-loop executor knobs (#5168).
+        {"key": "background", "struct_field": "background"}
     ])
 }
 

--- a/crates/librefang-api/tests/auth_public_allowlist.rs
+++ b/crates/librefang-api/tests/auth_public_allowlist.rs
@@ -237,7 +237,11 @@ const REGISTERED_GET_ROUTES: &[RouteEntry] = &[
     // concrete path like the one above covers that case. No separate Authed
     // entry is needed.
     re("/api/channels", Expect::DashboardRead),
-    re("/api/cron/list", Expect::DashboardRead),
+    // SECURITY #5139: `/api/cron/*` was intentionally removed from
+    // PUBLIC_ROUTES_DASHBOARD_READS because cron-job reads serialise the
+    // user-authored prompt. The stale `/api/cron/list` row (a path that was
+    // never registered as a route) was left behind by the catalog cleanup;
+    // dropped here.
     re("/api/hands", Expect::DashboardRead),
     re("/api/hands/active", Expect::DashboardRead),
     re("/api/hands/my-hand", Expect::DashboardRead),


### PR DESCRIPTION
## Summary

Two unrelated regressions are turning **main CI red on every push**. Both are tiny and well-isolated; bundled here because a follow-up PR can't ship while main is still red.

### 1. `config_schema_overlay::every_kernel_config_struct_field_is_exposed_via_overlay`

`KernelConfig.background: BackgroundConfig` was added in **#5168** for the autonomous-loop rate-limit breaker but never registered in `ui_sections_overlay()` (and not listed under `EXCLUDED` either), so the field is invisible in the dashboard ConfigPage. The overlay test panics with:

```
KernelConfig fields with no `x-sections` descriptor and no entry in EXCLUDED:
  background
```

**Fix**: append `{"key": "background", "struct_field": "background"}` to the sections overlay; also add `background` to `CATEGORY_SECTIONS.infra` in `ConfigPage.tsx` so the section actually renders on the Infra tab (otherwise the overlay entry would only paper over the test).

### 2. `auth_public_allowlist::dashboard_read_paths_are_in_catalog` + `dashboard_read_routes_reachable_without_auth_when_no_key_configured`

Both tests fail because `REGISTERED_GET_ROUTES` still expects `/api/cron/list` to be a `DashboardRead` route. That path was never registered as a real route — the actual cron endpoints are `/api/cron/jobs[…]` (`grep -rn '\.route("/api/cron'` confirms only one hit, and it is in a test fixture, not the live router). **#5139** deliberately removed `/api/cron/*` from `PUBLIC_ROUTES_DASHBOARD_READS` because cron-job reads serialise the user-authored prompt, but the matching entry in the test catalog was missed.

**Fix**: drop the stale `re("/api/cron/list", Expect::DashboardRead)` row from `REGISTERED_GET_ROUTES`; leave a `// SECURITY #5139:` comment so the reason for the absence does not get lost again.

## Files changed

- `crates/librefang-api/src/routes/config.rs` (+3 / -1) — overlay entry for `background`
- `crates/librefang-api/dashboard/src/pages/ConfigPage.tsx` (+1 / -1) — `background` in `CATEGORY_SECTIONS.infra`
- `crates/librefang-api/tests/auth_public_allowlist.rs` (+5 / -1) — drop stale catalog row, add explanatory comment

No production behaviour change beyond making the new field visible in the dashboard.

## Test plan

- [ ] CI `Test / Ubuntu (shard 2/4)` — `config_schema_overlay::every_kernel_config_struct_field_is_exposed_via_overlay` flips green
- [ ] CI `Test / Ubuntu (shard 4/4)` — both `auth_public_allowlist::dashboard_read_*` tests flip green
- [ ] CI `Test / macOS` + `Test / Windows shard 1/2 & 2/2` — same tests now pass on those lanes
- [ ] CI `Quality / Check formatting` — still clean (only added one JSON literal line in `ui_sections_overlay` and a comment in the test file)