### PR TITLE
refactor(runtime): migrate location_get to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -987,8 +987,8 @@ pub async fn execute_tool_raw(
             tool_docker_exec(input, *docker_config, *workspace_root, *caller_agent_id).await
         }
 
-        // Location tool
-        "location_get" => tool_location_get().await,
+        // Location tool (#3576: returns Result<String, ToolError>; narrow here)
+        "location_get" => tool_location_get().await.map_err(|e| e.to_string()),
 
         // System time tool
         "system_time" => Ok(tool_system_time()),

--- a/crates/librefang-runtime/src/tool_runner/system.rs
+++ b/crates/librefang-runtime/src/tool_runner/system.rs
@@ -1,11 +1,25 @@
 //! System info tools: location lookup and clock readout.
+//!
+//! `tool_location_get` migrated from `Result<String, String>` to
+//! `Result<String, ToolError>` (#3576). All failures are external HTTP / parse
+//! failures, mapped to `ToolError::Upstream`. The typed `reqwest::Error`s
+//! (build / send / json) keep their original prefixed message AND preserve the
+//! error on the `source()` chain (consistent with how the sibling slices wrap
+//! typed errors); the two non-`Error` API-level failures use `upstream_msg`.
+//! `Upstream`'s Display is the bare message, so the exact strings are
+//! preserved. `tool_system_time` is infallible (returns `String`), unchanged.
+
+use super::error::{ToolError, ToolResult};
 
 /// Look up approximate location via ip-api.com.
-pub(super) async fn tool_location_get() -> Result<String, String> {
+pub(super) async fn tool_location_get() -> ToolResult {
     let client = crate::http_client::proxied_client_builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()
-        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to create HTTP client: {e}"),
+            source: Some(Box::new(e)),
+        })?;
 
     // Use ip-api.com (free, no API key, JSON response)
     let resp = client
@@ -13,20 +27,28 @@ pub(super) async fn tool_location_get() -> Result<String, String> {
         .header("User-Agent", "LibreFang/0.1")
         .send()
         .await
-        .map_err(|e| format!("Location request failed: {e}"))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Location request failed: {e}"),
+            source: Some(Box::new(e)),
+        })?;
 
     if !resp.status().is_success() {
-        return Err(format!("Location API returned {}", resp.status()));
+        return Err(ToolError::upstream_msg(format!(
+            "Location API returned {}",
+            resp.status()
+        )));
     }
 
-    let body: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse location response: {e}"))?;
+    let body: serde_json::Value = resp.json().await.map_err(|e| ToolError::Upstream {
+        message: format!("Failed to parse location response: {e}"),
+        source: Some(Box::new(e)),
+    })?;
 
     if body["status"].as_str() != Some("success") {
         let msg = body["message"].as_str().unwrap_or("Unknown error");
-        return Err(format!("Location lookup failed: {msg}"));
+        return Err(ToolError::upstream_msg(format!(
+            "Location lookup failed: {msg}"
+        )));
     }
 
     let result = serde_json::json!({
@@ -41,7 +63,7 @@ pub(super) async fn tool_location_get() -> Result<String, String> {
         "ip": body["query"],
     });
 
-    serde_json::to_string_pretty(&result).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 /// Return current date, time, timezone, and Unix epoch.


### PR DESCRIPTION
## What

Seventh slice of the #3576 typed-error migration. Migrates `tool_location_get` from `Result<String, String>` to `Result<String, ToolError>`.

All failures in this tool are external HTTP / parse errors, mapped to `ToolError::upstream_msg`. `Upstream`'s `Display` is the bare `{message}`, so every string is preserved exactly on the wire:

- `"Failed to create HTTP client: {e}"`
- `"Location request failed: {e}"`
- `"Location API returned {status}"`
- `"Failed to parse location response: {e}"`
- `"Location lookup failed: {msg}"`

JSON serialization bubbles via `?` (`From<serde_json::Error>`). `tool_system_time` is infallible (returns `String`) and is unchanged. The dispatch arm narrows back to `Result<String, String>` at the boundary.

## Tests

No unit test added: `location_get` performs a live HTTP call to ip-api.com and is not offline-testable. The change is a pure error-channel remap with no logic change. (The `system_time` path is untouched.)

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean (compiles all targets)
