### PR TITLE
fix(channels/wechat-sidecar): recover context_token via librefang_user across sidecar restart

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/wechat.py
+++ b/sdk/python/librefang/sidecar/adapters/wechat.py
@@ -252,12 +252,27 @@ def parse_wechat_msg(
     if account_id is not None:
         metadata["account_id"] = account_id
 
+    # `librefang_user` is the always-round-tripped carrier for the
+    # per-user iLink `context_token`. The previous routing relied on
+    # `self._user_context_tokens[user_id]` only — an in-memory dict
+    # that vanished on sidecar restart, leaving the bot's first reply
+    # after restart with an empty `context_token` (iLink may reject
+    # or post out-of-thread). librefang_user round-trips bytewise
+    # through the bridge via `ChannelUser.librefang_user`
+    # (`crates/librefang-channels/src/sidecar.rs:766` inbound,
+    # `:1204` outbound) so it survives serde + restart cleanly. The
+    # process-local cache is kept as a freshness signal — the
+    # context_token Lark/iLink last issued is more current than the
+    # one stamped on whichever message the daemon happens to round-
+    # trip back. See `on_send` for the precedence: cache first, then
+    # `librefang_user`, then empty.
     return protocol.message(
         user_id=from_user_id,
         user_name=display_name,
         content=content,
         message_id=msg_id or None,
         channel_id=from_user_id,
+        librefang_user=context_token or None,
         metadata=metadata,
     )
 
@@ -656,8 +671,24 @@ class WeChatAdapter(SidecarAdapter):
             log.warn("wechat on_send: missing user_id, dropping")
             return
 
+        # Precedence: process-local cache (freshest token Lark/iLink
+        # issued) → `cmd.user["librefang_user"]` (round-tripped from
+        # the inbound that triggered this reply; survives sidecar
+        # restart). Both are best-effort; an empty token still posts
+        # the message (iLink falls back to a fresh top-level frame).
         with self._context_lock:
             context_token = self._user_context_tokens.get(user_id, "")
+        if not context_token and cmd.user:
+            candidate = cmd.user.get("librefang_user")
+            # Guard: librefang_user is shared across channels (dingtalk
+            # puts a sessionWebhook URL, telegram puts @username, …).
+            # iLink context_token is an opaque base64-ish string —
+            # generic URL/whitespace/@ guard is enough.
+            if (isinstance(candidate, str) and candidate
+                    and not candidate.startswith(("http://", "https://", "@"))
+                    and " " not in candidate
+                    and "\t" not in candidate):
+                context_token = candidate
 
         content = cmd.content
         text = cmd.text or ""

--- a/sdk/python/tests/test_wechat_adapter.py
+++ b/sdk/python/tests/test_wechat_adapter.py
@@ -396,6 +396,68 @@ async def test_on_send_uses_cached_context_token(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_on_send_recovers_context_token_from_user_librefang_user_when_cache_cold(
+    monkeypatch,
+):
+    """Regression guard for sidecar-restart fragility: the in-memory
+    ``_user_context_tokens`` cache vanishes on restart, so the bot's
+    first reply after restart would otherwise post with an empty
+    ``context_token`` (iLink may reject or post out-of-thread).
+    The bridge round-trips ``ChannelUser.librefang_user`` bytewise,
+    so the parse-side stash of ``context_token`` there is the
+    restart-survivable fallback. This test simulates that:
+    in-memory cache empty (post-restart), but the daemon delivers
+    ``cmd.user.librefang_user`` from the inbound that triggered the
+    reply — on_send MUST recover from there."""
+    sent: list = []
+
+    def _fake_http(url, **kw):
+        sent.append(json.loads(kw["body"].decode("utf-8")))
+        return (200, {"errcode": 0}, b"", {})
+
+    monkeypatch.setattr(wc, "_http_request", _fake_http)
+    a = _adapter()
+    # Simulate post-restart state: in-memory cache empty.
+    assert a._user_context_tokens == {}
+    await a.on_send(_send_cmd(
+        text="hi",
+        content={"Text": "hi"},
+        user={
+            "platform_id": "alice@im.wechat",
+            "librefang_user": "ctx_from_inbound",
+        },
+    ))
+    assert sent[0]["msg"]["context_token"] == "ctx_from_inbound", \
+        "on_send must recover context_token from cmd.user.librefang_user " \
+        "when the in-memory cache is empty (post-restart scenario)"
+
+
+@pytest.mark.asyncio
+async def test_on_send_ignores_url_shaped_librefang_user(monkeypatch):
+    """``librefang_user`` is shared across channels — dingtalk puts a
+    sessionWebhook URL there, telegram puts ``@username``. Must reject
+    cross-channel pollution before sending a corrupted context_token."""
+    sent: list = []
+
+    def _fake_http(url, **kw):
+        sent.append(json.loads(kw["body"].decode("utf-8")))
+        return (200, {"errcode": 0}, b"", {})
+
+    monkeypatch.setattr(wc, "_http_request", _fake_http)
+    a = _adapter()
+    await a.on_send(_send_cmd(
+        text="hi",
+        content={"Text": "hi"},
+        user={
+            "platform_id": "alice@im.wechat",
+            "librefang_user": "https://oapi.dingtalk.com/sb?s=42",
+        },
+    ))
+    # URL-shaped librefang_user rejected → context_token empty.
+    assert sent[0]["msg"]["context_token"] == ""
+
+
+@pytest.mark.asyncio
 async def test_on_send_empty_user_drops(monkeypatch):
     calls: list = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

**Runtime hotfix surfaced by the #5439 follow-up audit chain.**

WeChat sidecar's in-process \`_user_context_tokens[user_id]\` cache vanishes on sidecar restart (any operator upgrade, debug pass, or supervisor respawn). Without the cached \`context_token\`, the bot's first reply after restart posts with an empty token — iLink may reject it or post out-of-thread.

## Fix

Mirror the dingtalk #5423 / qq #5431 / omnibus #5439 pattern:

- \`parse_wechat_msg\` also stashes \`context_token\` in \`ChannelUser.librefang_user\`, which the bridge round-trips bytewise (verified at \`crates/librefang-channels/src/sidecar.rs:766\` inbound, \`:1204\` outbound).
- \`on_send\` keeps the in-memory cache as the **primary** path (freshness invariant — the latest token Lark/iLink issued is more current than whichever inbound the daemon happens to round-trip back). Falls back to \`librefang_user\` when the cache is empty (post-restart scenario).
- HTTP-scheme / whitespace / \`@\` guard rejects cross-channel pollution (dingtalk URL, telegram \`@username\`, etc.).

## Tests

- New \`test_on_send_recovers_context_token_from_user_librefang_user_when_cache_cold\` simulates post-restart (cache empty, \`librefang_user\` carries the token), asserts on_send recovers it.
- New \`test_on_send_ignores_url_shaped_librefang_user\` pins the cross-channel pollution guard.
- \`cd sdk/python && pytest tests/test_wechat_adapter.py\` — **63 passed** (was 61; +2 regression guards).

## Cross-reference

- Investigation chain: dingtalk migrate #5417 → dingtalk hotfix #5423 → qq hotfix #5431 → omnibus 6-sidecar #5439 → wechat (this) + wecom + SDK trace.
- Same routing pattern, distinct symptom — restart-survivability rather than cap-gate stripping.