### PR TITLE
fix(api/registry): return path relative to home_dir, not absolute

### DIFF
--- a/crates/librefang-api/src/routes/registry.rs
+++ b/crates/librefang-api/src/routes/registry.rs
@@ -273,11 +273,27 @@ async fn create_registry_content(
         }
     }
 
+    // Return a path relative to `home_dir` rather than an absolute path.
+    // The absolute form leaks the operator's OS username via
+    // `/Users/<user>` (macOS) or `/home/<user>` (Linux), which is a
+    // low-severity but unnecessary information disclosure to any caller
+    // of this endpoint. Relative paths still let the dashboard show
+    // "where" the file lives under `~/.librefang/` (e.g.
+    // `providers/openai.toml`) without revealing host filesystem layout.
+    // Falls back to the absolute path's file name if `strip_prefix`
+    // fails — defensive only; `target` is constructed from `home_dir`
+    // above so the prefix should always match.
+    let relative_path = target
+        .strip_prefix(&home_dir)
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|_| {
+            std::path::PathBuf::from(target.file_name().unwrap_or(target.as_os_str()))
+        });
     Json(serde_json::json!({
         "ok": true,
         "content_type": content_type,
         "identifier": identifier,
-        "path": target.display().to_string(),
+        "path": relative_path.display().to_string(),
     }))
     .into_response()
 }

--- a/crates/librefang-api/tests/registry_content_path_test.rs
+++ b/crates/librefang-api/tests/registry_content_path_test.rs
@@ -1,0 +1,147 @@
+//! Integration tests for `POST /api/registry/content/{content_type}`.
+//!
+//! The endpoint previously returned an absolute filesystem path in its
+//! response body, which leaks the operator's OS-username structure
+//! (`/Users/<user>` on macOS, `/home/<user>` on Linux). This file pins
+//! the fix: the response's `path` field must be **relative to the
+//! kernel `home_dir`**, never the absolute path.
+//!
+//! Run: `cargo test -p librefang-api --test registry_content_path_test`
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use axum::Router;
+use librefang_api::routes::AppState;
+use librefang_api::server;
+use librefang_kernel::LibreFangKernel;
+use librefang_types::config::{DefaultModelConfig, KernelConfig};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const TEST_API_KEY: &str = "test-secret-key";
+
+struct Harness {
+    app: Router,
+    home_dir: PathBuf,
+    _tmp: tempfile::TempDir,
+    _state: Arc<AppState>,
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self._state.kernel.shutdown();
+    }
+}
+
+async fn boot() -> Harness {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Populate the registry cache so the kernel boots without network.
+    librefang_kernel::registry_sync::sync_registry(
+        tmp.path(),
+        librefang_kernel::registry_sync::DEFAULT_CACHE_TTL_SECS,
+        "",
+    );
+
+    let config = KernelConfig {
+        home_dir: tmp.path().to_path_buf(),
+        data_dir: tmp.path().join("data"),
+        api_key: TEST_API_KEY.to_string(),
+        default_model: DefaultModelConfig {
+            provider: "ollama".to_string(),
+            model: "test-model".to_string(),
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        },
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("kernel boot");
+    let kernel = Arc::new(kernel);
+    kernel.set_self_handle();
+    let home_dir = kernel.home_dir().to_path_buf();
+
+    let (app, state) = server::build_router(kernel, "127.0.0.1:0".parse().expect("addr")).await;
+
+    Harness {
+        app,
+        home_dir,
+        _tmp: tmp,
+        _state: state,
+    }
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(path)
+        .header(header::AUTHORIZATION, format!("Bearer {TEST_API_KEY}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let value: serde_json::Value = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, value)
+}
+
+/// The response `path` must be **relative** — must not start with the
+/// host's home_dir, and must not contain the OS-username-bearing
+/// `/Users/` or `/home/` prefixes from the canonical Unix layouts.
+///
+/// This is the regression test for the registry-content abs-path leak
+/// noted in `docs/issues/registry-content-abs-path-leak.md`.
+#[tokio::test(flavor = "multi_thread")]
+async fn registry_content_path_is_relative_not_absolute() {
+    let h = boot().await;
+    let body = serde_json::json!({
+        "id": "test-provider-abs-path-leak",
+        "display_name": "Test Provider",
+        "api_key_env": "TEST_PROVIDER_ABS_PATH_LEAK_API_KEY",
+        "base_url": "https://example.invalid/v1",
+        "key_required": false
+    });
+    let (status, resp) = post_json(&h.app, "/api/registry/content/provider", body).await;
+    assert_eq!(status, StatusCode::OK, "unexpected status: {resp}");
+    assert_eq!(resp.get("ok").and_then(|v| v.as_bool()), Some(true));
+
+    let path = resp
+        .get("path")
+        .and_then(|v| v.as_str())
+        .expect("response missing `path` field");
+
+    // Must not be the absolute path — i.e. must not contain the
+    // tempdir's home_dir prefix.
+    let home_str = h.home_dir.display().to_string();
+    assert!(
+        !path.contains(&home_str),
+        "response `path` leaks absolute home_dir: path={path:?}, home_dir={home_str:?}"
+    );
+
+    // Must not look like an absolute Unix path at all.
+    assert!(
+        !path.starts_with('/'),
+        "response `path` is absolute (starts with `/`): {path:?}"
+    );
+
+    // Sanity: the expected relative form is `providers/<id>.toml`.
+    assert_eq!(
+        path, "providers/test-provider-abs-path-leak.toml",
+        "expected relative `providers/<id>.toml`, got {path:?}"
+    );
+}


### PR DESCRIPTION
Closes #5508

## Summary

`register_registry_content` (`POST /api/registry/content/{content_type}`) previously returned an absolute filesystem path in its response, leaking the operator's `/Users/<user>` or `/home/<user>` layout. Strip the kernel `home_dir` prefix so the response carries a path relative to `~/.librefang/` (e.g. `providers/openai.toml`).

Chose **relative path** over **bare identifier** because the relative form still conveys *which* registry slot the entry landed in (`providers/`, `agents/`, `hands/`, `mcp/catalog/`, `skills/`, `plugins/`), which is useful informational context for any future caller. The only existing caller — the dashboard's "Add provider" wizard in `ProvidersPage.tsx` — `await`s the mutation and discards the response, so this is not a behavioural change for the live UI.

## API impact

The shape of the `path` field changes from an absolute path to a path relative to `home_dir`. The field name and JSON envelope shape are unchanged.

The endpoint is not currently described in `openapi.json` (verified — `grep -n "registry/content" openapi.json` returns no matches), so no SDK regeneration is needed.

## Files changed

- `crates/librefang-api/src/routes/registry.rs` — strip `home_dir` prefix; fall back to file name on the (defensive) `strip_prefix` failure path
- `crates/librefang-api/tests/registry_content_path_test.rs` — new integration test asserting the response `path` is relative

## Verification

- `cargo fmt` — changed files clean (`rustfmt --check` on `routes/registry.rs` and the new test file passes; pre-existing fmt drift elsewhere in the workspace is out of scope)
- `cargo check --workspace --lib` — clean
- `cargo test -p librefang-api --test registry_content_path_test` — pass (1/1, added `registry_content_path_is_relative_not_absolute`)
- `cargo test -p librefang-api --lib -- routes::registry` — pass (4/4, existing `provider_body_tests` unaffected)

Refs `docs/issues/registry-content-abs-path-leak.md`. The other three sub-findings in that rollup (`validate_template_name` lift, dashboard NUL acceptance, CSP `unsafe-inline`) are intentionally out of scope for this PR — they belong in separate PRs per the audit doc's split.
