### PR TITLE
fix(api/openapi): backfill missing #[utoipa::path] handlers + regenerate openapi.json

### DIFF
--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -32,6 +32,7 @@ use crate::types;
         routes::config_schema,
         routes::config_set,
         routes::config_reload,
+        routes::export_config,
         routes::quick_init,
         routes::security_status,
         routes::shutdown,
@@ -42,6 +43,7 @@ use crate::types;
         routes::get_profile,
         routes::list_agent_templates,
         routes::get_agent_template,
+        routes::get_agent_template_toml,
         routes::list_commands,
         routes::get_command,
         routes::queue_status,
@@ -114,6 +116,17 @@ use crate::types;
         routes::install_skill,
         routes::uninstall_skill,
         routes::create_skill,
+        routes::get_skill_detail,
+        routes::get_supporting_file,
+        routes::list_skill_registry,
+        routes::reload_skills,
+        // Skill evolution (write / patch / rollback)
+        routes::evolve_write_file,
+        routes::evolve_remove_file,
+        routes::evolve_update_skill,
+        routes::evolve_patch_skill,
+        routes::evolve_delete_skill,
+        routes::evolve_rollback_skill,
         // Skill workshop pending review (#3328)
         routes::list_pending_candidates,
         routes::show_pending_candidate,
@@ -134,14 +147,17 @@ use crate::types;
         routes::install_hand,
         routes::list_active_hands,
         routes::get_hand,
+        routes::get_hand_manifest,
         routes::activate_hand,
         routes::check_hand_deps,
         routes::install_hand_deps,
         routes::get_hand_settings,
         routes::update_hand_settings,
+        routes::set_hand_secret,
         routes::pause_hand,
         routes::resume_hand,
         routes::deactivate_hand,
+        routes::uninstall_hand,
         routes::hand_stats,
         routes::hand_instance_browser,
         routes::reload_hands,
@@ -158,6 +174,12 @@ use crate::types;
         routes::mcp_health_handler,
         routes::reload_mcp_handler,
         routes::list_mcp_taint_rules,
+        routes::patch_mcp_server_taint,
+
+        // ── MCP Server OAuth (UI-driven PKCE flow) ──
+        routes::auth_start,
+        routes::auth_status,
+        routes::auth_revoke,
 
         // ── Extensions (dashboard-friendly aliases over MCP store) ──
         routes::list_extensions,
@@ -207,12 +229,22 @@ use crate::types;
 
         // ── Workflows / Triggers / Schedules / Cron ──
         routes::list_workflows,
+        routes::get_workflow,
         routes::create_workflow,
         routes::update_workflow,
         routes::delete_workflow,
         routes::run_workflow,
+        routes::dry_run_workflow,
         routes::list_workflow_runs,
+        routes::get_workflow_run,
+        routes::cancel_workflow_run,
+        routes::pause_workflow_run,
+        routes::resume_workflow_run,
+        routes::operator_action_workflow_run,
         routes::save_workflow_as_template,
+        routes::list_workflow_templates,
+        routes::get_workflow_template,
+        routes::instantiate_template,
         routes::list_triggers,
         routes::create_trigger,
         routes::get_trigger,
@@ -226,6 +258,7 @@ use crate::types;
         routes::run_schedule,
         routes::list_cron_jobs,
         routes::create_cron_job,
+        routes::get_cron_job,
         routes::delete_cron_job,
         routes::update_cron_job,
         routes::toggle_cron_job,
@@ -238,6 +271,7 @@ use crate::types;
         routes::set_session_label,
         routes::patch_session_model,
         routes::find_session_by_label,
+        routes::search_sessions,
         routes::session_cleanup,
 
         // ── Budget / Usage ──
@@ -248,9 +282,12 @@ use crate::types;
         routes::update_agent_budget,
         routes::user_budget_ranking,
         routes::user_budget_detail,
+        routes::update_user_budget,
+        routes::delete_user_budget,
         routes::usage_stats,
         routes::usage_summary,
         routes::usage_by_model,
+        routes::usage_by_model_performance,
         routes::usage_daily,
 
         // ── Auto-Dream (background memory consolidation) ──
@@ -267,6 +304,12 @@ use crate::types;
         routes::users::delete_user,
         routes::users::import_users,
         routes::users::rotate_user_key,
+        routes::users::get_user_policy,
+        routes::users::update_user_policy,
+
+        // ── Authorization (RBAC checks) ──
+        routes::check,
+        routes::effective_permissions,
 
         // ── Memory (KV) ──
         routes::get_agent_kv,
@@ -283,8 +326,10 @@ use crate::types;
         routes::memory_add,
         routes::memory_update,
         routes::memory_delete,
+        routes::memory_bulk_delete,
         routes::memory_stats,
         routes::memory_list_agent,
+        routes::memory_count_agent,
         routes::memory_reset_agent,
         routes::memory_clear_level,
         routes::memory_search_agent,
@@ -293,8 +338,13 @@ use crate::types;
         routes::memory_history,
         routes::memory_consolidate,
         routes::memory_cleanup,
+        routes::memory_decay,
         routes::memory_export_agent,
         routes::memory_import_agent,
+        routes::memory_query_relations,
+        routes::memory_store_relations,
+        routes::memory_config_get,
+        routes::memory_config_patch,
 
         // ── Audit / Logs ──
         routes::audit_recent,
@@ -305,10 +355,23 @@ use crate::types;
 
         // ── Approvals ──
         routes::list_approvals,
+        routes::approval_count,
         routes::create_approval,
         routes::get_approval,
         routes::approve_request,
         routes::reject_request,
+        routes::modify_request,
+        routes::batch_resolve,
+        routes::list_approvals_for_session,
+        routes::approve_all_for_session,
+        routes::reject_all_for_session,
+        routes::audit_log,
+
+        // ── Goals ──
+        routes::list_goal_templates,
+
+        // ── Inbox ──
+        routes::inbox_status,
 
         // ── Webhooks ──
         routes::webhook_wake,
@@ -336,6 +399,7 @@ use crate::types;
         routes::list_peers,
         routes::get_peer,
         routes::network_status,
+        routes::network_trusted_peers,
         routes::comms_topology,
         routes::comms_events,
         routes::comms_events_stream,
@@ -346,6 +410,7 @@ use crate::types;
         routes::a2a_list_external_agents,
         routes::a2a_get_external_agent,
         routes::a2a_discover_external,
+        routes::a2a_approve_external,
         routes::a2a_send_external,
         routes::a2a_external_task_status,
         routes::a2a_agent_card,
@@ -353,6 +418,34 @@ use crate::types;
         routes::a2a_send_task,
         routes::a2a_get_task,
         routes::a2a_cancel_task,
+
+        // ── Plugins ──
+        routes::list_plugins,
+        routes::get_plugin,
+        routes::install_plugin,
+        routes::uninstall_plugin,
+        routes::upgrade_plugin,
+        routes::enable_plugin,
+        routes::disable_plugin,
+        routes::reload_plugin,
+        routes::prewarm_plugin,
+        routes::plugin_status,
+        routes::plugin_env,
+        routes::plugin_advanced_config,
+        routes::plugin_doctor,
+        routes::lint_plugin,
+        routes::sign_plugin,
+        routes::scaffold_plugin,
+        routes::install_plugin_deps,
+        routes::test_plugin_hook,
+        routes::list_plugin_registries,
+        // Context engine (plugin-backed)
+        routes::context_engine_config,
+        routes::context_engine_chain,
+        routes::context_engine_health,
+        routes::context_engine_metrics,
+        routes::context_engine_traces,
+        routes::context_engine_sandbox_policy,
 
         // ── MCP HTTP ──
         routes::mcp_http,

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -2258,15 +2258,6 @@ pub async fn create_trigger(
     }
 }
 
-/// GET /api/triggers — List all triggers (optionally filter by ?agent_id=...).
-#[utoipa::path(
-    get,
-    path = "/api/triggers",
-    tag = "workflows",
-    responses(
-        (status = 200, description = "List triggers", body = crate::types::JsonObject)
-    )
-)]
 /// Serialize a `Trigger` to a JSON value (shared by list and get endpoints).
 fn trigger_to_json(t: &Trigger) -> serde_json::Value {
     let mut v = serde_json::json!({

--- a/crates/librefang-api/tests/openapi_path_coverage_test.rs
+++ b/crates/librefang-api/tests/openapi_path_coverage_test.rs
@@ -1,0 +1,234 @@
+//! OpenAPI path-coverage reflection test (refs the "openapi paths
+//! incomplete" finding).
+//!
+//! Catches the *inverse* of `dead_route_audit_test.rs`. The dead-route
+//! audit asserts that every path **in the spec** is wired into the axum
+//! router. This test asserts that every handler **annotated with
+//! `#[utoipa::path(...)]` in the crate source** is actually referenced
+//! from `ApiDoc::paths(...)` in `openapi.rs`, and therefore present in
+//! the generated `ApiDoc::openapi()` surface.
+//!
+//! Why this is needed: utoipa only includes a handler in the document if
+//! it is explicitly listed inside the `paths(...)` argument of the
+//! `#[derive(OpenApi)]` macro. Adding `#[utoipa::path]` to a new handler
+//! does **not** auto-register it. Forgetting the `paths(...)` entry
+//! silently drops the endpoint from `openapi.json` and from every
+//! generated SDK, with no compile error and no runtime symptom — exactly
+//! the drift this finding documented (the whole MCP-OAuth flow plus 80+
+//! other handlers were missing).
+//!
+//! Strategy (no extra dependency — the doc's `inventory`-based sketch
+//! would have required a new crate):
+//!   1. Walk every `*.rs` file under `crates/librefang-api/src/` at test
+//!      time via `CARGO_MANIFEST_DIR` (same trick as
+//!      `openapi_spec_test.rs` / `config_schema_golden.rs`).
+//!   2. Parse each `#[utoipa::path(...)]` attribute, extracting the HTTP
+//!      method and `path = "..."` string. This is the source-of-truth
+//!      set of `(method, path)` pairs the developer *intended* to expose.
+//!   3. Build the same `(method, path)` set from `ApiDoc::openapi()`.
+//!   4. Assert the source set is a subset of the documented set. Any
+//!      difference is a handler that carries `#[utoipa::path]` but was
+//!      never added to `paths(...)`.
+
+use librefang_api::openapi::ApiDoc;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use utoipa::OpenApi;
+
+/// HTTP methods utoipa recognises in a `#[utoipa::path(...)]` attribute.
+const HTTP_METHODS: &[&str] = &["get", "post", "put", "delete", "patch", "head", "options"];
+
+/// Recursively collect every `.rs` file under `dir`.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Extract the substring between the outermost balanced parentheses that
+/// follow `#[utoipa::path` starting at byte index `attr_start`. Returns
+/// the inner text (without the surrounding parens) and the byte index just
+/// past the closing paren, or `None` if no balanced block is found.
+fn balanced_paren_block(bytes: &[u8], open_paren: usize) -> Option<(String, usize)> {
+    debug_assert_eq!(bytes[open_paren], b'(');
+    let mut depth = 0usize;
+    let mut i = open_paren;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    let inner = std::str::from_utf8(&bytes[open_paren + 1..i]).ok()?;
+                    return Some((inner.to_string(), i + 1));
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Pull the `path = "..."` literal out of a `#[utoipa::path(...)]` body.
+fn extract_path(block: &str) -> Option<String> {
+    let needle = "path";
+    let mut search_from = 0;
+    while let Some(rel) = block[search_from..].find(needle) {
+        let idx = search_from + rel;
+        // Ensure this is the `path` key, not a substring like `sandbox_policy`.
+        let before_ok = idx == 0
+            || !block.as_bytes()[idx - 1].is_ascii_alphanumeric()
+                && block.as_bytes()[idx - 1] != b'_';
+        let after = &block[idx + needle.len()..];
+        let after_trimmed = after.trim_start();
+        if before_ok && after_trimmed.starts_with('=') {
+            // After the '=' find the first double-quoted string literal.
+            let rest = after_trimmed[1..].trim_start();
+            if let Some(start) = rest.find('"') {
+                if let Some(end) = rest[start + 1..].find('"') {
+                    return Some(rest[start + 1..start + 1 + end].to_string());
+                }
+            }
+        }
+        search_from = idx + needle.len();
+    }
+    None
+}
+
+/// Pull the HTTP method out of a `#[utoipa::path(...)]` body. Supports
+/// both the bareword form (`get`, `post`, …) and the explicit
+/// `method = "get"` form.
+fn extract_method(block: &str) -> Option<String> {
+    // Explicit `method = "..."` form first.
+    if let Some(rel) = block.find("method") {
+        let after = block[rel + "method".len()..].trim_start();
+        if let Some(stripped) = after.strip_prefix('=') {
+            let rest = stripped.trim_start();
+            let rest = rest.trim_start_matches('"');
+            for m in HTTP_METHODS {
+                if rest.to_ascii_lowercase().starts_with(m) {
+                    return Some((*m).to_string());
+                }
+            }
+        }
+    }
+    // Bareword form: the method appears as a standalone token, almost
+    // always the first token in the block.
+    for token in block.split(|c: char| !c.is_ascii_alphanumeric()) {
+        let lower = token.to_ascii_lowercase();
+        if HTTP_METHODS.contains(&lower.as_str()) {
+            return Some(lower);
+        }
+    }
+    None
+}
+
+/// Source-of-truth `(method, path)` pairs gathered from every
+/// `#[utoipa::path(...)]` attribute in the crate.
+fn annotated_pairs() -> BTreeSet<(String, String)> {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src_dir, &mut files);
+
+    let mut pairs = BTreeSet::new();
+    for file in files {
+        let content = match std::fs::read_to_string(&file) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let bytes = content.as_bytes();
+        let marker = "#[utoipa::path";
+        let mut from = 0;
+        while let Some(rel) = content[from..].find(marker) {
+            let attr_idx = from + rel;
+            // Find the opening paren after the marker.
+            let after_marker = attr_idx + marker.len();
+            let open_paren = match content[after_marker..].find('(') {
+                Some(p) => after_marker + p,
+                None => {
+                    from = after_marker;
+                    continue;
+                }
+            };
+            // Reject lines where the marker is inside a `//` comment.
+            let line_start = content[..attr_idx].rfind('\n').map(|i| i + 1).unwrap_or(0);
+            let line_prefix = &content[line_start..attr_idx];
+            if line_prefix.trim_start().starts_with("//") {
+                from = after_marker;
+                continue;
+            }
+            if let Some((block, next)) = balanced_paren_block(bytes, open_paren) {
+                if let (Some(method), Some(path)) = (extract_method(&block), extract_path(&block)) {
+                    pairs.insert((method, path));
+                }
+                from = next;
+            } else {
+                from = after_marker;
+            }
+        }
+    }
+    pairs
+}
+
+/// `(method, path)` pairs actually present in the generated OpenAPI doc.
+fn documented_pairs() -> BTreeSet<(String, String)> {
+    let spec = ApiDoc::openapi();
+    let json = spec.to_json().expect("OpenAPI spec must serialize");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("OpenAPI spec must be valid JSON");
+    let paths = parsed["paths"]
+        .as_object()
+        .expect("OpenAPI spec must declare a `paths` object");
+
+    let mut pairs = BTreeSet::new();
+    for (path, ops) in paths {
+        if let Some(ops_obj) = ops.as_object() {
+            for method in ops_obj.keys() {
+                let lower = method.to_ascii_lowercase();
+                if HTTP_METHODS.contains(&lower.as_str()) {
+                    pairs.insert((lower, path.clone()));
+                }
+            }
+        }
+    }
+    pairs
+}
+
+#[test]
+fn every_annotated_handler_is_in_openapi() {
+    let annotated = annotated_pairs();
+    let documented = documented_pairs();
+
+    // Sanity: the source scan must find a meaningful number of handlers,
+    // otherwise a broken parser would make this test pass vacuously.
+    assert!(
+        annotated.len() > 100,
+        "source scan found only {} #[utoipa::path] handlers — the parser \
+         likely regressed (expected 300+)",
+        annotated.len()
+    );
+
+    let missing: Vec<&(String, String)> = annotated.difference(&documented).collect();
+
+    assert!(
+        missing.is_empty(),
+        "{} handler(s) carry `#[utoipa::path]` in \
+         crates/librefang-api/src/ but are NOT referenced from \
+         `ApiDoc::paths(...)` in openapi.rs, so they are missing from \
+         openapi.json and every generated SDK. Add each one to the \
+         `paths(...)` macro (or, if the path was retired, remove the \
+         stale `#[utoipa::path]` annotation):\n\n{:#?}",
+        missing.len(),
+        missing,
+    );
+}

--- a/openapi.json
+++ b/openapi.json
@@ -200,6 +200,42 @@
         }
       }
     },
+    "/api/a2a/agents/{id}/approve": {
+      "post": {
+        "tags": [
+          "a2a"
+        ],
+        "summary": "POST /api/a2a/agents/{id}/approve — Approve a pending external A2A agent.",
+        "description": "Promotes the agent from the pending list into the kernel's trusted external-agent\nlist, allowing it to receive tasks via `/api/a2a/send`. The `{id}` path segment\nshould be the URL-encoded discovery URL of the agent returned by\n`POST /api/a2a/discover`.\n\nThis endpoint exists to enforce operator oversight of newly discovered agents\n(Bug #3786). Discovered agents are placed in a pending state and cannot be used\nuntil an operator explicitly calls this endpoint.",
+        "operationId": "a2a_approve_external",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Discovery URL of the pending agent (URL-encoded)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent approved and promoted to trusted list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No pending agent found for the given URL"
+          }
+        }
+      }
+    },
     "/api/a2a/discover": {
       "post": {
         "tags": [
@@ -2810,6 +2846,245 @@
         }
       }
     },
+    "/api/approvals/audit": {
+      "get": {
+        "tags": [
+          "approvals"
+        ],
+        "operationId": "audit_log",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max entries",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Offset",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "agent_id",
+            "in": "query",
+            "description": "Filter by agent",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tool_name",
+            "in": "query",
+            "description": "Filter by tool",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Audit log entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/approvals/batch": {
+      "post": {
+        "tags": [
+          "approvals"
+        ],
+        "operationId": "batch_resolve",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Batch resolve results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/approvals/count": {
+      "get": {
+        "tags": [
+          "approvals"
+        ],
+        "summary": "GET /api/approvals/count — Lightweight pending count for notification badges.",
+        "operationId": "approval_count",
+        "responses": {
+          "200": {
+            "description": "Pending approval count",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/approvals/session/{session_id}": {
+      "get": {
+        "tags": [
+          "approvals"
+        ],
+        "summary": "GET /api/approvals/session/{session_id} — List pending approvals for a session.",
+        "description": "Mirrors `has_blocking_approval(session_key)` from Hermes-Agent: returns all\npending `ApprovalRequest`s whose `session_id` field matches the path param.",
+        "operationId": "list_approvals_for_session",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pending approvals for session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/approvals/session/{session_id}/approve_all": {
+      "post": {
+        "tags": [
+          "approvals"
+        ],
+        "summary": "POST /api/approvals/session/{session_id}/approve_all — Approve all pending\napprovals for the given session atomically.",
+        "operationId": "approve_all_for_session",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApproveAllForSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "All pending session approvals approved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "TOTP required for one or more items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Pending set changed since request was issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/approvals/session/{session_id}/reject_all": {
+      "post": {
+        "tags": [
+          "approvals"
+        ],
+        "summary": "POST /api/approvals/session/{session_id}/reject_all — Reject all pending\napprovals for the given session atomically.",
+        "description": "Mirrors Hermes-Agent's `resolve_gateway_approval(session_key, \"deny\",\nresolve_all=True)`.",
+        "operationId": "reject_all_for_session",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All pending session approvals rejected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/approvals/{id}": {
       "get": {
         "tags": [
@@ -2875,6 +3150,47 @@
         "responses": {
           "200": {
             "description": "Request approved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/approvals/{id}/modify": {
+      "post": {
+        "tags": [
+          "approvals"
+        ],
+        "operationId": "modify_request",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Approval ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Request modified",
             "content": {
               "application/json": {
                 "schema": {
@@ -3465,6 +3781,96 @@
         }
       }
     },
+    "/api/authz/check": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "GET /api/authz/check — admin-only **user-policy-only** decision query.",
+        "description": "Answers \"would user X's per-user RBAC policy permit tool Y on channel\nZ?\" by calling [`AuthManager::resolve_decision_for_user`], which walks\nLayer A (the user's own `tool_policy` / `tool_categories` /\n`channel_tool_rules`) and Layer B (role-escalation: would an admin\nhave allowed it?).\n\n**Scope is intentionally narrow — this is NOT the full runtime gate\ndecision.** The production tool-gate path additionally intersects with:\n- per-agent [`ToolPolicy::check_tool`] (allow/blocklist from\n  `agent.toml` — varies per agent),\n- global `ApprovalPolicy.channel_rules` (e.g. `shell_*` always\n  requires approval regardless of user policy),\n- the existing per-call approval / capability gates.\n\nThose layers depend on which agent is invoking the tool and the\nruntime context, neither of which this query carries. So an `Allow`\nhere can still surface as `NeedsApproval` or `Deny` at runtime if a\nper-agent ToolPolicy or channel rule says so. The response always\ncarries `scope: \"user_policy_only\"` to make this contract explicit\nto operators debugging gate mismatches; widening to the full gate\npath is a future RFC (would require an `agent_id` query param —\nbreaking API change).\n\nReturns 404 when the user can't be matched, so external callers can\ndistinguish \"not registered\" from \"registered but denied\". The\nruntime gate path treats unknown senders as guests; the diagnostic\nsurface here surfaces the configuration gap explicitly.",
+        "operationId": "check",
+        "parameters": [
+          {
+            "name": "user",
+            "in": "query",
+            "description": "User UUID or configured name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "action",
+            "in": "query",
+            "description": "Tool / action name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "channel",
+            "in": "query",
+            "description": "Channel context (telegram, slack, api, ...)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User-policy decision payload (scope = user_policy_only)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthzCheckResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown user"
+          }
+        }
+      }
+    },
+    "/api/authz/effective/{user_id}": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "GET /api/authz/effective/{user_id} — admin-only effective-permissions snapshot.",
+        "description": "`user_id` accepts either a UUID (the canonical `UserId` form) or the\nraw configured name (re-derived via `UserId::from_name`) so operators\ncan paste a name from `config.toml` directly into the URL — same\nsemantics as `/api/budget/users/{user_id}`.\n\nReturns 404 when no user matches; we intentionally do NOT synthesize\n\"guest defaults\" because the simulator's value is showing the operator\nwhat they configured, not inventing inputs.",
+        "operationId": "effective_permissions",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "description": "User UUID or configured name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Effective permissions snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown user"
+          }
+        }
+      }
+    },
     "/api/auto-dream/agents/{id}/abort": {
       "post": {
         "tags": [
@@ -3979,6 +4385,84 @@
                 }
               }
             }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "budget"
+        ],
+        "summary": "PUT /api/budget/users/{user_id} — admin-only per-user budget upsert.",
+        "description": "`user_id` accepts the same forms as the GET sibling (UUID or configured\nname). The request body mirrors `UserBudgetConfig` and is a **full\nreplacement** of the user's budget — all four keys are required, any\nmissing key returns 400. Set a window to `0.0` to mean \"unlimited on\nthat window\" (same semantics as the kernel-side metering check); this\nis **not** the same as omitting the key.\n\n```json\n{ \"max_hourly_usd\": 1.0, \"max_daily_usd\": 10.0, \"max_monthly_usd\": 100.0,\n  \"alert_threshold\": 0.8 }\n```\n\nFull-replace was chosen over PATCH semantics so `curl -X PUT` with a\npartial body cannot silently zero out other windows (`UserBudgetConfig`\nderives `#[serde(default)]`, which would otherwise default any omitted\nfield to `0.0` / `0.8` and clear an existing cap).\n\nOn success the cap takes effect on the **next** LLM call — already-\nbilled responses are returned unchanged. Persists to `config.toml` via\n`users::persist_users` and triggers a kernel reload (auth manager picks\nup the new `UserConfig.budget`).",
+        "operationId": "update_user_budget",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "description": "User UUID or configured name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Budget written and reloaded — body is the canonical UserBudgetConfig (max_hourly_usd, max_daily_usd, max_monthly_usd, alert_threshold)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or partial budget payload"
+          },
+          "403": {
+            "description": "Caller is not an admin"
+          },
+          "404": {
+            "description": "No user matches the given id/name"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "budget"
+        ],
+        "summary": "DELETE /api/budget/users/{user_id} — clear the per-user budget.",
+        "description": "Sets `UserConfig.budget` back to `None` and persists. Subsequent LLM\ncalls from this user are bounded only by global / per-agent /\nper-provider caps. Returns 200 even when the user had no budget set\n(idempotent — same shape as `delete_agent_budget`'s sibling pattern).",
+        "operationId": "delete_user_budget",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "description": "User UUID or configured name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Budget cleared (or already absent)"
+          },
+          "403": {
+            "description": "Caller is not an admin"
+          },
+          "404": {
+            "description": "No user matches the given id/name"
           }
         }
       }
@@ -4606,6 +5090,24 @@
         }
       }
     },
+    "/api/config/export": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "GET /api/config/export — Download config.toml as a file attachment.",
+        "description": "Reads the raw config.toml from disk. If the file does not exist, falls back\nto serializing the in-memory config so a download is always available.",
+        "operationId": "export_config",
+        "responses": {
+          "200": {
+            "description": "config.toml file download",
+            "content": {
+              "application/toml": {}
+            }
+          }
+        }
+      }
+    },
     "/api/config/reload": {
       "post": {
         "tags": [
@@ -4678,6 +5180,146 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/context-engine/chain": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/context-engine/chain — Show the active context engine topology.",
+        "description": "Describes whether the engine is the default (no plugin), a single plugin,\nor a stacked chain of plugins, and lists hook coverage for each.",
+        "operationId": "context_engine_chain",
+        "responses": {
+          "200": {
+            "description": "Engine chain topology",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/context-engine/config": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/context-engine/config — Live context engine configuration snapshot.",
+        "description": "Returns the `[context_engine]` section of the running daemon's configuration,\nincluding `engine`, `plugin`, `plugin_stack`, and the full resolved hook\nsettings such as `hook_timeout_secs`, `on_hook_failure`, `max_retries`,\n`persistent_subprocess`, and the Round 11 additions.",
+        "operationId": "context_engine_config",
+        "responses": {
+          "200": {
+            "description": "Context engine configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/context-engine/health": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/context-engine/health — Lightweight smoke test of the active plugin engine.",
+        "description": "Verifies that all declared hook scripts exist on disk and are executable\n(for native runtime). Does not invoke any hook subprocess.\nReturns 200 when healthy, 503 when degraded.",
+        "operationId": "context_engine_health",
+        "responses": {
+          "200": {
+            "description": "Engine healthy"
+          },
+          "204": {
+            "description": "No plugin engine configured"
+          },
+          "503": {
+            "description": "Engine degraded — hook scripts missing or invalid"
+          }
+        }
+      }
+    },
+    "/api/context-engine/metrics": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/context-engine/metrics — Hook invocation metrics for the running context engine.",
+        "description": "Returns per-hook counters (calls, successes, failures, cumulative latency in ms).\nReturns 204 when the active context engine does not expose metrics (e.g. the\ndefault engine with no plugin configured).",
+        "operationId": "context_engine_metrics",
+        "responses": {
+          "200": {
+            "description": "Hook metrics snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No metrics available (no plugin engine active)"
+          }
+        }
+      }
+    },
+    "/api/context-engine/sandbox-policy": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/context-engine/sandbox-policy — Sandboxing policy for active plugins.",
+        "description": "Reports the effective filesystem and network isolation settings for every\nplugin that is currently loaded in the context engine chain.  The policy\nis derived from each plugin's `allow_filesystem`, `allow_network`, and\n`max_memory_mb` fields together with the global context engine defaults.",
+        "operationId": "context_engine_sandbox_policy",
+        "responses": {
+          "200": {
+            "description": "Sandbox policy for active plugins",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No plugin engine configured"
+          }
+        }
+      }
+    },
+    "/api/context-engine/traces": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/context-engine/traces — Recent hook invocation traces (ring buffer, last 100).",
+        "description": "Returns per-invocation debug data: hook name, timestamp, elapsed_ms, success/failure,\ninput/output previews. Returns 204 when no plugin engine is active.",
+        "operationId": "context_engine_traces",
+        "responses": {
+          "200": {
+            "description": "Hook invocation traces",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No plugin engine active"
           }
         }
       }
@@ -4757,6 +5399,40 @@
       }
     },
     "/api/cron/jobs/{id}": {
+      "get": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "GET /api/cron/jobs/{id} — Get a single cron job by ID.",
+        "description": "Response carries the cron `JobMeta` plus two #3693 observability\nfields:\n- `session_message_count` (`usize`): messages in the persistent\n  `(agent, \"cron\")` session.\n- `session_token_count` (`u64`): kernel-estimated tokens for those\n  messages (system prompt and tools excluded — same accounting as\n  the prune path).",
+        "operationId": "get_cron_job",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Cron job ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cron job details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found"
+          }
+        }
+      },
       "put": {
         "tags": [
           "workflows"
@@ -5015,6 +5691,27 @@
         "responses": {
           "200": {
             "description": "Catalog entry detail + install status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/goals/templates": {
+      "get": {
+        "tags": [
+          "goals"
+        ],
+        "summary": "GET /api/goals/templates — List built-in goal templates.",
+        "operationId": "list_goal_templates",
+        "responses": {
+          "200": {
+            "description": "Goal templates",
             "content": {
               "application/json": {
                 "schema": {
@@ -5310,6 +6007,43 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "hands"
+        ],
+        "summary": "DELETE /api/hands/{hand_id} — Uninstall a user-installed hand.",
+        "description": "Only hands that live under `home_dir/workspaces/{id}/` can be removed.\nBuilt-in hands (shipped by librefang-registry under `home_dir/registry/hands/`)\ncannot be uninstalled because the next registry sync would recreate them.\nHands with live instances must be deactivated first.",
+        "operationId": "uninstall_hand",
+        "parameters": [
+          {
+            "name": "hand_id",
+            "in": "path",
+            "description": "Hand ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Hand uninstalled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Hand not found or is a built-in"
+          },
+          "409": {
+            "description": "Hand is still active — deactivate first"
+          }
+        }
       }
     },
     "/api/hands/{hand_id}/activate": {
@@ -5411,6 +6145,77 @@
         "responses": {
           "200": {
             "description": "Auto-install missing dependencies for a hand",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/hands/{hand_id}/manifest": {
+      "get": {
+        "tags": [
+          "hands"
+        ],
+        "summary": "GET /api/hands/{hand_id}/manifest — Return the hand's HAND.toml as text.",
+        "description": "Reads the on-disk HAND.toml from either the registry or workspaces dir\nso comments and original formatting survive. Falls back to serializing\nthe in-memory `HandDefinition` if the file isn't on disk (e.g. installed\nprogrammatically), so the endpoint always has something to return for\nany hand the registry knows about.",
+        "operationId": "get_hand_manifest",
+        "parameters": [
+          {
+            "name": "hand_id",
+            "in": "path",
+            "description": "Hand ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "HAND.toml content",
+            "content": {
+              "application/toml": {}
+            }
+          }
+        }
+      }
+    },
+    "/api/hands/{hand_id}/secret": {
+      "post": {
+        "tags": [
+          "hands"
+        ],
+        "summary": "POST /api/hands/{hand_id}/secret — Set an environment variable (secret) for a hand requirement.",
+        "operationId": "set_hand_secret",
+        "parameters": [
+          {
+            "name": "hand_id",
+            "in": "path",
+            "description": "Hand ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Secret saved",
             "content": {
               "application/json": {
                 "schema": {
@@ -5608,6 +6413,27 @@
           },
           "404": {
             "description": "Webhook triggers not enabled"
+          }
+        }
+      }
+    },
+    "/api/inbox/status": {
+      "get": {
+        "tags": [
+          "inbox"
+        ],
+        "summary": "GET /api/inbox/status — Return inbox configuration and file counts.",
+        "operationId": "inbox_status",
+        "responses": {
+          "200": {
+            "description": "Inbox status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
           }
         }
       }
@@ -5944,6 +6770,117 @@
         }
       }
     },
+    "/api/mcp/servers/{name}/auth/revoke": {
+      "delete": {
+        "tags": [
+          "mcp"
+        ],
+        "summary": "DELETE /api/mcp/servers/{name}/auth/revoke",
+        "description": "Revokes OAuth tokens for an MCP server and clears auth state.",
+        "operationId": "auth_revoke",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "MCP server name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Auth revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP server not found"
+          }
+        }
+      }
+    },
+    "/api/mcp/servers/{name}/auth/start": {
+      "post": {
+        "tags": [
+          "mcp"
+        ],
+        "summary": "POST /api/mcp/servers/{name}/auth/start",
+        "description": "Initiates a UI-driven OAuth PKCE authorization flow for the specified\nMCP server. Discovers OAuth metadata, performs Dynamic Client\nRegistration if needed, generates PKCE challenge, and returns the\nauthorization URL for the UI to redirect to.",
+        "operationId": "auth_start",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "MCP server name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Auth flow started — returns auth URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Server has no HTTP transport or discovery failed"
+          },
+          "404": {
+            "description": "MCP server not found"
+          }
+        }
+      }
+    },
+    "/api/mcp/servers/{name}/auth/status": {
+      "get": {
+        "tags": [
+          "mcp"
+        ],
+        "summary": "GET /api/mcp/servers/{name}/auth/status",
+        "description": "Returns the current OAuth authentication state for an MCP server.",
+        "operationId": "auth_status",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "MCP server name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Auth status for the MCP server",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP server not found"
+          }
+        }
+      }
+    },
     "/api/mcp/servers/{name}/reconnect": {
       "post": {
         "tags": [
@@ -5975,6 +6912,57 @@
           },
           "404": {
             "description": "MCP server not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/servers/{name}/taint": {
+      "patch": {
+        "tags": [
+          "mcp"
+        ],
+        "operationId": "patch_mcp_server_taint",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Server name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Taint settings updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Server not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -6202,6 +7190,47 @@
         "responses": {
           "200": {
             "description": "Consolidation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/memory/agents/{id}/count": {
+      "get": {
+        "tags": [
+          "proactive-memory"
+        ],
+        "summary": "Count memories for an agent, optionally filtered by level (user/session/agent).",
+        "operationId": "memory_count_agent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "description": "Memory level filter (user, session, agent)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Memory count",
             "content": {
               "application/json": {
                 "schema": {
@@ -6514,6 +7543,107 @@
         }
       }
     },
+    "/api/memory/agents/{id}/relations": {
+      "get": {
+        "tags": [
+          "proactive-memory"
+        ],
+        "summary": "Query the knowledge graph for relations matching a pattern.",
+        "description": "All query parameters are optional — omitting all returns up to 100 relations.\nResults include full source entity, relation, and target entity for each match.",
+        "operationId": "memory_query_relations",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "description": "Source entity name or ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "relation",
+            "in": "query",
+            "description": "Relation type",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "description": "Target entity name or ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching relations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "proactive-memory"
+        ],
+        "summary": "Store relation triples into the knowledge graph for an agent.",
+        "description": "Accepts an array of `{ subject, subject_type, relation, object, object_type }` triples.\nDeduplicates automatically: existing identical relations are skipped.",
+        "operationId": "memory_store_relations",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Relations stored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/memory/agents/{id}/search": {
       "get": {
         "tags": [
@@ -6597,6 +7727,37 @@
         }
       }
     },
+    "/api/memory/bulk-delete": {
+      "post": {
+        "tags": [
+          "proactive-memory"
+        ],
+        "summary": "Bulk-delete multiple memories by ID.",
+        "operationId": "memory_bulk_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Bulk delete results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/memory/cleanup": {
       "post": {
         "tags": [
@@ -6608,6 +7769,76 @@
         "responses": {
           "200": {
             "description": "Cleanup result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/memory/config": {
+      "get": {
+        "tags": [
+          "memory"
+        ],
+        "operationId": "memory_config_get",
+        "responses": {
+          "200": {
+            "description": "Memory configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "memory"
+        ],
+        "operationId": "memory_config_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Memory configuration updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/memory/decay": {
+      "post": {
+        "tags": [
+          "proactive-memory"
+        ],
+        "summary": "Trigger manual confidence decay across all memories.",
+        "description": "Applies time-based exponential decay: memories not accessed recently\nlose confidence, while frequently accessed memories get boosted.\nNormally runs automatically during maintenance, but this endpoint\nallows triggering it on demand.",
+        "operationId": "memory_decay",
+        "responses": {
+          "200": {
+            "description": "Decay result",
             "content": {
               "application/json": {
                 "schema": {
@@ -7128,6 +8359,27 @@
         }
       }
     },
+    "/api/network/trusted-peers": {
+      "get": {
+        "tags": [
+          "network"
+        ],
+        "summary": "SECURITY (#3873): GET /api/network/trusted-peers — list every TOFU-pinned\npeer this node will accept under each `node_id`. Operators read this to\nverify what their daemon trusts and out-of-band-compare fingerprints\nwith remote operators before federating.",
+        "operationId": "network_trusted_peers",
+        "responses": {
+          "200": {
+            "description": "List TOFU-pinned peers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/pairing/complete": {
       "post": {
         "tags": [
@@ -7332,6 +8584,615 @@
           },
           "404": {
             "description": "Peer not found"
+          }
+        }
+      }
+    },
+    "/api/plugins": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/plugins — List all installed context engine plugins.",
+        "operationId": "list_plugins",
+        "responses": {
+          "200": {
+            "description": "List installed plugins",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/plugins/doctor": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/plugins/doctor — Diagnose runtime availability + per-plugin readiness.",
+        "description": "Probes every supported runtime (`python`, `node`, `go`, ...) for its\nlauncher on PATH, then cross-references with every installed plugin to\nflag which ones will fail at hook time because their runtime is missing.",
+        "operationId": "plugin_doctor",
+        "responses": {
+          "200": {
+            "description": "Runtime availability + per-plugin diagnostics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/plugins/install": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/install — Install a plugin from registry, local path, or git URL.",
+        "description": "Honours `Idempotency-Key` (#3637): when set, a duplicate request\nwith the same key + same body replays the cached response instead\nof re-installing. A different body under the same key is rejected\nwith 409 Conflict.\n\nRequest body:\n```json\n{\"source\": \"registry\", \"name\": \"qdrant-recall\"}\n{\"source\": \"local\", \"path\": \"/path/to/plugin\"}\n{\"source\": \"git\", \"url\": \"https://github.com/user/plugin.git\", \"branch\": \"main\"}\n```",
+        "operationId": "install_plugin",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Plugin installed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "409": {
+            "description": "Plugin already installed or Idempotency-Key conflict"
+          }
+        }
+      }
+    },
+    "/api/plugins/registries": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/plugins/registries — List configured plugin registries and their available plugins.",
+        "operationId": "list_plugin_registries",
+        "responses": {
+          "200": {
+            "description": "Configured registries with available plugins",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/plugins/scaffold": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/scaffold — Create a new plugin from template.",
+        "description": "Request body:\n```json\n{\n  \"name\": \"my-plugin\",\n  \"description\": \"My custom plugin\",\n  \"runtime\": \"python\"  // optional: python (default) | v | node | deno | go | native\n}\n```",
+        "operationId": "scaffold_plugin",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Plugin scaffolded"
+          },
+          "409": {
+            "description": "Plugin already exists"
+          }
+        }
+      }
+    },
+    "/api/plugins/uninstall": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/uninstall — Remove an installed plugin.",
+        "description": "Request body: `{\"name\": \"plugin-name\"}`",
+        "operationId": "uninstall_plugin",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Plugin removed"
+          },
+          "404": {
+            "description": "Plugin not found"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/plugins/:name — Get details of a specific plugin.",
+        "operationId": "get_plugin",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Plugin details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Plugin not found"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/advanced-config": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/plugins/:name/advanced-config — Round 11 hook configuration fields.",
+        "description": "Returns the advanced configuration fields added in Round 11:\n`circuit_breaker`, `after_turn_queue_depth`, `prewarm_subprocesses`,\n`allow_filesystem`, and `otel_endpoint`.  These fields are read directly\nfrom the installed plugin's `plugin.toml` manifest.",
+        "operationId": "plugin_advanced_config",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Advanced hook configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Plugin not found"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/disable": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/:name/disable — Disable a plugin without uninstalling it.",
+        "description": "Creates a `.disabled` marker file. The running context engine must be\nrestarted for the change to take effect.",
+        "operationId": "disable_plugin",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Plugin disabled"
+          },
+          "400": {
+            "description": "Plugin not found or already disabled"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/enable": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/:name/enable — Enable a disabled plugin.",
+        "description": "Removes the `.disabled` marker file. The running context engine must be\nrestarted for the change to take effect.",
+        "operationId": "enable_plugin",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Plugin enabled"
+          },
+          "400": {
+            "description": "Plugin not found or already enabled"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/env": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/plugins/:name/env — Plugin environment variable configuration.",
+        "description": "Returns the static `[env]` key-value pairs defined in the plugin manifest\n(with sensitive values masked) and the `[hooks.env_schema]` declarations\nthat describe which environment variables the plugin requires or accepts.\nRequired variables (keys prefixed with `!`) are checked against the current\ndaemon environment and their presence is reported in `resolved`.",
+        "operationId": "plugin_env",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Plugin environment configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Plugin not found"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/install-deps": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/:name/install-deps — Install Python dependencies for a plugin.",
+        "operationId": "install_plugin_deps",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dependencies installed"
+          },
+          "400": {
+            "description": "Installation failed"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/lint": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/plugins/:name/lint — Validate plugin manifest and hook script structure.",
+        "description": "Returns a lint report with errors (structural problems) and warnings\n(best-practice suggestions). Does not execute any hook scripts.",
+        "operationId": "lint_plugin",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lint report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Plugin not found"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/prewarm": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/:name/prewarm — Pre-warm persistent hook subprocesses.",
+        "description": "Triggers a warmup reload of the plugin so that when `persistent_subprocess = true`\nthe interpreter is already running before the first real hook call.  If the\nplugin does not declare `persistent_subprocess = true` the response body will\nindicate that pre-warming is not applicable; no error is returned.\n\nReloading the plugin manifest also picks up any changes to `plugin.toml`\nwithout requiring a full daemon restart.",
+        "operationId": "prewarm_plugin",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prewarm result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Plugin not found"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/reload": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/:name/reload — Re-read `plugin.toml` from disk and validate it.",
+        "description": "Script changes (edits to hook `.py` / binary files) take effect immediately\nbecause scripts are re-executed fresh on every invocation. Manifest changes\n(adding or removing hook declarations) are reflected in the response but\nrequire an **agent restart** to become active in the running context engine.",
+        "operationId": "reload_plugin",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Manifest reloaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Reload failed (invalid name or bad manifest)"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/sign": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/:name/sign — Compute and write SHA-256 integrity hashes into plugin.toml.",
+        "description": "After signing, the plugin will be verified against these hashes on every load.\nRe-run after editing any hook scripts to keep the hashes up to date.",
+        "operationId": "sign_plugin",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Hashes written to plugin.toml",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Plugin not found or no hooks declared"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/status": {
+      "get": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "GET /api/plugins/:name/status — Current runtime status of an installed plugin.",
+        "description": "Returns the plugin's manifest info plus whether it is currently active in the\nrunning context engine (i.e. matches the configured `plugin` or appears in\n`plugin_stack`).",
+        "operationId": "plugin_status",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Plugin status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Plugin not found or invalid name"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/test-hook": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/:name/test-hook — Invoke a specific hook with test input.",
+        "description": "Runs the hook subprocess with the given JSON input and returns the output.\nUseful for debugging and validating hook scripts without sending real messages.\n\nRequest body:\n```json\n{\n  \"hook\": \"ingest\",\n  \"input\": {\"type\": \"ingest\", \"agent_id\": \"test\", \"message\": \"hello\", \"peer_id\": null}\n}\n```",
+        "operationId": "test_plugin_hook",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Hook output"
+          },
+          "400": {
+            "description": "Hook not declared or invocation failed"
+          }
+        }
+      }
+    },
+    "/api/plugins/{name}/upgrade": {
+      "post": {
+        "tags": [
+          "plugins"
+        ],
+        "summary": "POST /api/plugins/:name/upgrade — Upgrade an installed plugin from a new source.",
+        "description": "Removes the current version and reinstalls from the given source. The\n`.disabled` state is preserved. Requires a context engine restart.\n\nRequest body (same as install):\n```json\n{\"source\": \"registry\", \"name\": \"qdrant-recall\"}\n{\"source\": \"local\", \"path\": \"/path/to/newer-version\"}\n{\"source\": \"git\", \"url\": \"https://github.com/user/plugin.git\", \"branch\": \"main\"}\n```",
+        "operationId": "upgrade_plugin",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Plugin name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Plugin upgraded"
+          },
+          "400": {
+            "description": "Plugin not installed or upgrade failed"
           }
         }
       }
@@ -8070,6 +9931,70 @@
         }
       }
     },
+    "/api/sessions/search": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "GET /api/sessions/search?q=...&agent_id=... — Full-text search across session content.",
+        "operationId": "search_sessions",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "FTS5 search query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_id",
+            "in": "query",
+            "description": "Optional agent ID filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max items (default 50, max 500)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Items to skip",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing query parameter"
+          }
+        }
+      }
+    },
     "/api/sessions/{id}": {
       "get": {
         "tags": [
@@ -8494,6 +10419,48 @@
         }
       }
     },
+    "/api/skills/registry": {
+      "get": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "GET /api/skills/registry — List official skills from the local registry cache (~/.librefang/registry/skills).",
+        "operationId": "list_skill_registry",
+        "responses": {
+          "200": {
+            "description": "Official skills available in the FangHub registry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/skills/reload": {
+      "post": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "POST /api/skills/reload — Rescan `~/.librefang/skills/` and refresh the\nin-memory registry. Use this after dropping a skill directory into the\nskills folder manually (install/uninstall via API already reload\nautomatically). Returns the new installed skill count.",
+        "operationId": "reload_skills",
+        "responses": {
+          "200": {
+            "description": "Rescan the skills directory from disk",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/skills/uninstall": {
       "post": {
         "tags": [
@@ -8521,6 +10488,350 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/skills/{name}": {
+      "get": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "Get detailed information about a specific skill, including linked files,\ntags, evolution history, and readiness status.",
+        "operationId": "get_skill_detail",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Skill name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill detail with evolution history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Skill not found"
+          }
+        }
+      }
+    },
+    "/api/skills/{name}/evolve/delete": {
+      "post": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "POST /api/skills/{name}/evolve/delete — delete a locally-evolved skill.",
+        "operationId": "evolve_delete_skill",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Skill name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Non-local skill — deletion refused"
+          },
+          "404": {
+            "description": "Skill not found"
+          }
+        }
+      }
+    },
+    "/api/skills/{name}/evolve/file": {
+      "post": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "POST /api/skills/{name}/evolve/file — add a supporting file.",
+        "operationId": "evolve_write_file",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Skill name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "File written",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path / over size limit"
+          },
+          "404": {
+            "description": "Skill not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "DELETE /api/skills/{name}/evolve/file — remove a supporting file.\nPath is supplied via the `?path=` query string since axum's DELETE\nbody handling is inconsistent across clients.",
+        "operationId": "evolve_remove_file",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Skill name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Relative path of the file to remove",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing 'path' parameter"
+          },
+          "404": {
+            "description": "Skill or file not found"
+          }
+        }
+      }
+    },
+    "/api/skills/{name}/evolve/patch": {
+      "post": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "POST /api/skills/{name}/evolve/patch — fuzzy find-and-replace.",
+        "operationId": "evolve_patch_skill",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Skill name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Skill patched",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request / fuzzy match failed"
+          },
+          "404": {
+            "description": "Skill not found"
+          }
+        }
+      }
+    },
+    "/api/skills/{name}/evolve/rollback": {
+      "post": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "POST /api/skills/{name}/evolve/rollback — roll back to previous version.",
+        "operationId": "evolve_rollback_skill",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Skill name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill rolled back",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Skill or snapshot not found"
+          }
+        }
+      }
+    },
+    "/api/skills/{name}/evolve/update": {
+      "post": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "POST /api/skills/{name}/evolve/update — full-rewrite prompt_context.",
+        "operationId": "evolve_update_skill",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Skill name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Skill updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request / security-blocked content"
+          },
+          "404": {
+            "description": "Skill not found"
+          }
+        }
+      }
+    },
+    "/api/skills/{name}/file": {
+      "get": {
+        "tags": [
+          "skills"
+        ],
+        "summary": "GET /api/skills/{name}/file?path=... — return the contents of a\nsupporting file so the dashboard can render it. Share the same\nsecurity rules as `skill_read_file` (no absolute paths, no traversal,\nmust resolve within the skill directory, size-capped).",
+        "operationId": "get_supporting_file",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Skill name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Relative file path inside the skill directory",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File contents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path"
+          },
+          "404": {
+            "description": "Skill or file not found"
           }
         }
       }
@@ -8592,6 +10903,38 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/templates/{name}/toml": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "GET /api/templates/:name/toml — Get the raw TOML content of a template.",
+        "operationId": "get_agent_template_toml",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Template name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Template TOML content as plain text",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -8959,6 +11302,27 @@
         }
       }
     },
+    "/api/usage/by-model/performance": {
+      "get": {
+        "tags": [
+          "budget"
+        ],
+        "summary": "GET /api/usage/by-model/performance — Get model performance metrics including latency statistics.",
+        "operationId": "usage_by_model_performance",
+        "responses": {
+          "200": {
+            "description": "Model performance metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/usage/daily": {
       "get": {
         "tags": [
@@ -9192,6 +11556,87 @@
         }
       }
     },
+    "/api/users/{name}/policy": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "operationId": "get_user_policy",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "User name (case-sensitive)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-user policy slice",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "users"
+        ],
+        "summary": "PUT /api/users/{name}/policy — upsert the per-user RBAC M3 policy slice.",
+        "description": "Body shape:\n```json\n{\n  \"tool_policy\":        {...} | null,\n  \"tool_categories\":    {...} | null,\n  \"memory_access\":      {...} | null,\n  \"channel_tool_rules\": {\"telegram\": {...}, ...}\n}\n```\n\nEach top-level key is independently optional:\n  * key absent       → preserve existing value (so a partial edit\n                       from the dashboard never clobbers a section\n                       the form didn't expose),\n  * key present null → clear the field,\n  * key present obj  → replace.\n\n`channel_tool_rules` collapses absent/null to \"preserve\" (use an empty\nobject `{}` to clear all rules), since a `null` map is rarely what an\noperator means.\n\nOwner-only — covered by `middleware::is_owner_only_write` which gates\nevery mutating call under `/api/users*`. Per-user policy edits change\nsomeone's authorization surface, which is unambiguously an Owner action.",
+        "operationId": "update_user_policy",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "User name (case-sensitive)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Updated user policy slice",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/api/users/{name}/rotate-key": {
       "post": {
         "tags": [
@@ -9270,6 +11715,135 @@
         }
       }
     },
+    "/api/workflow-templates": {
+      "get": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "GET /api/workflow-templates — List all workflow templates with optional search/filter.",
+        "operationId": "list_workflow_templates",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Search name, description, tags",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "Filter by category",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of workflow templates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workflow-templates/{id}": {
+      "get": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "GET /api/workflow-templates/:id — Get full template details.",
+        "operationId": "get_workflow_template",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Template ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Template details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template not found"
+          }
+        }
+      }
+    },
+    "/api/workflow-templates/{id}/instantiate": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "POST /api/workflow-templates/:id/instantiate — Create a live workflow from a template.",
+        "operationId": "instantiate_template",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Template ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {},
+                "propertyNames": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Workflow created from template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters"
+          },
+          "404": {
+            "description": "Template not found"
+          }
+        }
+      }
+    },
     "/api/workflows": {
       "get": {
         "tags": [
@@ -9324,7 +11898,270 @@
         }
       }
     },
+    "/api/workflows/runs/{run_id}": {
+      "get": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "GET /api/workflows/runs/:run_id — Get detailed info for a single workflow run.",
+        "operationId": "get_workflow_run",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Workflow run ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Workflow run details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found"
+          }
+        }
+      }
+    },
+    "/api/workflows/runs/{run_id}/cancel": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "POST /api/workflows/runs/:run_id/cancel — Cancel a workflow run.",
+        "description": "Transitions `Pending`, `Running`, or `Paused` runs to `Cancelled`.\nReturns 200 with `{\"run_id\": ..., \"state\": \"cancelled\"}` on success,\n400 for a malformed run ID, 404 if the run does not exist, or 409 if\nthe run is already in a terminal state (includes `{\"state\": <state>}`\nso callers can distinguish completed vs failed vs cancelled conflicts).",
+        "operationId": "cancel_workflow_run",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Workflow run ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed run ID"
+          },
+          "404": {
+            "description": "Run not found"
+          },
+          "409": {
+            "description": "Run already in terminal state"
+          }
+        }
+      }
+    },
+    "/api/workflows/runs/{run_id}/operator": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "POST /api/workflows/runs/:run_id/operator — Resolve a paused operator\nstep with an operator decision and drive the workflow forward (#5133).",
+        "description": "Auth: goes through the normal auth layer (NOT on the public allowlist).\nThe authenticated operator is the security boundary for this resolution\n— no resume token is required (unlike the generic `/resume` endpoint).\n\n- 200 `{\"run_id\":..,\"state\":\"running\"}` — resolution accepted; the run\n  resumes asynchronously (Approve/Edit/Input) or has been marked Failed\n  (Reject).\n- 400 — malformed run ID / unknown action / missing required payload.\n- 404 — run not found.\n- 409 — run not paused, not an operator-step pause, or the action is\n  not authorised at this step.",
+        "operationId": "operator_action_workflow_run",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Workflow run ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Operator action accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed run ID / action / payload"
+          },
+          "404": {
+            "description": "Run not found"
+          },
+          "409": {
+            "description": "Not an operator pause or action not authorised"
+          }
+        }
+      }
+    },
+    "/api/workflows/runs/{run_id}/pause": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "POST /api/workflows/runs/:run_id/pause — Pause a workflow run.",
+        "description": "Returns 200 with `{\"run_id\": \"...\", \"resume_token\": \"<uuid>\"}` on success.\n\n**SECURITY**: the `resume_token` in the response body is the ONLY surface\nfrom which the plaintext token is ever visible. Do not log this response.\n\nReturns 404 if the run is not found, 409 if the run is already paused\n(with the existing token hash) or already terminal.",
+        "operationId": "pause_workflow_run",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Workflow run ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Run paused",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed run ID"
+          },
+          "404": {
+            "description": "Run not found"
+          },
+          "409": {
+            "description": "Run already paused or terminal"
+          }
+        }
+      }
+    },
+    "/api/workflows/runs/{run_id}/resume": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "POST /api/workflows/runs/:run_id/resume — Resume a paused workflow run.",
+        "description": "Returns 200 with `{\"run_id\": \"...\", \"state\": \"running\"}` immediately after\nthe resume is initiated. The actual workflow continues asynchronously.\n\nReturns 401 if the resume token does not match.\nReturns 404 if the run is not found.\nReturns 409 if the run is not paused or is a DAG workflow (unsupported).",
+        "operationId": "resume_workflow_run",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "description": "Workflow run ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Run resumed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed run ID or missing token"
+          },
+          "401": {
+            "description": "Token mismatch"
+          },
+          "404": {
+            "description": "Run not found"
+          },
+          "409": {
+            "description": "Run not paused or DAG unsupported"
+          }
+        }
+      }
+    },
     "/api/workflows/{id}": {
+      "get": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "GET /api/workflows/:id — Get a single workflow by ID.",
+        "operationId": "get_workflow",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Workflow details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found"
+          }
+        }
+      },
       "put": {
         "tags": [
           "workflows"
@@ -9391,6 +12228,51 @@
         "responses": {
           "200": {
             "description": "Workflow deleted"
+          },
+          "404": {
+            "description": "Workflow not found"
+          }
+        }
+      }
+    },
+    "/api/workflows/{id}/dry-run": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "POST /api/workflows/:id/dry-run — Validate and preview a workflow without executing it.",
+        "operationId": "dry_run_workflow",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Workflow ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Dry-run preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              }
+            }
           },
           "404": {
             "description": "Workflow not found"
@@ -9742,6 +12624,31 @@
           }
         }
       },
+      "ApproveAllForSessionRequest": {
+        "type": "object",
+        "description": "POST /api/approvals/session/{session_id}/approve_all — Approve all pending\napprovals for the given session atomically.\n\nMirrors Hermes-Agent's `resolve_gateway_approval(session_key, \"once\",\nresolve_all=True)`.  TOTP pre-check is enforced — if any pending request\nrequires TOTP, the entire batch is rejected before any mutation.",
+        "properties": {
+          "expected_count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Optional count of approvals the caller expects to be pending.\nIf provided, the server verifies the actual pending count matches\nbefore approving.  Returns 409 Conflict if the count changed.",
+            "minimum": 0
+          },
+          "expected_ids": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of approval IDs the caller expects to be pending.\nIf provided, the server verifies the actual pending set matches before\napproving.  Returns 409 Conflict if a new high-risk approval landed\nbetween the operator viewing the list and clicking approve_all."
+          }
+        },
+        "additionalProperties": false
+      },
       "AttachmentRef": {
         "type": "object",
         "description": "A file attachment reference (from a prior upload).",
@@ -9760,6 +12667,53 @@
           }
         },
         "additionalProperties": false
+      },
+      "AuthzCheckResponse": {
+        "type": "object",
+        "description": "Response body for `GET /api/authz/check`.\n\nDashboard surfaces (when added) MUST display the disclaimer that\ngoes with `scope = \"user_policy_only\"`: \"User-policy decision only —\nruntime gate may differ\" because per-agent `ToolPolicy` and global\n`ApprovalPolicy.channel_rules` are not consulted by this endpoint.\nToday no dashboard page consumes this endpoint; new consumers must\nhonour that contract before shipping.",
+        "required": [
+          "user",
+          "action",
+          "decision",
+          "allowed",
+          "scope"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "Echoes the `action` query parameter."
+          },
+          "allowed": {
+            "type": "boolean",
+            "description": "Convenience flag — true only when `decision == \"allow\"`."
+          },
+          "channel": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Echoes the `channel` query parameter, or `null` when omitted."
+          },
+          "decision": {
+            "type": "string",
+            "description": "Decision label: `\"allow\"`, `\"deny\"`, or `\"needs_approval\"`."
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable reason when the decision is not `allow`. `None`\nfor `allow`."
+          },
+          "scope": {
+            "type": "string",
+            "description": "**Always** `\"user_policy_only\"`. Marker that this decision is\ncomputed from the user's RBAC slice alone (Layer A + Layer B in\n[`AuthManager::resolve_decision_for_user`]) and does NOT include\nper-agent `ToolPolicy::check_tool`, global\n`ApprovalPolicy.channel_rules`, or the per-call approval gate.\nThe runtime tool-gate may therefore deny or require approval for\na tool that this endpoint reports as allowed."
+          },
+          "user": {
+            "type": "string",
+            "description": "Echoes the `user` query parameter (UUID or name as supplied)."
+          }
+        }
       },
       "BulkActionResult": {
         "type": "object",

--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -40,12 +40,15 @@ type Client struct {
 	Budget *BudgetResource
 	Channels *ChannelsResource
 	Extensions *ExtensionsResource
+	Goals *GoalsResource
 	Hands *HandsResource
+	Inbox *InboxResource
 	Mcp *McpResource
 	Memory *MemoryResource
 	Models *ModelsResource
 	Network *NetworkResource
 	Pairing *PairingResource
+	Plugins *PluginsResource
 	ProactiveMemory *ProactiveMemoryResource
 	Sessions *SessionsResource
 	Skills *SkillsResource
@@ -72,12 +75,15 @@ func New(baseURL string) *Client {
 		c.Budget = &BudgetResource{client: c}
 		c.Channels = &ChannelsResource{client: c}
 		c.Extensions = &ExtensionsResource{client: c}
+		c.Goals = &GoalsResource{client: c}
 		c.Hands = &HandsResource{client: c}
+		c.Inbox = &InboxResource{client: c}
 		c.Mcp = &McpResource{client: c}
 		c.Memory = &MemoryResource{client: c}
 		c.Models = &ModelsResource{client: c}
 		c.Network = &NetworkResource{client: c}
 		c.Pairing = &PairingResource{client: c}
+		c.Plugins = &PluginsResource{client: c}
 		c.ProactiveMemory = &ProactiveMemoryResource{client: c}
 		c.Sessions = &SessionsResource{client: c}
 		c.Skills = &SkillsResource{client: c}
@@ -252,6 +258,10 @@ func (r *A2AResource) A2AListExternalAgents() (interface{}, error) {
 
 func (r *A2AResource) A2AGetExternalAgent(id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/a2a/agents/%s", id), nil, nil)
+}
+
+func (r *A2AResource) A2AApproveExternal(id string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/a2a/agents/%s/approve", id), nil, nil)
 }
 
 func (r *A2AResource) A2ADiscoverExternal(data map[string]interface{}) (interface{}, error) {
@@ -514,12 +524,40 @@ func (r *ApprovalsResource) CreateApproval(data map[string]interface{}) (interfa
 	return r.client.request("POST", "/api/approvals", data, nil)
 }
 
+func (r *ApprovalsResource) AuditLog(query map[string]string) (interface{}, error) {
+	return r.client.request("GET", "/api/approvals/audit", nil, query)
+}
+
+func (r *ApprovalsResource) BatchResolve(data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", "/api/approvals/batch", data, nil)
+}
+
+func (r *ApprovalsResource) ApprovalCount() (interface{}, error) {
+	return r.client.request("GET", "/api/approvals/count", nil, nil)
+}
+
+func (r *ApprovalsResource) ListApprovalsForSession(session_id string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/approvals/session/%s", session_id), nil, nil)
+}
+
+func (r *ApprovalsResource) ApproveAllForSession(session_id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/approvals/session/%s/approve_all", session_id), data, nil)
+}
+
+func (r *ApprovalsResource) RejectAllForSession(session_id string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/approvals/session/%s/reject_all", session_id), nil, nil)
+}
+
 func (r *ApprovalsResource) GetApproval(id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/approvals/%s", id), nil, nil)
 }
 
 func (r *ApprovalsResource) ApproveRequest(id string, data map[string]interface{}) (interface{}, error) {
 	return r.client.request("POST", fmt.Sprintf("/api/approvals/%s/approve", id), data, nil)
+}
+
+func (r *ApprovalsResource) ModifyRequest(id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/approvals/%s/modify", id), data, nil)
 }
 
 func (r *ApprovalsResource) RejectRequest(id string) (interface{}, error) {
@@ -630,12 +668,24 @@ func (r *BudgetResource) UserBudgetDetail(user_id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/budget/users/%s", user_id), nil, nil)
 }
 
+func (r *BudgetResource) UpdateUserBudget(user_id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("PUT", fmt.Sprintf("/api/budget/users/%s", user_id), data, nil)
+}
+
+func (r *BudgetResource) DeleteUserBudget(user_id string) (interface{}, error) {
+	return r.client.request("DELETE", fmt.Sprintf("/api/budget/users/%s", user_id), nil, nil)
+}
+
 func (r *BudgetResource) UsageStats() (interface{}, error) {
 	return r.client.request("GET", "/api/usage", nil, nil)
 }
 
 func (r *BudgetResource) UsageByModel() (interface{}, error) {
 	return r.client.request("GET", "/api/usage/by-model", nil, nil)
+}
+
+func (r *BudgetResource) UsageByModelPerformance() (interface{}, error) {
+	return r.client.request("GET", "/api/usage/by-model/performance", nil, nil)
 }
 
 func (r *BudgetResource) UsageDaily() (interface{}, error) {
@@ -690,6 +740,14 @@ func (r *ExtensionsResource) GetExtension(name string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/extensions/%s", name), nil, nil)
 }
 
+// ── Goals Resource
+
+type GoalsResource struct{ client *Client }
+
+func (r *GoalsResource) ListGoalTemplates() (interface{}, error) {
+	return r.client.request("GET", "/api/goals/templates", nil, nil)
+}
+
 // ── Hands Resource
 
 type HandsResource struct{ client *Client }
@@ -734,6 +792,10 @@ func (r *HandsResource) GetHand(hand_id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/hands/%s", hand_id), nil, nil)
 }
 
+func (r *HandsResource) UninstallHand(hand_id string) (interface{}, error) {
+	return r.client.request("DELETE", fmt.Sprintf("/api/hands/%s", hand_id), nil, nil)
+}
+
 func (r *HandsResource) ActivateHand(hand_id string, data map[string]interface{}) (interface{}, error) {
 	return r.client.request("POST", fmt.Sprintf("/api/hands/%s/activate", hand_id), data, nil)
 }
@@ -746,12 +808,28 @@ func (r *HandsResource) InstallHandDeps(hand_id string) (interface{}, error) {
 	return r.client.request("POST", fmt.Sprintf("/api/hands/%s/install-deps", hand_id), nil, nil)
 }
 
+func (r *HandsResource) GetHandManifest(hand_id string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/hands/%s/manifest", hand_id), nil, nil)
+}
+
+func (r *HandsResource) SetHandSecret(hand_id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/hands/%s/secret", hand_id), data, nil)
+}
+
 func (r *HandsResource) GetHandSettings(hand_id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/hands/%s/settings", hand_id), nil, nil)
 }
 
 func (r *HandsResource) UpdateHandSettings(hand_id string, data map[string]interface{}) (interface{}, error) {
 	return r.client.request("PUT", fmt.Sprintf("/api/hands/%s/settings", hand_id), data, nil)
+}
+
+// ── Inbox Resource
+
+type InboxResource struct{ client *Client }
+
+func (r *InboxResource) InboxStatus() (interface{}, error) {
+	return r.client.request("GET", "/api/inbox/status", nil, nil)
 }
 
 // ── Mcp Resource
@@ -794,8 +872,24 @@ func (r *McpResource) DeleteMcpServer(name string) (interface{}, error) {
 	return r.client.request("DELETE", fmt.Sprintf("/api/mcp/servers/%s", name), nil, nil)
 }
 
+func (r *McpResource) AuthRevoke(name string) (interface{}, error) {
+	return r.client.request("DELETE", fmt.Sprintf("/api/mcp/servers/%s/auth/revoke", name), nil, nil)
+}
+
+func (r *McpResource) AuthStart(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/mcp/servers/%s/auth/start", name), nil, nil)
+}
+
+func (r *McpResource) AuthStatus(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/mcp/servers/%s/auth/status", name), nil, nil)
+}
+
 func (r *McpResource) ReconnectMcpServerHandler(name string) (interface{}, error) {
 	return r.client.request("POST", fmt.Sprintf("/api/mcp/servers/%s/reconnect", name), nil, nil)
+}
+
+func (r *McpResource) PatchMcpServerTaint(name string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("PATCH", fmt.Sprintf("/api/mcp/servers/%s/taint", name), data, nil)
 }
 
 func (r *McpResource) ListMcpTaintRules() (interface{}, error) {
@@ -828,6 +922,14 @@ func (r *MemoryResource) SetAgentKvKey(id string, key string, data map[string]in
 
 func (r *MemoryResource) DeleteAgentKvKey(id string, key string) (interface{}, error) {
 	return r.client.request("DELETE", fmt.Sprintf("/api/memory/agents/%s/kv/%s", id, key), nil, nil)
+}
+
+func (r *MemoryResource) MemoryConfigGet() (interface{}, error) {
+	return r.client.request("GET", "/api/memory/config", nil, nil)
+}
+
+func (r *MemoryResource) MemoryConfigPatch(data map[string]interface{}) (interface{}, error) {
+	return r.client.request("PATCH", "/api/memory/config", data, nil)
 }
 
 // ── Models Resource
@@ -942,6 +1044,10 @@ func (r *NetworkResource) NetworkStatus() (interface{}, error) {
 	return r.client.request("GET", "/api/network/status", nil, nil)
 }
 
+func (r *NetworkResource) NetworkTrustedPeers() (interface{}, error) {
+	return r.client.request("GET", "/api/network/trusted-peers", nil, nil)
+}
+
 func (r *NetworkResource) ListPeers(query map[string]string) (interface{}, error) {
 	return r.client.request("GET", "/api/peers", nil, query)
 }
@@ -974,6 +1080,110 @@ func (r *PairingResource) PairingRequest() (interface{}, error) {
 	return r.client.request("POST", "/api/pairing/request", nil, nil)
 }
 
+// ── Plugins Resource
+
+type PluginsResource struct{ client *Client }
+
+func (r *PluginsResource) ContextEngineChain() (interface{}, error) {
+	return r.client.request("GET", "/api/context-engine/chain", nil, nil)
+}
+
+func (r *PluginsResource) ContextEngineConfig() (interface{}, error) {
+	return r.client.request("GET", "/api/context-engine/config", nil, nil)
+}
+
+func (r *PluginsResource) ContextEngineHealth() (interface{}, error) {
+	return r.client.request("GET", "/api/context-engine/health", nil, nil)
+}
+
+func (r *PluginsResource) ContextEngineMetrics() (interface{}, error) {
+	return r.client.request("GET", "/api/context-engine/metrics", nil, nil)
+}
+
+func (r *PluginsResource) ContextEngineSandboxPolicy() (interface{}, error) {
+	return r.client.request("GET", "/api/context-engine/sandbox-policy", nil, nil)
+}
+
+func (r *PluginsResource) ContextEngineTraces() (interface{}, error) {
+	return r.client.request("GET", "/api/context-engine/traces", nil, nil)
+}
+
+func (r *PluginsResource) ListPlugins() (interface{}, error) {
+	return r.client.request("GET", "/api/plugins", nil, nil)
+}
+
+func (r *PluginsResource) PluginDoctor() (interface{}, error) {
+	return r.client.request("GET", "/api/plugins/doctor", nil, nil)
+}
+
+func (r *PluginsResource) InstallPlugin(data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", "/api/plugins/install", data, nil)
+}
+
+func (r *PluginsResource) ListPluginRegistries() (interface{}, error) {
+	return r.client.request("GET", "/api/plugins/registries", nil, nil)
+}
+
+func (r *PluginsResource) ScaffoldPlugin(data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", "/api/plugins/scaffold", data, nil)
+}
+
+func (r *PluginsResource) UninstallPlugin(data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", "/api/plugins/uninstall", data, nil)
+}
+
+func (r *PluginsResource) GetPlugin(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/plugins/%s", name), nil, nil)
+}
+
+func (r *PluginsResource) PluginAdvancedConfig(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/plugins/%s/advanced-config", name), nil, nil)
+}
+
+func (r *PluginsResource) DisablePlugin(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/plugins/%s/disable", name), nil, nil)
+}
+
+func (r *PluginsResource) EnablePlugin(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/plugins/%s/enable", name), nil, nil)
+}
+
+func (r *PluginsResource) PluginEnv(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/plugins/%s/env", name), nil, nil)
+}
+
+func (r *PluginsResource) InstallPluginDeps(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/plugins/%s/install-deps", name), nil, nil)
+}
+
+func (r *PluginsResource) LintPlugin(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/plugins/%s/lint", name), nil, nil)
+}
+
+func (r *PluginsResource) PrewarmPlugin(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/plugins/%s/prewarm", name), nil, nil)
+}
+
+func (r *PluginsResource) ReloadPlugin(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/plugins/%s/reload", name), nil, nil)
+}
+
+func (r *PluginsResource) SignPlugin(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/plugins/%s/sign", name), nil, nil)
+}
+
+func (r *PluginsResource) PluginStatus(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/plugins/%s/status", name), nil, nil)
+}
+
+func (r *PluginsResource) TestPluginHook(name string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/plugins/%s/test-hook", name), data, nil)
+}
+
+func (r *PluginsResource) UpgradePlugin(name string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/plugins/%s/upgrade", name), data, nil)
+}
+
 // ── ProactiveMemory Resource
 
 type ProactiveMemoryResource struct{ client *Client }
@@ -998,6 +1208,10 @@ func (r *ProactiveMemoryResource) MemoryConsolidate(id string) (interface{}, err
 	return r.client.request("POST", fmt.Sprintf("/api/memory/agents/%s/consolidate", id), nil, nil)
 }
 
+func (r *ProactiveMemoryResource) MemoryCountAgent(id string, query map[string]string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/memory/agents/%s/count", id), nil, query)
+}
+
 func (r *ProactiveMemoryResource) MemoryDuplicates(id string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/memory/agents/%s/duplicates", id), nil, nil)
 }
@@ -1014,6 +1228,14 @@ func (r *ProactiveMemoryResource) MemoryClearLevel(id string, level string) (int
 	return r.client.request("DELETE", fmt.Sprintf("/api/memory/agents/%s/level/%s", id, level), nil, nil)
 }
 
+func (r *ProactiveMemoryResource) MemoryQueryRelations(id string, query map[string]string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/memory/agents/%s/relations", id), nil, query)
+}
+
+func (r *ProactiveMemoryResource) MemoryStoreRelations(id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/memory/agents/%s/relations", id), data, nil)
+}
+
 func (r *ProactiveMemoryResource) MemorySearchAgent(id string, query map[string]string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/memory/agents/%s/search", id), nil, query)
 }
@@ -1022,8 +1244,16 @@ func (r *ProactiveMemoryResource) MemoryStatsAgent(id string) (interface{}, erro
 	return r.client.request("GET", fmt.Sprintf("/api/memory/agents/%s/stats", id), nil, nil)
 }
 
+func (r *ProactiveMemoryResource) MemoryBulkDelete(data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", "/api/memory/bulk-delete", data, nil)
+}
+
 func (r *ProactiveMemoryResource) MemoryCleanup() (interface{}, error) {
 	return r.client.request("POST", "/api/memory/cleanup", nil, nil)
+}
+
+func (r *ProactiveMemoryResource) MemoryDecay() (interface{}, error) {
+	return r.client.request("POST", "/api/memory/decay", nil, nil)
 }
 
 func (r *ProactiveMemoryResource) MemoryUpdate(memory_id string, data map[string]interface{}) (interface{}, error) {
@@ -1064,6 +1294,10 @@ func (r *SessionsResource) ListSessions(query map[string]string) (interface{}, e
 
 func (r *SessionsResource) SessionCleanup() (interface{}, error) {
 	return r.client.request("POST", "/api/sessions/cleanup", nil, nil)
+}
+
+func (r *SessionsResource) SearchSessions(query map[string]string) (interface{}, error) {
+	return r.client.request("GET", "/api/sessions/search", nil, query)
 }
 
 func (r *SessionsResource) GetSession(id string) (interface{}, error) {
@@ -1138,8 +1372,48 @@ func (r *SkillsResource) RejectPendingCandidate(id string) (interface{}, error) 
 	return r.client.request("POST", fmt.Sprintf("/api/skills/pending/%s/reject", id), nil, nil)
 }
 
+func (r *SkillsResource) ListSkillRegistry() (interface{}, error) {
+	return r.client.request("GET", "/api/skills/registry", nil, nil)
+}
+
+func (r *SkillsResource) ReloadSkills() (interface{}, error) {
+	return r.client.request("POST", "/api/skills/reload", nil, nil)
+}
+
 func (r *SkillsResource) UninstallSkill(data map[string]interface{}) (interface{}, error) {
 	return r.client.request("POST", "/api/skills/uninstall", data, nil)
+}
+
+func (r *SkillsResource) GetSkillDetail(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/skills/%s", name), nil, nil)
+}
+
+func (r *SkillsResource) EvolveDeleteSkill(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/skills/%s/evolve/delete", name), nil, nil)
+}
+
+func (r *SkillsResource) EvolveWriteFile(name string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/skills/%s/evolve/file", name), data, nil)
+}
+
+func (r *SkillsResource) EvolveRemoveFile(name string, query map[string]string) (interface{}, error) {
+	return r.client.request("DELETE", fmt.Sprintf("/api/skills/%s/evolve/file", name), nil, query)
+}
+
+func (r *SkillsResource) EvolvePatchSkill(name string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/skills/%s/evolve/patch", name), data, nil)
+}
+
+func (r *SkillsResource) EvolveRollbackSkill(name string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/skills/%s/evolve/rollback", name), nil, nil)
+}
+
+func (r *SkillsResource) EvolveUpdateSkill(name string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/skills/%s/evolve/update", name), data, nil)
+}
+
+func (r *SkillsResource) GetSupportingFile(name string, query map[string]string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/skills/%s/file", name), nil, query)
 }
 
 func (r *SkillsResource) ListTools() (interface{}, error) {
@@ -1168,6 +1442,14 @@ func (r *SystemResource) AuditRecent() (interface{}, error) {
 
 func (r *SystemResource) AuditVerify() (interface{}, error) {
 	return r.client.request("GET", "/api/audit/verify", nil, nil)
+}
+
+func (r *SystemResource) Check(query map[string]string) (interface{}, error) {
+	return r.client.request("GET", "/api/authz/check", nil, query)
+}
+
+func (r *SystemResource) EffectivePermissions(user_id string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/authz/effective/%s", user_id), nil, nil)
 }
 
 func (r *SystemResource) CreateBackup() (interface{}, error) {
@@ -1204,6 +1486,10 @@ func (r *SystemResource) GetCommand(name string) (interface{}, error) {
 
 func (r *SystemResource) GetConfig() (interface{}, error) {
 	return r.client.request("GET", "/api/config", nil, nil)
+}
+
+func (r *SystemResource) ExportConfig() (interface{}, error) {
+	return r.client.request("GET", "/api/config/export", nil, nil)
 }
 
 func (r *SystemResource) ConfigReload() (interface{}, error) {
@@ -1286,6 +1572,10 @@ func (r *SystemResource) GetAgentTemplate(name string) (interface{}, error) {
 	return r.client.request("GET", fmt.Sprintf("/api/templates/%s", name), nil, nil)
 }
 
+func (r *SystemResource) GetAgentTemplateToml(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/templates/%s/toml", name), nil, nil)
+}
+
 func (r *SystemResource) Version() (interface{}, error) {
 	return r.client.request("GET", "/api/version", nil, nil)
 }
@@ -1330,6 +1620,14 @@ func (r *UsersResource) DeleteUser(name string) (interface{}, error) {
 	return r.client.request("DELETE", fmt.Sprintf("/api/users/%s", name), nil, nil)
 }
 
+func (r *UsersResource) GetUserPolicy(name string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/users/%s/policy", name), nil, nil)
+}
+
+func (r *UsersResource) UpdateUserPolicy(name string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("PUT", fmt.Sprintf("/api/users/%s/policy", name), data, nil)
+}
+
 func (r *UsersResource) RotateUserKey(name string) (interface{}, error) {
 	return r.client.request("POST", fmt.Sprintf("/api/users/%s/rotate-key", name), nil, nil)
 }
@@ -1356,6 +1654,10 @@ func (r *WorkflowsResource) ListCronJobs() (interface{}, error) {
 
 func (r *WorkflowsResource) CreateCronJob(data map[string]interface{}) (interface{}, error) {
 	return r.client.request("POST", "/api/cron/jobs", data, nil)
+}
+
+func (r *WorkflowsResource) GetCronJob(id string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/cron/jobs/%s", id), nil, nil)
 }
 
 func (r *WorkflowsResource) UpdateCronJob(id string, data map[string]interface{}) (interface{}, error) {
@@ -1418,6 +1720,18 @@ func (r *WorkflowsResource) UpdateTrigger(id string, data map[string]interface{}
 	return r.client.request("PATCH", fmt.Sprintf("/api/triggers/%s", id), data, nil)
 }
 
+func (r *WorkflowsResource) ListWorkflowTemplates(query map[string]string) (interface{}, error) {
+	return r.client.request("GET", "/api/workflow-templates", nil, query)
+}
+
+func (r *WorkflowsResource) GetWorkflowTemplate(id string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/workflow-templates/%s", id), nil, nil)
+}
+
+func (r *WorkflowsResource) InstantiateTemplate(id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/workflow-templates/%s/instantiate", id), data, nil)
+}
+
 func (r *WorkflowsResource) ListWorkflows() (interface{}, error) {
 	return r.client.request("GET", "/api/workflows", nil, nil)
 }
@@ -1426,12 +1740,40 @@ func (r *WorkflowsResource) CreateWorkflow(data map[string]interface{}) (interfa
 	return r.client.request("POST", "/api/workflows", data, nil)
 }
 
+func (r *WorkflowsResource) GetWorkflowRun(run_id string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/workflows/runs/%s", run_id), nil, nil)
+}
+
+func (r *WorkflowsResource) CancelWorkflowRun(run_id string) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/workflows/runs/%s/cancel", run_id), nil, nil)
+}
+
+func (r *WorkflowsResource) OperatorActionWorkflowRun(run_id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/workflows/runs/%s/operator", run_id), data, nil)
+}
+
+func (r *WorkflowsResource) PauseWorkflowRun(run_id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/workflows/runs/%s/pause", run_id), data, nil)
+}
+
+func (r *WorkflowsResource) ResumeWorkflowRun(run_id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/workflows/runs/%s/resume", run_id), data, nil)
+}
+
+func (r *WorkflowsResource) GetWorkflow(id string) (interface{}, error) {
+	return r.client.request("GET", fmt.Sprintf("/api/workflows/%s", id), nil, nil)
+}
+
 func (r *WorkflowsResource) UpdateWorkflow(id string, data map[string]interface{}) (interface{}, error) {
 	return r.client.request("PUT", fmt.Sprintf("/api/workflows/%s", id), data, nil)
 }
 
 func (r *WorkflowsResource) DeleteWorkflow(id string) (interface{}, error) {
 	return r.client.request("DELETE", fmt.Sprintf("/api/workflows/%s", id), nil, nil)
+}
+
+func (r *WorkflowsResource) DryRunWorkflow(id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("POST", fmt.Sprintf("/api/workflows/%s/dry-run", id), data, nil)
 }
 
 func (r *WorkflowsResource) RunWorkflow(id string, data map[string]interface{}) (interface{}, error) {

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -37,12 +37,15 @@ class LibreFang {
     this.budget = new BudgetResource(this);
     this.channels = new ChannelsResource(this);
     this.extensions = new ExtensionsResource(this);
+    this.goals = new GoalsResource(this);
     this.hands = new HandsResource(this);
+    this.inbox = new InboxResource(this);
     this.mcp = new McpResource(this);
     this.memory = new MemoryResource(this);
     this.models = new ModelsResource(this);
     this.network = new NetworkResource(this);
     this.pairing = new PairingResource(this);
+    this.plugins = new PluginsResource(this);
     this.proactive_memory = new ProactiveMemoryResource(this);
     this.sessions = new SessionsResource(this);
     this.skills = new SkillsResource(this);
@@ -117,6 +120,10 @@ class A2AResource {
 
   async a2aGetExternalAgent(id) {
     return this._c._request("GET", `/api/a2a/agents/${id}`);
+  }
+
+  async a2aApproveExternal(id) {
+    return this._c._request("POST", `/api/a2a/agents/${id}/approve`);
   }
 
   async a2aDiscoverExternal(data) {
@@ -383,12 +390,40 @@ class ApprovalsResource {
     return this._c._request("POST", "/api/approvals", data, undefined);
   }
 
+  async auditLog(query) {
+    return this._c._request("GET", "/api/approvals/audit", undefined, query);
+  }
+
+  async batchResolve(data) {
+    return this._c._request("POST", "/api/approvals/batch", data, undefined);
+  }
+
+  async approvalCount() {
+    return this._c._request("GET", "/api/approvals/count");
+  }
+
+  async listApprovalsForSession(session_id) {
+    return this._c._request("GET", `/api/approvals/session/${session_id}`);
+  }
+
+  async approveAllForSession(session_id, data) {
+    return this._c._request("POST", `/api/approvals/session/${session_id}/approve_all`, data, undefined);
+  }
+
+  async rejectAllForSession(session_id) {
+    return this._c._request("POST", `/api/approvals/session/${session_id}/reject_all`);
+  }
+
   async getApproval(id) {
     return this._c._request("GET", `/api/approvals/${id}`);
   }
 
   async approveRequest(id, data) {
     return this._c._request("POST", `/api/approvals/${id}/approve`, data, undefined);
+  }
+
+  async modifyRequest(id, data) {
+    return this._c._request("POST", `/api/approvals/${id}/modify`, data, undefined);
   }
 
   async rejectRequest(id) {
@@ -505,12 +540,24 @@ class BudgetResource {
     return this._c._request("GET", `/api/budget/users/${user_id}`);
   }
 
+  async updateUserBudget(user_id, data) {
+    return this._c._request("PUT", `/api/budget/users/${user_id}`, data, undefined);
+  }
+
+  async deleteUserBudget(user_id) {
+    return this._c._request("DELETE", `/api/budget/users/${user_id}`);
+  }
+
   async usageStats() {
     return this._c._request("GET", "/api/usage");
   }
 
   async usageByModel() {
     return this._c._request("GET", "/api/usage/by-model");
+  }
+
+  async usageByModelPerformance() {
+    return this._c._request("GET", "/api/usage/by-model/performance");
   }
 
   async usageDaily() {
@@ -570,6 +617,16 @@ class ExtensionsResource {
   }
 }
 
+// ── Goals Resource
+
+class GoalsResource {
+  constructor(client) { this._c = client; }
+
+  async listGoalTemplates() {
+    return this._c._request("GET", "/api/goals/templates");
+  }
+}
+
 // ── Hands Resource
 
 class HandsResource {
@@ -615,6 +672,10 @@ class HandsResource {
     return this._c._request("GET", `/api/hands/${hand_id}`);
   }
 
+  async uninstallHand(hand_id) {
+    return this._c._request("DELETE", `/api/hands/${hand_id}`);
+  }
+
   async activateHand(hand_id, data) {
     return this._c._request("POST", `/api/hands/${hand_id}/activate`, data, undefined);
   }
@@ -627,12 +688,30 @@ class HandsResource {
     return this._c._request("POST", `/api/hands/${hand_id}/install-deps`);
   }
 
+  async getHandManifest(hand_id) {
+    return this._c._request("GET", `/api/hands/${hand_id}/manifest`);
+  }
+
+  async setHandSecret(hand_id, data) {
+    return this._c._request("POST", `/api/hands/${hand_id}/secret`, data, undefined);
+  }
+
   async getHandSettings(hand_id) {
     return this._c._request("GET", `/api/hands/${hand_id}/settings`);
   }
 
   async updateHandSettings(hand_id, data) {
     return this._c._request("PUT", `/api/hands/${hand_id}/settings`, data, undefined);
+  }
+}
+
+// ── Inbox Resource
+
+class InboxResource {
+  constructor(client) { this._c = client; }
+
+  async inboxStatus() {
+    return this._c._request("GET", "/api/inbox/status");
   }
 }
 
@@ -677,8 +756,24 @@ class McpResource {
     return this._c._request("DELETE", `/api/mcp/servers/${name}`);
   }
 
+  async authRevoke(name) {
+    return this._c._request("DELETE", `/api/mcp/servers/${name}/auth/revoke`);
+  }
+
+  async authStart(name) {
+    return this._c._request("POST", `/api/mcp/servers/${name}/auth/start`);
+  }
+
+  async authStatus(name) {
+    return this._c._request("GET", `/api/mcp/servers/${name}/auth/status`);
+  }
+
   async reconnectMcpServerHandler(name) {
     return this._c._request("POST", `/api/mcp/servers/${name}/reconnect`);
+  }
+
+  async patchMcpServerTaint(name, data) {
+    return this._c._request("PATCH", `/api/mcp/servers/${name}/taint`, data, undefined);
   }
 
   async listMcpTaintRules() {
@@ -713,6 +808,14 @@ class MemoryResource {
 
   async deleteAgentKvKey(id, key) {
     return this._c._request("DELETE", `/api/memory/agents/${id}/kv/${key}`);
+  }
+
+  async memoryConfigGet() {
+    return this._c._request("GET", "/api/memory/config");
+  }
+
+  async memoryConfigPatch(data) {
+    return this._c._request("PATCH", "/api/memory/config", data, undefined);
   }
 }
 
@@ -831,6 +934,10 @@ class NetworkResource {
     return this._c._request("GET", "/api/network/status");
   }
 
+  async networkTrustedPeers() {
+    return this._c._request("GET", "/api/network/trusted-peers");
+  }
+
   async listPeers(query) {
     return this._c._request("GET", "/api/peers", undefined, query);
   }
@@ -866,6 +973,112 @@ class PairingResource {
   }
 }
 
+// ── Plugins Resource
+
+class PluginsResource {
+  constructor(client) { this._c = client; }
+
+  async contextEngineChain() {
+    return this._c._request("GET", "/api/context-engine/chain");
+  }
+
+  async contextEngineConfig() {
+    return this._c._request("GET", "/api/context-engine/config");
+  }
+
+  async contextEngineHealth() {
+    return this._c._request("GET", "/api/context-engine/health");
+  }
+
+  async contextEngineMetrics() {
+    return this._c._request("GET", "/api/context-engine/metrics");
+  }
+
+  async contextEngineSandboxPolicy() {
+    return this._c._request("GET", "/api/context-engine/sandbox-policy");
+  }
+
+  async contextEngineTraces() {
+    return this._c._request("GET", "/api/context-engine/traces");
+  }
+
+  async listPlugins() {
+    return this._c._request("GET", "/api/plugins");
+  }
+
+  async pluginDoctor() {
+    return this._c._request("GET", "/api/plugins/doctor");
+  }
+
+  async installPlugin(data) {
+    return this._c._request("POST", "/api/plugins/install", data, undefined);
+  }
+
+  async listPluginRegistries() {
+    return this._c._request("GET", "/api/plugins/registries");
+  }
+
+  async scaffoldPlugin(data) {
+    return this._c._request("POST", "/api/plugins/scaffold", data, undefined);
+  }
+
+  async uninstallPlugin(data) {
+    return this._c._request("POST", "/api/plugins/uninstall", data, undefined);
+  }
+
+  async getPlugin(name) {
+    return this._c._request("GET", `/api/plugins/${name}`);
+  }
+
+  async pluginAdvancedConfig(name) {
+    return this._c._request("GET", `/api/plugins/${name}/advanced-config`);
+  }
+
+  async disablePlugin(name) {
+    return this._c._request("POST", `/api/plugins/${name}/disable`);
+  }
+
+  async enablePlugin(name) {
+    return this._c._request("POST", `/api/plugins/${name}/enable`);
+  }
+
+  async pluginEnv(name) {
+    return this._c._request("GET", `/api/plugins/${name}/env`);
+  }
+
+  async installPluginDeps(name) {
+    return this._c._request("POST", `/api/plugins/${name}/install-deps`);
+  }
+
+  async lintPlugin(name) {
+    return this._c._request("GET", `/api/plugins/${name}/lint`);
+  }
+
+  async prewarmPlugin(name) {
+    return this._c._request("POST", `/api/plugins/${name}/prewarm`);
+  }
+
+  async reloadPlugin(name) {
+    return this._c._request("POST", `/api/plugins/${name}/reload`);
+  }
+
+  async signPlugin(name) {
+    return this._c._request("POST", `/api/plugins/${name}/sign`);
+  }
+
+  async pluginStatus(name) {
+    return this._c._request("GET", `/api/plugins/${name}/status`);
+  }
+
+  async testPluginHook(name, data) {
+    return this._c._request("POST", `/api/plugins/${name}/test-hook`, data, undefined);
+  }
+
+  async upgradePlugin(name, data) {
+    return this._c._request("POST", `/api/plugins/${name}/upgrade`, data, undefined);
+  }
+}
+
 // ── ProactiveMemory Resource
 
 class ProactiveMemoryResource {
@@ -891,6 +1104,10 @@ class ProactiveMemoryResource {
     return this._c._request("POST", `/api/memory/agents/${id}/consolidate`);
   }
 
+  async memoryCountAgent(id, query) {
+    return this._c._request("GET", `/api/memory/agents/${id}/count`, undefined, query);
+  }
+
   async memoryDuplicates(id) {
     return this._c._request("GET", `/api/memory/agents/${id}/duplicates`);
   }
@@ -907,6 +1124,14 @@ class ProactiveMemoryResource {
     return this._c._request("DELETE", `/api/memory/agents/${id}/level/${level}`);
   }
 
+  async memoryQueryRelations(id, query) {
+    return this._c._request("GET", `/api/memory/agents/${id}/relations`, undefined, query);
+  }
+
+  async memoryStoreRelations(id, data) {
+    return this._c._request("POST", `/api/memory/agents/${id}/relations`, data, undefined);
+  }
+
   async memorySearchAgent(id, query) {
     return this._c._request("GET", `/api/memory/agents/${id}/search`, undefined, query);
   }
@@ -915,8 +1140,16 @@ class ProactiveMemoryResource {
     return this._c._request("GET", `/api/memory/agents/${id}/stats`);
   }
 
+  async memoryBulkDelete(data) {
+    return this._c._request("POST", "/api/memory/bulk-delete", data, undefined);
+  }
+
   async memoryCleanup() {
     return this._c._request("POST", "/api/memory/cleanup");
+  }
+
+  async memoryDecay() {
+    return this._c._request("POST", "/api/memory/decay");
   }
 
   async memoryUpdate(memory_id, data) {
@@ -959,6 +1192,10 @@ class SessionsResource {
 
   async sessionCleanup() {
     return this._c._request("POST", "/api/sessions/cleanup");
+  }
+
+  async searchSessions(query) {
+    return this._c._request("GET", "/api/sessions/search", undefined, query);
   }
 
   async getSession(id) {
@@ -1035,8 +1272,48 @@ class SkillsResource {
     return this._c._request("POST", `/api/skills/pending/${id}/reject`);
   }
 
+  async listSkillRegistry() {
+    return this._c._request("GET", "/api/skills/registry");
+  }
+
+  async reloadSkills() {
+    return this._c._request("POST", "/api/skills/reload");
+  }
+
   async uninstallSkill(data) {
     return this._c._request("POST", "/api/skills/uninstall", data, undefined);
+  }
+
+  async getSkillDetail(name) {
+    return this._c._request("GET", `/api/skills/${name}`);
+  }
+
+  async evolveDeleteSkill(name) {
+    return this._c._request("POST", `/api/skills/${name}/evolve/delete`);
+  }
+
+  async evolveWriteFile(name, data) {
+    return this._c._request("POST", `/api/skills/${name}/evolve/file`, data, undefined);
+  }
+
+  async evolveRemoveFile(name, query) {
+    return this._c._request("DELETE", `/api/skills/${name}/evolve/file`, undefined, query);
+  }
+
+  async evolvePatchSkill(name, data) {
+    return this._c._request("POST", `/api/skills/${name}/evolve/patch`, data, undefined);
+  }
+
+  async evolveRollbackSkill(name) {
+    return this._c._request("POST", `/api/skills/${name}/evolve/rollback`);
+  }
+
+  async evolveUpdateSkill(name, data) {
+    return this._c._request("POST", `/api/skills/${name}/evolve/update`, data, undefined);
+  }
+
+  async getSupportingFile(name, query) {
+    return this._c._request("GET", `/api/skills/${name}/file`, undefined, query);
   }
 
   async listTools() {
@@ -1067,6 +1344,14 @@ class SystemResource {
 
   async auditVerify() {
     return this._c._request("GET", "/api/audit/verify");
+  }
+
+  async check(query) {
+    return this._c._request("GET", "/api/authz/check", undefined, query);
+  }
+
+  async effectivePermissions(user_id) {
+    return this._c._request("GET", `/api/authz/effective/${user_id}`);
   }
 
   async createBackup() {
@@ -1103,6 +1388,10 @@ class SystemResource {
 
   async getConfig() {
     return this._c._request("GET", "/api/config");
+  }
+
+  async exportConfig() {
+    return this._c._request("GET", "/api/config/export");
   }
 
   async configReload() {
@@ -1185,6 +1474,10 @@ class SystemResource {
     return this._c._request("GET", `/api/templates/${name}`);
   }
 
+  async getAgentTemplateToml(name) {
+    return this._c._request("GET", `/api/templates/${name}/toml`);
+  }
+
   async version() {
     return this._c._request("GET", "/api/version");
   }
@@ -1233,6 +1526,14 @@ class UsersResource {
     return this._c._request("DELETE", `/api/users/${name}`);
   }
 
+  async getUserPolicy(name) {
+    return this._c._request("GET", `/api/users/${name}/policy`);
+  }
+
+  async updateUserPolicy(name, data) {
+    return this._c._request("PUT", `/api/users/${name}/policy`, data, undefined);
+  }
+
   async rotateUserKey(name) {
     return this._c._request("POST", `/api/users/${name}/rotate-key`);
   }
@@ -1263,6 +1564,10 @@ class WorkflowsResource {
 
   async createCronJob(data) {
     return this._c._request("POST", "/api/cron/jobs", data, undefined);
+  }
+
+  async getCronJob(id) {
+    return this._c._request("GET", `/api/cron/jobs/${id}`);
   }
 
   async updateCronJob(id, data) {
@@ -1325,6 +1630,18 @@ class WorkflowsResource {
     return this._c._request("PATCH", `/api/triggers/${id}`, data, undefined);
   }
 
+  async listWorkflowTemplates(query) {
+    return this._c._request("GET", "/api/workflow-templates", undefined, query);
+  }
+
+  async getWorkflowTemplate(id) {
+    return this._c._request("GET", `/api/workflow-templates/${id}`);
+  }
+
+  async instantiateTemplate(id, data) {
+    return this._c._request("POST", `/api/workflow-templates/${id}/instantiate`, data, undefined);
+  }
+
   async listWorkflows() {
     return this._c._request("GET", "/api/workflows");
   }
@@ -1333,12 +1650,40 @@ class WorkflowsResource {
     return this._c._request("POST", "/api/workflows", data, undefined);
   }
 
+  async getWorkflowRun(run_id) {
+    return this._c._request("GET", `/api/workflows/runs/${run_id}`);
+  }
+
+  async cancelWorkflowRun(run_id) {
+    return this._c._request("POST", `/api/workflows/runs/${run_id}/cancel`);
+  }
+
+  async operatorActionWorkflowRun(run_id, data) {
+    return this._c._request("POST", `/api/workflows/runs/${run_id}/operator`, data, undefined);
+  }
+
+  async pauseWorkflowRun(run_id, data) {
+    return this._c._request("POST", `/api/workflows/runs/${run_id}/pause`, data, undefined);
+  }
+
+  async resumeWorkflowRun(run_id, data) {
+    return this._c._request("POST", `/api/workflows/runs/${run_id}/resume`, data, undefined);
+  }
+
+  async getWorkflow(id) {
+    return this._c._request("GET", `/api/workflows/${id}`);
+  }
+
   async updateWorkflow(id, data) {
     return this._c._request("PUT", `/api/workflows/${id}`, data, undefined);
   }
 
   async deleteWorkflow(id) {
     return this._c._request("DELETE", `/api/workflows/${id}`);
+  }
+
+  async dryRunWorkflow(id, data) {
+    return this._c._request("POST", `/api/workflows/${id}/dry-run`, data, undefined);
   }
 
   async runWorkflow(id, data) {

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -48,12 +48,15 @@ class LibreFang:
         self.budget = _BudgetResource(self)
         self.channels = _ChannelsResource(self)
         self.extensions = _ExtensionsResource(self)
+        self.goals = _GoalsResource(self)
         self.hands = _HandsResource(self)
+        self.inbox = _InboxResource(self)
         self.mcp = _McpResource(self)
         self.memory = _MemoryResource(self)
         self.models = _ModelsResource(self)
         self.network = _NetworkResource(self)
         self.pairing = _PairingResource(self)
+        self.plugins = _PluginsResource(self)
         self.proactive_memory = _ProactiveMemoryResource(self)
         self.sessions = _SessionsResource(self)
         self.skills = _SkillsResource(self)
@@ -130,6 +133,9 @@ class _A2AResource(_Resource):
 
     def a2a_get_external_agent(self, id: str):
         return self._c._request("GET", f"/api/a2a/agents/{id}")
+
+    def a2a_approve_external(self, id: str):
+        return self._c._request("POST", f"/api/a2a/agents/{id}/approve")
 
     def a2a_discover_external(self, **data):
         return self._c._request("POST", "/api/a2a/discover", data)
@@ -330,11 +336,32 @@ class _ApprovalsResource(_Resource):
     def create_approval(self, **data):
         return self._c._request("POST", "/api/approvals", data)
 
+    def audit_log(self, limit: Any = None, offset: Any = None, agent_id: Any = None, tool_name: Any = None):
+        return self._c._request("GET", "/api/approvals/audit", None, query={"limit": limit, "offset": offset, "agent_id": agent_id, "tool_name": tool_name})
+
+    def batch_resolve(self, **data):
+        return self._c._request("POST", "/api/approvals/batch", data)
+
+    def approval_count(self):
+        return self._c._request("GET", "/api/approvals/count")
+
+    def list_approvals_for_session(self, session_id: str):
+        return self._c._request("GET", f"/api/approvals/session/{session_id}")
+
+    def approve_all_for_session(self, session_id: str, **data):
+        return self._c._request("POST", f"/api/approvals/session/{session_id}/approve_all", data)
+
+    def reject_all_for_session(self, session_id: str):
+        return self._c._request("POST", f"/api/approvals/session/{session_id}/reject_all")
+
     def get_approval(self, id: str):
         return self._c._request("GET", f"/api/approvals/{id}")
 
     def approve_request(self, id: str, **data):
         return self._c._request("POST", f"/api/approvals/{id}/approve", data)
+
+    def modify_request(self, id: str, **data):
+        return self._c._request("POST", f"/api/approvals/{id}/modify", data)
 
     def reject_request(self, id: str):
         return self._c._request("POST", f"/api/approvals/{id}/reject")
@@ -423,11 +450,20 @@ class _BudgetResource(_Resource):
     def user_budget_detail(self, user_id: str):
         return self._c._request("GET", f"/api/budget/users/{user_id}")
 
+    def update_user_budget(self, user_id: str, **data):
+        return self._c._request("PUT", f"/api/budget/users/{user_id}", data)
+
+    def delete_user_budget(self, user_id: str):
+        return self._c._request("DELETE", f"/api/budget/users/{user_id}")
+
     def usage_stats(self):
         return self._c._request("GET", "/api/usage")
 
     def usage_by_model(self):
         return self._c._request("GET", "/api/usage/by-model")
+
+    def usage_by_model_performance(self):
+        return self._c._request("GET", "/api/usage/by-model/performance")
 
     def usage_daily(self):
         return self._c._request("GET", "/api/usage/daily")
@@ -473,6 +509,14 @@ class _ExtensionsResource(_Resource):
         return self._c._request("GET", f"/api/extensions/{name}")
 
 
+# ── Goals Resource ─────────────────────────────────────────────
+
+class _GoalsResource(_Resource):
+
+    def list_goal_templates(self):
+        return self._c._request("GET", "/api/goals/templates")
+
+
 # ── Hands Resource ─────────────────────────────────────────────
 
 class _HandsResource(_Resource):
@@ -507,6 +551,9 @@ class _HandsResource(_Resource):
     def get_hand(self, hand_id: str):
         return self._c._request("GET", f"/api/hands/{hand_id}")
 
+    def uninstall_hand(self, hand_id: str):
+        return self._c._request("DELETE", f"/api/hands/{hand_id}")
+
     def activate_hand(self, hand_id: str, **data):
         return self._c._request("POST", f"/api/hands/{hand_id}/activate", data)
 
@@ -516,11 +563,25 @@ class _HandsResource(_Resource):
     def install_hand_deps(self, hand_id: str):
         return self._c._request("POST", f"/api/hands/{hand_id}/install-deps")
 
+    def get_hand_manifest(self, hand_id: str):
+        return self._c._request("GET", f"/api/hands/{hand_id}/manifest")
+
+    def set_hand_secret(self, hand_id: str, **data):
+        return self._c._request("POST", f"/api/hands/{hand_id}/secret", data)
+
     def get_hand_settings(self, hand_id: str):
         return self._c._request("GET", f"/api/hands/{hand_id}/settings")
 
     def update_hand_settings(self, hand_id: str, **data):
         return self._c._request("PUT", f"/api/hands/{hand_id}/settings", data)
+
+
+# ── Inbox Resource ─────────────────────────────────────────────
+
+class _InboxResource(_Resource):
+
+    def inbox_status(self):
+        return self._c._request("GET", "/api/inbox/status")
 
 
 # ── Mcp Resource ───────────────────────────────────────────────
@@ -554,8 +615,20 @@ class _McpResource(_Resource):
     def delete_mcp_server(self, name: str):
         return self._c._request("DELETE", f"/api/mcp/servers/{name}")
 
+    def auth_revoke(self, name: str):
+        return self._c._request("DELETE", f"/api/mcp/servers/{name}/auth/revoke")
+
+    def auth_start(self, name: str):
+        return self._c._request("POST", f"/api/mcp/servers/{name}/auth/start")
+
+    def auth_status(self, name: str):
+        return self._c._request("GET", f"/api/mcp/servers/{name}/auth/status")
+
     def reconnect_mcp_server_handler(self, name: str):
         return self._c._request("POST", f"/api/mcp/servers/{name}/reconnect")
+
+    def patch_mcp_server_taint(self, name: str, **data):
+        return self._c._request("PATCH", f"/api/mcp/servers/{name}/taint", data)
 
     def list_mcp_taint_rules(self):
         return self._c._request("GET", "/api/mcp/taint-rules")
@@ -582,6 +655,12 @@ class _MemoryResource(_Resource):
 
     def delete_agent_kv_key(self, id: str, key: str):
         return self._c._request("DELETE", f"/api/memory/agents/{id}/kv/{key}")
+
+    def memory_config_get(self):
+        return self._c._request("GET", "/api/memory/config")
+
+    def memory_config_patch(self, **data):
+        return self._c._request("PATCH", "/api/memory/config", data)
 
 
 # ── Models Resource ────────────────────────────────────────────
@@ -671,6 +750,9 @@ class _NetworkResource(_Resource):
     def network_status(self):
         return self._c._request("GET", "/api/network/status")
 
+    def network_trusted_peers(self):
+        return self._c._request("GET", "/api/network/trusted-peers")
+
     def list_peers(self, offset: Any = None, limit: Any = None):
         return self._c._request("GET", "/api/peers", None, query={"offset": offset, "limit": limit})
 
@@ -698,6 +780,86 @@ class _PairingResource(_Resource):
         return self._c._request("POST", "/api/pairing/request")
 
 
+# ── Plugins Resource ───────────────────────────────────────────
+
+class _PluginsResource(_Resource):
+
+    def context_engine_chain(self):
+        return self._c._request("GET", "/api/context-engine/chain")
+
+    def context_engine_config(self):
+        return self._c._request("GET", "/api/context-engine/config")
+
+    def context_engine_health(self):
+        return self._c._request("GET", "/api/context-engine/health")
+
+    def context_engine_metrics(self):
+        return self._c._request("GET", "/api/context-engine/metrics")
+
+    def context_engine_sandbox_policy(self):
+        return self._c._request("GET", "/api/context-engine/sandbox-policy")
+
+    def context_engine_traces(self):
+        return self._c._request("GET", "/api/context-engine/traces")
+
+    def list_plugins(self):
+        return self._c._request("GET", "/api/plugins")
+
+    def plugin_doctor(self):
+        return self._c._request("GET", "/api/plugins/doctor")
+
+    def install_plugin(self, **data):
+        return self._c._request("POST", "/api/plugins/install", data)
+
+    def list_plugin_registries(self):
+        return self._c._request("GET", "/api/plugins/registries")
+
+    def scaffold_plugin(self, **data):
+        return self._c._request("POST", "/api/plugins/scaffold", data)
+
+    def uninstall_plugin(self, **data):
+        return self._c._request("POST", "/api/plugins/uninstall", data)
+
+    def get_plugin(self, name: str):
+        return self._c._request("GET", f"/api/plugins/{name}")
+
+    def plugin_advanced_config(self, name: str):
+        return self._c._request("GET", f"/api/plugins/{name}/advanced-config")
+
+    def disable_plugin(self, name: str):
+        return self._c._request("POST", f"/api/plugins/{name}/disable")
+
+    def enable_plugin(self, name: str):
+        return self._c._request("POST", f"/api/plugins/{name}/enable")
+
+    def plugin_env(self, name: str):
+        return self._c._request("GET", f"/api/plugins/{name}/env")
+
+    def install_plugin_deps(self, name: str):
+        return self._c._request("POST", f"/api/plugins/{name}/install-deps")
+
+    def lint_plugin(self, name: str):
+        return self._c._request("GET", f"/api/plugins/{name}/lint")
+
+    def prewarm_plugin(self, name: str):
+        return self._c._request("POST", f"/api/plugins/{name}/prewarm")
+
+    def reload_plugin(self, name: str):
+        return self._c._request("POST", f"/api/plugins/{name}/reload")
+
+    def sign_plugin(self, name: str):
+        return self._c._request("POST", f"/api/plugins/{name}/sign")
+
+    def plugin_status(self, name: str):
+        return self._c._request("GET", f"/api/plugins/{name}/status")
+
+    def test_plugin_hook(self, name: str, **data):
+        return self._c._request("POST", f"/api/plugins/{name}/test-hook", data)
+
+    def upgrade_plugin(self, name: str, **data):
+        return self._c._request("POST", f"/api/plugins/{name}/upgrade", data)
+
+
 # ── ProactiveMemory Resource ──────────────────────────────────
 
 class _ProactiveMemoryResource(_Resource):
@@ -717,6 +879,9 @@ class _ProactiveMemoryResource(_Resource):
     def memory_consolidate(self, id: str):
         return self._c._request("POST", f"/api/memory/agents/{id}/consolidate")
 
+    def memory_count_agent(self, id: str, level: Any = None):
+        return self._c._request("GET", f"/api/memory/agents/{id}/count", None, query={"level": level})
+
     def memory_duplicates(self, id: str):
         return self._c._request("GET", f"/api/memory/agents/{id}/duplicates")
 
@@ -729,14 +894,26 @@ class _ProactiveMemoryResource(_Resource):
     def memory_clear_level(self, id: str, level: str):
         return self._c._request("DELETE", f"/api/memory/agents/{id}/level/{level}")
 
+    def memory_query_relations(self, id: str, source: Any = None, relation: Any = None, target: Any = None):
+        return self._c._request("GET", f"/api/memory/agents/{id}/relations", None, query={"source": source, "relation": relation, "target": target})
+
+    def memory_store_relations(self, id: str, **data):
+        return self._c._request("POST", f"/api/memory/agents/{id}/relations", data)
+
     def memory_search_agent(self, id: str, q: Any = None, limit: Any = None):
         return self._c._request("GET", f"/api/memory/agents/{id}/search", None, query={"q": q, "limit": limit})
 
     def memory_stats_agent(self, id: str):
         return self._c._request("GET", f"/api/memory/agents/{id}/stats")
 
+    def memory_bulk_delete(self, **data):
+        return self._c._request("POST", "/api/memory/bulk-delete", data)
+
     def memory_cleanup(self):
         return self._c._request("POST", "/api/memory/cleanup")
+
+    def memory_decay(self):
+        return self._c._request("POST", "/api/memory/decay")
 
     def memory_update(self, memory_id: str, **data):
         return self._c._request("PUT", f"/api/memory/items/{memory_id}", data)
@@ -769,6 +946,9 @@ class _SessionsResource(_Resource):
 
     def session_cleanup(self):
         return self._c._request("POST", "/api/sessions/cleanup")
+
+    def search_sessions(self, q: Any = None, agent_id: Any = None, limit: Any = None, offset: Any = None):
+        return self._c._request("GET", "/api/sessions/search", None, query={"q": q, "agent_id": agent_id, "limit": limit, "offset": offset})
 
     def get_session(self, id: str):
         return self._c._request("GET", f"/api/sessions/{id}")
@@ -826,8 +1006,38 @@ class _SkillsResource(_Resource):
     def reject_pending_candidate(self, id: str):
         return self._c._request("POST", f"/api/skills/pending/{id}/reject")
 
+    def list_skill_registry(self):
+        return self._c._request("GET", "/api/skills/registry")
+
+    def reload_skills(self):
+        return self._c._request("POST", "/api/skills/reload")
+
     def uninstall_skill(self, **data):
         return self._c._request("POST", "/api/skills/uninstall", data)
+
+    def get_skill_detail(self, name: str):
+        return self._c._request("GET", f"/api/skills/{name}")
+
+    def evolve_delete_skill(self, name: str):
+        return self._c._request("POST", f"/api/skills/{name}/evolve/delete")
+
+    def evolve_write_file(self, name: str, **data):
+        return self._c._request("POST", f"/api/skills/{name}/evolve/file", data)
+
+    def evolve_remove_file(self, name: str, path: Any = None):
+        return self._c._request("DELETE", f"/api/skills/{name}/evolve/file", None, query={"path": path})
+
+    def evolve_patch_skill(self, name: str, **data):
+        return self._c._request("POST", f"/api/skills/{name}/evolve/patch", data)
+
+    def evolve_rollback_skill(self, name: str):
+        return self._c._request("POST", f"/api/skills/{name}/evolve/rollback")
+
+    def evolve_update_skill(self, name: str, **data):
+        return self._c._request("POST", f"/api/skills/{name}/evolve/update", data)
+
+    def get_supporting_file(self, name: str, path: Any = None):
+        return self._c._request("GET", f"/api/skills/{name}/file", None, query={"path": path})
 
     def list_tools(self):
         return self._c._request("GET", "/api/tools")
@@ -851,6 +1061,12 @@ class _SystemResource(_Resource):
 
     def audit_verify(self):
         return self._c._request("GET", "/api/audit/verify")
+
+    def check(self, user: Any = None, action: Any = None, channel: Any = None):
+        return self._c._request("GET", "/api/authz/check", None, query={"user": user, "action": action, "channel": channel})
+
+    def effective_permissions(self, user_id: str):
+        return self._c._request("GET", f"/api/authz/effective/{user_id}")
 
     def create_backup(self):
         return self._c._request("POST", "/api/backup")
@@ -878,6 +1094,9 @@ class _SystemResource(_Resource):
 
     def get_config(self):
         return self._c._request("GET", "/api/config")
+
+    def export_config(self):
+        return self._c._request("GET", "/api/config/export")
 
     def config_reload(self):
         return self._c._request("POST", "/api/config/reload")
@@ -939,6 +1158,9 @@ class _SystemResource(_Resource):
     def get_agent_template(self, name: str):
         return self._c._request("GET", f"/api/templates/{name}")
 
+    def get_agent_template_toml(self, name: str):
+        return self._c._request("GET", f"/api/templates/{name}/toml")
+
     def version(self):
         return self._c._request("GET", "/api/version")
 
@@ -976,6 +1198,12 @@ class _UsersResource(_Resource):
     def delete_user(self, name: str):
         return self._c._request("DELETE", f"/api/users/{name}")
 
+    def get_user_policy(self, name: str):
+        return self._c._request("GET", f"/api/users/{name}/policy")
+
+    def update_user_policy(self, name: str, **data):
+        return self._c._request("PUT", f"/api/users/{name}/policy", data)
+
     def rotate_user_key(self, name: str):
         return self._c._request("POST", f"/api/users/{name}/rotate-key")
 
@@ -1000,6 +1228,9 @@ class _WorkflowsResource(_Resource):
 
     def create_cron_job(self, **data):
         return self._c._request("POST", "/api/cron/jobs", data)
+
+    def get_cron_job(self, id: str):
+        return self._c._request("GET", f"/api/cron/jobs/{id}")
 
     def update_cron_job(self, id: str, **data):
         return self._c._request("PUT", f"/api/cron/jobs/{id}", data)
@@ -1046,17 +1277,47 @@ class _WorkflowsResource(_Resource):
     def update_trigger(self, id: str, **data):
         return self._c._request("PATCH", f"/api/triggers/{id}", data)
 
+    def list_workflow_templates(self, q: Any = None, category: Any = None):
+        return self._c._request("GET", "/api/workflow-templates", None, query={"q": q, "category": category})
+
+    def get_workflow_template(self, id: str):
+        return self._c._request("GET", f"/api/workflow-templates/{id}")
+
+    def instantiate_template(self, id: str, **data):
+        return self._c._request("POST", f"/api/workflow-templates/{id}/instantiate", data)
+
     def list_workflows(self):
         return self._c._request("GET", "/api/workflows")
 
     def create_workflow(self, **data):
         return self._c._request("POST", "/api/workflows", data)
 
+    def get_workflow_run(self, run_id: str):
+        return self._c._request("GET", f"/api/workflows/runs/{run_id}")
+
+    def cancel_workflow_run(self, run_id: str):
+        return self._c._request("POST", f"/api/workflows/runs/{run_id}/cancel")
+
+    def operator_action_workflow_run(self, run_id: str, **data):
+        return self._c._request("POST", f"/api/workflows/runs/{run_id}/operator", data)
+
+    def pause_workflow_run(self, run_id: str, **data):
+        return self._c._request("POST", f"/api/workflows/runs/{run_id}/pause", data)
+
+    def resume_workflow_run(self, run_id: str, **data):
+        return self._c._request("POST", f"/api/workflows/runs/{run_id}/resume", data)
+
+    def get_workflow(self, id: str):
+        return self._c._request("GET", f"/api/workflows/{id}")
+
     def update_workflow(self, id: str, **data):
         return self._c._request("PUT", f"/api/workflows/{id}", data)
 
     def delete_workflow(self, id: str):
         return self._c._request("DELETE", f"/api/workflows/{id}")
+
+    def dry_run_workflow(self, id: str, **data):
+        return self._c._request("POST", f"/api/workflows/{id}/dry-run", data)
 
     def run_workflow(self, id: str, **data):
         return self._c._request("POST", f"/api/workflows/{id}/run", data)

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -173,12 +173,15 @@ pub struct LibreFang {
     pub budget: Arc<BudgetResource>,
     pub channels: Arc<ChannelsResource>,
     pub extensions: Arc<ExtensionsResource>,
+    pub goals: Arc<GoalsResource>,
     pub hands: Arc<HandsResource>,
+    pub inbox: Arc<InboxResource>,
     pub mcp: Arc<McpResource>,
     pub memory: Arc<MemoryResource>,
     pub models: Arc<ModelsResource>,
     pub network: Arc<NetworkResource>,
     pub pairing: Arc<PairingResource>,
+    pub plugins: Arc<PluginsResource>,
     pub proactive_memory: Arc<ProactiveMemoryResource>,
     pub sessions: Arc<SessionsResource>,
     pub skills: Arc<SkillsResource>,
@@ -204,12 +207,15 @@ impl LibreFang {
             budget: Arc::new(BudgetResource::new(base_url.clone(), client.clone())),
             channels: Arc::new(ChannelsResource::new(base_url.clone(), client.clone())),
             extensions: Arc::new(ExtensionsResource::new(base_url.clone(), client.clone())),
+            goals: Arc::new(GoalsResource::new(base_url.clone(), client.clone())),
             hands: Arc::new(HandsResource::new(base_url.clone(), client.clone())),
+            inbox: Arc::new(InboxResource::new(base_url.clone(), client.clone())),
             mcp: Arc::new(McpResource::new(base_url.clone(), client.clone())),
             memory: Arc::new(MemoryResource::new(base_url.clone(), client.clone())),
             models: Arc::new(ModelsResource::new(base_url.clone(), client.clone())),
             network: Arc::new(NetworkResource::new(base_url.clone(), client.clone())),
             pairing: Arc::new(PairingResource::new(base_url.clone(), client.clone())),
+            plugins: Arc::new(PluginsResource::new(base_url.clone(), client.clone())),
             proactive_memory: Arc::new(ProactiveMemoryResource::new(
                 base_url.clone(),
                 client.clone(),
@@ -258,6 +264,18 @@ impl A2AResource {
             &self.base_url,
             reqwest::Method::GET,
             &format!("/api/a2a/agents/{}", id),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn a2a_approve_external(&self, id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/a2a/agents/{}/approve", id),
             None,
             &[],
         )
@@ -1080,6 +1098,89 @@ impl ApprovalsResource {
         .await
     }
 
+    pub async fn audit_log(
+        &self,
+        limit: Option<&str>,
+        offset: Option<&str>,
+        agent_id: Option<&str>,
+        tool_name: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/approvals/audit".to_string(),
+            None,
+            &[
+                ("limit", limit),
+                ("offset", offset),
+                ("agent_id", agent_id),
+                ("tool_name", tool_name),
+            ],
+        )
+        .await
+    }
+
+    pub async fn batch_resolve(&self, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/approvals/batch".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn approval_count(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/approvals/count".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn list_approvals_for_session(&self, session_id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/approvals/session/{}", session_id),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn approve_all_for_session(&self, session_id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/approvals/session/{}/approve_all", session_id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn reject_all_for_session(&self, session_id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/approvals/session/{}/reject_all", session_id),
+            None,
+            &[],
+        )
+        .await
+    }
+
     pub async fn get_approval(&self, id: &str) -> Result<Value> {
         do_req(
             &self.client,
@@ -1098,6 +1199,18 @@ impl ApprovalsResource {
             &self.base_url,
             reqwest::Method::POST,
             &format!("/api/approvals/{}/approve", id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn modify_request(&self, id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/approvals/{}/modify", id),
             Some(data),
             &[],
         )
@@ -1434,6 +1547,30 @@ impl BudgetResource {
         .await
     }
 
+    pub async fn update_user_budget(&self, user_id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/budget/users/{}", user_id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn delete_user_budget(&self, user_id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/budget/users/{}", user_id),
+            None,
+            &[],
+        )
+        .await
+    }
+
     pub async fn usage_stats(&self) -> Result<Value> {
         do_req(
             &self.client,
@@ -1452,6 +1589,18 @@ impl BudgetResource {
             &self.base_url,
             reqwest::Method::GET,
             &"/api/usage/by-model".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn usage_by_model_performance(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/usage/by-model/performance".to_string(),
             None,
             &[],
         )
@@ -1619,6 +1768,32 @@ impl ExtensionsResource {
     }
 }
 
+// ── Goals ──
+
+#[derive(Debug, Clone)]
+pub struct GoalsResource {
+    base_url: String,
+    client: Client,
+}
+
+impl GoalsResource {
+    fn new(base_url: String, client: Client) -> Self {
+        Self { base_url, client }
+    }
+
+    pub async fn list_goal_templates(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/goals/templates".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+}
+
 // ── Hands ──
 
 #[derive(Debug, Clone)]
@@ -1752,6 +1927,18 @@ impl HandsResource {
         .await
     }
 
+    pub async fn uninstall_hand(&self, hand_id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/hands/{}", hand_id),
+            None,
+            &[],
+        )
+        .await
+    }
+
     pub async fn activate_hand(&self, hand_id: &str, data: Value) -> Result<Value> {
         do_req(
             &self.client,
@@ -1788,6 +1975,30 @@ impl HandsResource {
         .await
     }
 
+    pub async fn get_hand_manifest(&self, hand_id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/hands/{}/manifest", hand_id),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn set_hand_secret(&self, hand_id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/hands/{}/secret", hand_id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
     pub async fn get_hand_settings(&self, hand_id: &str) -> Result<Value> {
         do_req(
             &self.client,
@@ -1807,6 +2018,32 @@ impl HandsResource {
             reqwest::Method::PUT,
             &format!("/api/hands/{}/settings", hand_id),
             Some(data),
+            &[],
+        )
+        .await
+    }
+}
+
+// ── Inbox ──
+
+#[derive(Debug, Clone)]
+pub struct InboxResource {
+    base_url: String,
+    client: Client,
+}
+
+impl InboxResource {
+    fn new(base_url: String, client: Client) -> Self {
+        Self { base_url, client }
+    }
+
+    pub async fn inbox_status(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/inbox/status".to_string(),
+            None,
             &[],
         )
         .await
@@ -1934,6 +2171,42 @@ impl McpResource {
         .await
     }
 
+    pub async fn auth_revoke(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/mcp/servers/{}/auth/revoke", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn auth_start(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/mcp/servers/{}/auth/start", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn auth_status(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/mcp/servers/{}/auth/status", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
     pub async fn reconnect_mcp_server_handler(&self, name: &str) -> Result<Value> {
         do_req(
             &self.client,
@@ -1941,6 +2214,18 @@ impl McpResource {
             reqwest::Method::POST,
             &format!("/api/mcp/servers/{}/reconnect", name),
             None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn patch_mcp_server_taint(&self, name: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PATCH,
+            &format!("/api/mcp/servers/{}/taint", name),
+            Some(data),
             &[],
         )
         .await
@@ -2039,6 +2324,30 @@ impl MemoryResource {
             reqwest::Method::DELETE,
             &format!("/api/memory/agents/{}/kv/{}", id, key),
             None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn memory_config_get(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/memory/config".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn memory_config_patch(&self, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PATCH,
+            &"/api/memory/config".to_string(),
+            Some(data),
             &[],
         )
         .await
@@ -2383,6 +2692,18 @@ impl NetworkResource {
         .await
     }
 
+    pub async fn network_trusted_peers(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/network/trusted-peers".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
     pub async fn list_peers(&self, offset: Option<&str>, limit: Option<&str>) -> Result<Value> {
         do_req(
             &self.client,
@@ -2482,6 +2803,320 @@ impl PairingResource {
     }
 }
 
+// ── Plugins ──
+
+#[derive(Debug, Clone)]
+pub struct PluginsResource {
+    base_url: String,
+    client: Client,
+}
+
+impl PluginsResource {
+    fn new(base_url: String, client: Client) -> Self {
+        Self { base_url, client }
+    }
+
+    pub async fn context_engine_chain(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/context-engine/chain".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn context_engine_config(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/context-engine/config".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn context_engine_health(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/context-engine/health".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn context_engine_metrics(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/context-engine/metrics".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn context_engine_sandbox_policy(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/context-engine/sandbox-policy".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn context_engine_traces(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/context-engine/traces".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn list_plugins(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/plugins".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn plugin_doctor(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/plugins/doctor".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn install_plugin(&self, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/plugins/install".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn list_plugin_registries(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/plugins/registries".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn scaffold_plugin(&self, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/plugins/scaffold".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn uninstall_plugin(&self, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/plugins/uninstall".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn get_plugin(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/plugins/{}", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn plugin_advanced_config(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/plugins/{}/advanced-config", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn disable_plugin(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/plugins/{}/disable", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn enable_plugin(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/plugins/{}/enable", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn plugin_env(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/plugins/{}/env", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn install_plugin_deps(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/plugins/{}/install-deps", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn lint_plugin(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/plugins/{}/lint", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn prewarm_plugin(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/plugins/{}/prewarm", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn reload_plugin(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/plugins/{}/reload", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn sign_plugin(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/plugins/{}/sign", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn plugin_status(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/plugins/{}/status", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn test_plugin_hook(&self, name: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/plugins/{}/test-hook", name),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn upgrade_plugin(&self, name: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/plugins/{}/upgrade", name),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+}
+
 // ── ProactiveMemory ──
 
 #[derive(Debug, Clone)]
@@ -2566,6 +3201,18 @@ impl ProactiveMemoryResource {
         .await
     }
 
+    pub async fn memory_count_agent(&self, id: &str, level: Option<&str>) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/agents/{}/count", id),
+            None,
+            &[("level", level)],
+        )
+        .await
+    }
+
     pub async fn memory_duplicates(&self, id: &str) -> Result<Value> {
         do_req(
             &self.client,
@@ -2614,6 +3261,40 @@ impl ProactiveMemoryResource {
         .await
     }
 
+    pub async fn memory_query_relations(
+        &self,
+        id: &str,
+        source: Option<&str>,
+        relation: Option<&str>,
+        target: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/memory/agents/{}/relations", id),
+            None,
+            &[
+                ("source", source),
+                ("relation", relation),
+                ("target", target),
+            ],
+        )
+        .await
+    }
+
+    pub async fn memory_store_relations(&self, id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/memory/agents/{}/relations", id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
     pub async fn memory_search_agent(
         &self,
         id: &str,
@@ -2643,12 +3324,36 @@ impl ProactiveMemoryResource {
         .await
     }
 
+    pub async fn memory_bulk_delete(&self, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/memory/bulk-delete".to_string(),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
     pub async fn memory_cleanup(&self) -> Result<Value> {
         do_req(
             &self.client,
             &self.base_url,
             reqwest::Method::POST,
             &"/api/memory/cleanup".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn memory_decay(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/memory/decay".to_string(),
             None,
             &[],
         )
@@ -2773,6 +3478,29 @@ impl SessionsResource {
             &"/api/sessions/cleanup".to_string(),
             None,
             &[],
+        )
+        .await
+    }
+
+    pub async fn search_sessions(
+        &self,
+        q: Option<&str>,
+        agent_id: Option<&str>,
+        limit: Option<&str>,
+        offset: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/sessions/search".to_string(),
+            None,
+            &[
+                ("q", q),
+                ("agent_id", agent_id),
+                ("limit", limit),
+                ("offset", offset),
+            ],
         )
         .await
     }
@@ -2995,6 +3723,30 @@ impl SkillsResource {
         .await
     }
 
+    pub async fn list_skill_registry(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/skills/registry".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn reload_skills(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &"/api/skills/reload".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
     pub async fn uninstall_skill(&self, data: Value) -> Result<Value> {
         do_req(
             &self.client,
@@ -3003,6 +3755,102 @@ impl SkillsResource {
             &"/api/skills/uninstall".to_string(),
             Some(data),
             &[],
+        )
+        .await
+    }
+
+    pub async fn get_skill_detail(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/skills/{}", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn evolve_delete_skill(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/skills/{}/evolve/delete", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn evolve_write_file(&self, name: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/skills/{}/evolve/file", name),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn evolve_remove_file(&self, name: &str, path: Option<&str>) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::DELETE,
+            &format!("/api/skills/{}/evolve/file", name),
+            None,
+            &[("path", path)],
+        )
+        .await
+    }
+
+    pub async fn evolve_patch_skill(&self, name: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/skills/{}/evolve/patch", name),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn evolve_rollback_skill(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/skills/{}/evolve/rollback", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn evolve_update_skill(&self, name: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/skills/{}/evolve/update", name),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn get_supporting_file(&self, name: &str, path: Option<&str>) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/skills/{}/file", name),
+            None,
+            &[("path", path)],
         )
         .await
     }
@@ -3129,6 +3977,35 @@ impl SystemResource {
         .await
     }
 
+    pub async fn check(
+        &self,
+        user: Option<&str>,
+        action: Option<&str>,
+        channel: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/authz/check".to_string(),
+            None,
+            &[("user", user), ("action", action), ("channel", channel)],
+        )
+        .await
+    }
+
+    pub async fn effective_permissions(&self, user_id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/authz/effective/{}", user_id),
+            None,
+            &[],
+        )
+        .await
+    }
+
     pub async fn create_backup(&self) -> Result<Value> {
         do_req(
             &self.client,
@@ -3231,6 +4108,18 @@ impl SystemResource {
             &self.base_url,
             reqwest::Method::GET,
             &"/api/config".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn export_config(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/config/export".to_string(),
             None,
             &[],
         )
@@ -3476,6 +4365,18 @@ impl SystemResource {
         .await
     }
 
+    pub async fn get_agent_template_toml(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/templates/{}/toml", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
     pub async fn version(&self) -> Result<Value> {
         do_req(
             &self.client,
@@ -3617,6 +4518,30 @@ impl UsersResource {
         .await
     }
 
+    pub async fn get_user_policy(&self, name: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/users/{}/policy", name),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn update_user_policy(&self, name: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/users/{}/policy", name),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
     pub async fn rotate_user_key(&self, name: &str) -> Result<Value> {
         do_req(
             &self.client,
@@ -3700,6 +4625,18 @@ impl WorkflowsResource {
             reqwest::Method::POST,
             &"/api/cron/jobs".to_string(),
             Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn get_cron_job(&self, id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/cron/jobs/{}", id),
+            None,
             &[],
         )
         .await
@@ -3885,6 +4822,46 @@ impl WorkflowsResource {
         .await
     }
 
+    pub async fn list_workflow_templates(
+        &self,
+        q: Option<&str>,
+        category: Option<&str>,
+    ) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/workflow-templates".to_string(),
+            None,
+            &[("q", q), ("category", category)],
+        )
+        .await
+    }
+
+    pub async fn get_workflow_template(&self, id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/workflow-templates/{}", id),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn instantiate_template(&self, id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/workflow-templates/{}/instantiate", id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
     pub async fn list_workflows(&self) -> Result<Value> {
         do_req(
             &self.client,
@@ -3909,6 +4886,78 @@ impl WorkflowsResource {
         .await
     }
 
+    pub async fn get_workflow_run(&self, run_id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/workflows/runs/{}", run_id),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn cancel_workflow_run(&self, run_id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/workflows/runs/{}/cancel", run_id),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn operator_action_workflow_run(&self, run_id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/workflows/runs/{}/operator", run_id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn pause_workflow_run(&self, run_id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/workflows/runs/{}/pause", run_id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn resume_workflow_run(&self, run_id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/workflows/runs/{}/resume", run_id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn get_workflow(&self, id: &str) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &format!("/api/workflows/{}", id),
+            None,
+            &[],
+        )
+        .await
+    }
+
     pub async fn update_workflow(&self, id: &str, data: Value) -> Result<Value> {
         do_req(
             &self.client,
@@ -3928,6 +4977,18 @@ impl WorkflowsResource {
             reqwest::Method::DELETE,
             &format!("/api/workflows/{}", id),
             None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn dry_run_workflow(&self, id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::POST,
+            &format!("/api/workflows/{}/dry-run", id),
+            Some(data),
             &[],
         )
         .await

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-95455a2e9001fc91b4085b630d6f20f551fbbc93874ec4ce5f153df6f8b7fd3d  openapi.json
+9ec7feaf36a2939c7a9f4fab61679cd7c35a0b72cc8c09b4a5e35d819a95aa17  openapi.json


### PR DESCRIPTION
## Summary
`ApiDoc::paths(...)` referenced only **287** of the **370** `#[utoipa::path]`-annotated handlers. utoipa documents a handler only if it is explicitly listed in `paths(...)`, so **81** live, router-wired endpoints — including the entire UI-driven MCP-OAuth flow — were silently absent from `openapi.json` and every generated SDK.

## Changes
- **Backfilled 81 missing handlers** into `ApiDoc::paths(...)` (`crates/librefang-api/src/openapi.rs`), grouped by domain: MCP-OAuth (`auth_start/status/revoke`), all 25 plugin + context-engine endpoints, skill evolution + detail, hands (`get_hand_manifest`, `set_hand_secret`, `uninstall_hand`), workflow run lifecycle + templates, per-session approval batch ops + audit log, memory relations/config/decay/bulk-delete, authz checks, user policy, budget user PUT/DELETE, `export_config`, `search_sessions`, `list_goal_templates`, `inbox_status`, `a2a_approve_external`, `network_trusted_peers`, `get_agent_template_toml`.
- **Removed a stray duplicate** `#[utoipa::path(GET /api/triggers)]` misattached to the private helper `trigger_to_json` in `routes/workflows.rs` (the real `list_triggers` already carries the annotation; a private fn can't be referenced from `paths(...)`).
- **Regenerated artifacts** (CI `openapi-drift` gate): `openapi.json` 246 → 318 path templates / 368 operations; Python/JS/Go/Rust SDKs; `xtask/baselines/openapi.sha256`. The two new body schemas (`ApproveAllForSessionRequest`, `AuthzCheckResponse`) are auto-collected by utoipa — verified no dangling `$ref`.
- **Added a reflection test** `tests/openapi_path_coverage_test.rs`: scans the crate source for every `#[utoipa::path]` (method, path) pair and asserts each is present in `ApiDoc::openapi()`. No new external dependency — it reads source via `CARGO_MANIFEST_DIR` (same approach as `openapi_spec_test.rs` / `config_schema_golden.rs`), unlike the doc's `inventory`-based sketch which would have required one. This is the inverse of the existing `dead_route_audit_test` (spec → router) and prevents future `paths(...)` omissions.

## Verification
- `cargo test -p librefang-api --test openapi_path_coverage_test` — passes; **also verified RED** by temporarily removing one entry (test reported the exact missing `(post, /api/mcp/servers/{name}/auth/start)` pair).
- `cargo test -p librefang-api --test dead_route_audit_test` — passes; confirms all 318 documented paths (incl. the backfilled ones) are actually router-wired.
- `cargo test -p librefang-api --lib` — 739 passed.
- `cargo test -p librefang-api --test approvals_routes_integration` — 22 passed.
- `openapi_spec_test` — passes during codegen.
- `cargo check --workspace --lib --exclude librefang-desktop` — clean (desktop excluded: needs GTK dev headers absent from the local toolchain image; unrelated to this change).
- `cargo xtask schema-check check` — all baselines match (no drift).

## Notes
- The CLAUDE.md note that the *pre-push* hook gates OpenAPI/SDK drift is inaccurate for the current `scripts/hooks/pre-push` (it only blocks pushes to protected branches). The drift gate lives in the CI `openapi-drift` job (`cargo xtask codegen --openapi` + `python3 scripts/codegen-sdks.py` + `cargo xtask schema-check gen`, then `git diff --exit-code openapi.json sdk/ xtask/baselines/`), which all three regenerated artifacts in this PR satisfy.

Closes #5618