### PR TITLE
[Medium] Per-trigger `session_mode_override = New` is throttled by the manifest's `Persistent` clamp

### DIFF
--- a/docs/architecture/trigger-dispatch-concurrency.md
+++ b/docs/architecture/trigger-dispatch-concurrency.md
@@ -100,11 +100,94 @@ session_mode = "new"
 max_concurrent_invocations = 4
 ```
 
+### Gotcha: per-trigger `session_mode = "new"` does NOT grant parallelism
+
+This is the most common surprise, so it is spelled out in full here.
+
+A per-trigger override (`[[triggers]] … session_mode = "new"`) controls
+**session isolation** — whether *that* fire gets a fresh `SessionId` — but
+it does **not** resize the per-agent concurrency semaphore. Those are two
+independent gates:
+
+- **Fresh session per fire** comes from the *effective* session mode:
+  `trigger.session_mode` (the per-trigger override) `>` manifest
+  `session_mode`. Resolved at dispatch in
+  `triggers_and_workflow.rs` (the `effective_mode` branch): `New` →
+  `Some(SessionId::for_trigger_fire(agent, trigger_id, fire_time))` (a
+  deterministic v5 UUID since #5604), `Persistent` → `None`.
+- **Per-agent parallelism cap** comes from `agent_concurrency_for`, which
+  reads the **manifest only** — never the per-trigger override. It is
+  sized **once**, lazily, on the agent's first dispatch, from a single
+  manifest snapshot of `(session_mode, max_concurrent_invocations)`.
+
+So a trigger that mints fresh sessions still queues behind a 1-permit
+per-agent semaphore whenever the **manifest** default is `Persistent`
+(the default) — because the `Persistent + cap > 1 → 1` clamp already
+fired when the semaphore was created. The override mints isolated
+sessions that then run *serially*. The dispatcher never rescans triggers
+when acquiring the per-agent permit, so a later override can't grow an
+already-sized semaphore.
+
+**Effective per-agent cap — exact resolution order.** Override is absent
+from this list on purpose: it cannot enter the cap computation.
+
+```
+manifest.session_mode == Persistent  AND  max_concurrent_invocations > 1
+    └─► clamped to 1   (WARN logged; per-trigger override is IGNORED here)
+
+manifest.max_concurrent_invocations = Some(n)   (any other session_mode)
+    └─► n
+
+manifest.max_concurrent_invocations = None
+    └─► queue.concurrency.default_per_agent   (default 1)
+
+…then max(1) floor applied to all branches.
+```
+
+**Surprising config (mints fresh sessions, still serial).** The manifest
+default stays `Persistent`, so the cap clamps to 1 regardless of the
+per-trigger `New`:
+
+```toml
+[agents.researcher]
+# session_mode defaults to "persistent"
+max_concurrent_invocations = 4   # clamped to 1 — WARN at first dispatch
+
+[[agents.researcher.triggers]]
+event = "task_posted"
+session_mode = "new"             # isolates each fire, but does NOT lift the cap
+```
+
+**Correct config for real per-trigger parallelism.** Move `New` to the
+**manifest default** so the clamp does not fire and the requested cap
+survives; keep the per-trigger override only where you want a one-off
+deviation:
+
+```toml
+[agents.researcher]
+session_mode = "new"             # manifest default — clamp does not fire
+max_concurrent_invocations = 4   # honored: up to 4 fires run in parallel
+
+[[agents.researcher.triggers]]
+event = "task_posted"
+# inherits manifest "new"; no per-trigger override needed for parallelism
+```
+
+If you genuinely want most fires `Persistent` but one trigger parallel,
+that is **not** expressible today: the per-agent cap is a manifest-wide
+property, and a `Persistent` manifest is hard-capped at 1. Split that
+workload onto a separate agent whose manifest is `New`.
+
+This is intentional, not a bug: a single `Persistent` session has one
+shared message history, and concurrent appends to it are undefined
+(see *Persistent + cap > 1 is auto-clamped* above). The override is a
+session-isolation knob, not a concurrency knob.
+
 ## What honors `session_mode = "new"` for parallelism
 
 | Path | Materializes session_id? | Per-agent cap applies? | Effect on locks |
 |---|---|---|---|
-| Event trigger dispatch (this doc) | yes — `SessionId::new()` per fire | **yes** | per-session mutex; agent cap throttles parallelism |
+| Event trigger dispatch (this doc) | yes — `SessionId::for_trigger_fire` per fire (deterministic v5 UUID since #5604) | **yes** | per-session mutex; agent cap throttles parallelism |
 | Cron with `job.session_mode = New` | yes — `SessionId::for_cron_run(agent, run_key)` | no | deterministic session id; serializes via per-session mutex |
 | `agent_send` | yes (when receiver manifest = New) | no | per-session mutex; not throttled by per-agent cap — see scope note above |
 | Channel messages (Telegram, Slack, …) | no — always `SessionId::for_channel(agent, ch:chat)` | no | per-channel session; serial per chat |

--- a/docs/src/app/agent/workflows/page.mdx
+++ b/docs/src/app/agent/workflows/page.mdx
@@ -506,6 +506,14 @@ When a trigger fires, the engine replaces `{{event}}` in the `prompt_template` w
 
 When `max_fires` is set to a value greater than 0, the trigger automatically disables itself (sets `enabled = false`) once `fire_count >= max_fires`. Setting `max_fires` to 0 means the trigger fires indefinitely.
 
+### Per-Trigger `session_mode` and Concurrency
+
+A trigger may carry a per-trigger `session_mode` override (`"new"` or `"persistent"`) that wins over the agent manifest's default for that trigger's fires. The override controls **session isolation only** — whether each fire gets a fresh `SessionId`.
+
+It does **not** grant parallelism. The per-agent concurrency cap (`max_concurrent_invocations`) is computed from the **manifest** alone and is hard-clamped to 1 when the manifest default `session_mode` is `"persistent"` (concurrent appends to one persistent session's history are undefined). So a trigger with `session_mode = "new"` on a `Persistent`-default agent mints isolated sessions that still run serially. To get real per-trigger parallelism, the **manifest** must set `session_mode = "new"` together with `max_concurrent_invocations > 1`.
+
+See [Trigger dispatch concurrency](https://github.com/librefang/librefang/blob/main/docs/architecture/trigger-dispatch-concurrency.md) (section "Gotcha: per-trigger `session_mode = "new"` does NOT grant parallelism") for the exact resolution order and worked config examples.
+
 ### Trigger Use Cases
 
 **Monitor agent health:**

--- a/docs/src/app/zh/agent/workflows/page.mdx
+++ b/docs/src/app/zh/agent/workflows/page.mdx
@@ -506,6 +506,14 @@ pub struct Trigger {
 
 当 `max_fires` 设置为大于 0 的值时，触发器在 `fire_count >= max_fires` 后会自动禁用（设置 `enabled = false`）。将 `max_fires` 设为 0 表示触发器无限次触发。
 
+### 单触发器 `session_mode` 与并发
+
+触发器可以携带单触发器的 `session_mode` 覆盖（`"new"` 或 `"persistent"`），对该触发器的每次触发，它优先于 Agent manifest 的默认值生效。该覆盖**仅控制会话隔离**——即每次触发是否获得全新的 `SessionId`。
+
+它**不会**带来并发能力。每个 Agent 的并发上限（`max_concurrent_invocations`）仅由 **manifest** 计算得出；当 manifest 默认 `session_mode` 为 `"persistent"` 时，该上限被硬性钳制为 1（对同一持久会话历史的并发追加是未定义行为）。因此在默认 `Persistent` 的 Agent 上，带有 `session_mode = "new"` 的触发器会生成相互隔离的会话，但仍然串行执行。要获得真正的单触发器并发，**manifest** 必须同时设置 `session_mode = "new"` 和 `max_concurrent_invocations > 1`。
+
+精确的解析顺序与配置示例见 [Trigger dispatch concurrency](https://github.com/librefang/librefang/blob/main/docs/architecture/trigger-dispatch-concurrency.md)（"Gotcha: per-trigger `session_mode = "new"` does NOT grant parallelism" 一节）。
+
 ### 触发器使用场景
 
 **监控 Agent 健康状态：**


### PR DESCRIPTION
Docs-only clarification. **Behavior is unchanged** — this picks the keep-as-is option from `docs/issues/session-mode-override-clamped.md`, consistent with `CLAUDE.md` documenting the clamp as intentional. No clamp/concurrency logic was modified.

## What was clarified + where

- **`docs/architecture/trigger-dispatch-concurrency.md`** — new prominent subsection *"Gotcha: per-trigger `session_mode = "new"` does NOT grant parallelism"*:
  - separates the two independent gates: session isolation (effective mode = per-trigger override > manifest) vs the per-agent concurrency cap (manifest-only, sized once on first dispatch);
  - gives the **exact effective per-agent cap resolution order**, explicitly showing the override is absent from it;
  - two worked configs — a *surprising* one (manifest `Persistent` + per-trigger `New` → clamped to 1, mints isolated-but-serial sessions) and a *correct* one (manifest `session_mode = "new"` + `max_concurrent_invocations = 4`);
  - notes the "most fires Persistent, one trigger parallel" case is not expressible today and requires splitting onto a separate agent.
- **`docs/src/app/agent/workflows/page.mdx`** (+ zh mirror `docs/src/app/zh/agent/workflows/page.mdx`) — new "Per-Trigger `session_mode` and Concurrency" subsection under the trigger docs, cross-referencing the architecture doc.

## Accuracy

Statements verified against `origin/main`:
- override site `crates/librefang-kernel/src/kernel/triggers_and_workflow.rs` (`effective_mode = mode_override.unwrap_or(manifest_mode)`; `New → Some(SessionId::new())`);
- clamp `crates/librefang-kernel/src/kernel/accessors.rs` (`agent_concurrency_for` reads manifest `(session_mode, max_concurrent_invocations)`, `Persistent + n>1 → 1` with WARN; `max(1)` floor).

No invented knobs.

## Pin test

None added. The override-cannot-escape-clamp property is structural: `agent_concurrency_for(&self, agent_id)` takes no override parameter. The existing `agent_concurrency_for_is_atomic_under_concurrent_first_callers` test already asserts `persistent + cap=4 → 1 permit`, which pins the documented behavior against drift. A test that drives the full per-trigger dispatch path would belong in `librefang-api/tests/` integration (non-trivial harness); skipped per the issue's "rely on the docs" guidance.

## Verification

Docs-only; no Rust touched, so no `cargo` runs. Markdown code-fence balance checked on all three files (balanced).

## Note for maintainer

The issue offered a "relax" alternative (let a per-trigger `New` override lift the cap). I did **not** implement it — it would make prompt-cache reuse and concurrent-history-append safety harder to reason about, and `CLAUDE.md` records the clamp as intentional. If you prefer the relax path, happy to scope it as a separate change.

Closes #5623