### PR TITLE
perf(api): unblock axum executor on create_backup + persist_budget (spawn_blocking)

### DIFF
--- a/crates/librefang-api/src/routes/backup.rs
+++ b/crates/librefang-api/src/routes/backup.rs
@@ -38,25 +38,40 @@ struct BackupManifest {
     components: Vec<String>,
 }
 
-/// POST /api/backup — Create a backup archive of kernel state.
+/// Outcome of a successful `create_backup_blocking` run.
 ///
-/// Returns the backup metadata including the filename. The archive is stored
-/// in `<home_dir>/backups/` with a timestamped filename.
-#[utoipa::path(post, path = "/api/backup", tag = "system", responses((status = 200, description = "Backup created", body = crate::types::JsonObject)))]
-pub async fn create_backup(
-    State(state): State<Arc<AppState>>,
-    lang: Option<axum::Extension<RequestLanguage>>,
-) -> impl IntoResponse {
-    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
-    let home_dir = &state.kernel.home_dir();
+/// Carries everything the async handler needs to build the JSON
+/// response and record an audit entry, so the spawn_blocking closure
+/// stays purely sync and owns no axum / kernel handles.
+struct BackupOutcome {
+    filename: String,
+    backup_path: std::path::PathBuf,
+    size_bytes: u64,
+    components: Vec<String>,
+    created_at: String,
+}
+
+/// Categorised failure mode for `create_backup_blocking`.
+///
+/// Maps 1:1 onto the original handler's distinct ApiErrorResponse
+/// branches so the translated client-facing message stays identical
+/// after the spawn_blocking refactor.
+enum BackupBuildError {
+    CreateDir(String),
+    CreateFile(String),
+    Finalize(String),
+}
+
+/// Sync, blocking implementation of `create_backup`. Walks the home
+/// directory tree (`walkdir` + `std::fs::read`) and produces a zip
+/// archive. Must be dispatched via `tokio::task::spawn_blocking` —
+/// running it directly on the axum/tokio worker stalls every other
+/// request scheduled on that worker for the duration of the walk
+/// (refs `docs/issues/blocking-fs-on-executor.md`).
+fn create_backup_blocking(home_dir: std::path::PathBuf) -> Result<BackupOutcome, BackupBuildError> {
     let backups_dir = home_dir.join("backups");
-    if let Err(e) = std::fs::create_dir_all(&backups_dir) {
-        return ApiErrorResponse::internal(t.t_args(
-            "api-error-backup-create-dir-failed",
-            &[("error", &e.to_string())],
-        ))
-        .into_json_tuple();
-    }
+    std::fs::create_dir_all(&backups_dir)
+        .map_err(|e| BackupBuildError::CreateDir(e.to_string()))?;
 
     let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
     let filename = format!("librefang_backup_{timestamp}.zip");
@@ -65,16 +80,8 @@ pub async fn create_backup(
     let mut components: Vec<String> = Vec::new();
 
     // Create zip archive
-    let file = match std::fs::File::create(&backup_path) {
-        Ok(f) => f,
-        Err(e) => {
-            return ApiErrorResponse::internal(t.t_args(
-                "api-error-backup-create-file-failed",
-                &[("error", &e.to_string())],
-            ))
-            .into_json_tuple();
-        }
-    };
+    let file = std::fs::File::create(&backup_path)
+        .map_err(|e| BackupBuildError::CreateFile(e.to_string()))?;
     let mut zip = zip::ZipWriter::new(file);
     let options = zip::write::SimpleFileOptions::default()
         .compression_method(zip::CompressionMethod::Deflated);
@@ -224,38 +231,102 @@ pub async fn create_backup(
         }
     }
 
-    if let Err(e) = zip.finish() {
-        return ApiErrorResponse::internal(t.t_args(
-            "api-error-backup-finalize-failed",
-            &[("error", &e.to_string())],
-        ))
-        .into_json_tuple();
-    }
+    zip.finish()
+        .map_err(|e| BackupBuildError::Finalize(e.to_string()))?;
 
-    let size = std::fs::metadata(&backup_path)
+    let size_bytes = std::fs::metadata(&backup_path)
         .map(|m| m.len())
         .unwrap_or(0);
 
+    Ok(BackupOutcome {
+        filename,
+        backup_path,
+        size_bytes,
+        components,
+        created_at: manifest.created_at,
+    })
+}
+
+/// POST /api/backup — Create a backup archive of kernel state.
+///
+/// Returns the backup metadata including the filename. The archive is stored
+/// in `<home_dir>/backups/` with a timestamped filename.
+///
+/// The actual zip-build work (`walkdir` + `std::fs::read`/`write` over the
+/// whole `~/.librefang/` tree) is dispatched onto
+/// `tokio::task::spawn_blocking` — running it directly on the axum/tokio
+/// worker would stall every other request scheduled on that worker for
+/// the duration of the walk (seconds, on a multi-GB home).
+#[utoipa::path(post, path = "/api/backup", tag = "system", responses((status = 200, description = "Backup created", body = crate::types::JsonObject)))]
+pub async fn create_backup(
+    State(state): State<Arc<AppState>>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> impl IntoResponse {
+    let home_dir = state.kernel.home_dir().to_path_buf();
+
+    // Dispatch the heavy `walkdir` + `std::fs` work onto a blocking
+    // thread. We must not hold any `!Send` value (notably
+    // `ErrorTranslator`, which wraps the fluent bundle) across this
+    // `.await` — the axum `Handler` bound rejects non-Send futures
+    // with a cryptic trait-bound error. The translator is constructed
+    // separately on each error branch below so it never crosses the
+    // suspend point.
+    let result = tokio::task::spawn_blocking(move || create_backup_blocking(home_dir)).await;
+
+    let outcome = match result {
+        Ok(Ok(o)) => o,
+        Ok(Err(BackupBuildError::CreateDir(msg))) => {
+            let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+            return ApiErrorResponse::internal(
+                t.t_args("api-error-backup-create-dir-failed", &[("error", &msg)]),
+            )
+            .into_json_tuple();
+        }
+        Ok(Err(BackupBuildError::CreateFile(msg))) => {
+            let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+            return ApiErrorResponse::internal(
+                t.t_args("api-error-backup-create-file-failed", &[("error", &msg)]),
+            )
+            .into_json_tuple();
+        }
+        Ok(Err(BackupBuildError::Finalize(msg))) => {
+            let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+            return ApiErrorResponse::internal(
+                t.t_args("api-error-backup-finalize-failed", &[("error", &msg)]),
+            )
+            .into_json_tuple();
+        }
+        Err(join_err) => {
+            let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+            return ApiErrorResponse::internal(t.t_args(
+                "api-error-backup-finalize-failed",
+                &[("error", &format!("backup task join: {join_err}"))],
+            ))
+            .into_json_tuple();
+        }
+    };
+
     tracing::info!(
-        "Backup created: {filename} ({} bytes, {} components)",
-        size,
-        components.len()
+        "Backup created: {} ({} bytes, {} components)",
+        outcome.filename,
+        outcome.size_bytes,
+        outcome.components.len()
     );
     state.kernel.audit().record(
         "system",
         librefang_kernel::audit::AuditAction::ConfigChange,
-        format!("Backup created: {filename}"),
+        format!("Backup created: {}", outcome.filename),
         "completed",
     );
 
     (
         StatusCode::OK,
         Json(serde_json::json!({
-            "filename": filename,
-            "path": backup_path.to_string_lossy(),
-            "size_bytes": size,
-            "components": components,
-            "created_at": manifest.created_at,
+            "filename": outcome.filename,
+            "path": outcome.backup_path.to_string_lossy(),
+            "size_bytes": outcome.size_bytes,
+            "components": outcome.components,
+            "created_at": outcome.created_at,
         })),
     )
 }

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -592,12 +592,17 @@ async fn persist_budget(
     // abort — falling back to "" would silently drop every other section
     // (`[[users]]`, `[mcp_servers]`, `[[taint_rules]]`, …) on the next
     // write, exactly the failure mode `persist_users` documents.
-    let raw = if config_path.exists() {
-        std::fs::read_to_string(&config_path).map_err(|e| {
-            PersistBudgetError::Internal(format!("could not read existing config.toml: {e}"))
-        })?
-    } else {
-        String::new()
+    //
+    // Async-native I/O so we don't block the tokio worker while reading
+    // config.toml — refs `docs/issues/blocking-fs-on-executor.md`.
+    let raw = match tokio::fs::read_to_string(&config_path).await {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(PersistBudgetError::Internal(format!(
+                "could not read existing config.toml: {e}"
+            )));
+        }
     };
     let mut doc: toml_edit::DocumentMut = raw.parse().map_err(|e| {
         PersistBudgetError::Internal(format!(
@@ -632,16 +637,29 @@ async fn persist_budget(
         )));
     }
 
-    if config_path.exists() {
-        if let Some(home_dir) = config_path.parent() {
-            let backups_dir = home_dir.join("backups");
-            if std::fs::create_dir_all(&backups_dir).is_ok() {
-                let _ = std::fs::copy(&config_path, backups_dir.join("config.toml.prev"));
-            }
+    // Snapshot the prior config to `backups/config.toml.prev` before we
+    // overwrite, so an operator can hand-restore if a budget edit
+    // produces an unexpected reload outcome. Best-effort: a failure
+    // here is logged and ignored, the primary write below is the
+    // authoritative path. Async-native (`tokio::fs`) to keep the
+    // executor free during the dotfile copy.
+    if let Some(home_dir) = config_path.parent() {
+        let backups_dir = home_dir.join("backups");
+        if tokio::fs::create_dir_all(&backups_dir).await.is_ok() {
+            let _ = tokio::fs::copy(&config_path, backups_dir.join("config.toml.prev")).await;
         }
     }
 
-    crate::atomic_write(&config_path, new_toml.as_bytes())
+    // `atomic_write` is synchronous because it relies on
+    // `std::fs::File::sync_all` for the fsync-then-rename durability
+    // guarantee. Dispatch via `spawn_blocking` so the fsync syscall
+    // doesn't stall the axum worker (refs
+    // `docs/issues/blocking-fs-on-executor.md`).
+    let bytes = new_toml.clone().into_bytes();
+    let write_path = config_path.clone();
+    tokio::task::spawn_blocking(move || crate::atomic_write(&write_path, &bytes))
+        .await
+        .map_err(|e| PersistBudgetError::Internal(format!("write task join: {e}")))?
         .map_err(|e| PersistBudgetError::Internal(format!("write failed: {e}")))?;
 
     state

--- a/crates/librefang-api/tests/pairing_backup_extra_test.rs
+++ b/crates/librefang-api/tests/pairing_backup_extra_test.rs
@@ -274,6 +274,58 @@ async fn create_backup_writes_archive_and_list_returns_it() {
     assert!(entry["librefang_version"].as_str().is_some());
 }
 
+/// Refs `docs/issues/blocking-fs-on-executor.md` — `create_backup`
+/// must dispatch its `walkdir` / `std::fs::read` work onto
+/// `tokio::task::spawn_blocking` so a large backup walk doesn't
+/// stall the axum worker. We can't directly probe for
+/// "did spawn_blocking get called" without poking internals, but we
+/// can assert the behavioural invariant: while a backup is in
+/// flight, another request submitted to the same router must make
+/// progress and complete. Pre-fix, the in-flight handler held the
+/// worker, so on a 2-worker runtime two concurrent backups would
+/// serialise (and on a 1-worker runtime the test would deadlock).
+/// With `spawn_blocking` the second request hops off onto a fresh
+/// worker thread immediately.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_backup_does_not_block_other_handlers() {
+    let h = boot(true).await;
+    let app1 = h.app.clone();
+    let app2 = h.app.clone();
+
+    // Kick off a backup. Don't await it yet — we want a second
+    // request to overlap.
+    let backup_task = tokio::spawn(async move {
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/api/backup")
+            .header("content-type", "application/json")
+            .header("host", "test.local")
+            .body(Body::from("{}"))
+            .unwrap();
+        app1.oneshot(req).await.unwrap()
+    });
+
+    // Concurrent listing must complete, with a generous-but-still-
+    // bounded timeout. If the backup ever migrates back onto the
+    // executor synchronously, this race tightens against the worker
+    // budget and starts flaking under load.
+    let list_req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/backups")
+        .header("host", "test.local")
+        .body(Body::empty())
+        .unwrap();
+    let list_resp = tokio::time::timeout(std::time::Duration::from_secs(5), app2.oneshot(list_req))
+        .await
+        .expect("GET /api/backups must complete while a backup is in flight")
+        .unwrap();
+    assert_eq!(list_resp.status(), StatusCode::OK);
+
+    // Backup itself eventually completes.
+    let backup_resp = backup_task.await.unwrap();
+    assert_eq!(backup_resp.status(), StatusCode::OK);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn delete_backup_rejects_path_traversal() {
     let h = boot(true).await;

--- a/openapi.json
+++ b/openapi.json
@@ -3606,7 +3606,7 @@
           "system"
         ],
         "summary": "POST /api/backup — Create a backup archive of kernel state.",
-        "description": "Returns the backup metadata including the filename. The archive is stored\nin `<home_dir>/backups/` with a timestamped filename.",
+        "description": "Returns the backup metadata including the filename. The archive is stored\nin `<home_dir>/backups/` with a timestamped filename.\n\nThe actual zip-build work (`walkdir` + `std::fs::read`/`write` over the\nwhole `~/.librefang/` tree) is dispatched onto\n`tokio::task::spawn_blocking` — running it directly on the axum/tokio\nworker would stall every other request scheduled on that worker for\nthe duration of the walk (seconds, on a multi-GB home).",
         "operationId": "create_backup",
         "responses": {
           "200": {

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-98beaf9c8ce02c9d4996336d25c9b90b404683e8aba2bcc06dfa793dff8f9f69  openapi.json
+95455a2e9001fc91b4085b630d6f20f551fbbc93874ec4ce5f153df6f8b7fd3d  openapi.json


### PR DESCRIPTION
Closes #5555

## Summary

Two blocking-on-executor sites in `crates/librefang-api/src/routes/` are now async-friendly:

- `backup.rs::create_backup` — sync work extracted into a blocking helper and dispatched via `tokio::task::spawn_blocking`. The axum worker is no longer held for the duration of a large backup walk.
- `budget.rs::persist_budget` — fsync sequence wrapped in `spawn_blocking`. `persist_budget` no longer fsync-blocks the executor on every budget update.

## Files changed

- `crates/librefang-api/src/routes/backup.rs` (+159 / -…)
- `crates/librefang-api/src/routes/budget.rs` (+44 / -…)
- `crates/librefang-api/tests/pairing_backup_extra_test.rs` (+52 — adds `create_backup_does_not_block_other_handlers`)

## Verification

- `cargo fmt -p librefang-api -- --check` — clean (on touched files)
- `cargo check -p librefang-api --lib` — clean
- `cargo test -p librefang-api --test pairing_backup_extra_test` — 18 passed (including the new `create_backup_does_not_block_other_handlers`)

Refs `docs/issues/blocking-fs-on-executor.md`.
