### PR TITLE
chore(deps): drop pulldown-cmark workspace dep, orphaned by matrix sidecar #5368

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,11 +157,10 @@ tokio-tungstenite = { version = "0.29.0", default-features = false, features = [
 url = "2"
 urlencoding = "2"
 
-# Markdown → HTML for Matrix's `formatted_body` (m.room.message). Matrix
-# expects CommonMark in `body` and rendered HTML in `formatted_body`; the
-# canonical Rust pull-parser. ~7 kLOC, MIT, no transitive deps that aren't
-# already in our tree.
-pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
+# pulldown-cmark removed: matrix migrated to a sidecar (#5368), which
+# was the sole consumer of CommonMark → HTML rendering for the Matrix
+# `formatted_body` field. The Python sidecar
+# (librefang.sidecar.adapters.matrix) brings its own stdlib renderer.
 
 # Public Suffix List — used by mcp_auth to decide whether a metadata-declared
 # token_endpoint shares a registrable domain with the operator-typed issuer


### PR DESCRIPTION
## Summary

Trailing cleanup from the matrix sidecar migration (#5368).

\`pulldown-cmark\` was added to the root \`Cargo.toml\` workspace deps as \"Markdown → HTML for Matrix's `formatted_body`\". That was the sole consumer. #5368 deleted \`crates/librefang-channels/src/matrix.rs\` and moved the rendering into the Python sidecar (\`librefang.sidecar.adapters.matrix\`, which ships its own stdlib subset renderer), so the workspace dep declaration has been a no-op since that PR landed. \`Cargo.lock\` lost the package entry when the consuming code went away — this commit just removes the now-orphan workspace declaration.

## Background

This fix originally rode along on #5402 as a follow-up commit, but #5402 was squash-merged at the first commit before this one synced, so the fix was stranded on the now-closed branch. Re-issued as a standalone PR.

## Test plan

- [x] \`cargo check --workspace --lib\` — clean
- [x] Pre-push hook (clippy zero-warnings + OpenAPI drift) — passed