### PR TITLE
chore(channels/whatsapp-sidecar): 3 nits from post-merge audit

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/whatsapp.py
+++ b/sdk/python/librefang/sidecar/adapters/whatsapp.py
@@ -19,8 +19,11 @@ operation:
   inbound itself (POSTs directly to LibreFang's REST API at
   ``/api/agents/{id}/message``, bypassing the channel adapter
   entirely), so the sidecar's webhook server is unused in this
-  mode. Voice messages with raw audio bytes go through
-  ``{gateway_url}/message/send-voice`` with base64-encoded audio.
+  mode. The sidecar handles text + URL-based media on the gateway
+  via ``{gateway_url}/message/send``; raw-bytes voice upload is
+  not implemented (the daemon's ``ChannelContent::Voice`` only
+  ever carries a URL at the dispatch boundary — see
+  ``crates/librefang-channels/src/sidecar.rs::send`` parity).
 
 Behaviour parity (citations against
 ``crates/librefang-channels/src/whatsapp.rs`` on the pre-migration
@@ -33,18 +36,10 @@ tree):
   (``type: "location", location: {latitude, longitude}``). All
   authed via ``Authorization: Bearer <access_token>``.
 
-* Cloud API media upload (``send_voice`` path): multipart POST to
-  ``/{phone_id}/media`` with ``messaging_product=whatsapp`` then
-  reference the returned ``id`` as ``audio.id`` on the message
-  POST. Mirrors whatsapp.rs:186-275.
-
 * Gateway outbound — ``POST {gateway}/message/send`` with
   ``{to, text}``, gracefully degrading non-text content
   (voice URL → "(Voice message: <url>)" text;
   image → caption-as-text; file/other → "(Unsupported …)").
-
-* Gateway voice (raw bytes) — ``POST {gateway}/message/send-voice``
-  with ``{to, audio: base64, mime_type}``.
 
 * 4096-char chunking via shared ``split_message``.
 
@@ -76,8 +71,14 @@ Improvements over the Rust adapter:
    bounded ``SeenSet`` (10000 / 5000) keeps redeliveries from
    double-emitting.
 
-3. **429 ``Retry-After`` honoured** on every outbound POST. Rust
-   warned-and-failed on the first non-2xx (whatsapp.rs:373-377).
+3. **429 ``Retry-After`` honoured on Cloud-API outbound POSTs**
+   (``_cloud_post_with_retry``). Rust warned-and-failed on the
+   first non-2xx (whatsapp.rs:373-377). The gateway path
+   (``_gateway_send_text`` / ``_gateway_send_voice``) does NOT
+   carry retry-after handling because the local Baileys gateway
+   does not return HTTP 429 in normal operation; if you proxy the
+   gateway behind a rate-limiting reverse-proxy, wrap the gateway
+   route with your own retry layer.
 
 4. **Explicit 30 s ``urlopen`` timeout** on every REST call.
 """
@@ -409,8 +410,23 @@ class WhatsAppAdapter(SidecarAdapter):
                   "DM policy: respond / allowed_only / ignore", "text",
                   placeholder=DM_RESPOND,
                   advanced=True),
+            # NOTE: WHATSAPP_GROUP_POLICY is currently inert in BOTH
+            # operating modes. Cloud API webhook payloads at
+            # `entry[].changes[].value.messages[]` don't surface a
+            # group/conversation distinction (we hardcode
+            # `is_group=False` at `_handle_post_webhook`), and gateway
+            # mode delegates inbound entirely to the Node Baileys
+            # gateway which never calls back into the sidecar's
+            # `should_handle_message` filter. The field is kept here so
+            # the schema stays forward-compatible with a future
+            # group-aware Cloud API webhook payload shape (Meta has
+            # been rolling out group-chat support gradually); operators
+            # who set it today get no effect, which is documented in
+            # the placeholder.
             Field("WHATSAPP_GROUP_POLICY",
-                  "Group policy: all / mention_only / commands_only / ignore",
+                  "Group policy (currently inert; reserved for future "
+                  "Cloud API group support): all / mention_only / "
+                  "commands_only / ignore",
                   "text",
                   placeholder=GROUP_ALL,
                   advanced=True),
@@ -445,6 +461,22 @@ class WhatsAppAdapter(SidecarAdapter):
                     "whatsapp WHATSAPP_APP_SECRET unset — X-Hub-Signature-256 "
                     "verification on inbound webhook is DISABLED. Production "
                     "deployments should always set this.",
+                )
+            if not self.verify_token:
+                # Without this, _handle_get_verify short-circuits on
+                # `self.verify_token` and Meta's subscription handshake
+                # silently returns 403 — operators see "subscription
+                # failed" in the Meta dashboard with no log line
+                # pointing back to the missing env var. WARN at startup
+                # so the failure is loud, matching the APP_SECRET
+                # pattern above.
+                log.warn(
+                    "whatsapp WHATSAPP_VERIFY_TOKEN unset — Meta's "
+                    "subscription handshake (GET /webhook with "
+                    "hub.mode=subscribe) will return 403 silently and "
+                    "Meta cannot subscribe to the webhook. Set this "
+                    "env var to the same string you enter in the "
+                    "Meta Developer console.",
                 )
 
         port_raw = os.environ.get("WHATSAPP_WEBHOOK_PORT", "").strip()

--- a/sdk/python/tests/test_whatsapp_adapter.py
+++ b/sdk/python/tests/test_whatsapp_adapter.py
@@ -440,6 +440,32 @@ def test_get_verify_wrong_mode_rejected():
     assert status == 403
 
 
+def test_get_verify_empty_self_token_rejects(monkeypatch):
+    """When WHATSAPP_VERIFY_TOKEN is empty at startup, the handler
+    must fail closed (403) — operator was warned at startup; this
+    test pins that the close-the-door behaviour didn't regress.
+    Without the close: an attacker who guesses the subscription
+    handshake (or just sends empty hub.verify_token from a script)
+    could subscribe their own callback URL to the bot.
+
+    Regression guard for the WHATSAPP_VERIFY_TOKEN startup-warn fix
+    (audit nit #2)."""
+    warns: list = []
+    monkeypatch.setattr(wa.log, "warn",
+                        lambda msg, **kw: warns.append((msg, kw)))
+    a = _cloud_adapter(WHATSAPP_VERIFY_TOKEN="")
+    # __init__ must have logged a structured warn about the empty
+    # verify_token (the operator-side debuggability fix).
+    assert any("WHATSAPP_VERIFY_TOKEN unset" in m for m, _ in warns), \
+        "Startup must WARN when WHATSAPP_VERIFY_TOKEN is empty so " \
+        "operators see why Meta subscription handshake silently fails."
+    # And the handshake itself must fail closed.
+    status, _body = a._handle_get_verify(
+        "hub.mode=subscribe&hub.verify_token=&hub.challenge=ECHO"
+    )
+    assert status == 403
+
+
 def test_post_webhook_signature_disabled_accepts_any():
     """When WHATSAPP_APP_SECRET is empty, signature is skipped —
     operator was warned at startup."""


### PR DESCRIPTION
## Summary

Surfaces from the post-#5445 audit (6th in the dingtalk/qq/omnibus review chain — first verdict that wasn't BROKEN/NEEDS_HOTFIX). All three are doc/UX cleanups, none are runtime regressions:

1. **Docstring claim #3 was wrong** — said \"429 Retry-After honoured on every outbound POST\", but only Cloud API uses \`_cloud_post_with_retry\`; the gateway path calls \`_http_request\` directly. Softened to \"Cloud-API outbound POSTs only\" + explained when gateway-side retry would matter.

2. **WHATSAPP_VERIFY_TOKEN unset failed silently** — Meta's subscription handshake returned 403 with no log line, operators saw \"subscription failed\" in the Meta dashboard with nothing in their daemon logs. Now warns at \`__init__\`.

3. **WHATSAPP_GROUP_POLICY is dead config** — Cloud API webhook doesn't surface groups (we hardcode \`is_group=False\`); gateway mode delegates inbound entirely to the Node gateway. So all values are ignored. Schema field kept for forward-compat but labeled \`(currently inert)\`.

## Drive-by

Dropped the misleading \`send-voice\` docstring claim — promised a \`{gateway}/message/send-voice\` multipart upload route that doesn't exist in code; rationale comment explains why we don't need it (daemon's \`ChannelContent::Voice\` only carries a URL at dispatch boundary).

## Tests

- New \`test_get_verify_empty_self_token_rejects\` asserts BOTH the \`__init__\` warn fires AND the handshake fails closed. Regression guard — without this an attacker who sends empty \`hub.verify_token\` could subscribe their own callback URL.
- \`cd sdk/python && pytest tests/test_whatsapp_adapter.py\` — **79 passed** (was 78; +1 regression guard).

## Audit chain

This closes the 6-review chain. WhatsApp itself is structurally clean — natural routing key (phone) is preserved as \`channel_id\` both directions, so the bug family from #5417 → #5449 doesn't apply by construction.

| # | PR | Found |
|---|----|-------|
| 1 | #5392 self-review | FeishuConfig dangling ref (race) |
| 2 | #5417 self-review | dingtalk on_send routing |
| 3 | #5431 post-hotfix | qq same bug class |
| 4 | #5439 post-hotfix | 6 sidecars same class |
| 5 | #5448+#5449+#5450 post-omnibus | wechat / wecom restart fragility + SDK trace |
| 6 | This | whatsapp CLEAN (3 nits only) |