### PR TITLE
test(api): convert tools integration tests from mock to full router

### DIFF
--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2134,46 +2134,122 @@ async fn test_auth_disabled_when_no_key() {
 // Tool endpoints
 // ---------------------------------------------------------------------------
 
+// These tests run against the **full router** (`start_full_router`) so the
+// `/api/tools` reads flow through the production middleware stack: auth,
+// rate-limit, body-size, and request-logging. The old `start_test_server`
+// mock harness mounted no auth layer at all on `/api/tools`, so the
+// authentication boundary on these endpoints went completely untested
+// (first slice of the mock-router -> full-router migration tracked in
+// docs/issues/integration-tests-mock-router.md). `/api/tools` and
+// `/api/tools/{name}` are NOT in any `PUBLIC_ROUTES_*` allowlist
+// (middleware.rs), so once an api_key is configured an unauthenticated read
+// must be rejected — `test_list_tools_requires_auth` pins that contract,
+// which the mock harness silently allowed through.
+const TOOLS_API_KEY: &str = "tools-cluster-test-key";
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_tools() {
-    let server = start_test_server().await;
-    let client = reqwest::Client::new();
+    let harness = start_full_router(TOOLS_API_KEY).await;
 
-    let resp = client
-        .get(format!("{}/api/tools", server.base_url))
-        .send()
+    let response = harness
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/tools")
+                .header("authorization", format!("Bearer {TOOLS_API_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
-    assert_eq!(resp.status(), 200);
+    assert_eq!(response.status(), StatusCode::OK);
 
-    let body: serde_json::Value = resp.json().await.unwrap();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert!(body["tools"].is_array());
     assert!(body["total"].as_u64().unwrap() > 0);
 }
 
+/// Coverage the mock harness could not provide: `/api/tools` is not in any
+/// public allowlist, so with an api_key configured an unauthenticated read
+/// must be rejected by the auth middleware (401), not served.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_tools_requires_auth() {
+    let harness = start_full_router(TOOLS_API_KEY).await;
+
+    let response = harness
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/tools")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let wrong_token = harness
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/tools")
+                .header("authorization", "Bearer wrong-key")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(wrong_token.status(), StatusCode::UNAUTHORIZED);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_tool_found() {
-    let server = start_test_server().await;
-    let client = reqwest::Client::new();
+    let harness = start_full_router(TOOLS_API_KEY).await;
 
-    // First list tools to get a known tool name
-    let resp = client
-        .get(format!("{}/api/tools", server.base_url))
-        .send()
+    // First list tools to get a known tool name.
+    let list_response = harness
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/tools")
+                .header("authorization", format!("Bearer {TOOLS_API_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
-    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_bytes = axum::body::to_bytes(list_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&list_bytes).unwrap();
     let first_tool_name = body["tools"][0]["name"].as_str().unwrap().to_string();
 
-    // Now fetch that specific tool
-    let resp = client
-        .get(format!("{}/api/tools/{}", server.base_url, first_tool_name))
-        .send()
+    // Now fetch that specific tool.
+    let tool_response = harness
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/tools/{first_tool_name}"))
+                .header("authorization", format!("Bearer {TOOLS_API_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
-    assert_eq!(resp.status(), 200);
-
-    let tool: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(tool_response.status(), StatusCode::OK);
+    let tool_bytes = axum::body::to_bytes(tool_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let tool: serde_json::Value = serde_json::from_slice(&tool_bytes).unwrap();
     assert_eq!(tool["name"].as_str().unwrap(), first_tool_name);
     assert!(tool["description"].is_string());
     assert!(tool["input_schema"].is_object());
@@ -2181,20 +2257,26 @@ async fn test_get_tool_found() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_tool_not_found() {
-    let server = start_test_server().await;
-    let client = reqwest::Client::new();
+    let harness = start_full_router(TOOLS_API_KEY).await;
 
-    let resp = client
-        .get(format!(
-            "{}/api/tools/nonexistent_tool_xyz",
-            server.base_url
-        ))
-        .send()
+    let response = harness
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/tools/nonexistent_tool_xyz")
+                .header("authorization", format!("Bearer {TOOLS_API_KEY}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
-    assert_eq!(resp.status(), 404);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-    let body: serde_json::Value = resp.json().await.unwrap();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert!(body["error"]["message"]
         .as_str()
         .unwrap()


### PR DESCRIPTION
## What

Converts the **tools** integration-test cluster in `crates/librefang-api/tests/api_integration_test.rs` from the mock harness (`start_test_server`) to `start_full_router`, so the tests now flow through the production middleware stack instead of a bare router with no middleware.

Converted:
- `test_list_tools` — `GET /api/tools`
- `test_get_tool_found` — `GET /api/tools` then `GET /api/tools/{name}`
- `test_get_tool_not_found` — `GET /api/tools/{name}` (404 path)

Added:
- `test_list_tools_requires_auth` — asserts `GET /api/tools` returns 401 with no Bearer token and with a wrong token, once an api_key is configured.

## Real-middleware coverage this adds

`start_test_server` mounts no auth layer at all on `/api/tools`. Under `start_full_router` these reads now pass through `middleware::auth`, the GCRA rate limiter, the body-size/JSON-depth guard, and request logging — the same stack a real client hits.

`/api/tools` and `/api/tools/{name}` are **not** in any `PUBLIC_ROUTES_*` allowlist (`middleware.rs`), so with an api_key configured an unauthenticated read must be rejected. The mock harness silently served it; `test_list_tools_requires_auth` now pins the 401 contract (no token + wrong token).

## Bug surfaced

None. The handlers (`tools_sessions::{list_tools,get_tool}`) behave identically under both routers; the gap was purely missing middleware coverage, which the new auth assertion now closes. The conversion confirmed the route is correctly auth-gated (not in the public allowlist).

## Verification

- `cargo check -p librefang-api --tests` — passes
- `cargo check --workspace --lib` — passes (excluding `librefang-desktop`, which needs GTK `gdk-3.0` not present in the local docker build image; unrelated to this test-only change)
- `cargo test -p librefang-api --test api_integration_test -- test_list_tools test_get_tool_found test_get_tool_not_found` — 4 passed, 0 failed; run 3x, deterministic (no fixed sleeps)

Note: `cargo clippy -p librefang-api --all-targets` reports 6 pre-existing lints in unmodified `src/` files (`registry.rs`, `validation.rs`, `webchat.rs`) surfaced by a newer clippy in the local image; none are in the changed test file and none are introduced by this PR.

Closes #5629

## Out-of-scope (follow-up)

The remaining mock-router tests in the same file (agents lifecycle, config reload, workflows, triggers, `mcp_http`, memory, sessions, etc.) are still on `start_test_server` and remain follow-up slices of the migration tracked in `docs/issues/integration-tests-mock-router.md`. This PR intentionally converts the tools cluster only.