### PR TITLE
fix(hooks/commit-msg): allow zero spaces in attribution regex

### DIFF
--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -14,7 +14,7 @@
 set -eu
 
 msg_file="$1"
-if grep -qiE '(Co-Authored-By:.*(Claude|Anthropic|noreply@anthropic\.com)|Generated with .{0,40}Claude|🤖.*Claude[[:space:]]+Code)' "$msg_file"; then
+if grep -qiE '(Co-Authored-By:.*(Claude|Anthropic|noreply@anthropic\.com)|Generated with .{0,40}Claude|🤖.*Claude[[:space:]]*Code)' "$msg_file"; then
   cat >&2 <<'EOF'
 [commit-msg] Refusing commit — message contains Claude / Anthropic
 attribution (Co-Authored-By / "Generated with Claude" / 🤖 Claude Code).

--- a/scripts/tests/commit-msg-attribution.sh
+++ b/scripts/tests/commit-msg-attribution.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Corpus test for scripts/hooks/commit-msg.
+#
+# Refs docs/issues/commit-msg-attribution-regex.md sub-finding "this":
+# the original regex used `Claude[[:space:]]+Code` which required at least
+# one space, so the zero-space variant `ClaudeCode` slipped through. After
+# the fix the space class is `*` (zero or more) and all spacing variants
+# are blocked equally.
+#
+# The hook is case-insensitive (`grep -iE`), so casings vary in the corpus
+# below to lock that behavior in too.
+set -euo pipefail
+
+# Resolve hook path relative to repo root so the test can be run from
+# anywhere (e.g. `bash scripts/tests/commit-msg-attribution.sh` from root,
+# or invoked by CI from a different cwd).
+repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+HOOK="$repo_root/scripts/hooks/commit-msg"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable at $HOOK" >&2
+  exit 1
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+run() {
+  local msg="$1"
+  local file="$tmpdir/msg"
+  printf '%s\n' "$msg" > "$file"
+  "$HOOK" "$file" >/dev/null 2>&1
+}
+
+# Should-reject corpus.
+#
+# - The 🤖 ... Code variants exercise the `[[:space:]]*` fix directly:
+#   zero spaces (the bug), single space (status quo), and double space.
+# - Co-Authored-By and "Generated with Claude" exercise the other two
+#   alternations of the same regex.
+# - Mixed case locks in the `-i` flag.
+REJECT_CORPUS=(
+  "🤖 ClaudeCode"
+  "🤖 Claude Code"
+  "🤖 Claude  Code"
+  "🤖 claudecode"
+  "Co-Authored-By: Claude <noreply@anthropic.com>"
+  "Co-Authored-By: Someone <noreply@anthropic.com>"
+  "Generated with Claude Code"
+  "generated with claude"
+)
+
+for bad in "${REJECT_CORPUS[@]}"; do
+  if run "$bad"; then
+    echo "FAIL: hook accepted attribution: $bad" >&2
+    exit 1
+  fi
+done
+
+# Should-accept corpus. Plain conventional commits and unrelated mentions
+# of the word "code" must not trigger the guard.
+ACCEPT_CORPUS=(
+  "fix(api): something"
+  "feat: add foo"
+  "refactor(kernel): tidy code paths"
+  "docs: mention Anthropic API as one option"
+)
+
+for ok in "${ACCEPT_CORPUS[@]}"; do
+  if ! run "$ok"; then
+    echo "FAIL: hook rejected legit message: $ok" >&2
+    exit 1
+  fi
+done
+
+echo "OK: $(basename "$0")"


### PR DESCRIPTION
Closes #5559

## Summary

`scripts/hooks/commit-msg` now matches `🤖.*Claude[[:space:]]*Code` (zero or more spaces) instead of `🤖.*Claude[[:space:]]+Code` (at least one). The zero-space variant `🤖 ClaudeCode` was previously slipping past the attribution guard, defeating the second-layer defense for AI attribution in commit messages.

The two sibling alternations in the same regex (`Co-Authored-By:.*(Claude|Anthropic|noreply@anthropic\.com)` and `Generated with .{0,40}Claude`) do not use a `+` space class and do not need the same change — they were swept and left untouched.

## Tests

New `scripts/tests/commit-msg-attribution.sh` is a self-contained shell corpus test that:

- Verifies the hook rejects `🤖 ClaudeCode` (the bug), `🤖 Claude Code`, `🤖 Claude  Code`, `🤖 claudecode`, `Co-Authored-By: …`, and `Generated with Claude …` in mixed case.
- Verifies the hook accepts legit conventional-commit messages including ones that mention `code` or `Anthropic` outside of an attribution context.

Run with `bash scripts/tests/commit-msg-attribution.sh` — expected output `OK: commit-msg-attribution.sh`. The test resolves the hook path relative to the repo root so it works from any cwd / CI.

## Files changed

- `scripts/hooks/commit-msg`
- `scripts/tests/commit-msg-attribution.sh` (NEW, executable)

## Out of scope

The three sibling sub-findings tracked in `docs/issues/commit-msg-attribution-regex.md` (`openapi-drift` `[skip ci]`, `pkill -f librefang` too broad, `RUST_TEST_THREADS` global) are separate items and will be handled in their own PRs.

Refs `docs/issues/commit-msg-attribution-regex.md`.
