### PR TITLE
refactor(runtime): migrate hand_* tools to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1051,11 +1051,18 @@ pub async fn execute_tool_raw(
         "process_kill" => tool_process_kill(input, *process_manager).await,
         "process_list" => tool_process_list(*process_manager, *caller_agent_id).await,
 
-        // Hand tools (curated autonomous capability packages)
-        "hand_list" => tool_hand_list(*kernel).await,
-        "hand_activate" => tool_hand_activate(input, *kernel).await,
-        "hand_status" => tool_hand_status(input, *kernel).await,
-        "hand_deactivate" => tool_hand_deactivate(input, *kernel).await,
+        // Hand tools (curated autonomous capability packages). #3576:
+        // submodule returns Result<String, ToolError>; narrow here.
+        "hand_list" => tool_hand_list(*kernel).await.map_err(|e| e.to_string()),
+        "hand_activate" => tool_hand_activate(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "hand_status" => tool_hand_status(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "hand_deactivate" => tool_hand_deactivate(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
 
         // A2A outbound tools (cross-instance agent communication)
         "a2a_discover" => tool_a2a_discover(input).await,

--- a/crates/librefang-runtime/src/tool_runner/hand.rs
+++ b/crates/librefang-runtime/src/tool_runner/hand.rs
@@ -1,14 +1,16 @@
 //! Hand tools (delegated to kernel via `KernelHandle`).
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). Clean kernel passthrough — no caller-auth concern.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
-pub(super) async fn tool_hand_list(
-    kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let hands = kh.hand_list().await.map_err(|e| e.to_string())?;
+pub(super) async fn tool_hand_list(kernel: Option<&Arc<dyn KernelHandle>>) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let hands = kh.hand_list().await.map_err(ToolError::upstream)?;
 
     if hands.is_empty() {
         return Ok(
@@ -46,11 +48,11 @@ pub(super) async fn tool_hand_list(
 pub(super) async fn tool_hand_activate(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let hand_id = input["hand_id"]
         .as_str()
-        .ok_or("Missing 'hand_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("hand_id"))?;
     let config: std::collections::HashMap<String, serde_json::Value> =
         if let Some(obj) = input["config"].as_object() {
             obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
@@ -61,7 +63,7 @@ pub(super) async fn tool_hand_activate(
     let result = kh
         .hand_activate(hand_id, config)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
 
     let instance_id = result["instance_id"].as_str().unwrap_or("?");
     let agent_name = result["agent_name"].as_str().unwrap_or("?");
@@ -76,13 +78,13 @@ pub(super) async fn tool_hand_activate(
 pub(super) async fn tool_hand_status(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let hand_id = input["hand_id"]
         .as_str()
-        .ok_or("Missing 'hand_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("hand_id"))?;
 
-    let result = kh.hand_status(hand_id).await.map_err(|e| e.to_string())?;
+    let result = kh.hand_status(hand_id).await.map_err(ToolError::upstream)?;
 
     let icon = result["icon"].as_str().unwrap_or("");
     let name = result["name"].as_str().unwrap_or(hand_id);
@@ -100,13 +102,51 @@ pub(super) async fn tool_hand_status(
 pub(super) async fn tool_hand_deactivate(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let instance_id = input["instance_id"]
         .as_str()
-        .ok_or("Missing 'instance_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("instance_id"))?;
     kh.hand_deactivate(instance_id)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Hand instance '{}' deactivated.", instance_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn hand_list_without_kernel_returns_unavailable() {
+        assert!(matches!(
+            tool_hand_list(None).await,
+            Err(ToolError::Unavailable("Kernel handle"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn hand_activate_without_kernel_returns_unavailable() {
+        assert!(matches!(
+            tool_hand_activate(&json!({"hand_id": "x"}), None).await,
+            Err(ToolError::Unavailable("Kernel handle"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn hand_status_without_kernel_returns_unavailable() {
+        assert!(matches!(
+            tool_hand_status(&json!({"hand_id": "x"}), None).await,
+            Err(ToolError::Unavailable("Kernel handle"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn hand_deactivate_without_kernel_returns_unavailable() {
+        assert!(matches!(
+            tool_hand_deactivate(&json!({"instance_id": "x"}), None).await,
+            Err(ToolError::Unavailable("Kernel handle"))
+        ));
+    }
 }


### PR DESCRIPTION
## What

Ninth slice of the #3576 typed-error migration. Migrates the Hand tools (`tool_hand_list` / `tool_hand_activate` / `tool_hand_status` / `tool_hand_deactivate`) from `Result<String, String>` to `Result<String, ToolError>`.

Clean kernel passthrough — no caller-auth / ACL concern:

- `require_kernel` -> `require_kernel_typed`
- missing params -> `ToolError::MissingParameter`
- kernel (`KernelOpError`) errors -> `ToolError::upstream` (typed, preserves the `source()` chain)
- the `Ok` message-building branches (hand list rendering, activate/status formatting) are unchanged

Dispatch arms narrow back to `Result<String, String>` at the boundary.

## Tests

Adds boundary unit tests (no kernel -> `Unavailable` for all four tools). No existing test references these tools directly, so no test fallout.

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib tool_runner::hand::` -> 4 passed, 0 failed
- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean
