### PR TITLE
fix(dashboard/i18n): escape translator HTML, route via <Trans>

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/i18n.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/i18n.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import i18n from "i18next";
+import { I18nextProvider, Trans } from "react-i18next";
+import { initReactI18next } from "react-i18next";
+
+// Regression test for the rollup item in
+// docs/issues/i18n-escapeValue-false.md ("i18n escapeValue: false +
+// dangerouslySetInnerHTML XSS landmine"). Before the fix, every value
+// interpolated through `t(...)` was inserted into the resulting string
+// without HTML escaping; consumers (MobilePairingPage, ConnectWizardPage)
+// then handed those strings to `dangerouslySetInnerHTML`. A translator-PR
+// that smuggled `<script>` into a locale file would execute in the
+// dashboard origin. We now (1) keep i18next's default escaping
+// (escapeValue: true) and (2) render any HTML-bearing translation via
+// `<Trans>` with an explicit `components` allowlist.
+
+beforeAll(async () => {
+  // Use an isolated i18next instance so this test does not race the
+  // browser-only LanguageDetector path in `lib/i18n.ts`.
+  await i18n.use(initReactI18next).init({
+    lng: "en",
+    fallbackLng: "en",
+    resources: {
+      en: {
+        translation: {
+          attack: {
+            // Simulates a malicious / careless translator submission.
+            payload: "hello {{user}} <script>alert(1)</script>",
+          },
+          // Mirrors `mobile_pairing.error_disabled_body` shape — uses a
+          // non-void HTML tag (<a>) so html-parse-stringify treats it as a
+          // container, not a self-closing void element like <link>.
+          link_body: "Enable pairing in <a>Config</a>.",
+        },
+      },
+    },
+    interpolation: { escapeValue: true },
+  });
+});
+
+describe("i18n escape configuration", () => {
+  it("escapes HTML in interpolated values so a translator payload cannot inject DOM", () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <p data-testid="payload">{i18n.t("attack.payload", { user: "<img onerror=x>" })}</p>
+      </I18nextProvider>,
+    );
+    const el = screen.getByTestId("payload");
+    // The crucial property is structural, not textual: nothing inside this
+    // paragraph is a live DOM node. The interpolated `<img onerror=x>` is
+    // entity-encoded by i18next (escapeValue: true) before reaching React;
+    // the literal `<script>` from the translation source is then placed by
+    // React as a text node. Neither can execute.
+    expect(el.querySelector("script")).toBeNull();
+    expect(el.querySelector("img")).toBeNull();
+    // No raw `<script` / `<img` tags ever appear in the rendered HTML.
+    expect(el.innerHTML).not.toContain("<script");
+    expect(el.innerHTML).not.toContain("<img");
+  });
+
+  it("<Trans> only renders the components listed in its allowlist", () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <p data-testid="link-body">
+          <Trans
+            i18n={i18n}
+            i18nKey="link_body"
+            components={{ a: <a href="/dashboard/config/security" /> }}
+          />
+        </p>
+      </I18nextProvider>,
+    );
+    const el = screen.getByTestId("link-body");
+    const anchor = el.querySelector("a");
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute("href")).toBe("/dashboard/config/security");
+    expect(anchor?.textContent).toBe("Config");
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/i18n.ts
+++ b/crates/librefang-api/dashboard/src/lib/i18n.ts
@@ -15,8 +15,13 @@ i18n
     },
     fallbackLng: "en",
     interpolation: {
-      // React already escapes interpolated values; double-escaping would break output
-      escapeValue: false,
+      // Keep i18next's default escaping (escapeValue: true). Translator-supplied
+      // strings must never be rendered as live DOM — any HTML structure in a
+      // translation goes through the <Trans> component with an explicit
+      // `components` allowlist instead. See pages/MobilePairingPage.tsx and
+      // pages/ConnectWizardPage.tsx for the pattern, and
+      // docs/issues/i18n-escapeValue-false.md for the rationale.
+      escapeValue: true,
     },
     ...(import.meta.env.DEV && {
       saveMissing: true,

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -3674,7 +3674,7 @@
     "remove_failed": "Failed to remove device: {{reason}}",
     "remove_unknown_error": "unknown error",
     "error_disabled_title": "Device pairing is disabled",
-    "error_disabled_body": "Enable pairing in <link>Config → Security</link> (<code>pairing.enabled = true</code>).",
+    "error_disabled_body": "Enable pairing in <a>Config → Security</a> (<code>pairing.enabled = true</code>).",
     "error_generic_title": "Failed to generate pairing code",
     "qr_aria_label": "QR code for pairing with a mobile device",
     "btn_try_again": "Try again"

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -3674,7 +3674,7 @@
     "remove_failed": "移除设备失败：{{reason}}",
     "remove_unknown_error": "未知错误",
     "error_disabled_title": "设备配对已禁用",
-    "error_disabled_body": "请在 <link>配置 → 安全</link> 中启用配对（<code>pairing.enabled = true</code>）。",
+    "error_disabled_body": "请在 <a>配置 → 安全</a> 中启用配对（<code>pairing.enabled = true</code>）。",
     "error_generic_title": "无法生成配对码",
     "qr_aria_label": "用于与移动设备配对的二维码",
     "btn_try_again": "重试"

--- a/crates/librefang-api/dashboard/src/pages/ConnectWizardPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ConnectWizardPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { Wifi, QrCode, Loader2, CheckCircle, AlertCircle, RefreshCw } from "lucide-react";
 import { isMobileTauri, scanQrCode, getCredentials, clearCredentials } from "../lib/tauri";
 import { useConnectManual, useConnectViaQr } from "../lib/mutations/connection";
@@ -190,11 +190,6 @@ export function ConnectWizardPage() {
   }
 
   const busy = step === "scanning" || step === "connecting";
-  // i18next supports embedded HTML when interpolation.escapeValue=false (set
-  // in lib/i18n.ts). The localised string includes <strong> for emphasis;
-  // we render it via dangerouslySetInnerHTML on a span that contains no
-  // user input — translator-supplied markup only.
-  const qrCardBodyHtml = { __html: t("connect_wizard.qr_card_body") };
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-main px-6 py-12">
@@ -319,7 +314,10 @@ export function ConnectWizardPage() {
               <div className="text-sm text-text-dim space-y-1">
                 <p className="font-medium">{t("connect_wizard.qr_card_title")}</p>
                 <p>
-                  <span dangerouslySetInnerHTML={qrCardBodyHtml} />
+                  <Trans
+                    i18nKey="connect_wizard.qr_card_body"
+                    components={{ strong: <strong /> }}
+                  />
                 </p>
               </div>
             </div>

--- a/crates/librefang-api/dashboard/src/pages/MobilePairingPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/MobilePairingPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import QRCode from "qrcode";
 import { Smartphone, RefreshCw, CheckCircle, Clock, Trash2, AlertCircle } from "lucide-react";
@@ -59,17 +59,6 @@ export function MobilePairingPage() {
   const removeDevice = useRemovePairedDevice();
 
   const expired = req ? new Date(req.expires_at).getTime() < Date.now() : false;
-  // Translator-supplied markup only (`<strong>`); no user input is interpolated
-  // into these strings, so dangerouslySetInnerHTML is safe here.
-  const subtitleHtml = { __html: t("mobile_pairing.subtitle") };
-  const disabledBodyHtml = {
-    // i18next <link> pseudo-tag → real <a>. Source is translator-only markup;
-    // no user input flows through these strings, so innerHTML is safe.
-    __html: t("mobile_pairing.error_disabled_body").replace(
-      /<link>(.*?)<\/link>/s,
-      '<a href="/dashboard/config/security" class="text-brand underline">$1</a>',
-    ),
-  };
 
   const refresh = () => {
     qc.removeQueries({ queryKey: pairingKeys.request() });
@@ -87,7 +76,22 @@ export function MobilePairingPage() {
             : t("mobile_pairing.error_generic_title")}
         </p>
         {isDisabled ? (
-          <p className="text-sm text-text-dim" dangerouslySetInnerHTML={disabledBodyHtml} />
+          <p className="text-sm text-text-dim">
+            {/*
+              Translator strings may contain only the tags listed in
+              `components`. i18next maps <link>…</link> → <a>, <code>…</code>
+              → <code>; any other tag in a translation is rendered as text,
+              so a malicious translator cannot inject <script> or new
+              attributes.
+            */}
+            <Trans
+              i18nKey="mobile_pairing.error_disabled_body"
+              components={{
+                a: <a href="/dashboard/config/security" className="text-brand underline" />,
+                code: <code />,
+              }}
+            />
+          </p>
         ) : (
           <button
             onClick={refresh}
@@ -108,7 +112,12 @@ export function MobilePairingPage() {
           <Smartphone className="w-6 h-6 text-brand" />
           {t("mobile_pairing.title")}
         </h1>
-        <p className="text-sm text-text-dim" dangerouslySetInnerHTML={subtitleHtml} />
+        <p className="text-sm text-text-dim">
+          <Trans
+            i18nKey="mobile_pairing.subtitle"
+            components={{ strong: <strong /> }}
+          />
+        </p>
       </div>
 
       {/* QR Card */}


### PR DESCRIPTION
Closes #5574

## Summary

`crates/librefang-api/dashboard/src/lib/i18n.ts` now uses i18next's default `escapeValue: true`, removing the global "translator-supplied HTML renders as live DOM" XSS landmine. The two cited `dangerouslySetInnerHTML` consumers (`MobilePairingPage.tsx`, `ConnectWizardPage.tsx`) are migrated to `<Trans>` with explicit `components` allowlists, so the HTML structure (anchors, `<strong>`, `<code>`) stays inline-rendered without giving translator strings free DOM-injection.

## Files changed

- `crates/librefang-api/dashboard/src/lib/i18n.ts` — `escapeValue: true`.
- `crates/librefang-api/dashboard/src/pages/MobilePairingPage.tsx` — both `dangerouslySetInnerHTML` sites replaced with `<Trans>` (`subtitle` uses `<strong>`; `error_disabled_body` uses `<a>` + `<code>`).
- `crates/librefang-api/dashboard/src/pages/ConnectWizardPage.tsx` — `qr_card_body` replaced with `<Trans components={{ strong }}>`.
- `crates/librefang-api/dashboard/src/locales/en.json`, `crates/librefang-api/dashboard/src/locales/zh.json` — rename `<link>…</link>` to `<a>…</a>` inside `mobile_pairing.error_disabled_body`. `<link>` is on HTML's void-element list and `html-parse-stringify` (used by `<Trans>`) would drop its inner text; `<a>` is the semantic tag and is mapped to a real anchor by `<Trans components>`.
- `crates/librefang-api/dashboard/src/lib/i18n.test.tsx` — new vitest covering the escape contract and the `<Trans>` allowlist.

`rg dangerouslySetInnerHTML crates/librefang-api/dashboard/src/` returns zero hits after the change.

## Verification

- `pnpm typecheck` — clean.
- `pnpm build` — clean.
- `pnpm vitest run src/lib/i18n.test.tsx` — 2 / 2 passing. Test 1 confirms an interpolated `<img onerror=x>` / `<script>` payload produces zero `<script>` / `<img>` DOM nodes; test 2 confirms `<Trans>` only renders the components in its allowlist.
- `pnpm test:i18n-parity` — zh / en parity intact (3473 keys).
- Full `pnpm test --run` was run; the only failures are 13 pre-existing `ModelsPage.test.tsx` failures that reproduce on `origin/main` without this PR's changes (root cause: `localStorage` not being available to the zustand persist middleware inside that test file — unrelated to i18n / `dangerouslySetInnerHTML`).

## Out of scope

- `lf_creds` ↔ `librefang-api-key` localStorage rename (other rollup row in `docs/issues/i18n-escapeValue-false.md`).
- No-invalidate mutation marker ESLint rule (other rollup row).
- `react/no-danger-with-children` ESLint rule (tracked in #5561 — dashboard has no ESLint setup yet).

Refs `docs/issues/i18n-escapeValue-false.md`.
