### PR TITLE
fix(channels): emit poll bursts in chronological order across sidecar adapters

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/bluesky.py
+++ b/sdk/python/librefang/sidecar/adapters/bluesky.py
@@ -436,7 +436,13 @@ class BlueskyAdapter(SidecarAdapter):
         if not isinstance(notifs, list):
             return last_seen_at
         new_seen = last_seen_at
-        for notif in notifs:
+        # `listNotifications` returns notifications newest-first. Emit
+        # them oldest-first so a burst caught in one poll reaches the
+        # agent in conversation order; the high-water mark below is the
+        # max `indexedAt` and so is order-independent. The Rust adapter
+        # iterated the raw newest-first list and delivered such bursts
+        # backwards.
+        for notif in reversed(notifs):
             if not isinstance(notif, dict):
                 continue
             indexed = notif.get("indexedAt")

--- a/sdk/python/librefang/sidecar/adapters/mastodon.py
+++ b/sdk/python/librefang/sidecar/adapters/mastodon.py
@@ -330,7 +330,12 @@ class MastodonAdapter(SidecarAdapter):
         newest = None
         if notifs and isinstance(notifs[0], dict):
             newest = str(notifs[0].get("id") or "") or None
-        for notif in notifs:
+        # Emit oldest-first so a burst of mentions caught in one poll
+        # reaches the agent in conversation order. The list is
+        # newest-first off the wire (and the high-water mark above is
+        # taken from notifs[0] accordingly); the Rust adapter iterated it
+        # as-is and delivered multi-mention bursts backwards.
+        for notif in reversed(notifs):
             if not isinstance(notif, dict):
                 continue
             ev = self._parse_notification(notif)

--- a/sdk/python/librefang/sidecar/adapters/reddit.py
+++ b/sdk/python/librefang/sidecar/adapters/reddit.py
@@ -630,7 +630,12 @@ class RedditAdapter(SidecarAdapter):
             ) else None
             if not isinstance(children, list):
                 continue
-            for child in children:
+            # `?sort=new` returns comments newest-first. Emit them
+            # oldest-first so a burst caught in one poll reaches the
+            # agent in conversation order; the Rust adapter iterated the
+            # raw newest-first listing and delivered such bursts
+            # backwards.
+            for child in reversed(children):
                 if not isinstance(child, dict):
                     continue
                 comment_id = str(

--- a/sdk/python/librefang/sidecar/adapters/rocketchat.py
+++ b/sdk/python/librefang/sidecar/adapters/rocketchat.py
@@ -46,7 +46,11 @@ configured interval (default 2 s, matching the Rust adapter, with a
 floor of 1 s). On startup, ``GET /api/v1/me`` validates the token and
 discovers the bot's own username (also kept as a fallback self-skip
 key). Empty ``ROCKETCHAT_CHANNELS`` discovers joined channels via
-``GET /api/v1/channels.list.joined``. Slash-command bodies (``/cmd
+``GET /api/v1/channels.list.joined``. ``channels.history`` returns
+messages newest-first, so each poll batch is reversed to oldest-first
+before emitting — a burst caught in one poll reaches the agent in
+conversation order (the Rust adapter delivered such bursts backwards).
+Slash-command bodies (``/cmd
 args``) become ``Content.command``; everything else is plain
 ``Content.text``. Metadata carries ``sender_id``, ``sender_username``,
 ``room_id``, ``ts``, ``tmid`` (when inbound was inside a thread), and
@@ -492,9 +496,15 @@ class RocketChatAdapter(SidecarAdapter):
             messages = body.get("messages")
             if not isinstance(messages, list):
                 continue
-
+            # `channels.history` returns messages newest-first
+            # (descending by `ts`). Emit them oldest-first so a burst of
+            # messages caught in one poll reaches the agent in
+            # conversation order. The Rust adapter iterated the raw
+            # newest-first array and delivered a multi-message poll
+            # backwards; this matches the chronological order
+            # nextcloud's Talk feed already yields.
             newest_ts = oldest
-            for msg in messages:
+            for msg in reversed(messages):
                 if not isinstance(msg, dict):
                     continue
                 msg_id = str(msg.get("_id") or "")

--- a/sdk/python/tests/test_bluesky_adapter.py
+++ b/sdk/python/tests/test_bluesky_adapter.py
@@ -641,3 +641,39 @@ def test_poll_once_seenAt_query_param_when_set(monkeypatch):
     url = fake.calls[0]["url"]
     assert "seenAt=2026-05-19T09" in url
     assert "limit=25" in url
+
+
+def test_poll_once_emits_in_chronological_order(monkeypatch):
+    """Regression: `listNotifications` returns notifications
+    newest-first. A burst caught in one poll must reach the agent
+    oldest -> newest, not reversed (the Rust adapter iterated the raw
+    newest-first list). The high-water mark is the max `indexedAt` and
+    so is independent of emit order."""
+    a = _adapter()
+    a.own_did = "did:plc:bot"
+    a._access_jwt = "access-1"
+    a._refresh_jwt = "refresh-1"
+    a._session_did = "did:plc:bot"
+    a._session_created_at = ba.time.monotonic()
+
+    def _n(uri, text, indexed):
+        n = _notif(text=text, uri=uri, cid="bafy" + uri[-1])
+        n["indexedAt"] = indexed
+        return n
+
+    fake = _FakeUrlopen([
+        (200, {"notifications": [  # API order: newest-first
+            _n("at://post/C", "@bot third", "2026-05-19T10:00:30.000Z"),
+            _n("at://post/B", "@bot second", "2026-05-19T10:00:20.000Z"),
+            _n("at://post/A", "@bot first", "2026-05-19T10:00:10.000Z"),
+        ]}),
+        (200, {}),  # updateSeen
+    ])
+    monkeypatch.setattr(ba.urllib.request, "urlopen", fake)
+    emitted: list[dict] = []
+    new_seen = a._poll_once(emitted.append, last_seen_at=None)
+    assert [e["params"]["message_id"] for e in emitted] == [
+        "at://post/A", "at://post/B", "at://post/C",
+    ]
+    # High-water mark = max indexedAt, order-independent.
+    assert new_seen == "2026-05-19T10:00:30.000Z"

--- a/sdk/python/tests/test_mastodon_adapter.py
+++ b/sdk/python/tests/test_mastodon_adapter.py
@@ -453,3 +453,48 @@ def test_self_mention_skipped_only_after_verify():
     # is silenced.
     a.own_account_id = "own-1"
     assert a._parse_notification(notif) is None
+
+
+# ---- _poll_once: chronological emit order -------------------------
+
+
+def _mention(nid, text, sender="acc-x"):
+    return {
+        "id": nid,
+        "type": "mention",
+        "account": {
+            "id": sender, "username": "u",
+            "display_name": "U", "acct": "u@example.com",
+        },
+        "status": {
+            "id": f"st-{nid}", "content": f"<p>{text}</p>",
+            "visibility": "public", "in_reply_to_id": None,
+        },
+    }
+
+
+def test_poll_once_emits_in_chronological_order(monkeypatch):
+    """Regression: `/api/v1/notifications` returns newest-first. A burst
+    of mentions caught in one poll must reach the agent oldest -> newest,
+    not reversed (the Rust adapter iterated the raw newest-first list).
+    The high-water mark stays the newest id regardless of emit order."""
+    a = _adapter()
+    a.own_account_id = "own-123"
+    # API order: newest (n3) first, oldest (n1) last.
+    notifs = [
+        _mention("n3", "third"),
+        _mention("n2", "second"),
+        _mention("n1", "first"),
+    ]
+
+    def fake_urlopen(req, timeout=None):
+        return _FakeResp(200, json.dumps(notifs).encode("utf-8"))
+
+    monkeypatch.setattr(ma.urllib.request, "urlopen", fake_urlopen)
+    emitted = []
+    newest = a._poll_once(emitted.append, None)
+    assert [e["params"]["content"]["Text"] for e in emitted] == [
+        "first", "second", "third",
+    ]
+    # High-water mark = newest id (notifs[0]), order-independent.
+    assert newest == "n3"

--- a/sdk/python/tests/test_reddit_adapter.py
+++ b/sdk/python/tests/test_reddit_adapter.py
@@ -578,17 +578,21 @@ def test_poll_once_emits_parsed_comments(monkeypatch):
     a = _adapter()
     a.own_username = "test-user"
     a._cached_token = ("tok", ra.time.monotonic() + 600)
+    # `?sort=new` returns comments newest-first, so c2 (the newer one)
+    # leads and c1 trails — the way the real listing arrives. The
+    # adapter reverses to chronological before emitting.
     fake = _FakeUrlopen([
         (200, _children(
-            _comment(cid="c1", fullname="t1_c1", body="hi"),
-            _comment(kind="t3", cid="p1"),  # skipped: post
             _comment(cid="c2", fullname="t1_c2", body="/help me"),
+            _comment(kind="t3", cid="p1"),  # skipped: post
+            _comment(cid="c1", fullname="t1_c1", body="hi"),
         )),
     ])
     monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
     emitted = []
     a._poll_once(emitted.append)
     assert len(emitted) == 2
+    # Emitted oldest-first despite the newest-first API order.
     assert emitted[0]["params"]["message_id"] == "c1"
     assert emitted[0]["params"]["thread_id"] == "t1_c1"
     assert emitted[1]["params"]["content"] == {
@@ -598,6 +602,27 @@ def test_poll_once_emits_parsed_comments(monkeypatch):
     # under its id to avoid reparsing).
     assert "c1" in a._seen_comments_set
     assert "c2" in a._seen_comments_set
+
+
+def test_poll_once_emits_in_chronological_order(monkeypatch):
+    """Regression: `?sort=new` returns comments newest-first. A burst
+    caught in one poll must reach the agent oldest -> newest, not
+    reversed (the Rust adapter iterated the raw newest-first listing)."""
+    a = _adapter()
+    a.own_username = "test-user"
+    a._cached_token = ("tok", ra.time.monotonic() + 600)
+    # API order: newest (c3) first, oldest (c1) last.
+    fake = _FakeUrlopen([
+        (200, _children(
+            _comment(cid="c3", fullname="t1_c3", body="third"),
+            _comment(cid="c2", fullname="t1_c2", body="second"),
+            _comment(cid="c1", fullname="t1_c1", body="first"),
+        )),
+    ])
+    monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
+    emitted = []
+    a._poll_once(emitted.append)
+    assert [e["params"]["message_id"] for e in emitted] == ["c1", "c2", "c3"]
 
 
 def test_poll_once_dedupes_seen_comments(monkeypatch):

--- a/sdk/python/tests/test_rocketchat_adapter.py
+++ b/sdk/python/tests/test_rocketchat_adapter.py
@@ -437,18 +437,24 @@ def test_poll_once_emits_messages_and_advances_watermark(monkeypatch):
     a = _adapter()
     a.own_username = "librefang-bot"
     a._room_watermarks["R1"] = "2026-01-01T00:00:00.000Z"
+    # Rocket.Chat's `channels.history` returns messages NEWEST-FIRST, so
+    # the scripted payload has m2 (ts ...06) ahead of m1 (ts ...05) the
+    # way the real API would. The adapter must re-order to chronological
+    # before emitting.
     fake = _FakeUrlopen([
         (200, {"messages": [
-            _msg(mid="m1", ts="2026-01-01T00:00:05.000Z"),
             _msg(mid="m2", ts="2026-01-01T00:00:06.000Z",
                  text="/cmd args"),
+            _msg(mid="m1", ts="2026-01-01T00:00:05.000Z"),
         ]}),
     ])
     monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
     emitted = []
     a._poll_once(emitted.append, ["R1"])
     assert len(emitted) == 2
+    # Emitted oldest-first despite the newest-first API order.
     assert emitted[0]["params"]["message_id"] == "m1"
+    assert emitted[1]["params"]["message_id"] == "m2"
     assert emitted[1]["params"]["content"] == {
         "Command": {"name": "cmd", "args": ["args"]},
     }
@@ -457,6 +463,32 @@ def test_poll_once_emits_messages_and_advances_watermark(monkeypatch):
     # Both message ids tracked for dedupe.
     assert "m1" in a._seen_messages_set
     assert "m2" in a._seen_messages_set
+
+
+def test_poll_once_emits_in_chronological_order(monkeypatch):
+    """Regression: `channels.history` returns newest-first. A burst of
+    several messages caught in one poll must reach the agent oldest →
+    newest, not reversed. The Rust adapter (and the first cut of this
+    sidecar) iterated the raw newest-first array and delivered the burst
+    backwards."""
+    a = _adapter()
+    a.own_username = "librefang-bot"
+    a._room_watermarks["R1"] = "2026-01-01T00:00:00.000Z"
+    # API order: newest (m3) first, oldest (m1) last.
+    fake = _FakeUrlopen([
+        (200, {"messages": [
+            _msg(mid="m3", ts="2026-01-01T00:00:30.000Z", text="third"),
+            _msg(mid="m2", ts="2026-01-01T00:00:20.000Z", text="second"),
+            _msg(mid="m1", ts="2026-01-01T00:00:10.000Z", text="first"),
+        ]}),
+    ])
+    monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
+    emitted = []
+    a._poll_once(emitted.append, ["R1"])
+    assert [e["params"]["message_id"] for e in emitted] == ["m1", "m2", "m3"]
+    assert [e["params"]["content"]["Text"] for e in emitted] == [
+        "first", "second", "third",
+    ]
 
 
 def test_poll_once_dedupes_same_ts_repeats(monkeypatch):
@@ -485,7 +517,9 @@ def test_poll_once_dedupes_same_ts_repeats(monkeypatch):
     monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
     emitted = []
     a._poll_once(emitted.append, ["R1"])
-    assert [e["params"]["message_id"] for e in emitted] == ["m1", "m2"]
+    # Order is asserted by the chronological-order tests; here we only
+    # care that both same-ts ids are emitted exactly once.
+    assert sorted(e["params"]["message_id"] for e in emitted) == ["m1", "m2"]
     emitted.clear()
     a._poll_once(emitted.append, ["R1"])
     # Only the new m3 emits on the second poll.


### PR DESCRIPTION
## Summary

Surfaced while reviewing the Rocket.Chat sidecar migration (#5298): four
polling sidecar adapters delivered multi-message poll bursts to the agent
in **reverse chronological order**.

`rocketchat` (`channels.history`), `mastodon` (`/api/v1/notifications`),
`reddit` (`?sort=new`), and `bluesky` (`listNotifications`) all poll
upstreams that return **newest-first**, but each iterated the raw response
and emitted in that order. When a single poll caught more than one new
message, the agent received them backwards — wrong for conversation
context. `nextcloud` (the closest sibling) is unaffected because Talk's
chat feed already returns oldest-first.

The bug was faithfully reproduced from the original in-process Rust
adapters, so each migration carried it forward.

## Fix

Reverse each batch to oldest-first before emitting:

- `rocketchat.py` — `for msg in reversed(messages)` in `_poll_once`
- `mastodon.py` — `for notif in reversed(notifs)` in `_poll_once`
- `reddit.py` — `for child in reversed(children)` in `_poll_once`
- `bluesky.py` — `for notif in reversed(notifs)` in `_poll_once`

Dedupe sets and the per-room / `since_id` / max-`indexedAt` high-water
marks are all order-independent, so this changes **delivery order only** —
no impact on watermark advancement or duplicate suppression.

## Tests

- Added `test_poll_once_emits_in_chronological_order` to each of the four
  adapter suites: feeds a realistic newest-first batch, asserts oldest →
  newest emit, and (where applicable) asserts the high-water mark still
  tracks the newest item regardless of emit order.
- Updated existing fixtures that hand-ordered input ascending (which masked
  the bug) to the realistic newest-first shape:
  `test_poll_once_emits_messages_and_advances_watermark` (rocketchat),
  `test_poll_once_emits_parsed_comments` (reddit).
- `test_poll_once_dedupes_same_ts_repeats` (rocketchat) assertion made
  order-insensitive since it covers dedupe, not ordering.

## Verification

```
cd sdk/python && PYTHONPATH=. pytest tests/ -q
478 passed
```

No Rust changed (Python SDK only); `cargo clippy --workspace` ran clean via
the pre-push hook.

## Out-of-scope (flagged, not changed here)

`CHANGELOG.md` on `main` already has **two `## [Unreleased]` sections**
(line 8 and ~1105) — a pre-existing structural issue (the pre-commit guard
warns release tooling silently drops entries from all but the first). It
predates this branch and would require merging hundreds of lines of
unrelated entries, so I left it alone and omitted a CHANGELOG entry for
this fix rather than reorganize others' notes. Worth a dedicated cleanup.
