### PR TITLE
fix(nix): include sdk/python/librefang in flake source filter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,9 @@
             ./crates/librefang-desktop/capabilities
             ./crates/librefang-desktop/icons
             ./crates/librefang-desktop/gen
+            # librefang-channels embeds this tree via include_dir!
+            # at compile time (crates/librefang-channels/src/embedded_sdk.rs).
+            ./sdk/python/librefang
             ./packages/whatsapp-gateway
             ./deploy/docker-compose.observability.yml
             ./deploy/grafana


### PR DESCRIPTION
## Summary

Adds `./sdk/python/librefang` to `flake.nix`'s `fileset.unions` source
filter so `librefang-channels`' `include_dir!` macro can find the
Python sidecar tree at compile time inside the Nix sandbox.

Closes #5713.

## Root cause (recap)

- #5472 introduced `crates/librefang-channels/src/embedded_sdk.rs:80`:
  ```rust
  static EMBEDDED_SDK: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../sdk/python/librefang");
  ```
- `flake.nix:64-84` builds with an explicit allowlist filter via
  `pkgs.lib.fileset.toSource` — anything not listed is excluded from
  the build sandbox.
- The allowlist did not include `./sdk/python/librefang`, so
  `include_dir!` panicked at proc-macro evaluation:
  ```
  help: "/build/source/crates/librefang-channels/../../sdk/python/librefang" is not a directory
  ```
- `cargo build` outside Nix is unaffected because the full repo is on
  disk, which is why the regression slipped past local verification on
  #5472 and only surfaced on the Nix CI lane.
- `v2026.5.25-beta.13` is the first tag containing the offending
  commit; that tag's `Nix Build` and the `Nix Build` lane on `main`
  have been red since merge.

## Diff

```diff
             ./crates/librefang-desktop/icons
             ./crates/librefang-desktop/gen
+            # librefang-channels embeds this tree via include_dir!
+            # at compile time (crates/librefang-channels/src/embedded_sdk.rs).
+            ./sdk/python/librefang
             ./packages/whatsapp-gateway
```

The inline comment exists so a future reader extending the filter
list knows why this path is there — without the comment it would look
like an arbitrary entry.

## Verification

- Local Nix build cannot run from the AI session (no Nix on the dev
  machine in use here; per repo policy I do not run `cargo build`
  either). CI's `Nix Build` job on this PR is the authoritative check
  — it should turn green where the equivalent job on the
  `v2026.5.25-beta.13` tag and current `main` is red.
- `cargo check --workspace --lib` is unaffected by this change; only
  the Nix source-filter is touched.
- No changes to crate sources, Cargo.toml, lockfile, or
  CI workflows — single 3-line addition to `flake.nix`.

## Scope

- Not on the Release publish path — npm / PyPI / crates.io / Docker /
  CLI binary publishes are unaffected and were not retriggered.
- Targets `main`; no backport needed (there is no release branch with
  the affected code that doesn't also need the same fix on `main`
  first).
