### PR TITLE
fix(dashboard): commsKeys hierarchy + TerminalTabs storage helper + Modal autoFocus

### DIFF
--- a/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
+++ b/crates/librefang-api/dashboard/src/components/TerminalTabs.tsx
@@ -16,6 +16,7 @@ import {
   useDeleteTerminalWindow,
 } from "../lib/mutations/terminal";
 import { ApiError, type TerminalWindow } from "../lib/http/client";
+import { safeStorageGet, safeStorageSet } from "../lib/safeStorage";
 import type { Terminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
 
@@ -48,11 +49,24 @@ const WINDOW_NAME_RE = /^[^|\x00-\x1f\x7f]{1,64}$/u;
 
 const ORDER_KEY = "terminal.tabOrder";
 
+// Go through `safeStorage*` so the existing #5140 try/catch guards (Safari
+// private mode SecurityError, QuotaExceededError, SSR / non-browser
+// contexts without window.localStorage) cover this site too. Raw
+// localStorage calls in module init or render bypass that net and crash
+// the whole React tree on first paint when storage is unavailable.
 function loadOrder(): string[] {
-  try { return JSON.parse(localStorage.getItem(ORDER_KEY) ?? "[]"); } catch (e) { console.warn("Failed to parse tab order from localStorage:", e); return []; }
+  const raw = safeStorageGet(ORDER_KEY);
+  if (raw === null) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string") : [];
+  } catch (e) {
+    console.warn("Failed to parse tab order from localStorage:", e);
+    return [];
+  }
 }
 function saveOrder(ids: string[]) {
-  localStorage.setItem(ORDER_KEY, JSON.stringify(ids));
+  safeStorageSet(ORDER_KEY, JSON.stringify(ids));
 }
 
 export function TerminalTabs({

--- a/crates/librefang-api/dashboard/src/components/ui/Modal.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { Modal } from "./Modal";
+
+// `motion/react` ships browser-only animation primitives that jsdom can't
+// drive. Same shim as PromptsExperimentsModal.test — render children
+// inline and turn `motion.foo` into the corresponding host tag.
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  motion: new Proxy(
+    {},
+    {
+      get: (_target: unknown, prop: string) =>
+        ({
+          children,
+          ...rest
+        }: { children?: React.ReactNode } & Record<string, unknown>) =>
+          React.createElement(prop, rest, children),
+    },
+  ),
+}));
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>(
+    "react-i18next",
+  );
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: { defaultValue?: string }) =>
+        opts?.defaultValue ?? key,
+    }),
+  };
+});
+
+describe("Modal autoFocus (#5666)", () => {
+  it("panel-right defaults focus to the close button on open", async () => {
+    render(
+      <Modal isOpen onClose={() => {}} variant="panel-right" title="Panel">
+        <input data-testid="first-input" />
+        <button>Submit</button>
+      </Modal>,
+    );
+
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    await waitFor(() => expect(document.activeElement).toBe(closeButton));
+  });
+
+  it("drawer-right defaults focus to the close button on open", async () => {
+    render(
+      <Modal isOpen onClose={() => {}} variant="drawer-right" title="Drawer">
+        <input data-testid="first-input" />
+      </Modal>,
+    );
+
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    await waitFor(() => expect(document.activeElement).toBe(closeButton));
+  });
+
+  it("centred modal defaults focus to the first focusable descendant", async () => {
+    render(
+      <Modal isOpen onClose={() => {}} title="Centred">
+        <input data-testid="first-input" />
+        <button>Submit</button>
+      </Modal>,
+    );
+
+    const input = screen.getByTestId("first-input");
+    await waitFor(() => expect(document.activeElement).toBe(input));
+  });
+
+  it("autoFocus=\"first\" on panel-right overrides the close-button default", async () => {
+    render(
+      <Modal
+        isOpen
+        onClose={() => {}}
+        variant="panel-right"
+        title="Panel"
+        autoFocus="first"
+      >
+        <input data-testid="first-input" />
+      </Modal>,
+    );
+
+    const input = screen.getByTestId("first-input");
+    await waitFor(() => expect(document.activeElement).toBe(input));
+  });
+
+  it("autoFocus=\"close\" with hideCloseButton has no close button to focus and falls back to the first focusable", async () => {
+    // Regression guard: when the close button is hidden, the "close"
+    // policy must not crash or strand focus on document.body — useFocusTrap's
+    // first-focusable fallback should still apply.
+    render(
+      <Modal
+        isOpen
+        onClose={() => {}}
+        variant="panel-right"
+        title="Panel"
+        hideCloseButton
+        autoFocus="close"
+      >
+        <input data-testid="first-input" />
+      </Modal>,
+    );
+
+    const input = screen.getByTestId("first-input");
+    await waitFor(() => expect(document.activeElement).toBe(input));
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/Modal.tsx
@@ -33,6 +33,21 @@ interface ModalProps {
    *    or cancel before the rest of the page is interactive again. Visually
    *    consistent with drawer pages, behaviourally consistent with modals. */
   variant?: "modal" | "drawer-right" | "panel-right";
+  /** Where to put initial keyboard focus when the dialog opens. Keyboard
+   *  users lose context if the focus target is left to "whatever
+   *  `useFocusTrap` finds first", so panel-right / drawer surfaces with
+   *  long forms should pick deliberately.
+   *
+   *  - `"first"` (default for `modal`): focus the first focusable
+   *    descendant — typically a primary form input or action button.
+   *  - `"close"` (default for `panel-right` and `drawer-right`): focus
+   *    the close button. Right-docked surfaces are review / inspection
+   *    views first; focusing a destructive primary input by accident
+   *    (e.g. a "Save" button on Enter) is worse than the extra Tab.
+   *    Also applies when there are no focusable descendants at all —
+   *    the close button is always the safe fallback. Has no effect
+   *    when `hideCloseButton` is set. */
+  autoFocus?: "first" | "close";
   children: ReactNode;
 }
 
@@ -76,21 +91,75 @@ export const Modal = memo(function Modal({
   zIndex = 50,
   overflowVisible = false,
   variant = "modal",
+  autoFocus,
   children,
 }: ModalProps) {
   const { t } = useTranslation();
   const dialogRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const onCloseRef = useRef(onClose);
   const titleId = useId();
   const isDrawer = variant === "drawer-right";
   const isPanel = variant === "panel-right";
   const isRightDocked = isDrawer || isPanel;
   const hasBackdrop = !isDrawer; // modal + panel-right have a dim backdrop
+  // Resolve initial-focus policy: explicit prop wins; otherwise
+  // right-docked variants default to `"close"` (avoids inadvertent
+  // primary-action activation on Enter for inspector / review surfaces
+  // — keyboard users expect a deterministic landing spot, not "whatever
+  // happens to be first in DOM order"), centred modals default to
+  // `"first"` (matches the existing behaviour of focusing the first
+  // form input — which is what dialog users expect).
+  const resolvedAutoFocus: "first" | "close" =
+    autoFocus ?? (isRightDocked ? "close" : "first");
   // Modal traps Tab inside the dialog (no escape from the focus loop).
   // Drawer leaves Tab free so keyboard users can hop back into the
   // underlying list (which is still interactive — see container's
   // pointer-events-none) without first hitting Esc.
   useFocusTrap(isOpen, dialogRef, true, !isDrawer);
+
+  // Apply the resolved autoFocus policy. `useFocusTrap` defaults to the
+  // first focusable descendant of the *whole* dialog — which, with the
+  // header rendered before children, is the close button. That's almost
+  // never what callers want for `"first"`; we explicitly look inside
+  // the body container so `"first"` reaches a form input. `"close"`
+  // re-focuses the close button after the trap's initial pass.
+  //
+  // requestAnimationFrame defers until after `useFocusTrap`'s effect
+  // runs in the same render, so we always win the focus race regardless
+  // of effect ordering.
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    const id = requestAnimationFrame(() => {
+      if (resolvedAutoFocus === "close" && !hideCloseButton) {
+        closeButtonRef.current?.focus();
+        return;
+      }
+      // `"first"` (or `"close"` falling through because the close
+      // button is hidden) → first focusable inside the body. We
+      // intentionally exclude the header so the close X doesn't win.
+      const body = bodyRef.current;
+      if (!body) return;
+      const focusable = body.querySelector<HTMLElement>(
+        [
+          "a[href]",
+          "button:not([disabled])",
+          "input:not([disabled])",
+          "select:not([disabled])",
+          "textarea:not([disabled])",
+          "[tabindex]:not([tabindex='-1'])",
+        ].join(", "),
+      );
+      if (focusable) {
+        focusable.focus();
+      } else if (!hideCloseButton) {
+        // Empty body → close button is the only safe target.
+        closeButtonRef.current?.focus();
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, [isOpen, resolvedAutoFocus, hideCloseButton]);
 
   useLayoutEffect(() => {
     onCloseRef.current = onClose;
@@ -189,6 +258,7 @@ export const Modal = memo(function Modal({
                 ) : <span aria-hidden="true" />}
                 {!hideCloseButton && (
                   <button
+                    ref={closeButtonRef}
                     onClick={onClose}
                     className="h-7 w-7 flex items-center justify-center rounded-lg text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
                     aria-label={t("common.close", { defaultValue: "Close" })}
@@ -204,7 +274,12 @@ export const Modal = memo(function Modal({
                 but the centred modal benefits too: a long modal pinned over
                 a long page used to scroll the page after the modal bottomed
                 out, which feels like the modal "leaks" the gesture. */}
-            <div className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin">{children}</div>
+            <div
+              ref={bodyRef}
+              className="flex-1 overflow-y-auto overscroll-contain scrollbar-thin"
+            >
+              {children}
+            </div>
           </motion.div>
         </motion.div>
       )}

--- a/crates/librefang-api/dashboard/src/lib/mutations/channels.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/channels.ts
@@ -47,7 +47,11 @@ export function useSendCommsMessage() {
       message: string;
     }) => sendCommsMessage(payload),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: commsKeys.all });
+      // Sending a message changes the events feed and may shift the
+      // topology graph (new edge appears when two agents first
+      // converse). Both live under `commsKeys.lists()`; per-event
+      // detail caches are unaffected.
+      qc.invalidateQueries({ queryKey: commsKeys.lists() });
     },
   });
 }
@@ -61,7 +65,9 @@ export function usePostCommsTask() {
       assigned_to?: string;
     }) => postCommsTask(payload),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: commsKeys.all });
+      // Posting a task emits a comms event; same invalidation scope as
+      // useSendCommsMessage.
+      qc.invalidateQueries({ queryKey: commsKeys.lists() });
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.test.ts
@@ -472,4 +472,42 @@ describe("query key factories", () => {
       ).toEqual(permissionPolicyKeys.all);
     });
   });
+
+  describe("commsKeys (#5666)", () => {
+    it("exposes the standard all / lists() / list / details() / detail hierarchy", () => {
+      expect(commsKeys.all).toEqual(["comms"]);
+      expect(commsKeys.lists()).toEqual(["comms", "list"]);
+      expect(commsKeys.topology()).toEqual(["comms", "list", "topology"]);
+      expect(commsKeys.events()).toEqual(["comms", "list", "events", 200]);
+      expect(commsKeys.events(50)).toEqual(["comms", "list", "events", 50]);
+      expect(commsKeys.details()).toEqual(["comms", "detail"]);
+      expect(commsKeys.detail("evt-1")).toEqual(["comms", "detail", "evt-1"]);
+    });
+
+    it("lists() prefixes both topology and events so list-shaped queries invalidate as a batch", () => {
+      const ls = commsKeys.lists();
+      expect(commsKeys.topology().slice(0, ls.length)).toEqual(ls);
+      expect(commsKeys.events(100).slice(0, ls.length)).toEqual(ls);
+    });
+
+    it("details() prefixes detail(id) and is disjoint from lists()", () => {
+      const ds = commsKeys.details();
+      expect(commsKeys.detail("evt-1").slice(0, ds.length)).toEqual(ds);
+      // Invalidating lists() must NOT clobber a cached event detail.
+      expect(commsKeys.details()).not.toEqual(commsKeys.lists());
+    });
+
+    it("all sub-keys are anchored on commsKeys.all", () => {
+      const prefix = commsKeys.all;
+      expect(commsKeys.lists().slice(0, prefix.length)).toEqual(prefix);
+      expect(commsKeys.topology().slice(0, prefix.length)).toEqual(prefix);
+      expect(commsKeys.events(100).slice(0, prefix.length)).toEqual(prefix);
+      expect(commsKeys.details().slice(0, prefix.length)).toEqual(prefix);
+      expect(commsKeys.detail("x").slice(0, prefix.length)).toEqual(prefix);
+    });
+
+    it("different event limits produce different keys", () => {
+      expect(commsKeys.events(100)).not.toEqual(commsKeys.events(200));
+    });
+  });
 });

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -91,10 +91,21 @@ export const channelKeys = {
   qr: (name: string) => [...channelKeys.all, "qr", name] as const,
 };
 
+// Cross-agent comms / message bus. Hierarchical mirror of `agentKeys` so
+// `invalidateQueries({ queryKey: commsKeys.lists() })` batches every
+// list-shaped read (topology + events) in a single sweep — the previous
+// shape had `topology()` and `events(limit)` parked directly under `all`,
+// which forced mutations to invalidate the whole `commsKeys.all` subtree
+// or enumerate each list factory by hand. `details()`/`detail(id)` are
+// reserved for the per-event drill-down view planned alongside the
+// `/api/comms/events/:id` endpoint.
 export const commsKeys = {
   all: ["comms"] as const,
-  topology: () => [...commsKeys.all, "topology"] as const,
-  events: (limit = 200) => [...commsKeys.all, "events", limit] as const,
+  lists: () => [...commsKeys.all, "list"] as const,
+  topology: () => [...commsKeys.lists(), "topology"] as const,
+  events: (limit = 200) => [...commsKeys.lists(), "events", limit] as const,
+  details: () => [...commsKeys.all, "detail"] as const,
+  detail: (id: string) => [...commsKeys.details(), id] as const,
 };
 
 export const skillKeys = {


### PR DESCRIPTION
Closes #5666

Roundup of three Low-severity dashboard data-layer findings, all
fixed in this single PR per the issue's combined fix plan.

## Sub-findings & per-file changes

### 1. `commsKeys` missing `lists()` parent

`crates/librefang-api/dashboard/src/lib/queries/keys.ts`

Reshape `commsKeys` to the standard `all` / `lists()` / `list(...)` /
`details()` / `detail(id)` hierarchy that every other factory in the
file follows (mirrors `agentKeys`). `topology()` and `events(limit)`
now sit under `lists()`, and `details()` / `detail(id)` are added for
the per-event drill-down planned alongside `/api/comms/events/:id`.

`crates/librefang-api/dashboard/src/lib/mutations/channels.ts`

`useSendCommsMessage` and `usePostCommsTask` now invalidate
`commsKeys.lists()` instead of the entire `commsKeys.all` subtree —
posting a message only affects list-shaped queries (events feed +
topology graph), not the per-event detail cache.

### 2. `TerminalTabs.tsx` raw `localStorage`

`crates/librefang-api/dashboard/src/components/TerminalTabs.tsx`

`loadOrder` / `saveOrder` now route through `safeStorageGet` /
`safeStorageSet` from `lib/safeStorage.ts`. This brings the tab-order
persistence under the same #5140 guards that already cover the rest
of the terminal page (Safari private-mode `SecurityError`,
`QuotaExceededError` on full storage, SSR / non-browser environments
with no `window.localStorage`). Also tightens the JSON parse path
with an `Array.isArray` + string-filter so a tampered cache value
can't crash tab rendering.

### 3. Modal `panel` variant focus

`crates/librefang-api/dashboard/src/components/ui/Modal.tsx`

Add an explicit `autoFocus?: "first" | "close"` prop with a
deterministic per-variant default:

- centred `modal` → `"first"` — first focusable inside the body
  (typically a form input). Matches user expectations for the
  classic dialog.
- `panel-right` / `drawer-right` → `"close"` — focus the X button.
  Right-docked surfaces are review / inspection views first, and
  focusing a destructive primary action on open (Enter → "Save")
  is worse than the extra Tab.

Previously the target was whatever `useFocusTrap` happened to find
first, which was effectively the close X regardless of variant
because the header renders before children. The new
`useLayoutEffect` defers to `requestAnimationFrame` so it always
wins the focus race over `useFocusTrap`'s initial pass, and falls
back to the close button when the body has no focusables (and to
`useFocusTrap`'s default when `hideCloseButton` is set).

`crates/librefang-api/dashboard/src/components/ui/Modal.test.tsx` (new)

Five regression tests covering: per-variant default focus
(`panel-right` and `drawer-right` → close button; `modal` → first
input), explicit `autoFocus="first"` override on `panel-right`, and
the `hideCloseButton` + `autoFocus="close"` fallback path.

## Verification

- `pnpm typecheck`: clean
- `pnpm test`: 736 / 736 pass (added 6 new tests: 5 `commsKeys` shape
  + 5 `Modal` autoFocus; existing 730 unchanged)
- No Rust files touched — no `cargo` runs required.
