### PR TITLE
refactor(runtime): migrate process_* tools to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1044,12 +1044,23 @@ pub async fn execute_tool_raw(
             .await
         }
 
-        // Persistent process tools
-        "process_start" => tool_process_start(input, *process_manager, *caller_agent_id).await,
-        "process_poll" => tool_process_poll(input, *process_manager).await,
-        "process_write" => tool_process_write(input, *process_manager).await,
-        "process_kill" => tool_process_kill(input, *process_manager).await,
-        "process_list" => tool_process_list(*process_manager, *caller_agent_id).await,
+        // Persistent process tools (#3576: return Result<String, ToolError>;
+        // narrow to Result<String, String> here at the boundary).
+        "process_start" => tool_process_start(input, *process_manager, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "process_poll" => tool_process_poll(input, *process_manager)
+            .await
+            .map_err(|e| e.to_string()),
+        "process_write" => tool_process_write(input, *process_manager)
+            .await
+            .map_err(|e| e.to_string()),
+        "process_kill" => tool_process_kill(input, *process_manager)
+            .await
+            .map_err(|e| e.to_string()),
+        "process_list" => tool_process_list(*process_manager, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Hand tools (curated autonomous capability packages)
         "hand_list" => tool_hand_list(*kernel).await,

--- a/crates/librefang-runtime/src/tool_runner/process.rs
+++ b/crates/librefang-runtime/src/tool_runner/process.rs
@@ -1,16 +1,24 @@
 //! Persistent process tools — start / poll / write / kill / list.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). A missing `ProcessManager` -> `Unavailable("Process manager")`;
+//! missing params -> `MissingParameter`; the `ProcessManager` operations (all
+//! `Result<_, String>`) -> `upstream_msg`. The JSON status payloads are built
+//! infallibly and unchanged.
+
+use super::error::{ToolError, ToolResult};
 
 /// Start a long-running process (REPL, server, watcher).
 pub(super) async fn tool_process_start(
     input: &serde_json::Value,
     pm: Option<&crate::process_manager::ProcessManager>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let agent_id = caller_agent_id.unwrap_or("default");
     let command = input["command"]
         .as_str()
-        .ok_or("Missing 'command' parameter")?;
+        .ok_or(ToolError::MissingParameter("command"))?;
     let args: Vec<String> = input["args"]
         .as_array()
         .map(|arr| {
@@ -20,7 +28,10 @@ pub(super) async fn tool_process_start(
         })
         .unwrap_or_default();
 
-    let proc_id = pm.start(agent_id, command, &args).await?;
+    let proc_id = pm
+        .start(agent_id, command, &args)
+        .await
+        .map_err(ToolError::upstream_msg)?;
     Ok(serde_json::json!({
         "process_id": proc_id,
         "status": "started"
@@ -32,12 +43,12 @@ pub(super) async fn tool_process_start(
 pub(super) async fn tool_process_poll(
     input: &serde_json::Value,
     pm: Option<&crate::process_manager::ProcessManager>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let proc_id = input["process_id"]
         .as_str()
-        .ok_or("Missing 'process_id' parameter")?;
-    let (stdout, stderr) = pm.read(proc_id).await?;
+        .ok_or(ToolError::MissingParameter("process_id"))?;
+    let (stdout, stderr) = pm.read(proc_id).await.map_err(ToolError::upstream_msg)?;
     Ok(serde_json::json!({
         "stdout": stdout,
         "stderr": stderr,
@@ -49,19 +60,23 @@ pub(super) async fn tool_process_poll(
 pub(super) async fn tool_process_write(
     input: &serde_json::Value,
     pm: Option<&crate::process_manager::ProcessManager>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let proc_id = input["process_id"]
         .as_str()
-        .ok_or("Missing 'process_id' parameter")?;
-    let data = input["data"].as_str().ok_or("Missing 'data' parameter")?;
+        .ok_or(ToolError::MissingParameter("process_id"))?;
+    let data = input["data"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("data"))?;
     // Always append newline if not present (common expectation for REPLs)
     let data = if data.ends_with('\n') {
         data.to_string()
     } else {
         format!("{data}\n")
     };
-    pm.write(proc_id, &data).await?;
+    pm.write(proc_id, &data)
+        .await
+        .map_err(ToolError::upstream_msg)?;
     Ok(r#"{"status": "written"}"#.to_string())
 }
 
@@ -69,12 +84,12 @@ pub(super) async fn tool_process_write(
 pub(super) async fn tool_process_kill(
     input: &serde_json::Value,
     pm: Option<&crate::process_manager::ProcessManager>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let proc_id = input["process_id"]
         .as_str()
-        .ok_or("Missing 'process_id' parameter")?;
-    pm.kill(proc_id).await?;
+        .ok_or(ToolError::MissingParameter("process_id"))?;
+    pm.kill(proc_id).await.map_err(ToolError::upstream_msg)?;
     Ok(r#"{"status": "killed"}"#.to_string())
 }
 
@@ -82,8 +97,8 @@ pub(super) async fn tool_process_kill(
 pub(super) async fn tool_process_list(
     pm: Option<&crate::process_manager::ProcessManager>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let agent_id = caller_agent_id.unwrap_or("default");
     let procs = pm.list(agent_id);
     let list: Vec<serde_json::Value> = procs
@@ -98,4 +113,34 @@ pub(super) async fn tool_process_list(
         })
         .collect();
     Ok(serde_json::Value::Array(list).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn process_tools_without_manager_return_unavailable() {
+        assert!(matches!(
+            tool_process_start(&json!({}), None, None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+        assert!(matches!(
+            tool_process_poll(&json!({}), None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+        assert!(matches!(
+            tool_process_write(&json!({}), None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+        assert!(matches!(
+            tool_process_kill(&json!({}), None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+        assert!(matches!(
+            tool_process_list(None, None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+    }
 }


### PR DESCRIPTION
## What

Sixteenth slice of the #3576 typed-error migration. Migrates the five persistent-process tools (`tool_process_start` / `poll` / `write` / `kill` / `list`) from `Result<String, String>` to `Result<String, ToolError>`.

- a missing `ProcessManager` -> `Unavailable("Process manager")`
- missing params (`command` / `process_id` / `data`) -> `MissingParameter`
- the `ProcessManager` operations (`start`/`read`/`write`/`kill`, all `Result<_, String>`) -> `upstream_msg`
- `pm.list` is infallible; the JSON status payloads (`process_id`/`status`/`stdout`/`stderr`/list) are built infallibly and unchanged

Dispatch arms narrow back to `Result<String, String>`.

## Tests

No existing test invokes these fns directly. Adds a boundary unit test (all five tools without a manager -> `Unavailable`).

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib tool_runner::process::` -> 1 passed, 0 failed
- `rustfmt --check` on the changed files -> clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` -> clean
