### PR TITLE
fix(runtime): enforce ownership in schedule_delete; migrate schedule_* to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -898,12 +898,20 @@ pub async fn execute_tool_raw(
         "task_status" => tool_task_status(input, *kernel).await,
         "event_publish" => tool_event_publish(input, *kernel).await,
 
-        // Scheduling tools (delegate to CronScheduler via kernel handle)
-        "schedule_create" => {
-            tool_schedule_create(input, *kernel, *caller_agent_id, *sender_id).await
-        }
-        "schedule_list" => tool_schedule_list(*kernel, *caller_agent_id).await,
-        "schedule_delete" => tool_schedule_delete(input, *kernel).await,
+        // Scheduling tools (delegate to CronScheduler via kernel handle).
+        // Second slice of the #3576 typed-error migration: the submodule now
+        // returns `Result<String, ToolError>`; the dispatch arms narrow it to
+        // `Result<String, String>` here at the boundary so the broader
+        // dispatch table stays uniform until every submodule has migrated.
+        "schedule_create" => tool_schedule_create(input, *kernel, *caller_agent_id, *sender_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "schedule_list" => tool_schedule_list(*kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "schedule_delete" => tool_schedule_delete(input, *kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Knowledge graph tools
         "knowledge_add_entity" => tool_knowledge_add_entity(input, *kernel).await,

--- a/crates/librefang-runtime/src/tool_runner/schedule.rs
+++ b/crates/librefang-runtime/src/tool_runner/schedule.rs
@@ -2,10 +2,32 @@
 //!
 //! Accept natural language schedules ("daily at 9am") and delegate to
 //! `kh.cron_create/list/cancel`, which use the real kernel tick loop (#2024).
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576) — second slice after `tool_runner::cron`. The internal
+//! `parse_schedule_to_cron` / `parse_time_to_hour` helpers keep their
+//! `Result<_, String>` shape (a pure sub-layer with no kernel contact) and
+//! are mapped to `ToolError::InvalidParameter` at the tool boundary.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
+
+/// `ToolError` for a `schedule_*` tool reached with no caller agent id.
+/// Mirrors `tool_runner::cron::caller_agent_id_missing`: the MCP HTTP route
+/// legitimately passes `None` (missing/unknown `X-LibreFang-Agent-Id`), which
+/// is user-recoverable input, so it surfaces as `MissingParameter` (→ 400)
+/// rather than `Internal`. The direct agent-loop dispatcher always attributes
+/// a caller, so `None` there is a wiring bug the LLM cannot patch either way;
+/// the tool name is preserved on the tracing channel for operators.
+fn caller_agent_id_missing(tool: &'static str) -> ToolError {
+    tracing::warn!(
+        tool,
+        "caller agent_id missing — surfaced as MissingParameter to the LLM"
+    );
+    ToolError::MissingParameter("agent_id")
+}
 
 /// Parse a natural language schedule into a cron expression.
 pub(super) fn parse_schedule_to_cron(input: &str) -> Result<String, String> {
@@ -133,18 +155,22 @@ pub(super) async fn tool_schedule_create(
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
     sender_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let agent_id = caller_agent_id.ok_or("Agent ID required for schedule_create")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("schedule_create"))?;
     let description = input["description"]
         .as_str()
-        .ok_or("Missing 'description' parameter")?;
+        .ok_or(ToolError::MissingParameter("description"))?;
     let schedule_str = input["schedule"]
         .as_str()
-        .ok_or("Missing 'schedule' parameter")?;
+        .ok_or(ToolError::MissingParameter("schedule"))?;
     let message = input["message"].as_str().unwrap_or(description);
 
-    let cron_expr = parse_schedule_to_cron(schedule_str)?;
+    let cron_expr =
+        parse_schedule_to_cron(schedule_str).map_err(|reason| ToolError::InvalidParameter {
+            name: "schedule",
+            reason,
+        })?;
 
     // CronJob name only allows alphanumeric + space/hyphen/underscore (max 128 chars).
     // Sanitize the user-provided description to fit these constraints.
@@ -188,7 +214,7 @@ pub(super) async fn tool_schedule_create(
     let result = kh
         .cron_create(agent_id, job_json)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!(
         "Schedule created and will execute automatically.\n  Cron: {cron_expr}\n  Original: {schedule_str}\n  {result}"
     ))
@@ -197,10 +223,10 @@ pub(super) async fn tool_schedule_create(
 pub(super) async fn tool_schedule_list(
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let agent_id = caller_agent_id.ok_or("Agent ID required for schedule_list")?;
-    let jobs = kh.cron_list(agent_id).await.map_err(|e| e.to_string())?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("schedule_list"))?;
+    let jobs = kh.cron_list(agent_id).await.map_err(ToolError::upstream)?;
 
     if jobs.is_empty() {
         return Ok("No scheduled tasks.".to_string());
@@ -229,13 +255,76 @@ pub(super) async fn tool_schedule_list(
 pub(super) async fn tool_schedule_delete(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+    caller_agent_id: Option<&str>,
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     // Accept either "id" or "job_id" for backward compatibility
     let id = input["id"]
         .as_str()
         .or_else(|| input["job_id"].as_str())
-        .ok_or("Missing 'id' parameter")?;
-    kh.cron_cancel(id).await.map_err(|e| e.to_string())?;
+        .ok_or(ToolError::MissingParameter("id"))?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("schedule_delete"))?;
+    // Authorize: the caller may only delete jobs that belong to them.
+    // `KernelHandle::cron_cancel` removes by UUID with no ownership check
+    // (see `kernel/handles/cron_control.rs`), and the sibling `cron_cancel`
+    // tool already enforces this guard at the tool layer — `schedule_delete`
+    // must too, or it is a trivial bypass: any agent with this tool could
+    // cancel another agent's job by learning its UUID.
+    let owned = kh.cron_list(agent_id).await.map_err(ToolError::upstream)?;
+    let owns_job = owned.iter().any(|job| {
+        job.get("id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|jid| jid == id)
+    });
+    if !owns_job {
+        // Collapse "not owned" and "doesn't exist" into one NotFound — see
+        // the variant doc on `ToolError::NotFound` for the side-channel
+        // rationale (mirrors `cron_cancel`).
+        return Err(ToolError::NotFound {
+            kind: "Schedule",
+            id: id.to_string(),
+        });
+    }
+    kh.cron_cancel(id).await.map_err(ToolError::upstream)?;
     Ok(format!("Schedule '{id}' deleted."))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure validation / wiring-boundary tests that run BEFORE any kernel
+    //! call. The ownership-check path in `tool_schedule_delete` (which needs
+    //! `cron_list` to return jobs) lives in the integration test file
+    //! `tests/tool_runner_forwarding_task_cron.rs` alongside the cron
+    //! equivalents, where the `CapturingKernel` stub is available — same split
+    //! as `tool_runner::cron`.
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn schedule_create_without_kernel_returns_unavailable() {
+        let r = tool_schedule_create(&json!({}), None, Some("agent-a"), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn schedule_list_without_kernel_returns_unavailable() {
+        let r = tool_schedule_list(None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn schedule_delete_without_kernel_returns_unavailable() {
+        let r = tool_schedule_delete(&json!({"id": "x"}), None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[test]
+    fn caller_agent_id_missing_surfaces_as_missing_parameter() {
+        let e = caller_agent_id_missing("schedule_delete");
+        assert!(
+            matches!(e, ToolError::MissingParameter("agent_id")),
+            "expected MissingParameter(\"agent_id\"), got {e:?}"
+        );
+        assert!(e.to_string().contains("agent_id"));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/tests/policy.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/policy.rs
@@ -589,7 +589,11 @@ async fn test_schedule_tools_without_kernel() {
     )
     .await;
     assert!(result.is_error);
-    assert!(result.content.contains("Kernel handle not available"));
+    // #3576: schedule_* now goes through `require_kernel_typed`, which yields
+    // `ToolError::Unavailable("Kernel handle")` rendered as "Kernel handle
+    // unavailable" (the old `require_kernel` string was "Kernel handle not
+    // available ..."). shell.rs still asserts the old text until shell migrates.
+    assert!(result.content.contains("Kernel handle unavailable"));
 }
 
 // ─── Canvas / A2UI tests ────────────────────────────────────────

--- a/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
+++ b/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
@@ -631,3 +631,85 @@ async fn test_cron_cancel_missing_job_id_renders_as_missing_parameter() {
 fn cancel_was_never_called(calls: &CapturedCalls) -> bool {
     calls.cron_cancel.lock().unwrap().is_empty()
 }
+
+// schedule_delete ownership coverage (#3576 second-slice migration). The
+// natural-language `schedule_delete` shares `KernelHandle::cron_cancel` with
+// `cron_cancel`, which cancels by UUID with no ownership filtering. These pin
+// that `schedule_delete` enforces the same tool-layer ownership guard as
+// `cron_cancel` — previously it did not, so it was a bypass.
+
+#[tokio::test]
+async fn test_schedule_delete_succeeds_when_caller_owns_the_job() {
+    let (kernel, calls) = CapturingKernel::new();
+    kernel.set_cron_list_response(vec![json!({"id": "sched-99"})]);
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, Some("agent-1"));
+    let result = execute_tool_raw("s1", "schedule_delete", &json!({"id": "sched-99"}), &ctx).await;
+
+    assert!(
+        !result.is_error,
+        "schedule_delete should succeed when caller owns the job: {}",
+        result.content
+    );
+    let cancel_calls = calls.cron_cancel.lock().unwrap();
+    assert_eq!(cancel_calls.len(), 1);
+    assert_eq!(cancel_calls[0], "sched-99");
+}
+
+#[tokio::test]
+async fn test_schedule_delete_unowned_job_renders_as_not_found() {
+    // Regression: before #3576's second slice, schedule_delete called
+    // cron_cancel directly with no ownership check, so any agent could delete
+    // another agent's job by UUID. It must now collapse unowned/missing into
+    // NotFound and never reach the kernel.
+    let (kernel, calls) = CapturingKernel::new();
+    kernel.set_cron_list_response(vec![json!({"id": "sched-mine"})]);
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, Some("agent-1"));
+    let result = execute_tool_raw(
+        "s2",
+        "schedule_delete",
+        &json!({"id": "sched-other-agents"}),
+        &ctx,
+    )
+    .await;
+
+    assert!(
+        result.is_error,
+        "schedule_delete on unowned job must error: {}",
+        result.content
+    );
+    assert!(
+        result
+            .content
+            .contains("Schedule 'sched-other-agents' not found"),
+        "expected NotFound display, got: {}",
+        result.content
+    );
+    assert!(
+        cancel_was_never_called(&calls),
+        "schedule_delete must NOT reach the kernel when the caller doesn't own the job"
+    );
+}
+
+#[tokio::test]
+async fn test_schedule_delete_missing_id_renders_as_missing_parameter() {
+    let (kernel, _calls) = CapturingKernel::new();
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, Some("agent-1"));
+    let result = execute_tool_raw("s3", "schedule_delete", &json!({}), &ctx).await;
+
+    assert!(
+        result.is_error,
+        "schedule_delete without id must error: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("Missing required parameter 'id'"),
+        "expected MissingParameter display, got: {}",
+        result.content
+    );
+}


### PR DESCRIPTION
## What

Second slice of the #3576 typed-error migration, plus an authorization fix found while doing it.

### 1. Migrate `schedule_*` tools to `ToolError` (#3576)

Follows the cron slice (#5258) exactly. `tool_schedule_create` / `tool_schedule_list` / `tool_schedule_delete` now return `Result<String, ToolError>` instead of `Result<String, String>`:

- `require_kernel` -> `require_kernel_typed`.
- Missing params -> `ToolError::MissingParameter`; bad schedule string -> `ToolError::InvalidParameter { name: "schedule", reason }`.
- Kernel errors -> `ToolError::upstream` (preserves the source chain instead of stringifying).
- Missing caller agent id -> `MissingParameter("agent_id")` via a local `caller_agent_id_missing` helper mirroring cron's (the MCP route passes `None` legitimately -> user-recoverable 400, not 500).

The internal `parse_schedule_to_cron` / `parse_time_to_hour` helpers keep their `Result<_, String>` shape (a pure sub-layer with no kernel contact) and are mapped to `ToolError` at the tool boundary. The dispatch arms narrow back to `Result<String, String>` with `.map_err(|e| e.to_string())`, the same bridge pattern as the cron slice, until every submodule has migrated.

### 2. Fix: `schedule_delete` skipped the ownership check (authz bypass)

`KernelHandle::cron_cancel(job_id)` removes a job by UUID with **no** ownership filtering (`kernel/handles/cron_control.rs:123`). `tool_cron_cancel` compensates by verifying the caller owns the job before cancelling (`cron.rs:86-100`). But `tool_schedule_delete` — which ends at the same `cron_cancel` — did no such check and did not even take `caller_agent_id`. So any agent with the `schedule_delete` tool could cancel **another agent's** job by learning its UUID, trivially bypassing the guard `cron_cancel` enforces.

Fixed by threading `caller_agent_id` into `tool_schedule_delete` and applying the same ownership check (`cron_list` -> membership -> `NotFound` collapsing unowned/missing, mirroring `cron_cancel`). `schedule_delete` now never reaches the kernel for a job the caller does not own.

## Tests

- `schedule.rs` unit tests (boundary, no kernel): create/list/delete without a kernel -> `Unavailable`; `caller_agent_id_missing` -> `MissingParameter`.
- `tests/tool_runner_forwarding_task_cron.rs` integration tests with the `CapturingKernel` stub: `schedule_delete` succeeds when owned, renders `NotFound` and never reaches the kernel when unowned (the authz regression test), and `MissingParameter` when `id` is absent.

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib tool_runner::schedule::` -> 4 passed, 0 failed
- `cargo test -p librefang-runtime --test tool_runner_forwarding_task_cron` -> 15 passed, 0 failed (incl. the 3 new `schedule_delete` tests)
- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean
