### PR TITLE
refactor(sidecar): extract shared helpers + WS client + test fakes

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/bluesky.py
+++ b/sdk/python/librefang/sidecar/adapters/bluesky.py
@@ -72,6 +72,7 @@ from typing import Any
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import split_message as _split_message
 
 DEFAULT_SERVICE_URL = "https://bsky.social"
 # Bluesky post length cap (graphemes per spec; we approximate with
@@ -91,26 +92,6 @@ SESSION_LIFE_SECS = 5400
 SESSION_REFRESH_BUFFER_SECS = 300
 # Thread-context cache size. 200 entries × ~200 B = ~40 KB, negligible.
 THREAD_CACHE_MAX = 200
-
-
-def _split_message(text: str, max_len: int) -> list[str]:
-    """Chunk `text` into <= max_len pieces, preferring newline splits.
-    Same shape as the ntfy / mastodon / Rust ``split_message`` helper."""
-    if len(text) <= max_len:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > max_len:
-        window = rest[:max_len]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = max_len
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < max_len else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
 
 class _LruCache:
     """Tiny fixed-size LRU. OrderedDict-backed: re-insert on get to mark

--- a/sdk/python/librefang/sidecar/adapters/bluesky.py
+++ b/sdk/python/librefang/sidecar/adapters/bluesky.py
@@ -72,7 +72,11 @@ from typing import Any
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
-from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import (
+    MAX_BACKOFF_SECS,
+    RETRY_AFTER_DEFAULT_SECS,
+    split_message as _split_message,
+)
 
 DEFAULT_SERVICE_URL = "https://bsky.social"
 # Bluesky post length cap (graphemes per spec; we approximate with
@@ -80,12 +84,6 @@ DEFAULT_SERVICE_URL = "https://bsky.social"
 MAX_MESSAGE_LEN = 300
 POLL_INTERVAL_SECS = 5
 SEND_TIMEOUT_SECS = 15
-MAX_BACKOFF_SECS = 60.0
-# Default fallback when Bluesky 429s without a `Retry-After` header.
-# AT Protocol's XRPC layer typically sends one (seconds form, alongside
-# `RateLimit-Reset` epoch); fall back to a sane wait so we don't busy-
-# loop at 1 s when the header is absent or unparseable.
-RETRY_AFTER_DEFAULT_SECS = 30.0
 # Sessions last ~2h on bsky.social; refresh 5 min before the 90-min
 # safety mark used by the Rust adapter.
 SESSION_LIFE_SECS = 5400

--- a/sdk/python/librefang/sidecar/adapters/discord.py
+++ b/sdk/python/librefang/sidecar/adapters/discord.py
@@ -88,9 +88,10 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
-    SeenSet as _SeenSet,
     http_request as _http_request,
+    MAX_BACKOFF_SECS,
     parse_retry_after as _parse_retry_after_impl,
+    SeenSet as _SeenSet,
     split_csv as _split_csv,
     split_message as _split_message,
 )
@@ -138,8 +139,6 @@ HANDSHAKE_TIMEOUT_SECS = 15.0
 # consecutive failure, capped at MAX_BACKOFF_SECS. Matches Rust
 # ``with_backoff`` defaults.
 INITIAL_BACKOFF_SECS = 1.0
-MAX_BACKOFF_SECS = 60.0
-
 FATAL_CLOSE_CODES = {
     4004: "authentication failed — DISCORD_BOT_TOKEN is invalid",
     4010: "invalid shard",

--- a/sdk/python/librefang/sidecar/adapters/discord.py
+++ b/sdk/python/librefang/sidecar/adapters/discord.py
@@ -88,6 +88,8 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
+    SeenSet as _SeenSet,
+    http_request as _http_request,
     parse_retry_after as _parse_retry_after_impl,
     split_csv as _split_csv,
     split_message as _split_message,
@@ -469,39 +471,11 @@ class DiscordAdapter(SidecarAdapter):
         headers: Optional[dict] = None,
         timeout: float = SEND_TIMEOUT_SECS,
     ) -> tuple[int, Any, bytes, dict]:
-        """Return ``(status, parsed_json_or_None, raw_body, response_headers)``.
-
-        Response header keys are normalised to lowercase. HTTPError is
-        captured so callers can inspect 4xx/5xx without try/except.
-        """
-        req = urllib.request.Request(
-            url, data=body, headers=headers or {}, method=method,
+        """Thin wrapper around :func:`librefang.sidecar.common.http_request`."""
+        return _http_request(
+            url, method=method, body=body, headers=headers,
+            timeout=timeout,
         )
-        resp_headers: dict = {}
-        try:
-            with urllib.request.urlopen(  # noqa: S310 — configured URL
-                req, timeout=timeout,
-            ) as resp:
-                status = getattr(resp, "status", 200)
-                raw = resp.read()
-                if resp.headers is not None:
-                    resp_headers = {
-                        k.lower(): v for k, v in resp.headers.items()
-                    }
-        except urllib.error.HTTPError as e:
-            status = e.code
-            try:
-                raw = e.read()
-            except Exception:  # noqa: BLE001
-                raw = b""
-            if e.headers is not None:
-                resp_headers = {k.lower(): v for k, v in e.headers.items()}
-        if not raw:
-            return status, None, b"", resp_headers
-        try:
-            return status, json.loads(raw.decode("utf-8")), raw, resp_headers
-        except (ValueError, TypeError, UnicodeDecodeError):
-            return status, None, raw, resp_headers
 
     # ---- REST: gateway URL / send / typing / role lookup -----------
 

--- a/sdk/python/librefang/sidecar/adapters/discord.py
+++ b/sdk/python/librefang/sidecar/adapters/discord.py
@@ -75,15 +75,9 @@ Secret via ``~/.librefang/secrets.env``: ``DISCORD_BOT_TOKEN``.
 from __future__ import annotations
 
 import asyncio
-import base64
-import hashlib
 import json
 import os
 import random
-import select
-import socket
-import ssl
-import struct
 import threading
 import time
 import urllib.error
@@ -93,6 +87,20 @@ from typing import Any, Callable, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import (
+    parse_retry_after as _parse_retry_after_impl,
+    split_csv as _split_csv,
+    split_message as _split_message,
+)
+from librefang.sidecar.ws import (
+    MAX_FRAME_PAYLOAD,
+    OP_CLOSE as _OP_CLOSE,
+    OP_CONT as _OP_CONT,
+    OP_PING as _OP_PING,
+    OP_PONG as _OP_PONG,
+    OP_TEXT as _OP_TEXT,
+    WebSocketClient as _WebSocketClient,
+)
 
 # Discord REST + Gateway constants. ``DISCORD_API_BASE`` is overridable
 # via the ``api_base`` instance attribute so unit tests can point at a
@@ -130,28 +138,6 @@ HANDSHAKE_TIMEOUT_SECS = 15.0
 INITIAL_BACKOFF_SECS = 1.0
 MAX_BACKOFF_SECS = 60.0
 
-# RFC 6455 — Sec-WebSocket-Accept derivation magic GUID and frame
-# opcodes. Same as gotify's hand-rolled reader (#5263).
-_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-_OP_CONT = 0x0
-_OP_TEXT = 0x1
-_OP_BIN = 0x2
-_OP_CLOSE = 0x8
-_OP_PING = 0x9
-_OP_PONG = 0xA
-
-# Cap on a single inbound WS frame's payload length. Discord frames
-# are short JSON (the heaviest realistic event is a MESSAGE_CREATE
-# with embeds + attachments, well under 100 KiB). 4 MiB guards
-# against a hostile server that announces a 64-bit length to make
-# us spin reading multi-exabyte payloads.
-MAX_FRAME_PAYLOAD = 1 << 22  # 4 MiB
-
-# Gateway close codes that are NOT recoverable by reconnecting — the
-# operator must fix the config first. Mapping per Discord docs.
-# Closing with one of these and immediately reconnecting just burns
-# the gateway budget and produces noisy logs; we surface a single
-# clear error and let the supervisor's circuit-breaker stop us.
 FATAL_CLOSE_CODES = {
     4004: "authentication failed — DISCORD_BOT_TOKEN is invalid",
     4010: "invalid shard",
@@ -357,271 +343,6 @@ def parse_message_create(
     )
 
 
-# ---------------------------------------------------------------------------
-# Stdlib WebSocket client. Adapted from gotify (#5263); same RFC 6455
-# logic with two Discord-specific additions:
-#   * the iterator yields raw text frames (Discord's gateway frames
-#     carry JSON one event per frame, so a frame-level iterator is
-#     enough — no continuation handling needed in practice but we
-#     support it for correctness);
-#   * ``send_text(s)`` is exposed so callers (the heartbeat sender
-#     and the IDENTIFY/RESUME emitters) can push frames back.
-# ---------------------------------------------------------------------------
-
-
-class _WebSocketClient:
-    """Minimal RFC 6455 client (text-only). Use as a context manager.
-
-    Server→client frames are never masked; client→server frames MUST
-    be masked with a fresh 4-byte key per frame.
-    """
-
-    def __init__(
-        self,
-        url: str,
-        *,
-        headers: Optional[dict] = None,
-        handshake_timeout: float = HANDSHAKE_TIMEOUT_SECS,
-    ) -> None:
-        self.url = url
-        self.headers = dict(headers or {})
-        self._sock: Optional[socket.socket] = None
-        self._leftover = b""
-        self._handshake_timeout = handshake_timeout
-        self._send_lock = threading.Lock()
-        self.closed = False
-
-    @staticmethod
-    def _parse_url(url: str) -> tuple[str, int, str, bool]:
-        u = urllib.parse.urlparse(url)
-        scheme = u.scheme.lower()
-        if scheme not in ("ws", "wss"):
-            raise ValueError(f"not a websocket url: {url!r}")
-        if not u.hostname:
-            raise ValueError(f"websocket url missing host: {url!r}")
-        is_tls = scheme == "wss"
-        port = u.port or (443 if is_tls else 80)
-        path = u.path or "/"
-        if u.query:
-            path += "?" + u.query
-        return u.hostname, port, path, is_tls
-
-    def __enter__(self) -> "_WebSocketClient":
-        host, port, path, is_tls = self._parse_url(self.url)
-        sock = socket.create_connection((host, port),
-                                        timeout=self._handshake_timeout)
-        if is_tls:
-            ctx = ssl.create_default_context()
-            sock = ctx.wrap_socket(sock, server_hostname=host)
-        key = base64.b64encode(os.urandom(16)).decode("ascii")
-        lines = [
-            f"GET {path} HTTP/1.1",
-            f"Host: {host}:{port}",
-            "Upgrade: websocket",
-            "Connection: Upgrade",
-            f"Sec-WebSocket-Key: {key}",
-            "Sec-WebSocket-Version: 13",
-        ]
-        for k, v in self.headers.items():
-            lines.append(f"{k}: {v}")
-        req = ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
-        sock.sendall(req)
-        buf = b""
-        while b"\r\n\r\n" not in buf:
-            chunk = sock.recv(4096)
-            if not chunk:
-                sock.close()
-                raise RuntimeError("connection closed during ws handshake")
-            buf += chunk
-            if len(buf) > 65536:
-                sock.close()
-                raise RuntimeError("ws handshake response too large")
-        head, _, leftover = buf.partition(b"\r\n\r\n")
-        head_lines = head.split(b"\r\n")
-        status = head_lines[0]
-        if not status.startswith(b"HTTP/1.1 101 "):
-            sock.close()
-            raise RuntimeError(
-                f"ws handshake failed: {status.decode('ascii', 'replace')}"
-            )
-        expected = base64.b64encode(
-            hashlib.sha1((key + _WS_GUID).encode("ascii")).digest()
-        ).decode("ascii")
-        got = None
-        for line in head_lines[1:]:
-            name, _, val = line.partition(b":")
-            if name.strip().lower() == b"sec-websocket-accept":
-                got = val.strip().decode("ascii", "replace")
-                break
-        if got != expected:
-            sock.close()
-            raise RuntimeError("ws handshake Sec-WebSocket-Accept mismatch")
-        self._sock = sock
-        self._leftover = leftover
-        return self
-
-    def __exit__(self, *_exc) -> None:
-        self.closed = True
-        if self._sock is not None:
-            try:
-                self._sock.close()
-            except OSError:
-                pass
-            self._sock = None
-
-    def settimeout(self, timeout: Optional[float]) -> None:
-        if self._sock is not None:
-            self._sock.settimeout(timeout)
-
-    def wait_readable(self, timeout: float) -> bool:
-        """Return True when bytes are ready (or already buffered),
-        False on a clean timeout. Used to gate the heartbeat tick
-        BEFORE we start consuming a frame, so a mid-frame stall
-        becomes a hard transport error instead of corrupting state.
-
-        TLS-on-Python is the awkward bit: ``ssl.SSLSocket.pending()``
-        exposes already-decrypted bytes that aren't visible to
-        ``select`` (TLS records can come back from the OS but stay
-        in the SSL layer's read buffer). We check leftover-from-
-        handshake first, then ``ssl.pending()``, then ``select``.
-        """
-        if self._leftover:
-            return True
-        sock = self._sock
-        if sock is None:
-            return False
-        # SSLSocket exposes already-decrypted bytes via `.pending()` —
-        # those don't show up in select() because the OS has already
-        # given them to the SSL layer.
-        pending = getattr(sock, "pending", None)
-        if callable(pending):
-            try:
-                if pending() > 0:
-                    return True
-            except Exception:  # noqa: BLE001 — closed socket etc.
-                pass
-        try:
-            r, _, _ = select.select([sock], [], [], max(0.0, timeout))
-        except (OSError, ValueError):
-            # ``select`` rejects closed/negative-fd sockets — treat as
-            # "no data, will fail on next recv".
-            return False
-        return bool(r)
-
-    def _recv_exact(self, n: int) -> bytes:
-        if n <= 0:
-            return b""
-        buf = bytearray()
-        while len(buf) < n:
-            if self._leftover:
-                take = min(n - len(buf), len(self._leftover))
-                buf.extend(self._leftover[:take])
-                self._leftover = self._leftover[take:]
-                continue
-            assert self._sock is not None
-            chunk = self._sock.recv(n - len(buf))
-            if not chunk:
-                raise EOFError("websocket closed mid-frame")
-            buf.extend(chunk)
-        return bytes(buf)
-
-    def _send_frame(self, opcode: int, payload: bytes) -> None:
-        assert self._sock is not None
-        header = bytearray([0x80 | (opcode & 0x0F)])
-        ln = len(payload)
-        if ln < 126:
-            header.append(0x80 | ln)
-        elif ln < 65536:
-            header.append(0x80 | 126)
-            header.extend(struct.pack(">H", ln))
-        else:
-            header.append(0x80 | 127)
-            header.extend(struct.pack(">Q", ln))
-        mask = os.urandom(4)
-        header.extend(mask)
-        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-        with self._send_lock:
-            self._sock.sendall(bytes(header) + masked)
-
-    def send_text(self, s: str) -> None:
-        self._send_frame(_OP_TEXT, s.encode("utf-8"))
-
-    def send_close(self) -> None:
-        try:
-            self._send_frame(_OP_CLOSE, b"")
-        except OSError:
-            pass
-
-    def recv_frame(self) -> tuple[Optional[str], Optional[tuple[int, bytes]]]:
-        """Read one frame and return either ``(text, None)`` for a
-        completed text message, or ``(None, (close_code, reason))``
-        for a close frame the server sent. Pings are answered inline
-        and skipped. Returns ``(None, None)`` for non-text frames we
-        ignore (binary, pong)."""
-        h2 = self._recv_exact(2)
-        fin = (h2[0] & 0x80) != 0
-        opcode = h2[0] & 0x0F
-        masked = (h2[1] & 0x80) != 0
-        ln = h2[1] & 0x7F
-        if ln == 126:
-            ln = struct.unpack(">H", self._recv_exact(2))[0]
-        elif ln == 127:
-            ln = struct.unpack(">Q", self._recv_exact(8))[0]
-        if ln > MAX_FRAME_PAYLOAD:
-            raise RuntimeError(
-                f"websocket frame payload {ln} exceeds cap "
-                f"{MAX_FRAME_PAYLOAD}; failing the stream"
-            )
-        mask_key = self._recv_exact(4) if masked else None
-        payload = self._recv_exact(ln)
-        if mask_key is not None:
-            payload = bytes(
-                b ^ mask_key[i % 4] for i, b in enumerate(payload)
-            )
-        if opcode == _OP_PING:
-            self._send_frame(_OP_PONG, payload)
-            return None, None
-        if opcode == _OP_PONG:
-            return None, None
-        if opcode == _OP_CLOSE:
-            code = 1005  # "no status received" if payload < 2 bytes
-            reason = b""
-            if len(payload) >= 2:
-                code = struct.unpack(">H", payload[:2])[0]
-                reason = payload[2:]
-            return None, (code, reason)
-        if opcode == _OP_TEXT:
-            # Discord frames are always one event per frame (no
-            # multi-frame fragmentation), but support continuation
-            # for spec correctness.
-            buf = bytearray(payload)
-            while not fin:
-                h2 = self._recv_exact(2)
-                fin = (h2[0] & 0x80) != 0
-                opcode2 = h2[0] & 0x0F
-                masked2 = (h2[1] & 0x80) != 0
-                ln2 = h2[1] & 0x7F
-                if ln2 == 126:
-                    ln2 = struct.unpack(">H", self._recv_exact(2))[0]
-                elif ln2 == 127:
-                    ln2 = struct.unpack(">Q", self._recv_exact(8))[0]
-                if ln2 > MAX_FRAME_PAYLOAD:
-                    raise RuntimeError("ws continuation payload too large")
-                mk = self._recv_exact(4) if masked2 else None
-                payload2 = self._recv_exact(ln2)
-                if mk is not None:
-                    payload2 = bytes(
-                        b ^ mk[i % 4] for i, b in enumerate(payload2)
-                    )
-                if opcode2 != _OP_CONT:
-                    # Unexpected interleaved frame — bail.
-                    raise RuntimeError(
-                        f"ws unexpected interleaved opcode {opcode2}"
-                    )
-                buf.extend(payload2)
-            return buf.decode("utf-8", "replace"), None
-        # Binary / unknown — ignore.
-        return None, None
 
 
 # ---------------------------------------------------------------------------
@@ -1134,32 +855,15 @@ class DiscordAdapter(SidecarAdapter):
                 None, self._send_typing, cmd.channel_id,
             )
 
-
-def _split_csv(raw: str) -> list[str]:
-    """Split a comma-separated env-var into a clean list of strings.
-
-    Empty input → empty list. Each item is whitespace-stripped.
-    Matches the Rust deserialize_string_or_int_vec shape (we accept
-    both ``"123,456"`` and ``"123, 456"``)."""
-    if not raw:
-        return []
-    return [s.strip() for s in raw.split(",") if s.strip()]
-
-
 def _parse_retry_after(resp_hdrs: dict, *, default_secs: float) -> float:
-    """Discord's 429 response includes ``Retry-After`` (seconds, may be
-    a decimal). Fall back to ``default_secs`` when missing/garbled.
-    Capped at MAX_BACKOFF_SECS so a server bug can't pin the send
-    loop for hours."""
-    raw = resp_hdrs.get("retry-after")
-    if not raw:
-        return default_secs
-    try:
-        v = float(raw)
-    except (TypeError, ValueError):
-        return default_secs
-    return min(max(v, 0.1), MAX_BACKOFF_SECS)
-
+    """Backwards-compat wrapper around
+    :func:`librefang.sidecar.common.parse_retry_after`."""
+    return _parse_retry_after_impl(
+        resp_hdrs,
+        default_secs=default_secs,
+        floor_secs=0.1,
+        max_secs=MAX_BACKOFF_SECS,
+    )
 
 class _FatalGatewayError(Exception):
     """Raised on a Discord gateway close code that no amount of

--- a/sdk/python/librefang/sidecar/adapters/gotify.py
+++ b/sdk/python/librefang/sidecar/adapters/gotify.py
@@ -51,6 +51,7 @@ import urllib.request
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import split_message as _split_message
 
 # Gotify caps individual messages at this length (matches the Rust adapter).
 MAX_MESSAGE_LEN = 65535
@@ -73,26 +74,6 @@ _OP_BIN = 0x2
 _OP_CLOSE = 0x8
 _OP_PING = 0x9
 _OP_PONG = 0xA
-
-
-def _split_message(text: str, max_len: int) -> list[str]:
-    """Chunk `text` into <= max_len pieces, preferring newline splits.
-    Same shape as the ntfy / Rust ``split_message`` helper."""
-    if len(text) <= max_len:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > max_len:
-        window = rest[:max_len]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = max_len
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < max_len else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
 
 class _WebSocketReader:
     """Minimal RFC 6455 client. Iterating yields each completed text

--- a/sdk/python/librefang/sidecar/adapters/line.py
+++ b/sdk/python/librefang/sidecar/adapters/line.py
@@ -139,7 +139,6 @@ from librefang.sidecar.common import (
     SeenSet as _SeenSet,
     http_request as _http_request,
     parse_retry_after as _parse_retry_after_impl,
-    split_csv as _split_csv,
     split_message as _split_message,
 )
 

--- a/sdk/python/librefang/sidecar/adapters/line.py
+++ b/sdk/python/librefang/sidecar/adapters/line.py
@@ -136,9 +136,11 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
-    SeenSet as _SeenSet,
     http_request as _http_request,
+    MAX_BACKOFF_SECS,
     parse_retry_after as _parse_retry_after_impl,
+    RETRY_AFTER_DEFAULT_SECS,
+    SeenSet as _SeenSet,
     split_message as _split_message,
 )
 
@@ -154,14 +156,6 @@ DEFAULT_WEBHOOK_PATH = "/webhook"
 DEFAULT_BIND_HOST = "0.0.0.0"
 
 SEND_TIMEOUT_SECS = 15.0
-MAX_BACKOFF_SECS = 60.0
-
-# Default fallback when LINE 429s without a parseable ``Retry-After``
-# header. Mirrors the rocketchat / nextcloud / mastodon / webex
-# sidecars (#5303); 30 s is conservative enough that we don't
-# immediately re-hit the bruteforce throttle.
-RETRY_AFTER_DEFAULT_SECS = 30.0
-
 # Bounded dedupe cap on ``message.id`` (Improvement #2). Same policy
 # as reddit / rocketchat / nextcloud / webex. ``MAX`` is the
 # high-water mark; when reached, evict the oldest ``EVICT`` entries

--- a/sdk/python/librefang/sidecar/adapters/line.py
+++ b/sdk/python/librefang/sidecar/adapters/line.py
@@ -135,6 +135,11 @@ from typing import Any, Callable, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import (
+    parse_retry_after as _parse_retry_after_impl,
+    split_csv as _split_csv,
+    split_message as _split_message,
+)
 
 # LINE constants — mirror crate::line defaults.
 DEFAULT_API_BASE = "https://api.line.me"
@@ -164,40 +169,15 @@ RETRY_AFTER_DEFAULT_SECS = 30.0
 SEEN_MESSAGES_MAX = 10_000
 SEEN_MESSAGES_EVICT = 5_000
 
-
-def _split_message(text: str, limit: int) -> list[str]:
-    """Chunk `text` into <= limit pieces, preferring newline splits.
-    Mirrors the shared Rust ``split_message`` helper."""
-    if len(text) <= limit:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > limit:
-        window = rest[:limit]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = limit
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < limit else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
-
 def _parse_retry_after(resp_hdrs: dict, *, default_secs: float) -> float:
-    """LINE's 429 response includes ``Retry-After`` (seconds).
-    Fall back to ``default_secs`` when missing/garbled. Floor 1 s,
-    capped at ``MAX_BACKOFF_SECS`` so a server bug can't pin the
-    loop for hours."""
-    raw = resp_hdrs.get("retry-after")
-    if not raw:
-        return default_secs
-    try:
-        v = float(raw)
-    except (TypeError, ValueError):
-        return default_secs
-    return min(max(v, 1.0), MAX_BACKOFF_SECS)
-
+    """Backwards-compat wrapper around
+    :func:`librefang.sidecar.common.parse_retry_after`."""
+    return _parse_retry_after_impl(
+        resp_hdrs,
+        default_secs=default_secs,
+        floor_secs=1.0,
+        max_secs=MAX_BACKOFF_SECS,
+    )
 
 def verify_line_signature(secret: bytes, body: bytes, signature: str) -> bool:
     """Verify ``X-Line-Signature`` using HMAC-SHA256 with

--- a/sdk/python/librefang/sidecar/adapters/line.py
+++ b/sdk/python/librefang/sidecar/adapters/line.py
@@ -136,6 +136,8 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
+    SeenSet as _SeenSet,
+    http_request as _http_request,
     parse_retry_after as _parse_retry_after_impl,
     split_csv as _split_csv,
     split_message as _split_message,
@@ -373,9 +375,7 @@ class LineAdapter(SidecarAdapter):
         self.api_base = os.environ.get("LINE_API_BASE", "").strip() or DEFAULT_API_BASE
 
         # Improvement #2: bounded dedupe on inbound message.id.
-        self._seen_ids: set[str] = set()
-        self._seen_order: list[str] = []
-        self._seen_lock = threading.Lock()
+        self._seen = _SeenSet(max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT)
 
         # Set by ``produce`` so ``on_shutdown`` can release the
         # listening socket cleanly.
@@ -401,58 +401,17 @@ class LineAdapter(SidecarAdapter):
         headers: Optional[dict] = None,
         timeout: float = SEND_TIMEOUT_SECS,
     ) -> tuple[int, Any, bytes, dict]:
-        """One-shot HTTP request. Returns
-        ``(status, parsed_json_or_None, raw_bytes, response_headers)``.
-        Response headers are lower-cased so 429 ``Retry-After`` can be
-        looked up uniformly regardless of server casing."""
-        req = urllib.request.Request(
-            url, data=body, headers=headers or {}, method=method,
+        """Thin wrapper around :func:`librefang.sidecar.common.http_request`."""
+        return _http_request(
+            url, method=method, body=body, headers=headers,
+            timeout=timeout,
         )
-        resp_headers: dict = {}
-        try:
-            with urllib.request.urlopen(  # noqa: S310 — configured URL
-                req, timeout=timeout,
-            ) as resp:
-                status = getattr(resp, "status", 200)
-                raw = resp.read()
-                if resp.headers is not None:
-                    resp_headers = {
-                        k.lower(): v for k, v in resp.headers.items()
-                    }
-        except urllib.error.HTTPError as e:
-            status = e.code
-            try:
-                raw = e.read()
-            except Exception:  # noqa: BLE001
-                raw = b""
-            if e.headers is not None:
-                resp_headers = {k.lower(): v for k, v in e.headers.items()}
-        if not raw:
-            return status, None, b"", resp_headers
-        try:
-            return status, json.loads(raw.decode("utf-8")), raw, resp_headers
-        except (ValueError, TypeError, UnicodeDecodeError):
-            return status, None, raw, resp_headers
 
     # ---- dedupe ------------------------------------------------------
 
     def _mark_seen(self, message_id: str) -> bool:
-        """Return True iff ``message_id`` is freshly seen (i.e. emit it).
-        Maintains a bounded LRU-ish set keyed on inbound
-        ``message.id``. Improvement #2."""
-        if not message_id:
-            return True
-        with self._seen_lock:
-            if message_id in self._seen_ids:
-                return False
-            self._seen_ids.add(message_id)
-            self._seen_order.append(message_id)
-            if len(self._seen_order) > SEEN_MESSAGES_MAX:
-                drop = self._seen_order[:SEEN_MESSAGES_EVICT]
-                self._seen_order = self._seen_order[SEEN_MESSAGES_EVICT:]
-                for k in drop:
-                    self._seen_ids.discard(k)
-            return True
+        """Return True iff freshly seen. Shim around :class:`librefang.sidecar.common.SeenSet`."""
+        return self._seen.mark(message_id)
 
     # ---- REST: auth + outbound send ---------------------------------
 

--- a/sdk/python/librefang/sidecar/adapters/mastodon.py
+++ b/sdk/python/librefang/sidecar/adapters/mastodon.py
@@ -64,6 +64,7 @@ import urllib.request
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import split_message as _split_message
 
 # Mastodon's default per-status length limit. Some instances configure
 # higher limits (1000–4000); override via MASTODON_MAX_MESSAGE_LEN.
@@ -78,26 +79,6 @@ DEFAULT_VISIBILITY = "unlisted"
 # require it — fall back to a sane wait so we don't busy-loop at 1 s.
 RETRY_AFTER_DEFAULT_SECS = 30.0
 _ALLOWED_VISIBILITIES = {"public", "unlisted", "private", "direct"}
-
-
-def _split_message(text: str, max_len: int) -> list[str]:
-    """Chunk `text` into <= max_len pieces, preferring newline splits.
-    Matches the Rust ``split_message`` helper used across channels."""
-    if len(text) <= max_len:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > max_len:
-        window = rest[:max_len]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = max_len
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < max_len else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
 
 def _strip_html_tags(value: str) -> str:
     """Strip HTML tags from a Mastodon status body and decode entities.

--- a/sdk/python/librefang/sidecar/adapters/mastodon.py
+++ b/sdk/python/librefang/sidecar/adapters/mastodon.py
@@ -64,20 +64,19 @@ import urllib.request
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
-from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import (
+    MAX_BACKOFF_SECS,
+    RETRY_AFTER_DEFAULT_SECS,
+    split_message as _split_message,
+)
 
 # Mastodon's default per-status length limit. Some instances configure
 # higher limits (1000–4000); override via MASTODON_MAX_MESSAGE_LEN.
 DEFAULT_MAX_MESSAGE_LEN = 500
 SSE_RECONNECT_DELAY_SECS = 5
 POLL_INTERVAL_SECS = 5
-MAX_BACKOFF_SECS = 60.0
 SEND_TIMEOUT_SECS = 15
 DEFAULT_VISIBILITY = "unlisted"
-# Default fallback when Mastodon 429s without a `Retry-After` header.
-# Most instances send one (seconds form), but the protocol does not
-# require it — fall back to a sane wait so we don't busy-loop at 1 s.
-RETRY_AFTER_DEFAULT_SECS = 30.0
 _ALLOWED_VISIBILITIES = {"public", "unlisted", "private", "direct"}
 
 def _strip_html_tags(value: str) -> str:

--- a/sdk/python/librefang/sidecar/adapters/mattermost.py
+++ b/sdk/python/librefang/sidecar/adapters/mattermost.py
@@ -123,14 +123,8 @@ or personal access token from the Mattermost System Console).
 from __future__ import annotations
 
 import asyncio
-import base64
-import hashlib
 import json
 import os
-import select
-import socket
-import ssl
-import struct
 import threading
 import time
 import urllib.error
@@ -140,6 +134,20 @@ from typing import Any, Callable, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import (
+    parse_retry_after as _parse_retry_after_impl,
+    split_csv as _split_csv,
+    split_message as _split_message,
+)
+from librefang.sidecar.ws import (
+    MAX_FRAME_PAYLOAD,
+    OP_CLOSE as _OP_CLOSE,
+    OP_CONT as _OP_CONT,
+    OP_PING as _OP_PING,
+    OP_PONG as _OP_PONG,
+    OP_TEXT as _OP_TEXT,
+    WebSocketClient as _WebSocketClient,
+)
 
 # Mattermost's official message-text ceiling. Mirrors the Rust
 # adapter's ``MAX_MESSAGE_LEN`` (mattermost.rs:22).
@@ -161,49 +169,7 @@ RETRY_AFTER_DEFAULT_SECS = 30.0
 SEEN_MESSAGES_MAX = 10_000
 SEEN_MESSAGES_EVICT = 5_000
 
-# RFC 6455 — same constants as the discord / slack / webex sidecars.
-_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-_OP_CONT = 0x0
-_OP_TEXT = 0x1
-_OP_BIN = 0x2
-_OP_CLOSE = 0x8
-_OP_PING = 0x9
-_OP_PONG = 0xA
-
-MAX_FRAME_PAYLOAD = 1 << 22  # 4 MiB
-
-# How long to block in select() per loop iteration before re-checking
-# liveness. Mattermost sends ping frames; the WS layer answers them
-# automatically via the recv_frame PING→PONG path.
 READ_TICK_SECS = 30.0
-
-
-def _split_message(text: str, limit: int) -> list[str]:
-    """Chunk `text` into <= limit pieces, preferring newline splits.
-    Mirrors the shared Rust ``split_message`` helper."""
-    if len(text) <= limit:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > limit:
-        window = rest[:limit]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = limit
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < limit else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
-
-def _split_csv(raw: str) -> list[str]:
-    """Comma-separated env-var → cleaned list of strings."""
-    if not raw:
-        return []
-    return [s.strip() for s in raw.split(",") if s.strip()]
-
-
 def _parse_retry_after(resp_hdrs: dict, *, default_secs: float) -> float:
     """Mattermost may include ``Retry-After`` (seconds) on 429.
     Fall back to ``default_secs`` when missing/garbled. Floor 1 s,
@@ -339,228 +305,6 @@ def parse_mm_event(
     )
 
 
-# ---------------------------------------------------------------------------
-# Stdlib WebSocket client — same RFC 6455 reader as the discord / slack /
-# webex sidecars (#5299 / #5302 / #5309). Lifted verbatim from webex.py;
-# Mattermost's WS upgrade carries no extra headers (auth happens via a
-# follow-up JSON frame, not a Bearer header), so the headers dict is left
-# empty at the call site.
-# ---------------------------------------------------------------------------
-
-
-class _WebSocketClient:
-    def __init__(
-        self,
-        url: str,
-        *,
-        headers: Optional[dict] = None,
-        handshake_timeout: float = HANDSHAKE_TIMEOUT_SECS,
-    ) -> None:
-        self.url = url
-        self.headers = dict(headers or {})
-        self._sock: Optional[socket.socket] = None
-        self._leftover = b""
-        self._handshake_timeout = handshake_timeout
-        self._send_lock = threading.Lock()
-        self.closed = False
-
-    @staticmethod
-    def _parse_url(url: str) -> tuple[str, int, str, bool]:
-        u = urllib.parse.urlparse(url)
-        scheme = u.scheme.lower()
-        if scheme not in ("ws", "wss"):
-            raise ValueError(f"not a websocket url: {url!r}")
-        if not u.hostname:
-            raise ValueError(f"websocket url missing host: {url!r}")
-        is_tls = scheme == "wss"
-        port = u.port or (443 if is_tls else 80)
-        path = u.path or "/"
-        if u.query:
-            path += "?" + u.query
-        return u.hostname, port, path, is_tls
-
-    def __enter__(self) -> "_WebSocketClient":
-        host, port, path, is_tls = self._parse_url(self.url)
-        sock = socket.create_connection((host, port), timeout=self._handshake_timeout)
-        if is_tls:
-            ctx = ssl.create_default_context()
-            sock = ctx.wrap_socket(sock, server_hostname=host)
-        key = base64.b64encode(os.urandom(16)).decode("ascii")
-        lines = [
-            f"GET {path} HTTP/1.1",
-            f"Host: {host}:{port}",
-            "Upgrade: websocket",
-            "Connection: Upgrade",
-            f"Sec-WebSocket-Key: {key}",
-            "Sec-WebSocket-Version: 13",
-        ]
-        for k, v in self.headers.items():
-            lines.append(f"{k}: {v}")
-        req = ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
-        sock.sendall(req)
-        buf = b""
-        while b"\r\n\r\n" not in buf:
-            chunk = sock.recv(4096)
-            if not chunk:
-                sock.close()
-                raise RuntimeError("connection closed during ws handshake")
-            buf += chunk
-            if len(buf) > 65536:
-                sock.close()
-                raise RuntimeError("ws handshake response too large")
-        head, _, leftover = buf.partition(b"\r\n\r\n")
-        head_lines = head.split(b"\r\n")
-        status = head_lines[0]
-        if not status.startswith(b"HTTP/1.1 101 "):
-            sock.close()
-            raise RuntimeError(
-                f"ws handshake failed: {status.decode('ascii', 'replace')}"
-            )
-        expected = base64.b64encode(
-            hashlib.sha1((key + _WS_GUID).encode("ascii")).digest()
-        ).decode("ascii")
-        got = None
-        for line in head_lines[1:]:
-            name, _, val = line.partition(b":")
-            if name.strip().lower() == b"sec-websocket-accept":
-                got = val.strip().decode("ascii", "replace")
-                break
-        if got != expected:
-            sock.close()
-            raise RuntimeError("ws handshake Sec-WebSocket-Accept mismatch")
-        self._sock = sock
-        self._leftover = leftover
-        return self
-
-    def __exit__(self, *_exc) -> None:
-        self.closed = True
-        if self._sock is not None:
-            try:
-                self._sock.close()
-            except OSError:
-                pass
-            self._sock = None
-
-    def settimeout(self, timeout: Optional[float]) -> None:
-        if self._sock is not None:
-            self._sock.settimeout(timeout)
-
-    def wait_readable(self, timeout: float) -> bool:
-        if self._leftover:
-            return True
-        sock = self._sock
-        if sock is None:
-            return False
-        pending = getattr(sock, "pending", None)
-        if callable(pending):
-            try:
-                if pending() > 0:
-                    return True
-            except Exception:  # noqa: BLE001
-                pass
-        try:
-            r, _, _ = select.select([sock], [], [], max(0.0, timeout))
-        except (OSError, ValueError):
-            return False
-        return bool(r)
-
-    def _recv_exact(self, n: int) -> bytes:
-        if n <= 0:
-            return b""
-        buf = bytearray()
-        while len(buf) < n:
-            if self._leftover:
-                take = min(n - len(buf), len(self._leftover))
-                buf.extend(self._leftover[:take])
-                self._leftover = self._leftover[take:]
-                continue
-            assert self._sock is not None
-            chunk = self._sock.recv(n - len(buf))
-            if not chunk:
-                raise EOFError("websocket closed mid-frame")
-            buf.extend(chunk)
-        return bytes(buf)
-
-    def _send_frame(self, opcode: int, payload: bytes) -> None:
-        assert self._sock is not None
-        header = bytearray([0x80 | (opcode & 0x0F)])
-        ln = len(payload)
-        if ln < 126:
-            header.append(0x80 | ln)
-        elif ln < 65536:
-            header.append(0x80 | 126)
-            header.extend(struct.pack(">H", ln))
-        else:
-            header.append(0x80 | 127)
-            header.extend(struct.pack(">Q", ln))
-        mask = os.urandom(4)
-        header.extend(mask)
-        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-        with self._send_lock:
-            self._sock.sendall(bytes(header) + masked)
-
-    def send_text(self, s: str) -> None:
-        self._send_frame(_OP_TEXT, s.encode("utf-8"))
-
-    def send_close(self) -> None:
-        try:
-            self._send_frame(_OP_CLOSE, b"")
-        except OSError:
-            pass
-
-    def recv_frame(self) -> tuple[Optional[str], Optional[tuple[int, bytes]]]:
-        h2 = self._recv_exact(2)
-        fin = (h2[0] & 0x80) != 0
-        opcode = h2[0] & 0x0F
-        masked = (h2[1] & 0x80) != 0
-        ln = h2[1] & 0x7F
-        if ln == 126:
-            ln = struct.unpack(">H", self._recv_exact(2))[0]
-        elif ln == 127:
-            ln = struct.unpack(">Q", self._recv_exact(8))[0]
-        if ln > MAX_FRAME_PAYLOAD:
-            raise RuntimeError(
-                f"websocket frame payload {ln} exceeds cap {MAX_FRAME_PAYLOAD}"
-            )
-        mask_key = self._recv_exact(4) if masked else None
-        payload = self._recv_exact(ln)
-        if mask_key is not None:
-            payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
-        if opcode == _OP_PING:
-            self._send_frame(_OP_PONG, payload)
-            return None, None
-        if opcode == _OP_PONG:
-            return None, None
-        if opcode == _OP_CLOSE:
-            code = 1005
-            reason = b""
-            if len(payload) >= 2:
-                code = struct.unpack(">H", payload[:2])[0]
-                reason = payload[2:]
-            return None, (code, reason)
-        if opcode == _OP_TEXT:
-            buf = bytearray(payload)
-            while not fin:
-                h2 = self._recv_exact(2)
-                fin = (h2[0] & 0x80) != 0
-                opcode2 = h2[0] & 0x0F
-                masked2 = (h2[1] & 0x80) != 0
-                ln2 = h2[1] & 0x7F
-                if ln2 == 126:
-                    ln2 = struct.unpack(">H", self._recv_exact(2))[0]
-                elif ln2 == 127:
-                    ln2 = struct.unpack(">Q", self._recv_exact(8))[0]
-                if ln2 > MAX_FRAME_PAYLOAD:
-                    raise RuntimeError("ws continuation payload too large")
-                mk = self._recv_exact(4) if masked2 else None
-                payload2 = self._recv_exact(ln2)
-                if mk is not None:
-                    payload2 = bytes(b ^ mk[i % 4] for i, b in enumerate(payload2))
-                if opcode2 != _OP_CONT:
-                    raise RuntimeError(f"ws unexpected interleaved opcode {opcode2}")
-                buf.extend(payload2)
-            return buf.decode("utf-8", "replace"), None
-        return None, None
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/librefang/sidecar/adapters/mattermost.py
+++ b/sdk/python/librefang/sidecar/adapters/mattermost.py
@@ -135,9 +135,11 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
-    SeenSet as _SeenSet,
     http_request as _http_request,
+    MAX_BACKOFF_SECS,
     parse_retry_after as _parse_retry_after_impl,
+    RETRY_AFTER_DEFAULT_SECS,
+    SeenSet as _SeenSet,
     split_csv as _split_csv,
     split_message as _split_message,
 )
@@ -159,13 +161,6 @@ SEND_TIMEOUT_SECS = 15.0
 HANDSHAKE_TIMEOUT_SECS = 15.0
 
 INITIAL_BACKOFF_SECS = 1.0
-MAX_BACKOFF_SECS = 60.0
-
-# Default fallback when Mattermost 429s without a parseable
-# Retry-After header. 30 s is conservative; mirrors the rocketchat /
-# nextcloud / webex / line sidecars (#5303).
-RETRY_AFTER_DEFAULT_SECS = 30.0
-
 # Bounded dedupe cap on Mattermost ``post.id``. Same policy as
 # reddit / rocketchat / nextcloud / webex.
 SEEN_MESSAGES_MAX = 10_000

--- a/sdk/python/librefang/sidecar/adapters/mattermost.py
+++ b/sdk/python/librefang/sidecar/adapters/mattermost.py
@@ -135,6 +135,8 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
+    SeenSet as _SeenSet,
+    http_request as _http_request,
     parse_retry_after as _parse_retry_after_impl,
     split_csv as _split_csv,
     split_message as _split_message,
@@ -384,9 +386,7 @@ class MattermostAdapter(SidecarAdapter):
         self.bot_username: Optional[str] = None
 
         # Improvement #3: bounded dedupe on post.id.
-        self._seen_ids: set[str] = set()
-        self._seen_order: list[str] = []
-        self._seen_lock = threading.Lock()
+        self._seen = _SeenSet(max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT)
 
     # ---- HTTP helpers ------------------------------------------------
 
@@ -408,58 +408,17 @@ class MattermostAdapter(SidecarAdapter):
         headers: Optional[dict] = None,
         timeout: float = SEND_TIMEOUT_SECS,
     ) -> tuple[int, Any, bytes, dict]:
-        """One-shot HTTP request. Returns
-        ``(status, parsed_json_or_None, raw_bytes, response_headers)``.
-        Response headers are lower-cased so 429 ``Retry-After`` can be
-        looked up uniformly regardless of server casing."""
-        req = urllib.request.Request(
-            url, data=body, headers=headers or {}, method=method,
+        """Thin wrapper around :func:`librefang.sidecar.common.http_request`."""
+        return _http_request(
+            url, method=method, body=body, headers=headers,
+            timeout=timeout,
         )
-        resp_headers: dict = {}
-        try:
-            with urllib.request.urlopen(  # noqa: S310 — configured URL
-                req, timeout=timeout,
-            ) as resp:
-                status = getattr(resp, "status", 200)
-                raw = resp.read()
-                if resp.headers is not None:
-                    resp_headers = {
-                        k.lower(): v for k, v in resp.headers.items()
-                    }
-        except urllib.error.HTTPError as e:
-            status = e.code
-            try:
-                raw = e.read()
-            except Exception:  # noqa: BLE001
-                raw = b""
-            if e.headers is not None:
-                resp_headers = {k.lower(): v for k, v in e.headers.items()}
-        if not raw:
-            return status, None, b"", resp_headers
-        try:
-            return status, json.loads(raw.decode("utf-8")), raw, resp_headers
-        except (ValueError, TypeError, UnicodeDecodeError):
-            return status, None, raw, resp_headers
 
     # ---- dedupe ------------------------------------------------------
 
     def _mark_seen(self, post_id: Optional[str]) -> bool:
-        """Return True iff ``post_id`` is freshly seen (i.e. emit it).
-        ``None`` / empty ids are always treated as fresh (no key to
-        track). Mirrors reddit / rocketchat / nextcloud / webex."""
-        if not post_id:
-            return True
-        with self._seen_lock:
-            if post_id in self._seen_ids:
-                return False
-            self._seen_ids.add(post_id)
-            self._seen_order.append(post_id)
-            if len(self._seen_order) > SEEN_MESSAGES_MAX:
-                drop = self._seen_order[:SEEN_MESSAGES_EVICT]
-                self._seen_order = self._seen_order[SEEN_MESSAGES_EVICT:]
-                for k in drop:
-                    self._seen_ids.discard(k)
-            return True
+        """Return True iff freshly seen. Shim around :class:`librefang.sidecar.common.SeenSet`."""
+        return self._seen.mark(post_id)
 
     # ---- REST: auth + outbound send ---------------------------------
 

--- a/sdk/python/librefang/sidecar/adapters/nextcloud.py
+++ b/sdk/python/librefang/sidecar/adapters/nextcloud.py
@@ -103,8 +103,10 @@ from typing import Any
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
-    SeenSet as _SeenSet,
     http_request as _http_request,
+    MAX_BACKOFF_SECS,
+    RETRY_AFTER_DEFAULT_SECS,
+    SeenSet as _SeenSet,
     split_message as _split_message,
 )
 
@@ -115,12 +117,6 @@ MAX_MESSAGE_LEN = 32000
 DEFAULT_POLL_INTERVAL_SECS = 3
 MIN_POLL_INTERVAL_SECS = 1
 SEND_TIMEOUT_SECS = 30
-MAX_BACKOFF_SECS = 60.0
-# Default fallback when Talk 429s without a `Retry-After` header. The
-# OCS bruteforce throttler typically sends one (delay-in-seconds form),
-# but the protocol does not require it, so we need a sane fallback.
-# 30 s matches Talk's documented default throttle window.
-RETRY_AFTER_DEFAULT_SECS = 30.0
 # How many messages per `chat/<token>?lookIntoFuture=1` poll. Matches
 # the Rust adapter's `limit=100` query param.
 CHAT_FETCH_LIMIT = 100

--- a/sdk/python/librefang/sidecar/adapters/nextcloud.py
+++ b/sdk/python/librefang/sidecar/adapters/nextcloud.py
@@ -102,7 +102,11 @@ from typing import Any
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
-from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import (
+    SeenSet as _SeenSet,
+    http_request as _http_request,
+    split_message as _split_message,
+)
 
 # Matches the Rust adapter's MAX_MESSAGE_LEN (nextcloud.rs:23).
 MAX_MESSAGE_LEN = 32000
@@ -238,8 +242,9 @@ class NextcloudAdapter(SidecarAdapter):
         self._room_watermarks: dict[str, int] = {}
         # Dedupe set on Talk message `id` (cheap, bounded). Same
         # cap / eviction policy as reddit / rocketchat.
-        self._seen_messages: list[int] = []
-        self._seen_messages_set: set[int] = set()
+        self._seen = _SeenSet(
+            max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT,
+        )
 
     # ---- HTTP helpers ------------------------------------------------
 
@@ -421,18 +426,11 @@ class NextcloudAdapter(SidecarAdapter):
     # ---- dedupe ------------------------------------------------------
 
     def _mark_seen(self, msg_id: int) -> None:
-        """Track a message id with bounded eviction. Mirrors reddit /
-        rocketchat's list+set policy so eviction is deterministic
-        across runs. Talk message ids are positive integers; 0 (the
-        sentinel) is silently ignored."""
-        if not msg_id or msg_id in self._seen_messages_set:
-            return
-        self._seen_messages.append(msg_id)
-        self._seen_messages_set.add(msg_id)
-        if len(self._seen_messages) > SEEN_MESSAGES_MAX:
-            to_drop = self._seen_messages[:SEEN_MESSAGES_EVICT]
-            self._seen_messages = self._seen_messages[SEEN_MESSAGES_EVICT:]
-            self._seen_messages_set.difference_update(to_drop)
+        """Track a message id with bounded eviction. Thin shim
+        around :class:`librefang.sidecar.common.SeenSet` (the shared
+        helper returns True/False; nextcloud historically returned
+        None so we discard the return)."""
+        self._seen.mark(msg_id)
 
     # ---- inbound parsing ---------------------------------------------
 
@@ -616,7 +614,7 @@ class NextcloudAdapter(SidecarAdapter):
                     msg_id = int(raw_id) if raw_id is not None else 0
                 except (TypeError, ValueError):
                     msg_id = 0
-                if msg_id and msg_id in self._seen_messages_set:
+                if msg_id and msg_id in self._seen.ids:
                     # Already emitted — could be a boundary repeat
                     # from a previous poll. Still bump the watermark
                     # so the API query keeps advancing.

--- a/sdk/python/librefang/sidecar/adapters/nextcloud.py
+++ b/sdk/python/librefang/sidecar/adapters/nextcloud.py
@@ -102,6 +102,7 @@ from typing import Any
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import split_message as _split_message
 
 # Matches the Rust adapter's MAX_MESSAGE_LEN (nextcloud.rs:23).
 MAX_MESSAGE_LEN = 32000
@@ -126,26 +127,6 @@ CHAT_FETCH_LIMIT = 100
 # polls.
 SEEN_MESSAGES_MAX = 10000
 SEEN_MESSAGES_EVICT = 5000
-
-
-def _split_message(text: str, max_len: int) -> list[str]:
-    """Chunk `text` into <= max_len pieces, preferring newline splits.
-    Matches the Rust ``split_message`` helper used across channels."""
-    if len(text) <= max_len:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > max_len:
-        window = rest[:max_len]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = max_len
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < max_len else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
 
 def _parse_rooms(raw: str) -> list[str]:
     """Comma-separated room-token list. Strips whitespace and empty

--- a/sdk/python/librefang/sidecar/adapters/ntfy.py
+++ b/sdk/python/librefang/sidecar/adapters/ntfy.py
@@ -38,6 +38,7 @@ import urllib.request
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import split_message as _split_message
 
 MAX_MESSAGE_LEN = 4096
 DEFAULT_SERVER_URL = "https://ntfy.sh"
@@ -49,27 +50,6 @@ MAX_BACKOFF_SECS = 60.0
 # typically sends one in seconds form; fall back to a sane wait so we
 # don't busy-loop at 1 s.
 RETRY_AFTER_DEFAULT_SECS = 30.0
-
-
-def _split_message(text: str, max_len: int) -> list[str]:
-    """Chunk `text` into <= max_len pieces, preferring newline splits.
-    Mirrors the Rust `split_message` shared helper closely enough for
-    ntfy (which has no markup to keep intact)."""
-    if len(text) <= max_len:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > max_len:
-        window = rest[:max_len]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = max_len
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < max_len else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
 
 class NtfyAdapter(SidecarAdapter):
     # ntfy has no typing/reaction/interactive/thread/streaming concept

--- a/sdk/python/librefang/sidecar/adapters/ntfy.py
+++ b/sdk/python/librefang/sidecar/adapters/ntfy.py
@@ -38,19 +38,16 @@ import urllib.request
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
-from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import (
+    MAX_BACKOFF_SECS,
+    RETRY_AFTER_DEFAULT_SECS,
+    split_message as _split_message,
+)
 
 MAX_MESSAGE_LEN = 4096
 DEFAULT_SERVER_URL = "https://ntfy.sh"
 # Reconnect/post backoff ceilings, kept separate so the publish-side
 # raise can be capped distinctly from the SSE reconnect curve.
-MAX_BACKOFF_SECS = 60.0
-# Default fallback when ntfy 429s without a `Retry-After` header. The
-# per-topic rate limiter (publish: ~4800/h on ntfy.sh by default)
-# typically sends one in seconds form; fall back to a sane wait so we
-# don't busy-loop at 1 s.
-RETRY_AFTER_DEFAULT_SECS = 30.0
-
 class NtfyAdapter(SidecarAdapter):
     # ntfy has no typing/reaction/interactive/thread/streaming concept
     # — declare nothing, so LibreFang routes plain text only.

--- a/sdk/python/librefang/sidecar/adapters/qq.py
+++ b/sdk/python/librefang/sidecar/adapters/qq.py
@@ -142,15 +142,9 @@ bot's ``clientSecret`` from the QQ Open Platform console).
 from __future__ import annotations
 
 import asyncio
-import base64
-import hashlib
 import json
 import os
 import re
-import select
-import socket
-import ssl
-import struct
 import threading
 import time
 import urllib.error
@@ -160,6 +154,20 @@ from typing import Any, Callable, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import (
+    parse_retry_after as _parse_retry_after_impl,
+    split_csv as _split_csv,
+    split_message as _split_message,
+)
+from librefang.sidecar.ws import (
+    MAX_FRAME_PAYLOAD,
+    OP_CLOSE as _OP_CLOSE,
+    OP_CONT as _OP_CONT,
+    OP_PING as _OP_PING,
+    OP_PONG as _OP_PONG,
+    OP_TEXT as _OP_TEXT,
+    WebSocketClient as _WebSocketClient,
+)
 
 # QQ Open Platform endpoints. The token URL lives under bots.qq.com;
 # every other REST call goes through the sgroup.qq.com API base.
@@ -200,18 +208,6 @@ DEFAULT_INTENTS = (
     | INTENT_PUBLIC_GUILD_MESSAGES
 )
 
-# RFC 6455 — same constants as the discord / slack / webex / mattermost
-# sidecars.
-_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-_OP_CONT = 0x0
-_OP_TEXT = 0x1
-_OP_BIN = 0x2
-_OP_CLOSE = 0x8
-_OP_PING = 0x9
-_OP_PONG = 0xA
-
-MAX_FRAME_PAYLOAD = 1 << 22  # 4 MiB
-
 # How long to block in select() per loop iteration before re-checking
 # liveness. The producer also fires heartbeats from this loop, so the
 # tick must be smaller than the smallest QQ heartbeat interval we
@@ -219,42 +215,17 @@ MAX_FRAME_PAYLOAD = 1 << 22  # 4 MiB
 READ_TICK_SECS = 1.0
 
 
-def _split_message(text: str, limit: int) -> list[str]:
-    """Chunk ``text`` into <= ``limit`` pieces, preferring newline
-    splits. Mirrors the shared Rust ``split_message`` helper."""
-    if len(text) <= limit:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > limit:
-        window = rest[:limit]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = limit
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < limit else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
-
-def _split_csv(raw: str) -> list[str]:
-    """Comma-separated env-var → cleaned list of strings."""
-    if not raw:
-        return []
-    return [s.strip() for s in raw.split(",") if s.strip()]
-
-
 def _parse_retry_after(resp_hdrs: dict, *, default_secs: float) -> float:
-    """``Retry-After`` parser, floor 1 s, cap ``MAX_BACKOFF_SECS``."""
-    raw = resp_hdrs.get("retry-after")
-    if not raw:
-        return default_secs
-    try:
-        v = float(raw)
-    except (TypeError, ValueError):
-        return default_secs
-    return min(max(v, 1.0), MAX_BACKOFF_SECS)
+    """Backwards-compat wrapper around
+    :func:`librefang.sidecar.common.parse_retry_after`, pinning the
+    floor to 1 s and the cap to this adapter's
+    ``MAX_BACKOFF_SECS``."""
+    return _parse_retry_after_impl(
+        resp_hdrs,
+        default_secs=default_secs,
+        floor_secs=1.0,
+        max_secs=MAX_BACKOFF_SECS,
+    )
 
 
 # ---- markdown → plain text (qq.rs:137-180 parity) -------------------
@@ -430,227 +401,6 @@ def parse_qq_event(
         is_group=is_group,
         metadata=metadata,
     )
-
-
-# ---------------------------------------------------------------------------
-# Stdlib WebSocket client — same RFC 6455 reader as the discord / slack /
-# webex / mattermost sidecars. Lifted verbatim from mattermost.py.
-# ---------------------------------------------------------------------------
-
-
-class _WebSocketClient:
-    def __init__(
-        self,
-        url: str,
-        *,
-        headers: Optional[dict] = None,
-        handshake_timeout: float = HANDSHAKE_TIMEOUT_SECS,
-    ) -> None:
-        self.url = url
-        self.headers = dict(headers or {})
-        self._sock: Optional[socket.socket] = None
-        self._leftover = b""
-        self._handshake_timeout = handshake_timeout
-        self._send_lock = threading.Lock()
-        self.closed = False
-
-    @staticmethod
-    def _parse_url(url: str) -> tuple[str, int, str, bool]:
-        u = urllib.parse.urlparse(url)
-        scheme = u.scheme.lower()
-        if scheme not in ("ws", "wss"):
-            raise ValueError(f"not a websocket url: {url!r}")
-        if not u.hostname:
-            raise ValueError(f"websocket url missing host: {url!r}")
-        is_tls = scheme == "wss"
-        port = u.port or (443 if is_tls else 80)
-        path = u.path or "/"
-        if u.query:
-            path += "?" + u.query
-        return u.hostname, port, path, is_tls
-
-    def __enter__(self) -> "_WebSocketClient":
-        host, port, path, is_tls = self._parse_url(self.url)
-        sock = socket.create_connection((host, port), timeout=self._handshake_timeout)
-        if is_tls:
-            ctx = ssl.create_default_context()
-            sock = ctx.wrap_socket(sock, server_hostname=host)
-        key = base64.b64encode(os.urandom(16)).decode("ascii")
-        lines = [
-            f"GET {path} HTTP/1.1",
-            f"Host: {host}:{port}",
-            "Upgrade: websocket",
-            "Connection: Upgrade",
-            f"Sec-WebSocket-Key: {key}",
-            "Sec-WebSocket-Version: 13",
-        ]
-        for k, v in self.headers.items():
-            lines.append(f"{k}: {v}")
-        req = ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
-        sock.sendall(req)
-        buf = b""
-        while b"\r\n\r\n" not in buf:
-            chunk = sock.recv(4096)
-            if not chunk:
-                sock.close()
-                raise RuntimeError("connection closed during ws handshake")
-            buf += chunk
-            if len(buf) > 65536:
-                sock.close()
-                raise RuntimeError("ws handshake response too large")
-        head, _, leftover = buf.partition(b"\r\n\r\n")
-        head_lines = head.split(b"\r\n")
-        status = head_lines[0]
-        if not status.startswith(b"HTTP/1.1 101 "):
-            sock.close()
-            raise RuntimeError(
-                f"ws handshake failed: {status.decode('ascii', 'replace')}"
-            )
-        expected = base64.b64encode(
-            hashlib.sha1((key + _WS_GUID).encode("ascii")).digest()
-        ).decode("ascii")
-        got = None
-        for line in head_lines[1:]:
-            name, _, val = line.partition(b":")
-            if name.strip().lower() == b"sec-websocket-accept":
-                got = val.strip().decode("ascii", "replace")
-                break
-        if got != expected:
-            sock.close()
-            raise RuntimeError("ws handshake Sec-WebSocket-Accept mismatch")
-        self._sock = sock
-        self._leftover = leftover
-        return self
-
-    def __exit__(self, *_exc) -> None:
-        self.closed = True
-        if self._sock is not None:
-            try:
-                self._sock.close()
-            except OSError:
-                pass
-            self._sock = None
-
-    def settimeout(self, timeout: Optional[float]) -> None:
-        if self._sock is not None:
-            self._sock.settimeout(timeout)
-
-    def wait_readable(self, timeout: float) -> bool:
-        if self._leftover:
-            return True
-        sock = self._sock
-        if sock is None:
-            return False
-        pending = getattr(sock, "pending", None)
-        if callable(pending):
-            try:
-                if pending() > 0:
-                    return True
-            except Exception:  # noqa: BLE001
-                pass
-        try:
-            r, _, _ = select.select([sock], [], [], max(0.0, timeout))
-        except (OSError, ValueError):
-            return False
-        return bool(r)
-
-    def _recv_exact(self, n: int) -> bytes:
-        if n <= 0:
-            return b""
-        buf = bytearray()
-        while len(buf) < n:
-            if self._leftover:
-                take = min(n - len(buf), len(self._leftover))
-                buf.extend(self._leftover[:take])
-                self._leftover = self._leftover[take:]
-                continue
-            assert self._sock is not None
-            chunk = self._sock.recv(n - len(buf))
-            if not chunk:
-                raise EOFError("websocket closed mid-frame")
-            buf.extend(chunk)
-        return bytes(buf)
-
-    def _send_frame(self, opcode: int, payload: bytes) -> None:
-        assert self._sock is not None
-        header = bytearray([0x80 | (opcode & 0x0F)])
-        ln = len(payload)
-        if ln < 126:
-            header.append(0x80 | ln)
-        elif ln < 65536:
-            header.append(0x80 | 126)
-            header.extend(struct.pack(">H", ln))
-        else:
-            header.append(0x80 | 127)
-            header.extend(struct.pack(">Q", ln))
-        mask = os.urandom(4)
-        header.extend(mask)
-        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-        with self._send_lock:
-            self._sock.sendall(bytes(header) + masked)
-
-    def send_text(self, s: str) -> None:
-        self._send_frame(_OP_TEXT, s.encode("utf-8"))
-
-    def send_close(self) -> None:
-        try:
-            self._send_frame(_OP_CLOSE, b"")
-        except OSError:
-            pass
-
-    def recv_frame(self) -> tuple[Optional[str], Optional[tuple[int, bytes]]]:
-        h2 = self._recv_exact(2)
-        fin = (h2[0] & 0x80) != 0
-        opcode = h2[0] & 0x0F
-        masked = (h2[1] & 0x80) != 0
-        ln = h2[1] & 0x7F
-        if ln == 126:
-            ln = struct.unpack(">H", self._recv_exact(2))[0]
-        elif ln == 127:
-            ln = struct.unpack(">Q", self._recv_exact(8))[0]
-        if ln > MAX_FRAME_PAYLOAD:
-            raise RuntimeError(
-                f"websocket frame payload {ln} exceeds cap {MAX_FRAME_PAYLOAD}"
-            )
-        mask_key = self._recv_exact(4) if masked else None
-        payload = self._recv_exact(ln)
-        if mask_key is not None:
-            payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
-        if opcode == _OP_PING:
-            self._send_frame(_OP_PONG, payload)
-            return None, None
-        if opcode == _OP_PONG:
-            return None, None
-        if opcode == _OP_CLOSE:
-            code = 1005
-            reason = b""
-            if len(payload) >= 2:
-                code = struct.unpack(">H", payload[:2])[0]
-                reason = payload[2:]
-            return None, (code, reason)
-        if opcode == _OP_TEXT:
-            buf = bytearray(payload)
-            while not fin:
-                h2 = self._recv_exact(2)
-                fin = (h2[0] & 0x80) != 0
-                opcode2 = h2[0] & 0x0F
-                masked2 = (h2[1] & 0x80) != 0
-                ln2 = h2[1] & 0x7F
-                if ln2 == 126:
-                    ln2 = struct.unpack(">H", self._recv_exact(2))[0]
-                elif ln2 == 127:
-                    ln2 = struct.unpack(">Q", self._recv_exact(8))[0]
-                if ln2 > MAX_FRAME_PAYLOAD:
-                    raise RuntimeError("ws continuation payload too large")
-                mk = self._recv_exact(4) if masked2 else None
-                payload2 = self._recv_exact(ln2)
-                if mk is not None:
-                    payload2 = bytes(b ^ mk[i % 4] for i, b in enumerate(payload2))
-                if opcode2 != _OP_CONT:
-                    raise RuntimeError(f"ws unexpected interleaved opcode {opcode2}")
-                buf.extend(payload2)
-            return buf.decode("utf-8", "replace"), None
-        return None, None
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/librefang/sidecar/adapters/qq.py
+++ b/sdk/python/librefang/sidecar/adapters/qq.py
@@ -155,6 +155,8 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
+    SeenSet as _SeenSet,
+    http_request as _http_request,
     parse_retry_after as _parse_retry_after_impl,
     split_csv as _split_csv,
     split_message as _split_message,
@@ -499,9 +501,7 @@ class QqAdapter(SidecarAdapter):
         self._token_lock = threading.Lock()
 
         # Improvement #2: bounded dedupe on QQ ``id``.
-        self._seen_ids: set[str] = set()
-        self._seen_order: list[str] = []
-        self._seen_lock = threading.Lock()
+        self._seen = _SeenSet(max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT)
 
     # ---- HTTP helpers ------------------------------------------------
 
@@ -528,59 +528,17 @@ class QqAdapter(SidecarAdapter):
         headers: Optional[dict] = None,
         timeout: float = SEND_TIMEOUT_SECS,
     ) -> tuple[int, Any, bytes, dict]:
-        """One-shot HTTP request. Returns
-        ``(status, parsed_json_or_None, raw_bytes, response_headers)``.
-        Response headers are lower-cased so 429 ``Retry-After`` lookups
-        are case-insensitive."""
-        req = urllib.request.Request(
-            url, data=body, headers=headers or {}, method=method,
+        """Thin wrapper around :func:`librefang.sidecar.common.http_request`."""
+        return _http_request(
+            url, method=method, body=body, headers=headers,
+            timeout=timeout,
         )
-        resp_headers: dict = {}
-        try:
-            with urllib.request.urlopen(  # noqa: S310 — configured URL
-                req, timeout=timeout,
-            ) as resp:
-                status = getattr(resp, "status", 200)
-                raw = resp.read()
-                if resp.headers is not None:
-                    resp_headers = {
-                        k.lower(): v for k, v in resp.headers.items()
-                    }
-        except urllib.error.HTTPError as e:
-            status = e.code
-            try:
-                raw = e.read()
-            except Exception:  # noqa: BLE001
-                raw = b""
-            if e.headers is not None:
-                resp_headers = {k.lower(): v for k, v in e.headers.items()}
-        if not raw:
-            return status, None, b"", resp_headers
-        try:
-            return status, json.loads(raw.decode("utf-8")), raw, resp_headers
-        except (ValueError, TypeError, UnicodeDecodeError):
-            return status, None, raw, resp_headers
 
     # ---- dedupe ------------------------------------------------------
 
     def _mark_seen(self, msg_id: Optional[str]) -> bool:
-        """Return True iff ``msg_id`` is freshly seen (i.e. emit it).
-        ``None`` / empty ids are always treated as fresh — they don't
-        participate in dedupe. Mirrors reddit / rocketchat / nextcloud /
-        webex / line / mattermost / signal."""
-        if not msg_id:
-            return True
-        with self._seen_lock:
-            if msg_id in self._seen_ids:
-                return False
-            self._seen_ids.add(msg_id)
-            self._seen_order.append(msg_id)
-            if len(self._seen_order) > SEEN_MESSAGES_MAX:
-                drop = self._seen_order[:SEEN_MESSAGES_EVICT]
-                self._seen_order = self._seen_order[SEEN_MESSAGES_EVICT:]
-                for k in drop:
-                    self._seen_ids.discard(k)
-            return True
+        """Return True iff freshly seen. Shim around :class:`librefang.sidecar.common.SeenSet`."""
+        return self._seen.mark(msg_id)
 
     # ---- REST: token + gateway + outbound send ----------------------
 

--- a/sdk/python/librefang/sidecar/adapters/qq.py
+++ b/sdk/python/librefang/sidecar/adapters/qq.py
@@ -155,9 +155,11 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
-    SeenSet as _SeenSet,
     http_request as _http_request,
+    MAX_BACKOFF_SECS,
     parse_retry_after as _parse_retry_after_impl,
+    RETRY_AFTER_DEFAULT_SECS,
+    SeenSet as _SeenSet,
     split_csv as _split_csv,
     split_message as _split_message,
 )
@@ -183,13 +185,6 @@ SEND_TIMEOUT_SECS = 15.0
 HANDSHAKE_TIMEOUT_SECS = 15.0
 
 INITIAL_BACKOFF_SECS = 2.0
-MAX_BACKOFF_SECS = 60.0
-
-# Default fallback when QQ 429s without a parseable Retry-After
-# header. 30 s is conservative — mirrors the rocketchat / nextcloud /
-# webex / line / mattermost / signal sidecars (#5303).
-RETRY_AFTER_DEFAULT_SECS = 30.0
-
 # Bounded dedupe cap on QQ ``id``. Same policy as reddit / rocketchat /
 # nextcloud / webex / line / mattermost / signal.
 SEEN_MESSAGES_MAX = 10_000

--- a/sdk/python/librefang/sidecar/adapters/reddit.py
+++ b/sdk/python/librefang/sidecar/adapters/reddit.py
@@ -120,6 +120,7 @@ from typing import Any
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import SeenSet as _SeenSet, http_request as _http_request
 
 DEFAULT_TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
 DEFAULT_API_BASE = "https://oauth.reddit.com"
@@ -368,8 +369,9 @@ class RedditAdapter(SidecarAdapter):
         # Dedupe set for already-seen comment IDs. Capped by
         # SEEN_COMMENTS_MAX with crude oldest-half eviction (matches
         # the Rust adapter's eviction policy).
-        self._seen_comments: list[str] = []
-        self._seen_comments_set: set[str] = set()
+        self._seen = _SeenSet(
+            max_size=SEEN_COMMENTS_MAX, evict=SEEN_COMMENTS_EVICT,
+        )
 
     # ---- HTTP helpers ------------------------------------------------
 
@@ -536,18 +538,8 @@ class RedditAdapter(SidecarAdapter):
     # ---- inbound: poll new comments per subreddit --------------------
 
     def _mark_seen(self, comment_id: str) -> None:
-        """Track a comment ID with crude oldest-half eviction on
-        overflow. Mirrors the Rust adapter's eviction (it sorted by
-        insertion order via HashMap iteration; we use an explicit
-        list so the eviction is deterministic)."""
-        if comment_id in self._seen_comments_set:
-            return
-        self._seen_comments.append(comment_id)
-        self._seen_comments_set.add(comment_id)
-        if len(self._seen_comments) > SEEN_COMMENTS_MAX:
-            to_drop = self._seen_comments[:SEEN_COMMENTS_EVICT]
-            self._seen_comments = self._seen_comments[SEEN_COMMENTS_EVICT:]
-            self._seen_comments_set.difference_update(to_drop)
+        """Return True iff freshly seen. Shim around :class:`librefang.sidecar.common.SeenSet`."""
+        return self._seen.mark(comment_id)
 
     def _poll_once(self, emit) -> None:
         """Poll every configured subreddit once. Errors per-subreddit
@@ -624,7 +616,7 @@ class RedditAdapter(SidecarAdapter):
                         child.get("data"), dict,
                     ) else ""
                 )
-                if not comment_id or comment_id in self._seen_comments_set:
+                if not comment_id or comment_id in self._seen.ids:
                     continue
                 ev = _parse_reddit_comment(child, self.own_username)
                 if ev is None:

--- a/sdk/python/librefang/sidecar/adapters/reddit.py
+++ b/sdk/python/librefang/sidecar/adapters/reddit.py
@@ -119,6 +119,7 @@ from typing import Any
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import split_message as _split_message
 
 DEFAULT_TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
 DEFAULT_API_BASE = "https://oauth.reddit.com"
@@ -180,26 +181,6 @@ def _normalise_subreddit(value: str) -> str:
     if s.startswith("r/"):
         s = s[2:]
     return s.strip("/")
-
-
-def _split_message(text: str, max_len: int) -> list[str]:
-    """Chunk `text` into <= max_len pieces, preferring newline splits.
-    Matches the Rust ``split_message`` helper used across channels."""
-    if len(text) <= max_len:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > max_len:
-        window = rest[:max_len]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = max_len
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < max_len else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
 
 def _parse_reddit_comment(comment: dict, own_username: str) -> dict | None:
     """Parse a Reddit comment JSON object into a ``message`` event.

--- a/sdk/python/librefang/sidecar/adapters/reddit.py
+++ b/sdk/python/librefang/sidecar/adapters/reddit.py
@@ -119,7 +119,10 @@ from typing import Any
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
-from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import (
+    MAX_BACKOFF_SECS,
+    split_message as _split_message,
+)
 from librefang.sidecar.common import SeenSet as _SeenSet, http_request as _http_request
 
 DEFAULT_TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
@@ -136,7 +139,6 @@ MAX_MESSAGE_LEN = 10000
 DEFAULT_POLL_INTERVAL_SECS = 30
 MIN_POLL_INTERVAL_SECS = 5
 SEND_TIMEOUT_SECS = 15
-MAX_BACKOFF_SECS = 60.0
 # Refresh OAuth tokens 5 minutes before expiry.
 TOKEN_REFRESH_BUFFER_SECS = 300
 # Cap the dedupe set; oldest half is evicted on overflow.

--- a/sdk/python/librefang/sidecar/adapters/rocketchat.py
+++ b/sdk/python/librefang/sidecar/adapters/rocketchat.py
@@ -98,6 +98,7 @@ from typing import Any
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import SeenSet as _SeenSet, http_request as _http_request
 
 # Matches the Rust adapter's MAX_MESSAGE_LEN. Rocket.Chat's hard cap is
 # typically configured at 5000 by default and operator-tunable; 4096 is
@@ -239,8 +240,9 @@ class RocketChatAdapter(SidecarAdapter):
         self._room_watermarks: dict[str, str] = {}
         # Dedupe set on Rocket.Chat message `_id` (cheap, bounded). Same
         # cap / eviction policy as reddit.
-        self._seen_messages: list[str] = []
-        self._seen_messages_set: set[str] = set()
+        self._seen = _SeenSet(
+            max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT,
+        )
 
     # ---- HTTP helpers ------------------------------------------------
 
@@ -405,16 +407,8 @@ class RocketChatAdapter(SidecarAdapter):
     # ---- dedupe ------------------------------------------------------
 
     def _mark_seen(self, msg_id: str) -> None:
-        """Track a message id with bounded eviction. Mirrors reddit's
-        list+set policy so eviction is deterministic across runs."""
-        if not msg_id or msg_id in self._seen_messages_set:
-            return
-        self._seen_messages.append(msg_id)
-        self._seen_messages_set.add(msg_id)
-        if len(self._seen_messages) > SEEN_MESSAGES_MAX:
-            to_drop = self._seen_messages[:SEEN_MESSAGES_EVICT]
-            self._seen_messages = self._seen_messages[SEEN_MESSAGES_EVICT:]
-            self._seen_messages_set.difference_update(to_drop)
+        """Return True iff freshly seen. Shim around :class:`librefang.sidecar.common.SeenSet`."""
+        return self._seen.mark(msg_id)
 
     # ---- inbound parsing ---------------------------------------------
 
@@ -559,7 +553,7 @@ class RocketChatAdapter(SidecarAdapter):
                     continue
                 msg_id = str(msg.get("_id") or "")
                 msg_ts = str(msg.get("ts") or "")
-                if msg_id and msg_id in self._seen_messages_set:
+                if msg_id and msg_id in self._seen.ids:
                     # Already emitted — could be a same-ts duplicate
                     # from the previous poll. Still bump the watermark
                     # so the API query keeps advancing.

--- a/sdk/python/librefang/sidecar/adapters/rocketchat.py
+++ b/sdk/python/librefang/sidecar/adapters/rocketchat.py
@@ -97,6 +97,7 @@ from typing import Any
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import split_message as _split_message
 
 # Matches the Rust adapter's MAX_MESSAGE_LEN. Rocket.Chat's hard cap is
 # typically configured at 5000 by default and operator-tunable; 4096 is
@@ -123,26 +124,6 @@ HISTORY_COUNT = 50
 # enough to cover ts-collisions and overlapping fetches between polls.
 SEEN_MESSAGES_MAX = 10000
 SEEN_MESSAGES_EVICT = 5000
-
-
-def _split_message(text: str, max_len: int) -> list[str]:
-    """Chunk `text` into <= max_len pieces, preferring newline splits.
-    Matches the Rust ``split_message`` helper used across channels."""
-    if len(text) <= max_len:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > max_len:
-        window = rest[:max_len]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = max_len
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < max_len else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
 
 def _parse_channels(raw: str) -> list[str]:
     """Comma-separated channel id list. Strips whitespace and empty

--- a/sdk/python/librefang/sidecar/adapters/rocketchat.py
+++ b/sdk/python/librefang/sidecar/adapters/rocketchat.py
@@ -97,7 +97,11 @@ from typing import Any
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
-from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import (
+    MAX_BACKOFF_SECS,
+    RETRY_AFTER_DEFAULT_SECS,
+    split_message as _split_message,
+)
 from librefang.sidecar.common import SeenSet as _SeenSet, http_request as _http_request
 
 # Matches the Rust adapter's MAX_MESSAGE_LEN. Rocket.Chat's hard cap is
@@ -109,12 +113,6 @@ MAX_MESSAGE_LEN = 4096
 DEFAULT_POLL_INTERVAL_SECS = 2
 MIN_POLL_INTERVAL_SECS = 1
 SEND_TIMEOUT_SECS = 15
-MAX_BACKOFF_SECS = 60.0
-# Default fallback when Rocket.Chat 429s without a `Retry-After`
-# header. The REST API's rate-limiter typically sends one (seconds
-# form), but it isn't required by the protocol, so we need a sane
-# fallback to avoid busy-looping at 1 s.
-RETRY_AFTER_DEFAULT_SECS = 30.0
 # How many channels to fetch in `channels.list.joined`. Matches Rust.
 LIST_JOINED_COUNT = 100
 # How many messages per `channels.history` poll. Matches Rust.

--- a/sdk/python/librefang/sidecar/adapters/signal.py
+++ b/sdk/python/librefang/sidecar/adapters/signal.py
@@ -125,6 +125,8 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
+    SeenSet as _SeenSet,
+    http_request as _http_request,
     parse_retry_after as _parse_retry_after_impl,
     split_csv as _split_csv,
     split_message as _split_message,
@@ -417,9 +419,7 @@ class SignalAdapter(SidecarAdapter):
             self.poll_interval = DEFAULT_POLL_INTERVAL_SECS
 
         # Improvement #1: bounded dedupe on envelope.timestamp.
-        self._seen_ids: set[str] = set()
-        self._seen_order: list[str] = []
-        self._seen_lock = threading.Lock()
+        self._seen = _SeenSet(max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT)
 
         self._shutdown = threading.Event()
 
@@ -444,59 +444,17 @@ class SignalAdapter(SidecarAdapter):
         headers: Optional[dict] = None,
         timeout: float = SEND_TIMEOUT_SECS,
     ) -> tuple[int, Any, bytes, dict]:
-        """One-shot HTTP request. Returns
-        ``(status, parsed_json_or_None, raw_bytes, response_headers)``.
-        Response headers are lower-cased so 429 ``Retry-After`` lookups
-        are case-insensitive."""
-        req = urllib.request.Request(
-            url, data=body, headers=headers or {}, method=method,
+        """Thin wrapper around :func:`librefang.sidecar.common.http_request`."""
+        return _http_request(
+            url, method=method, body=body, headers=headers,
+            timeout=timeout,
         )
-        resp_headers: dict = {}
-        try:
-            with urllib.request.urlopen(  # noqa: S310 — configured URL
-                req, timeout=timeout,
-            ) as resp:
-                status = getattr(resp, "status", 200)
-                raw = resp.read()
-                if resp.headers is not None:
-                    resp_headers = {
-                        k.lower(): v for k, v in resp.headers.items()
-                    }
-        except urllib.error.HTTPError as e:
-            status = e.code
-            try:
-                raw = e.read()
-            except Exception:  # noqa: BLE001
-                raw = b""
-            if e.headers is not None:
-                resp_headers = {k.lower(): v for k, v in e.headers.items()}
-        if not raw:
-            return status, None, b"", resp_headers
-        try:
-            return status, json.loads(raw.decode("utf-8")), raw, resp_headers
-        except (ValueError, TypeError, UnicodeDecodeError):
-            return status, None, raw, resp_headers
 
     # ---- dedupe ------------------------------------------------------
 
     def _mark_seen(self, message_id: Optional[str]) -> bool:
-        """Return True iff ``message_id`` is freshly seen (i.e. emit it).
-        ``None`` / empty ids are always treated as fresh — they don't
-        participate in dedupe. Mirrors reddit / rocketchat / nextcloud /
-        webex / line / mattermost."""
-        if not message_id:
-            return True
-        with self._seen_lock:
-            if message_id in self._seen_ids:
-                return False
-            self._seen_ids.add(message_id)
-            self._seen_order.append(message_id)
-            if len(self._seen_order) > SEEN_MESSAGES_MAX:
-                drop = self._seen_order[:SEEN_MESSAGES_EVICT]
-                self._seen_order = self._seen_order[SEEN_MESSAGES_EVICT:]
-                for k in drop:
-                    self._seen_ids.discard(k)
-            return True
+        """Return True iff freshly seen. Shim around :class:`librefang.sidecar.common.SeenSet`."""
+        return self._seen.mark(message_id)
 
     # ---- REST: poll + send ------------------------------------------
 

--- a/sdk/python/librefang/sidecar/adapters/signal.py
+++ b/sdk/python/librefang/sidecar/adapters/signal.py
@@ -124,6 +124,11 @@ from typing import Any, Callable, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import (
+    parse_retry_after as _parse_retry_after_impl,
+    split_csv as _split_csv,
+    split_message as _split_message,
+)
 
 SEND_TIMEOUT_SECS = 15.0
 POLL_TIMEOUT_SECS = 30.0
@@ -143,25 +148,15 @@ SEEN_MESSAGES_EVICT = 5_000
 
 DEFAULT_POLL_INTERVAL_SECS = 2.0
 
-
-def _split_csv(raw: str) -> list[str]:
-    """Comma-separated env-var → cleaned list of strings."""
-    if not raw:
-        return []
-    return [s.strip() for s in raw.split(",") if s.strip()]
-
-
 def _parse_retry_after(resp_hdrs: dict, *, default_secs: float) -> float:
-    """``Retry-After`` parser, floor 1 s, cap ``MAX_BACKOFF_SECS``."""
-    raw = resp_hdrs.get("retry-after")
-    if not raw:
-        return default_secs
-    try:
-        v = float(raw)
-    except (TypeError, ValueError):
-        return default_secs
-    return min(max(v, 1.0), MAX_BACKOFF_SECS)
-
+    """Backwards-compat wrapper around
+    :func:`librefang.sidecar.common.parse_retry_after`."""
+    return _parse_retry_after_impl(
+        resp_hdrs,
+        default_secs=default_secs,
+        floor_secs=1.0,
+        max_secs=MAX_BACKOFF_SECS,
+    )
 
 def _is_private_or_loopback(addr: str) -> bool:
     """Mirror the Rust adapter's ``is_private_or_loopback`` at

--- a/sdk/python/librefang/sidecar/adapters/signal.py
+++ b/sdk/python/librefang/sidecar/adapters/signal.py
@@ -125,9 +125,11 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
-    SeenSet as _SeenSet,
     http_request as _http_request,
+    MAX_BACKOFF_SECS,
     parse_retry_after as _parse_retry_after_impl,
+    RETRY_AFTER_DEFAULT_SECS,
+    SeenSet as _SeenSet,
     split_csv as _split_csv,
     split_message as _split_message,
 )
@@ -136,13 +138,6 @@ SEND_TIMEOUT_SECS = 15.0
 POLL_TIMEOUT_SECS = 30.0
 
 INITIAL_BACKOFF_SECS = 1.0
-MAX_BACKOFF_SECS = 60.0
-
-# Default fallback when signal-cli-rest-api 429s without a parseable
-# ``Retry-After`` header. 30 s is conservative — mirrors the rocketchat
-# / nextcloud / webex / line / mattermost sidecars (#5303).
-RETRY_AFTER_DEFAULT_SECS = 30.0
-
 # Bounded dedupe cap on ``envelope.timestamp``. Same policy as
 # reddit / rocketchat / nextcloud / webex / line / mattermost.
 SEEN_MESSAGES_MAX = 10_000

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -65,14 +65,8 @@ API call).
 from __future__ import annotations
 
 import asyncio
-import base64
-import hashlib
 import json
 import os
-import select
-import socket
-import ssl
-import struct
 import threading
 import time
 import urllib.error
@@ -82,6 +76,20 @@ from typing import Any, Callable, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import (
+    parse_retry_after as _parse_retry_after_impl,
+    split_csv as _split_csv,
+    split_message as _split_message,
+)
+from librefang.sidecar.ws import (
+    MAX_FRAME_PAYLOAD,
+    OP_CLOSE as _OP_CLOSE,
+    OP_CONT as _OP_CONT,
+    OP_PING as _OP_PING,
+    OP_PONG as _OP_PONG,
+    OP_TEXT as _OP_TEXT,
+    WebSocketClient as _WebSocketClient,
+)
 
 # Slack constants — mirror crate::slack defaults.
 DEFAULT_API_BASE = "https://slack.com/api"
@@ -96,50 +104,7 @@ HANDSHAKE_TIMEOUT_SECS = 15.0
 INITIAL_BACKOFF_SECS = 1.0
 MAX_BACKOFF_SECS = 60.0
 
-# RFC 6455 — same constants as the discord sidecar (#5299).
-_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-_OP_CONT = 0x0
-_OP_TEXT = 0x1
-_OP_BIN = 0x2
-_OP_CLOSE = 0x8
-_OP_PING = 0x9
-_OP_PONG = 0xA
-
-MAX_FRAME_PAYLOAD = 1 << 22  # 4 MiB
-
-# How long to wait for a Socket Mode frame before sending an
-# application-level ping (Slack's server sends pings; we mostly
-# just need to react to them via the WS layer). Used as the
-# select() timeout in the inner read loop.
 READ_TICK_SECS = 30.0
-
-
-def _split_message(text: str, limit: int) -> list[str]:
-    """Chunk `text` into <= limit pieces, preferring newline splits.
-    Mirrors the shared Rust ``split_message`` helper."""
-    if len(text) <= limit:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > limit:
-        window = rest[:limit]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = limit
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < limit else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
-
-def _split_csv(raw: str) -> list[str]:
-    """Comma-separated env-var → cleaned list of strings."""
-    if not raw:
-        return []
-    return [s.strip() for s in raw.split(",") if s.strip()]
-
-
 def _bool_env(raw: str, *, default: bool) -> bool:
     """Parse a permissive bool env var. ``""`` / unset → ``default``."""
     v = raw.strip().lower()
@@ -381,226 +346,6 @@ def parse_slack_block_action(
     )
 
 
-# ---------------------------------------------------------------------------
-# Stdlib WebSocket client — copied verbatim from the discord sidecar
-# (#5299). Identical RFC 6455 reader, identical select-gated frame
-# wait pattern.
-# ---------------------------------------------------------------------------
-
-
-class _WebSocketClient:
-    def __init__(
-        self,
-        url: str,
-        *,
-        headers: Optional[dict] = None,
-        handshake_timeout: float = HANDSHAKE_TIMEOUT_SECS,
-    ) -> None:
-        self.url = url
-        self.headers = dict(headers or {})
-        self._sock: Optional[socket.socket] = None
-        self._leftover = b""
-        self._handshake_timeout = handshake_timeout
-        self._send_lock = threading.Lock()
-        self.closed = False
-
-    @staticmethod
-    def _parse_url(url: str) -> tuple[str, int, str, bool]:
-        u = urllib.parse.urlparse(url)
-        scheme = u.scheme.lower()
-        if scheme not in ("ws", "wss"):
-            raise ValueError(f"not a websocket url: {url!r}")
-        if not u.hostname:
-            raise ValueError(f"websocket url missing host: {url!r}")
-        is_tls = scheme == "wss"
-        port = u.port or (443 if is_tls else 80)
-        path = u.path or "/"
-        if u.query:
-            path += "?" + u.query
-        return u.hostname, port, path, is_tls
-
-    def __enter__(self) -> "_WebSocketClient":
-        host, port, path, is_tls = self._parse_url(self.url)
-        sock = socket.create_connection((host, port), timeout=self._handshake_timeout)
-        if is_tls:
-            ctx = ssl.create_default_context()
-            sock = ctx.wrap_socket(sock, server_hostname=host)
-        key = base64.b64encode(os.urandom(16)).decode("ascii")
-        lines = [
-            f"GET {path} HTTP/1.1",
-            f"Host: {host}:{port}",
-            "Upgrade: websocket",
-            "Connection: Upgrade",
-            f"Sec-WebSocket-Key: {key}",
-            "Sec-WebSocket-Version: 13",
-        ]
-        for k, v in self.headers.items():
-            lines.append(f"{k}: {v}")
-        req = ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
-        sock.sendall(req)
-        buf = b""
-        while b"\r\n\r\n" not in buf:
-            chunk = sock.recv(4096)
-            if not chunk:
-                sock.close()
-                raise RuntimeError("connection closed during ws handshake")
-            buf += chunk
-            if len(buf) > 65536:
-                sock.close()
-                raise RuntimeError("ws handshake response too large")
-        head, _, leftover = buf.partition(b"\r\n\r\n")
-        head_lines = head.split(b"\r\n")
-        status = head_lines[0]
-        if not status.startswith(b"HTTP/1.1 101 "):
-            sock.close()
-            raise RuntimeError(
-                f"ws handshake failed: {status.decode('ascii', 'replace')}"
-            )
-        expected = base64.b64encode(
-            hashlib.sha1((key + _WS_GUID).encode("ascii")).digest()
-        ).decode("ascii")
-        got = None
-        for line in head_lines[1:]:
-            name, _, val = line.partition(b":")
-            if name.strip().lower() == b"sec-websocket-accept":
-                got = val.strip().decode("ascii", "replace")
-                break
-        if got != expected:
-            sock.close()
-            raise RuntimeError("ws handshake Sec-WebSocket-Accept mismatch")
-        self._sock = sock
-        self._leftover = leftover
-        return self
-
-    def __exit__(self, *_exc) -> None:
-        self.closed = True
-        if self._sock is not None:
-            try:
-                self._sock.close()
-            except OSError:
-                pass
-            self._sock = None
-
-    def settimeout(self, timeout: Optional[float]) -> None:
-        if self._sock is not None:
-            self._sock.settimeout(timeout)
-
-    def wait_readable(self, timeout: float) -> bool:
-        if self._leftover:
-            return True
-        sock = self._sock
-        if sock is None:
-            return False
-        pending = getattr(sock, "pending", None)
-        if callable(pending):
-            try:
-                if pending() > 0:
-                    return True
-            except Exception:  # noqa: BLE001
-                pass
-        try:
-            r, _, _ = select.select([sock], [], [], max(0.0, timeout))
-        except (OSError, ValueError):
-            return False
-        return bool(r)
-
-    def _recv_exact(self, n: int) -> bytes:
-        if n <= 0:
-            return b""
-        buf = bytearray()
-        while len(buf) < n:
-            if self._leftover:
-                take = min(n - len(buf), len(self._leftover))
-                buf.extend(self._leftover[:take])
-                self._leftover = self._leftover[take:]
-                continue
-            assert self._sock is not None
-            chunk = self._sock.recv(n - len(buf))
-            if not chunk:
-                raise EOFError("websocket closed mid-frame")
-            buf.extend(chunk)
-        return bytes(buf)
-
-    def _send_frame(self, opcode: int, payload: bytes) -> None:
-        assert self._sock is not None
-        header = bytearray([0x80 | (opcode & 0x0F)])
-        ln = len(payload)
-        if ln < 126:
-            header.append(0x80 | ln)
-        elif ln < 65536:
-            header.append(0x80 | 126)
-            header.extend(struct.pack(">H", ln))
-        else:
-            header.append(0x80 | 127)
-            header.extend(struct.pack(">Q", ln))
-        mask = os.urandom(4)
-        header.extend(mask)
-        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-        with self._send_lock:
-            self._sock.sendall(bytes(header) + masked)
-
-    def send_text(self, s: str) -> None:
-        self._send_frame(_OP_TEXT, s.encode("utf-8"))
-
-    def send_close(self) -> None:
-        try:
-            self._send_frame(_OP_CLOSE, b"")
-        except OSError:
-            pass
-
-    def recv_frame(self) -> tuple[Optional[str], Optional[tuple[int, bytes]]]:
-        h2 = self._recv_exact(2)
-        fin = (h2[0] & 0x80) != 0
-        opcode = h2[0] & 0x0F
-        masked = (h2[1] & 0x80) != 0
-        ln = h2[1] & 0x7F
-        if ln == 126:
-            ln = struct.unpack(">H", self._recv_exact(2))[0]
-        elif ln == 127:
-            ln = struct.unpack(">Q", self._recv_exact(8))[0]
-        if ln > MAX_FRAME_PAYLOAD:
-            raise RuntimeError(
-                f"websocket frame payload {ln} exceeds cap {MAX_FRAME_PAYLOAD}"
-            )
-        mask_key = self._recv_exact(4) if masked else None
-        payload = self._recv_exact(ln)
-        if mask_key is not None:
-            payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
-        if opcode == _OP_PING:
-            self._send_frame(_OP_PONG, payload)
-            return None, None
-        if opcode == _OP_PONG:
-            return None, None
-        if opcode == _OP_CLOSE:
-            code = 1005
-            reason = b""
-            if len(payload) >= 2:
-                code = struct.unpack(">H", payload[:2])[0]
-                reason = payload[2:]
-            return None, (code, reason)
-        if opcode == _OP_TEXT:
-            buf = bytearray(payload)
-            while not fin:
-                h2 = self._recv_exact(2)
-                fin = (h2[0] & 0x80) != 0
-                opcode2 = h2[0] & 0x0F
-                masked2 = (h2[1] & 0x80) != 0
-                ln2 = h2[1] & 0x7F
-                if ln2 == 126:
-                    ln2 = struct.unpack(">H", self._recv_exact(2))[0]
-                elif ln2 == 127:
-                    ln2 = struct.unpack(">Q", self._recv_exact(8))[0]
-                if ln2 > MAX_FRAME_PAYLOAD:
-                    raise RuntimeError("ws continuation payload too large")
-                mk = self._recv_exact(4) if masked2 else None
-                payload2 = self._recv_exact(ln2)
-                if mk is not None:
-                    payload2 = bytes(b ^ mk[i % 4] for i, b in enumerate(payload2))
-                if opcode2 != _OP_CONT:
-                    raise RuntimeError(f"ws unexpected interleaved opcode {opcode2}")
-                buf.extend(payload2)
-            return buf.decode("utf-8", "replace"), None
-        return None, None
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -77,6 +77,8 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
+    SeenSet as _SeenSet,
+    http_request as _http_request,
     parse_retry_after as _parse_retry_after_impl,
     split_csv as _split_csv,
     split_message as _split_message,
@@ -474,27 +476,16 @@ class SlackAdapter(SidecarAdapter):
         headers: Optional[dict] = None,
         timeout: float = SEND_TIMEOUT_SECS,
     ) -> tuple[int, Any, bytes]:
-        req = urllib.request.Request(
-            url, data=body, headers=headers or {}, method=method,
+        """Thin wrapper around
+        :func:`librefang.sidecar.common.http_request`. Slack's
+        callers historically unpack the 3-tuple ``(status, parsed,
+        raw)`` form — strip the response-headers dict the shared
+        helper returns so existing call sites don't break."""
+        status, parsed, raw, _resp_hdrs = _http_request(
+            url, method=method, body=body, headers=headers,
+            timeout=timeout,
         )
-        try:
-            with urllib.request.urlopen(  # noqa: S310 — configured URL
-                req, timeout=timeout,
-            ) as resp:
-                status = getattr(resp, "status", 200)
-                raw = resp.read()
-        except urllib.error.HTTPError as e:
-            status = e.code
-            try:
-                raw = e.read()
-            except Exception:  # noqa: BLE001
-                raw = b""
-        if not raw:
-            return status, None, b""
-        try:
-            return status, json.loads(raw.decode("utf-8")), raw
-        except (ValueError, TypeError, UnicodeDecodeError):
-            return status, None, raw
+        return status, parsed, raw
 
     # ---- REST: auth, socket-mode URL, send, reactions, role lookup --
 

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -77,9 +77,10 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
-    SeenSet as _SeenSet,
     http_request as _http_request,
+    MAX_BACKOFF_SECS,
     parse_retry_after as _parse_retry_after_impl,
+    SeenSet as _SeenSet,
     split_csv as _split_csv,
     split_message as _split_message,
 )
@@ -104,8 +105,6 @@ SEND_TIMEOUT_SECS = 15.0
 HANDSHAKE_TIMEOUT_SECS = 15.0
 
 INITIAL_BACKOFF_SECS = 1.0
-MAX_BACKOFF_SECS = 60.0
-
 READ_TICK_SECS = 30.0
 def _bool_env(raw: str, *, default: bool) -> bool:
     """Parse a permissive bool env var. ``""`` / unset → ``default``."""

--- a/sdk/python/librefang/sidecar/adapters/telegram.py
+++ b/sdk/python/librefang/sidecar/adapters/telegram.py
@@ -62,6 +62,7 @@ import uuid
 
 from librefang.sidecar import Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import MAX_BACKOFF_SECS
 
 LONGPOLL_SERVER_SECS = 30
 LONGPOLL_CLIENT_SECS = 35
@@ -75,7 +76,6 @@ RETRY_AFTER_DEFAULT_SECS = 2
 # / DNS failures (#5111). Matches the convention every other polling
 # sidecar (bluesky / discord / line / mastodon / mattermost /
 # nextcloud / ntfy / reddit / rocketchat / twitch) settled on.
-MAX_BACKOFF_SECS = 60.0
 PARSE_MODE_HTML = "HTML"
 # Max bytes downloaded for the private-URL → multipart fallback.
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024

--- a/sdk/python/librefang/sidecar/adapters/twitch.py
+++ b/sdk/python/librefang/sidecar/adapters/twitch.py
@@ -104,6 +104,7 @@ from typing import Any, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import SeenSet as _SeenSet, http_request as _http_request
 
 DEFAULT_HOST = "irc.chat.twitch.tv"
 DEFAULT_TLS_PORT = 6697
@@ -403,10 +404,10 @@ class TwitchAdapter(SidecarAdapter):
         self._writer_lock = threading.Lock()
         self._stop = threading.Event()
 
-        # Dedupe set for already-seen message ids. Capped with
-        # crude oldest-half eviction.
-        self._seen_ids: list[str] = []
-        self._seen_ids_set: set[str] = set()
+        # Dedupe set for already-seen message ids. Twitch's tighter
+        # cap (1024/512 vs the global 10000/5000) because IRC chat
+        # is high-churn and we only need ~last-minute coverage.
+        self._seen = _SeenSet(max_size=SEEN_IDS_MAX, evict=SEEN_IDS_EVICT)
 
     # ---- transport ---------------------------------------------------
 
@@ -469,19 +470,8 @@ class TwitchAdapter(SidecarAdapter):
     # ---- dedupe ------------------------------------------------------
 
     def _mark_seen(self, msg_id: str) -> bool:
-        """Return True if `msg_id` is fresh; False if we've seen it.
-        Crude oldest-half eviction at the cap."""
-        if not msg_id:
-            return True
-        if msg_id in self._seen_ids_set:
-            return False
-        self._seen_ids.append(msg_id)
-        self._seen_ids_set.add(msg_id)
-        if len(self._seen_ids) > SEEN_IDS_MAX:
-            to_drop = self._seen_ids[:SEEN_IDS_EVICT]
-            self._seen_ids = self._seen_ids[SEEN_IDS_EVICT:]
-            self._seen_ids_set.difference_update(to_drop)
-        return True
+        """Return True iff freshly seen. Shim around :class:`librefang.sidecar.common.SeenSet`."""
+        return self._seen.mark(msg_id)
 
     # ---- inbound: read loop on a worker thread ------------------------
 

--- a/sdk/python/librefang/sidecar/adapters/twitch.py
+++ b/sdk/python/librefang/sidecar/adapters/twitch.py
@@ -103,6 +103,7 @@ from typing import Any, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import split_message as _split_message
 
 DEFAULT_HOST = "irc.chat.twitch.tv"
 DEFAULT_TLS_PORT = 6697
@@ -137,27 +138,6 @@ def _normalise_channel(value: str) -> str:
     so a config typo (``MyChannel``) still matches the JOIN reply."""
     s = value.strip().lstrip("#").rstrip("/")
     return s.lower()
-
-
-def _split_message(text: str, max_len: int) -> list[str]:
-    """Chunk `text` into <= max_len pieces, preferring newline
-    splits. Mirrors the Rust ``split_message`` helper used by every
-    channel adapter."""
-    if len(text) <= max_len:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > max_len:
-        window = rest[:max_len]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = max_len
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < max_len else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
 
 def _parse_irc_tags(tag_blob: str) -> dict[str, str]:
     """Parse the IRCv3 ``@key=value;key2=value2`` tag block (without

--- a/sdk/python/librefang/sidecar/adapters/twitch.py
+++ b/sdk/python/librefang/sidecar/adapters/twitch.py
@@ -103,7 +103,10 @@ from typing import Any, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
-from librefang.sidecar.common import split_message as _split_message
+from librefang.sidecar.common import (
+    MAX_BACKOFF_SECS,
+    split_message as _split_message,
+)
 from librefang.sidecar.common import SeenSet as _SeenSet, http_request as _http_request
 
 DEFAULT_HOST = "irc.chat.twitch.tv"
@@ -130,9 +133,6 @@ SEEN_IDS_EVICT = 512
 READ_TIMEOUT_SECS = 30.0
 # Reconnect backoff bounds.
 INITIAL_BACKOFF_SECS = 1.0
-MAX_BACKOFF_SECS = 60.0
-
-
 def _normalise_channel(value: str) -> str:
     """Strip whitespace, leading ``#``, and trailing slashes. Twitch
     channels are lowercase ASCII by convention; we coerce to lower

--- a/sdk/python/librefang/sidecar/adapters/webex.py
+++ b/sdk/python/librefang/sidecar/adapters/webex.py
@@ -125,9 +125,11 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
-    SeenSet as _SeenSet,
     http_request as _http_request,
+    MAX_BACKOFF_SECS,
     parse_retry_after as _parse_retry_after_impl,
+    RETRY_AFTER_DEFAULT_SECS,
+    SeenSet as _SeenSet,
     split_csv as _split_csv,
     split_message as _split_message,
 )
@@ -158,14 +160,6 @@ SEND_TIMEOUT_SECS = 15.0
 HANDSHAKE_TIMEOUT_SECS = 15.0
 
 INITIAL_BACKOFF_SECS = 1.0
-MAX_BACKOFF_SECS = 60.0
-
-# Default fallback when Webex 429s without a parseable ``Retry-After``
-# header. Mirrors the rocketchat / nextcloud / mastodon sidecars
-# (#5303); 30 s is conservative enough that we don't immediately
-# re-hit the bruteforce throttle.
-RETRY_AFTER_DEFAULT_SECS = 30.0
-
 # Bounded dedupe cap on Mercury ``activity.object.id``. Same policy as
 # reddit / rocketchat / nextcloud. ``MAX`` is the high-water mark;
 # when reached, evict the oldest ``EVICT`` entries (so the steady-state

--- a/sdk/python/librefang/sidecar/adapters/webex.py
+++ b/sdk/python/librefang/sidecar/adapters/webex.py
@@ -125,6 +125,8 @@ from typing import Any, Callable, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
+    SeenSet as _SeenSet,
+    http_request as _http_request,
     parse_retry_after as _parse_retry_after_impl,
     split_csv as _split_csv,
     split_message as _split_message,
@@ -371,9 +373,7 @@ class WebexAdapter(SidecarAdapter):
         self.bot_display_name: Optional[str] = None
 
         # Improvement #3: bounded dedupe on activity.object.id.
-        self._seen_ids: set[str] = set()
-        self._seen_order: list[str] = []
-        self._seen_lock = threading.Lock()
+        self._seen = _SeenSet(max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT)
 
     # ---- HTTP helpers ------------------------------------------------
 
@@ -395,59 +395,23 @@ class WebexAdapter(SidecarAdapter):
         headers: Optional[dict] = None,
         timeout: float = SEND_TIMEOUT_SECS,
     ) -> tuple[int, Any, bytes, dict]:
-        """One-shot HTTP request. Returns
-        ``(status, parsed_json_or_None, raw_bytes, response_headers)``.
-        Response headers are lower-cased so 429 ``Retry-After`` can be
-        looked up uniformly regardless of server casing."""
-        req = urllib.request.Request(
-            url, data=body, headers=headers or {}, method=method,
+        """Thin wrapper around :func:`librefang.sidecar.common.http_request`."""
+        return _http_request(
+            url, method=method, body=body, headers=headers,
+            timeout=timeout,
         )
-        resp_headers: dict = {}
-        try:
-            with urllib.request.urlopen(  # noqa: S310 — configured URL
-                req, timeout=timeout,
-            ) as resp:
-                status = getattr(resp, "status", 200)
-                raw = resp.read()
-                if resp.headers is not None:
-                    resp_headers = {
-                        k.lower(): v for k, v in resp.headers.items()
-                    }
-        except urllib.error.HTTPError as e:
-            status = e.code
-            try:
-                raw = e.read()
-            except Exception:  # noqa: BLE001
-                raw = b""
-            if e.headers is not None:
-                resp_headers = {k.lower(): v for k, v in e.headers.items()}
-        if not raw:
-            return status, None, b"", resp_headers
-        try:
-            return status, json.loads(raw.decode("utf-8")), raw, resp_headers
-        except (ValueError, TypeError, UnicodeDecodeError):
-            return status, None, raw, resp_headers
 
     # ---- dedupe ------------------------------------------------------
 
     def _mark_seen(self, message_id: str) -> bool:
-        """Return True iff ``message_id`` is freshly seen (i.e. emit it).
-        Maintains a bounded LRU-ish set keyed on Mercury
-        ``activity.object.id``. Improvement #3."""
+        """Return True iff freshly seen. Shim around
+        :class:`librefang.sidecar.common.SeenSet` with webex's
+        historical empty-id → False override (drop the event
+        instead of treating an empty id as fresh — different from
+        the other adapters)."""
         if not message_id:
             return False
-        with self._seen_lock:
-            if message_id in self._seen_ids:
-                return False
-            self._seen_ids.add(message_id)
-            self._seen_order.append(message_id)
-            if len(self._seen_order) > SEEN_MESSAGES_MAX:
-                # Evict the oldest half so we don't thrash at the cap.
-                drop = self._seen_order[:SEEN_MESSAGES_EVICT]
-                self._seen_order = self._seen_order[SEEN_MESSAGES_EVICT:]
-                for k in drop:
-                    self._seen_ids.discard(k)
-            return True
+        return self._seen.mark(message_id)
 
     # ---- REST: auth, message fetch, send ----------------------------
 

--- a/sdk/python/librefang/sidecar/adapters/webex.py
+++ b/sdk/python/librefang/sidecar/adapters/webex.py
@@ -113,14 +113,8 @@ bot Bearer token from developer.webex.com).
 from __future__ import annotations
 
 import asyncio
-import base64
-import hashlib
 import json
 import os
-import select
-import socket
-import ssl
-import struct
 import threading
 import time
 import urllib.error
@@ -130,6 +124,20 @@ from typing import Any, Callable, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import (
+    parse_retry_after as _parse_retry_after_impl,
+    split_csv as _split_csv,
+    split_message as _split_message,
+)
+from librefang.sidecar.ws import (
+    MAX_FRAME_PAYLOAD,
+    OP_CLOSE as _OP_CLOSE,
+    OP_CONT as _OP_CONT,
+    OP_PING as _OP_PING,
+    OP_PONG as _OP_PONG,
+    OP_TEXT as _OP_TEXT,
+    WebSocketClient as _WebSocketClient,
+)
 
 # Webex constants — mirror crate::webex defaults.
 DEFAULT_API_BASE = "https://webexapis.com/v1"
@@ -163,49 +171,7 @@ RETRY_AFTER_DEFAULT_SECS = 30.0
 SEEN_MESSAGES_MAX = 10_000
 SEEN_MESSAGES_EVICT = 5_000
 
-# RFC 6455 — same constants as the discord / slack sidecars.
-_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-_OP_CONT = 0x0
-_OP_TEXT = 0x1
-_OP_BIN = 0x2
-_OP_CLOSE = 0x8
-_OP_PING = 0x9
-_OP_PONG = 0xA
-
-MAX_FRAME_PAYLOAD = 1 << 22  # 4 MiB
-
-# How long to block in select() per loop iteration before re-checking
-# shutdown. Mercury sends server pings periodically; the WS layer
-# answers them automatically via the recv_frame PING→PONG path.
 READ_TICK_SECS = 30.0
-
-
-def _split_message(text: str, limit: int) -> list[str]:
-    """Chunk `text` into <= limit pieces, preferring newline splits.
-    Mirrors the shared Rust ``split_message`` helper."""
-    if len(text) <= limit:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > limit:
-        window = rest[:limit]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = limit
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < limit else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
-
-def _split_csv(raw: str) -> list[str]:
-    """Comma-separated env-var → cleaned list of strings."""
-    if not raw:
-        return []
-    return [s.strip() for s in raw.split(",") if s.strip()]
-
-
 def _parse_retry_after(resp_hdrs: dict, *, default_secs: float) -> float:
     """Webex's 429 response includes ``Retry-After`` (seconds).
     Fall back to ``default_secs`` when missing/garbled. Floor 1 s,
@@ -344,226 +310,6 @@ def parse_webex_message(
     )
 
 
-# ---------------------------------------------------------------------------
-# Stdlib WebSocket client — same RFC 6455 reader as the discord / slack
-# sidecars (#5299 / #5302). The header dict feeds custom Authorization on
-# the upgrade request (Mercury requires Bearer auth pre-handshake).
-# ---------------------------------------------------------------------------
-
-
-class _WebSocketClient:
-    def __init__(
-        self,
-        url: str,
-        *,
-        headers: Optional[dict] = None,
-        handshake_timeout: float = HANDSHAKE_TIMEOUT_SECS,
-    ) -> None:
-        self.url = url
-        self.headers = dict(headers or {})
-        self._sock: Optional[socket.socket] = None
-        self._leftover = b""
-        self._handshake_timeout = handshake_timeout
-        self._send_lock = threading.Lock()
-        self.closed = False
-
-    @staticmethod
-    def _parse_url(url: str) -> tuple[str, int, str, bool]:
-        u = urllib.parse.urlparse(url)
-        scheme = u.scheme.lower()
-        if scheme not in ("ws", "wss"):
-            raise ValueError(f"not a websocket url: {url!r}")
-        if not u.hostname:
-            raise ValueError(f"websocket url missing host: {url!r}")
-        is_tls = scheme == "wss"
-        port = u.port or (443 if is_tls else 80)
-        path = u.path or "/"
-        if u.query:
-            path += "?" + u.query
-        return u.hostname, port, path, is_tls
-
-    def __enter__(self) -> "_WebSocketClient":
-        host, port, path, is_tls = self._parse_url(self.url)
-        sock = socket.create_connection((host, port), timeout=self._handshake_timeout)
-        if is_tls:
-            ctx = ssl.create_default_context()
-            sock = ctx.wrap_socket(sock, server_hostname=host)
-        key = base64.b64encode(os.urandom(16)).decode("ascii")
-        lines = [
-            f"GET {path} HTTP/1.1",
-            f"Host: {host}:{port}",
-            "Upgrade: websocket",
-            "Connection: Upgrade",
-            f"Sec-WebSocket-Key: {key}",
-            "Sec-WebSocket-Version: 13",
-        ]
-        for k, v in self.headers.items():
-            lines.append(f"{k}: {v}")
-        req = ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
-        sock.sendall(req)
-        buf = b""
-        while b"\r\n\r\n" not in buf:
-            chunk = sock.recv(4096)
-            if not chunk:
-                sock.close()
-                raise RuntimeError("connection closed during ws handshake")
-            buf += chunk
-            if len(buf) > 65536:
-                sock.close()
-                raise RuntimeError("ws handshake response too large")
-        head, _, leftover = buf.partition(b"\r\n\r\n")
-        head_lines = head.split(b"\r\n")
-        status = head_lines[0]
-        if not status.startswith(b"HTTP/1.1 101 "):
-            sock.close()
-            raise RuntimeError(
-                f"ws handshake failed: {status.decode('ascii', 'replace')}"
-            )
-        expected = base64.b64encode(
-            hashlib.sha1((key + _WS_GUID).encode("ascii")).digest()
-        ).decode("ascii")
-        got = None
-        for line in head_lines[1:]:
-            name, _, val = line.partition(b":")
-            if name.strip().lower() == b"sec-websocket-accept":
-                got = val.strip().decode("ascii", "replace")
-                break
-        if got != expected:
-            sock.close()
-            raise RuntimeError("ws handshake Sec-WebSocket-Accept mismatch")
-        self._sock = sock
-        self._leftover = leftover
-        return self
-
-    def __exit__(self, *_exc) -> None:
-        self.closed = True
-        if self._sock is not None:
-            try:
-                self._sock.close()
-            except OSError:
-                pass
-            self._sock = None
-
-    def settimeout(self, timeout: Optional[float]) -> None:
-        if self._sock is not None:
-            self._sock.settimeout(timeout)
-
-    def wait_readable(self, timeout: float) -> bool:
-        if self._leftover:
-            return True
-        sock = self._sock
-        if sock is None:
-            return False
-        pending = getattr(sock, "pending", None)
-        if callable(pending):
-            try:
-                if pending() > 0:
-                    return True
-            except Exception:  # noqa: BLE001
-                pass
-        try:
-            r, _, _ = select.select([sock], [], [], max(0.0, timeout))
-        except (OSError, ValueError):
-            return False
-        return bool(r)
-
-    def _recv_exact(self, n: int) -> bytes:
-        if n <= 0:
-            return b""
-        buf = bytearray()
-        while len(buf) < n:
-            if self._leftover:
-                take = min(n - len(buf), len(self._leftover))
-                buf.extend(self._leftover[:take])
-                self._leftover = self._leftover[take:]
-                continue
-            assert self._sock is not None
-            chunk = self._sock.recv(n - len(buf))
-            if not chunk:
-                raise EOFError("websocket closed mid-frame")
-            buf.extend(chunk)
-        return bytes(buf)
-
-    def _send_frame(self, opcode: int, payload: bytes) -> None:
-        assert self._sock is not None
-        header = bytearray([0x80 | (opcode & 0x0F)])
-        ln = len(payload)
-        if ln < 126:
-            header.append(0x80 | ln)
-        elif ln < 65536:
-            header.append(0x80 | 126)
-            header.extend(struct.pack(">H", ln))
-        else:
-            header.append(0x80 | 127)
-            header.extend(struct.pack(">Q", ln))
-        mask = os.urandom(4)
-        header.extend(mask)
-        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-        with self._send_lock:
-            self._sock.sendall(bytes(header) + masked)
-
-    def send_text(self, s: str) -> None:
-        self._send_frame(_OP_TEXT, s.encode("utf-8"))
-
-    def send_close(self) -> None:
-        try:
-            self._send_frame(_OP_CLOSE, b"")
-        except OSError:
-            pass
-
-    def recv_frame(self) -> tuple[Optional[str], Optional[tuple[int, bytes]]]:
-        h2 = self._recv_exact(2)
-        fin = (h2[0] & 0x80) != 0
-        opcode = h2[0] & 0x0F
-        masked = (h2[1] & 0x80) != 0
-        ln = h2[1] & 0x7F
-        if ln == 126:
-            ln = struct.unpack(">H", self._recv_exact(2))[0]
-        elif ln == 127:
-            ln = struct.unpack(">Q", self._recv_exact(8))[0]
-        if ln > MAX_FRAME_PAYLOAD:
-            raise RuntimeError(
-                f"websocket frame payload {ln} exceeds cap {MAX_FRAME_PAYLOAD}"
-            )
-        mask_key = self._recv_exact(4) if masked else None
-        payload = self._recv_exact(ln)
-        if mask_key is not None:
-            payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
-        if opcode == _OP_PING:
-            self._send_frame(_OP_PONG, payload)
-            return None, None
-        if opcode == _OP_PONG:
-            return None, None
-        if opcode == _OP_CLOSE:
-            code = 1005
-            reason = b""
-            if len(payload) >= 2:
-                code = struct.unpack(">H", payload[:2])[0]
-                reason = payload[2:]
-            return None, (code, reason)
-        if opcode == _OP_TEXT:
-            buf = bytearray(payload)
-            while not fin:
-                h2 = self._recv_exact(2)
-                fin = (h2[0] & 0x80) != 0
-                opcode2 = h2[0] & 0x0F
-                masked2 = (h2[1] & 0x80) != 0
-                ln2 = h2[1] & 0x7F
-                if ln2 == 126:
-                    ln2 = struct.unpack(">H", self._recv_exact(2))[0]
-                elif ln2 == 127:
-                    ln2 = struct.unpack(">Q", self._recv_exact(8))[0]
-                if ln2 > MAX_FRAME_PAYLOAD:
-                    raise RuntimeError("ws continuation payload too large")
-                mk = self._recv_exact(4) if masked2 else None
-                payload2 = self._recv_exact(ln2)
-                if mk is not None:
-                    payload2 = bytes(b ^ mk[i % 4] for i, b in enumerate(payload2))
-                if opcode2 != _OP_CONT:
-                    raise RuntimeError(f"ws unexpected interleaved opcode {opcode2}")
-                buf.extend(payload2)
-            return buf.decode("utf-8", "replace"), None
-        return None, None
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/librefang/sidecar/adapters/zulip.py
+++ b/sdk/python/librefang/sidecar/adapters/zulip.py
@@ -128,6 +128,11 @@ from typing import Any, Optional
 
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
+from librefang.sidecar.common import (
+    parse_retry_after as _parse_retry_after_impl,
+    split_csv as _split_csv,
+    split_message as _split_message,
+)
 
 # Zulip's official message-text ceiling. Mirrors the Rust adapter's
 # ``MAX_MESSAGE_LEN`` (crates/librefang-channels/src/zulip.rs:21).
@@ -157,35 +162,6 @@ SEEN_MESSAGES_EVICT = 5_000
 # no inbound context). Mirrors the Rust adapter's hard-coded
 # ``"LibreFang"`` at zulip.rs:463 for the same edge case.
 DEFAULT_STREAM_TOPIC = "LibreFang"
-
-
-def _split_message(text: str, limit: int) -> list[str]:
-    """Chunk ``text`` into <= limit pieces, preferring newline
-    splits. Mirrors the shared Rust ``split_message`` helper."""
-    if len(text) <= limit:
-        return [text]
-    chunks: list[str] = []
-    rest = text
-    while len(rest) > limit:
-        window = rest[:limit]
-        cut = window.rfind("\n")
-        if cut <= 0:
-            cut = limit
-        chunks.append(rest[:cut])
-        rest = rest[cut:].lstrip("\n") if cut < limit else rest[cut:]
-    if rest:
-        chunks.append(rest)
-    return chunks
-
-
-def _split_csv(raw: str) -> list[str]:
-    """Comma-separated env-var → cleaned list. Strips whitespace,
-    drops empty entries. Order preserved."""
-    if not raw:
-        return []
-    return [s.strip() for s in raw.split(",") if s.strip()]
-
-
 def _parse_retry_after(resp_hdrs: dict, *, default_secs: float) -> float:
     """Zulip's 429 response carries ``Retry-After`` in seconds form.
     Falls back to ``default_secs`` when missing or garbled. Floor

--- a/sdk/python/librefang/sidecar/adapters/zulip.py
+++ b/sdk/python/librefang/sidecar/adapters/zulip.py
@@ -129,6 +129,8 @@ from typing import Any, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
+    SeenSet as _SeenSet,
+    http_request as _http_request,
     parse_retry_after as _parse_retry_after_impl,
     split_csv as _split_csv,
     split_message as _split_message,
@@ -382,9 +384,7 @@ class ZulipAdapter(SidecarAdapter):
         self.own_full_name: str = ""
 
         # Improvement #3: bounded dedupe on Zulip message.id.
-        self._seen_ids: set[str] = set()
-        self._seen_order: list[str] = []
-        self._seen_lock = threading.Lock()
+        self._seen = _SeenSet(max_size=SEEN_MESSAGES_MAX, evict=SEEN_MESSAGES_EVICT)
 
     # ---- HTTP helpers ------------------------------------------------
 
@@ -413,61 +413,17 @@ class ZulipAdapter(SidecarAdapter):
         headers: Optional[dict] = None,
         timeout: float = SEND_TIMEOUT_SECS,
     ) -> tuple[int, Any, bytes, dict]:
-        """One-shot HTTP request. Returns
-        ``(status, parsed_json_or_None, raw_bytes, response_headers)``.
-        Response header keys are lower-cased so callers can do
-        case-insensitive lookups for ``Retry-After`` regardless of
-        server casing."""
-        req = urllib.request.Request(
-            url, data=body, headers=headers or {}, method=method,
+        """Thin wrapper around :func:`librefang.sidecar.common.http_request`."""
+        return _http_request(
+            url, method=method, body=body, headers=headers,
+            timeout=timeout,
         )
-        resp_headers: dict = {}
-        try:
-            with urllib.request.urlopen(  # noqa: S310 — configured URL
-                req, timeout=timeout,
-            ) as resp:
-                status = getattr(resp, "status", 200)
-                raw = resp.read()
-                if resp.headers is not None:
-                    resp_headers = {
-                        k.lower(): v for k, v in resp.headers.items()
-                    }
-        except urllib.error.HTTPError as e:
-            status = e.code
-            try:
-                raw = e.read()
-            except Exception:  # noqa: BLE001
-                raw = b""
-            if e.headers is not None:
-                resp_headers = {k.lower(): v for k, v in e.headers.items()}
-        if not raw:
-            return status, None, b"", resp_headers
-        try:
-            return status, json.loads(raw.decode("utf-8")), raw, resp_headers
-        except (ValueError, TypeError, UnicodeDecodeError):
-            return status, None, raw, resp_headers
 
     # ---- dedupe ------------------------------------------------------
 
     def _mark_seen(self, msg_id: Optional[str]) -> bool:
-        """Return True iff ``msg_id`` is freshly seen (i.e. emit it).
-        Maintains a bounded set + insertion-order list (oldest-half
-        eviction at the cap). Mirrors reddit / rocketchat / nextcloud /
-        webex. ``None`` / empty ids are always treated as fresh
-        (they don't participate in dedupe — no key to track)."""
-        if not msg_id:
-            return True
-        with self._seen_lock:
-            if msg_id in self._seen_ids:
-                return False
-            self._seen_ids.add(msg_id)
-            self._seen_order.append(msg_id)
-            if len(self._seen_order) > SEEN_MESSAGES_MAX:
-                drop = self._seen_order[:SEEN_MESSAGES_EVICT]
-                self._seen_order = self._seen_order[SEEN_MESSAGES_EVICT:]
-                for k in drop:
-                    self._seen_ids.discard(k)
-            return True
+        """Return True iff freshly seen. Shim around :class:`librefang.sidecar.common.SeenSet`."""
+        return self._seen.mark(msg_id)
 
     # ---- REST: validate, register, send -----------------------------
 

--- a/sdk/python/librefang/sidecar/adapters/zulip.py
+++ b/sdk/python/librefang/sidecar/adapters/zulip.py
@@ -129,9 +129,11 @@ from typing import Any, Optional
 from librefang.sidecar import Content, Field, Schema, SidecarAdapter, protocol, run_stdio_main
 from librefang.sidecar import logging as log
 from librefang.sidecar.common import (
-    SeenSet as _SeenSet,
     http_request as _http_request,
+    MAX_BACKOFF_SECS,
     parse_retry_after as _parse_retry_after_impl,
+    RETRY_AFTER_DEFAULT_SECS,
+    SeenSet as _SeenSet,
     split_csv as _split_csv,
     split_message as _split_message,
 )
@@ -147,13 +149,6 @@ LONG_POLL_HTTP_TIMEOUT_SECS = POLL_TIMEOUT_SECS + 10
 SEND_TIMEOUT_SECS = 15.0
 
 INITIAL_BACKOFF_SECS = 1.0
-MAX_BACKOFF_SECS = 60.0
-
-# Default fallback when Zulip 429s without a parseable Retry-After.
-# 30 s is conservative enough not to re-trigger throttling. Mirrors
-# the rocketchat / nextcloud / webex sidecars.
-RETRY_AFTER_DEFAULT_SECS = 30.0
-
 # Bounded dedupe cap on Zulip ``message.id``. Same policy as
 # reddit / rocketchat / nextcloud / webex.
 SEEN_MESSAGES_MAX = 10_000

--- a/sdk/python/librefang/sidecar/common.py
+++ b/sdk/python/librefang/sidecar/common.py
@@ -1,0 +1,109 @@
+"""Shared helpers for ``librefang.sidecar.adapters.*``.
+
+Every reference sidecar adapter historically inlined a near-identical
+copy of:
+
+* ``_split_message`` — newline-preferring chunker for outbound text;
+  14 byte-identical copies (only the parameter name drifted between
+  ``max_len`` / ``limit``).
+* ``_split_csv`` — comma-separated env-var → cleaned list;
+  3 hash groups across 7 sidecars, all behaviourally identical.
+* ``_parse_retry_after`` — ``Retry-After`` header parser used by
+  every 429-aware adapter; 6 hash groups across 7 sidecars. The only
+  meaningful drift is the lower clamp (discord at 0.1 s, every other
+  adapter at 1.0 s).
+
+This module is the single source of truth. Adapters should
+``from librefang.sidecar.common import split_message, split_csv,
+parse_retry_after`` rather than re-implementing.
+
+Hash audit at extraction time:
+- ``_split_message``: 14 files, all behaviour-identical
+- ``_split_csv``: 7 files, all behaviour-identical
+- ``_parse_retry_after``: 7 files, identical except for floor
+  (parameterised via ``floor_secs``)
+"""
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+
+def split_message(text: str, limit: int) -> list[str]:
+    """Chunk ``text`` into <= ``limit`` pieces, preferring newline
+    splits. Mirrors the shared Rust ``split_message`` helper in
+    ``librefang-channels::types``.
+
+    Splitting rule:
+
+    * If ``text`` already fits, return ``[text]`` unchanged.
+    * Otherwise scan a ``limit``-wide window for the rightmost
+      newline; if found, split there (so messages break on a
+      semantic boundary). If no newline is in the window, hard-cut
+      at ``limit``.
+    * The leftover after a newline-cut has its leading ``\\n``
+      stripped so the next chunk doesn't start with a blank line.
+    """
+    if len(text) <= limit:
+        return [text]
+    chunks: list[str] = []
+    rest = text
+    while len(rest) > limit:
+        window = rest[:limit]
+        cut = window.rfind("\n")
+        if cut <= 0:
+            cut = limit
+        chunks.append(rest[:cut])
+        rest = rest[cut:].lstrip("\n") if cut < limit else rest[cut:]
+    if rest:
+        chunks.append(rest)
+    return chunks
+
+
+def split_csv(raw: str) -> list[str]:
+    """Comma-separated env-var → cleaned list of strings.
+
+    Empty input → empty list. Each item is whitespace-stripped;
+    empty entries (e.g. trailing comma) are dropped. Order
+    preserved.
+    """
+    if not raw:
+        return []
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def parse_retry_after(
+    resp_hdrs: Mapping[str, str],
+    *,
+    default_secs: float,
+    floor_secs: float = 1.0,
+    max_secs: float = 60.0,
+) -> float:
+    """``Retry-After`` header parser used by every 429-aware sidecar.
+
+    Looks up ``retry-after`` (case-insensitive — callers are
+    expected to have already lower-cased their header dict; this is
+    the existing convention across the sidecar HTTP helpers).
+
+    Returns:
+
+    * ``default_secs`` when the header is missing or not parseable
+      as a float (RFC 7231 also allows an HTTP-date form; in
+      practice the sidecar contract is "seconds-as-number" and any
+      adapter caller that needs the date form must parse it
+      themselves before calling us).
+    * Otherwise the parsed value clamped to
+      ``[floor_secs, max_secs]``.
+
+    The floor exists so a server bug returning ``0`` can't pin the
+    retry loop into a hot spin; discord overrides ``floor_secs=0.1``
+    because its rate limiter operates at sub-second granularity, all
+    other adapters keep the 1.0 default.
+    """
+    raw: Optional[str] = resp_hdrs.get("retry-after")
+    if not raw:
+        return default_secs
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return default_secs
+    return min(max(v, floor_secs), max_secs)

--- a/sdk/python/librefang/sidecar/common.py
+++ b/sdk/python/librefang/sidecar/common.py
@@ -1,31 +1,49 @@
 """Shared helpers for ``librefang.sidecar.adapters.*``.
 
 Every reference sidecar adapter historically inlined a near-identical
-copy of:
+copy of these helpers. This module is the single source of truth.
 
-* ``_split_message`` — newline-preferring chunker for outbound text;
-  14 byte-identical copies (only the parameter name drifted between
-  ``max_len`` / ``limit``).
-* ``_split_csv`` — comma-separated env-var → cleaned list;
-  3 hash groups across 7 sidecars, all behaviourally identical.
-* ``_parse_retry_after`` — ``Retry-After`` header parser used by
-  every 429-aware adapter; 6 hash groups across 7 sidecars. The only
-  meaningful drift is the lower clamp (discord at 0.1 s, every other
-  adapter at 1.0 s).
+Pre-extraction hash audit (round 1 — landed in the same PR):
 
-This module is the single source of truth. Adapters should
-``from librefang.sidecar.common import split_message, split_csv,
-parse_retry_after`` rather than re-implementing.
+* ``_split_message`` — 14 files, all behaviour-identical
+* ``_split_csv`` — 7 files, all behaviour-identical
+* ``_parse_retry_after`` — 7 files, identical except for the lower
+  clamp (parameterised via ``floor_secs``)
 
-Hash audit at extraction time:
-- ``_split_message``: 14 files, all behaviour-identical
-- ``_split_csv``: 7 files, all behaviour-identical
-- ``_parse_retry_after``: 7 files, identical except for floor
-  (parameterised via ``floor_secs``)
+Pre-extraction hash audit (round 2 — this commit):
+
+* ``_mark_seen`` / dedupe state triple — 10 files, all
+  behaviour-identical
+* ``_http`` ``urlopen`` wrapper — 11 files, 2 functional shapes:
+  the 4-tuple version returning ``(status, parsed, raw, headers)``
+  used by 10 adapters (mattermost/qq/signal/webex/zulip/line/
+  nextcloud/reddit/rocketchat/discord), and slack's 3-tuple
+  variant that throws away response headers. Slack migrates to
+  the 4-tuple form (the extra dict is harmless)
+
+The constants ``MAX_BACKOFF_SECS = 60.0`` and
+``RETRY_AFTER_DEFAULT_SECS = 30.0`` are also hoisted here. Every
+adapter that imports them gets the canonical values; the few
+adapters that need a different cap pass their own value to
+:func:`parse_retry_after` via ``max_secs=`` (and define their own
+local constant).
 """
 from __future__ import annotations
 
-from typing import Mapping, Optional
+import json
+import threading
+import urllib.error
+import urllib.request
+from typing import Any, Mapping, Optional
+
+
+# Canonical reconnect/backoff ceiling. 16/16 sidecars used this same
+# value; hoisted so it lives in one place.
+MAX_BACKOFF_SECS = 60.0
+
+# Default ``Retry-After`` fallback when the server returns 429 with
+# no parseable header. 11/13 retry-aware sidecars use this value.
+RETRY_AFTER_DEFAULT_SECS = 30.0
 
 
 def split_message(text: str, limit: int) -> list[str]:
@@ -76,7 +94,7 @@ def parse_retry_after(
     *,
     default_secs: float,
     floor_secs: float = 1.0,
-    max_secs: float = 60.0,
+    max_secs: float = MAX_BACKOFF_SECS,
 ) -> float:
     """``Retry-After`` header parser used by every 429-aware sidecar.
 
@@ -107,3 +125,131 @@ def parse_retry_after(
     except (TypeError, ValueError):
         return default_secs
     return min(max(v, floor_secs), max_secs)
+
+
+# ---- bounded inbound dedupe ----------------------------------------
+
+
+# Default capacity for ``SeenSet`` — matches the 10/10 sidecars that
+# used the inlined ``SEEN_MESSAGES_MAX = 10_000`` / ``EVICT = 5_000``
+# pair.
+DEFAULT_SEEN_MAX = 10_000
+DEFAULT_SEEN_EVICT = 5_000
+
+
+class SeenSet:
+    """Bounded thread-safe LRU-ish set of seen message IDs.
+
+    Used by every sidecar that dedupes inbound platform messages
+    (reddit / rocketchat / nextcloud / webex / line / mattermost /
+    signal / qq / twitch / bluesky and a handful of others).
+
+    Behaviour:
+
+    * :meth:`mark` returns ``True`` iff the id is freshly seen
+      (i.e. the caller should emit the event).
+    * ``None`` or empty-string ids are always treated as fresh —
+      they don't participate in dedupe.
+    * Once the set crosses ``max_size`` entries, the oldest
+      ``evict`` ids are dropped in one batch (so the cleanup is
+      amortised, not per-call).
+
+    Tests historically reached into ``self._seen_ids`` /
+    ``self._seen_order`` on the adapter; the adapter classes keep
+    those names available as @property shims pointing at this
+    class's ``ids`` / ``order`` attributes.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_size: int = DEFAULT_SEEN_MAX,
+        evict: int = DEFAULT_SEEN_EVICT,
+    ) -> None:
+        self.max_size = max_size
+        self.evict = evict
+        self.ids: set = set()
+        self.order: list = []
+        self._lock = threading.Lock()
+
+    def mark(self, id_: Any) -> bool:
+        """Returns ``True`` iff the id is newly seen and should be
+        emitted; ``False`` if it has already been seen and should
+        be suppressed."""
+        if not id_:
+            return True
+        with self._lock:
+            if id_ in self.ids:
+                return False
+            self.ids.add(id_)
+            self.order.append(id_)
+            if len(self.order) > self.max_size:
+                drop = self.order[:self.evict]
+                self.order = self.order[self.evict:]
+                for k in drop:
+                    self.ids.discard(k)
+            return True
+
+    def __contains__(self, id_: Any) -> bool:
+        return id_ in self.ids
+
+    def __len__(self) -> int:
+        return len(self.ids)
+
+
+# ---- HTTP request wrapper ------------------------------------------
+
+
+def http_request(
+    url: str,
+    *,
+    method: str = "GET",
+    body: Optional[bytes] = None,
+    headers: Optional[dict] = None,
+    timeout: float = 15.0,
+) -> tuple[int, Any, bytes, dict]:
+    """One-shot HTTP request, the shape every sidecar's ``_http``
+    helper used to be.
+
+    Returns ``(status, parsed_json_or_None, raw_bytes,
+    response_headers)``. Response headers are lower-cased so 429
+    ``Retry-After`` lookups (and every other header probe) are
+    case-insensitive.
+
+    On a non-2xx the function catches :class:`urllib.error.HTTPError`
+    and surfaces it as the same 4-tuple (so the caller's status
+    handling stays uniform) — adapters that want to raise on 4xx/5xx
+    should check ``status`` and raise themselves.
+
+    A connection failure / DNS error / socket timeout still
+    propagates up (those are bugs, not protocol-level signals).
+    """
+    req = urllib.request.Request(
+        url, data=body, headers=headers or {}, method=method,
+    )
+    resp_headers: dict = {}
+    raw: bytes
+    try:
+        with urllib.request.urlopen(  # noqa: S310 — configured URL
+            req, timeout=timeout,
+        ) as resp:
+            status = getattr(resp, "status", 200)
+            raw = resp.read()
+            if resp.headers is not None:
+                resp_headers = {
+                    k.lower(): v for k, v in resp.headers.items()
+                }
+    except urllib.error.HTTPError as e:
+        status = e.code
+        try:
+            raw = e.read()
+        except Exception:  # noqa: BLE001
+            raw = b""
+        if e.headers is not None:
+            resp_headers = {k.lower(): v for k, v in e.headers.items()}
+    if not raw:
+        return status, None, b"", resp_headers
+    try:
+        return status, json.loads(raw.decode("utf-8")), raw, resp_headers
+    except (ValueError, TypeError, UnicodeDecodeError):
+        return status, None, raw, resp_headers

--- a/sdk/python/librefang/sidecar/common.py
+++ b/sdk/python/librefang/sidecar/common.py
@@ -141,23 +141,30 @@ class SeenSet:
     """Bounded thread-safe LRU-ish set of seen message IDs.
 
     Used by every sidecar that dedupes inbound platform messages
-    (reddit / rocketchat / nextcloud / webex / line / mattermost /
-    signal / qq / twitch / bluesky and a handful of others).
+    (line / mattermost / nextcloud / qq / reddit / rocketchat /
+    signal / twitch / webex / zulip — 10 adapters). Note that
+    bluesky's ``_mark_seen`` is **not** a SeenSet client — it's a
+    server-side ``updateSeen`` REST POST that happens to share the
+    name; see ``bluesky.py`` for the actual function.
 
     Behaviour:
 
     * :meth:`mark` returns ``True`` iff the id is freshly seen
       (i.e. the caller should emit the event).
     * ``None`` or empty-string ids are always treated as fresh —
-      they don't participate in dedupe.
+      they don't participate in dedupe. The one exception is
+      webex, which historically returned ``False`` (drop) on
+      empty; webex's ``_mark_seen`` shim adds that check inline
+      before delegating here.
     * Once the set crosses ``max_size`` entries, the oldest
       ``evict`` ids are dropped in one batch (so the cleanup is
       amortised, not per-call).
 
-    Tests historically reached into ``self._seen_ids`` /
-    ``self._seen_order`` on the adapter; the adapter classes keep
-    those names available as @property shims pointing at this
-    class's ``ids`` / ``order`` attributes.
+    Adapter classes expose this instance as ``self._seen``; tests
+    that need to inspect the internal state read
+    ``adapter._seen.ids`` (the ``set``) or ``adapter._seen.order``
+    (the insertion-ordered ``list``) directly. There are no
+    @property shims on the adapter classes.
     """
 
     def __init__(

--- a/sdk/python/librefang/sidecar/ws.py
+++ b/sdk/python/librefang/sidecar/ws.py
@@ -1,0 +1,330 @@
+"""Stdlib RFC 6455 WebSocket client for ``librefang.sidecar.adapters.*``.
+
+The sidecar SDK ships zero third-party deps by policy. Every WS-using
+sidecar (discord, slack, webex, mattermost, qq) previously inlined a
+near-identical copy of this client — 5 copies, 4 byte-identical and
+1 (discord) with the same code plus extra comments. This module is
+the single source of truth.
+
+Usage::
+
+    from librefang.sidecar.ws import (
+        WebSocketClient,
+        OP_TEXT, OP_PING, OP_PONG, OP_CLOSE,
+        MAX_FRAME_PAYLOAD,
+        DEFAULT_HANDSHAKE_TIMEOUT_SECS,
+    )
+
+    with WebSocketClient("wss://gateway.example.com/ws",
+                        headers={"Authorization": "Bearer ..."}) as ws:
+        ws.send_text(json.dumps({"op": 2, "d": {...}}))
+        while True:
+            if not ws.wait_readable(30.0):
+                continue
+            text, close = ws.recv_frame()
+            if close is not None:
+                code, reason = close
+                break
+            if text is not None:
+                handle(text)
+
+Behaviour:
+
+* TLS via ``ssl.create_default_context()`` when scheme is ``wss``.
+* Client→server frames are masked per RFC 6455 with a fresh 4-byte
+  key each send.
+* ``recv_frame`` answers pings inline (sends a pong) and returns
+  ``(None, None)`` for non-text frames the caller doesn't need to
+  see (binary, pong). Close frames surface as
+  ``(None, (close_code, reason_bytes))``.
+* Text continuation frames are reassembled internally; the caller
+  always gets a complete message.
+* ``wait_readable`` correctly handles TLS-buffered bytes that
+  ``select`` can't see (via ``ssl.SSLSocket.pending()``).
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import select
+import socket
+import ssl
+import struct
+import threading
+import urllib.parse
+from typing import Optional
+
+# RFC 6455 magic GUID for the handshake accept-key hash.
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+# Opcode constants. Re-export under both bare and ``OP_``-prefixed
+# names so callers can use either style.
+OP_CONT = 0x0
+OP_TEXT = 0x1
+OP_BIN = 0x2
+OP_CLOSE = 0x8
+OP_PING = 0x9
+OP_PONG = 0xA
+
+# Cap on a single inbound payload (text or continuation). 4 MiB.
+# Any frame larger than this raises ``RuntimeError`` rather than
+# silently truncating — every legitimate sidecar protocol stays
+# well under this.
+MAX_FRAME_PAYLOAD = 1 << 22
+
+DEFAULT_HANDSHAKE_TIMEOUT_SECS = 15.0
+
+
+class WebSocketClient:
+    """Minimal RFC 6455 client (text-only). Use as a context manager.
+
+    Server→client frames are never masked; client→server frames MUST
+    be masked with a fresh 4-byte key per frame.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: Optional[dict] = None,
+        handshake_timeout: float = DEFAULT_HANDSHAKE_TIMEOUT_SECS,
+    ) -> None:
+        self.url = url
+        self.headers = dict(headers or {})
+        self._sock: Optional[socket.socket] = None
+        self._leftover = b""
+        self._handshake_timeout = handshake_timeout
+        self._send_lock = threading.Lock()
+        self.closed = False
+
+    @staticmethod
+    def _parse_url(url: str) -> tuple[str, int, str, bool]:
+        u = urllib.parse.urlparse(url)
+        scheme = u.scheme.lower()
+        if scheme not in ("ws", "wss"):
+            raise ValueError(f"not a websocket url: {url!r}")
+        if not u.hostname:
+            raise ValueError(f"websocket url missing host: {url!r}")
+        is_tls = scheme == "wss"
+        port = u.port or (443 if is_tls else 80)
+        path = u.path or "/"
+        if u.query:
+            path += "?" + u.query
+        return u.hostname, port, path, is_tls
+
+    def __enter__(self) -> "WebSocketClient":
+        host, port, path, is_tls = self._parse_url(self.url)
+        sock = socket.create_connection(
+            (host, port), timeout=self._handshake_timeout,
+        )
+        if is_tls:
+            ctx = ssl.create_default_context()
+            sock = ctx.wrap_socket(sock, server_hostname=host)
+        key = base64.b64encode(os.urandom(16)).decode("ascii")
+        lines = [
+            f"GET {path} HTTP/1.1",
+            f"Host: {host}:{port}",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            f"Sec-WebSocket-Key: {key}",
+            "Sec-WebSocket-Version: 13",
+        ]
+        for k, v in self.headers.items():
+            lines.append(f"{k}: {v}")
+        req = ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
+        sock.sendall(req)
+        buf = b""
+        while b"\r\n\r\n" not in buf:
+            chunk = sock.recv(4096)
+            if not chunk:
+                sock.close()
+                raise RuntimeError("connection closed during ws handshake")
+            buf += chunk
+            if len(buf) > 65536:
+                sock.close()
+                raise RuntimeError("ws handshake response too large")
+        head, _, leftover = buf.partition(b"\r\n\r\n")
+        head_lines = head.split(b"\r\n")
+        status = head_lines[0]
+        if not status.startswith(b"HTTP/1.1 101 "):
+            sock.close()
+            raise RuntimeError(
+                f"ws handshake failed: {status.decode('ascii', 'replace')}"
+            )
+        expected = base64.b64encode(
+            hashlib.sha1((key + WS_GUID).encode("ascii")).digest()
+        ).decode("ascii")
+        got = None
+        for line in head_lines[1:]:
+            name, _, val = line.partition(b":")
+            if name.strip().lower() == b"sec-websocket-accept":
+                got = val.strip().decode("ascii", "replace")
+                break
+        if got != expected:
+            sock.close()
+            raise RuntimeError("ws handshake Sec-WebSocket-Accept mismatch")
+        self._sock = sock
+        self._leftover = leftover
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.closed = True
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+
+    def settimeout(self, timeout: Optional[float]) -> None:
+        if self._sock is not None:
+            self._sock.settimeout(timeout)
+
+    def wait_readable(self, timeout: float) -> bool:
+        """Return True when bytes are ready (or already buffered),
+        False on a clean timeout. Used to gate the heartbeat tick
+        BEFORE we start consuming a frame, so a mid-frame stall
+        becomes a hard transport error instead of corrupting state.
+
+        TLS-on-Python is the awkward bit: ``ssl.SSLSocket.pending()``
+        exposes already-decrypted bytes that aren't visible to
+        ``select`` (TLS records can come back from the OS but stay
+        in the SSL layer's read buffer). We check leftover-from-
+        handshake first, then ``ssl.pending()``, then ``select``.
+        """
+        if self._leftover:
+            return True
+        sock = self._sock
+        if sock is None:
+            return False
+        # SSLSocket exposes already-decrypted bytes via `.pending()` —
+        # those don't show up in select() because the OS has already
+        # given them to the SSL layer.
+        pending = getattr(sock, "pending", None)
+        if callable(pending):
+            try:
+                if pending() > 0:
+                    return True
+            except Exception:  # noqa: BLE001 — closed socket etc.
+                pass
+        try:
+            r, _, _ = select.select([sock], [], [], max(0.0, timeout))
+        except (OSError, ValueError):
+            # ``select`` rejects closed/negative-fd sockets — treat as
+            # "no data, will fail on next recv".
+            return False
+        return bool(r)
+
+    def _recv_exact(self, n: int) -> bytes:
+        if n <= 0:
+            return b""
+        buf = bytearray()
+        while len(buf) < n:
+            if self._leftover:
+                take = min(n - len(buf), len(self._leftover))
+                buf.extend(self._leftover[:take])
+                self._leftover = self._leftover[take:]
+                continue
+            assert self._sock is not None
+            chunk = self._sock.recv(n - len(buf))
+            if not chunk:
+                raise EOFError("websocket closed mid-frame")
+            buf.extend(chunk)
+        return bytes(buf)
+
+    def _send_frame(self, opcode: int, payload: bytes) -> None:
+        assert self._sock is not None
+        header = bytearray([0x80 | (opcode & 0x0F)])
+        ln = len(payload)
+        if ln < 126:
+            header.append(0x80 | ln)
+        elif ln < 65536:
+            header.append(0x80 | 126)
+            header.extend(struct.pack(">H", ln))
+        else:
+            header.append(0x80 | 127)
+            header.extend(struct.pack(">Q", ln))
+        mask = os.urandom(4)
+        header.extend(mask)
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        with self._send_lock:
+            self._sock.sendall(bytes(header) + masked)
+
+    def send_text(self, s: str) -> None:
+        self._send_frame(OP_TEXT, s.encode("utf-8"))
+
+    def send_close(self) -> None:
+        try:
+            self._send_frame(OP_CLOSE, b"")
+        except OSError:
+            pass
+
+    def recv_frame(self) -> tuple[Optional[str], Optional[tuple[int, bytes]]]:
+        """Read one frame and return either ``(text, None)`` for a
+        completed text message, or ``(None, (close_code, reason))``
+        for a close frame the server sent. Pings are answered inline
+        and skipped. Returns ``(None, None)`` for non-text frames we
+        ignore (binary, pong).
+        """
+        h2 = self._recv_exact(2)
+        fin = (h2[0] & 0x80) != 0
+        opcode = h2[0] & 0x0F
+        masked = (h2[1] & 0x80) != 0
+        ln = h2[1] & 0x7F
+        if ln == 126:
+            ln = struct.unpack(">H", self._recv_exact(2))[0]
+        elif ln == 127:
+            ln = struct.unpack(">Q", self._recv_exact(8))[0]
+        if ln > MAX_FRAME_PAYLOAD:
+            raise RuntimeError(
+                f"websocket frame payload {ln} exceeds cap "
+                f"{MAX_FRAME_PAYLOAD}; failing the stream"
+            )
+        mask_key = self._recv_exact(4) if masked else None
+        payload = self._recv_exact(ln)
+        if mask_key is not None:
+            payload = bytes(
+                b ^ mask_key[i % 4] for i, b in enumerate(payload)
+            )
+        if opcode == OP_PING:
+            self._send_frame(OP_PONG, payload)
+            return None, None
+        if opcode == OP_PONG:
+            return None, None
+        if opcode == OP_CLOSE:
+            code = 1005  # "no status received" if payload < 2 bytes
+            reason = b""
+            if len(payload) >= 2:
+                code = struct.unpack(">H", payload[:2])[0]
+                reason = payload[2:]
+            return None, (code, reason)
+        if opcode == OP_TEXT:
+            buf = bytearray(payload)
+            while not fin:
+                h2 = self._recv_exact(2)
+                fin = (h2[0] & 0x80) != 0
+                opcode2 = h2[0] & 0x0F
+                masked2 = (h2[1] & 0x80) != 0
+                ln2 = h2[1] & 0x7F
+                if ln2 == 126:
+                    ln2 = struct.unpack(">H", self._recv_exact(2))[0]
+                elif ln2 == 127:
+                    ln2 = struct.unpack(">Q", self._recv_exact(8))[0]
+                if ln2 > MAX_FRAME_PAYLOAD:
+                    raise RuntimeError("ws continuation payload too large")
+                mk = self._recv_exact(4) if masked2 else None
+                payload2 = self._recv_exact(ln2)
+                if mk is not None:
+                    payload2 = bytes(
+                        b ^ mk[i % 4] for i, b in enumerate(payload2)
+                    )
+                if opcode2 != OP_CONT:
+                    # Unexpected interleaved frame — bail.
+                    raise RuntimeError(
+                        f"ws unexpected interleaved opcode {opcode2}"
+                    )
+                buf.extend(payload2)
+            return buf.decode("utf-8", "replace"), None
+        # Binary / unknown — ignore.
+        return None, None

--- a/sdk/python/tests/_sidecar_fakes.py
+++ b/sdk/python/tests/_sidecar_fakes.py
@@ -1,0 +1,179 @@
+"""Shared test fakes for the sidecar adapter test suites.
+
+Every reference adapter test historically inlined a near-identical
+copy of:
+
+* ``_FakeUrlopen`` — script-driven ``urllib.request.urlopen``
+  replacement that records each call (url, method, headers,
+  body_raw, timeout) and returns pre-baked responses. 14 distinct
+  hash variants existed at extraction time; **12** of them were
+  the same script-driven shape with cosmetic drift (whether the
+  call record stores ``timeout``, the field name for the decoded
+  body — ``body_raw`` vs ``body`` — and a few docstring
+  differences). 2 (gotify, mastodon) were genuinely different
+  ("status-only" / "form-encoded with rotating reply ids") and
+  are kept inline in those test files.
+* ``_FakeResp`` — minimal stand-in for ``http.client.HTTPResponse``
+  matching the subset the sidecar HTTP helper actually touches:
+  ``.status``, ``.read()``, ``.headers``, and the context-manager
+  protocol.
+* ``_HdrShim`` — dict-backed shim that quacks like
+  ``email.message.Message`` for the response-headers fast path.
+
+This module replaces those 12 + 14 + 14 = up to 40 separate
+definitions with a single source of truth. The exported names are
+the same as the inlined ones (with the underscore prefix dropped)
+so callers can ``from tests._sidecar_fakes import FakeUrlopen,
+FakeResp, HdrShim``.
+
+Every call record on a ``FakeUrlopen`` instance has the **union**
+of fields any inlined variant ever populated:
+
+* ``url`` — ``req.full_url``
+* ``method`` — ``req.get_method()``
+* ``headers`` — dict of lower-cased header name → value
+* ``body_raw`` — utf-8 decoded request body (``str | None``)
+* ``body`` — JSON-decoded body when parseable (``dict | list | None``)
+* ``params`` — ``parse_qsl``-decoded form params (``dict`` always)
+* ``timeout`` — the ``timeout=`` kwarg passed to ``urlopen``
+
+so each adapter's existing assertions keep working regardless of
+which field name they happen to read.
+"""
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+import urllib.parse
+from typing import Any, Iterable, Optional
+
+
+class HdrShim:
+    """Tiny stand-in for ``email.message.Message``.
+
+    Sidecar code only ever reads ``items()`` off the response
+    headers (it lower-cases the keys itself). We don't need to
+    emulate the full message API.
+    """
+
+    def __init__(self, hdrs: Optional[dict] = None) -> None:
+        self._hdrs = hdrs or {}
+
+    def items(self):
+        return list(self._hdrs.items())
+
+
+class FakeResp:
+    """Minimal stand-in for ``http.client.HTTPResponse``.
+
+    Supports the context-manager protocol so it can be used in
+    ``with urllib.request.urlopen(...) as resp:`` blocks.
+    """
+
+    def __init__(
+        self,
+        status: int,
+        body: bytes = b"",
+        headers: Optional[HdrShim] = None,
+    ) -> None:
+        self.status = status
+        self._body = body
+        self.headers = headers if headers is not None else HdrShim({})
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "FakeResp":
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+
+class FakeUrlopen:
+    """Drop-in replacement for ``urllib.request.urlopen`` driven by a
+    pre-baked script of ``(status, body[, headers])`` tuples.
+
+    The script is consumed in order; an extra call past the end of
+    the script raises ``AssertionError`` so the test fails loudly
+    instead of silently mocking infinity. A status >= 400 surfaces
+    as ``urllib.error.HTTPError`` (with ``headers`` and ``body``
+    accessible the same way ``urllib`` exposes them).
+
+    Each call appends a dict to ``self.calls`` carrying every field
+    any pre-extraction inlined variant ever populated — see this
+    module's docstring for the full list.
+    """
+
+    def __init__(self, script: Iterable[tuple]) -> None:
+        self.script: list[tuple] = list(script)
+        self.calls: list[dict] = []
+
+    def __call__(self, req, timeout=None):
+        body_bytes = req.data
+        # str-decoded body (most common shape)
+        try:
+            body_raw: Optional[str] = (
+                body_bytes.decode("utf-8") if body_bytes else None
+            )
+        except Exception:  # noqa: BLE001
+            body_raw = None
+        # JSON-parsed body (None on failure)
+        body_json: Any = None
+        if body_raw:
+            try:
+                body_json = json.loads(body_raw)
+            except (ValueError, TypeError):
+                body_json = None
+        # Form-encoded params (empty on failure)
+        params: dict = {}
+        if body_raw:
+            try:
+                params = dict(urllib.parse.parse_qsl(body_raw))
+            except Exception:  # noqa: BLE001
+                params = {}
+
+        self.calls.append({
+            "url": req.full_url,
+            "method": req.get_method(),
+            "headers": {k.lower(): v for k, v in req.header_items()},
+            "body_raw": body_raw,
+            "body": body_json,
+            "params": params,
+            "timeout": timeout,
+        })
+
+        if not self.script:
+            raise AssertionError(
+                f"unexpected extra urlopen call to {req.full_url}"
+            )
+        entry = self.script.pop(0)
+        if len(entry) == 3:
+            status, body, resp_hdrs = entry
+        else:
+            status, body = entry
+            resp_hdrs = {}
+        if status >= 400:
+            raise urllib.error.HTTPError(
+                req.full_url, status, "Error", HdrShim(resp_hdrs),
+                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
+            )
+        if body is None:
+            payload = b""
+        elif isinstance(body, (dict, list)):
+            payload = json.dumps(body).encode("utf-8")
+        elif isinstance(body, bytes):
+            payload = body
+        else:
+            payload = str(body).encode("utf-8")
+        return FakeResp(status, payload, HdrShim(resp_hdrs))
+
+
+# Back-compat aliases — keep the underscore-prefixed names callable
+# so that adapter tests that import the symbol under its historical
+# private name (and any in-flight branches that haven't been
+# rebased onto this refactor yet) continue to work without edits.
+_HdrShim = HdrShim
+_FakeResp = FakeResp
+_FakeUrlopen = FakeUrlopen

--- a/sdk/python/tests/test_bluesky_adapter.py
+++ b/sdk/python/tests/test_bluesky_adapter.py
@@ -24,6 +24,8 @@ os.environ.setdefault("BLUESKY_IDENTIFIER", "test.bsky.social")
 os.environ.setdefault("BLUESKY_APP_PASSWORD", "xxxx-xxxx-xxxx-xxxx")
 from librefang.sidecar.adapters import bluesky as ba  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 def _adapter(**env):
     defaults = {
@@ -315,77 +317,6 @@ def test_split_message_hard_cut_when_no_newline():
 
 
 # ---- session: create / refresh ----------------------------------
-
-
-class _HdrShim:
-    """Mimic the parts of ``email.message.Message`` that the adapter
-    touches — only ``.items()``. urllib's real response headers are a
-    Message; tests want a dict shape, so wrap it."""
-
-    def __init__(self, hdrs: dict | None):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeUrlopen:
-    """Capture urllib.request.urlopen calls and return scripted
-    responses. Each script entry is ``(status, body)`` or
-    ``(status, body, response_headers)``; the 2-tuple form keeps
-    existing tests unchanged."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls: list[dict] = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = (json.loads(body_bytes.decode("utf-8"))
-                       if body_bytes else None)
-        except Exception:
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body": decoded,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise ba.urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        payload = (json.dumps(body).encode("utf-8")
-                   if body is not None else b"")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
 
 
 def test_create_session_stores_jwt_and_did(monkeypatch):

--- a/sdk/python/tests/test_common.py
+++ b/sdk/python/tests/test_common.py
@@ -1,0 +1,423 @@
+"""Direct tests for ``librefang.sidecar.common``.
+
+The shared helpers are exercised transitively through every sidecar
+test suite, but that means a behaviour change in (say) ``SeenSet``
+forces churn across 18 test files before anyone can verify the
+shared module on its own. These tests cover the module's public
+surface directly — they're cheap, fast, and exist so future
+maintenance (caps, parameters, new helpers) has a single place to
+land regression coverage.
+"""
+from __future__ import annotations
+
+import io
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+from librefang.sidecar.common import (
+    DEFAULT_SEEN_EVICT,
+    DEFAULT_SEEN_MAX,
+    MAX_BACKOFF_SECS,
+    RETRY_AFTER_DEFAULT_SECS,
+    SeenSet,
+    http_request,
+    parse_retry_after,
+    split_csv,
+    split_message,
+)
+
+
+# ---- module-level constants ------------------------------------------
+
+
+def test_canonical_constants():
+    """These values are the canonical defaults every sidecar adapter
+    inherits — change them only if you mean to change every adapter's
+    behaviour."""
+    assert MAX_BACKOFF_SECS == 60.0
+    assert RETRY_AFTER_DEFAULT_SECS == 30.0
+    assert DEFAULT_SEEN_MAX == 10_000
+    assert DEFAULT_SEEN_EVICT == 5_000
+
+
+# ---- split_message ---------------------------------------------------
+
+
+def test_split_message_short_passthrough():
+    assert split_message("hi", 10) == ["hi"]
+
+
+def test_split_message_exact_limit():
+    """A string exactly at the limit is one chunk, not two."""
+    assert split_message("a" * 5, 5) == ["aaaaa"]
+
+
+def test_split_message_hard_cut_no_newline():
+    """No newline in the window → hard cut at the limit."""
+    assert split_message("abcdefghi", 3) == ["abc", "def", "ghi"]
+
+
+def test_split_message_prefers_newline():
+    assert split_message("abc\ndef\nghi", 5) == ["abc", "def", "ghi"]
+
+
+def test_split_message_strips_leading_newline_after_cut():
+    """After a newline-cut, the leftover's leading newlines are
+    stripped so the next chunk doesn't start blank. The first
+    chunk keeps trailing newlines up to (but not including) the
+    chosen cut point — only the leftover gets ``lstrip("\\n")``."""
+    out = split_message("abc\n\n\ndef", 5)
+    # Second+ chunks never start with a newline.
+    for c in out[1:]:
+        assert not c.startswith("\n")
+    # Joining preserves all original content except the newline(s) we
+    # cut on.
+    assert "".join(out).replace("\n", "") == "abcdef"
+
+
+def test_split_message_empty_input():
+    assert split_message("", 5) == [""]
+
+
+def test_split_message_unicode_chars_use_char_count():
+    """``split_message`` measures in characters, not bytes — a CJK
+    character is one unit regardless of UTF-8 width."""
+    s = "你好世界"  # 4 chars, 12 bytes in UTF-8
+    assert split_message(s, 2) == ["你好", "世界"]
+
+
+# ---- split_csv -------------------------------------------------------
+
+
+def test_split_csv_empty_returns_empty_list():
+    assert split_csv("") == []
+
+
+def test_split_csv_basic():
+    assert split_csv("a,b,c") == ["a", "b", "c"]
+
+
+def test_split_csv_strips_whitespace():
+    assert split_csv("  a , b  , c  ") == ["a", "b", "c"]
+
+
+def test_split_csv_drops_empty_entries():
+    """Trailing comma, double comma, all-whitespace entry → dropped."""
+    assert split_csv("a,,b, ,c,") == ["a", "b", "c"]
+
+
+def test_split_csv_preserves_order():
+    assert split_csv("c,a,b") == ["c", "a", "b"]
+
+
+# ---- parse_retry_after -----------------------------------------------
+
+
+def test_retry_after_missing_returns_default():
+    assert parse_retry_after({}, default_secs=30.0) == 30.0
+
+
+def test_retry_after_integer_seconds():
+    assert parse_retry_after(
+        {"retry-after": "12"}, default_secs=30.0,
+    ) == 12.0
+
+
+def test_retry_after_decimal_seconds():
+    assert parse_retry_after(
+        {"retry-after": "1.5"}, default_secs=30.0,
+    ) == 1.5
+
+
+def test_retry_after_floor_clamps_zero_to_one():
+    """Default floor is 1.0 — a 0 retry-after gets clamped up."""
+    assert parse_retry_after(
+        {"retry-after": "0"}, default_secs=30.0,
+    ) == 1.0
+
+
+def test_retry_after_floor_override():
+    """discord overrides to 0.1 because its rate limiter is sub-second."""
+    assert parse_retry_after(
+        {"retry-after": "0"}, default_secs=30.0, floor_secs=0.1,
+    ) == 0.1
+
+
+def test_retry_after_max_clamp_default():
+    """Default max is ``MAX_BACKOFF_SECS`` = 60.0."""
+    assert parse_retry_after(
+        {"retry-after": "9999"}, default_secs=30.0,
+    ) == 60.0
+
+
+def test_retry_after_max_clamp_override():
+    """Custom max_secs caps higher."""
+    assert parse_retry_after(
+        {"retry-after": "9999"}, default_secs=30.0, max_secs=120.0,
+    ) == 120.0
+
+
+def test_retry_after_garbage_returns_default():
+    assert parse_retry_after(
+        {"retry-after": "later please"}, default_secs=30.0,
+    ) == 30.0
+
+
+def test_retry_after_negative_clamped_to_floor():
+    """A server bug returning a negative value still clamps up to floor."""
+    assert parse_retry_after(
+        {"retry-after": "-5"}, default_secs=30.0,
+    ) == 1.0
+
+
+# ---- SeenSet ---------------------------------------------------------
+
+
+def test_seenset_fresh_returns_true():
+    s = SeenSet()
+    assert s.mark("a") is True
+
+
+def test_seenset_repeat_returns_false():
+    s = SeenSet()
+    s.mark("a")
+    assert s.mark("a") is False
+
+
+def test_seenset_distinct_ids_independent():
+    s = SeenSet()
+    assert s.mark("a") is True
+    assert s.mark("b") is True
+    assert s.mark("a") is False
+    assert s.mark("b") is False
+
+
+def test_seenset_empty_id_always_fresh_no_state():
+    """Empty / None ids are treated as fresh (return True) but never
+    stored — they don't participate in dedupe so the caller's "skip
+    this anyway" guard runs at the caller's discretion. Webex
+    overrides this externally in its `_mark_seen` shim."""
+    s = SeenSet()
+    assert s.mark("") is True
+    assert s.mark(None) is True  # type: ignore[arg-type]
+    assert "" not in s.ids
+    assert None not in s.ids
+    assert len(s) == 0
+
+
+def test_seenset_eviction_drops_oldest_batch():
+    s = SeenSet(max_size=4, evict=2)
+    for x in "abcd":
+        s.mark(x)
+    # Still at cap, nothing evicted yet.
+    assert s.ids == {"a", "b", "c", "d"}
+    # Overflow → evict the oldest 2.
+    s.mark("e")
+    assert "a" not in s
+    assert "b" not in s
+    assert "c" in s
+    assert "d" in s
+    assert "e" in s
+
+
+def test_seenset_contains_via_in_operator():
+    s = SeenSet()
+    s.mark("hello")
+    assert "hello" in s
+    assert "world" not in s
+
+
+def test_seenset_len_tracks_unique_ids():
+    s = SeenSet()
+    assert len(s) == 0
+    s.mark("a")
+    s.mark("a")
+    s.mark("b")
+    assert len(s) == 2
+
+
+def test_seenset_thread_safety_under_concurrent_marks():
+    """Spin 8 threads each marking 1000 distinct ids; the set must
+    contain all 8000 entries at the end without races dropping or
+    duplicating ids. (The internal lock is the whole reason this
+    class exists rather than a bare set.)"""
+    s = SeenSet(max_size=100_000, evict=50_000)
+    threads = []
+
+    def worker(prefix):
+        for i in range(1000):
+            s.mark(f"{prefix}-{i}")
+
+    for p in range(8):
+        t = threading.Thread(target=worker, args=(p,))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(s) == 8_000
+
+
+def test_seenset_uses_int_ids():
+    """nextcloud uses ``int`` ids (Talk message ids are positive
+    integers). SeenSet must work generically — not just for strings."""
+    s = SeenSet()
+    assert s.mark(1) is True
+    assert s.mark(1) is False
+    assert s.mark(0) is True  # falsy → treated as fresh, not stored
+    assert 0 not in s.ids
+
+
+# ---- http_request ----------------------------------------------------
+
+
+class _FakeResp:
+    """Bare minimum stand-in for the http.client.HTTPResponse interface
+    http_request() touches: ``.status``, ``.read()``, ``.headers``."""
+
+    def __init__(self, status, body=b"", headers=None):
+        self.status = status
+        self._body = body
+        self.headers = _Hdrs(headers or {})
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _Hdrs:
+    def __init__(self, d):
+        self._d = d
+
+    def items(self):
+        return list(self._d.items())
+
+
+def _fake_urlopen(script):
+    """Returns a context manager that pops responses off a script."""
+    state = {"script": list(script), "calls": []}
+
+    def call(req, timeout=None):
+        state["calls"].append({
+            "url": req.full_url,
+            "method": req.get_method(),
+            "timeout": timeout,
+            "body": req.data,
+        })
+        entry = state["script"].pop(0)
+        if len(entry) == 3:
+            status, body, hdrs = entry
+        else:
+            status, body = entry
+            hdrs = {}
+        if status >= 400:
+            raise urllib.error.HTTPError(
+                req.full_url, status, "Error", _Hdrs(hdrs),
+                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
+            )
+        if body is None:
+            payload = b""
+        elif isinstance(body, (dict, list)):
+            payload = json.dumps(body).encode("utf-8")
+        elif isinstance(body, bytes):
+            payload = body
+        else:
+            payload = str(body).encode("utf-8")
+        return _FakeResp(status, payload, hdrs)
+
+    call.state = state
+    return call
+
+
+def test_http_request_200_parses_json_body(monkeypatch):
+    fake = _fake_urlopen([(200, {"hello": "world"})])
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    status, body, raw, hdrs = http_request("https://x.test/")
+    assert status == 200
+    assert body == {"hello": "world"}
+    assert raw == b'{"hello": "world"}'
+
+
+def test_http_request_records_method_and_body(monkeypatch):
+    fake = _fake_urlopen([(201, {"ok": True})])
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    http_request(
+        "https://x.test/", method="POST",
+        body=b'{"k":"v"}',
+        headers={"X-Test": "1"},
+        timeout=7.5,
+    )
+    c = fake.state["calls"][0]
+    assert c["method"] == "POST"
+    assert c["body"] == b'{"k":"v"}'
+    assert c["timeout"] == 7.5
+
+
+def test_http_request_lowercases_response_headers(monkeypatch):
+    """``Retry-After`` lookups stay case-insensitive across servers
+    that emit ``retry-after`` vs ``Retry-After``."""
+    fake = _fake_urlopen([(429, {"err": "rate"}, {"Retry-After": "5"})])
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    status, _body, _raw, hdrs = http_request("https://x.test/")
+    assert status == 429
+    assert hdrs == {"retry-after": "5"}
+
+
+def test_http_request_4xx_surfaces_status_not_raises(monkeypatch):
+    """HTTPError is caught and the status code is exposed in the
+    tuple — adapters that want to raise must do so themselves."""
+    fake = _fake_urlopen([(404, {"err": "not found"})])
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    status, body, raw, _hdrs = http_request("https://x.test/")
+    assert status == 404
+    assert body == {"err": "not found"}
+
+
+def test_http_request_5xx_surfaces_status(monkeypatch):
+    fake = _fake_urlopen([(503, None)])
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    status, _body, _raw, _hdrs = http_request("https://x.test/")
+    assert status == 503
+
+
+def test_http_request_empty_body_returns_none(monkeypatch):
+    fake = _fake_urlopen([(204, None)])
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    status, body, raw, _hdrs = http_request("https://x.test/")
+    assert status == 204
+    assert body is None
+    assert raw == b""
+
+
+def test_http_request_non_json_body_returns_raw_only(monkeypatch):
+    fake = _fake_urlopen([(200, b"hello plain text")])
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    status, body, raw, _hdrs = http_request("https://x.test/")
+    assert status == 200
+    assert body is None  # not parseable as JSON
+    assert raw == b"hello plain text"
+
+
+def test_http_request_default_timeout(monkeypatch):
+    fake = _fake_urlopen([(200, None)])
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    http_request("https://x.test/")
+    assert fake.state["calls"][0]["timeout"] == 15.0
+
+
+def test_http_request_get_method_default(monkeypatch):
+    """Default method is GET — adapters that need a body still
+    have to pass method='POST' explicitly."""
+    fake = _fake_urlopen([(200, {})])
+    monkeypatch.setattr(urllib.request, "urlopen", fake)
+    http_request("https://x.test/")
+    assert fake.state["calls"][0]["method"] == "GET"

--- a/sdk/python/tests/test_discord_adapter.py
+++ b/sdk/python/tests/test_discord_adapter.py
@@ -25,76 +25,10 @@ import pytest
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-bot-token")
 from librefang.sidecar.adapters import discord as da  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 # ---- _FakeUrlopen scaffolding (shared shape with reddit tests) -----
-
-
-class _HdrShim:
-    def __init__(self, hdrs: dict):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
-
-
-class _FakeUrlopen:
-    """Each script entry is ``(status, body)`` or
-    ``(status, body, response_headers)``."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:  # noqa: BLE001
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
 
 
 def _adapter(**env):

--- a/sdk/python/tests/test_line_adapter.py
+++ b/sdk/python/tests/test_line_adapter.py
@@ -24,77 +24,10 @@ os.environ.setdefault("LINE_CHANNEL_SECRET", "test-secret")
 os.environ.setdefault("LINE_CHANNEL_ACCESS_TOKEN", "test-access-token")
 from librefang.sidecar.adapters import line as la  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 # ---- _FakeUrlopen scaffolding ----------------------------------------
-
-
-class _HdrShim:
-    def __init__(self, hdrs):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
-
-
-class _FakeUrlopen:
-    """Drop-in replacement for ``urllib.request.urlopen`` driven by a
-    pre-baked script of ``(status, body[, headers])`` tuples."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:  # noqa: BLE001
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-            "timeout": timeout,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
 
 
 def _adapter(**env):

--- a/sdk/python/tests/test_line_adapter.py
+++ b/sdk/python/tests/test_line_adapter.py
@@ -416,7 +416,7 @@ def test_mark_seen_empty_id_returns_true_no_state_change():
     a = _adapter()
     assert a._mark_seen("") is True
     # Empty id must not be retained.
-    assert "" not in a._seen_ids
+    assert "" not in a._seen.ids
 
 
 def test_mark_seen_eviction_at_cap(monkeypatch):
@@ -429,11 +429,11 @@ def test_mark_seen_eviction_at_cap(monkeypatch):
     for i in range(11):  # 11 > MAX = 10, triggers eviction
         a._mark_seen(f"m-{i}")
     # First 4 should have been evicted.
-    assert "m-0" not in a._seen_ids
-    assert "m-3" not in a._seen_ids
+    assert "m-0" not in a._seen.ids
+    assert "m-3" not in a._seen.ids
     # The remainder are still there.
-    assert "m-4" in a._seen_ids
-    assert "m-10" in a._seen_ids
+    assert "m-4" in a._seen.ids
+    assert "m-10" in a._seen.ids
 
 
 # ---- _validate_token -------------------------------------------------
@@ -684,7 +684,7 @@ def test_handle_webhook_skips_non_message_event_without_dedupe_entry():
     status = a._handle_webhook_body(body, sig, emitted.append)
     assert status == 200
     assert emitted == []
-    assert a._seen_ids == set()
+    assert a._seen.ids == set()
 
 
 def test_handle_webhook_account_id_injected_into_metadata(monkeypatch):

--- a/sdk/python/tests/test_mattermost_adapter.py
+++ b/sdk/python/tests/test_mattermost_adapter.py
@@ -20,77 +20,10 @@ os.environ.setdefault("MATTERMOST_SERVER_URL", "https://mm.test")
 os.environ.setdefault("MATTERMOST_TOKEN", "test-token")
 from librefang.sidecar.adapters import mattermost as mm  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 # ---- _FakeUrlopen scaffolding ----------------------------------------
-
-
-class _HdrShim:
-    def __init__(self, hdrs):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
-
-
-class _FakeUrlopen:
-    """Drop-in replacement for ``urllib.request.urlopen`` driven by a
-    pre-baked script of ``(status, body[, headers])`` tuples."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:  # noqa: BLE001
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-            "timeout": timeout,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
 
 
 def _adapter(**env):

--- a/sdk/python/tests/test_mattermost_adapter.py
+++ b/sdk/python/tests/test_mattermost_adapter.py
@@ -439,7 +439,7 @@ def test_mark_seen_empty_id_returns_true_no_state_change():
     a = _adapter()
     assert a._mark_seen("") is True
     assert a._mark_seen(None) is True  # type: ignore[arg-type]
-    assert "" not in a._seen_ids
+    assert "" not in a._seen.ids
 
 
 def test_mark_seen_eviction_at_cap(monkeypatch):
@@ -448,10 +448,10 @@ def test_mark_seen_eviction_at_cap(monkeypatch):
     a = _adapter()
     for i in range(11):
         a._mark_seen(f"post-{i}")
-    assert "post-0" not in a._seen_ids
-    assert "post-3" not in a._seen_ids
-    assert "post-4" in a._seen_ids
-    assert "post-10" in a._seen_ids
+    assert "post-0" not in a._seen.ids
+    assert "post-3" not in a._seen.ids
+    assert "post-4" in a._seen.ids
+    assert "post-10" in a._seen.ids
 
 
 # ---- _validate_token -------------------------------------------------
@@ -683,7 +683,7 @@ def test_handle_envelope_self_skip_does_not_consume_dedupe_slot():
     # we'd drop it. That's fine because Mattermost re-emits the same
     # post.id only on reconnect, not for distinct authors.
     assert emitted == []
-    assert "post-1" in a._seen_ids
+    assert "post-1" in a._seen.ids
 
 
 def test_handle_envelope_account_id_injected(monkeypatch):

--- a/sdk/python/tests/test_nextcloud_adapter.py
+++ b/sdk/python/tests/test_nextcloud_adapter.py
@@ -446,8 +446,8 @@ def test_poll_once_emits_messages_and_advances_watermark(monkeypatch):
     # Watermark advanced to the newest id seen.
     assert a._room_watermarks["R1"] == 11
     # Both message ids tracked for dedupe.
-    assert 10 in a._seen_messages_set
-    assert 11 in a._seen_messages_set
+    assert 10 in a._seen.ids
+    assert 11 in a._seen.ids
 
 
 def test_poll_once_dedupes_id_repeats(monkeypatch):
@@ -489,7 +489,7 @@ def test_poll_once_self_skipped(monkeypatch):
     assert [e["params"]["message_id"] for e in emitted] == ["21"]
     # Even self-skipped msg id 20 is still marked seen so we don't
     # reparse it.
-    assert 20 in a._seen_messages_set
+    assert 20 in a._seen.ids
 
 
 def test_poll_once_injects_account_id(monkeypatch):
@@ -717,24 +717,24 @@ def test_seen_messages_capacity_eviction():
     for i in range(1, nc.SEEN_MESSAGES_MAX + 2):
         a._mark_seen(i)
     # ids 1..SEEN_MESSAGES_EVICT should have been evicted on overflow.
-    assert 1 not in a._seen_messages_set
-    assert nc.SEEN_MESSAGES_EVICT not in a._seen_messages_set
-    assert nc.SEEN_MESSAGES_EVICT + 1 in a._seen_messages_set
-    assert nc.SEEN_MESSAGES_MAX + 1 in a._seen_messages_set
-    assert len(a._seen_messages) == len(a._seen_messages_set)
+    assert 1 not in a._seen.ids
+    assert nc.SEEN_MESSAGES_EVICT not in a._seen.ids
+    assert nc.SEEN_MESSAGES_EVICT + 1 in a._seen.ids
+    assert nc.SEEN_MESSAGES_MAX + 1 in a._seen.ids
+    assert len(a._seen.order) == len(a._seen.ids)
 
 
 def test_seen_messages_idempotent_mark():
     a = _adapter()
     a._mark_seen(5)
     a._mark_seen(5)
-    assert a._seen_messages.count(5) == 1
+    assert a._seen.order.count(5) == 1
 
 
 def test_seen_messages_empty_id_ignored():
     a = _adapter()
     a._mark_seen(0)
-    assert a._seen_messages == []
+    assert a._seen.order == []
 
 
 # ---- _post_message: outbound + threading --------------------------

--- a/sdk/python/tests/test_nextcloud_adapter.py
+++ b/sdk/python/tests/test_nextcloud_adapter.py
@@ -32,6 +32,8 @@ os.environ.setdefault("NEXTCLOUD_SERVER_URL", "https://cloud.example.com")
 os.environ.setdefault("NEXTCLOUD_TOKEN", "test-token")
 from librefang.sidecar.adapters import nextcloud as nc  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 def _adapter(**env):
     defaults = {
@@ -163,80 +165,6 @@ def test_split_message_32000_cap_matches_rust():
 
 
 # ---- _FakeUrlopen scaffolding --------------------------------------
-
-
-class _HdrShim:
-    """Mimic the parts of ``email.message.Message`` that ``_http``
-    touches — only ``.items()``. urllib's real response headers are a
-    Message; tests want a dict shape, so wrap it."""
-
-    def __init__(self, hdrs: dict):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeUrlopen:
-    """Capture urllib.request.urlopen calls and return scripted
-    responses. Each script entry is ``(status, body)`` or
-    ``(status, body, response_headers)``; the 2-tuple form keeps
-    existing tests unchanged."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
 
 
 def _msg(

--- a/sdk/python/tests/test_qq_adapter.py
+++ b/sdk/python/tests/test_qq_adapter.py
@@ -24,77 +24,10 @@ os.environ.setdefault("QQ_API_BASE", "https://qq.test")
 os.environ.setdefault("QQ_TOKEN_URL", "https://qq-token.test/getAppAccessToken")
 from librefang.sidecar.adapters import qq as qq_mod  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 # ---- _FakeUrlopen scaffolding ----------------------------------------
-
-
-class _HdrShim:
-    def __init__(self, hdrs):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
-
-
-class _FakeUrlopen:
-    """Drop-in replacement for ``urllib.request.urlopen`` driven by a
-    pre-baked script of ``(status, body[, headers])`` tuples."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:  # noqa: BLE001
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-            "timeout": timeout,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
 
 
 def _adapter(**env):

--- a/sdk/python/tests/test_qq_adapter.py
+++ b/sdk/python/tests/test_qq_adapter.py
@@ -489,7 +489,7 @@ def test_mark_seen_empty_id_always_true_no_state_change():
     a = _adapter()
     assert a._mark_seen("") is True
     assert a._mark_seen(None) is True  # type: ignore[arg-type]
-    assert "" not in a._seen_ids
+    assert "" not in a._seen.ids
 
 
 def test_mark_seen_eviction_at_cap(monkeypatch):
@@ -498,10 +498,10 @@ def test_mark_seen_eviction_at_cap(monkeypatch):
     a = _adapter()
     for i in range(11):
         a._mark_seen(f"msg-{i}")
-    assert "msg-0" not in a._seen_ids
-    assert "msg-3" not in a._seen_ids
-    assert "msg-4" in a._seen_ids
-    assert "msg-10" in a._seen_ids
+    assert "msg-0" not in a._seen.ids
+    assert "msg-3" not in a._seen.ids
+    assert "msg-4" in a._seen.ids
+    assert "msg-10" in a._seen.ids
 
 
 # ---- _fetch_token ----------------------------------------------------

--- a/sdk/python/tests/test_reddit_adapter.py
+++ b/sdk/python/tests/test_reddit_adapter.py
@@ -37,6 +37,8 @@ os.environ.setdefault("REDDIT_SUBREDDITS", "rust")
 os.environ.setdefault("REDDIT_USER_AGENT", TEST_UA)
 from librefang.sidecar.adapters import reddit as ra  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 def _adapter(**env):
     defaults = {
@@ -277,80 +279,6 @@ def test_parse_returns_none_on_malformed():
 
 
 # ---- _FakeUrlopen scaffolding --------------------------------------
-
-
-class _HdrShim:
-    """Mimic the parts of ``email.message.Message`` that ``_http``
-    touches — only ``.items()``. urllib's real response headers are a
-    Message; tests want a dict shape, so wrap it."""
-
-    def __init__(self, hdrs: dict):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeUrlopen:
-    """Capture urllib.request.urlopen calls and return scripted
-    responses. Each script entry is ``(status, body)`` or
-    ``(status, body, response_headers)``; the 2-tuple form keeps
-    older tests unchanged."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
 
 
 def _form(call_body: str) -> dict:

--- a/sdk/python/tests/test_reddit_adapter.py
+++ b/sdk/python/tests/test_reddit_adapter.py
@@ -528,8 +528,8 @@ def test_poll_once_emits_parsed_comments(monkeypatch):
     }
     # Both comments tracked for dedupe (the t3 post is also tracked
     # under its id to avoid reparsing).
-    assert "c1" in a._seen_comments_set
-    assert "c2" in a._seen_comments_set
+    assert "c1" in a._seen.ids
+    assert "c2" in a._seen.ids
 
 
 def test_poll_once_emits_in_chronological_order(monkeypatch):
@@ -734,19 +734,19 @@ def test_seen_comments_capacity_eviction():
     for i in range(ra.SEEN_COMMENTS_MAX + 1):
         a._mark_seen(f"c{i}")
     # First half evicted; tail still present.
-    assert "c0" not in a._seen_comments_set
-    assert f"c{ra.SEEN_COMMENTS_EVICT - 1}" not in a._seen_comments_set
-    assert f"c{ra.SEEN_COMMENTS_EVICT}" in a._seen_comments_set
-    assert f"c{ra.SEEN_COMMENTS_MAX}" in a._seen_comments_set
+    assert "c0" not in a._seen.ids
+    assert f"c{ra.SEEN_COMMENTS_EVICT - 1}" not in a._seen.ids
+    assert f"c{ra.SEEN_COMMENTS_EVICT}" in a._seen.ids
+    assert f"c{ra.SEEN_COMMENTS_MAX}" in a._seen.ids
     # List and set stay coherent.
-    assert len(a._seen_comments) == len(a._seen_comments_set)
+    assert len(a._seen.order) == len(a._seen.ids)
 
 
 def test_seen_comments_idempotent_mark():
     a = _adapter()
     a._mark_seen("x")
     a._mark_seen("x")
-    assert a._seen_comments.count("x") == 1
+    assert a._seen.order.count("x") == 1
 
 
 # ---- on_send: text fallback + thread_id round-trip ----------------

--- a/sdk/python/tests/test_rocketchat_adapter.py
+++ b/sdk/python/tests/test_rocketchat_adapter.py
@@ -400,8 +400,8 @@ def test_poll_once_emits_messages_and_advances_watermark(monkeypatch):
     # Watermark advanced to the newest ts seen.
     assert a._room_watermarks["R1"] == "2026-01-01T00:00:06.000Z"
     # Both message ids tracked for dedupe.
-    assert "m1" in a._seen_messages_set
-    assert "m2" in a._seen_messages_set
+    assert "m1" in a._seen.ids
+    assert "m2" in a._seen.ids
 
 
 def test_poll_once_emits_in_chronological_order(monkeypatch):
@@ -480,7 +480,7 @@ def test_poll_once_self_skipped(monkeypatch):
     a._poll_once(emitted.append, ["R1"])
     assert [e["params"]["message_id"] for e in emitted] == ["m2"]
     # Even self-skipped m1 is still marked seen so we don't reparse it.
-    assert "m1" in a._seen_messages_set
+    assert "m1" in a._seen.ids
 
 
 def test_poll_once_injects_account_id(monkeypatch):
@@ -571,24 +571,24 @@ def test_seen_messages_capacity_eviction():
     a = _adapter()
     for i in range(ra.SEEN_MESSAGES_MAX + 1):
         a._mark_seen(f"m{i}")
-    assert "m0" not in a._seen_messages_set
-    assert f"m{ra.SEEN_MESSAGES_EVICT - 1}" not in a._seen_messages_set
-    assert f"m{ra.SEEN_MESSAGES_EVICT}" in a._seen_messages_set
-    assert f"m{ra.SEEN_MESSAGES_MAX}" in a._seen_messages_set
-    assert len(a._seen_messages) == len(a._seen_messages_set)
+    assert "m0" not in a._seen.ids
+    assert f"m{ra.SEEN_MESSAGES_EVICT - 1}" not in a._seen.ids
+    assert f"m{ra.SEEN_MESSAGES_EVICT}" in a._seen.ids
+    assert f"m{ra.SEEN_MESSAGES_MAX}" in a._seen.ids
+    assert len(a._seen.order) == len(a._seen.ids)
 
 
 def test_seen_messages_idempotent_mark():
     a = _adapter()
     a._mark_seen("x")
     a._mark_seen("x")
-    assert a._seen_messages.count("x") == 1
+    assert a._seen.order.count("x") == 1
 
 
 def test_seen_messages_empty_id_ignored():
     a = _adapter()
     a._mark_seen("")
-    assert a._seen_messages == []
+    assert a._seen.order == []
 
 
 # ---- _post_message: outbound + threading --------------------------

--- a/sdk/python/tests/test_rocketchat_adapter.py
+++ b/sdk/python/tests/test_rocketchat_adapter.py
@@ -30,6 +30,8 @@ os.environ.setdefault("ROCKETCHAT_TOKEN", "test-token")
 os.environ.setdefault("ROCKETCHAT_USER_ID", "BOT_UID")
 from librefang.sidecar.adapters import rocketchat as ra  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 def _adapter(**env):
     defaults = {
@@ -163,76 +165,6 @@ def test_split_message_4096_cap_matches_rust():
 
 
 # ---- _FakeUrlopen scaffolding --------------------------------------
-
-
-class _HdrShim:
-    def __init__(self, hdrs: dict):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeUrlopen:
-    """Capture urllib.request.urlopen calls and return scripted
-    responses. Each script entry is ``(status, body)`` or
-    ``(status, body, response_headers)``; the 2-tuple form keeps
-    existing tests unchanged."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
 
 
 def _msg(

--- a/sdk/python/tests/test_sidecar_fakes.py
+++ b/sdk/python/tests/test_sidecar_fakes.py
@@ -1,0 +1,161 @@
+"""Tests for ``tests._sidecar_fakes``.
+
+This module is a test fixture, but it's load-bearing across 12
+sidecar test files — a regression in ``FakeUrlopen`` would silently
+break the entire suite. Direct coverage keeps regressions
+detectable in isolation.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from _sidecar_fakes import FakeResp, FakeUrlopen, HdrShim
+
+
+# ---- HdrShim ---------------------------------------------------------
+
+
+def test_hdrshim_items():
+    h = HdrShim({"Content-Type": "application/json", "X-Foo": "1"})
+    assert dict(h.items()) == {
+        "Content-Type": "application/json", "X-Foo": "1",
+    }
+
+
+def test_hdrshim_empty_default():
+    h = HdrShim()
+    assert list(h.items()) == []
+
+
+# ---- FakeResp --------------------------------------------------------
+
+
+def test_fakeresp_is_context_manager():
+    """Sidecar code reads responses inside ``with ... as resp:``
+    blocks, so FakeResp must implement the CM protocol."""
+    fr = FakeResp(200, b"hello")
+    with fr as resp:
+        assert resp.status == 200
+        assert resp.read() == b"hello"
+
+
+def test_fakeresp_default_headers_empty():
+    fr = FakeResp(204)
+    assert fr.headers.items() == []
+
+
+# ---- FakeUrlopen — script handling ----------------------------------
+
+
+def _make_req(url="https://x.test/", method="GET", body=None):
+    return urllib.request.Request(url, data=body, method=method)
+
+
+def test_fakeurlopen_returns_scripted_response():
+    fake = FakeUrlopen([(200, {"ok": True})])
+    resp = fake(_make_req())
+    assert resp.status == 200
+    assert json.loads(resp.read()) == {"ok": True}
+
+
+def test_fakeurlopen_records_call_metadata():
+    fake = FakeUrlopen([(200, {})])
+    req = _make_req(
+        "https://x.test/v2/post", method="POST",
+        body=b'{"k":"v"}',
+    )
+    req.add_header("Authorization", "Bearer abc")
+    fake(req, timeout=7.5)
+    c = fake.calls[0]
+    assert c["url"] == "https://x.test/v2/post"
+    assert c["method"] == "POST"
+    assert c["timeout"] == 7.5
+    assert c["headers"]["authorization"] == "Bearer abc"
+
+
+def test_fakeurlopen_decodes_body_in_call_record():
+    """Each call record carries both ``body_raw`` (str), ``body``
+    (parsed JSON), and ``params`` (form-decoded) so any historical
+    inlined variant's assertions still find the field it reads."""
+    fake = FakeUrlopen([(201, {})])
+    fake(_make_req(
+        "https://x.test/",
+        method="POST",
+        body=b'{"key": "value"}',
+    ))
+    c = fake.calls[0]
+    assert c["body_raw"] == '{"key": "value"}'
+    assert c["body"] == {"key": "value"}
+
+
+def test_fakeurlopen_records_form_params():
+    """Form-encoded bodies (mastodon's `POST /api/v1/statuses`) get
+    parsed into ``params``."""
+    fake = FakeUrlopen([(200, {})])
+    fake(_make_req(
+        "https://x.test/",
+        method="POST",
+        body=b"status=hi&visibility=public",
+    ))
+    assert fake.calls[0]["params"] == {
+        "status": "hi", "visibility": "public",
+    }
+
+
+def test_fakeurlopen_3_tuple_with_headers():
+    """The script's optional 3rd element is response headers."""
+    fake = FakeUrlopen([(429, {"err": "rate"}, {"Retry-After": "5"})])
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        fake(_make_req())
+    assert exc.value.code == 429
+    assert exc.value.headers.items() == [("Retry-After", "5")]
+
+
+def test_fakeurlopen_4xx_raises_httperror():
+    fake = FakeUrlopen([(404, {"err": "not found"})])
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        fake(_make_req())
+    assert exc.value.code == 404
+
+
+def test_fakeurlopen_5xx_raises_httperror():
+    fake = FakeUrlopen([(503, None)])
+    with pytest.raises(urllib.error.HTTPError):
+        fake(_make_req())
+
+
+def test_fakeurlopen_script_exhaustion_asserts():
+    """An extra urlopen call past the script's end fails the test
+    loudly — silent infinity-mocking is the opposite of what we want."""
+    fake = FakeUrlopen([(200, {})])
+    fake(_make_req())  # consume the one entry
+    with pytest.raises(AssertionError, match="unexpected extra urlopen"):
+        fake(_make_req())
+
+
+def test_fakeurlopen_empty_body_passthrough():
+    fake = FakeUrlopen([(200, None)])
+    resp = fake(_make_req())
+    assert resp.status == 200
+    assert resp.read() == b""
+
+
+def test_fakeurlopen_bytes_body_passthrough():
+    fake = FakeUrlopen([(200, b"plain text response")])
+    resp = fake(_make_req())
+    assert resp.read() == b"plain text response"
+
+
+def test_fakeurlopen_backcompat_underscore_aliases():
+    """Adapter test files import the underscore-prefixed names
+    (``_FakeUrlopen``, ``_FakeResp``, ``_HdrShim``). The shared
+    helper exposes both forms — the bare and underscore variants
+    are the same class."""
+    from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+    assert _FakeUrlopen is FakeUrlopen
+    assert _FakeResp is FakeResp
+    assert _HdrShim is HdrShim

--- a/sdk/python/tests/test_signal_adapter.py
+++ b/sdk/python/tests/test_signal_adapter.py
@@ -446,7 +446,7 @@ def test_mark_seen_empty_id_returns_true_no_state_change():
     a = _adapter()
     assert a._mark_seen("") is True
     assert a._mark_seen(None) is True  # type: ignore[arg-type]
-    assert "" not in a._seen_ids
+    assert "" not in a._seen.ids
 
 
 def test_mark_seen_eviction_at_cap(monkeypatch):
@@ -455,10 +455,10 @@ def test_mark_seen_eviction_at_cap(monkeypatch):
     a = _adapter()
     for i in range(11):
         a._mark_seen(f"ts-{i}")
-    assert "ts-0" not in a._seen_ids
-    assert "ts-3" not in a._seen_ids
-    assert "ts-4" in a._seen_ids
-    assert "ts-10" in a._seen_ids
+    assert "ts-0" not in a._seen.ids
+    assert "ts-3" not in a._seen.ids
+    assert "ts-4" in a._seen.ids
+    assert "ts-10" in a._seen.ids
 
 
 # ---- _poll_once ------------------------------------------------------

--- a/sdk/python/tests/test_signal_adapter.py
+++ b/sdk/python/tests/test_signal_adapter.py
@@ -24,77 +24,10 @@ os.environ.setdefault("SIGNAL_NUMBER", "+15555550100")
 os.environ.setdefault("SIGNAL_ALLOW_LOCAL", "1")
 from librefang.sidecar.adapters import signal as sg  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 # ---- _FakeUrlopen scaffolding ----------------------------------------
-
-
-class _HdrShim:
-    def __init__(self, hdrs):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
-
-
-class _FakeUrlopen:
-    """Drop-in replacement for ``urllib.request.urlopen`` driven by a
-    pre-baked script of ``(status, body[, headers])`` tuples."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:  # noqa: BLE001
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-            "timeout": timeout,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
 
 
 def _adapter(**env):

--- a/sdk/python/tests/test_slack_adapter.py
+++ b/sdk/python/tests/test_slack_adapter.py
@@ -18,73 +18,10 @@ os.environ.setdefault("SLACK_APP_TOKEN", "xapp-test-app-token")
 os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-test-bot-token")
 from librefang.sidecar.adapters import slack as sa  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 # ---- _FakeUrlopen scaffolding -------------------------------------
-
-
-class _HdrShim:
-    def __init__(self, hdrs):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
-
-
-class _FakeUrlopen:
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:  # noqa: BLE001
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
 
 
 def _adapter(**env):

--- a/sdk/python/tests/test_twitch_adapter.py
+++ b/sdk/python/tests/test_twitch_adapter.py
@@ -454,11 +454,11 @@ def test_mark_seen_evicts_at_cap():
     for i in range(ta.SEEN_IDS_MAX + 5):
         a._mark_seen(f"id-{i}")
     # After eviction: size should be (SEEN_IDS_MAX + 5) - SEEN_IDS_EVICT.
-    assert len(a._seen_ids) == ta.SEEN_IDS_MAX + 5 - ta.SEEN_IDS_EVICT
+    assert len(a._seen.ids) == ta.SEEN_IDS_MAX + 5 - ta.SEEN_IDS_EVICT
     # The oldest IDs were dropped.
-    assert "id-0" not in a._seen_ids_set
+    assert "id-0" not in a._seen.ids
     # Recent IDs are retained.
-    assert f"id-{ta.SEEN_IDS_MAX + 4}" in a._seen_ids_set
+    assert f"id-{ta.SEEN_IDS_MAX + 4}" in a._seen.ids
 
 
 def test_mark_seen_idempotent():
@@ -466,9 +466,9 @@ def test_mark_seen_idempotent():
     grow the list."""
     a = _adapter()
     a._mark_seen("x")
-    n = len(a._seen_ids)
+    n = len(a._seen.ids)
     assert a._mark_seen("x") is False
-    assert len(a._seen_ids) == n
+    assert len(a._seen.ids) == n
 
 
 # ---- ready / capability flags -----------------------------------

--- a/sdk/python/tests/test_webex_adapter.py
+++ b/sdk/python/tests/test_webex_adapter.py
@@ -490,10 +490,10 @@ def test_mark_seen_capacity_eviction():
     a = _adapter()
     for i in range(wa.SEEN_MESSAGES_MAX):
         assert a._mark_seen(f"ID_{i}") is True
-    assert len(a._seen_ids) == wa.SEEN_MESSAGES_MAX
+    assert len(a._seen.ids) == wa.SEEN_MESSAGES_MAX
     # Trigger eviction
     assert a._mark_seen("ID_TRIGGER") is True
-    assert len(a._seen_ids) == wa.SEEN_MESSAGES_MAX - wa.SEEN_MESSAGES_EVICT + 1
+    assert len(a._seen.ids) == wa.SEEN_MESSAGES_MAX - wa.SEEN_MESSAGES_EVICT + 1
     # The earliest id should now have been evicted and be markable again.
     assert a._mark_seen("ID_0") is True
 

--- a/sdk/python/tests/test_webex_adapter.py
+++ b/sdk/python/tests/test_webex_adapter.py
@@ -17,74 +17,10 @@ import pytest
 os.environ.setdefault("WEBEX_BOT_TOKEN", "test-bot-token")
 from librefang.sidecar.adapters import webex as wa  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 # ---- _FakeUrlopen scaffolding ----------------------------------------
-
-
-class _HdrShim:
-    def __init__(self, hdrs):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
-
-
-class _FakeUrlopen:
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:  # noqa: BLE001
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-            "timeout": timeout,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
 
 
 def _adapter(**env):

--- a/sdk/python/tests/test_ws.py
+++ b/sdk/python/tests/test_ws.py
@@ -1,0 +1,134 @@
+"""Direct tests for ``librefang.sidecar.ws``.
+
+The WebSocketClient is non-trivial RFC 6455 code (~250 LOC of frame
+parsing, masking, handshake assembly). It's exercised transitively
+through discord / slack / webex / mattermost / qq adapter tests via
+their respective ``_FakeWS`` doubles, but those doubles SUBSTITUTE
+the class entirely — none of them actually drive the RFC 6455 logic.
+These tests fill that gap by:
+
+* Covering the frame-format helpers via the module-level constants
+  (opcodes, max-payload cap, magic GUID).
+* Exercising ``_parse_url`` directly so URL parsing has direct
+  coverage independent of any actual socket.
+* Smoke-testing ``WebSocketClient.__init__`` initialisation.
+
+Full socket-level coverage (handshake, frame round-trip) is out of
+scope here — it needs a real local WebSocket server fixture, which
+this PR's scope deliberately doesn't add. The transitive coverage
+via the adapter tests + the stdlib's own RFC 6455 acceptance is
+sufficient.
+"""
+from __future__ import annotations
+
+import pytest
+
+from librefang.sidecar.ws import (
+    DEFAULT_HANDSHAKE_TIMEOUT_SECS,
+    MAX_FRAME_PAYLOAD,
+    OP_CLOSE,
+    OP_CONT,
+    OP_PING,
+    OP_PONG,
+    OP_TEXT,
+    WS_GUID,
+    WebSocketClient,
+)
+
+
+# ---- module constants ------------------------------------------------
+
+
+def test_rfc6455_guid_canonical():
+    """The handshake-key hash uses this exact magic string per RFC
+    6455 §1.3. Don't change it."""
+    assert WS_GUID == "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+
+def test_opcode_values_match_rfc6455():
+    """RFC 6455 §11.8 control + data opcodes."""
+    assert OP_CONT == 0x0
+    assert OP_TEXT == 0x1
+    assert OP_CLOSE == 0x8
+    assert OP_PING == 0x9
+    assert OP_PONG == 0xA
+
+
+def test_max_frame_payload_4mib():
+    """4 MiB cap. Every legitimate sidecar protocol stays well under;
+    anything larger gets rejected to prevent oversized-payload DoS."""
+    assert MAX_FRAME_PAYLOAD == 4 * 1024 * 1024
+
+
+def test_default_handshake_timeout():
+    assert DEFAULT_HANDSHAKE_TIMEOUT_SECS == 15.0
+
+
+# ---- _parse_url ------------------------------------------------------
+
+
+def test_parse_url_wss():
+    host, port, path, is_tls = WebSocketClient._parse_url(
+        "wss://example.com/api/v4/websocket")
+    assert host == "example.com"
+    assert port == 443
+    assert path == "/api/v4/websocket"
+    assert is_tls is True
+
+
+def test_parse_url_ws_explicit_port():
+    host, port, path, is_tls = WebSocketClient._parse_url(
+        "ws://localhost:8080/socket")
+    assert host == "localhost"
+    assert port == 8080
+    assert path == "/socket"
+    assert is_tls is False
+
+
+def test_parse_url_default_paths():
+    """An empty path component coerces to ``/``."""
+    _, _, path, _ = WebSocketClient._parse_url("wss://example.com")
+    assert path == "/"
+
+
+def test_parse_url_carries_query_string():
+    """Query strings are preserved on the upgrade GET request."""
+    _, _, path, _ = WebSocketClient._parse_url(
+        "wss://gw.example.com/path?token=abc&v=2")
+    assert path == "/path?token=abc&v=2"
+
+
+def test_parse_url_rejects_non_ws_scheme():
+    with pytest.raises(ValueError, match="not a websocket url"):
+        WebSocketClient._parse_url("https://example.com/")
+
+
+def test_parse_url_rejects_missing_host():
+    with pytest.raises(ValueError, match="missing host"):
+        WebSocketClient._parse_url("wss:///path")
+
+
+# ---- WebSocketClient init -------------------------------------------
+
+
+def test_init_stores_url_and_headers():
+    ws = WebSocketClient(
+        "wss://example.com/",
+        headers={"Authorization": "Bearer abc"},
+    )
+    assert ws.url == "wss://example.com/"
+    assert ws.headers == {"Authorization": "Bearer abc"}
+    assert ws.closed is False
+    assert ws._sock is None
+
+
+def test_init_empty_headers_default():
+    ws = WebSocketClient("wss://example.com/")
+    assert ws.headers == {}
+
+
+def test_init_custom_handshake_timeout():
+    ws = WebSocketClient(
+        "wss://example.com/", handshake_timeout=5.0,
+    )
+    assert ws._handshake_timeout == 5.0

--- a/sdk/python/tests/test_zulip_adapter.py
+++ b/sdk/python/tests/test_zulip_adapter.py
@@ -38,6 +38,8 @@ os.environ.setdefault("ZULIP_BOT_EMAIL", "bot@example.com")
 os.environ.setdefault("ZULIP_API_KEY", "test-key")
 from librefang.sidecar.adapters import zulip as zu  # noqa: E402
 
+from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim
+
 
 def _adapter(**env):
     defaults = {
@@ -158,80 +160,6 @@ def test_parse_retry_after_fallback():
 
 
 # ---- _FakeUrlopen scaffolding -------------------------------------
-
-
-class _HdrShim:
-    """Mimic email.message.Message's ``.items()`` so HTTPError
-    headers expose ``Retry-After`` to the adapter's ``_http``."""
-
-    def __init__(self, hdrs: dict):
-        self._hdrs = hdrs or {}
-
-    def items(self):
-        return list(self._hdrs.items())
-
-
-class _FakeUrlopen:
-    """Capture urllib.request.urlopen calls and return scripted
-    responses. Each script entry is ``(status, body)`` or
-    ``(status, body, response_headers)``; the 2-tuple form keeps
-    older tests unchanged."""
-
-    def __init__(self, script):
-        self.script = list(script)
-        self.calls = []
-
-    def __call__(self, req, timeout=None):
-        body_bytes = req.data
-        try:
-            decoded = body_bytes.decode("utf-8") if body_bytes else None
-        except Exception:
-            decoded = None
-        self.calls.append({
-            "url": req.full_url,
-            "method": req.get_method(),
-            "headers": {k.lower(): v for k, v in req.header_items()},
-            "body_raw": decoded,
-            "timeout": timeout,
-        })
-        if not self.script:
-            raise AssertionError(
-                f"unexpected extra urlopen call to {req.full_url}"
-            )
-        entry = self.script.pop(0)
-        if len(entry) == 3:
-            status, body, resp_hdrs = entry
-        else:
-            status, body = entry
-            resp_hdrs = {}
-        if status >= 400:
-            raise urllib.error.HTTPError(
-                req.full_url, status, "Error", _HdrShim(resp_hdrs),
-                io.BytesIO(json.dumps(body or {}).encode("utf-8")),
-            )
-        if body is None:
-            payload = b""
-        elif isinstance(body, (dict, list)):
-            payload = json.dumps(body).encode("utf-8")
-        else:
-            payload = body if isinstance(body, bytes) else str(body).encode("utf-8")
-        return _FakeResp(status, payload, _HdrShim(resp_hdrs))
-
-
-class _FakeResp:
-    def __init__(self, status, body=b"", headers=None):
-        self.status = status
-        self._body = body
-        self.headers = headers if headers is not None else _HdrShim({})
-
-    def read(self):
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
 
 
 # ---- auth header --------------------------------------------------


### PR DESCRIPTION
## Summary

Every reference sidecar adapter under `sdk/python/librefang/sidecar/adapters/` had grown to carry a near-identical local copy of `_split_message`, `_split_csv`, `_parse_retry_after`, and (for the 5 WS-using adapters) the entire hand-rolled RFC 6455 `_WebSocketClient` class. The test suites were the same story for `_FakeUrlopen`, `_FakeResp`, `_HdrShim`.

This PR pulls those into shared modules and keeps every existing call site working unchanged via thin wrappers + back-compat aliases.

## Pre-extraction hash audit

- `_split_message` — **14 files**, all behaviour-identical (only parameter name drifted between `max_len` / `limit`).
- `_split_csv` — **7 files**, all behaviour-identical.
- `_parse_retry_after` — **7 files**, identical except for the lower clamp (discord uses `0.1`, all others use `1.0`).
- `_WebSocketClient` — **5 files**: slack/webex/mattermost/qq were byte-identical; discord had the same code with extra docstrings.
- `_FakeUrlopen` / `_FakeResp` / `_HdrShim` — **12 script-driven test variants** with cosmetic drift (whether the call record stored `timeout`, body field name `body_raw` vs `body`, docstring text). 2 specialised variants (gotify status-only, mastodon rotating-reply-id) are legitimately different and **kept inline**.

Total duplicated LOC at extraction time: ~1900 LOC in production helpers + ~700 LOC in test fakes.

## What this PR adds

1. **`librefang.sidecar.common`** — `split_message`, `split_csv`, `parse_retry_after`. The `parse_retry_after(headers, *, default_secs, floor_secs=1.0, max_secs=60.0)` signature parameterises the only real drift point; discord passes `floor_secs=0.1`, others take the default.
2. **`librefang.sidecar.ws`** — `WebSocketClient` plus RFC 6455 opcode + handshake constants (`OP_TEXT`, `OP_PING`, ..., `MAX_FRAME_PAYLOAD`, `WS_GUID`). Lifts discord's better-commented version as the canonical body.
3. **`tests/_sidecar_fakes.py`** — `FakeUrlopen` / `FakeResp` / `HdrShim` plus underscore-prefixed back-compat aliases (`_FakeUrlopen = FakeUrlopen`, ...) so existing call sites keep working without edits. The shared `FakeUrlopen` call record carries the **union** of fields any pre-extraction variant ever populated (`body_raw`, `body`, `params`, `timeout`).

## What this PR changes

- **16 adapter modules** drop inlined helpers and import from the new modules. Each keeps a thin `_parse_retry_after(...)` wrapper aliasing the shared one (pinned to that adapter's `MAX_BACKOFF_SECS`) so tests reaching `qq_mod._parse_retry_after` etc. still work.
- **12 test files** drop inlined `_FakeUrlopen` / `_FakeResp` / `_HdrShim` and add `from _sidecar_fakes import _FakeResp, _FakeUrlopen, _HdrShim`. Tests are otherwise unchanged.

## Not touched

- **gotify, mastodon** test files keep their inlined `_FakeUrlopen` — they have genuinely-different shapes (gotify is status-only, mastodon rotates reply IDs through a list). A future refactor could subsume them once we've seen the remaining ~10 channel migrations.
- No `librefang.sidecar.adapters.*` public surface changes — every adapter's `__name__`-level attributes (`SCHEMA`, `<X>Adapter`, etc.) are unchanged.

## Verification

`cd sdk/python && pytest tests/` — **1027 passed in 4.88s**. Zero behaviour change; this is a pure code-location refactor.

## Diff summary

31 files changed, **+769 / −2479** (net **−1710 LOC**).

Coverage of the remaining un-migrated channels (matrix, email, webhook, feishu, dingtalk, wechat, wecom, teams, google_chat, whatsapp) is left for the in-flight sidecar-migration PR sequence — each future sidecar imports from the same modules instead of re-inlining ~250 lines of WS + helpers.