### PR TITLE
perf(llm-drivers): block_in_place for ImageFile reads (4 sites)

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -1273,24 +1273,26 @@ fn convert_message(msg: &Message) -> ApiMessage {
                         cache_control: None,
                     }),
                     ContentBlock::Thinking { .. } => None,
-                    ContentBlock::ImageFile { media_type, path } => match std::fs::read(path) {
-                        Ok(bytes) => {
-                            use base64::Engine;
-                            let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
-                            Some(ApiContentBlock::Image {
-                                source: ApiImageSource {
-                                    source_type: "base64".to_string(),
-                                    media_type: media_type.clone(),
-                                    data,
-                                },
-                                cache_control: None,
-                            })
+                    ContentBlock::ImageFile { media_type, path } => {
+                        match tokio::task::block_in_place(|| std::fs::read(path)) {
+                            Ok(bytes) => {
+                                use base64::Engine;
+                                let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                                Some(ApiContentBlock::Image {
+                                    source: ApiImageSource {
+                                        source_type: "base64".to_string(),
+                                        media_type: media_type.clone(),
+                                        data,
+                                    },
+                                    cache_control: None,
+                                })
+                            }
+                            Err(e) => {
+                                warn!(path = %path, error = %e, "ImageFile missing, skipping");
+                                None
+                            }
                         }
-                        Err(e) => {
-                            warn!(path = %path, error = %e, "ImageFile missing, skipping");
-                            None
-                        }
-                    },
+                    }
                     ContentBlock::Unknown => None,
                 })
                 .collect();
@@ -1379,6 +1381,54 @@ mod tests {
         let msg = Message::user("Hello");
         let api_msg = convert_message(&msg);
         assert_eq!(api_msg.role, "user");
+    }
+
+    /// Regression: `ContentBlock::ImageFile` paths must be read via
+    /// `tokio::task::block_in_place` so a multi-MB image read does not
+    /// stall the tokio worker pool. The base64-encoded bytes in the
+    /// resulting `ApiContentBlock::Image` must match the bytes on disk.
+    ///
+    /// Wrap with `flavor = "multi_thread"` so `block_in_place` does not
+    /// panic on a single-threaded runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn convert_message_imagefile_reads_bytes_without_blocking_worker() {
+        use base64::Engine;
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("img.png");
+        // Minimal PNG magic + a few payload bytes — drivers do not
+        // validate format, they only base64-encode the file contents.
+        let bytes: Vec<u8> = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3, 4];
+        std::fs::File::create(&path)
+            .and_then(|mut f| f.write_all(&bytes))
+            .expect("write png");
+
+        let msg = Message {
+            role: Role::User,
+            content: MessageContent::Blocks(vec![ContentBlock::ImageFile {
+                media_type: "image/png".to_string(),
+                path: path.to_string_lossy().into_owned(),
+            }]),
+            pinned: false,
+            timestamp: None,
+        };
+        let api_msg = convert_message(&msg);
+        let blocks = match api_msg.content {
+            ApiContent::Blocks(b) => b,
+            ApiContent::Text(_) => panic!("expected Blocks content"),
+        };
+        let img = blocks
+            .into_iter()
+            .find_map(|b| match b {
+                ApiContentBlock::Image { source, .. } => Some(source),
+                _ => None,
+            })
+            .expect("ApiContentBlock::Image present");
+        assert_eq!(img.source_type, "base64");
+        assert_eq!(img.media_type, "image/png");
+        let expected = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        assert_eq!(img.data, expected, "encoded bytes must round-trip");
     }
 
     #[test]

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -356,21 +356,24 @@ pub(crate) fn convert_messages(
                                 },
                             });
                         }
-                        ContentBlock::ImageFile { media_type, path } => match std::fs::read(path) {
-                            Ok(bytes) => {
-                                use base64::Engine;
-                                let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
-                                parts.push(GeminiPart::InlineData {
-                                    inline_data: GeminiInlineData {
-                                        mime_type: media_type.clone(),
-                                        data,
-                                    },
-                                });
+                        ContentBlock::ImageFile { media_type, path } => {
+                            match tokio::task::block_in_place(|| std::fs::read(path)) {
+                                Ok(bytes) => {
+                                    use base64::Engine;
+                                    let data =
+                                        base64::engine::general_purpose::STANDARD.encode(&bytes);
+                                    parts.push(GeminiPart::InlineData {
+                                        inline_data: GeminiInlineData {
+                                            mime_type: media_type.clone(),
+                                            data,
+                                        },
+                                    });
+                                }
+                                Err(e) => {
+                                    warn!(path = %path, error = %e, "ImageFile missing, skipping");
+                                }
                             }
-                            Err(e) => {
-                                warn!(path = %path, error = %e, "ImageFile missing, skipping");
-                            }
-                        },
+                        }
                         ContentBlock::ToolResult {
                             content, tool_name, ..
                         } => {
@@ -2386,5 +2389,47 @@ mod tests {
             "thoughtSignature: None should be skipped in serialization"
         );
         assert_eq!(json["text"], "Regular text");
+    }
+
+    /// Regression: `ContentBlock::ImageFile` paths must be read via
+    /// `tokio::task::block_in_place` so a multi-MB image read does not
+    /// stall the tokio worker pool. The base64-encoded bytes in the
+    /// resulting `GeminiPart::InlineData` must match the bytes on disk.
+    ///
+    /// Wrap with `flavor = "multi_thread"` so `block_in_place` does not
+    /// panic on a single-threaded runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn convert_messages_imagefile_reads_bytes_without_blocking_worker() {
+        use base64::Engine;
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("img.png");
+        let bytes: Vec<u8> = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 9, 8, 7];
+        std::fs::File::create(&path)
+            .and_then(|mut f| f.write_all(&bytes))
+            .expect("write png");
+
+        let messages = vec![Message {
+            role: Role::User,
+            content: MessageContent::Blocks(vec![ContentBlock::ImageFile {
+                media_type: "image/png".to_string(),
+                path: path.to_string_lossy().into_owned(),
+            }]),
+            pinned: false,
+            timestamp: None,
+        }];
+        let (contents, _) = convert_messages(&messages, &None);
+        let inline = contents
+            .into_iter()
+            .flat_map(|c| c.parts)
+            .find_map(|p| match p {
+                GeminiPart::InlineData { inline_data } => Some(inline_data),
+                _ => None,
+            })
+            .expect("GeminiPart::InlineData present");
+        assert_eq!(inline.mime_type, "image/png");
+        let expected = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        assert_eq!(inline.data, expected, "encoded bytes must round-trip");
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/ollama.rs
+++ b/crates/librefang-llm-drivers/src/drivers/ollama.rs
@@ -210,21 +210,24 @@ impl OllamaDriver {
                             ContentBlock::Image { data, .. } => {
                                 images.push(data.clone());
                             }
-                            ContentBlock::ImageFile { path, .. } => match std::fs::read(path) {
-                                Ok(bytes) => {
-                                    use base64::Engine;
-                                    images.push(
-                                        base64::engine::general_purpose::STANDARD.encode(&bytes),
-                                    );
+                            ContentBlock::ImageFile { path, .. } => {
+                                match tokio::task::block_in_place(|| std::fs::read(path)) {
+                                    Ok(bytes) => {
+                                        use base64::Engine;
+                                        images.push(
+                                            base64::engine::general_purpose::STANDARD
+                                                .encode(&bytes),
+                                        );
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            path = %path,
+                                            error = %e,
+                                            "ImageFile missing, skipping"
+                                        );
+                                    }
                                 }
-                                Err(e) => {
-                                    warn!(
-                                        path = %path,
-                                        error = %e,
-                                        "ImageFile missing, skipping"
-                                    );
-                                }
-                            },
+                            }
                             ContentBlock::Thinking { .. } | ContentBlock::ToolUse { .. } => {
                                 // Thinking and ToolUse on a User role are nonsensical —
                                 // session_repair shouldn't produce them, and the
@@ -1399,5 +1402,53 @@ mod tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    /// Regression: `ContentBlock::ImageFile` paths must be read via
+    /// `tokio::task::block_in_place` so a multi-MB image read does not
+    /// stall the tokio worker pool. The base64-encoded bytes attached
+    /// to the resulting `OllamaMessage.images` must match the bytes on
+    /// disk.
+    ///
+    /// Wrap with `flavor = "multi_thread"` so `block_in_place` does not
+    /// panic on a single-threaded runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn build_request_imagefile_reads_bytes_without_blocking_worker() {
+        use base64::Engine;
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("img.png");
+        let bytes: Vec<u8> = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 42, 43, 44];
+        std::fs::File::create(&path)
+            .and_then(|mut f| f.write_all(&bytes))
+            .expect("write png");
+
+        let driver = OllamaDriver::new(String::new(), "http://x".to_string());
+        let mut r = req("m");
+        r.messages = std::sync::Arc::new(vec![Message {
+            role: Role::User,
+            content: MessageContent::Blocks(vec![
+                ContentBlock::Text {
+                    text: "what's this?".to_string(),
+                    provider_metadata: None,
+                },
+                ContentBlock::ImageFile {
+                    media_type: "image/png".to_string(),
+                    path: path.to_string_lossy().into_owned(),
+                },
+            ]),
+            pinned: false,
+            timestamp: None,
+        }]);
+        let wire = driver.build_request(&r).expect("build");
+        let user = wire
+            .messages
+            .iter()
+            .find(|m| m.role == "user")
+            .expect("user message");
+        let images = user.images.as_ref().expect("images present");
+        let expected = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        assert_eq!(images, &vec![expected], "encoded bytes must round-trip");
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -865,7 +865,7 @@ impl OpenAIDriver {
                                 });
                             }
                             ContentBlock::ImageFile { media_type, path } => {
-                                match std::fs::read(path) {
+                                match tokio::task::block_in_place(|| std::fs::read(path)) {
                                     Ok(bytes) => {
                                         use base64::Engine;
                                         let data = base64::engine::general_purpose::STANDARD
@@ -3775,5 +3775,76 @@ mod tests {
             map_oai_finish_reason(choice.finish_reason.as_deref(), false),
             StopReason::ContentFiltered
         );
+    }
+
+    /// Regression: `ContentBlock::ImageFile` paths must be read via
+    /// `tokio::task::block_in_place` so a multi-MB image read does not
+    /// stall the tokio worker pool. The base64-encoded bytes embedded
+    /// in the resulting `OaiContentPart::ImageUrl` data URL must match
+    /// the bytes on disk.
+    ///
+    /// Wrap with `flavor = "multi_thread"` so `block_in_place` does not
+    /// panic on a single-threaded runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn build_request_imagefile_reads_bytes_without_blocking_worker() {
+        use base64::Engine;
+        use librefang_types::message::Message;
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("img.png");
+        let bytes: Vec<u8> = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 11, 22, 33];
+        std::fs::File::create(&path)
+            .and_then(|mut f| f.write_all(&bytes))
+            .expect("write png");
+
+        let driver = OpenAIDriver::new("k".to_string(), "https://api.openai.com/v1".to_string());
+        let request = CompletionRequest {
+            model: "gpt-4o-mini".to_string(),
+            messages: std::sync::Arc::new(vec![Message {
+                role: Role::User,
+                content: MessageContent::Blocks(vec![ContentBlock::ImageFile {
+                    media_type: "image/png".to_string(),
+                    path: path.to_string_lossy().into_owned(),
+                }]),
+                pinned: false,
+                timestamp: None,
+            }]),
+            tools: std::sync::Arc::new(Vec::new()),
+            max_tokens: 256,
+            temperature: 0.7,
+            system: None,
+            thinking: None,
+            prompt_caching: false,
+            cache_ttl: None,
+            prompt_cache_strategy: None,
+            response_format: None,
+            timeout_secs: None,
+            extra_body: None,
+            agent_id: None,
+            session_id: None,
+            step_id: None,
+            reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+        };
+        let wire = driver.build_request(&request).expect("build");
+        let user = wire
+            .messages
+            .iter()
+            .find(|m| m.role == "user")
+            .expect("user message");
+        let parts = match user.content.as_ref().expect("content present") {
+            OaiMessageContent::Parts(p) => p,
+            OaiMessageContent::Text(_) => panic!("expected Parts content"),
+        };
+        let url = parts
+            .iter()
+            .find_map(|p| match p {
+                OaiContentPart::ImageUrl { image_url } => Some(image_url.url.clone()),
+                _ => None,
+            })
+            .expect("OaiContentPart::ImageUrl present");
+        let expected = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let want = format!("data:image/png;base64,{expected}");
+        assert_eq!(url, want, "encoded bytes must round-trip");
     }
 }


### PR DESCRIPTION
Closes #5529

## Summary

Four LLM driver image-loading sites (`anthropic.rs:1276`, `gemini.rs:359`, `ollama.rs:213`, `openai.rs:868`) read `ContentBlock::ImageFile` paths with synchronous `std::fs::read`, blocking the current tokio worker for tens to hundreds of milliseconds per multi-MB image. They now use `tokio::task::block_in_place(|| std::fs::read(path))` so the runtime can migrate other tasks off the blocked worker.

## Files changed

- `crates/librefang-llm-drivers/src/drivers/anthropic.rs` (1 site + 1 test)
- `crates/librefang-llm-drivers/src/drivers/gemini.rs` (1 site + 1 test)
- `crates/librefang-llm-drivers/src/drivers/ollama.rs` (1 site + 1 test)
- `crates/librefang-llm-drivers/src/drivers/openai.rs` (1 site + 1 test)

## Pre-check

All four sites cited in `docs/issues/driver-blocking-fs-read.md` were still using `std::fs::read` on `origin/main` at fetch time (`9f38b30a`). None were already fixed. The openai driver does already use `tokio::fs::read(...).await` in its `attach_files` path, which is what the audit refers to when it says "Moonshot's `convert_message` correctly uses `tokio::fs::read`" — there is no `moonshot.rs` in the tree, the proof-of-pattern lives in `openai.rs:260`.

## Why `block_in_place` instead of the audit's literal `tokio::fs::read(&path).await`

`async fn`-ifying `convert_message` / `convert_messages` / `build_request` would force `.await` propagation across every caller. `gemini::convert_messages` is also called from `crates/librefang-llm-drivers/src/drivers/vertex_ai.rs` (out of scope for this PR), and many synchronous `#[test]` callers exist in the same files. `block_in_place` is the smallest local change that delivers the worker-starvation fix without rippling.

Pre-loading images at the agent-loop layer so drivers receive `Bytes` rather than a `PathBuf` (audit suggests this as a follow-up) is the cleaner structural fix and deserves its own PR.

## Verification

- `cargo fmt -p librefang-llm-drivers -- --check` — clean (rustfmt re-wrapped the new `match` arms onto multiple lines after my initial single-line edits)
- `cargo check -p librefang-llm-drivers --lib --tests` — clean
- `cargo clippy -p librefang-llm-drivers --all-targets -- -D warnings` — clean
- `cargo test -p librefang-llm-drivers` — all green, including the 4 new tests:
  - `drivers::anthropic::tests::convert_message_imagefile_reads_bytes_without_blocking_worker`
  - `drivers::gemini::tests::convert_messages_imagefile_reads_bytes_without_blocking_worker`
  - `drivers::ollama::tests::build_request_imagefile_reads_bytes_without_blocking_worker`
  - `drivers::openai::tests::build_request_imagefile_reads_bytes_without_blocking_worker`

Each test writes a tiny PNG to a `tempfile::tempdir()`, builds the wire request through the driver, and asserts the base64-encoded image data in the resulting `ApiContentBlock::Image` / `GeminiPart::InlineData` / `OllamaMessage.images` / `OaiContentPart::ImageUrl` round-trips byte-for-byte against the source bytes.

Tests are `#[tokio::test(flavor = "multi_thread")]` — `block_in_place` panics on a single-threaded runtime. The existing 523 driver tests remain green; none of them exercise `ContentBlock::ImageFile` so none of them risk hitting `block_in_place` on a default `#[tokio::test]` runtime.

## Out of scope

- Pre-loading images at the agent-loop layer so drivers receive `Bytes` rather than a `PathBuf` (mentioned as a follow-up in the audit) — a structural change deserving its own PR.
- Touching `vertex_ai.rs` / `bedrock.rs` / `openai_compat.rs` callers — none of them were affected by this fix because function signatures did not change.

Refs `docs/issues/driver-blocking-fs-read.md`.
