### PR TITLE
ci(deploy): skip Cloudflare Pages deploy on Dependabot PRs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -50,7 +50,13 @@ jobs:
       - run: cd docs && pnpm build
 
       - name: Deploy to Cloudflare Pages
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+        # Dependabot PRs come from in-repo `dependabot/...` branches, so
+        # they match the same-repo guard below, but they run with the
+        # restricted Dependabot token which cannot read Actions secrets.
+        # Without the actor check, wrangler errors with "Not logged in"
+        # because CLOUDFLARE_API_TOKEN expands to an empty string. The
+        # post-merge push to main still triggers a real deploy.
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -52,7 +52,13 @@ jobs:
       - run: cd web && pnpm build
 
       - name: Deploy to Cloudflare Pages
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+        # Dependabot PRs come from in-repo `dependabot/...` branches, so
+        # they match the same-repo guard below, but they run with the
+        # restricted Dependabot token which cannot read Actions secrets.
+        # Without the actor check, wrangler errors with "Not logged in"
+        # because CLOUDFLARE_API_TOKEN expands to an empty string. The
+        # post-merge push to main still triggers a real deploy.
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Closes #5500

## Summary

Dependabot PRs (e.g. #5493) fail the `deploy` job in `deploy-docs.yml`
and `deploy-web.yml` because they reach the Cloudflare Pages step with
empty `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`. Wrangler then
errors with `Not logged in` ([example failed run](https://github.com/librefang/librefang/actions/runs/26261616332/job/77296081343)).

## Root cause

Dependabot PRs run with the special restricted `GITHUB_TOKEN` and **do
not** have access to repository Actions secrets by default. They only
see secrets explicitly scoped to Dependabot in repo settings, which we
don't grant for Cloudflare credentials.

The existing `if:` clause:

```yaml
if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
  || github.event.pull_request.head.repo.full_name == github.repository
```

was intended to gate the deploy step to push / dispatch / same-repo PRs
(i.e. block forks, where secrets also wouldn't be available). But
Dependabot branches like `dependabot/npm_and_yarn/docs/docs-minor-patch-…`
live in the same repo, so the same-repo guard lets them through — at
which point the empty secret values trip wrangler.

## Fix

Add `&& github.actor != 'dependabot[bot]'` to both step `if:` clauses.
This is the documented GitHub Actions + Dependabot + Cloudflare pattern.

```yaml
if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     || github.event.pull_request.head.repo.full_name == github.repository)
  && github.actor != 'dependabot[bot]'
```

Preview deploys for Dependabot PRs are intentionally skipped — they
aren't useful to reviewers for lockfile-only bumps, and granting
Dependabot the Cloudflare credentials would expose them to post-install
scripts in any npm dep the bot bumps. The post-merge push to `main`
still triggers a real deploy, so production is unaffected.

## Scope

- `deploy-docs.yml` — fixed (the workflow PR #5493 hit)
- `deploy-web.yml` — fixed (same structural bug, would have hit the next
  Dependabot bump that touches `web/`)
- `deploy-worker.yml` — left alone; no `pull_request:` trigger, so
  Dependabot never reaches it

## Verification

- `git diff --stat` → two `if:` lines + comment in each file, no other
  changes
- Diff is workflow-only, no Rust/SDK code touched
- The fix is testable end-to-end on the next Dependabot PR after merge;
  this PR's own CI does not exercise the changed step

## Out of scope

Granting Dependabot a scoped set of secrets (the alternative fix) is a
repo-settings change, not a code change, and carries a small
supply-chain risk. Not pursued here.
