### PR TITLE
fix(build): harden build.rs git/date invocation; document pnpm audit ignores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,6 +2181,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4166,6 +4172,7 @@ dependencies = [
  "utoipa",
  "uuid",
  "walkdir",
+ "which",
  "windows-sys 0.61.2",
  "zip 8.6.0",
 ]
@@ -4249,6 +4256,7 @@ dependencies = [
  "unic-langid",
  "uuid",
  "walkdir",
+ "which",
  "zeroize",
 ]
 
@@ -11152,6 +11160,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11700,6 +11720,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,6 +282,11 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # Performance
 smallvec = "1"
 
+# Build-script helpers — used by `crates/librefang-api/build.rs` and
+# `crates/librefang-cli/build.rs` to resolve `git` via PATH instead of
+# invoking it by bare name (refs #5667). Lightweight, well-maintained.
+which = { version = "7", default-features = false }
+
 [profile.dev]
 split-debuginfo = "unpacked" # Speeds up incremental linking on macOS
 # Shrinks debug test binaries by ~60% to relieve Ubuntu CI memory pressure

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -116,6 +116,13 @@ windows-sys = { version = "0.61", features = [
     "Win32_Security_Authorization",
 ] }
 
+[build-dependencies]
+# `build.rs` uses `chrono::Utc::now()` to stamp `BUILD_DATE` instead of
+# shelling out to `date`, and `which::which("git")` to resolve git on
+# PATH instead of invoking it by bare name (refs #5667).
+chrono = { workspace = true }
+which = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 uuid = { workspace = true }

--- a/crates/librefang-api/build.rs
+++ b/crates/librefang-api/build.rs
@@ -15,34 +15,26 @@ fn main() {
             .expect("failed to create static/react placeholder directory");
     }
 
+    // Re-run when the env inputs to git-sha / build-date capture change so
+    // cargo invalidates this build script appropriately (refs #5667).
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+    println!("cargo:rerun-if-env-changed=CI_COMMIT_SHA");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
     // Capture git commit hash at build time.
-    let git_sha = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| "unknown".to_string());
+    //
+    // Prefer CI-provided env vars (`GITHUB_SHA`, `CI_COMMIT_SHA`) — they're
+    // authoritative on hosted runners and avoid spawning `git` entirely.
+    // Outside CI, resolve the `git` binary via `which` first so we don't
+    // depend on shell PATH lookup semantics, then call `git rev-parse`.
+    let git_sha = resolve_git_sha();
     println!("cargo:rustc-env=GIT_SHA={git_sha}");
 
-    // Capture build date (UTC, date only).
-    let build_date = Command::new("date")
-        .args(["-u", "+%Y-%m-%d"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| "unknown".to_string());
+    // Capture build date (UTC, date only) via `chrono::Utc::now()` rather
+    // than shelling out to `date -u +%Y-%m-%d`. Removes a platform-specific
+    // process spawn (BSD `date` and GNU `date` accept different flags) and
+    // keeps the build script reproducible across hosts.
+    let build_date = chrono::Utc::now().format("%Y-%m-%d").to_string();
     println!("cargo:rustc-env=BUILD_DATE={build_date}");
 
     // Capture rustc version.
@@ -59,4 +51,51 @@ fn main() {
         })
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=RUSTC_VERSION={rustc_ver}");
+}
+
+/// Resolve the short git SHA for the build.
+///
+/// Order of preference:
+/// 1. `GITHUB_SHA` (GitHub Actions)
+/// 2. `CI_COMMIT_SHA` (GitLab CI, generic)
+/// 3. `git rev-parse --short HEAD`, with `git` located via `which`.
+/// 4. `"unknown"` if all of the above fail.
+fn resolve_git_sha() -> String {
+    if let Ok(sha) = std::env::var("GITHUB_SHA") {
+        let sha = sha.trim();
+        if !sha.is_empty() {
+            // GitHub provides a full 40-char SHA; truncate to the same
+            // short form `git rev-parse --short HEAD` would produce.
+            return short_sha(sha);
+        }
+    }
+    if let Ok(sha) = std::env::var("CI_COMMIT_SHA") {
+        let sha = sha.trim();
+        if !sha.is_empty() {
+            return short_sha(sha);
+        }
+    }
+
+    let Ok(git) = which::which("git") else {
+        return "unknown".to_string();
+    };
+    Command::new(git)
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn short_sha(sha: &str) -> String {
+    // git's default short SHA length is 7. Match it for parity with the
+    // `git rev-parse --short HEAD` fallback.
+    sha.chars().take(7).collect()
 }

--- a/crates/librefang-api/dashboard/AUDIT_IGNORES.md
+++ b/crates/librefang-api/dashboard/AUDIT_IGNORES.md
@@ -1,0 +1,54 @@
+# Dashboard pnpm audit ignores
+
+This file enumerates each entry under `pnpm.auditConfig.ignoreGhsas` in
+[`package.json`](./package.json), with the rationale and unlock
+condition for each ignore. Add a new section here whenever you add a
+GHSA to that list; remove the section when the ignore is dropped.
+
+The list is parsed by `pnpm audit` at every dashboard CI run
+(`xtask deps --audit --web`); ignores are not a free pass — they are a
+deliberate trade-off documented in writing so a future maintainer (or
+auditor) can re-evaluate without spelunking the git history. Refs #5667.
+
+## Currently ignored
+
+### `GHSA-rmmr-r34h-pfm5` — `@tanstack/history` (critical, "malware")
+
+- **Why ignored.** The advisory was filed to cover the supply-chain
+  hijack of `@tanstack/history` (the malicious `1.161.9` /
+  `1.161.12` publishes), but its affected-range expression is
+  `>= 0`, so it also flags the legitimate `1.161.6` we resolve to.
+  Our lockfile (`pnpm-lock.yaml`) is pinned to the clean `1.161.6`
+  via `@tanstack/react-router`, and the dashboard never imports
+  `@tanstack/history` directly. Re-pinning to a hotfix tag isn't
+  available because `react-router` controls the transitive
+  resolution.
+- **Risk if wrong.** None at the pinned version: the malicious
+  versions are never installed (verified by `grep -A1
+  '@tanstack/history@' pnpm-lock.yaml`).
+- **Unlock condition.** Drop this ignore when *any* of the following
+  is true:
+  1. The advisory's affected range is narrowed upstream to exclude
+     `1.161.6` (re-check via `pnpm audit --json | jq
+     '.advisories["GHSA-rmmr-r34h-pfm5"]'`).
+  2. `@tanstack/react-router` ships a release that resolves
+     `@tanstack/history` to a version the advisory does not flag,
+     and we bump to it.
+  3. The dashboard stops depending on `@tanstack/react-router`
+     entirely (the only path that pulls `@tanstack/history` in).
+- **Owner / last review.** Originally landed in #4944
+  (`fix(ci): unblock Security audit job`). Re-audit at the next
+  dependency-hygiene roundup (refs #5667) or whenever
+  `@tanstack/react-router` is bumped, whichever comes first.
+
+## How to add a new ignore
+
+1. Verify the advisory genuinely does not apply to the resolved
+   version (grep `pnpm-lock.yaml`, read the advisory's affected
+   range, confirm we don't call the affected API path).
+2. Add the GHSA id to `pnpm.auditConfig.ignoreGhsas` in
+   `package.json`.
+3. Add a section here with **Why**, **Risk**, **Unlock condition**,
+   and **Owner / last review**.
+4. Reference both files in the PR body so reviewers see the
+   trade-off explicitly.

--- a/crates/librefang-api/dashboard/package.json
+++ b/crates/librefang-api/dashboard/package.json
@@ -16,6 +16,7 @@
       ]
     }
   },
+  "//audit-ignores-doc": "Every GHSA listed under pnpm.auditConfig.ignoreGhsas MUST have a matching section in ./AUDIT_IGNORES.md explaining the trade-off and unlock condition (refs #5667).",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/crates/librefang-cli/Cargo.toml
+++ b/crates/librefang-cli/Cargo.toml
@@ -78,6 +78,13 @@ tracing-opentelemetry = { workspace = true, optional = true }
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }
 
+[build-dependencies]
+# `build.rs` uses `chrono::Utc::now()` to stamp `BUILD_DATE` instead of
+# shelling out to `date`, and `which::which("git")` to resolve git on
+# PATH instead of invoking it by bare name (refs #5667).
+chrono = { workspace = true }
+which = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/librefang-cli/build.rs
+++ b/crates/librefang-cli/build.rs
@@ -1,34 +1,26 @@
 use std::process::Command;
 
 fn main() {
+    // Re-run when the env inputs to git-sha / build-date capture change so
+    // cargo invalidates this build script appropriately (refs #5667).
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+    println!("cargo:rerun-if-env-changed=CI_COMMIT_SHA");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
     // Capture git commit hash at build time.
-    let git_sha = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| "unknown".to_string());
+    //
+    // Prefer CI-provided env vars (`GITHUB_SHA`, `CI_COMMIT_SHA`) — they're
+    // authoritative on hosted runners and avoid spawning `git` entirely.
+    // Outside CI, resolve the `git` binary via `which` first so we don't
+    // depend on shell PATH lookup semantics, then call `git rev-parse`.
+    let git_sha = resolve_git_sha();
     println!("cargo:rustc-env=GIT_SHA={git_sha}");
 
-    // Capture build date (UTC, date only).
-    let build_date = Command::new("date")
-        .args(["-u", "+%Y-%m-%d"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| "unknown".to_string());
+    // Capture build date (UTC, date only) via `chrono::Utc::now()` rather
+    // than shelling out to `date -u +%Y-%m-%d`. Removes a platform-specific
+    // process spawn (BSD `date` and GNU `date` accept different flags) and
+    // keeps the build script reproducible across hosts.
+    let build_date = chrono::Utc::now().format("%Y-%m-%d").to_string();
     println!("cargo:rustc-env=BUILD_DATE={build_date}");
 
     // Capture rustc version.
@@ -45,4 +37,51 @@ fn main() {
         })
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=RUSTC_VERSION={rustc_ver}");
+}
+
+/// Resolve the short git SHA for the build.
+///
+/// Order of preference:
+/// 1. `GITHUB_SHA` (GitHub Actions)
+/// 2. `CI_COMMIT_SHA` (GitLab CI, generic)
+/// 3. `git rev-parse --short HEAD`, with `git` located via `which`.
+/// 4. `"unknown"` if all of the above fail.
+fn resolve_git_sha() -> String {
+    if let Ok(sha) = std::env::var("GITHUB_SHA") {
+        let sha = sha.trim();
+        if !sha.is_empty() {
+            // GitHub provides a full 40-char SHA; truncate to the same
+            // short form `git rev-parse --short HEAD` would produce.
+            return short_sha(sha);
+        }
+    }
+    if let Ok(sha) = std::env::var("CI_COMMIT_SHA") {
+        let sha = sha.trim();
+        if !sha.is_empty() {
+            return short_sha(sha);
+        }
+    }
+
+    let Ok(git) = which::which("git") else {
+        return "unknown".to_string();
+    };
+    Command::new(git)
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn short_sha(sha: &str) -> String {
+    // git's default short SHA length is 7. Match it for parity with the
+    // `git rev-parse --short HEAD` fallback.
+    sha.chars().take(7).collect()
 }


### PR DESCRIPTION
Refs #5667 (sub-findings #4 and #5 from the dependency-hygiene roundup).

## Summary

Contained build-hygiene + audit-documentation fixes from the
quarterly dependency-hygiene roundup. The roundup tracks six
sub-findings; this PR closes the two that don't require a policy
decision. The remaining four are explicitly deferred and the umbrella
issue stays open via `Refs` rather than `Closes`.

## What this PR does

### 1. `build.rs` hardening (#5667 finding #5)

Both `crates/librefang-api/build.rs` and `crates/librefang-cli/build.rs`
previously called `git` and `date` by bare name. On a CI runner with
a malicious shim earlier on `PATH`, that's an arbitrary-code-execution
path during the build. This PR:

- **Prefers CI env vars.** `GITHUB_SHA` and `CI_COMMIT_SHA` are checked
  first; on hosted runners we avoid spawning `git` entirely.
- **Anchors `git` via `which::which("git")`.** When env vars are
  absent (dev machines, local builds), the git binary is resolved
  through the `which` crate before invocation, closing the bare-name
  PATH-shim attack.
- **Replaces `date -u +%Y-%m-%d` with `chrono::Utc::now()`**, removing
  a platform-specific subprocess (BSD `date` and GNU `date` differ on
  flag handling) and keeping the build reproducible across hosts.
- **Adds `cargo:rerun-if-env-changed`** for `GITHUB_SHA`,
  `CI_COMMIT_SHA`, and `SOURCE_DATE_EPOCH` so cargo correctly
  invalidates the build script when those inputs change.

Behaviour is preserved end-to-end:
- `GIT_SHA` is still a short SHA (env values are truncated to the
  same 7-char form `git rev-parse --short HEAD` produces).
- `BUILD_DATE` still formats as `%Y-%m-%d`.
- `"unknown"` fallback still applies when every source fails.

### 2. pnpm audit ignore documentation (#5667 finding #4)

`crates/librefang-api/dashboard/package.json` carries a single
`pnpm.auditConfig.ignoreGhsas` entry (`GHSA-rmmr-r34h-pfm5`) that had
no inline rationale. This PR adds:

- **`crates/librefang-api/dashboard/AUDIT_IGNORES.md`** — one section
  per ignored GHSA, with **why ignored**, **risk if wrong**, **unlock
  condition**, and **owner / last review**.
- **`//audit-ignores-doc`** key in `package.json` pointing at the new
  file so the trade-off is one click away from the ignore list.
  (`//`-prefixed keys are an npm/pnpm-tolerated comment convention.)

### 3. Workspace dependency

Adds `which = "7"` (default-features off) to `[workspace.dependencies]`
and pulls it in as a `[build-dependencies]` entry on both crates,
alongside the existing workspace `chrono`.

## Files touched

- `Cargo.toml` — add `which` to `[workspace.dependencies]`.
- `Cargo.lock` — regenerated (`which 7.0.3` + transitive `env_home`).
- `crates/librefang-api/Cargo.toml` — `[build-dependencies]` block.
- `crates/librefang-api/build.rs` — full rewrite of git/date capture.
- `crates/librefang-cli/Cargo.toml` — `[build-dependencies]` block.
- `crates/librefang-cli/build.rs` — full rewrite of git/date capture.
- `crates/librefang-api/dashboard/package.json` —
  `//audit-ignores-doc` reference key.
- `crates/librefang-api/dashboard/AUDIT_IGNORES.md` — new.

## Verification

- `cargo check -p librefang-api` — pass (1m 25s).
- `cargo check -p librefang-cli` — pass (57.77s).
- `cargo clippy -p librefang-api -p librefang-cli -- -D warnings`
  — pass (no warnings, 1m 01s).
- `package.json` still parses as JSON (`python3 -c "import
  json; json.load(open(...))"`).
- The `//`-prefixed key in `package.json` is the long-standing
  npm-tolerated comment convention (documented in the npm/CLI repo);
  pnpm forwards unrecognized top-level keys untouched.

## Deferred (NOT in this PR)

These items from #5667 need a policy call and/or touch many transitive
deps; doing them here would balloon the diff and conflate two
different review surfaces. Pulled out of scope:

- **Multi-version convergence** (#5667 finding #1, partially #6) —
  `phf_generator 0.8` bump to drop `rand 0.7.3` + `rand_core 0.5.1`,
  and flipping `deny.toml [bans.multiple-versions]` to `deny` with
  per-crate `[[bans.skip]]` for `windows-sys` / `hashbrown` /
  `rand` / `base64`. Needs a maintainer decision on which clusters to
  flip first.
- **Workspace `tokio = ["full"]` convergence** (#5667 finding #3) —
  per-crate feature audit; most leaf crates only need
  `["rt", "macros", "sync"]`. Substantial mechanical change.
- **GTK / `proc-macro-error` chain** (#5667 finding #2) — the original
  finding explicitly says "no new action; revisit quarterly". Skip.
- **`Cargo.lock` duplicate-version sprawl** (#5667 finding #6) — same
  policy surface as #1; revisit alongside the `deny.toml` flip.

The umbrella issue (#5667) stays open via `Refs` to track these.
