### PR TITLE
fix(channels,sdk): sidecar protocol/SDK follow-ups from #5219/#5220 review

### DIFF
--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -20,6 +20,20 @@ use tokio::process::Command;
 use tokio::sync::{mpsc, oneshot, watch, Mutex};
 use tracing::{debug, error, info, warn};
 
+/// Deserialize `T`, mapping an explicit JSON `null` to `T::default()`.
+///
+/// `#[serde(default)]` alone only covers an *omitted* field; a present
+/// `"params": null` (emitted by many JSON-RPC libraries for no-arg
+/// notifications) would otherwise fail to deserialize into a struct and
+/// the whole event would be dropped.
+fn de_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
+
 // ── JSON-RPC Protocol Types ────────────────────────────────────────
 
 /// Messages from the sidecar process TO LibreFang (one JSON per line on stdout).
@@ -35,11 +49,12 @@ pub enum SidecarEvent {
     #[serde(rename = "message")]
     Message { params: Box<SidecarMessageParams> },
     /// Adapter is ready to receive commands. Carries the declared
-    /// capability set + identity metadata. The bare legacy form
-    /// `{"method":"ready"}` still parses (`params` defaults).
+    /// capability set + identity metadata. Both the bare legacy form
+    /// `{"method":"ready"}` (field omitted) and the JSON-RPC
+    /// `{"method":"ready","params":null}` form parse to defaults.
     #[serde(rename = "ready")]
     Ready {
-        #[serde(default)]
+        #[serde(default, deserialize_with = "de_null_default")]
         params: SidecarReadyParams,
     },
     /// Adapter encountered an error.
@@ -554,8 +569,13 @@ async fn spawn_once(
                                         );
                                     }
                                     if let Some(h) = params.username {
+                                        // `sender_username` is the key the
+                                        // bridge reads when building
+                                        // `SenderContext` and upserting the
+                                        // group roster; `"username"` was a
+                                        // dead key the bridge never consumed.
                                         metadata.insert(
-                                            "username".to_string(),
+                                            "sender_username".to_string(),
                                             serde_json::Value::String(h),
                                         );
                                     }
@@ -1319,6 +1339,27 @@ mod tests {
     }
 
     #[test]
+    fn test_sidecar_event_ready_null_params_parses_to_default() {
+        // JSON-RPC libraries emit `params: null` for no-arg
+        // notifications. `#[serde(default)]` alone only covers an
+        // omitted field; explicit null must also fold to defaults or
+        // the supervisor never sees `ready` and churns on restart.
+        for json in [
+            r#"{"method":"ready","params":null}"#,
+            r#"{"method":"ready"}"#,
+        ] {
+            match serde_json::from_str::<SidecarEvent>(json).unwrap() {
+                SidecarEvent::Ready { params } => {
+                    assert!(params.capabilities.is_empty());
+                    assert!(params.account_id.is_none());
+                    assert!(params.protocol_version.is_none());
+                }
+                other => panic!("Expected Ready for {json}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn test_sidecar_event_ready_with_capabilities() {
         let json = r#"{"method":"ready","params":{
             "capabilities":["typing","streaming"],
@@ -2032,6 +2073,49 @@ mod tests {
         }
         adapter.stop().await.unwrap();
         assert!(!adapter.status().connected);
+    }
+
+    #[tokio::test]
+    async fn test_sidecar_username_folds_to_sender_username_metadata() {
+        // Regression: the reader must fold `username` into
+        // `metadata["sender_username"]` — the key the bridge reads for
+        // SenderContext / roster — not the dead `"username"` key. The
+        // child also sends `ready` with `params: null` to exercise the
+        // null-params parse end-to-end.
+        let python = match which_python() {
+            Some(p) => p,
+            None => return,
+        };
+        let script = concat!(
+            "import sys,json;",
+            "print(json.dumps({'method':'ready','params':None}),flush=True);",
+            "print(json.dumps({'method':'message','params':",
+            "{'user_id':'u','user_name':'n','text':'hi',",
+            "'username':'@handle'}}),flush=True);",
+            "sys.exit(0)"
+        );
+        let config = cfg(
+            "test-username",
+            &python,
+            vec!["-u".to_string(), "-c".to_string(), script.to_string()],
+        );
+        let adapter = SidecarAdapter::new(&config);
+        let mut stream = adapter.start().await.unwrap();
+        use futures::StreamExt;
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(30), stream.next())
+            .await
+            .expect("timed out waiting for message")
+            .expect("stream ended unexpectedly");
+        assert_eq!(
+            msg.metadata.get("sender_username").and_then(|v| v.as_str()),
+            Some("@handle"),
+            "username must land under the bridge-consumed key"
+        );
+        assert!(
+            !msg.metadata.contains_key("username"),
+            "the dead `username` key must not be written"
+        );
+        adapter.stop().await.unwrap();
     }
 
     /// Find python3 or python on PATH.

--- a/sdk/python/librefang/sidecar/protocol.py
+++ b/sdk/python/librefang/sidecar/protocol.py
@@ -200,6 +200,7 @@ def ready(capabilities: Optional[List[str]] = None,
 
 def message(user_id: str, user_name: str, *, text: Optional[str] = None,
             content: Optional[Dict[str, Any]] = None,
+            message_id: Optional[str] = None,
             channel_id: Optional[str] = None,
             platform: Optional[str] = None,
             username: Optional[str] = None,
@@ -210,10 +211,15 @@ def message(user_id: str, user_name: str, *, text: Optional[str] = None,
             metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Build a ``message`` event. ``content`` (a :class:`Content`
     result) supersedes ``text``; legacy text-only adapters may pass
-    only ``text``."""
+    only ``text``. ``message_id`` is the platform's *native* id —
+    supply it so reactions/edits target the real message instead of a
+    server-generated UUID (the #5219+ daemon stores it as
+    ``platform_message_id``)."""
     params: Dict[str, Any] = {"user_id": user_id, "user_name": user_name}
     if text is not None:
         params["text"] = text
+    if message_id is not None:
+        params["message_id"] = message_id
     if content is not None:
         params["content"] = content
         # Back-compat: a pre-#5219 daemon ignores `content` and reads
@@ -303,6 +309,9 @@ class Interactive:
 class StreamStart:
     channel_id: str
     stream_id: str
+    #: Thread to stream the reply into; ``None`` for a top-level reply.
+    #: The #5219+ daemon sends this for threaded streamed replies.
+    thread_id: Optional[str] = None
 
 
 @dataclass
@@ -338,9 +347,15 @@ Command = Union[
 
 def parse_command(line: str) -> Command:
     """Parse one stdin line into a typed command. Raises
-    ``json.JSONDecodeError`` only on malformed JSON; unknown methods
-    become :class:`UnknownCommand`."""
+    ``json.JSONDecodeError`` on malformed JSON *and* on syntactically
+    valid JSON that is not an object (e.g. a bare number/array) — the
+    reader treats both the same: emit a protocol error and continue,
+    rather than letting an ``AttributeError`` escape and wedge the
+    adapter. Unknown methods become :class:`UnknownCommand`."""
     obj = json.loads(line)
+    if not isinstance(obj, dict):
+        raise json.JSONDecodeError(
+            "expected a JSON object", line, 0)
     method = obj.get("method")
     p = obj.get("params") or {}
     if method == "send":
@@ -359,7 +374,8 @@ def parse_command(line: str) -> Command:
     if method == "interactive":
         return Interactive(p.get("channel_id", ""), p.get("message", {}))
     if method == "stream_start":
-        return StreamStart(p.get("channel_id", ""), p.get("stream_id", ""))
+        return StreamStart(p.get("channel_id", ""), p.get("stream_id", ""),
+                           p.get("thread_id"))
     if method == "stream_delta":
         return StreamDelta(p.get("stream_id", ""), p.get("text", ""))
     if method == "stream_end":

--- a/sdk/python/librefang/sidecar/runtime.py
+++ b/sdk/python/librefang/sidecar/runtime.py
@@ -158,6 +158,7 @@ async def run(
     keeps serving without flooding stdout."""
     acked = asyncio.Event()
     stop = asyncio.Event()
+    producer_error: Optional[BaseException] = None
 
     async def ready_loop() -> None:
         attempts = 0
@@ -179,12 +180,14 @@ async def run(
                 return
 
     async def producer() -> None:
+        nonlocal producer_error
         try:
             await adapter.produce(emit)
         except asyncio.CancelledError:
             raise
         except Exception as e:  # noqa: BLE001
             log.error("producer crashed", error=str(e))
+            producer_error = e
             stop.set()
 
     async def reader() -> None:
@@ -227,6 +230,13 @@ async def run(
             await adapter.on_shutdown()
         except Exception as e:  # noqa: BLE001
             log.error("on_shutdown failed", error=str(e))
+    # A producer crash is a fatal, unhandled adapter failure — exit
+    # nonzero so it is distinguishable from a clean `shutdown`/EOF
+    # (cleanup above still ran). The daemon supervisor restarts on any
+    # non-shutdown exit; the nonzero code makes the failure explicit to
+    # operators and any non-supervised runner.
+    if producer_error is not None:
+        raise SystemExit(1)
 
 
 def run_stdio(adapter: SidecarAdapter, *, ready_interval: float = 2.0,

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -44,7 +44,9 @@ include = ["librefang*"]
 exclude = ["examples*"]
 
 [tool.setuptools.package-data]
-librefang = ["py.typed"]
+# `sidecar/template/*` ships the adapter scaffold the sidecar docs tell
+# users to copy — without this it is absent from the installed wheel.
+librefang = ["py.typed", "sidecar/template/*"]
 
 # `python_files = ["*.py"]` made pytest import every example *script*
 # as a test module (they target the legacy flat `librefang_sdk`

--- a/sdk/python/tests/test_sidecar_protocol.py
+++ b/sdk/python/tests/test_sidecar_protocol.py
@@ -7,6 +7,8 @@ SidecarEvent/SidecarCommand + ChannelContent shapes byte-for-byte
 
 import json
 
+import pytest
+
 from librefang.sidecar import protocol
 from librefang.sidecar.protocol import (
     Content,
@@ -171,3 +173,33 @@ def test_parse_command_unknown_is_tolerated():
     assert isinstance(u, UnknownCommand)
     assert u.method == "some_future_thing"
     assert u.raw["params"] == {"x": 1}
+
+
+def test_parse_command_non_object_json_raises_decode_error():
+    # Syntactically valid JSON that is not an object must surface as a
+    # JSONDecodeError (the reader's existing handled path), not an
+    # AttributeError that escapes and wedges the adapter.
+    for bad in ("123", '"a string"', "[1,2,3]", "true", "null"):
+        with pytest.raises(json.JSONDecodeError):
+            parse_command(bad)
+
+
+def test_parse_command_stream_start_carries_thread_id():
+    ss = parse_command(json.dumps({
+        "method": "stream_start",
+        "params": {"channel_id": "c", "stream_id": "s", "thread_id": "t-1"},
+    }))
+    assert isinstance(ss, StreamStart)
+    assert ss.thread_id == "t-1"
+    # Absent → None (pre-thread wire shape).
+    ss2 = parse_command(
+        '{"method":"stream_start","params":{"channel_id":"c","stream_id":"s"}}')
+    assert isinstance(ss2, StreamStart) and ss2.thread_id is None
+
+
+def test_message_carries_platform_message_id():
+    p = protocol.message("u", "n", text="hi", message_id="plat-7")["params"]
+    assert p["message_id"] == "plat-7"
+    # Absent → omitted (server generates a UUID).
+    p2 = protocol.message("u", "n", text="hi")["params"]
+    assert "message_id" not in p2

--- a/sdk/python/tests/test_sidecar_runtime.py
+++ b/sdk/python/tests/test_sidecar_runtime.py
@@ -182,3 +182,26 @@ async def test_blank_lines_are_skipped(bad):
     adapter = RecordingAdapter()
     await _drive(adapter, [bad, '{"method":"shutdown"}'])
     assert adapter.shutdown_called
+
+
+async def test_producer_crash_exits_nonzero_after_cleanup():
+    # A fatal, unhandled producer error must exit nonzero (not look
+    # like a clean shutdown), and on_shutdown cleanup must still run.
+    class Crashing(SidecarAdapter):
+        def __init__(self):
+            self.shutdown_called = False
+
+        async def on_send(self, cmd):
+            pass
+
+        async def produce(self, emit):
+            raise RuntimeError("transport died unrecoverably")
+
+        async def on_shutdown(self):
+            self.shutdown_called = True
+
+    adapter = Crashing()
+    with pytest.raises(SystemExit) as ei:
+        await _drive(adapter, [])
+    assert ei.value.code == 1
+    assert adapter.shutdown_called, "cleanup must run before nonzero exit"


### PR DESCRIPTION
## Summary

Six confirmed-real regressions/gaps that shipped to `main` with sidecar parity (#5219) and the Python SDK (#5220), flagged by Codex post-merge and verified against the merged code (not taken at face value).

### `librefang-channels` (#5219)
- **`Ready { params: null }` parse regression (high — restart churn).** `SidecarEvent::Ready` used `#[serde(default)] params`, which only covers an *omitted* field. JSON-RPC libraries emit `{"method":"ready","params":null}` for no-arg notifications; that failed to deserialize, so the reader logged a parse error, never resolved `ready`, and the supervisor killed/restarted the adapter every `ready_timeout_secs` — forever. The pre-#5219 unit `Ready` variant ignored `params`, so this is a true regression. Fixed with a `null → default` deserializer.
- **`username` written to a dead metadata key.** The reader folded the sidecar-supplied handle into `metadata["username"]`, but `bridge.rs` reads `metadata["sender_username"]` when building `SenderContext` and upserting the group roster (`bridge.rs:2359`, `:2401`). Sidecar handles never reached the agent. Now writes the bridge-consumed key.

### Python SDK (#5220)
- **Non-object JSON wedged the adapter.** `parse_command` did `json.loads(line).get(...)`; valid-but-non-object JSON (a bare number/array) raised an uncaught `AttributeError` out of `reader()`, so `stop` was never set and `run()` hung on `stop.wait()` forever. Now raises `JSONDecodeError`, routed through the existing emit-error-and-continue path.
- **`stream_start` dropped `thread_id`.** The #5219 daemon now sends it for threaded streamed replies; `StreamStart` + the parser now carry it.
- **`message()` had no `message_id`.** SDK adapters couldn't supply the platform's native id, so reactions/edits never resolved (the SDK-side mirror of the #5219 `platform_message_id` fix).
- **Template scaffold not packaged.** `sidecar/template/{adapter.py.tmpl,README.md,requirements.txt}` was excluded from the wheel (`package-data` only had `py.typed`), breaking the documented copy-the-template workflow.
- **Fatal `produce()` crash exited 0.** Indistinguishable from a clean `shutdown`. Now exits nonzero *after* running `on_shutdown` cleanup.

## Verification
- `cargo clippy -p librefang-channels --all-targets -- -D warnings` — clean
- `cargo test -p librefang-channels --lib sidecar` — 24 passed (incl. 2 new)
- `cargo check --workspace --lib` — clean
- SDK: `pytest` (pytest-asyncio) — 21 passed (incl. 4 new)

## Test plan
- [x] `ready` parses with `params` omitted, `params: null`, and `params: {...}`
- [x] inbound `username` lands in `metadata["sender_username"]` (via the supervised subprocess path), dead `username` key absent
- [x] `parse_command` raises `JSONDecodeError` on non-object JSON
- [x] `stream_start` round-trips `thread_id` (present → value, absent → None)
- [x] `message(message_id=...)` emits `params.message_id`; absent → omitted
- [x] producer crash → `SystemExit(1)` after `on_shutdown`

## Notes
- `package-data` (template packaging) is a declarative config fix; verified by inspection rather than a build-level test (a full `python -m build` assertion would be disproportionate for CI).
- Bundled as one PR because all six are the same domain (sidecar protocol/SDK parity follow-ups) — a tight cluster, per the one-PR-one-concern guidance.
