### PR TITLE
fix(audit): downgrade boot integrity-check failure to WARN

### DIFF
--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -470,11 +470,18 @@ impl AuditLog {
             chain_anchor: Mutex::new(recovered_anchor),
         };
 
-        // Verify chain integrity on load
+        // Verify chain integrity on load. Logged at WARN: the message itself
+        // recommends `audit-reset` for the dev case and the loaded chain
+        // remains queryable, so this is an alert-worthy condition for
+        // compliance operators (who keep a custom WARN→pager rule) but
+        // not a daemon error in the dev / single-laptop case where this
+        // path fires routinely after every untracked restart. Keeping it
+        // at ERROR (the original level) made `grep ERROR daemon.log`
+        // useless on dev hosts (#5478).
         if count > 0 {
             if let Err(e) = log.verify_integrity() {
-                tracing::error!(
-                    "Audit trail integrity check FAILED on boot: {e}. \
+                tracing::warn!(
+                    "Audit trail integrity check failed on boot: {e}. \
                      Run `librefang security verify` to inspect; if you accept the \
                      loss of pre-break forensic value (typical in dev), \
                      `librefang security audit-reset` truncates the chain and \


### PR DESCRIPTION
## Summary

- Downgrade the audit-trail integrity-check failure on boot from `ERROR` → `WARN` in `crates/librefang-runtime-audit/src/lib.rs:475`.

The original message text already framed `audit-reset` as "typical in dev"; on a single-laptop dev host the path fires routinely after every untracked restart, drowning `grep ERROR daemon.log` in benign noise. Compliance operators who do want a pager on this still get it via a custom WARN→pager rule.

## What this does NOT do

- The boot path was only one log-call deep (`with_db_anchored` → `verify_integrity` → one `tracing::error!`), so no de-dup work was needed at that site. If the reporter is still seeing N ≈ 6 lines per boot it is downstream (different log-target fan-out, e.g. stderr + ndjson + file rotation) and out of scope for this PR.
- Did not add a `[audit] strict_chain_check` config flag (issue's suggestion 3) or dev-mode auto-reset (suggestion 4). Both are deferrable; the severity downgrade is enough to unbreak `grep ERROR` on dev hosts and is the smallest fix that matches what the message already recommends.

## Verification

```
cargo check -p librefang-runtime-audit  →  ok
```

No tests grep the literal "FAILED" verb (`grep -rn 'integrity check FAILED' crates/ --include='*.rs'` → empty).

Closes #5478.
