### PR TITLE
refactor(kernel): return librefang-types IntegrationError from install_integration (stop leaking ExtensionResult)

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -6105,7 +6105,9 @@ pub async fn install_extension(
         Err(e) => {
             let err_str = e.to_string();
             let status = match e {
-                librefang_extensions::ExtensionError::NotFound(_) => StatusCode::NOT_FOUND,
+                librefang_types::integration::IntegrationError::NotFound(_) => {
+                    StatusCode::NOT_FOUND
+                }
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             };
             return (status, Json(serde_json::json!({"error": err_str})));

--- a/crates/librefang-extensions/src/lib.rs
+++ b/crates/librefang-extensions/src/lib.rs
@@ -69,6 +69,37 @@ pub enum ExtensionError {
 
 pub type ExtensionResult<T> = Result<T, ExtensionError>;
 
+/// Bridge the extensions-crate error space to the dependency-free
+/// [`librefang_types::integration::IntegrationError`] that the kernel's
+/// HTTP-layer `install_integration` façade now returns. Keeping the
+/// conversion here lets the real kernel impl `?`/`map_err` cleanly while
+/// reimplementers of the trait (mocks, alternate kernels) construct
+/// `IntegrationError` directly without ever touching this crate.
+///
+/// The mapping preserves the discriminant the API layer keys HTTP status
+/// codes off (`NotFound` → 404; everything else → 500). Variants that don't
+/// have a direct counterpart collapse into `IntegrationError::Other`, whose
+/// `Display` carries the original `ExtensionError` message so operator-facing
+/// responses are unchanged.
+impl From<ExtensionError> for librefang_types::integration::IntegrationError {
+    fn from(err: ExtensionError) -> Self {
+        use librefang_types::integration::IntegrationError as IE;
+        match err {
+            ExtensionError::NotFound(s) => IE::NotFound(s),
+            ExtensionError::AlreadyInstalled(s) => IE::AlreadyInstalled(s),
+            ExtensionError::Vault(s) => IE::Vault(s),
+            // `VaultLocked` / `VaultKeyMismatch` are still vault failures at
+            // the trait boundary — fold them into `Vault`, carrying each
+            // variant's own `Display` message so the operator-facing text is
+            // unchanged.
+            err @ (ExtensionError::VaultLocked | ExtensionError::VaultKeyMismatch { .. }) => {
+                IE::Vault(err.to_string())
+            }
+            other => IE::Other(other.to_string()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,5 +110,37 @@ mod tests {
         assert!(err.to_string().contains("github"));
         let err = ExtensionError::VaultLocked;
         assert!(err.to_string().contains("vault"));
+    }
+
+    /// The `From<ExtensionError>` bridge must preserve the `NotFound`
+    /// discriminant the API layer keys its 404 response off, fold the vault
+    /// family into `IntegrationError::Vault`, and collapse everything else
+    /// into `Other` while keeping the original `Display` message.
+    #[test]
+    fn extension_error_maps_to_integration_error() {
+        use librefang_types::integration::IntegrationError as IE;
+
+        let mapped: IE = ExtensionError::NotFound("github".to_string()).into();
+        assert!(matches!(mapped, IE::NotFound(ref s) if s == "github"));
+
+        let mapped: IE = ExtensionError::AlreadyInstalled("slack".to_string()).into();
+        assert!(matches!(mapped, IE::AlreadyInstalled(ref s) if s == "slack"));
+
+        let mapped: IE = ExtensionError::Vault("disk full".to_string()).into();
+        assert!(matches!(mapped, IE::Vault(ref s) if s == "disk full"));
+
+        // VaultLocked folds into Vault, carrying its own Display message.
+        let mapped: IE = ExtensionError::VaultLocked.into();
+        assert!(matches!(&mapped, IE::Vault(s) if s.contains("vault")));
+
+        // A variant with no direct counterpart collapses into Other but keeps
+        // the original message verbatim.
+        let original = ExtensionError::Http("502 from registry".to_string());
+        let original_msg = original.to_string();
+        let mapped: IE = original.into();
+        match mapped {
+            IE::Other(s) => assert_eq!(s, original_msg),
+            other => panic!("expected Other, got {other:?}"),
+        }
     }
 }

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -174,13 +174,25 @@ pub trait KernelApi: KernelHandle + Send + Sync {
     // unlock-time Argon2id KDF on every install request (#3598). The trait
     // exposes the high-level installer; the underlying `vault_handle` stays
     // an inherent method to keep the trait surface small.
+    //
+    // The error half is `librefang_types::integration::IntegrationError` (not
+    // the extensions-crate `ExtensionResult`) so a mock / alternate kernel can
+    // implement this trait without depending on `librefang-extensions`. The
+    // real kernel impl converts via the `From<ExtensionError>` bridge defined
+    // in that crate. The success type still references
+    // `librefang_extensions::installer::InstallResult` — eliminating that
+    // remaining leak is part of the broader kernel-depends-on-extensions
+    // refactor, tracked separately.
     // ====================================================================
 
     fn install_integration(
         &self,
         template_id: &str,
         provided_keys: &std::collections::HashMap<String, String>,
-    ) -> librefang_extensions::ExtensionResult<librefang_extensions::installer::InstallResult>;
+    ) -> Result<
+        librefang_extensions::installer::InstallResult,
+        librefang_types::integration::IntegrationError,
+    >;
 
     // ====================================================================
     // Inbox / auto-dream observability
@@ -861,8 +873,15 @@ impl KernelApi for LibreFangKernel {
         &self,
         template_id: &str,
         provided_keys: &std::collections::HashMap<String, String>,
-    ) -> librefang_extensions::ExtensionResult<librefang_extensions::installer::InstallResult> {
-        Self::install_integration(self, template_id, provided_keys)
+    ) -> Result<
+        librefang_extensions::installer::InstallResult,
+        librefang_types::integration::IntegrationError,
+    > {
+        // The inherent method keeps returning `ExtensionResult`; convert its
+        // error into the dependency-free `IntegrationError` at the trait
+        // boundary via the `From<ExtensionError>` bridge in
+        // `librefang-extensions`.
+        Self::install_integration(self, template_id, provided_keys).map_err(Into::into)
     }
 
     // -- Inbox / auto-dream --

--- a/crates/librefang-types/src/integration.rs
+++ b/crates/librefang-types/src/integration.rs
@@ -1,0 +1,102 @@
+//! Error type for the MCP-integration install façade.
+//!
+//! `KernelApi::install_integration` (the HTTP-layer trait surface in
+//! `librefang-kernel`) used to return `librefang_extensions::ExtensionResult`,
+//! which forced every reimplementer of the trait — mocks, alternate kernels —
+//! to depend on `librefang-extensions` even when they had no other reason to.
+//! `IntegrationError` lives here, in the dependency-free types crate, so the
+//! trait can speak a shared error vocabulary while the concrete kernel impl
+//! keeps converting from its internal `ExtensionError` via `From` (the
+//! conversion impl lives in `librefang-extensions`).
+//!
+//! The variants intentionally preserve the discriminants the API layer maps
+//! to HTTP status codes (`NotFound` → 404; everything else → 500), so the
+//! switch from `ExtensionError` does not silently change response shapes.
+
+use thiserror::Error;
+
+/// Failure surfaced by the kernel's MCP-integration install façade.
+///
+/// Mirrors the subset of the extensions-crate error space that can reach the
+/// trait boundary. `librefang-extensions` provides
+/// `impl From<ExtensionError> for IntegrationError` so the real kernel impl
+/// converts cleanly; reimplementers that don't depend on the extensions crate
+/// construct these variants directly.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum IntegrationError {
+    /// The requested MCP catalog template id was not found.
+    #[error("MCP catalog entry not found: {0}")]
+    NotFound(String),
+
+    /// An MCP server with this id / name is already configured.
+    #[error("MCP server already configured: {0}")]
+    AlreadyInstalled(String),
+
+    /// The credential vault was unavailable or rejected the operation.
+    #[error("Vault error: {0}")]
+    Vault(String),
+
+    /// Any other install failure (IO, parse, HTTP, health-check, …) that does
+    /// not need its own discriminant at the trait boundary. The full message
+    /// is preserved for the operator-facing response.
+    #[error("Install failed: {0}")]
+    Other(String),
+}
+
+/// Convenience `Result` alias over [`IntegrationError`], mirroring the shape
+/// of the extensions-crate `ExtensionResult` the trait used to return.
+pub type IntegrationResult<T> = Result<T, IntegrationError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Display` strings are part of the operator-facing API contract (the
+    /// `install_integration` route renders them straight into the JSON
+    /// `error` field). Pin them so a refactor can't silently shift response
+    /// text.
+    #[test]
+    fn display_strings_are_stable() {
+        assert_eq!(
+            IntegrationError::NotFound("github".into()).to_string(),
+            "MCP catalog entry not found: github"
+        );
+        assert_eq!(
+            IntegrationError::AlreadyInstalled("slack".into()).to_string(),
+            "MCP server already configured: slack"
+        );
+        assert_eq!(
+            IntegrationError::Vault("locked".into()).to_string(),
+            "Vault error: locked"
+        );
+        assert_eq!(
+            IntegrationError::Other("502".into()).to_string(),
+            "Install failed: 502"
+        );
+    }
+
+    /// Acceptance for the typed-error refactor: a reimplementer of the
+    /// kernel's `install_integration` façade can model the contract's error
+    /// half and key HTTP status off the discriminant using
+    /// only `librefang-types` — no `librefang-extensions` dependency. This
+    /// crate has no dependency on `librefang-extensions`, so the fact that
+    /// this test compiles and runs *is* the proof.
+    #[test]
+    fn error_is_usable_without_extensions_crate() {
+        // Stand in for a mock kernel's install path returning the typed error.
+        fn mock_install(template_id: &str) -> IntegrationResult<()> {
+            if template_id == "github" {
+                Ok(())
+            } else {
+                Err(IntegrationError::NotFound(template_id.to_string()))
+            }
+        }
+
+        assert!(mock_install("github").is_ok());
+
+        let err = mock_install("does-not-exist").unwrap_err();
+        // The discriminant the API layer maps to HTTP 404 survives.
+        assert!(matches!(err, IntegrationError::NotFound(ref s) if s == "does-not-exist"));
+    }
+}

--- a/crates/librefang-types/src/lib.rs
+++ b/crates/librefang-types/src/lib.rs
@@ -16,6 +16,7 @@ pub mod error_code;
 pub mod event;
 pub mod goal;
 pub mod i18n;
+pub mod integration;
 pub mod manifest_signing;
 pub mod mcp;
 pub mod media;


### PR DESCRIPTION
Closes #5621.

## Problem

`KernelApi::install_integration` returned `librefang_extensions::ExtensionResult<_>`, forcing every reimplementer of the HTTP-layer trait (mocks, alternate kernels) to depend on `librefang-extensions` for the error type even when they need nothing else from that crate.

## Changes

- **New `IntegrationError` in `librefang-types`** (`crates/librefang-types/src/integration.rs`, registered in `lib.rs`). Enum with `NotFound` / `AlreadyInstalled` / `Vault` / `Other`; derives `Error, Debug` and is `#[non_exhaustive]`, matching the existing `LibreFangError` convention. **No new dependency** — `thiserror` is already a `librefang-types` dep. Includes an `IntegrationResult<T>` alias.
- **Trait + impl updated** (`crates/librefang-kernel/src/kernel_api.rs`): both the `KernelApi::install_integration` declaration and the `LibreFangKernel` impl now return `Result<InstallResult, IntegrationError>`. The inherent `Kernel::install_integration` method keeps returning `ExtensionResult`; the trait impl converts at the boundary via `map_err(Into::into)`.
- **`From` conversion in `librefang-extensions`** (`crates/librefang-extensions/src/lib.rs`): `impl From<ExtensionError> for IntegrationError`. The mapping preserves the discriminant the API layer keys HTTP status off (`NotFound` → 404; everything else → 500); unmapped variants (`VaultLocked`, `VaultKeyMismatch`, `Io`, `Http`, …) collapse into `Other` while keeping the original `Display` message, so operator-facing responses are unchanged.
- **Caller updated** (`crates/librefang-api/src/routes/skills.rs`): the `install_extension` handler now matches on `IntegrationError::NotFound` for its 404 mapping (same status/message behaviour). The other caller already only used `Display`, so it needed no change.

## Out of scope (broader refactor remains tracked separately)

The success type still references `librefang_extensions::installer::InstallResult`, so a mock kernel does not yet escape `librefang-extensions` entirely. Removing that remaining leak (and the same extension-typed pattern on other `KernelApi` methods) is part of the larger kernel-depends-on-extensions cluster and is intentionally **not** in this PR. This PR fixes only the error half of `install_integration`'s return type, per the assigned issue's scope.

## Tests

- `librefang-types`: `IntegrationError` `Display` strings pinned (operator-facing API contract); a mock-style install path returning the typed error compiles/runs in a crate that has no `librefang-extensions` dependency — the acceptance proof.
- `librefang-extensions`: `From<ExtensionError>` mapping covered (NotFound / AlreadyInstalled / Vault / VaultLocked / Other).
- Existing `librefang-kernel` `install_integration_writes_through_cached_vault_handle` lib test still passes (exercises the inherent method + trait conversion seam).

## Verification

- `cargo check --workspace --lib` (excluding `librefang-desktop` — the build image lacks GTK/`gdk-3.0` system libs; that crate does not reference `install_integration` and is untouched).
- `cargo clippy` clean on `librefang-types` and `librefang-extensions` (`--all-targets`) and `librefang-kernel` (`--lib`). (Pre-existing `librefang-api` lib lints in `registry.rs` / `validation.rs` / `webchat.rs` from the build image's newer clippy are present identically on `origin/main` and are unrelated to this change.)
- Scoped tests above via `cargo test -p <crate>`.
- `openapi.json` unchanged (no route shape change).