### PR TITLE
release: v2026.5.25-beta.14

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,7 +175,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "929b5531f933164784179610dc6d44c9e4fe5e28",
         "is_verified": false,
-        "line_number": 1338
+        "line_number": 1347
       }
     ],
     "articles/hello-librefang.md": [
@@ -4038,5 +4038,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-25T12:03:09Z"
+  "generated_at": "2026-05-25T13:05:20Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ## [2026.5.25] - 2026-05-25
 
-_No notable changes._
+_1 PR from 1 contributor since v2026.5.25-beta.13._
+
+### Highlights
+
+- **Python SDK in Nix flake** — the `sdk/python/librefang` package is now included in the Nix source filter, so Nix-based builds and derivations correctly pick up Python SDK changes without manual workarounds.
+
+### Fixed
+
+- Include sdk/python/librefang in flake source filter (#5714) (@houko)
+
 
 ## [Unreleased]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-acp"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-tokio",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "async-trait",
  "axum",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "axum",
  "clap",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "librefang-types",
  "reqwest",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-import"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "librefang-llm-driver",
  "librefang-memory",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4545,7 +4545,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory-wiki"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "chrono",
  "librefang-kernel-handle",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-rl-export"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-audit"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "chrono",
  "hex",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-media"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-sandbox-docker"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4718,7 +4718,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4754,7 +4754,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4776,7 +4776,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -11976,7 +11976,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.5.32263",
+  "version": "26.5.32264",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
     },
-    "version": "2026.5.25-beta.13"
+    "version": "2026.5.25-beta.14"
   },
   "paths": {
     "/.well-known/agent.json": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.5.25-beta.13",
+  "version": "2026.5.25-beta.14",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.5.25-beta.13",
+  "version": "2026.5.25-beta.14",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.5.25b13",
+    version="2026.5.25b14",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.5.25-beta.13"
+version = "2026.5.25-beta.14"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-cde6a88bc6dff5265dee4d761f23f1376a1592eece43edfeac75efcd96c68c53  openapi.json
+43ace20ce21770464f9eb0399839246bd8100428ac4db453bcc119113adbe0b1  openapi.json


### PR DESCRIPTION
<!-- release-tag:v2026.5.25-beta.14 -->
## Release v2026.5.25-beta.14

_1 PR from 1 contributor since v2026.5.25-beta.13._

### Highlights

- **Python SDK in Nix flake** — the `sdk/python/librefang` package is now included in the Nix source filter, so Nix-based builds and derivations correctly pick up Python SDK changes without manual workarounds.

### Fixed

- Include sdk/python/librefang in flake source filter (#5714) (@houko)

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.5.25-beta.13...v2026.5.25-beta.14