### PR TITLE
refactor(runtime): migrate event_publish + goal_update to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -896,7 +896,9 @@ pub async fn execute_tool_raw(
         "task_complete" => tool_task_complete(input, *kernel, *caller_agent_id).await,
         "task_list" => tool_task_list(input, *kernel).await,
         "task_status" => tool_task_status(input, *kernel).await,
-        "event_publish" => tool_event_publish(input, *kernel).await,
+        "event_publish" => tool_event_publish(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Scheduling tools (delegate to CronScheduler via kernel handle)
         "schedule_create" => {
@@ -1061,8 +1063,9 @@ pub async fn execute_tool_raw(
         "a2a_discover" => tool_a2a_discover(input).await,
         "a2a_send" => tool_a2a_send(input, *kernel).await,
 
-        // Goal tracking tool
-        "goal_update" => tool_goal_update(input, *kernel),
+        // Goal tracking tool (#3576: sync tool now returns
+        // Result<String, ToolError>; narrow to Result<String, String> here)
+        "goal_update" => tool_goal_update(input, *kernel).map_err(|e| e.to_string()),
 
         // Workflow tools
         "workflow_run" => tool_workflow_run(input, *kernel).await,

--- a/crates/librefang-runtime/src/tool_runner/event.rs
+++ b/crates/librefang-runtime/src/tool_runner/event.rs
@@ -1,23 +1,39 @@
 //! `event_publish` — fan out an event onto the kernel bus.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). Pure kernel passthrough — no caller-auth concern.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
 pub(super) async fn tool_event_publish(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let event_type = input["event_type"]
         .as_str()
-        .ok_or("Missing 'event_type' parameter")?;
+        .ok_or(ToolError::MissingParameter("event_type"))?;
     let payload = input
         .get("payload")
         .cloned()
         .unwrap_or(serde_json::json!({}));
     kh.publish_event(event_type, payload)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Event '{event_type}' published successfully."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn event_publish_without_kernel_returns_unavailable() {
+        let r = tool_event_publish(&json!({"event_type": "x"}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/goal.rs
+++ b/crates/librefang-runtime/src/tool_runner/goal.rs
@@ -1,36 +1,88 @@
 //! Goal tracking tool.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). Synchronous tool; `require_kernel_typed` is sync so it works here
+//! unchanged.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
 pub(super) fn tool_goal_update(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
+) -> ToolResult {
     // Validate input before touching the kernel
     let goal_id = input["goal_id"]
         .as_str()
-        .ok_or("Missing 'goal_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("goal_id"))?;
     let status = input["status"].as_str();
     let progress = input["progress"].as_u64().map(|p| p.min(100) as u8);
 
     if status.is_none() && progress.is_none() {
-        return Err("At least one of 'status' or 'progress' must be provided".to_string());
+        // Reason text kept byte-identical to the pre-#3576 String error; only
+        // the error channel changed.
+        return Err(ToolError::InvalidParameter {
+            name: "status",
+            reason: "At least one of 'status' or 'progress' must be provided".to_string(),
+        });
     }
 
     if let Some(s) = status {
         if !["pending", "in_progress", "completed", "cancelled"].contains(&s) {
-            return Err(format!(
-                "Invalid status '{}'. Must be: pending, in_progress, completed, or cancelled",
-                s
-            ));
+            return Err(ToolError::InvalidParameter {
+                name: "status",
+                reason: format!(
+                    "Invalid status '{s}'. Must be: pending, in_progress, completed, or cancelled"
+                ),
+            });
         }
     }
 
-    let kh = require_kernel(kernel)?;
+    let kh = require_kernel_typed(kernel)?;
     let updated = kh
         .goal_update(goal_id, status, progress)
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(serde_json::to_string_pretty(&updated).unwrap_or_else(|_| updated.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn goal_update_without_status_or_progress_is_invalid_parameter() {
+        let r = tool_goal_update(&json!({"goal_id": "g1"}), None);
+        match r {
+            Err(ToolError::InvalidParameter { name, reason }) => {
+                assert_eq!(name, "status");
+                assert!(reason.contains("At least one"));
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn goal_update_rejects_unknown_status() {
+        let r = tool_goal_update(&json!({"goal_id": "g1", "status": "bogus"}), None);
+        assert!(matches!(
+            r,
+            Err(ToolError::InvalidParameter { name: "status", .. })
+        ));
+    }
+
+    #[test]
+    fn goal_update_missing_goal_id_is_missing_parameter() {
+        let r = tool_goal_update(&json!({"status": "completed"}), None);
+        assert!(matches!(r, Err(ToolError::MissingParameter("goal_id"))));
+    }
+
+    #[test]
+    fn goal_update_without_kernel_returns_unavailable() {
+        // Valid input, but no kernel handle -> Unavailable (validation passed).
+        let r = tool_goal_update(&json!({"goal_id": "g1", "status": "completed"}), None);
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/tests/policy.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/policy.rs
@@ -1421,7 +1421,8 @@ fn test_goal_update_missing_kernel() {
     });
     let result = tool_goal_update(&input, None);
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Kernel handle"));
+    // #3576: Err is now ToolError; assert via its Display.
+    assert!(result.unwrap_err().to_string().contains("Kernel handle"));
 }
 
 #[test]
@@ -1440,7 +1441,7 @@ fn test_goal_update_no_fields() {
     });
     let result = tool_goal_update(&input, None);
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("At least one"));
+    assert!(result.unwrap_err().to_string().contains("At least one"));
 }
 
 #[test]
@@ -1451,7 +1452,7 @@ fn test_goal_update_invalid_status() {
     });
     let result = tool_goal_update(&input, None);
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Invalid status"));
+    assert!(result.unwrap_err().to_string().contains("Invalid status"));
 }
 
 /// Mock kernel that validates capability inheritance in spawn_agent_checked.


### PR DESCRIPTION
## What

Fifth slice of the #3576 typed-error migration (after `cron` #5258, `schedule` #5720, `task` #5721, `knowledge` #5722). Migrates the last two clean kernel-passthrough tools — `event_publish` and `goal_update` — from `Result<String, String>` to `Result<String, ToolError>`:

- `require_kernel` -> `require_kernel_typed` (sync-compatible; `goal_update` is a sync fn).
- Missing params -> `ToolError::MissingParameter`; cross-field / enum validation in `goal_update` -> `ToolError::InvalidParameter`; kernel errors -> `ToolError::upstream`.
- Both are kernel passthrough with no caller-auth concern. Dispatch arms narrow back to `Result<String, String>` at the boundary.

## Test fallout handled

Three existing `tool_goal_update` assertions in `tests/policy.rs` matched on the old `String` error via `.contains(...)`. Updated them to assert against the `ToolError` `Display` (`.to_string().contains(...)`). The `InvalidParameter` reason wording shifts slightly because `Display` prepends `Invalid parameter 'status': ` — e.g. `"At least one ..."` -> `"at least one ..."`. No behaviour change, only the error-channel type and that wording.

Adds boundary unit tests for both tools (no-kernel -> `Unavailable`, plus `goal_update` validation variants). Existing `event_publish` integration tests in `tool_runner_agent_event.rs` pass unchanged.

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib goal_update` -> 11 passed, 0 failed
- `cargo test -p librefang-runtime --lib event_publish` -> 1 passed, 0 failed
- `cargo test -p librefang-runtime --test tool_runner_agent_event` -> 6 passed, 0 failed
- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean

## Status of the #3576 grind

This completes the genuinely-mechanical, no-auth kernel-passthrough slices (cron, schedule, task, knowledge, event, goal). The remaining `tool_runner` submodules are a different tier — security-contract messages (`a2a`, `sandbox`, `shell`), HTTP/IO error mapping (`system`, `image`, `web_*`, `media`), or large surfaces (`skill`, `workflow`, `process`, `fs`) — each needs per-file ToolError-variant decisions rather than a rote pass.
