### PR TITLE
fix(memory/migration): detect partial-upgrade drift between migrations table and user_version pragma

### DIFF
--- a/crates/librefang-memory/src/migration.rs
+++ b/crates/librefang-memory/src/migration.rs
@@ -27,6 +27,75 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
         ));
     }
 
+    // Boot-time ladder invariant: `MAX(migrations.version)` must not
+    // exceed `pragma user_version`. Each `migrate_vN` runs in its own
+    // transaction that bundles the DDL, the `INSERT INTO migrations`
+    // audit row, and the `set_schema_version` pragma bump — so under
+    // normal operation a mid-ladder crash rolls everything back atomically
+    // and the two stay in sync. Drift in the *opposite* direction
+    // (audit row present, pragma stuck behind) can still happen via:
+    //   * a refactor that moves `INSERT INTO migrations` or the pragma
+    //     update outside the per-step tx,
+    //   * manual operator surgery on one and not the other,
+    //   * two binaries racing on the same DB file.
+    // When that drift exists, the run_step! loop below would start from
+    // the wrong base (`current_version = user_version`) and silently
+    // re-apply DDL whose audit row already exists, corrupting subsequent
+    // ALTER TABLEs. Detect it here, before any per-step DDL runs.
+    //
+    // The opposite direction (`MAX(migrations) < user_version`) is the
+    // pre-#3538 audit-drift case, and is healed by the backfill at the
+    // end of this function — do not fail on it here.
+    //
+    // Skip this check on a fresh DB (`user_version == 0`): the
+    // `migrations` table itself is created by `migrate_v1`, so it does
+    // not yet exist on the very first boot.
+    //
+    // Operator recovery on `InconsistentLadder`: pick one side as
+    // canonical, then realign the other.
+    //   * If the live schema matches `table_max`:
+    //       `PRAGMA user_version = <table_max>;`
+    //   * If the live schema matches `pragma_user_version`:
+    //       `DELETE FROM migrations WHERE version > <pragma_user_version>;`
+    // Take a backup first; an incorrect choice will mis-route subsequent
+    // ALTER TABLEs.
+    if current_version > 0 {
+        let migrations_table_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='table' AND name='migrations'",
+                [],
+                |row| row.get::<_, i64>(0).map(|n| n > 0),
+            )
+            .unwrap_or(false);
+        if migrations_table_exists {
+            let table_max: u32 = conn
+                .query_row(
+                    "SELECT IFNULL(MAX(version), 0) FROM migrations",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0);
+            if table_max > current_version {
+                return Err(rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error {
+                        code: rusqlite::ffi::ErrorCode::DatabaseCorrupt,
+                        extended_code: 0,
+                    },
+                    Some(format!(
+                        "InconsistentLadder: migrations audit table reports \
+                         MAX(version)={table_max} but pragma user_version={current_version}. \
+                         Refusing to apply migrations from an inconsistent base. \
+                         Recovery: if live schema matches version {table_max}, run \
+                         `PRAGMA user_version = {table_max};`. If it matches version \
+                         {current_version}, run `DELETE FROM migrations WHERE version > {current_version};`. \
+                         Back up the database first."
+                    )),
+                ));
+            }
+        }
+    }
+
     macro_rules! run_step {
         ($version:expr, $migrate_fn:expr) => {
             if current_version < $version {
@@ -1643,6 +1712,104 @@ mod tests {
         }
     }
 
+    /// Boot-time ladder invariant: a DB whose `migrations` audit table
+    /// claims a higher MAX(version) than `pragma user_version` is in an
+    /// inconsistent state — `run_migrations` would otherwise restart
+    /// from the wrong base and re-apply DDL whose audit row already
+    /// exists, silently corrupting later ALTER TABLEs. Simulate the
+    /// drift, then assert `run_migrations` refuses to proceed and the
+    /// error message names both sides so the operator can recover.
+    #[test]
+    fn test_run_migrations_rejects_audit_ahead_of_pragma() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        // Simulate "audit row present, pragma stuck behind": insert a
+        // phantom future audit row without bumping user_version. This is
+        // what an out-of-tx INSERT (refactor regression) or manual
+        // operator surgery on one side would leave behind.
+        let phantom_version = SCHEMA_VERSION + 1;
+        conn.execute(
+            "INSERT INTO migrations (version, applied_at, description) \
+             VALUES (?1, datetime('now'), 'phantom test row')",
+            [phantom_version],
+        )
+        .unwrap();
+
+        let err = run_migrations(&conn).expect_err(
+            "run_migrations must refuse to proceed when MAX(migrations) > user_version",
+        );
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("InconsistentLadder"),
+            "error must name the InconsistentLadder condition, got: {msg}"
+        );
+        assert!(
+            msg.contains(&phantom_version.to_string()),
+            "error must surface the table_max ({phantom_version}) for operator recovery, got: {msg}"
+        );
+        assert!(
+            msg.contains(&SCHEMA_VERSION.to_string()),
+            "error must surface the pragma user_version ({SCHEMA_VERSION}) for operator recovery, got: {msg}"
+        );
+    }
+
+    /// Happy path: a freshly migrated DB has `MAX(migrations.version) ==
+    /// pragma user_version` and re-running `run_migrations` is a no-op.
+    /// Guards against the invariant check itself spuriously tripping on
+    /// the common path.
+    #[test]
+    fn test_run_migrations_accepts_consistent_ladder() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let table_max: u32 = conn
+            .query_row("SELECT MAX(version) FROM migrations", [], |row| row.get(0))
+            .unwrap();
+        let user_version: u32 = conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            table_max, user_version,
+            "fresh migrate must leave MAX(migrations)==user_version"
+        );
+
+        // Re-running on a consistent ladder must succeed.
+        run_migrations(&conn).expect("idempotent re-run on consistent ladder must succeed");
+    }
+
+    /// The pre-#3538 drift direction (`MAX(migrations) < user_version`)
+    /// is the legacy audit-trail drift that the backfill at the end of
+    /// `run_migrations` self-heals. The new invariant must NOT fail on
+    /// this direction or it would block every pre-#3538 prod DB from
+    /// upgrading. Guards against an over-eager equality check.
+    #[test]
+    fn test_run_migrations_tolerates_audit_behind_pragma() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        // Drop the last audit row to simulate the legacy drift.
+        conn.execute(
+            "DELETE FROM migrations WHERE version = ?1",
+            [SCHEMA_VERSION],
+        )
+        .unwrap();
+
+        // Must NOT error — the backfill heals this direction.
+        run_migrations(&conn)
+            .expect("MAX(migrations) < user_version is the #3538 self-heal path, not a fatal");
+
+        // Confirm the heal happened.
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM migrations WHERE version = ?1",
+                [SCHEMA_VERSION],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "backfill must restore the deleted audit row");
+    }
+
     /// Regression for #3538 follow-up: a DB whose migrations table is
     /// already drifted (some audit rows missing) must self-heal on the
     /// next `run_migrations` call instead of warning forever. Simulates
@@ -1730,7 +1897,11 @@ mod tests {
         )
         .unwrap();
         conn.pragma_update(None, "user_version", 37_i32).unwrap();
-        conn.execute("DELETE FROM migrations WHERE version = 38", [])
+        // Drop every audit row past v37 — a real DB at user_version=37
+        // would never have rows for v38+, and the boot-time ladder
+        // invariant (MAX(migrations) <= user_version) refuses to start
+        // otherwise.
+        conn.execute("DELETE FROM migrations WHERE version > 37", [])
             .unwrap();
 
         // Sanity: the legacy column is missing before the upgrade runs.
@@ -2621,6 +2792,9 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(n, 1, "v41 sessions index must exist exactly once after repeated boots");
+        assert_eq!(
+            n, 1,
+            "v41 sessions index must exist exactly once after repeated boots"
+        );
     }
 }


### PR DESCRIPTION
Closes #5527

## Summary

`crates/librefang-memory/src/migration.rs` now checks at the top of the migration entry point that `MAX(migrations.version) <= pragma user_version`. Partial-upgrade drift where the audit table is ahead of the pragma surfaces as a typed `InconsistentLadder` SQLite failure (extended message names both sides) instead of silently advancing from the wrong start point and re-applying DDL whose audit row already exists.

Per-step transactions preserved (whole-ladder rollback is worse per the audit). Detection-only.

The opposite drift direction (`MAX(migrations) < user_version`) is the pre-#3538 audit-trail drift and is still healed by the existing backfill at the end of `run_migrations` — the new check explicitly tolerates it.

## Why not a typed `MigrationError` enum

`run_migrations` already returns `rusqlite::Error` (mapped to `LibreFangError::memory` at the substrate boundary) and uses `rusqlite::Error::SqliteFailure` with an extended message for the existing newer-binary-refusal case. Introducing a new error enum just for one invariant would touch three callsites outside `librefang-memory/src/migration.rs` and was out of scope for this sub-finding. Followed the existing pattern instead; the error message string carries the `InconsistentLadder` discriminant + both numeric sides.

## Operator recovery

Inline at the error site:

* if the live schema matches `table_max`: `PRAGMA user_version = <table_max>;`
* if the live schema matches `pragma_user_version`: `DELETE FROM migrations WHERE version > <pragma_user_version>;`

Back up the database first.

## Test setup correction

`test_migrate_v38_backfills_second_factor_used_on_legacy_v17_schema` previously set `pragma user_version = 37` while leaving `migrations` audit rows for v38..v41 in place — a state that cannot occur in production at that version and which the new invariant correctly rejects. Cleanup expanded from `DELETE … WHERE version = 38` to `DELETE … WHERE version > 37` so the test reproduces a faithful pre-v38 DB.

## Files changed

- `crates/librefang-memory/src/migration.rs`

## Verification

- `cargo fmt -p librefang-memory -- --check` — clean
- `cargo check -p librefang-memory --lib` — clean
- `cargo clippy -p librefang-memory --all-targets -- -D warnings` — clean
- `cargo test -p librefang-memory` — 258 passed, 0 failed
- New tests: `test_run_migrations_rejects_audit_ahead_of_pragma`, `test_run_migrations_accepts_consistent_ladder`, `test_run_migrations_tolerates_audit_behind_pragma`

Refs `docs/issues/migration-ladder-partial-upgrade-hazard.md` (sub-finding "this" only).
