### PR TITLE
style: cargo fmt — fix rustfmt drift on main after channel-removal merges

### DIFF
--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -51,12 +51,12 @@ pub fn router() -> axum::Router<std::sync::Arc<super::AppState>> {
         )
 }
 
+use super::sidecar_describe::{describe_sidecar, SidecarSchema};
 use super::skills::{
     append_channel_instance, remove_channel_config, remove_channel_instance, remove_secret_env,
     update_channel_instance, upsert_channel_config, validate_env_var, write_secret_env,
     CHANNEL_AOT_CONFLICT_PREFIX,
 };
-use super::sidecar_describe::{describe_sidecar, SidecarSchema};
 use super::AppState;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
@@ -832,8 +832,8 @@ fn inject_callback_url(
 /// or None if the channel does not use webhook routes.
 fn webhook_route_suffix(channel_name: &str) -> Option<&'static str> {
     match channel_name {
-        "feishu" | "teams" | "dingtalk" | "line" | "google_chat"
-        | "flock" | "pumble" | "threema" | "webhook" | "wecom" => Some("/webhook"),
+        "feishu" | "teams" | "dingtalk" | "line" | "google_chat" | "flock" | "pumble"
+        | "threema" | "webhook" | "wecom" => Some("/webhook"),
         "voice" => Some("/ws"),
         _ => None,
     }
@@ -1338,28 +1338,27 @@ pub async fn configure_sidecar_channel(
         // helper directly so quote/whitespace handling stays consistent
         // with how the sidecar actually inherits env vars at spawn time
         // (codex review fix #9).
-        let secrets_env_keys: std::collections::HashSet<String> = std::fs::read_to_string(
-            &secrets_path,
-        )
-        .ok()
-        .map(|s| {
-            s.lines()
-                .filter_map(|line| {
-                    let line = line.trim();
-                    if line.is_empty() || line.starts_with('#') {
-                        return None;
-                    }
-                    let eq = line.find('=')?;
-                    let k = line[..eq].trim();
-                    if k.is_empty() {
-                        None
-                    } else {
-                        Some(k.to_string())
-                    }
+        let secrets_env_keys: std::collections::HashSet<String> =
+            std::fs::read_to_string(&secrets_path)
+                .ok()
+                .map(|s| {
+                    s.lines()
+                        .filter_map(|line| {
+                            let line = line.trim();
+                            if line.is_empty() || line.starts_with('#') {
+                                return None;
+                            }
+                            let eq = line.find('=')?;
+                            let k = line[..eq].trim();
+                            if k.is_empty() {
+                                None
+                            } else {
+                                Some(k.to_string())
+                            }
+                        })
+                        .collect()
                 })
-                .collect()
-        })
-        .unwrap_or_default();
+                .unwrap_or_default();
         let mut shadowed: Vec<String> = schema
             .fields
             .iter()
@@ -1385,12 +1384,10 @@ pub async fn configure_sidecar_channel(
                 continue;
             }
             if f.field_type == "secret" {
-                super::secrets_env::upsert_secret(&secrets_path, &f.key, trimmed).map_err(
-                    |e| {
-                        ApiErrorResponse::internal(format!("failed to write secret: {e}"))
-                            .into_json_tuple()
-                    },
-                )?;
+                super::secrets_env::upsert_secret(&secrets_path, &f.key, trimmed).map_err(|e| {
+                    ApiErrorResponse::internal(format!("failed to write secret: {e}"))
+                        .into_json_tuple()
+                })?;
             } else {
                 nonsecret_env.insert(f.key.clone(), trimmed.to_string());
             }

--- a/crates/librefang-api/src/routes/secrets_env.rs
+++ b/crates/librefang-api/src/routes/secrets_env.rs
@@ -78,10 +78,7 @@ pub fn upsert_secret(path: &Path, key: &str, value: &str) -> Result<(), String> 
     // tests, or two HTTP handlers racing on the same secrets file).
     static SEQ: AtomicU64 = AtomicU64::new(0);
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
-    let tmp = parent.join(format!(
-        ".secrets.env.tmp.{}.{seq}",
-        std::process::id()
-    ));
+    let tmp = parent.join(format!(".secrets.env.tmp.{}.{seq}", std::process::id()));
     {
         let mut f = fs::OpenOptions::new()
             .write(true)

--- a/crates/librefang-api/src/routes/sidecar_describe.rs
+++ b/crates/librefang-api/src/routes/sidecar_describe.rs
@@ -35,10 +35,7 @@ pub struct SidecarSchema {
 /// Timeout is 5s — describe should be sub-second; if it hangs (the
 /// adapter's __init__ blocks on a network call before reading argv,
 /// for example) we'd rather skip than block daemon boot.
-pub async fn describe_sidecar(
-    command: &str,
-    args: &[String],
-) -> Result<SidecarSchema, String> {
+pub async fn describe_sidecar(command: &str, args: &[String]) -> Result<SidecarSchema, String> {
     let mut full_args: Vec<String> = args.to_vec();
     full_args.push("--describe".into());
 

--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -1221,15 +1221,17 @@ async fn channels_list_discovery_rows_carry_form_fields_when_schema_cached() {
             name: "telegram".into(),
             display_name: "Telegram".into(),
             description: "Telegram Bot API adapter".into(),
-            fields: vec![librefang_api::routes::sidecar_describe::SidecarSchemaField {
-                key: "TELEGRAM_BOT_TOKEN".into(),
-                label: "Bot Token".into(),
-                field_type: "secret".into(),
-                required: true,
-                placeholder: "123:ABC".into(),
-                advanced: false,
-                options: None,
-            }],
+            fields: vec![
+                librefang_api::routes::sidecar_describe::SidecarSchemaField {
+                    key: "TELEGRAM_BOT_TOKEN".into(),
+                    label: "Bot Token".into(),
+                    field_type: "secret".into(),
+                    required: true,
+                    placeholder: "123:ABC".into(),
+                    advanced: false,
+                    options: None,
+                },
+            ],
         },
     )]);
 

--- a/crates/librefang-api/tests/sidecar_describe_test.rs
+++ b/crates/librefang-api/tests/sidecar_describe_test.rs
@@ -28,10 +28,7 @@ async fn describe_telegram_returns_schema_or_skips_when_sdk_missing() {
 
 #[tokio::test]
 async fn describe_failing_command_returns_err() {
-    let result = describe_sidecar(
-        "python3",
-        &["-c".into(), "import sys; sys.exit(2)".into()],
-    )
-    .await;
+    let result =
+        describe_sidecar("python3", &["-c".into(), "import sys; sys.exit(2)".into()]).await;
     assert!(result.is_err());
 }

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -464,10 +464,7 @@ fn strip_matching_outer_quotes(s: &str) -> &str {
 /// `Command::env`, with both layers merged. The parent env is NOT
 /// returned here — the spawned child already inherits it via
 /// `Command::env_clear` not being called.
-fn build_spawn_env(
-    home_dir: &Path,
-    ctx_env: &HashMap<String, String>,
-) -> Vec<(String, String)> {
+fn build_spawn_env(home_dir: &Path, ctx_env: &HashMap<String, String>) -> Vec<(String, String)> {
     let mut merged: HashMap<String, String> = HashMap::new();
     let secrets_path = home_dir.join("secrets.env");
     for (k, v) in parse_secrets_env(&secrets_path) {
@@ -921,10 +918,7 @@ impl SidecarAdapter {
     /// matches the path the API layer writes to. Recomputing from
     /// `LIBREFANG_HOME`/`~/.librefang` here would silently diverge when
     /// the operator overrides `KernelConfig.home_dir`.
-    pub fn new(
-        config: &librefang_types::config::SidecarChannelConfig,
-        home_dir: PathBuf,
-    ) -> Self {
+    pub fn new(config: &librefang_types::config::SidecarChannelConfig, home_dir: PathBuf) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let channel_type = config
             .channel_type
@@ -2337,7 +2331,8 @@ mod tests {
         let merged = build_spawn_env(tmp.path(), &ctx_env);
         let got: HashMap<_, _> = merged.into_iter().collect();
         assert_eq!(
-            got.get("LIBREFANG_TEST_BSE_SECRETS_ONLY").map(|s| s.as_str()),
+            got.get("LIBREFANG_TEST_BSE_SECRETS_ONLY")
+                .map(|s| s.as_str()),
             Some("from_file"),
         );
     }

--- a/crates/librefang-types/tests/config_default_roundtrip.rs
+++ b/crates/librefang-types/tests/config_default_roundtrip.rs
@@ -35,12 +35,12 @@ use librefang_types::config::{
     BrowserConfig, BudgetConfig, CanvasConfig, ChannelsConfig, ChunkConfig, CompactionTomlConfig,
     ContextEngineTomlConfig, DockerSandboxConfig, ExtensionsConfig, ExternalAuthConfig,
     HealthCheckConfig, HeartbeatTomlConfig, InboxConfig, JinaSearchConfig, KernelConfig,
-    MemoryConfig, MemoryDecayConfig, NetworkConfig, PairingConfig,
-    ParallelToolsConfig, PerplexitySearchConfig, PrivacyConfig, PromptIntelligenceConfig,
-    QueueConcurrencyConfig, QueueConfig, RateLimitConfig, RegistryConfig, ReloadConfig,
-    SanitizeConfig, SessionConfig, SkillsConfig, TaskBoardConfig, TavilySearchConfig,
-    TelemetryConfig, TerminalConfig, ThinkingConfig, TriggersConfig, TtsConfig, VaultConfig,
-    VoiceConfig, WebConfig, WebFetchConfig, WebhookTriggerConfig,
+    MemoryConfig, MemoryDecayConfig, NetworkConfig, PairingConfig, ParallelToolsConfig,
+    PerplexitySearchConfig, PrivacyConfig, PromptIntelligenceConfig, QueueConcurrencyConfig,
+    QueueConfig, RateLimitConfig, RegistryConfig, ReloadConfig, SanitizeConfig, SessionConfig,
+    SkillsConfig, TaskBoardConfig, TavilySearchConfig, TelemetryConfig, TerminalConfig,
+    ThinkingConfig, TriggersConfig, TtsConfig, VaultConfig, VoiceConfig, WebConfig, WebFetchConfig,
+    WebhookTriggerConfig,
 };
 use serde::Serialize;
 
@@ -357,7 +357,6 @@ fn terminal_config_default_roundtrips_through_toml() {
 fn voice_config_default_roundtrips_through_toml() {
     assert_default_roundtrip::<VoiceConfig>("VoiceConfig");
 }
-
 
 // Issue #3462 — extend the round-trip property to nested config types
 // referenced from agent manifests and channel wiring. These three are the


### PR DESCRIPTION
## Summary

\`Quality / Check formatting\` CI lane is broken on \`main\` after #5265 (6-channel removal) and the user's parallel 12-channel removal landed. Both PRs' deletions shortened match arms / function signatures enough that rustfmt now wants the re-flowed form, but neither PR's followup fmt commit landed before merge.

This is the **exact rustfmt diff from the failed Quality job**, applied verbatim:

| File | What rustfmt wants |
|---|---|
| \`librefang-api/src/routes/channels.rs\` | sort imports; collapse \`webhook_route_suffix\` arms; re-indent \`secrets_env_keys\` read; collapse \`upsert_secret().map_err()\` |
| \`librefang-api/src/routes/secrets_env.rs\` | \`parent.join(format!(...))\` on one line |
| \`librefang-api/src/routes/sidecar_describe.rs\` | \`describe_sidecar(cmd, args)\` signature on one line |
| \`librefang-api/tests/channels_routes_test.rs\` | \`vec![ Struct {...} ]\` → multi-line \`vec![\\n  Struct {...},\\n]\` |
| \`librefang-api/tests/sidecar_describe_test.rs\` | collapse \`describe_sidecar(...).await\` |
| \`librefang-channels/src/sidecar.rs\` | collapse \`build_spawn_env\` / \`SidecarTask::new\` sigs; expand assert chain |
| \`librefang-types/tests/config_default_roundtrip.rs\` | re-flow import list; drop double blank line |

## Test plan

- [ ] CI \`Quality / Check formatting\` goes from ❌ → ✅
- [ ] No other check regresses (pure rustfmt — no logic changes)

No \`cargo fmt\` was run locally — the host has no native rust toolchain, but the diffs were copied byte-for-byte from the CI job log. The next CI run on this branch is the authoritative confirmation.