### PR TITLE
fix(channels/wecom-sidecar): recover req_id via librefang_user across sidecar restart

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/wecom.py
+++ b/sdk/python/librefang/sidecar/adapters/wecom.py
@@ -228,6 +228,20 @@ def parse_wecom_event(
     if account_id:
         metadata["account_id"] = account_id
 
+    # `librefang_user` is the always-round-tripped carrier for the
+    # per-user `req_id` (which unlocks the passive
+    # `aibot_respond_msg` send). The previous routing relied on
+    # `self._pending_req_ids[user_id]` only — an in-memory dict that
+    # vanished on sidecar restart, leaving the bot's first reply
+    # after restart with no cached `req_id` and falling back to
+    # `aibot_send_msg` (the active-message path, which counts against
+    # WeCom's per-bot active-message quota and is heavily rate-limited
+    # for unlicensed bots). librefang_user round-trips bytewise
+    # through the bridge so it survives serde + restart cleanly.
+    # See `on_send` for the precedence: in-memory cache first (still
+    # gets evicted on use, mirroring `aibot_respond_msg`'s one-shot
+    # semantics), then `librefang_user` as the restart-survivable
+    # fallback.
     return protocol.message(
         user_id=from_user,
         user_name=from_user,
@@ -235,6 +249,7 @@ def parse_wecom_event(
         message_id=req_id,
         platform="wecom",
         is_group=is_group,
+        librefang_user=req_id or None,
         metadata=metadata,
     )
 
@@ -385,10 +400,18 @@ class WeComAdapter(SidecarAdapter):
 
     # ---- send-frame routing ------------------------------------------
 
-    def _enqueue_text(self, user_id: str, text: str) -> None:
+    def _enqueue_text(
+        self, user_id: str, text: str, *,
+        req_id_hint: Optional[str] = None,
+    ) -> None:
         """Enqueue text chunks as outbound WS frames. Uses
-        ``aibot_respond_msg`` once per cached ``req_id``, then falls
-        back to ``aibot_send_msg`` for the remainder."""
+        ``aibot_respond_msg`` once per cached ``req_id`` (in-memory
+        cache primary), then falls back to a `req_id_hint` (from
+        `cmd.user.librefang_user` — survives sidecar restart), then
+        finally to ``aibot_send_msg`` for the remainder.
+        ``aibot_respond_msg`` is the passive-reply path; missing
+        ``req_id`` falls through to the active-message quota which
+        unlicensed bots have set to zero."""
         if not text:
             # ``split_message("", N)`` returns ``[""]`` not ``[]``;
             # gate up front so empty/whitespace-stripped sends don't
@@ -397,6 +420,10 @@ class WeComAdapter(SidecarAdapter):
         chunks = _split_message(text, WECOM_MAX_MESSAGE_LEN)
         with self._pending_lock:
             req_id = self._pending_req_ids.pop(user_id, None)
+        # If the in-memory cache was empty (e.g. sidecar restarted
+        # between inbound and reply), try the round-tripped hint.
+        if req_id is None and req_id_hint:
+            req_id = req_id_hint
         first = chunks[0]
         if req_id:
             self._send_queue.put(_build_reply_frame(req_id, first))
@@ -608,7 +635,24 @@ class WeComAdapter(SidecarAdapter):
 
         if not text:
             return
-        self._enqueue_text(user_id, text)
+
+        # Restart-survivable req_id recovery: cmd.user["librefang_user"]
+        # carries the inbound req_id (set in parse_wecom_event). The
+        # in-memory _pending_req_ids cache vanishes on sidecar restart
+        # so without this the bot's first reply after restart would
+        # silently downgrade to aibot_send_msg (active-message quota).
+        # Guard: librefang_user is shared across channels; reject
+        # URL-shaped or whitespace-bearing values.
+        req_id_hint: Optional[str] = None
+        if cmd.user:
+            candidate = cmd.user.get("librefang_user")
+            if (isinstance(candidate, str) and candidate
+                    and not candidate.startswith(("http://", "https://", "@"))
+                    and " " not in candidate
+                    and "\t" not in candidate):
+                req_id_hint = candidate
+
+        self._enqueue_text(user_id, text, req_id_hint=req_id_hint)
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_wecom_adapter.py
+++ b/sdk/python/tests/test_wecom_adapter.py
@@ -467,6 +467,79 @@ async def test_on_send_falls_back_to_user_platform_id():
 
 
 @pytest.mark.asyncio
+async def test_on_send_recovers_req_id_from_user_librefang_user_when_cache_cold():
+    """Regression guard for sidecar-restart fragility: the in-memory
+    ``_pending_req_ids`` cache vanishes on restart, so the bot's
+    first reply after restart would fall back to ``aibot_send_msg``
+    (active-message quota, blocked for unlicensed bots and rate-
+    limited hard for licensed ones). The bridge round-trips
+    ``ChannelUser.librefang_user`` bytewise, so the parse-side stash
+    of ``req_id`` there is the restart-survivable fallback. This
+    test simulates post-restart: ``_pending_req_ids`` empty,
+    ``cmd.user.librefang_user`` carries the inbound req_id."""
+    a = _adapter()
+    # Post-restart: cache empty.
+    assert a._pending_req_ids == {}
+    await a.on_send(_FakeSend(
+        channel_id="alice",
+        text="hi",
+        user={
+            "platform_id": "alice",
+            "librefang_user": "req-id-from-inbound-42",
+        },
+    ))
+    f = json.loads(a._send_queue.get_nowait())
+    # Must use aibot_respond_msg (passive) keyed on the recovered
+    # req_id — NOT aibot_send_msg (active) which is what the
+    # pre-fix code would degrade to.
+    assert f["cmd"] == "aibot_respond_msg", \
+        "on_send must recover req_id from cmd.user.librefang_user when " \
+        "_pending_req_ids cache is empty (post-restart scenario)"
+    assert f["headers"]["req_id"] == "req-id-from-inbound-42"
+
+
+@pytest.mark.asyncio
+async def test_on_send_in_memory_cache_wins_over_librefang_user():
+    """The in-memory cache holds the FRESHEST req_id (the latest
+    inbound's id) — it should take precedence over librefang_user
+    (which is whichever inbound the daemon happens to round-trip
+    back to us, possibly stale). Cache-first, librefang_user as
+    fallback."""
+    a = _adapter()
+    a._pending_req_ids["alice"] = "req-cache-fresh"
+    await a.on_send(_FakeSend(
+        channel_id="alice",
+        text="hi",
+        user={
+            "platform_id": "alice",
+            "librefang_user": "req-stale-roundtrip",
+        },
+    ))
+    f = json.loads(a._send_queue.get_nowait())
+    assert f["headers"]["req_id"] == "req-cache-fresh"
+
+
+@pytest.mark.asyncio
+async def test_on_send_ignores_url_shaped_librefang_user():
+    """``librefang_user`` is shared across channels — must reject
+    cross-channel pollution (dingtalk URL, telegram @username, …)
+    before using as a wecom req_id."""
+    a = _adapter()
+    # Cache empty + URL-shaped librefang_user → must NOT use it,
+    # must fall through to aibot_send_msg.
+    await a.on_send(_FakeSend(
+        channel_id="alice",
+        text="hi",
+        user={
+            "platform_id": "alice",
+            "librefang_user": "https://oapi.dingtalk.com/sb?s=42",
+        },
+    ))
+    f = json.loads(a._send_queue.get_nowait())
+    assert f["cmd"] == "aibot_send_msg"
+
+
+@pytest.mark.asyncio
 async def test_on_send_unsupported_content_uses_placeholder():
     a = _adapter()
     await a.on_send(_FakeSend(


### PR DESCRIPTION
## Summary

**Runtime hotfix surfaced by the #5439 follow-up audit chain.**

WeCom sidecar's in-process \`_pending_req_ids[user_id]\` cache vanishes on sidecar restart, so the bot's first reply after restart degrades from \`aibot_respond_msg\` (passive, free) to \`aibot_send_msg\` (active, quota-burning, blocked for unlicensed bots and rate-limited hard for licensed ones).

## Fix

- \`parse_wecom_event\` also surfaces \`req_id\` via \`ChannelUser.librefang_user\` (bytewise bridge round-trip).
- \`_enqueue_text\` learns a \`req_id_hint\` keyword that falls back to \`librefang_user\` when the in-memory cache is empty.
- Cache stays as the **primary** path because it holds the FRESHEST \`req_id\` (subsequent inbounds clobber the dict; round-tripped \`librefang_user\` is whichever inbound the daemon happens to surface — possibly stale).
- HTTP-scheme / whitespace / \`@\` guard rejects cross-channel pollution.

## Tests

- \`test_on_send_recovers_req_id_from_user_librefang_user_when_cache_cold\` drives the post-restart shape, asserts \`aibot_respond_msg\` with the recovered \`req_id\` rather than \`aibot_send_msg\` degradation.
- \`test_on_send_in_memory_cache_wins_over_librefang_user\` pins the cache-first precedence.
- \`test_on_send_ignores_url_shaped_librefang_user\` pins the cross-channel pollution guard.
- \`cd sdk/python && pytest tests/test_wecom_adapter.py\` — **65 passed** (was 62; +3 regression guards).

## Cross-reference

Same investigation chain as wechat restart hotfix.