### PR TITLE
fix(channels): sidecar channels visible AND read-only on the dashboard (no 404 actions)

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -142,15 +142,21 @@ const ChannelCard = memo(function ChannelCard({ channel: c, isSelected, viewMode
           {msgs > 0 ? t("common.running") : t("common.idle")}
         </span>
       </Badge>
-      <button
-        type="button"
-        onClick={(e) => { e.stopPropagation(); onConfigure(c); }}
-        className="shrink-0 p-1.5 rounded-md text-text-dim hover:text-text-main hover:bg-main/40 transition-colors"
-        aria-label={t("channels.config")}
-        title={t("channels.config")}
-      >
-        <Settings className="w-3.5 h-3.5" />
-      </button>
+      {/* Sidecar channels are config.toml-managed (no /api/channels
+          configure endpoint — it would 404), so suppress the inline
+          Configure affordance; the whole-card click still opens the
+          read-only details drawer. */}
+      {c.category !== "sidecar" && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onConfigure(c); }}
+          className="shrink-0 p-1.5 rounded-md text-text-dim hover:text-text-main hover:bg-main/40 transition-colors"
+          aria-label={t("channels.config")}
+          title={t("channels.config")}
+        >
+          <Settings className="w-3.5 h-3.5" />
+        </button>
+      )}
       {viewMode === "grid" && (
         <ChevronRight className="w-4 h-4 text-text-dim/60 shrink-0" aria-hidden="true" />
       )}
@@ -283,17 +289,31 @@ function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
             </div>
           )}
 
-          {/* Actions */}
-          <div className="flex gap-2 pt-2">
-            <Button variant="primary" className="flex-1" onClick={onConfigure} leftIcon={<Settings className="w-4 h-4" />}>
-              {channel.configured ? t("channels.update_config") : t("channels.setup_adapter")}
-            </Button>
-            {channel.configured && (
-              <Button variant="secondary" onClick={onTest} leftIcon={<CheckCircle2 className="w-4 h-4" />}>
-                {t("channels.test") || "Test"}
+          {/* Actions — sidecar channels run out-of-process and have no
+              /api/channels configure/test endpoint (those are
+              CHANNEL_REGISTRY-only and 404 for a sidecar name), so show
+              a read-only note pointing at where they ARE managed
+              instead of broken Configure/Test buttons. */}
+          {channel.category === "sidecar" ? (
+            <div className="p-4 rounded-xl bg-brand/5 border border-brand/20">
+              <p className="text-xs text-text-dim">
+                Runs as an out-of-process sidecar adapter. Manage it in
+                config.toml (<code className="font-mono">[[sidecar_channels]]</code>)
+                — Config → Sidecar Channels.
+              </p>
+            </div>
+          ) : (
+            <div className="flex gap-2 pt-2">
+              <Button variant="primary" className="flex-1" onClick={onConfigure} leftIcon={<Settings className="w-4 h-4" />}>
+                {channel.configured ? t("channels.update_config") : t("channels.setup_adapter")}
               </Button>
-            )}
-          </div>
+              {channel.configured && (
+                <Button variant="secondary" onClick={onTest} leftIcon={<CheckCircle2 className="w-4 h-4" />}>
+                  {t("channels.test") || "Test"}
+                </Button>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Footer */}

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -959,6 +959,80 @@ fn find_channel_meta(name: &str) -> Option<&'static ChannelMeta> {
     CHANNEL_REGISTRY.iter().find(|c| c.name == name)
 }
 
+/// Synthesize dashboard channel rows for configured `[[sidecar_channels]]`.
+///
+/// telegram / ntfy (and any other sidecar adapter) were removed from
+/// `CHANNEL_REGISTRY` when they migrated out-of-process (#5241 / #5224),
+/// which silently dropped them from the dashboard channels page. They
+/// are still channels — surface the configured ones here so the
+/// operator view stays consistent regardless of whether an adapter
+/// runs in-process or as a sidecar. These rows are config.toml-managed
+/// (`[[sidecar_channels]]`, also under Config -> Sidecar Channels), so
+/// they carry no editable `fields`; the page renders them as
+/// configured/online cards (it conditionally hides empty
+/// `fields`/`setup_steps`).
+fn sidecar_channel_rows(
+    sidecar: &[librefang_types::config::SidecarChannelConfig],
+    msgs_24h: &std::collections::HashMap<String, u64>,
+    with_msgs: bool,
+) -> Vec<serde_json::Value> {
+    let registry: std::collections::HashSet<&str> =
+        CHANNEL_REGISTRY.iter().map(|c| c.name).collect();
+    let mut instance_counts: std::collections::HashMap<&str, usize> =
+        std::collections::HashMap::new();
+    for sc in sidecar {
+        *instance_counts.entry(sc.name.as_str()).or_insert(0) += 1;
+    }
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut rows = Vec::new();
+    for sc in sidecar {
+        let name = sc.name.as_str();
+        // One card per distinct sidecar name; never shadow an
+        // in-process registry entry that happens to share the name.
+        if registry.contains(name) || !seen.insert(name) {
+            continue;
+        }
+        let channel_type = sc.channel_type.as_deref().unwrap_or(name);
+        let mut row = serde_json::json!({
+            "name": name,
+            "display_name": name,
+            "icon": "SC",
+            "description": format!(
+                "Out-of-process sidecar adapter ({} {})",
+                sc.command,
+                sc.args.join(" ")
+            ),
+            "category": "sidecar",
+            "difficulty": "",
+            "setup_time": "",
+            "quick_setup": "",
+            "setup_type": "sidecar",
+            "configured": true,
+            "instance_count": instance_counts.get(name).copied().unwrap_or(1),
+            "has_token": true,
+            "fields": Vec::<serde_json::Value>::new(),
+            "setup_steps": [
+                "Runs as an out-of-process sidecar adapter",
+                "Configured via [[sidecar_channels]] in config.toml \
+                 (Config \u{2192} Sidecar Channels)",
+            ],
+            "config_template": format!(
+                "[[sidecar_channels]]\nname = \"{name}\"\nchannel_type = \"{channel_type}\""
+            ),
+        });
+        if with_msgs {
+            let m = msgs_24h
+                .get(channel_type)
+                .or_else(|| msgs_24h.get(name))
+                .copied()
+                .unwrap_or(0);
+            row["msgs_24h"] = serde_json::json!(m);
+        }
+        rows.push(row);
+    }
+    rows
+}
+
 /// Serialize a channel's config to a JSON Value for pre-populating dashboard forms.
 fn channel_config_values(
     config: &librefang_types::config::ChannelsConfig,
@@ -1337,6 +1411,16 @@ pub async fn list_channels(State(state): State<Arc<AppState>>) -> impl IntoRespo
         channels.push(channel_json);
     }
 
+    // Sidecar-backed channels (telegram / ntfy / …) are not in
+    // CHANNEL_REGISTRY but are still channels — surface the configured
+    // ones so the operator view stays consistent (#5241 / #5224).
+    {
+        let kcfg = state.kernel.config_ref();
+        let rows = sidecar_channel_rows(&kcfg.sidecar_channels, &msgs_24h, true);
+        configured_count += rows.len() as u32;
+        channels.extend(rows);
+    }
+
     let total = channels.len();
     // Canonical PaginatedResponse envelope (#3842) hand-built so the bespoke
     // `configured_count` sibling can ride alongside `items`/`total`/`offset`/
@@ -1395,6 +1479,17 @@ pub(crate) async fn channels_snapshot(state: &Arc<AppState>) -> Vec<serde_json::
             channel_json["webhook_endpoint"] = serde_json::Value::String(endpoint);
         }
         channels.push(channel_json);
+    }
+
+    // Sidecar-backed channels — keep the snapshot consistent with
+    // /api/channels (#5241 / #5224).
+    {
+        let kcfg = state.kernel.config_ref();
+        channels.extend(sidecar_channel_rows(
+            &kcfg.sidecar_channels,
+            &std::collections::HashMap::new(),
+            false,
+        ));
     }
 
     channels

--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -29,7 +29,7 @@ use axum::http::{Method, Request, StatusCode};
 use axum::Router;
 use librefang_api::routes::{self, AppState};
 use librefang_testing::{MockKernelBuilder, TestAppState};
-use librefang_types::config::{ChannelsConfig, DiscordConfig, OneOrMany};
+use librefang_types::config::{ChannelsConfig, DiscordConfig, OneOrMany, SidecarChannelConfig};
 use std::path::Path;
 use std::sync::Arc;
 use tower::ServiceExt;
@@ -976,5 +976,94 @@ async fn channels_test_known_channel_with_no_creds_reports_missing_env() {
     assert!(
         body.get("status").is_none(),
         "legacy `status` field must be gone post-#3505: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar-backed channels stay visible on /api/channels (#5241 / #5224)
+// ---------------------------------------------------------------------------
+
+/// `SidecarChannelConfig` has no `Default` and many serde-defaulted
+/// fields — build it from JSON so the test stays robust to new fields.
+fn sidecar_telegram() -> SidecarChannelConfig {
+    serde_json::from_value(serde_json::json!({
+        "name": "telegram",
+        "command": "python3",
+        "args": ["-m", "librefang.sidecar.adapters.telegram"],
+        "channel_type": "telegram",
+    }))
+    .expect("valid SidecarChannelConfig")
+}
+
+async fn boot_with_sidecar(sidecar: Vec<SidecarChannelConfig>) -> Harness {
+    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(move |cfg| {
+        cfg.sidecar_channels = sidecar.clone();
+    }));
+    let state = test.state.clone();
+    let app = Router::new()
+        .nest("/api", routes::channels::router())
+        .with_state(state.clone());
+    Harness {
+        app,
+        _state: state,
+        _test: test,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_list_includes_configured_sidecar_channels() {
+    // Regression: telegram / ntfy migrated out-of-process were removed
+    // from CHANNEL_REGISTRY and silently vanished from the dashboard
+    // channels page. A configured [[sidecar_channels]] entry must still
+    // surface as a channel row so the operator view stays consistent
+    // regardless of in-process vs sidecar (#5241 / #5224).
+    let h = boot_with_sidecar(vec![sidecar_telegram()]).await;
+    let (status, body) = json_request(&h, Method::GET, "/api/channels", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let arr = body["items"].as_array().expect("items");
+    let tg = arr
+        .iter()
+        .find(|r| r["name"] == "telegram")
+        .expect("configured sidecar telegram must appear in /api/channels");
+    assert_eq!(
+        tg["configured"], true,
+        "a declared [[sidecar_channels]] is configured: {tg}"
+    );
+    assert_eq!(tg["category"], "sidecar");
+    assert_eq!(tg["setup_type"], "sidecar");
+    // config.toml-managed — no editable dashboard form fields (the page
+    // renders it as a configured/online card, not a broken setup form).
+    assert_eq!(
+        tg["fields"].as_array().map(|a| a.len()),
+        Some(0),
+        "sidecar row must carry no editable fields: {tg}"
+    );
+    // Counts toward the dashboard's "X configured" sub-line.
+    assert!(body["configured_count"].as_u64().unwrap_or(0) >= 1);
+    // Exactly one telegram row — the in-process ChannelMeta is gone, so
+    // the sidecar row must not be shadowed or duplicated.
+    assert_eq!(
+        arr.iter().filter(|r| r["name"] == "telegram").count(),
+        1,
+        "exactly one telegram row (the sidecar one)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_list_without_sidecar_has_no_sidecar_rows() {
+    // Negative control: with nothing configured, no synthetic sidecar
+    // rows leak in (only the in-process CHANNEL_REGISTRY).
+    let h = boot().await;
+    let (status, body) = json_request(&h, Method::GET, "/api/channels", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let arr = body["items"].as_array().expect("items");
+    assert!(
+        !arr.iter().any(|r| r["category"] == "sidecar"),
+        "no sidecar rows when none are configured"
+    );
+    assert!(
+        !arr.iter().any(|r| r["name"] == "telegram"),
+        "telegram is not in CHANNEL_REGISTRY and none configured"
     );
 }


### PR DESCRIPTION
## Problem (regression from the sidecar migration)

telegram (#5241) / ntfy (#5224) moved out-of-process → their `ChannelMeta` left `CHANNEL_REGISTRY` → `/api/channels` (which only enumerated the registry) silently dropped them → they vanished from `/dashboard/channels`. The operator experience was no longer consistent across in-process vs sidecar adapters.

## Fix — two parts (both needed; reviewed for completeness)

**1. Backend — make them visible.** `list_channels` (`GET /api/channels`) and `channels_snapshot` synthesize a row per configured `[[sidecar_channels]]` entry: `configured: true`, `category`/`setup_type = "sidecar"`, `instance_count`, `msgs_24h`, no editable `fields`, `setup_steps` pointing at Config → Sidecar Channels. Counted in `configured_count`. Never shadows/duplicates an in-process registry row of the same name.

**2. Frontend — make them honestly read-only.** Surfacing them alone was a half-fix: `get_channel` / `configure_channel` / `test_channel` are all `CHANNEL_REGISTRY`-only (`find_channel_meta → None → 404`), so the card appeared but Configure/Test 404'd. `ChannelsPage` now treats `category === "sidecar"` as read-only — the inline Configure affordance is suppressed and the DetailsModal's Configure/Test buttons are replaced with a note ("runs out-of-process; manage in config.toml `[[sidecar_channels]]` under Config → Sidecar Channels"). DetailsModal renders from the list row (no per-channel fetch) so opening details was already safe; the selection checkbox is inert (no bulk action consumes it), so no other path 404s.

Net: sidecar channels (telegram / ntfy / any) show as configured/online cards with **zero broken interactions** — the migration is transparent to operators and the card points at where the channel is actually managed.

## Verification

- `cargo check -p librefang-api --lib` clean; `cargo test -p librefang-api --test channels_routes_test` **30 passed** (28 prior + 2 new: configured-sidecar-appears + negative control); `cargo clippy -p librefang-api --lib --tests -- -D warnings` clean.
- Frontend change is type-safe by construction (`category` is an already-typed `ChannelItem` field used elsewhere in `ChannelsPage.tsx`; no new symbols; conditional rendering mirrors existing patterns). Dashboard typecheck/build is covered by the `dashboard-build` CI lane.