### PR TITLE
fix(hooks): fail-closed when guard-bash-safety lib is missing

### DIFF
--- a/.claude/hooks/forbid-main-worktree.sh
+++ b/.claude/hooks/forbid-main-worktree.sh
@@ -147,17 +147,29 @@ case "$main_root" in
   *) exit 0 ;;
 esac
 
-msg="$(python3 "$LIB" \
+# Fail closed if the rule library is missing or broken: a partial clone
+# or corrupt lib must not silently bypass the cargo / git-mutation-on-main
+# bans via the swallowed dispatch error. Reached only for Bash commands
+# inside librefang — the Edit/Write protection above is inline bash and
+# does not depend on the lib. Exit 2 (the PreToolUse block code), not 1.
+[ -f "$LIB" ] || { echo "[forbid-main-worktree] missing $LIB" >&2; exit 2; }
+
+# check-bash-rules.py is contractually exit-0 (message on a hit, nothing
+# on a pass); a non-zero exit means the lib itself is broken — fail closed.
+if msg="$(python3 "$LIB" \
   --rules "$rules" \
   --cwd "$cwd" \
   --main-root "$main_root" \
-  --kind "${kind:-}" <<<"$cmd" 2>/dev/null || true)"
-
-if [ -n "$msg" ]; then
-  cat >&2 <<EOF
+  --kind "${kind:-}" <<<"$cmd" 2>/dev/null)"; then
+  if [ -n "$msg" ]; then
+    cat >&2 <<EOF
 [forbid-main-worktree] $msg
 Command: $cmd
 EOF
+    exit 2
+  fi
+else
+  echo "[forbid-main-worktree] rule library failed to run (corrupt or unreadable): $LIB" >&2
   exit 2
 fi
 

--- a/.claude/hooks/guard-bash-safety.sh
+++ b/.claude/hooks/guard-bash-safety.sh
@@ -13,6 +13,14 @@ input="$(cat)"
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 LIB="$script_dir/lib/check-bash-rules.py"
 
+# Fail-closed if the rule library is missing. A half-broken clone
+# (partial checkout, accidentally-deleted lib) must NOT silently bypass
+# the safety hook — the developer should see the error and fix their
+# clone before any bash command is allowed through. Exit 2 (not 1): per
+# the Claude Code PreToolUse contract only exit 2 blocks the tool call;
+# exit 1 is a non-blocking error and the command would still run.
+[ -f "$LIB" ] || { echo "[guard-bash-safety] missing $LIB" >&2; exit 2; }
+
 py() { python3 -c "$1" 2>/dev/null || true; }
 
 # Use here-strings (`<<<"$input"`) instead of `printf … | py …` pipelines.
@@ -34,13 +42,20 @@ cmd="$(py 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get(
 
 rules="force-push-main,no-verify,broad-git-add,sensitive-file-add,claude-attribution,rm-rf-dangerous,librefang-daemon-launch"
 
-msg="$(python3 "$LIB" --rules "$rules" <<<"$cmd" 2>/dev/null || true)"
-
-if [ -n "$msg" ]; then
-  cat >&2 <<MSG
+# check-bash-rules.py is contractually exit-0: it prints a message on a
+# rule hit and nothing on a pass. A non-zero exit therefore means the
+# library itself is broken (corrupt / unreadable / wrong interpreter) —
+# fail closed instead of letting the swallowed error allow the command.
+if msg="$(python3 "$LIB" --rules "$rules" <<<"$cmd" 2>/dev/null)"; then
+  if [ -n "$msg" ]; then
+    cat >&2 <<MSG
 [guard-bash-safety] $msg
 Command: $cmd
 MSG
+    exit 2
+  fi
+else
+  echo "[guard-bash-safety] rule library failed to run (corrupt or unreadable): $LIB" >&2
   exit 2
 fi
 


### PR DESCRIPTION
Closes #5595

## Summary

`.claude/hooks/guard-bash-safety.sh` now fails-closed when `lib/check-bash-rules.py` is missing instead of silently allowing the hook to pass via the dispatch line's `|| true`. A half-broken clone (partial checkout, accidentally-deleted lib) now refuses to run the hook — the developer sees the error and fixes their clone before continuing.

## Files changed

- `.claude/hooks/guard-bash-safety.sh`

## Verification

Manual hook invocation with synthetic PreToolUse JSON:

- Lib present, safe command (`ls -la`) → exit 0 (allow). Existing behaviour preserved.
- Lib present, blocked command (`rm -rf /`) → exit 2 with rule message. Existing behaviour preserved.
- Lib moved away → exit 1 with `[guard-bash-safety] missing <path>` on stderr. Fail-closed as intended.
- Lib restored → exit 0 again. No residual state.

Refs `docs/issues/guard-bash-safety-missing-lib.md` (sub-finding "this").
