### PR TITLE
fix(api): clear clippy Quality lane (needless borrow, doc indentation, manual char comparison, await-holding-lock)

### DIFF
--- a/crates/librefang-api/src/oauth.rs
+++ b/crates/librefang-api/src/oauth.rs
@@ -2463,6 +2463,11 @@ mod tests {
 
     static OAUTH_CACHE_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    // The `OAUTH_CACHE_TEST_MUTEX` guard is deliberately held across the
+    // `.await`s below: it serializes these cases against the process-global
+    // caches, so it must stay locked for the whole test body, awaits
+    // included.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn test_invalidate_oauth_caches_clears_jwks_entries() {
         let _g = OAUTH_CACHE_TEST_MUTEX
@@ -2511,6 +2516,8 @@ mod tests {
         );
     }
 
+    // Guard held across awaits on purpose — see the JWKS test above.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn test_invalidate_oauth_caches_clears_discovery_entries() {
         let _g = OAUTH_CACHE_TEST_MUTEX
@@ -2554,6 +2561,8 @@ mod tests {
         );
     }
 
+    // Guard held across awaits on purpose — see the JWKS test above.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn test_invalidate_oauth_caches_is_idempotent_on_empty() {
         let _g = OAUTH_CACHE_TEST_MUTEX

--- a/crates/librefang-api/src/routes/registry.rs
+++ b/crates/librefang-api/src/routes/registry.rs
@@ -284,7 +284,7 @@ async fn create_registry_content(
     // fails — defensive only; `target` is constructed from `home_dir`
     // above so the prefix should always match.
     let relative_path = target
-        .strip_prefix(&home_dir)
+        .strip_prefix(home_dir)
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|_| {
             std::path::PathBuf::from(target.file_name().unwrap_or(target.as_os_str()))

--- a/crates/librefang-api/src/validation.rs
+++ b/crates/librefang-api/src/validation.rs
@@ -465,10 +465,10 @@ fn canonicalize_nonexistent(input: &std::path::Path) -> std::io::Result<std::pat
 /// provider is not in the catalog, then write that env var into the
 /// live `std::env` and persist it to `secrets.env`. Without a charset
 /// + length cap an Admin can plant arbitrary process-wide env vars
-/// (`STRIPE_API_KEY`, `AWS_SECRET_ACCESS_KEY`, …) — silently
-/// re-targeting any third-party crate that reads them — or submit
-/// `name = "a".repeat(1_000_000)` to plant a 1 MB env var. See
-/// `docs/issues/set-provider-key-arbitrary-names.md`.
+///   (`STRIPE_API_KEY`, `AWS_SECRET_ACCESS_KEY`, …) — silently
+///   re-targeting any third-party crate that reads them — or submit
+///   `name = "a".repeat(1_000_000)` to plant a 1 MB env var. See
+///   `docs/issues/set-provider-key-arbitrary-names.md`.
 pub fn check_provider_name_shape(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("provider name must not be empty".to_string());

--- a/crates/librefang-api/src/webchat.rs
+++ b/crates/librefang-api/src/webchat.rs
@@ -274,7 +274,7 @@ fn is_safe_asset_path(path: &str) -> bool {
     // separator on Windows; on Unix it's a legal filename character but
     // a dashboard asset would never legitimately contain one.
     let mut saw_segment = false;
-    for seg in path.split(|c| c == '/' || c == '\\') {
+    for seg in path.split(['/', '\\']) {
         if seg.is_empty() {
             // Empty segments come from leading/trailing/repeated separators;
             // they're benign in URLs ("/a//b" canonicalizes to "/a/b") but


### PR DESCRIPTION
## What

Restores `main`: the CI **Quality** lane (`cargo clippy --all-targets --all-features -- -D warnings`, stable toolchain) was RED on `main` and every open PR. `librefang-api` failed to compile under `-D warnings`. This clears every clippy error the lane hits in `librefang-api`.

Toolchain targeted: stable Rust **1.95.0** / clippy **0.1.95** (matches CI's `rust-toolchain.toml` `channel = "stable"` + `dtolnay/rust-toolchain@stable` in `.github/workflows/ci.yml` quality job).

## Lints fixed

- **`routes/registry.rs:287`** — `needless_borrows_for_generic_args`: `strip_prefix(&home_dir)` → `strip_prefix(home_dir)`. `home_dir` is `&Path` (from `KernelHandle::home_dir()`), which already impls `AsRef<Path>`; it's `Copy`, and this is its last use in the fn, so dropping the `&` is behavior-preserving.
- **`validation.rs:468-471`** (×4) — `doc_lazy_continuation`: the preceding doc line ends with a `+` that markdown reads as a list bullet, so the four wrapped continuation lines were flagged as un-indented list continuations. Indented them 2 spaces per clippy's own suggestion. Prose unchanged.
- **`webchat.rs:277`** — `manual_pattern_char_comparison`: `split(\|c\| c == '/' \|\| c == '\\')` → `split(['/', '\\'])`. Same split behavior.
- **`oauth.rs`** (×3) — `await_holding_lock`: the three `invalidate_oauth_caches` `#[tokio::test]`s hold `OAUTH_CACHE_TEST_MUTEX` across `.await`s **on purpose** — it serializes them against the process-global JWKS / discovery caches, so the guard must live for the whole test body. Annotated each with `#[allow(clippy::await_holding_lock)]` and a comment explaining why. (Landed on main via #5594; blocks the same lane, so fixed here rather than punted.)

All changes are behavior-preserving lint fixes only — no logic touched.

## Verification

- `cargo clippy -p librefang-api --all-targets --all-features -- -D warnings` — clean (`Finished`, 0 errors/warnings), run serially to rule out the unrelated parallel-build `E0463` rlib race.
- `cargo check -p librefang-api` — clean.
- `rustfmt --check --edition 2021` on all 4 changed files — clean (pre-commit hook also passed).

## Out-of-scope

None deferred. The oauth.rs errors were in a different PR's code but block the identical lane, so they're fixed here too.

Closes #5653