### PR TITLE
feat(channels/bridge): route approval popup to originating chat (follow-up to #5483)

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1612,6 +1612,62 @@ impl BridgeManager {
                                         // #4985 was about (admin inbox +
                                         // unrelated bound chat both
                                         // receiving the same approval).
+                                        // ── Fast path: route back to the
+                                        // originating chat when the kernel
+                                        // populated `sender_id` + `channel`
+                                        // on the request. This is the common
+                                        // case for tool calls triggered by a
+                                        // user chatting with the agent in
+                                        // Telegram / Slack / Feishu: the
+                                        // approval prompt goes straight back
+                                        // to that chat, no
+                                        // `notification_recipients` or
+                                        // `AgentBinding` config needed.
+                                        //
+                                        // Pre-fix this branch didn't exist;
+                                        // the kernel didn't even put
+                                        // `sender_id` / `channel` on the
+                                        // event payload, so approvals on
+                                        // freshly-set-up Telegram adapters
+                                        // silently dropped at the
+                                        // empty-recipients DEBUG line below.
+                                        if let (Some(src_sender), Some(src_channel)) =
+                                            (approval.sender_id.as_deref(), approval.channel.as_deref())
+                                        {
+                                            if src_channel == ct_str
+                                                && !src_sender.is_empty()
+                                            {
+                                                let direct_recipient = ChannelUser {
+                                                    platform_id: src_sender.to_string(),
+                                                    display_name: String::new(),
+                                                    librefang_user: None,
+                                                };
+                                                if let Err(e) = adapter
+                                                    .send_interactive(&direct_recipient, &approval_keyboard)
+                                                    .await
+                                                {
+                                                    warn!(
+                                                        adapter = adapter.name(),
+                                                        request_id = %approval.request_id,
+                                                        recipient = %direct_recipient.platform_id,
+                                                        error = %e,
+                                                        "Failed to deliver approval notification (direct-route)"
+                                                    );
+                                                } else {
+                                                    info!(
+                                                        adapter = adapter.name(),
+                                                        request_id = %approval.request_id,
+                                                        recipient = %direct_recipient.platform_id,
+                                                        "Delivered approval notification (direct-route to originating chat)"
+                                                    );
+                                                }
+                                                // Direct route handled this
+                                                // adapter; skip the legacy
+                                                // recipients fan-out below.
+                                                continue;
+                                            }
+                                        }
+
                                         let recipients: Vec<ChannelUser> = match bound_agent {
                                             Some(bound) if bound == requesting_agent => {
                                                 adapter.notification_recipients()
@@ -5879,6 +5935,51 @@ mod tests {
         // button click can't carry a 6-digit code, so users need the
         // slash form for those.
         assert!(msg.text.contains("TOTP"));
+    }
+
+    #[test]
+    fn approval_requested_event_carries_routing_fields() {
+        // Pin the new wire shape on `ApprovalRequestedEvent`. Pre-fix the
+        // event had only request_id / agent_id / tool_name / description /
+        // risk_level, which is what stranded Telegram approvals: the
+        // channel listener subscribed to the EventBus version (NOT the
+        // approval_manager's broadcast) and got no `sender_id` / `channel`
+        // to route by.
+        use librefang_types::event::ApprovalRequestedEvent;
+        let evt = ApprovalRequestedEvent {
+            request_id: "req-12345678".to_string(),
+            agent_id: "agent".to_string(),
+            tool_name: "file_write".to_string(),
+            description: "desc".to_string(),
+            risk_level: "high".to_string(),
+            sender_id: Some("telegram-chat-12345".to_string()),
+            channel: Some("telegram".to_string()),
+        };
+        assert_eq!(evt.sender_id.as_deref(), Some("telegram-chat-12345"));
+        assert_eq!(evt.channel.as_deref(), Some("telegram"));
+
+        // And the JSON shape: new fields are `#[serde(default,
+        // skip_serializing_if = Option::is_none)]` so an event without
+        // them (the dashboard-direct / cron / autonomous path) emits the
+        // pre-fix payload byte-identically. This pins the wire-compat.
+        let bare = ApprovalRequestedEvent {
+            request_id: "req".to_string(),
+            agent_id: "agent".to_string(),
+            tool_name: "tool".to_string(),
+            description: "desc".to_string(),
+            risk_level: "low".to_string(),
+            sender_id: None,
+            channel: None,
+        };
+        let json = serde_json::to_string(&bare).unwrap();
+        assert!(
+            !json.contains("sender_id"),
+            "absent sender_id must be omitted, got: {json}"
+        );
+        assert!(
+            !json.contains(r#""channel""#),
+            "absent channel must be omitted, got: {json}"
+        );
     }
 
     #[test]

--- a/crates/librefang-channels/tests/bridge_integration_test.rs
+++ b/crates/librefang-channels/tests/bridge_integration_test.rs
@@ -1626,6 +1626,7 @@ async fn test_approval_listener_delivers_to_configured_recipients() {
         tool_name: "shell_exec".to_string(),
         description: "rm -rf /tmp/foo".to_string(),
         risk_level: "high".to_string(),
+        ..Default::default()
     };
     let event = Arc::new(Event::new(
         AgentId::new(),
@@ -1696,6 +1697,7 @@ async fn test_approval_listener_skips_adapter_without_recipients() {
                 tool_name: "shell_exec".to_string(),
                 description: "ls".to_string(),
                 risk_level: "low".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -1786,6 +1788,7 @@ async fn test_approval_listener_scopes_delivery_to_requesting_agent_adapter() {
                 tool_name: "shell_exec".to_string(),
                 description: "rm -rf /tmp/foo".to_string(),
                 risk_level: "high".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -1865,6 +1868,7 @@ async fn test_approval_listener_skips_unbound_adapter() {
                 tool_name: "shell_exec".to_string(),
                 description: "ls".to_string(),
                 risk_level: "low".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -1929,6 +1933,7 @@ async fn test_approval_listener_drops_malformed_agent_id() {
                 tool_name: "shell_exec".to_string(),
                 description: "rm -rf /tmp/foo".to_string(),
                 risk_level: "high".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -2012,6 +2017,7 @@ async fn test_approval_listener_does_not_fall_back_from_qualified_to_bare_key() 
                 tool_name: "shell_exec".to_string(),
                 description: "rm -rf /tmp/foo".to_string(),
                 risk_level: "high".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -2107,6 +2113,7 @@ async fn test_approval_listener_scopes_to_non_telegram_multibot_adapter() {
                 tool_name: "shell_exec".to_string(),
                 description: "rm -rf /tmp/foo".to_string(),
                 risk_level: "high".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -2215,6 +2222,7 @@ async fn test_approval_listener_falls_back_to_agent_binding_when_default_unset()
                 tool_name: "shell_exec".to_string(),
                 description: "rm -rf /tmp/foo".to_string(),
                 risk_level: "high".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -2293,6 +2301,7 @@ async fn test_approval_listener_binding_fallback_does_not_leak_cross_agent() {
                 tool_name: "shell_exec".to_string(),
                 description: "ls".to_string(),
                 risk_level: "low".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -2366,6 +2375,7 @@ async fn test_approval_listener_fans_out_to_all_bound_chats() {
                 tool_name: "shell_exec".to_string(),
                 description: "rm -rf /tmp/foo".to_string(),
                 risk_level: "high".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -2446,6 +2456,7 @@ async fn test_approval_listener_skips_binding_with_no_peer_id() {
                 tool_name: "shell_exec".to_string(),
                 description: "ls".to_string(),
                 risk_level: "low".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");
@@ -2513,6 +2524,7 @@ async fn test_approval_listener_binding_respects_account_id_scope() {
                 tool_name: "shell_exec".to_string(),
                 description: "rm".to_string(),
                 risk_level: "high".to_string(),
+                ..Default::default()
             }),
         )))
         .expect("broadcast send");

--- a/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
+++ b/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
@@ -131,7 +131,12 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
             tool_use_id: None,
         };
 
-        // Publish an ApprovalRequested event so channel adapters can notify users
+        // Publish an ApprovalRequested event so channel adapters can notify users.
+        // Blocking path: the `KernelHandle::request_approval` signature does
+        // not carry sender context (it's used by tools that wait inline),
+        // so sender_id / channel are `None` here. Channel listener falls
+        // back to its `notification_recipients` + `AgentBinding` fan-out
+        // for these — same behaviour as pre-fix.
         {
             use librefang_types::event::{
                 ApprovalRequestedEvent, Event, EventPayload, EventTarget,
@@ -145,6 +150,8 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
                     tool_name: tool_name.to_string(),
                     description: description.clone(),
                     risk_level: format!("{:?}", risk_level),
+                    sender_id: None,
+                    channel: None,
                 }),
             );
             self.events.event_bus.publish(event).await;
@@ -267,6 +274,16 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
         let agent_display = self.approval_agent_display(agent_id);
         let description = format!("Agent {} requests to execute {}", agent_display, tool_name);
         let request_id = uuid::Uuid::new_v4();
+        // The deferred payload built in `tool_runner::dispatch.rs`
+        // carries the channel + sender from the agent_loop's
+        // `SenderContext`. Pre-fix these were hardcoded to `None`,
+        // which is what stranded Telegram approvals — the channel
+        // listener had no idea which chat to route the
+        // `[Approve] [Deny]` keyboard to and silently dropped the
+        // notification (only a DEBUG line, nothing visible to the
+        // operator).
+        let routed_sender_id = deferred.sender_id.clone();
+        let routed_channel = deferred.channel.clone();
         let req = TypedRequest {
             id: request_id,
             agent_id: agent_id.to_string(),
@@ -279,8 +296,8 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
             risk_level,
             requested_at: chrono::Utc::now(),
             timeout_secs: policy.timeout_secs,
-            sender_id: None,
-            channel: None,
+            sender_id: routed_sender_id.clone(),
+            channel: routed_channel.clone(),
             route_to: Vec::new(),
             escalation_count: 0,
             session_id: session_id.map(|s| s.to_string()),
@@ -296,7 +313,13 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
             .submit_request(req.clone(), deferred)
             .map_err(|e| e.to_string())?;
 
-        // Publish event + push notification (same as blocking path)
+        // Publish event + push notification (same as blocking path).
+        // The channel listener subscribes to the EventBus (NOT the
+        // approval_manager's own broadcast); the new sender_id +
+        // channel fields are what let it route the `[Approve] [Deny]`
+        // keyboard straight back to the originating chat without
+        // needing any `notification_recipients` / `AgentBinding`
+        // operator-inbox configuration.
         {
             use librefang_types::event::{
                 ApprovalRequestedEvent, Event, EventPayload, EventTarget,
@@ -310,6 +333,8 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
                     tool_name: tool_name.to_string(),
                     description: description.clone(),
                     risk_level: format!("{:?}", risk_level),
+                    sender_id: routed_sender_id,
+                    channel: routed_channel,
                 }),
             );
             self.events.event_bus.publish(event).await;

--- a/crates/librefang-types/src/event.rs
+++ b/crates/librefang-types/src/event.rs
@@ -91,7 +91,7 @@ pub enum EventPayload {
 }
 
 /// Fired when a tool invocation requires human approval before proceeding.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ApprovalRequestedEvent {
     /// The approval request ID.
     pub request_id: String,
@@ -103,6 +103,28 @@ pub struct ApprovalRequestedEvent {
     pub description: String,
     /// Risk classification.
     pub risk_level: String,
+    /// Platform user id of the chat that originated the agent message
+    /// whose tool call now needs approval. Populated when the request
+    /// reached the agent via a channel adapter (Telegram / Slack /
+    /// Discord etc.); `None` for non-channel sources (dashboard direct
+    /// invocation, cron, autonomous loops).
+    ///
+    /// The channel approval listener uses this to route the
+    /// `[Approve] [Deny]` keyboard **back to the originating chat** —
+    /// no `notification_recipients` / `AgentBinding` configuration
+    /// required for the common case where the user is talking to the
+    /// agent in a single chat. Skipped from JSON when absent so the
+    /// pre-fix event shape stays compatible for consumers that never
+    /// looked at this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_id: Option<String>,
+    /// Channel-type string (`"telegram"`, `"discord"`, …) the request
+    /// originated from. `None` for non-channel sources. Paired with
+    /// `sender_id` for the direct-route path; both must be set for
+    /// the listener to fast-path; otherwise it falls back to the
+    /// pre-fix `notification_recipients` + `AgentBinding` fan-out.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
 }
 
 /// Payload for `EventPayload::ApprovalResolved`.


### PR DESCRIPTION
## Problem

After #5483 ([inline keyboard for approval notifications](https://github.com/librefang/librefang/pull/5483)) landed, a fresh Telegram-sidecar install still doesn't see any approval popup — the inline-keyboard delivery path is correct, but the channel listener has no way to know **which chat** to deliver to. It falls back to `notification_recipients` (empty by default — that's a sidecar `ready`-event capability that no first-party sidecar populates yet) and `AgentBinding` (no entries in the out-of-the-box config), and the approval gets silently dropped at the `if recipients.is_empty()` DEBUG line.

Root cause: the kernel-wide EventBus payload for approvals (`librefang-types::event::ApprovalRequestedEvent`) carries only `request_id` / `agent_id` / `tool_name` / `description` / `risk_level`. The agent_loop knows the originating `(sender_id, channel)` for every tool call — and `DeferredToolExecution` already carries it — but `librefang-kernel/src/kernel/handles/approval_gate.rs::submit_tool_approval` hardcoded `sender_id: None, channel: None` when constructing both the `ApprovalRequest` AND the broadcast event. The listener subscribes to the event and gets a routing-blind payload.

## Fix

Three coordinated changes:

### 1. Propagate routing context on `ApprovalRequestedEvent`

```rust
pub struct ApprovalRequestedEvent {
    pub request_id: String,
    pub agent_id: String,
    pub tool_name: String,
    pub description: String,
    pub risk_level: String,
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub sender_id: Option<String>,  // NEW
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub channel: Option<String>,    // NEW
}
```

Both fields `#[serde(default, skip_serializing_if = Option::is_none)]` so any consumer that wrote a `risk_level`-and-back wire archive still parses, and the JSON shape stays byte-identical for the dashboard-direct / cron / autonomous paths that never populate them. `#[derive(Default)]` added so the 12 existing literal-initializer sites in `bridge_integration_test.rs` migrate to a single `..Default::default()` rather than the touch-everywhere churn.

### 2. Populate at the source

`approval_gate.rs::submit_tool_approval` now propagates `deferred.sender_id` / `deferred.channel` (already populated by `tool_runner::dispatch.rs:1456-1457`) into both the `ApprovalRequest` it submits AND the `ApprovalRequestedEvent` it publishes. The blocking `request_approval` path (the `KernelHandle` signature doesn't carry sender context — used by tools that wait inline) keeps `None` and continues to fall back through the legacy fan-out.

### 3. Direct-route fast path in the listener

```
spawn:
  if let (Some(sender), Some(chan)) = (approval.sender_id, approval.channel) {
      if chan == this adapter's channel-type-string && !sender.is_empty() {
          send_interactive(ChannelUser { platform_id: sender, .. }, &keyboard)
          continue;   // skip the legacy recipients fan-out below
      }
  }
  // … existing channel_default + bound_recipients_for_agent fall-back path …
```

End-to-end:

```
user chats with agent on Telegram
  → agent triggers tool needing approval
  → kernel publishes ApprovalRequested with sender_id + channel
  → listener sees channel == this adapter's channel-type
  → sends [Approve] [Deny] keyboard back to the originating chat
  → user taps a button
  → ButtonCallback { action: "/approve abc12345", .. }
  → existing /approve handler at bridge.rs:5673 resolves the approval
```

No `notification_recipients` configuration required, no `AgentBinding` rules required. The pre-fix `notification_recipients` + `AgentBinding` paths remain the fallback when `(sender_id, channel)` is absent (dashboard-direct, cron, autonomous, and the blocking-inline `request_approval` path).

## Generic, not Telegram-specific

The change lives entirely in `librefang-channels::bridge`, `librefang-types::event`, and `librefang-kernel::approval_gate`. **Nothing was added to `sdk/python/librefang/sidecar/adapters/telegram.py`**. Every channel sidecar declaring the `interactive` capability (Telegram today; Slack / Feishu / Discord / Mattermost when their sidecars declare it) benefits automatically because the listener routes by channel-type-string and the round-trip uses `ChannelContent::ButtonCallback` which every interactive sidecar protocol already produces.

## Tests (1 new lib unit + 12 existing literal-init patches; all green)

`bridge::tests::approval_requested_event_carries_routing_fields` pins:

- New `sender_id` / `channel` fields round-trip through serde.
- The `skip_serializing_if = "Option::is_none"` guarantee that absent fields emit byte-identically to the pre-fix payload — wire-compat for any consumer that snapshotted the old event shape.

12 existing `ApprovalRequestedEvent { … }` literal initializers in `crates/librefang-channels/tests/bridge_integration_test.rs` migrated to end with `..Default::default()` so the new optional fields don't force a per-site touch.

## Verification

```
cargo check  --workspace --lib                                         # green
cargo clippy --workspace --all-targets -- -D warnings                  # zero warnings
cargo test   -p librefang-channels --lib                               # 446 passed
cargo test   -p librefang-channels --test bridge_integration_test      # 27 passed
cargo test   -p librefang-kernel --lib approval                        # 88 passed
```

## Out of scope (follow-ups)

- Smarter recipient selection when `(sender_id, channel)` matches multiple adapter instances of the same channel-type (today the fast-path picks the first matching adapter; mixed multi-bot setups should pick the bot the originating message actually came through — needs the kernel to also stamp `account_id` on the event).
- Edit-in-place on the approval message after resolution (`EditInteractive`): strike out the buttons so chat history doesn't keep dangling `[Approve] [Deny]` UI. Cosmetic; bot posts a separate confirmation today.
- A dashboard control to set `notification_recipients` so operators who DO want operator-inbox-style fan-out (not just back-to-originating-chat) have a UI for it without hand-editing config.

## Companion warning

Validating this fix end-to-end requires the agent to actually invoke a tool (not just narrate one). Small open-source models like `gemma4:8b` are unreliable at function-calling and tend to hallucinate "approval popups" in their prose instead. If post-merge the Telegram popup still doesn't appear, **first switch the default model to something with strong tool-calling** (`qwen3:14b` if you're on Ollama, or any frontier API) before assuming this PR didn't land its fix.
