### PR TITLE
fix(sidecar): handle inbound poll_answer in telegram adapter (sidecar parity)

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/telegram.py
+++ b/sdk/python/librefang/sidecar/adapters/telegram.py
@@ -22,8 +22,9 @@ port of the audited Rust (function-by-function, not re-derived):
 * DONE — full inbound parsing: text/bot-command, photo, document,
   audio, voice, animation, video, video_note, location, sticker;
   ``from`` / ``sender_chat`` sender extraction; ``callback_query`` →
-  ButtonCallback; ``edited_message``; reply-to context; getFile URL
-  resolution with text fallback; ALLOWED_USERS by id *and* username.
+  ButtonCallback; ``poll_answer`` → PollAnswer; ``edited_message``;
+  reply-to context; getFile URL resolution with text fallback;
+  ALLOWED_USERS by id *and* username.
 * DONE — full outbound dispatch for every ``ChannelContent`` variant
   (Image→sendPhoto, File→sendDocument/sendVoice, Voice/Video/Audio/
   Animation→send*, Sticker, Location, MediaGroup, Poll, Interactive,
@@ -1346,10 +1347,49 @@ class TelegramAdapter(SidecarAdapter):
             metadata={"callback_query_id": cqid},
         )
 
+    def _poll_answer_to_event(self, poll_answer: dict):
+        # Mirrors in-process telegram.rs:2129-2230. Telegram only fires
+        # `poll_answer` for non-anonymous polls in private chats, so
+        # `user.id` doubles as the DM chat_id — see the Rust comment
+        # near `SENDER_USER_ID_KEY` on line 2161.
+        poll_id = poll_answer.get("poll_id")
+        if not poll_id:
+            return None
+        user = poll_answer.get("user") or {}
+        uid = user.get("id")
+        if not isinstance(uid, int):
+            return None
+        username = user.get("username")
+        if not self._allowed(str(uid), username):
+            return None
+        first = user.get("first_name") or "Unknown"
+        last = user.get("last_name") or ""
+        name = first if not last else f"{first} {last}"
+        # Rust coerces each id to `u8` (Telegram uses 0-based option
+        # indices, max 9 per poll); non-int / negative entries are
+        # silently dropped, matching `filter_map(.. as u64 .. as u8)`.
+        option_ids = [
+            int(o) for o in (poll_answer.get("option_ids") or [])
+            if isinstance(o, int) and 0 <= o <= 255
+        ]
+        return protocol.message(
+            user_id=str(uid),
+            user_name=name,
+            content=protocol.Content.poll_answer(poll_id, option_ids),
+            message_id=poll_id,
+            channel_id=str(uid),
+            username=username,
+            is_group=False,
+            metadata={"user_id": str(uid), "sender_user_id": str(uid)},
+        )
+
     def _update_to_event(self, update: dict):
         callback = update.get("callback_query")
         if callback:
             return self._callback_to_event(callback)
+        poll_answer = update.get("poll_answer")
+        if poll_answer:
+            return self._poll_answer_to_event(poll_answer)
         message = update.get("message") or update.get("edited_message")
         if not message:
             return None
@@ -1385,7 +1425,8 @@ class TelegramAdapter(SidecarAdapter):
             f"{self.api_base}/getUpdates",
             {"offset": state["offset"], "timeout": LONGPOLL_SERVER_SECS,
              "allowed_updates": json.dumps(
-                 ["message", "edited_message", "callback_query"])},
+                 ["message", "edited_message", "callback_query",
+                  "poll_answer"])},
             LONGPOLL_CLIENT_SECS,
         )
         if not data.get("ok"):

--- a/sdk/python/tests/test_telegram_adapter.py
+++ b/sdk/python/tests/test_telegram_adapter.py
@@ -225,6 +225,132 @@ def test_inbound_callback_query(monkeypatch):
     assert ("answerCallbackQuery", {"callback_query_id": "cq1"}) in answered
 
 
+def test_inbound_poll_answer_matches_rust_oracle():
+    # Oracle: crates/librefang-channels/src/telegram.rs:2129-2230 (the
+    # in-process `poll_answer` handler). Telegram only fires
+    # poll_answer for non-anonymous polls in private chats, so
+    # `user.id` doubles as the DM chat_id (see SENDER_USER_ID_KEY
+    # comment on line 2161). Field-by-field mirror.
+    a = _adapter()
+    ev = a._update_to_event({
+        "update_id": 42,
+        "poll_answer": {
+            "poll_id": "p-9001",
+            "user": {"id": 12345, "first_name": "Alice", "last_name": "B",
+                     "username": "al"},
+            "option_ids": [0, 2],
+        },
+    })
+    assert ev is not None, "poll_answer must produce an event"
+    p = ev["params"]
+    # sender.platform_id = user.id; display_name = "first last"
+    assert p["user_id"] == "12345"
+    assert p["user_name"] == "Alice B"
+    assert p["username"] == "al"
+    # content = PollAnswer { poll_id, option_ids }
+    assert p["content"] == {
+        "PollAnswer": {"poll_id": "p-9001", "option_ids": [0, 2]}
+    }
+    # platform_message_id = poll_id
+    assert p["message_id"] == "p-9001"
+    # DM-only — channel_id falls back to the user id (Rust comment)
+    assert p["channel_id"] == "12345"
+    # is_group = false, no thread_id
+    assert p.get("is_group", False) is False
+    assert "thread_id" not in p
+    # metadata mirrors the two keys the Rust path writes
+    assert p["metadata"] == {"user_id": "12345", "sender_user_id": "12345"}
+
+
+def test_inbound_poll_answer_user_only_first_name():
+    # Rust: `last_name` defaults to empty; display_name = first_name
+    # alone when last_name is empty.
+    a = _adapter()
+    ev = a._update_to_event({
+        "poll_answer": {
+            "poll_id": "p1",
+            "user": {"id": 7, "first_name": "Solo"},
+            "option_ids": [1],
+        },
+    })
+    assert ev["params"]["user_name"] == "Solo"
+
+
+def test_inbound_poll_answer_missing_first_name_defaults_unknown():
+    # Rust: `first_name` defaults to "Unknown" when absent.
+    a = _adapter()
+    ev = a._update_to_event({
+        "poll_answer": {
+            "poll_id": "p1",
+            "user": {"id": 8},
+            "option_ids": [],
+        },
+    })
+    assert ev["params"]["user_name"] == "Unknown"
+    # empty option_ids is valid (user retracted their vote)
+    assert ev["params"]["content"] == {
+        "PollAnswer": {"poll_id": "p1", "option_ids": []}
+    }
+
+
+def test_inbound_poll_answer_empty_poll_id_dropped():
+    # Rust: `if !poll_id.is_empty() && ...` — empty poll_id skipped.
+    a = _adapter()
+    assert a._update_to_event({
+        "poll_answer": {"poll_id": "", "user": {"id": 1}, "option_ids": []},
+    }) is None
+    # Same for missing poll_id entirely.
+    assert a._update_to_event({
+        "poll_answer": {"user": {"id": 1}, "option_ids": []},
+    }) is None
+
+
+def test_inbound_poll_answer_respects_allowed_users():
+    # Rust: `telegram_user_allowed(&allowed_users, user_id, username)`.
+    a = _adapter(ALLOWED_USERS="111,@alice")
+    # disallowed id+username
+    assert a._update_to_event({
+        "poll_answer": {"poll_id": "p", "user": {"id": 999},
+                        "option_ids": [0]},
+    }) is None
+    # allowed by id
+    assert a._update_to_event({
+        "poll_answer": {"poll_id": "p", "user": {"id": 111},
+                        "option_ids": [0]},
+    })["params"]["user_id"] == "111"
+    # allowed by username (case-insensitive, @ optional — see _allowed)
+    assert a._update_to_event({
+        "poll_answer": {"poll_id": "p",
+                        "user": {"id": 7, "username": "Alice"},
+                        "option_ids": [0]},
+    })["params"]["user_id"] == "7"
+
+
+def test_poll_answer_in_allowed_updates_subscription():
+    # The long-poll request must subscribe to `poll_answer` or
+    # Telegram simply never delivers it. Mirrors telegram.rs:2008.
+    captured = {}
+
+    def fake_get(url, params, timeout):
+        captured["params"] = params
+        return {"ok": True, "result": []}
+
+    import librefang.sidecar.adapters.telegram as tg_mod
+    a = _adapter()
+    orig = tg_mod._api_get
+    tg_mod._api_get = fake_get
+    try:
+        a._poll_once(lambda _ev: None, {"offset": 0})
+    finally:
+        tg_mod._api_get = orig
+    import json as _json
+    subs = _json.loads(captured["params"]["allowed_updates"])
+    assert "poll_answer" in subs
+    # don't accidentally drop existing subscriptions
+    for required in ("message", "edited_message", "callback_query"):
+        assert required in subs
+
+
 def test_inbound_edited_message_and_reply(monkeypatch):
     a = _adapter()
     monkeypatch.setattr(a, "_get_file_url", lambda fid: None)


### PR DESCRIPTION
## Why
Follow-up to #5232 — review caught that the sidecar Telegram adapter quietly
drops Telegram's `poll_answer` update while the in-process adapter at
`crates/librefang-channels/src/telegram.rs:2129-2230` handles it end-to-end.
Two problems compounded:

1. `getUpdates` `allowed_updates` was `["message", "edited_message", "callback_query"]` — Telegram never sent `poll_answer` to begin with.
2. `_update_to_event` had no branch for it even if it arrived.

Result: any non-anonymous poll vote silently disappears in the sidecar but is delivered as a `PollAnswer` `ChannelMessage` in-process. Per the project rule against silent in-process/sidecar drift, this needs to be fixed in the same release as #5232.

## What
- Add a `_poll_answer_to_event` method, dispatched from `_update_to_event` (alongside the existing `callback_query` branch).
- Extend `allowed_updates` with `"poll_answer"`.
- Update the module-level docstring's inbound-coverage line.

Field-by-field mirror of the Rust oracle (telegram.rs:2129-2230):

| Field | Source | Rust line |
|---|---|---|
| `user_id` (= sender.platform_id) | `poll_answer.user.id` | 2132, 2177 |
| `user_name` | `first_name` + `" "` + `last_name`, with `"Unknown"`/empty-last fallbacks | 2134-2142, 2178 |
| `content` | `PollAnswer { poll_id, option_ids }` | 2181-2184 |
| `message_id` (= platform_message_id) | `poll_answer.poll_id` | 2175 |
| `channel_id` | falls back to `user.id` — polls fire DM-only | 2161-2167 |
| `is_group` | `false` | 2187 |
| `metadata.user_id`, `metadata.sender_user_id` | both = `str(user.id)` | 2156-2171 |
| filter: drop empty `poll_id` | | 2144 |
| filter: `_allowed(user_id, username)` | | 2145 |
| `option_ids` coercion | int → u8 (Rust); ints in `[0, 255]` (Python) | 2147-2154 |

Two Rust-only fields are deliberately *not* mirrored:
- `account_id` metadata — sidecar passes `account_id` once in `ready`, not per-message.
- `poll_question` / `poll_options` cache — sidecar has no equivalent cache; outbound `sendPoll` (telegram.py:1028) doesn't track per-poll context. Out of scope for sidecar parity; a separate change if/when that cache lands.

Neither divergence is new (both predate this PR); calling it out so reviewers don't go looking.

## Tests
Six new tests in `tests/test_telegram_adapter.py` against the Rust oracle:
- `test_inbound_poll_answer_matches_rust_oracle` — every mapped field pinned to the exact expected value.
- `test_inbound_poll_answer_user_only_first_name` — empty last_name → display_name = first_name only.
- `test_inbound_poll_answer_missing_first_name_defaults_unknown` — missing first_name → `"Unknown"`; empty option_ids passes through.
- `test_inbound_poll_answer_empty_poll_id_dropped` — empty / missing `poll_id` returns `None`.
- `test_inbound_poll_answer_respects_allowed_users` — id and username allowlist both work.
- `test_poll_answer_in_allowed_updates_subscription` — the long-poll request actually subscribes to `poll_answer` (and doesn't accidentally drop the existing three).

## Verification
- `cd sdk/python && python3 -m pytest tests/test_telegram_adapter.py -v` — 23/23 pass.
- `python3 -c "from librefang.sidecar.adapters import telegram"` — stdlib-only import still clean.
- No changes to in-process `telegram.rs` (it is the oracle).

## Scope
Sidecar adapter + tests only. No changes to:
- `crates/librefang-channels/src/telegram.rs` (oracle, untouched)
- `protocol.py` (`Content.poll_answer` already exists from #5232)
- Outbound paths, formatter, sanitizer, chunker