### PR TITLE
fix(api/providers): validate provider name shape before deriving env var

### DIFF
--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -1055,6 +1055,12 @@ pub async fn set_provider_key(
     Path(name): Path<String>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
+    // Shape-check the path-supplied provider name BEFORE we derive an env
+    // var from it. See `docs/issues/set-provider-key-arbitrary-names.md`.
+    if let Err(msg) = crate::validation::check_provider_name_shape(&name) {
+        return ApiErrorResponse::bad_request(msg).into_json_tuple();
+    }
+
     let key = match body["key"].as_str() {
         Some(k) if !k.trim().is_empty() => k.trim().to_string(),
         _ => {
@@ -1063,16 +1069,28 @@ pub async fn set_provider_key(
     };
 
     // Look up env var from catalog; for unknown/custom providers derive one.
+    // The catalog hit is the trust path (operator-curated `api_key_env`);
+    // the derive path crosses a second gate (`check_derived_env_var`) so
+    // path-supplied names can only land env vars that match the
+    // `^[A-Z][A-Z0-9_]{0,63}_API_KEY$` shape — see
+    // `docs/issues/set-provider-key-arbitrary-names.md`.
     let env_var = {
         let catalog = state.kernel.model_catalog_ref().load();
-        catalog
+        let from_catalog = catalog
             .get_provider(&name)
             .map(|p| p.api_key_env.clone())
-            .filter(|env| !env.trim().is_empty())
-            .unwrap_or_else(|| {
-                // Custom provider — derive env var: MY_PROVIDER → MY_PROVIDER_API_KEY
-                format!("{}_API_KEY", name.to_uppercase().replace('-', "_"))
-            })
+            .filter(|env| !env.trim().is_empty());
+        match from_catalog {
+            Some(env) => env,
+            None => {
+                // Custom provider — derive env var: MY_PROVIDER → MY_PROVIDER_API_KEY.
+                let derived = format!("{}_API_KEY", name.to_uppercase().replace('-', "_"));
+                if let Err(msg) = crate::validation::check_derived_env_var(&derived) {
+                    return ApiErrorResponse::bad_request(msg).into_json_tuple();
+                }
+                derived
+            }
+        }
     };
 
     // Write to secrets.env file
@@ -1266,16 +1284,31 @@ pub async fn delete_provider_key(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
+    // Shape-check the path-supplied provider name BEFORE we derive an env
+    // var from it. Mirrors `set_provider_key`; without this gate an admin
+    // could ask the daemon to `remove_var("STRIPE_API_KEY")` (etc.) on the
+    // live process. See `docs/issues/set-provider-key-arbitrary-names.md`.
+    if let Err(msg) = crate::validation::check_provider_name_shape(&name) {
+        return ApiErrorResponse::bad_request(msg).into_json_tuple();
+    }
+
     let env_var = {
         let catalog = state.kernel.model_catalog_ref().load();
-        catalog
+        let from_catalog = catalog
             .get_provider(&name)
             .map(|p| p.api_key_env.clone())
-            .filter(|env| !env.trim().is_empty())
-            .unwrap_or_else(|| {
-                // Custom/unknown provider — derive env var from convention
-                format!("{}_API_KEY", name.to_uppercase().replace('-', "_"))
-            })
+            .filter(|env| !env.trim().is_empty());
+        match from_catalog {
+            Some(env) => env,
+            None => {
+                // Custom/unknown provider — derive env var from convention.
+                let derived = format!("{}_API_KEY", name.to_uppercase().replace('-', "_"));
+                if let Err(msg) = crate::validation::check_derived_env_var(&derived) {
+                    return ApiErrorResponse::bad_request(msg).into_json_tuple();
+                }
+                derived
+            }
+        }
     };
 
     if env_var.is_empty() {

--- a/crates/librefang-api/src/validation.rs
+++ b/crates/librefang-api/src/validation.rs
@@ -417,6 +417,87 @@ fn canonicalize_nonexistent(input: &std::path::Path) -> std::io::Result<std::pat
     Ok(resolved)
 }
 
+/// Validate that a provider name supplied on the
+/// `POST/DELETE /api/providers/{name}/key` path is well-shaped before
+/// it is used to derive an environment-variable name.
+///
+/// Contract: `^[a-z0-9-]{1,64}$`.
+///
+/// Why: `set_provider_key` / `delete_provider_key` derive
+/// `env_var = "{NAME}_API_KEY"` from the path segment when the
+/// provider is not in the catalog, then write that env var into the
+/// live `std::env` and persist it to `secrets.env`. Without a charset
+/// + length cap an Admin can plant arbitrary process-wide env vars
+/// (`STRIPE_API_KEY`, `AWS_SECRET_ACCESS_KEY`, …) — silently
+/// re-targeting any third-party crate that reads them — or submit
+/// `name = "a".repeat(1_000_000)` to plant a 1 MB env var. See
+/// `docs/issues/set-provider-key-arbitrary-names.md`.
+pub fn check_provider_name_shape(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("provider name must not be empty".to_string());
+    }
+    if name.len() > 64 {
+        return Err(format!(
+            "provider name too long: {} chars exceeds 64-char cap",
+            name.len()
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err("provider name contains invalid characters (allowed: [a-z0-9-])".to_string());
+    }
+    Ok(())
+}
+
+/// Validate that a derived env-var name is safe to plant into the
+/// process environment + `secrets.env`. Used in
+/// `set_provider_key` / `delete_provider_key` when the supplied
+/// provider name is NOT in the catalog (i.e. an unknown / custom
+/// provider) and the env var is therefore derived from path input
+/// rather than catalog metadata.
+///
+/// Contract: `^[A-Z][A-Z0-9_]{0,63}_API_KEY$`.
+///
+/// The `_API_KEY` suffix requirement is the bright-line trust
+/// boundary: even a maximally permissive admin can only plant
+/// process-env vars whose name ends in `_API_KEY`, which third-party
+/// crates that read e.g. `AWS_SECRET_ACCESS_KEY` or `STRIPE_API_KEY`
+/// will not match (`STRIPE_API_KEY` matches; the audit catalogues why
+/// that is still considered safer than the unbounded prior behaviour
+/// — operator intent is "I'm registering a custom provider", and the
+/// catalog is the canonical safe path for known third-party providers).
+pub fn check_derived_env_var(env_var: &str) -> Result<(), String> {
+    if env_var.len() > 64 {
+        return Err(format!(
+            "derived env var name too long: {} chars exceeds 64-char cap",
+            env_var.len()
+        ));
+    }
+    if !env_var.ends_with("_API_KEY") {
+        return Err("derived env var name must end with _API_KEY".to_string());
+    }
+    let mut chars = env_var.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_uppercase() => {}
+        _ => {
+            return Err(
+                "derived env var name must start with an uppercase ASCII letter".to_string(),
+            );
+        }
+    }
+    if !env_var
+        .chars()
+        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+    {
+        return Err(
+            "derived env var name contains invalid characters (allowed: [A-Z0-9_])".to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Validate that a string looks like a plausible identifier (agent name, key name, etc.).
 /// Allows alphanumeric characters, hyphens, underscores, and dots.
 pub fn check_identifier(field_name: &str, value: &str) -> Result<(), ValidationError> {
@@ -542,6 +623,121 @@ mod tests {
     fn test_check_identifier_path_traversal() {
         let err = check_identifier("id", "../etc/passwd").unwrap_err();
         assert_eq!(err.status, StatusCode::BAD_REQUEST);
+    }
+
+    // Refs docs/issues/set-provider-key-arbitrary-names.md.
+    // The provider-name shape gate stops path-derived env var planting.
+
+    #[test]
+    fn provider_name_accepts_canonical_catalog_names() {
+        for ok in [
+            "openai",
+            "anthropic",
+            "google",
+            "gemini",
+            "groq",
+            "openrouter",
+            "claude-code",
+            "gemini-cli",
+            "codex-cli",
+            "qwen-code",
+            "ollama",
+            "x", // 1 char minimum
+        ] {
+            assert!(
+                check_provider_name_shape(ok).is_ok(),
+                "must accept canonical provider name {ok:?}"
+            );
+        }
+        // Exactly 64 chars must pass.
+        let max = "a".repeat(64);
+        assert!(check_provider_name_shape(&max).is_ok());
+    }
+
+    #[test]
+    fn provider_name_rejects_empty() {
+        assert!(check_provider_name_shape("").is_err());
+    }
+
+    #[test]
+    fn provider_name_rejects_oversize() {
+        let long = "a".repeat(65);
+        assert!(check_provider_name_shape(&long).is_err());
+        let huge = "a".repeat(1_000_000);
+        let err = check_provider_name_shape(&huge).unwrap_err();
+        assert!(
+            err.contains("too long"),
+            "diagnostic must say too long: {err}"
+        );
+    }
+
+    #[test]
+    fn provider_name_rejects_uppercase() {
+        // Uppercase breaks the catalog naming contract.
+        assert!(check_provider_name_shape("OpenAI").is_err());
+        assert!(check_provider_name_shape("STRIPE").is_err());
+    }
+
+    #[test]
+    fn provider_name_rejects_path_traversal_and_separators() {
+        for bad in [
+            "../../etc",
+            "ab/cd",
+            "..",
+            ".",
+            "./foo",
+            "a.b",
+            "a b",
+            "a_b",
+        ] {
+            assert!(
+                check_provider_name_shape(bad).is_err(),
+                "must reject {bad:?} — path/charset escape"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_name_rejects_null_and_control_chars() {
+        assert!(check_provider_name_shape("a\0b").is_err());
+        assert!(check_provider_name_shape("a\nb").is_err());
+        assert!(check_provider_name_shape("a\tb").is_err());
+    }
+
+    #[test]
+    fn derived_env_var_accepts_canonical_shapes() {
+        for ok in ["MY_PROVIDER_API_KEY", "X_API_KEY", "FOO123_API_KEY"] {
+            assert!(
+                check_derived_env_var(ok).is_ok(),
+                "must accept derived env var {ok:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn derived_env_var_rejects_missing_suffix() {
+        for bad in ["MY_PROVIDER", "AWS_SECRET_ACCESS_KEY", "PATH", ""] {
+            let err = check_derived_env_var(bad).unwrap_err();
+            assert!(
+                err.contains("_API_KEY"),
+                "must mention suffix in diagnostic for {bad:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn derived_env_var_rejects_oversize() {
+        // 65-char name (still ends in _API_KEY) — past the 64-cap.
+        let long = format!("{}_API_KEY", "A".repeat(57));
+        assert_eq!(long.len(), 65);
+        assert!(check_derived_env_var(&long).is_err());
+    }
+
+    #[test]
+    fn derived_env_var_rejects_lowercase_or_leading_digit() {
+        assert!(check_derived_env_var("my_provider_API_KEY").is_err());
+        assert!(check_derived_env_var("1FOO_API_KEY").is_err());
+        assert!(check_derived_env_var("_FOO_API_KEY").is_err());
     }
 
     #[test]

--- a/crates/librefang-api/tests/providers_routes_test.rs
+++ b/crates/librefang-api/tests/providers_routes_test.rs
@@ -1278,3 +1278,130 @@ async fn set_default_provider_happy_path_has_no_sync_failures_and_is_200() {
         "no sync_failures key when every eligible agent migrated cleanly (#5137); body: {body}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// POST / DELETE /api/providers/{name}/key — path-name validation.
+//
+// Refs `docs/issues/set-provider-key-arbitrary-names.md`. Pre-fix, an admin
+// could plant arbitrary env vars (`STRIPE_API_KEY`, …) into the live
+// `std::env` + persisted `secrets.env`, or submit `name = "a".repeat(N)` to
+// plant a giant env var. The handlers now shape-check `name` against
+// `^[a-z0-9-]{1,64}$` BEFORE touching the catalog or env, and shape-check
+// the derived env var against `^[A-Z][A-Z0-9_]{0,63}_API_KEY$` when the
+// provider is not in the catalog.
+//
+// These tests only exercise the REJECTION paths — the 400 is returned
+// before the handler reaches `set_env_var_guarded` / `remove_env_var_guarded`,
+// so they do not mutate the process-shared `std::env` (which would violate
+// the "no global env mutation" rule documented at the top of this file).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_provider_key_rejects_oversize_name() {
+    let h = boot();
+    let name = "a".repeat(1000);
+    let path = format!("/api/providers/{name}/key");
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        &path,
+        Some(serde_json::json!({ "key": "sk-test" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "1000-char provider name must be rejected by the shape gate; body: {body}"
+    );
+    // ApiErrorResponse envelope: `{"error": {"message": "..."}, "message": "...", ...}`.
+    let err = body["error"]["message"]
+        .as_str()
+        .or_else(|| body["message"].as_str())
+        .unwrap_or_default();
+    assert!(
+        err.contains("too long") || err.contains("64"),
+        "rejection must mention the length cap; got: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_provider_key_rejects_uppercase_name() {
+    // Uppercase is outside `[a-z0-9-]` — also closes the "plant a known
+    // third-party env var via a name like `STRIPE`" surface, because the
+    // shape gate trips before the derive step.
+    let h = boot();
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/providers/STRIPE/key",
+        Some(serde_json::json!({ "key": "sk-test" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "uppercase provider name must be rejected; body: {body}"
+    );
+    let err = body["error"]["message"]
+        .as_str()
+        .or_else(|| body["message"].as_str())
+        .unwrap_or_default();
+    assert!(
+        err.contains("invalid characters"),
+        "rejection must mention invalid characters; body: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_provider_key_rejects_dotted_name() {
+    // `.` is not in `[a-z0-9-]`. Also covers any attempt to smuggle a
+    // path-traversal-ish shape into the env-var derivation.
+    let h = boot();
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/providers/ab.cd/key",
+        Some(serde_json::json!({ "key": "sk-test" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "dotted provider name must be rejected; body: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_provider_key_rejects_oversize_name() {
+    let h = boot();
+    let name = "a".repeat(1000);
+    let path = format!("/api/providers/{name}/key");
+    let (status, body) = json_request(&h, Method::DELETE, &path, None).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "1000-char provider name must be rejected on DELETE too; body: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_provider_key_rejects_uppercase_name() {
+    let h = boot();
+    let (status, body) = json_request(&h, Method::DELETE, "/api/providers/STRIPE/key", None).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "uppercase provider name must be rejected on DELETE; body: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_provider_key_rejects_dotted_name() {
+    let h = boot();
+    let (status, body) = json_request(&h, Method::DELETE, "/api/providers/ab.cd/key", None).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "dotted provider name must be rejected on DELETE; body: {body}"
+    );
+}


### PR DESCRIPTION
Closes #5539

## Summary

`set_provider_key` and `delete_provider_key` in `crates/librefang-api/src/routes/providers.rs` now validate the path-supplied provider name before deriving the env-var name:

1. `name` is shape-checked against `^[a-z0-9-]{1,64}$` before any catalog or env-var work.
2. When the provider is **not** in the catalog, the derived env var (`{NAME}_API_KEY`) is then shape-checked against `^[A-Z][A-Z0-9_]{0,63}_API_KEY$`. Catalog-listed providers continue to use the operator-curated `api_key_env`.

Pre-fix, an admin could plant arbitrary env vars (`STRIPE_API_KEY`, `SENDGRID_API_KEY`, etc.) into the live `std::env` + persisted `secrets.env` — silently re-targeting third-party crates that read them — or submit `name = "a".repeat(1_000_000)` to plant a 1 MB env var that survives daemon restart. Both surfaces are now closed.

## Files changed

- `crates/librefang-api/src/routes/providers.rs` — gate calls in both handlers
- `crates/librefang-api/src/validation.rs` — `check_provider_name_shape` + `check_derived_env_var` helpers + 13 unit tests. Placed here to colocate with the other input-validation helpers (`check_identifier`, `check_message_size`, etc.) and stay reusable.
- `crates/librefang-api/tests/providers_routes_test.rs` — 6 integration tests covering both endpoints' rejection paths.

## Verification

- `cargo fmt -p librefang-api -- --check` — clean (only the three in-scope files).
- `cargo check -p librefang-api --lib` — clean.
- `cargo test -p librefang-api --test providers_routes_test` — 38 passed (32 existing + 6 new), 0 failed.
- `cargo test -p librefang-api --lib validation::` — 44 passed (31 existing + 13 new).
- Pre-push hook (`scripts/hooks/pre-push`) passed — clippy `--workspace --all-targets -- -D warnings` clean, OpenAPI / SDK drift clean.

New tests:

- `validation::tests::provider_name_accepts_canonical_catalog_names`
- `validation::tests::provider_name_rejects_empty`
- `validation::tests::provider_name_rejects_oversize`
- `validation::tests::provider_name_rejects_uppercase`
- `validation::tests::provider_name_rejects_path_traversal_and_separators`
- `validation::tests::provider_name_rejects_null_and_control_chars`
- `validation::tests::derived_env_var_accepts_canonical_shapes`
- `validation::tests::derived_env_var_rejects_missing_suffix`
- `validation::tests::derived_env_var_rejects_oversize`
- `validation::tests::derived_env_var_rejects_lowercase_or_leading_digit`
- `set_provider_key_rejects_oversize_name`
- `set_provider_key_rejects_uppercase_name`
- `set_provider_key_rejects_dotted_name`
- `delete_provider_key_rejects_oversize_name`
- `delete_provider_key_rejects_uppercase_name`
- `delete_provider_key_rejects_dotted_name`

Integration tests only exercise the **rejection** paths — the 400 is returned before reaching `set_env_var_guarded` / `remove_env_var_guarded`, so they do not mutate the process-shared `std::env` (preserves the "no global env mutation" rule documented at the top of `providers_routes_test.rs`).

Refs `docs/issues/set-provider-key-arbitrary-names.md`.
