### PR TITLE
fix(kernel/config): external_auth IdP change is hot-reload, not restart (restore main)

### DIFF
--- a/crates/librefang-kernel/src/config_reload.rs
+++ b/crates/librefang-kernel/src/config_reload.rs
@@ -691,8 +691,16 @@ pub fn build_reload_plan_with_caps(
             old.max_concurrent_bg_llm != new.max_concurrent_bg_llm,
             "max_concurrent_bg_llm",
         );
+        // external_auth IdP-identity changes (enabled / issuer_url / per-provider
+        // issuer+jwks) are hot-reloaded above via `ReloadExternalAuth` (#5594) —
+        // they evict the JWKS/discovery caches without a restart. Only a NON-IdP
+        // external_auth change (e.g. session_ttl, allowed_domains, scopes) has no
+        // hot path wired, so it still requires a restart. Without this guard the
+        // backfill double-classified IdP changes as both hot AND restart, which
+        // regressed `test_external_auth_issuer_url_change_evicts_oauth_caches`.
         restart_if_changed(
-            field_changed(&old.external_auth, &new.external_auth),
+            field_changed(&old.external_auth, &new.external_auth)
+                && !external_auth_idp_changed(&old.external_auth, &new.external_auth),
             "external_auth",
         );
         restart_if_changed(


### PR DESCRIPTION
## Restores main (red since ~15:31)

`test_external_auth_issuer_url_change_evicts_oauth_caches` is failing on **Unit + macOS + Windows** — a green-in-isolation / broken-in-aggregate regression:

- **#5594** routes external_auth IdP-identity changes (enabled / issuer_url / per-provider issuer+jwks) to a HOT action (`ReloadExternalAuth`) that evicts the stale JWKS + OIDC-discovery caches — **no restart**.
- **#5619** (reload-classification backfill) then unconditionally classified *any* `external_auth` change as `restart_required`. So an IdP change set BOTH a hot action AND `restart_required = true`, violating #5594's contract (the test asserts `!restart_required`).

Each PR was green on its own base; the conflict only surfaced once both were on main.

## Fix

Gate the backfill's restart on a **non-IdP** change:
```rust
field_changed(&old.external_auth, &new.external_auth)
    && !external_auth_idp_changed(&old.external_auth, &new.external_auth)
```
IdP changes stay hot (cache eviction, no restart); other external_auth sub-fields (session_ttl, allowed_domains, scopes, …) keep the conservative restart since no hot path is wired for them.

## Verification

In-container (rust:latest + libdbus): `cargo test -p librefang-kernel --lib config_reload::tests` → **40 passed, 0 failed**, including the previously-failing test and the #5619 reload-classification completeness guard.

## Not in scope

The Windows/macOS-only intermittent failures seen in the same run (`scheduler::…record_tool_calls_evicts_stale…`, `registry_content_path_is_relative_not_absolute`, `test_migrate_scan_rejects_path_outside_home`, `test_run_migrate_rejects_source_dir_outside_home`) all **pass on Linux** here and were green on main at 15:30 with the same code — they are pre-existing platform-brittle/flaky tests (e.g. `/etc` not canonicalizing on Windows changes the rejection *message*, not the 400), not this aggregation regression. Flagged for separate attention rather than masked.