### PR TITLE
fix(sidecar/wechat): log bot_token fingerprint instead of full token (fixes #5543)

### DIFF
--- a/sdk/python/librefang/sidecar/adapters/wechat.py
+++ b/sdk/python/librefang/sidecar/adapters/wechat.py
@@ -71,6 +71,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import json
 import os
 import random
@@ -500,32 +501,40 @@ class WeChatAdapter(SidecarAdapter):
                     # The Rust adapter relied on the dashboard's
                     # /channels/wechat/qr/start + /qr/status endpoints
                     # to capture the token and write it to secrets.env.
-                    # Those routes are gone in the sidecar — surface
-                    # the token at DEBUG so an operator running the
-                    # sidecar at -v can copy it into
-                    # ~/.librefang/secrets.env as WECHAT_BOT_TOKEN to
-                    # skip QR login on subsequent restarts. INFO-level
-                    # message intentionally omits the token to keep
-                    # production logs free of secrets.
+                    # Those routes are gone in the sidecar. The token
+                    # is held in memory for the current session only;
+                    # we log a short SHA-256 fingerprint at DEBUG so
+                    # operators can correlate sessions across logs
+                    # without exposing the raw secret to any log
+                    # aggregator (fixes #5543 — previously logged the
+                    # full token, which is a strict regression vs the
+                    # original Rust-path leak audited under
+                    # docs/issues/wechat-bot-token-prefix-debug-log.md).
+                    token_fp = hashlib.sha256(
+                        token.encode("utf-8"),
+                    ).hexdigest()[:8]
                     log.info(
                         "wechat QR login successful — set WECHAT_BOT_TOKEN "
                         "in ~/.librefang/secrets.env to skip QR on next "
-                        "restart (token logged at DEBUG)",
+                        "restart (re-scan QR to retrieve the token; it is "
+                        "no longer logged in plaintext)",
                     )
-                    log.debug("wechat captured bot_token", bot_token=token)
+                    log.debug(
+                        "wechat captured bot_token",
+                        bot_token_fingerprint=token_fp,
+                    )
                     if emit is not None:
                         # Token is NOT in the protocol event — see
                         # `protocol.qr_status` docstring for why. The
-                        # dashboard surfaces this message verbatim;
-                        # the operator copies the token (logged at
-                        # DEBUG above) into secrets.env by hand.
+                        # dashboard surfaces this message verbatim.
                         emit(protocol.qr_status(
                             "confirmed",
                             message=(
                                 "Login successful. To skip QR on next "
                                 "restart, set WECHAT_BOT_TOKEN in "
-                                "~/.librefang/secrets.env (the token "
-                                "is logged at DEBUG by this sidecar)"
+                                "~/.librefang/secrets.env (re-scan QR "
+                                "to retrieve the token; the sidecar no "
+                                "longer logs it in plaintext)"
                             ),
                         ))
                     return token

--- a/sdk/python/tests/test_wechat_adapter.py
+++ b/sdk/python/tests/test_wechat_adapter.py
@@ -814,8 +814,9 @@ async def test_on_command_typing_empty_user_drops(monkeypatch):
 # dashboard's `GET /api/channels/{name}/qr` projection. These tests
 # pin the contract: the right events fire on the right transitions,
 # with the right payloads (qrcode string surfaced, terminal failure
-# / expiry message populated, captured token logged at DEBUG only —
-# never on the protocol event, see `protocol.qr_status` docstring).
+# / expiry message populated, the raw token never on the protocol
+# event — only a short SHA-256 fingerprint is logged at DEBUG, see
+# `protocol.qr_status` docstring and issue #5543).
 
 
 def _make_qr_responses(*pairs):
@@ -918,6 +919,39 @@ def test_qr_login_emits_failed_on_qrcode_request_error(monkeypatch):
         f"got: {methods}"
     )
     assert captured[-1]["params"]["status"] == "failed"
+
+
+def test_qr_login_never_logs_full_bot_token(monkeypatch, capsys):
+    # Regression for #5543: the captured bot_token MUST NOT appear in
+    # any stderr log line (INFO or DEBUG). Only a short SHA-256
+    # fingerprint may surface for cross-session correlation.
+    import hashlib
+
+    secret = "tok_live_secret_value"
+    fp = hashlib.sha256(secret.encode("utf-8")).hexdigest()[:8]
+    monkeypatch.setattr(
+        wc, "_http_request",
+        _make_qr_responses(
+            (200, {"qrcode": "opaque-token"}),
+            (200, {"status": "confirmed", "bot_token": secret}),
+        ),
+    )
+    a = _adapter(WECHAT_BOT_TOKEN="")
+    captured: list = []
+    token = a._qr_login(emit=captured.append)
+    assert token == secret  # in-process return path unchanged
+
+    err = capsys.readouterr().err
+    assert secret not in err, (
+        "full bot_token leaked into stderr logs — see issue #5543"
+    )
+    assert fp in err, (
+        "SHA-256 fingerprint missing from DEBUG log — operator loses "
+        "cross-session correlation signal"
+    )
+    # Protocol event is the second guardrail.
+    confirmed = next(e for e in captured if e["method"] == "qr_status")
+    assert secret not in json.dumps(confirmed)
 
 
 def test_qr_login_without_emit_still_returns_token(monkeypatch):


### PR DESCRIPTION
## Summary

The Python WeChat sidecar adapter logged the full `bot_token` at DEBUG
(`sdk/python/librefang/sidecar/adapters/wechat.py:515`). This is a
strict regression vs. the original Rust-path leak audited under
`docs/issues/wechat-bot-token-prefix-debug-log.md` (which logged only
the first 10 chars). A captured bot token grants the holder full
impersonation access to the WeChat platform's outbound messaging, and
DEBUG-level logs typically ship to aggregators with longer retention
than the OAuth flow that produced the token.

Replace the value with a short SHA-256 fingerprint (first 8 hex chars)
so cross-session correlation still works for operators / debuggers
without leaking the raw secret.

The previous INFO line and `qr_status` event message both advertised
"token logged at DEBUG" — that's now false, so the operator guidance
is updated to "re-scan QR to retrieve the token". The
`WECHAT_BOT_TOKEN` / `secrets.env` references are preserved (the
existing dashboard contract test pins them).

## Files

- `sdk/python/librefang/sidecar/adapters/wechat.py` — fingerprint the
  DEBUG log; update the surrounding INFO and `qr_status` message; add
  `hashlib` import; refresh the doc comment to cite #5543.
- `sdk/python/tests/test_wechat_adapter.py` — new regression
  `test_qr_login_never_logs_full_bot_token` asserts the raw token
  appears nowhere in stderr logs and the SHA-256 fingerprint is
  present at DEBUG; section header comment updated to match.

## Sibling-leak audit

Searched all `bot_token` references across `sdk/python/librefang/sidecar/`
— `slack.py` and `webex.py` hold tokens in instance attrs but never log
the value. `wechat.py:515` was the sole leak.

## Verification

- `python3 -m ast` parses both files cleanly.
- `pytest -k qr_login` → 10 passed (new regression test included).
- The two pre-existing async-test failures (`test_on_send_*`) are
  unrelated and reproduce on `origin/main`; root cause is missing
  `pytest-asyncio` registration, not this change.

Fixes #5543.