### PR TITLE
fix(api/mcp): wrap connect_mcp_servers spawns in spawn_supervised

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -4418,8 +4418,15 @@ pub async fn add_mcp_server(
     };
 
     // Establish connection to the newly added server in the background.
+    // Wrap in `spawn_supervised` so a panic inside `connect_mcp_servers`
+    // (e.g. parse failure, OAuth handshake, tool list deserialization) is
+    // logged at `error!` rather than silently aborting the detached task
+    // and leaving the new server stuck in a half-connecting state.
     let kernel = std::sync::Arc::clone(&state.kernel);
-    tokio::spawn(async move { kernel.connect_mcp_servers().await });
+    librefang_kernel::supervised_spawn::spawn_supervised(
+        "connect_mcp_servers_after_add",
+        async move { kernel.connect_mcp_servers().await },
+    );
 
     state.kernel.audit().record(
         "system",
@@ -4525,7 +4532,10 @@ pub async fn update_mcp_server(
     // Disconnect the old connection so connect_mcp_servers picks up the new config.
     state.kernel.disconnect_mcp_server(&name).await;
     let kernel = std::sync::Arc::clone(&state.kernel);
-    tokio::spawn(async move { kernel.connect_mcp_servers().await });
+    librefang_kernel::supervised_spawn::spawn_supervised(
+        "connect_mcp_servers_after_update",
+        async move { kernel.connect_mcp_servers().await },
+    );
 
     state.kernel.audit().record(
         "system",
@@ -4643,7 +4653,10 @@ pub async fn patch_mcp_server_taint(
     // already updates via `reload_config` without a reconnect.
     state.kernel.disconnect_mcp_server(&name).await;
     let kernel = std::sync::Arc::clone(&state.kernel);
-    tokio::spawn(async move { kernel.connect_mcp_servers().await });
+    librefang_kernel::supervised_spawn::spawn_supervised(
+        "connect_mcp_servers_after_taint_patch",
+        async move { kernel.connect_mcp_servers().await },
+    );
 
     state.kernel.audit().record(
         "system",

--- a/crates/librefang-kernel/src/supervised_spawn.rs
+++ b/crates/librefang-kernel/src/supervised_spawn.rs
@@ -92,6 +92,71 @@ mod tests {
         assert!(result.is_ok(), "supervised handle must not propagate panic");
     }
 
+    /// Regression for the MCP-reconnect detached spawn (#5598): when the
+    /// future passed to `spawn_supervised` panics, the wrapper MUST emit
+    /// an `error!`-level log line carrying both the task name and the
+    /// panic payload. The `routes::skills::add/update/patch_mcp_server`
+    /// handlers spawn `connect_mcp_servers` fire-and-forget; without this
+    /// log the operator has no signal that the connection task died.
+    // Same `current_thread` constraint as `supervised_task_inherits_caller_span`.
+    #[tokio::test]
+    async fn panic_emits_error_log_with_task_name_and_payload() {
+        use std::io;
+        use std::sync::Mutex;
+        use tracing_subscriber::fmt::MakeWriter;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        #[derive(Clone)]
+        struct VecWriter(Arc<Mutex<Vec<u8>>>);
+        impl io::Write for VecWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for VecWriter {
+            type Writer = VecWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let writer = VecWriter(buf.clone());
+        let layer = tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .with_ansi(false)
+            .with_target(false);
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _g = tracing::subscriber::set_default(subscriber);
+
+        let h = spawn_supervised("connect_mcp_servers_after_add", async {
+            panic!("simulated mcp connect failure");
+        });
+        h.await.expect("supervised handle must resolve cleanly");
+
+        let captured = String::from_utf8(buf.lock().unwrap().clone()).expect("utf8");
+        assert!(
+            captured.contains("ERROR"),
+            "expected ERROR-level log, captured: {captured:?}"
+        );
+        assert!(
+            captured.contains("supervised task panicked"),
+            "expected supervisor message, captured: {captured:?}"
+        );
+        assert!(
+            captured.contains("connect_mcp_servers_after_add"),
+            "expected task name in log, captured: {captured:?}"
+        );
+        assert!(
+            captured.contains("simulated mcp connect failure"),
+            "expected panic payload in log, captured: {captured:?}"
+        );
+    }
+
     /// Regression: spawned future must inherit the calling task's tracing
     /// span so events emitted inside it carry `agent.id` / `session.id` set
     /// by `#[instrument]` on `run_agent_loop`. Without `.in_current_span()`


### PR DESCRIPTION
Closes #5598

## Summary

The three `tokio::spawn(async move { kernel.connect_mcp_servers().await })` detached tasks in `crates/librefang-api/src/routes/skills.rs` (after add / update / patch-taint of an MCP server config) silently aborted on any panic inside `connect_mcp_servers` — operator saw no log, server entry stuck half-connecting. Migrate to the existing `librefang_kernel::supervised_spawn::spawn_supervised(name, fut)` helper (#3740) so panics are caught and logged at `error!` level with the task name and panic payload.

This is the "this" sub-finding of the rollup at `docs/issues/spawn-connect-mcp-swallows-panic.md`. The other five rows (request_approval spawn, JSON reshape, create_dir_all swallow, reqwest builder expect, counter overflow) remain open and are out of scope here.

## Files changed

- `crates/librefang-api/src/routes/skills.rs` — three call sites in `add_mcp_server`, `update_mcp_server`, and `patch_mcp_server_taint`. Each spawn now uses `spawn_supervised` with a distinct task name (`connect_mcp_servers_after_add`, `_after_update`, `_after_taint_patch`) so log correlation can distinguish them.
- `crates/librefang-kernel/src/supervised_spawn.rs` — added regression test `panic_emits_error_log_with_task_name_and_payload` that pins the captured-log shape the API call sites rely on (ERROR level, `supervised task panicked` message, task name, panic payload).

`crates/librefang-kernel/src/kernel/mcp_setup.rs:33` (the audit's other citation) is the `connect_mcp_servers` definition itself — synchronous body, no spawn — so it needs no change; the spawn boundary is on the caller side.

## Verification

- `rustfmt --check crates/librefang-api/src/routes/skills.rs crates/librefang-kernel/src/supervised_spawn.rs` — clean
- `cargo check -p librefang-kernel -p librefang-api --lib` — clean
- `cargo test -p librefang-kernel --lib supervised_spawn` — 4/4 pass, including new `panic_emits_error_log_with_task_name_and_payload`

Refs `docs/issues/spawn-connect-mcp-swallows-panic.md`.
