### PR TITLE
fix(migrate): drop dangling channels.feishu access in openclaw roundtrip test

### DIFF
--- a/crates/librefang-migrate/src/openclaw.rs
+++ b/crates/librefang-migrate/src/openclaw.rs
@@ -3971,13 +3971,16 @@ mod tests {
         // assertions below for the token round-trip).
         let teams = cfg.channels.teams.iter().next().expect("teams configured");
         assert_eq!(teams.allowed_tenants, vec!["tenant-xyz".to_string()]); // was "tenant_id" scalar before
-        let feishu = cfg
-            .channels
-            .feishu
-            .iter()
-            .next()
-            .expect("feishu configured");
-        assert_eq!(feishu.region, "intl"); // domain "lark.com" → region "intl"
+        // Feishu migrated to a sidecar (#5380); `cfg.channels.feishu`
+        // no longer exists. The migrator records the legacy `feishu:`
+        // block as a skipped channel — mirror the matrix/signal
+        // assertion shape from earlier in this test.
+        assert!(
+            report.skipped.iter().any(|s| s.kind == ItemKind::Channel
+                && s.name == "feishu"
+                && s.reason.contains("sidecar")),
+            "Feishu must surface as a skipped sidecar channel"
+        );
 
         // ---- agent.toml round-trip ----
         let agent_str =


### PR DESCRIPTION
## Hotfix — main is red.

`test_roundtrip_migrate_output_into_real_structs` in `crates/librefang-migrate/src/openclaw.rs:3974` still calls `cfg.channels.feishu.iter()`. The `feishu` field on `ChannelsConfig` was deleted by #5380 (Feishu sidecar migration). Wecom (#5392) landed on a base that didn't yet have that deletion applied to this particular test, so main now fails `cargo test -p librefang-migrate` compile.

Same pattern as the matrix / signal / mattermost walkthroughs above this point in the test: assert the channel is recorded in `report.skipped` with the `sidecar` reason string. The migrator already does this at `openclaw.rs:1930-1942`.

Supersedes parts of #5403 (which had a textual conflict on the now-already-merged FeishuConfig assertion via #5402).
