### PR TITLE
fix(runtime/file_read_tracker): reclaim per-session bucket on session delete

### DIFF
--- a/crates/librefang-api/src/routes/tools_sessions.rs
+++ b/crates/librefang-api/src/routes/tools_sessions.rs
@@ -473,7 +473,13 @@ pub async fn delete_session(
         }
     };
 
-    match state.kernel.memory_substrate().delete_session(session_id) {
+    // Route through the kernel orchestrator (rather than calling
+    // `memory_substrate().delete_session(...)` directly) so the per-session
+    // `file_read_tracker` bucket is reclaimed at the same time. Calling the
+    // substrate directly leaked one tracker entry per ever-deleted session
+    // for the daemon's lifetime — context-compression GC never runs on a
+    // dead session.
+    match state.kernel.delete_session(session_id) {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => {
             ApiErrorResponse::internal(t.t_args("api-error-generic", &[("error", &e.to_string())]))

--- a/crates/librefang-kernel/src/kernel/session_ops.rs
+++ b/crates/librefang-kernel/src/kernel/session_ops.rs
@@ -209,6 +209,37 @@ impl LibreFangKernel {
         }
     }
 
+    /// Delete a single session by id and reclaim any process-local side-state
+    /// keyed on it.
+    ///
+    /// Session-keyed side-state currently means the per-session
+    /// `file_read_tracker` bucket. Before this method existed the API DELETE
+    /// route called `memory_substrate().delete_session(...)` directly, which
+    /// left a tracker entry per ever-existed session in the daemon — the
+    /// only reclamation path was the context compressor, and deleted sessions
+    /// never reach the compressor. Long-lived daemons leaked one entry per
+    /// deleted session monotonically.
+    ///
+    /// Unlike [`Self::reset_session`] / [`Self::reboot_session`], this method
+    /// does **not** recreate an empty session at the same sid, does not fire
+    /// `SessionEnd` / `SessionReset` external hooks, and does not touch the
+    /// agent registry pointer — it is a plain hard delete intended for the
+    /// dashboard "delete session" affordance and any equivalent CLI path.
+    /// Callers that need the recreate-and-fire-hooks semantic want
+    /// `reset_session(_, ResetScope::Session(sid))` instead.
+    pub fn delete_session(&self, session_id: SessionId) -> KernelResult<()> {
+        self.memory
+            .substrate
+            .delete_session(session_id)
+            .map_err(KernelError::LibreFang)?;
+        // Reclaim the per-session `file_read_tracker` bucket so the
+        // process-wide registry doesn't accumulate one entry per ever-deleted
+        // session. Context-compression GC remains the fallback for live
+        // sessions that never reach this path.
+        librefang_runtime::file_read_tracker::forget_session(&session_id);
+        Ok(())
+    }
+
     /// Implementation of [`ResetScope::Agent`] — wipe every session for this
     /// agent. `save_summary` distinguishes reset (true) vs. reboot (false).
     ///

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -233,6 +233,13 @@ pub trait KernelApi: KernelHandle + Send + Sync {
     /// [`ResetScope`] for the agent-wide vs. per-session split (#4868).
     async fn reboot_session(&self, agent_id: AgentId, scope: ResetScope) -> KernelResult<()>;
     async fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()>;
+    /// Delete a single session by id and any process-local side-state keyed
+    /// on it (currently the per-session `file_read_tracker` bucket — see
+    /// `librefang_runtime::file_read_tracker::forget_session`). Use this in
+    /// preference to calling `memory_substrate().delete_session(...)`
+    /// directly so the side-state map does not leak across the daemon's
+    /// lifetime.
+    fn delete_session(&self, session_id: SessionId) -> KernelResult<()>;
     fn list_agent_sessions(&self, agent_id: AgentId) -> KernelResult<Vec<serde_json::Value>>;
     fn create_agent_session(
         &self,
@@ -913,6 +920,9 @@ impl KernelApi for LibreFangKernel {
     }
     async fn clear_agent_history(&self, agent_id: AgentId) -> KernelResult<()> {
         Self::clear_agent_history(self, agent_id).await
+    }
+    fn delete_session(&self, session_id: SessionId) -> KernelResult<()> {
+        Self::delete_session(self, session_id)
     }
     fn list_agent_sessions(&self, agent_id: AgentId) -> KernelResult<Vec<serde_json::Value>> {
         Self::list_agent_sessions(self, agent_id)

--- a/crates/librefang-runtime/src/file_read_tracker.rs
+++ b/crates/librefang-runtime/src/file_read_tracker.rs
@@ -200,6 +200,28 @@ pub fn reset_session(session_id: SessionId) {
     }
 }
 
+/// Remove the tracker bucket for `session_id` entirely. No-op if it doesn't
+/// exist.
+///
+/// Called from the session-delete path so the process-wide registry doesn't
+/// accumulate one entry per ever-existed session for the lifetime of the
+/// daemon. Unlike [`reset_session`] (which empties the bucket but keeps the
+/// `(SessionId, _)` pair so a live session can continue tracking after a
+/// compression pass), the session is gone and will never be looked up again
+/// — drop the whole entry. Context-compression GC remains the fallback for
+/// long-lived sessions that never hit the delete path.
+pub fn forget_session(session_id: &SessionId) {
+    let mut guard = registry().lock().unwrap_or_else(|p| p.into_inner());
+    guard.remove(session_id);
+}
+
+/// Number of sessions currently tracked in the process-wide registry. Test
+/// helper.
+#[cfg(test)]
+fn registry_len() -> usize {
+    registry().lock().unwrap_or_else(|p| p.into_inner()).len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,5 +372,61 @@ mod tests {
         // s2 untouched.
         let after = with_session(s2, |t| t.observe(&PathBuf::from("/tmp/x"), "v1"));
         assert_eq!(after, ReadOutcome::Unchanged { first_turn: 1 });
+    }
+
+    #[test]
+    fn forget_session_drops_bucket_and_preserves_others() {
+        // The registry is process-wide so other tests' sessions count too.
+        // We compare deltas relative to the starting size rather than asserting
+        // absolute counts, and use fresh `SessionId::new()` UUIDs to avoid
+        // colliding with sibling tests.
+        let s1 = SessionId::new();
+        let s2 = SessionId::new();
+        let s3 = SessionId::new();
+        with_session(s1, |t| {
+            t.observe(&PathBuf::from("/tmp/x"), "v1");
+        });
+        with_session(s2, |t| {
+            t.observe(&PathBuf::from("/tmp/x"), "v1");
+        });
+        with_session(s3, |t| {
+            t.observe(&PathBuf::from("/tmp/x"), "v1");
+        });
+        let before = registry_len();
+
+        forget_session(&s2);
+
+        // Bucket count dropped by exactly one (s2's bucket).
+        assert_eq!(registry_len(), before - 1, "exactly one bucket removed");
+
+        // s2 is gone — next access materialises a fresh tracker, so the same
+        // path read returns `First` (would have returned `Unchanged` before).
+        let after_s2 = with_session(s2, |t| t.observe(&PathBuf::from("/tmp/x"), "v1"));
+        assert_eq!(after_s2, ReadOutcome::First);
+
+        // s1 and s3 are untouched — their prior reads still register as
+        // `Unchanged`, proving forget did not touch siblings.
+        let after_s1 = with_session(s1, |t| t.observe(&PathBuf::from("/tmp/x"), "v1"));
+        assert_eq!(after_s1, ReadOutcome::Unchanged { first_turn: 1 });
+        let after_s3 = with_session(s3, |t| t.observe(&PathBuf::from("/tmp/x"), "v1"));
+        assert_eq!(after_s3, ReadOutcome::Unchanged { first_turn: 1 });
+
+        // Clean up — leave the registry as we found it for other tests.
+        forget_session(&s1);
+        forget_session(&s2);
+        forget_session(&s3);
+    }
+
+    #[test]
+    fn forget_session_is_idempotent_on_missing_id() {
+        let unknown = SessionId::new();
+        let before = registry_len();
+        forget_session(&unknown);
+        forget_session(&unknown);
+        assert_eq!(
+            registry_len(),
+            before,
+            "forget on a never-tracked id is a no-op"
+        );
     }
 }


### PR DESCRIPTION
Closes #5533

## Summary

`FileReadTracker` (`crates/librefang-runtime/src/file_read_tracker.rs`) gained a `forget_session(&SessionId)` helper that drops the bucket from the process-wide registry. The API `DELETE /api/sessions/{id}` route used to call `state.kernel.memory_substrate().delete_session(...)` directly, leaving one HashMap entry per ever-deleted session for the daemon's lifetime — context-compression GC never runs on a dead session. The route now routes through a new `LibreFangKernel::delete_session` / `KernelApi::delete_session` orchestrator that pairs the substrate delete with the `forget_session` reclaim. Context-compression GC remains the fallback for live sessions that never reach the delete path.

## Wiring

Chose **Option B (kernel-side orchestrator)** over an observer trait: `librefang-kernel` already depends on `librefang-runtime`, so the kernel can call `file_read_tracker::forget_session` directly; `librefang-memory` does not depend on runtime, so introducing an observer would have added new infra for one caller. The thin wrapper on `LibreFangKernel` is the minimal change, parallels the existing `reset_session` / `reboot_session` surface in the same file (`kernel/session_ops.rs`), and gives the route a typed `KernelResult` rather than a bare `LibreFangError`.

The existing reset-then-recreate path in `reset_one_session` was intentionally **not** changed: it deletes the session row but immediately re-creates an empty session at the same `SessionId`, so the tracker bucket is correctly reused on the next `with_session` call. Adding a `forget_session` call there would be a no-op-with-overhead.

## Files changed

- `crates/librefang-runtime/src/file_read_tracker.rs` — `forget_session` module-level helper + `registry_len` test helper + two unit tests (`forget_session_drops_bucket_and_preserves_others`, `forget_session_is_idempotent_on_missing_id`).
- `crates/librefang-kernel/src/kernel/session_ops.rs` — `LibreFangKernel::delete_session` inherent method (calls substrate then forgets the bucket).
- `crates/librefang-kernel/src/kernel_api.rs` — `KernelApi::delete_session` trait method + impl forwarder.
- `crates/librefang-api/src/routes/tools_sessions.rs` — DELETE route switched from `state.kernel.memory_substrate().delete_session(...)` to `state.kernel.delete_session(...)`. Response shape unchanged (still 204 / 500).

## Verification

- `rustfmt --check` on the 4 changed files — clean.
- `cargo check -p librefang-runtime -p librefang-kernel -p librefang-api --lib` — clean.
- `cargo clippy -p librefang-runtime -p librefang-kernel -p librefang-api --lib -- -D warnings` — clean.
- `cargo test -p librefang-runtime --lib file_read_tracker` — 13 passed (including 2 new tests).
- `cargo test -p librefang-kernel --lib` — 1098 passed, 0 failed (no regressions from the new trait method).
- `cargo check -p librefang-api --tests` — clean (existing integration tests still build against the wider `KernelApi`).

Refs `docs/issues/file-read-tracker-leak.md` (sub-finding "this"). The other two sub-findings (`save_session_async` clone, Vite lazy audit) are out of scope for this PR.
