### PR TITLE
fix(daemon): bound graceful shutdown so daemon.lock release isn't blocked by a hung phase

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -7240,8 +7240,7 @@ mod tests {
         };
         let session_override = Some(SessionId::new());
 
-        let (sender_ctx, incognito, sid) =
-            build_streaming_kernel_args(&req, session_override.clone());
+        let (sender_ctx, incognito, sid) = build_streaming_kernel_args(&req, session_override);
 
         // sender_context: every field that influences resolver behaviour
         // must flow through.

--- a/crates/librefang-api/src/server.rs
+++ b/crates/librefang-api/src/server.rs
@@ -2175,6 +2175,27 @@ pub async fn run_daemon(
     .with_graceful_shutdown(shutdown_signal(api_shutdown))
     .await?;
 
+    // Once axum has returned (the shutdown signal fired), bound the total
+    // post-shutdown cleanup window with a watchdog. If we are still holding
+    // the daemon.lock after `SHUTDOWN_HARD_DEADLINE`, abort the process so
+    // launchd / systemd / the operator's `librefang restart` script does
+    // not see a half-dead daemon hold the lock while a new one tries to
+    // start (#5477). flock(2) releases on process exit even via abort.
+    const SHUTDOWN_HARD_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+    let _shutdown_watchdog = tokio::spawn(async move {
+        tokio::time::sleep(SHUTDOWN_HARD_DEADLINE).await;
+        tracing::error!(
+            deadline_secs = SHUTDOWN_HARD_DEADLINE.as_secs(),
+            "shutdown cleanup exceeded hard deadline; aborting process to \
+             release daemon.lock and avoid a zombie-vs-respawn race (#5477)"
+        );
+        // `process::abort` is async-signal-safe and skips Drop impls — by
+        // this point the operator has already lost any clean-shutdown
+        // benefit, and holding the lock for another minute is strictly
+        // worse than restarting.
+        std::process::abort();
+    });
+
     // Signal background tasks to exit their loops gracefully, then wait up to
     // 5 seconds for each to finish. Abort any that haven't exited by then so
     // we don't stall shutdown indefinitely.
@@ -2207,10 +2228,23 @@ pub async fn run_daemon(
     // Stop channel bridges. Swap out the bridge atomically so no new readers
     // can acquire it, then unwrap the Arc (we just removed the only strong
     // reference stored in AppState) and call stop().
+    //
+    // Bounded with a 5-second hard timeout (#5477): a hung sidecar
+    // subprocess that does not drain on its shutdown channel must not
+    // hold the whole daemon shutdown open until the outer watchdog
+    // fires. The bridge `stop()` is best-effort cleanup — losing it
+    // means orphan sidecar processes the operator must reap, which is
+    // strictly less bad than a zombie daemon holding daemon.lock.
     {
         let old = state.bridge_manager.swap(std::sync::Arc::new(None));
         if let Ok(Some(ref mut b)) = std::sync::Arc::try_unwrap(old) {
-            b.stop().await;
+            match tokio::time::timeout(std::time::Duration::from_secs(5), b.stop()).await {
+                Ok(()) => {}
+                Err(_) => tracing::warn!(
+                    "channel bridge stop did not finish within 5s; \
+                     continuing shutdown without waiting (#5477)"
+                ),
+            }
         }
     }
 
@@ -2240,10 +2274,16 @@ pub async fn run_daemon(
             tmux_cleanup_path,
             crate::terminal_tmux::DEFAULT_TMUX_SESSION_NAME.to_string(),
         );
-        if let Err(e) = ctrl.kill_session().await {
-            tracing::debug!("tmux session cleanup: {e}");
-        } else {
-            info!("tmux session cleaned up");
+        // 5s bound (#5477): `tmux kill-session` over a socket can stall
+        // if the tmux daemon itself is wedged. Don't let that hold up
+        // daemon.lock release.
+        match tokio::time::timeout(std::time::Duration::from_secs(5), ctrl.kill_session()).await {
+            Ok(Ok(())) => info!("tmux session cleaned up"),
+            Ok(Err(e)) => tracing::debug!("tmux session cleanup: {e}"),
+            Err(_) => tracing::warn!(
+                "tmux session cleanup did not finish within 5s; \
+                 skipping (#5477)"
+            ),
         }
     }
 


### PR DESCRIPTION
## Summary

Bound the three previously-unbounded `.await` phases in `start_api_server`'s shutdown path so a hung sidecar / wedged tmux socket / stalled task cannot keep the process holding `~/.librefang/daemon.lock` past launchd's `KeepAlive` respawn window (#5477).

| Phase | Old | New |
|---|---|---|
| Outer cleanup | unbounded | **30s watchdog → `std::process::abort()`** |
| `bridge_manager.stop()` | unbounded | **5s `tokio::time::timeout`, WARN on miss** |
| `tmux kill-session` | unbounded | **5s `tokio::time::timeout`, WARN on miss** |
| Background tasks | 5s per-task abort | unchanged (already correct) |

flock(2) releases on *any* process exit including `abort`, so the watchdog firing yields the lock immediately and launchd respawns into a free file — exactly the failure mode the reporter was hitting (`pgrep -fl 'librefang start' | wc -l` returning 2).

## What this does NOT do

- Does not refactor the kernel-internal cleanup (`kernel.shutdown()`, `observability_guard.take()` Drop) — those run synchronously and don't have a known hang path today. If a future regression surfaces, the outer watchdog still catches it before the lock window closes.
- Does not change the SIGTERM dispatch shape (`shutdown_signal` selector at line 2782). The reporter's "~30-40% of the time" rate is consistent with a downstream hang, not a signal-handler bug.
- Does not de-anchor `launchd KeepAlive` from the `--foreground` mode; that's the operator's plist concern.

## Trade-off accepted

Hard `process::abort` skips Drop impls. Sidecar `compose down`, last log flush, etc. may be lost when the watchdog fires. This is consistent with the SIGTERM / panic path the existing `observability_guard.take()` already accepts — holding `daemon.lock` for another full minute under a wedge is strictly worse for the operator than losing best-effort cleanup once.

## Verification

```
cargo check -p librefang-api  →  ok (1m 41s)
```

No new tests — the failure mode is "process-wide hang after axum returns," which a unit test of `start_api_server` cannot exercise without spawning a real daemon. Manual repro on the reporter's symptom would be the right validation; deferring to ops to confirm under their launchd setup.

Closes #5477.
