### PR TITLE
fix(dashboard/queries): switch useSessionStream to authenticated WebSocket

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/queries/sessions-stream.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions-stream.test.tsx
@@ -2,61 +2,89 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { useSessionStream } from "./sessions";
 
-// Minimal in-test EventSource fake. Native EventSource exists in jsdom only
-// as a no-op stub; we drive our own so we can deterministically assert
-// open / message / error transitions.
+// Minimal in-test WebSocket fake. jsdom does not implement WebSocket; we
+// drive our own so we can deterministically assert open / message /
+// close transitions and assert the bearer sub-protocol is carried
+// correctly (audit `docs/issues/session-sse-withcredentials.md`).
 //
-// Intentionally NOT `implements Partial<EventSource>`: the real interface
-// declares add/removeEventListener with overloaded signatures that pin
-// MessageEvent on typed channels, which a plain `EventListener` arg cannot
-// satisfy (TS2416). The hook only depends on duck-typed access through
-// the `as unknown as typeof EventSource` cast at the call sites, so
+// Intentionally NOT `implements WebSocket`: the real interface declares
+// add/removeEventListener with overloaded signatures and a number of
+// dom-only members (binaryType, bufferedAmount, extensions, …) that the
+// hook never touches. The hook only depends on duck-typed access through
+// the `as unknown as typeof WebSocket` cast at the call sites, so
 // formal interface conformance buys us nothing and just fights the
 // type checker.
-class FakeEventSource {
-  static instances: FakeEventSource[] = [];
-  url: string;
-  withCredentials: boolean;
-  readyState: number = 0; // CONNECTING
-  closed = false;
-  private listeners = new Map<string, Set<EventListener>>();
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static CONNECTING = 0 as const;
+  static OPEN = 1 as const;
+  static CLOSING = 2 as const;
+  static CLOSED = 3 as const;
 
-  constructor(url: string, init?: EventSourceInit) {
+  url: string;
+  protocols: string[];
+  readyState: number = FakeWebSocket.CONNECTING;
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+
+  closeCode: number | undefined;
+  closeReason: string | undefined;
+
+  constructor(url: string, protocols?: string | string[]) {
     this.url = url;
-    this.withCredentials = init?.withCredentials ?? false;
-    FakeEventSource.instances.push(this);
+    this.protocols = Array.isArray(protocols)
+      ? protocols
+      : protocols
+      ? [protocols]
+      : [];
+    FakeWebSocket.instances.push(this);
   }
-  addEventListener(type: string, fn: EventListener) {
-    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
-    this.listeners.get(type)!.add(fn);
+
+  close(code?: number, reason?: string) {
+    if (
+      this.readyState === FakeWebSocket.CLOSED ||
+      this.readyState === FakeWebSocket.CLOSING
+    ) {
+      return;
+    }
+    this.closeCode = code;
+    this.closeReason = reason;
+    this.readyState = FakeWebSocket.CLOSED;
   }
-  removeEventListener(type: string, fn: EventListener) {
-    this.listeners.get(type)?.delete(fn);
-  }
-  close() {
-    this.closed = true;
-    this.readyState = 2;
-  }
+
   // Test helpers
   emitOpen() {
-    this.readyState = 1;
-    for (const fn of this.listeners.get("open") ?? []) fn(new Event("open"));
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
   }
-  emit(type: string, data: string) {
-    const ev = new MessageEvent(type, { data });
-    for (const fn of this.listeners.get(type) ?? []) fn(ev);
+  emitMessage(data: string) {
+    this.onmessage?.(new MessageEvent("message", { data }));
   }
-  emitError(closed: boolean) {
-    if (closed) this.readyState = 2;
-    for (const fn of this.listeners.get("error") ?? []) fn(new Event("error"));
+  emitClose(code: number, reason = "") {
+    this.readyState = FakeWebSocket.CLOSED;
+    // Synthesise a CloseEvent-shaped object. jsdom does not expose the
+    // CloseEvent constructor in all versions; a plain Event with the
+    // extra fields satisfies the hook's structural use.
+    const ev = new Event("close") as CloseEvent;
+    Object.assign(ev, { code, reason, wasClean: code === 1000 });
+    this.onclose?.(ev);
   }
 }
 
+const stubAuth = (path: string) => ({
+  url: `ws://test${path}`,
+  protocols: ["bearer.test-token"],
+});
+
 beforeEach(() => {
-  FakeEventSource.instances = [];
+  FakeWebSocket.instances = [];
+  vi.useFakeTimers();
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -64,138 +92,223 @@ describe("useSessionStream", () => {
   it("does nothing when ids are missing", () => {
     const { result } = renderHook(() =>
       useSessionStream(null, null, {
-        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
       }),
     );
-    expect(FakeEventSource.instances).toHaveLength(0);
+    expect(FakeWebSocket.instances).toHaveLength(0);
     expect(result.current.isAttached).toBe(false);
     expect(result.current.events).toEqual([]);
     expect(result.current.lastError).toBeNull();
   });
 
-  it("opens a stream when both ids are present and parses events", () => {
-    const { result } = renderHook(() =>
+  it("opens a WebSocket with the bearer sub-protocol when both ids are present", () => {
+    renderHook(() =>
       useSessionStream("agent-1", "sess-1", {
-        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
       }),
     );
-    expect(FakeEventSource.instances).toHaveLength(1);
-    const es = FakeEventSource.instances[0];
-    expect(es.url).toBe("/api/agents/agent-1/sessions/sess-1/stream");
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    const ws = FakeWebSocket.instances[0];
+    // Regression: must NOT use HTTP / EventSource — the URL is a ws://
+    // URL built by `buildAuthenticatedWebSocket`, and the bearer token
+    // rides on `Sec-WebSocket-Protocol` rather than a cookie.
+    expect(ws.url).toBe("ws://test/api/agents/agent-1/sessions/sess-1/stream");
+    expect(ws.protocols).toEqual(["bearer.test-token"]);
+  });
 
-    act(() => es.emitOpen());
+  it("parses typed envelopes and surfaces them via `events`", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
+      }),
+    );
+    const ws = FakeWebSocket.instances[0];
+    act(() => ws.emitOpen());
     expect(result.current.isAttached).toBe(true);
 
-    act(() => es.emit("chunk", JSON.stringify({ content: "hi" })));
+    act(() => ws.emitMessage(JSON.stringify({ type: "chunk", content: "hi" })));
     expect(result.current.events).toHaveLength(1);
     expect(result.current.events[0].type).toBe("chunk");
     expect(result.current.events[0].data).toEqual({ content: "hi" });
 
-    act(() => es.emit("tool_use", JSON.stringify({ tool: "fs_read", input: { path: "/tmp" } })));
+    act(() =>
+      ws.emitMessage(
+        JSON.stringify({ type: "tool_use", tool: "fs_read", input: { path: "/tmp" } }),
+      ),
+    );
     expect(result.current.events).toHaveLength(2);
     expect(result.current.events[1].type).toBe("tool_use");
+    expect(
+      (result.current.events[1].data as { tool?: string }).tool,
+    ).toBe("fs_read");
   });
 
   it("auto-detaches on `done` and surfaces the event", () => {
     const { result } = renderHook(() =>
       useSessionStream("agent-1", "sess-1", {
-        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
       }),
     );
-    const es = FakeEventSource.instances[0];
-    act(() => es.emitOpen());
+    const ws = FakeWebSocket.instances[0];
+    act(() => ws.emitOpen());
     expect(result.current.isAttached).toBe(true);
 
-    act(() => es.emit("done", "{}"));
+    act(() => ws.emitMessage(JSON.stringify({ type: "done" })));
     expect(result.current.isAttached).toBe(false);
-    // Indexed access instead of `.at(-1)` — tsconfig targets ES2020,
-    // and `Array.prototype.at` is ES2022.
     expect(
       result.current.events[result.current.events.length - 1]?.type,
     ).toBe("done");
   });
 
-  it("treats error-before-any-data as a silent no-op (404 / not-deployed)", () => {
+  it("treats first-attempt close-without-data as a silent no-op (route not deployed)", () => {
     const { result } = renderHook(() =>
       useSessionStream("agent-1", "sess-1", {
-        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
       }),
     );
-    const es = FakeEventSource.instances[0];
-    // Connection closed without a single event arriving — looks exactly
-    // like a 404 from the not-yet-deployed route.
-    act(() => es.emitError(true));
+    const ws = FakeWebSocket.instances[0];
+    // Server closes without ever opening / sending data — looks exactly
+    // like a 404 against the not-yet-deployed handler.
+    act(() => ws.emitClose(1006));
     expect(result.current.isAttached).toBe(false);
     expect(result.current.lastError).toBeNull();
     expect(result.current.events).toHaveLength(0);
+    // Must NOT schedule a reconnect for the first-attempt no-payload case.
+    expect(FakeWebSocket.instances).toHaveLength(1);
   });
 
-  it("surfaces mid-stream disconnects via lastError", () => {
+  it("surfaces an auth-required error and stops reconnecting on 4401", () => {
     const { result } = renderHook(() =>
       useSessionStream("agent-1", "sess-1", {
-        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
       }),
     );
-    const es = FakeEventSource.instances[0];
-    act(() => es.emitOpen());
-    act(() => es.emit("chunk", JSON.stringify({ content: "partial" })));
-    act(() => es.emitError(true));
-    expect(result.current.lastError).toBe("session stream disconnected");
+    const ws = FakeWebSocket.instances[0];
+    act(() => ws.emitClose(4401, "Unauthorized"));
+    expect(result.current.lastError).toBe(
+      "session stream authentication required",
+    );
     expect(result.current.isAttached).toBe(false);
+    // No reconnect attempt — auth errors require user action.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
   });
 
-  it("closes the stream on unmount", () => {
+  it("reconnects with backoff after a mid-stream disconnect", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
+      }),
+    );
+    const ws = FakeWebSocket.instances[0];
+    act(() => ws.emitOpen());
+    act(() => ws.emitMessage(JSON.stringify({ type: "chunk", content: "partial" })));
+    act(() => ws.emitClose(1006));
+    expect(result.current.isAttached).toBe(false);
+    // First backoff is 1s (2^0 * 1000ms).
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances[1].url).toBe(ws.url);
+  });
+
+  it("gives up after WS_MAX_RETRIES and surfaces `lastError`", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
+      }),
+    );
+    // First connection: open + receive so the first-attempt swallow
+    // doesn't fire; then close abnormally repeatedly.
+    act(() => FakeWebSocket.instances[0].emitOpen());
+    act(() =>
+      FakeWebSocket.instances[0].emitMessage(
+        JSON.stringify({ type: "chunk", content: "ok" }),
+      ),
+    );
+    act(() => FakeWebSocket.instances[0].emitClose(1006));
+    // Drive reconnect attempts to exhaustion (5 retries → 5 new
+    // instances after the first).
+    for (let i = 0; i < 5; i++) {
+      act(() => {
+        vi.advanceTimersByTime(20_000);
+      });
+      const latest = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+      act(() => latest.emitClose(1006));
+    }
+    expect(result.current.lastError).toBe("session stream disconnected");
+  });
+
+  it("falls back to chunk { content } when a frame is non-JSON", () => {
+    const { result } = renderHook(() =>
+      useSessionStream("agent-1", "sess-1", {
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
+      }),
+    );
+    const ws = FakeWebSocket.instances[0];
+    act(() => ws.emitOpen());
+    act(() => ws.emitMessage("not-json"));
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current.events[0].type).toBe("chunk");
+    expect(result.current.events[0].data).toEqual({ content: "not-json" });
+  });
+
+  it("closes the WebSocket on unmount", () => {
     const { unmount } = renderHook(() =>
       useSessionStream("agent-1", "sess-1", {
-        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
       }),
     );
-    const es = FakeEventSource.instances[0];
-    expect(es.closed).toBe(false);
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.readyState).not.toBe(FakeWebSocket.CLOSED);
     unmount();
-    expect(es.closed).toBe(true);
+    expect(ws.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(ws.closeCode).toBe(1000);
   });
 
-  it("closes and reconnects when sessionId changes", () => {
+  it("closes and reopens when sessionId changes", () => {
     const { rerender } = renderHook(
       ({ s }: { s: string }) =>
         useSessionStream("agent-1", s, {
-          eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+          webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+          buildWebSocket: stubAuth,
         }),
       { initialProps: { s: "sess-1" } },
     );
-    expect(FakeEventSource.instances).toHaveLength(1);
-    const first = FakeEventSource.instances[0];
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    const first = FakeWebSocket.instances[0];
 
     rerender({ s: "sess-2" });
-    expect(first.closed).toBe(true);
-    expect(FakeEventSource.instances).toHaveLength(2);
-    expect(FakeEventSource.instances[1].url).toContain("sess-2");
-  });
-
-  it("falls back to raw content when payload is non-JSON", () => {
-    const { result } = renderHook(() =>
-      useSessionStream("agent-1", "sess-1", {
-        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
-      }),
-    );
-    const es = FakeEventSource.instances[0];
-    act(() => es.emitOpen());
-    act(() => es.emit("chunk", "not-json"));
-    expect(result.current.events[0].data).toEqual({ content: "not-json" });
+    expect(first.readyState).toBe(FakeWebSocket.CLOSED);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances[1].url).toContain("sess-2");
   });
 
   it("caps the event buffer at 500 to bound memory", () => {
     const { result } = renderHook(() =>
       useSessionStream("agent-1", "sess-1", {
-        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
       }),
     );
-    const es = FakeEventSource.instances[0];
-    act(() => es.emitOpen());
+    const ws = FakeWebSocket.instances[0];
+    act(() => ws.emitOpen());
     act(() => {
       for (let i = 0; i < 600; i++) {
-        es.emit("chunk", JSON.stringify({ content: `c${i}` }));
+        ws.emitMessage(JSON.stringify({ type: "chunk", content: `c${i}` }));
       }
     });
     expect(result.current.events.length).toBe(500);
@@ -205,15 +318,14 @@ describe("useSessionStream", () => {
     ).toBe("c100");
   });
 
-  it("uses a custom buildUrl when supplied", () => {
+  it("uses a custom buildPath when supplied", () => {
     renderHook(() =>
       useSessionStream("agent-1", "sess-1", {
-        eventSourceCtor: FakeEventSource as unknown as typeof EventSource,
-        buildUrl: (a, s) => `https://example.test/x/${a}/${s}`,
+        webSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+        buildWebSocket: stubAuth,
+        buildPath: (a, s) => `/custom/${a}/${s}`,
       }),
     );
-    expect(FakeEventSource.instances[0].url).toBe(
-      "https://example.test/x/agent-1/sess-1",
-    );
+    expect(FakeWebSocket.instances[0].url).toBe("ws://test/custom/agent-1/sess-1");
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/sessions.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/sessions.ts
@@ -1,6 +1,11 @@
 import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
-import { listSessions, getSessionDetails, type ListSessionsResult } from "../http/client";
+import {
+  listSessions,
+  getSessionDetails,
+  type ListSessionsResult,
+} from "../http/client";
+import { buildAuthenticatedWebSocket } from "../../api";
 import { sessionKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
 
@@ -39,7 +44,7 @@ export function useSessionDetails(sessionId: string, options: QueryOverrides = {
 }
 
 // ---------------------------------------------------------------------------
-// useSessionStream — multi-attach SSE consumer for in-flight session events.
+// useSessionStream — multi-attach consumer for in-flight session events.
 //
 // Subscribes to `GET /api/agents/{agentId}/sessions/{sessionId}/stream` so
 // that any client (extra browser tab, desktop, CLI) can co-watch the events
@@ -47,28 +52,52 @@ export function useSessionDetails(sessionId: string, options: QueryOverrides = {
 // sends its turn over `POST /message/stream` (single-consumer mpsc); this
 // hook is for read-only observers.
 //
-// The hook intentionally does NOT go through TanStack Query's cache: an SSE
-// connection is a long-lived stream of imperative events, not cacheable
-// snapshot data. This is the same exception called out in
+// Transport: WebSocket (audit `docs/issues/session-sse-withcredentials.md`).
+// Previously the hook used `EventSource` with `withCredentials: true`,
+// which only carries cookies — but the dashboard's auth is a
+// `Authorization: Bearer <token>` header, and `EventSource` does not
+// support custom headers. The result was an effectively unauthenticated
+// upstream request that only survived because the route returns mock
+// data today; once #3078 gates the route on auth, every attach would
+// 401 silently. The dashboard's existing authenticated WebSocket pattern
+// (#3963, `buildAuthenticatedWebSocket`) carries the bearer via the
+// `Sec-WebSocket-Protocol` sub-protocol — the token never reaches URLs,
+// proxy access logs, browser history, or `Referer` headers.
+//
+// SERVER-SIDE NOTE: the route handler at
+// `crates/librefang-api/src/routes/agents.rs::attach_session_stream` is
+// currently an SSE responder. A coordinated server-side change is
+// required to accept the WebSocket upgrade; until that lands the
+// connection fails at handshake (and the close code surfaces via
+// `lastError`). The audit doc tracks both halves.
+//
+// The hook intentionally does NOT go through TanStack Query's cache: a
+// streaming connection is a long-lived stream of imperative events, not
+// cacheable snapshot data. This is the same exception called out in
 // `dashboard/AGENTS.md` ("Streaming / SSE … may call native browser APIs
 // directly").
 //
 // Behaviour:
-// - opens an EventSource when both ids are truthy
+// - opens a WebSocket when both ids are truthy
 // - closes cleanly on unmount, agent change, or session change
 // - surfaces parsed events as an in-memory append-only list capped at
 //   MAX_EVENTS to bound worst-case memory
-// - swallows the "404 because the route isn't deployed yet / the session
-//   has no active turn" case silently — `lastError` stays null, no toast.
-//   Native EventSource cannot read HTTP status codes, so the heuristic is:
-//   an error event that fires before any payload arrived AND closes the
-//   connection is treated as a no-op. Mid-stream errors after data has
-//   flowed are surfaced via `lastError`.
+// - reconnects with exponential backoff (capped at WS_MAX_RETRIES) for
+//   transient mid-stream disconnects; auth-error close codes
+//   (4401 / 4403) stop reconnect and surface via `lastError`
+// - swallows the "route not deployed / session has no active turn" case
+//   silently when the first attempt closes before any payload arrived
+//   AND the close code is non-auth — `lastError` stays null, matching
+//   the prior SSE behaviour the audit explicitly preserves
 // ---------------------------------------------------------------------------
 
 const MAX_EVENTS = 500;
+const WS_MAX_RETRIES = 5;
+const WS_AUTH_ERROR_CODES = new Set([4401, 4403]);
+// Normal closure (1000) is a clean shutdown, not a fault.
+const WS_NORMAL_CLOSE = 1000;
 
-/** Discriminated union of SSE event payloads emitted by the backend stream. */
+/** Discriminated union of session event payloads emitted by the backend stream. */
 export type SessionStreamEvent =
   | { type: "chunk"; data: { content?: string; [k: string]: unknown }; receivedAt: number }
   | { type: "tool_use"; data: { tool?: string; input?: unknown; id?: string; [k: string]: unknown }; receivedAt: number }
@@ -80,32 +109,48 @@ export type SessionStreamEvent =
 export type UseSessionStreamResult = {
   /** Append-only list of parsed events, capped at MAX_EVENTS (oldest dropped). */
   events: SessionStreamEvent[];
-  /** True while the EventSource is open and accepting events. */
+  /** True while the WebSocket is open and accepting events. */
   isAttached: boolean;
-  /** Last surfaced error, or null. 404-on-open is intentionally swallowed. */
+  /** Last surfaced error, or null. Open-then-close before any data flowed
+   *  with a non-auth close code is intentionally swallowed. */
   lastError: string | null;
 };
 
 export type UseSessionStreamOptions = {
   /**
-   * Override the default endpoint builder. Tests inject a stub URL; production
-   * callers should not need this.
+   * Override the default endpoint path builder. Tests inject a stub path;
+   * production callers should not need this. This returns a PATH (e.g.
+   * `/api/...`); the hook prepends scheme + host through
+   * `buildAuthenticatedWebSocket`.
    */
-  buildUrl?: (agentId: string, sessionId: string) => string;
+  buildPath?: (agentId: string, sessionId: string) => string;
   /**
-   * Optional EventSource constructor — defaults to globalThis.EventSource.
-   * Tests can pass a fake. If the environment has no EventSource (older
-   * browsers, jsdom without polyfill) the hook returns a no-op state.
+   * Optional WebSocket constructor — defaults to `globalThis.WebSocket`.
+   * Tests pass a fake. If the environment has no WebSocket the hook
+   * returns a no-op state.
    */
-  eventSourceCtor?: typeof EventSource;
+  webSocketCtor?: typeof WebSocket;
+  /**
+   * Optional override for the URL builder. Tests use this to inject a
+   * deterministic `ws://test/...` URL without depending on
+   * `window.location` or stored auth state. Production callers should
+   * not need this.
+   */
+  buildWebSocket?: (path: string) => { url: string; protocols: string[] };
 };
 
-const SSE_TYPES = ["chunk", "tool_use", "tool_result", "phase", "done", "owner_notice"] as const;
-type SseType = (typeof SSE_TYPES)[number];
+const STREAM_TYPES = ["chunk", "tool_use", "tool_result", "phase", "done", "owner_notice"] as const;
+type StreamType = (typeof STREAM_TYPES)[number];
 
-function defaultBuildUrl(agentId: string, sessionId: string): string {
+function defaultBuildPath(agentId: string, sessionId: string): string {
   return `/api/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/stream`;
 }
+
+/** Shape of a single parsed envelope from the server. The server emits
+ *  one JSON message per event with `{ type, ...data }`; we keep the
+ *  parsed payload (minus `type`) under `data` so consumers see the same
+ *  shape they saw under SSE. */
+type EventEnvelope = { type?: string } & Record<string, unknown>;
 
 export function useSessionStream(
   agentId: string | null | undefined,
@@ -115,9 +160,9 @@ export function useSessionStream(
   const [events, setEvents] = useState<SessionStreamEvent[]>([]);
   const [isAttached, setIsAttached] = useState(false);
   const [lastError, setLastError] = useState<string | null>(null);
-  // Track whether any payload arrived before an error fires. If not, an
-  // error+close is almost certainly a 404 / not-deployed / no-active-turn —
-  // swallow it.
+  // Track whether any payload arrived before close. If not, a close with
+  // a non-auth code on the first attempt is almost certainly route-not-
+  // deployed / no-active-turn — swallow it (parity with prior SSE).
   const receivedAnyRef = useRef(false);
 
   useEffect(() => {
@@ -128,90 +173,166 @@ export function useSessionStream(
     receivedAnyRef.current = false;
 
     if (!agentId || !sessionId) return;
-    const Ctor = options.eventSourceCtor ?? (typeof EventSource !== "undefined" ? EventSource : undefined);
+    const Ctor =
+      options.webSocketCtor ??
+      (typeof WebSocket !== "undefined" ? WebSocket : undefined);
     if (!Ctor) return;
 
-    const url = (options.buildUrl ?? defaultBuildUrl)(agentId, sessionId);
+    const path = (options.buildPath ?? defaultBuildPath)(agentId, sessionId);
+    const { url, protocols } = (options.buildWebSocket ?? buildAuthenticatedWebSocket)(path);
 
-    let es: EventSource;
-    try {
-      es = new Ctor(url, { withCredentials: true });
-    } catch {
-      // Constructor itself threw — environment doesn't support EventSource
-      // for this URL (e.g. invalid scheme in tests). Stay detached, silent.
-      return;
-    }
+    let cancelled = false;
+    let ws: WebSocket | null = null;
+    let retries = 0;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
-    const handlePayload = (type: SseType, raw: string) => {
-      receivedAnyRef.current = true;
-      let parsed: Record<string, unknown> = {};
-      try {
-        parsed = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
-      } catch {
-        // Non-JSON payload — preserve as raw content so callers can still
-        // render it.
-        parsed = { content: raw };
-      }
+    const appendEvent = (type: StreamType, parsed: Record<string, unknown>) => {
       const evt = {
         type,
         data: parsed,
         receivedAt: Date.now(),
       } as SessionStreamEvent;
       setEvents((prev) => {
-        const next = prev.length >= MAX_EVENTS ? prev.slice(prev.length - MAX_EVENTS + 1) : prev;
+        const next =
+          prev.length >= MAX_EVENTS
+            ? prev.slice(prev.length - MAX_EVENTS + 1)
+            : prev;
         return [...next, evt];
       });
-      // Auto-detach on terminal "done" so consumers can react without polling.
       if (type === "done") {
         setIsAttached(false);
       }
     };
 
-    const listeners = SSE_TYPES.map((type) => {
-      const fn = (ev: MessageEvent) => handlePayload(type, typeof ev.data === "string" ? ev.data : "");
-      es.addEventListener(type, fn as EventListener);
-      return { type, fn };
-    });
-
-    const onOpen = () => {
-      setIsAttached(true);
-      setLastError(null);
-    };
-    const onError = () => {
-      // EventSource doesn't expose HTTP status. If we never received any
-      // payload AND the connection closed, assume the route isn't there
-      // (deployed in #3078 but not yet on this client's server) or the
-      // session has no active turn — both of which are valid no-ops.
-      const closed = es.readyState === 2; // EventSource.CLOSED
-      if (!receivedAnyRef.current && closed) {
-        // Silent no-op — don't surface to the UI.
-        setIsAttached(false);
+    const handleMessage = (raw: string) => {
+      let envelope: EventEnvelope = {};
+      try {
+        envelope = raw ? (JSON.parse(raw) as EventEnvelope) : {};
+      } catch {
+        // Non-JSON frame — preserve under `content` so callers can still
+        // render it. Treat as a `chunk` (the most common payload type
+        // and the one that the previous SSE fallback assumed).
+        receivedAnyRef.current = true;
+        appendEvent("chunk", { content: raw });
         return;
       }
-      if (closed) {
-        // Mid-stream drop after data flowed — worth telling the caller, but
-        // don't toast: a co-watcher dropping isn't a destructive error.
-        setLastError("session stream disconnected");
-        setIsAttached(false);
+      const type = envelope.type;
+      if (typeof type !== "string" || !STREAM_TYPES.includes(type as StreamType)) {
+        // Unknown / missing type — surface as a chunk so we don't lose
+        // the payload but don't poison the typed consumers.
+        receivedAnyRef.current = true;
+        appendEvent("chunk", { ...envelope });
+        return;
       }
-      // Transient errors (readyState === CONNECTING) are EventSource's own
-      // automatic reconnect; ignore them.
+      receivedAnyRef.current = true;
+      // Strip `type` from the data envelope so consumers see only the
+      // payload fields (matches the previous SSE shape, which delivered
+      // `data` separately from the event name).
+      const { type: _drop, ...payload } = envelope;
+      void _drop;
+      appendEvent(type as StreamType, payload);
     };
 
-    es.addEventListener("open", onOpen);
-    es.addEventListener("error", onError);
+    function connect() {
+      if (cancelled) return;
+      let socket: WebSocket;
+      try {
+        socket = new Ctor!(url, protocols.length > 0 ? protocols : undefined);
+      } catch {
+        // Constructor itself threw — environment doesn't support
+        // WebSocket for this URL (e.g. invalid scheme in tests). Stay
+        // detached, silent.
+        return;
+      }
+      ws = socket;
+
+      socket.onopen = () => {
+        if (cancelled) return;
+        setIsAttached(true);
+        setLastError(null);
+        retries = 0;
+      };
+
+      socket.onmessage = (ev: MessageEvent) => {
+        if (cancelled) return;
+        if (typeof ev.data === "string") {
+          handleMessage(ev.data);
+        }
+        // Binary frames (Blob / ArrayBuffer) are not part of the
+        // protocol; ignore them rather than guess at a decoding.
+      };
+
+      socket.onerror = () => {
+        // onclose fires after onerror; reconnect / surface decisions
+        // happen there so we see the close code.
+      };
+
+      socket.onclose = (event: CloseEvent) => {
+        if (cancelled) return;
+        setIsAttached(false);
+
+        // Auth failure — stop retrying, surface a clear message so the
+        // dashboard can prompt the operator to refresh / re-auth.
+        if (WS_AUTH_ERROR_CODES.has(event.code)) {
+          setLastError("session stream authentication required");
+          return;
+        }
+
+        // Clean shutdown initiated by the server (1000) — nothing to do.
+        if (event.code === WS_NORMAL_CLOSE) {
+          return;
+        }
+
+        // Open-then-close before any payload arrived AND a non-auth code
+        // on the first attempt: most likely the route isn't deployed on
+        // this server yet or the session has no active turn. Swallow
+        // silently to match the previous SSE-era behaviour the audit
+        // explicitly preserves.
+        if (!receivedAnyRef.current && retries === 0) {
+          return;
+        }
+
+        // Mid-stream drop or transient failure — try to reconnect with
+        // exponential backoff up to WS_MAX_RETRIES. Surface a soft
+        // status only when we give up so the UI can show a real error.
+        if (retries >= WS_MAX_RETRIES) {
+          setLastError("session stream disconnected");
+          return;
+        }
+        const delay = Math.min(1000 * 2 ** retries, 15000);
+        retries += 1;
+        reconnectTimer = setTimeout(connect, delay);
+      };
+    }
+
+    connect();
 
     return () => {
-      es.removeEventListener("open", onOpen);
-      es.removeEventListener("error", onError);
-      for (const { type, fn } of listeners) {
-        es.removeEventListener(type, fn as EventListener);
+      cancelled = true;
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
       }
-      es.close();
+      if (ws) {
+        // Tear down handlers before close so a late onclose can't
+        // re-enter React state for an unmounted hook.
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.onclose = null;
+        try {
+          ws.close(WS_NORMAL_CLOSE, "unmount");
+        } catch {
+          // ignore — close on an already-closing socket throws in some
+          // environments.
+        }
+        ws = null;
+      }
       setIsAttached(false);
     };
-    // buildUrl/eventSourceCtor are stable in production; tests pass them
-    // once at mount. Excluding them keeps the connection from churning.
+    // buildPath / webSocketCtor / buildWebSocket are stable in
+    // production; tests pass them once at mount. Excluding them keeps
+    // the connection from churning.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agentId, sessionId]);
 


### PR DESCRIPTION
Closes #5566

## Summary

`crates/librefang-api/dashboard/src/lib/queries/sessions.ts::useSessionStream` no longer uses `EventSource` with `withCredentials: true` — that combo sent cookies, but the dashboard's auth is `Authorization: Bearer <token>` in an HTTP header, so the upstream request was effectively unauthenticated. Today this is hidden because the route returns mock data; once `#3078` gates the route on auth, every attach would 401 silently (line 186's `onError` swallowed the failure).

Switched to `WebSocket` and routed the token through the existing dashboard helper `buildAuthenticatedWebSocket` (`Sec-WebSocket-Protocol` sub-protocol, per `#3963`), matching the chat WS pattern in `ChatPage.tsx`. Added an exponential-backoff reconnect loop (capped at `WS_MAX_RETRIES = 5`) since WebSocket lacks `EventSource`'s built-in auto-reconnect. Auth-error close codes (`4401` / `4403`) now stop reconnect and surface a real `lastError` so the UI can show a real error instead of the previous silent no-op.

The first-attempt "close without data on a non-auth code" path is still treated as a silent "route not deployed / no active turn" no-op, matching the SSE behaviour the audit explicitly asked to preserve.

## Server-side dependency

`crates/librefang-api/src/routes/agents.rs::attach_session_stream` currently responds with axum `Sse`. A coordinated server-side change is required to accept the WebSocket upgrade; until that lands the close code (1006) surfaces as a transient connection that the reconnect loop will retry. The linked issue tracks both halves — the audit explicitly anticipated this dependency.

## Files changed

- `crates/librefang-api/dashboard/src/lib/queries/sessions.ts` — primary fix
- `crates/librefang-api/dashboard/src/lib/queries/sessions-stream.test.tsx` — rewritten against `FakeWebSocket`

## Tests added

- `opens a WebSocket with the bearer sub-protocol when both ids are present` — regression test for the audit
- `parses typed envelopes and surfaces them via events`
- `auto-detaches on done and surfaces the event`
- `treats first-attempt close-without-data as a silent no-op (route not deployed)`
- `surfaces an auth-required error and stops reconnecting on 4401`
- `reconnects with backoff after a mid-stream disconnect`
- `gives up after WS_MAX_RETRIES and surfaces lastError`
- `falls back to chunk { content } when a frame is non-JSON`
- `closes the WebSocket on unmount`
- `closes and reopens when sessionId changes`
- `caps the event buffer at 500 to bound memory`
- `uses a custom buildPath when supplied`
- `does nothing when ids are missing`

## Verification

```
pnpm typecheck                                                   # clean
pnpm vitest run src/lib/queries/sessions-stream.test.tsx         # 13/13 pass
pnpm vitest run src/lib/queries                                  # 163/163 pass
pnpm build                                                       # clean
```

(Workspace `pnpm test` shows pre-existing flaky failures in `ApprovalsPage.test.tsx` unrelated to this change — same test file passes 8/8 when run in isolation both with and without this branch's diff.)

Refs `docs/issues/session-sse-withcredentials.md`.
