### PR TITLE
fix(kernel): unblock main — pass force=false in compact gate test (#5210/#5213 collision)

### DIFF
--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -8968,8 +8968,12 @@ async fn test_compact_gate_passes_when_tokens_above_threshold_but_messages_below
     // it proceeds past the gate and either compacts or errors at the LLM
     // step (no provider configured in test).  Either way the result must
     // not be the early-return sentinel.
+    //
+    // `force = false` — this test pins the *token-trigger gate* (#5210),
+    // not the user-forced bypass path (#5213). The force=true case is
+    // covered separately.
     let result = kernel
-        .compact_agent_session_with_id(agent_id, Some(session_id))
+        .compact_agent_session_with_id(agent_id, Some(session_id), false)
         .await;
 
     match &result {


### PR DESCRIPTION
## Problem

main has been red since #5213 merged on top of #5210:

- #5210 added `test_compact_gate_passes_when_tokens_above_threshold_but_messages_below` at `crates/librefang-kernel/src/kernel/tests.rs:8972`, calling `compact_agent_session_with_id(agent_id, Some(session_id))` — two args.
- #5213 changed the method signature to take a third `force: bool` parameter (forced /compact, async spawn). #5213's branch was forked before #5210 landed, so when #5213 was rebased the new test was not updated. Both PRs' own CI was green at merge time; the collision only surfaces on `main` after the second merge.

Result: every CI lane red since `ae410968`:

```
error[E0061]: this method takes 3 arguments but 2 arguments were supplied
   --> crates/librefang-kernel/src/kernel/tests.rs:8972:10
8972 |         .compact_agent_session_with_id(agent_id, Some(session_id))
     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------------- argument #3 of type `bool` is missing
```

## Fix

Pass `force = false` at that call site. The test pins the *token-trigger gate* (#5210), not the user-forced bypass path (#5213); `false` is the correct value, with a 3-line comment explaining the choice.

## Verification

- `cargo check -p librefang-kernel --profile=test --lib` clean (was the failing target).
- Surrounding test logic untouched — only the missing argument is added.

## Notes

No follow-up needed; the force=true case is already covered by #5213's own tests. Surfaced while triaging CI red on #5241.