### PR TITLE
fix(ci/secret-scan): strip line_number drift from detect-secrets baseline diff

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -44,26 +44,37 @@ jobs:
 
       - name: Scan against baseline
         # `detect-secrets scan --baseline .secrets.baseline` rewrites
-        # the baseline in place. The `generated_at` timestamp is
-        # refreshed on every scan even when nothing else changed, so a
-        # raw `diff` would always fail — strip it (and the auxiliary
-        # `version` field, which only changes when detect-secrets
-        # itself is upgraded) before comparing. We treat any structural
-        # diff as a failure: either the contributor introduced a real
-        # secret, or they audited a false positive without committing
-        # the refreshed baseline. Either way, fix it in the PR.
+        # the baseline in place. Three fields drift on every scan even
+        # when no secret content changed, so a raw `diff` would always
+        # fail — strip them on both sides before comparing:
+        #
+        #   - `generated_at`: refreshed every run (added #5691).
+        #   - `version`: changes only when detect-secrets itself is
+        #     upgraded.
+        #   - `results[][].line_number`: shifts whenever any line is
+        #     added or removed above a previously-audited finding in
+        #     the same file. The audit identity is `hashed_secret +
+        #     filename`, not the line number, so a pure line shift
+        #     carries no security signal but used to break CI on every
+        #     unrelated edit (#5694).
+        #
+        # We treat any remaining structural diff as a failure: either
+        # the contributor introduced a real secret, or they audited a
+        # false positive without committing the refreshed baseline.
+        # Either way, fix it in the PR.
         run: |
           cp .secrets.baseline .secrets.baseline.orig
           detect-secrets scan --baseline .secrets.baseline
+          STRIP='del(.generated_at, .version, .results[][].line_number)'
           if ! diff -q \
-              <(jq 'del(.generated_at, .version)' .secrets.baseline.orig) \
-              <(jq 'del(.generated_at, .version)' .secrets.baseline) \
+              <(jq "$STRIP" .secrets.baseline.orig) \
+              <(jq "$STRIP" .secrets.baseline) \
               >/dev/null; then
             echo "::error::detect-secrets found a change against the committed baseline."
-            echo "Diff (expected vs. scanned, ignoring generated_at / version):"
+            echo "Diff (expected vs. scanned, ignoring generated_at / version / line_number):"
             diff -u \
-              <(jq 'del(.generated_at, .version)' .secrets.baseline.orig) \
-              <(jq 'del(.generated_at, .version)' .secrets.baseline) || true
+              <(jq "$STRIP" .secrets.baseline.orig) \
+              <(jq "$STRIP" .secrets.baseline) || true
             echo ""
             echo "If this is a real secret: revoke it, remove it from the diff, force-push."
             echo "If this is a false positive: run locally"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": ".github/workflows/secret-scan.yml",
         "hashed_secret": "363592208b02dbf9dd9785a3c46ff136a4841c42",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 65
       }
     ],
     "CHANGELOG.md": [
@@ -175,7 +175,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "929b5531f933164784179610dc6d44c9e4fe5e28",
         "is_verified": false,
-        "line_number": 1332
+        "line_number": 1333
       }
     ],
     "articles/hello-librefang.md": [
@@ -4029,5 +4029,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-24T03:07:46Z"
+  "generated_at": "2026-05-24T06:26:02Z"
 }


### PR DESCRIPTION
## Summary

`secrets / detect-secrets scan` is red on `main` (commits since `4c47ac9c`). The only structural change against the committed baseline is one audited CHANGELOG.md false-positive whose `line_number` shifted from 1332 → 1333. The `hashed_secret` and `filename` are unchanged — pure line-shift noise.

PR #5691 fixed the same treadmill for `generated_at` (refreshed on every scan) by stripping it from both sides of the diff. `line_number` has the same property: it carries no security signal once an entry is audited (the identity is `hashed_secret + filename`), and it shifts on every unrelated edit that adds a line above the finding.

This PR extends the strip filter to also drop `line_number` from `results[][]`. CI still catches:

- a new `hashed_secret` appearing,
- an audited entry vanishing from the baseline (revoked-but-not-removed mistakes),
- a previously-audited entry moving to a different `filename`.

It stops catching pure line drift.

The committed `.secrets.baseline` is also refreshed (CHANGELOG.md 1332 → 1333 from today's drift, plus secret-scan.yml's own baselined comment-string 55 → 65 from this PR's edit) so the local `detect-secrets-hook` stays quiet for the next contributor on this branch.

## Verification

Reproduced the current CI failure locally against the unfixed filter, then re-ran with the new filter:

```
$ cp .secrets.baseline /tmp/orig.json
$ detect-secrets scan --baseline .secrets.baseline
$ STRIP='del(.generated_at, .version, .results[][].line_number)'
$ diff -q <(jq "$STRIP" /tmp/orig.json) <(jq "$STRIP" .secrets.baseline) && echo PASS
PASS
```

## Test plan

- [x] Local: `detect-secrets scan --baseline` produces no structural diff under the new filter
- [ ] `secrets / detect-secrets scan` green on CI for this PR
- [ ] Same workflow green on `main` after merge

Closes #5694
