### PR TITLE
feat(approval): cache per-session approvals so the same tool only prompts once

### DIFF
--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -67,6 +67,15 @@ pub struct ApprovalManager {
     /// memory so user-level remembered decisions don't outlive an
     /// `acp` invocation in surprising ways.
     remembered: DashMap<(String, String), ApprovalDecision>,
+    /// Per-session approval cache (#5600): once a user approves a tool
+    /// inside a chat session, every subsequent call of that exact tool
+    /// name in the same session auto-approves without re-prompting.
+    /// Keyed on `(session_id, tool_name)`; populated by [`Self::resolve`]
+    /// on `Approved` outcomes and read in
+    /// `LibreFangKernel::submit_tool_approval`. Lives in memory only —
+    /// daemon restart drops the cache, matching the in-memory
+    /// `remembered` slot above.
+    session_approvals: DashMap<(String, String), ()>,
 }
 
 struct PendingRequest {
@@ -110,6 +119,7 @@ impl ApprovalManager {
             failure_rw_mutex: StdMutex::new(()),
             events_tx,
             remembered: DashMap::new(),
+            session_approvals: DashMap::new(),
         }
     }
 
@@ -135,6 +145,7 @@ impl ApprovalManager {
             failure_rw_mutex: StdMutex::new(()),
             events_tx,
             remembered: DashMap::new(),
+            session_approvals: DashMap::new(),
         }
     }
 
@@ -163,6 +174,56 @@ impl ApprovalManager {
         self.remembered
             .remove(&(agent_id.to_string(), tool_name.to_string()))
             .map(|(_, v)| v)
+    }
+
+    // -----------------------------------------------------------------
+    // Per-session approval cache (#5600)
+    // -----------------------------------------------------------------
+
+    /// Record that the user approved `tool_name` inside `session_id`.
+    /// Future calls of the same tool in the same session short-circuit
+    /// to `AutoApproved` without re-prompting. Idempotent.
+    pub fn remember_session_approval(&self, session_id: &str, tool_name: &str) {
+        if session_id.is_empty() || tool_name.is_empty() {
+            return;
+        }
+        self.session_approvals
+            .insert((session_id.to_string(), tool_name.to_string()), ());
+    }
+
+    /// True iff `(session_id, tool_name)` is in the per-session approval
+    /// cache (i.e. the user already approved this tool earlier in the
+    /// same chat session).
+    pub fn has_session_approval(&self, session_id: &str, tool_name: &str) -> bool {
+        if session_id.is_empty() || tool_name.is_empty() {
+            return false;
+        }
+        self.session_approvals
+            .contains_key(&(session_id.to_string(), tool_name.to_string()))
+    }
+
+    /// Drop the per-session approval entry for `(session_id, tool_name)`.
+    /// Returns `true` if an entry was actually removed.
+    pub fn forget_session_approval(&self, session_id: &str, tool_name: &str) -> bool {
+        self.session_approvals
+            .remove(&(session_id.to_string(), tool_name.to_string()))
+            .is_some()
+    }
+
+    /// Drop every session-cached approval for `session_id` (e.g. on
+    /// session reset). Returns the number of entries removed.
+    pub fn clear_session_approvals(&self, session_id: &str) -> usize {
+        let to_remove: Vec<(String, String)> = self
+            .session_approvals
+            .iter()
+            .filter(|kv| kv.key().0 == session_id)
+            .map(|kv| kv.key().clone())
+            .collect();
+        let n = to_remove.len();
+        for k in to_remove {
+            self.session_approvals.remove(&k);
+        }
+        n
     }
 
     /// Subscribe to [`ApprovalEvent`]s from this manager.
@@ -939,6 +1000,18 @@ impl ApprovalManager {
                         if policy.tool_requires_totp(&pending.request.tool_name) {
                             self.record_totp_grace(uid);
                         }
+                    }
+                }
+
+                // Record per-session approval (#5600) so the same tool
+                // does not re-prompt for the rest of this chat session.
+                // Guarded by `policy.cache_approvals_per_session` so
+                // operators who want strict per-call approval can opt
+                // out. Only populates on `Approved`; denials never
+                // auto-approve future calls.
+                if decision.is_approved() && policy.cache_approvals_per_session {
+                    if let Some(sid) = pending.request.session_id.as_deref() {
+                        self.remember_session_approval(sid, &pending.request.tool_name);
                     }
                 }
 
@@ -1956,6 +2029,24 @@ mod tests {
         ApprovalManager::new(ApprovalPolicy::default())
     }
 
+    fn make_deferred(agent_id: &str) -> DeferredToolExecution {
+        DeferredToolExecution {
+            agent_id: agent_id.to_string(),
+            tool_use_id: "tool-use-test".to_string(),
+            tool_name: "test".to_string(),
+            input: serde_json::json!({}),
+            allowed_tools: None,
+            allowed_env_vars: None,
+            exec_policy: None,
+            sender_id: None,
+            channel: None,
+            chat_id: None,
+            workspace_root: None,
+            force_human: false,
+            session_id: None,
+        }
+    }
+
     fn make_request(agent_id: &str, tool_name: &str, timeout_secs: u64) -> ApprovalRequest {
         ApprovalRequest {
             id: Uuid::new_v4(),
@@ -1985,6 +2076,112 @@ mod tests {
         let mgr = default_manager();
         assert!(mgr.requires_approval("shell_exec"));
         assert!(!mgr.requires_approval("file_read"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-session approval cache (#5600)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn session_approval_round_trip() {
+        let mgr = default_manager();
+        assert!(!mgr.has_session_approval("sess-1", "mcp_jira_create"));
+        mgr.remember_session_approval("sess-1", "mcp_jira_create");
+        assert!(mgr.has_session_approval("sess-1", "mcp_jira_create"));
+        // Different session: cache miss.
+        assert!(!mgr.has_session_approval("sess-2", "mcp_jira_create"));
+        // Different tool in same session: cache miss.
+        assert!(!mgr.has_session_approval("sess-1", "mcp_jira_delete"));
+    }
+
+    #[test]
+    fn session_approval_idempotent_and_safe_against_empty_keys() {
+        let mgr = default_manager();
+        mgr.remember_session_approval("sess-1", "tool");
+        mgr.remember_session_approval("sess-1", "tool");
+        assert!(mgr.has_session_approval("sess-1", "tool"));
+        // Empty session_id / tool_name are accepted but never cached —
+        // a defensive guard so a missing context doesn't grant blanket
+        // approval to all later calls.
+        mgr.remember_session_approval("", "tool");
+        mgr.remember_session_approval("sess-1", "");
+        assert!(!mgr.has_session_approval("", "tool"));
+        assert!(!mgr.has_session_approval("sess-1", ""));
+    }
+
+    #[test]
+    fn session_approval_forget_clears_entry() {
+        let mgr = default_manager();
+        mgr.remember_session_approval("sess-1", "tool");
+        assert!(mgr.forget_session_approval("sess-1", "tool"));
+        assert!(!mgr.has_session_approval("sess-1", "tool"));
+        // Second forget is a no-op, returns false.
+        assert!(!mgr.forget_session_approval("sess-1", "tool"));
+    }
+
+    #[test]
+    fn session_approval_clear_all_for_session_drops_only_matching() {
+        let mgr = default_manager();
+        mgr.remember_session_approval("sess-1", "tool_a");
+        mgr.remember_session_approval("sess-1", "tool_b");
+        mgr.remember_session_approval("sess-2", "tool_a");
+        assert_eq!(mgr.clear_session_approvals("sess-1"), 2);
+        assert!(!mgr.has_session_approval("sess-1", "tool_a"));
+        assert!(!mgr.has_session_approval("sess-1", "tool_b"));
+        // sess-2 entries survive — clear_session_approvals is scoped.
+        assert!(mgr.has_session_approval("sess-2", "tool_a"));
+    }
+
+    #[test]
+    fn resolve_approved_populates_session_cache_when_policy_allows() {
+        let mgr = default_manager();
+        let mut req = make_request("agent-x", "mcp_jira_create", 60);
+        req.session_id = Some("sess-1".to_string());
+        let id = req.id;
+        mgr.submit_request(req, make_deferred("agent-x"))
+            .expect("submit");
+        mgr.resolve(id, ApprovalDecision::Approved, None, false, None)
+            .expect("resolve");
+        assert!(
+            mgr.has_session_approval("sess-1", "mcp_jira_create"),
+            "Approved + cache_approvals_per_session=true (default) must populate session cache"
+        );
+    }
+
+    #[test]
+    fn resolve_denied_does_not_populate_session_cache() {
+        let mgr = default_manager();
+        let mut req = make_request("agent-x", "mcp_jira_delete", 60);
+        req.session_id = Some("sess-1".to_string());
+        let id = req.id;
+        mgr.submit_request(req, make_deferred("agent-x"))
+            .expect("submit");
+        mgr.resolve(id, ApprovalDecision::Denied, None, false, None)
+            .expect("resolve");
+        assert!(
+            !mgr.has_session_approval("sess-1", "mcp_jira_delete"),
+            "Denied outcome must NOT populate session cache"
+        );
+    }
+
+    #[test]
+    fn resolve_approved_skips_cache_when_policy_disables() {
+        let policy = ApprovalPolicy {
+            cache_approvals_per_session: false,
+            ..Default::default()
+        };
+        let mgr = ApprovalManager::new(policy);
+        let mut req = make_request("agent-x", "mcp_jira_create", 60);
+        req.session_id = Some("sess-1".to_string());
+        let id = req.id;
+        mgr.submit_request(req, make_deferred("agent-x"))
+            .expect("submit");
+        mgr.resolve(id, ApprovalDecision::Approved, None, false, None)
+            .expect("resolve");
+        assert!(
+            !mgr.has_session_approval("sess-1", "mcp_jira_create"),
+            "cache_approvals_per_session=false must keep the cache empty even on Approved"
+        );
     }
 
     #[test]

--- a/crates/librefang-kernel/src/approval.rs
+++ b/crates/librefang-kernel/src/approval.rs
@@ -1009,7 +1009,22 @@ impl ApprovalManager {
                 // operators who want strict per-call approval can opt
                 // out. Only populates on `Approved`; denials never
                 // auto-approve future calls.
-                if decision.is_approved() && policy.cache_approvals_per_session {
+                //
+                // SECURITY (RBAC M3, #3054): skip cache population when
+                // the underlying deferred call had `force_human=true`.
+                // That flag means the per-user policy demanded an
+                // explicit human approval on every call — caching the
+                // outcome would let future calls in the same session
+                // pick it up via `has_session_approval` and bypass the
+                // per-call requirement. Symmetric with the read-side
+                // guard in `LibreFangKernel::submit_tool_approval`.
+                let from_force_human = pending
+                    .deferred
+                    .as_ref()
+                    .map(|d| d.force_human)
+                    .unwrap_or(false);
+                if decision.is_approved() && policy.cache_approvals_per_session && !from_force_human
+                {
                     if let Some(sid) = pending.request.session_id.as_deref() {
                         self.remember_session_approval(sid, &pending.request.tool_name);
                     }
@@ -2181,6 +2196,32 @@ mod tests {
         assert!(
             !mgr.has_session_approval("sess-1", "mcp_jira_create"),
             "cache_approvals_per_session=false must keep the cache empty even on Approved"
+        );
+    }
+
+    /// RBAC M3 (#3054) regression guard for #5600.
+    ///
+    /// When a deferred tool call carries `force_human=true` the
+    /// per-user policy demanded an explicit human approval on every
+    /// invocation. The session cache MUST NOT capture that outcome —
+    /// otherwise the next call of the same tool in the same session
+    /// would hit `has_session_approval` and silently auto-approve,
+    /// defeating the RBAC M3 carve-out enforced in
+    /// `LibreFangKernel::submit_tool_approval`.
+    #[test]
+    fn resolve_approved_skips_cache_when_deferred_force_human() {
+        let mgr = default_manager();
+        let mut req = make_request("agent-x", "mcp_jira_create", 60);
+        req.session_id = Some("sess-1".to_string());
+        let id = req.id;
+        let mut deferred = make_deferred("agent-x");
+        deferred.force_human = true;
+        mgr.submit_request(req, deferred).expect("submit");
+        mgr.resolve(id, ApprovalDecision::Approved, None, false, None)
+            .expect("resolve");
+        assert!(
+            !mgr.has_session_approval("sess-1", "mcp_jira_create"),
+            "force_human=true approvals must NOT populate the session cache (RBAC M3 #3054)"
         );
     }
 

--- a/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
+++ b/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
@@ -272,6 +272,29 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
         }
 
         let policy = self.governance.approval_manager.policy();
+        // #5600: per-session approval cache. If this exact tool name has
+        // already been approved earlier in the same session, skip the
+        // prompt. Gated by `policy.cache_approvals_per_session`
+        // (default true). Hand-agent fast-path above already returned
+        // for that case, so this only fires for normal user-facing
+        // agents.
+        if policy.cache_approvals_per_session {
+            if let Some(sid) = session_id {
+                if self
+                    .governance
+                    .approval_manager
+                    .has_session_approval(sid, tool_name)
+                {
+                    info!(
+                        agent_id,
+                        tool_name,
+                        session_id = sid,
+                        "Auto-approved by per-session cache (#5600)"
+                    );
+                    return Ok(ToolApprovalSubmission::AutoApproved);
+                }
+            }
+        }
         let risk_level = crate::approval::ApprovalManager::classify_risk(tool_name);
         let agent_display = self.approval_agent_display(agent_id);
         let description = format!("Agent {} requests to execute {}", agent_display, tool_name);

--- a/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
+++ b/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
@@ -275,10 +275,15 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
         // #5600: per-session approval cache. If this exact tool name has
         // already been approved earlier in the same session, skip the
         // prompt. Gated by `policy.cache_approvals_per_session`
-        // (default true). Hand-agent fast-path above already returned
-        // for that case, so this only fires for normal user-facing
-        // agents.
-        if policy.cache_approvals_per_session {
+        // (default true).
+        //
+        // SECURITY (RBAC M3, #3054): MUST be skipped when
+        // `deferred.force_human=true`. The user-policy gate flips
+        // `force_human` on every call that demanded human approval —
+        // honouring the session cache here would let the second call
+        // of a tool silently bypass the per-call approval that the
+        // RBAC M3 carve-out is designed to enforce.
+        if policy.cache_approvals_per_session && !deferred.force_human {
             if let Some(sid) = session_id {
                 if self
                     .governance

--- a/crates/librefang-types/src/approval.rs
+++ b/crates/librefang-types/src/approval.rs
@@ -706,6 +706,25 @@ pub struct ApprovalPolicy {
     /// Default: 90. Set to 0 to disable pruning.
     #[serde(default = "default_approval_audit_retention_days")]
     pub audit_retention_days: u64,
+    /// Cache approvals within a chat session (#5600).
+    ///
+    /// When `true` (the default), the first time a user approves a tool
+    /// inside a session, subsequent calls of the same tool name in that
+    /// session auto-approve without re-prompting. This matches typical
+    /// IDE / MCP-client behaviour (one approval per (session, tool) is
+    /// enough). Set to `false` to require per-call approval — useful for
+    /// compliance environments that need an explicit human decision on
+    /// every tool execution.
+    ///
+    /// Scope: in-memory only. Daemon restart clears the cache. The cache
+    /// keys on `(session_id, tool_name)`; different sessions still each
+    /// see one prompt per distinct tool.
+    #[serde(default = "default_cache_approvals_per_session")]
+    pub cache_approvals_per_session: bool,
+}
+
+fn default_cache_approvals_per_session() -> bool {
+    true
 }
 
 fn default_approval_audit_retention_days() -> u64 {
@@ -743,6 +762,7 @@ impl Default for ApprovalPolicy {
             totp_grace_period_secs: default_totp_grace_period(),
             totp_tools: Vec::new(),
             audit_retention_days: default_approval_audit_retention_days(),
+            cache_approvals_per_session: default_cache_approvals_per_session(),
         }
     }
 }

--- a/crates/librefang-types/src/approval.rs
+++ b/crates/librefang-types/src/approval.rs
@@ -1456,6 +1456,7 @@ mod tests {
             totp_grace_period_secs: 300,
             totp_tools: Vec::new(),
             audit_retention_days: 90,
+            cache_approvals_per_session: true,
         };
         let json = serde_json::to_string(&policy).unwrap();
         let back: ApprovalPolicy = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary

Once a user approves `tool_name` inside a chat session, subsequent calls of the **same tool name in the same session** auto-approve. Matches what the issue reporter (and most IDE / MCP-client UX) expected: one approval per (session, tool) is enough.

In-memory only — daemon restart drops the cache, matching the existing `remembered: DashMap<(String, String), ApprovalDecision>` slot at `crates/librefang-kernel/src/approval.rs:69`.

## Wiring

| File | Change |
|---|---|
| `crates/librefang-kernel/src/approval.rs` | New `session_approvals: DashMap<(String, String), ()>` field + `remember_session_approval` / `has_session_approval` / `forget_session_approval` / `clear_session_approvals` helpers. `resolve()` populates the cache on `Approved` when the request carries a `session_id` and the policy flag is on. |
| `crates/librefang-kernel/src/kernel/handles/approval_gate.rs` | `submit_tool_approval` checks the cache after the hand-agent fast-path. Cache hit → `ToolApprovalSubmission::AutoApproved`, same shape as the hand-agent carve-out. |
| `crates/librefang-types/src/approval.rs` | New policy field `ApprovalPolicy.cache_approvals_per_session: bool` (default `true`). |

## Defensive guards

- Empty `session_id` or empty `tool_name` never enter the cache and never match — prevents a missing context from granting blanket approval to all future calls.
- Cache is per-session **and** per-tool. Different sessions still each see one prompt per distinct tool; different tools in the same session still each see a prompt.
- `Denied` outcomes never populate the cache — only `Approved`.

## Opt-out for compliance

Operators who need per-call approval (compliance environments) set `cache_approvals_per_session = false` in `[approval]` — the cache stays empty even on `Approved` and the old per-call semantics persist.

## Tests

7 new tests in `approval::tests`. All passing:

```
$ cargo test -p librefang-kernel --lib -- approval::tests::session approval::tests::resolve_approved approval::tests::resolve_denied
test approval::tests::session_approval_forget_clears_entry ... ok
test approval::tests::session_approval_round_trip ... ok
test approval::tests::session_approval_idempotent_and_safe_against_empty_keys ... ok
test approval::tests::session_approval_clear_all_for_session_drops_only_matching ... ok
test approval::tests::resolve_approved_skips_cache_when_policy_disables ... ok
test approval::tests::resolve_denied_does_not_populate_session_cache ... ok
test approval::tests::resolve_approved_populates_session_cache_when_policy_allows ... ok
test result: ok. 7 passed; 0 failed
```

Coverage spans: helper round-trip, empty-key defence, single-entry forget, scoped clear, end-to-end via `submit_request` + `resolve` for both `Approved` and `Denied` outcomes, and policy opt-out.

## What this does NOT do

- Does not persist the cache across daemon restarts. Same scope as the existing in-memory `remembered` slot. If durability is wanted, the `pending_approvals` SQLite table pattern is the precedent.
- Does not address the issue's second ask ("add tool name into `capabilities.tools` and `exec_policy.allowed_commands`"). That's a separate auto-allowlist feature — call sites are different, security implications are wider, and it deserves its own issue + PR.
- Does not auto-clear the cache on session reset. A `/new` or `/reboot` in a chat channel will not wipe per-session approvals today. Adding it where `kernel::session_lifecycle` resets sessions is one extra line (`approval_manager.clear_session_approvals(&session_id)`), worth a follow-up once we agree it's wanted.

Closes #5600.
