### PR TITLE
docs(channels): fix stale telegram.rs reference in custom-channel example

### DIFF
--- a/examples/custom-channel/README.md
+++ b/examples/custom-channel/README.md
@@ -276,7 +276,7 @@ For real-world examples, study these existing adapters (simplest to most complex
 | **webhook** | `webhook.rs` | HTTP server with HMAC-SHA256 signature verification |
 | **gotify** | `gotify.rs` | WebSocket subscription + REST API publishing |
 | **slack** | `slack.rs` | WebSocket (Socket Mode) + Web API |
-| **telegram** | `telegram.rs` | Long-polling + Bot API |
+| **matrix** | `matrix.rs` | Client-server API + Markdown→HTML |
 
 ## Further Reading
 


### PR DESCRIPTION
## Problem

#5241 removed the in-process Telegram adapter (`crates/librefang-channels/src/telegram.rs` deleted; telegram is now a `[[sidecar_channels]]` adapter). The "Reference adapters" table in `examples/custom-channel/README.md` still listed a `telegram` / `telegram.rs` row, so it points at a deleted file. It was outside the scope of #5241's doc-cleanup commits and landed on `main` with the squash-merge.

## Fix

Swap the row for `matrix.rs` — a real in-process adapter not already in the table — exactly as #5224 swapped ntfy's row for `discord` when it removed `ntfy.rs`. One-line docs change, no code impact.

## Context

Found during a thorough post-merge sweep of the five surfaces a removed channel can leave stale (docs / usage / config-init / examples / TUI). The other four are clean on `main` (the #5241 mdx + per-crate doc commits and the TUI ChannelDef removal covered them); this example README row was the only residue.

## Out of scope (flagged, not fixed here)

`docs/issues/channel-bridge-bypasses-lane-semaphore.md:42` references `crates/librefang-channels/src/telegram.rs:177, 1949, 1987` — an audit-backlog tracking item (from the #5240 import-audit backlog), now obsolete-by-removal. Triaging that backlog is a different domain and #5224's analogous ntfy cleanup didn't touch backlog docs either; surfaced here for awareness rather than scope expansion.