### PR TITLE
fix: hotfix dangling refs from #5368 + #5380 sidecar migrations (FeishuConfig + pulldown-cmark)

### DIFF
--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -971,14 +971,12 @@ admin_role = "admin"
     #[test]
     fn test_account_id_in_channel_configs() {
         // Verify account_id field exists and defaults to None.
-        // Matrix witness deleted by #5368; rotated to WhatsApp + Email +
-        // WeChat + DingTalk + Feishu — every remaining in-process
-        // channel struct that exposes `account_id`.
+        // Matrix witness deleted by #5368, Feishu by #5380; remaining
+        // in-process witnesses that expose `account_id` are below.
         assert!(WhatsAppConfig::default().account_id.is_none());
         assert!(EmailConfig::default().account_id.is_none());
         assert!(WeChatConfig::default().account_id.is_none());
         assert!(DingTalkConfig::default().account_id.is_none());
-        assert!(FeishuConfig::default().account_id.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Hotfix — main is currently red.**

PR #5392 (wecom sidecar migration) added a \`FeishuConfig::default().account_id.is_none()\` assertion to \`test_account_id_in_channel_configs\` to broaden the account-id-defaults-to-None coverage after #5368 deleted MatrixConfig. But the wecom PR landed AFTER the feishu sidecar migration #5380 (\`425ef656\`), which deleted \`FeishuConfig\` between this PR's branch base and its squash merge.

Main (\`3c0e690e\`) now fails:

\`\`\`
error[E0433]: cannot find type \`FeishuConfig\` in this scope
   --> crates/librefang-types/src/config/mod.rs:981:17
error: could not compile \`librefang-types\` (lib test) due to 1 previous error
\`\`\`

Surfaces in the unit-fast CI lane (\`-E 'kind(lib) | kind(bin)'\`) — ~2 min to red after every push from any PR.

## Fix

Drop the dangling line. The remaining four assertions (WhatsApp / Email / WeChat / DingTalk) still cover four distinct in-process configs that expose \`account_id\`, so the test's contract (account_id defaults to None across remaining in-process channels) is preserved.

## Test plan

- [x] \`cargo test -p librefang-types --lib\` — **831 passed** locally
- [x] Pre-push hook (clippy zero-warnings + OpenAPI drift) — passed

## Why this slipped past CI on the wecom PR

The wecom PR's CI on \`2fc6a1c1\` ran against the pre-#5380 base where \`FeishuConfig\` still existed, so the assertion compiled. After the wecom branch tip got squashed onto today's main (which had absorbed #5380 in the interim), the now-stale type reference surfaced. Classic race between two BREAKING channel migrations sharing the same test-witness rotation pattern.