### PR TITLE
refactor(runtime): migrate task_* tools to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -889,13 +889,26 @@ pub async fn execute_tool_raw(
         "wiki_search" => tool_wiki_search(input, *kernel, *sender_id, *channel),
         "wiki_write" => tool_wiki_write(input, *kernel, *caller_agent_id, *sender_id, *channel),
 
-        // Collaboration tools
+        // Collaboration tools. task_* is the #3576 third slice: the submodule
+        // returns `Result<String, ToolError>`; arms narrow to
+        // `Result<String, String>` here at the boundary (same bridge as the
+        // cron / schedule slices) until the dispatch return type itself lifts.
         "agent_find" => tool_agent_find(input, *kernel),
-        "task_post" => tool_task_post(input, *kernel, *caller_agent_id).await,
-        "task_claim" => tool_task_claim(*kernel, *caller_agent_id).await,
-        "task_complete" => tool_task_complete(input, *kernel, *caller_agent_id).await,
-        "task_list" => tool_task_list(input, *kernel).await,
-        "task_status" => tool_task_status(input, *kernel).await,
+        "task_post" => tool_task_post(input, *kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "task_claim" => tool_task_claim(*kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "task_complete" => tool_task_complete(input, *kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "task_list" => tool_task_list(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "task_status" => tool_task_status(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
         "event_publish" => tool_event_publish(input, *kernel).await,
 
         // Scheduling tools (delegate to CronScheduler via kernel handle)

--- a/crates/librefang-runtime/src/tool_runner/task.rs
+++ b/crates/librefang-runtime/src/tool_runner/task.rs
@@ -1,37 +1,60 @@
 //! Cross-agent task board tools backed by `KernelHandle::task_*`.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576) — third slice after `tool_runner::{cron, schedule}`.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
+
+/// `ToolError` for a `task_*` tool reached with no caller agent id. Same
+/// rationale as `tool_runner::cron::caller_agent_id_missing`: the MCP HTTP
+/// route legitimately passes `None`, which is user-recoverable input, so it
+/// surfaces as `MissingParameter` (→ 400) rather than `Internal`; the tool
+/// name is preserved on the tracing channel for operators.
+//
+// Note: cron, schedule (#5720), and task each carry a local copy of this
+// 6-line helper. Hoisting it to a shared `tool_runner` util is the obvious
+// dedup once those slices have all landed on `main`; doing it here would
+// conflict with the still-open #5720, so it is flagged for a follow-up rather
+// than deferred silently.
+fn caller_agent_id_missing(tool: &'static str) -> ToolError {
+    tracing::warn!(
+        tool,
+        "caller agent_id missing — surfaced as MissingParameter to the LLM"
+    );
+    ToolError::MissingParameter("agent_id")
+}
 
 pub(super) async fn tool_task_post(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let title = input["title"].as_str().ok_or("Missing 'title' parameter")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let title = input["title"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("title"))?;
     let description = input["description"]
         .as_str()
-        .ok_or("Missing 'description' parameter")?;
+        .ok_or(ToolError::MissingParameter("description"))?;
     let assigned_to = input["assigned_to"].as_str();
     let task_id = kh
         .task_post(title, description, assigned_to, caller_agent_id)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Task created with ID: {task_id}"))
 }
 
 pub(super) async fn tool_task_claim(
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let agent_id = caller_agent_id.ok_or("task_claim requires a calling agent context")?;
-    match kh.task_claim(agent_id).await.map_err(|e| e.to_string())? {
-        Some(task) => {
-            serde_json::to_string_pretty(&task).map_err(|e| format!("Serialize error: {e}"))
-        }
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("task_claim"))?;
+    match kh.task_claim(agent_id).await.map_err(ToolError::upstream)? {
+        Some(task) => Ok(serde_json::to_string_pretty(&task)?),
         None => Ok("No tasks available.".to_string()),
     }
 }
@@ -40,43 +63,43 @@ pub(super) async fn tool_task_complete(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let agent_id = caller_agent_id.ok_or("task_complete requires a calling agent context")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("task_complete"))?;
     let task_id = input["task_id"]
         .as_str()
-        .ok_or("Missing 'task_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("task_id"))?;
     let result = input["result"]
         .as_str()
-        .ok_or("Missing 'result' parameter")?;
+        .ok_or(ToolError::MissingParameter("result"))?;
     kh.task_complete(agent_id, task_id, result)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Task {task_id} marked as completed."))
 }
 
 pub(super) async fn tool_task_list(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let status = input["status"].as_str();
-    let tasks = kh.task_list(status).await.map_err(|e| e.to_string())?;
+    let tasks = kh.task_list(status).await.map_err(ToolError::upstream)?;
     if tasks.is_empty() {
         return Ok("No tasks found.".to_string());
     }
-    serde_json::to_string_pretty(&tasks).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&tasks)?)
 }
 
 pub(super) async fn tool_task_status(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let task_id = input["task_id"]
         .as_str()
-        .ok_or("Missing 'task_id' parameter")?;
-    match kh.task_get(task_id).await.map_err(|e| e.to_string())? {
+        .ok_or(ToolError::MissingParameter("task_id"))?;
+    match kh.task_get(task_id).await.map_err(ToolError::upstream)? {
         Some(task) => {
             // Project to the same six columns comms_task_status returns from
             // the bridge SQL — keeps the native tool's contract tight even if
@@ -89,8 +112,57 @@ pub(super) async fn tool_task_status(
                 "created_at":   task.get("created_at").cloned().unwrap_or(serde_json::Value::Null),
                 "completed_at": task.get("completed_at").cloned().unwrap_or(serde_json::Value::Null),
             });
-            serde_json::to_string_pretty(&projected).map_err(|e| format!("Serialize error: {e}"))
+            Ok(serde_json::to_string_pretty(&projected)?)
         }
+        // Behaviour preserved from the pre-#3576 contract: a missing task is a
+        // readable success message, NOT a `NotFound` error (see
+        // `test_task_status_not_found_returns_message`).
         None => Ok(format!("Task '{task_id}' not found.")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Boundary tests that run BEFORE any kernel call. Kernel-roundtrip paths
+    //! (success, not-found message, projection) are covered against the
+    //! `CapturingKernel` stub in `tests/tool_runner_forwarding_task_cron.rs`.
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn task_post_without_kernel_returns_unavailable() {
+        let r = tool_task_post(&json!({}), None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn task_claim_without_kernel_returns_unavailable() {
+        let r = tool_task_claim(None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn task_complete_without_kernel_returns_unavailable() {
+        let r = tool_task_complete(&json!({}), None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn task_list_without_kernel_returns_unavailable() {
+        let r = tool_task_list(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn task_status_without_kernel_returns_unavailable() {
+        let r = tool_task_status(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[test]
+    fn caller_agent_id_missing_surfaces_as_missing_parameter() {
+        let e = caller_agent_id_missing("task_claim");
+        assert!(matches!(e, ToolError::MissingParameter("agent_id")));
+        assert!(e.to_string().contains("agent_id"));
     }
 }


### PR DESCRIPTION
## What

Third slice of the #3576 typed-error migration (after `cron` #5258 and
`schedule` #5720). Migrates the `task_*` board tools in
`tool_runner/task.rs` from `Result<String, String>` to
`Result<String, ToolError>`:

- `require_kernel` -> `require_kernel_typed`.
- Missing params -> `ToolError::MissingParameter`; kernel errors ->
  `ToolError::upstream` (preserves the source chain instead of stringifying);
  JSON serialisation bubbles via `?` (`From<serde_json::Error>`), dropping the
  ad-hoc `"Serialize error: {e}"` strings.
- Missing caller agent id -> `MissingParameter("agent_id")` via a local
  `caller_agent_id_missing` helper, same as the cron / schedule slices.

The dispatch arms narrow back to `Result<String, String>` with
`.map_err(|e| e.to_string())` — the same boundary bridge as the prior slices,
until the dispatch return type itself is lifted.

**Behaviour-preserving.** Notably, `task_status` on a missing task still
returns a readable `Ok("Task '…' not found.")` message (not a `NotFound`
error) — pinned by the existing `test_task_status_not_found_returns_message`.
Only the error-channel *type* changes; which outcomes are errors does not.

## Tests

- New boundary unit tests in `task.rs`: all five tools without a kernel ->
  `Unavailable`; `caller_agent_id_missing` -> `MissingParameter`.
- Existing integration tests in `tests/tool_runner_forwarding_task_cron.rs`
  (`test_task_post_*`, `test_task_status_*`) pass unchanged, confirming the
  migration preserved behaviour.

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` /
`CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib tool_runner::task::` -> 6 passed, 0 failed
- `cargo test -p librefang-runtime --test tool_runner_forwarding_task_cron` -> 12 passed, 0 failed (existing task/cron tests, unchanged)
- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean

## Follow-up flagged (not deferred silently)

`caller_agent_id_missing` now exists as a local copy in `cron`, `schedule`
(#5720) and `task`. Hoisting it to a shared `tool_runner` util is the obvious
dedup, but doing it here would conflict with the still-open #5720 — worth a
small follow-up once these slices land on `main`.
