### PR TITLE
test(api): convert load_test from mock to full router (exercise real middleware)

### DIFF
--- a/crates/librefang-api/tests/load_test.rs
+++ b/crates/librefang-api/tests/load_test.rs
@@ -3,16 +3,40 @@
 //! Measures throughput under concurrent access: agent spawning, API endpoint
 //! latency, session management, and memory usage.
 //!
+//! These tests drive the **full production router** (`server::build_router`)
+//! over a real TCP socket, so every request crosses the same middleware stack
+//! the daemon serves: auth, GCRA + auth-login rate-limiting, idempotency,
+//! JSON-depth / body-size guards, security headers, and API-version headers.
+//! Previously they used a hand-rolled mock router that bypassed all of those
+//! layers (refs `docs/issues/integration-tests-mock-router.md`).
+//!
+//! ### Rate-limiting under load
+//!
+//! The full router applies real per-IP rate limiting. These tests bind the
+//! server to `127.0.0.1` and inject the peer `SocketAddr` via
+//! `into_make_service_with_connect_info`, exactly as the daemon does. Both the
+//! GCRA limiter and the auth-login limiter exempt loopback callers that send no
+//! forwarding header (`rate_limiter.rs`: "Loopback (127.0.0.0/8 + ::1) bypasses
+//! the limiter"), which is the documented production behavior for a same-host
+//! caller (the dashboard, the CLI, a local agent). The load clients here are
+//! exactly that — plain reqwest calls from loopback with no `X-Forwarded-For` —
+//! so the limiter *runs and evaluates the loopback-bypass branch on every
+//! request* without 429'ing the burst. This preserves each test's
+//! throughput / concurrency intent while still exercising the real middleware
+//! wiring; we deliberately do NOT disable any layer or weaken any assertion.
+//!
+//! Auth is configured open (empty `api_key`); combined with the genuine
+//! loopback peer the auth middleware lets requests through without a bearer
+//! token (`middleware.rs`: empty key + loopback ConnectInfo => pass).
+//!
 //! Run: cargo test -p librefang-api --test load_test -- --nocapture
 
-use axum::Router;
-use librefang_api::middleware;
-use librefang_api::routes;
-use librefang_testing::TestAppState;
+use librefang_kernel::LibreFangKernel;
+use librefang_types::config::{DefaultModelConfig, KernelConfig};
 use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tower_http::cors::CorsLayer;
-use tower_http::trace::TraceLayer;
 
 // ---------------------------------------------------------------------------
 // Race-hardening helpers (#3817)
@@ -65,7 +89,7 @@ where
 
 struct TestServer {
     base_url: String,
-    state: std::sync::Arc<librefang_api::routes::AppState>,
+    state: Arc<librefang_api::routes::AppState>,
     _tmp: tempfile::TempDir,
 }
 
@@ -75,76 +99,75 @@ impl Drop for TestServer {
     }
 }
 
+/// Boot a real kernel, build the **full production router**, and serve it over
+/// a real TCP socket on `127.0.0.1`.
+///
+/// Mirrors `start_full_router` in `api_integration_test.rs` for kernel/config
+/// setup, but unlike that helper (which drives `app.oneshot(...)` in-process)
+/// this one serves the router on an ephemeral port via
+/// `into_make_service_with_connect_info::<SocketAddr>()` — the same call the
+/// daemon uses in `server::serve`. The load tests need a real socket so their
+/// `reqwest` + `tokio::spawn` concurrency exercises genuine HTTP throughput,
+/// and the injected loopback `SocketAddr` is what lets the auth and rate-limit
+/// middleware apply their documented same-host policy (open auth on loopback
+/// with an empty `api_key`; rate-limit bypass for loopback callers that send no
+/// forwarding header). See the module-level doc for the rate-limit rationale.
 async fn start_test_server() -> TestServer {
-    let test = TestAppState::new();
-    test.state.kernel.clone().set_self_handle();
-    let state = test.state.clone();
+    let tmp = tempfile::tempdir().expect("Failed to create temp dir");
 
-    let app = Router::new()
-        .route("/api/health", axum::routing::get(routes::health))
-        .route("/api/status", axum::routing::get(routes::status))
-        .route("/api/version", axum::routing::get(routes::version))
-        .route(
-            "/api/metrics",
-            axum::routing::get(routes::prometheus_metrics),
-        )
-        .route(
-            "/api/agents",
-            axum::routing::get(routes::list_agents).post(routes::spawn_agent),
-        )
-        .route(
-            "/api/agents/{id}",
-            axum::routing::get(routes::get_agent).delete(routes::kill_agent),
-        )
-        .route(
-            "/api/agents/{id}/session",
-            axum::routing::get(routes::get_agent_session),
-        )
-        .route(
-            "/api/agents/{id}/session/reset",
-            axum::routing::post(routes::reset_session),
-        )
-        .route(
-            "/api/agents/{id}/session/reboot",
-            axum::routing::post(routes::reboot_session),
-        )
-        .route(
-            "/api/agents/{id}/sessions",
-            axum::routing::get(routes::list_agent_sessions).post(routes::create_agent_session),
-        )
-        .route("/api/tools", axum::routing::get(routes::list_tools))
-        .route("/api/models", axum::routing::get(routes::list_models))
-        .route("/api/providers", axum::routing::get(routes::list_providers))
-        .route("/api/usage", axum::routing::get(routes::usage_stats))
-        .route(
-            "/api/workflows",
-            axum::routing::get(routes::list_workflows).post(routes::create_workflow),
-        )
-        .route(
-            "/api/workflows/{id}/run",
-            axum::routing::post(routes::run_workflow),
-        )
-        .route("/api/config", axum::routing::get(routes::get_config))
-        .layer(axum::middleware::from_fn(middleware::request_logging))
-        .layer(TraceLayer::new_for_http())
-        .layer(CorsLayer::permissive())
-        .with_state(state.clone());
+    // Populate the model catalog in the temp home so the kernel boots with a
+    // real registry (matches start_full_router in api_integration_test.rs).
+    librefang_kernel::registry_sync::sync_registry(
+        tmp.path(),
+        librefang_kernel::registry_sync::DEFAULT_CACHE_TTL_SECS,
+        "",
+    );
+
+    let config = KernelConfig {
+        home_dir: tmp.path().to_path_buf(),
+        data_dir: tmp.path().join("data"),
+        // Empty api_key => auth is open; combined with the genuine loopback
+        // peer (below) the auth middleware passes requests without a token.
+        api_key: String::new(),
+        default_model: DefaultModelConfig {
+            provider: "ollama".to_string(),
+            model: "test-model".to_string(),
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        },
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+    let kernel = Arc::new(kernel);
+    kernel.set_self_handle();
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("Failed to bind test server");
     let addr = listener.local_addr().unwrap();
 
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
+    let (app, state) = librefang_api::server::build_router(kernel, addr).await;
 
-    let (_state, _tmp, _) = test.into_parts();
+    tokio::spawn(async move {
+        // SECURITY: `into_make_service_with_connect_info` injects the peer
+        // SocketAddr so the auth + rate-limit middleware can recognize the
+        // loopback caller — exactly as `server::serve` does for the daemon.
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
 
     TestServer {
         base_url: format!("http://{}", addr),
         state,
-        _tmp,
+        _tmp: tmp,
     }
 }
 


### PR DESCRIPTION
Closes #5631 (slice of `docs/issues/integration-tests-mock-router.md`).

## What changed

`crates/librefang-api/tests/load_test.rs` previously built a hand-rolled mock `Router` (`start_test_server`) wired with a tiny subset of routes and only `request_logging` + CORS + trace layers, served bare via `axum::serve(listener, app)`. All 7 load tests therefore measured throughput against a router that bypassed the production middleware stack and could silently shadow unregistered routes (the failure mode the parent doc calls out).

This PR rewrites the single helper to boot a **real kernel** and serve the **full production router** (`librefang_api::server::build_router`) over a real TCP socket — the same `into_make_service_with_connect_info::<SocketAddr>()` call the daemon uses in `server::serve`. Every request now crosses the real stack: auth, GCRA + auth-login rate-limiting, idempotency, JSON-depth and body-size guards, security headers, and API-version headers.

- Kernel/config setup mirrors `start_full_router` in `api_integration_test.rs` (temp home, `registry_sync`, ollama default model — no API key, no real LLM calls).
- The `TestServer { base_url, state, _tmp }` struct shape is unchanged, so **all 7 test bodies are untouched** — only the constructor swaps from mock to full router.
- Removed now-unused imports (`axum::Router`, `routes`, `middleware`, `TestAppState`, `CorsLayer`, `TraceLayer`); added `LibreFangKernel`, `KernelConfig`/`DefaultModelConfig`, `SocketAddr`, `Arc`.

## How the rate-limit / middleware interaction is handled (and why)

The full router applies real per-IP rate limiting, which is the crux of converting a *load* test. A naive conversion would 429 the burst-heavy tests (20 concurrent spawns, 50 concurrent reads, 200 sequential metrics hits).

I handled this by binding the test server to `127.0.0.1` and injecting the peer `SocketAddr` via `into_make_service_with_connect_info` — exactly as the daemon does. Both the GCRA limiter and the auth-login limiter **exempt loopback callers that send no forwarding header** (documented production behavior in `rate_limiter.rs`: "Loopback (127.0.0.0/8 + ::1) bypasses the limiter" — the same-host caller threat model, i.e. the dashboard / CLI / a local agent). The load clients here are precisely that: plain `reqwest` calls from loopback with no `X-Forwarded-For`. So the limiter **runs and evaluates its loopback-bypass branch on every request** without throttling the burst.

This is the honest choice required by the doc:
- I did **not** disable any middleware layer.
- I did **not** weaken any assertion (still asserting 50/50 reads, 20/20 spawns, all 200 metrics requests = 200, monotonic registry convergence, etc.).
- I did **not** dodge the point — the full stack is exercised; the bypass I rely on is the real production code path for a same-host caller, not a test-only escape hatch.

Auth is configured open (empty `api_key`); combined with the genuine loopback peer, the auth middleware passes requests without a bearer token (`middleware.rs`: empty key + loopback `ConnectInfo` => pass). This matches how `start_full_router("")` operates in `api_integration_test.rs`.

A module-level doc comment in `load_test.rs` records this rationale for future readers.

Determinism is preserved: the existing `poll_until` convergence helper (no fixed sleeps) is retained for the registry read-after-write assertions.

## Verification

Run with the native stable toolchain (rustc 1.95.0) against this worktree:

- `cargo check -p librefang-api --tests` — clean.
- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-api --all-targets -- -D warnings` — **0 hits in `load_test.rs`**. (Local clippy 1.95.0 flags 6 pre-existing `doc_lazy_continuation` / `manual_pattern_char_comparison` items in untouched `src/` files — `registry.rs`, `validation.rs`, `webchat.rs` — these are newer-clippy noise on `origin/main`, not introduced here; the diff touches only `tests/load_test.rs`.)
- `cargo test -p librefang-api --test load_test` — **7 passed, 0 failed, run 3× consecutively with identical results** (no flakiness, no 429s). Representative output: `Concurrent reads: 50/50`, `Concurrent spawns: 20/20`, `Metrics 200 requests` all 200, all latency p95 < budget.

## Out-of-scope (follow-up under #5631 / the parent doc)

The remaining mock-router tests — chiefly the clusters in `api_integration_test.rs` and other `tests/*.rs` files still on `start_test_server` — are not touched here. They are tracked by `docs/issues/integration-tests-mock-router.md` and being migrated separately.