### PR TITLE
fix(sdk/python): surface producer crash via ProducerCrashed, not SystemExit

### DIFF
--- a/sdk/python/librefang/sidecar/__init__.py
+++ b/sdk/python/librefang/sidecar/__init__.py
@@ -42,9 +42,16 @@ from .protocol import (
     UnknownCommand,
     parse_command,
 )
-from .runtime import SidecarAdapter, run, run_stdio, with_backoff
+from .runtime import (
+    ProducerCrashed,
+    SidecarAdapter,
+    run,
+    run_stdio,
+    with_backoff,
+)
 
 __all__ = [
+    "ProducerCrashed",
     "SidecarAdapter",
     "run",
     "run_stdio",

--- a/sdk/python/librefang/sidecar/runtime.py
+++ b/sdk/python/librefang/sidecar/runtime.py
@@ -58,6 +58,18 @@ EmitFn = Callable[[Dict[str, Any]], None]
 LineSource = Callable[[], Awaitable[Optional[str]]]
 
 
+class ProducerCrashed(Exception):
+    """Raised from :func:`run` when :meth:`SidecarAdapter.produce` exits
+    with an unhandled error.
+
+    Cleanup (``on_shutdown``) has already run by the time this is raised.
+    :func:`run_stdio` converts it to ``SystemExit(1)`` so the daemon
+    supervisor sees a nonzero exit (distinguishable from a clean
+    ``shutdown``/EOF). Library callers using :func:`run` directly can
+    catch this to inspect ``__cause__`` (the original transport error)
+    before deciding how to surface the failure."""
+
+
 class SidecarAdapter:
     """Base class for a sidecar channel adapter.
 
@@ -230,13 +242,23 @@ async def run(
             await adapter.on_shutdown()
         except Exception as e:  # noqa: BLE001
             log.error("on_shutdown failed", error=str(e))
-    # A producer crash is a fatal, unhandled adapter failure — exit
-    # nonzero so it is distinguishable from a clean `shutdown`/EOF
-    # (cleanup above still ran). The daemon supervisor restarts on any
-    # non-shutdown exit; the nonzero code makes the failure explicit to
-    # operators and any non-supervised runner.
+    # A producer crash is a fatal, unhandled adapter failure. Surface it
+    # as a regular Exception (with the original error chained); the
+    # `run_stdio` wrapper converts that into a nonzero process exit so it
+    # is distinguishable from a clean `shutdown`/EOF (cleanup above still
+    # ran). The daemon supervisor restarts on any non-shutdown exit; the
+    # nonzero code makes the failure explicit to operators and any
+    # non-supervised runner. Raising a plain Exception here (rather than
+    # SystemExit) keeps `run` library-friendly: callers driving it from
+    # their own event loop can catch and inspect the failure without
+    # tripping interpreter-level exit semantics — and the assertion is
+    # portable across Python versions (a SystemExit raised from inside an
+    # awaited sub-Task short-circuits the event loop on <3.11, making the
+    # contract unobservable to test code on supported runtimes).
     if producer_error is not None:
-        raise SystemExit(1)
+        raise ProducerCrashed(
+            "sidecar producer crashed; cleanup ran"
+        ) from producer_error
 
 
 def run_stdio(adapter: SidecarAdapter, *, ready_interval: float = 2.0,
@@ -244,9 +266,16 @@ def run_stdio(adapter: SidecarAdapter, *, ready_interval: float = 2.0,
     """Wire ``run`` to real stdio and run it to completion. stdout is
     written under a lock and carries only protocol frames; stdin is read
     on a daemon thread (portable, unlike async stdin). See :func:`run`
-    for ``ready_max_attempts``."""
-    asyncio.run(_run_stdio(adapter, ready_interval=ready_interval,
-                           ready_max_attempts=ready_max_attempts))
+    for ``ready_max_attempts``.
+
+    A :class:`ProducerCrashed` from ``run`` becomes ``SystemExit(1)`` so
+    the daemon supervisor (and any non-supervised runner) sees a nonzero
+    exit code, distinguishable from a clean ``shutdown``/EOF."""
+    try:
+        asyncio.run(_run_stdio(adapter, ready_interval=ready_interval,
+                               ready_max_attempts=ready_max_attempts))
+    except ProducerCrashed:
+        raise SystemExit(1)
 
 
 async def _run_stdio(adapter: SidecarAdapter, *,

--- a/sdk/python/tests/test_sidecar_runtime.py
+++ b/sdk/python/tests/test_sidecar_runtime.py
@@ -9,7 +9,7 @@ import json
 
 import pytest
 
-from librefang.sidecar import SidecarAdapter, run
+from librefang.sidecar import ProducerCrashed, SidecarAdapter, run
 from librefang.sidecar.protocol import Send
 
 
@@ -185,8 +185,9 @@ async def test_blank_lines_are_skipped(bad):
 
 
 async def test_producer_crash_exits_nonzero_after_cleanup():
-    # A fatal, unhandled producer error must exit nonzero (not look
-    # like a clean shutdown), and on_shutdown cleanup must still run.
+    # A fatal, unhandled producer error must surface as ProducerCrashed
+    # (which run_stdio turns into a nonzero process exit, not a clean
+    # shutdown), and on_shutdown cleanup must still run before it.
     class Crashing(SidecarAdapter):
         def __init__(self):
             self.shutdown_called = False
@@ -201,7 +202,39 @@ async def test_producer_crash_exits_nonzero_after_cleanup():
             self.shutdown_called = True
 
     adapter = Crashing()
-    with pytest.raises(SystemExit) as ei:
+    with pytest.raises(ProducerCrashed) as ei:
         await _drive(adapter, [])
-    assert ei.value.code == 1
+    # __cause__ preserves the original transport error for diagnostics.
+    assert isinstance(ei.value.__cause__, RuntimeError)
+    assert "transport died unrecoverably" in str(ei.value.__cause__)
     assert adapter.shutdown_called, "cleanup must run before nonzero exit"
+
+
+def test_run_stdio_translates_producer_crash_to_nonzero_exit():
+    # run_stdio is the process entry point: a ProducerCrashed from run()
+    # must become SystemExit(1) so the daemon supervisor sees a nonzero
+    # exit, distinguishable from a clean shutdown/EOF. Exercised
+    # synchronously because run_stdio owns its own event loop.
+    from librefang.sidecar import run_stdio
+
+    class Crashing(SidecarAdapter):
+        async def on_send(self, cmd):
+            pass
+
+        async def produce(self, emit):
+            raise RuntimeError("transport died unrecoverably")
+
+    # Closed stdin -> reader thread hits EOF immediately; the producer
+    # crash still wins the race because `stop` is set before EOF reaches
+    # the loop. ready_max_attempts=1 caps the ready-loop quickly.
+    import io
+    import sys
+    saved_stdin, saved_stdout = sys.stdin, sys.stdout
+    sys.stdin = io.StringIO("")
+    sys.stdout = io.StringIO()
+    try:
+        with pytest.raises(SystemExit) as ei:
+            run_stdio(Crashing(), ready_interval=0.01, ready_max_attempts=1)
+        assert ei.value.code == 1
+    finally:
+        sys.stdin, sys.stdout = saved_stdin, saved_stdout


### PR DESCRIPTION
## Background

`test_producer_crash_exits_nonzero_after_cleanup` was added in #5223 (codex-review follow-up to #5220) and shipped to `main` failing on Python 3.9 — verified pre-existing on `origin/main` (independent of #5228). The PR description claimed `21 SDK tests pass`; that almost certainly came from a 3.11+ local run where the failure mode does not reproduce.

## Root cause

`runtime.run()` raised `SystemExit(1)` directly when `produce()` crashed. On Python <3.11, `pytest-asyncio` uses the backports `asyncio.Runner`, whose outer task is a `_PyTask`. When the inner sub-Task that `asyncio.wait_for` wraps around `run()` raises `SystemExit`, `_PyTask.__step`'s explicit re-raise branch (`except (KeyboardInterrupt, SystemExit) as exc: super().set_exception(exc); raise`) short-circuits the event loop *before* the `await` resumes in the test coroutine — so `pytest.raises(SystemExit)` never observes it. The contract was therefore unobservable on the SDK's own minimum supported runtime (`requires-python = "">=3.8""`).

Raising `SystemExit` from a library `await`-able is also rude on principle: it encodes a process-exit policy in a primitive that callers may want to drive from their own event loop.

## Fix

- New `ProducerCrashed(Exception)`; `run()` raises it after cleanup, with the original transport error preserved via `__cause__`.
- `run_stdio` — the documented process entry point — catches `ProducerCrashed` and re-raises as `SystemExit(1)`. The supervisor-visible nonzero-exit contract is unchanged.
- Test updated to assert on `ProducerCrashed` (portable across Python versions); a new `test_run_stdio_translates_producer_crash_to_nonzero_exit` pins the `SystemExit(1)` translation at the process entry point.

## Verification

- `python3 -m pytest sdk/python/tests/ -v` — 27/27 pass on Python 3.9.6 (previously: 1 fail).
- Same suite on Python 3.12.13 — 27/27 pass.
- `cargo test -p librefang-channels --lib sidecar::` — 24/24 pass, including `test_supervisor_restarts_crashing_child` and `test_sidecar_adapter_spawn_echo` (so the wire/process-exit contract that the supervisor relies on is intact).