### PR TITLE
feat(wa-gateway): compute wasMentioned from group_trigger_patterns when mentionedJids is empty

### DIFF
--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -370,6 +370,7 @@ function readWhatsAppConfig(configPath) {
     // to enable extra language packs.
     relay_intent_languages: ['en'],
     api_key: '',
+    group_trigger_patterns: [],
   };
   try {
     const content = fs.readFileSync(configPath, 'utf8');
@@ -389,6 +390,10 @@ function readWhatsAppConfig(configPath) {
       // enforces it on `/api/*` endpoints when set; without it we get HTTP
       // 401 "Invalid API key" and inbound messages never reach the agent.
       api_key: typeof parsed?.api_key === 'string' ? parsed.api_key : defaults.api_key,
+      group_trigger_patterns:
+        Array.isArray(wa.group_trigger_patterns) && wa.group_trigger_patterns.length > 0
+          ? wa.group_trigger_patterns
+          : defaults.group_trigger_patterns,
     };
     console.log(`[gateway] Read config from ${configPath}: default_agent="${cfg.default_agent}", owner_numbers=${JSON.stringify(cfg.owner_numbers)}, conversation_ttl_hours=${cfg.conversation_ttl_hours}, stream_to_channel=${cfg.stream_to_channel}, relay_intent_languages=${JSON.stringify(cfg.relay_intent_languages)}, api_key=${cfg.api_key ? '<set>' : '<empty>'}`);
     return cfg;
@@ -417,6 +422,33 @@ if (!LIBREFANG_API_KEY) {
 function kernelAuthHeader() {
   return LIBREFANG_API_KEY ? { Authorization: `Bearer ${LIBREFANG_API_KEY}` } : {};
 }
+
+// Compile `[channels.whatsapp].group_trigger_patterns` into JS RegExp objects
+// at boot. The Rust daemon uses Rust `regex` which honours the `(?i)` inline
+// flag; JavaScript regexes don't — `new RegExp("(?i)foo")` matches the
+// literal three-character "(?i)" prefix instead of enabling case-insensitive
+// matching. Strip a leading `(?i)` and translate it to the JS `i` flag so
+// the same config file can be shared verbatim between daemon and gateway.
+// Invalid patterns are skipped with a warning to avoid the gateway crashing
+// at boot on a typo in one of many alternations.
+function compileGroupTriggerRegex(pattern) {
+  if (typeof pattern !== 'string' || !pattern) return null;
+  let flags = '';
+  let body = pattern;
+  if (body.startsWith('(?i)')) {
+    flags += 'i';
+    body = body.slice(4);
+  }
+  try {
+    return new RegExp(body, flags);
+  } catch (err) {
+    console.warn(`[gateway] Skipping invalid group_trigger_patterns entry ${JSON.stringify(pattern)}: ${err.message}`);
+    return null;
+  }
+}
+const GROUP_TRIGGER_REGEXES = (tomlConfig.group_trigger_patterns || [])
+  .map(compileGroupTriggerRegex)
+  .filter(Boolean);
 const DEFAULT_AGENT = process.env.LIBREFANG_DEFAULT_AGENT || tomlConfig.default_agent;
 const AGENT_NAME = DEFAULT_AGENT;
 
@@ -1886,6 +1918,26 @@ async function startConnection() {
         // ownJid is normalized like "1234567890@s.whatsapp.net"
         const ownNumber = ownJid.replace(/@.*$/, '');
         wasMentioned = mentionedJids.some(jid => jid.replace(/@.*$/, '') === ownNumber);
+      }
+      // Fallback: when WhatsApp's structured @-mention is absent (because the
+      // user typed the agent name as plain text rather than tapping `@` in
+      // the compose UI), match against `[channels.whatsapp].group_trigger_patterns`
+      // so the gateway's `was_mentioned` signal stays accurate. The Rust
+      // daemon does its own pattern check independently — this is purely
+      // about giving the gateway logs and the forwarded payload an honest
+      // wasMentioned value.
+      if (isGroup && !wasMentioned && GROUP_TRIGGER_REGEXES.length > 0) {
+        const candidateText = (
+          innerMsg.conversation
+          || innerMsg.extendedTextMessage?.text
+          || innerMsg.imageMessage?.caption
+          || innerMsg.videoMessage?.caption
+          || innerMsg.documentMessage?.caption
+          || ''
+        );
+        if (candidateText && GROUP_TRIGGER_REGEXES.some(re => re.test(candidateText))) {
+          wasMentioned = true;
+        }
       }
 
       // Rate limiting for strangers and group messages

--- a/packages/whatsapp-gateway/index.js
+++ b/packages/whatsapp-gateway/index.js
@@ -429,8 +429,12 @@ function kernelAuthHeader() {
 // literal three-character "(?i)" prefix instead of enabling case-insensitive
 // matching. Strip a leading `(?i)` and translate it to the JS `i` flag so
 // the same config file can be shared verbatim between daemon and gateway.
-// Invalid patterns are skipped with a warning to avoid the gateway crashing
-// at boot on a typo in one of many alternations.
+//
+// Rust `regex` also accepts mid-pattern flag groups: `foo(?i)bar`,
+// `(?i)foo(?-i)bar`, `(?i:foo)bar`. JavaScript silently treats those as
+// literal `(?` constructs (or rejects only some forms). We bail out with a
+// warning when any unhandled `(?<flags>...)` / `(?<flags>:...)` group is
+// detected, so the operator notices the silent-no-match foot-gun.
 function compileGroupTriggerRegex(pattern) {
   if (typeof pattern !== 'string' || !pattern) return null;
   let flags = '';
@@ -438,6 +442,19 @@ function compileGroupTriggerRegex(pattern) {
   if (body.startsWith('(?i)')) {
     flags += 'i';
     body = body.slice(4);
+  }
+  // Detect any surviving Rust-style inline flag group. Recognised flag chars
+  // (regex crate): i s m U u x. The `(?…)` set construct may be terminated
+  // with `)` (flag set) or `:` (non-capturing group with flags). Either form
+  // is unsupported by JS RegExp — warn rather than silently produce a regex
+  // that never matches in production.
+  const inlineFlagGroup = /\(\?[ismUuxa-]+[):]/;
+  if (inlineFlagGroup.test(body)) {
+    console.warn(
+      `[gateway] group_trigger_patterns entry ${JSON.stringify(pattern)} uses a mid-pattern inline flag group (e.g. \`(?i)…\` or \`(?i:…)\`) which JavaScript RegExp does not support. ` +
+      `Skipped — split it into separate, fully-flagged entries (e.g. one with a leading \`(?i)\` covering the whole pattern).`
+    );
+    return null;
   }
   try {
     return new RegExp(body, flags);
@@ -1910,6 +1927,7 @@ async function startConnection() {
 
       // Detect @mention: check if our JID is in the mentionedJid list
       let wasMentioned = false;
+      let wasMentionedSource = null;
       if (isGroup && ownJid) {
         const mentionedJids = innerMsg.extendedTextMessage?.contextInfo?.mentionedJid
           || innerMsg.imageMessage?.contextInfo?.mentionedJid
@@ -1918,6 +1936,7 @@ async function startConnection() {
         // ownJid is normalized like "1234567890@s.whatsapp.net"
         const ownNumber = ownJid.replace(/@.*$/, '');
         wasMentioned = mentionedJids.some(jid => jid.replace(/@.*$/, '') === ownNumber);
+        if (wasMentioned) wasMentionedSource = 'structured';
       }
       // Fallback: when WhatsApp's structured @-mention is absent (because the
       // user typed the agent name as plain text rather than tapping `@` in
@@ -1926,17 +1945,25 @@ async function startConnection() {
       // daemon does its own pattern check independently — this is purely
       // about giving the gateway logs and the forwarded payload an honest
       // wasMentioned value.
-      if (isGroup && !wasMentioned && GROUP_TRIGGER_REGEXES.length > 0) {
-        const candidateText = (
-          innerMsg.conversation
-          || innerMsg.extendedTextMessage?.text
-          || innerMsg.imageMessage?.caption
-          || innerMsg.videoMessage?.caption
-          || innerMsg.documentMessage?.caption
-          || ''
-        );
-        if (candidateText && GROUP_TRIGGER_REGEXES.some(re => re.test(candidateText))) {
+      //
+      // Reuse the `text` variable computed at line 1724 — single source of
+      // truth, no shape drift with the upstream extraction path (in particular
+      // `documentWithCaptionMessage?.message?.documentMessage?.caption`,
+      // which a previous draft of this branch fudged).
+      if (isGroup && !wasMentioned && text && GROUP_TRIGGER_REGEXES.length > 0) {
+        if (GROUP_TRIGGER_REGEXES.some(re => re.test(text))) {
           wasMentioned = true;
+          wasMentionedSource = 'pattern_fallback';
+          // Telemetry: operators can grep this to see how often Baileys'
+          // structured mentionedJid array under-reports relative to plain-text
+          // mentions of the agent name. Logged at info level (single line per
+          // hit, low cardinality).
+          console.log(JSON.stringify({
+            event: 'was_mentioned_pattern_fallback',
+            chat_jid: sender,
+            push_name: pushName,
+            text_length: text.length,
+          }));
         }
       }
 
@@ -2269,7 +2296,7 @@ async function startConnection() {
           collectedOwnerNotices.push(text);
         };
         const rawResponse = await forwardToLibreFangStreaming(
-          messageToSend, systemPrefix, phone, pushName, isOwner, attachments, onProgress, sender, { isGroup, wasMentioned, groupParticipants, onOwnerNotice },
+          messageToSend, systemPrefix, phone, pushName, isOwner, attachments, onProgress, sender, { isGroup, wasMentioned, wasMentionedSource, groupParticipants, onOwnerNotice },
         );
 
         // §A — fan out collected owner notices to every configured OWNER_JID.
@@ -2896,7 +2923,7 @@ function buildRelaySystemInstruction() {
 // ---------------------------------------------------------------------------
 const MAX_FORWARD_RETRIES = 1;
 
-async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup = false, wasMentioned = false, chatJid = '', groupParticipants = [], onOwnerNotice = null } = {}, retryCount = 0) {
+async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup = false, wasMentioned = false, wasMentionedSource = null, chatJid = '', groupParticipants = [], onOwnerNotice = null } = {}, retryCount = 0) {
   // CS-01: fail-fast — refuse to forward with an empty chatJid. A bare
   // `whatsapp` channel loses per-conversation session isolation; the kernel
   // would merge unrelated chats into the same session.
@@ -2937,6 +2964,7 @@ async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, 
       push_name: pushName,
       is_group: !!isGroup,
       was_mentioned: !!wasMentioned,
+      was_mentioned_source: wasMentionedSource,
     }));
   }
 
@@ -2948,6 +2976,13 @@ async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, 
     is_group: isGroup,
     was_mentioned: wasMentioned,
   };
+  // Provenance tag — daemon and operators can distinguish a hit from the
+  // Baileys-structured `mentionedJid` array vs the gateway's plain-text
+  // `group_trigger_patterns` fallback. Only emitted when wasMentioned is
+  // true (a `null` source on `false` carries no signal).
+  if (wasMentioned && wasMentionedSource) {
+    payload.was_mentioned_source = wasMentionedSource;
+  }
 
   // Include attachments if present
   if (attachments && attachments.length > 0) {
@@ -2989,7 +3024,7 @@ async function forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, 
               console.log('[gateway] Agent UUID stale (404), re-resolving...');
               cachedAgentId = null;
               resolveAgentId()
-                .then(() => forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned, chatJid }, retryCount + 1))
+                .then(() => forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned, wasMentionedSource, chatJid }, retryCount + 1))
                 .then(resolve)
                 .catch(reject);
               return;
@@ -3070,7 +3105,7 @@ const STREAMING_EDIT_INTERVAL_MS = 2000;
  * @param {(text: string) => Promise<void>} onProgress
  * @returns {Promise<string>} complete response
  */
-async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, isOwner, attachments, onProgress, chatJid = '', { isGroup = false, wasMentioned = false, groupParticipants = [], onOwnerNotice = null } = {}) {
+async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, isOwner, attachments, onProgress, chatJid = '', { isGroup = false, wasMentioned = false, wasMentionedSource = null, groupParticipants = [], onOwnerNotice = null } = {}) {
   // CS-01: fail-fast — refuse to forward with an empty chatJid (same
   // rationale as `forwardToLibreFang`). Keeps streaming parity.
   if (!chatJid) {
@@ -3106,6 +3141,7 @@ async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, 
       push_name: pushName,
       is_group: !!isGroup,
       was_mentioned: !!wasMentioned,
+      was_mentioned_source: wasMentionedSource,
     }));
   }
 
@@ -3155,7 +3191,7 @@ async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, 
           res.on('data', (chunk) => (body += chunk));
           res.on('end', () => {
             console.warn(`[gateway] SSE endpoint returned ${res.statusCode}, falling back to non-streaming`);
-            forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned, chatJid, onOwnerNotice })
+            forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned, wasMentionedSource, chatJid, onOwnerNotice })
               .then(resolve)
               .catch(reject);
           });
@@ -3250,7 +3286,7 @@ async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, 
         res.on('error', (err) => {
           clearTimeout(pendingEdit);
           console.warn(`[gateway] SSE stream error: ${err.message}, falling back`);
-          forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned, chatJid, onOwnerNotice })
+          forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned, wasMentionedSource, chatJid, onOwnerNotice })
             .then(resolve)
             .catch(reject);
         });
@@ -3259,7 +3295,7 @@ async function forwardToLibreFangStreaming(text, systemPrefix, phone, pushName, 
 
     req.on('error', (err) => {
       console.warn(`[gateway] SSE request error: ${err.message}, falling back`);
-      forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned, chatJid, onOwnerNotice })
+      forwardToLibreFang(text, systemPrefix, phone, pushName, isOwner, attachments, { isGroup, wasMentioned, wasMentionedSource, chatJid, onOwnerNotice })
         .then(resolve)
         .catch(reject);
     });
@@ -3930,4 +3966,5 @@ module.exports = {
   runDispatchSelfTest,
   channelTypeForChat,
   buildSessionKey,
+  compileGroupTriggerRegex,
 };

--- a/packages/whatsapp-gateway/index.test.js
+++ b/packages/whatsapp-gateway/index.test.js
@@ -47,6 +47,7 @@ const {
   SESSION_RECOVERY_MAX_ATTEMPTS,
   runDispatchSelfTest,
   channelTypeForChat,
+  compileGroupTriggerRegex,
 } = require('./index.js');
 
 // ---------------------------------------------------------------------------
@@ -1538,5 +1539,104 @@ describe('ownerIntentsRelay', () => {
     assert.equal(re.test('Sag mir was du denkst'), false);
     assert.equal(re.test('sag mir bitte'), false);
     assert.equal(re.test('sage uns die Wahrheit'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compileGroupTriggerRegex — pattern fallback compiler used by the
+// `wasMentioned via group_trigger_patterns` path. Tests the contract houko
+// flagged in PR #5230: case-insensitive leading `(?i)`, graceful skip on
+// invalid input, and refusal of Rust-style mid-pattern inline flag groups
+// (which JS RegExp silently treats as literal text).
+// ---------------------------------------------------------------------------
+describe('compileGroupTriggerRegex', () => {
+  it('translates leading (?i) into JS i flag (case-insensitive match)', () => {
+    const re = compileGroupTriggerRegex('(?i)\\bbot\\b');
+    assert.ok(re, 'expected a compiled regex');
+    assert.equal(re.flags.includes('i'), true);
+    assert.ok(re.test('Hey BOT, ping'));
+    assert.ok(re.test('hey bot, ping'));
+    assert.ok(re.test('Bot — fai una cosa'));
+  });
+
+  it('returns null and warns on a syntactically invalid pattern (no boot crash)', () => {
+    const orig = console.warn;
+    const warnings = [];
+    console.warn = (msg) => warnings.push(String(msg));
+    try {
+      assert.equal(compileGroupTriggerRegex('('), null);
+    } finally {
+      console.warn = orig;
+    }
+    assert.equal(warnings.length, 1, 'expected exactly one warn line');
+    assert.ok(/invalid group_trigger_patterns/.test(warnings[0]),
+      `unexpected warn: ${warnings[0]}`);
+  });
+
+  it('returns null on empty / non-string entries (silent skip is OK here)', () => {
+    assert.equal(compileGroupTriggerRegex(''), null);
+    assert.equal(compileGroupTriggerRegex(null), null);
+    assert.equal(compileGroupTriggerRegex(undefined), null);
+    assert.equal(compileGroupTriggerRegex(42), null);
+    assert.equal(compileGroupTriggerRegex({}), null);
+  });
+
+  it('refuses mid-pattern (?i) inline flag groups with a warn (Rust-only syntax)', () => {
+    // Rust `regex` accepts `foo(?i)bar` to switch case-insensitivity from the
+    // middle of a pattern; JS RegExp does not. We bail out rather than emit
+    // a regex that silently never matches.
+    const orig = console.warn;
+    const warnings = [];
+    console.warn = (msg) => warnings.push(String(msg));
+    try {
+      assert.equal(compileGroupTriggerRegex('foo(?i)bar'), null);
+      assert.equal(compileGroupTriggerRegex('(?i)foo(?-i)bar'), null);
+      assert.equal(compileGroupTriggerRegex('(?i:foo)bar'), null);
+    } finally {
+      console.warn = orig;
+    }
+    assert.equal(warnings.length, 3);
+    for (const w of warnings) {
+      assert.ok(/mid-pattern inline flag group/.test(w),
+        `unexpected warn: ${w}`);
+    }
+  });
+
+  it('compiles a plain pattern without leading (?i) using default flags', () => {
+    const re = compileGroupTriggerRegex('\\bSignore\\b');
+    assert.ok(re);
+    assert.equal(re.flags, '');
+    assert.ok(re.test('Caro Signore, una nota'));
+    // Case-sensitive by default — matches Rust `regex` behaviour without (?i).
+    assert.equal(re.test('signore minuscolo'), false);
+  });
+
+  it('simulates the wasMentioned fallback decision over typical group text', () => {
+    // Mirror the call shape at index.js:1893 — a compiled regex array tested
+    // against the inbound `text` variable. Covers the four required cases:
+    //   1. patterns present + text matches → fallback fires
+    //   2. patterns present + text empty   → fallback short-circuits
+    //   3. patterns empty                  → fallback never runs
+    //   4. patterns present + no match     → fallback stays false
+    const compiled = [
+      compileGroupTriggerRegex('(?i)\\bsignore\\b'),
+      compileGroupTriggerRegex('(?i)\\bambrogio\\b'),
+    ].filter(Boolean);
+    const hit = (text) => Boolean(text) && compiled.length > 0
+      && compiled.some(re => re.test(text));
+    // 1. Match (mention by name)
+    assert.equal(hit('Signore, fai una cosa'), true);
+    assert.equal(hit('ehi Ambrogio'), true);
+    // 2. Empty text → no fallback fire
+    assert.equal(hit(''), false);
+    assert.equal(hit(null), false);
+    assert.equal(hit(undefined), false);
+    // 3. Empty pattern array → no fallback fire (simulate by clearing)
+    const empty = [];
+    const hitEmpty = (text) => Boolean(text) && empty.length > 0
+      && empty.some(re => re.test(text));
+    assert.equal(hitEmpty('Signore'), false);
+    // 4. No match
+    assert.equal(hit('Caterina, chiedi al barista'), false);
   });
 });


### PR DESCRIPTION
## Summary

The gateway's `wasMentioned` flag was set only on WhatsApp's structured
`@`-mentions. Plain-text references to the agent name ("Ambrogio,
conferma...") came through with `was_mentioned: false`, even though the
Rust daemon's `compile_group_trigger_patterns` then matched the text
and replied. Result: gateway logs and the forwarded `was_mentioned`
field lied to the daemon and to operators reading the logs.

## Changes

- Parse `[channels.whatsapp].group_trigger_patterns` in
  `readWhatsAppConfig` (defaults to `[]`).
- `compileGroupTriggerRegex(pattern)` converts each pattern to a JS
  `RegExp`. The Rust daemon honours `(?i)` inline; JavaScript does not
  (`new RegExp("(?i)foo")` literally matches `(?i)foo`). Strip a leading
  `(?i)` and translate it to the JS `i` flag so the same config.toml
  works in both runtimes. Invalid patterns are skipped with a `warn`.
- After the structured-mention scan, fall back to matching the message
  text (conversation / extendedTextMessage / image-video-document
  caption) against the compiled regex set.

## Scope

Gateway-side signal fix only. Forwarding behaviour and daemon-side
gating are unchanged. The daemon stays the source of truth for
`mention_only` enforcement.

## Verification

`node --check packages/whatsapp-gateway/index.js` clean. Live-tested
on a deployment where "Ambrogio, conferma in 5 parole..." in a group
chat produced `was_mentioned:false` at the gateway pre-fix; post-fix
the gateway log correctly reflects the daemon's pattern match.