### PR TITLE
fix(kernel/triggers): derive deterministic SessionId for New-mode fires

### DIFF
--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -263,6 +263,11 @@ impl LibreFangKernel {
             }
         }
 
+        // Capture event.timestamp before the bus move — the trigger
+        // dispatcher below uses it as the deterministic fire instant for
+        // `SessionId::for_trigger_fire`. audit: trigger-new-session-non-deterministic.
+        let event_timestamp = event.timestamp;
+
         // Publish to the event bus
         self.events.event_bus.publish(event).await;
 
@@ -285,8 +290,9 @@ impl LibreFangKernel {
         //
         // Resolution order for effective session mode:
         //   trigger_match.session_mode_override → manifest.session_mode.
-        // We materialize `SessionId::new()` only when the resolved mode is
-        // `New`; persistent fires reuse the canonical session and must
+        // We materialize a deterministic `SessionId::for_trigger_fire`
+        // override only when the resolved mode is `New`; persistent fires
+        // reuse the canonical session and must
         // serialize at the per-agent mutex, so we leave session_id_override
         // = None for them.
         // Bug #3841: burst events fire triggers out-of-order via independent
@@ -344,8 +350,21 @@ impl LibreFangKernel {
                         None => continue,
                     };
                     let effective_mode = mode_override.unwrap_or(manifest_mode);
+                    // audit: trigger-new-session-non-deterministic
+                    // `SessionId::new()` here was a random v4 UUID, which
+                    // made "trigger X fired at T" log lines impossible to
+                    // correlate to the actual SessionId for diagnostics.
+                    // Mirror cron's `for_cron_run` shape: derive a
+                    // deterministic v5 UUID from
+                    // `(agent, trigger_id, event_timestamp)` so the SessionId
+                    // is reproducible from logs after the fact. `event_timestamp`
+                    // is the canonical fire instant — the same value the
+                    // trigger registry stamps into `last_fired_at` (captured
+                    // before the event was moved into the bus publish).
                     let sid_override = match effective_mode {
-                        librefang_types::agent::SessionMode::New => Some(SessionId::new()),
+                        librefang_types::agent::SessionMode::New => Some(
+                            SessionId::for_trigger_fire(aid, trigger_id.0, event_timestamp),
+                        ),
                         librefang_types::agent::SessionMode::Persistent => None,
                     };
                     let agent_sem = kernel.agent_concurrency_for(aid);
@@ -1021,5 +1040,62 @@ impl LibreFangKernel {
                 kernel: Arc::downgrade(self),
             });
         self.workflows.engine.set_operator_hooks(notifier, driver);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod trigger_dispatch_session_id_tests {
+    //! audit: trigger-new-session-non-deterministic
+    //!
+    //! Contract tests pinning the SessionId materialized for `SessionMode::New`
+    //! trigger fires. Mirrors `fire_session_override_new_matches_for_cron_run_contract_3657`
+    //! in `crates/librefang-kernel/src/cron.rs` so both audit paths fail loudly
+    //! if anyone changes the derivation shape (timestamp precision, separator,
+    //! ordering, namespace) without updating the corresponding helper.
+    //!
+    //! These are unit tests on the helper rather than full publish_event paths
+    //! because spinning a real LibreFangKernel inside this file would pull in
+    //! the full integration harness — the integration suite already covers
+    //! the dispatcher end-to-end (`crates/librefang-api/tests/`).
+    use chrono::TimeZone;
+    use librefang_types::agent::{AgentId, SessionId};
+
+    /// Regression for the audit item: pin the exact session id a `New`-mode
+    /// trigger fire receives. If anyone changes the derivation shape without
+    /// updating `SessionId::for_trigger_fire`, this test fails loudly. This
+    /// pins the helper contract the dispatcher's `New` arm relies on; that the
+    /// dispatcher actually calls `for_trigger_fire` (and not the original
+    /// random `SessionId::new()`) is exercised end-to-end in
+    /// `crates/librefang-api/tests/`.
+    #[test]
+    fn fire_session_override_new_matches_for_trigger_fire_contract() {
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let trigger_id = uuid::Uuid::parse_str("b2b3b4b5-c2c3-d2d3-e2e3-f2f3f4f5f6f7").unwrap();
+        let fire_time = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 0, 0).unwrap();
+
+        let sid = SessionId::for_trigger_fire(agent, trigger_id, fire_time);
+
+        // Determinism: a second call with identical inputs must produce the
+        // same SessionId. Random `SessionId::new()` would fail this.
+        assert_eq!(
+            sid,
+            SessionId::for_trigger_fire(agent, trigger_id, fire_time),
+            "for_trigger_fire must be deterministic over (agent, trigger_id, fire_time); \
+             see docs/issues/trigger-new-session-non-deterministic.md"
+        );
+
+        // A different fire_time on the same agent/trigger must NOT collide,
+        // even at sub-second resolution — log correlation requires that two
+        // burst fires of the same event-triggered job land on distinct ids.
+        let later = fire_time + chrono::Duration::nanoseconds(1);
+        assert_ne!(
+            sid,
+            SessionId::for_trigger_fire(agent, trigger_id, later),
+            "consecutive fires must yield distinct SessionIds"
+        );
     }
 }

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -278,6 +278,20 @@ const CRON_RUN_SESSION_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
     0x7e, 0x91, 0x2c, 0x4f, 0xb5, 0xa3, 0x48, 0xd1, 0xa0, 0x6c, 0xe2, 0x83, 0x1f, 0x57, 0xc4, 0x09,
 ]);
 
+/// Distinct UUID v5 namespace for per-fire trigger session IDs.
+/// audit: trigger-new-session-non-deterministic — random `SessionId::new()`
+/// minted at `triggers_and_workflow.rs` dispatch made "trigger X fired at T"
+/// log lines impossible to correlate to a specific SessionId. Mirror the
+/// cron `for_cron_run` design: derive deterministic v5 UUID from
+/// `(agent, trigger_id, fire_time)`. Disjoint from both
+/// `CHANNEL_SESSION_NAMESPACE` and `CRON_RUN_SESSION_NAMESPACE` so a
+/// `for_trigger_fire` id can never collide with any other session-key
+/// flavour even if input strings happen to coincide.
+/// Generated via `uuidgen`: e1e39b22-c416-4e06-93a5-60657b06e003.
+const TRIGGER_FIRE_SESSION_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
+    0xe1, 0xe3, 0x9b, 0x22, 0xc4, 0x16, 0x4e, 0x06, 0x93, 0xa5, 0x60, 0x65, 0x7b, 0x06, 0xe0, 0x03,
+]);
+
 impl SessionId {
     /// Create a new random SessionId.
     pub fn new() -> Self {
@@ -337,6 +351,39 @@ impl SessionId {
         let name = format!("{}:{}", agent_id.0, run_key.to_lowercase());
         Self(uuid::Uuid::new_v5(
             &CRON_RUN_SESSION_NAMESPACE,
+            name.as_bytes(),
+        ))
+    }
+
+    /// Derive a per-fire trigger session id keyed by
+    /// `(agent, trigger_id, fire_time)`.
+    ///
+    /// audit: trigger-new-session-non-deterministic — used when an event
+    /// trigger fires with `SessionMode::New` (manifest default or
+    /// per-trigger override). The dispatcher previously minted a random
+    /// `SessionId::new()`, which made it impossible to correlate a
+    /// "trigger X fired at T" log line to the actual SessionId for
+    /// diagnostics. Mirrors `for_cron_run` so log-driven debugging on
+    /// triggers behaves the same as cron.
+    ///
+    /// `trigger_id` is taken as a raw `Uuid` to avoid a layering inversion:
+    /// the concrete `TriggerId` newtype lives in `librefang-kernel`, which
+    /// depends on this crate. The dispatcher passes `trigger_match.trigger_id.0`.
+    /// `fire_time` is the moment the dispatcher resolved the match; the
+    /// kernel event bus already carries `Event::timestamp` for this.
+    pub fn for_trigger_fire(
+        agent_id: AgentId,
+        trigger_id: uuid::Uuid,
+        fire_time: DateTime<Utc>,
+    ) -> Self {
+        let name = format!(
+            "{}:{}:{}",
+            agent_id.0,
+            trigger_id,
+            fire_time.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
+        );
+        Self(uuid::Uuid::new_v5(
+            &TRIGGER_FIRE_SESSION_NAMESPACE,
             name.as_bytes(),
         ))
     }
@@ -3012,6 +3059,107 @@ model = "llama-3.3-70b-versatile"
         let persistent = SessionId::for_channel(agent, "cron");
         let isolated = SessionId::for_cron_run(agent, "cron");
         assert_ne!(persistent, isolated);
+    }
+
+    // audit: trigger-new-session-non-deterministic
+    // The tests below pin the contract for `SessionId::for_trigger_fire`.
+    // Mirrors `for_cron_run_*` and `fire_session_override_new_matches_for_cron_run_contract_3657`
+    // (in `librefang-kernel/src/cron.rs`). Any change to derivation shape
+    // (timestamp precision, separator, ordering, namespace) must update all of
+    // these in lockstep — random `SessionId::new()` regressed log-correlation
+    // once, and a quiet shape change would silently repeat that.
+
+    #[test]
+    fn for_trigger_fire_deterministic() {
+        use chrono::TimeZone;
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let trigger_id = uuid::Uuid::parse_str("b2b3b4b5-c2c3-d2d3-e2e3-f2f3f4f5f6f7").unwrap();
+        let t = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 0, 0).unwrap();
+        let a = SessionId::for_trigger_fire(agent, trigger_id, t);
+        let b = SessionId::for_trigger_fire(agent, trigger_id, t);
+        assert_eq!(
+            a, b,
+            "same (agent, trigger_id, fire_time) must yield identical SessionId"
+        );
+    }
+
+    #[test]
+    fn for_trigger_fire_distinguishes_fire_time() {
+        use chrono::TimeZone;
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let trigger_id = uuid::Uuid::parse_str("b2b3b4b5-c2c3-d2d3-e2e3-f2f3f4f5f6f7").unwrap();
+        let t1 = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 0, 0).unwrap();
+        let t2 = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 0, 1).unwrap();
+        assert_ne!(
+            SessionId::for_trigger_fire(agent, trigger_id, t1),
+            SessionId::for_trigger_fire(agent, trigger_id, t2),
+            "different fire_times must yield different SessionIds"
+        );
+    }
+
+    #[test]
+    fn for_trigger_fire_distinguishes_trigger_id() {
+        use chrono::TimeZone;
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let t = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 0, 0).unwrap();
+        let tid_a = uuid::Uuid::parse_str("b2b3b4b5-c2c3-d2d3-e2e3-f2f3f4f5f6f7").unwrap();
+        let tid_b = uuid::Uuid::parse_str("c3c4c5c6-d3d4-e3e4-f3f4-a3a4a5a6a7a8").unwrap();
+        assert_ne!(
+            SessionId::for_trigger_fire(agent, tid_a, t),
+            SessionId::for_trigger_fire(agent, tid_b, t),
+            "different trigger_ids at the same instant must yield different SessionIds"
+        );
+    }
+
+    #[test]
+    fn for_trigger_fire_distinguishes_agent() {
+        use chrono::TimeZone;
+        let agent_a =
+            AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        let agent_b =
+            AgentId(uuid::Uuid::parse_str("d4d5d6d7-e4e5-f4f5-a4a5-b4b5b6b7b8b9").unwrap());
+        let trigger_id = uuid::Uuid::parse_str("b2b3b4b5-c2c3-d2d3-e2e3-f2f3f4f5f6f7").unwrap();
+        let t = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 0, 0).unwrap();
+        assert_ne!(
+            SessionId::for_trigger_fire(agent_a, trigger_id, t),
+            SessionId::for_trigger_fire(agent_b, trigger_id, t),
+            "different agents must yield different SessionIds for the same trigger fire"
+        );
+    }
+
+    #[test]
+    fn for_trigger_fire_distinct_namespace_from_cron_and_channel() {
+        use chrono::TimeZone;
+        // Distinct namespaces guarantee: even if a future caller hands
+        // identical input strings to all three derivation flavours, the
+        // resulting SessionIds cannot collide. This pins
+        // TRIGGER_FIRE_SESSION_NAMESPACE as semantically disjoint from
+        // CHANNEL_SESSION_NAMESPACE and CRON_RUN_SESSION_NAMESPACE.
+        let agent = AgentId(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap());
+        // Use the trigger_id's UUID *string* as the colliding input for the
+        // other two namespaces — purely to force the same byte sequence.
+        let trigger_id = uuid::Uuid::parse_str("b2b3b4b5-c2c3-d2d3-e2e3-f2f3f4f5f6f7").unwrap();
+        let t = chrono::Utc.with_ymd_and_hms(2026, 4, 25, 10, 0, 0).unwrap();
+        let trigger_sid = SessionId::for_trigger_fire(agent, trigger_id, t);
+        let cron_sid = SessionId::for_cron_run(
+            agent,
+            &format!(
+                "{}:{}",
+                trigger_id,
+                t.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true)
+            ),
+        );
+        let channel_sid = SessionId::for_channel(
+            agent,
+            &format!(
+                "{}:{}",
+                trigger_id,
+                t.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true)
+            ),
+        );
+        assert_ne!(trigger_sid, cron_sid);
+        assert_ne!(trigger_sid, channel_sid);
+        assert_ne!(cron_sid, channel_sid);
     }
 
     #[test]


### PR DESCRIPTION
Closes #5603

## Summary

Triggers firing in `SessionMode::New` now derive their SessionId
deterministically via `SessionId::for_trigger_fire(agent, trigger_id, fire_time)` —
UUID v5 over a dedicated `TRIGGER_FIRE_SESSION_NAMESPACE`, mirroring
cron's existing `for_cron_run` shape. Operators can now correlate a
"trigger X fired at T" log line back to the specific SessionId the fire
landed on; the previous random `SessionId::new()` made that impossible
and obscured diagnostics when two fires of the same trigger collided on
the event timestamp.

`fire_time` is `Event.timestamp`, captured before the event is moved
into the bus publish so the same instant flows into both the trigger
registry's `last_fired_at` and the SessionId derivation.

## Files changed

- `crates/librefang-types/src/agent.rs` — `for_trigger_fire` helper,
  `TRIGGER_FIRE_SESSION_NAMESPACE` constant
  (`e1e39b22-c416-4e06-93a5-60657b06e003`, generated via `uuidgen`,
  disjoint from `CHANNEL_SESSION_NAMESPACE` and
  `CRON_RUN_SESSION_NAMESPACE`), plus five colocated tests
- `crates/librefang-kernel/src/kernel/triggers_and_workflow.rs` —
  dispatcher uses `for_trigger_fire`; captures `event.timestamp` into
  `event_timestamp` before the bus move; new
  `trigger_dispatch_session_id_tests` contract module

## Verification

- `cargo check -p librefang-types -p librefang-kernel --lib` — clean
- `cargo fmt --check` on the two touched files — clean
- `cargo clippy -p librefang-types -p librefang-kernel --lib -- -D warnings` — clean
- `cargo test -p librefang-types --lib for_trigger_fire` — 5 pass
  (`for_trigger_fire_deterministic`,
  `for_trigger_fire_distinguishes_fire_time`,
  `for_trigger_fire_distinguishes_trigger_id`,
  `for_trigger_fire_distinguishes_agent`,
  `for_trigger_fire_distinct_namespace_from_cron_and_channel`)
- `cargo test -p librefang-kernel --lib fire_session_override_new_matches_for_trigger_fire_contract` — 1 pass

Refs `docs/issues/trigger-new-session-non-deterministic.md`.
