### PR TITLE
fix(runtime-audit): soft-cap in-memory entries between trims at 1.5x max_in_memory_entries

### DIFF
--- a/crates/librefang-kernel/src/kernel/boot.rs
+++ b/crates/librefang-kernel/src/kernel/boot.rs
@@ -1420,6 +1420,13 @@ impl LibreFangKernel {
             pools
         };
 
+        // Capture the audit append-path soft-cap (#5665) before
+        // `config` is moved into the ArcSwap below — the value is then
+        // pushed into the freshly-constructed `AuditLog` via
+        // `set_max_in_memory_entries`. `None` / `0` leaves the default
+        // `MAX_AUDIT_ENTRIES` fallback in place.
+        let audit_soft_cap = config.audit.retention.max_in_memory_entries.unwrap_or(0);
+
         let kernel = Self {
             home_dir_boot: config.home_dir.clone(),
             data_dir_boot: config.data_dir.clone(),
@@ -1501,7 +1508,17 @@ impl LibreFangKernel {
             config_reload_lock: tokio::sync::RwLock::new(()),
             prompt_metadata_cache: PromptMetadataCache::new(),
             metering: crate::kernel::subsystems::MeteringSubsystem::new(
-                Arc::new(AuditLog::with_db_anchored(memory.pool(), audit_anchor_path)),
+                {
+                    let audit_log = AuditLog::with_db_anchored(memory.pool(), audit_anchor_path);
+                    // Project the operator-configured cap onto the
+                    // append-path soft ceiling (#5665) so the in-memory
+                    // window stays bounded between scheduled `trim()`
+                    // cycles, not just at trim-tick boundaries. `0`
+                    // (the `None` case) leaves the default
+                    // `MAX_AUDIT_ENTRIES` fallback in effect.
+                    audit_log.set_max_in_memory_entries(audit_soft_cap);
+                    Arc::new(audit_log)
+                },
                 metering,
                 initial_budget,
             ),

--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -15,9 +15,11 @@ use r2d2_sqlite::SqliteConnectionManager;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
-/// Hard cap on the number of audit entries kept in memory.
+/// Default hard cap on the number of audit entries kept in memory when no
+/// operator-supplied `max_in_memory_entries` is configured.
 ///
 /// When `record_with_context` appends an entry that would push the in-memory
 /// buffer above this ceiling, the oldest entries are drained from the front so
@@ -26,7 +28,24 @@ use std::sync::Mutex;
 /// policy. The cap applies only to the in-memory window; entries have already
 /// been persisted to SQLite before the drain, so forensic completeness is
 /// preserved on disk.
+///
+/// When an operator sets `audit.retention.max_in_memory_entries`, that value
+/// (multiplied by `MAX_IN_MEMORY_SOFT_CAP_NUMERATOR / DENOMINATOR`, i.e.
+/// `× 1.5`) takes precedence — see [`AuditLog::set_max_in_memory_entries`]
+/// and `record_with_context`. This default exists only as a fallback for
+/// deployments that have not opted in to a configured cap.
 const MAX_AUDIT_ENTRIES: usize = 10_000;
+
+/// Numerator of the soft-cap multiplier applied to the configured
+/// `max_in_memory_entries`. The full ratio is
+/// `MAX_IN_MEMORY_SOFT_CAP_NUMERATOR / MAX_IN_MEMORY_SOFT_CAP_DENOMINATOR`,
+/// i.e. 1.5× by default. The soft cap is enforced inside
+/// `record_with_context` so memory stays bounded between scheduled trim
+/// cycles (#5665) — without it, an operator that sets
+/// `max_in_memory_entries = 5000` would still grow to the 10_000 hard
+/// default until the next `trim()` tick fired.
+const MAX_IN_MEMORY_SOFT_CAP_NUMERATOR: usize = 3;
+const MAX_IN_MEMORY_SOFT_CAP_DENOMINATOR: usize = 2;
 
 /// Categories of auditable actions within the agent runtime.
 ///
@@ -207,6 +226,19 @@ pub struct AuditLog {
     /// genesis sentinel, that `prev_hash` IS the anchor (it points at
     /// the dropped predecessor). No new schema column required.
     chain_anchor: Mutex<Option<String>>,
+    /// Soft ceiling on the in-memory entry count enforced inside
+    /// `record_with_context`, expressed as the operator's configured
+    /// `audit.retention.max_in_memory_entries` (#5665). `0` means
+    /// "not configured" and falls back to the hard `MAX_AUDIT_ENTRIES`
+    /// default. When non-zero, `record_with_context` drops the oldest
+    /// non-anchor prefix once `entries.len()` exceeds
+    /// `configured × MAX_IN_MEMORY_SOFT_CAP_NUMERATOR /
+    /// MAX_IN_MEMORY_SOFT_CAP_DENOMINATOR` so the in-memory window
+    /// stays bounded between scheduled `trim()` cycles. Atomic so
+    /// `set_max_in_memory_entries` can update it without taking the
+    /// `entries` mutex — important because the setter is called from
+    /// boot before any append-path contention exists.
+    max_in_memory_entries: AtomicUsize,
 }
 
 /// Per-trim summary returned by [`AuditLog::trim`].
@@ -253,6 +285,7 @@ impl AuditLog {
             db: None,
             anchor_path: None,
             chain_anchor: Mutex::new(None),
+            max_in_memory_entries: AtomicUsize::new(0),
         }
     }
 
@@ -378,6 +411,41 @@ impl AuditLog {
         log
     }
 
+    /// Update the soft cap on the in-memory window enforced inside
+    /// `record_with_context` (#5665).
+    ///
+    /// `entries` is the operator-supplied
+    /// `audit.retention.max_in_memory_entries` from `config.toml`. `0`
+    /// disables the configured cap and falls back to the hard
+    /// `MAX_AUDIT_ENTRIES` default. The effective ceiling enforced on
+    /// every append is `entries × MAX_IN_MEMORY_SOFT_CAP_NUMERATOR /
+    /// MAX_IN_MEMORY_SOFT_CAP_DENOMINATOR` (i.e. 1.5× by default), so
+    /// the buffer can grow that far between scheduled `trim()` cycles
+    /// before the append path itself drops the oldest non-anchor
+    /// prefix.
+    ///
+    /// Audit retention config does NOT hot-reload (see
+    /// `config_reload.rs: build_reload_plan`), so this is typically
+    /// called once at boot from `with_db_anchored`'s caller. It is
+    /// nonetheless atomic so a future hot-reload path or test
+    /// scaffolding can flip the cap mid-run safely.
+    pub fn set_max_in_memory_entries(&self, entries: usize) {
+        self.max_in_memory_entries.store(entries, Ordering::Relaxed);
+    }
+
+    /// Soft cap enforced inside `record_with_context`. Returns the
+    /// operator-configured value multiplied by the 1.5× safety
+    /// headroom, or [`MAX_AUDIT_ENTRIES`] when no cap is configured.
+    fn effective_soft_cap(&self) -> usize {
+        let configured = self.max_in_memory_entries.load(Ordering::Relaxed);
+        if configured == 0 {
+            MAX_AUDIT_ENTRIES
+        } else {
+            configured.saturating_mul(MAX_IN_MEMORY_SOFT_CAP_NUMERATOR)
+                / MAX_IN_MEMORY_SOFT_CAP_DENOMINATOR
+        }
+    }
+
     /// Creates an audit log backed by a database connection.
     ///
     /// On construction, loads all existing entries from the `audit_entries`
@@ -468,6 +536,7 @@ impl AuditLog {
             db: Some(pool),
             anchor_path: None,
             chain_anchor: Mutex::new(recovered_anchor),
+            max_in_memory_entries: AtomicUsize::new(0),
         };
 
         // Verify chain integrity on load. Logged at WARN: the message itself
@@ -680,16 +749,24 @@ impl AuditLog {
         entries.push(entry);
         *tip = hash.clone();
 
-        // Hard cap: if the in-memory buffer grew beyond MAX_AUDIT_ENTRIES,
-        // drain the oldest prefix.  Every entry in `entries` is now
-        // known to be persisted on disk (the only path that pushes is
-        // the success branch above), so dropping the prefix loses no
-        // forensic data — a restart would reload the same rows from
-        // SQLite anyway.  We update `chain_anchor` to the hash of the
-        // last dropped entry so `verify_integrity()` keeps working
-        // across the trim boundary.
-        if entries.len() > MAX_AUDIT_ENTRIES {
-            let overflow = entries.len() - MAX_AUDIT_ENTRIES;
+        // Soft cap: if the in-memory buffer grew beyond the configured
+        // ceiling (1.5× `max_in_memory_entries` when set, otherwise the
+        // hard `MAX_AUDIT_ENTRIES` default), drain the oldest prefix.
+        // This pins memory between scheduled `trim()` cycles (#5665) —
+        // without it, an operator that sets `max_in_memory_entries =
+        // 5000` would still grow to 10_000 (the old hard default)
+        // until the next `trim_interval_secs` tick fired.
+        //
+        // Every entry in `entries` is now known to be persisted on
+        // disk (the only path that pushes is the success branch
+        // above), so dropping the prefix loses no forensic data — a
+        // restart would reload the same rows from SQLite anyway. We
+        // update `chain_anchor` to the hash of the last dropped entry
+        // so `verify_integrity()` keeps working across the trim
+        // boundary.
+        let soft_cap = self.effective_soft_cap();
+        if entries.len() > soft_cap {
+            let overflow = entries.len() - soft_cap;
             let new_anchor = entries[overflow - 1].hash.clone();
             {
                 let mut anchor = self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());

--- a/crates/librefang-runtime-audit/src/tests.rs
+++ b/crates/librefang-runtime-audit/src/tests.rs
@@ -728,6 +728,78 @@ fn test_max_in_memory_cap_enforced() {
 }
 
 #[test]
+fn test_record_soft_caps_in_memory_between_trims() {
+    // Regression for #5665: operators that set
+    // `audit.retention.max_in_memory_entries` expect the in-memory
+    // window to stay close to that number even when `trim()` has not
+    // yet fired (it only runs every `trim_interval_secs`, default
+    // 3600s). The append path must therefore enforce its own soft
+    // cap at `configured × 1.5`.
+    let log = AuditLog::new();
+    log.set_max_in_memory_entries(100);
+
+    for i in 0..200 {
+        log.record(
+            "agent-1",
+            AuditAction::RoleChange,
+            format!("event #{i}"),
+            "ok",
+        );
+    }
+
+    // 100 × 3 / 2 = 150 is the soft ceiling.
+    let len = log.len();
+    assert!(
+        len <= 150,
+        "in-memory window grew to {len}, expected <= 150 (1.5× cap)"
+    );
+    // And the cap is actually clamping — i.e. we did evict, not just
+    // sit at 200 because the cap was ignored.
+    assert!(
+        len < 200,
+        "in-memory window stayed at {len}, soft cap was not applied"
+    );
+
+    // Chain still verifies across the trim boundary the soft cap
+    // introduced — the chain_anchor must have been advanced to the
+    // hash of the last dropped entry. Without that, the first
+    // survivor's `prev_hash` would dangle and `verify_integrity()`
+    // would return `chain break at seq …`.
+    assert!(
+        log.verify_integrity().is_ok(),
+        "chain anchor not advanced across soft-cap eviction"
+    );
+    let anchor = log.chain_anchor.lock().unwrap().clone();
+    assert!(
+        anchor.is_some(),
+        "expected chain anchor to be set after soft-cap eviction"
+    );
+
+    // The tail must still be intact — we evict the oldest prefix,
+    // not random rows.
+    let survivors = log.recent(len);
+    assert_eq!(survivors.last().unwrap().detail, "event #199");
+}
+
+#[test]
+fn test_record_soft_cap_default_falls_back_to_hard_cap() {
+    // When `max_in_memory_entries` is left unset (the `0` sentinel),
+    // the record path falls back to `MAX_AUDIT_ENTRIES = 10_000`.
+    // We don't push 10_001 entries here (slow); we instead assert
+    // the helper returns the hard default unchanged.
+    let log = AuditLog::new();
+    assert_eq!(log.effective_soft_cap(), 10_000);
+    log.set_max_in_memory_entries(0);
+    assert_eq!(log.effective_soft_cap(), 10_000);
+
+    // Sanity: configured cap > 0 multiplies through.
+    log.set_max_in_memory_entries(5000);
+    assert_eq!(log.effective_soft_cap(), 7500);
+    log.set_max_in_memory_entries(1);
+    assert_eq!(log.effective_soft_cap(), 1); // 1 × 3 / 2 = 1
+}
+
+#[test]
 fn test_default_config_is_no_op() {
     let log = AuditLog::new();
     log.record("agent-1", AuditAction::ToolInvoke, "x", "ok");


### PR DESCRIPTION
## Summary

Operators that set `audit.retention.max_in_memory_entries = 5000` expected
the in-memory buffer to stay near that ceiling. In practice the configured
value was honored only inside `AuditLog::trim()`, which runs on
`trim_interval_secs` (default 3600s) — between trim ticks the only
enforced ceiling was the hard-coded `MAX_AUDIT_ENTRIES = 10_000` in
`crates/librefang-runtime-audit/src/lib.rs`. A 5000-cap deployment could
sit at 10_000 entries for up to an hour.

This PR extends `record_with_context` with a soft cap at
`1.5 × max_in_memory_entries` so the configured value actually pins
memory continuously, not just at trim-tick boundaries. When no cap is
configured the existing `MAX_AUDIT_ENTRIES = 10_000` fallback still
applies, so behaviour is unchanged for deployments that have not opted
in.

## Changes

- `crates/librefang-runtime-audit/src/lib.rs`
  - New `max_in_memory_entries: AtomicUsize` field on `AuditLog`
    (`0` = unset → fall back to `MAX_AUDIT_ENTRIES`).
  - New `set_max_in_memory_entries(usize)` setter and private
    `effective_soft_cap()` helper. The soft cap is
    `configured × MAX_IN_MEMORY_SOFT_CAP_NUMERATOR /
    MAX_IN_MEMORY_SOFT_CAP_DENOMINATOR` (= 1.5×).
  - `record_with_context` now uses `effective_soft_cap()` in place of
    the hard-coded `MAX_AUDIT_ENTRIES`. The chain-anchor advancement on
    front-eviction is preserved verbatim, so `verify_integrity()` keeps
    passing across the soft-cap boundary.
- `crates/librefang-kernel/src/kernel/boot.rs`
  - Project `config.audit.retention.max_in_memory_entries` onto the
    new setter immediately after `AuditLog::with_db_anchored`. Captured
    into a local before `config` is moved into the ArcSwap.

## Tests

Added two unit tests in `crates/librefang-runtime-audit/src/tests.rs`:

- `test_record_soft_caps_in_memory_between_trims` — push 200 entries
  with cap=100, assert `len <= 150`, assert `verify_integrity()` passes
  (chain anchor advanced), assert the tail is intact (most recent
  entry survives).
- `test_record_soft_cap_default_falls_back_to_hard_cap` — assert
  `effective_soft_cap() == 10_000` when cap is 0, and that configured
  values multiply through the 1.5× ratio.

## Verification

```
cargo check -p librefang-runtime-audit          # clean
cargo clippy -p librefang-runtime-audit \
  --all-targets -- -D warnings                  # clean
cargo test -p librefang-runtime-audit           # 31 passed, 0 failed
cargo check -p librefang-kernel --lib           # clean
cargo clippy -p librefang-kernel --lib \
  -- -D warnings                                # clean
```

Closes #5665
