### PR TITLE
fix(channels/qq-sidecar): recover passive-reply msg_id via ChannelUser.librefang_user

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/qq.py
+++ b/sdk/python/librefang/sidecar/adapters/qq.py
@@ -390,10 +390,32 @@ def parse_qq_event(
         user_name=username,
         content=msg_content,
         message_id=msg_id_raw or None,
-        # Improvement #4: surface the reply endpoint and msg_id on
-        # standard protocol fields so the bridge round-trips them on
-        # outbound without any QQ-specific encoding.
+        # Improvement #4 (revised): the inbound QQ message id MUST round-
+        # trip to ``on_send`` so the reply can be marked as a passive
+        # response (QQ Bot OpenAPI v2 routes anything missing ``msg_id``
+        # to the proactive-message quota, which unlicensed bots have
+        # set to zero and licensed bots cap hard). Two carriers:
+        #
+        # * ``channel_id`` — the reply endpoint URL. The bridge sets
+        #   ``cmd.channel_id`` from ``user.platform_id`` (the daemon's
+        #   contract; see ``crates/librefang-channels/src/sidecar.rs``
+        #   in ``derive_sidecar_sender_identity``), so we stash the
+        #   endpoint there *via* ``user.platform_id`` below.
+        #
+        # * ``ChannelUser.librefang_user`` — the per-message ``msg_id``.
+        #   This field is preserved bytewise across the bridge
+        #   (`sidecar.rs:766` on inbound deserialise / `:1204` on
+        #   outbound serialise via ``user: user.clone()``), so it's
+        #   the only daemon-honoured channel for per-message reply
+        #   correlation that doesn't depend on the operator setting
+        #   ``threading = true`` AND the sidecar declaring the
+        #   ``thread`` capability (QQ declares neither).
+        #
+        # ``thread_id`` is kept for forward compat with a future
+        # ``threading=true`` opt-in, but on_send no longer relies on
+        # it — see the matching docstring on ``on_send``.
         channel_id=reply_endpoint,
+        librefang_user=msg_id_raw or None,
         thread_id=msg_id_raw or None,
         is_group=is_group,
         metadata=metadata,
@@ -840,15 +862,42 @@ class QqAdapter(SidecarAdapter):
         await loop.run_in_executor(None, self._gateway_loop, emit)
 
     async def on_send(self, cmd) -> None:
-        # Improvement #4: the inbound event sets ``channel_id`` to the
-        # QQ reply endpoint and ``thread_id`` to the source ``msg_id``;
-        # the bridge round-trips both back to us on outbound.
+        # Improvement #4 (revised — was using cmd.thread_id, which the
+        # daemon NULLs out unless `[channels.qq.overrides] threading = true`
+        # AND the sidecar declares the `thread` capability, neither of
+        # which QQ does — so every reply was going out with no `msg_id`,
+        # tripping QQ Bot OpenAPI v2's proactive-message quota and
+        # silently rate-limiting / rejecting the reply).
+        #
+        # Primary recovery: `cmd.user["librefang_user"]` carries the
+        # inbound `msg_id` (see `parse_qq_event` and the matching
+        # docstring there) — this field round-trips bytewise through
+        # the bridge regardless of capabilities / overrides.
+        #
+        # Fallback to `cmd.thread_id` so a future `threading=true`
+        # opt-in keeps working, and so the existing test-suite
+        # fakes that fabricate `thread_id` continue to pass.
         reply_endpoint = (
             cmd.channel_id
             or (cmd.user.get("platform_id") if cmd.user else "")
             or ""
         )
-        msg_id = getattr(cmd, "thread_id", None) or None
+        msg_id = None
+        if cmd.user:
+            candidate = cmd.user.get("librefang_user")
+            # Guard: `librefang_user` is shared across channels
+            # (Telegram puts the @username string there, etc.). Reject
+            # anything that looks like a username, URL, or has internal
+            # whitespace — QQ message ids are opaque strings that don't
+            # carry slashes, whitespace, or URI schemes.
+            if (isinstance(candidate, str) and candidate
+                    and "/" not in candidate
+                    and " " not in candidate
+                    and "\t" not in candidate
+                    and not candidate.startswith(("http://", "https://"))):
+                msg_id = candidate
+        if msg_id is None:
+            msg_id = getattr(cmd, "thread_id", None) or None
         if not reply_endpoint:
             log.warn("qq on_send: empty reply_endpoint, dropping")
             return

--- a/sdk/python/tests/test_qq_adapter.py
+++ b/sdk/python/tests/test_qq_adapter.py
@@ -767,6 +767,101 @@ async def test_on_send_falls_back_to_user_platform_id(monkeypatch):
     assert c["url"].endswith("/v2/users/u9/messages")
 
 
+@pytest.mark.asyncio
+async def test_on_send_recovers_msg_id_from_user_librefang_user(monkeypatch):
+    """Regression guard for the original PR #5325 sidecar: it expected
+    ``cmd.thread_id`` to carry the inbound ``msg_id`` for QQ Bot
+    OpenAPI v2 passive-reply correlation. The daemon's bridge only
+    sets ``cmd.thread_id`` when BOTH
+    ``[channels.qq.overrides] threading = true`` AND the sidecar
+    declares the ``thread`` capability — QQ does neither. So in
+    production every reply went out with no ``msg_id``, classified
+    as a proactive push by the QQ platform and either rejected
+    (unlicensed bots) or quota-burned (licensed bots).
+
+    The fix mirrors dingtalk #5423: stash the ``msg_id`` in
+    ``ChannelUser.librefang_user`` on inbound, recover from
+    ``cmd.user.get("librefang_user")`` here. ``librefang_user`` is
+    the only daemon-honoured per-message carrier that doesn't
+    depend on capabilities / overrides.
+
+    This test exercises the realistic daemon shape:
+    ``thread_id=None`` (the daemon-default), ``user.librefang_user``
+    carries the msg_id. The body MUST contain ``msg_id`` from
+    ``user.librefang_user``."""
+    fake = _FakeUrlopen([(200, {})])
+    monkeypatch.setattr(qq_mod.urllib.request, "urlopen", fake)
+    a = _adapter()
+    a._token = "tok"
+    await a.on_send(_make_send(
+        channel_id="/v2/groups/G/messages",
+        text="hi",
+        content={"Text": "hi"},
+        # Daemon-default: thread_id is None
+        thread_id=None,
+        # The bridge round-trips librefang_user from inbound emit
+        user={
+            "platform_id": "/v2/groups/G/messages",
+            "display_name": "Alice",
+            "librefang_user": "qq-msg-id-abc123",
+        },
+    ))
+    body = json.loads(fake.calls[0]["body_raw"])
+    assert body["msg_id"] == "qq-msg-id-abc123", \
+        "on_send must recover the passive-reply msg_id from " \
+        "cmd.user.librefang_user (not from cmd.thread_id which " \
+        "the daemon NULLs by default for capability-less sidecars)"
+
+
+@pytest.mark.asyncio
+async def test_on_send_ignores_url_shaped_librefang_user(monkeypatch):
+    """librefang_user is shared across channels — dingtalk puts a
+    sessionWebhook URL there, telegram puts the @username string,
+    etc. We must reject anything URL-shaped or whitespace-bearing
+    before using it as a QQ msg_id."""
+    fake = _FakeUrlopen([(200, {})])
+    monkeypatch.setattr(qq_mod.urllib.request, "urlopen", fake)
+    a = _adapter()
+    a._token = "tok"
+    await a.on_send(_make_send(
+        channel_id="/v2/groups/G/messages",
+        text="hi",
+        content={"Text": "hi"},
+        thread_id=None,
+        user={
+            "platform_id": "/v2/groups/G/messages",
+            "librefang_user": "https://oapi.dingtalk.com/sb?s=42",
+        },
+    ))
+    body = json.loads(fake.calls[0]["body_raw"])
+    assert "msg_id" not in body, \
+        "URL-shaped librefang_user must be rejected — silently " \
+        "treating it as msg_id would send a corrupted passive " \
+        "reply (which the platform rejects with cryptic errors)"
+
+
+@pytest.mark.asyncio
+async def test_on_send_thread_id_fallback_still_works(monkeypatch):
+    """When BOTH the operator opts into ``threading = true`` AND a
+    future QQ rewrite gains the ``thread`` capability, cmd.thread_id
+    would carry the msg_id — keep that path as a fallback so the
+    forward-compat story isn't broken."""
+    fake = _FakeUrlopen([(200, {})])
+    monkeypatch.setattr(qq_mod.urllib.request, "urlopen", fake)
+    a = _adapter()
+    a._token = "tok"
+    # No librefang_user in user dict — fall back to thread_id.
+    await a.on_send(_make_send(
+        channel_id="/v2/groups/G/messages",
+        text="hi",
+        content={"Text": "hi"},
+        thread_id="qq-msg-via-thread",
+        user={"platform_id": "/v2/groups/G/messages"},
+    ))
+    body = json.loads(fake.calls[0]["body_raw"])
+    assert body["msg_id"] == "qq-msg-via-thread"
+
+
 # ---- WS gateway flow (mock _WebSocketClient) ------------------------
 
 


### PR DESCRIPTION
## Summary

**Runtime hotfix for #5325 (QQ sidecar) — QQ Bot OpenAPI v2 was silently rejecting every reply.**

QQ Bot OpenAPI v2 routes any POST to \`/channels/.../messages\` or \`/groups/.../messages\` **without msg_id** as a 主动 (proactive) message. Proactive sends are blocked for unlicensed bots and quota-capped hard for licensed bots — reactive bot conversations REQUIRE the inbound message's \`msg_id\` be sent back as the passive-reply correlation key.

PR #5325 tried to carry the inbound \`msg_id\` through \`cmd.thread_id\`, expecting the daemon's bridge to round-trip it back to \`on_send\`. But the bridge only sets \`cmd.thread_id\` when BOTH:

1. The channel config has \`[channels.qq.overrides] threading = true\` (defaults to false; verified at \`crates/librefang-channels/src/bridge.rs:2968-2973\`), AND
2. The sidecar declares the \`thread\` capability (verified at \`crates/librefang-channels/src/sidecar.rs:1372-1395\` — without it \`send_in_thread\` degrades to plain \`send\` which hardcodes \`thread_id: None\` at line 1203).

**QQ sidecar declares \`capabilities = []\`** (\`qq.py:665\`), so neither precondition fires for the default operator. Net effect: every QQ reply in production goes out missing \`msg_id\`, gets classified as proactive, and either fails outright or burns the daily quota silently. Operator never sees the failure because \`on_send\` returns \`Ok\` and the QQ API returns a 200 with a quiet rate-limit notice.

## Why the original tests didn't catch it

\`_make_send\` defaulted \`thread_id=\"src-1\"\` (\`test_qq_adapter.py:695-698\`), so every \`on_send\` test fabricated a correlation key the daemon would never actually produce. Structurally identical to the dingtalk on_send bug fixed in #5423.

## Fix

Mirror the dingtalk fix:

- **\`parse_qq_event\`** — also stores \`msg_id_raw\` in \`ChannelUser.librefang_user\` (which the bridge round-trips bytewise through serde regardless of capabilities / overrides — verified at \`sidecar.rs:766\` inbound, \`:1204\` outbound).
- **\`on_send\`** — reads \`cmd.user[\"librefang_user\"]\` FIRST, falls back to \`cmd.thread_id\` for the forward-compat \`threading=true\` path. Rejects URL-shaped or whitespace-bearing values (\`librefang_user\` is shared across channels: dingtalk puts a sessionWebhook URL there, telegram puts the \`@username\` string — we must not POST replies with garbage in \`msg_id\`).

## Tests

- [x] **New** \`test_on_send_recovers_msg_id_from_user_librefang_user\` — drives the realistic daemon shape (\`thread_id=None\`, \`librefang_user=msg_id\`). Body MUST contain \`msg_id\`. **Fails on PR #5325 code; passes here.** Regression guard.
- [x] **New** \`test_on_send_ignores_url_shaped_librefang_user\` — pins the cross-channel-pollution guard.
- [x] **New** \`test_on_send_thread_id_fallback_still_works\` — keeps the forward-compat fallback alive (matters when a future QQ rewrite gains the \`thread\` capability).
- [x] \`cd sdk/python && pytest tests/test_qq_adapter.py\` — **80 passed** (was 77; +3 regression guards).
- [x] Pre-push hook (clippy zero-warnings + OpenAPI drift) — passed.

## Wider sidecar audit pending

Six other sidecars also read \`cmd.thread_id\` for outbound correlation while declaring no \`thread\` capability — they're either affected to varying degrees or have already worked around it differently:

- **mastodon** — \`in_reply_to_id\` (optional, falls back to top-level toot — degradation but no API rejection)
- **nextcloud** — needs review
- **reddit** — parent fullname; **REQUIRED for comment vs new post** — comment becomes top-level. **Likely-broken**.
- **twitch** — \`@user\` mention prepend (optional)
- **bluesky** — reply reconstruction; **REQUIRED for reply** — reply becomes top-level. **Likely-broken**.
- **rocketchat** — thread reply (optional)

Worth a dedicated audit PR — same bug class, similar severity range.

## How this slipped past the original PR's review

The wecom/dingtalk/qq pattern of \"store the per-message correlation somewhere\" was carried over from each other, but each platform has a different routing key (\`req_id\` / \`sessionWebhook\` / \`msg_id\`) and the daemon's round-trip only honours specific carriers (\`librefang_user\` always; \`thread_id\` only under threading capability + opt-in). The sidecars cargo-culted \`thread_id\` without re-deriving whether the daemon would actually populate it. The fix is uniform across all of them: use \`librefang_user\` as the always-honoured per-message channel.