### PR TITLE
fix: recover main from #5368 fallout (orphan helper + ChannelsConfig::matrix tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,7 +4419,6 @@ dependencies = [
  "librefang-types",
  "mailparse",
  "pdf-extract",
- "pulldown-cmark",
  "regex",
  "regex-lite",
  "reqwest",
@@ -7051,24 +7050,6 @@ name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
-dependencies = [
- "bitflags 2.11.1",
- "memchr",
- "pulldown-cmark-escape",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulley-interpreter"

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -6805,14 +6805,17 @@ bot_token_env = \"SLACK_BOT_TOKEN\"
         );
         assert!(raw.contains("SECOND"), "new entry must be present: {raw}");
 
-        // Round-trip through the typed config to make sure the kernel will
-        // see both instances post-promotion.
-        #[derive(serde::Deserialize)]
-        struct Doc {
-            channels: librefang_types::config::ChannelsConfig,
-        }
-        let parsed: Doc = toml::from_str(&raw).unwrap();
-        assert_eq!(parsed.channels.matrix.len(), 2);
+        // The kernel will see both instances post-promotion. We can't
+        // round-trip into `ChannelsConfig` since `matrix` migrated to a
+        // sidecar (#5368) and the typed shape no longer has the field,
+        // but counting `[[channels.matrix]]` markers is equivalent for
+        // this helper — `append_channel_instance` writes one array-of-
+        // tables header per instance, end of story.
+        let array_header_count = raw.matches("[[channels.matrix]]").count();
+        assert_eq!(
+            array_header_count, 2,
+            "promoted layout must contain two array-of-tables headers: {raw}"
+        );
     }
 
     #[test]
@@ -6918,12 +6921,15 @@ bot_token_env = \"SLACK_BOT_TOKEN\"
             "removed instance must be gone: {raw}"
         );
 
-        #[derive(serde::Deserialize)]
-        struct Doc {
-            channels: librefang_types::config::ChannelsConfig,
-        }
-        let parsed: Doc = toml::from_str(&raw).unwrap();
-        assert_eq!(parsed.channels.matrix.len(), 2);
+        // Same as in `append_channel_instance_promotes_legacy_single_table`:
+        // matrix is now a sidecar channel, so typed `ChannelsConfig`
+        // round-trip is no longer available — count the array headers
+        // in the raw TOML instead.
+        let array_header_count = raw.matches("[[channels.matrix]]").count();
+        assert_eq!(
+            array_header_count, 2,
+            "removing the middle entry must leave two array-of-tables headers: {raw}"
+        );
     }
 
     #[test]
@@ -6934,14 +6940,20 @@ bot_token_env = \"SLACK_BOT_TOKEN\"
         remove_channel_instance(&path, "matrix", 0).unwrap();
         let raw = std::fs::read_to_string(&path).unwrap();
         // Either the channels.matrix entry is gone entirely, or the channels
-        // table itself is empty — both forms parse back to zero instances.
-        #[derive(serde::Deserialize, Default)]
-        struct Doc {
-            #[serde(default)]
-            channels: librefang_types::config::ChannelsConfig,
-        }
-        let parsed: Doc = toml::from_str(&raw).unwrap_or_default();
-        assert_eq!(parsed.channels.matrix.len(), 0);
+        // table itself is empty. Same constraint as the sibling tests:
+        // matrix migrated to a sidecar (#5368), so we count remaining
+        // array-of-tables headers (and the legacy single-table header)
+        // in the raw text instead of round-tripping through
+        // `ChannelsConfig`.
+        assert_eq!(
+            raw.matches("[[channels.matrix]]").count(),
+            0,
+            "last instance removed: no array-of-tables headers must remain: {raw}"
+        );
+        assert!(
+            !raw.contains("[channels.matrix]"),
+            "legacy single-table header must also be absent: {raw}"
+        );
     }
 
     #[test]

--- a/crates/librefang-kernel/src/config_reload.rs
+++ b/crates/librefang-kernel/src/config_reload.rs
@@ -664,12 +664,13 @@ mod tests {
     fn test_channels_hot_reload() {
         let a = default_cfg();
         let mut b = default_cfg();
-        // Change the channels config by adding a Matrix config
-        // (Discord and Slack were migrated to sidecars; Matrix is the
-        // in-process fixture).
-        b.channels.matrix =
-            librefang_types::config::OneOrMany(vec![librefang_types::config::MatrixConfig {
-                access_token_env: "MATRIX_TOKEN".to_string(),
+        // Change the channels config by adding a WeChat config
+        // (Discord, Slack, Signal, Mattermost, Matrix, Line, Webex,
+        // and QQ have all migrated to sidecars; WeChat is one of the
+        // remaining in-process fixtures with a usable Default impl).
+        b.channels.wechat =
+            librefang_types::config::OneOrMany(vec![librefang_types::config::WeChatConfig {
+                bot_token_env: "WECHAT_TOKEN".to_string(),
                 ..Default::default()
             }]);
         let plan = build_reload_plan(&a, &b);

--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -398,14 +398,16 @@ admin_role = "admin"
         let config = KernelConfig {
             channels: ChannelsConfig {
                 whatsapp: OneOrMany(vec![WhatsAppConfig::default()]),
-                matrix: OneOrMany(vec![MatrixConfig::default()]),
+                // matrix migrated to a sidecar (#5368) — use wechat as
+                // the in-process fixture with a usable Default impl.
+                wechat: OneOrMany(vec![WeChatConfig::default()]),
                 email: OneOrMany(vec![EmailConfig::default()]),
                 ..Default::default()
             },
             ..Default::default()
         };
         assert!(config.channels.whatsapp.is_some());
-        assert!(config.channels.matrix.is_some());
+        assert!(config.channels.wechat.is_some());
         assert!(config.channels.email.is_some());
     }
 
@@ -873,46 +875,47 @@ admin_role = "admin"
 
     #[test]
     fn test_one_or_many_single_toml_table() {
-        // Single [channels.matrix] table should parse as OneOrMany with one element
+        // Single [channels.wechat] table should parse as OneOrMany with one element.
+        // Matrix migrated to a sidecar (#5368); these tests cover the
+        // OneOrMany helper itself, not the channel — swapped to wechat
+        // because it's one of the in-process fixtures that survived.
         let toml_str = r#"
-            [channels.matrix]
-            access_token_env = "MY_MX_TOKEN"
-            homeserver_url = "https://matrix.example.org"
+            [channels.wechat]
+            bot_token_env = "WECHAT_TOKEN_SINGLE"
             account_id = "bot1"
         "#;
         let config: KernelConfig = toml::from_str(toml_str).unwrap();
-        assert!(config.channels.matrix.is_some());
-        assert_eq!(config.channels.matrix.len(), 1);
-        let mx = config.channels.matrix.first().unwrap();
-        assert_eq!(mx.access_token_env, "MY_MX_TOKEN");
-        assert_eq!(mx.account_id.as_deref(), Some("bot1"));
+        assert!(config.channels.wechat.is_some());
+        assert_eq!(config.channels.wechat.len(), 1);
+        let wc = config.channels.wechat.first().unwrap();
+        assert_eq!(wc.bot_token_env, "WECHAT_TOKEN_SINGLE");
+        assert_eq!(wc.account_id.as_deref(), Some("bot1"));
     }
 
     #[test]
     fn test_one_or_many_array_of_tables() {
-        // [[channels.matrix]] should parse as OneOrMany with multiple elements
+        // [[channels.wechat]] should parse as OneOrMany with multiple elements
+        // (matrix migrated to a sidecar — see _single_toml_table).
         let toml_str = r#"
-            [[channels.matrix]]
-            access_token_env = "MX_TOKEN_1"
-            homeserver_url = "https://a.example.org"
+            [[channels.wechat]]
+            bot_token_env = "WECHAT_TOKEN_1"
             account_id = "bot1"
             default_agent = "assistant"
 
-            [[channels.matrix]]
-            access_token_env = "MX_TOKEN_2"
-            homeserver_url = "https://b.example.org"
+            [[channels.wechat]]
+            bot_token_env = "WECHAT_TOKEN_2"
             account_id = "bot2"
             default_agent = "coder"
         "#;
         let config: KernelConfig = toml::from_str(toml_str).unwrap();
-        assert!(config.channels.matrix.is_some());
-        assert_eq!(config.channels.matrix.len(), 2);
+        assert!(config.channels.wechat.is_some());
+        assert_eq!(config.channels.wechat.len(), 2);
 
-        let bots: Vec<_> = config.channels.matrix.iter().collect();
-        assert_eq!(bots[0].access_token_env, "MX_TOKEN_1");
+        let bots: Vec<_> = config.channels.wechat.iter().collect();
+        assert_eq!(bots[0].bot_token_env, "WECHAT_TOKEN_1");
         assert_eq!(bots[0].account_id.as_deref(), Some("bot1"));
         assert_eq!(bots[0].default_agent.as_deref(), Some("assistant"));
-        assert_eq!(bots[1].access_token_env, "MX_TOKEN_2");
+        assert_eq!(bots[1].bot_token_env, "WECHAT_TOKEN_2");
         assert_eq!(bots[1].account_id.as_deref(), Some("bot2"));
         assert_eq!(bots[1].default_agent.as_deref(), Some("coder"));
     }
@@ -967,38 +970,40 @@ admin_role = "admin"
 
     #[test]
     fn test_one_or_many_empty_default() {
+        // Matrix migrated to a sidecar (#5368); use wechat as the
+        // surviving in-process fixture.
         let config = KernelConfig::default();
-        assert!(config.channels.matrix.is_none());
-        assert!(config.channels.matrix.is_empty());
-        assert_eq!(config.channels.matrix.len(), 0);
-        assert!(config.channels.matrix.first().is_none());
-        assert!(config.channels.matrix.as_ref().is_none());
+        assert!(config.channels.wechat.is_none());
+        assert!(config.channels.wechat.is_empty());
+        assert_eq!(config.channels.wechat.len(), 0);
+        assert!(config.channels.wechat.first().is_none());
+        assert!(config.channels.wechat.as_ref().is_none());
     }
 
     #[test]
     fn test_one_or_many_serialize_roundtrip() {
-        // Single element serializes as a bare table, multi as array-of-tables
-        let single = OneOrMany(vec![MatrixConfig::default()]);
+        // Single element serializes as a bare table, multi as array-of-tables.
+        // Matrix migrated to a sidecar (#5368) — uses wechat instead.
+        let single = OneOrMany(vec![WeChatConfig::default()]);
         let json = serde_json::to_string(&single).unwrap();
-        let back: OneOrMany<MatrixConfig> = serde_json::from_str(&json).unwrap();
+        let back: OneOrMany<WeChatConfig> = serde_json::from_str(&json).unwrap();
         assert_eq!(back.len(), 1);
 
-        let multi = OneOrMany(vec![MatrixConfig::default(), MatrixConfig::default()]);
+        let multi = OneOrMany(vec![WeChatConfig::default(), WeChatConfig::default()]);
         let json = serde_json::to_string(&multi).unwrap();
-        let back: OneOrMany<MatrixConfig> = serde_json::from_str(&json).unwrap();
+        let back: OneOrMany<WeChatConfig> = serde_json::from_str(&json).unwrap();
         assert_eq!(back.len(), 2);
 
-        let empty: OneOrMany<MatrixConfig> = OneOrMany::default();
+        let empty: OneOrMany<WeChatConfig> = OneOrMany::default();
         let json = serde_json::to_string(&empty).unwrap();
         assert_eq!(json, "null");
     }
 
     #[test]
     fn test_account_id_in_channel_configs() {
-        // Verify account_id field exists and defaults to None
-        assert!(MatrixConfig::default().account_id.is_none());
+        // Verify account_id field exists and defaults to None.
+        // (Matrix entry removed: migrated to a sidecar in #5368.)
         assert!(WhatsAppConfig::default().account_id.is_none());
-        assert!(MatrixConfig::default().account_id.is_none());
         assert!(EmailConfig::default().account_id.is_none());
         assert!(WeChatConfig::default().account_id.is_none());
         assert!(WeComConfig::default().account_id.is_none());

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -5657,10 +5657,13 @@ fn default_true() -> bool {
 
 // ── Shared channel timeout defaults ────────────────────────────────
 
-/// Default initial backoff in seconds for channels using exponential backoff (1s).
-fn default_channel_initial_backoff_secs() -> u64 {
-    1
-}
+// `default_channel_initial_backoff_secs` (1s) was removed alongside
+// the Signal sidecar migration and the Matrix in-process → sidecar
+// migration (#5368): the in-process Matrix adapter was the last
+// remaining consumer, and the sidecar version controls its own
+// backoff via env vars. Remaining channel adapters that still need
+// `serde(default = ...)` for backoff fields use
+// `default_channel_initial_backoff_2s` below.
 
 /// Default maximum backoff in seconds for channels using exponential backoff (60s).
 fn default_channel_max_backoff_secs() -> u64 {


### PR DESCRIPTION
## What

Recovers main from three hard-build failures introduced by #5368 (Matrix in-process → sidecar):

1. **Orphan helper** in `librefang-types/src/config/types.rs`: `default_channel_initial_backoff_secs` (1s variant) lost its last caller when Signal and Matrix both migrated to sidecars. With workspace lints set to `warnings = "deny"`, this surfaces as `error: function is never used` and turns the whole workspace red.
2. **Stale typed round-trip** in `librefang-api/src/routes/skills.rs`: three tests round-tripped TOML through `librefang_types::config::ChannelsConfig` and asserted on `parsed.channels.matrix.len()`. After #5368 there is no `matrix` field on `ChannelsConfig`, so the test build fails with `E0609`.
3. **Stale config-reload test** in `librefang-kernel/src/config_reload.rs`: `test_channels_hot_reload` built a `MatrixConfig` and assigned to `b.channels.matrix`. Same E0609 — both the field and the type are gone.

## Why — main is currently red on `cargo check --workspace --lib --tests`

```
[workspace.lints.rust]
warnings = "deny"
```

`librefang-types`, `librefang-api`, and `librefang-kernel` all opt in via `[lints] workspace = true`, so dead code becomes a hard error. Combined with the typed round-trip in `skills.rs` and the test fixture in `config_reload.rs`, every audit / refactor PR built against `origin/main` started failing.

## Change

* `crates/librefang-types/src/config/types.rs` — delete `default_channel_initial_backoff_secs`. Sibling helpers (`_2s`, `_max_backoff_secs`) still have live consumers and stay; a short comment in the same module records the removal so the next channel migration knows the pattern.
* `crates/librefang-api/src/routes/skills.rs` — replace the typed `ChannelsConfig` round-trip in the three failing tests with a raw count of `[[channels.matrix]]` headers. Equivalent assertion for the helpers under test (`append_channel_instance`, `remove_channel_instance`) — both operate on the TOML string itself. Legacy-single-table-form coverage is kept via the `[channels.matrix]` absence check.
* `crates/librefang-kernel/src/config_reload.rs::test_channels_hot_reload` — swap `MatrixConfig` / `b.channels.matrix` for `WeChatConfig` / `b.channels.wechat`. WeChat is one of the remaining in-process channels with a usable `Default` impl.

## Verification

- `cargo check -p librefang-types --lib` clean.
- `cargo check -p librefang-api --lib --tests` clean.
- `cargo test -p librefang-api --lib -- append_channel_instance_promotes remove_channel_instance_drops` — 4/4 pass.
- `cargo test -p librefang-kernel --lib test_channels_hot_reload` — 1/1 pass.
- No public-API surface change.

## Scope

Strictly the three main-red symptoms above. All share the same root cause (#5368 fallout), so bundling them is the right shape rather than three near-trivial PRs.