### PR TITLE
fix(secrets): add provider_budget_routes_test to detect-secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1230,6 +1230,15 @@
         "line_number": 64
       }
     ],
+    "crates/librefang-api/tests/provider_budget_routes_test.rs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "crates/librefang-api/tests/provider_budget_routes_test.rs",
+        "hashed_secret": "17bb10d3f44323963c21bf3c97341ebb5accf05e",
+        "is_verified": false,
+        "line_number": 61
+      }
+    ],
     "crates/librefang-api/tests/providers_routes_test.rs": [
       {
         "type": "Secret Keyword",
@@ -2260,56 +2269,56 @@
         "filename": "crates/librefang-runtime-mcp/src/lib.rs",
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_verified": false,
-        "line_number": 1722
+        "line_number": 1845
       },
       {
         "type": "GitHub Token",
         "filename": "crates/librefang-runtime-mcp/src/lib.rs",
         "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
         "is_verified": false,
-        "line_number": 2780
+        "line_number": 3001
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "crates/librefang-runtime-mcp/src/lib.rs",
         "hashed_secret": "ff710f15aabf3e96e11af9b0bfc454eb30a5031d",
         "is_verified": false,
-        "line_number": 2780
+        "line_number": 3001
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "crates/librefang-runtime-mcp/src/lib.rs",
         "hashed_secret": "87955f1ea3e6ed149e981f737a5dc8ceaf5786e6",
         "is_verified": false,
-        "line_number": 2960
+        "line_number": 3181
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-runtime-mcp/src/lib.rs",
         "hashed_secret": "87955f1ea3e6ed149e981f737a5dc8ceaf5786e6",
         "is_verified": false,
-        "line_number": 2960
+        "line_number": 3181
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "crates/librefang-runtime-mcp/src/lib.rs",
         "hashed_secret": "b8529592e3cf6195df4ca70cba25403168b625cd",
         "is_verified": false,
-        "line_number": 3027
+        "line_number": 3248
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "crates/librefang-runtime-mcp/src/lib.rs",
         "hashed_secret": "ee333313f1b6a2ecff54d01edf73f965d161d1b3",
         "is_verified": false,
-        "line_number": 3060
+        "line_number": 3281
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "crates/librefang-runtime-mcp/src/lib.rs",
         "hashed_secret": "91b90695a8e87ed73a50a2912d71f6da9ee5de6c",
         "is_verified": false,
-        "line_number": 3779
+        "line_number": 4000
       }
     ],
     "crates/librefang-runtime-mcp/src/mcp_oauth.rs": [
@@ -2702,21 +2711,21 @@
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "e84fc93286dec77fb75fbe036dff86318eb3503e",
         "is_verified": false,
-        "line_number": 3604
+        "line_number": 3605
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "c6c914a1fb807d140dfafbe0139614358330e43f",
         "is_verified": false,
-        "line_number": 3619
+        "line_number": 3620
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "6baf51b50e44bb41da5fb5dc6dbbb801217ffd32",
         "is_verified": false,
-        "line_number": 4238
+        "line_number": 4239
       }
     ],
     "crates/librefang-types/src/config/version.rs": [
@@ -4029,5 +4038,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-24T06:26:02Z"
+  "generated_at": "2026-05-25T09:00:58Z"
 }


### PR DESCRIPTION
## Problem

The authoritative `detect-secrets scan` gate (`secret-scan.yml`) is red on `main` (commit d4f992b6):

```
##[error]detect-secrets found a change against the committed baseline.
+    "crates/librefang-api/tests/provider_budget_routes_test.rs": [
+      { "type": "Secret Keyword", "hashed_secret": "17bb10d3...", "is_verified": false }
+    ],
```

## Root cause

#5705 ("per-provider budget caps") added `crates/librefang-api/tests/provider_budget_routes_test.rs`, which contains:

```rust
api_key_env: "OLLAMA_API_KEY".to_string(),
```

`"OLLAMA_API_KEY"` is an environment-variable **name** (which env var to read the key from), not a secret — a Secret Keyword false positive. #5705 did not refresh `.secrets.baseline`, so the live scan now finds an entry the committed baseline lacks and the gate fails.

The flagged value is provably benign: `17bb10d3f44323963c21bf3c97341ebb5accf05e` is the SHA-1 of the literal string `OLLAMA_API_KEY`, and that exact hash is **already** whitelisted in the baseline for the analogous `providers_routes_test.rs` (line 833). Same false positive, just missed for the new file.

## Fix

Regenerated `.secrets.baseline` with `detect-secrets scan --baseline .secrets.baseline` (local v1.5.0, matching CI's `>=1.5.0,<2.0.0` pin and the baseline's recorded version). The only substantive change is the one new `is_verified: false` entry; `generated_at` / `version` / `line_number` are stripped by the CI diff.

## Verification

- Confirmed the diff (ignoring stripped fields) contains exactly one new entry and removes nothing.
- Hash equality verified locally: `printf 'OLLAMA_API_KEY' | shasum -a 1` → `17bb10d3...`.
- This is independent of the Docker fix in #5702; that one is already merged.
