### PR TITLE
fix(channels): surface telegram/ntfy discovery rows on the channels page

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -148,6 +148,11 @@ export interface ChannelItem {
   setup_type?: string;
   setup_steps?: string[];
   fields?: ChannelField[];
+  /** TOML snippet shown for read-only sidecar discovery rows so operators
+   *  can copy it into config.toml. Backend always emits this; the UI only
+   *  renders it for `category === "sidecar"` to avoid noise on regular
+   *  CHANNEL_REGISTRY rows that already have a setup form. */
+  config_template?: string;
   /** Webhook endpoint path on the shared server (e.g. "/channels/feishu/webhook"). */
   webhook_endpoint?: string;
   /** Messages exchanged through this channel in the last 24 hours.

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -293,14 +293,23 @@ function DetailsModal({ channel, onClose, onConfigure, onTest, t }: {
               /api/channels configure/test endpoint (those are
               CHANNEL_REGISTRY-only and 404 for a sidecar name), so show
               a read-only note pointing at where they ARE managed
-              instead of broken Configure/Test buttons. */}
+              instead of broken Configure/Test buttons. For unconfigured
+              discovery rows we additionally render the TOML snippet so
+              the operator can copy it into config.toml directly. */}
           {channel.category === "sidecar" ? (
-            <div className="p-4 rounded-xl bg-brand/5 border border-brand/20">
-              <p className="text-xs text-text-dim">
-                Runs as an out-of-process sidecar adapter. Manage it in
-                config.toml (<code className="font-mono">[[sidecar_channels]]</code>)
-                — Config → Sidecar Channels.
-              </p>
+            <div className="space-y-3">
+              <div className="p-4 rounded-xl bg-brand/5 border border-brand/20">
+                <p className="text-xs text-text-dim">
+                  {channel.configured
+                    ? <>Runs as an out-of-process sidecar adapter. Manage it in config.toml (<code className="font-mono">[[sidecar_channels]]</code>) — Config → Sidecar Channels.</>
+                    : <>This adapter ships as an out-of-process sidecar. Paste the snippet below into <code className="font-mono">~/.librefang/config.toml</code>, set the required env vars, and reload — then it will appear here as configured.</>}
+                </p>
+              </div>
+              {!channel.configured && channel.config_template && (
+                <pre className="p-4 rounded-xl bg-main/30 border border-border-subtle text-[11px] font-mono text-text-main whitespace-pre overflow-x-auto select-all">
+                  {channel.config_template}
+                </pre>
+              )}
             </div>
           ) : (
             <div className="flex gap-2 pt-2">
@@ -1027,7 +1036,12 @@ export function ChannelsPage() {
   };
   const handlePick = (ch: Channel) => {
     setPickerOpen(false);
-    if (ch.setup_type === "qr") setQrLoginChannel(ch);
+    // Sidecar discovery rows have no in-process configure endpoint
+    // (Configure would 404 against CHANNEL_REGISTRY); the details modal
+    // already renders the read-only "manage via config.toml" note for
+    // category === "sidecar" — route the pick there.
+    if (ch.category === "sidecar") setDetailsChannel(ch);
+    else if (ch.setup_type === "qr") setQrLoginChannel(ch);
     else setConfiguringChannel(ch);
   };
 

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -1033,6 +1033,112 @@ fn sidecar_channel_rows(
     rows
 }
 
+/// One discoverable, first-party sidecar adapter shipped in the SDK.
+///
+/// `name` doubles as the catalog key — it must match the value the
+/// operator will put in `[[sidecar_channels]].channel_type` (or
+/// `name`, when `channel_type` is omitted), so a configured entry
+/// suppresses the matching catalog row in `sidecar_discovery_rows`.
+struct SidecarCatalogEntry {
+    name: &'static str,
+    display_name: &'static str,
+    description: &'static str,
+    config_template: &'static str,
+}
+
+/// First-party sidecar adapters shipped under
+/// `sdk/python/librefang/sidecar/adapters/`. Listed here so they stay
+/// discoverable on the dashboard channels page after migrating out of
+/// `CHANNEL_REGISTRY` (#5241 / #5224) — without an entry, an operator
+/// who has never configured them sees no card and no picker entry, so
+/// the only way to learn telegram / ntfy exist is to read source code
+/// or release notes. `webhook` is deliberately omitted: it still has an
+/// in-process entry in `CHANNEL_REGISTRY` and we must not show two
+/// "webhook" cards on the page.
+const SIDECAR_CATALOG: &[SidecarCatalogEntry] = &[
+    SidecarCatalogEntry {
+        name: "telegram",
+        display_name: "Telegram",
+        description: "Telegram Bot API adapter (out-of-process sidecar)",
+        config_template: "\
+[[sidecar_channels]]
+name = \"telegram\"
+channel_type = \"telegram\"
+command = \"python3\"
+args = [\"-m\", \"librefang.sidecar.adapters.telegram\"]
+
+[sidecar_channels.env]
+TELEGRAM_BOT_TOKEN = \"...\"
+",
+    },
+    SidecarCatalogEntry {
+        name: "ntfy",
+        display_name: "ntfy",
+        description: "ntfy.sh pub/sub notifications (out-of-process sidecar)",
+        config_template: "\
+[[sidecar_channels]]
+name = \"ntfy\"
+channel_type = \"ntfy\"
+command = \"python3\"
+args = [\"-m\", \"librefang.sidecar.adapters.ntfy\"]
+
+[sidecar_channels.env]
+NTFY_TOPIC = \"...\"
+",
+    },
+];
+
+/// Synthesize **unconfigured** dashboard rows for catalog sidecar
+/// adapters (`telegram`, `ntfy`) so they remain discoverable in the
+/// Add picker after the out-of-process migration. A catalog entry is
+/// suppressed when ANY `[[sidecar_channels]]` already has a matching
+/// `channel_type` (or, when `channel_type` is unset, a matching `name`)
+/// — i.e. once the operator has set up "telegram" under whatever local
+/// alias, the discovery card has done its job and should yield to the
+/// configured rows emitted by [`sidecar_channel_rows`].
+fn sidecar_discovery_rows(
+    sidecar: &[librefang_types::config::SidecarChannelConfig],
+) -> Vec<serde_json::Value> {
+    let registry: std::collections::HashSet<&str> =
+        CHANNEL_REGISTRY.iter().map(|c| c.name).collect();
+    let mut covered: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for sc in sidecar {
+        let kind = sc.channel_type.as_deref().unwrap_or(sc.name.as_str());
+        covered.insert(kind);
+        covered.insert(sc.name.as_str());
+    }
+    let mut rows = Vec::new();
+    for entry in SIDECAR_CATALOG {
+        // Guard against a future where the same name appears both
+        // in-process and in the catalog — never shadow CHANNEL_REGISTRY.
+        if registry.contains(entry.name) || covered.contains(entry.name) {
+            continue;
+        }
+        rows.push(serde_json::json!({
+            "name": entry.name,
+            "display_name": entry.display_name,
+            "icon": "SC",
+            "description": entry.description,
+            "category": "sidecar",
+            "difficulty": "",
+            "setup_time": "",
+            "quick_setup": "",
+            "setup_type": "sidecar",
+            "configured": false,
+            "instance_count": 0,
+            "has_token": false,
+            "fields": Vec::<serde_json::Value>::new(),
+            "setup_steps": [
+                "Runs as an out-of-process sidecar adapter",
+                "Add a [[sidecar_channels]] entry in config.toml \
+                 (Config \u{2192} Sidecar Channels) using the template below",
+            ],
+            "config_template": entry.config_template,
+        }));
+    }
+    rows
+}
+
 /// Serialize a channel's config to a JSON Value for pre-populating dashboard forms.
 fn channel_config_values(
     config: &librefang_types::config::ChannelsConfig,
@@ -1413,12 +1519,15 @@ pub async fn list_channels(State(state): State<Arc<AppState>>) -> impl IntoRespo
 
     // Sidecar-backed channels (telegram / ntfy / …) are not in
     // CHANNEL_REGISTRY but are still channels — surface the configured
-    // ones so the operator view stays consistent (#5241 / #5224).
+    // ones so the operator view stays consistent (#5241 / #5224), and
+    // emit unconfigured catalog rows for the first-party SDK adapters
+    // so they remain discoverable in the Add picker.
     {
         let kcfg = state.kernel.config_ref();
         let rows = sidecar_channel_rows(&kcfg.sidecar_channels, &msgs_24h, true);
         configured_count += rows.len() as u32;
         channels.extend(rows);
+        channels.extend(sidecar_discovery_rows(&kcfg.sidecar_channels));
     }
 
     let total = channels.len();
@@ -1482,7 +1591,8 @@ pub(crate) async fn channels_snapshot(state: &Arc<AppState>) -> Vec<serde_json::
     }
 
     // Sidecar-backed channels — keep the snapshot consistent with
-    // /api/channels (#5241 / #5224).
+    // /api/channels (#5241 / #5224), including the unconfigured
+    // catalog rows for first-party SDK adapters.
     {
         let kcfg = state.kernel.config_ref();
         channels.extend(sidecar_channel_rows(
@@ -1490,6 +1600,7 @@ pub(crate) async fn channels_snapshot(state: &Arc<AppState>) -> Vec<serde_json::
             &std::collections::HashMap::new(),
             false,
         ));
+        channels.extend(sidecar_discovery_rows(&kcfg.sidecar_channels));
     }
 
     channels

--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -1051,19 +1051,88 @@ async fn channels_list_includes_configured_sidecar_channels() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn channels_list_without_sidecar_has_no_sidecar_rows() {
-    // Negative control: with nothing configured, no synthetic sidecar
-    // rows leak in (only the in-process CHANNEL_REGISTRY).
+async fn channels_list_without_sidecar_surfaces_discovery_catalog() {
+    // With nothing configured under [[sidecar_channels]], the first-party
+    // SDK adapters (telegram, ntfy) must still appear as unconfigured
+    // catalog rows — otherwise the Add picker has no way to surface them
+    // after the out-of-process migration (#5241 / #5224). Operators who
+    // have never touched config.toml saw telegram/ntfy vanish from the
+    // dashboard entirely before this; the discovery rows close that gap.
     let h = boot().await;
     let (status, body) = json_request(&h, Method::GET, "/api/channels", None).await;
     assert_eq!(status, StatusCode::OK);
     let arr = body["items"].as_array().expect("items");
+
+    for kind in ["telegram", "ntfy"] {
+        let row = arr
+            .iter()
+            .find(|r| r["name"] == kind)
+            .unwrap_or_else(|| panic!("discovery row for sidecar `{kind}` must appear"));
+        assert_eq!(
+            row["configured"], false,
+            "discovery row must be unconfigured: {row}"
+        );
+        assert_eq!(row["category"], "sidecar");
+        assert_eq!(row["setup_type"], "sidecar");
+        assert_eq!(
+            row["fields"].as_array().map(|a| a.len()),
+            Some(0),
+            "catalog row has no editable form fields: {row}"
+        );
+        // Picker uses display_name; must be non-empty.
+        assert!(
+            row["display_name"].as_str().is_some_and(|s| !s.is_empty()),
+            "discovery row needs a display name: {row}"
+        );
+    }
+
+    // Unconfigured catalog rows must not bump the configured counter —
+    // they represent "available to set up", not "already set up".
+    let configured_count = body["configured_count"].as_u64().unwrap_or(0);
+    let sidecar_unconfigured = arr
+        .iter()
+        .filter(|r| r["category"] == "sidecar" && r["configured"] == false)
+        .count() as u64;
     assert!(
-        !arr.iter().any(|r| r["category"] == "sidecar"),
-        "no sidecar rows when none are configured"
+        configured_count + sidecar_unconfigured <= arr.len() as u64,
+        "configured_count must not include discovery rows"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_list_discovery_row_hidden_when_kind_configured() {
+    // Discovery row for `telegram` must yield to a configured
+    // `[[sidecar_channels]]` entry of the same kind — regardless of the
+    // local alias the operator picked for `name`. Otherwise the page
+    // would render both a "telegram (configured)" row and a "telegram
+    // (set me up)" row simultaneously.
+    let aliased: SidecarChannelConfig = serde_json::from_value(serde_json::json!({
+        "name": "my_alerts",
+        "command": "python3",
+        "args": ["-m", "librefang.sidecar.adapters.telegram"],
+        "channel_type": "telegram",
+    }))
+    .expect("valid SidecarChannelConfig");
+    let h = boot_with_sidecar(vec![aliased]).await;
+    let (status, body) = json_request(&h, Method::GET, "/api/channels", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let arr = body["items"].as_array().expect("items");
+
+    // The aliased configured row appears under its local name.
+    assert!(
+        arr.iter()
+            .any(|r| r["name"] == "my_alerts" && r["configured"] == true),
+        "configured aliased telegram row must appear"
+    );
+    // No discovery row for telegram — it has been "covered".
     assert!(
         !arr.iter().any(|r| r["name"] == "telegram"),
-        "telegram is not in CHANNEL_REGISTRY and none configured"
+        "discovery row for `telegram` must be suppressed when channel_type=telegram is configured"
+    );
+    // ntfy discovery row is still there (independent kind, not configured).
+    assert!(
+        arr.iter()
+            .any(|r| r["name"] == "ntfy" && r["configured"] == false),
+        "ntfy discovery row remains when only telegram is configured"
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to #5241 (telegram) and #5224 (ntfy). #5249 fixed the **configured** case, but operators who had never configured them still saw nothing on `/dashboard/channels` — both adapters were removed from `CHANNEL_REGISTRY` and the new sidecar synthesizer only emits rows for entries already declared in `config.toml`. The Add picker (`pickerChannels` in `ChannelsPage.tsx:1014-1022`) filters on `configured: false`, so the only way to discover the two first-party SDK sidecar adapters was to read source or release notes.

This PR adds a small `SIDECAR_CATALOG` (telegram, ntfy) next to `CHANNEL_REGISTRY` and emits `configured: false, category: "sidecar"` rows for catalog entries not covered by any `[[sidecar_channels]]`.

- A catalog entry is "covered" when ANY configured sidecar entry has `name == entry` OR `channel_type == entry`. So `name = "my_alerts", channel_type = "telegram"` correctly suppresses the `telegram` discovery row instead of double-rendering.
- `webhook` is deliberately excluded — it still has an in-process `CHANNEL_REGISTRY` entry; surfacing both would render two `webhook` cards.

### Dashboard

- `ChannelItem` gains `config_template?: string` (backend already emits it).
- `handlePick` routes `category === "sidecar"` to the read-only details modal instead of the configure form (which would 404 against `/api/channels/{name}/configure` — that endpoint is `CHANNEL_REGISTRY`-only).
- `DetailsModal` renders the TOML snippet for unconfigured sidecar rows so operators can copy it into `config.toml` directly.

## Tests

`crates/librefang-api/tests/channels_routes_test.rs`:

- Replaced `channels_list_without_sidecar_has_no_sidecar_rows` (which asserted the now-wrong "no rows when unconfigured" contract) with `channels_list_without_sidecar_surfaces_discovery_catalog`, which asserts both telegram and ntfy appear as unconfigured catalog rows with `category="sidecar"`, no editable fields, and a display_name; also asserts discovery rows don't bump `configured_count`.
- Added `channels_list_discovery_row_hidden_when_kind_configured`: a configured `name="my_alerts", channel_type="telegram"` must suppress the telegram discovery row while leaving the ntfy one in place.

## Verification

- `cargo check -p librefang-api --lib --tests`: clean
- `cargo clippy -p librefang-api --lib --tests -- -D warnings`: clean
- `cargo test -p librefang-api --test channels_routes_test`: 31/31 pass
- `pnpm typecheck`: clean
- `pnpm test --run`: 650/650 pass
- `pnpm build`: success

## Test plan

- [ ] On a fresh `config.toml` with no `[[sidecar_channels]]`, the Channels page Add picker shows Telegram and ntfy entries
- [ ] Clicking a sidecar entry in the picker opens the read-only details drawer (no setup form, no 404)
- [ ] The drawer shows the TOML snippet for the unconfigured entry
- [ ] After adding `[[sidecar_channels]]` for telegram and reloading, the Add picker no longer shows Telegram; the configured-cards section does
- [ ] An aliased entry (`name="my_alerts", channel_type="telegram"`) suppresses the telegram discovery row but keeps ntfy