### PR TITLE
refactor(runtime): migrate image_analyze to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -922,7 +922,10 @@ pub async fn execute_tool_raw(
                 extra.push(dl);
             }
             let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
-            tool_image_analyze(input, *workspace_root, &extra_refs).await
+            // #3576: tool returns Result<String, ToolError>; narrow here.
+            tool_image_analyze(input, *workspace_root, &extra_refs)
+                .await
+                .map_err(|e| e.to_string())
         }
 
         // Media understanding tools

--- a/crates/librefang-runtime/src/tool_runner/image.rs
+++ b/crates/librefang-runtime/src/tool_runner/image.rs
@@ -1,7 +1,15 @@
 //! `image_analyze` — read an image from the agent's workspace sandbox,
 //! identify its format and dimensions, and return a JSON description plus
 //! a base64 preview the LLM can hand to a vision-capable provider.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). The shared `resolve_file_path_ext` (sandbox path resolver, still
+//! `Result<_, String>`) maps to `InvalidParameter { name: "path" }` with its
+//! message preserved; the file read (`io::Error`) maps to `ToolError::Upstream`
+//! keeping the prefix message and the source. The format/dimension helpers are
+//! infallible and unchanged.
 
+use super::error::{ToolError, ToolResult};
 use super::resolve_file_path_ext;
 use std::path::Path;
 
@@ -9,18 +17,29 @@ pub(super) async fn tool_image_analyze(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
-) -> Result<String, String> {
-    let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
+) -> ToolResult {
+    let raw_path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
     let prompt = input["prompt"].as_str().unwrap_or("");
     // Route through the workspace sandbox so user-supplied paths cannot
     // escape to arbitrary filesystem locations (e.g. /etc/passwd). Named
     // workspace prefixes are honored via `additional_roots` so agents can
     // analyze images that live under declared `[workspaces]` mounts.
-    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
+    let resolved =
+        resolve_file_path_ext(raw_path, workspace_root, additional_roots).map_err(|reason| {
+            ToolError::InvalidParameter {
+                name: "path",
+                reason,
+            }
+        })?;
 
     let data = tokio::fs::read(&resolved)
         .await
-        .map_err(|e| format!("Failed to read image '{raw_path}': {e}"))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to read image '{raw_path}': {e}"),
+            source: Some(Box::new(e)),
+        })?;
 
     let file_size = data.len();
 
@@ -67,7 +86,7 @@ pub(super) async fn tool_image_analyze(
 
     result["base64_preview"] = serde_json::json!(base64_preview);
 
-    serde_json::to_string_pretty(&result).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 /// Detect image format from magic bytes.
@@ -166,5 +185,26 @@ pub(super) fn format_file_size(bytes: usize) -> String {
         format!("{:.1} KB", bytes as f64 / 1024.0)
     } else {
         format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn image_analyze_missing_path_is_missing_parameter() {
+        let r = tool_image_analyze(&serde_json::json!({}), None, &[]).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("path"))));
+    }
+
+    #[tokio::test]
+    async fn image_analyze_without_workspace_is_invalid_parameter() {
+        // resolve_file_path_ext rejects when no workspace sandbox is configured.
+        let r = tool_image_analyze(&serde_json::json!({"path": "x.png"}), None, &[]).await;
+        assert!(matches!(
+            r,
+            Err(ToolError::InvalidParameter { name: "path", .. })
+        ));
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/tests/policy.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/policy.rs
@@ -519,7 +519,9 @@ async fn test_media_tools_honor_named_workspace_prefixes() {
          no named-workspace prefixes are provided, got: {:?}",
         denied
     );
-    let err = denied.unwrap_err();
+    // #3576: Err is now ToolError; assert via its Display (the sandbox reason
+    // is preserved inside InvalidParameter).
+    let err = denied.unwrap_err().to_string();
     assert!(
         err.contains("resolves outside workspace") || err.contains("Access denied"),
         "expected sandbox rejection, got: {err}"


### PR DESCRIPTION
## What

Thirteenth slice of the #3576 typed-error migration. Migrates `tool_image_analyze` from `Result<String, String>` to `Result<String, ToolError>`.

- missing `path` -> `MissingParameter`
- the shared `resolve_file_path_ext` sandbox resolver (still `Result<_, String>`, also used by fs) -> `InvalidParameter { name: "path" }` with its message (sandbox-escape / not-found) preserved verbatim
- the file read (`io::Error`) -> `ToolError::Upstream` keeping the `"Failed to read image"` prefix AND the `source()` chain
- JSON serialization via `?`

The `detect_image_format` / `extract_*_dimensions` / `format_file_size` helpers are infallible and unchanged. Dispatch arm narrows back to `Result<String, String>`.

## Tests

One existing assertion in `tests/policy.rs` (the sandbox-escape test calls `tool_image_analyze` directly and asserted `err.contains(...)`) is updated to read the reason off the `ToolError` `Display` (`.to_string()`); the substring is preserved because the sandbox message is carried inside `InvalidParameter`. The other `image_analyze` tests go through `execute_tool_raw` (assert on `result.content`) and are unaffected. Adds boundary unit tests (missing path -> `MissingParameter`; no workspace -> `InvalidParameter`).

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib image` -> 19 passed, 0 failed (incl. the sandbox dotdot/outside-staging escape tests + the 2 new boundary tests)
- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean
