### PR TITLE
fix: recover main from #5380 feishu-sidecar fallout (test compile)

### DIFF
--- a/crates/librefang-migrate/src/openclaw.rs
+++ b/crates/librefang-migrate/src/openclaw.rs
@@ -3971,13 +3971,16 @@ mod tests {
         // assertions below for the token round-trip).
         let teams = cfg.channels.teams.iter().next().expect("teams configured");
         assert_eq!(teams.allowed_tenants, vec!["tenant-xyz".to_string()]); // was "tenant_id" scalar before
-        let feishu = cfg
-            .channels
-            .feishu
-            .iter()
-            .next()
-            .expect("feishu configured");
-        assert_eq!(feishu.region, "intl"); // domain "lark.com" → region "intl"
+        // Feishu migrated to a sidecar (#5380); `cfg.channels.feishu`
+        // no longer exists. The migrator records the legacy `feishu:`
+        // block as a skipped channel — mirror the matrix/signal
+        // assertion shape from earlier in this test.
+        assert!(
+            report.skipped.iter().any(|s| s.kind == ItemKind::Channel
+                && s.name == "feishu"
+                && s.reason.contains("sidecar")),
+            "Feishu must surface as a skipped sidecar channel"
+        );
 
         // ---- agent.toml round-trip ----
         let agent_str =

--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -972,13 +972,13 @@ admin_role = "admin"
     fn test_account_id_in_channel_configs() {
         // Verify account_id field exists and defaults to None.
         // Matrix witness deleted by #5368; rotated to WhatsApp + Email +
-        // WeChat + DingTalk + Feishu — every remaining in-process
-        // channel struct that exposes `account_id`.
+        // WeChat + DingTalk — Feishu was migrated to a sidecar
+        // (#5380), so `FeishuConfig` is gone alongside the field on
+        // `ChannelsConfig`.
         assert!(WhatsAppConfig::default().account_id.is_none());
         assert!(EmailConfig::default().account_id.is_none());
         assert!(WeChatConfig::default().account_id.is_none());
         assert!(DingTalkConfig::default().account_id.is_none());
-        assert!(FeishuConfig::default().account_id.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Recovers main from two `cargo check --workspace --lib --tests` failures introduced by #5380 (Feishu in-process → sidecar):

1. **`crates/librefang-types/src/config/mod.rs:981`** — `test_account_id_in_channel_configs` still constructed `FeishuConfig::default()`. The type was removed alongside the `channels.feishu` field by #5380. Drop the now-impossible assertion (sibling assertions for the surviving in-process channels stay).

2. **`crates/librefang-migrate/src/openclaw.rs:3974`** — the openclaw migration walkthrough test extracted `cfg.channels.feishu.first()` and asserted on the migrated `region`. Replace with the same `skipped sidecar` assertion shape used elsewhere in the same test for Matrix / Signal / Mattermost (record the legacy `feishu:` block as a skipped channel via the migration report).

## Why

The workspace lint policy is `warnings = "deny"` and the test build is gated on the unit-fast CI lane. Without this PR every audit / refactor PR built against `origin/main` fails with `E0609 / E0433`.

## Verification

- `cargo check --workspace --lib --tests` clean.
- No public-API surface change.

## Scope

Strictly the two main-red symptoms above. Same root cause (#5380 fallout) so bundled into one PR per the AGENTS.md "tight cluster" rule.

## Companion

#5379 is the original main-red recovery PR for the earlier #5368 (Matrix sidecar) fallout. Its scope partially overlaps with the upstream cleanup that #5392 (WeCom migration) already shipped, so #5379 may now be redundant — needs a rebase to confirm. This PR is the strictly-incremental delta needed against current `origin/main`.
