### PR TITLE
fix(channels/dingtalk-sidecar): recover sessionWebhook via ChannelUser.librefang_user

### DIFF
--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -2641,10 +2641,8 @@ Complete table of all environment variables referenced by the configuration. Non
 | `FLOCK_BOT_TOKEN` | Flock | Flock bot token. |
 | `TWIST_TOKEN` | Twist | Twist API token. |
 | `MUMBLE_PASSWORD` | Mumble | Mumble server password. |
-| `DINGTALK_APP_KEY` | DingTalk | DingTalk App Key / Client ID (stream mode). |
-| `DINGTALK_APP_SECRET` | DingTalk | DingTalk App Secret / Client Secret (stream mode). |
-| `DINGTALK_ACCESS_TOKEN` | DingTalk | DingTalk webhook access token (webhook mode). |
-| `DINGTALK_SECRET` | DingTalk | DingTalk signing secret (webhook mode). |
+| `DINGTALK_APP_KEY` | DingTalk | DingTalk App Key / Client ID (sidecar — `librefang.sidecar.adapters.dingtalk`, stream mode only). |
+| `DINGTALK_APP_SECRET` | DingTalk | DingTalk App Secret / Client Secret (sidecar — `librefang.sidecar.adapters.dingtalk`, stream mode only). |
 | `GITTER_TOKEN` | Gitter | Gitter auth token. |
 | `NTFY_TOKEN` | ntfy | ntfy auth token (optional for public topics). |
 | `GOTIFY_APP_TOKEN` | Gotify | Gotify app token (sending). |
@@ -2685,7 +2683,7 @@ For every **enabled channel** (i.e., its config section is present in the TOML),
 | Flock | `bot_token_env` |
 | Twist | `token_env` |
 | Mumble | `password_env` |
-| DingTalk | `app_key_env` (stream) or `access_token_env` (webhook) |
+| DingTalk | _sidecar — validation handled by `librefang.sidecar.adapters.dingtalk`'s `DINGTALK_APP_KEY` / `DINGTALK_APP_SECRET` env check_ |
 | Gitter | `token_env` |
 | ntfy | `token_env` (only if `token_env` is non-empty; public topics are OK without auth) |
 | Webhook | `secret_env` |

--- a/docs/src/app/configuration/security/page.mdx
+++ b/docs/src/app/configuration/security/page.mdx
@@ -386,10 +386,8 @@ Complete table of all environment variables referenced by the configuration. Non
 | `FLOCK_BOT_TOKEN` | Flock | Flock bot token. |
 | `TWIST_TOKEN` | Twist | Twist API token. |
 | `MUMBLE_PASSWORD` | Mumble | Mumble server password. |
-| `DINGTALK_APP_KEY` | DingTalk | DingTalk App Key / Client ID (stream mode). |
-| `DINGTALK_APP_SECRET` | DingTalk | DingTalk App Secret / Client Secret (stream mode). |
-| `DINGTALK_ACCESS_TOKEN` | DingTalk | DingTalk webhook access token (webhook mode). |
-| `DINGTALK_SECRET` | DingTalk | DingTalk signing secret (webhook mode). |
+| `DINGTALK_APP_KEY` | DingTalk | DingTalk App Key / Client ID (sidecar — `librefang.sidecar.adapters.dingtalk`, stream mode only). |
+| `DINGTALK_APP_SECRET` | DingTalk | DingTalk App Secret / Client Secret (sidecar — `librefang.sidecar.adapters.dingtalk`, stream mode only). |
 | `GITTER_TOKEN` | Gitter | Gitter auth token. |
 | `NTFY_TOKEN` | ntfy | ntfy auth token (optional for public topics). |
 | `GOTIFY_APP_TOKEN` | Gotify | Gotify app token (sending). |

--- a/docs/src/app/zh/configuration/page.mdx
+++ b/docs/src/app/zh/configuration/page.mdx
@@ -2631,10 +2631,8 @@ max_versions_per_agent = 50
 | `FLOCK_BOT_TOKEN` | Flock | Flock Bot 令牌。 |
 | `TWIST_TOKEN` | Twist | Twist API 令牌。 |
 | `MUMBLE_PASSWORD` | Mumble | Mumble 服务器密码。 |
-| `DINGTALK_APP_KEY` | DingTalk | 钉钉 App Key / Client ID（stream 模式）。 |
-| `DINGTALK_APP_SECRET` | DingTalk | 钉钉 App Secret / Client Secret（stream 模式）。 |
-| `DINGTALK_ACCESS_TOKEN` | DingTalk | 钉钉 Webhook 访问令牌（webhook 模式）。 |
-| `DINGTALK_SECRET` | DingTalk | 钉钉签名密钥（webhook 模式）。 |
+| `DINGTALK_APP_KEY` | DingTalk | 钉钉 App Key / Client ID（sidecar 适配器 `librefang.sidecar.adapters.dingtalk`，仅 stream 模式）。 |
+| `DINGTALK_APP_SECRET` | DingTalk | 钉钉 App Secret / Client Secret（sidecar 适配器 `librefang.sidecar.adapters.dingtalk`，仅 stream 模式）。 |
 | `GITTER_TOKEN` | Gitter | Gitter 认证令牌。 |
 | `NTFY_TOKEN` | ntfy | ntfy 认证令牌（公共主题可选）。 |
 | `GOTIFY_APP_TOKEN` | Gotify | Gotify 应用令牌（发送）。 |
@@ -2675,7 +2673,7 @@ max_versions_per_agent = 50
 | Flock | `bot_token_env` |
 | Twist | `token_env` |
 | Mumble | `password_env` |
-| DingTalk | `app_key_env`（stream）或 `access_token_env`（webhook） |
+| DingTalk | _sidecar — 由 `librefang.sidecar.adapters.dingtalk` 的 `DINGTALK_APP_KEY` / `DINGTALK_APP_SECRET` env 检查负责_ |
 | Gitter | `token_env` |
 | ntfy | `token_env`（仅当 `token_env` 非空时；公共主题无需认证） |
 | Gotify | `app_token_env` |

--- a/docs/src/app/zh/configuration/security/page.mdx
+++ b/docs/src/app/zh/configuration/security/page.mdx
@@ -385,10 +385,8 @@ max_versions_per_agent = 50
 | `FLOCK_BOT_TOKEN` | Flock | Flock Bot 令牌。 |
 | `TWIST_TOKEN` | Twist | Twist API 令牌。 |
 | `MUMBLE_PASSWORD` | Mumble | Mumble 服务器密码。 |
-| `DINGTALK_APP_KEY` | DingTalk | 钉钉 App Key / Client ID（stream 模式）。 |
-| `DINGTALK_APP_SECRET` | DingTalk | 钉钉 App Secret / Client Secret（stream 模式）。 |
-| `DINGTALK_ACCESS_TOKEN` | DingTalk | 钉钉 Webhook 访问令牌（webhook 模式）。 |
-| `DINGTALK_SECRET` | DingTalk | 钉钉签名密钥（webhook 模式）。 |
+| `DINGTALK_APP_KEY` | DingTalk | 钉钉 App Key / Client ID（sidecar 适配器 `librefang.sidecar.adapters.dingtalk`，仅 stream 模式）。 |
+| `DINGTALK_APP_SECRET` | DingTalk | 钉钉 App Secret / Client Secret（sidecar 适配器 `librefang.sidecar.adapters.dingtalk`，仅 stream 模式）。 |
 | `GITTER_TOKEN` | Gitter | Gitter 认证令牌。 |
 | `NTFY_TOKEN` | ntfy | ntfy 认证令牌（公共主题可选）。 |
 | `GOTIFY_APP_TOKEN` | Gotify | Gotify 应用令牌（发送）。 |

--- a/docs/src/app/zh/integrations/channels/integrations/page.mdx
+++ b/docs/src/app/zh/integrations/channels/integrations/page.mdx
@@ -47,72 +47,38 @@ sidecar 作为 LibreFang 的被监管子进程运行。它在 `LINE_WEBHOOK_PORT
 
 ## 钉钉
 
-支持两种接收模式：
-- **Stream 模式**（默认，推荐）：通过钉钉 Stream 协议建立 WebSocket 长连接。无需公网 IP 或端口。
-- **Webhook 模式**（传统）：HTTP 回调服务器。需要公网可访问的 URL。
+钉钉由 Python sidecar 适配器（`librefang.sidecar.adapters.dingtalk`）提供，**仅 stream 模式**。in-process `[channels.dingtalk]` 配置块已在 sidecar 迁移中移除；请改为通过 `[[sidecar_channels]]` 条目声明。原 in-process `webhook` 模式（基于 `timestamp + secret + body` 的 HMAC-SHA256）已**未**迁移 —— 请在钉钉管理后台将机器人切换到 stream 订阅。
 
 ### 前置条件
 
 - 在[钉钉开放平台](https://open.dingtalk.com/document/)创建的应用
-- **Stream 模式**：需要应用的 App Key 和 App Secret
-- **Webhook 模式**：需要自定义机器人的 webhook 访问令牌和签名密钥
+- 应用的 App Key 和 App Secret
+- 守护进程主机上有 `python3`（无第三方包要求 —— stdlib-only sidecar）
 
-### 设置步骤（Stream 模式 -- 推荐）
+### 设置步骤
 
 1. 前往[钉钉开放平台](https://open.dingtalk.com/)，创建应用（或使用现有应用）。
 2. 启用 **机器人** 能力，记录 **App Key**（Client ID）和 **App Secret**（Client Secret）。
-3. 设置环境变量：
-
-```bash
-export DINGTALK_APP_KEY=your-app-key          # 环境变量
-export DINGTALK_APP_SECRET=your-app-secret
-librefang vault set DINGTALK_APP_KEY          # 加密金库（推荐）
-librefang vault set DINGTALK_APP_SECRET
-```
-
-4. 添加到配置文件：
+3. 添加到 `config.toml`：
 
 ```toml
-[channels.dingtalk]
-receive_mode = "stream"
-app_key_env = "DINGTALK_APP_KEY"
-app_secret_env = "DINGTALK_APP_SECRET"
-default_agent = "assistant"
+[[sidecar_channels]]
+name = "dingtalk"
+command = "python3"
+args = ["-m", "librefang.sidecar.adapters.dingtalk"]
+channel_type = "dingtalk"
+[sidecar_channels.env]
+DINGTALK_APP_KEY = "dingxxx..."
+# DINGTALK_ACCOUNT_ID = "prod-bot"     # 可选，多机器人路由键
+# DINGTALK_ALLOWED_USERS = "staff1,staff2"   # 可选，staffId 白名单
 ```
 
+4. 把 `DINGTALK_APP_SECRET` 放入 `~/.librefang/secrets.env`（仪表板的"通道"页面会替你写入）。
 5. 重启守护进程。
-
-### 设置步骤（Webhook 模式）
-
-1. 在钉钉中，打开群聊，前往 **群设置 > 智能群助手 > 添加机器人**。
-2. 选择 **自定义机器人**，启用 **安全设置**（建议使用签名模式）。
-3. 记录 webhook 访问令牌和签名密钥。
-4. 设置环境变量：
-
-```bash
-export DINGTALK_ACCESS_TOKEN=your-token       # 环境变量
-export DINGTALK_SECRET=your-signing-secret
-librefang vault set DINGTALK_ACCESS_TOKEN     # 加密金库（推荐）
-librefang vault set DINGTALK_SECRET
-```
-
-5. 添加到配置文件：
-
-```toml
-[channels.dingtalk]
-receive_mode = "webhook"
-access_token_env = "DINGTALK_ACCESS_TOKEN"
-secret_env = "DINGTALK_SECRET"
-default_agent = "assistant"
-```
-
-6. 重启守护进程。
 
 ### 工作原理
 
-在 **Stream 模式** 下，适配器向钉钉网关 API（`/v1.0/gateway/connections/open`）注册以获取 WebSocket 端点和票据，然后维持持久的 WebSocket 连接，接收机器人消息回调并响应 ACK 帧。心跳 ping/pong 自动处理。
-
-在 **Webhook 模式** 下，适配器通过 HTTP 回调接收来自钉钉机器人 API 的消息。每个请求使用配置的密钥通过 HMAC-SHA256 签名进行验证。响应通过带有签名时间戳的钉钉 webhook URL 发送。
+sidecar 通过 `POST /v1.0/gateway/connections/open` 向钉钉网关注册以获取 WebSocket 端点和票据，建立 WS 连接后对每一帧 CALLBACK 立即 ACK，并向钉钉随每条入站事件返回的 per-message `sessionWebhook` URL POST 回复。SYSTEM ping/pong 心跳自动处理。重连为 3 → 60 秒指数退避。
 
 ---
 

--- a/sdk/python/librefang/sidecar/adapters/dingtalk.py
+++ b/sdk/python/librefang/sidecar/adapters/dingtalk.py
@@ -254,9 +254,16 @@ def parse_dingtalk_event(
     if account_id:
         metadata["account_id"] = account_id
     if session_webhook:
-        # Stash the per-message reply URL so on_send can route the
-        # outbound to the right sessionWebhook (Rust stuffs it into
-        # ChannelUser.librefang_user; we surface it explicitly).
+        # Surface the per-message reply URL in BOTH places:
+        #
+        # 1. As `metadata.session_webhook` — preserved for any caller
+        #    that wants to log / inspect the URL.
+        # 2. As `ChannelUser.librefang_user` — this is the field the
+        #    daemon round-trips back through `cmd.user["librefang_user"]`
+        #    on `Send`, so `on_send` can recover the URL without
+        #    relying on a per-process `_session_webhooks` cache that
+        #    the bridge wouldn't address into. The deleted Rust adapter
+        #    used the same field (`dingtalk.rs:233-238` / `:357`).
         metadata["session_webhook"] = session_webhook
 
     return protocol.message(
@@ -266,6 +273,10 @@ def parse_dingtalk_event(
         message_id=msg_id,
         platform="dingtalk",
         is_group=is_group,
+        # See comment above — `librefang_user` is the round-trip channel
+        # for the per-message reply URL. Empty when DingTalk did not
+        # send a `sessionWebhook` (proactive non-reply or expired).
+        librefang_user=session_webhook or None,
         metadata=metadata,
     )
 
@@ -599,21 +610,30 @@ class DingTalkAdapter(SidecarAdapter):
         await loop.run_in_executor(None, self._producer_blocking, emit)
 
     async def on_send(self, cmd) -> None:
-        # The bridge round-trips the inbound message_id back as
-        # cmd.channel_id, which we use to look up the cached
-        # sessionWebhook. Fall back to metadata if the daemon happens
-        # to forward it explicitly.
+        # The daemon round-trips `ChannelUser.librefang_user` (which
+        # `parse_dingtalk_event` populates with the per-message
+        # `sessionWebhook` URL) back through `cmd.user["librefang_user"]`
+        # on `Send`. That's the primary recovery path — matches the
+        # deleted Rust adapter's `stream_reply_url(user)` helper
+        # (`dingtalk.rs:233-238`).
+        #
+        # The per-process `_session_webhooks` cache is a secondary path
+        # for clients that send `cmd.channel_id = message_id`, but the
+        # production bridge sets `channel_id = user.platform_id` instead,
+        # so cmd.user is the load-bearing one. Try cache first anyway
+        # (cheap dict lookup, covers stream_id-routed clients), then
+        # user.librefang_user.
         session_webhook = None
         msg_id = cmd.channel_id or ""
         if msg_id:
             with self._session_lock:
                 session_webhook = self._session_webhooks.pop(msg_id, None)
-        if not session_webhook:
-            # Last resort — let the agent peek at user metadata
-            # (proactive sends from agent that didn't come via inbound).
-            session_webhook = (
-                cmd.user.get("session_webhook") if cmd.user else None
-            )
+        if not session_webhook and cmd.user:
+            librefang_user = cmd.user.get("librefang_user")
+            if isinstance(librefang_user, str) and librefang_user.startswith(
+                ("http://", "https://"),
+            ):
+                session_webhook = librefang_user
         if not session_webhook:
             log.warn(
                 "dingtalk on_send: no sessionWebhook for message; dropping",

--- a/sdk/python/tests/test_dingtalk_adapter.py
+++ b/sdk/python/tests/test_dingtalk_adapter.py
@@ -434,14 +434,54 @@ async def test_on_send_uses_cached_session_webhook():
 
 
 @pytest.mark.asyncio
-async def test_on_send_falls_back_to_user_session_webhook():
+async def test_on_send_recovers_session_webhook_from_user_librefang_user():
+    """The production daemon rebuilds ``cmd.user`` from
+    ``ChannelUser{platform_id, display_name, librefang_user}`` and
+    sets ``cmd.channel_id = user.platform_id`` (NOT message_id). So
+    ``on_send`` MUST recover the per-message reply URL from
+    ``cmd.user["librefang_user"]`` (the field
+    ``parse_dingtalk_event`` populates via ``protocol.message(
+    librefang_user=session_webhook)``). Cache-by-message_id path is
+    only a secondary route and not hit by the real bridge.
+
+    Regression guard: the first sidecar landing had this backwards —
+    it tried ``_session_webhooks[cmd.channel_id]`` first and read
+    ``cmd.user["session_webhook"]`` (a key that doesn't exist in the
+    daemon's serialization) as fallback, silently dropping every
+    reply. See PR #5417 self-review."""
     a = _adapter()
     await a.on_send(_FakeSend(
+        # Real daemon shape: channel_id is sender's staffId, not the
+        # inbound message_id — the cache lookup misses.
+        channel_id="alice",
         text="hello",
-        user={"session_webhook": "https://oapi.dingtalk.com/sb?u=1"},
+        user={
+            "platform_id": "alice",
+            "display_name": "Alice",
+            "librefang_user": "https://oapi.dingtalk.com/robot/sendBySession?s=42",
+        },
     ))
     url, chunk = a._send_queue.get_nowait()
-    assert url.endswith("u=1")
+    assert url.endswith("s=42"), \
+        "on_send must recover the URL from cmd.user.librefang_user " \
+        "(not cmd.user.session_webhook, not _session_webhooks[channel_id])"
+    assert chunk == "hello"
+
+
+@pytest.mark.asyncio
+async def test_on_send_ignores_non_http_librefang_user():
+    """`librefang_user` is reused across many channels (Telegram puts the
+    Telegram username there, etc.). on_send must only treat it as a
+    sessionWebhook URL when it actually looks like an HTTP(S) URL —
+    otherwise we'd POST replies to garbage destinations."""
+    a = _adapter()
+    await a.on_send(_FakeSend(
+        channel_id="alice",
+        text="hi",
+        user={"platform_id": "alice", "librefang_user": "alice"},
+    ))
+    with pytest.raises(queue.Empty):
+        a._send_queue.get_nowait()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Runtime hotfix for #5417 — DingTalk sidecar can't reply.**

PR #5417's \`on_send\` tried to recover the per-message \`sessionWebhook\` URL in two ways, both wrong:

1. \`_session_webhooks[cmd.channel_id]\` — cache keyed by inbound \`message_id\`, but the daemon's \`KernelBridgeAdapter\` sets \`cmd.channel_id = user.platform_id\` (sender's staffId), so the lookup always misses.
2. \`cmd.user[\"session_webhook\"]\` — a key that does not exist in the \`ChannelUser\` serialization. \`grep crates/ -E session_webhook\` confirms zero hits.

**Net effect**: every outbound reply from a DingTalk agent hit the \`\"no sessionWebhook for message; dropping\"\` warn-and-drop branch. The bot can receive messages but cannot reply at all.

## Fix

Mirror the deleted Rust adapter's pattern:

- **On inbound (\`parse_dingtalk_event\`)** — set \`ChannelUser.librefang_user = sessionWebhook\` via \`protocol.message(librefang_user=...)\`. Rust did this at \`dingtalk.rs:357\`.
- **On outbound (\`on_send\`)** — recover the URL from \`cmd.user[\"librefang_user\"]\`. Rust did this via \`stream_reply_url(user)\` at \`dingtalk.rs:233-238\`. \`ChannelUser{platform_id, display_name, librefang_user}\` round-trips through the daemon's bridge code intact, so this path is reliable without per-process caching.

Also reject non-HTTP \`librefang_user\` values up-front — the field is shared across channels (Telegram puts the username there, etc.) and we must not POST replies to garbage destinations.

## Regression guard

The original PR's tests passed because they manually planted \`_session_webhooks[\"m1\"]\` then called \`on_send(channel_id=\"m1\")\` — a setup the daemon never produces. The new tests assert the daemon-shaped path:

- \`test_on_send_recovers_session_webhook_from_user_librefang_user\` — drives the realistic shape (\`channel_id=staffId\`, \`user.librefang_user=url\`). Fails on the #5417 code; passes here.
- \`test_on_send_ignores_non_http_librefang_user\` — pins the HTTP-scheme filter.

## Drive-by doc cleanup

Surfaced by the same self-review pass (CLAUDE.md \"fix what you found\"):

- 4 env-var tables in \`configuration/{page.mdx,security/page.mdx}\` + zh equivalents still listed \`DINGTALK_ACCESS_TOKEN\` / \`DINGTALK_SECRET\` as live webhook-mode credentials, but the validator reading them was removed in #5417. Operators following those tables would set vars the sidecar silently ignores.
- The zh integrations/channels/integrations/page.mdx still documented the now-removed Webhook setup section (the EN version was already rewritten in #5417; the zh one was not, leaving the bilingual docs out of sync).
- Validator-table dingtalk row updated to point at the sidecar's own env check.

## Test plan

- [x] \`cd sdk/python && pytest tests/test_dingtalk_adapter.py\` — **62 passed** (was 61 in #5417; +2 new regression guards, -1 deleted dead-key test)
- [x] Pre-push hook (clippy zero-warnings + OpenAPI drift) — passed

## How this slipped past the original PR's review

The wecom/dingtalk pattern of \"cache per-message reply context\" was carried over from wecom, but wecom routes outbounds by \`bot_id\`+\`req_id\` (cached map populated and consumed in the same WS thread) and DingTalk routes by per-message \`sessionWebhook\` URL that must round-trip through the daemon. The two don't share a control flow despite looking similar. Cargo-culted the cache approach without re-deriving the routing key.