### PR TITLE
fix(docker): replace removed `all-channels` feature with `telemetry`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -92,6 +92,14 @@ i18n
 web
 *.md
 !crates/**/*.md
+# sdk/python/librefang is embedded into the binary at compile time by
+# librefang-channels (include_dir! in embedded_sdk.rs, #5472), so the
+# `sdk` exclusion above must let this one subtree back into the build
+# context. Placed after the *.md rule so the lone tracked Markdown file
+# (sidecar/template/README.md) survives — .dockerignore honors the last
+# matching pattern.
+!sdk/python/librefang
+!sdk/python/librefang/**
 LICENSE-*
 CLAUDE.md
 AGENTS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,12 +59,12 @@ COPY --from=dashboard-builder /build/static/react ./crates/librefang-api/static/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/build/target \
-    # `--features all-channels`: the published Docker image is the full
-    # daemon, so opt back in to every channel adapter. The CLI's `default`
-    # was slimmed to a "core-channels" subset (see #3655 / #3688) to keep
-    # developer cold-build time low; release/packaging pipelines re-enable
-    # the full set explicitly.
-    cargo build --release --bin librefang --features all-channels && \
+    # `--features telemetry`: the published Docker image is the full
+    # daemon, so it ships with telemetry on. Channel adapters all run as
+    # out-of-process sidecars now (see #5408 / #5461), so the old
+    # `all-channels` / `core-channels` aliases are gone — `telemetry` is
+    # the whole opt-in surface left, matching the CLI's own `default`.
+    cargo build --release --bin librefang --features telemetry && \
     cp target/release/librefang /usr/local/bin/librefang
 
 # Pinned to a specific Node 22 LTS minor (not floating `node:lts-bookworm-slim`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,12 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY xtask ./xtask
 COPY packages ./packages
+# librefang-channels embeds the Python SDK tree at compile time via
+# include_dir!("$CARGO_MANIFEST_DIR/../../sdk/python/librefang") in
+# embedded_sdk.rs (added in #5472). Without this COPY the proc macro
+# panics with "sdk/python/librefang is not a directory". Only this one
+# subtree is needed — .dockerignore keeps the rest of sdk/ out.
+COPY sdk/python/librefang ./sdk/python/librefang
 # librefang-api uses include_str!("../../../deploy/...") to embed the
 # observability stack (prometheus / tempo / otel-collector / grafana
 # configs) at compile time — added in #3062. Without this COPY the


### PR DESCRIPTION
## Problem

The `Docker Build` job on `main` has been red since at least 2026-05-21 (commit 7b130dd6 most recently):

```
error: none of the selected packages contains this feature: all-channels
ERROR: process "/bin/sh -c cargo build --release --bin librefang --features all-channels ..." exit code: 101
```

## Root cause

Two failures, the second masked by the first, both fallout from the channel→sidecar migration (#5408 / #5461 / #5472) updating the workspace but not the Docker build:

1. **Removed feature.** #5461 deleted the `all-channels` feature from `librefang-cli` / `librefang-api`. The release workflows moved to `--features telemetry` / `mini`, but the `Dockerfile` (last touched in #4787, before the migration) still built with `--features all-channels`. cargo failed at feature resolution, before compiling anything.

2. **Missing embedded SDK.** Once the feature error was cleared, the build advanced to compiling `librefang-channels` and hit:
   ```
   error: proc macro panicked
     --> crates/librefang-channels/src/embedded_sdk.rs:80:32
      = help: message: ".../sdk/python/librefang" is not a directory
   ```
   `embedded_sdk.rs` (#5472) embeds the Python SDK tree at compile time via `include_dir!`. The Dockerfile never copied `sdk/` into the build context, and `.dockerignore` actively excluded the whole `sdk` directory.

## Fix

- `Dockerfile:67`: `--features all-channels` → `--features telemetry` (the only opt-in left for the full daemon image; matches the CLI's own `default = ["telemetry"]`).
- `Dockerfile`: `COPY sdk/python/librefang ./sdk/python/librefang` — only the subtree the macro reads.
- `.dockerignore`: re-admit that subtree, after the `*.md` rule so the tracked `sidecar/template/README.md` survives (last matching pattern wins).
- Stale comments updated.

## Verification

- Scanned every cross-crate `include_dir!`/`include_str!` to rule out a third masked gap: `deploy/` and `static/react` are already copied; `examples/` is read only from `#[test]` code (not compiled in release); `init_wizard.rs`'s `templates/` resolves inside the crate dir (`COPY crates` covers it).
- Cannot build the image locally (sandbox blocks release builds + the daemon). Verified by manual `workflow_dispatch` of `docker-build.yml` against this branch — run linked below. The first dispatch confirmed fix #1 (build advanced past feature resolution into compilation); the post-fix-#2 dispatch is the full-build verification.
- Did **not** touch `docker-build.yml`'s trigger `paths`: that list tracks structural build inputs (Dockerfile, lockfiles, manifests), not embedded content — `crates/**/*.rs` isn't there either, so adding `sdk/**` would be inconsistent.
