### PR TITLE
refactor(runtime): migrate docker_exec to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -981,11 +981,11 @@ pub async fn execute_tool_raw(
             tool_speech_to_text(input, *media_engine, *workspace_root, &extra_refs).await
         }
 
-        // Docker sandbox tool
+        // Docker sandbox tool (#3576: returns Result<String, ToolError>)
         #[cfg(feature = "docker-sandbox")]
-        "docker_exec" => {
-            tool_docker_exec(input, *docker_config, *workspace_root, *caller_agent_id).await
-        }
+        "docker_exec" => tool_docker_exec(input, *docker_config, *workspace_root, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Location tool
         "location_get" => tool_location_get().await,

--- a/crates/librefang-runtime/src/tool_runner/sandbox.rs
+++ b/crates/librefang-runtime/src/tool_runner/sandbox.rs
@@ -1,6 +1,14 @@
 //! `docker_exec` sandbox tool — run an LLM-supplied command inside a
 //! disposable Docker container scoped to the agent's workspace.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). The "subsystem not wired" cases (docker not configured / disabled
+//! / not installed / no workspace context) map to `ToolError::Unavailable`,
+//! the documented category for them (see the variant doc: "docker exec
+//! disabled" is an Unavailable case → HTTP 503). The container create / exec
+//! failures (`Result<_, String>`) map to `ToolError::upstream_msg`.
 
+use super::error::{ToolError, ToolResult};
 use std::path::Path;
 use tracing::warn;
 
@@ -9,29 +17,29 @@ pub(super) async fn tool_docker_exec(
     docker_config: Option<&librefang_types::config::DockerSandboxConfig>,
     workspace_root: Option<&Path>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let config = docker_config.ok_or("Docker sandbox not configured")?;
+) -> ToolResult {
+    let config = docker_config.ok_or(ToolError::Unavailable("Docker sandbox"))?;
 
     if !config.enabled {
-        return Err("Docker sandbox is disabled. Set docker.enabled=true in config.".into());
+        return Err(ToolError::Unavailable("Docker sandbox"));
     }
 
     let command = input["command"]
         .as_str()
-        .ok_or("Missing 'command' parameter")?;
+        .ok_or(ToolError::MissingParameter("command"))?;
 
-    let workspace = workspace_root.ok_or("Docker exec requires a workspace directory")?;
+    let workspace = workspace_root.ok_or(ToolError::Unavailable("workspace directory"))?;
     let agent_id = caller_agent_id.unwrap_or("default");
 
     // Check Docker availability
     if !crate::docker_sandbox::is_docker_available().await {
-        return Err(
-            "Docker is not available on this system. Install Docker to use docker_exec.".into(),
-        );
+        return Err(ToolError::Unavailable("Docker"));
     }
 
     // Create sandbox container
-    let container = crate::docker_sandbox::create_sandbox(config, agent_id, workspace).await?;
+    let container = crate::docker_sandbox::create_sandbox(config, agent_id, workspace)
+        .await
+        .map_err(ToolError::upstream_msg)?;
 
     // Execute command with timeout
     let timeout = std::time::Duration::from_secs(config.timeout_secs);
@@ -42,7 +50,7 @@ pub(super) async fn tool_docker_exec(
         warn!("Failed to destroy Docker sandbox: {e}");
     }
 
-    let exec_result = result?;
+    let exec_result = result.map_err(ToolError::upstream_msg)?;
 
     let response = serde_json::json!({
         "exit_code": exec_result.exit_code,
@@ -51,5 +59,32 @@ pub(super) async fn tool_docker_exec(
         "container_id": container.container_id,
     });
 
-    serde_json::to_string_pretty(&response).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&response)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn docker_exec_without_config_is_unavailable() {
+        let r = tool_docker_exec(&serde_json::json!({"command": "ls"}), None, None, None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Docker sandbox"))));
+    }
+
+    #[tokio::test]
+    async fn docker_exec_disabled_is_unavailable() {
+        let cfg = librefang_types::config::DockerSandboxConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        let r = tool_docker_exec(
+            &serde_json::json!({"command": "ls"}),
+            Some(&cfg),
+            None,
+            None,
+        )
+        .await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Docker sandbox"))));
+    }
 }


### PR DESCRIPTION
## What

Eleventh slice of the #3576 typed-error migration. Migrates `tool_docker_exec` from `Result<String, String>` to `Result<String, ToolError>`.

- The "subsystem not wired" cases — docker **not configured**, **disabled**, **not installed**, and **missing workspace context** — map to `ToolError::Unavailable`. This is the documented category for them: the `Unavailable` variant doc explicitly lists *"docker exec disabled"* as an Unavailable case (→ HTTP 503).
- missing `command` param -> `MissingParameter`
- container create / exec failures (`Result<_, String>`) -> `ToolError::upstream_msg`
- JSON serialization via `?`

Note: the previous strings carried operator guidance suffixes (e.g. *"Set docker.enabled=true in config"*, *"Install Docker…"*). These are dropped in favor of the correct `Unavailable` categorization, since that variant carries a `&'static str` capability name rather than free text — and the dispatch boundary stringifies today regardless. The guidance lives in the ops/config docs.

The dispatch arm (feature-gated on `docker-sandbox`, which is in **default** features) narrows back to `Result<String, String>`.

## Tests

Adds boundary unit tests (no config / disabled -> `Unavailable`). No existing test invokes the tool or asserts its messages (only a tool-registration name check, unaffected).

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image (default features, so `docker-sandbox` is compiled) with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib tool_runner::sandbox::` -> 2 passed, 0 failed
- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean
