### PR TITLE
perf(api/config): memoize dashboard_snapshot_inner with 900ms TTL cache

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -3023,7 +3023,83 @@ pub async fn dashboard_snapshot(
     axum::Json(dashboard_snapshot_inner(&state).await)
 }
 
+/// TTL for the [`dashboard_snapshot_inner`] memoization cache.
+///
+/// 900 ms is well below the dashboard's 5 s poll interval (so a polling tab
+/// rebuilds on every tick and the data still feels "live"), but enough to
+/// fold the burst of back-to-back polls that arrive when a user opens
+/// multiple dashboard tabs, switches windows, or the page rapidly remounts
+/// during a route change.
+const DASHBOARD_SNAPSHOT_TTL: std::time::Duration = std::time::Duration::from_millis(900);
+
+/// Cached aggregated payload for `/api/dashboard/snapshot`.
+///
+/// The payload is wrapped in an `Arc` so cache lookups clone the pointer,
+/// not the (possibly large) JSON tree. The final return type of
+/// [`dashboard_snapshot_inner`] is still `serde_json::Value`, so we pay one
+/// `(*payload).clone()` per cache hit — still 10–100× cheaper than
+/// re-running per-agent manifest enrichment + provider/channel probes +
+/// memory queries.
+struct CachedDashboardSnapshot {
+    generated_at: std::time::Instant,
+    payload: Arc<serde_json::Value>,
+}
+
+/// Process-wide cache for [`dashboard_snapshot_inner`], keyed by
+/// `AppState` pointer identity.
+///
+/// We deliberately do **not** store the cache on `AppState` itself —
+/// adding a field there ripples into `librefang-testing` and every
+/// inline test that constructs an `AppState` literal (5+ call sites).
+/// Keying by `Arc::as_ptr(state) as usize` instead gives every test its
+/// own cache slot for free, while production (one long-lived `AppState`)
+/// gets exactly one slot.
+///
+/// Entries are evicted opportunistically: on each lookup we discard the
+/// caller's expired entry; on each insert we drop any entries older than
+/// 60× the TTL, which is enough to prevent the test process from
+/// accumulating slots over time without paying a global scan on the hot
+/// path.
+static DASHBOARD_SNAPSHOT_CACHE: std::sync::OnceLock<
+    dashmap::DashMap<usize, CachedDashboardSnapshot>,
+> = std::sync::OnceLock::new();
+
+fn dashboard_snapshot_cache() -> &'static dashmap::DashMap<usize, CachedDashboardSnapshot> {
+    DASHBOARD_SNAPSHOT_CACHE.get_or_init(dashmap::DashMap::new)
+}
+
 async fn dashboard_snapshot_inner(state: &Arc<AppState>) -> serde_json::Value {
+    // Fast path: serve the memoized payload if it's still within TTL.
+    // Keyed by the `AppState` Arc pointer so concurrent tests with
+    // distinct kernels don't poison each other's cache.
+    let cache_key = Arc::as_ptr(state) as usize;
+    let cache = dashboard_snapshot_cache();
+    if let Some(entry) = cache.get(&cache_key) {
+        if entry.generated_at.elapsed() < DASHBOARD_SNAPSHOT_TTL {
+            return (*entry.payload).clone();
+        }
+    }
+
+    let payload = dashboard_snapshot_compute(state).await;
+    let payload = Arc::new(payload);
+    cache.insert(
+        cache_key,
+        CachedDashboardSnapshot {
+            generated_at: std::time::Instant::now(),
+            payload: Arc::clone(&payload),
+        },
+    );
+    // Opportunistic prune so test processes that construct many
+    // short-lived `AppState`s don't accumulate dead cache slots
+    // indefinitely. The threshold is 60× TTL so production's single
+    // long-lived state is never pruned, and we only walk the (tiny)
+    // table when we're already taking the write path.
+    let prune_threshold = DASHBOARD_SNAPSHOT_TTL * 60;
+    cache.retain(|_, v| v.generated_at.elapsed() < prune_threshold);
+    (*payload).clone()
+}
+
+async fn dashboard_snapshot_compute(state: &Arc<AppState>) -> serde_json::Value {
     // Health (same logic as /api/health)
     let shared_id = librefang_types::agent::AgentId(uuid::Uuid::from_bytes([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,

--- a/crates/librefang-api/tests/config_status_session_count_test.rs
+++ b/crates/librefang-api/tests/config_status_session_count_test.rs
@@ -77,7 +77,8 @@ async fn get_json(h: &Harness, path: &str) -> (StatusCode, serde_json::Value) {
     let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
         .await
         .unwrap();
-    let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    let value: serde_json::Value =
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
     (status, value)
 }
 
@@ -124,6 +125,14 @@ async fn dashboard_snapshot_session_count_matches_substrate_after_seeding() {
     let substrate = h.state.kernel.memory_substrate();
     substrate.create_session(agent_id).expect("seed 1");
     substrate.create_session(agent_id).expect("seed 2");
+
+    // `/api/dashboard/snapshot` memoizes its payload with a short TTL
+    // (see `DASHBOARD_SNAPSHOT_TTL` in `routes/config.rs`). The seeds
+    // above bypass the route and go straight to the substrate, so the
+    // cached payload is stale relative to the truth we just wrote.
+    // Wait past the TTL before re-polling so the second request rebuilds
+    // and observes the new sessions.
+    tokio::time::sleep(std::time::Duration::from_millis(1_000)).await;
 
     let (status, body) = get_json(&h, "/api/dashboard/snapshot").await;
     assert_eq!(status, StatusCode::OK, "{body:?}");

--- a/crates/librefang-api/tests/dashboard_snapshot_cache_test.rs
+++ b/crates/librefang-api/tests/dashboard_snapshot_cache_test.rs
@@ -1,0 +1,172 @@
+//! Regression guard for the `dashboard-snapshot-no-cache` audit fix.
+//!
+//! `/api/dashboard/snapshot` is the dashboard's primary poll endpoint,
+//! hit every 5 seconds. Pre-fix, every request walked every agent and
+//! enriched manifest + current session + recent message count from
+//! scratch — at N=200 agents a single dashboard tab pushed ~40 QPS of
+//! pure cache-miss work into SQLite + kernel snapshot accessors.
+//!
+//! The fix memoizes the assembled payload behind a short TTL inside
+//! `routes/config.rs::dashboard_snapshot_inner`. These tests pin the
+//! contract:
+//!
+//!   1. Two polls inside the TTL window return the *same* payload —
+//!      including fields that we deliberately mutate behind the route's
+//!      back between polls. If the cache is missing, the second poll
+//!      would observe the mutation and the test would fail.
+//!   2. Once the TTL elapses, the route rebuilds and observes the
+//!      mutation. This is the "stays live for 5 s polls" guarantee —
+//!      the cache must never out-live a single dashboard tick.
+//!
+//! Audit ticket: `docs/issues/dashboard-snapshot-no-cache.md`.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use axum::Router;
+use librefang_api::routes::{self, AppState};
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use librefang_types::agent::AgentId;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+struct Harness {
+    app: Router,
+    state: Arc<AppState>,
+    _test: TestAppState,
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.state.kernel.shutdown();
+    }
+}
+
+async fn boot() -> Harness {
+    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(|cfg| {
+        cfg.default_model = librefang_types::config::DefaultModelConfig {
+            provider: "ollama".into(),
+            model: "test-model".into(),
+            api_key_env: "OLLAMA_API_KEY".into(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        };
+    }));
+
+    let state = test.state.clone();
+    let app = Router::new()
+        .route(
+            "/api/dashboard/snapshot",
+            axum::routing::get(routes::dashboard_snapshot),
+        )
+        .with_state(state.clone());
+
+    Harness {
+        app,
+        state,
+        _test: test,
+    }
+}
+
+async fn get_json(h: &Harness, path: &str) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .body(Body::empty())
+        .unwrap();
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let value: serde_json::Value =
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, value)
+}
+
+/// Back-to-back polls within the TTL window must return the *same*
+/// payload, even when a side-effect (a substrate session insert) lands
+/// between them. We use `session_count` as the side-effect probe
+/// because it's the cheapest piece of cached state that visibly
+/// reflects substrate writes — if the second poll's `session_count`
+/// already shows the new seeds, the cache is bypassed.
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshot_is_cached_within_ttl_window() {
+    let h = boot().await;
+
+    // Prime the cache.
+    let (status, first) = get_json(&h, "/api/dashboard/snapshot").await;
+    assert_eq!(status, StatusCode::OK, "{first:?}");
+    let baseline = first["status"]["session_count"]
+        .as_u64()
+        .expect("status.session_count must be a number");
+
+    // Mutate substrate state behind the route's back. A fresh, un-cached
+    // route would observe this; a cached one must not.
+    let agent_id = AgentId(uuid::Uuid::new_v4());
+    let substrate = h.state.kernel.memory_substrate();
+    for _ in 0..5 {
+        substrate.create_session(agent_id).expect("seed session");
+    }
+
+    // Second poll inside the TTL window: must serve the cached payload
+    // and therefore must *not* observe the 5 fresh sessions yet.
+    let (status, second) = get_json(&h, "/api/dashboard/snapshot").await;
+    assert_eq!(status, StatusCode::OK, "{second:?}");
+    assert_eq!(
+        second["status"]["session_count"].as_u64(),
+        Some(baseline),
+        "in-TTL second poll must return cached session_count (baseline={baseline}); \
+         observing the +5 substrate seeds means the cache is being bypassed: \
+         second={second:?}"
+    );
+
+    // Stronger: the entire payload must be byte-identical between the
+    // two cached calls. If anything inside the payload is non-deterministic
+    // (e.g. a `now()` timestamp baked at serialize time), this catches it
+    // — and would catch a bug where the cache stores stale data but the
+    // route also re-stamps a "served_at" field.
+    assert_eq!(
+        first, second,
+        "cached payload must be byte-identical between back-to-back polls"
+    );
+}
+
+/// After the TTL elapses the cache must miss, the route must rebuild,
+/// and the new payload must reflect substrate writes that happened
+/// during the cached window. This is the "stays live for 5 s polls"
+/// half of the contract — without TTL expiry the cache would become a
+/// permanent staleness.
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshot_rebuilds_after_ttl_expires() {
+    let h = boot().await;
+
+    let (status, first) = get_json(&h, "/api/dashboard/snapshot").await;
+    assert_eq!(status, StatusCode::OK, "{first:?}");
+    let baseline = first["status"]["session_count"]
+        .as_u64()
+        .expect("status.session_count must be a number");
+
+    let agent_id = AgentId(uuid::Uuid::new_v4());
+    let substrate = h.state.kernel.memory_substrate();
+    for _ in 0..3 {
+        substrate.create_session(agent_id).expect("seed session");
+    }
+
+    // Sleep past the cache TTL. The route's TTL is 900 ms; we wait
+    // 1.5 s to leave generous headroom for slow CI without making the
+    // test slow on a healthy machine.
+    tokio::time::sleep(std::time::Duration::from_millis(1_500)).await;
+
+    let (status, second) = get_json(&h, "/api/dashboard/snapshot").await;
+    assert_eq!(status, StatusCode::OK, "{second:?}");
+    assert_eq!(
+        second["status"]["session_count"].as_u64(),
+        Some(baseline + 3),
+        "post-TTL poll must rebuild and observe the 3 seeded sessions \
+         (baseline={baseline}). If this fails, the cache TTL is too long \
+         or the route is pinning to the cache without checking expiry: \
+         second={second:?}"
+    );
+}


### PR DESCRIPTION
Closes #5551

## Summary

`dashboard_snapshot_inner` in `crates/librefang-api/src/routes/config.rs`
is now memoized with a 900 ms TTL cache. Back-to-back polls within the
same second return a cached `Arc<serde_json::Value>` (one clone, no
per-agent enrichment, no provider/channel probes); the next dashboard
tick (5 s later) rebuilds. For an N-agent deployment with a dashboard
tab open this collapses N enrichments + a SQLite `count_sessions` +
provider/channel probes into a single rebuild every 5 s, and folds
multi-tab / refresh-storm bursts into the same.

## Approach — TTL, not generation

The audit (`docs/issues/dashboard-snapshot-no-cache.md`) prefers a
generation-based cache keyed on `(manifest_rev, session_rev)` with
counters bumped in `librefang-kernel::replace_manifest` and on
substrate session-writes. That would be more precise but is
cross-crate (kernel + memory) and disproportionate to this fix.

Implemented as a process-wide `OnceLock<DashMap<usize,
CachedDashboardSnapshot>>` keyed by `Arc::as_ptr(state) as usize`.
This deliberately does **not** store the cache as a field on
`AppState` — adding a field there ripples into `librefang-testing`'s
`TestAppState` plus four inline test constructors in
`routes/{agents,memory,network}.rs` and `server.rs`. The pointer-key
approach keeps the diff inside `routes/config.rs` (the route's own
boundary) and gives every parallel test its own cache slot for free.
An opportunistic prune on the write path evicts entries older than
60× TTL so test processes can't accumulate dead slots indefinitely
(production has exactly one long-lived `AppState`, so it's never
pruned).

## Files changed

- `crates/librefang-api/src/routes/config.rs` — TTL cache wrapper
  around the existing enrichment code, which moved unchanged into
  `dashboard_snapshot_compute`.
- `crates/librefang-api/tests/dashboard_snapshot_cache_test.rs` —
  new integration test, two cases:
  - `snapshot_is_cached_within_ttl_window` — primes cache, mutates
    substrate behind the route's back, re-polls inside TTL, asserts
    the cached payload is returned byte-identical (the substrate
    mutation must not be visible yet).
  - `snapshot_rebuilds_after_ttl_expires` — same setup but sleeps
    1.5 s before the second poll, asserts the route rebuilds and
    observes the new sessions. This is the "stays live for 5 s
    polls" half of the contract.
- `crates/librefang-api/tests/config_status_session_count_test.rs` —
  the existing
  `dashboard_snapshot_session_count_matches_substrate_after_seeding`
  test seeds substrate then re-polls immediately; with the cache that
  pattern observes stale data, so it now `sleep(1_000ms)` past the
  TTL with a comment pointing at `DASHBOARD_SNAPSHOT_TTL`. The
  `get_json` helper in the same file was rewrapped to satisfy
  `rustfmt --check` (a pre-existing nit the pre-commit hook surfaces
  now that the file is staged again).

## Out of scope

The audit's preferred generation-based cache requires bumping rev
counters in `librefang-kernel` (manifest write) and `librefang-memory`
(session write). Cross-crate, disproportionate to this PR's scope.
Tracked in #5551's "Fix" section as a deferred follow-up.

## Verification

- `cargo check -p librefang-api --lib` — clean
- `cargo clippy -p librefang-api --lib --tests -- -D warnings` — clean
- `cargo test -p librefang-api --test dashboard_snapshot_cache_test --test config_status_session_count_test` — 4/4 pass:
  - `dashboard_snapshot_cache_test::snapshot_is_cached_within_ttl_window`
  - `dashboard_snapshot_cache_test::snapshot_rebuilds_after_ttl_expires`
  - `config_status_session_count_test::status_session_count_matches_substrate_after_seeding`
  - `config_status_session_count_test::dashboard_snapshot_session_count_matches_substrate_after_seeding`

Refs `docs/issues/dashboard-snapshot-no-cache.md`.
