### PR TITLE
chore(deps): replace unmaintained serde_yaml with serde_yaml_ng (RUSTSEC-2024-0320)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4389,7 +4389,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "serial_test",
  "sha2",
  "subtle",
@@ -4525,7 +4525,7 @@ dependencies = [
  "librefang-types",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
@@ -4542,7 +4542,7 @@ dependencies = [
  "librefang-types",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "tempfile",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
@@ -4722,7 +4722,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "serial_test",
  "sha2",
  "tempfile",
@@ -8194,10 +8194,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,8 +194,9 @@ dirs = "6"
 # the OS keyring is genuinely unavailable.
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
-# YAML parsing
-serde_yaml = "0.9"
+# YAML parsing — maintained drop-in fork of the archived serde_yaml (RUSTSEC-2024-0320).
+# Aliased to the `serde_yaml` name so existing `use serde_yaml::...` call sites stay unchanged.
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 
 # JSON5 parsing
 json5 = "1.3.1"


### PR DESCRIPTION
## Advisory

**RUSTSEC-2024-0320** — `serde_yaml` is archived/unmaintained. `Cargo.lock` resolved it to `0.9.34+deprecated`. No `deny.toml` ignore exists, so cargo-deny CI breaks once the advisory DB lists it.

## What changed

- `Cargo.toml` (`[workspace.dependencies]`): `serde_yaml = "0.9"` → `serde_yaml = { package = "serde_yaml_ng", version = "0.10" }`.
- `Cargo.lock` regenerated: `serde_yaml v0.9.34+deprecated` removed, `serde_yaml_ng v0.10.0` added.

**Approach: package alias, no call-site rewrite.** `serde_yaml_ng` is an API-compatible drop-in fork. Aliasing it to the `serde_yaml` name keeps every `use serde_yaml::...` call site in the 4 consumer crates (`librefang-kernel`, `librefang-memory-wiki`, `librefang-migrate`, `librefang-skills`) unchanged — zero source diffs, only the two manifest files.

## cargo tree (before → after)

Before: `serde_yaml v0.9.34+deprecated` (deps: indexmap, itoa, ryu, serde, unsafe-libyaml).

After:
```
$ cargo tree -i serde_yaml      → error: package ID specification `serde_yaml` did not match any packages
$ cargo tree -i serde_yaml_ng   → serde_yaml_ng v0.10.0 ← librefang-kernel, librefang-memory-wiki, librefang-migrate, librefang-skills
```
`grep 'name = "serde_yaml' Cargo.lock` → only `serde_yaml_ng` remains.

`serde_yaml_ng 0.10.0` normal deps are identical to the archived crate (indexmap, itoa, ryu, serde, unsafe-libyaml) — no new transitives.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-memory-wiki -p librefang-migrate -p librefang-skills --lib -- -D warnings` — clean. (kernel lib covered by the workspace check; the only `--all-targets` clippy hits were pre-existing newer-clippy lints in `librefang-api`, untouched here.)
- `cargo test -p librefang-skills` — 201 passed.
- `cargo test -p librefang-memory-wiki` — frontmatter roundtrip / malformed-frontmatter tests passed.
- `cargo test -p librefang-migrate` — `openclaw` legacy-YAML parse + roundtrip tests passed.

## Note on unsafe-libyaml

`serde_yaml_ng` still pulls in `unsafe-libyaml 0.2.11` (same as the archived crate). This PR resolves the **maintenance / RUSTSEC-2024-0320** concern (the crate is now actively maintained); it does not remove `unsafe-libyaml`.

---

**⚠ DEP CHOICE NEEDS MAINTAINER CONFIRMATION: serde_yaml → serde_yaml_ng (v0.10) — alternative is serde_yml; please confirm the fork preference before merge.**

Closes #5625