### PR TITLE
test(kernel): parallel semaphore-contention coverage for trigger concurrency caps

### DIFF
--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -6446,6 +6446,371 @@ fn session_mode_persistent_plus_cap_two_is_clamped_preventing_parallel_fires() {
     kernel.shutdown();
 }
 
+// ─── end-to-end parallel-firing concurrency-cap tests ────────────────────────
+//
+// The #3755 tests above check the *resolver* math (`available_permits()`) and
+// prove that a third `try_acquire_owned()` fails once a lane/per-agent
+// semaphore is exhausted. None of them actually fire N tasks at once and
+// observe the real peak in-flight count under load — they hold permits with
+// `try_acquire` and never spawn contending work.
+//
+// These tests close that gap. Each spawns N tasks that replicate the exact
+// acquire-then-work shape of the production trigger dispatcher
+// (`triggers_and_workflow.rs`): take the global `Lane::Trigger` permit, then
+// (agent path) the per-agent permit, then run a body that increments a shared
+// in-flight counter, records the peak, sleeps to create real overlap, and
+// decrements on drop. We then assert `peak <= cap`.
+//
+// We exercise the kernel's *real* semaphores — `kernel.workflows.command_queue`
+// (the same field the dispatcher reads at triggers_and_workflow.rs:357) and
+// `kernel.agent_concurrency_for(aid)` — rather than a standalone semaphore, so
+// a regression in how the kernel sizes either one is caught.
+//
+// What these tests do NOT cover: the full `send_message_full` LLM round-trip.
+// The production dispatcher executes triggers from a *single* event
+// sequentially inside one spawned task (bug #3841 fix), so genuine parallelism
+// across the lane only arises from independent events / workflow re-spawns,
+// neither of which can be driven without real LLM wiring. These tests model
+// the enforcement primitive the dispatcher relies on, which is where the cap
+// is actually held.
+
+/// RAII in-flight tracker: increments a live counter on construction, updates a
+/// monotonic peak, and decrements on drop. Sampling the peak this way is robust
+/// to scheduler jitter — every concurrent body that is simultaneously alive is
+/// counted, so the recorded peak is the true maximum overlap the semaphore
+/// allowed, not an inference from wall-clock time.
+struct InFlightGuard {
+    live: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl InFlightGuard {
+    fn enter(
+        live: &std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        peak: &std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        use std::sync::atomic::Ordering;
+        // fetch_add returns the value *before* the add, so the new live count
+        // is +1.
+        let now = live.fetch_add(1, Ordering::SeqCst) + 1;
+        // Monotonic max-update; SeqCst keeps the peak coherent with `live`.
+        // The peak is sampled here on entry — the guard only needs to hold
+        // `live` so it can decrement on drop.
+        peak.fetch_max(now, Ordering::SeqCst);
+        Self {
+            live: std::sync::Arc::clone(live),
+        }
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.live.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+/// E2E: the global `Lane::Trigger` semaphore must cap total in-flight trigger
+/// dispatches kernel-wide. Boot a kernel with `trigger_lane = 2`, fire 10
+/// tasks that each acquire the lane permit then hold it for 40 ms, and assert
+/// the sampled peak overlap never exceeds 2.
+///
+/// This is the behavioural counterpart to
+/// `trigger_lane_global_semaphore_limits_total_concurrency` (#3755), which only
+/// proves a third `try_acquire` fails — it never spawns 10 contending tasks and
+/// measures the real peak.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn e2e_trigger_lane_global_cap_holds_under_parallel_fires() {
+    use librefang_runtime::command_lane::Lane;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().join("e2e-trigger-lane-cap");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let mut config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    config.queue.concurrency.trigger_lane = 2;
+    let kernel = Arc::new(LibreFangKernel::boot_with_config(config).expect("kernel boots"));
+
+    // Precondition: the kernel sized its lane semaphore from config.
+    let lane_sem = kernel
+        .workflows
+        .command_queue
+        .semaphore_for_lane(Lane::Trigger);
+    assert_eq!(
+        lane_sem.available_permits(),
+        2,
+        "kernel must size the trigger lane from queue.concurrency.trigger_lane"
+    );
+
+    const FIRES: usize = 10;
+    let live = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicUsize::new(0));
+
+    let mut handles = Vec::with_capacity(FIRES);
+    for _ in 0..FIRES {
+        let k = Arc::clone(&kernel);
+        let live = Arc::clone(&live);
+        let peak = Arc::clone(&peak);
+        let completed = Arc::clone(&completed);
+        handles.push(tokio::spawn(async move {
+            // Mirror the dispatcher: acquire the global Lane::Trigger permit
+            // before doing any work (triggers_and_workflow.rs step (1)).
+            let sem = k.workflows.command_queue.semaphore_for_lane(Lane::Trigger);
+            let _permit = sem
+                .acquire_owned()
+                .await
+                .expect("trigger lane must not be closed mid-test");
+            let _guard = InFlightGuard::enter(&live, &peak);
+            // Hold the permit long enough that all 10 tasks are scheduled and
+            // contending — so if the cap were broken, peak would exceed 2.
+            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+            completed.fetch_add(1, Ordering::SeqCst);
+        }));
+    }
+    for h in handles {
+        h.await.expect("fire task panicked");
+    }
+
+    assert_eq!(
+        completed.load(Ordering::SeqCst),
+        FIRES,
+        "every fire must run to completion"
+    );
+    assert_eq!(
+        live.load(Ordering::SeqCst),
+        0,
+        "all in-flight permits must be released after the test"
+    );
+    let observed_peak = peak.load(Ordering::SeqCst);
+    assert!(
+        observed_peak >= 1,
+        "at least one fire must have run (sanity: peak={observed_peak})"
+    );
+    assert!(
+        observed_peak <= 2,
+        "global Lane::Trigger cap=2 must hold under {FIRES} parallel fires; \
+         observed peak in-flight = {observed_peak}. If this exceeds 2, the \
+         dispatcher's Lane::Trigger acquire (triggers_and_workflow.rs step 1) \
+         has stopped gating concurrency."
+    );
+
+    Arc::try_unwrap(kernel).ok().unwrap().shutdown();
+}
+
+/// E2E: the per-agent semaphore (`max_concurrent_invocations`) caps how many of
+/// ONE agent's fires run in parallel, independently of the global lane. Use a
+/// `session_mode = "new"` agent with cap = 2 and a roomy global lane (8), fire
+/// 10 tasks that each take the per-agent permit, and assert peak <= 2.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn e2e_per_agent_cap_holds_under_parallel_fires() {
+    use librefang_types::agent::SessionMode;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // default trigger_lane = 8, well above the per-agent cap so the per-agent
+    // semaphore is the binding constraint under test.
+    let (kernel, _dir) = minimal_kernel("e2e-per-agent-cap");
+    let aid = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("e2e-per-agent-agent", SessionMode::New, Some(2)),
+            None,
+            None,
+            None,
+        )
+        .expect("agent spawns");
+    assert_eq!(
+        kernel.agent_concurrency_for(aid).available_permits(),
+        2,
+        "precondition: New + cap=2 resolves to a 2-permit semaphore"
+    );
+
+    let kernel = Arc::new(kernel);
+    const FIRES: usize = 10;
+    let live = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    let mut handles = Vec::with_capacity(FIRES);
+    for _ in 0..FIRES {
+        let k = Arc::clone(&kernel);
+        let live = Arc::clone(&live);
+        let peak = Arc::clone(&peak);
+        handles.push(tokio::spawn(async move {
+            // Mirror the dispatcher's per-agent acquire (step 2). The cached
+            // Arc means every fire contends on the SAME semaphore.
+            let sem = k.agent_concurrency_for(aid);
+            let _permit = sem
+                .acquire_owned()
+                .await
+                .expect("per-agent semaphore must not be closed mid-test");
+            let _guard = InFlightGuard::enter(&live, &peak);
+            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+        }));
+    }
+    for h in handles {
+        h.await.expect("fire task panicked");
+    }
+
+    assert_eq!(live.load(Ordering::SeqCst), 0, "all permits released");
+    let observed_peak = peak.load(Ordering::SeqCst);
+    assert!(
+        (1..=2).contains(&observed_peak),
+        "per-agent cap=2 must hold under {FIRES} parallel fires; observed peak \
+         in-flight = {observed_peak}"
+    );
+
+    Arc::try_unwrap(kernel).ok().unwrap().shutdown();
+}
+
+/// E2E: a `session_mode = "persistent"` agent with `max_concurrent_invocations
+/// = 4` is auto-clamped to 1 by the resolver (parallel writes to one session's
+/// history are undefined). Firing 10 tasks must therefore fully serialise:
+/// peak in-flight == 1.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn e2e_persistent_plus_cap_gt_one_serialises_under_parallel_fires() {
+    use librefang_types::agent::SessionMode;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let (kernel, _dir) = minimal_kernel("e2e-persistent-clamp");
+    let aid = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("e2e-persistent-agent", SessionMode::Persistent, Some(4)),
+            None,
+            None,
+            None,
+        )
+        .expect("agent spawns");
+    assert_eq!(
+        kernel.agent_concurrency_for(aid).available_permits(),
+        1,
+        "precondition: Persistent + cap=4 must clamp to 1 permit"
+    );
+
+    let kernel = Arc::new(kernel);
+    const FIRES: usize = 10;
+    let live = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    let mut handles = Vec::with_capacity(FIRES);
+    for _ in 0..FIRES {
+        let k = Arc::clone(&kernel);
+        let live = Arc::clone(&live);
+        let peak = Arc::clone(&peak);
+        handles.push(tokio::spawn(async move {
+            let sem = k.agent_concurrency_for(aid);
+            let _permit = sem
+                .acquire_owned()
+                .await
+                .expect("clamped semaphore must not be closed mid-test");
+            let _guard = InFlightGuard::enter(&live, &peak);
+            tokio::time::sleep(std::time::Duration::from_millis(15)).await;
+        }));
+    }
+    for h in handles {
+        h.await.expect("fire task panicked");
+    }
+
+    assert_eq!(live.load(Ordering::SeqCst), 0, "all permits released");
+    assert_eq!(
+        peak.load(Ordering::SeqCst),
+        1,
+        "Persistent + cap>1 is clamped to 1; {FIRES} parallel fires must \
+         serialise (peak in-flight must be exactly 1). A peak > 1 means the \
+         clamp in agent_concurrency_for stopped enforcing single-writer \
+         access to the persistent session's history."
+    );
+
+    Arc::try_unwrap(kernel).ok().unwrap().shutdown();
+}
+
+/// E2E: the global lane and per-agent caps compose. With `trigger_lane = 4` and
+/// a per-agent cap = 2, firing 10 tasks for the SAME agent must be bounded by
+/// the *tighter* of the two (the per-agent cap = 2), since each fire holds both
+/// permits for the duration of its work — exactly as the dispatcher does
+/// (lane permit, then per-agent permit, both held across the body).
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn e2e_layered_caps_compose_to_tighter_bound() {
+    use librefang_runtime::command_lane::Lane;
+    use librefang_types::agent::SessionMode;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().join("e2e-layered-caps");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let mut config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    config.queue.concurrency.trigger_lane = 4;
+    let kernel = Arc::new(LibreFangKernel::boot_with_config(config).expect("kernel boots"));
+
+    let aid = kernel
+        .spawn_agent_inner(
+            concurrency_manifest("e2e-layered-agent", SessionMode::New, Some(2)),
+            None,
+            None,
+            None,
+        )
+        .expect("agent spawns");
+    assert_eq!(
+        kernel
+            .workflows
+            .command_queue
+            .semaphore_for_lane(Lane::Trigger)
+            .available_permits(),
+        4,
+        "precondition: lane cap = 4"
+    );
+    assert_eq!(
+        kernel.agent_concurrency_for(aid).available_permits(),
+        2,
+        "precondition: per-agent cap = 2"
+    );
+
+    const FIRES: usize = 10;
+    let live = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    let mut handles = Vec::with_capacity(FIRES);
+    for _ in 0..FIRES {
+        let k = Arc::clone(&kernel);
+        let live = Arc::clone(&live);
+        let peak = Arc::clone(&peak);
+        handles.push(tokio::spawn(async move {
+            // Acquire in the dispatcher's order: lane permit first, then the
+            // per-agent permit, both held across the body.
+            let lane_sem = k.workflows.command_queue.semaphore_for_lane(Lane::Trigger);
+            let _lane_permit = lane_sem
+                .acquire_owned()
+                .await
+                .expect("lane not closed mid-test");
+            let agent_sem = k.agent_concurrency_for(aid);
+            let _agent_permit = agent_sem
+                .acquire_owned()
+                .await
+                .expect("per-agent sem not closed mid-test");
+            let _guard = InFlightGuard::enter(&live, &peak);
+            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+        }));
+    }
+    for h in handles {
+        h.await.expect("fire task panicked");
+    }
+
+    assert_eq!(live.load(Ordering::SeqCst), 0, "all permits released");
+    let observed_peak = peak.load(Ordering::SeqCst);
+    assert!(
+        (1..=2).contains(&observed_peak),
+        "layered caps (lane=4, per-agent=2) must bound a single agent's fires \
+         to the tighter per-agent cap=2; observed peak in-flight = \
+         {observed_peak}"
+    );
+
+    Arc::try_unwrap(kernel).ok().unwrap().shutdown();
+}
+
 // ─── spawn_agent error path unit tests ──────────────────────────────────────────
 // These tests verify error handling without requiring an LLM API key.
 // See issue #3816: kernel/mod.rs has zero unit tests.


### PR DESCRIPTION
Closes #5615.

## Problem

The existing trigger-concurrency tests (#3755 cluster in
`crates/librefang-kernel/src/kernel/tests.rs`) verify the **resolver
math** — `available_permits()` and a third `try_acquire_owned()` failing
once a semaphore is exhausted — but none spawn N contending tasks and
measure the real peak in-flight count under load. A regression in the
dispatcher's acquire ordering or permit-hold duration could land
unnoticed.

## What this PR adds

Four `#[tokio::test(flavor = "multi_thread", worker_threads = 8)]` cases
in `crates/librefang-kernel/src/kernel/tests.rs`. Each fires 10 tasks in
parallel that replicate the production dispatcher's acquire-then-work
shape (`triggers_and_workflow.rs`: Lane::Trigger permit, then per-agent
permit, both held across the body) against the kernel's **real**
semaphores — `kernel.workflows.command_queue` (the same field the
dispatcher reads) and `agent_concurrency_for`. An RAII `InFlightGuard`
samples the peak overlap via atomics (increment on entry, `fetch_max` the
peak, decrement on drop), and each test asserts `peak <= cap`.

Cases covered (all four from the assigned doc):

- **Global `Lane::Trigger` cap** — boot kernel with `trigger_lane = 2`,
  fire 10, assert peak ≤ 2.
- **Per-agent cap** — `session_mode = "new"` + `max_concurrent_invocations
  = 2`, roomy global lane, assert peak ≤ 2.
- **Per-session mutex via `persistent + cap>1` auto-clamp** — `persistent`
  + cap=4 clamps to 1, so 10 fires fully serialise: peak == 1. (This is
  the per-session-serialisation guarantee — the `New`-mode cases exercise
  the parallel side.)
- **Layered caps compose** — lane=4, per-agent=2 for one agent → bounded
  by the tighter per-agent cap (peak ≤ 2).

## Verification

- `cargo check -p librefang-kernel --tests` — clean.
- `cargo check --workspace --lib` — clean (exit 0).
- `cargo clippy -p librefang-kernel --lib -- -D warnings` — clean; the
  `--tests` target produces **zero** diagnostics in any `librefang-kernel`
  source file. (The container's clippy 1.95.0 flags six pre-existing lints
  in `librefang-api` — `registry.rs`, `validation.rs`, `webchat.rs` —
  pulled in transitively via the `librefang-testing` dev-dep; these exist
  unchanged on `origin/main` and are out of scope for this PR.)
- `rustfmt --edition 2021 --check` on the changed file — clean.
- `cargo test -p librefang-kernel kernel::tests::e2e_` — all 4 pass; ran
  6 times total for non-flakiness, full set finishes in ~5s (no
  `#[ignore]` needed).

## Scope notes

These tests intentionally do **not** drive the full `send_message_full`
LLM round-trip. The dispatcher executes triggers from a *single* event
sequentially inside one spawned task (bug #3841 fix), so genuine
cross-lane parallelism only arises from independent events / workflow
re-spawns, neither of which can be driven without real LLM wiring. The
tests model the enforcement primitive the dispatcher relies on (the same
semaphores, acquired in the same order), which is where the cap is
actually held. Driving the end-to-end LLM path would require the
human-only Live Integration Testing harness.