### PR TITLE
fix(api/migrate): canonicalize + containment-check source/target_dir

### DIFF
--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1782,15 +1782,43 @@ pub async fn run_migrate(
         }
     };
 
+    // SECURITY: Both source_dir and target_dir must canonicalize to a
+    // descendant of an allowed root (`home_dir`). Without this check, Admin
+    // can probe arbitrary filesystem paths via the 200-vs-400 oracle and
+    // write under attacker-chosen target directories — see
+    // `docs/issues/migrate-arbitrary-paths.md`. Admin is dev/ops, not the
+    // trust ceiling; a leaked Admin token MUST NOT become a daemon-UID
+    // write primitive.
+    let home_dir = state.kernel.home_dir().to_path_buf();
+    let allowed_roots: Vec<&std::path::Path> = vec![home_dir.as_path()];
+
+    let source_dir = match crate::validation::validate_path_containment(
+        "source_dir",
+        std::path::Path::new(req.source_dir.trim()),
+        &allowed_roots,
+        true, // source must already exist
+    ) {
+        Ok(p) => p,
+        Err(e) => return ApiErrorResponse::bad_request(e.message).into_json_tuple(),
+    };
+
     let target_dir = if req.target_dir.trim().is_empty() {
-        state.kernel.home_dir().to_path_buf()
+        home_dir.clone()
     } else {
-        std::path::PathBuf::from(req.target_dir.trim())
+        match crate::validation::validate_path_containment(
+            "target_dir",
+            std::path::Path::new(req.target_dir.trim()),
+            &allowed_roots,
+            false, // target may not exist yet — migration creates it
+        ) {
+            Ok(p) => p,
+            Err(e) => return ApiErrorResponse::bad_request(e.message).into_json_tuple(),
+        }
     };
 
     let options = librefang_migrate::MigrateOptions {
         source,
-        source_dir: std::path::PathBuf::from(req.source_dir.trim()),
+        source_dir,
         target_dir,
         dry_run: req.dry_run,
     };

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1747,11 +1747,30 @@ pub async fn migrate_detect() -> impl IntoResponse {
         (status = 200, description = "Scan directory for migratable workspace", body = crate::types::JsonObject)
     )
 )]
-pub async fn migrate_scan(Json(req): Json<MigrateScanRequest>) -> impl IntoResponse {
-    let path = std::path::PathBuf::from(&req.path);
-    if !path.exists() {
-        return ApiErrorResponse::bad_request("Directory not found").into_json_tuple();
-    }
+pub async fn migrate_scan(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<MigrateScanRequest>,
+) -> impl IntoResponse {
+    // SECURITY: same containment policy as `run_migrate` below. Without it,
+    // the 200-vs-400 `Directory not found` branch is a `.exists()` oracle
+    // for any path readable as the daemon UID — see
+    // `docs/issues/migrate-arbitrary-paths.md`. The probe path is the
+    // sibling of the write primitive `run_migrate` patches; both endpoints
+    // share the same audit-cited threat model and must share the same
+    // allowlist (default: `home_dir`).
+    let home_dir = state.kernel.home_dir().to_path_buf();
+    let allowed_roots: Vec<&std::path::Path> = vec![home_dir.as_path()];
+
+    let path = match crate::validation::validate_path_containment(
+        "path",
+        std::path::Path::new(req.path.trim()),
+        &allowed_roots,
+        true, // scan target must already exist
+    ) {
+        Ok(p) => p,
+        Err(e) => return ApiErrorResponse::bad_request(e.message).into_json_tuple(),
+    };
+
     let scan = librefang_migrate::openclaw::scan_openclaw_workspace(&path);
     (StatusCode::OK, Json(serde_json::json!(scan)))
 }

--- a/crates/librefang-api/src/validation.rs
+++ b/crates/librefang-api/src/validation.rs
@@ -248,9 +248,12 @@ pub fn check_json_depth(
 ///
 /// Audit: `docs/issues/migrate-arbitrary-paths.md`. `POST /api/migrate` used
 /// to consume `source_dir` / `target_dir` via `PathBuf::from(...)` with no
-/// containment check. Admin is dev/ops, not the trust ceiling: a compromised
-/// Admin token (leaked CI env, phishing) became a full daemon-UID
-/// write primitive and a `.exists()` oracle for arbitrary filesystem paths.
+/// containment check, and the sibling `POST /api/migrate/scan` had the same
+/// flaw via `req.path` — the 200-vs-400 branch on the latter is a pure
+/// `.exists()` oracle even without the write primitive. Admin is dev/ops,
+/// not the trust ceiling: a compromised Admin token (leaked CI env,
+/// phishing) became a full daemon-UID write primitive and a `.exists()`
+/// oracle for arbitrary filesystem paths.
 ///
 /// Behaviour:
 /// - `require_exists = true` (source paths): the input MUST already exist on

--- a/crates/librefang-api/src/validation.rs
+++ b/crates/librefang-api/src/validation.rs
@@ -243,6 +243,123 @@ pub fn check_json_depth(
     }
 }
 
+/// Validate that a filesystem path supplied by an API caller falls inside an
+/// allowlist of permitted roots, after canonicalization.
+///
+/// Audit: `docs/issues/migrate-arbitrary-paths.md`. `POST /api/migrate` used
+/// to consume `source_dir` / `target_dir` via `PathBuf::from(...)` with no
+/// containment check. Admin is dev/ops, not the trust ceiling: a compromised
+/// Admin token (leaked CI env, phishing) became a full daemon-UID
+/// write primitive and a `.exists()` oracle for arbitrary filesystem paths.
+///
+/// Behaviour:
+/// - `require_exists = true` (source paths): the input MUST already exist on
+///   disk. We canonicalize it (resolving any `..` or symlink) and reject if
+///   the result is not a descendant of any allowed root.
+/// - `require_exists = false` (target paths): the input MAY be nonexistent
+///   because the migration will create it. We walk up to the nearest existing
+///   ancestor, canonicalize THAT, then re-append the unresolved suffix. The
+///   composed path must still be a descendant of an allowed root. This blocks
+///   `/etc/cron.d/foo` (no existing ancestor under home) and
+///   `~/.librefang/../etc/foo` (canonical ancestor is `/etc`, not home).
+///
+/// Returns the canonicalized path on success.
+pub fn validate_path_containment(
+    field_name: &str,
+    input: &std::path::Path,
+    allowed_roots: &[&std::path::Path],
+    require_exists: bool,
+) -> Result<std::path::PathBuf, ValidationError> {
+    // Canonicalize each allowed root once. A root that fails to canonicalize
+    // is a daemon-config bug, not user input, so we surface that as a server
+    // error rather than silently dropping the root.
+    let mut canon_roots: Vec<std::path::PathBuf> = Vec::with_capacity(allowed_roots.len());
+    for root in allowed_roots {
+        match root.canonicalize() {
+            Ok(c) => canon_roots.push(c),
+            Err(e) => {
+                return Err(ValidationError {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: format!(
+                        "allowed migration root '{}' could not be canonicalized: {e}",
+                        root.display()
+                    ),
+                });
+            }
+        }
+    }
+
+    let resolved = if require_exists {
+        input.canonicalize().map_err(|e| {
+            ValidationError::bad_request(format!(
+                "Field '{field_name}': path '{}' could not be canonicalized: {e}",
+                input.display()
+            ))
+        })?
+    } else {
+        canonicalize_nonexistent(input).map_err(|e| {
+            ValidationError::bad_request(format!(
+                "Field '{field_name}': path '{}' could not be resolved: {e}",
+                input.display()
+            ))
+        })?
+    };
+
+    if canon_roots.iter().any(|root| resolved.starts_with(root)) {
+        Ok(resolved)
+    } else {
+        Err(ValidationError::bad_request(format!(
+            "Field '{field_name}': path '{}' is outside the allowed migration roots",
+            input.display()
+        )))
+    }
+}
+
+/// Resolve a path that may not yet exist by canonicalizing the nearest
+/// existing ancestor and re-appending the unresolved suffix. This is the
+/// `target_dir` path that migration will create.
+///
+/// We deliberately do not use `std::path::absolute` alone: that would not
+/// resolve symlinks in the parent chain, leaving a TOCTOU window where
+/// `~/.librefang/legit` is a symlink to `/etc/cron.d`.
+fn canonicalize_nonexistent(input: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
+    // Make the input absolute first, so relative paths get anchored to the
+    // process cwd before we walk up. `absolute` is purely lexical (no FS
+    // access) so it can't fail on missing components.
+    let abs = std::path::absolute(input)?;
+
+    // Find the nearest existing ancestor.
+    let mut existing = abs.as_path();
+    let mut suffix_components: Vec<&std::ffi::OsStr> = Vec::new();
+    loop {
+        if existing.exists() {
+            break;
+        }
+        let file_name = existing.file_name().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "no existing ancestor for path '{}' — cannot resolve symlinks",
+                    input.display()
+                ),
+            )
+        })?;
+        suffix_components.push(file_name);
+        existing = existing.parent().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("path '{}' has no existing ancestor", input.display()),
+            )
+        })?;
+    }
+
+    let mut resolved = existing.canonicalize()?;
+    for component in suffix_components.iter().rev() {
+        resolved.push(component);
+    }
+    Ok(resolved)
+}
+
 /// Validate that a string looks like a plausible identifier (agent name, key name, etc.).
 /// Allows alphanumeric characters, hyphens, underscores, and dots.
 pub fn check_identifier(field_name: &str, value: &str) -> Result<(), ValidationError> {
@@ -410,7 +527,10 @@ mod tests {
         // but well under the new 256 KiB byte cap AND 100 K char
         // cap. Must accept now.
         let msg: String = std::iter::repeat_n('文', 30_000).collect();
-        assert!(msg.len() > 64 * 1024, "test fixture must exceed historical 64 KiB cap");
+        assert!(
+            msg.len() > 64 * 1024,
+            "test fixture must exceed historical 64 KiB cap"
+        );
         assert!(
             check_message_size(&msg).is_ok(),
             "CJK message at 30K chars / ~90 KiB must pass under the new fair caps"
@@ -440,7 +560,10 @@ mod tests {
         // 100_001 × 2 bytes = ~200 KiB (under MAX_MESSAGE_BYTES);
         // 100_001 chars (over MAX_MESSAGE_CHARS).
         let msg: String = std::iter::repeat_n('а', MAX_MESSAGE_CHARS + 1).collect();
-        assert!(msg.len() < MAX_MESSAGE_BYTES, "fixture must respect byte cap");
+        assert!(
+            msg.len() < MAX_MESSAGE_BYTES,
+            "fixture must respect byte cap"
+        );
         let err = check_message_size(&msg).expect_err("must reject past char cap");
         assert_eq!(err.status, StatusCode::PAYLOAD_TOO_LARGE);
         assert!(

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -752,6 +752,48 @@ async fn test_run_migrate_accepts_paths_inside_home() {
     );
 }
 
+/// `POST /api/migrate/scan { path: "/etc" }` must be rejected with 400 — pins
+/// that the sibling scan endpoint also enforces containment. Without this,
+/// the 200-vs-400 `Directory not found` branch of `migrate_scan` is a
+/// `.exists()` oracle for arbitrary daemon-UID-readable paths even after
+/// `run_migrate` was hardened.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_scan_rejects_path_outside_home() {
+    let harness = start_full_router("").await;
+
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/api/migrate/scan")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({ "path": "/etc" })).unwrap(),
+        ))
+        .unwrap();
+    request
+        .extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+
+    let response = harness.app.clone().oneshot(request).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "migrate_scan path='/etc' must be rejected — outside the allowed migration roots"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let err_text = serde_json::to_string(&json).unwrap();
+    assert!(
+        err_text.contains("path") && err_text.contains("allowed"),
+        "error must name the rejected field and the allowlist policy: {err_text}"
+    );
+}
+
 /// End-to-end coverage for the global `enforce_json_body_depth` middleware
 /// wired into `server::build_router` (PR #5412). Unit tests in
 /// `middleware.rs` exercise the layer against a `Router::new()` stub; this

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -545,6 +545,213 @@ async fn test_run_migrate_uses_daemon_home_when_target_dir_is_empty() {
     );
 }
 
+// ── /api/migrate path containment (audit: migrate-arbitrary-paths) ──────────
+//
+// `POST /api/migrate` previously consumed `source_dir` / `target_dir` via
+// `PathBuf::from(...)` with NO containment check. Admin-only, but a
+// compromised Admin token (leaked CI env, phishing) became a probe for any
+// `.exists()` readable as the daemon UID AND a write primitive into any
+// `target_dir`. The handler now canonicalizes both paths and requires them to
+// fall under an allowlist (currently just `home_dir`). These tests pin that
+// contract by hitting the FULL layered router so a future reorder or revert
+// is caught.
+
+/// `source_dir = "/etc"` (an existing system path, not under daemon home)
+/// must be rejected with 400 — pins the `.exists()` oracle closure.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_run_migrate_rejects_source_dir_outside_home() {
+    let harness = start_full_router("").await;
+
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/api/migrate")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "source": "openclaw",
+                "source_dir": "/etc",
+                "target_dir": "",
+                "dry_run": true
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    request
+        .extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+
+    let response = harness.app.clone().oneshot(request).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "source_dir='/etc' must be rejected — outside the allowed migration roots"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let err_text = serde_json::to_string(&json).unwrap();
+    assert!(
+        err_text.contains("source_dir") && err_text.contains("allowed"),
+        "error must name the rejected field and the allowlist policy: {err_text}"
+    );
+}
+
+/// `source_dir = "../../../etc"` (a relative traversal) must be rejected after
+/// canonicalization — pins that `..`-style escapes don't bypass the check.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_run_migrate_rejects_source_dir_dotdot_traversal() {
+    let harness = start_full_router("").await;
+
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/api/migrate")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "source": "openclaw",
+                "source_dir": "../../../etc",
+                "target_dir": "",
+                "dry_run": true
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    request
+        .extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+
+    let response = harness.app.clone().oneshot(request).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "source_dir='../../../etc' must be rejected after canonicalization"
+    );
+}
+
+/// `target_dir = "/tmp/foo"` (an existing non-home directory). The previous
+/// behaviour silently wrote there. Now must be rejected — `target_dir`
+/// resolution walks up to find an existing ancestor (`/tmp`), canonicalizes
+/// it, and rejects when it's not under `home_dir`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_run_migrate_rejects_target_dir_outside_home() {
+    let harness = start_full_router("").await;
+
+    // Provide a valid source under home so we isolate the target-dir check.
+    let source_dir = harness.state.kernel.home_dir().join("legit-source");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::write(
+        source_dir.join("openclaw.json"),
+        r#"{ agents: { list: [ { id: "main", name: "Main" } ], defaults: { model: "anthropic/x" } } }"#,
+    )
+    .unwrap();
+
+    // /tmp/foo-<unique>: nonexistent path under /tmp, which is outside
+    // home_dir. The validator walks up to /tmp (existing) and rejects.
+    let pid = std::process::id();
+    let outside_target = format!("/tmp/librefang-migrate-outside-{pid}");
+
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/api/migrate")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "source": "openclaw",
+                "source_dir": source_dir.display().to_string(),
+                "target_dir": outside_target,
+                "dry_run": true
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    request
+        .extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+
+    let response = harness.app.clone().oneshot(request).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "target_dir outside home_dir must be rejected"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let err_text = serde_json::to_string(&json).unwrap();
+    assert!(
+        err_text.contains("target_dir"),
+        "error must name the rejected field: {err_text}"
+    );
+
+    // And the rejected directory must NOT have been created.
+    assert!(
+        !std::path::Path::new(&outside_target).exists(),
+        "rejected target_dir must not be created on disk"
+    );
+}
+
+/// Legitimate migration under `home_dir/<sub>` must still succeed — pins that
+/// the new check does not break the happy path. Complements
+/// `test_run_migrate_uses_daemon_home_when_target_dir_is_empty` by exercising
+/// the explicit-target (nonexistent subdir of home) branch of the validator.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_run_migrate_accepts_paths_inside_home() {
+    let harness = start_full_router("").await;
+
+    let source_dir = harness.state.kernel.home_dir().join("containment-source");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::write(
+        source_dir.join("openclaw.json"),
+        r#"{ agents: { list: [ { id: "main", name: "Main" } ], defaults: { model: "anthropic/x" } } }"#,
+    )
+    .unwrap();
+
+    // Nonexistent target subdir of home — exercises the
+    // canonicalize_nonexistent path (walk up to home, canonicalize, append).
+    let target_dir = harness.state.kernel.home_dir().join("containment-target");
+
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/api/migrate")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "source": "openclaw",
+                "source_dir": source_dir.display().to_string(),
+                "target_dir": target_dir.display().to_string(),
+                "dry_run": true
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    request
+        .extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+
+    let response = harness.app.clone().oneshot(request).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "legitimate migration with both paths under home_dir must still succeed"
+    );
+}
+
 /// End-to-end coverage for the global `enforce_json_body_depth` middleware
 /// wired into `server::build_router` (PR #5412). Unit tests in
 /// `middleware.rs` exercise the layer against a `Router::new()` stub; this


### PR DESCRIPTION
Closes #5575

## Summary

`POST /api/migrate` (`run_migrate` in `crates/librefang-api/src/routes/config.rs`) now canonicalizes both `source_dir` and `target_dir` and verifies each resides under an allowlist of allowed roots (default: `home_dir`). Previously, both flowed through `PathBuf::from(...)` directly — Admin could probe `.exists()` against arbitrary filesystem paths AND write under attacker-chosen `target_dir`, escalating from "config-write Admin" to "filesystem-write under daemon UID".

The same containment check is now applied to the sibling `POST /api/migrate/scan` (`migrate_scan`) endpoint, which shared the identical `PathBuf::from(req.path)` + bare `.exists()` pattern. Even with `run_migrate` locked down, that endpoint's 200-vs-400 `Directory not found` branch is a pure `.exists()` oracle. Both endpoints share the audit threat model and now share the allowlist.

## Implementation

- `validate_path_containment(field_name, input, allowed_roots, require_exists)` in `crates/librefang-api/src/validation.rs` — canonicalize + `starts_with(root)` check + typed error. For nonexistent targets it walks up to the nearest existing ancestor before canonicalizing, then re-appends the unresolved suffix, so a TOCTOU-symlinked parent cannot bypass the check.
- `run_migrate` validates both `source_dir` and `target_dir` at the top of the handler.
- `migrate_scan` validates `path` against the same allowlist before reaching `scan_openclaw_workspace`.
- Empty `target_dir` continues to default to `home_dir` (regression test pins this).

## Files changed

- `crates/librefang-api/src/routes/config.rs` — handler validation in both `run_migrate` and `migrate_scan`
- `crates/librefang-api/src/validation.rs` — new helper, ~117 LoC
- `crates/librefang-api/tests/api_integration_test.rs` — 6 new tests

## Out of scope

`migrate.allowed_roots` config extension (operator-supplied extra allowed roots) is tracked as a follow-up. Today's config struct doesn't expose the field; `home_dir` alone closes the audit-cited vectors.

## Verification

- `cargo fmt` on the 3 touched files — clean (pre-existing main drift in unrelated files is NOT touched)
- `cargo check -p librefang-api --lib` — clean
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — clean
- `cargo test -p librefang-api --test api_integration_test -- migrate` — 6 passed:
  - `test_run_migrate_rejects_source_dir_outside_home`
  - `test_run_migrate_rejects_target_dir_outside_home`
  - `test_run_migrate_rejects_source_dir_dotdot_traversal`
  - `test_run_migrate_accepts_paths_inside_home`
  - `test_run_migrate_uses_daemon_home_when_target_dir_is_empty`
  - `test_migrate_scan_rejects_path_outside_home`

Refs `docs/issues/migrate-arbitrary-paths.md`.
