### PR TITLE
chore(channels/whatsapp-sidecar): rephrase docstring "stub" mentions to stop bot false positives

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/whatsapp.py
+++ b/sdk/python/librefang/sidecar/adapters/whatsapp.py
@@ -9,7 +9,7 @@ operation:
   empty): talks to Meta's official WhatsApp Business Cloud API
   (``graph.facebook.com``) for outbound messages, and runs its own
   HTTP webhook server for inbound. (The in-process Rust adapter's
-  ``start()`` was a stub that logged "webhook ready" but never
+  ``start()`` was a no-op that logged "webhook ready" but never
   actually parsed inbound activities — see whatsapp.rs:454-483.
   This sidecar implements the real webhook handler.)
 
@@ -56,9 +56,10 @@ tree):
 Improvements over the Rust adapter:
 
 1. **Real Cloud API webhook server**. Rust's ``start()`` at
-   whatsapp.rs:454-483 was a TODO stub — operators wanting Cloud
-   API inbound had to wire their own webhook → ``/api/agents/…``
-   forwarder. The sidecar implements the real handler:
+   whatsapp.rs:454-483 was an unimplemented TODO — operators
+   wanting Cloud API inbound had to wire their own webhook →
+   ``/api/agents/…`` forwarder. The sidecar implements the real
+   handler:
    ``GET {path}`` returns ``hub.challenge`` for Meta's subscription
    confirmation when ``hub.mode == "subscribe"`` and
    ``hub.verify_token`` matches ``WHATSAPP_VERIFY_TOKEN``;
@@ -151,8 +152,8 @@ def verify_xhub_signature(
     Empty / missing / wrong-prefix / non-hex all reject.
 
     The Rust adapter didn't actually run a webhook (whatsapp.rs:454-
-    483 was a TODO stub); this verification path is new in the
-    sidecar.
+    483 was an unimplemented TODO); this verification path is new in
+    the sidecar.
     """
     if not isinstance(header, str) or not header:
         return False


### PR DESCRIPTION
## Summary

Rephrases 3 docstring mentions of "stub" in `sdk/python/librefang/sidecar/adapters/whatsapp.py` so the repo's stub-detection github-actions bot stops opening false-positive issues against them.

## Why

The bot scans for the literal word `stub` in source and auto-opens an issue per occurrence with a permalink to the surrounding lines. Three mentions in `whatsapp.py` are describing the **historical, already-removed** Rust adapter (`whatsapp.rs:454-483`, deleted in #5445) — every one of them explicitly contrasts the removed code with the current Python implementation. The bot can't tell "current code is a stub" from "historical removed code was a stub", and opened two issues yesterday on this docstring:

- #5457 → `whatsapp.py:153-155` ("The Rust adapter didn't actually run a webhook (whatsapp.rs:454-483 was a TODO stub); **this verification path is new in the sidecar**.")
- #5458 → `whatsapp.py:64-83` ("Rust's `start()` ... was a TODO stub — operators wanting Cloud API inbound had to wire their own webhook ... **The sidecar implements the real handler**.")

A third mention at L11-14 hadn't been scanned yet; this PR also touches it before it becomes a third false positive.

Both issues are factually wrong — the Python sidecar IS the real Cloud-API webhook implementation, pinned by 79 tests in `sdk/python/tests/test_whatsapp_adapter.py`.

## What changed

Three `stub` → `no-op` / `unimplemented TODO` substitutions preserving the semantic contrast with the removed Rust adapter:

```diff
- ``start()`` was a stub that logged "webhook ready" but never
+ ``start()`` was a no-op that logged "webhook ready" but never

- whatsapp.rs:454-483 was a TODO stub — operators wanting Cloud
+ whatsapp.rs:454-483 was an unimplemented TODO — operators
- API inbound had to wire their own webhook → ``/api/agents/…``
- forwarder. The sidecar implements the real handler:
+ wanting Cloud API inbound had to wire their own webhook →
+ ``/api/agents/…`` forwarder. The sidecar implements the real
+ handler:

- The Rust adapter didn't actually run a webhook (whatsapp.rs:454-
- 483 was a TODO stub); this verification path is new in the
- sidecar.
+ The Rust adapter didn't actually run a webhook (whatsapp.rs:454-
+ 483 was an unimplemented TODO); this verification path is new in
+ the sidecar.
```

## Verification

* `grep -n stub sdk/python/librefang/sidecar/adapters/whatsapp.py` → no matches.
* `python3 -c "import librefang.sidecar.adapters.whatsapp"` → imports cleanly.
* `cd sdk/python && pytest tests/test_whatsapp_adapter.py` → **79 passed** (was 79 — docstring change, no behaviour change).

## Closes

* #5457 (already closed manually with the same false-positive explanation; this PR is the durable fix that stops the bot re-opening it).
* #5458 (same).

## Out of scope

The bot's false-positive rate could be lowered by skipping the keyword inside `#` / `"""` docstring contexts when followed by "was" / "removed" / a code-citation pattern, but that's a separate change to the bot's scanner and lives outside this repo.
