### PR TITLE
chore(ci): drop per-merge auto-update trigger from auto-update-branches

### DIFF
--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -2,9 +2,7 @@ name: Auto Update PR Branches
 
 on:
   schedule:
-    - cron: '0 */6 * * *'  # every 6 hours — safety net for stragglers
-  push:
-    branches: [main]       # re-evaluate open PRs immediately after every main update
+    - cron: '0 */6 * * *'  # every 6 hours — primary trigger; catches failing PRs
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Removes the `push: branches: [main]` trigger from `.github/workflows/auto-update-branches.yml` so the workflow no longer fires on every merge to main. The 6h `schedule:` cron and `workflow_dispatch` remain.

## Why

Per-merge fan-out compounds CI cost. With N currently-failing PRs and M merges in a time window, the previous trigger fired the auto-update job M times and each run rebased every failing PR (= N × M auto-rebases, each followed by a full CI run on the rebased commit). The 6h cron bounds this to 4 sweeps/day regardless of merge volume.

The existing in-script filter ("only update PRs whose CI is failing") already limited the per-merge damage, but the workflow itself still woke up and scanned all open PRs on every merge — plus any one failing PR cost a fresh CI run via the `updateBranch` push.

## Trade-off

A PR whose CI is failing will not pick up newer main commits until the next 6h cron tick (max 6h latency). Mitigations:

1. PR author can manually click "Update branch" on the GitHub UI any time.
2. Anyone with write access can `workflow_dispatch` the workflow ad-hoc.
3. The pre-merge "Update branch" / merge-queue check still validates against fresh main right before the actual merge.

A failing PR is already failing — auto-rebasing to fresh main doesn't fix the underlying CI failure faster.

## Test plan

- [ ] Merge a PR; verify "Auto Update PR Branches" does NOT fire on the resulting push to main (check Actions tab)
- [ ] Wait for the next 6h tick (or trigger via workflow_dispatch); verify it still runs and updates any failing PR
- [ ] Author of a failing PR can still manually click "Update branch"