### PR TITLE
fix(channels): add default_agent to SidecarChannelConfig — restore inbound routing pin (closes #5294)

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -3282,7 +3282,13 @@ pub async fn start_channel_bridge_with_config(
             sidecar_config,
             kernel.home_dir().to_path_buf(),
         ));
-        adapters.push((adapter, None, None));
+        // #5294 — propagate `default_agent` from the sidecar config so the
+        // router-population loop below seeds `AgentRouter.channel_defaults`
+        // for this channel. Without this, sidecar adapters fall through to
+        // the non-deterministic "first available agent" branch in
+        // `resolve_or_fallback`, silently routing traffic to whichever agent
+        // happens to be first in the registry iteration order.
+        adapters.push((adapter, sidecar_config.default_agent.clone(), None));
     }
 
     if adapters.is_empty() {

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -2057,6 +2057,30 @@ mod tests {
         .expect("SidecarChannelConfig from minimal json")
     }
 
+    /// #5294 — `default_agent` is `None` when absent and round-trips
+    /// when explicitly set. The field exists so the router-population
+    /// loop in `channel_bridge.rs` can seed `AgentRouter.channel_defaults`
+    /// for sidecar adapters; missing it caused inbound traffic on sidecar
+    /// channels to fall through to the non-deterministic
+    /// "first available agent" branch.
+    #[test]
+    fn sidecar_default_agent_roundtrip_5294() {
+        // Absent → None (no-op for deployments that don't need routing pin).
+        let minimal = cfg("telegram", "python3", vec![]);
+        assert!(minimal.default_agent.is_none());
+
+        // Explicit value round-trips so channel_bridge.rs can seed the router.
+        let c: librefang_types::config::SidecarChannelConfig =
+            serde_json::from_value(serde_json::json!({
+                "name": "telegram",
+                "command": "python3",
+                "args": ["-m", "librefang.sidecar.adapters.telegram"],
+                "default_agent": "fandangorodelo",
+            }))
+            .unwrap();
+        assert_eq!(c.default_agent.as_deref(), Some("fandangorodelo"));
+    }
+
     #[test]
     fn test_supcfg_defaults_and_overflow_parsing() {
         // Minimal config -> every supervision field at its serde default.

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2166,6 +2166,18 @@ pub struct SidecarChannelConfig {
     /// Channel type identifier (defaults to Custom(name)).
     #[serde(default)]
     pub channel_type: Option<String>,
+    /// Default agent name for incoming messages on this sidecar channel.
+    ///
+    /// When set, seeds the `AgentRouter.channel_defaults` map at boot so
+    /// inbound messages with no explicit binding route to this agent. This
+    /// mirrors the `default_agent` field that lived on the per-channel
+    /// in-process configs (`TelegramConfig`, `DiscordConfig`, …) before the
+    /// sidecar migration (#5241 / #5294). Without this, the resolver falls
+    /// through to the non-deterministic "first available agent" branch in
+    /// `resolve_or_fallback`, which silently routes traffic to a different
+    /// agent whenever a new agent is spawned.
+    #[serde(default)]
+    pub default_agent: Option<String>,
     /// Restart the subprocess automatically when it exits unexpectedly.
     #[serde(default = "default_sidecar_restart")]
     pub restart: bool,


### PR DESCRIPTION
Closes #5294.

## Problem

Sidecar adapter migration (#5241) dropped the per-channel `default_agent` field that in-process configs (`TelegramConfig`, `DiscordConfig`, …) used to seed `AgentRouter.channel_defaults` at boot. The router-population loop in `channel_bridge.rs` (around line 3295) pushes sidecar adapters into the `adapters` vec with `None` for the default-agent slot, so the per-channel `router.set_channel_default_with_name` call never fires for sidecar channels.

Result: inbound messages on a sidecar channel with no explicit binding fall through to the **non-deterministic 'first available agent'** branch in `resolve_or_fallback`. Spawning a new agent (without restricting its `channels` allowlist) silently redirects inbound traffic to it.

## Reproduction

1. Configure Telegram via `[[sidecar_channels]]`. Existing agent (e.g. `fandangorodelo`) with `channels = ["telegram"]` in its manifest, receiving Telegram traffic correctly.
2. Create a second agent (any purpose, e.g. `Profesor`) without restricting its `channels` list (defaults to `channels = []`).
3. Send a Telegram message → ends up routed to `Profesor` instead of `fandangorodelo`, because the router has no `channel_defaults["telegram"]` and falls through to first-available.

## Fix

Add `default_agent: Option<String>` to `SidecarChannelConfig` (mirrors the equivalent field on in-process channel configs) and propagate it through the adapter-push so the existing population loop seeds the router.

```toml
[[sidecar_channels]]
name = "telegram"
command = "python3"
args = ["-m", "librefang.sidecar.adapters.telegram"]
channel_type = "telegram"
default_agent = "fandangorodelo"   # NEW
```

No behavioural change when the field is absent — deployments that currently rely on the "first available" fallback continue working.

## Test plan

- [x] `cargo check -p librefang-types -p librefang-channels` — clean
- [x] `cargo clippy -p librefang-types -p librefang-channels --all-targets -- -D warnings` — clean
- [x] `cargo test -p librefang-channels --lib sidecar_default_agent_roundtrip_5294` — passes (new test covering absent + explicit-value round-trip).
- [x] Manual repro on live deploy (rodela-ai fork): without fix, traffic routed to wrong agent; with fix + `default_agent = "fandangorodelo"` in config, traffic routes correctly even when other agents exist.

## Notes

This only addresses the missing-router-default half of #5294. The two related concerns (`channels = []` accept-all semantics, and the 'first available' fallback being a silent footgun) are separate and need their own discussion — see the issue body. Happy to follow up on either if maintainers want to flip those defaults too.