### PR TITLE
fix(ci): restore main — fmt drift + stale config schema baseline

### DIFF
--- a/crates/librefang-api/tests/channels_routes_test.rs
+++ b/crates/librefang-api/tests/channels_routes_test.rs
@@ -719,13 +719,8 @@ async fn channels_delete_instance_missing_signature_returns_400() {
         ..ChannelsConfig::default()
     };
     let h = boot_with_channels(channels).await;
-    let (status, body) = json_request(
-        &h,
-        Method::DELETE,
-        "/api/channels/matrix/instances/0",
-        None,
-    )
-    .await;
+    let (status, body) =
+        json_request(&h, Method::DELETE, "/api/channels/matrix/instances/0", None).await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
     assert!(
         body["error"]["message"]

--- a/crates/librefang-migrate/src/openclaw.rs
+++ b/crates/librefang-migrate/src/openclaw.rs
@@ -4056,9 +4056,10 @@ mod tests {
         assert!(!ch_table.contains_key("slack"));
         for name in ["telegram", "discord", "slack"] {
             assert!(
-                report.skipped.iter().any(|s|
-                    s.kind == ItemKind::Channel && s.name == name
-                ),
+                report
+                    .skipped
+                    .iter()
+                    .any(|s| s.kind == ItemKind::Channel && s.name == name),
                 "expected {name} in report.skipped",
             );
         }

--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -1624,8 +1624,9 @@ admin_role = "admin"
             # operator's intent was lost.
             defaul_agent = "research"
         "#;
-        let err = toml::from_str::<KernelConfig>(toml_src)
-            .expect_err("typo inside [[channels.whatsapp]] must be rejected by deny_unknown_fields");
+        let err = toml::from_str::<KernelConfig>(toml_src).expect_err(
+            "typo inside [[channels.whatsapp]] must be rejected by deny_unknown_fields",
+        );
         let msg = err.to_string();
         assert!(
             msg.contains("defaul_agent") || msg.contains("unknown field"),

--- a/xtask/baselines/config.sha256
+++ b/xtask/baselines/config.sha256
@@ -1,1 +1,1 @@
-882545a64ed148449ba2ca064721b8a0e0bc46ebef8eb6d35fdd684965d03066  librefang.toml.example
+bfadbe588e7187027094a6607535d4b30403e727d1a4ccca704e211fa60b4635  librefang.toml.example


### PR DESCRIPTION
## Problem

The channel sidecar migration series (#5298–#5302) merged to `main` left CI red across multiple gates. On the latest `main` HEAD (`88e67c33`) the still-failing gates are:

- **Quality / `cargo fmt`** — three files were committed unformatted.
- **OpenAPI Drift** — `xtask/baselines/config.sha256` is stale.

(`CHANGELOG Attribution (full [Unreleased])` was also red on earlier commits but is already green on HEAD — no action needed.)

## Changes

- **`cargo fmt`** reformat of the three files the migrations left unformatted:
  - `crates/librefang-api/tests/channels_routes_test.rs`
  - `crates/librefang-migrate/src/openclaw.rs`
  - `crates/librefang-types/src/config/mod.rs`
- **Regenerate `xtask/baselines/config.sha256`.** The migrations removed channel config structs/fields, changing the `KernelConfig` schema, but the baseline was never regenerated — so the drift gate failed on every push to `main`.

## Verification

- `cargo fmt --check` → clean.
- `cargo xtask codegen --openapi` → `openapi.json` unchanged (296 endpoints, already in sync).
- `python3 scripts/codegen-sdks.py` → all four SDKs unchanged (already in sync).
- `cargo xtask schema-check gen` → only `config.sha256` changed; `openapi.sha256` and `agent.sha256` unchanged.
- `git push` passed the `pre-push` hook (`cargo clippy --workspace --all-targets -- -D warnings` + OpenAPI/SDK drift detection).
