### PR TITLE
fix(channels/sidecar): preserve specific cause in last_error after circuit-breaker trip

### DIFF
--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -890,18 +890,34 @@ async fn spawn_once(
 
 /// Circuit-breaker: restarts exhausted. Logged exactly once (the
 /// supervisor breaks right after), so no log-rate gate is needed.
+///
+/// Preserves the most recent per-attempt `last_error` (spawn error,
+/// sidecar-emitted `error` event, or stdout read failure) by composing
+/// it into the final `last_error` and surfacing it on the structured
+/// log as `last_cause`. The earlier behaviour overwrote the specific
+/// cause with a generic "circuit-breaker tripped" message, leaving
+/// `GET /api/channels` / dashboard operators with no actionable signal
+/// when a sidecar had been retrying-and-failing for the same reason
+/// (missing required env var, bad token, etc.) all along.
 fn trip_circuit(ctx: &SpawnCtx, attempt: u32) {
-    {
+    let prior = {
         let mut s = ctx.status.lock().unwrap_or_else(|e| e.into_inner());
         s.connected = false;
-        s.last_error = Some(format!(
-            "sidecar restart circuit-breaker tripped after {attempt} attempts"
-        ));
-    }
+        let prior = s.last_error.clone();
+        s.last_error = Some(match prior.as_deref() {
+            Some(cause) if !cause.is_empty() => format!(
+                "sidecar restart circuit-breaker tripped after {attempt} attempts; \
+                 last cause: {cause}"
+            ),
+            _ => format!("sidecar restart circuit-breaker tripped after {attempt} attempts"),
+        });
+        prior
+    };
     error!(
         adapter = %ctx.name,
         attempt,
         max_retries = ctx.sup.max_retries,
+        last_cause = prior.as_deref().unwrap_or("(none recorded)"),
         "Sidecar exceeded restart attempts; giving up (circuit-break)"
     );
 }
@@ -2396,6 +2412,68 @@ mod tests {
         }
         adapter.stop().await.unwrap();
         assert!(!adapter.status().connected);
+    }
+
+    /// Regression: `trip_circuit` must preserve the specific per-attempt
+    /// cause in `status.last_error` after the breaker trips. Operators
+    /// reading `GET /api/channels` / dashboard rely on `last_error` to
+    /// see *why* a sidecar died (e.g. "TELEGRAM_BOT_TOKEN is required",
+    /// missing binary, bad config); the prior implementation overwrote
+    /// it with a generic "circuit-breaker tripped after N attempts"
+    /// notice, hiding the actionable signal.
+    ///
+    /// Drives the spawn-failure branch via a non-existent command so
+    /// the supervisor never even reaches `ready`; the OS spawn error
+    /// is recorded as `last_error` on each attempt, and after
+    /// `restart_max_retries` the trip must compose both pieces.
+    #[tokio::test]
+    async fn circuit_break_preserves_last_specific_cause() {
+        let config: librefang_types::config::SidecarChannelConfig =
+            serde_json::from_value(serde_json::json!({
+                "name": "circuit-cause",
+                // An absolute path that cannot exist — `Command::spawn`
+                // fails synchronously with a stable OS error message
+                // wrapped by `spawn_once` as "Failed to spawn sidecar
+                // '<name>' (<cmd>): <os err>".
+                "command": "/nonexistent/librefang-sidecar-circuit-test",
+                "restart_max_retries": 1,
+                "restart_initial_backoff_ms": 1,
+                "restart_max_backoff_ms": 2,
+            }))
+            .expect("valid SidecarChannelConfig");
+        let adapter = SidecarAdapter::new(&config, std::env::temp_dir());
+        let _stream = adapter.start().await.unwrap();
+
+        // Two failed spawns (attempt 0, attempt 1) then trip
+        // (1 >= max_retries). Backoff is 1-2ms so the test is bounded
+        // by spawn latency; 5s leaves ample headroom on slow CI.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let last_error = loop {
+            if let Some(e) = adapter.status().last_error {
+                if e.contains("circuit-breaker tripped") {
+                    break e;
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!(
+                    "supervisor did not trip in time; last_error={:?}",
+                    adapter.status().last_error
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        };
+        adapter.stop().await.unwrap();
+
+        assert!(
+            last_error.contains("last cause:"),
+            "circuit-break message must carry the prior cause, got: {last_error}"
+        );
+        // The OS phrasing for "no such file" varies across platforms;
+        // the supervisor's own wrapper is stable, so assert on that.
+        assert!(
+            last_error.contains("Failed to spawn sidecar"),
+            "circuit-break message must surface the spawn-failed wrapper, got: {last_error}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

When a sidecar adapter's restart supervisor exhausts retries and trips the
circuit-breaker, `crates/librefang-channels/src/sidecar.rs::trip_circuit`
overwrites `ChannelStatus.last_error` with the generic string
`"sidecar restart circuit-breaker tripped after N attempts"`, **erasing**
the per-attempt cause (spawn error, sidecar-emitted `error` event, or
stdout read failure) that `GET /api/channels` and the dashboard rely on
to surface *why* a sidecar died.

Concretely, an operator who sees

```
ERROR Sidecar exceeded restart attempts; giving up (circuit-break) adapter=telegram attempt=10 max_retries=10
```

gets `last_error = "sidecar restart circuit-breaker tripped after 10
attempts"` in the API/dashboard — no signal that, say,
`TELEGRAM_BOT_TOKEN` was missing the whole time and every spawn died on
the same `SystemExit(2)` at `sdk/python/librefang/sidecar/adapters/telegram.py:815`.

## Fix

Compose, don't clobber. `trip_circuit` now reads the existing
`last_error` before overwriting and folds it into the final message:

```
sidecar restart circuit-breaker tripped after 10 attempts; last cause: <prior cause>
```

The structured `error!` event also gains a `last_cause` field, so the
give-up log line itself becomes actionable — no more scrolling 10
backoff cycles up to find the real reason.

When no prior cause was recorded (rare — the ready-timeout path can hit
trip without ever setting `last_error`), the message degrades cleanly
to the original generic form and `last_cause` logs as `(none recorded)`.

## Behaviour matrix

| Prior `last_error` at trip-time             | New `last_error`                                                           | Structured log `last_cause` |
| ------------------------------------------- | -------------------------------------------------------------------------- | --------------------------- |
| `Some("Failed to spawn sidecar 'telegram' (python3): No such file…")` | `…tripped after 10 attempts; last cause: Failed to spawn sidecar …` | actual cause                |
| `Some("<sidecar error event message>")`     | `…tripped after 10 attempts; last cause: <message>`                        | actual cause                |
| `None` (ready-timeout path, no prior set)   | `…tripped after N attempts` (unchanged)                                    | `(none recorded)`           |

## Tests

- New `circuit_break_preserves_last_specific_cause` in
  `crates/librefang-channels/src/sidecar.rs` (lib-unit). Drives the
  spawn-failure branch with a non-existent binary
  (`/nonexistent/librefang-sidecar-circuit-test`), waits for the
  supervisor to trip with `restart_max_retries=1` +
  `restart_initial_backoff_ms=1`, then asserts the final `last_error`
  carries both the supervisor's stable `Failed to spawn sidecar` wrapper
  AND the new `last cause:` preamble.
- All 40 pre-existing `sidecar::tests::*` continue to pass; no behaviour
  change outside the trip path.

## Verification

```bash
cargo check --workspace --lib                          # green (2m 03s)
cargo clippy --workspace --all-targets -- -D warnings  # clean (2m 01s)
cargo test -p librefang-channels --lib sidecar::       # 40 passed
```

## Scope

Single file (`crates/librefang-channels/src/sidecar.rs`). No protocol
change, no config change, no `ChannelStatus` schema change — `last_error`
is still a single `Option<String>`. The only observable difference is
that the string carries more information after a trip.

## Out of scope (explicitly NOT bundled)

The deeper question of whether the supervisor should distinguish
permanent config errors (e.g. `SystemExit(2)` from missing required env)
from transient crashes and skip the retry-then-trip cycle entirely is a
larger discussion (protocol bit / exit-code convention) and intentionally
left for a separate decision.
