### PR TITLE
fix(dashboard): agent wizard tools/skills selectable + MCP servers dropdown (#5246)

### DIFF
--- a/crates/librefang-api/dashboard/src/components/AgentManifestForm.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/AgentManifestForm.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { AgentManifestForm, type ManifestCatalogEntry } from "./AgentManifestForm";
+import {
+  emptyManifestExtras,
+  emptyManifestForm,
+  type ManifestFormState,
+} from "../lib/agentManifest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, opts?: { defaultValue?: string } | Record<string, unknown>) => {
+      if (opts && typeof opts === "object" && "defaultValue" in opts) {
+        return (opts as { defaultValue?: string }).defaultValue ?? _key;
+      }
+      return _key;
+    },
+  }),
+}));
+
+function Harness({
+  skillCatalog,
+  toolCatalog,
+  mcpCatalog,
+}: {
+  skillCatalog?: ManifestCatalogEntry[];
+  toolCatalog?: ManifestCatalogEntry[];
+  mcpCatalog?: ManifestCatalogEntry[];
+}) {
+  const [state, setState] = useState<ManifestFormState>(() => emptyManifestForm());
+  return (
+    <AgentManifestForm
+      value={state}
+      onChange={setState}
+      providers={[{ name: "openai" }]}
+      models={[{ provider: "openai", id: "gpt-4o" }]}
+      invalidFields={new Set()}
+      extras={emptyManifestExtras()}
+      skillCatalog={skillCatalog}
+      toolCatalog={toolCatalog}
+      mcpCatalog={mcpCatalog}
+    />
+  );
+}
+
+describe("AgentManifestForm — tools/skills/mcp selection (#5246)", () => {
+  it("clicking a tool option from the dropdown adds it as a chip", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        toolCatalog={[
+          { name: "read_file", description: "Read a file" },
+          { name: "write_file", description: "Write a file" },
+        ]}
+      />,
+    );
+
+    // Open the tools combobox: target the search input by its placeholder.
+    const toolsInput = screen.getByPlaceholderText("Search tools…");
+    await user.click(toolsInput);
+
+    // Wait for the option to appear, then click it.
+    const option = await screen.findByText("read_file");
+    await user.click(option);
+
+    // Chip should appear; remove button is the canonical signal.
+    expect(
+      screen.getByRole("button", { name: "Remove read_file" }),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking a skill option from the dropdown adds it as a chip", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        skillCatalog={[
+          { name: "summarise", description: "Summarise text" },
+          { name: "translate", description: "Translate text" },
+        ]}
+      />,
+    );
+
+    const skillsInput = screen.getByPlaceholderText("Search installed skills…");
+    await user.click(skillsInput);
+
+    const option = await screen.findByText("summarise");
+    await user.click(option);
+
+    expect(
+      screen.getByRole("button", { name: "Remove summarise" }),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking an MCP server option adds it as a chip (#5246)", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        mcpCatalog={[
+          { name: "filesystem", description: "Local filesystem MCP" },
+          { name: "github", description: "GitHub MCP" },
+        ]}
+      />,
+    );
+
+    // The MCP field should render a combobox, not a free-text TagInput.
+    const mcpInput = screen.getByPlaceholderText("Search MCP servers…");
+    await user.click(mcpInput);
+
+    const option = await screen.findByText("github");
+    await user.click(option);
+
+    expect(
+      screen.getByRole("button", { name: "Remove github" }),
+    ).toBeInTheDocument();
+  });
+
+  it("when no MCP catalog is supplied, falls back to a tag input (no crash)", async () => {
+    render(<Harness />);
+    // The mcp_servers Field always exists; without a catalog the TagInput is used
+    // — verified by the absence of the cmdk search placeholder.
+    expect(screen.queryByPlaceholderText("Search MCP servers…")).not.toBeInTheDocument();
+  });
+
+  it("tool dropdown options are within a listbox region after focus", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        toolCatalog={[
+          { name: "read_file" },
+          { name: "write_file" },
+        ]}
+      />,
+    );
+    const toolsInput = screen.getByPlaceholderText("Search tools…");
+    await user.click(toolsInput);
+
+    const list = await screen.findByRole("listbox");
+    expect(within(list).getByText("read_file")).toBeInTheDocument();
+    expect(within(list).getByText("write_file")).toBeInTheDocument();
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/AgentManifestForm.tsx
+++ b/crates/librefang-api/dashboard/src/components/AgentManifestForm.tsx
@@ -39,6 +39,14 @@ interface AgentManifestFormProps {
    * affordance for the "Tool ID Allowlist" capability field.
    */
   toolCatalog?: ManifestCatalogEntry[];
+  /**
+   * Configured MCP servers catalog from `GET /api/mcp/servers`. When
+   * present, the "MCP Servers" field renders a multi-select dropdown
+   * seeded with these names (#5246); when absent the field falls back
+   * to the plain tag input so callers without a catalog still work and
+   * users can reference servers the dashboard doesn't know about yet.
+   */
+  mcpCatalog?: ManifestCatalogEntry[];
 }
 
 export function AgentManifestForm({
@@ -50,6 +58,7 @@ export function AgentManifestForm({
   extras,
   skillCatalog,
   toolCatalog,
+  mcpCatalog,
 }: AgentManifestFormProps) {
   const { t } = useTranslation();
 
@@ -85,6 +94,10 @@ export function AgentManifestForm({
   const toolFinder = useMemo(
     () => mergeCatalog(toolCatalog, value.capabilities.tools),
     [toolCatalog, value.capabilities.tools],
+  );
+  const mcpFinder = useMemo(
+    () => mergeCatalog(mcpCatalog, value.mcp_servers),
+    [mcpCatalog, value.mcp_servers],
   );
 
   const jsonSchemaFormat =
@@ -454,12 +467,29 @@ export function AgentManifestForm({
             />
           )}
         </Field>
-        <Field label={t("agents.form.mcp_servers")}>
-          <TagInput
-            value={value.mcp_servers}
-            onChange={(next) => update({ mcp_servers: next })}
-            placeholder={t("agents.form.mcp_servers_placeholder")}
-          />
+        <Field label={t("agents.form.mcp_servers")} hint={t("agents.form.mcp_servers_hint")}>
+          {mcpFinder ? (
+            <MultiSelectCmdk
+              options={mcpFinder.options}
+              optionMeta={mcpFinder.meta}
+              value={value.mcp_servers}
+              onChange={(next) => {
+                const nextValue =
+                  typeof next === "function" ? next(value.mcp_servers) : next;
+                update({ mcp_servers: nextValue });
+              }}
+              placeholder={t("agents.form.mcp_servers_search_placeholder", {
+                defaultValue: "Search MCP servers…",
+              })}
+              allowFreeText
+            />
+          ) : (
+            <TagInput
+              value={value.mcp_servers}
+              onChange={(next) => update({ mcp_servers: next })}
+              placeholder={t("agents.form.mcp_servers_placeholder")}
+            />
+          )}
         </Field>
       </Section>
 
@@ -1109,11 +1139,20 @@ function Field({
   invalid?: boolean;
   children: React.ReactNode;
 }) {
-  // Wrap children inside the <label> rather than relying on htmlFor —
-  // implicit association works without each child needing an id, and
-  // clicking the label text focuses the input as users expect.
+  // Use a <div> wrapper rather than a <label> (#5246). A <label>
+  // forwards every click within its bounds to its first labelable form
+  // control, which silently steals clicks on composite widgets like
+  // MultiSelectCmdk (cmdk dropdown options): the click that lights up
+  // an item was being redirected to the search input, so picking a
+  // skill / tool from the catalog never reached the option's
+  // onSelect handler and the chip was never added. Switching to <div>
+  // makes each interactive child (input, button, option) receive its
+  // own click as the user intends. The trade-off is that the label
+  // text no longer focuses the input on click — which is a non-issue
+  // here because every field already gets focus via direct click on
+  // its visible control.
   return (
-    <label className="block">
+    <div className="block">
       {label && (
         <span
           className={`text-[10px] font-bold uppercase block ${
@@ -1126,7 +1165,7 @@ function Field({
       )}
       <span className={label ? "mt-1 block" : "block"}>{children}</span>
       {hint && <span className="mt-1 text-[10px] text-text-dim/70 block">{hint}</span>}
-    </label>
+    </div>
   );
 }
 

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -378,6 +378,8 @@
       "skills_search_placeholder": "Search installed skills…",
       "mcp_servers": "MCP Servers",
       "mcp_servers_placeholder": "Empty = all connected servers",
+      "mcp_servers_hint": "Empty = all configured MCP servers available.",
+      "mcp_servers_search_placeholder": "Search MCP servers…",
       "live_toml": "Live TOML Preview",
       "preview_toml": "TOML",
       "preview_markdown": "Markdown",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -378,6 +378,8 @@
       "skills_search_placeholder": "搜索已安装的技能…",
       "mcp_servers": "MCP 服务器",
       "mcp_servers_placeholder": "留空=可用全部已连接服务器",
+      "mcp_servers_hint": "留空=可使用全部已配置 MCP 服务器。",
+      "mcp_servers_search_placeholder": "搜索 MCP 服务器…",
       "live_toml": "TOML 实时预览",
       "preview_toml": "TOML",
       "preview_markdown": "Markdown",

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -39,6 +39,7 @@ import { useAgentTriggers } from "../lib/queries/schedules";
 import { useProviders } from "../lib/queries/providers";
 import { useModels } from "../lib/queries/models";
 import { useSkills } from "../lib/queries/skills";
+import { useMcpServers } from "../lib/queries/mcp";
 import { AgentManifestForm } from "../components/AgentManifestForm";
 import { AgentSkillItem } from "../components/AgentSkillItem";
 import {
@@ -599,6 +600,28 @@ export function AgentsPage() {
           }))
         : undefined,
     [toolsListQuery.data],
+  );
+  // Configured MCP servers catalog for the create-dialog finder (#5246).
+  // The MCP servers field previously rendered as a free-text TagInput,
+  // forcing users to remember server names exactly. Gate-fetch the
+  // catalog only while the form-mode create dialog is open so we don't
+  // hold an open `/api/mcp/servers` poll when the page first loads.
+  // `refetchInterval: false` overrides the 30s default poll baked into
+  // `useMcpServers` — the catalog only needs to be fresh on dialog open,
+  // and reopening the dialog triggers a fresh fetch via the `enabled`
+  // toggle anyway.
+  const mcpServersQuery = useMcpServers({
+    enabled: showCreate && createMode === "form",
+    refetchInterval: false,
+  });
+  const mcpCatalogForForm = useMemo<
+    { name: string; description?: string }[] | undefined
+  >(
+    () =>
+      mcpServersQuery.data
+        ? mcpServersQuery.data.configured.map((s) => ({ name: s.name }))
+        : undefined,
+    [mcpServersQuery.data],
   );
   const serializedFormToml = useMemo(
     () => serializeManifestForm(formState, formExtras),
@@ -2342,6 +2365,7 @@ export function AgentsPage() {
                 extras={formExtras}
                 skillCatalog={skillCatalogForForm}
                 toolCatalog={toolCatalogForForm}
+                mcpCatalog={mcpCatalogForForm}
               />
               <div className="space-y-2">
                 <div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
## Summary

The create-agent wizard's "Form" mode silently broke three pickers; this PR fixes all three:

- **Tools selection** — clicking an option in the cmdk dropdown did nothing. Root cause: `Field` (the wrapper used for every form row in `AgentManifestForm`) wrapped its children in a `<label>`. A `<label>` element forwards every click within its bounds to its first labelable form control, which silently stole clicks on cmdk dropdown options — picks never reached the option's `onSelect` handler, so the chip was never added. Switched `Field` to a `<div>` wrapper; each interactive child (input, button, option) now receives its own click.
- **Skills selection** — same root cause (same `<label>` wrapper around the same `MultiSelectCmdk` widget), fixed by the same change.
- **MCP Servers** — previously a free-text `TagInput`. Now renders a `MultiSelectCmdk` seeded from `GET /api/mcp/servers` when a catalog is available (and falls back to `TagInput` when not, preserving the ability to reference servers the dashboard doesn't know about yet). `allowFreeText` preserved for the same reason.

## Files changed

- `crates/librefang-api/dashboard/src/components/AgentManifestForm.tsx` — `Field` wrapper switched from `<label>` to `<div>` (fix for tools/skills); new `mcpCatalog` prop + MCP `MultiSelectCmdk` branch.
- `crates/librefang-api/dashboard/src/pages/AgentsPage.tsx` — wire `useMcpServers` gated on the open form-mode dialog (`refetchInterval: false`, no continuous poll), pass `mcpCatalog` to `AgentManifestForm`.
- `crates/librefang-api/dashboard/src/locales/en.json`, `zh.json` — two new keys (`agents.form.mcp_servers_hint`, `agents.form.mcp_servers_search_placeholder`); zh kept in parity.
- `crates/librefang-api/dashboard/src/components/AgentManifestForm.test.tsx` (new) — regression coverage: clicking tools / skills / MCP options each adds the chip; no-catalog MCP falls back to `TagInput`.

## Closes

Closes #5246

## Test plan

- [x] `pnpm test --run src/components/AgentManifestForm.test.tsx` — 5/5 pass
- [x] `pnpm test --run src/lib/agentManifest.test.ts src/lib/agentManifestMarkdown.test.ts src/components/AgentManifestForm.test.tsx` — 39/39 pass
- [x] `pnpm test --run src/components/ui/MultiSelectCmdk.test.tsx` — 11/11 pass (no regressions)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [x] `pnpm test:i18n-parity` — clean
- [x] `cargo check --workspace --lib` — clean (no Rust changed; safety check)
- [ ] Manual: open the new-agent wizard with at least one configured MCP server, pick a tool, a skill, and an MCP server; submit; confirm all three land in the generated TOML preview and in the created agent's manifest.

## Out-of-scope

None — the three reported bugs all live in the same `AgentManifestForm` component and ship as one PR per the "one PR ↔ one issue" rule.