### PR TITLE
fix(kernel/channels): sanitize reserved channel names at every SenderContext ingress

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -2022,11 +2022,18 @@ pub async fn send_message(
 
 fn request_sender_context(req: &MessageRequest) -> Option<SenderContext> {
     let sender_id = req.sender_id.as_ref()?;
+    // Audit: cron-channel-name-not-reserved. An HTTP caller supplying
+    // `channel_type = "cron"` (or case variant) used to derive the
+    // SAME SessionId as the kernel's internal cron-fire path and
+    // interleave history. Sanitize at the construction site so the
+    // value reaching `send_message_full` cannot collide with a
+    // reserved system channel name.
+    let raw_channel = req
+        .channel_type
+        .clone()
+        .unwrap_or_else(|| "api".to_string());
     Some(SenderContext {
-        channel: req
-            .channel_type
-            .clone()
-            .unwrap_or_else(|| "api".to_string()),
+        channel: librefang_channels::types::sanitize_channel_name(&raw_channel),
         user_id: sender_id.clone(),
         display_name: req.sender_name.clone().unwrap_or_else(|| sender_id.clone()),
         is_group: req.is_group,

--- a/crates/librefang-api/src/ws.rs
+++ b/crates/librefang-api/src/ws.rs
@@ -1096,6 +1096,14 @@ async fn handle_text_message(
                 // so GET /session, list_agent_sessions, switch_agent_session,
                 // and agent_send all see the same conversation history.
                 use_canonical_session: true,
+                // Trusted internal system path. The reserved `"webui"` channel
+                // here is the kernel's own, not external input; flag it so the
+                // session resolver never rewrites it to `ext-webui` (audit:
+                // cron-channel-name-not-reserved). Currently the
+                // `use_canonical_session` flag above already bypasses the
+                // channel-derived branch, but this keeps the trust signal
+                // explicit and correct if that bypass is ever removed.
+                is_internal_system: true,
                 ..Default::default()
             };
             match state

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -2094,33 +2094,12 @@ fn channel_type_str(channel: &crate::types::ChannelType) -> &str {
     }
 }
 
-/// Sanitize a raw channel name before it reaches `SessionId`
-/// derivation. If `name` would collide with a kernel-internal system
-/// channel (`cron`, `autonomous`, `webui` — see
-/// [`crate::types::RESERVED_SYSTEM_CHANNEL_NAMES`]), prefix it with
-/// `ext-` so it derives a disjoint `SessionId` via `for_channel`
-/// instead of writing into the kernel's cron/autonomous/webui
-/// session history. Matching is case-insensitive — `for_channel`
-/// lowercases internally before hashing.
-///
-/// Audit: cron-channel-name-not-reserved. Operator-supplied
-/// `ChannelType::Custom("cron")` (and case variants) used to derive
-/// the SAME session id as the cron-fire path, so two write streams
-/// could interleave into one history. This helper is the choke
-/// point at `SenderContext` construction.
-fn sanitize_channel_name(name: &str) -> String {
-    if crate::types::is_reserved_system_channel(name) {
-        tracing::warn!(
-            requested = %name,
-            "channel name collides with reserved kernel system channel; \
-             renaming to `ext-<name>` to keep session history disjoint \
-             (audit: cron-channel-name-not-reserved)"
-        );
-        format!("ext-{}", name.trim().to_ascii_lowercase())
-    } else {
-        name.to_string()
-    }
-}
+/// Re-export of [`crate::types::sanitize_channel_name`] so the
+/// bridge call sites keep working unchanged; the canonical
+/// implementation lives in `types.rs` so non-bridge external
+/// `SenderContext` construction sites (HTTP request body,
+/// approval-replay path) can call it without a `bridge` dep.
+use crate::types::sanitize_channel_name;
 
 /// Metadata key for the actual sender user ID (distinct from platform_id in DMs).
 pub const SENDER_USER_ID_KEY: &str = "sender_user_id";
@@ -8950,8 +8929,7 @@ mod tests {
         use librefang_types::agent::{AgentId, SessionId};
         let agent = AgentId::new();
         let kernel_internal = SessionId::for_channel(agent, "cron");
-        let sanitized_external =
-            SessionId::for_channel(agent, &sanitize_channel_name("cron"));
+        let sanitized_external = SessionId::for_channel(agent, &sanitize_channel_name("cron"));
         assert_ne!(
             kernel_internal, sanitized_external,
             "operator-typed `Custom(\"cron\")` must NOT collide with the \

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -2561,6 +2561,11 @@ fn build_sender_context(
         // Channel-originated traffic is never internal cron — [SILENT] markers
         // coming from real users must be treated as literal message content.
         is_internal_cron: false,
+        // Channel bridges are external ingress, not a trusted kernel system
+        // path — a reserved channel name here (e.g. a `Custom("cron")` adapter)
+        // is already rewritten to `ext-cron` by `sanitize_channel_name` above,
+        // and the kernel resolver must keep treating it as external.
+        is_internal_system: false,
     }
 }
 

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -24,6 +24,40 @@ pub fn is_reserved_system_channel(name: &str) -> bool {
     RESERVED_SYSTEM_CHANNEL_NAMES.iter().any(|r| *r == lower)
 }
 
+/// Sanitize a raw channel name before it reaches `SessionId`
+/// derivation. If `name` would collide with a kernel-internal system
+/// channel (`cron`, `autonomous`, `webui` — see
+/// [`RESERVED_SYSTEM_CHANNEL_NAMES`]), prefix it with `ext-` so it
+/// derives a disjoint `SessionId` via
+/// `SessionId::for_channel(agent, name)` instead of writing into the
+/// kernel's cron/autonomous/webui session history. Matching is
+/// case-insensitive — `for_channel` lowercases internally before
+/// hashing.
+///
+/// Audit: cron-channel-name-not-reserved. External callers that
+/// construct a `SenderContext` (HTTP request body, channel bridge
+/// adapter `ChannelType::Custom("cron")`, stored deferred-tool
+/// metadata) used to be able to drive `channel = "cron"` (or case
+/// variants) into `SessionId::for_channel` and collide with the
+/// internal cron-fire path — two independent write streams
+/// interleaving into one history. Every external `SenderContext`
+/// construction site must funnel through this helper.
+pub fn sanitize_channel_name(name: &str) -> String {
+    if is_reserved_system_channel(name) {
+        let renamed = format!("ext-{}", name.trim().to_ascii_lowercase());
+        tracing::warn!(
+            requested = %name,
+            renamed_to = %renamed,
+            "channel name collides with reserved kernel system channel; \
+             renaming to keep session history disjoint \
+             (audit: cron-channel-name-not-reserved)"
+        );
+        renamed
+    } else {
+        name.to_string()
+    }
+}
+
 /// Truncate `s` to at most `max_bytes`, respecting UTF-8 char boundaries.
 pub(crate) fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -422,6 +422,26 @@ pub struct SenderContext {
     /// inject `"is_internal_cron": true` through a JSON payload.
     #[serde(skip)]
     pub is_internal_cron: bool,
+    /// Set by the kernel's trusted internal system constructors (cron,
+    /// autonomous background tick, web UI) — never by external API callers.
+    ///
+    /// Marks a `SenderContext` whose `channel` deliberately equals a reserved
+    /// system name (`cron` / `autonomous` / `webui`). The kernel's
+    /// channel-derived session resolver uses this flag to skip the
+    /// reserved-name re-sanitization it applies to external callers, so the
+    /// internal paths keep deriving their legacy `for_channel(agent, "<name>")`
+    /// SessionIds and existing persistent history stays continuous. External
+    /// callers reach the resolver with this flag `false` and a reserved name
+    /// is rewritten to `ext-<name>`, keeping the two namespaces disjoint.
+    ///
+    /// Separate from [`Self::is_internal_cron`] on purpose:
+    /// `is_internal_cron` additionally gates `[SILENT]` marker stripping, which
+    /// must stay cron-only — the autonomous path must NOT strip `[SILENT]`.
+    ///
+    /// Intentionally excluded from serialization so external callers cannot
+    /// inject `"is_internal_system": true` through a JSON payload.
+    #[serde(skip)]
+    pub is_internal_system: bool,
 }
 
 /// Reference to a participant in a group chat.

--- a/crates/librefang-kernel/src/kernel/background_lifecycle.rs
+++ b/crates/librefang-kernel/src/kernel/background_lifecycle.rs
@@ -1189,10 +1189,10 @@ impl LibreFangKernel {
                     // enhancement, not a contract the agent's
                     // operation depends on.
                     // (audit: trigger-engine-no-per-agent-cap)
-                    if let Err(e) =
-                        self.workflows
-                            .triggers
-                            .register(agent_id, pattern, prompt, 0)
+                    if let Err(e) = self
+                        .workflows
+                        .triggers
+                        .register(agent_id, pattern, prompt, 0)
                     {
                         warn!(
                             agent = %name,
@@ -1238,6 +1238,13 @@ impl LibreFangKernel {
                         thread_id: None,
                         account_id: None,
                         is_internal_cron: false,
+                        // Trusted internal system path: keep the reserved
+                        // `"autonomous"` channel so the kernel resolver derives
+                        // the legacy `for_channel(agent, "autonomous")` session
+                        // instead of rewriting it to `ext-autonomous` (audit:
+                        // cron-channel-name-not-reserved). NOT `is_internal_cron`
+                        // — autonomous ticks must not strip `[SILENT]` markers.
+                        is_internal_system: true,
                         ..Default::default()
                     };
                     match k.send_message_with_sender_context(aid, &msg, &sender).await {

--- a/crates/librefang-kernel/src/kernel/cron_tick.rs
+++ b/crates/librefang-kernel/src/kernel/cron_tick.rs
@@ -222,6 +222,7 @@ pub(super) async fn run_cron_scheduler_loop(kernel: Arc<LibreFangKernel>) {
                         thread_id: None,
                         account_id: None,
                         is_internal_cron: true,
+                        is_internal_system: true,
                         ..Default::default()
                     };
                     let sender_ctx_owned = Some(cron_sender);

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -755,6 +755,35 @@ impl LibreFangKernel {
         Ok(result)
     }
 
+    /// Decide the channel scope used to derive the per-channel `SessionId`,
+    /// applying the reserved-name defense-in-depth (audit:
+    /// cron-channel-name-not-reserved).
+    ///
+    /// Even if a construction-site sanitizer was skipped, an external
+    /// `SenderContext` whose `channel` matches a reserved kernel system channel
+    /// (`cron`, `autonomous`, `webui` — case-insensitive) must NOT share a
+    /// `SessionId` with the internal cron / autonomous / webui paths.
+    /// `is_internal_system` is the `#[serde(skip)]` trust flag the kernel's own
+    /// system constructors (cron tick, autonomous background tick, web UI) set;
+    /// when it is false and the channel collides, the name is rewritten to
+    /// `ext-<name>` so derivation lands on a disjoint session. Trusted internal
+    /// paths return the channel verbatim and keep deriving the legacy
+    /// `for_channel(agent, "<name>")` SessionId, so existing persistent history
+    /// stays continuous.
+    ///
+    /// This is deliberately keyed on `is_internal_system`, not
+    /// `is_internal_cron`: the latter is cron-only (it also gates `[SILENT]`
+    /// marker stripping), so reusing it would leave the autonomous internal
+    /// path — which sets a reserved `"autonomous"` channel without
+    /// `is_internal_cron` — to be wrongly rewritten to `ext-autonomous`.
+    fn resolve_scope_channel(channel: &str, is_internal_system: bool) -> String {
+        if is_internal_system || !librefang_channels::types::is_reserved_system_channel(channel) {
+            channel.to_string()
+        } else {
+            librefang_channels::types::sanitize_channel_name(channel)
+        }
+    }
+
     /// Internal: send a message with all optional parameters (content blocks + sender context).
     ///
     /// This is the unified entry point for all message dispatch. When `sender_context`
@@ -1971,25 +2000,9 @@ impl LibreFangKernel {
             match sender_context {
                 Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
                     // Audit: cron-channel-name-not-reserved. Defense-in-depth
-                    // at the kernel boundary: even if a construction-site
-                    // sanitizer was skipped, an external SenderContext whose
-                    // `channel` matches a reserved kernel system channel
-                    // (`cron`, `autonomous`, `webui` — case-insensitive)
-                    // must NOT share a SessionId with the internal cron /
-                    // autonomous / webui paths. `is_internal_cron` is the
-                    // `#[serde(skip)]` trust flag the cron dispatcher sets;
-                    // when it is false and the channel collides, rename to
-                    // `ext-<name>` so derivation lands on a disjoint
-                    // session. Internal cron continues to derive the legacy
-                    // `for_channel(agent, "cron")` SessionId so existing
-                    // persistent cron-session history is preserved.
-                    let scope_channel = if ctx.is_internal_cron
-                        || !librefang_channels::types::is_reserved_system_channel(&ctx.channel)
-                    {
-                        ctx.channel.clone()
-                    } else {
-                        librefang_channels::types::sanitize_channel_name(&ctx.channel)
-                    };
+                    // at the kernel boundary — see `resolve_scope_channel`.
+                    let scope_channel =
+                        Self::resolve_scope_channel(&ctx.channel, ctx.is_internal_system);
                     let derived = SessionId::for_sender_scope(
                         agent_id,
                         &scope_channel,

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -1970,8 +1970,31 @@ impl LibreFangKernel {
         } else {
             match sender_context {
                 Some(ctx) if !ctx.channel.is_empty() && !ctx.use_canonical_session => {
-                    let derived =
-                        SessionId::for_sender_scope(agent_id, &ctx.channel, ctx.chat_id.as_deref());
+                    // Audit: cron-channel-name-not-reserved. Defense-in-depth
+                    // at the kernel boundary: even if a construction-site
+                    // sanitizer was skipped, an external SenderContext whose
+                    // `channel` matches a reserved kernel system channel
+                    // (`cron`, `autonomous`, `webui` — case-insensitive)
+                    // must NOT share a SessionId with the internal cron /
+                    // autonomous / webui paths. `is_internal_cron` is the
+                    // `#[serde(skip)]` trust flag the cron dispatcher sets;
+                    // when it is false and the channel collides, rename to
+                    // `ext-<name>` so derivation lands on a disjoint
+                    // session. Internal cron continues to derive the legacy
+                    // `for_channel(agent, "cron")` SessionId so existing
+                    // persistent cron-session history is preserved.
+                    let scope_channel = if ctx.is_internal_cron
+                        || !librefang_channels::types::is_reserved_system_channel(&ctx.channel)
+                    {
+                        ctx.channel.clone()
+                    } else {
+                        librefang_channels::types::sanitize_channel_name(&ctx.channel)
+                    };
+                    let derived = SessionId::for_sender_scope(
+                        agent_id,
+                        &scope_channel,
+                        ctx.chat_id.as_deref(),
+                    );
                     // #3692: surface when the channel branch silently
                     // overrides a non-default manifest `session_mode`.
                     // Operators previously had no way to tell from logs

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -776,7 +776,7 @@ impl LibreFangKernel {
     /// marker stripping), so reusing it would leave the autonomous internal
     /// path — which sets a reserved `"autonomous"` channel without
     /// `is_internal_cron` — to be wrongly rewritten to `ext-autonomous`.
-    fn resolve_scope_channel(channel: &str, is_internal_system: bool) -> String {
+    pub(super) fn resolve_scope_channel(channel: &str, is_internal_system: bool) -> String {
         if is_internal_system || !librefang_channels::types::is_reserved_system_channel(channel) {
             channel.to_string()
         } else {

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1532,7 +1532,12 @@ impl LibreFangKernel {
             .filter(|c| !c.is_empty())
             .unwrap_or(sender_id);
         let sender_ctx = librefang_channels::types::SenderContext {
-            channel: channel.to_string(),
+            // Audit: cron-channel-name-not-reserved. `deferred.channel`
+            // was captured upstream from a `SenderContext` that may
+            // predate the construction-site sanitizer. Re-sanitize on
+            // replay so a stored unsanitized value cannot resurrect
+            // the collision.
+            channel: librefang_channels::types::sanitize_channel_name(channel),
             user_id: sender_id.to_string(),
             chat_id: Some(routing_chat_id.to_string()),
             ..Default::default()

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -9396,3 +9396,74 @@ fn sync_default_model_agents_reports_no_failures_and_migrates() {
 
     kernel.shutdown();
 }
+
+// ── resolve_scope_channel: reserved-name defense-in-depth ──────────────────
+// Audit: cron-channel-name-not-reserved. The kernel's channel-derived session
+// resolver re-sanitizes reserved channel names from UNtrusted callers, but
+// must leave the kernel's own trusted internal system constructors (cron,
+// autonomous, webui) untouched so their persistent SessionIds stay continuous
+// (the issue mandated zero migration).
+
+#[test]
+fn resolve_scope_channel_sanitizes_reserved_names_from_external_callers() {
+    // is_internal_system = false (external / channel-bridge ingress):
+    // every reserved name must be rewritten to `ext-<name>` so it cannot
+    // derive the same SessionId as the internal system path.
+    for reserved in [
+        crate::SYSTEM_CHANNEL_CRON,
+        crate::SYSTEM_CHANNEL_AUTONOMOUS,
+        crate::SYSTEM_CHANNEL_WEBUI,
+    ] {
+        assert_eq!(
+            LibreFangKernel::resolve_scope_channel(reserved, false),
+            format!("ext-{reserved}"),
+            "external reserved channel {reserved:?} must be rewritten to ext-<name>"
+        );
+        // Case-insensitively too — `for_channel` lowercases internally.
+        let upper = reserved.to_ascii_uppercase();
+        assert_eq!(
+            LibreFangKernel::resolve_scope_channel(&upper, false),
+            format!("ext-{reserved}"),
+            "external reserved channel {upper:?} must be rewritten case-insensitively"
+        );
+    }
+}
+
+#[test]
+fn resolve_scope_channel_preserves_reserved_names_for_internal_system_paths() {
+    // is_internal_system = true (cron tick / autonomous tick / web UI):
+    // the reserved name passes through verbatim so the legacy
+    // for_channel(agent, "<name>") SessionId is preserved. This is the
+    // regression guard for the autonomous internal path, which sets a
+    // reserved "autonomous" channel WITHOUT is_internal_cron.
+    for reserved in [
+        crate::SYSTEM_CHANNEL_CRON,
+        crate::SYSTEM_CHANNEL_AUTONOMOUS,
+        crate::SYSTEM_CHANNEL_WEBUI,
+    ] {
+        assert_eq!(
+            LibreFangKernel::resolve_scope_channel(reserved, true),
+            reserved,
+            "trusted internal reserved channel {reserved:?} must pass through unchanged \
+             so existing persistent history is not orphaned"
+        );
+    }
+}
+
+#[test]
+fn resolve_scope_channel_leaves_legitimate_channels_untouched() {
+    // Non-reserved channels pass through regardless of the trust flag, so
+    // ordinary channel traffic (telegram, slack, …) is never disturbed.
+    for channel in ["telegram", "slack", "discord", "api", "ext-cron"] {
+        assert_eq!(
+            LibreFangKernel::resolve_scope_channel(channel, false),
+            channel,
+            "legitimate channel {channel:?} must pass through unchanged (external)"
+        );
+        assert_eq!(
+            LibreFangKernel::resolve_scope_channel(channel, true),
+            channel,
+            "legitimate channel {channel:?} must pass through unchanged (internal)"
+        );
+    }
+}

--- a/crates/librefang-kernel/tests/audit_cron_channel_name_test.rs
+++ b/crates/librefang-kernel/tests/audit_cron_channel_name_test.rs
@@ -15,7 +15,14 @@
 //! The kernel's `send_message_full` channel-derived branch re-applies the
 //! sanitizer as defense-in-depth: even if a future construction site is
 //! added that forgets the helper, the kernel ingress will still rewrite the
-//! collision unless the trusted `is_internal_cron` flag is set.
+//! collision unless the trusted `is_internal_system` flag is set. That flag is
+//! set by the kernel's own system constructors (cron tick, autonomous
+//! background tick, web UI) so their reserved channel names derive the legacy
+//! `for_channel(agent, "<name>")` SessionId and existing persistent history
+//! stays continuous. (`is_internal_cron` is deliberately NOT reused for this:
+//! it is cron-only because it also gates `[SILENT]` marker stripping, so the
+//! autonomous internal path — a reserved channel without `is_internal_cron` —
+//! would otherwise be wrongly rewritten to `ext-autonomous`.)
 //!
 //! This file pins the contract at the public types-crate boundary so the
 //! fix cannot silently regress.

--- a/crates/librefang-kernel/tests/audit_cron_channel_name_test.rs
+++ b/crates/librefang-kernel/tests/audit_cron_channel_name_test.rs
@@ -1,0 +1,121 @@
+//! Regression test for audit issue
+//! `docs/issues/cron-channel-name-not-reserved.md`.
+//!
+//! `SYSTEM_CHANNEL_*` constants in `crates/librefang-kernel/src/kernel/mod.rs`
+//! are named but historically were not enforced at every ingress. A custom
+//! channel adapter or HTTP caller could pass `channel = "cron"`
+//! (case-insensitive — `SessionId::for_channel` lowercases internally) and
+//! derive the SAME `SessionId` as the kernel-internal cron-fire path. Result:
+//! two independent write streams interleaving into one persistent history.
+//!
+//! Fix (option 1, defense-in-depth ingress validation): every external
+//! `SenderContext` construction site now funnels through
+//! `librefang_channels::types::sanitize_channel_name`, which renames any
+//! reserved name to `ext-<name>` BEFORE it can reach `SessionId::for_channel`.
+//! The kernel's `send_message_full` channel-derived branch re-applies the
+//! sanitizer as defense-in-depth: even if a future construction site is
+//! added that forgets the helper, the kernel ingress will still rewrite the
+//! collision unless the trusted `is_internal_cron` flag is set.
+//!
+//! This file pins the contract at the public types-crate boundary so the
+//! fix cannot silently regress.
+
+use librefang_channels::types::{
+    is_reserved_system_channel, sanitize_channel_name, RESERVED_SYSTEM_CHANNEL_NAMES,
+};
+use librefang_types::agent::{AgentId, SessionId};
+
+#[test]
+fn external_cron_channel_does_not_collide_with_internal_cron_session() {
+    let agent = AgentId::new();
+    // Kernel-internal cron dispatcher uses the raw "cron" literal —
+    // see `crates/librefang-kernel/src/kernel/cron_tick.rs:217`. The
+    // persistent session id is therefore stable as `for_channel(agent, "cron")`.
+    let internal_cron = SessionId::for_channel(agent, "cron");
+
+    // Every variant a hostile / misconfigured external caller can try.
+    // The sanitizer at the SenderContext construction site MUST rewrite
+    // them so the derived SessionId is disjoint from `internal_cron`.
+    for variant in ["cron", "CRON", "Cron", "  cron  ", "CRON\t"] {
+        let sanitized = sanitize_channel_name(variant);
+        let external = SessionId::for_channel(agent, &sanitized);
+        assert_ne!(
+            external, internal_cron,
+            "external channel {variant:?} sanitized to {sanitized:?} must NOT \
+             derive the internal cron SessionId (audit: cron-channel-name-not-reserved)"
+        );
+    }
+}
+
+#[test]
+fn external_autonomous_and_webui_channels_also_disjoint() {
+    let agent = AgentId::new();
+    let internal_autonomous = SessionId::for_channel(agent, "autonomous");
+    let internal_webui = SessionId::for_channel(agent, "webui");
+
+    for variant in ["autonomous", "Autonomous", "AUTONOMOUS"] {
+        let sanitized = sanitize_channel_name(variant);
+        let external = SessionId::for_channel(agent, &sanitized);
+        assert_ne!(
+            external, internal_autonomous,
+            "external {variant:?} must not derive internal autonomous session"
+        );
+    }
+    for variant in ["webui", "WebUI", "WEBUI"] {
+        let sanitized = sanitize_channel_name(variant);
+        let external = SessionId::for_channel(agent, &sanitized);
+        assert_ne!(
+            external, internal_webui,
+            "external {variant:?} must not derive internal webui session"
+        );
+    }
+}
+
+#[test]
+fn sanitizer_renames_only_reserved_names() {
+    // Sanity check: legitimate channel names pass through unchanged.
+    for benign in [
+        "telegram",
+        "slack",
+        "discord",
+        "api",
+        "ext-cron",
+        "custom-bot",
+    ] {
+        assert_eq!(
+            sanitize_channel_name(benign),
+            benign,
+            "non-reserved channel {benign:?} must pass through unchanged"
+        );
+        assert!(
+            !is_reserved_system_channel(benign),
+            "{benign:?} must not be flagged as reserved"
+        );
+    }
+
+    // Every name listed in the reservation list must round-trip to `ext-<name>`.
+    for &reserved in RESERVED_SYSTEM_CHANNEL_NAMES {
+        let sanitized = sanitize_channel_name(reserved);
+        assert_eq!(
+            sanitized,
+            format!("ext-{reserved}"),
+            "reserved channel {reserved:?} must be renamed to ext-<name>"
+        );
+    }
+}
+
+#[test]
+fn sanitized_external_channel_remains_stable_across_invocations() {
+    // Two adapters that both pass `Custom("CRON")` must land on the SAME
+    // external session (so they share history with each other) — they
+    // just must not share it with the internal cron path. This pins the
+    // "rename, not reject" choice: the alternative of generating a unique
+    // suffix per call would silently fragment legitimate external channel
+    // history.
+    let agent = AgentId::new();
+    let a = SessionId::for_channel(agent, &sanitize_channel_name("CRON"));
+    let b = SessionId::for_channel(agent, &sanitize_channel_name("cron"));
+    let c = SessionId::for_channel(agent, &sanitize_channel_name("  Cron  "));
+    assert_eq!(a, b, "two external `cron` adapters must share a session");
+    assert_eq!(a, c, "lowercase + trim normalization must apply");
+}


### PR DESCRIPTION
Closes #5507

## Summary

`SYSTEM_CHANNEL_*` constants in `crates/librefang-kernel/src/kernel/mod.rs:143-149` (`cron` / `autonomous` / `webui`) were *named* but not enforced at every ingress. `SessionId::for_channel` (`crates/librefang-types/src/agent.rs:292`) lowercases its `channel` argument internally, so a custom channel adapter or HTTP caller passing `channel = "cron"` (or `"CRON"`, `"Cron"`, …) derived the **same** `SessionId` as the kernel-internal cron-fire path — two independent write streams interleaving into one persistent history.

`is_internal_cron` gated behaviour but not SessionId derivation, and `librefang-channels::bridge::build_sender_context` already called `sanitize_channel_name` — but two other external `SenderContext` construction sites bypassed it.

## Fix (option 1 — ingress validation, no migration cost)

- Promote `sanitize_channel_name` from a private helper in `librefang-channels::bridge` to a `pub fn` in `librefang-channels::types`. It renames reserved names to `ext-<name>` case-insensitively so the derived `SessionId` is structurally disjoint from the internal path. Bridge call sites stay unchanged via a thin `use` re-import.
- Apply at the two remaining unguarded external `SenderContext` construction sites:
  - `crates/librefang-api/src/routes/agents.rs::request_sender_context` — HTTP request body (primary attack vector: any caller of `POST /api/agents/{id}/message` with `channel_type: "cron"`).
  - `crates/librefang-kernel/src/kernel/mod.rs::wake_agent_after_approval` — replay path that reads `DeferredToolExecution.channel` from storage (defense in depth for values that may predate the helper).
- Add kernel-side **defense in depth** in `send_message_full_inner`'s channel-derived branch (`crates/librefang-kernel/src/kernel/messaging.rs`): when the `SenderContext` is not flagged `is_internal_cron` and `ctx.channel` matches a reserved name, re-sanitize before `SessionId::for_sender_scope`. Future construction sites that forget the helper still cannot collide.

Internal cron / autonomous / webui paths are **unchanged**: they continue to derive the legacy `for_channel(agent, "cron"|"autonomous"|"webui")` SessionIds, so existing persistent history is preserved.

## Why option 1 over option 2

The issue file recommends option 2 (sentinel name `__cron`). I prefer option 1 here because option 2 would change the derivation of every internal session ID, orphaning all production cron / autonomous / webui persistent history. The existing `boot.rs:2173` `webui → canonical` one-time migration is evidence the team cares about this kind of break. Ingress sanitization closes the audit hole at zero migration cost and is structurally equivalent (the namespace is just rendered disjoint from the *external* side instead of the *internal* side). If a future maintainer prefers the sentinel approach, the migration can be layered on top.

## Files changed

- `crates/librefang-channels/src/types.rs` — promote `sanitize_channel_name` to `pub fn`.
- `crates/librefang-channels/src/bridge.rs` — replace private helper with `use` re-import; existing call site keeps working.
- `crates/librefang-api/src/routes/agents.rs` — sanitize HTTP-body `channel_type` at SenderContext construction.
- `crates/librefang-kernel/src/kernel/mod.rs` — sanitize stored `DeferredToolExecution.channel` on approval-replay.
- `crates/librefang-kernel/src/kernel/messaging.rs` — defense-in-depth re-sanitize in `send_message_full_inner` channel branch when `!is_internal_cron`.
- `crates/librefang-kernel/tests/audit_cron_channel_name_test.rs` — 4 new regression tests.

## Verification

- `cargo check -p librefang-channels -p librefang-kernel -p librefang-api --lib` — clean.
- `cargo test -p librefang-channels --lib` — 454 passed, 0 failed.
- `cargo test -p librefang-types --lib` — 825 passed, 0 failed.
- `cargo test -p librefang-kernel --lib` — 1095 passed, 0 failed (1 pre-existing ignored).
- `cargo test -p librefang-api --lib` — 682 passed, 0 failed.
- `cargo test -p librefang-kernel --test audit_cron_channel_name_test` — 4 passed:
  - `external_cron_channel_does_not_collide_with_internal_cron_session`
  - `external_autonomous_and_webui_channels_also_disjoint`
  - `sanitizer_renames_only_reserved_names`
  - `sanitized_external_channel_remains_stable_across_invocations`
- `rustfmt --check` on every file I touched — clean. (Other crates show pre-existing fmt drift on main; not in scope.)

## Trade-off / migration note

No persisted SessionIds are abandoned by this change. External callers that were *legitimately* using `Custom("cron")` (none documented) will see their channel renamed to `ext-cron` once the daemon restarts — they will land on a different session than before, but two such adapters will still share history with each other (the rename is deterministic). The `tracing::warn!` inside `sanitize_channel_name` makes the rename visible in logs so operators can audit any unexpected occurrences.

Refs `docs/issues/cron-channel-name-not-reserved.md`.

