### PR TITLE
docs(channels): sidecar-first channel documentation (P6)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -586,57 +586,76 @@ Summarize the following email thread in 3 bullet points:
 
 ## How to Add a New Channel Adapter
 
-Channel adapters live in `crates/librefang-channels/src/`. Each adapter implements the `ChannelAdapter` trait.
+**Channels are sidecar-first.** A new channel adapter is an
+out-of-process subprocess (Python or any language) that speaks
+newline-delimited JSON-RPC over stdin/stdout. New *in-process* Rust
+adapters are rejected by a policy gate (see the maintainers-only note
+below). See `docs/architecture/sidecar-channels.md` for the full
+model.
 
-### Steps
+### Add a sidecar channel adapter
 
-1. Create a new file: `crates/librefang-channels/src/myplatform.rs`
+1. Install the SDK: `pip install librefang-sdk` (source:
+   `sdk/python/`).
 
-2. Implement the `ChannelAdapter` trait (defined in `types.rs`):
+2. Subclass `SidecarAdapter`. Implement `on_send` (deliver to the
+   platform) and, for platforms you poll, `produce` (push inbound
+   messages via `emit`). Declare the rich features you support in
+   `capabilities` — anything you don't declare degrades to plain text
+   automatically.
 
-```rust
-use crate::types::{ChannelAdapter, ChannelMessage, ChannelType};
-use async_trait::async_trait;
+   ```python
+   from librefang.sidecar import Content, SidecarAdapter, protocol, run_stdio
 
-pub struct MyPlatformAdapter {
-    // token, client, config fields
-}
+   class MyAdapter(SidecarAdapter):
+       capabilities = ["typing"]
 
-#[async_trait]
-impl ChannelAdapter for MyPlatformAdapter {
-    fn channel_type(&self) -> ChannelType {
-        ChannelType::Custom("myplatform".to_string())
-    }
+       async def on_send(self, cmd):
+           ...  # deliver cmd.text / cmd.content to the platform
 
-    async fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        // Start polling/listening for messages
-        Ok(())
-    }
+       async def produce(self, emit):
+           async for m in my_platform_stream():
+               emit(protocol.message(m.user_id, m.user_name,
+                                     content=Content.text(m.text)))
 
-    async fn send(&self, channel_id: &str, content: &str) -> Result<(), Box<dyn std::error::Error>> {
-        // Send a message back to the platform
-        Ok(())
-    }
+   if __name__ == "__main__":
+       run_stdio(MyAdapter())
+   ```
 
-    async fn stop(&mut self) {
-        // Clean shutdown
-    }
-}
-```
+   Start from `sdk/python/librefang/sidecar/template/` and read
+   `examples/sidecar-channel-python/ntfy_adapter.py` — the canonical
+   migration (a real SSE-in / HTTP-out adapter, stdlib-only).
 
-3. Register the module in `crates/librefang-channels/src/lib.rs`:
+3. Register it in `~/.librefang/config.toml`:
 
-```rust
-pub mod myplatform;
-```
+   ```toml
+   [[sidecar_channels]]
+   name = "myplatform"
+   command = "python3"
+   args = ["adapters/my_adapter.py"]
+   # restart / backoff / ready_timeout / message_buffer / overflow …
+   # are all optional — see librefang.toml.example for defaults.
+   ```
 
-4. Wire it up in the channel bridge (`crates/librefang-api/src/channel_bridge.rs`) so the daemon starts it alongside other adapters.
+4. **stdout is the protocol channel** — never `print()` to it. Log via
+   `from librefang.sidecar import logging`. The daemon supervises the
+   process (crash → backoff restart → circuit-break); your job is
+   platform reconnection (`with_backoff`) and being crash-safe.
 
-5. Add configuration support in `librefang-types` config structs (add a `[channels.myplatform]` section).
+5. Add tests (the `librefang.sidecar` SDK is unit-test-friendly with
+   injectable I/O — see `sdk/python/tests/`) and submit a PR.
 
-6. Add CLI setup wizard instructions in `crates/librefang-cli/src/main.rs` under `cmd_channel_setup`.
+### In-process Rust adapter — maintainers only
 
-7. Write tests and submit a PR.
+The ~46 pre-existing in-process adapters under
+`crates/librefang-channels/src/` are grandfathered in
+`channels-allowlist.txt`. `scripts/hooks/pre-commit` and
+`cargo xtask channel-policy` (run in CI) **reject any new** file that
+`impl`s `ChannelAdapter` and is not on that allowlist. Adding a new
+in-process adapter requires an explicit maintainer decision and an
+allowlist entry in a separate reviewed commit — it is not the normal
+path. Such adapters still owe a `tests/<channel>_wiremock.rs`
+send-path test (see `crates/librefang-channels/CLAUDE.md`).
 
 ---
 

--- a/crates/librefang-channels/AGENTS.md
+++ b/crates/librefang-channels/AGENTS.md
@@ -54,12 +54,24 @@ Inbound parsing has 795 tests. Outbound `send()` has historically had ~zero (#38
 
 ## Adding a new channel
 
-1. New file `src/<channel>/mod.rs` implementing `ChannelAdapter`.
-2. New cargo feature `channel-<name>` in `Cargo.toml`.
-3. Default-feature decision: every channel ships off-by-default. The `all-channels` feature aggregates them.
-4. Wire HTTP webhook (if needed) in `librefang-api/src/routes/channels.rs`.
-5. Add a `tests/<channel>_wiremock.rs` covering at least the send() happy path + one error response.
-6. Document any required env vars in the adapter's doc comment.
+Sidecar-first. A new channel is an out-of-process sidecar adapter, not
+a new module here. See `CONTRIBUTING.md` ("Add a sidecar channel
+adapter"), `docs/architecture/sidecar-channels.md`, and the
+`librefang.sidecar` SDK (`sdk/python/`).
+
+A new in-process `impl ChannelAdapter` is **rejected** by
+`scripts/hooks/pre-commit` and `cargo xtask channel-policy` (CI) unless
+its basename is in `src/channels-allowlist.txt` — that list only
+shrinks (a sidecar migration deletes the module and its line). Adding
+a name back is an explicit maintainer decision in a separate reviewed
+commit, not routine.
+
+The grandfathered in-process adapters still obey the existing rules:
+new `send()` work owes a `tests/<channel>_wiremock.rs` (happy path +
+one error); HTTP webhooks wire through
+`librefang-api/src/routes/channels.rs`; channels ship off-by-default
+behind `channel-<name>`; required env vars go in the adapter's doc
+comment.
 
 ## Taboos
 

--- a/docs/architecture/sidecar-channels.md
+++ b/docs/architecture/sidecar-channels.md
@@ -1,0 +1,158 @@
+# Sidecar channel adapters
+
+LibreFang is **sidecar-first** for channels. A channel adapter is an
+out-of-process subprocess in any language that speaks newline-delimited
+JSON-RPC over stdin/stdout; the daemon supervises it. New channels are
+written this way — the ~46 in-process Rust adapters that predate the
+policy are grandfathered and frozen (see "Policy gate" below).
+
+Why: a channel adapter is high-churn, low-risk integration glue. As an
+in-process Rust module a bad adapter could panic the daemon, leak, or
+drag a supply-chain dependency into the kernel process, and every new
+one raised the contributor bar to "writes Rust + passes clippy +
+rebuilds the workspace". As a supervised subprocess it is isolated
+(a crash is not a daemon crash), restartable, and writable in ~40
+lines of Python against a documented protocol.
+
+This was delivered across the #5219 (protocol + supervision + config),
+#5220 (Python SDK), #5221 (policy gate), and #5224 (ntfy migration)
+series.
+
+## Process model
+
+```
+ daemon (librefang-channels)                external subprocess
+ ┌───────────────────────────┐              ┌──────────────────────┐
+ │ SidecarAdapter             │   stdin     │ adapter (py/any lang) │
+ │  supervisor task ──────────┼── cmds ────▶│  reads commands       │
+ │   spawn_once()             │             │  talks to platform    │
+ │   ChannelMessage stream ◀──┼── events ───┤  writes events        │
+ │  (survives child restarts) │   stdout    │                       │
+ └───────────────────────────┘   stderr ───▶ daemon log             │
+                                              └──────────────────────┘
+```
+
+`SidecarAdapter` (`crates/librefang-channels/src/sidecar.rs`)
+implements the same `ChannelAdapter` trait every in-process adapter
+does, so the bridge, router, and approval paths treat it identically.
+`start()` returns one long-lived `ChannelMessage` stream; the
+supervisor re-spawns the child underneath it on crash without breaking
+that stream.
+
+## Protocol
+
+Events (subprocess → daemon, stdout):
+
+| method   | payload |
+|----------|---------|
+| `ready`  | `params`: `capabilities[]`, `account_id?`, `suppress_error_responses`, `notification_recipients[]`, `header_rules[]`, `protocol_version?` — all optional; bare `{"method":"ready"}` still parses |
+| `message`| full `ChannelContent` (all 24 variants) + `is_group`, `thread_id`, sender, group roster, metadata |
+| `typing` | `user_id`, `user_name`, `is_typing` |
+| `error`  | `message` |
+
+Commands (daemon → subprocess, stdin): `send`, `ready_ack`, `typing`,
+`reaction`, `interactive`, `stream_start` / `stream_delta` /
+`stream_end`, `heartbeat`, `shutdown`. Unknown methods (either
+direction) are tolerated, not fatal — that is what lets a new daemon
+send `ready_ack` to an older adapter and vice versa.
+
+stdout carries only protocol frames. All adapter logging goes to
+stderr (the SDK enforces this).
+
+## Capability negotiation
+
+An adapter declares what it supports in the `ready` event's
+`capabilities`: `typing`, `reaction`, `interactive`, `thread`,
+`streaming`, `typing_events`. Each gates the matching optional
+`ChannelAdapter` method; an absent capability degrades to exactly the
+pre-sidecar behaviour (plain text). `create_webhook_routes` stays
+`None` for sidecars — an `axum::Router` can't cross stdio; an adapter
+that needs inbound HTTP runs its own listener and POSTs events back
+through stdout.
+
+## Supervision
+
+The supervisor owns the (re)spawn loop. State machine:
+
+```
+        ┌────────────────────────────────────────────┐
+        ▼                                             │
+   spawn_once ──▶ wait ready (≤ ready_timeout_secs) ──▶ running
+        ▲              │ timeout                       │ child exits
+        │ backoff      ▼                               ▼
+        └──────── attempt++ ◀── ChildClosed ◀──────────┘
+                   │
+       attempt ≥ restart_max_retries ──▶ circuit-break (stop, one error log)
+       clean Shutdown / receiver gone ──▶ stop (no restart)
+       stable uptime ≥ reset_after   ──▶ attempt = 0
+```
+
+Backoff is exponential with dependency-free wall-clock jitter (≤20%),
+capped at `restart_max_backoff_ms`. After `restart_max_retries`
+consecutive failures the supervisor gives up with a single `error!`
+(no crash-loop log spam). Backoff sleeps are shutdown-interruptible.
+Backpressure: the inbound stream is a bounded `mpsc(message_buffer)`;
+`overflow = "block"` (default — applies backpressure, never drops a
+user message) or `"drop_newest"` (shed load for high-volume
+notification adapters).
+
+All tunables are per-adapter `[[sidecar_channels]]` config fields
+(`restart`, `restart_initial_backoff_ms`, `restart_max_backoff_ms`,
+`restart_max_retries`, `restart_reset_after_secs`,
+`ready_timeout_secs`, `shutdown_grace_secs`, `message_buffer`,
+`overflow`). `librefang.toml.example` documents them with defaults.
+
+## Responsibility split
+
+- **Process restart is the daemon's job.** The supervisor respawns a
+  crashed child with backoff + circuit-break. An adapter must be
+  *crash-safe*: hold no irreplaceable in-process state and re-announce
+  `ready` on every fresh start (the SDK does this automatically).
+- **Platform reconnect is the adapter's job.** Reconnecting a dropped
+  Telegram long-poll / WebSocket / SSE stream is the adapter's
+  transport concern (`librefang.sidecar.with_backoff` helps). It is
+  independent of the daemon-managed process lifecycle.
+
+## Policy gate
+
+`crates/librefang-channels/src/channels-allowlist.txt` grandfathers the
+in-process adapters that predate sidecar-first. The list only ever
+**shrinks**: migrating an adapter to a sidecar and deleting its module
+removes its line, after which it can never return in-process.
+
+`scripts/hooks/pre-commit` (fast feedback) and `cargo xtask
+channel-policy` — run unconditionally in the CI `quality` job, the
+authoritative gate — reject any file under
+`crates/librefang-channels/src/{<name>.rs, <name>/*.rs}` containing
+`ChannelAdapter for` whose basename is not allowlisted. Known accepted
+limitation: a macro-generated impl, or an adapter impl added inside an
+already-allowlisted file, is not detected — this is a policy ratchet,
+not a security boundary.
+
+## Worked example: ntfy
+
+`examples/sidecar-channel-python/ntfy_adapter.py` is the canonical
+migration (#5224). It replaced the former in-process
+`librefang-channels::ntfy` adapter with behaviour preserved (SSE
+subscribe, `/command` parsing, `title`→sender, `topic` metadata,
+chunked plain-text publish, optional Bearer auth, backoff reconnect).
+`NtfyConfig` / `[channels.ntfy]` were removed and `ntfy` deleted from
+the allowlist, so the gate now permanently blocks an in-process ntfy.
+This was a **breaking config change**: an existing `[channels.ntfy]`
+block is re-declared as a `[[sidecar_channels]]` running
+`ntfy_adapter.py`. The separate ntfy *push-notification provider*
+(`push_provider = "ntfy"`) is an unrelated feature and was untouched.
+
+## Long-tail migration backlog
+
+ntfy proved the pipeline but also showed that fully removing one
+in-process channel's config type has a wide, kernel-touching,
+**breaking** blast radius (config schema, api routes/features, kernel
+`channel_sender` registry, cli TUI, validation, golden). Remaining
+candidates (genuinely text-only / low-traffic, e.g. `gitter`,
+`gotify`) should migrate **opportunistically** — when someone next
+touches one, or on explicit maintainer decision — not as a batch
+rewrite. New channels are sidecar by policy, so the in-process set
+only shrinks over time without a forced campaign. Each migration is a
+breaking change for that channel's `[channels.<x>]` config and must be
+called out in `CHANGELOG.md` under `### Changed`.


### PR DESCRIPTION
Documents the sidecar-first channel model realized by the
#5219 / #5220 / #5221 (+ #5224) series. Docs-only — no code.

## Changes

- **New `docs/architecture/sidecar-channels.md`** (matches the
  `docs/architecture/` house style): process model + ASCII supervisor
  state machine; the JSON-RPC event/command protocol tables;
  capability negotiation; exponential backoff + jitter +
  circuit-break + backpressure; the **process-restart (daemon) vs
  platform-reconnect (adapter)** responsibility split; the
  `channels-allowlist.txt` + `cargo xtask channel-policy` gate; ntfy
  as the worked migration; and a **long-tail backlog policy**
  (opportunistic, not a batch rewrite — explicitly informed by P7
  showing one channel's full removal is a wide, kernel-touching,
  breaking blast radius).
- **`CONTRIBUTING.md` "How to Add a New Channel Adapter" rewritten**:
  sidecar-first is the documented path (install `librefang-sdk`,
  subclass `SidecarAdapter`, `[[sidecar_channels]]`, template + ntfy
  reference). The in-process Rust recipe becomes a "maintainers
  only — allowlist + reviewed exception" note. Also **fixes a
  pre-existing inaccurate trait sketch** in that section — it showed
  `start(&mut self) -> Result<()>`, `send(&self, &str, &str)`,
  `stop(&mut self)`, none of which match the real `ChannelAdapter`
  signatures (`start(&self) -> Stream`, `send(&self, &ChannelUser,
  ChannelContent)`, `stop(&self)`). Removed the wrong sample rather
  than maintain it.
- **`crates/librefang-channels/AGENTS.md`** (the `CLAUDE.md` symlink
  target) "Adding a new channel": sidecar-first pointer + the
  pre-commit / CI allowlist gate; the grandfathered-adapter rules
  (wiremock send test, webhook wiring, off-by-default feature) are
  kept.

## Verification

Docs-only. Cross-references checked against `main`:
`sdk/python/librefang/sidecar/template/`,
`crates/librefang-channels/src/channels-allowlist.txt`,
`scripts/hooks/pre-commit`, and the `cargo xtask channel-policy`
subcommand all present (P4/P5 merged).

## Sequencing note

One forward reference: `examples/sidecar-channel-python/ntfy_adapter.py`
arrives in **#5224** (ntfy migration). The architecture doc
PR-attributes it to #5224, so it reads correctly as series
documentation, but the CONTRIBUTING "canonical migration" pointer
only resolves once #5224 lands — **merge this with or after #5224**.
The rest of the docs are accurate against current `main`.