### PR TITLE
refactor(kernel): return types-owned outcome from install_integration (stop leaking InstallResult)

### DIFF
--- a/crates/librefang-extensions/src/installer.rs
+++ b/crates/librefang-extensions/src/installer.rs
@@ -30,6 +30,28 @@ pub struct InstallResult {
     pub message: String,
 }
 
+/// Bridge the extensions-crate `InstallResult` to the dependency-free
+/// [`librefang_types::integration::IntegrationOutcome`] that the kernel's
+/// HTTP-layer `install_integration` façade now returns on its `Ok` side.
+/// Keeping the conversion here lets the real kernel impl `.map(Into::into)`
+/// cleanly while reimplementers of the trait (mocks, alternate kernels)
+/// construct `IntegrationOutcome` directly without ever touching this crate.
+///
+/// The mapping is field-for-field — all field types already live in
+/// `librefang-types` — so the success payload the API layer reads (`server`,
+/// `id`, …) is unchanged.
+impl From<InstallResult> for librefang_types::integration::IntegrationOutcome {
+    fn from(result: InstallResult) -> Self {
+        librefang_types::integration::IntegrationOutcome {
+            id: result.id,
+            server: result.server,
+            status: result.status,
+            missing_credentials: result.missing_credentials,
+            message: result.message,
+        }
+    }
+}
+
 /// Resolve a catalog entry + provided credentials into a new
 /// `McpServerConfigEntry`.
 ///

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -175,14 +175,14 @@ pub trait KernelApi: KernelHandle + Send + Sync {
     // exposes the high-level installer; the underlying `vault_handle` stays
     // an inherent method to keep the trait surface small.
     //
-    // The error half is `librefang_types::integration::IntegrationError` (not
-    // the extensions-crate `ExtensionResult`) so a mock / alternate kernel can
-    // implement this trait without depending on `librefang-extensions`. The
-    // real kernel impl converts via the `From<ExtensionError>` bridge defined
-    // in that crate. The success type still references
-    // `librefang_extensions::installer::InstallResult` — eliminating that
-    // remaining leak is part of the broader kernel-depends-on-extensions
-    // refactor, tracked separately.
+    // Both halves of the return type are `librefang-types`-owned
+    // (`IntegrationOutcome` / `IntegrationError`), not the extensions-crate
+    // `InstallResult` / `ExtensionResult`, so a mock / alternate kernel can
+    // implement this trait without depending on `librefang-extensions` at all.
+    // The real kernel impl converts via the `From<InstallResult>` /
+    // `From<ExtensionError>` bridges defined in that crate. The remaining
+    // extension-typed surfaces on other `KernelApi` methods are tracked under
+    // the broader kernel-depends-on-extensions refactor.
     // ====================================================================
 
     fn install_integration(
@@ -190,7 +190,7 @@ pub trait KernelApi: KernelHandle + Send + Sync {
         template_id: &str,
         provided_keys: &std::collections::HashMap<String, String>,
     ) -> Result<
-        librefang_extensions::installer::InstallResult,
+        librefang_types::integration::IntegrationOutcome,
         librefang_types::integration::IntegrationError,
     >;
 
@@ -874,14 +874,17 @@ impl KernelApi for LibreFangKernel {
         template_id: &str,
         provided_keys: &std::collections::HashMap<String, String>,
     ) -> Result<
-        librefang_extensions::installer::InstallResult,
+        librefang_types::integration::IntegrationOutcome,
         librefang_types::integration::IntegrationError,
     > {
-        // The inherent method keeps returning `ExtensionResult`; convert its
-        // error into the dependency-free `IntegrationError` at the trait
-        // boundary via the `From<ExtensionError>` bridge in
+        // The inherent method keeps returning the extensions-crate
+        // `ExtensionResult<InstallResult>`; convert both halves to the
+        // dependency-free `librefang-types` types at the trait boundary via the
+        // `From<InstallResult>` / `From<ExtensionError>` bridges in
         // `librefang-extensions`.
-        Self::install_integration(self, template_id, provided_keys).map_err(Into::into)
+        Self::install_integration(self, template_id, provided_keys)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     // -- Inbox / auto-dream --

--- a/crates/librefang-types/src/integration.rs
+++ b/crates/librefang-types/src/integration.rs
@@ -1,19 +1,54 @@
-//! Error type for the MCP-integration install façade.
+//! Outcome and error types for the MCP-integration install façade.
 //!
 //! `KernelApi::install_integration` (the HTTP-layer trait surface in
-//! `librefang-kernel`) used to return `librefang_extensions::ExtensionResult`,
+//! `librefang-kernel`) used to return
+//! `librefang_extensions::ExtensionResult<librefang_extensions::installer::InstallResult>`,
 //! which forced every reimplementer of the trait — mocks, alternate kernels —
 //! to depend on `librefang-extensions` even when they had no other reason to.
-//! `IntegrationError` lives here, in the dependency-free types crate, so the
-//! trait can speak a shared error vocabulary while the concrete kernel impl
-//! keeps converting from its internal `ExtensionError` via `From` (the
-//! conversion impl lives in `librefang-extensions`).
+//! `IntegrationError` (the error half, #5622) and `IntegrationOutcome` (the
+//! success half) both live here, in the dependency-free types crate, so the
+//! trait can speak a shared vocabulary while the concrete kernel impl keeps
+//! converting from its internal `ExtensionError` / `InstallResult` via `From`
+//! (the conversion impls live in `librefang-extensions`).
 //!
 //! The variants intentionally preserve the discriminants the API layer maps
 //! to HTTP status codes (`NotFound` → 404; everything else → 500), so the
 //! switch from `ExtensionError` does not silently change response shapes.
 
+use crate::config::McpServerConfigEntry;
+use crate::mcp::McpStatus;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+/// Success outcome of the kernel's MCP-integration install façade.
+///
+/// `KernelApi::install_integration` used to return
+/// `librefang_extensions::installer::InstallResult` on the `Ok` side, which —
+/// like the error half before #5622 — forced every reimplementer of the trait
+/// (mocks, alternate kernels) to depend on `librefang-extensions` even when
+/// they need nothing else from it. `IntegrationOutcome` lives here, in the
+/// dependency-free types crate, and mirrors `InstallResult`'s public fields
+/// one-for-one. The concrete kernel impl converts via the
+/// `From<InstallResult>` bridge defined in `librefang-extensions`;
+/// reimplementers that don't depend on that crate construct this struct
+/// directly.
+///
+/// All field types (`McpServerConfigEntry`, `McpStatus`) already live in
+/// `librefang-types`, so this introduces no new dependency on the extensions
+/// crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IntegrationOutcome {
+    /// MCP server id (matches `McpServerConfigEntry.name`).
+    pub id: String,
+    /// The `[[mcp_servers]]` entry the caller should persist into config.toml.
+    pub server: McpServerConfigEntry,
+    /// Final status of the installed integration.
+    pub status: McpStatus,
+    /// Names of required env vars that still have no credential.
+    pub missing_credentials: Vec<String>,
+    /// Message to display to the user.
+    pub message: String,
+}
 
 /// Failure surfaced by the kernel's MCP-integration install façade.
 ///
@@ -98,5 +133,55 @@ mod tests {
         let err = mock_install("does-not-exist").unwrap_err();
         // The discriminant the API layer maps to HTTP 404 survives.
         assert!(matches!(err, IntegrationError::NotFound(ref s) if s == "does-not-exist"));
+    }
+
+    /// Acceptance for the success-type refactor: a reimplementer of the
+    /// kernel's `install_integration` façade can construct the full success
+    /// outcome — including the fields the API handler reads (`server`, `id`) —
+    /// using only `librefang-types`, with no `librefang-extensions`
+    /// dependency. This crate has no dependency on `librefang-extensions`, so
+    /// the fact that this test compiles and runs *is* the proof.
+    #[test]
+    fn outcome_is_constructible_without_extensions_crate() {
+        use crate::config::{McpServerConfigEntry, McpTransportEntry};
+        use crate::mcp::McpStatus;
+
+        // Stand in for a mock kernel's install path returning the typed
+        // success outcome.
+        fn mock_install(template_id: &str) -> IntegrationResult<IntegrationOutcome> {
+            if template_id != "github" {
+                return Err(IntegrationError::NotFound(template_id.to_string()));
+            }
+            let server = McpServerConfigEntry {
+                name: template_id.to_string(),
+                template_id: Some(template_id.to_string()),
+                transport: Some(McpTransportEntry::Stdio {
+                    command: "github-mcp".to_string(),
+                    args: vec![],
+                }),
+                timeout_secs: 30,
+                env: vec![],
+                headers: vec![],
+                oauth: None,
+                taint_scanning: true,
+                taint_policy: None,
+            };
+            Ok(IntegrationOutcome {
+                id: template_id.to_string(),
+                server,
+                status: McpStatus::Ready,
+                missing_credentials: vec![],
+                message: "github added.".to_string(),
+            })
+        }
+
+        let outcome = mock_install("github").expect("install should succeed");
+        // The two fields the API handler reads off the success outcome.
+        assert_eq!(outcome.id, "github");
+        assert_eq!(outcome.server.name, "github");
+        assert_eq!(outcome.status, McpStatus::Ready);
+        assert!(outcome.missing_credentials.is_empty());
+
+        assert!(mock_install("nope").is_err());
     }
 }


### PR DESCRIPTION
Closes #5643.

## Problem

`KernelApi::install_integration` returned `librefang_extensions::installer::InstallResult` on its `Ok` side, forcing every reimplementer of the HTTP-layer trait (mocks, alternate kernels) to depend on `librefang-extensions` for the success type even when they need nothing else from it. #5622 fixed the **error** half (`IntegrationError`) but explicitly left the success half leaking. This PR completes `install_integration`'s signature decoupling.

## Changes

- **New `IntegrationOutcome` in `librefang-types`** (`crates/librefang-types/src/integration.rs`) mirroring `InstallResult`'s public fields one-for-one (`id`, `server`, `status`, `missing_credentials`, `message`). All field types (`McpServerConfigEntry`, `McpStatus`) already live in `librefang-types` — **no new dependency**. Derives `Debug, Clone, Serialize, Deserialize` to match the neighboring `config`/`mcp` types.
- **Trait + impl updated** (`crates/librefang-kernel/src/kernel_api.rs`): `KernelApi::install_integration` decl and the `LibreFangKernel` impl now return `Result<IntegrationOutcome, IntegrationError>`. The impl converts both halves at the boundary via `.map(Into::into).map_err(Into::into)`. The inherent `Kernel::install_integration` method keeps returning `ExtensionResult<InstallResult>` (internal — unchanged).
- **`From` conversion in `librefang-extensions`** (`crates/librefang-extensions/src/installer.rs`): `impl From<InstallResult> for IntegrationOutcome`, field-for-field.
- **API handlers unchanged** (`crates/librefang-api/src/routes/skills.rs`): both callers only read `result.server` / `result.id`, which are identical on `IntegrationOutcome`, so the **HTTP response shape is byte-identical**. (Confirmed: zero diff to `librefang-api`.)

## Acceptance / tests

- `librefang-types`: new `outcome_is_constructible_without_extensions_crate` test constructs the full success outcome (incl. the `server`/`id` fields the API handler reads) using only `librefang-types`, which has no `librefang-extensions` dependency — the cross-crate proof. Existing `IntegrationError` tests still pass.
- `librefang-extensions`: existing installer tests pass (5/5); the new `From<InstallResult>` impl compiles and is exercised by the kernel impl.
- `librefang-kernel`: existing lib test `install_integration_writes_through_cached_vault_handle` passes (exercises the inherent method + the trait conversion seam).

## Verification

- `cargo check -p librefang-types`, `cargo check -p librefang-kernel`, `cargo check --workspace --lib --exclude librefang-desktop` (desktop excluded — build image lacks GTK; that crate is untouched).
- `cargo clippy` clean on `librefang-types`, `librefang-kernel` (`--lib`), `librefang-extensions` (`--lib`). The only `--all-targets` clippy failures were pre-existing image-clippy-1.95 lints in `librefang-api` (`validation.rs`/`webchat.rs`) pulled in as a dev-dep — identical on `origin/main`, and this PR makes **zero** changes to `librefang-api`.
- `cargo test -p librefang-types integration` (3/3), `cargo test -p librefang-kernel --lib install_integration` (1/1), `cargo test -p librefang-extensions --lib installer::` (5/5). `librefang-api` lib tests compile against the new type.

## Out of scope

The broader kernel↔extensions decoupling (the remaining extension-typed surfaces on other `KernelApi` methods, and removing the `librefang-extensions` entry from the kernel's `Cargo.toml`) remains tracked under the umbrella roadmap in `docs/issues/kernel-depends-on-extensions.md`. This PR completes only `install_integration`'s signature.