### PR TITLE
refactor(runtime): migrate a2a_* tools to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/a2a.rs
+++ b/crates/librefang-runtime/src/tool_runner/a2a.rs
@@ -1,34 +1,49 @@
 //! A2A outbound tools — cross-instance agent communication.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). The security blocks here (SSRF, taint sinks, trusted-agent gate)
+//! keep their exact messages — they are wrapped in message-preserving
+//! `ToolError` variants (`PermissionDenied` / `InvalidParameter`) so the wire
+//! string the LLM and operator logs see is unchanged.
 
-use super::{check_taint_net_fetch, check_taint_outbound_text, require_kernel};
+use super::error::{ToolError, ToolResult};
+use super::{check_taint_net_fetch, check_taint_outbound_text, require_kernel_typed};
 use crate::kernel_handle::prelude::*;
 use librefang_types::taint::TaintSink;
 use std::sync::Arc;
 
 /// Discover an external A2A agent by fetching its agent card.
-pub(super) async fn tool_a2a_discover(input: &serde_json::Value) -> Result<String, String> {
-    let url = input["url"].as_str().ok_or("Missing 'url' parameter")?;
+pub(super) async fn tool_a2a_discover(input: &serde_json::Value) -> ToolResult {
+    let url = input["url"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("url"))?;
 
     // SSRF protection: block private/metadata IPs
     if crate::web_fetch::check_ssrf(url, &[]).is_err() {
-        return Err("SSRF blocked: URL resolves to a private or metadata address".to_string());
+        return Err(ToolError::InvalidParameter {
+            name: "url",
+            reason: "SSRF blocked: URL resolves to a private or metadata address".to_string(),
+        });
     }
 
     let client = crate::a2a::A2aClient::new();
-    let card = client.discover(url).await?;
+    let card = client
+        .discover(url)
+        .await
+        .map_err(ToolError::upstream_msg)?;
 
-    serde_json::to_string_pretty(&card).map_err(|e| format!("Serialization error: {e}"))
+    Ok(serde_json::to_string_pretty(&card)?)
 }
 
 /// Send a task to an external A2A agent.
 pub(super) async fn tool_a2a_send(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let message = input["message"]
         .as_str()
-        .ok_or("Missing 'message' parameter")?;
+        .ok_or(ToolError::MissingParameter("message"))?;
 
     // Resolve agent URL: either directly provided or looked up by name.
     // Canonicalize early so the trust gate below sees the same string the
@@ -36,27 +51,42 @@ pub(super) async fn tool_a2a_send(
     let url = if let Some(raw) = input["agent_url"].as_str() {
         // SSRF protection
         if crate::web_fetch::check_ssrf(raw, &[]).is_err() {
-            return Err("SSRF blocked: URL resolves to a private or metadata address".to_string());
+            return Err(ToolError::InvalidParameter {
+                name: "agent_url",
+                reason: "SSRF blocked: URL resolves to a private or metadata address".to_string(),
+            });
         }
         crate::a2a::canonicalize_a2a_url(raw).unwrap_or_else(|| raw.to_string())
     } else if let Some(name) = input["agent_name"].as_str() {
-        kh.get_a2a_agent_url(name)
-            .ok_or_else(|| format!("No known A2A agent with name '{name}'. Use a2a_discover first or provide agent_url directly."))?
+        kh.get_a2a_agent_url(name).ok_or_else(|| {
+            // Reason kept byte-identical to the pre-#3576 String error.
+            let reason = format!(
+                "No known A2A agent with name '{name}'. Use a2a_discover first or provide agent_url directly."
+            );
+            ToolError::InvalidParameter {
+                name: "agent_name",
+                reason,
+            }
+        })?
     } else {
-        return Err("Missing 'agent_url' or 'agent_name' parameter".to_string());
+        return Err(ToolError::InvalidParameter {
+            name: "agent_url",
+            reason: "provide either 'agent_url' or 'agent_name'".to_string(),
+        });
     };
 
     // Taint sink: block secrets from being exfiltrated to an external A2A peer.
     // Runs before the trust gate so a tainted-message attempt always reports
     // the data-exfil reason (the test suite asserts this contract) — the
     // trust gate is purely about target authorization and would mask the
-    // more serious finding.
+    // more serious finding. The original violation message is preserved inside
+    // PermissionDenied so its "taint"/"violation" wording survives.
     if let Some(violation) = check_taint_outbound_text(message, &TaintSink::agent_message()) {
-        return Err(violation);
+        return Err(ToolError::PermissionDenied(violation));
     }
     // Also gate the URL itself against query-string credential leaks.
     if let Some(violation) = check_taint_net_fetch(&url) {
-        return Err(violation);
+        return Err(ToolError::PermissionDenied(violation));
     }
 
     // SECURITY (Bug #3786): the HTTP route at `/api/a2a/send` enforces a
@@ -66,14 +96,38 @@ pub(super) async fn tool_a2a_send(
     // the same check here.
     let trusted_urls: Vec<String> = kh.list_a2a_agents().into_iter().map(|(_, u)| u).collect();
     if !trusted_urls.iter().any(|u| u == &url) {
-        return Err(format!(
+        return Err(ToolError::PermissionDenied(format!(
             "A2A target '{url}' is not on the trusted-agent list. Discover and have an operator approve it via POST /api/a2a/agents/{{url}}/approve before agents may send to it."
-        ));
+        )));
     }
 
     let session_id = input["session_id"].as_str();
     let client = crate::a2a::A2aClient::new();
-    let task = client.send_task(&url, message, session_id).await?;
+    let task = client
+        .send_task(&url, message, session_id)
+        .await
+        .map_err(ToolError::upstream_msg)?;
 
-    serde_json::to_string_pretty(&task).map_err(|e| format!("Serialization error: {e}"))
+    Ok(serde_json::to_string_pretty(&task)?)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Boundary tests that run before any network / kernel call. The taint
+    //! sink and trust-gate paths are exercised against a real kernel stub in
+    //! `tool_runner::tests` (`test_tool_a2a_send_blocks_secret_in_message`).
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn a2a_discover_missing_url_is_missing_parameter() {
+        let r = tool_a2a_discover(&json!({})).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("url"))));
+    }
+
+    #[tokio::test]
+    async fn a2a_send_without_kernel_returns_unavailable() {
+        let r = tool_a2a_send(&json!({"message": "hi"}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1057,9 +1057,12 @@ pub async fn execute_tool_raw(
         "hand_status" => tool_hand_status(input, *kernel).await,
         "hand_deactivate" => tool_hand_deactivate(input, *kernel).await,
 
-        // A2A outbound tools (cross-instance agent communication)
-        "a2a_discover" => tool_a2a_discover(input).await,
-        "a2a_send" => tool_a2a_send(input, *kernel).await,
+        // A2A outbound tools (cross-instance agent communication). #3576:
+        // submodule returns Result<String, ToolError>; narrow at the boundary.
+        "a2a_discover" => tool_a2a_discover(input).await.map_err(|e| e.to_string()),
+        "a2a_send" => tool_a2a_send(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Goal tracking tool
         "goal_update" => tool_goal_update(input, *kernel),

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -227,7 +227,8 @@ async fn test_tool_a2a_send_blocks_secret_in_message() {
     });
     let err = tool_a2a_send(&input, Some(&kernel))
         .await
-        .expect_err("a2a_send must reject tainted message");
+        .expect_err("a2a_send must reject tainted message")
+        .to_string(); // #3576: Err is now ToolError; assert via its Display.
     assert!(
         err.contains("taint") || err.contains("violation"),
         "expected taint violation, got: {err}"


### PR DESCRIPTION
## What

Sixth slice of the #3576 typed-error migration, and the first of the security-sensitive tier. Migrates `tool_a2a_discover` and `tool_a2a_send` from `Result<String, String>` to `Result<String, ToolError>`.

The security blocks keep their **exact wire messages** by wrapping the original strings in message-preserving variants:

- SSRF block -> `ToolError::InvalidParameter { name: "url" | "agent_url", .. }`
- taint-sink violations (message + URL) and the trusted-agent gate (Bug #3786) -> `ToolError::PermissionDenied(<original message>)`
- `A2aClient::{discover,send_task}` transport errors -> `ToolError::upstream_msg` (these return `String`, which is not `std::error::Error`, so `upstream()` does not apply)
- JSON serialization via `?` (`From<serde_json::Error>`)
- missing params -> `MissingParameter`; unknown `agent_name` / "one of `agent_url`|`agent_name`" -> `InvalidParameter`
- `require_kernel` -> `require_kernel_typed`

The taint check still runs **before** the trust gate (the documented exfil-reason-wins ordering), and the original violation text is carried inside `PermissionDenied`, so its `"taint"/"violation"` wording is preserved on the wire.

## Test fallout handled

`test_tool_a2a_send_blocks_secret_in_message` (in `tool_runner/tests/mod.rs`) asserted on the `String` error via `.contains(...)`; updated to read the `ToolError` `Display` (`.to_string()`). The substring assertion is unchanged and still passes because the violation message is preserved.

Adds boundary unit tests: `a2a_discover` missing url -> `MissingParameter`; `a2a_send` no kernel -> `Unavailable`.

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib a2a` -> 22 passed, 0 failed (incl. the taint test + the 2 new boundary tests)
- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean
