### PR TITLE
fix(kernel/config): WARN when [agents.<name>.proactive_memory] appears in config.toml (real path is agent.toml)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -62,6 +62,12 @@
       ]
     }
   ],
-  "results": {},
+  "results": {
+    "crates/librefang-types/src/config/mod.rs": [
+      { "type": "Secret Keyword", "filename": "crates/librefang-types/src/config/mod.rs", "hashed_secret": "1a37d41260f96724ee881be5e261b4d043f0626b", "is_verified": false, "line_number": 431 },
+      { "type": "Secret Keyword", "filename": "crates/librefang-types/src/config/mod.rs", "hashed_secret": "99f5c3ce825ee2626243581c87810ba866778f79", "is_verified": false, "line_number": 755 },
+      { "type": "Basic Auth Credentials", "filename": "crates/librefang-types/src/config/mod.rs", "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684", "is_verified": false, "line_number": 828 }
+    ]
+  },
   "generated_at": "2026-05-02T00:00:00Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,28 @@ The daemon command is `start` (not `daemon`).
   `MIN_HISTORY_MESSAGES = 4` are clamped up with a warning.
   Resolution: agent override > kernel config > compiled default. See
   `docs/architecture/message-history-trimming.md`.
+- **Per-agent `proactive_memory` / `skill_workshop` / `compaction`
+  overrides live in `agent.toml`, NOT `config.toml`** (#5476).
+  `KernelConfig` has no `agents` field, so a block like:
+  ```toml
+  # ~/.librefang/config.toml — silently ignored, NOT honoured
+  [agents.my-agent.proactive_memory]
+  auto_memorize = true
+  ```
+  parses but never feeds into any `AgentManifest`. The kernel emits a
+  targeted `WARN` at boot and on `POST /api/config/reload` pointing
+  operators at the correct surface (see
+  `KernelConfig::detect_misplaced_per_agent_overrides`); the
+  load-bearing path is the agent's own manifest:
+  ```toml
+  # ~/.librefang/workspaces/agents/my-agent/agent.toml — per-agent override
+  [proactive_memory]
+  auto_memorize = true
+  ```
+  Same shape for `[skill_workshop]` and `[compaction]`. Inside a
+  `HAND.toml` the override sits under `[agents.<name>.<key>]`, which
+  *is* read because `HandManifest` does have an `agents` table —
+  `config.toml` does not.
 - **Trigger dispatch concurrency** has three layered caps, scoped to
   the **trigger dispatcher only** (`agent_send`, channel bridges, and
   cron still serialize at the existing per-agent / per-session locks

--- a/crates/librefang-kernel/src/config.rs
+++ b/crates/librefang-kernel/src/config.rs
@@ -138,6 +138,26 @@ pub fn load_config(path: Option<&Path>) -> Result<KernelConfig, String> {
                         }
                     }
 
+                    // #5476: targeted warning for `[agents.<name>.<key>]`
+                    // blocks placed in `config.toml`. These look plausible
+                    // (the original #4870 issue body even published the
+                    // syntax) but `KernelConfig` has no `agents` field, so
+                    // the override silently no-ops. Point operators at
+                    // `agent.toml`'s top-level `[<key>]`, which is the
+                    // actual surface AgentManifest deserialises.
+                    for (agent, key) in
+                        KernelConfig::detect_misplaced_per_agent_overrides(&root_value)
+                    {
+                        tracing::warn!(
+                            agent = %agent,
+                            key = %key,
+                            "[agents.{agent}.{key}] in config.toml is ignored; \
+                             per-agent overrides live in {{workspace}}/agent.toml's \
+                             top-level [{key}] block (or the [agents.{agent}] \
+                             section of a HAND.toml), not in config.toml — see #5476"
+                        );
+                    }
+
                     match root_value.try_into::<KernelConfig>() {
                         Ok(config) => {
                             // Write migrated config back to disk so future loads skip migration
@@ -290,6 +310,21 @@ pub fn try_load_config(path: &Path) -> Result<KernelConfig, String> {
         for field in &all_unknown {
             tracing::warn!(field, "Unknown config field (ignored on reload)");
         }
+    }
+
+    // #5476: same misplaced per-agent override warning as `load_config`,
+    // applied on hot-reload so an operator who tries to "fix" the
+    // override by editing config.toml + `POST /api/config/reload` still
+    // sees the actionable hint instead of silent no-op.
+    for (agent, key) in KernelConfig::detect_misplaced_per_agent_overrides(&root_value) {
+        tracing::warn!(
+            agent = %agent,
+            key = %key,
+            "[agents.{agent}.{key}] in config.toml is ignored on reload; \
+             per-agent overrides live in {{workspace}}/agent.toml's \
+             top-level [{key}] block (or the [agents.{agent}] section of \
+             a HAND.toml), not in config.toml — see #5476"
+        );
     }
 
     root_value
@@ -1183,5 +1218,86 @@ mod tests {
             .expect("unknown-field forward-compat path must still load successfully");
         assert_eq!(config.log_level, "debug");
         assert_eq!(config.api_key, "secret");
+    }
+
+    /// Regression for #5476: a `[agents.<name>.proactive_memory]` block
+    /// in `config.toml` is silently ignored by the kernel (the actual
+    /// surface is `{workspace}/agent.toml`'s top-level
+    /// `[proactive_memory]`). Operators following the original #4870
+    /// issue body's published syntax used to get a silent no-op with
+    /// no log entry pointing at the correct location. Load must now
+    /// (a) still succeed and (b) emit a targeted WARN naming the
+    /// agent and the correct path.
+    #[test]
+    fn test_load_config_misplaced_per_agent_proactive_memory_warns() {
+        use std::io;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt::MakeWriter;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        #[derive(Clone)]
+        struct VecWriter(Arc<Mutex<Vec<u8>>>);
+        impl io::Write for VecWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for VecWriter {
+            type Writer = VecWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("config.toml");
+
+        let mut f = std::fs::File::create(&root).unwrap();
+        writeln!(f, "log_level = \"debug\"").unwrap();
+        writeln!(f, "[proactive_memory]").unwrap();
+        writeln!(f, "enabled = true").unwrap();
+        writeln!(f, "auto_memorize = false").unwrap();
+        writeln!(f).unwrap();
+        // The misplaced override — published verbatim in the #4870
+        // issue description but silently no-ops in beta.12 (#5476).
+        writeln!(f, "[agents.lifeos-daily-brief.proactive_memory]").unwrap();
+        writeln!(f, "auto_memorize = true").unwrap();
+        drop(f);
+
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let writer = VecWriter(buf.clone());
+        let layer = tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .with_ansi(false)
+            .with_target(false);
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _g = tracing::subscriber::set_default(subscriber);
+
+        // Must still load successfully — the misplaced block is a soft
+        // warning, not a hard error.
+        let config = load_config(Some(&root)).expect("misplaced block must not fail load");
+        assert_eq!(config.log_level, "debug");
+
+        let captured = String::from_utf8(buf.lock().unwrap().clone()).expect("utf8");
+        assert!(
+            captured.contains("lifeos-daily-brief"),
+            "warning must name the offending agent; captured: {captured:?}"
+        );
+        assert!(
+            captured.contains("proactive_memory"),
+            "warning must name the offending override key; captured: {captured:?}"
+        );
+        assert!(
+            captured.contains("agent.toml"),
+            "warning must point at the correct surface (agent.toml); captured: {captured:?}"
+        );
+        assert!(
+            captured.contains("#5476"),
+            "warning must reference the tracking issue; captured: {captured:?}"
+        );
     }
 }

--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -1431,4 +1431,88 @@ admin_role = "admin"
         .expect("well-formed repeated tables must still parse with deny_unknown_fields");
         assert_eq!(cfg.mcp_servers.len(), 1);
     }
+
+    // ---------------------------------------------------------------
+    // #5476 — `[agents.<name>.<override_key>]` blocks in config.toml
+    // are silently ignored because `KernelConfig` has no `agents`
+    // field. The detector lists each (agent, key) pair so the kernel
+    // can emit a targeted warning pointing at agent.toml.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn detect_misplaced_per_agent_overrides_flags_proactive_memory_5476() {
+        let raw: toml::Value = toml::from_str(
+            r#"
+            [proactive_memory]
+            enabled = true
+
+            [agents.my-agent.proactive_memory]
+            auto_memorize = true
+            "#,
+        )
+        .expect("toml parse");
+        let found = KernelConfig::detect_misplaced_per_agent_overrides(&raw);
+        assert_eq!(
+            found,
+            vec![("my-agent".to_string(), "proactive_memory".to_string())]
+        );
+    }
+
+    #[test]
+    fn detect_misplaced_per_agent_overrides_handles_multiple_agents_5476() {
+        let raw: toml::Value = toml::from_str(
+            r#"
+            [agents.beta.skill_workshop]
+            enabled = true
+
+            [agents.alpha.proactive_memory]
+            auto_memorize = true
+
+            [agents.alpha.compaction]
+            keep_recent = 20
+            "#,
+        )
+        .expect("toml parse");
+        let found = KernelConfig::detect_misplaced_per_agent_overrides(&raw);
+        // Sorted: (alpha, compaction), (alpha, proactive_memory), (beta, skill_workshop)
+        assert_eq!(
+            found,
+            vec![
+                ("alpha".to_string(), "compaction".to_string()),
+                ("alpha".to_string(), "proactive_memory".to_string()),
+                ("beta".to_string(), "skill_workshop".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn detect_misplaced_per_agent_overrides_empty_without_agents_section_5476() {
+        let raw: toml::Value = toml::from_str(
+            r#"
+            log_level = "debug"
+
+            [proactive_memory]
+            enabled = true
+            "#,
+        )
+        .expect("toml parse");
+        assert!(KernelConfig::detect_misplaced_per_agent_overrides(&raw).is_empty());
+    }
+
+    #[test]
+    fn detect_misplaced_per_agent_overrides_ignores_unrelated_agent_keys_5476() {
+        // Generic typos under `[agents.<name>]` should NOT be flagged
+        // by this detector — they're caught (less specifically) by
+        // the unknown-top-level pass. This detector exists only to
+        // give actionable guidance for the override keys operators
+        // actually try to set per-agent.
+        let raw: toml::Value = toml::from_str(
+            r#"
+            [agents.my-agent.some_random_typo]
+            value = 1
+            "#,
+        )
+        .expect("toml parse");
+        assert!(KernelConfig::detect_misplaced_per_agent_overrides(&raw).is_empty());
+    }
 }

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -251,6 +251,57 @@ impl KernelConfig {
         unknown
     }
 
+    /// Detect `[agents.<name>.<override_key>]` blocks placed in
+    /// `config.toml` (#5476).
+    ///
+    /// `KernelConfig` has no `agents` field — per-agent overrides for
+    /// `proactive_memory`, `skill_workshop`, and `compaction` live in
+    /// each agent's own `agent.toml` (or the `[agents.<name>]` section
+    /// of a `HAND.toml`), not in `config.toml`. The original #4870
+    /// issue body proposed the `config.toml` syntax in error, and the
+    /// kernel silently accepted-and-ignored the block (the unknown
+    /// top-level `agents` key was warned about generically, but the
+    /// warning did not point at the correct surface). Operators
+    /// following the published syntax got a silent no-op.
+    ///
+    /// This helper walks the raw TOML for `[agents.<name>.<key>]`
+    /// sub-tables and returns one `(agent_name, override_key)` pair
+    /// per occurrence, sorted deterministically, so the caller can
+    /// emit a targeted warning that names the correct location. Only
+    /// the keys that are *actually* `agent.toml`-only overrides are
+    /// flagged — generic typos under `[agents]` fall through to the
+    /// existing unknown-top-level warning.
+    pub fn detect_misplaced_per_agent_overrides(raw: &toml::Value) -> Vec<(String, String)> {
+        // Keep this list in sync with the fields on `AgentManifest`
+        // that the kernel honours as per-agent overrides of a global
+        // `KernelConfig` section. Adding a new override here is a
+        // one-line update — the warning text below auto-includes it.
+        const PER_AGENT_OVERRIDE_KEYS: &[&str] =
+            &["proactive_memory", "skill_workshop", "compaction"];
+
+        let Some(agents_tbl) = raw
+            .as_table()
+            .and_then(|t| t.get("agents"))
+            .and_then(|v| v.as_table())
+        else {
+            return Vec::new();
+        };
+
+        let mut found = Vec::new();
+        for (agent_name, agent_value) in agents_tbl {
+            let Some(agent_tbl) = agent_value.as_table() else {
+                continue;
+            };
+            for key in PER_AGENT_OVERRIDE_KEYS {
+                if agent_tbl.contains_key(*key) {
+                    found.push((agent_name.clone(), (*key).to_string()));
+                }
+            }
+        }
+        found.sort();
+        found
+    }
+
     /// Validate the configuration, returning a list of warnings.
     ///
     /// Checks for common misconfigurations such as missing API keys for

--- a/crates/librefang-types/src/memory.rs
+++ b/crates/librefang-types/src/memory.rs
@@ -292,6 +292,23 @@ impl Default for ProactiveMemoryConfig {
 /// [proactive_memory]
 /// auto_memorize = false
 /// ```
+///
+/// **The override surface is `{workspace}/agent.toml`, NOT `config.toml`** (#5476).
+/// A `[agents.<name>.proactive_memory]` block in `~/.librefang/config.toml`
+/// is silently ignored — `KernelConfig` has no `agents` field, so the
+/// block parses but never feeds into any `AgentManifest`. Since #5476
+/// the kernel emits a targeted `WARN` at boot (and on
+/// `POST /api/config/reload`) when this misplacement is detected, but
+/// the load-bearing path is still the agent's own manifest:
+/// ```toml
+/// # ~/.librefang/config.toml — kernel-global default
+/// [proactive_memory]
+/// auto_memorize = false
+///
+/// # ~/.librefang/workspaces/agents/my-agent/agent.toml — per-agent override
+/// [proactive_memory]
+/// auto_memorize = true
+/// ```
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
 pub struct ProactiveMemoryOverrides {


### PR DESCRIPTION
## Summary

`[agents.<name>.proactive_memory]` blocks in `~/.librefang/config.toml`
silently no-op because `KernelConfig` has no `agents` field — the
original #4870 issue body published that exact syntax, so operators
following the docs got a silent failure with no log entry pointing at
the correct surface (`{workspace}/agent.toml`'s top-level
`[proactive_memory]`).

This PR adds defense-in-depth so the footgun is no longer silent.

Closes #5476.

## Changes

1. **Detector** — `KernelConfig::detect_misplaced_per_agent_overrides`
   (in `crates/librefang-types/src/config/validation.rs`) walks raw
   TOML for `[agents.<name>.<key>]` blocks where `<key>` is one of
   the recognised per-agent override surfaces (`proactive_memory`,
   `skill_workshop`, `compaction`). Returns `(agent, key)` pairs in
   deterministic sorted order. Adding a new override surface in the
   future is a one-line update to the `PER_AGENT_OVERRIDE_KEYS`
   array — the warning text auto-includes the new key.

2. **Boot WARN** — both `load_config` (initial boot) and
   `try_load_config` (the hot-reload path used by
   `POST /api/config/reload`) in `crates/librefang-kernel/src/config.rs`
   now emit a targeted `tracing::warn!` per occurrence:

   ```
   [agents.<agent>.<key>] in config.toml is ignored; per-agent
   overrides live in {workspace}/agent.toml's top-level [<key>]
   block (or the [agents.<agent>] section of a HAND.toml), not in
   config.toml — see #5476
   ```

   Generic typos under `[agents]` still fall through to the existing
   unknown-top-level warning (this detector only flags the override
   keys operators actually try to set per-agent, to keep the guidance
   actionable).

3. **Docs** —
   - `ProactiveMemoryOverrides` rustdoc in
     `crates/librefang-types/src/memory.rs` gains an explicit
     "**The override surface is `agent.toml`, NOT `config.toml`**"
     paragraph with a code-block contrast and the issue number.
   - Project `CLAUDE.md` Architecture Notes gain a matching bullet
     covering all three override surfaces (`proactive_memory`,
     `skill_workshop`, `compaction`), so future agents reading the
     repo's anchor doc see the gotcha alongside the existing
     `agent.toml` vs `config.toml` distinctions.

## Verification

Scoped tests (workspace-wide `cargo test` is forbidden per CLAUDE.md):

- `cargo check -p librefang-types -p librefang-kernel --lib` — clean.
- `cargo clippy -p librefang-types -p librefang-kernel --lib --tests -- -D warnings` — clean.
- `cargo test -p librefang-types --lib config::` — 137 passed, 0 failed
  (4 new tests for the detector).
- `cargo test -p librefang-kernel --lib config::` — 37 passed, 0 failed
  (1 new test capturing `tracing` output via a `MakeWriter` and
  asserting the WARN names the agent, the key, the correct surface,
  and the issue number).

## New tests

| Test | File | What it asserts |
|---|---|---|
| `detect_misplaced_per_agent_overrides_flags_proactive_memory_5476` | `librefang-types/src/config/mod.rs` | Single `[agents.X.proactive_memory]` returns `[("X","proactive_memory")]`. |
| `detect_misplaced_per_agent_overrides_handles_multiple_agents_5476` | `librefang-types/src/config/mod.rs` | Multiple agents × multiple override keys are all flagged, sorted deterministically. |
| `detect_misplaced_per_agent_overrides_empty_without_agents_section_5476` | `librefang-types/src/config/mod.rs` | No false positives when `[agents]` isn't present. |
| `detect_misplaced_per_agent_overrides_ignores_unrelated_agent_keys_5476` | `librefang-types/src/config/mod.rs` | Generic typos under `[agents.X]` aren't claimed by this detector (they belong to the unknown-top-level pass). |
| `test_load_config_misplaced_per_agent_proactive_memory_warns` | `librefang-kernel/src/config.rs` | End-to-end: `load_config` of a misplaced block must succeed *and* emit a `WARN` that names the agent (`lifeos-daily-brief`), the key (`proactive_memory`), the correct surface (`agent.toml`), and the tracking issue (`#5476`). |

## Out-of-scope note

The companion `.secrets.baseline` change adds 3 pre-existing
false-positive entries (`api_key_env = "GROQ_API_KEY"`,
`api_key_env = "NVIDIA_PRIMARY_KEY"`, and a `user:pass@…` test
fixture in `redact_proxy_url`'s test). These are all test fixtures
already on `main`; the local `scripts/hooks/pre-commit` detect-secrets
scan was flagging them on any edit to `config/mod.rs` because the
baseline previously had `"results": {}`. Maintainers without
detect-secrets installed locally never saw the block — recording the
known false positives in the baseline restores parity.
