### PR TITLE
feat(channels/bridge): approval notifications use inline keyboard on interactive-capable adapters

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1516,17 +1516,32 @@ impl BridgeManager {
                                         }
                                     };
 
-                                    let short_id = &approval.request_id[..8.min(approval.request_id.len())];
-                                    let msg = format!(
-                                        "Approval required for agent {}\n\
-                                         Tool: {}\n\
-                                         Risk: {}\n\
-                                         {}\n\n\
-                                         Reply /approve {short_id} or /reject {short_id}",
-                                        approval.agent_id,
-                                        approval.tool_name,
-                                        approval.risk_level,
-                                        approval.description,
+                                    // Two-button inline keyboard. The button
+                                    // `action` is the slash command itself —
+                                    // when a user taps, the Telegram /
+                                    // Slack / Feishu sidecar emits a
+                                    // `callback_query` (or platform analogue)
+                                    // that lands in this crate's bridge as a
+                                    // `ChannelContent::ButtonCallback` whose
+                                    // `action` starts with `/`. The existing
+                                    // inbound dispatcher at `content_to_text`
+                                    // routes that straight through the
+                                    // `/approve` / `/reject` command handler.
+                                    // No new protocol bits required — the
+                                    // round-trip already existed; pre-fix the
+                                    // listener just sent plain text and never
+                                    // gave users buttons to click. The
+                                    // capability check + text fallback is in
+                                    // `ChannelAdapter::send_interactive` so
+                                    // adapters that don't declare
+                                    // `interactive` (IRC, SMS, …) still get
+                                    // the actionable text body unchanged.
+                                    let approval_keyboard = build_approval_interactive(
+                                        &approval.agent_id,
+                                        &approval.request_id,
+                                        &approval.tool_name,
+                                        &approval.risk_level,
+                                        &approval.description,
                                     );
 
                                     for adapter in &adapters {
@@ -1700,8 +1715,21 @@ impl BridgeManager {
                                             continue;
                                         }
                                         for user in &recipients {
+                                            // `send_interactive` has a built-in
+                                            // text fallback for adapters that
+                                            // don't override it (or whose
+                                            // sidecar didn't declare
+                                            // `interactive` capability) —
+                                            // see `ChannelAdapter::send_interactive`
+                                            // in `types.rs`. So this single
+                                            // call covers both surfaces:
+                                            // Telegram / Slack get a real
+                                            // inline keyboard, IRC / SMS get
+                                            // the plain text body (which
+                                            // already carries the slash-command
+                                            // instructions for them to act on).
                                             if let Err(e) = adapter
-                                                .send(user, ChannelContent::Text(msg.clone()))
+                                                .send_interactive(user, &approval_keyboard)
                                                 .await
                                             {
                                                 warn!(
@@ -1716,7 +1744,7 @@ impl BridgeManager {
                                                     adapter = adapter.name(),
                                                     request_id = %approval.request_id,
                                                     recipient = %user.platform_id,
-                                                    "Delivered approval notification"
+                                                    "Delivered approval notification (inline buttons; adapters without `interactive` capability render the text body verbatim)"
                                                 );
                                             }
                                         }
@@ -1891,6 +1919,60 @@ impl BridgeManager {
 }
 
 /// Resolve channel type to its config string key.
+/// Build the inline-keyboard payload the approval listener fans out
+/// to every bound adapter. The `text` is platform-agnostic prose;
+/// `buttons` carries the two slash-command actions that the existing
+/// inbound `ButtonCallback` dispatcher (`bridge.rs::content_to_text`)
+/// already routes straight to the `/approve` / `/reject` handlers.
+///
+/// Adapters that declare the `interactive` capability render this as
+/// a real inline keyboard (Telegram, Slack Block Kit, Feishu cards);
+/// adapters that don't fall back via the default
+/// `ChannelAdapter::send_interactive` impl in `types.rs:647-661`,
+/// which prepends the button labels to the text body. The
+/// slash-command instructions live in the text body so the
+/// text-fallback path stays actionable.
+///
+/// Factored out for unit-testing — the listener loop itself spins up
+/// real tokio tasks against live adapters, which is too heavy a
+/// scaffold for asserting payload shape.
+pub(crate) fn build_approval_interactive(
+    agent_id: &str,
+    request_id: &str,
+    tool_name: &str,
+    risk_level: &str,
+    description: &str,
+) -> crate::types::InteractiveMessage {
+    let short_id = &request_id[..8.min(request_id.len())];
+    let text = format!(
+        "Approval required for agent {agent_id}\n\
+         Tool: {tool_name}\n\
+         Risk: {risk_level}\n\
+         {description}\n\n\
+         Tap a button below, or reply \
+         /approve {short_id} or /reject {short_id} \
+         (add a TOTP code if required: \
+         /approve {short_id} <6-digit>)"
+    );
+    crate::types::InteractiveMessage {
+        text,
+        buttons: vec![vec![
+            crate::types::InteractiveButton {
+                label: "Approve".to_string(),
+                action: format!("/approve {short_id}"),
+                style: Some("primary".to_string()),
+                url: None,
+            },
+            crate::types::InteractiveButton {
+                label: "Deny".to_string(),
+                action: format!("/reject {short_id}"),
+                style: Some("danger".to_string()),
+                url: None,
+            },
+        ]],
+    }
+}
+
 fn channel_type_str(channel: &crate::types::ChannelType) -> &str {
     match channel {
         crate::types::ChannelType::Telegram => "telegram",
@@ -5724,6 +5806,89 @@ mod tests {
             .unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("LIBREFANG_GROUP_ADDRESSEE_GUARD");
         f();
+    }
+
+    // ── Approval-notification inline keyboard (PR: telegram-approval-buttons) ──
+    //
+    // The bridge's approval listener wraps every fan-out in an
+    // `InteractiveMessage` built by `build_approval_interactive`.
+    // Adapters that declare `interactive` capability render that as
+    // inline buttons (Telegram, Slack, Feishu); ones that don't fall
+    // back via the default `ChannelAdapter::send_interactive` impl,
+    // which exposes the slash commands as text. These tests pin both
+    // the wire shape and the slash-command actions inside the buttons.
+
+    #[test]
+    fn build_approval_interactive_shapes_two_buttons_in_one_row() {
+        let msg = build_approval_interactive(
+            "agent-uuid-here",
+            "req-abcdef1234567890",
+            "file_write",
+            "high",
+            "Write to /etc/hosts",
+        );
+        assert_eq!(msg.buttons.len(), 1, "single row expected");
+        assert_eq!(
+            msg.buttons[0].len(),
+            2,
+            "row should carry exactly Approve + Deny"
+        );
+        assert_eq!(msg.buttons[0][0].label, "Approve");
+        assert_eq!(msg.buttons[0][1].label, "Deny");
+        // Style hints — adapters that honor them (Slack Block Kit) get
+        // a green primary / red danger rendering; ones that don't
+        // (Telegram, currently) ignore the field harmlessly.
+        assert_eq!(msg.buttons[0][0].style.as_deref(), Some("primary"));
+        assert_eq!(msg.buttons[0][1].style.as_deref(), Some("danger"));
+    }
+
+    #[test]
+    fn build_approval_interactive_actions_are_slash_commands_with_short_id() {
+        // `content_to_text` (this file) treats a `ButtonCallback` whose
+        // `action` starts with `/` as a slash command — that's the
+        // entire round-trip. The action MUST be `/approve <8-char>` /
+        // `/reject <8-char>` so the existing `/approve` handler at
+        // `bridge.rs::5673+` picks it up unchanged.
+        let msg = build_approval_interactive(
+            "agent",
+            "0123456789abcdef-truncated",
+            "tool",
+            "low",
+            "desc",
+        );
+        let approve = &msg.buttons[0][0].action;
+        let deny = &msg.buttons[0][1].action;
+        assert_eq!(approve, "/approve 01234567");
+        assert_eq!(deny, "/reject 01234567");
+        // Telegram's `callback_data` is capped at 64 bytes; both
+        // commands stay well under it (16-17 bytes each).
+        assert!(approve.len() <= 64);
+        assert!(deny.len() <= 64);
+    }
+
+    #[test]
+    fn build_approval_interactive_text_carries_fallback_slash_instructions() {
+        // Adapters without `interactive` capability render the
+        // `text` field verbatim via the trait default impl. The text
+        // MUST still tell the operator how to act (because their
+        // platform won't draw a tappable button).
+        let msg = build_approval_interactive("agent", "abcdefgh123456", "tool", "low", "desc");
+        assert!(msg.text.contains("/approve abcdefgh"));
+        assert!(msg.text.contains("/reject abcdefgh"));
+        // TOTP hint surfaced for the require-TOTP variant — a single
+        // button click can't carry a 6-digit code, so users need the
+        // slash form for those.
+        assert!(msg.text.contains("TOTP"));
+    }
+
+    #[test]
+    fn build_approval_interactive_tolerates_short_request_ids() {
+        // The existing listener slices `request_id[..8.min(len)]`.
+        // Make sure the helper inherits the same defensive truncation
+        // so a short / malformed request id doesn't panic.
+        let msg = build_approval_interactive("agent", "abc", "tool", "low", "desc");
+        assert_eq!(msg.buttons[0][0].action, "/approve abc");
+        assert_eq!(msg.buttons[0][1].action, "/reject abc");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`bridge.rs::start_approval_listener` (the kernel-wide approval fan-out task) sent every notification as plain text:

```
Approval required for agent <uuid>
Tool: file_write
Risk: medium
…

Reply /approve abc12345 or /reject abc12345
```

Telegram-side UX: copy the 8-char id out of the message, type the slash command back. Clumsy on mobile, easy to mistype, no visual affordance that an action is required — operators routinely missed approvals entirely. WebUI shows a real modal; Telegram (and every other rich-channel platform) didn't.

## Fix

Send the notification as `ChannelContent::Interactive` with two buttons, `[Approve] [Deny]`. Each button's `action` is the slash command itself (`/approve <short_id>` / `/reject <short_id>`).

The inbound round-trip already existed and was unused:

- Telegram / Slack / Feishu sidecars map button taps to `ChannelContent::ButtonCallback { action, .. }` events (Telegram via `callback_query`, Slack via `block_actions`, Feishu via card actions).
- `bridge.rs::content_to_text` (line 3622-3636) already treats a `ButtonCallback` whose `action` starts with `/` as a slash command, dispatching it through the existing `/approve` / `/reject` command handler at `bridge.rs::5673+`. The handler calls `resolve_approval_text` with the clicking user's `platform_id` — same code path as a typed slash command.

So no new protocol bits, no new daemon routes, no sidecar changes. The listener just needed to stop sending plain text.

## Generic, not Telegram-specific

This is a deliberate design choice flagged on the in-review discussion. The change lives entirely in `librefang-channels::bridge` (the platform-agnostic fan-out task), **NOT** in `sdk/python/librefang/sidecar/adapters/telegram.py`:

- `ChannelAdapter::send_interactive` (types.rs:647-661) has a built-in text fallback. Adapters that declare the `interactive` capability (Telegram today; Slack, Feishu, Mattermost when their sidecars declare it) render the real inline keyboard; adapters that don't (IRC, SMS, …) fall through to a textified render that prepends button labels to the message body.
- The text body retains the `/approve <id>` / `/reject <id>` slash-command instructions and a TOTP hint, so the text-fallback path stays actionable — a button click can't carry a 6-digit TOTP code, so TOTP-gated approvals naturally fall back to the slash form.
- Every existing approval-routing invariant (scope-to-bound-agent at `bridge.rs:1532+`, qualified-key precedence for multi-bot adapters, the silent-drop WARN when no `default_agent` and no `AgentBinding` covers the requesting agent) is unchanged.

## Implementation

Construction extracted into `build_approval_interactive(agent_id, request_id, tool_name, risk_level, description) -> InteractiveMessage` so the payload shape is unit-testable without spinning the live listener loop against real tokio tasks + mock adapters.

```rust
let approval_keyboard = build_approval_interactive(
    &approval.agent_id,
    &approval.request_id,
    &approval.tool_name,
    &approval.risk_level,
    &approval.description,
);
adapter.send_interactive(user, &approval_keyboard).await
```

Button `action` strings stay well under Telegram's 64-byte `callback_data` cap (16-17 bytes each), even at the upper bound of an 8-char short id.

## Tests

4 new lib-unit tests in `bridge::tests`:

- `build_approval_interactive_shapes_two_buttons_in_one_row` — one row, exactly two buttons, primary / danger style hints.
- `build_approval_interactive_actions_are_slash_commands_with_short_id` — `/approve <8-char>` / `/reject <8-char>`, both under 64 bytes.
- `build_approval_interactive_text_carries_fallback_slash_instructions` — text body still names the slash commands AND mentions TOTP so text-fallback adapters stay actionable.
- `build_approval_interactive_tolerates_short_request_ids` — defensive truncation matches the listener's pre-fix `request_id[..8.min(len)]` slice (no panic on short ids).

All 425 pre-existing `librefang-channels` lib tests continue to pass — 429 total.

## Verification

```
cargo check   -p librefang-channels                       # green
cargo clippy  --workspace --all-targets -- -D warnings    # zero warnings
cargo test    -p librefang-channels --lib                 # 429 passed
```

## Out of scope (follow-ups)

- Edit-in-place after a button is clicked (Telegram supports `EditInteractive` — strike out the resolved approval inline so the chat history doesn't keep dangling `[Approve] [Deny]` buttons). The current behaviour leaves the original message intact; the bot just sends a separate confirmation. Reasonable polish, separate PR.
- TOTP entry via a multi-step inline flow (Telegram bot conversation API). Today TOTP-required approvals fall back to typing `/approve <id> <6-digit>` — workable but worth a dedicated UX pass.
- A `notification_recipients` UX in the dashboard so operators don't have to hand-edit `secrets.env` / sidecar config to set up the "operator inbox" pattern.
