### PR TITLE
fix(memory): never silently default or fabricate from corrupt JSON-in-TEXT columns

### DIFF
--- a/crates/librefang-memory/src/knowledge.rs
+++ b/crates/librefang-memory/src/knowledge.rs
@@ -10,6 +10,7 @@ use librefang_types::memory::{
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use std::collections::HashMap;
+use tracing::error;
 use uuid::Uuid;
 
 /// Knowledge graph store backed by SQLite.
@@ -203,7 +204,7 @@ impl KnowledgeStore {
                     &r.s_props,
                     &r.s_created,
                     &r.s_updated,
-                ),
+                )?,
                 relation: parse_relation(
                     &r.r_source,
                     &r.r_type,
@@ -211,7 +212,7 @@ impl KnowledgeStore {
                     &r.r_props,
                     r.r_confidence,
                     &r.r_created,
-                ),
+                )?,
                 target: parse_entity(
                     &r.t_id,
                     &r.t_type,
@@ -219,7 +220,7 @@ impl KnowledgeStore {
                     &r.t_props,
                     &r.t_created,
                     &r.t_updated,
-                ),
+                )?,
             });
         }
         Ok(matches)
@@ -264,25 +265,40 @@ fn parse_entity(
     props: &str,
     created: &str,
     updated: &str,
-) -> Entity {
+) -> LibreFangResult<Entity> {
     let entity_type: EntityType =
         serde_json::from_str(etype).unwrap_or(EntityType::Custom("unknown".to_string()));
-    let properties: HashMap<String, serde_json::Value> =
-        serde_json::from_str(props).unwrap_or_default();
+    // Refuse to silently substitute `HashMap::default()` for a corrupt
+    // `properties` blob — that disguises corruption as "this entity has
+    // no properties", which the operator cannot tell apart from a row
+    // that legitimately has none (audit: json-text-silent-parse-fallback).
+    let properties: HashMap<String, serde_json::Value> = match serde_json::from_str(props) {
+        Ok(m) => m,
+        Err(e) => {
+            error!(
+                row_id = %id,
+                table = "entities",
+                column = "properties",
+                error = %e,
+                "corrupt JSON in TEXT column"
+            );
+            return Err(LibreFangError::serialization(e));
+        }
+    };
     let created_at = chrono::DateTime::parse_from_rfc3339(created)
         .map(|dt| dt.with_timezone(&Utc))
         .unwrap_or_else(|_| Utc::now());
     let updated_at = chrono::DateTime::parse_from_rfc3339(updated)
         .map(|dt| dt.with_timezone(&Utc))
         .unwrap_or_else(|_| Utc::now());
-    Entity {
+    Ok(Entity {
         id: id.to_string(),
         entity_type,
         name: name.to_string(),
         properties,
         created_at,
         updated_at,
-    }
+    })
 }
 
 fn parse_relation(
@@ -292,21 +308,36 @@ fn parse_relation(
     props: &str,
     confidence: f64,
     created: &str,
-) -> Relation {
+) -> LibreFangResult<Relation> {
     let relation: RelationType = serde_json::from_str(rtype).unwrap_or(RelationType::RelatedTo);
-    let properties: HashMap<String, serde_json::Value> =
-        serde_json::from_str(props).unwrap_or_default();
+    // Same rationale as `parse_entity`: a corrupt `properties` blob must
+    // surface as an error, not as a silent empty map (audit:
+    // json-text-silent-parse-fallback).
+    let properties: HashMap<String, serde_json::Value> = match serde_json::from_str(props) {
+        Ok(m) => m,
+        Err(e) => {
+            error!(
+                source = %source,
+                target = %target,
+                table = "relations",
+                column = "properties",
+                error = %e,
+                "corrupt JSON in TEXT column"
+            );
+            return Err(LibreFangError::serialization(e));
+        }
+    };
     let created_at = chrono::DateTime::parse_from_rfc3339(created)
         .map(|dt| dt.with_timezone(&Utc))
         .unwrap_or_else(|_| Utc::now());
-    Relation {
+    Ok(Relation {
         source: source.to_string(),
         relation,
         target: target.to_string(),
         properties,
         confidence: confidence as f32,
         created_at,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -457,5 +488,147 @@ mod tests {
         );
         assert_eq!(matches[0].source.name, "Alice");
         assert_eq!(matches[0].target.name, "Acme Corp");
+    }
+
+    /// Regression for the audit item `json-text-silent-parse-fallback`.
+    ///
+    /// Pre-fix, `parse_entity` / `parse_relation` silently substituted
+    /// `HashMap::default()` when the `properties` TEXT column failed to
+    /// parse — so a corrupt row was indistinguishable from one that
+    /// legitimately had no properties. After the fix, a corrupt
+    /// `properties` blob causes `query_graph` to fail loudly with a
+    /// `Serialization` error instead of returning a fabricated empty map.
+    #[test]
+    fn query_graph_surfaces_corrupt_entity_properties_instead_of_defaulting() {
+        let store = setup();
+        let alice_id = store
+            .add_entity(
+                Entity {
+                    id: "alice".to_string(),
+                    entity_type: EntityType::Person,
+                    name: "Alice".to_string(),
+                    properties: HashMap::new(),
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+                "test-agent",
+            )
+            .unwrap();
+        let company_id = store
+            .add_entity(
+                Entity {
+                    id: "acme".to_string(),
+                    entity_type: EntityType::Organization,
+                    name: "Acme Corp".to_string(),
+                    properties: HashMap::new(),
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+                "test-agent",
+            )
+            .unwrap();
+        store
+            .add_relation(
+                Relation {
+                    source: alice_id.clone(),
+                    relation: RelationType::WorksAt,
+                    target: company_id,
+                    properties: HashMap::new(),
+                    confidence: 0.9,
+                    created_at: Utc::now(),
+                },
+                "test-agent",
+            )
+            .unwrap();
+
+        // Corrupt Alice's `properties` blob directly — simulates a manual
+        // SQL edit, upstream serde drift, or partial-write recovery.
+        {
+            let conn = store.pool.get().unwrap();
+            conn.execute(
+                "UPDATE entities SET properties = ?1 WHERE id = ?2",
+                rusqlite::params!["this is not json", &alice_id],
+            )
+            .unwrap();
+        }
+
+        let res = store.query_graph(GraphPattern {
+            source: Some(alice_id),
+            relation: Some(RelationType::WorksAt),
+            target: None,
+            max_depth: 1,
+        });
+        assert!(
+            matches!(res, Err(LibreFangError::Serialization { .. })),
+            "corrupt entity properties must surface as Serialization, not be silently defaulted; \
+             got: {res:?}"
+        );
+    }
+
+    /// Same audit item, but the corruption is on the relation row's
+    /// `properties` column instead of the entity's.
+    #[test]
+    fn query_graph_surfaces_corrupt_relation_properties_instead_of_defaulting() {
+        let store = setup();
+        let alice_id = store
+            .add_entity(
+                Entity {
+                    id: "alice".to_string(),
+                    entity_type: EntityType::Person,
+                    name: "Alice".to_string(),
+                    properties: HashMap::new(),
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+                "test-agent",
+            )
+            .unwrap();
+        let company_id = store
+            .add_entity(
+                Entity {
+                    id: "acme".to_string(),
+                    entity_type: EntityType::Organization,
+                    name: "Acme Corp".to_string(),
+                    properties: HashMap::new(),
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+                "test-agent",
+            )
+            .unwrap();
+        let rel_id = store
+            .add_relation(
+                Relation {
+                    source: alice_id.clone(),
+                    relation: RelationType::WorksAt,
+                    target: company_id,
+                    properties: HashMap::new(),
+                    confidence: 0.9,
+                    created_at: Utc::now(),
+                },
+                "test-agent",
+            )
+            .unwrap();
+
+        {
+            let conn = store.pool.get().unwrap();
+            conn.execute(
+                "UPDATE relations SET properties = ?1 WHERE id = ?2",
+                rusqlite::params!["{not-valid-json", &rel_id],
+            )
+            .unwrap();
+        }
+
+        let res = store.query_graph(GraphPattern {
+            source: Some(alice_id),
+            relation: Some(RelationType::WorksAt),
+            target: None,
+            max_depth: 1,
+        });
+        assert!(
+            matches!(res, Err(LibreFangError::Serialization { .. })),
+            "corrupt relation properties must surface as Serialization, not be silently defaulted; \
+             got: {res:?}"
+        );
     }
 }

--- a/crates/librefang-memory/src/semantic.rs
+++ b/crates/librefang-memory/src/semantic.rs
@@ -21,7 +21,7 @@ use r2d2_sqlite::SqliteConnectionManager;
 pub use librefang_types::memory::cosine_similarity;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 /// Semantic store backed by SQLite with optional vector search.
 ///
@@ -346,8 +346,25 @@ impl SemanticStore {
                 .map_err(LibreFangError::memory)?;
             let source: MemorySource =
                 serde_json::from_str(&source_str).unwrap_or(MemorySource::System);
-            let metadata: HashMap<String, serde_json::Value> =
-                serde_json::from_str(&meta_str).unwrap_or_default();
+            // Refuse to silently substitute `HashMap::default()` for a TEXT
+            // blob we cannot parse — that disguises corruption (manual SQL
+            // edit, pre-#3451 FTS bug, serde drift) as "no metadata". Skip
+            // the row with a loud log so the operator can audit / repair it
+            // (audit: json-text-silent-parse-fallback).
+            let metadata: HashMap<String, serde_json::Value> = match serde_json::from_str(&meta_str)
+            {
+                Ok(m) => m,
+                Err(e) => {
+                    error!(
+                        row_id = %id_str,
+                        table = "memories",
+                        column = "metadata",
+                        error = %e,
+                        "corrupt JSON in TEXT column; skipping row in recall"
+                    );
+                    continue;
+                }
+            };
             let created_at = chrono::DateTime::parse_from_rfc3339(&created_str)
                 .map(|dt| dt.with_timezone(&Utc))
                 .unwrap_or_else(|_| Utc::now());
@@ -527,8 +544,10 @@ impl SemanticStore {
              FROM memories WHERE id IN ({placeholders}){deleted_clause}",
         );
         let id_strs: Vec<String> = ids.iter().map(|m| m.0.to_string()).collect();
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-            id_strs.iter().map(|s| s as &dyn rusqlite::types::ToSql).collect();
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> = id_strs
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
 
         let mut stmt = conn.prepare(&sql).map_err(LibreFangError::memory)?;
         let rows = stmt
@@ -906,10 +925,24 @@ fn decode_memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<MemoryFragment
     let agent_id = uuid::Uuid::parse_str(&agent_str)
         .map(librefang_types::agent::AgentId)
         .map_err(|e| fsql(1, rusqlite::types::Type::Text, e))?;
-    let source: MemorySource =
-        serde_json::from_str(&source_str).unwrap_or(MemorySource::System);
-    let metadata: HashMap<String, serde_json::Value> =
-        serde_json::from_str(&meta_str).unwrap_or_default();
+    let source: MemorySource = serde_json::from_str(&source_str).unwrap_or(MemorySource::System);
+    // Surface corruption rather than disguising it as "no metadata" — the
+    // caller (`get_by_id` / `get_by_ids_batch`) receives a `Result`, so a
+    // bad row should be loud, not a silent `HashMap::default()` (audit:
+    // json-text-silent-parse-fallback).
+    let metadata: HashMap<String, serde_json::Value> = match serde_json::from_str(&meta_str) {
+        Ok(m) => m,
+        Err(e) => {
+            error!(
+                row_id = %id_str,
+                table = "memories",
+                column = "metadata",
+                error = %e,
+                "corrupt JSON in TEXT column"
+            );
+            return Err(fsql(6, rusqlite::types::Type::Text, e));
+        }
+    };
     let created_at = chrono::DateTime::parse_from_rfc3339(&created_str)
         .map(|dt| dt.with_timezone(&Utc))
         .unwrap_or_else(|_| Utc::now());
@@ -955,10 +988,7 @@ fn decode_memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<MemoryFragment
 /// logged + ignored (recall already returned the fragments to
 /// the caller; we don't want to surface a write-side error on a
 /// successful read).
-fn bump_recall_access_counts(
-    conn: &mut rusqlite::Connection,
-    fragments: &[MemoryFragment],
-) {
+fn bump_recall_access_counts(conn: &mut rusqlite::Connection, fragments: &[MemoryFragment]) {
     if fragments.is_empty() {
         return;
     }
@@ -981,9 +1011,7 @@ fn bump_recall_access_counts(
             }
         };
         for frag in fragments {
-            if let Err(e) =
-                stmt.execute(rusqlite::params![now, frag.id.0.to_string()])
-            {
+            if let Err(e) = stmt.execute(rusqlite::params![now, frag.id.0.to_string()]) {
                 warn!(memory_id = %frag.id.0, error = %e, "Failed to update access tracking");
             }
         }
@@ -1103,8 +1131,25 @@ impl VectorStore for SqliteVectorStore {
                 skipped_non_comparable += 1;
                 continue;
             };
-            let metadata: HashMap<String, serde_json::Value> =
-                serde_json::from_str(&meta_str).unwrap_or_default();
+            // Skip rather than silently substitute `HashMap::default()` for
+            // a corrupt `metadata` TEXT blob — that disguises corruption as
+            // a row with no metadata, which the operator cannot tell apart
+            // from a legitimately empty row (audit:
+            // json-text-silent-parse-fallback).
+            let metadata: HashMap<String, serde_json::Value> = match serde_json::from_str(&meta_str)
+            {
+                Ok(m) => m,
+                Err(e) => {
+                    error!(
+                        row_id = %id,
+                        table = "memories",
+                        column = "metadata",
+                        error = %e,
+                        "corrupt JSON in TEXT column; skipping vector search candidate"
+                    );
+                    continue;
+                }
+            };
             results.push(VectorSearchResult {
                 id,
                 payload: content,
@@ -1566,5 +1611,88 @@ mod tests {
         assert_eq!(store.count(agent_id, Some("session_memory")).unwrap(), 1);
         assert_eq!(store.count(agent_id, Some("user_memory")).unwrap(), 1);
         assert_eq!(store.count(agent_id, Some("agent_memory")).unwrap(), 0);
+    }
+
+    /// Regression for the audit item `json-text-silent-parse-fallback`.
+    ///
+    /// Pre-fix, `recall` decoded a row whose `metadata` TEXT column was
+    /// corrupt by silently substituting `HashMap::default()` — so the
+    /// caller could not distinguish "this memory has no metadata" from
+    /// "this memory's metadata is destroyed". After the fix, the loop
+    /// drops the corrupt row with a loud `error!` log and the healthy
+    /// row beside it still surfaces.
+    #[test]
+    fn recall_skips_corrupt_metadata_row_instead_of_returning_default() {
+        let store = setup();
+        let agent_id = AgentId::new();
+        store
+            .remember(
+                agent_id,
+                "healthy memory",
+                MemorySource::Conversation,
+                "episodic",
+                HashMap::new(),
+            )
+            .unwrap();
+        let corrupt_id = store
+            .remember(
+                agent_id,
+                "corrupt memory",
+                MemorySource::Conversation,
+                "episodic",
+                HashMap::new(),
+            )
+            .unwrap();
+        {
+            let conn = store.pool.get().unwrap();
+            conn.execute(
+                "UPDATE memories SET metadata = ?1 WHERE id = ?2",
+                rusqlite::params!["not-json", corrupt_id.0.to_string()],
+            )
+            .unwrap();
+        }
+
+        let results = store.recall("memory", 10, None).unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "corrupt row must be skipped (not silently coerced to default metadata)"
+        );
+        assert_eq!(results[0].content, "healthy memory");
+    }
+
+    /// Same audit item, on the `decode_memory_row` path — used by
+    /// `get_by_id` / `get_by_ids_batch`. Pre-fix, a corrupt `metadata`
+    /// blob would silently produce a `MemoryFragment` with empty
+    /// metadata; after the fix, the row decoder returns an error so
+    /// callers see the failure instead of working with poisoned data.
+    #[test]
+    fn get_by_id_surfaces_corrupt_metadata_instead_of_defaulting() {
+        let store = setup();
+        let agent_id = AgentId::new();
+        let id = store
+            .remember(
+                agent_id,
+                "fragment",
+                MemorySource::Conversation,
+                "episodic",
+                HashMap::new(),
+            )
+            .unwrap();
+        {
+            let conn = store.pool.get().unwrap();
+            conn.execute(
+                "UPDATE memories SET metadata = ?1 WHERE id = ?2",
+                rusqlite::params!["not-json", id.0.to_string()],
+            )
+            .unwrap();
+        }
+
+        let res = store.get_by_id(id, false);
+        assert!(
+            res.is_err(),
+            "corrupt metadata must surface as Err from get_by_id, not be silently defaulted; \
+             got: {res:?}"
+        );
     }
 }

--- a/crates/librefang-memory/src/structured.rs
+++ b/crates/librefang-memory/src/structured.rs
@@ -5,6 +5,7 @@ use librefang_types::agent::{AgentEntry, AgentId};
 use librefang_types::error::{LibreFangError, LibreFangResult};
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
+use tracing::error;
 
 /// Hard ceiling on a single serialized KV value, enforced inside
 /// [`StructuredStore::set`] / [`StructuredStore::modify`] /
@@ -258,12 +259,26 @@ impl StructuredStore {
         let mut pairs = Vec::new();
         for row in rows {
             let (key, blob) = row.map_err(LibreFangError::memory)?;
-            let value: serde_json::Value = serde_json::from_slice(&blob).unwrap_or_else(|_| {
-                // Fallback: try as UTF-8 string
-                String::from_utf8(blob)
-                    .map(serde_json::Value::String)
-                    .unwrap_or(serde_json::Value::Null)
-            });
+            // Audit: json-text-silent-parse-fallback. The previous code
+            // fell back to a `Value::String` reconstructed from the raw
+            // bytes when JSON decode failed, laundering corrupted blobs
+            // into the agent's LLM context as plausible-looking strings.
+            // Skip the row with a loud log so the operator can audit /
+            // repair it; under no circumstance fabricate a value here.
+            let value: serde_json::Value = match serde_json::from_slice(&blob) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(
+                        agent_id = %agent_id.0,
+                        key = %key,
+                        table = "kv_store",
+                        column = "value",
+                        error = %e,
+                        "corrupt JSON blob in kv_store; skipping row in list_kv"
+                    );
+                    continue;
+                }
+            };
             pairs.push((key, value));
         }
         Ok(pairs)
@@ -1304,5 +1319,53 @@ mod tests {
                 "cascade over-deleted: control agent's row vanished from '{table}'",
             );
         }
+    }
+
+    /// Regression for the audit item `json-text-silent-parse-fallback`.
+    ///
+    /// Pre-fix, `list_kv` decoded a row whose `value` BLOB was not valid
+    /// JSON by **fabricating** a `Value::String` out of the raw bytes
+    /// (falling all the way to `Value::Null` only on a non-UTF-8 blob).
+    /// That laundered corrupted blobs into the agent's LLM context as
+    /// plausible-looking strings. After the fix, the corrupted row is
+    /// skipped with a loud `error!` log and the healthy row beside it
+    /// still surfaces — under no circumstance does a fabricated string
+    /// appear in the result set.
+    #[test]
+    fn list_kv_skips_corrupt_blob_instead_of_fabricating_string() {
+        let store = setup();
+        let agent = AgentId::new();
+        // Healthy row written through the normal API.
+        store
+            .set(agent, "healthy", serde_json::json!({"ok": true}))
+            .unwrap();
+        // Corrupt row written directly under the API, simulating a
+        // manual SQL edit or upstream serde drift that left the blob
+        // un-decodable as JSON but still valid UTF-8 (the worst case
+        // for the old code — it would have fabricated `Value::String`).
+        {
+            let conn = store.pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO kv_store (agent_id, key, value, version, updated_at)
+                 VALUES (?1, ?2, ?3, 1, ?4)",
+                rusqlite::params![
+                    agent.0.to_string(),
+                    "corrupt",
+                    b"this is not json".as_slice(),
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+            .unwrap();
+        }
+
+        let pairs = store.list_kv(agent).unwrap();
+        // Healthy row survives; corrupt row is dropped, never fabricated.
+        assert_eq!(pairs.len(), 1, "corrupt row must be skipped, not coerced");
+        assert_eq!(pairs[0].0, "healthy");
+        assert!(
+            !pairs.iter().any(|(k, v)| k == "corrupt"
+                || matches!(v, serde_json::Value::String(s) if s == "this is not json")),
+            "list_kv must never fabricate a Value::String from undecodable bytes"
+        );
     }
 }


### PR DESCRIPTION
Closes #5531

## Summary

Six call sites across `crates/librefang-memory/` no longer silently substitute `HashMap::default()` (or fabricate a `Value::String`) when a JSON-in-TEXT column fails to parse. Each now logs the corruption with `row_id` + table + column context, and either propagates the error or skips the unreadable row (depending on whether the surrounding function returns `Result` or iterates).

`structured.rs::list_kv`'s `Value::String` fabrication path is removed — that was actively laundering corruption into LLM context as plausible-looking strings.

## Sites changed

- `crates/librefang-memory/src/semantic.rs` — 3 sites
  - `recall_with_embedding` SQLite loop (audit line 346): log + `continue`.
  - `decode_memory_row` (audit line 555): propagate as `FromSqlConversionFailure` via the existing `fsql` helper, so `get_by_id` / `get_by_ids_batch` see the failure.
  - `SqliteVectorStore::query` loop (audit line 991): log + `continue`.
- `crates/librefang-memory/src/knowledge.rs` — 2 sites
  - `parse_entity` (audit line 271) and `parse_relation` (audit line 298): both now return `LibreFangResult` and propagate `LibreFangError::Serialization`; call sites in `query_graph` updated with `?`.
- `crates/librefang-memory/src/structured.rs` — 1 site
  - `list_kv` (audit lines 261-266): log + `continue`; the `Value::String` fabrication branch is removed entirely.

No new error variant was added — `LibreFangError::Serialization` already exists in `librefang-types`, and the `rusqlite::Error::FromSqlConversionFailure` shape was already in use inside `decode_memory_row`.

## Pre-check

All 6 cited sites were still unfixed on `origin/main` at fetch time (verified with `rg "unwrap_or_default" crates/librefang-memory/src/{semantic,knowledge,structured}.rs` and `git log --oneline` over those files).

## Verification

- `cargo fmt -p librefang-memory -- --check` — clean (only the 3 cited files touched; pre-existing fmt drift in `migration.rs` / `substrate.rs` from `cargo fmt` was reverted to keep scope tight).
- `cargo check -p librefang-memory --lib` — clean.
- `cargo clippy -p librefang-memory --all-targets -- -D warnings` — clean.
- `cargo test -p librefang-memory` — 260 lib tests pass + 2 integration tests pass. 5 new regression tests included:
  - `structured::tests::list_kv_skips_corrupt_blob_instead_of_fabricating_string`
  - `knowledge::tests::query_graph_surfaces_corrupt_entity_properties_instead_of_defaulting`
  - `knowledge::tests::query_graph_surfaces_corrupt_relation_properties_instead_of_defaulting`
  - `semantic::tests::recall_skips_corrupt_metadata_row_instead_of_returning_default`
  - `semantic::tests::get_by_id_surfaces_corrupt_metadata_instead_of_defaulting`

Each regression test seeds a healthy row through the public API, then directly `UPDATE`s the TEXT column to invalid JSON (or for `list_kv`, INSERTs a raw byte blob), then asserts the reader skips / errors instead of returning a default or a fabricated string.

Refs `docs/issues/json-text-silent-parse-fallback.md`.
