### PR TITLE
fix(channels/sidecars): recover per-message reply correlation via ChannelUser.librefang_user across 6 sidecars

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/bluesky.py
+++ b/sdk/python/librefang/sidecar/adapters/bluesky.py
@@ -456,9 +456,15 @@ class BlueskyAdapter(SidecarAdapter):
             content=content,
             message_id=uri,
             is_group=False,
-            # Surface the URI as thread_id so LibreFang threads outbound
-            # replies through to on_send via cmd.thread_id; the sidecar
-            # then reconstructs the reply struct from its cache.
+            # `librefang_user` is the always-round-tripped carrier for
+            # the at:// URI that on_send uses to look up the cached
+            # `{root, parent}` reply struct. Without it, the daemon
+            # would strip `cmd.thread_id` to None for cap-less
+            # sidecars and the reply would post as a top-level skeet
+            # instead of a thread reply. `thread_id` kept for
+            # forward-compat with a future `threading=true` + cap
+            # opt-in.
+            librefang_user=uri or None,
             thread_id=uri or None,
             metadata=metadata,
         )
@@ -638,11 +644,26 @@ class BlueskyAdapter(SidecarAdapter):
             text = "(Unsupported content type)"
         else:
             text = cmd.text or ""
-        thread_id = getattr(cmd, "thread_id", None)
-        if thread_id is not None and not isinstance(thread_id, str):
-            thread_id = str(thread_id) if thread_id else None
+        # Primary recovery: cmd.user["librefang_user"] (always round-
+        # tripped). Fallback: cmd.thread_id (forward-compat). Bluesky
+        # URIs have a deterministic `at://` prefix — strong sanity
+        # guard.
+        uri_key: "Optional[str]" = None
+        user = getattr(cmd, "user", None) or {}
+        if isinstance(user, dict):
+            candidate = user.get("librefang_user")
+            if (isinstance(candidate, str)
+                    and candidate.startswith("at://")
+                    and " " not in candidate):
+                uri_key = candidate
+        if uri_key is None:
+            thread_id = getattr(cmd, "thread_id", None)
+            if thread_id is not None and not isinstance(thread_id, str):
+                thread_id = str(thread_id) if thread_id else None
+            uri_key = thread_id
+
         await asyncio.get_event_loop().run_in_executor(
-            None, self._post_status, text, thread_id,
+            None, self._post_status, text, uri_key,
         )
 
 

--- a/sdk/python/librefang/sidecar/adapters/mastodon.py
+++ b/sdk/python/librefang/sidecar/adapters/mastodon.py
@@ -294,13 +294,25 @@ class MastodonAdapter(SidecarAdapter):
         if in_reply_to:
             metadata["in_reply_to_id"] = in_reply_to
 
+        # `status_id` is the id of the mention itself — i.e. the status
+        # we want to reply TO when the bot answers. The pre-fix
+        # behaviour surfaced `in_reply_to` here (the PARENT the mention
+        # was responding to), which had two bugs at once: (1) the wrong
+        # target — the bot would reply to whoever the user was
+        # responding to, not the user; (2) the daemon's bridge only
+        # round-trips `thread_id` under
+        # `[channels.mastodon.overrides] threading = true` AND `thread`
+        # capability, neither of which mastodon has, so the field was
+        # always `None` in `on_send` regardless. Both fixed by using
+        # `librefang_user` (always round-tripped) as the carrier.
         return protocol.message(
             user_id=account_id,
             user_name=display_name,
             content=content,
             message_id=status_id,
             is_group=False,
-            thread_id=in_reply_to,
+            librefang_user=status_id or None,
+            thread_id=status_id or None,
             metadata=metadata,
         )
 
@@ -531,14 +543,35 @@ class MastodonAdapter(SidecarAdapter):
             text = "(Unsupported content type)"
         else:
             text = cmd.text or ""
-        # `cmd.thread_id` carries the in_reply_to_id from the inbound
-        # mention (we surfaced it as the metadata.in_reply_to_id and
-        # the SDK forwards it on send). When set, post as a reply.
-        thread_id = getattr(cmd, "thread_id", None)
-        if thread_id is not None and not isinstance(thread_id, str):
-            thread_id = str(thread_id) if thread_id else None
+        # Primary recovery: cmd.user["librefang_user"] carries the
+        # status_id of the mention the bot is replying TO (set in
+        # _parse_notification — librefang_user round-trips bytewise
+        # through the bridge regardless of capabilities/overrides).
+        # Fallback to cmd.thread_id for the forward-compat
+        # threading=true path (would also require a future
+        # `thread` capability declaration).
+        in_reply_to: "Optional[str]" = None
+        user = getattr(cmd, "user", None) or {}
+        if isinstance(user, dict):
+            candidate = user.get("librefang_user")
+            # Guard: librefang_user is shared across channels (dingtalk
+            # puts a sessionWebhook URL, telegram puts @username, …).
+            # Mastodon status ids are typically pure-digit strings on
+            # mastodon.social but opaque alphanumerics on some forks —
+            # keep the guard generic (no URL, no whitespace, no @).
+            if (isinstance(candidate, str) and candidate
+                    and not candidate.startswith(("http://", "https://", "@"))
+                    and " " not in candidate
+                    and "\t" not in candidate):
+                in_reply_to = candidate
+        if in_reply_to is None:
+            thread_id = getattr(cmd, "thread_id", None)
+            if thread_id is not None and not isinstance(thread_id, str):
+                thread_id = str(thread_id) if thread_id else None
+            in_reply_to = thread_id
+
         await asyncio.get_event_loop().run_in_executor(
-            None, self._post_status, text, thread_id,
+            None, self._post_status, text, in_reply_to,
         )
 
 

--- a/sdk/python/librefang/sidecar/adapters/nextcloud.py
+++ b/sdk/python/librefang/sidecar/adapters/nextcloud.py
@@ -533,6 +533,13 @@ class NextcloudAdapter(SidecarAdapter):
             channel_id=room_token,
             message_id=str(msg_id) if msg_id else None,
             is_group=True,
+            # `librefang_user` is the always-round-tripped carrier for
+            # the per-message reply correlation (Talk's `replyTo` form
+            # param). `thread_id` is kept for forward-compat with a
+            # future `threading=true` + `thread` capability path, but
+            # the daemon strips it to `None` for cap-less sidecars —
+            # see the matching `on_send` recovery.
+            librefang_user=thread_id,
             thread_id=thread_id,
             metadata=metadata,
         )
@@ -780,10 +787,24 @@ class NextcloudAdapter(SidecarAdapter):
         if not room_token:
             room_token = str(getattr(cmd, "channel_id", "") or "")
 
-        thread_id = getattr(cmd, "thread_id", None)
-        if thread_id is not None and not isinstance(thread_id, str):
-            thread_id = str(thread_id) if thread_id else None
-        reply_to = thread_id or None
+        # Primary recovery: cmd.user["librefang_user"] (always
+        # round-tripped). Fallback: cmd.thread_id (forward-compat
+        # threading=true + `thread` capability path). Talk msg ids
+        # are pure-digit numeric strings — generic URL/whitespace
+        # guard is enough.
+        reply_to: "Optional[str]" = None
+        if isinstance(user, dict):
+            candidate = user.get("librefang_user")
+            if (isinstance(candidate, str) and candidate
+                    and not candidate.startswith(("http://", "https://", "@"))
+                    and " " not in candidate
+                    and "\t" not in candidate):
+                reply_to = candidate
+        if reply_to is None:
+            thread_id = getattr(cmd, "thread_id", None)
+            if thread_id is not None and not isinstance(thread_id, str):
+                thread_id = str(thread_id) if thread_id else None
+            reply_to = thread_id or None
 
         await asyncio.get_event_loop().run_in_executor(
             None, self._post_message, room_token, text, reply_to,

--- a/sdk/python/librefang/sidecar/adapters/reddit.py
+++ b/sdk/python/librefang/sidecar/adapters/reddit.py
@@ -237,11 +237,18 @@ def _parse_reddit_comment(comment: dict, own_username: str) -> dict | None:
         content=content,
         message_id=comment_id,
         is_group=True,  # Subreddit comments are public/group, like Rust.
-        # P1: surface fullname as thread_id so on_send uses it as the
-        # parent fullname for POST /api/comment. The Rust adapter's
-        # thread_id was the subreddit, which broke per-comment replies
-        # in production (user.platform_id was the author, not the
-        # fullname /api/comment requires).
+        # P1 (revised): the parent fullname MUST round-trip to on_send —
+        # POST /api/comment requires `thing_id` (a fullname like `t1_…`);
+        # without it Reddit returns 400. The original P1 used `thread_id`
+        # as the carrier, but the daemon's bridge only honours
+        # `cmd.thread_id` under `[channels.reddit.overrides] threading = true`
+        # AND the `thread` capability (reddit declares neither), so every
+        # production reply RAISED `RuntimeError("missing parent fullname")`
+        # and got swallowed by the SDK's bare-except `on_command` wrapper
+        # — operator saw nothing land. Fixed by `librefang_user` (always
+        # round-tripped). `thread_id` is kept for forward-compat with a
+        # future opt-in.
+        librefang_user=fullname or None,
         thread_id=fullname or None,
         metadata=metadata,
     )
@@ -747,16 +754,39 @@ class RedditAdapter(SidecarAdapter):
             text = "(Unsupported content type — Reddit only supports text replies)"
         else:
             text = cmd.text or ""
-        # cmd.thread_id carries the parent fullname (e.g. "t1_abc123")
-        # that inbound parsing surfaced. The Rust adapter used
-        # user.platform_id for this, but parse_reddit_comment writes
-        # the author username there — the only fullname round-trip we
-        # can rely on is thread_id (see module docstring P1 note).
-        thread_id = getattr(cmd, "thread_id", None)
-        if thread_id is not None and not isinstance(thread_id, str):
-            thread_id = str(thread_id) if thread_id else None
+        # Primary recovery: cmd.user["librefang_user"] carries the
+        # parent fullname (set in parse_reddit_comment). The daemon's
+        # bridge round-trips `ChannelUser.librefang_user` bytewise
+        # regardless of capabilities/overrides — verified at
+        # crates/librefang-channels/src/sidecar.rs:766 inbound,
+        # :1204 outbound.
+        #
+        # Fallback: cmd.thread_id for the forward-compat threading=true
+        # path (would also require a future `thread` capability).
+        #
+        # Strongest sanity guard of all sidecars in this fix family —
+        # Reddit fullnames have a deterministic `t{1,3,4,5}_` prefix
+        # (t1=comment, t3=submission, t4=message, t5=subreddit). Reject
+        # anything else so a cross-channel `librefang_user` (a
+        # dingtalk URL, a telegram @username, etc.) can never POST
+        # garbage as the parent fullname.
+        parent_fullname: "Optional[str]" = None
+        user = getattr(cmd, "user", None) or {}
+        if isinstance(user, dict):
+            candidate = user.get("librefang_user")
+            if (isinstance(candidate, str)
+                    and candidate.startswith(("t1_", "t3_", "t4_", "t5_"))
+                    and " " not in candidate
+                    and "/" not in candidate):
+                parent_fullname = candidate
+        if parent_fullname is None:
+            thread_id = getattr(cmd, "thread_id", None)
+            if thread_id is not None and not isinstance(thread_id, str):
+                thread_id = str(thread_id) if thread_id else None
+            parent_fullname = thread_id
+
         await asyncio.get_event_loop().run_in_executor(
-            None, self._post_comment, thread_id or "", text,
+            None, self._post_comment, parent_fullname or "", text,
         )
 
 

--- a/sdk/python/librefang/sidecar/adapters/rocketchat.py
+++ b/sdk/python/librefang/sidecar/adapters/rocketchat.py
@@ -480,6 +480,13 @@ class RocketChatAdapter(SidecarAdapter):
             channel_id=room_id,
             message_id=msg_id or None,
             is_group=True,
+            # `librefang_user` is the always-round-tripped carrier for
+            # the `tmid` thread correlation. The daemon strips
+            # `cmd.thread_id` to None for cap-less sidecars, so the
+            # original `thread_id` route silently lost the thread
+            # context. Kept for forward-compat with a future
+            # `threading=true` + `thread` cap opt-in.
+            librefang_user=thread_id,
             thread_id=thread_id,
             metadata=metadata,
         )
@@ -726,10 +733,23 @@ class RocketChatAdapter(SidecarAdapter):
         if not room_id:
             room_id = str(getattr(cmd, "channel_id", "") or "")
 
-        thread_id = getattr(cmd, "thread_id", None)
-        if thread_id is not None and not isinstance(thread_id, str):
-            thread_id = str(thread_id) if thread_id else None
-        tmid = thread_id or None
+        # Primary recovery: cmd.user["librefang_user"] (always round-
+        # tripped). Fallback: cmd.thread_id (forward-compat). Rocket.Chat
+        # msg ids are MongoDB ObjectId-shape (17-char alphanumeric) —
+        # generic URL/whitespace/@ guard is enough.
+        tmid: "Optional[str]" = None
+        if isinstance(user, dict):
+            candidate = user.get("librefang_user")
+            if (isinstance(candidate, str) and candidate
+                    and not candidate.startswith(("http://", "https://", "@"))
+                    and " " not in candidate
+                    and "\t" not in candidate):
+                tmid = candidate
+        if tmid is None:
+            thread_id = getattr(cmd, "thread_id", None)
+            if thread_id is not None and not isinstance(thread_id, str):
+                thread_id = str(thread_id) if thread_id else None
+            tmid = thread_id or None
 
         await asyncio.get_event_loop().run_in_executor(
             None, self._post_message, room_id, text, tmid,

--- a/sdk/python/librefang/sidecar/adapters/twitch.py
+++ b/sdk/python/librefang/sidecar/adapters/twitch.py
@@ -544,8 +544,14 @@ class TwitchAdapter(SidecarAdapter):
             # a server-generated UUID.
             message_id=msg_id or None,
             is_group=True,  # Twitch chat is always a public channel.
-            # P2: surface @id as thread_id so on_send can attach
-            # @reply-parent-msg-id back to the source message.
+            # P2 (revised): `librefang_user` is the always-round-tripped
+            # carrier for the @reply-parent-msg-id correlation. The
+            # daemon strips `cmd.thread_id` to None for cap-less
+            # sidecars (twitch declares no `thread` cap), so the
+            # original P2 silently lost the reply context. Keep
+            # `thread_id` for forward-compat with a future
+            # `threading=true` + cap opt-in.
+            librefang_user=msg_id or None,
             thread_id=msg_id or None,
             metadata=metadata,
         )
@@ -682,13 +688,29 @@ class TwitchAdapter(SidecarAdapter):
                 "twitch on_send: missing channel target "
                 "(cmd.channel_id and cmd.user.platform_id are both empty)"
             )
-        thread_id = getattr(cmd, "thread_id", None)
-        if thread_id is not None and not isinstance(thread_id, str):
-            thread_id = str(thread_id) if thread_id else None
+        # Primary recovery: cmd.user["librefang_user"] (always round-
+        # tripped). Fallback: cmd.thread_id (forward-compat threading=
+        # true + `thread` cap path). Twitch msg ids are UUID-shape —
+        # generic URL/whitespace/@ guard is enough.
+        reply_parent_id: "Optional[str]" = None
+        raw_user2 = getattr(cmd, "user", None) or {}
+        if isinstance(raw_user2, dict):
+            candidate = raw_user2.get("librefang_user")
+            if (isinstance(candidate, str) and candidate
+                    and not candidate.startswith(("http://", "https://", "@"))
+                    and " " not in candidate
+                    and "\t" not in candidate):
+                reply_parent_id = candidate
+        if reply_parent_id is None:
+            thread_id = getattr(cmd, "thread_id", None)
+            if thread_id is not None and not isinstance(thread_id, str):
+                thread_id = str(thread_id) if thread_id else None
+            reply_parent_id = thread_id or None
+
         await asyncio.get_event_loop().run_in_executor(
             None,
             self._send_privmsg_blocking,
-            channel, text, thread_id or None,
+            channel, text, reply_parent_id,
         )
 
     async def on_shutdown(self) -> None:

--- a/sdk/python/tests/test_bluesky_adapter.py
+++ b/sdk/python/tests/test_bluesky_adapter.py
@@ -431,6 +431,46 @@ def test_post_status_p1b_threads_when_thread_id_cached(monkeypatch):
     assert body["record"]["reply"] == {"root": parent, "parent": parent}
 
 
+def test_on_send_recovers_uri_from_user_librefang_user(monkeypatch):
+    """End-to-end on_send regression guard. The daemon-shape pre-fix
+    bug meant cmd.thread_id=None so the cached `{root, parent}` reply
+    struct was never looked up, and every reply posted as a top-level
+    skeet instead of a thread reply. librefang_user is the always-
+    round-tripped carrier — recover from there."""
+    import asyncio
+    a = _adapter()
+    parent = {"uri": "at://did:plc:alice/post/1", "cid": "bafy1"}
+    a._thread_cache.put(
+        "at://did:plc:alice/post/1",
+        {"root": parent, "parent": parent},
+    )
+    fake = _FakeUrlopen([
+        (200, {
+            "accessJwt": "access-1",
+            "refreshJwt": "refresh-1",
+            "did": "did:plc:bot",
+        }),
+        (200, {"uri": "at://did:plc:bot/post/reply", "cid": "bafyreply"}),
+    ])
+    monkeypatch.setattr(ba.urllib.request, "urlopen", fake)
+
+    class _Cmd:
+        text = "threaded reply"
+        content = {"Text": "threaded reply"}
+        thread_id = None  # daemon-default
+        user = {
+            "platform_id": "alice",
+            "librefang_user": "at://did:plc:alice/post/1",
+        }
+
+    asyncio.run(a.on_send(_Cmd()))
+    body = fake.calls[1]["body"]
+    assert body["record"]["reply"] == {"root": parent, "parent": parent}, \
+        "on_send must thread via cmd.user.librefang_user when " \
+        "cmd.thread_id is None (the daemon default for sidecars " \
+        "that don't declare the `thread` capability)"
+
+
 def test_post_status_cold_cache_falls_back_to_unthreaded(monkeypatch):
     """Cache miss (e.g. sidecar restarted between mention arrival and
     user reply) must NOT crash — fall back to a non-threaded post,

--- a/sdk/python/tests/test_mastodon_adapter.py
+++ b/sdk/python/tests/test_mastodon_adapter.py
@@ -180,13 +180,26 @@ def test_parse_notification_full_shape():
     }
 
 
-def test_parse_notification_thread_id_carries_in_reply_to():
+def test_parse_notification_thread_id_carries_mention_status_id():
+    """The mention's OWN status id is what the bot replies TO — the
+    pre-fix behaviour surfaced ``status.in_reply_to_id`` (the parent
+    the mention was responding to) which had two bugs at once: it
+    pointed at the wrong target AND the daemon's bridge strips
+    ``cmd.thread_id`` to ``None`` for cap-less sidecars, so the value
+    never reached ``on_send`` anyway. Both fixed by surfacing
+    ``status.id`` AND duplicating it on ``librefang_user``."""
     a = _adapter()
     a.own_account_id = "own-123"
     notif, _ = _notif_fixture(in_reply_to="status-prev")
     ev = a._parse_notification(notif)
     p = ev["params"]
-    assert p["thread_id"] == "status-prev"
+    # Reply target is the mention itself (`status_id` from the fixture),
+    # NOT what the mention was responding to (`in_reply_to_id`).
+    assert p["thread_id"] == "status-42"
+    assert p["librefang_user"] == "status-42"
+    # The pre-fix `in_reply_to_id` is still in metadata for any
+    # operator-side logging that needs it, but it must NOT govern the
+    # reply target.
     assert p["metadata"]["in_reply_to_id"] == "status-prev"
 
 
@@ -357,6 +370,34 @@ def test_post_status_reply_to_inbound_thread(monkeypatch):
     a._post_status("reply", in_reply_to_id="orig-status-123")
     c = fake.calls[0]
     assert c["params"]["in_reply_to_id"] == "orig-status-123"
+
+
+def test_on_send_recovers_in_reply_to_from_user_librefang_user(monkeypatch):
+    """End-to-end on_send regression guard. The daemon-shape pre-fix
+    bug meant cmd.thread_id=None so every reply posted as a top-level
+    toot instead of an in-reply-to. librefang_user is the always-
+    round-tripped carrier; recover from there. Also asserts the
+    bonus pre-existing fix — the reply targets the mention's own
+    status_id, not the parent the mention was responding to."""
+    import asyncio
+    a = _adapter()
+    fake = _FakeUrlopen()
+    monkeypatch.setattr(ma.urllib.request, "urlopen", fake)
+
+    class _Cmd:
+        text = "reply"
+        content = {"Text": "reply"}
+        thread_id = None  # daemon-default
+        user = {
+            "platform_id": "alice",
+            "librefang_user": "mention-status-42",
+        }
+
+    asyncio.run(a.on_send(_Cmd()))
+    c = fake.calls[0]
+    assert c["params"]["in_reply_to_id"] == "mention-status-42", \
+        "on_send must recover in_reply_to_id from " \
+        "cmd.user.librefang_user when cmd.thread_id is None"
 
 
 def test_post_status_http_error_surfaced(monkeypatch):

--- a/sdk/python/tests/test_nextcloud_adapter.py
+++ b/sdk/python/tests/test_nextcloud_adapter.py
@@ -852,7 +852,12 @@ def test_on_send_uses_platform_id_as_room(monkeypatch):
 
 
 def test_on_send_threads_via_thread_id(monkeypatch):
-    """P1 round-trip: cmd.thread_id → replyTo on the outbound."""
+    """Forward-compat fallback: even with the daemon-default
+    `threading=false`, this test's fabricated `thread_id` still
+    reaches on_send because no `librefang_user` is present to
+    take precedence. (In production with a real bridge round-trip
+    the librefang_user path wins — see the regression-guard test
+    below.)"""
     a = _adapter()
     fake = _FakeUrlopen([(201, {"ocs": {"meta": {"status": "ok"}, "data": {}}})])
     monkeypatch.setattr(nc.urllib.request, "urlopen", fake)
@@ -864,6 +869,26 @@ def test_on_send_threads_via_thread_id(monkeypatch):
     )))
     parsed = dict(urllib.parse.parse_qsl(fake.calls[0]["body_raw"]))
     assert parsed == {"message": "threaded reply", "replyTo": "42"}
+
+
+def test_on_send_recovers_reply_to_from_user_librefang_user(monkeypatch):
+    """Regression guard: the daemon-shape pre-fix bug meant
+    `cmd.thread_id=None` so every chunked reply landed at room root
+    despite the module docstring claiming to fix exactly that. The
+    bridge round-trips librefang_user bytewise — recover from there."""
+    a = _adapter()
+    fake = _FakeUrlopen([(201, {"ocs": {"meta": {"status": "ok"}, "data": {}}})])
+    monkeypatch.setattr(nc.urllib.request, "urlopen", fake)
+    import asyncio as _asyncio
+    _asyncio.run(a.on_send(_StubCmd(
+        text="hi",
+        thread_id=None,  # daemon-default
+        user={"platform_id": "ROOM1", "librefang_user": "42"},
+    )))
+    parsed = dict(urllib.parse.parse_qsl(fake.calls[0]["body_raw"]))
+    assert parsed == {"message": "hi", "replyTo": "42"}, \
+        "on_send must thread via cmd.user.librefang_user when " \
+        "cmd.thread_id is None (which is the daemon default)"
 
 
 def test_on_send_falls_back_to_channel_id(monkeypatch):

--- a/sdk/python/tests/test_reddit_adapter.py
+++ b/sdk/python/tests/test_reddit_adapter.py
@@ -753,10 +753,11 @@ def test_seen_comments_idempotent_mark():
 
 
 class _StubCmd:
-    def __init__(self, *, text=None, content=None, thread_id=None):
+    def __init__(self, *, text=None, content=None, thread_id=None, user=None):
         self.text = text
         self.content = content
         self.thread_id = thread_id
+        self.user = user if user is not None else {}
 
 
 def test_on_send_uses_thread_id_as_parent_fullname(monkeypatch):
@@ -789,3 +790,64 @@ def test_on_send_non_text_content_falls_back_to_placeholder(monkeypatch):
     )))
     form = _form(fake.calls[0]["body_raw"])
     assert "Unsupported content type" in form["text"]
+
+
+def test_on_send_recovers_parent_fullname_from_user_librefang_user(monkeypatch):
+    """Regression guard for the daemon-shape pre-fix bug: the bridge
+    only round-trips cmd.thread_id when [overrides] threading=true AND
+    the sidecar declares the `thread` capability — reddit declares
+    neither, so cmd.thread_id is always None in production. The pre-fix
+    on_send then RAISED RuntimeError("missing parent fullname"), which
+    the SDK's bare-except `on_command` swallowed silently. Bot looked
+    healthy, no replies ever landed.
+
+    librefang_user is the always-round-tripped carrier — this drives
+    the realistic daemon shape and asserts the POST contains the
+    correct thing_id."""
+    a = _adapter()
+    a._cached_token = ("tok", ra.time.monotonic() + 600)
+    fake = _FakeUrlopen([
+        (200, {"json": {"errors": [], "data": {}}}),
+    ])
+    monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
+    import asyncio as _asyncio
+    _asyncio.run(a.on_send(_StubCmd(
+        text="hello",
+        # Daemon-default: thread_id is None
+        thread_id=None,
+        # The bridge round-trips librefang_user from inbound emit
+        user={
+            "platform_id": "alice",
+            "librefang_user": "t1_abc123",
+        },
+    )))
+    form = _form(fake.calls[0]["body_raw"])
+    assert form["thing_id"] == "t1_abc123", \
+        "on_send must recover parent fullname from " \
+        "cmd.user.librefang_user (not from cmd.thread_id, which " \
+        "the daemon NULLs by default for capability-less sidecars)"
+
+
+def test_on_send_rejects_non_reddit_fullname_in_librefang_user(monkeypatch):
+    """librefang_user is shared across channels (dingtalk puts a
+    sessionWebhook URL, telegram puts @username, etc.). Reddit's
+    `thing_id` must start with a deterministic prefix
+    (t1_/t3_/t4_/t5_); anything else must be rejected so we don't
+    POST garbage and trigger Reddit's 400."""
+    a = _adapter()
+    a._cached_token = ("tok", ra.time.monotonic() + 600)
+    fake = _FakeUrlopen([
+        (200, {"json": {"errors": [], "data": {}}}),
+    ])
+    monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
+    import asyncio as _asyncio
+    _asyncio.run(a.on_send(_StubCmd(
+        text="hi",
+        # Daemon-default thread_id; valid-looking but non-reddit
+        # librefang_user.
+        thread_id="t1_fallback",
+        user={"platform_id": "alice", "librefang_user": "https://oapi.dingtalk.com/sb?s=42"},
+    )))
+    form = _form(fake.calls[0]["body_raw"])
+    # URL-shaped librefang_user rejected → falls back to thread_id.
+    assert form["thing_id"] == "t1_fallback"

--- a/sdk/python/tests/test_rocketchat_adapter.py
+++ b/sdk/python/tests/test_rocketchat_adapter.py
@@ -720,7 +720,10 @@ def test_on_send_uses_platform_id_as_room(monkeypatch):
 
 
 def test_on_send_threads_via_thread_id(monkeypatch):
-    """P1 round-trip: cmd.thread_id → tmid on the outbound."""
+    """Forward-compat fallback (a future threading=true + `thread` cap
+    opt-in would deliver thread_id directly). In production today, the
+    bridge strips cmd.thread_id to None for cap-less sidecars — see
+    the regression-guard test below."""
     a = _adapter()
     fake = _FakeUrlopen([(200, {"success": True})])
     monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
@@ -732,6 +735,26 @@ def test_on_send_threads_via_thread_id(monkeypatch):
     )))
     body = json.loads(fake.calls[0]["body_raw"])
     assert body["tmid"] == "PARENT_MSG"
+
+
+def test_on_send_recovers_tmid_from_user_librefang_user(monkeypatch):
+    """Regression guard: the daemon-shape pre-fix bug meant
+    cmd.thread_id=None so the bot's threaded reply landed at channel
+    root despite the module docstring claiming to fix exactly that.
+    librefang_user is the always-round-tripped carrier."""
+    a = _adapter()
+    fake = _FakeUrlopen([(200, {"success": True})])
+    monkeypatch.setattr(ra.urllib.request, "urlopen", fake)
+    import asyncio as _asyncio
+    _asyncio.run(a.on_send(_StubCmd(
+        text="threaded reply",
+        thread_id=None,  # daemon-default
+        user={"platform_id": "ROOM1", "librefang_user": "PARENT_MSG"},
+    )))
+    body = json.loads(fake.calls[0]["body_raw"])
+    assert body["tmid"] == "PARENT_MSG", \
+        "on_send must recover tmid from cmd.user.librefang_user " \
+        "when cmd.thread_id is None"
 
 
 def test_on_send_falls_back_to_channel_id(monkeypatch):

--- a/sdk/python/tests/test_twitch_adapter.py
+++ b/sdk/python/tests/test_twitch_adapter.py
@@ -812,12 +812,33 @@ def _make_send(channel_id: str = "", thread_id=None,
 
 
 def test_on_send_uses_channel_id_and_thread_id():
-    """on_send should forward channel_id + thread_id to the wire path,
-    yielding a @reply-parent-msg-id-tagged PRIVMSG on the right channel."""
+    """Forward-compat fallback: a future threading=true + `thread` cap
+    opt-in would deliver thread_id directly. In production today, the
+    bridge strips cmd.thread_id to None for cap-less sidecars — see
+    the regression-guard test below."""
     import asyncio
     a = _adapter()
     fake = _install_fake_sock(a)
     cmd = _make_send(channel_id="#librefang", thread_id="src-7", text="ack")
+    asyncio.run(a.on_send(cmd))
+    sent = b"".join(fake.sent).decode("utf-8")
+    assert sent == "@reply-parent-msg-id=src-7 PRIVMSG #librefang :ack\r\n"
+
+
+def test_on_send_recovers_reply_parent_from_user_librefang_user():
+    """Regression guard: the daemon-shape pre-fix bug meant
+    cmd.thread_id=None so the @reply-parent-msg-id tag was never
+    attached and chat UI lost the inline reply preview. librefang_user
+    is the always-round-tripped carrier."""
+    import asyncio
+    a = _adapter()
+    fake = _install_fake_sock(a)
+    cmd = _make_send(
+        channel_id="#librefang",
+        thread_id=None,  # daemon-default
+        text="ack",
+        user={"platform_id": "#librefang", "librefang_user": "src-7"},
+    )
     asyncio.run(a.on_send(cmd))
     sent = b"".join(fake.sent).decode("utf-8")
     assert sent == "@reply-parent-msg-id=src-7 PRIVMSG #librefang :ack\r\n"


### PR DESCRIPTION
## Summary

**Omnibus runtime hotfix for 6 sidecars** — same bug class as dingtalk #5423 and qq #5431.

Each of mastodon / nextcloud / reddit / twitch / bluesky / rocketchat reads \`cmd.thread_id\` in \`on_send\` to recover a per-message correlation key, but the daemon's bridge only sets \`cmd.thread_id\` when BOTH \`[overrides] threading = true\` AND the sidecar declares the \`thread\` capability. All six declare \`capabilities: list = []\`, so in production every reply lost the correlation.

### Severity ranking

| Sidecar | Severity | Production impact |
|---|---|---|
| **reddit** | **HIGH** | Every reply RAISED \`RuntimeError(\"missing parent fullname\")\` swallowed by SDK bare-except. Bot looked healthy, **zero messages landed**. |
| **nextcloud** | MED | \"Thread reply\" posted at room root, no link back to trigger. Module docstring loudly advertised this as the headline P1 improvement over Rust parity. In fact shipped the same bug. |
| **rocketchat** | MED | Same shape as nextcloud — \`tmid\` never sent, thread context lost. Docstring also advertised the broken fix. |
| **bluesky** | MED | Reply intent became top-level skeet, visible to all followers' feeds instead of just thread participants. |
| **mastodon** | LOW | Reply degraded to top-level toot; message still landed. **Bonus pre-existing semantic bug also fixed**: parse surfaced \`status.in_reply_to_id\` (the PARENT the mention was responding to) as the reply target instead of \`status.id\` (the mention itself) — bot would have replied to the wrong account even if round-trip worked. |
| **twitch** | LOW | Chat UI lost the \`@reply-parent-msg-id\` badge; plain PRIVMSG still delivered the text. |

## Fix (uniform across all six)

- **\`parse_X_event\`** — stash the correlation key in \`ChannelUser.librefang_user\` (which the bridge round-trips bytewise through serde regardless of capabilities/overrides — verified at \`crates/librefang-channels/src/sidecar.rs:766\` inbound, \`:1204\` outbound). Keep the existing \`thread_id\` assignment for the forward-compat \`threading=true\` path.
- **\`on_send\`** — read \`cmd.user[\"librefang_user\"]\` FIRST, fall back to \`cmd.thread_id\`. Sanity guard: reject URL-shaped or whitespace-bearing values (the field is shared across channels — dingtalk puts a sessionWebhook URL there, telegram puts \`@username\`).
- **Reddit** gets the strongest guard: enforce \`t{1,3,4,5}_\` prefix.
- **Bluesky** gets the strongest guard: enforce \`at://\` prefix.

## Tests

| Adapter | Coverage | Result |
|---|---|---|
| mastodon | New \`test_on_send_recovers_in_reply_to_from_user_librefang_user\` + parse-test rewrite (pre-fix asserted the wrong-behaviour value) | green |
| nextcloud | New \`test_on_send_recovers_reply_to_from_user_librefang_user\` | green |
| reddit | New \`test_on_send_recovers_parent_fullname_from_user_librefang_user\` + new \`test_on_send_rejects_non_reddit_fullname_in_librefang_user\` (prefix-guard) | green |
| twitch | New \`test_on_send_recovers_reply_parent_from_user_librefang_user\` | green |
| bluesky | New \`test_on_send_recovers_uri_from_user_librefang_user\` | green |
| rocketchat | New \`test_on_send_recovers_tmid_from_user_librefang_user\` | green |
| **Total** | **+7 regression guards, -1 wrong-behaviour assertion** | **343 passed** (was 336) |

Each new test drives the realistic daemon shape (\`thread_id=None\`, \`user.librefang_user=<id>\`) and asserts the outbound payload contains the correct correlation key. **Each fails on the pre-fix code** — real regression guards, not just coverage.

## Pre-existing structural issue NOT fixed here

\`sdk/python/librefang/sidecar/runtime.py:245-247\` has a bare-except on \`on_command\` that swallowed Reddit's \`RuntimeError\` silently. The immediate fix here is to not raise in the first place (no production path now reaches the missing-parent branch), but the bare-except itself is a footgun — future raises from \`on_send\` will also vanish to stderr only. Worth a follow-up: re-raise after logging so the bridge can record the failure and trigger the agent's error-handling path.

## Investigation chain

1. **dingtalk #5417** merged with the bug; post-merge self-review surfaced it.
2. **dingtalk #5423** hotfix landed; post-hotfix review found the bug generalised — flagged QQ.
3. **qq #5431** hotfix landed; same review flagged 6 more sidecars.
4. **This PR** closes out the 6.

The same pattern (sidecars cargo-cult \`cmd.thread_id\` from each other without re-deriving whether the daemon would actually populate it) keeps reappearing. Worth documenting in \`sdk/python/AGENTS.md\` so the next sidecar author doesn't ship a 4th iteration.