### PR TITLE
chore: prune unused dependencies across the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -43,19 +43,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "aes"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
-dependencies = [
- "cipher 0.5.1",
- "cpubits",
- "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -65,8 +54,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
@@ -678,15 +667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -879,16 +859,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher 0.4.4",
-]
-
-[[package]]
-name = "cbc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
-dependencies = [
- "cipher 0.5.1",
+ "cipher",
 ]
 
 [[package]]
@@ -961,7 +932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
 ]
 
@@ -1033,18 +1004,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
- "inout 0.1.4",
-]
-
-[[package]]
-name = "cipher"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
-dependencies = [
- "crypto-common 0.2.1",
- "inout 0.2.2",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1275,12 +1236,6 @@ checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "cpubits"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
 name = "cpufeatures"
@@ -1589,15 +1544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,7 +1615,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1892,7 +1838,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1903,7 +1849,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
 ]
 
@@ -2102,7 +2048,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -3289,15 +3235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "html-escape"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
-dependencies = [
- "utf8-width",
-]
-
-[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,15 +3300,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -3704,18 +3632,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding 0.3.3",
+ "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "inout"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
-dependencies = [
- "block-padding 0.4.2",
- "hybrid-array",
 ]
 
 [[package]]
@@ -4177,7 +4095,6 @@ dependencies = [
  "librefang-kernel-handle",
  "librefang-llm-driver",
  "librefang-types",
- "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -4268,20 +4185,15 @@ dependencies = [
 name = "librefang-channels"
 version = "2026.5.17-beta.12"
 dependencies = [
- "aes 0.9.0",
  "async-trait",
  "axum",
  "base64 0.22.1",
  "bitflags 2.11.1",
  "bytes",
- "cbc 0.2.0",
  "chrono",
  "criterion",
  "dashmap",
  "futures",
- "hex",
- "hmac",
- "html-escape",
  "image",
  "librefang-types",
  "pdf-extract",
@@ -4292,22 +4204,17 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
  "smallvec",
  "subtle",
  "tempfile",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
  "tower",
  "tracing",
  "url",
- "urlencoding",
  "uuid",
  "webpki-roots",
  "wiremock",
- "zeroize",
 ]
 
 [[package]]
@@ -4315,7 +4222,6 @@ name = "librefang-cli"
 version = "2026.5.17-beta.12"
 dependencies = [
  "arc-swap",
- "async-trait",
  "base64 0.22.1",
  "chrono",
  "clap",
@@ -4336,7 +4242,6 @@ dependencies = [
  "librefang-types",
  "open",
  "opentelemetry",
- "opentelemetry_sdk",
  "ratatui",
  "reqwest",
  "rusqlite",
@@ -4518,7 +4423,6 @@ dependencies = [
  "bytes",
  "librefang-types",
  "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -4756,7 +4660,6 @@ dependencies = [
  "sha2",
  "tempfile",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -4789,20 +4692,15 @@ version = "2026.5.17-beta.12"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "chrono",
  "dashmap",
  "hex",
  "librefang-http",
  "librefang-types",
  "reqwest",
- "serde",
  "serde_json",
  "serial_test",
- "sha2",
  "tokio",
  "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -4812,7 +4710,6 @@ dependencies = [
  "chrono",
  "dashmap",
  "librefang-types",
- "serde_json",
  "tokio",
  "tracing",
 ]
@@ -4999,9 +4896,9 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "bitflags 2.11.1",
- "cbc 0.1.2",
+ "cbc",
  "ecb",
  "encoding_rs",
  "flate2",
@@ -6507,8 +6404,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
- "aes 0.8.4",
- "cbc 0.1.2",
+ "aes",
+ "cbc",
  "der",
  "pbkdf2 0.12.2",
  "scrypt",
@@ -7684,12 +7581,12 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a229f2a03daea3f62cee897b40329ce548600cca615906d98d58b8db3029b19"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "aes-gcm",
  "async-trait",
  "bitflags 2.11.1",
  "byteorder",
- "cbc 0.1.2",
+ "cbc",
  "chacha20 0.9.1",
  "ctr",
  "curve25519-dalek",
@@ -7748,12 +7645,12 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89757474f7c9ee30121d8cc7fe293a954ba10b204a82ccf5850a5352a532ebc7"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "async-trait",
  "bcrypt-pbkdf",
- "block-padding 0.3.3",
+ "block-padding",
  "byteorder",
- "cbc 0.1.2",
+ "cbc",
  "ctr",
  "data-encoding",
  "der",
@@ -7764,7 +7661,7 @@ dependencies = [
  "futures",
  "hmac",
  "home",
- "inout 0.1.4",
+ "inout",
  "log",
  "md5",
  "num-integer",
@@ -7799,13 +7696,13 @@ version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "788a2439ce385856585346beb37c48e7c9eb5de5f4f00736720a19ffdb3f5bb5"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "async-trait",
  "bcrypt-pbkdf",
- "block-padding 0.3.3",
+ "block-padding",
  "byteorder",
  "bytes",
- "cbc 0.1.2",
+ "cbc",
  "ctr",
  "data-encoding",
  "der",
@@ -7817,7 +7714,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hmac",
  "home",
- "inout 0.1.4",
+ "inout",
  "log",
  "md5",
  "num-integer",
@@ -8002,7 +7899,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -8797,11 +8694,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "aes-gcm",
- "cbc 0.1.2",
+ "cbc",
  "chacha20 0.9.1",
- "cipher 0.4.4",
+ "cipher",
  "ctr",
  "poly1305",
  "ssh-encoding",
@@ -10451,7 +10348,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
 ]
 
@@ -10538,12 +10435,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8-zero"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4209,7 +4209,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tower",
  "tracing",
  "url",
  "uuid",
@@ -4406,7 +4405,6 @@ dependencies = [
  "tera",
  "thiserror 2.0.18",
  "tokio",
- "tokio-test",
  "toml 1.1.2+spec-1.1.0",
  "totp-rs",
  "tracing",
@@ -9746,17 +9744,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,6 @@ flate2 = "1"
 tar = "0.4"
 
 # Testing
-tokio-test = "0.4"
 tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,11 +205,6 @@ walkdir = "2"
 
 # Security
 sha2 = { version = "0.10", features = ["oid"] }
-# sha1 0.10 is paired with hmac 0.12 via digest 0.10. sha1 0.11+ moved to
-# digest 0.11 and is incompatible with our hmac version.
-sha1 = "0.10"
-aes = "0.9"
-cbc = "0.2"
 hmac = "0.12"
 hex = "0.4"
 subtle = "2"
@@ -249,9 +244,6 @@ colored = "3"
 # Encryption
 aes-gcm = "0.10"
 argon2 = { version = "0.5", features = ["rand"] }
-
-# HTML entity decoding
-html-escape = "0.2"
 
 # Lightweight regex
 regex = "1"

--- a/crates/librefang-acp/Cargo.toml
+++ b/crates/librefang-acp/Cargo.toml
@@ -28,7 +28,6 @@ agent-client-protocol-tokio = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 async-trait = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -71,7 +71,6 @@ rustls = { workspace = true }
 criterion = { workspace = true }
 tempfile = { workspace = true }
 wiremock = "0.6"
-tower = { workspace = true }
 serde_json = { workspace = true }
 
 [[bench]]

--- a/crates/librefang-channels/Cargo.toml
+++ b/crates/librefang-channels/Cargo.toml
@@ -30,17 +30,10 @@ reqwest = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-tokio-tungstenite = { workspace = true }
 url = { workspace = true }
-zeroize = { workspace = true }
 axum = { workspace = true }
-hmac = { workspace = true }
-sha2 = { workspace = true }
-sha1 = { workspace = true }
 base64 = { workspace = true }
-hex = { workspace = true }
 subtle = { workspace = true }
-html-escape = { workspace = true }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 pdf-extract = "0.10"
 regex = { workspace = true }
@@ -48,21 +41,31 @@ regex-lite = { workspace = true }
 smallvec = { workspace = true }
 webpki-roots = { workspace = true }
 rustls-native-certs = { workspace = true }
-urlencoding = { workspace = true }
+# TLS config for the shared HTTP client (`http_client.rs`). The code
+# builds its provider via `rustls::crypto::aws_lc_rs` (rustls' default
+# backend), so no extra provider feature is requested here — the old
+# `features = ["ring"]` pulled an unused second crypto backend.
+rustls = { workspace = true }
 
-# Channel-specific optional dependencies
-# `rsa` was a `channel-google-chat`-only dep for service-account JWT
-# signing; google_chat migrated to a sidecar, no remaining consumer.
-aes = { version = "0.9", optional = true }
-cbc = { version = "0.2", optional = true }
-rustls = { workspace = true, features = ["ring"] }
-
-# Email-sidecar migration (#…): the `lettre` / `imap` /
-# `rustls-connector` / `rustls-pemfile` / `mailparse` optional deps
-# the in-process channel-email feature used to gate are removed
-# alongside the adapter — the sidecar runs on Python's stdlib
-# `imaplib` + `smtplib` + `email` packages and pulls nothing of the
-# sort into the Rust workspace.
+# Sidecar migration cleanup: with every channel adapter moved
+# out-of-process (`librefang.sidecar.adapters.*`), the crypto and
+# transport deps the in-process adapters needed have no remaining
+# consumer in this crate and were removed:
+#   - `hmac` / `sha2` / `sha1` — inbound webhook signature
+#     verification now runs inside each Python sidecar (see AGENTS.md
+#     "Webhook security").
+#   - `aes` / `cbc` — AES-CBC envelope decryption of WeCom (#5392) /
+#     Feishu (#5380) webhook payloads; now done in those sidecars.
+#     (Were `optional` with no feature to enable them, so already
+#     unreachable from this crate.)
+#   - `tokio-tungstenite` — Socket-Mode / gateway websockets (e.g.
+#     WeCom) are the sidecar's concern now.
+#   - `hex` / `html-escape` / `urlencoding` / `zeroize` — no remaining
+#     in-crate caller after the adapters left.
+# `lettre` / `imap` / `rustls-connector` / `rustls-pemfile` /
+# `mailparse` (the email adapter) and `rsa` (google_chat
+# service-account JWT) were dropped earlier alongside their adapters;
+# the sidecars use Python stdlib instead.
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -30,7 +30,7 @@ default = ["telemetry"]
 # coordinated workflow + Cargo.toml change is out of scope for the
 # scaffolding cleanup PR that introduced this stub.
 mini = []
-telemetry = ["librefang-api/telemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:tracing-opentelemetry"]
+telemetry = ["librefang-api/telemetry", "dep:opentelemetry", "dep:tracing-opentelemetry"]
 
 [[bin]]
 name = "librefang"
@@ -62,7 +62,6 @@ walkdir = { workspace = true }
 base64 = { workspace = true }
 librefang-runtime = { path = "../librefang-runtime" }
 librefang-acp = { path = "../librefang-acp", features = ["kernel-adapter"] }
-async-trait = { workspace = true }
 rusqlite = { workspace = true }
 uuid = { workspace = true }
 ratatui = { workspace = true }
@@ -74,7 +73,6 @@ open = "5.3.5"
 toml_edit = "0.25.8"
 rustls = "0.23"
 opentelemetry = { workspace = true, optional = true }
-opentelemetry_sdk = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/librefang-kernel-handle/Cargo.toml
+++ b/crates/librefang-kernel-handle/Cargo.toml
@@ -10,7 +10,6 @@ librefang-types = { path = "../librefang-types" }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 serde_json = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/librefang-kernel/Cargo.toml
+++ b/crates/librefang-kernel/Cargo.toml
@@ -64,7 +64,11 @@ name = "purge_sentinels"
 path = "bin/purge_sentinels.rs"
 
 [dev-dependencies]
-tokio-test = { workspace = true }
+# `test-util` enables `tokio::time::{pause,advance,resume}` and
+# `#[tokio::test(start_paused = true)]`, used by the workflow / cron
+# timing tests. (Not in the `full` feature set; previously pulled in
+# transitively by the now-removed `tokio-test` dev-dep.)
+tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 serial_test = "3"
 proptest = "1"

--- a/crates/librefang-runtime-audit/Cargo.toml
+++ b/crates/librefang-runtime-audit/Cargo.toml
@@ -18,7 +18,6 @@ metrics = { workspace = true }
 rusqlite = { workspace = true }
 r2d2 = { workspace = true }
 r2d2_sqlite = { workspace = true }
-uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/librefang-runtime-media/Cargo.toml
+++ b/crates/librefang-runtime-media/Cargo.toml
@@ -11,17 +11,12 @@ librefang-types = { path = "../librefang-types" }
 librefang-http = { path = "../librefang-http" }
 tokio = { workspace = true }
 reqwest = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
 tracing = { workspace = true }
 base64 = { workspace = true }
-chrono = { workspace = true }
-uuid = { workspace = true }
-sha2 = { workspace = true }
 hex = { workspace = true }
-url = { workspace = true }
 
 [dev-dependencies]
 # Serialises the env-mutating ElevenLabs voice_id validator tests so

--- a/crates/librefang-runtime-sandbox-docker/Cargo.toml
+++ b/crates/librefang-runtime-sandbox-docker/Cargo.toml
@@ -11,7 +11,6 @@ librefang-types = { path = "../librefang-types" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 dashmap = { workspace = true }
-serde_json = { workspace = true }
 chrono = { workspace = true }
 
 [lints]


### PR DESCRIPTION
## What

Workspace-wide unused-dependency sweep. Triggered by "the channels all moved to sidecars — weren't the deps cleaned up?", then extended to every crate flagged by `cargo-machete` (both default and `--with-metadata` modes).

## Changes

### `librefang-channels` — sidecar-migration leftovers
Removed 10 deps with **zero references** across `src/`, `tests/`, `benches/`:
`tokio-tungstenite`, `hmac`, `sha2`, `sha1`, `hex`, `html-escape`, `urlencoding`, `zeroize`, `aes`, `cbc`.
- `aes`/`cbc` were `optional` with **no feature able to enable them** → already unreachable.
- The crypto/transport work they backed now runs in the Python sidecars: webhook HMAC verification, WeCom (#5392) / Feishu (#5380) AES-CBC envelope decryption, Socket-Mode/gateway websockets.
- Dropped `rustls`'s `features = ["ring"]`: `http_client.rs` builds its provider via `rustls::crypto::aws_lc_rs` (the default backend); `ring` pulled an unused second crypto backend.
- Also removed the `tower` dev-dependency (no test/bench reference).

### Other crates flagged by `cargo-machete`
| crate | removed |
|-------|---------|
| `librefang-runtime-media` | `chrono`, `serde`, `sha2`, `url`, `uuid` |
| `librefang-cli` | `async-trait`, `opentelemetry_sdk` |
| `librefang-runtime-audit` | `uuid` |
| `librefang-runtime-sandbox-docker` | `serde_json` |
| `librefang-acp` | `serde` |
| `librefang-kernel-handle` | `thiserror` |
| `librefang-kernel` | `tokio-test` (dev) |

`opentelemetry_sdk` was also removed from `librefang-cli`'s `telemetry` feature list. The SDK provider is initialized in `librefang-api` (`telemetry.rs`), whose `telemetry` feature `cli` already enables, so `cli`'s direct dep was redundant. Verified with `cargo check -p librefang-cli --features telemetry`.

### Behaviour-preserving fix uncovered by removing `tokio-test`
`librefang-kernel`'s workflow/cron timing tests use `tokio::time::{pause,advance,resume}` and `#[tokio::test(start_paused = true)]`, which require tokio's `test-util` feature (not in the `full` set). That feature was being pulled in **transitively** by the `tokio-test` dev-dep. Removing `tokio-test` therefore broke the test build — caught by `cargo check --workspace --all-targets`. Fixed by declaring it explicitly:
```toml
[dev-dependencies]
tokio = { workspace = true, features = ["test-util"] }
```
This makes the dependency intent explicit instead of relying on feature unification through an otherwise-unused crate.

### `Cargo.toml` (workspace)
Removed `sha1`, `aes`, `cbc`, `html-escape`, `tokio-test` from `[workspace.dependencies]` — each orphaned once the crate that referenced it stopped. `sha1` stays in `Cargo.lock` transitively via `axum`; the rest leave the graph. The remaining workspace deps are each still referenced by ≥1 crate.

### `Cargo.lock`
Net **−11 packages**: `aes`, `cbc`, `html-escape`, `tokio-test` + their transitive-only crypto crates (`block-padding`, `cipher`, `cpubits`, `crypto-common`, `hybrid-array`, `inout`, `utf8-width`).

## Kept (cargo-machete reports, but intentionally NOT removed)
- **`librefang-desktop` `tauri-build`** — false positive; used in `build.rs` (`tauri_build::build()`).
- **`librefang-desktop` `tauri-plugin-barcode-scanner`** — intentional iOS/Android mobile-support scaffold (added in #3886). Reserved for a future mobile feature, not a leftover.

## Verification
- `cargo-machete` (default + `--with-metadata`): no unused deps except the two intentional keeps above
- `cargo check --workspace --all-targets`: clean (catches the test-target feature-unification break that a `--lib`-only check misses)
- `cargo check -p librefang-cli --features telemetry`: clean (guards the `opentelemetry_sdk` feature change)
- `cargo clippy` on every touched crate `--all-targets -- -D warnings`: clean

## Out of scope (flagged for a maintainer decision, not done here)
- **Retire the `mini` cargo feature in `librefang-cli`.** `mini = []` no longer gates anything (0 `#[cfg(feature = "mini")]`); the in-code comment notes that since the per-channel features were removed, `librefang-*-mini.tar.gz` is byte-identical to the default build. Removing it means deleting the `cli_linux_mini` / `cli_mac_mini` jobs in `.github/workflows/release.yml` and their artifact uploads — a coordinated CI-workflow change in a different domain, which the original author explicitly deferred. Happy to do it in a follow-up if wanted.
