### PR TITLE
test(api/triggers): replace fixed 150ms sleeps with condition-based polling

### DIFF
--- a/crates/librefang-api/tests/trigger_workflow_test.rs
+++ b/crates/librefang-api/tests/trigger_workflow_test.rs
@@ -126,6 +126,37 @@ async fn create_workflow(h: &Harness) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: poll for a workflow run to appear instead of guessing at a fixed
+// sleep. The trigger → workflow dispatch happens on a spawned task, so the run
+// is recorded asynchronously after `publish_typed_event`. Polling on the
+// observable side effect (a run with the expected workflow_id) removes the
+// wall-clock race that made a fixed 150ms sleep flaky under CI load.
+//
+// Returns the matching run, or `None` if none appears within the 5s deadline
+// (25ms poll interval). Callers craft their own assertion message so the
+// failure can name the domain-specific context (e.g. the case-insensitive
+// name-lookup forms in test 5).
+// ---------------------------------------------------------------------------
+
+async fn wait_for_workflow_run(
+    h: &Harness,
+    wf_id: librefang_kernel::workflow::WorkflowId,
+) -> Option<librefang_kernel::workflow::WorkflowRun> {
+    let engine = h.state.kernel.workflow_engine();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let runs = engine.list_runs(None).await;
+        if let Some(run) = runs.into_iter().find(|r| r.workflow_id == wf_id) {
+            return Some(run);
+        }
+        if std::time::Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Test 1: trigger with workflow_id fires a workflow run on a matching event
 // ---------------------------------------------------------------------------
 
@@ -181,18 +212,14 @@ async fn trigger_with_workflow_id_fires_workflow_on_matching_event() {
     );
     h.state.kernel.publish_typed_event(event).await;
 
-    // Give the spawned workflow dispatch task time to create the run.
-    // We don't wait for full LLM execution (none in the test kernel) —
-    // just for create_run to be recorded.
-    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-
-    // Confirm a run was created for the workflow.
-    let engine = h.state.kernel.workflow_engine();
-    let runs = engine.list_runs(None).await;
-    let wf_run = runs.iter().find(|r| r.workflow_id == wf_id);
+    // The spawned workflow dispatch task records the run asynchronously. We
+    // don't wait for full LLM execution (none in the test kernel) — just poll
+    // until create_run is recorded.
+    let wf_run = wait_for_workflow_run(&h, wf_id).await;
     assert!(
         wf_run.is_some(),
-        "Expected at least one run for workflow {wf_id_str}, got runs: {runs:?}"
+        "Expected at least one run for workflow {wf_id_str} within 5s; got runs: {:?}",
+        h.state.kernel.workflow_engine().list_runs(None).await
     );
 }
 
@@ -453,14 +480,15 @@ async fn trigger_workflow_id_resolves_name_case_insensitively() {
     );
     h.state.kernel.publish_typed_event(event).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-
-    let engine = h.state.kernel.workflow_engine();
-    let runs = engine.list_runs(None).await;
-    let wf_run = runs.iter().find(|r| r.workflow_id == wf_uuid);
+    // Poll for the run instead of guessing at a fixed sleep. If the
+    // case-insensitive name lookup fails to resolve `lowercase_form` to the
+    // `mixed_name` workflow, no run is ever recorded and this fails with a clear
+    // message naming both forms and the expected workflow id.
+    let wf_run = wait_for_workflow_run(&h, wf_uuid).await;
     assert!(
         wf_run.is_some(),
-        "case-insensitive name lookup must resolve `{lowercase_form}` to workflow `{mixed_name}` (id {wf_uuid:?}); got runs: {runs:?}"
+        "case-insensitive name lookup must resolve `{lowercase_form}` to workflow `{mixed_name}` (id {wf_uuid:?}) within 5s; got runs: {:?}",
+        h.state.kernel.workflow_engine().list_runs(None).await
     );
 }
 


### PR DESCRIPTION
## What

Replaces the two fixed `tokio::time::sleep(Duration::from_millis(150))` calls in `crates/librefang-api/tests/trigger_workflow_test.rs` (lines 187 and 456 on `origin/main`) with condition-based polling.

The trigger → workflow dispatch runs on a spawned task, so the run is recorded asynchronously after `publish_typed_event`. The 150ms sleep was a wall-clock guess that goes flaky under CI load when the spawned task is delayed past the deadline.

## Changes

- Add file-local helper `wait_for_workflow_run(h, wf_id) -> Option<WorkflowRun>` that polls `workflow_engine().list_runs(None)` on a **25ms interval** up to a **5s deadline** for a run matching the expected `WorkflowId`, returning `None` on timeout.
- `trigger_with_workflow_id_fires_workflow_on_matching_event`: replace sleep + manual lookup with the helper; assertion meaning unchanged, timeout message dumps observed runs.
- `trigger_workflow_id_resolves_name_case_insensitively`: same; the assertion keeps its case-insensitive-lookup diagnostic message (names both `lowercase_form` and `mixed_name`).

No assertion semantics changed; only the wait strategy.

## Verification

- `cargo check -p librefang-api` — clean.
- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — no new warnings from the changed test file (the 6 errors my local clippy 1.95.0 reports are all pre-existing lints in unchanged `src/` files: `webchat.rs:277`, `registry.rs:287`, `validation.rs:468-471`; verified identical on `origin/main` — these are newer-toolchain lints, out of scope here).
- `rustfmt --check --edition 2021` on the changed file — clean.
- `cargo test -p librefang-api --test trigger_workflow_test` — 8/8 pass.
- Repeated-run flakiness check: the two affected tests run **30×** with `--test-threads=16` → 30/30 pass; full test binary run **10×** → 10/10 pass.

Closes #5612

## Out-of-scope

This PR is the primary ("this") sub-finding of the test-infrastructure roundup `docs/issues/trigger-test-fixed-sleep.md`. The other five sub-findings are **not** addressed here and remain tracked in that doc:

- test-helper leak: `pub fn install_peer_registry_for_test` lacks a `#[cfg(test)]` gate
- rate limiter integration: no live-router integration test
- unit-fast heavy I/O: CI Unit-fast lane runs kernel-heavy I/O tests
- proptest idle: `proptest` dep used by only 2 modules
- hand-curated allowlist: drift-prone hand-maintained allowlist tables