### PR TITLE
refactor(runtime): migrate knowledge_* tools to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -905,10 +905,18 @@ pub async fn execute_tool_raw(
         "schedule_list" => tool_schedule_list(*kernel, *caller_agent_id).await,
         "schedule_delete" => tool_schedule_delete(input, *kernel).await,
 
-        // Knowledge graph tools
-        "knowledge_add_entity" => tool_knowledge_add_entity(input, *kernel).await,
-        "knowledge_add_relation" => tool_knowledge_add_relation(input, *kernel).await,
-        "knowledge_query" => tool_knowledge_query(input, *kernel).await,
+        // Knowledge graph tools (#3576 fourth slice: submodule returns
+        // Result<String, ToolError>; arms narrow to Result<String, String>
+        // here, same boundary bridge as the cron / schedule / task slices).
+        "knowledge_add_entity" => tool_knowledge_add_entity(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "knowledge_add_relation" => tool_knowledge_add_relation(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "knowledge_query" => tool_knowledge_query(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Image analysis tool
         "image_analyze" => {

--- a/crates/librefang-runtime/src/tool_runner/knowledge.rs
+++ b/crates/librefang-runtime/src/tool_runner/knowledge.rs
@@ -1,6 +1,13 @@
 //! Knowledge-graph tools — add_entity / add_relation / query.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576) — fourth slice after `tool_runner::{cron, schedule, task}`. These
+//! tools take no caller agent id (no per-caller authorization), so the
+//! migration is purely the error-channel type. The `parse_entity_type` /
+//! `parse_relation_type` helpers are infallible and unchanged.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
@@ -39,12 +46,14 @@ fn parse_relation_type(s: &str) -> librefang_types::memory::RelationType {
 pub(super) async fn tool_knowledge_add_entity(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
     let entity_type_str = input["entity_type"]
         .as_str()
-        .ok_or("Missing 'entity_type' parameter")?;
+        .ok_or(ToolError::MissingParameter("entity_type"))?;
     let properties = input
         .get("properties")
         .and_then(|v| v.as_object())
@@ -63,24 +72,24 @@ pub(super) async fn tool_knowledge_add_entity(
     let id = kh
         .knowledge_add_entity(&entity)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Entity '{name}' added with ID: {id}"))
 }
 
 pub(super) async fn tool_knowledge_add_relation(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let source = input["source"]
         .as_str()
-        .ok_or("Missing 'source' parameter")?;
+        .ok_or(ToolError::MissingParameter("source"))?;
     let relation_str = input["relation"]
         .as_str()
-        .ok_or("Missing 'relation' parameter")?;
+        .ok_or(ToolError::MissingParameter("relation"))?;
     let target = input["target"]
         .as_str()
-        .ok_or("Missing 'target' parameter")?;
+        .ok_or(ToolError::MissingParameter("target"))?;
     let confidence = input["confidence"].as_f64().unwrap_or(1.0) as f32;
     let properties = input
         .get("properties")
@@ -100,7 +109,7 @@ pub(super) async fn tool_knowledge_add_relation(
     let id = kh
         .knowledge_add_relation(&relation)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!(
         "Relation '{source}' --[{relation_str}]--> '{target}' added with ID: {id}"
     ))
@@ -109,8 +118,8 @@ pub(super) async fn tool_knowledge_add_relation(
 pub(super) async fn tool_knowledge_query(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let source = input["source"].as_str().map(|s| s.to_string());
     let target = input["target"].as_str().map(|s| s.to_string());
     let relation = input["relation"].as_str().map(parse_relation_type);
@@ -133,7 +142,7 @@ pub(super) async fn tool_knowledge_query(
     let matches = kh
         .knowledge_query(pattern)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     if matches.is_empty() {
         return Ok("No matching knowledge graph entries found.".to_string());
     }
@@ -151,4 +160,56 @@ pub(super) async fn tool_knowledge_query(
         ));
     }
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn knowledge_add_entity_without_kernel_returns_unavailable() {
+        let r = tool_knowledge_add_entity(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn knowledge_add_relation_without_kernel_returns_unavailable() {
+        let r = tool_knowledge_add_relation(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn knowledge_query_without_kernel_returns_unavailable() {
+        let r = tool_knowledge_query(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[test]
+    fn parse_entity_type_maps_known_and_custom() {
+        use librefang_types::memory::EntityType;
+        assert!(matches!(parse_entity_type("person"), EntityType::Person));
+        assert!(matches!(parse_entity_type("org"), EntityType::Organization));
+        match parse_entity_type("alien") {
+            EntityType::Custom(s) => assert_eq!(s, "alien"),
+            other => panic!("expected Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_relation_type_maps_known_and_custom() {
+        use librefang_types::memory::RelationType;
+        assert!(matches!(
+            parse_relation_type("works_at"),
+            RelationType::WorksAt
+        ));
+        assert!(matches!(
+            parse_relation_type("knows"),
+            RelationType::KnowsAbout
+        ));
+        match parse_relation_type("orbits") {
+            RelationType::Custom(s) => assert_eq!(s, "orbits"),
+            other => panic!("expected Custom, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## What

Fourth slice of the #3576 typed-error migration (after `cron` #5258, `schedule` #5720, `task` #5721). Migrates the knowledge-graph tools in `tool_runner/knowledge.rs` from `Result<String, String>` to `Result<String, ToolError>`:

- `require_kernel` -> `require_kernel_typed`.
- Missing params -> `ToolError::MissingParameter`; kernel errors -> `ToolError::upstream` (preserves the source chain).
- These tools take no caller agent id, so there is no ownership/auth concern (unlike `schedule_delete` in #5720). The `parse_entity_type` / `parse_relation_type` helpers are infallible and unchanged.

Dispatch arms narrow back to `Result<String, String>` with `.map_err(|e| e.to_string())`, the same boundary bridge as the prior slices.

Behaviour-preserving — no existing test invoked these tools or asserted the old error strings.

## Tests

New unit tests in `knowledge.rs`: all three tools without a kernel -> `Unavailable`; plus `parse_entity_type` / `parse_relation_type` coverage (known variants + `Custom` fallback).

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib tool_runner::knowledge::` -> 5 passed, 0 failed
- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean
