### PR TITLE
fix(kernel/workflow): hold Lane::Trigger permit across run_workflow spawn

### DIFF
--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4878,6 +4878,88 @@ fn workflow_send_message_closure_contains_per_agent_semaphore_acquire() {
     );
 }
 
+/// Regression for the audit item
+/// `docs/issues/workflow-path-drops-lane-permit.md`: the workflow-dispatch
+/// path in `triggers_and_workflow.rs` MUST move the `Lane::Trigger` permit
+/// (`_lane_permit`, acquired once per dispatch iteration) into the
+/// `tokio::spawn` future for `kernel.run_workflow(...)`. Otherwise the permit
+/// drops as soon as the iteration yields and the run inside the spawn escapes
+/// the `queue.concurrency.trigger_lane` cap — N bursty workflow triggers
+/// produce N concurrent workflow runs, breaking the kernel-wide invariant.
+///
+/// This is a source-shape lint (matches the style of
+/// `workflow_send_message_closure_contains_per_agent_semaphore_acquire`
+/// above): we strip comments so a leftover doc reference can't satisfy the
+/// assertion, then require a non-comment binding that re-anchors the permit
+/// inside the spawn block. Behavioral coverage of the lane cap itself lives
+/// in `trigger_lane_global_semaphore_limits_total_concurrency`; this test
+/// pins the wiring that connects the cap to the workflow path.
+#[test]
+fn workflow_spawn_holds_lane_permit_across_run() {
+    let src = include_str!("triggers_and_workflow.rs");
+    // Strip line + block comments (same approach as the per-agent-semaphore
+    // lint test above) so the assertion is grounded in executable code.
+    let stripped: String = {
+        let mut out = String::with_capacity(src.len());
+        let mut in_block = false;
+        for line in src.lines() {
+            let mut s = line.to_string();
+            if in_block {
+                if let Some(end) = s.find("*/") {
+                    s = s.split_at(end + 2).1.to_string();
+                    in_block = false;
+                } else {
+                    continue;
+                }
+            }
+            while let Some(start) = s.find("/*") {
+                if let Some(end_rel) = s[start..].find("*/") {
+                    let end = start + end_rel + 2;
+                    s.replace_range(start..end, "");
+                } else {
+                    s.truncate(start);
+                    in_block = true;
+                    break;
+                }
+            }
+            if let Some(idx) = s.find("//") {
+                s.truncate(idx);
+            }
+            out.push_str(&s);
+            out.push('\n');
+        }
+        out
+    };
+
+    // (1) The capture must exist: the workflow branch rebinds `_lane_permit`
+    // so it can be moved INTO the spawn. Without this binding the permit
+    // would drop at the end of the for-loop iteration (i.e. as soon as
+    // `tokio::spawn` returned), exactly the pre-fix behaviour.
+    assert!(
+        stripped.contains("let lane_permit_for_spawn = _lane_permit"),
+        "expected `let lane_permit_for_spawn = _lane_permit` in the workflow \
+         branch of triggers_and_workflow.rs — without it, the Lane::Trigger \
+         permit drops at iteration end and concurrent workflow runs escape \
+         `queue.concurrency.trigger_lane`. See \
+         docs/issues/workflow-path-drops-lane-permit.md."
+    );
+
+    // (2) The spawned future must actually reference the rebound permit so
+    // Rust's move-capture keeps it alive for the workflow run. The explicit
+    // `drop(lane_permit_for_spawn)` at the tail of the async block serves
+    // both as the capture and as documentation of intent (an unused
+    // `_`-prefixed binding would otherwise let the compiler drop it
+    // immediately).
+    assert!(
+        stripped.contains("drop(lane_permit_for_spawn)"),
+        "expected `drop(lane_permit_for_spawn)` inside the workflow spawn \
+         block so the Lane::Trigger permit is held until the workflow run \
+         ends. Removing the drop allows Rust to release the permit early — \
+         the bug that \
+         docs/issues/workflow-path-drops-lane-permit.md describes."
+    );
+}
+
 // ---------------------------------------------------------------------------
 // push_notification routing — locks the global-fallback match arm.
 //

--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -454,12 +454,22 @@ impl LibreFangKernel {
                                             workflow_id = %wid_str,
                                             "Trigger fired workflow (async)"
                                         );
-                                        // Spawn the run so the Lane::Trigger permit drops as
-                                        // soon as this iteration yields. A slow workflow must
-                                        // not pin Lane::Trigger kernel-wide (default lane cap
-                                        // is 8 per CLAUDE.md), starving agent-path triggers.
-                                        // Mirrors the fire-and-forget shape of
-                                        // WorkflowRunner::start_workflow_async (#4910).
+                                        // Hold the Lane::Trigger permit for the full
+                                        // duration of the workflow run, NOT just the
+                                        // resolution above. Earlier code released the
+                                        // permit as soon as this iteration yielded
+                                        // (the permit lived on the loop stack, not in
+                                        // the spawn), so N bursty workflow triggers
+                                        // produced N concurrent workflow runs that
+                                        // escaped the `queue.concurrency.trigger_lane`
+                                        // invariant (default 8). The audit doc
+                                        // `docs/issues/workflow-path-drops-lane-permit.md`
+                                        // calls this out; fix is option 1 (move the
+                                        // permit into the spawn). Per-fire
+                                        // `fire_timeout` still bounds permit-hold
+                                        // duration, so a stuck workflow cannot pin
+                                        // Lane::Trigger kernel-wide.
+                                        let lane_permit_for_spawn = _lane_permit;
                                         let kernel_for_spawn = std::sync::Arc::clone(&kernel);
                                         let wid_for_spawn = wid_str.clone();
                                         let trigger_id_for_spawn = trigger_id;
@@ -495,6 +505,14 @@ impl LibreFangKernel {
                                                     );
                                                 }
                                             }
+                                            // Lane::Trigger permit is dropped here,
+                                            // when the spawned future ends — held for
+                                            // the full workflow run, not just for
+                                            // resolution. Explicit drop documents
+                                            // intent (the `_`-prefixed binding hint
+                                            // would otherwise allow Rust to drop it
+                                            // immediately).
+                                            drop(lane_permit_for_spawn);
                                         });
                                     }
                                     None => {


### PR DESCRIPTION
Closes #5601

## Summary

`crates/librefang-kernel/src/kernel/triggers_and_workflow.rs` now holds `_lane_permit` across the workflow spawn — the permit moves INTO the `async move` block and is held for the duration of `kernel.run_workflow(...)`. Previously the permit was held only during resolution, letting N bursty workflow triggers escape the `Lane::Trigger` cap inside the spawn.

## Files changed

- `crates/librefang-kernel/src/kernel/triggers_and_workflow.rs`
- `crates/librefang-kernel/src/kernel/tests.rs` — `workflow_spawn_holds_lane_permit_across_run`

## Out of scope

A separate `Lane::Workflow` semaphore (audit option 2) was not added — that's a config-surface addition deserving its own review. This PR is the minimum fix that respects the existing `Lane::Trigger` invariant.

## Verification

- `cargo fmt -p librefang-kernel -- --check` — clean
- `cargo check -p librefang-kernel --lib` — clean
- `cargo test -p librefang-kernel --lib workflow_spawn_holds_lane_permit` — 1 passed

Refs `docs/issues/workflow-path-drops-lane-permit.md`.
