### PR TITLE
fix(sdk): regenerate SDKs for /api/budget/providers to repair main CI drift

### DIFF
--- a/sdk/go/librefang.go
+++ b/sdk/go/librefang.go
@@ -660,6 +660,14 @@ func (r *BudgetResource) UpdateAgentBudget(id string, data map[string]interface{
 	return r.client.request("PUT", fmt.Sprintf("/api/budget/agents/%s", id), data, nil)
 }
 
+func (r *BudgetResource) ProviderBudgetList() (interface{}, error) {
+	return r.client.request("GET", "/api/budget/providers", nil, nil)
+}
+
+func (r *BudgetResource) UpdateProviderBudget(provider_id string, data map[string]interface{}) (interface{}, error) {
+	return r.client.request("PUT", fmt.Sprintf("/api/budget/providers/%s", provider_id), data, nil)
+}
+
 func (r *BudgetResource) UserBudgetRanking(query map[string]string) (interface{}, error) {
 	return r.client.request("GET", "/api/budget/users", nil, query)
 }

--- a/sdk/javascript/index.js
+++ b/sdk/javascript/index.js
@@ -532,6 +532,14 @@ class BudgetResource {
     return this._c._request("PUT", `/api/budget/agents/${id}`, data, undefined);
   }
 
+  async providerBudgetList() {
+    return this._c._request("GET", "/api/budget/providers");
+  }
+
+  async updateProviderBudget(provider_id, data) {
+    return this._c._request("PUT", `/api/budget/providers/${provider_id}`, data, undefined);
+  }
+
   async userBudgetRanking(query) {
     return this._c._request("GET", "/api/budget/users", undefined, query);
   }

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -444,6 +444,12 @@ class _BudgetResource(_Resource):
     def update_agent_budget(self, id: str, **data):
         return self._c._request("PUT", f"/api/budget/agents/{id}", data)
 
+    def provider_budget_list(self):
+        return self._c._request("GET", "/api/budget/providers")
+
+    def update_provider_budget(self, provider_id: str, **data):
+        return self._c._request("PUT", f"/api/budget/providers/{provider_id}", data)
+
     def user_budget_ranking(self, limit: Any = None):
         return self._c._request("GET", "/api/budget/users", None, query={"limit": limit})
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1523,6 +1523,30 @@ impl BudgetResource {
         .await
     }
 
+    pub async fn provider_budget_list(&self) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::GET,
+            &"/api/budget/providers".to_string(),
+            None,
+            &[],
+        )
+        .await
+    }
+
+    pub async fn update_provider_budget(&self, provider_id: &str, data: Value) -> Result<Value> {
+        do_req(
+            &self.client,
+            &self.base_url,
+            reqwest::Method::PUT,
+            &format!("/api/budget/providers/{}", provider_id),
+            Some(data),
+            &[],
+        )
+        .await
+    }
+
     pub async fn user_budget_ranking(&self, limit: Option<&str>) -> Result<Value> {
         do_req(
             &self.client,


### PR DESCRIPTION
## Problem

`main` is red: the push-event **OpenAPI Drift** check (CI job, run `26393061204` on `7d5e3e5d`) fails with:

> openapi.json, generated SDKs, or schema baselines are out of sync with the source code.

On a push to `main` the job runs with `IS_INTERNAL_PR=false`, so the auto-commit path is disabled and the drift just fails the build.

## Root cause

PR #5705 (per-provider budget caps surface) added two endpoints:

- `GET /api/budget/providers`
- `PUT /api/budget/providers/{provider_id}`

and regenerated `openapi.json` + `xtask/baselines/openapi.sha256` — but it never ran `scripts/codegen-sdks.py`. Its merged diff touched **0 files under `sdk/`**. So `openapi.json` advertises the provider endpoints while the four generated SDK clients (`python` / `javascript` / `go` / `rust`) lack the matching methods. The drift check regenerates all artifacts and catches the mismatch.

## Fix

Regenerated the four SDKs from the committed `openapi.json` (`python3 scripts/codegen-sdks.py`). The diff is exactly the two new provider-budget client methods per SDK (+46 lines total, no deletions).

## Verification

- `python3 scripts/codegen-sdks.py` → `git diff` shows only the provider-budget methods in `sdk/{python,javascript,go,rust}`.
- `rustfmt --check --edition 2021 sdk/rust/src/lib.rs` → clean (matches the pre-commit hook).
- Confirmed the other two artifact groups are already in sync, so `sdk/` is the sole drift:
  - `openapi.json`, `xtask/baselines/*`, `crates/librefang-types`, and `crates/librefang-kernel/src/config.rs` are **unchanged since #5705** (empty `git diff 739993f7 7d5e3e5d -- …`).
  - committed `xtask/baselines/openapi.sha256` (`6e96817…`) equals `shasum -a 256 openapi.json`.
  - #5704 (the only other API-adjacent post-#5705 PR) touched only `librefang-runtime-mcp` / `librefang-runtime`, not config/agent/types schemas.

Full `cargo`-based regeneration of `openapi.json` + baselines was not run locally (build is CI-only per project policy); the evidence above shows those artifacts are already correct, and CI will regenerate and re-verify all three groups on this PR.
