### PR TITLE
fix(runtime-audit): update audit_retention_test for #5683 soft-cap drain

### DIFF
--- a/crates/librefang-kernel/tests/audit_retention_test.rs
+++ b/crates/librefang-kernel/tests/audit_retention_test.rs
@@ -42,6 +42,12 @@ async fn test_kernel_boot_with_retention_config_starts_trim_task() {
     // Seed 50 audit entries — well over the cap of 10. Use RoleChange
     // so no per-action retention rule could kick in (we want the cap
     // path to be the sole reason rows are dropped).
+    //
+    // Since #5683, `record()` enforces a synchronous soft cap at
+    // `1.5 × max_in_memory_entries` (= 15 here), so the in-memory
+    // buffer never grows past ~15 entries during the seed loop. That
+    // still leaves the buffer above the hard cap (10), which is all
+    // the periodic trim task needs to have work to do.
     let audit = kernel.audit_log().clone();
     for i in 0..50 {
         audit.record(
@@ -51,7 +57,11 @@ async fn test_kernel_boot_with_retention_config_starts_trim_task() {
             "ok",
         );
     }
-    assert!(audit.len() >= 50);
+    assert!(
+        audit.len() > 10,
+        "seed should leave the buffer above the hard cap so the periodic trim has rows to drop, got len={}",
+        audit.len()
+    );
 
     // Boot the periodic tasks.
     kernel.start_background_agents().await;


### PR DESCRIPTION
## Summary

`audit_retention_test::test_kernel_boot_with_retention_config_starts_trim_task` has been failing on main since `4c47ac9c` (#5683). The failure shows up on every CI lane that runs kernel integration tests — macOS, Ubuntu shard 1/4, and the `Coverage` workflow all panic at the same pre-boot assertion:

```
crates/librefang-kernel/tests/audit_retention_test.rs:54
assertion failed: audit.len() >= 50
```

The bug is in the test, not in production code. #5683 added a synchronous prefix drain inside `AuditLog::record()` at `1.5 × max_in_memory_entries`. With `max_in_memory_entries = 10`, the in-memory buffer caps at ~15 during the seed loop, so the `>= 50` sanity check is now structurally impossible.

This PR relaxes the sanity check to `audit.len() > 10` — still confirms the buffer is above the hard cap, which is all the periodic trim task needs to have work to do — and documents why in the seed-loop comment. The rest of the test still verifies the periodic trim fires, writes a `RetentionTrim` self-audit row, and preserves chain integrity.

## Verification

```
$ cargo test -p librefang-kernel --test audit_retention_test
running 1 test
test test_kernel_boot_with_retention_config_starts_trim_task ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.10s
```

## Test plan

- [x] `cargo test -p librefang-kernel --test audit_retention_test` passes locally
- [ ] `Test / macOS` green on CI
- [ ] `Test / Ubuntu (shard 1/4)` green on CI
- [ ] `Workspace coverage (llvm-cov)` green on CI

## Out of scope

- `detect-secrets scan` is also red on main (`.secrets.baseline` line-number drift, `line_number: 1332 → 1333`). Independent root cause, tracked separately.

Closes #5692
