### PR TITLE
refactor(api): widen ApiErrorResponse::internal_scrub sweep across routes

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -7240,8 +7240,7 @@ mod tests {
         };
         let session_override = Some(SessionId::new());
 
-        let (sender_ctx, incognito, sid) =
-            build_streaming_kernel_args(&req, session_override.clone());
+        let (sender_ctx, incognito, sid) = build_streaming_kernel_args(&req, session_override);
 
         // sender_context: every field that influences resolver behaviour
         // must flow through.

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -2563,7 +2563,7 @@ pub async fn kill_agent(
                 );
             }
             tracing::warn!("kill_agent failed for {id}: {e}");
-            ApiErrorResponse::internal(format!("Failed to kill agent {id}: {e}"))
+            ApiErrorResponse::internal_scrub(e)
                 .with_code("agent_kill_failed")
                 .into_response()
         }

--- a/crates/librefang-api/src/routes/budget.rs
+++ b/crates/librefang-api/src/routes/budget.rs
@@ -987,8 +987,7 @@ pub async fn user_budget_ranking(
     let ranking = match usage_store.query_user_ranking(Some(limit)) {
         Ok(r) => r,
         Err(e) => {
-            return ApiErrorResponse::internal(format!("Failed to query user spend: {e}"))
-                .into_response();
+            return ApiErrorResponse::internal_scrub(e).into_response();
         }
     };
 

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -784,10 +784,8 @@ pub async fn configure_sidecar_channel(
                 continue;
             }
             if f.field_type == "secret" {
-                super::secrets_env::upsert_secret(&secrets_path, &f.key, trimmed).map_err(|e| {
-                    ApiErrorResponse::internal(format!("failed to write secret: {e}"))
-                        .into_json_tuple()
-                })?;
+                super::secrets_env::upsert_secret(&secrets_path, &f.key, trimmed)
+                    .map_err(|e| ApiErrorResponse::internal_scrub(e).into_json_tuple())?;
             } else {
                 nonsecret_env.insert(f.key.clone(), trimmed.to_string());
             }
@@ -819,19 +817,18 @@ pub async fn configure_sidecar_channel(
             &nonsecret_env,
             &managed_env_keys,
         )
-        .map_err(|e| {
-            ApiErrorResponse::internal(format!("failed to write config.toml: {e}"))
-                .into_json_tuple()
-        })?;
+        .map_err(|e| ApiErrorResponse::internal_scrub(e).into_json_tuple())?;
     }
 
     // 6. Trigger hot-reload. The kernel diffs the on-disk config
     //    against the live snapshot and returns the resulting plan;
     //    the dashboard surfaces `restart_required` so the operator
     //    knows whether further action is needed.
-    let plan = state.kernel.reload_config().await.map_err(|e| {
-        ApiErrorResponse::internal(format!("config reload failed: {e}")).into_json_tuple()
-    })?;
+    let plan = state
+        .kernel
+        .reload_config()
+        .await
+        .map_err(|e| ApiErrorResponse::internal_scrub(e).into_json_tuple())?;
 
     // 7. When the plan emits `ReloadChannels`, the kernel has already
     //    cleared `mesh.channel_adapters` — but the supervisor map is

--- a/crates/librefang-api/src/routes/config.rs
+++ b/crates/librefang-api/src/routes/config.rs
@@ -1942,7 +1942,7 @@ pub async fn run_migrate(
                 })),
             )
         }
-        Err(e) => ApiErrorResponse::internal(format!("Migration failed: {e}")).into_json_tuple(),
+        Err(e) => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
     }
 }
 

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -90,7 +90,7 @@ pub async fn get_goal(
         Ok(_) => ApiErrorResponse::not_found(format!("Goal '{}' not found", id)).into_json_tuple(),
         Err(e) => {
             tracing::warn!("Failed to load goals: {e}");
-            ApiErrorResponse::internal(format!("Failed to load goals: {e}")).into_json_tuple()
+            ApiErrorResponse::internal_scrub(e).into_json_tuple()
         }
     }
 }
@@ -218,7 +218,7 @@ pub async fn create_goal(
             }
         }
         tracing::warn!("Failed to save goal: {e}");
-        return ApiErrorResponse::internal(format!("Failed to save goal: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     (StatusCode::CREATED, Json(entry))
@@ -386,8 +386,7 @@ pub async fn update_goal_by_id(
                 .into_json_tuple();
         }
         Err(e) => {
-            return ApiErrorResponse::internal(format!("Failed to update goal: {e}"))
-                .into_json_tuple();
+            return ApiErrorResponse::internal_scrub(e).into_json_tuple();
         }
     };
 
@@ -457,7 +456,7 @@ pub async fn delete_goal(
                     .into_response();
             }
         }
-        return ApiErrorResponse::internal(format!("Failed to delete goal: {e}"))
+        return ApiErrorResponse::internal_scrub(e)
             .into_json_tuple()
             .into_response();
     }

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -443,8 +443,7 @@ pub async fn auth_start(
     }
     if let Err(e) = store("pkce_state", &pkce_state) {
         tracing::error!(error = %e, "Failed to store PKCE state in vault");
-        return ApiErrorResponse::internal(format!("Failed to store auth state: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
     if let Err(e) = store("token_endpoint", &metadata.token_endpoint) {
         tracing::warn!(error = %e, "Failed to store token_endpoint in vault");

--- a/crates/librefang-api/src/routes/media.rs
+++ b/crates/librefang-api/src/routes/media.rs
@@ -227,7 +227,7 @@ pub async fn synthesize_speech(
             "sample_rate": result.sample_rate,
         }))
         .into_response(),
-        Err(e) => ApiErrorResponse::internal(format!("Failed to save audio: {e}")).into_response(),
+        Err(e) => ApiErrorResponse::internal_scrub(e).into_response(),
     }
 }
 
@@ -370,7 +370,7 @@ pub async fn generate_music(
             "sample_rate": result.sample_rate,
         }))
         .into_response(),
-        Err(e) => ApiErrorResponse::internal(format!("Failed to save audio: {e}")).into_response(),
+        Err(e) => ApiErrorResponse::internal_scrub(e).into_response(),
     }
 }
 
@@ -421,13 +421,12 @@ pub async fn transcribe_audio(
         .channels
         .effective_file_download_dir();
     if let Err(e) = std::fs::create_dir_all(&upload_dir) {
-        return ApiErrorResponse::internal(format!("Failed to create upload dir: {e}"))
-            .into_response();
+        return ApiErrorResponse::internal_scrub(e).into_response();
     }
     let file_id = uuid::Uuid::new_v4().to_string();
     let file_path = upload_dir.join(&file_id);
     if let Err(e) = std::fs::write(&file_path, &body) {
-        return ApiErrorResponse::internal(format!("Failed to write audio: {e}")).into_response();
+        return ApiErrorResponse::internal_scrub(e).into_response();
     }
 
     let attachment = librefang_types::media::MediaAttachment {
@@ -452,7 +451,7 @@ pub async fn transcribe_audio(
         }
         Err(e) => {
             let _ = std::fs::remove_file(&file_path);
-            ApiErrorResponse::internal(format!("Transcription failed: {e}")).into_response()
+            ApiErrorResponse::internal_scrub(e).into_response()
         }
     }
 }

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1413,15 +1413,13 @@ pub async fn memory_config_patch(
     let content = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
         Err(e) => {
-            return ApiErrorResponse::internal(format!("Failed to read config: {e}"))
-                .into_json_tuple();
+            return ApiErrorResponse::internal_scrub(e).into_json_tuple();
         }
     };
     let mut table: toml::Value = match toml::from_str(&content) {
         Ok(t) => t,
         Err(e) => {
-            return ApiErrorResponse::internal(format!("Failed to parse config: {e}"))
-                .into_json_tuple();
+            return ApiErrorResponse::internal_scrub(e).into_json_tuple();
         }
     };
 
@@ -1481,8 +1479,7 @@ pub async fn memory_config_patch(
 
     let new_content = toml::to_string_pretty(&table).unwrap_or_default();
     if let Err(e) = std::fs::write(&config_path, &new_content) {
-        return ApiErrorResponse::internal(format!("Failed to write config: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     tracing::info!("Memory config updated via API");

--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -506,7 +506,7 @@ pub async fn a2a_send_task(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(serde_json::to_value(&failed_task).unwrap_or_default()),
                 ),
-                None => ApiErrorResponse::internal(format!("Agent error: {e}")).into_json_tuple(),
+                None => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
             }
         }
     }
@@ -2129,9 +2129,7 @@ pub async fn comms_send(
             }
             (StatusCode::OK, Json(resp))
         }
-        Err(e) => {
-            ApiErrorResponse::internal(format!("Message delivery failed: {e}")).into_json_tuple()
-        }
+        Err(e) => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
     }
 }
 
@@ -2170,7 +2168,7 @@ pub async fn comms_task(
                 "task_id": task_id,
             })),
         ),
-        Err(e) => ApiErrorResponse::internal(format!("Failed to post task: {e}")).into_json_tuple(),
+        Err(e) => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
     }
 }
 

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -416,8 +416,7 @@ pub async fn set_model_overrides(
                     catalog.remove_overrides(&id_for_rollback);
                 }
             });
-        return ApiErrorResponse::internal(format!("Failed to persist overrides: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
     // Return the persisted overrides entity so callers can `setQueryData`
     // without a follow-up GET. (Refs #3832.)
@@ -979,8 +978,7 @@ pub async fn add_custom_model(
         state.kernel.model_catalog_update(&mut move |catalog| {
             catalog.remove_custom_model(&id_for_rollback);
         });
-        return ApiErrorResponse::internal(format!("Failed to persist custom model: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     (
@@ -1030,8 +1028,7 @@ pub async fn remove_custom_model(
                 catalog.add_custom_model(entry.clone());
             });
         }
-        return ApiErrorResponse::internal(format!("Failed to persist custom model: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
@@ -1096,8 +1093,7 @@ pub async fn set_provider_key(
     // Write to secrets.env file
     let secrets_path = state.kernel.home_dir().join("secrets.env");
     if let Err(e) = write_secret_env(&secrets_path, &env_var, &key) {
-        return ApiErrorResponse::internal(format!("Failed to write secrets.env: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     // Set env var in current process so detect_auth picks it up. Serialized
@@ -1319,8 +1315,7 @@ pub async fn delete_provider_key(
     // Remove from secrets.env
     let secrets_path = state.kernel.home_dir().join("secrets.env");
     if let Err(e) = remove_secret_env(&secrets_path, &env_var) {
-        return ApiErrorResponse::internal(format!("Failed to update secrets.env: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     // Remove from process environment. `std::env::remove_var` carries the
@@ -1773,7 +1768,7 @@ pub async fn set_provider_url(
     // Persist to config.toml [provider_urls] section
     let config_path = state.kernel.home_dir().join("config.toml");
     if let Err(e) = upsert_provider_url(&config_path, &name, &base_url) {
-        return ApiErrorResponse::internal(format!("Failed to save config: {e}")).into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
     if let Some(ref pu) = proxy_url {
         if let Err(e) = upsert_provider_proxy_url(&config_path, &name, pu) {

--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -412,8 +412,7 @@ pub async fn install_skill(
         home.join("skills")
     };
     if let Err(e) = std::fs::create_dir_all(&skills_dir) {
-        return ApiErrorResponse::internal(format!("Failed to create skills dir: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     // Install from local registry (~/.librefang/registry/skills/{name}/)
@@ -458,7 +457,7 @@ pub async fn install_skill(
             tracing::warn!("Skill install failed: {e}");
             // Clean up partial copy
             let _ = std::fs::remove_dir_all(&dest);
-            ApiErrorResponse::internal(format!("Install failed: {e}")).into_json_tuple()
+            ApiErrorResponse::internal_scrub(e).into_json_tuple()
         }
     }
 }
@@ -3376,8 +3375,7 @@ pub async fn set_hand_secret(
     // Write to secrets.env
     let secrets_path = state.kernel.home_dir().join("secrets.env");
     if let Err(e) = write_secret_env(&secrets_path, &env_key, &value) {
-        return ApiErrorResponse::internal(format!("Failed to write secret: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     // Set in current process. Serialized through the process-global env
@@ -3822,7 +3820,7 @@ pub async fn hand_send_message(
         }
         Err(e) => {
             tracing::warn!("hand_send_message failed for instance {id}: {e}");
-            ApiErrorResponse::internal(format!("Message delivery failed: {e}")).into_json_tuple()
+            ApiErrorResponse::internal_scrub(e).into_json_tuple()
         }
     }
 }
@@ -3924,9 +3922,7 @@ pub async fn hand_get_session(
             )
         }
         Ok(None) => (StatusCode::OK, Json(serde_json::json!({ "messages": [] }))),
-        Err(e) => {
-            ApiErrorResponse::internal(format!("Failed to load session: {e}")).into_json_tuple()
-        }
+        Err(e) => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
     }
 }
 
@@ -4401,8 +4397,7 @@ pub async fn add_mcp_server(
     // Persist to config.toml
     let config_path = state.kernel.home_dir().join("config.toml");
     if let Err(e) = upsert_mcp_server_config(&config_path, &entry) {
-        return ApiErrorResponse::internal(format!("Failed to write config: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     // Trigger config reload
@@ -5220,8 +5215,7 @@ pub async fn get_supporting_file(
     let content = match std::fs::read_to_string(&canonical) {
         Ok(s) => s,
         Err(e) => {
-            return ApiErrorResponse::internal(format!("Failed to read file: {e}"))
-                .into_json_tuple();
+            return ApiErrorResponse::internal_scrub(e).into_json_tuple();
         }
     };
     let (truncated, body) = if content.len() > MAX_BYTES {
@@ -6184,8 +6178,7 @@ pub async fn uninstall_extension(
 
     let config_path = state.kernel.home_dir().join("config.toml");
     if let Err(e) = remove_mcp_server_config(&config_path, &server_name) {
-        return ApiErrorResponse::internal(format!("Failed to update config: {e}"))
-            .into_json_tuple();
+        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
     // Sync the in-memory config before reload_mcp_servers runs. Otherwise

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -2843,9 +2843,7 @@ pub async fn create_schedule(
             entry["id"] = serde_json::Value::String(job_id.to_string());
             (StatusCode::CREATED, Json(entry))
         }
-        Err(e) => {
-            ApiErrorResponse::internal(format!("Failed to create schedule: {e}")).into_json_tuple()
-        }
+        Err(e) => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
     }
 }
 


### PR DESCRIPTION
## Summary

Sweep the remaining 37 `ApiErrorResponse::internal(format!("...{e}"))` call sites under `crates/librefang-api/src/routes/` to `ApiErrorResponse::internal_scrub(e)` — the migration #5378 explicitly scoped as a follow-up audit item rather than its own diff.

Files touched (12):

| Route | Sites |
|---|---|
| agents.rs | 1 |
| budget.rs | 1 |
| channels.rs | 3 |
| config.rs | 1 |
| goals.rs | 4 |
| mcp_auth.rs | 1 |
| media.rs | 5 |
| memory.rs | 3 |
| network.rs | 3 |
| providers.rs | 6 |
| skills.rs | 8 |
| workflows.rs | 1 |

## Why

Same threat model as #5378 — `rusqlite::Error::to_string()` (the most common `e` source-text in these handlers) leaks SQL internals to clients on the error path: schema fingerprinting via column / constraint names, `UNIQUE constraint failed: <table>.<col>` as a "row exists" enumeration oracle, `database is locked` as a DB-engine signal. `internal_scrub` logs the full error chain server-side at `tracing::error!` (operators retain forensics via journald / Sentry / log aggregator) and returns the static `"Internal server error"` to the client.

## Trade-off

`internal_scrub` drops the human-readable prefix (e.g. `"Failed to load goals"`) from the **server-side log line too** — the full `e.to_string()` is preserved but the prefix is lost. Mirrors the pattern PR #5378 established at `routes/agents.rs:1158` (single-line `internal_scrub(e).into_response()` with a comment block above explaining the leak source). Operators who want richer context per route can wrap with a preceding `tracing::error!(prefix = "...", error = %e)` at the call site without changing the wire response.

## Verification

```
$ rg -n 'ApiErrorResponse::internal\(format!\(.*\{e\}' crates/librefang-api/src/routes/ | wc -l
0

$ cargo check -p librefang-api
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 37s
```

## Out of scope

- Other crates' error helpers (`MemoryRouteError::Internal`, …) — already follow the scrub-on-render shape per PR #5378's reference.
- Sites that use `ApiErrorResponse::internal(...)` without `format!("...{e}")` — those carry static strings, not raw error text, and aren't part of the audit.

Closes #5546.
