### PR TITLE
style: restore rustfmt-clean main (Quality CI gate)

### DIFF
--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -825,17 +825,15 @@ impl CronScheduler {
                 // daemon doesn't push the retry absurdly far out. errors is
                 // in 1..MAX_CONSECUTIVE_ERRORS here. Issue #5136.
                 let now = Utc::now();
-                meta.job.next_run = Some(match compute_next_run_after_opt(
-                    &meta.job.schedule,
-                    now,
-                ) {
-                    Some(base) => {
-                        let backoff_steps = meta.consecutive_errors.saturating_sub(1).min(10);
-                        let backoff_secs: i64 = 60i64.saturating_mul(1i64 << backoff_steps);
-                        base + Duration::seconds(backoff_secs)
-                    }
-                    None => now + Duration::hours(1),
-                });
+                meta.job.next_run =
+                    Some(match compute_next_run_after_opt(&meta.job.schedule, now) {
+                        Some(base) => {
+                            let backoff_steps = meta.consecutive_errors.saturating_sub(1).min(10);
+                            let backoff_secs: i64 = 60i64.saturating_mul(1i64 << backoff_steps);
+                            base + Duration::seconds(backoff_secs)
+                        }
+                        None => now + Duration::hours(1),
+                    });
                 false
             }
         } else {

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -9096,7 +9096,6 @@ fn test_context_report_honours_manifest_context_window_override() {
     kernel.shutdown();
 }
 
-
 /// #5137: `suspend_agent` / `resume_agent` previously discarded the
 /// `set_state` `Result` with `let _ =`, so the API could report success
 /// while the in-memory `AgentState` never changed — yet

--- a/crates/librefang-runtime/src/tool_runner/agent.rs
+++ b/crates/librefang-runtime/src/tool_runner/agent.rs
@@ -91,9 +91,7 @@ pub(super) async fn tool_agent_send(
                         .await
                 }
                 (Some(parent), None) => kh.send_to_agent_as(agent_id, message, parent).await,
-                (None, Some(key)) => {
-                    kh.send_to_agent_with_key(agent_id, message, key).await
-                }
+                (None, Some(key)) => kh.send_to_agent_with_key(agent_id, message, key).await,
                 (None, None) => kh.send_to_agent(agent_id, message).await,
             }
         })

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -611,8 +611,7 @@ async fn agent_send_no_key_with_caller_routes_to_send_to_agent_as() {
     let kernel: Arc<dyn KernelHandle> = cap.clone();
     let input = serde_json::json!({ "agent_id": "target", "message": "hi" });
 
-    let result =
-        super::agent::tool_agent_send(&input, Some(&kernel), Some("parent-agent")).await;
+    let result = super::agent::tool_agent_send(&input, Some(&kernel), Some("parent-agent")).await;
 
     assert_eq!(result.unwrap(), "no-key-with-parent");
     let calls = cap.calls.lock().unwrap();


### PR DESCRIPTION
## Summary

`cargo fmt --check` currently fails on `main`, breaking the **Quality**
CI job for every open PR (observed on #5220, but the failing files are
byte-identical to `main` and untouched by that PR).

#5216 restored a clean tree; later merges reintroduced drift:
- `crates/librefang-kernel/src/cron.rs` — `next_run` match re-wrap (#5136/#5175)
- `crates/librefang-kernel/src/kernel/tests.rs` — doubled blank line (#5176)
- `crates/librefang-runtime/src/tool_runner/agent.rs` — match-arm reflow (#5176)
- `crates/librefang-runtime/src/tool_runner/tests/mod.rs` — `let` reflow (#5176)

Pure `cargo fmt` output — `git diff` shows only structural reflow, no
token or behavior change.

## Verification

- `cargo fmt --all --check` → exit 0 (whole workspace clean)
- Diff inspected line-by-line: no semantic change
- pre-push hook: workspace clippy + OpenAPI/SDK drift clean

## Test plan

- [ ] Quality CI job (`cargo fmt --check`) goes green
- [ ] No behavior change — formatting only