### PR TITLE
refactor(runtime): migrate tool_runner tools to ToolError (#3576)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/a2a.rs
+++ b/crates/librefang-runtime/src/tool_runner/a2a.rs
@@ -1,34 +1,49 @@
 //! A2A outbound tools — cross-instance agent communication.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). The security blocks here (SSRF, taint sinks, trusted-agent gate)
+//! keep their exact messages — they are wrapped in message-preserving
+//! `ToolError` variants (`PermissionDenied` / `InvalidParameter`) so the wire
+//! string the LLM and operator logs see is unchanged.
 
-use super::{check_taint_net_fetch, check_taint_outbound_text, require_kernel};
+use super::error::{ToolError, ToolResult};
+use super::{check_taint_net_fetch, check_taint_outbound_text, require_kernel_typed};
 use crate::kernel_handle::prelude::*;
 use librefang_types::taint::TaintSink;
 use std::sync::Arc;
 
 /// Discover an external A2A agent by fetching its agent card.
-pub(super) async fn tool_a2a_discover(input: &serde_json::Value) -> Result<String, String> {
-    let url = input["url"].as_str().ok_or("Missing 'url' parameter")?;
+pub(super) async fn tool_a2a_discover(input: &serde_json::Value) -> ToolResult {
+    let url = input["url"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("url"))?;
 
     // SSRF protection: block private/metadata IPs
     if crate::web_fetch::check_ssrf(url, &[]).is_err() {
-        return Err("SSRF blocked: URL resolves to a private or metadata address".to_string());
+        return Err(ToolError::InvalidParameter {
+            name: "url",
+            reason: "SSRF blocked: URL resolves to a private or metadata address".to_string(),
+        });
     }
 
     let client = crate::a2a::A2aClient::new();
-    let card = client.discover(url).await?;
+    let card = client
+        .discover(url)
+        .await
+        .map_err(ToolError::upstream_msg)?;
 
-    serde_json::to_string_pretty(&card).map_err(|e| format!("Serialization error: {e}"))
+    Ok(serde_json::to_string_pretty(&card)?)
 }
 
 /// Send a task to an external A2A agent.
 pub(super) async fn tool_a2a_send(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let message = input["message"]
         .as_str()
-        .ok_or("Missing 'message' parameter")?;
+        .ok_or(ToolError::MissingParameter("message"))?;
 
     // Resolve agent URL: either directly provided or looked up by name.
     // Canonicalize early so the trust gate below sees the same string the
@@ -36,27 +51,42 @@ pub(super) async fn tool_a2a_send(
     let url = if let Some(raw) = input["agent_url"].as_str() {
         // SSRF protection
         if crate::web_fetch::check_ssrf(raw, &[]).is_err() {
-            return Err("SSRF blocked: URL resolves to a private or metadata address".to_string());
+            return Err(ToolError::InvalidParameter {
+                name: "agent_url",
+                reason: "SSRF blocked: URL resolves to a private or metadata address".to_string(),
+            });
         }
         crate::a2a::canonicalize_a2a_url(raw).unwrap_or_else(|| raw.to_string())
     } else if let Some(name) = input["agent_name"].as_str() {
-        kh.get_a2a_agent_url(name)
-            .ok_or_else(|| format!("No known A2A agent with name '{name}'. Use a2a_discover first or provide agent_url directly."))?
+        kh.get_a2a_agent_url(name).ok_or_else(|| {
+            // Reason kept byte-identical to the pre-#3576 String error.
+            let reason = format!(
+                "No known A2A agent with name '{name}'. Use a2a_discover first or provide agent_url directly."
+            );
+            ToolError::InvalidParameter {
+                name: "agent_name",
+                reason,
+            }
+        })?
     } else {
-        return Err("Missing 'agent_url' or 'agent_name' parameter".to_string());
+        return Err(ToolError::InvalidParameter {
+            name: "agent_url",
+            reason: "provide either 'agent_url' or 'agent_name'".to_string(),
+        });
     };
 
     // Taint sink: block secrets from being exfiltrated to an external A2A peer.
     // Runs before the trust gate so a tainted-message attempt always reports
     // the data-exfil reason (the test suite asserts this contract) — the
     // trust gate is purely about target authorization and would mask the
-    // more serious finding.
+    // more serious finding. The original violation message is preserved inside
+    // PermissionDenied so its "taint"/"violation" wording survives.
     if let Some(violation) = check_taint_outbound_text(message, &TaintSink::agent_message()) {
-        return Err(violation);
+        return Err(ToolError::PermissionDenied(violation));
     }
     // Also gate the URL itself against query-string credential leaks.
     if let Some(violation) = check_taint_net_fetch(&url) {
-        return Err(violation);
+        return Err(ToolError::PermissionDenied(violation));
     }
 
     // SECURITY (Bug #3786): the HTTP route at `/api/a2a/send` enforces a
@@ -66,14 +96,38 @@ pub(super) async fn tool_a2a_send(
     // the same check here.
     let trusted_urls: Vec<String> = kh.list_a2a_agents().into_iter().map(|(_, u)| u).collect();
     if !trusted_urls.iter().any(|u| u == &url) {
-        return Err(format!(
+        return Err(ToolError::PermissionDenied(format!(
             "A2A target '{url}' is not on the trusted-agent list. Discover and have an operator approve it via POST /api/a2a/agents/{{url}}/approve before agents may send to it."
-        ));
+        )));
     }
 
     let session_id = input["session_id"].as_str();
     let client = crate::a2a::A2aClient::new();
-    let task = client.send_task(&url, message, session_id).await?;
+    let task = client
+        .send_task(&url, message, session_id)
+        .await
+        .map_err(ToolError::upstream_msg)?;
 
-    serde_json::to_string_pretty(&task).map_err(|e| format!("Serialization error: {e}"))
+    Ok(serde_json::to_string_pretty(&task)?)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Boundary tests that run before any network / kernel call. The taint
+    //! sink and trust-gate paths are exercised against a real kernel stub in
+    //! `tool_runner::tests` (`test_tool_a2a_send_blocks_secret_in_message`).
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn a2a_discover_missing_url_is_missing_parameter() {
+        let r = tool_a2a_discover(&json!({})).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("url"))));
+    }
+
+    #[tokio::test]
+    async fn a2a_send_without_kernel_returns_unavailable() {
+        let r = tool_a2a_send(&json!({"message": "hi"}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/agent.rs
+++ b/crates/librefang-runtime/src/tool_runner/agent.rs
@@ -76,11 +76,15 @@ pub(super) async fn tool_agent_send(
         )));
     }
 
-    // Check + increment inter-agent call depth
+    // Check + increment inter-agent call depth. Surfaced as
+    // `PermissionDenied` (→ `LibreFangError::CapabilityDenied` → HTTP 403),
+    // not `Upstream` (→ 5xx): this is a kernel-policy quota, not a downstream
+    // crash. Lifting to 5xx would mislead caller retry logic into treating a
+    // self-imposed limit as a transient infra failure.
     let max_depth = kh.max_agent_call_depth();
     let current_depth = AGENT_CALL_DEPTH.try_with(|d| d.get()).unwrap_or(0);
     if current_depth >= max_depth {
-        return Err(ToolError::upstream_msg(format!(
+        return Err(ToolError::PermissionDenied(format!(
             "Inter-agent call depth exceeded (max {max_depth}). \
              A->B->C chain is too deep. Use the task queue instead."
         )));

--- a/crates/librefang-runtime/src/tool_runner/agent.rs
+++ b/crates/librefang-runtime/src/tool_runner/agent.rs
@@ -1,7 +1,8 @@
 //! Inter-agent tools: `agent_find`, `agent_send`, `agent_spawn`,
 //! `agent_list`, `agent_kill`.
 
-use super::{check_taint_outbound_text, require_kernel, AGENT_CALL_DEPTH};
+use super::error::{ToolError, ToolResult};
+use super::{check_taint_outbound_text, require_kernel_typed, AGENT_CALL_DEPTH};
 use crate::kernel_handle::prelude::*;
 use librefang_types::taint::TaintSink;
 use std::sync::Arc;
@@ -9,9 +10,11 @@ use std::sync::Arc;
 pub(super) fn tool_agent_find(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let query = input["query"].as_str().ok_or("Missing 'query' parameter")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let query = input["query"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("query"))?;
     let agents = kh.find_agents(query);
     if agents.is_empty() {
         return Ok(format!("No agents found matching '{query}'."));
@@ -30,21 +33,21 @@ pub(super) fn tool_agent_find(
             })
         })
         .collect();
-    serde_json::to_string_pretty(&result).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 pub(super) async fn tool_agent_send(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let agent_id = input["agent_id"]
         .as_str()
-        .ok_or("Missing 'agent_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("agent_id"))?;
     let message = input["message"]
         .as_str()
-        .ok_or("Missing 'message' parameter")?;
+        .ok_or(ToolError::MissingParameter("message"))?;
     let conversation_key = input["conversation_key"].as_str();
 
     // Self-send guard: sending a message to oneself would attempt to acquire
@@ -52,7 +55,10 @@ pub(super) async fn tool_agent_send(
     // turn, causing an unrecoverable deadlock (issue #3613).
     if let Some(caller) = caller_agent_id {
         if caller == agent_id {
-            return Err("agent_send: an agent cannot send a message to itself".to_string());
+            return Err(ToolError::InvalidParameter {
+                name: "agent_id",
+                reason: "agent_send: an agent cannot send a message to itself".to_string(),
+            });
         }
     }
 
@@ -65,18 +71,19 @@ pub(super) async fn tool_agent_send(
     // rejection message matches the shape documented in the taint
     // module.
     if let Some(violation) = check_taint_outbound_text(message, &TaintSink::agent_message()) {
-        return Err(format!("Taint violation: {violation}"));
+        return Err(ToolError::PermissionDenied(format!(
+            "Taint violation: {violation}"
+        )));
     }
 
     // Check + increment inter-agent call depth
     let max_depth = kh.max_agent_call_depth();
     let current_depth = AGENT_CALL_DEPTH.try_with(|d| d.get()).unwrap_or(0);
     if current_depth >= max_depth {
-        return Err(format!(
-            "Inter-agent call depth exceeded (max {}). \
-             A->B->C chain is too deep. Use the task queue instead.",
-            max_depth
-        ));
+        return Err(ToolError::upstream_msg(format!(
+            "Inter-agent call depth exceeded (max {max_depth}). \
+             A->B->C chain is too deep. Use the task queue instead."
+        )));
     }
 
     AGENT_CALL_DEPTH
@@ -96,7 +103,7 @@ pub(super) async fn tool_agent_send(
             }
         })
         .await
-        .map_err(|e| e.to_string())
+        .map_err(ToolError::upstream)
 }
 
 /// Build agent manifest TOML from parsed parameters.
@@ -187,13 +194,15 @@ pub(super) async fn tool_agent_spawn(
     kernel: Option<&Arc<dyn KernelHandle>>,
     parent_id: Option<&str>,
     parent_allowed_tools: Option<&[String]>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
 
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
     let system_prompt = input["system_prompt"]
         .as_str()
-        .ok_or("Missing 'system_prompt' parameter")?;
+        .ok_or(ToolError::MissingParameter("system_prompt"))?;
 
     let tools: Vec<String> = input["tools"]
         .as_array()
@@ -214,7 +223,8 @@ pub(super) async fn tool_agent_spawn(
         })
         .unwrap_or_default();
 
-    let manifest_toml = build_agent_manifest_toml(name, system_prompt, tools, shell, network)?;
+    let manifest_toml = build_agent_manifest_toml(name, system_prompt, tools, shell, network)
+        .map_err(ToolError::upstream_msg)?;
     // Build parent capabilities from the parent's allowed tools list.
     // This prevents a sub-agent from escalating privileges beyond what
     // its parent is permitted to use (capability inheritance enforcement).
@@ -236,14 +246,14 @@ pub(super) async fn tool_agent_spawn(
     let (id, agent_name) = kh
         .spawn_agent_checked(&manifest_toml, parent_id, &parent_caps)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!(
         "Agent spawned successfully.\n  ID: {id}\n  Name: {agent_name}"
     ))
 }
 
-pub(super) fn tool_agent_list(kernel: Option<&Arc<dyn KernelHandle>>) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+pub(super) fn tool_agent_list(kernel: Option<&Arc<dyn KernelHandle>>) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let agents = kh.list_agents();
     if agents.is_empty() {
         return Ok("No agents currently running.".to_string());
@@ -261,11 +271,11 @@ pub(super) fn tool_agent_list(kernel: Option<&Arc<dyn KernelHandle>>) -> Result<
 pub(super) fn tool_agent_kill(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let agent_id = input["agent_id"]
         .as_str()
-        .ok_or("Missing 'agent_id' parameter")?;
-    kh.kill_agent(agent_id).map_err(|e| e.to_string())?;
+        .ok_or(ToolError::MissingParameter("agent_id"))?;
+    kh.kill_agent(agent_id).map_err(ToolError::upstream)?;
     Ok(format!("Agent {agent_id} killed successfully."))
 }

--- a/crates/librefang-runtime/src/tool_runner/canvas.rs
+++ b/crates/librefang-runtime/src/tool_runner/canvas.rs
@@ -1,6 +1,13 @@
 //! Canvas / A2UI tool — sanitize agent-generated HTML and write it to the
 //! workspace `output/` directory.
+//!
+//! `tool_canvas_present` migrated from `Result<String, String>` to
+//! `Result<String, ToolError>` (#3576). The `sanitize_canvas_html` helper is
+//! `pub` (re-exported and unit-tested directly), so its `Result<_, String>`
+//! signature is left untouched; its validation/security messages are mapped to
+//! `ToolError::InvalidParameter` at the tool boundary, preserved verbatim.
 
+use super::error::{ToolError, ToolResult};
 use super::CANVAS_MAX_BYTES;
 use std::path::{Path, PathBuf};
 
@@ -62,13 +69,21 @@ pub fn sanitize_canvas_html(html: &str, max_bytes: usize) -> Result<String, Stri
 pub(super) async fn tool_canvas_present(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
-) -> Result<String, String> {
-    let html = input["html"].as_str().ok_or("Missing 'html' parameter")?;
+) -> ToolResult {
+    let html = input["html"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("html"))?;
     let title = input["title"].as_str().unwrap_or("Canvas");
 
     // Use configured max from task-local (set by agent_loop from KernelConfig), or default 512KB.
     let max_bytes = CANVAS_MAX_BYTES.try_with(|v| *v).unwrap_or(512 * 1024);
-    let sanitized = sanitize_canvas_html(html, max_bytes)?;
+    // The sanitizer's validation/security messages are user-facing — map them
+    // onto the `html` parameter, keeping the text verbatim.
+    let sanitized =
+        sanitize_canvas_html(html, max_bytes).map_err(|reason| ToolError::InvalidParameter {
+            name: "html",
+            reason,
+        })?;
 
     // Generate canvas ID
     let canvas_id = uuid::Uuid::new_v4().to_string();
@@ -94,7 +109,10 @@ pub(super) async fn tool_canvas_present(
     );
     tokio::fs::write(&filepath, &full_html)
         .await
-        .map_err(|e| format!("Failed to save canvas: {e}"))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to save canvas: {e}"),
+            source: Some(Box::new(e)),
+        })?;
 
     let response = serde_json::json!({
         "canvas_id": canvas_id,
@@ -103,5 +121,28 @@ pub(super) async fn tool_canvas_present(
         "size_bytes": full_html.len(),
     });
 
-    serde_json::to_string_pretty(&response).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&response)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn canvas_present_missing_html_is_missing_parameter() {
+        let r = tool_canvas_present(&serde_json::json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("html"))));
+    }
+
+    #[tokio::test]
+    async fn canvas_present_forbidden_tag_is_invalid_parameter() {
+        let input = serde_json::json!({ "html": "<script>alert(1)</script>" });
+        match tool_canvas_present(&input, None).await {
+            Err(ToolError::InvalidParameter { name, reason }) => {
+                assert_eq!(name, "html");
+                assert!(reason.contains("Forbidden"));
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/cron.rs
+++ b/crates/librefang-runtime/src/tool_runner/cron.rs
@@ -7,32 +7,9 @@
 //! `docs/architecture/error-contracts.md` for the migration sequence.
 
 use super::error::{ToolError, ToolResult};
-use super::require_kernel_typed;
+use super::{caller_agent_id_missing, require_kernel_typed};
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
-
-/// Build the `ToolError` returned when no caller agent id reaches a cron tool.
-///
-/// Two legitimate dispatchers feed these tools:
-///   * The direct agent-loop dispatcher always attributes a caller — `None`
-///     here is a wiring bug, but the LLM cannot recover from it either way.
-///   * The MCP HTTP route (`/mcp`) intentionally passes `None` when the
-///     `X-LibreFang-Agent-Id` header is missing or names an unknown agent;
-///     external clients are expected to receive a user-recoverable error.
-///
-/// `MissingParameter("agent_id")` is the honest user-facing mapping for the
-/// second case (lifts to `LibreFangError::InvalidInput` → HTTP 400) and is
-/// not worse than `Internal` for the first: in both cases the immediate LLM
-/// turn cannot patch the wiring. The tool name (and the fact that it dropped
-/// attribution) is preserved on the operator-facing tracing channel so a
-/// real direct-loop regression can still be traced.
-fn caller_agent_id_missing(tool: &'static str) -> ToolError {
-    tracing::warn!(
-        tool,
-        "caller agent_id missing — surfaced as MissingParameter to the LLM"
-    );
-    ToolError::MissingParameter("agent_id")
-}
 
 pub(super) async fn tool_cron_create(
     input: &serde_json::Value,

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1092,12 +1092,23 @@ pub async fn execute_tool_raw(
             .await
         }
 
-        // Persistent process tools
-        "process_start" => tool_process_start(input, *process_manager, *caller_agent_id).await,
-        "process_poll" => tool_process_poll(input, *process_manager).await,
-        "process_write" => tool_process_write(input, *process_manager).await,
-        "process_kill" => tool_process_kill(input, *process_manager).await,
-        "process_list" => tool_process_list(*process_manager, *caller_agent_id).await,
+        // Persistent process tools (#3576: return Result<String, ToolError>;
+        // narrow to Result<String, String> here at the boundary).
+        "process_start" => tool_process_start(input, *process_manager, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "process_poll" => tool_process_poll(input, *process_manager)
+            .await
+            .map_err(|e| e.to_string()),
+        "process_write" => tool_process_write(input, *process_manager)
+            .await
+            .map_err(|e| e.to_string()),
+        "process_kill" => tool_process_kill(input, *process_manager)
+            .await
+            .map_err(|e| e.to_string()),
+        "process_list" => tool_process_list(*process_manager, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Hand tools (curated autonomous capability packages). #3576:
         // submodule returns Result<String, ToolError>; narrow here.

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -889,13 +889,26 @@ pub async fn execute_tool_raw(
         "wiki_search" => tool_wiki_search(input, *kernel, *sender_id, *channel),
         "wiki_write" => tool_wiki_write(input, *kernel, *caller_agent_id, *sender_id, *channel),
 
-        // Collaboration tools
+        // Collaboration tools. task_* is the #3576 third slice: the submodule
+        // returns `Result<String, ToolError>`; arms narrow to
+        // `Result<String, String>` here at the boundary (same bridge as the
+        // cron / schedule slices) until the dispatch return type itself lifts.
         "agent_find" => tool_agent_find(input, *kernel),
-        "task_post" => tool_task_post(input, *kernel, *caller_agent_id).await,
-        "task_claim" => tool_task_claim(*kernel, *caller_agent_id).await,
-        "task_complete" => tool_task_complete(input, *kernel, *caller_agent_id).await,
-        "task_list" => tool_task_list(input, *kernel).await,
-        "task_status" => tool_task_status(input, *kernel).await,
+        "task_post" => tool_task_post(input, *kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "task_claim" => tool_task_claim(*kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "task_complete" => tool_task_complete(input, *kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "task_list" => tool_task_list(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "task_status" => tool_task_status(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
         "event_publish" => tool_event_publish(input, *kernel)
             .await
             .map_err(|e| e.to_string()),

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -952,7 +952,10 @@ pub async fn execute_tool_raw(
                 extra.push(dl);
             }
             let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
-            tool_image_analyze(input, *workspace_root, &extra_refs).await
+            // #3576: tool returns Result<String, ToolError>; narrow here.
+            tool_image_analyze(input, *workspace_root, &extra_refs)
+                .await
+                .map_err(|e| e.to_string())
         }
 
         // Media understanding tools

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1010,11 +1010,11 @@ pub async fn execute_tool_raw(
             tool_speech_to_text(input, *media_engine, *workspace_root, &extra_refs).await
         }
 
-        // Docker sandbox tool
+        // Docker sandbox tool (#3576: returns Result<String, ToolError>)
         #[cfg(feature = "docker-sandbox")]
-        "docker_exec" => {
-            tool_docker_exec(input, *docker_config, *workspace_root, *caller_agent_id).await
-        }
+        "docker_exec" => tool_docker_exec(input, *docker_config, *workspace_root, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Location tool (#3576: returns Result<String, ToolError>; narrow here)
         "location_get" => tool_location_get().await.map_err(|e| e.to_string()),

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -885,9 +885,15 @@ pub async fn execute_tool_raw(
         "memory_list" => tool_memory_list(*kernel, *caller_agent_id, *sender_id, *channel),
 
         // Memory wiki tools (issue #3329) — same #5139 per-user ACL gate.
-        "wiki_get" => tool_wiki_get(input, *kernel, *sender_id, *channel),
-        "wiki_search" => tool_wiki_search(input, *kernel, *sender_id, *channel),
-        "wiki_write" => tool_wiki_write(input, *kernel, *caller_agent_id, *sender_id, *channel),
+        // #3576: submodule returns Result<String, ToolError>; narrow here.
+        "wiki_get" => {
+            tool_wiki_get(input, *kernel, *sender_id, *channel).map_err(|e| e.to_string())
+        }
+        "wiki_search" => {
+            tool_wiki_search(input, *kernel, *sender_id, *channel).map_err(|e| e.to_string())
+        }
+        "wiki_write" => tool_wiki_write(input, *kernel, *caller_agent_id, *sender_id, *channel)
+            .map_err(|e| e.to_string()),
 
         // Collaboration tools. task_* is the #3576 third slice: the submodule
         // returns `Result<String, ToolError>`; arms narrow to

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -472,7 +472,10 @@ pub async fn execute_tool_raw(
                             spill_or_passthrough("web_fetch", body, threshold, max_artifact)
                         })
                 } else {
-                    tool_web_fetch_legacy(input, threshold, max_artifact).await
+                    // #3576: tool returns Result<String, ToolError>; narrow here.
+                    tool_web_fetch_legacy(input, threshold, max_artifact)
+                        .await
+                        .map_err(|e| e.to_string())
                 }
             }
         },
@@ -577,9 +580,13 @@ pub async fn execute_tool_raw(
                         spill_or_passthrough("web_search", body, threshold, max_artifact)
                     })
                 } else {
-                    tool_web_search_legacy(input).await.map(|body| {
-                        spill_or_passthrough("web_search", body, threshold, max_artifact)
-                    })
+                    // #3576: tool returns Result<String, ToolError>; narrow here.
+                    tool_web_search_legacy(input)
+                        .await
+                        .map(|body| {
+                            spill_or_passthrough("web_search", body, threshold, max_artifact)
+                        })
+                        .map_err(|e| e.to_string())
                 }
             }
         },

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -987,8 +987,8 @@ pub async fn execute_tool_raw(
             tool_docker_exec(input, *docker_config, *workspace_root, *caller_agent_id).await
         }
 
-        // Location tool
-        "location_get" => tool_location_get().await,
+        // Location tool (#3576: returns Result<String, ToolError>; narrow here)
+        "location_get" => tool_location_get().await.map_err(|e| e.to_string()),
 
         // System time tool
         "system_time" => Ok(tool_system_time()),

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -935,12 +935,20 @@ pub async fn execute_tool_raw(
             .await
             .map_err(|e| e.to_string()),
 
-        // Scheduling tools (delegate to CronScheduler via kernel handle)
-        "schedule_create" => {
-            tool_schedule_create(input, *kernel, *caller_agent_id, *sender_id).await
-        }
-        "schedule_list" => tool_schedule_list(*kernel, *caller_agent_id).await,
-        "schedule_delete" => tool_schedule_delete(input, *kernel).await,
+        // Scheduling tools (delegate to CronScheduler via kernel handle).
+        // Second slice of the #3576 typed-error migration: the submodule now
+        // returns `Result<String, ToolError>`; the dispatch arms narrow it to
+        // `Result<String, String>` here at the boundary so the broader
+        // dispatch table stays uniform until every submodule has migrated.
+        "schedule_create" => tool_schedule_create(input, *kernel, *caller_agent_id, *sender_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "schedule_list" => tool_schedule_list(*kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "schedule_delete" => tool_schedule_delete(input, *kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Knowledge graph tools (#3576 fourth slice: submodule returns
         // Result<String, ToolError>; arms narrow to Result<String, String>

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -907,10 +907,18 @@ pub async fn execute_tool_raw(
         "schedule_list" => tool_schedule_list(*kernel, *caller_agent_id).await,
         "schedule_delete" => tool_schedule_delete(input, *kernel).await,
 
-        // Knowledge graph tools
-        "knowledge_add_entity" => tool_knowledge_add_entity(input, *kernel).await,
-        "knowledge_add_relation" => tool_knowledge_add_relation(input, *kernel).await,
-        "knowledge_query" => tool_knowledge_query(input, *kernel).await,
+        // Knowledge graph tools (#3576 fourth slice: submodule returns
+        // Result<String, ToolError>; arms narrow to Result<String, String>
+        // here, same boundary bridge as the cron / schedule / task slices).
+        "knowledge_add_entity" => tool_knowledge_add_entity(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "knowledge_add_relation" => tool_knowledge_add_relation(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "knowledge_query" => tool_knowledge_query(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Image analysis tool
         "image_analyze" => {

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -249,6 +249,7 @@ pub async fn execute_tool_raw(
             let raw_input_path = input.get("path").and_then(|v| v.as_str());
             let resolved_for_dedup = raw_input_path
                 .and_then(|p| resolve_file_path_ext(p, *workspace_root, &extra_refs).ok());
+            // #3576: tool returns Result<String, ToolError>; narrow here.
             tool_file_read(input, *workspace_root, &extra_refs)
                 .await
                 .map(|content| match resolved_for_dedup {
@@ -257,6 +258,7 @@ pub async fn execute_tool_raw(
                     }
                     None => content,
                 })
+                .map_err(|e| e.to_string())
         }
         "file_write" => {
             // Enforce named workspace read-only restrictions before the sandbox resolves the path.
@@ -325,7 +327,9 @@ pub async fn execute_tool_raw(
             }
             maybe_snapshot(checkpoint_manager, *workspace_root, "pre file_write").await;
             let extra_refs: Vec<&Path> = writable.iter().map(|p| p.as_path()).collect();
-            tool_file_write(input, *workspace_root, &extra_refs).await
+            tool_file_write(input, *workspace_root, &extra_refs)
+                .await
+                .map_err(|e| e.to_string())
         }
         "file_list" => {
             let mut extra = named_ws_prefixes(*kernel, *caller_agent_id);
@@ -334,7 +338,9 @@ pub async fn execute_tool_raw(
                 extra.push(dl);
             }
             let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
-            tool_file_list(input, *workspace_root, &extra_refs).await
+            tool_file_list(input, *workspace_root, &extra_refs)
+                .await
+                .map_err(|e| e.to_string())
         }
         "apply_patch" => {
             // SECURITY #3662: Enforce named workspace read-only restrictions
@@ -404,7 +410,9 @@ pub async fn execute_tool_raw(
             // set.
             let ro_prefixes = named_ws_prefixes_readonly(*kernel, *caller_agent_id);
             let ro_refs: Vec<&Path> = ro_prefixes.iter().map(|p| p.as_path()).collect();
-            tool_apply_patch(input, *workspace_root, &extra_refs, &ro_refs).await
+            tool_apply_patch(input, *workspace_root, &extra_refs, &ro_refs)
+                .await
+                .map_err(|e| e.to_string())
         }
 
         // Web tools (upgraded: multi-provider search, SSRF-protected fetch)

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -896,7 +896,9 @@ pub async fn execute_tool_raw(
         "task_complete" => tool_task_complete(input, *kernel, *caller_agent_id).await,
         "task_list" => tool_task_list(input, *kernel).await,
         "task_status" => tool_task_status(input, *kernel).await,
-        "event_publish" => tool_event_publish(input, *kernel).await,
+        "event_publish" => tool_event_publish(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Scheduling tools (delegate to CronScheduler via kernel handle)
         "schedule_create" => {
@@ -1061,8 +1063,9 @@ pub async fn execute_tool_raw(
         "a2a_discover" => tool_a2a_discover(input).await,
         "a2a_send" => tool_a2a_send(input, *kernel).await,
 
-        // Goal tracking tool
-        "goal_update" => tool_goal_update(input, *kernel),
+        // Goal tracking tool (#3576: sync tool now returns
+        // Result<String, ToolError>; narrow to Result<String, String> here)
+        "goal_update" => tool_goal_update(input, *kernel).map_err(|e| e.to_string()),
 
         // Workflow tools
         "workflow_run" => tool_workflow_run(input, *kernel).await,

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1054,25 +1054,36 @@ pub async fn execute_tool_raw(
         // System time tool
         "system_time" => Ok(tool_system_time()),
 
-        // Skill file read tool
-        "skill_read_file" => tool_skill_read_file(input, *skill_registry, *allowed_skills).await,
+        // Skill file read tool (#3576: return Result<String, ToolError>;
+        // narrow to Result<String, String> here at the boundary).
+        "skill_read_file" => tool_skill_read_file(input, *skill_registry, *allowed_skills)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Skill evolution tools
-        "skill_evolve_create" => {
-            tool_skill_evolve_create(input, *skill_registry, *caller_agent_id).await
-        }
-        "skill_evolve_update" => {
-            tool_skill_evolve_update(input, *skill_registry, *caller_agent_id).await
-        }
-        "skill_evolve_patch" => {
-            tool_skill_evolve_patch(input, *skill_registry, *caller_agent_id).await
-        }
-        "skill_evolve_delete" => tool_skill_evolve_delete(input, *skill_registry).await,
+        "skill_evolve_create" => tool_skill_evolve_create(input, *skill_registry, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "skill_evolve_update" => tool_skill_evolve_update(input, *skill_registry, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "skill_evolve_patch" => tool_skill_evolve_patch(input, *skill_registry, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "skill_evolve_delete" => tool_skill_evolve_delete(input, *skill_registry)
+            .await
+            .map_err(|e| e.to_string()),
         "skill_evolve_rollback" => {
-            tool_skill_evolve_rollback(input, *skill_registry, *caller_agent_id).await
+            tool_skill_evolve_rollback(input, *skill_registry, *caller_agent_id)
+                .await
+                .map_err(|e| e.to_string())
         }
-        "skill_evolve_write_file" => tool_skill_evolve_write_file(input, *skill_registry).await,
-        "skill_evolve_remove_file" => tool_skill_evolve_remove_file(input, *skill_registry).await,
+        "skill_evolve_write_file" => tool_skill_evolve_write_file(input, *skill_registry)
+            .await
+            .map_err(|e| e.to_string()),
+        "skill_evolve_remove_file" => tool_skill_evolve_remove_file(input, *skill_registry)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Cron scheduling tools — first slice of the #3576 typed-error
         // migration. The submodule now returns `Result<String, ToolError>`;

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1080,11 +1080,18 @@ pub async fn execute_tool_raw(
         "process_kill" => tool_process_kill(input, *process_manager).await,
         "process_list" => tool_process_list(*process_manager, *caller_agent_id).await,
 
-        // Hand tools (curated autonomous capability packages)
-        "hand_list" => tool_hand_list(*kernel).await,
-        "hand_activate" => tool_hand_activate(input, *kernel).await,
-        "hand_status" => tool_hand_status(input, *kernel).await,
-        "hand_deactivate" => tool_hand_deactivate(input, *kernel).await,
+        // Hand tools (curated autonomous capability packages). #3576:
+        // submodule returns Result<String, ToolError>; narrow here.
+        "hand_list" => tool_hand_list(*kernel).await.map_err(|e| e.to_string()),
+        "hand_activate" => tool_hand_activate(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "hand_status" => tool_hand_status(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "hand_deactivate" => tool_hand_deactivate(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
 
         // A2A outbound tools (cross-instance agent communication). #3576:
         // submodule returns Result<String, ToolError>; narrow at the boundary.

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -995,7 +995,9 @@ pub async fn execute_tool_raw(
                 extra.push(dl);
             }
             let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
-            tool_media_describe(input, *media_engine, *workspace_root, &extra_refs).await
+            tool_media_describe(input, *media_engine, *workspace_root, &extra_refs)
+                .await
+                .map_err(|e| e.to_string())
         }
         #[cfg(feature = "media")]
         "media_transcribe" => {
@@ -1008,7 +1010,9 @@ pub async fn execute_tool_raw(
                 extra.push(dl);
             }
             let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
-            tool_media_transcribe(input, *media_engine, *workspace_root, &extra_refs).await
+            tool_media_transcribe(input, *media_engine, *workspace_root, &extra_refs)
+                .await
+                .map_err(|e| e.to_string())
         }
 
         // Media generation tools (MediaDriver-based)
@@ -1017,19 +1021,29 @@ pub async fn execute_tool_raw(
             let upload_dir = kernel
                 .map(|k| k.effective_upload_dir())
                 .unwrap_or_else(|| std::env::temp_dir().join("librefang_uploads"));
-            tool_image_generate(input, *media_drivers, *workspace_root, &upload_dir).await
+            tool_image_generate(input, *media_drivers, *workspace_root, &upload_dir)
+                .await
+                .map_err(|e| e.to_string())
         }
         #[cfg(feature = "media")]
-        "video_generate" => tool_video_generate(input, *media_drivers).await,
+        "video_generate" => tool_video_generate(input, *media_drivers)
+            .await
+            .map_err(|e| e.to_string()),
         #[cfg(feature = "media")]
-        "video_status" => tool_video_status(input, *media_drivers).await,
+        "video_status" => tool_video_status(input, *media_drivers)
+            .await
+            .map_err(|e| e.to_string()),
         #[cfg(feature = "media")]
-        "music_generate" => tool_music_generate(input, *media_drivers, *workspace_root).await,
+        "music_generate" => tool_music_generate(input, *media_drivers, *workspace_root)
+            .await
+            .map_err(|e| e.to_string()),
 
         // TTS/STT tools
         #[cfg(feature = "media")]
         "text_to_speech" => {
-            tool_text_to_speech(input, *media_drivers, *tts_engine, *workspace_root).await
+            tool_text_to_speech(input, *media_drivers, *tts_engine, *workspace_root)
+                .await
+                .map_err(|e| e.to_string())
         }
         #[cfg(feature = "media")]
         "speech_to_text" => {
@@ -1039,7 +1053,9 @@ pub async fn execute_tool_raw(
                 extra.push(dl);
             }
             let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
-            tool_speech_to_text(input, *media_engine, *workspace_root, &extra_refs).await
+            tool_speech_to_text(input, *media_engine, *workspace_root, &extra_refs)
+                .await
+                .map_err(|e| e.to_string())
         }
 
         // Docker sandbox tool (#3576: returns Result<String, ToolError>)

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1080,9 +1080,12 @@ pub async fn execute_tool_raw(
         "hand_status" => tool_hand_status(input, *kernel).await,
         "hand_deactivate" => tool_hand_deactivate(input, *kernel).await,
 
-        // A2A outbound tools (cross-instance agent communication)
-        "a2a_discover" => tool_a2a_discover(input).await,
-        "a2a_send" => tool_a2a_send(input, *kernel).await,
+        // A2A outbound tools (cross-instance agent communication). #3576:
+        // submodule returns Result<String, ToolError>; narrow at the boundary.
+        "a2a_discover" => tool_a2a_discover(input).await.map_err(|e| e.to_string()),
+        "a2a_send" => tool_a2a_send(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Goal tracking tool (#3576: sync tool now returns
         // Result<String, ToolError>; narrow to Result<String, String> here)

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1158,15 +1158,24 @@ pub async fn execute_tool_raw(
         // Result<String, ToolError>; narrow to Result<String, String> here)
         "goal_update" => tool_goal_update(input, *kernel).map_err(|e| e.to_string()),
 
-        // Workflow tools
-        "workflow_run" => tool_workflow_run(input, *kernel).await,
-        "workflow_list" => tool_workflow_list(*kernel).await,
-        "workflow_describe" => tool_workflow_describe(input, *kernel).await,
-        "workflow_status" => tool_workflow_status(input, *kernel).await,
-        "workflow_start" => {
-            tool_workflow_start(input, *kernel, *caller_agent_id, *session_id).await
-        }
-        "workflow_cancel" => tool_workflow_cancel(input, *kernel).await,
+        // Workflow tools (#3576: return Result<String, ToolError>; narrow
+        // to Result<String, String> here at the boundary).
+        "workflow_run" => tool_workflow_run(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "workflow_list" => tool_workflow_list(*kernel).await.map_err(|e| e.to_string()),
+        "workflow_describe" => tool_workflow_describe(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "workflow_status" => tool_workflow_status(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
+        "workflow_start" => tool_workflow_start(input, *kernel, *caller_agent_id, *session_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "workflow_cancel" => tool_workflow_cancel(input, *kernel)
+            .await
+            .map_err(|e| e.to_string()),
 
         // Browser automation tools
         #[cfg(feature = "browser")]

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1244,8 +1244,10 @@ pub async fn execute_tool_raw(
             tool_read_artifact(input, &artifact_dir).await
         }
 
-        // Canvas / A2UI tool
-        "canvas_present" => tool_canvas_present(input, *workspace_root).await,
+        // Canvas / A2UI tool (#3576: returns Result<String, ToolError>)
+        "canvas_present" => tool_canvas_present(input, *workspace_root)
+            .await
+            .map_err(|e| e.to_string()),
 
         other => {
             // Fallback 1: MCP tools (mcp_{server}_{tool} prefix)

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -884,11 +884,16 @@ pub async fn execute_tool_raw(
             .map_err(|e| e.to_string()) // #3576: narrow ToolError at the boundary
         }
 
-        // Inter-agent tools (require kernel handle)
-        "agent_send" => tool_agent_send(input, *kernel, *caller_agent_id).await,
-        "agent_spawn" => tool_agent_spawn(input, *kernel, *caller_agent_id, *allowed_tools).await,
-        "agent_list" => tool_agent_list(*kernel),
-        "agent_kill" => tool_agent_kill(input, *kernel),
+        // Inter-agent tools (require kernel handle). #3576: return
+        // Result<String, ToolError>; narrow to Result<String, String> here.
+        "agent_send" => tool_agent_send(input, *kernel, *caller_agent_id)
+            .await
+            .map_err(|e| e.to_string()),
+        "agent_spawn" => tool_agent_spawn(input, *kernel, *caller_agent_id, *allowed_tools)
+            .await
+            .map_err(|e| e.to_string()),
+        "agent_list" => tool_agent_list(*kernel).map_err(|e| e.to_string()),
+        "agent_kill" => tool_agent_kill(input, *kernel).map_err(|e| e.to_string()),
 
         // Shared memory tools (peer-scoped when sender_id is present).
         // #5139: the per-user `UserMemoryAccess` ACL is enforced inside each
@@ -915,7 +920,7 @@ pub async fn execute_tool_raw(
         // returns `Result<String, ToolError>`; arms narrow to
         // `Result<String, String>` here at the boundary (same bridge as the
         // cron / schedule slices) until the dispatch return type itself lifts.
-        "agent_find" => tool_agent_find(input, *kernel),
+        "agent_find" => tool_agent_find(input, *kernel).map_err(|e| e.to_string()),
         "task_post" => tool_task_post(input, *kernel, *caller_agent_id)
             .await
             .map_err(|e| e.to_string()),

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -866,6 +866,7 @@ pub async fn execute_tool_raw(
                 interrupt.clone(),
             )
             .await
+            .map_err(|e| e.to_string()) // #3576: narrow ToolError at the boundary
         }
 
         // Inter-agent tools (require kernel handle)

--- a/crates/librefang-runtime/src/tool_runner/event.rs
+++ b/crates/librefang-runtime/src/tool_runner/event.rs
@@ -1,23 +1,39 @@
 //! `event_publish` — fan out an event onto the kernel bus.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). Pure kernel passthrough — no caller-auth concern.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
 pub(super) async fn tool_event_publish(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let event_type = input["event_type"]
         .as_str()
-        .ok_or("Missing 'event_type' parameter")?;
+        .ok_or(ToolError::MissingParameter("event_type"))?;
     let payload = input
         .get("payload")
         .cloned()
         .unwrap_or(serde_json::json!({}));
     kh.publish_event(event_type, payload)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Event '{event_type}' published successfully."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn event_publish_without_kernel_returns_unavailable() {
+        let r = tool_event_publish(&json!({"event_type": "x"}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/fs.rs
+++ b/crates/librefang-runtime/src/tool_runner/fs.rs
@@ -304,9 +304,14 @@ pub(super) async fn tool_file_list(
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
 ) -> ToolResult {
-    let raw_path = input["path"]
-        .as_str()
-        .ok_or(ToolError::MissingParameter("path"))?;
+    // Keep the self-correction hint the pre-#3576 message carried: an LLM that
+    // calls file_list with no path recovers in one turn by re-calling with
+    // {"path": "."}. MissingParameter can't carry free text, so use
+    // InvalidParameter to preserve the guidance.
+    let raw_path = input["path"].as_str().ok_or(ToolError::InvalidParameter {
+        name: "path",
+        reason: "retry with {\"path\": \".\"} to list the workspace root".to_string(),
+    })?;
     let resolved = resolve_path(raw_path, workspace_root, additional_roots)?;
     let mut entries = tokio::fs::read_dir(&resolved)
         .await
@@ -485,9 +490,17 @@ mod toolerror_tests {
     }
 
     #[tokio::test]
-    async fn file_list_missing_path_is_missing_parameter() {
+    async fn file_list_missing_path_is_invalid_parameter_with_hint() {
+        // file_list maps a missing path to InvalidParameter so it can carry the
+        // {"path": "."} self-correction hint (MissingParameter is name-only).
         let r = tool_file_list(&json!({}), None, &[]).await;
-        assert!(matches!(r, Err(ToolError::MissingParameter("path"))));
+        match r {
+            Err(ToolError::InvalidParameter { name, reason }) => {
+                assert_eq!(name, "path");
+                assert!(reason.contains("\"path\": \".\""), "got: {reason}");
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/tool_runner/fs.rs
+++ b/crates/librefang-runtime/src/tool_runner/fs.rs
@@ -3,6 +3,15 @@
 //! checkpoint-snapshot helpers used by the dispatcher to enforce the
 //! agent's filesystem boundary.
 
+//! #3576: the four tool fns (`tool_file_read/write/list/apply_patch`) return
+//! `Result<String, ToolError>`. Missing params -> `MissingParameter`; the
+//! shared `resolve_file_path_ext` / `parse_patch` (both still `Result<_,
+//! String>`) -> `InvalidParameter` with the message preserved; the `io::Error`
+//! sites -> `ToolError::Upstream` keeping the prefix and source. The path /
+//! checkpoint helpers below keep their `Result<_, String>` / `Option<String>`
+//! shapes (shared with the dispatcher and unmigrated tools).
+
+use super::error::{ToolError, ToolResult};
 use crate::kernel_handle::prelude::*;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -27,6 +36,24 @@ pub(super) fn resolve_file_path_ext(
          Set a workspace_root in the agent manifest or kernel config to enable file tools.",
     )?;
     crate::workspace_sandbox::resolve_sandbox_path_ext(raw_path, root, additional_roots)
+}
+
+/// #3576 thin wrapper over [`resolve_file_path_ext`] that maps its
+/// stringly-typed rejection (sandbox-escape / not-configured) onto a typed
+/// `ToolError::InvalidParameter` while preserving the message. The underlying
+/// resolver keeps its `Result<_, String>` shape because it is shared with
+/// tools that haven't migrated yet.
+fn resolve_path(
+    raw_path: &str,
+    workspace_root: Option<&Path>,
+    additional_roots: &[&Path],
+) -> Result<PathBuf, ToolError> {
+    resolve_file_path_ext(raw_path, workspace_root, additional_roots).map_err(|reason| {
+        ToolError::InvalidParameter {
+            name: "path",
+            reason,
+        }
+    })
 }
 
 /// Fetch the named-workspace prefixes (all modes) for the calling agent.
@@ -188,12 +215,17 @@ pub(super) async fn tool_file_read(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
-) -> Result<String, String> {
-    let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
-    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
+) -> ToolResult {
+    let raw_path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
+    let resolved = resolve_path(raw_path, workspace_root, additional_roots)?;
     tokio::fs::read_to_string(&resolved)
         .await
-        .map_err(|e| format!("Failed to read file: {e}"))
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to read file: {e}"),
+            source: Some(Box::new(e)),
+        })
 }
 
 /// `file_read` deduplication shim (#4971).
@@ -238,20 +270,28 @@ pub(super) async fn tool_file_write(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
-) -> Result<String, String> {
-    let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
-    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
+) -> ToolResult {
+    let raw_path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
+    let resolved = resolve_path(raw_path, workspace_root, additional_roots)?;
     let content = input["content"]
         .as_str()
-        .ok_or("Missing 'content' parameter")?;
+        .ok_or(ToolError::MissingParameter("content"))?;
     if let Some(parent) = resolved.parent() {
         tokio::fs::create_dir_all(parent)
             .await
-            .map_err(|e| format!("Failed to create directories: {e}"))?;
+            .map_err(|e| ToolError::Upstream {
+                message: format!("Failed to create directories: {e}"),
+                source: Some(Box::new(e)),
+            })?;
     }
     tokio::fs::write(&resolved, content)
         .await
-        .map_err(|e| format!("Failed to write file: {e}"))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to write file: {e}"),
+            source: Some(Box::new(e)),
+        })?;
     Ok(format!(
         "Successfully wrote {} bytes to {}",
         content.len(),
@@ -263,19 +303,25 @@ pub(super) async fn tool_file_list(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
-) -> Result<String, String> {
-    let raw_path = input["path"].as_str().ok_or(
-        "Missing 'path' parameter — retry with {\"path\": \".\"} to list the workspace root",
-    )?;
-    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
+) -> ToolResult {
+    let raw_path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
+    let resolved = resolve_path(raw_path, workspace_root, additional_roots)?;
     let mut entries = tokio::fs::read_dir(&resolved)
         .await
-        .map_err(|e| format!("Failed to list directory: {e}"))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to list directory: {e}"),
+            source: Some(Box::new(e)),
+        })?;
     let mut files = Vec::new();
     while let Some(entry) = entries
         .next_entry()
         .await
-        .map_err(|e| format!("Failed to read entry: {e}"))?
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to read entry: {e}"),
+            source: Some(Box::new(e)),
+        })?
     {
         let name = entry.file_name().to_string_lossy().to_string();
         let metadata = entry.metadata().await;
@@ -294,10 +340,17 @@ pub(super) async fn tool_apply_patch(
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
     readonly_roots: &[&Path],
-) -> Result<String, String> {
-    let patch_str = input["patch"].as_str().ok_or("Missing 'patch' parameter")?;
-    let root = workspace_root.ok_or("apply_patch requires a workspace root")?;
-    let ops = crate::apply_patch::parse_patch(patch_str)?;
+) -> ToolResult {
+    let patch_str = input["patch"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("patch"))?;
+    let root = workspace_root.ok_or(ToolError::Unavailable("workspace directory"))?;
+    let ops = crate::apply_patch::parse_patch(patch_str).map_err(|reason| {
+        ToolError::InvalidParameter {
+            name: "patch",
+            reason,
+        }
+    })?;
     // SECURITY #3662: defense-in-depth — pass readonly named-workspace prefixes
     // through to `apply_patch_ext` so any resolved target path that lands
     // inside a read-only workspace is rejected at the write site as well as
@@ -307,11 +360,13 @@ pub(super) async fn tool_apply_patch(
     if result.is_ok() {
         Ok(result.summary())
     } else {
-        Err(format!(
+        // A partial apply is a downstream outcome, not bad input — keep the
+        // summary + per-hunk errors verbatim.
+        Err(ToolError::upstream_msg(format!(
             "Patch partially applied: {}. Errors: {}",
             result.summary(),
             result.errors.join("; ")
-        ))
+        )))
     }
 }
 
@@ -409,5 +464,44 @@ mod path_check_tests {
         let err = check_absolute_path_inside_workspace(Some("../../etc/shadow"), Some(&root), &[])
             .expect("relative `..` must be blocked");
         assert!(err.contains("'..'"));
+    }
+}
+
+#[cfg(test)]
+mod toolerror_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn file_read_missing_path_is_missing_parameter() {
+        let r = tool_file_read(&json!({}), None, &[]).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("path"))));
+    }
+
+    #[tokio::test]
+    async fn file_write_missing_path_is_missing_parameter() {
+        let r = tool_file_write(&json!({}), None, &[]).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("path"))));
+    }
+
+    #[tokio::test]
+    async fn file_list_missing_path_is_missing_parameter() {
+        let r = tool_file_list(&json!({}), None, &[]).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("path"))));
+    }
+
+    #[tokio::test]
+    async fn apply_patch_missing_patch_is_missing_parameter() {
+        let r = tool_apply_patch(&json!({}), None, &[], &[]).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("patch"))));
+    }
+
+    #[tokio::test]
+    async fn apply_patch_without_workspace_is_unavailable() {
+        let r = tool_apply_patch(&json!({"patch": "x"}), None, &[], &[]).await;
+        assert!(matches!(
+            r,
+            Err(ToolError::Unavailable("workspace directory"))
+        ));
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/goal.rs
+++ b/crates/librefang-runtime/src/tool_runner/goal.rs
@@ -1,36 +1,88 @@
 //! Goal tracking tool.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). Synchronous tool; `require_kernel_typed` is sync so it works here
+//! unchanged.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
 pub(super) fn tool_goal_update(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
+) -> ToolResult {
     // Validate input before touching the kernel
     let goal_id = input["goal_id"]
         .as_str()
-        .ok_or("Missing 'goal_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("goal_id"))?;
     let status = input["status"].as_str();
     let progress = input["progress"].as_u64().map(|p| p.min(100) as u8);
 
     if status.is_none() && progress.is_none() {
-        return Err("At least one of 'status' or 'progress' must be provided".to_string());
+        // Reason text kept byte-identical to the pre-#3576 String error; only
+        // the error channel changed.
+        return Err(ToolError::InvalidParameter {
+            name: "status",
+            reason: "At least one of 'status' or 'progress' must be provided".to_string(),
+        });
     }
 
     if let Some(s) = status {
         if !["pending", "in_progress", "completed", "cancelled"].contains(&s) {
-            return Err(format!(
-                "Invalid status '{}'. Must be: pending, in_progress, completed, or cancelled",
-                s
-            ));
+            return Err(ToolError::InvalidParameter {
+                name: "status",
+                reason: format!(
+                    "Invalid status '{s}'. Must be: pending, in_progress, completed, or cancelled"
+                ),
+            });
         }
     }
 
-    let kh = require_kernel(kernel)?;
+    let kh = require_kernel_typed(kernel)?;
     let updated = kh
         .goal_update(goal_id, status, progress)
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(serde_json::to_string_pretty(&updated).unwrap_or_else(|_| updated.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn goal_update_without_status_or_progress_is_invalid_parameter() {
+        let r = tool_goal_update(&json!({"goal_id": "g1"}), None);
+        match r {
+            Err(ToolError::InvalidParameter { name, reason }) => {
+                assert_eq!(name, "status");
+                assert!(reason.contains("At least one"));
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn goal_update_rejects_unknown_status() {
+        let r = tool_goal_update(&json!({"goal_id": "g1", "status": "bogus"}), None);
+        assert!(matches!(
+            r,
+            Err(ToolError::InvalidParameter { name: "status", .. })
+        ));
+    }
+
+    #[test]
+    fn goal_update_missing_goal_id_is_missing_parameter() {
+        let r = tool_goal_update(&json!({"status": "completed"}), None);
+        assert!(matches!(r, Err(ToolError::MissingParameter("goal_id"))));
+    }
+
+    #[test]
+    fn goal_update_without_kernel_returns_unavailable() {
+        // Valid input, but no kernel handle -> Unavailable (validation passed).
+        let r = tool_goal_update(&json!({"goal_id": "g1", "status": "completed"}), None);
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/hand.rs
+++ b/crates/librefang-runtime/src/tool_runner/hand.rs
@@ -1,14 +1,16 @@
 //! Hand tools (delegated to kernel via `KernelHandle`).
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). Clean kernel passthrough — no caller-auth concern.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
-pub(super) async fn tool_hand_list(
-    kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let hands = kh.hand_list().await.map_err(|e| e.to_string())?;
+pub(super) async fn tool_hand_list(kernel: Option<&Arc<dyn KernelHandle>>) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let hands = kh.hand_list().await.map_err(ToolError::upstream)?;
 
     if hands.is_empty() {
         return Ok(
@@ -46,11 +48,11 @@ pub(super) async fn tool_hand_list(
 pub(super) async fn tool_hand_activate(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let hand_id = input["hand_id"]
         .as_str()
-        .ok_or("Missing 'hand_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("hand_id"))?;
     let config: std::collections::HashMap<String, serde_json::Value> =
         if let Some(obj) = input["config"].as_object() {
             obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
@@ -61,7 +63,7 @@ pub(super) async fn tool_hand_activate(
     let result = kh
         .hand_activate(hand_id, config)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
 
     let instance_id = result["instance_id"].as_str().unwrap_or("?");
     let agent_name = result["agent_name"].as_str().unwrap_or("?");
@@ -76,13 +78,13 @@ pub(super) async fn tool_hand_activate(
 pub(super) async fn tool_hand_status(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let hand_id = input["hand_id"]
         .as_str()
-        .ok_or("Missing 'hand_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("hand_id"))?;
 
-    let result = kh.hand_status(hand_id).await.map_err(|e| e.to_string())?;
+    let result = kh.hand_status(hand_id).await.map_err(ToolError::upstream)?;
 
     let icon = result["icon"].as_str().unwrap_or("");
     let name = result["name"].as_str().unwrap_or(hand_id);
@@ -100,13 +102,51 @@ pub(super) async fn tool_hand_status(
 pub(super) async fn tool_hand_deactivate(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let instance_id = input["instance_id"]
         .as_str()
-        .ok_or("Missing 'instance_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("instance_id"))?;
     kh.hand_deactivate(instance_id)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Hand instance '{}' deactivated.", instance_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn hand_list_without_kernel_returns_unavailable() {
+        assert!(matches!(
+            tool_hand_list(None).await,
+            Err(ToolError::Unavailable("Kernel handle"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn hand_activate_without_kernel_returns_unavailable() {
+        assert!(matches!(
+            tool_hand_activate(&json!({"hand_id": "x"}), None).await,
+            Err(ToolError::Unavailable("Kernel handle"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn hand_status_without_kernel_returns_unavailable() {
+        assert!(matches!(
+            tool_hand_status(&json!({"hand_id": "x"}), None).await,
+            Err(ToolError::Unavailable("Kernel handle"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn hand_deactivate_without_kernel_returns_unavailable() {
+        assert!(matches!(
+            tool_hand_deactivate(&json!({"instance_id": "x"}), None).await,
+            Err(ToolError::Unavailable("Kernel handle"))
+        ));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/image.rs
+++ b/crates/librefang-runtime/src/tool_runner/image.rs
@@ -1,7 +1,15 @@
 //! `image_analyze` — read an image from the agent's workspace sandbox,
 //! identify its format and dimensions, and return a JSON description plus
 //! a base64 preview the LLM can hand to a vision-capable provider.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). The shared `resolve_file_path_ext` (sandbox path resolver, still
+//! `Result<_, String>`) maps to `InvalidParameter { name: "path" }` with its
+//! message preserved; the file read (`io::Error`) maps to `ToolError::Upstream`
+//! keeping the prefix message and the source. The format/dimension helpers are
+//! infallible and unchanged.
 
+use super::error::{ToolError, ToolResult};
 use super::resolve_file_path_ext;
 use std::path::Path;
 
@@ -9,18 +17,29 @@ pub(super) async fn tool_image_analyze(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
-) -> Result<String, String> {
-    let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
+) -> ToolResult {
+    let raw_path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
     let prompt = input["prompt"].as_str().unwrap_or("");
     // Route through the workspace sandbox so user-supplied paths cannot
     // escape to arbitrary filesystem locations (e.g. /etc/passwd). Named
     // workspace prefixes are honored via `additional_roots` so agents can
     // analyze images that live under declared `[workspaces]` mounts.
-    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
+    let resolved =
+        resolve_file_path_ext(raw_path, workspace_root, additional_roots).map_err(|reason| {
+            ToolError::InvalidParameter {
+                name: "path",
+                reason,
+            }
+        })?;
 
     let data = tokio::fs::read(&resolved)
         .await
-        .map_err(|e| format!("Failed to read image '{raw_path}': {e}"))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to read image '{raw_path}': {e}"),
+            source: Some(Box::new(e)),
+        })?;
 
     let file_size = data.len();
 
@@ -67,7 +86,7 @@ pub(super) async fn tool_image_analyze(
 
     result["base64_preview"] = serde_json::json!(base64_preview);
 
-    serde_json::to_string_pretty(&result).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 /// Detect image format from magic bytes.
@@ -166,5 +185,26 @@ pub(super) fn format_file_size(bytes: usize) -> String {
         format!("{:.1} KB", bytes as f64 / 1024.0)
     } else {
         format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn image_analyze_missing_path_is_missing_parameter() {
+        let r = tool_image_analyze(&serde_json::json!({}), None, &[]).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("path"))));
+    }
+
+    #[tokio::test]
+    async fn image_analyze_without_workspace_is_invalid_parameter() {
+        // resolve_file_path_ext rejects when no workspace sandbox is configured.
+        let r = tool_image_analyze(&serde_json::json!({"path": "x.png"}), None, &[]).await;
+        assert!(matches!(
+            r,
+            Err(ToolError::InvalidParameter { name: "path", .. })
+        ));
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/knowledge.rs
+++ b/crates/librefang-runtime/src/tool_runner/knowledge.rs
@@ -1,6 +1,13 @@
 //! Knowledge-graph tools — add_entity / add_relation / query.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576) — fourth slice after `tool_runner::{cron, schedule, task}`. These
+//! tools take no caller agent id (no per-caller authorization), so the
+//! migration is purely the error-channel type. The `parse_entity_type` /
+//! `parse_relation_type` helpers are infallible and unchanged.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
@@ -39,12 +46,14 @@ fn parse_relation_type(s: &str) -> librefang_types::memory::RelationType {
 pub(super) async fn tool_knowledge_add_entity(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
     let entity_type_str = input["entity_type"]
         .as_str()
-        .ok_or("Missing 'entity_type' parameter")?;
+        .ok_or(ToolError::MissingParameter("entity_type"))?;
     let properties = input
         .get("properties")
         .and_then(|v| v.as_object())
@@ -63,24 +72,24 @@ pub(super) async fn tool_knowledge_add_entity(
     let id = kh
         .knowledge_add_entity(&entity)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Entity '{name}' added with ID: {id}"))
 }
 
 pub(super) async fn tool_knowledge_add_relation(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let source = input["source"]
         .as_str()
-        .ok_or("Missing 'source' parameter")?;
+        .ok_or(ToolError::MissingParameter("source"))?;
     let relation_str = input["relation"]
         .as_str()
-        .ok_or("Missing 'relation' parameter")?;
+        .ok_or(ToolError::MissingParameter("relation"))?;
     let target = input["target"]
         .as_str()
-        .ok_or("Missing 'target' parameter")?;
+        .ok_or(ToolError::MissingParameter("target"))?;
     let confidence = input["confidence"].as_f64().unwrap_or(1.0) as f32;
     let properties = input
         .get("properties")
@@ -100,7 +109,7 @@ pub(super) async fn tool_knowledge_add_relation(
     let id = kh
         .knowledge_add_relation(&relation)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!(
         "Relation '{source}' --[{relation_str}]--> '{target}' added with ID: {id}"
     ))
@@ -109,8 +118,8 @@ pub(super) async fn tool_knowledge_add_relation(
 pub(super) async fn tool_knowledge_query(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let source = input["source"].as_str().map(|s| s.to_string());
     let target = input["target"].as_str().map(|s| s.to_string());
     let relation = input["relation"].as_str().map(parse_relation_type);
@@ -133,7 +142,7 @@ pub(super) async fn tool_knowledge_query(
     let matches = kh
         .knowledge_query(pattern)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     if matches.is_empty() {
         return Ok("No matching knowledge graph entries found.".to_string());
     }
@@ -151,4 +160,56 @@ pub(super) async fn tool_knowledge_query(
         ));
     }
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn knowledge_add_entity_without_kernel_returns_unavailable() {
+        let r = tool_knowledge_add_entity(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn knowledge_add_relation_without_kernel_returns_unavailable() {
+        let r = tool_knowledge_add_relation(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn knowledge_query_without_kernel_returns_unavailable() {
+        let r = tool_knowledge_query(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[test]
+    fn parse_entity_type_maps_known_and_custom() {
+        use librefang_types::memory::EntityType;
+        assert!(matches!(parse_entity_type("person"), EntityType::Person));
+        assert!(matches!(parse_entity_type("org"), EntityType::Organization));
+        match parse_entity_type("alien") {
+            EntityType::Custom(s) => assert_eq!(s, "alien"),
+            other => panic!("expected Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_relation_type_maps_known_and_custom() {
+        use librefang_types::memory::RelationType;
+        assert!(matches!(
+            parse_relation_type("works_at"),
+            RelationType::WorksAt
+        ));
+        assert!(matches!(
+            parse_relation_type("knows"),
+            RelationType::KnowsAbout
+        ));
+        match parse_relation_type("orbits") {
+            RelationType::Custom(s) => assert_eq!(s, "orbits"),
+            other => panic!("expected Custom, got {other:?}"),
+        }
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/media.rs
+++ b/crates/librefang-runtime/src/tool_runner/media.rs
@@ -2,9 +2,25 @@
 //! transcribe, image / video / music generation, text-to-speech /
 //! speech-to-text.
 
+use super::error::{ToolError, ToolResult};
 use super::resolve_file_path_ext;
 use std::path::Path;
 use tracing::warn;
+
+/// #3576: map the shared `resolve_file_path_ext` (still `Result<_, String>`)
+/// rejection onto a typed `InvalidParameter`, message preserved.
+fn resolve_media_path(
+    raw_path: &str,
+    workspace_root: Option<&Path>,
+    additional_roots: &[&Path],
+) -> Result<std::path::PathBuf, ToolError> {
+    resolve_file_path_ext(raw_path, workspace_root, additional_roots).map_err(|reason| {
+        ToolError::InvalidParameter {
+            name: "path",
+            reason,
+        }
+    })
+}
 
 /// Describe an image using a vision-capable LLM provider.
 pub(super) async fn tool_media_describe(
@@ -12,21 +28,23 @@ pub(super) async fn tool_media_describe(
     media_engine: Option<&crate::media_understanding::MediaEngine>,
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
-) -> Result<String, String> {
+) -> ToolResult {
     use base64::Engine;
-    let engine = media_engine.ok_or("Media engine not available. Check media configuration.")?;
-    let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
+    let engine = media_engine.ok_or(ToolError::Unavailable("Media engine"))?;
+    let raw_path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
     // Route through the workspace sandbox so all media reads stay inside
     // the agent's dir — a plain `..` check would miss absolute paths like
     // `/etc/passwd`. Named workspace prefixes are honored via
     // `additional_roots` so agents can describe media that lives under
     // declared `[workspaces]` mounts.
-    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
+    let resolved = resolve_media_path(raw_path, workspace_root, additional_roots)?;
 
     // Read image file
     let data = tokio::fs::read(&resolved)
         .await
-        .map_err(|e| format!("Failed to read image file: {e}"))?;
+        .map_err(|e| ToolError::upstream_msg(format!("Failed to read image file: {e}")))?;
 
     // Detect MIME type from extension
     let ext = resolved
@@ -41,7 +59,12 @@ pub(super) async fn tool_media_describe(
         "webp" => "image/webp",
         "bmp" => "image/bmp",
         "svg" => "image/svg+xml",
-        _ => return Err(format!("Unsupported image format: .{ext}")),
+        _ => {
+            return Err(ToolError::InvalidParameter {
+                name: "path",
+                reason: format!("Unsupported image format: .{ext}"),
+            })
+        }
     };
 
     let attachment = librefang_types::media::MediaAttachment {
@@ -54,8 +77,11 @@ pub(super) async fn tool_media_describe(
         size_bytes: data.len() as u64,
     };
 
-    let understanding = engine.describe_image(&attachment).await?;
-    serde_json::to_string_pretty(&understanding).map_err(|e| format!("Serialize error: {e}"))
+    let understanding = engine
+        .describe_image(&attachment)
+        .await
+        .map_err(ToolError::upstream_msg)?;
+    Ok(serde_json::to_string_pretty(&understanding)?)
 }
 
 /// Human-readable list of audio extensions accepted by `audio_mime_from_ext`,
@@ -88,21 +114,23 @@ pub(super) async fn tool_media_transcribe(
     media_engine: Option<&crate::media_understanding::MediaEngine>,
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
-) -> Result<String, String> {
+) -> ToolResult {
     use base64::Engine;
-    let engine = media_engine.ok_or("Media engine not available. Check media configuration.")?;
-    let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
+    let engine = media_engine.ok_or(ToolError::Unavailable("Media engine"))?;
+    let raw_path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
     // Route through the workspace sandbox so all media reads stay inside
     // the agent's dir — a plain `..` check would miss absolute paths like
     // `/etc/passwd`. Named workspace prefixes are honored via
     // `additional_roots` so agents can transcribe audio under declared
     // `[workspaces]` mounts.
-    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
+    let resolved = resolve_media_path(raw_path, workspace_root, additional_roots)?;
 
     // Read audio file
     let data = tokio::fs::read(&resolved)
         .await
-        .map_err(|e| format!("Failed to read audio file: {e}"))?;
+        .map_err(|e| ToolError::upstream_msg(format!("Failed to read audio file: {e}")))?;
 
     // Detect MIME type from extension
     let ext = resolved
@@ -110,8 +138,10 @@ pub(super) async fn tool_media_transcribe(
         .and_then(|e| e.to_str())
         .unwrap_or("")
         .to_lowercase();
-    let mime =
-        audio_mime_from_ext(&ext).ok_or_else(|| format!("Unsupported audio format: .{ext}"))?;
+    let mime = audio_mime_from_ext(&ext).ok_or_else(|| ToolError::InvalidParameter {
+        name: "path",
+        reason: format!("Unsupported audio format: .{ext}"),
+    })?;
 
     let attachment = librefang_types::media::MediaAttachment {
         media_type: librefang_types::media::MediaType::Audio,
@@ -123,8 +153,11 @@ pub(super) async fn tool_media_transcribe(
         size_bytes: data.len() as u64,
     };
 
-    let understanding = engine.transcribe_audio(&attachment).await?;
-    serde_json::to_string_pretty(&understanding).map_err(|e| format!("Serialize error: {e}"))
+    let understanding = engine
+        .transcribe_audio(&attachment)
+        .await
+        .map_err(ToolError::upstream_msg)?;
+    Ok(serde_json::to_string_pretty(&understanding)?)
 }
 
 // ---------------------------------------------------------------------------
@@ -137,10 +170,10 @@ pub(super) async fn tool_image_generate(
     media_drivers: Option<&crate::media::MediaDriverCache>,
     workspace_root: Option<&Path>,
     upload_dir: &Path,
-) -> Result<String, String> {
+) -> ToolResult {
     let prompt = input["prompt"]
         .as_str()
-        .ok_or("Missing 'prompt' parameter")?;
+        .ok_or(ToolError::MissingParameter("prompt"))?;
 
     let provider = input["provider"].as_str().map(|s| s.to_string());
     let model = input["model"].as_str().map(|s| s.to_string());
@@ -164,19 +197,24 @@ pub(super) async fn tool_image_generate(
             seed: None,
         };
 
-        request.validate().map_err(|e| e.to_string())?;
+        request
+            .validate()
+            .map_err(|e| ToolError::InvalidParameter {
+                name: "request",
+                reason: e.to_string(),
+            })?;
 
         let driver = if let Some(ref name) = provider {
             cache.get_or_create(name, None)
         } else {
             cache.detect_for_capability(librefang_types::media::MediaCapability::ImageGeneration)
         }
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| ToolError::upstream_msg(e.to_string()))?;
 
         let result = driver
             .generate_image(&request)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| ToolError::upstream_msg(e.to_string()))?;
 
         // Save images to workspace and uploads dir
         let saved_paths = save_media_images_to_workspace(&result.images, workspace_root);
@@ -191,8 +229,7 @@ pub(super) async fn tool_image_generate(
             "image_urls": image_urls,
         });
 
-        return serde_json::to_string_pretty(&response)
-            .map_err(|e| format!("Serialize error: {e}"));
+        return Ok(serde_json::to_string_pretty(&response)?);
     }
 
     // Fallback: old OpenAI-only path (when media_drivers is None)
@@ -202,9 +239,13 @@ pub(super) async fn tool_image_generate(
         "dall-e-2" | "dalle2" | "dalle-2" => librefang_types::media::ImageGenModel::DallE2,
         "gpt-image-1" | "gpt_image_1" => librefang_types::media::ImageGenModel::GptImage1,
         _ => {
-            return Err(format!(
+            let reason = format!(
                 "Unknown image model: {model_str}. Use 'dall-e-3', 'dall-e-2', or 'gpt-image-1'."
-            ))
+            );
+            return Err(ToolError::InvalidParameter {
+                name: "model",
+                reason,
+            });
         }
     };
 
@@ -220,7 +261,9 @@ pub(super) async fn tool_image_generate(
         count: count_val,
     };
 
-    let result = crate::image_gen::generate_image(&request).await?;
+    let result = crate::image_gen::generate_image(&request)
+        .await
+        .map_err(ToolError::upstream_msg)?;
 
     let saved_paths = if let Some(workspace) = workspace_root {
         match crate::image_gen::save_images_to_workspace(&result, workspace) {
@@ -258,7 +301,7 @@ pub(super) async fn tool_image_generate(
         "image_urls": image_urls,
     });
 
-    serde_json::to_string_pretty(&response).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&response)?)
 }
 
 /// Save MediaImageResult images to workspace output/ dir.
@@ -325,12 +368,11 @@ fn save_media_images_to_uploads(
 pub(super) async fn tool_video_generate(
     input: &serde_json::Value,
     media_drivers: Option<&crate::media::MediaDriverCache>,
-) -> Result<String, String> {
-    let cache =
-        media_drivers.ok_or("Media drivers not available. Ensure media drivers are configured.")?;
+) -> ToolResult {
+    let cache = media_drivers.ok_or(ToolError::Unavailable("Media drivers"))?;
     let prompt = input["prompt"]
         .as_str()
-        .ok_or("Missing 'prompt' parameter")?;
+        .ok_or(ToolError::MissingParameter("prompt"))?;
 
     let request = librefang_types::media::MediaVideoRequest {
         prompt: prompt.to_string(),
@@ -345,20 +387,25 @@ pub(super) async fn tool_video_generate(
     // Validate request parameters before sending to the provider
     request
         .validate()
-        .map_err(|e| format!("Invalid request: {e}"))?;
+        .map_err(|e| ToolError::InvalidParameter {
+            name: "request",
+            reason: e.to_string(),
+        })?;
 
     let driver = if let Some(p) = &request.provider {
-        cache.get_or_create(p, None).map_err(|e| e.to_string())?
+        cache
+            .get_or_create(p, None)
+            .map_err(|e| ToolError::upstream_msg(e.to_string()))?
     } else {
         cache
             .detect_for_capability(librefang_types::media::MediaCapability::VideoGeneration)
-            .map_err(|e| e.to_string())?
+            .map_err(|e| ToolError::upstream_msg(e.to_string()))?
     };
 
     let result = driver
         .submit_video(&request)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| ToolError::upstream_msg(e.to_string()))?;
 
     let response = serde_json::json!({
         "task_id": result.task_id,
@@ -367,40 +414,41 @@ pub(super) async fn tool_video_generate(
         "note": "Use video_status tool with this task_id to check progress"
     });
 
-    serde_json::to_string_pretty(&response).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&response)?)
 }
 
 /// Check the status of a video generation task. Returns download URL when complete.
 pub(super) async fn tool_video_status(
     input: &serde_json::Value,
     media_drivers: Option<&crate::media::MediaDriverCache>,
-) -> Result<String, String> {
-    let cache =
-        media_drivers.ok_or("Media drivers not available. Ensure media drivers are configured.")?;
+) -> ToolResult {
+    let cache = media_drivers.ok_or(ToolError::Unavailable("Media drivers"))?;
     let task_id = input["task_id"]
         .as_str()
-        .ok_or("Missing 'task_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("task_id"))?;
     let provider = input["provider"].as_str();
 
     let driver = if let Some(p) = provider {
-        cache.get_or_create(p, None).map_err(|e| e.to_string())?
+        cache
+            .get_or_create(p, None)
+            .map_err(|e| ToolError::upstream_msg(e.to_string()))?
     } else {
         cache
             .detect_for_capability(librefang_types::media::MediaCapability::VideoGeneration)
-            .map_err(|e| e.to_string())?
+            .map_err(|e| ToolError::upstream_msg(e.to_string()))?
     };
 
     let status = driver
         .poll_video(task_id)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| ToolError::upstream_msg(e.to_string()))?;
 
     // If completed, also fetch the full result with download URL
     if status == librefang_types::media::MediaTaskStatus::Completed {
         let video_result = driver
             .get_video_result(task_id)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| ToolError::upstream_msg(e.to_string()))?;
         let response = serde_json::json!({
             "status": "completed",
             "file_url": video_result.file_url,
@@ -410,8 +458,7 @@ pub(super) async fn tool_video_status(
             "provider": video_result.provider,
             "model": video_result.model,
         });
-        return serde_json::to_string_pretty(&response)
-            .map_err(|e| format!("Serialize error: {e}"));
+        return Ok(serde_json::to_string_pretty(&response)?);
     }
 
     let response = serde_json::json!({
@@ -420,7 +467,7 @@ pub(super) async fn tool_video_status(
         "note": "Task is still in progress. Poll again after a few seconds."
     });
 
-    serde_json::to_string_pretty(&response).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&response)?)
 }
 
 /// Generate music from a prompt and/or lyrics. Saves audio to workspace output/ directory.
@@ -428,9 +475,8 @@ pub(super) async fn tool_music_generate(
     input: &serde_json::Value,
     media_drivers: Option<&crate::media::MediaDriverCache>,
     workspace_root: Option<&Path>,
-) -> Result<String, String> {
-    let cache =
-        media_drivers.ok_or("Media drivers not available. Ensure media drivers are configured.")?;
+) -> ToolResult {
+    let cache = media_drivers.ok_or(ToolError::Unavailable("Media drivers"))?;
 
     let request = librefang_types::media::MediaMusicRequest {
         prompt: input["prompt"].as_str().map(String::from),
@@ -444,27 +490,32 @@ pub(super) async fn tool_music_generate(
     // Validate request parameters before sending to the provider
     request
         .validate()
-        .map_err(|e| format!("Invalid request: {e}"))?;
+        .map_err(|e| ToolError::InvalidParameter {
+            name: "request",
+            reason: e.to_string(),
+        })?;
 
     let driver = if let Some(p) = &request.provider {
-        cache.get_or_create(p, None).map_err(|e| e.to_string())?
+        cache
+            .get_or_create(p, None)
+            .map_err(|e| ToolError::upstream_msg(e.to_string()))?
     } else {
         cache
             .detect_for_capability(librefang_types::media::MediaCapability::MusicGeneration)
-            .map_err(|e| e.to_string())?
+            .map_err(|e| ToolError::upstream_msg(e.to_string()))?
     };
 
     let result = driver
         .generate_music(&request)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| ToolError::upstream_msg(e.to_string()))?;
 
     // Save audio to workspace output/ directory (same pattern as text_to_speech)
     let saved_path = if let Some(workspace) = workspace_root {
         let output_dir = workspace.join("output");
         tokio::fs::create_dir_all(&output_dir)
             .await
-            .map_err(|e| format!("Failed to create output dir: {e}"))?;
+            .map_err(|e| ToolError::upstream_msg(format!("Failed to create output dir: {e}")))?;
 
         let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
         let filename = format!("music_{timestamp}.{}", result.format);
@@ -472,7 +523,7 @@ pub(super) async fn tool_music_generate(
 
         tokio::fs::write(&path, &result.audio_data)
             .await
-            .map_err(|e| format!("Failed to write audio file: {e}"))?;
+            .map_err(|e| ToolError::upstream_msg(format!("Failed to write audio file: {e}")))?;
 
         Some(path.display().to_string())
     } else {
@@ -496,7 +547,7 @@ pub(super) async fn tool_music_generate(
             serde_json::json!(base64::engine::general_purpose::STANDARD.encode(&result.audio_data));
     }
 
-    serde_json::to_string_pretty(&response).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&response)?)
 }
 
 // ---------------------------------------------------------------------------
@@ -508,8 +559,10 @@ pub(super) async fn tool_text_to_speech(
     media_drivers: Option<&crate::media::MediaDriverCache>,
     tts_engine: Option<&crate::tts::TtsEngine>,
     workspace_root: Option<&Path>,
-) -> Result<String, String> {
-    let text = input["text"].as_str().ok_or("Missing 'text' parameter")?;
+) -> ToolResult {
+    let text = input["text"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("text"))?;
     let voice = input["voice"].as_str();
     let format = input["format"].as_str();
     let provider = input["provider"].as_str();
@@ -559,7 +612,7 @@ pub(super) async fn tool_text_to_speech(
             let result = driver
                 .synthesize_speech(&request)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| ToolError::upstream_msg(e.to_string()))?;
 
             return finish_tts_result(
                 &result.audio_data,
@@ -575,10 +628,12 @@ pub(super) async fn tool_text_to_speech(
     }
 
     // Fallback: old TtsEngine (OpenAI / ElevenLabs only)
-    let engine =
-        tts_engine.ok_or("TTS not available. No media driver or TTS engine configured.")?;
+    let engine = tts_engine.ok_or(ToolError::Unavailable("TTS"))?;
 
-    let result = engine.synthesize(text, voice, format).await?;
+    let result = engine
+        .synthesize(text, voice, format)
+        .await
+        .map_err(ToolError::upstream_msg)?;
 
     finish_tts_result(
         &result.audio_data,
@@ -699,12 +754,12 @@ async fn finish_tts_result(
     duration_ms: Option<u64>,
     workspace_root: Option<&Path>,
     output_format: &str,
-) -> Result<String, String> {
+) -> ToolResult {
     let (saved_path, final_format, final_size, warning) = if let Some(workspace) = workspace_root {
         let output_dir = workspace.join("output");
         tokio::fs::create_dir_all(&output_dir)
             .await
-            .map_err(|e| format!("Failed to create output dir: {e}"))?;
+            .map_err(|e| ToolError::upstream_msg(format!("Failed to create output dir: {e}")))?;
 
         let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
 
@@ -716,9 +771,9 @@ async fn finish_tts_result(
                 Ok(None) => {
                     let filename = format!("tts_{timestamp}.{format}");
                     let path = output_dir.join(&filename);
-                    tokio::fs::write(&path, audio_data)
-                        .await
-                        .map_err(|e| format!("Failed to write audio file: {e}"))?;
+                    tokio::fs::write(&path, audio_data).await.map_err(|e| {
+                        ToolError::upstream_msg(format!("Failed to write audio file: {e}"))
+                    })?;
                     (
                         Some(path.display().to_string()),
                         format.to_string(),
@@ -733,9 +788,9 @@ async fn finish_tts_result(
                     tracing::warn!("OGG Opus conversion failed, falling back to {format}: {e}");
                     let filename = format!("tts_{timestamp}.{format}");
                     let path = output_dir.join(&filename);
-                    tokio::fs::write(&path, audio_data)
-                        .await
-                        .map_err(|e| format!("Failed to write audio file: {e}"))?;
+                    tokio::fs::write(&path, audio_data).await.map_err(|e| {
+                        ToolError::upstream_msg(format!("Failed to write audio file: {e}"))
+                    })?;
                     (
                         Some(path.display().to_string()),
                         format.to_string(),
@@ -751,7 +806,7 @@ async fn finish_tts_result(
             let path = output_dir.join(&filename);
             tokio::fs::write(&path, audio_data)
                 .await
-                .map_err(|e| format!("Failed to write audio file: {e}"))?;
+                .map_err(|e| ToolError::upstream_msg(format!("Failed to write audio file: {e}")))?;
 
             (
                 Some(path.display().to_string()),
@@ -783,7 +838,7 @@ async fn finish_tts_result(
             serde_json::json!(base64::engine::general_purpose::STANDARD.encode(audio_data));
     }
 
-    serde_json::to_string_pretty(&response).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&response)?)
 }
 
 pub(super) async fn tool_speech_to_text(
@@ -791,17 +846,19 @@ pub(super) async fn tool_speech_to_text(
     media_engine: Option<&crate::media_understanding::MediaEngine>,
     workspace_root: Option<&Path>,
     additional_roots: &[&Path],
-) -> Result<String, String> {
-    let engine = media_engine.ok_or("Media engine not available for speech-to-text")?;
-    let raw_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
+) -> ToolResult {
+    let engine = media_engine.ok_or(ToolError::Unavailable("Media engine"))?;
+    let raw_path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
     let _language = input["language"].as_str();
 
-    let resolved = resolve_file_path_ext(raw_path, workspace_root, additional_roots)?;
+    let resolved = resolve_media_path(raw_path, workspace_root, additional_roots)?;
 
     // Read the audio file
     let data = tokio::fs::read(&resolved)
         .await
-        .map_err(|e| format!("Failed to read audio file: {e}"))?;
+        .map_err(|e| ToolError::upstream_msg(format!("Failed to read audio file: {e}")))?;
 
     // Determine MIME type from extension. Unknown extensions fall back to
     // audio/mpeg here (the speech_to_text path is permissive); the strict
@@ -827,7 +884,10 @@ pub(super) async fn tool_speech_to_text(
         size_bytes: data.len() as u64,
     };
 
-    let understanding = engine.transcribe_audio(&attachment).await?;
+    let understanding = engine
+        .transcribe_audio(&attachment)
+        .await
+        .map_err(ToolError::upstream_msg)?;
 
     let response = serde_json::json!({
         "transcript": understanding.description,
@@ -835,5 +895,5 @@ pub(super) async fn tool_speech_to_text(
         "model": understanding.model,
     });
 
-    serde_json::to_string_pretty(&response).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&response)?)
 }

--- a/crates/librefang-runtime/src/tool_runner/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/mod.rs
@@ -156,9 +156,12 @@ pub(super) fn require_kernel_typed(
 /// `MissingParameter("agent_id")` is the honest mapping for the second case
 /// (lifts to `LibreFangError::InvalidInput` → HTTP 400) and no worse than
 /// `Internal` for the first. The tool name is preserved on the tracing channel
-/// so a real direct-loop regression can still be traced.
+/// at `debug!` so a real direct-loop regression can still be traced under
+/// `RUST_LOG=debug` without spamming `warn!` on every legitimate MCP-without-
+/// `X-LibreFang-Agent-Id` call — which would otherwise become the dominant
+/// signal on the warn channel for any deployment with MCP traffic.
 pub(super) fn caller_agent_id_missing(tool: &'static str) -> ToolError {
-    tracing::warn!(
+    tracing::debug!(
         tool,
         "caller agent_id missing — surfaced as MissingParameter to the LLM"
     );

--- a/crates/librefang-runtime/src/tool_runner/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/mod.rs
@@ -144,6 +144,27 @@ pub(super) fn require_kernel_typed(
     kernel.ok_or(ToolError::Unavailable("Kernel handle"))
 }
 
+/// The `ToolError` returned when a tool that needs caller attribution is
+/// reached with no caller agent id (#3576). Two legitimate dispatchers feed
+/// these tools:
+///   * the direct agent-loop dispatcher always attributes a caller — `None`
+///     here is a wiring bug, but the LLM cannot recover from it either way;
+///   * the MCP HTTP route (`/mcp`) intentionally passes `None` when the
+///     `X-LibreFang-Agent-Id` header is missing or names an unknown agent —
+///     external clients should get a user-recoverable error.
+///
+/// `MissingParameter("agent_id")` is the honest mapping for the second case
+/// (lifts to `LibreFangError::InvalidInput` → HTTP 400) and no worse than
+/// `Internal` for the first. The tool name is preserved on the tracing channel
+/// so a real direct-loop regression can still be traced.
+pub(super) fn caller_agent_id_missing(tool: &'static str) -> ToolError {
+    tracing::warn!(
+        tool,
+        "caller agent_id missing — surfaced as MissingParameter to the LLM"
+    );
+    ToolError::MissingParameter("agent_id")
+}
+
 /// The memory-namespace operation a memory / wiki tool is about to perform.
 /// Maps onto [`librefang_memory::namespace_acl::MemoryNamespaceGuard`]'s
 /// `check_read` / `check_write`.

--- a/crates/librefang-runtime/src/tool_runner/process.rs
+++ b/crates/librefang-runtime/src/tool_runner/process.rs
@@ -1,16 +1,24 @@
 //! Persistent process tools — start / poll / write / kill / list.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). A missing `ProcessManager` -> `Unavailable("Process manager")`;
+//! missing params -> `MissingParameter`; the `ProcessManager` operations (all
+//! `Result<_, String>`) -> `upstream_msg`. The JSON status payloads are built
+//! infallibly and unchanged.
+
+use super::error::{ToolError, ToolResult};
 
 /// Start a long-running process (REPL, server, watcher).
 pub(super) async fn tool_process_start(
     input: &serde_json::Value,
     pm: Option<&crate::process_manager::ProcessManager>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let agent_id = caller_agent_id.unwrap_or("default");
     let command = input["command"]
         .as_str()
-        .ok_or("Missing 'command' parameter")?;
+        .ok_or(ToolError::MissingParameter("command"))?;
     let args: Vec<String> = input["args"]
         .as_array()
         .map(|arr| {
@@ -20,7 +28,10 @@ pub(super) async fn tool_process_start(
         })
         .unwrap_or_default();
 
-    let proc_id = pm.start(agent_id, command, &args).await?;
+    let proc_id = pm
+        .start(agent_id, command, &args)
+        .await
+        .map_err(ToolError::upstream_msg)?;
     Ok(serde_json::json!({
         "process_id": proc_id,
         "status": "started"
@@ -32,12 +43,12 @@ pub(super) async fn tool_process_start(
 pub(super) async fn tool_process_poll(
     input: &serde_json::Value,
     pm: Option<&crate::process_manager::ProcessManager>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let proc_id = input["process_id"]
         .as_str()
-        .ok_or("Missing 'process_id' parameter")?;
-    let (stdout, stderr) = pm.read(proc_id).await?;
+        .ok_or(ToolError::MissingParameter("process_id"))?;
+    let (stdout, stderr) = pm.read(proc_id).await.map_err(ToolError::upstream_msg)?;
     Ok(serde_json::json!({
         "stdout": stdout,
         "stderr": stderr,
@@ -49,19 +60,23 @@ pub(super) async fn tool_process_poll(
 pub(super) async fn tool_process_write(
     input: &serde_json::Value,
     pm: Option<&crate::process_manager::ProcessManager>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let proc_id = input["process_id"]
         .as_str()
-        .ok_or("Missing 'process_id' parameter")?;
-    let data = input["data"].as_str().ok_or("Missing 'data' parameter")?;
+        .ok_or(ToolError::MissingParameter("process_id"))?;
+    let data = input["data"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("data"))?;
     // Always append newline if not present (common expectation for REPLs)
     let data = if data.ends_with('\n') {
         data.to_string()
     } else {
         format!("{data}\n")
     };
-    pm.write(proc_id, &data).await?;
+    pm.write(proc_id, &data)
+        .await
+        .map_err(ToolError::upstream_msg)?;
     Ok(r#"{"status": "written"}"#.to_string())
 }
 
@@ -69,12 +84,12 @@ pub(super) async fn tool_process_write(
 pub(super) async fn tool_process_kill(
     input: &serde_json::Value,
     pm: Option<&crate::process_manager::ProcessManager>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let proc_id = input["process_id"]
         .as_str()
-        .ok_or("Missing 'process_id' parameter")?;
-    pm.kill(proc_id).await?;
+        .ok_or(ToolError::MissingParameter("process_id"))?;
+    pm.kill(proc_id).await.map_err(ToolError::upstream_msg)?;
     Ok(r#"{"status": "killed"}"#.to_string())
 }
 
@@ -82,8 +97,8 @@ pub(super) async fn tool_process_kill(
 pub(super) async fn tool_process_list(
     pm: Option<&crate::process_manager::ProcessManager>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let pm = pm.ok_or("Process manager not available")?;
+) -> ToolResult {
+    let pm = pm.ok_or(ToolError::Unavailable("Process manager"))?;
     let agent_id = caller_agent_id.unwrap_or("default");
     let procs = pm.list(agent_id);
     let list: Vec<serde_json::Value> = procs
@@ -98,4 +113,34 @@ pub(super) async fn tool_process_list(
         })
         .collect();
     Ok(serde_json::Value::Array(list).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn process_tools_without_manager_return_unavailable() {
+        assert!(matches!(
+            tool_process_start(&json!({}), None, None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+        assert!(matches!(
+            tool_process_poll(&json!({}), None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+        assert!(matches!(
+            tool_process_write(&json!({}), None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+        assert!(matches!(
+            tool_process_kill(&json!({}), None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+        assert!(matches!(
+            tool_process_list(None, None).await,
+            Err(ToolError::Unavailable("Process manager"))
+        ));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/sandbox.rs
+++ b/crates/librefang-runtime/src/tool_runner/sandbox.rs
@@ -20,8 +20,13 @@ pub(super) async fn tool_docker_exec(
 ) -> ToolResult {
     let config = docker_config.ok_or(ToolError::Unavailable("Docker sandbox"))?;
 
+    // `disabled` and `not-installed` carry an operator-actionable hint, so keep
+    // the full pre-#3576 message (via upstream_msg) rather than the bare
+    // `Unavailable` category — the hint is the point.
     if !config.enabled {
-        return Err(ToolError::Unavailable("Docker sandbox"));
+        return Err(ToolError::upstream_msg(
+            "Docker sandbox is disabled. Set docker.enabled=true in config.",
+        ));
     }
 
     let command = input["command"]
@@ -33,7 +38,9 @@ pub(super) async fn tool_docker_exec(
 
     // Check Docker availability
     if !crate::docker_sandbox::is_docker_available().await {
-        return Err(ToolError::Unavailable("Docker"));
+        return Err(ToolError::upstream_msg(
+            "Docker is not available on this system. Install Docker to use docker_exec.",
+        ));
     }
 
     // Create sandbox container
@@ -73,7 +80,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn docker_exec_disabled_is_unavailable() {
+    async fn docker_exec_disabled_returns_actionable_message() {
         let cfg = librefang_types::config::DockerSandboxConfig {
             enabled: false,
             ..Default::default()
@@ -85,6 +92,8 @@ mod tests {
             None,
         )
         .await;
-        assert!(matches!(r, Err(ToolError::Unavailable("Docker sandbox"))));
+        // Disabled carries the actionable hint rather than a bare Unavailable.
+        let msg = r.unwrap_err().to_string();
+        assert!(msg.contains("docker.enabled=true"), "got: {msg}");
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/sandbox.rs
+++ b/crates/librefang-runtime/src/tool_runner/sandbox.rs
@@ -1,6 +1,14 @@
 //! `docker_exec` sandbox tool — run an LLM-supplied command inside a
 //! disposable Docker container scoped to the agent's workspace.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). The "subsystem not wired" cases (docker not configured / disabled
+//! / not installed / no workspace context) map to `ToolError::Unavailable`,
+//! the documented category for them (see the variant doc: "docker exec
+//! disabled" is an Unavailable case → HTTP 503). The container create / exec
+//! failures (`Result<_, String>`) map to `ToolError::upstream_msg`.
 
+use super::error::{ToolError, ToolResult};
 use std::path::Path;
 use tracing::warn;
 
@@ -9,29 +17,29 @@ pub(super) async fn tool_docker_exec(
     docker_config: Option<&librefang_types::config::DockerSandboxConfig>,
     workspace_root: Option<&Path>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let config = docker_config.ok_or("Docker sandbox not configured")?;
+) -> ToolResult {
+    let config = docker_config.ok_or(ToolError::Unavailable("Docker sandbox"))?;
 
     if !config.enabled {
-        return Err("Docker sandbox is disabled. Set docker.enabled=true in config.".into());
+        return Err(ToolError::Unavailable("Docker sandbox"));
     }
 
     let command = input["command"]
         .as_str()
-        .ok_or("Missing 'command' parameter")?;
+        .ok_or(ToolError::MissingParameter("command"))?;
 
-    let workspace = workspace_root.ok_or("Docker exec requires a workspace directory")?;
+    let workspace = workspace_root.ok_or(ToolError::Unavailable("workspace directory"))?;
     let agent_id = caller_agent_id.unwrap_or("default");
 
     // Check Docker availability
     if !crate::docker_sandbox::is_docker_available().await {
-        return Err(
-            "Docker is not available on this system. Install Docker to use docker_exec.".into(),
-        );
+        return Err(ToolError::Unavailable("Docker"));
     }
 
     // Create sandbox container
-    let container = crate::docker_sandbox::create_sandbox(config, agent_id, workspace).await?;
+    let container = crate::docker_sandbox::create_sandbox(config, agent_id, workspace)
+        .await
+        .map_err(ToolError::upstream_msg)?;
 
     // Execute command with timeout
     let timeout = std::time::Duration::from_secs(config.timeout_secs);
@@ -42,7 +50,7 @@ pub(super) async fn tool_docker_exec(
         warn!("Failed to destroy Docker sandbox: {e}");
     }
 
-    let exec_result = result?;
+    let exec_result = result.map_err(ToolError::upstream_msg)?;
 
     let response = serde_json::json!({
         "exit_code": exec_result.exit_code,
@@ -51,5 +59,32 @@ pub(super) async fn tool_docker_exec(
         "container_id": container.container_id,
     });
 
-    serde_json::to_string_pretty(&response).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&response)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn docker_exec_without_config_is_unavailable() {
+        let r = tool_docker_exec(&serde_json::json!({"command": "ls"}), None, None, None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Docker sandbox"))));
+    }
+
+    #[tokio::test]
+    async fn docker_exec_disabled_is_unavailable() {
+        let cfg = librefang_types::config::DockerSandboxConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        let r = tool_docker_exec(
+            &serde_json::json!({"command": "ls"}),
+            Some(&cfg),
+            None,
+            None,
+        )
+        .await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Docker sandbox"))));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/schedule.rs
+++ b/crates/librefang-runtime/src/tool_runner/schedule.rs
@@ -10,24 +10,9 @@
 //! are mapped to `ToolError::InvalidParameter` at the tool boundary.
 
 use super::error::{ToolError, ToolResult};
-use super::require_kernel_typed;
+use super::{caller_agent_id_missing, require_kernel_typed};
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
-
-/// `ToolError` for a `schedule_*` tool reached with no caller agent id.
-/// Mirrors `tool_runner::cron::caller_agent_id_missing`: the MCP HTTP route
-/// legitimately passes `None` (missing/unknown `X-LibreFang-Agent-Id`), which
-/// is user-recoverable input, so it surfaces as `MissingParameter` (→ 400)
-/// rather than `Internal`. The direct agent-loop dispatcher always attributes
-/// a caller, so `None` there is a wiring bug the LLM cannot patch either way;
-/// the tool name is preserved on the tracing channel for operators.
-fn caller_agent_id_missing(tool: &'static str) -> ToolError {
-    tracing::warn!(
-        tool,
-        "caller agent_id missing — surfaced as MissingParameter to the LLM"
-    );
-    ToolError::MissingParameter("agent_id")
-}
 
 /// Parse a natural language schedule into a cron expression.
 pub(super) fn parse_schedule_to_cron(input: &str) -> Result<String, String> {

--- a/crates/librefang-runtime/src/tool_runner/schedule.rs
+++ b/crates/librefang-runtime/src/tool_runner/schedule.rs
@@ -2,10 +2,32 @@
 //!
 //! Accept natural language schedules ("daily at 9am") and delegate to
 //! `kh.cron_create/list/cancel`, which use the real kernel tick loop (#2024).
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576) — second slice after `tool_runner::cron`. The internal
+//! `parse_schedule_to_cron` / `parse_time_to_hour` helpers keep their
+//! `Result<_, String>` shape (a pure sub-layer with no kernel contact) and
+//! are mapped to `ToolError::InvalidParameter` at the tool boundary.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
+
+/// `ToolError` for a `schedule_*` tool reached with no caller agent id.
+/// Mirrors `tool_runner::cron::caller_agent_id_missing`: the MCP HTTP route
+/// legitimately passes `None` (missing/unknown `X-LibreFang-Agent-Id`), which
+/// is user-recoverable input, so it surfaces as `MissingParameter` (→ 400)
+/// rather than `Internal`. The direct agent-loop dispatcher always attributes
+/// a caller, so `None` there is a wiring bug the LLM cannot patch either way;
+/// the tool name is preserved on the tracing channel for operators.
+fn caller_agent_id_missing(tool: &'static str) -> ToolError {
+    tracing::warn!(
+        tool,
+        "caller agent_id missing — surfaced as MissingParameter to the LLM"
+    );
+    ToolError::MissingParameter("agent_id")
+}
 
 /// Parse a natural language schedule into a cron expression.
 pub(super) fn parse_schedule_to_cron(input: &str) -> Result<String, String> {
@@ -133,18 +155,22 @@ pub(super) async fn tool_schedule_create(
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
     sender_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let agent_id = caller_agent_id.ok_or("Agent ID required for schedule_create")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("schedule_create"))?;
     let description = input["description"]
         .as_str()
-        .ok_or("Missing 'description' parameter")?;
+        .ok_or(ToolError::MissingParameter("description"))?;
     let schedule_str = input["schedule"]
         .as_str()
-        .ok_or("Missing 'schedule' parameter")?;
+        .ok_or(ToolError::MissingParameter("schedule"))?;
     let message = input["message"].as_str().unwrap_or(description);
 
-    let cron_expr = parse_schedule_to_cron(schedule_str)?;
+    let cron_expr =
+        parse_schedule_to_cron(schedule_str).map_err(|reason| ToolError::InvalidParameter {
+            name: "schedule",
+            reason,
+        })?;
 
     // CronJob name only allows alphanumeric + space/hyphen/underscore (max 128 chars).
     // Sanitize the user-provided description to fit these constraints.
@@ -188,7 +214,7 @@ pub(super) async fn tool_schedule_create(
     let result = kh
         .cron_create(agent_id, job_json)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!(
         "Schedule created and will execute automatically.\n  Cron: {cron_expr}\n  Original: {schedule_str}\n  {result}"
     ))
@@ -197,10 +223,10 @@ pub(super) async fn tool_schedule_create(
 pub(super) async fn tool_schedule_list(
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let agent_id = caller_agent_id.ok_or("Agent ID required for schedule_list")?;
-    let jobs = kh.cron_list(agent_id).await.map_err(|e| e.to_string())?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("schedule_list"))?;
+    let jobs = kh.cron_list(agent_id).await.map_err(ToolError::upstream)?;
 
     if jobs.is_empty() {
         return Ok("No scheduled tasks.".to_string());
@@ -229,13 +255,76 @@ pub(super) async fn tool_schedule_list(
 pub(super) async fn tool_schedule_delete(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+    caller_agent_id: Option<&str>,
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     // Accept either "id" or "job_id" for backward compatibility
     let id = input["id"]
         .as_str()
         .or_else(|| input["job_id"].as_str())
-        .ok_or("Missing 'id' parameter")?;
-    kh.cron_cancel(id).await.map_err(|e| e.to_string())?;
+        .ok_or(ToolError::MissingParameter("id"))?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("schedule_delete"))?;
+    // Authorize: the caller may only delete jobs that belong to them.
+    // `KernelHandle::cron_cancel` removes by UUID with no ownership check
+    // (see `kernel/handles/cron_control.rs`), and the sibling `cron_cancel`
+    // tool already enforces this guard at the tool layer — `schedule_delete`
+    // must too, or it is a trivial bypass: any agent with this tool could
+    // cancel another agent's job by learning its UUID.
+    let owned = kh.cron_list(agent_id).await.map_err(ToolError::upstream)?;
+    let owns_job = owned.iter().any(|job| {
+        job.get("id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|jid| jid == id)
+    });
+    if !owns_job {
+        // Collapse "not owned" and "doesn't exist" into one NotFound — see
+        // the variant doc on `ToolError::NotFound` for the side-channel
+        // rationale (mirrors `cron_cancel`).
+        return Err(ToolError::NotFound {
+            kind: "Schedule",
+            id: id.to_string(),
+        });
+    }
+    kh.cron_cancel(id).await.map_err(ToolError::upstream)?;
     Ok(format!("Schedule '{id}' deleted."))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure validation / wiring-boundary tests that run BEFORE any kernel
+    //! call. The ownership-check path in `tool_schedule_delete` (which needs
+    //! `cron_list` to return jobs) lives in the integration test file
+    //! `tests/tool_runner_forwarding_task_cron.rs` alongside the cron
+    //! equivalents, where the `CapturingKernel` stub is available — same split
+    //! as `tool_runner::cron`.
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn schedule_create_without_kernel_returns_unavailable() {
+        let r = tool_schedule_create(&json!({}), None, Some("agent-a"), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn schedule_list_without_kernel_returns_unavailable() {
+        let r = tool_schedule_list(None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn schedule_delete_without_kernel_returns_unavailable() {
+        let r = tool_schedule_delete(&json!({"id": "x"}), None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[test]
+    fn caller_agent_id_missing_surfaces_as_missing_parameter() {
+        let e = caller_agent_id_missing("schedule_delete");
+        assert!(
+            matches!(e, ToolError::MissingParameter("agent_id")),
+            "expected MissingParameter(\"agent_id\"), got {e:?}"
+        );
+        assert!(e.to_string().contains("agent_id"));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/shell.rs
+++ b/crates/librefang-runtime/src/tool_runner/shell.rs
@@ -6,7 +6,15 @@
 //! upstream in the dispatcher and `tool_runner::{taint, shell_safety}`;
 //! by the time we reach this function the command has already been
 //! cleared for execution.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). Command-parse failures -> `InvalidParameter`; the two `io::Error`
+//! sites (spawn / collect) -> `ToolError::Upstream` keeping the prefix message
+//! AND the source; the interrupt / timeout control strings -> `upstream_msg`
+//! so their exact wire text (`[interrupted]`, `Command timed out …`) is
+//! preserved.
 
+use super::error::{ToolError, ToolResult};
 use std::path::Path;
 
 pub(super) async fn tool_shell_exec(
@@ -15,10 +23,10 @@ pub(super) async fn tool_shell_exec(
     workspace_root: Option<&Path>,
     exec_policy: Option<&librefang_types::config::ExecPolicy>,
     interrupt: Option<crate::interrupt::SessionInterrupt>,
-) -> Result<String, String> {
+) -> ToolResult {
     let command = input["command"]
         .as_str()
-        .ok_or("Missing 'command' parameter")?;
+        .ok_or(ToolError::MissingParameter("command"))?;
     // Use LLM-specified timeout, or fall back to exec policy timeout, or default 30s
     let policy_timeout = exec_policy.map(|p| p.timeout_secs).unwrap_or(30);
     let timeout_secs = input["timeout_seconds"].as_u64().unwrap_or(policy_timeout);
@@ -38,11 +46,15 @@ pub(super) async fn tool_shell_exec(
     let mut cmd = if use_direct_exec {
         // SAFE PATH: Split command into argv using POSIX shell lexer rules,
         // then execute the binary directly — no shell interpreter involved.
-        let argv = shlex::split(command).ok_or_else(|| {
-            "Command contains unmatched quotes or invalid shell syntax".to_string()
+        let argv = shlex::split(command).ok_or(ToolError::InvalidParameter {
+            name: "command",
+            reason: "Command contains unmatched quotes or invalid shell syntax".to_string(),
         })?;
         if argv.is_empty() {
-            return Err("Empty command after parsing".to_string());
+            return Err(ToolError::InvalidParameter {
+                name: "command",
+                reason: "Empty command after parsing".to_string(),
+            });
         }
         let mut c = tokio::process::Command::new(&argv[0]);
         if argv.len() > 1 {
@@ -103,7 +115,7 @@ pub(super) async fn tool_shell_exec(
     // Check for interrupt before we even launch the subprocess — the user may
     // have hit /stop while approval was pending or while a prior tool was running.
     if interrupt.as_ref().is_some_and(|i| i.is_cancelled()) {
-        return Err("[interrupted before execution]".to_string());
+        return Err(ToolError::upstream_msg("[interrupted before execution]"));
     }
 
     // Capture piped output so we can collect it after the process exits.
@@ -120,7 +132,12 @@ pub(super) async fn tool_shell_exec(
     // never be observed mid-execution — the whole point of this feature.
     let child = match cmd.spawn() {
         Ok(c) => c,
-        Err(e) => return Err(format!("Failed to execute command: {e}")),
+        Err(e) => {
+            return Err(ToolError::Upstream {
+                message: format!("Failed to execute command: {e}"),
+                source: Some(Box::new(e)),
+            })
+        }
     };
 
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
@@ -148,15 +165,20 @@ pub(super) async fn tool_shell_exec(
         tokio::select! {
             biased;
             // Process exited (with pipes drained — that's the bug fix). Take the result.
-            res = &mut wait_fut => break res.map_err(|e| format!("Failed to collect output: {e}")),
+            res = &mut wait_fut => break res.map_err(|e| ToolError::Upstream {
+                message: format!("Failed to collect output: {e}"),
+                source: Some(Box::new(e)),
+            }),
             // Periodic interrupt + deadline check. We drop wait_fut on either,
             // which kills the child via kill_on_drop.
             _ = interrupt_tick.tick() => {
                 if interrupt_clone.as_ref().is_some_and(|i| i.is_cancelled()) {
-                    return Err("[interrupted]".to_string());
+                    return Err(ToolError::upstream_msg("[interrupted]"));
                 }
                 if tokio::time::Instant::now() >= deadline {
-                    return Err(format!("Command timed out after {timeout_secs}s"));
+                    return Err(ToolError::upstream_msg(format!(
+                        "Command timed out after {timeout_secs}s"
+                    )));
                 }
             }
         }
@@ -194,5 +216,38 @@ pub(super) async fn tool_shell_exec(
             ))
         }
         Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn shell_exec_missing_command_is_missing_parameter() {
+        let r = tool_shell_exec(&json!({}), &[], None, None, None).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("command"))));
+    }
+
+    #[tokio::test]
+    async fn shell_exec_unmatched_quotes_is_invalid_parameter() {
+        // Default policy (None) uses the safe argv path, which rejects bad
+        // shell syntax before spawning anything.
+        let r = tool_shell_exec(
+            &json!({"command": "echo \"unterminated"}),
+            &[],
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(matches!(
+            r,
+            Err(ToolError::InvalidParameter {
+                name: "command",
+                ..
+            })
+        ));
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/skill.rs
+++ b/crates/librefang-runtime/src/tool_runner/skill.rs
@@ -1,7 +1,16 @@
 //! Skill evolution tools — create / update / patch / delete / rollback /
 //! write_file / remove_file, plus `skill_read_file` for reading companion
 //! files from an installed skill directory.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). A missing registry -> `Unavailable("Skill registry")`; the freeze
+//! gate and the read-file allowlist / absolute-path / containment guards ->
+//! `PermissionDenied` (messages preserved); missing params ->
+//! `MissingParameter`; a skill that can't be loaded -> `NotFound`; the
+//! `librefang_skills::evolution` operations (typed `SkillError`) ->
+//! `ToolError::upstream`; JSON serialization via `?`.
 
+use super::error::{ToolError, ToolResult};
 use librefang_skills::registry::SkillRegistry;
 
 /// Build the author tag for an agent-triggered evolution. Use the
@@ -20,11 +29,21 @@ fn agent_author_tag(caller: Option<&str>) -> String {
 /// this gate, an agent running under Stable mode would silently
 /// persist skill mutations that'd be picked up at the next unfreeze
 /// or restart — defeating the whole point of the mode.
-fn ensure_not_frozen(registry: &SkillRegistry) -> Result<(), String> {
+fn ensure_not_frozen(registry: &SkillRegistry) -> Result<(), ToolError> {
     if registry.is_frozen() {
-        Err("Skill registry is frozen (Stable mode) — skill evolution is disabled".to_string())
+        Err(ToolError::PermissionDenied(
+            "Skill registry is frozen (Stable mode) — skill evolution is disabled".to_string(),
+        ))
     } else {
         Ok(())
+    }
+}
+
+/// Typed `NotFound` for a skill that the registry / on-disk loader can't find.
+fn skill_not_found(name: &str) -> ToolError {
+    ToolError::NotFound {
+        kind: "Skill",
+        id: name.to_string(),
     }
 }
 
@@ -32,16 +51,18 @@ pub(super) async fn tool_skill_evolve_create(
     input: &serde_json::Value,
     skill_registry: Option<&SkillRegistry>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let registry = skill_registry.ok_or("Skill registry not available")?;
+) -> ToolResult {
+    let registry = skill_registry.ok_or(ToolError::Unavailable("Skill registry"))?;
     ensure_not_frozen(registry)?;
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
     let description = input["description"]
         .as_str()
-        .ok_or("Missing 'description' parameter")?;
+        .ok_or(ToolError::MissingParameter("description"))?;
     let prompt_context = input["prompt_context"]
         .as_str()
-        .ok_or("Missing 'prompt_context' parameter")?;
+        .ok_or(ToolError::MissingParameter("prompt_context"))?;
     let tags: Vec<String> = input["tags"]
         .as_array()
         .map(|a| {
@@ -53,33 +74,34 @@ pub(super) async fn tool_skill_evolve_create(
 
     let author = agent_author_tag(caller_agent_id);
     let skills_dir = registry.skills_dir();
-    match librefang_skills::evolution::create_skill(
+    let result = librefang_skills::evolution::create_skill(
         skills_dir,
         name,
         description,
         prompt_context,
         tags,
         Some(&author),
-    ) {
-        Ok(result) => serde_json::to_string(&result).map_err(|e| e.to_string()),
-        Err(e) => Err(format!("Failed to create skill: {e}")),
-    }
+    )
+    .map_err(ToolError::upstream)?;
+    Ok(serde_json::to_string(&result)?)
 }
 
 pub(super) async fn tool_skill_evolve_update(
     input: &serde_json::Value,
     skill_registry: Option<&SkillRegistry>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let registry = skill_registry.ok_or("Skill registry not available")?;
+) -> ToolResult {
+    let registry = skill_registry.ok_or(ToolError::Unavailable("Skill registry"))?;
     ensure_not_frozen(registry)?;
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
     let prompt_context = input["prompt_context"]
         .as_str()
-        .ok_or("Missing 'prompt_context' parameter")?;
+        .ok_or(ToolError::MissingParameter("prompt_context"))?;
     let changelog = input["changelog"]
         .as_str()
-        .ok_or("Missing 'changelog' parameter")?;
+        .ok_or(ToolError::MissingParameter("changelog"))?;
 
     // Registry hot-reload happens AFTER the turn finishes, so within
     // the same turn `create` followed by `update` would find the
@@ -94,36 +116,37 @@ pub(super) async fn tool_skill_evolve_update(
                 registry.skills_dir(),
                 name,
             )
-            .map_err(|e| format!("Skill '{name}' not found: {e}"))?;
+            .map_err(|_| skill_not_found(name))?;
             &skill_owned
         }
     };
 
     let author = agent_author_tag(caller_agent_id);
-    match librefang_skills::evolution::update_skill(skill, prompt_context, changelog, Some(&author))
-    {
-        Ok(result) => serde_json::to_string(&result).map_err(|e| e.to_string()),
-        Err(e) => Err(format!("Failed to update skill: {e}")),
-    }
+    let result =
+        librefang_skills::evolution::update_skill(skill, prompt_context, changelog, Some(&author))
+            .map_err(ToolError::upstream)?;
+    Ok(serde_json::to_string(&result)?)
 }
 
 pub(super) async fn tool_skill_evolve_patch(
     input: &serde_json::Value,
     skill_registry: Option<&SkillRegistry>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let registry = skill_registry.ok_or("Skill registry not available")?;
+) -> ToolResult {
+    let registry = skill_registry.ok_or(ToolError::Unavailable("Skill registry"))?;
     ensure_not_frozen(registry)?;
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
     let old_string = input["old_string"]
         .as_str()
-        .ok_or("Missing 'old_string' parameter")?;
+        .ok_or(ToolError::MissingParameter("old_string"))?;
     let new_string = input["new_string"]
         .as_str()
-        .ok_or("Missing 'new_string' parameter")?;
+        .ok_or(ToolError::MissingParameter("new_string"))?;
     let changelog = input["changelog"]
         .as_str()
-        .ok_or("Missing 'changelog' parameter")?;
+        .ok_or(ToolError::MissingParameter("changelog"))?;
     let replace_all = input["replace_all"].as_bool().unwrap_or(false);
 
     // Same-turn create→patch fallback (see tool_skill_evolve_update).
@@ -135,32 +158,33 @@ pub(super) async fn tool_skill_evolve_patch(
                 registry.skills_dir(),
                 name,
             )
-            .map_err(|e| format!("Skill '{name}' not found: {e}"))?;
+            .map_err(|_| skill_not_found(name))?;
             &skill_owned
         }
     };
 
     let author = agent_author_tag(caller_agent_id);
-    match librefang_skills::evolution::patch_skill(
+    let result = librefang_skills::evolution::patch_skill(
         skill,
         old_string,
         new_string,
         changelog,
         replace_all,
         Some(&author),
-    ) {
-        Ok(result) => serde_json::to_string(&result).map_err(|e| e.to_string()),
-        Err(e) => Err(format!("Failed to patch skill: {e}")),
-    }
+    )
+    .map_err(ToolError::upstream)?;
+    Ok(serde_json::to_string(&result)?)
 }
 
 pub(super) async fn tool_skill_evolve_delete(
     input: &serde_json::Value,
     skill_registry: Option<&SkillRegistry>,
-) -> Result<String, String> {
-    let registry = skill_registry.ok_or("Skill registry not available")?;
+) -> ToolResult {
+    let registry = skill_registry.ok_or(ToolError::Unavailable("Skill registry"))?;
     ensure_not_frozen(registry)?;
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
 
     // Resolve the actual installed skill's parent directory instead of
     // blindly targeting `registry.skills_dir() + name`. Workspace skills
@@ -180,20 +204,21 @@ pub(super) async fn tool_skill_evolve_delete(
         // NotFound if nothing exists there either.
         None => registry.skills_dir().to_path_buf(),
     };
-    match librefang_skills::evolution::delete_skill(&parent, name) {
-        Ok(result) => serde_json::to_string(&result).map_err(|e| e.to_string()),
-        Err(e) => Err(format!("Failed to delete skill: {e}")),
-    }
+    let result =
+        librefang_skills::evolution::delete_skill(&parent, name).map_err(ToolError::upstream)?;
+    Ok(serde_json::to_string(&result)?)
 }
 
 pub(super) async fn tool_skill_evolve_rollback(
     input: &serde_json::Value,
     skill_registry: Option<&SkillRegistry>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let registry = skill_registry.ok_or("Skill registry not available")?;
+) -> ToolResult {
+    let registry = skill_registry.ok_or(ToolError::Unavailable("Skill registry"))?;
     ensure_not_frozen(registry)?;
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
 
     // Same-turn create→rollback fallback (see tool_skill_evolve_update).
     let skill_owned;
@@ -204,29 +229,32 @@ pub(super) async fn tool_skill_evolve_rollback(
                 registry.skills_dir(),
                 name,
             )
-            .map_err(|e| format!("Skill '{name}' not found: {e}"))?;
+            .map_err(|_| skill_not_found(name))?;
             &skill_owned
         }
     };
 
     let author = agent_author_tag(caller_agent_id);
-    match librefang_skills::evolution::rollback_skill(skill, Some(&author)) {
-        Ok(result) => serde_json::to_string(&result).map_err(|e| e.to_string()),
-        Err(e) => Err(format!("Failed to rollback skill: {e}")),
-    }
+    let result = librefang_skills::evolution::rollback_skill(skill, Some(&author))
+        .map_err(ToolError::upstream)?;
+    Ok(serde_json::to_string(&result)?)
 }
 
 pub(super) async fn tool_skill_evolve_write_file(
     input: &serde_json::Value,
     skill_registry: Option<&SkillRegistry>,
-) -> Result<String, String> {
-    let registry = skill_registry.ok_or("Skill registry not available")?;
+) -> ToolResult {
+    let registry = skill_registry.ok_or(ToolError::Unavailable("Skill registry"))?;
     ensure_not_frozen(registry)?;
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
-    let path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
+    let path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
     let content = input["content"]
         .as_str()
-        .ok_or("Missing 'content' parameter")?;
+        .ok_or(ToolError::MissingParameter("content"))?;
 
     // Same-turn create→write_file fallback.
     let skill_owned;
@@ -237,25 +265,28 @@ pub(super) async fn tool_skill_evolve_write_file(
                 registry.skills_dir(),
                 name,
             )
-            .map_err(|e| format!("Skill '{name}' not found: {e}"))?;
+            .map_err(|_| skill_not_found(name))?;
             &skill_owned
         }
     };
 
-    match librefang_skills::evolution::write_supporting_file(skill, path, content) {
-        Ok(result) => serde_json::to_string(&result).map_err(|e| e.to_string()),
-        Err(e) => Err(format!("Failed to write file: {e}")),
-    }
+    let result = librefang_skills::evolution::write_supporting_file(skill, path, content)
+        .map_err(ToolError::upstream)?;
+    Ok(serde_json::to_string(&result)?)
 }
 
 pub(super) async fn tool_skill_evolve_remove_file(
     input: &serde_json::Value,
     skill_registry: Option<&SkillRegistry>,
-) -> Result<String, String> {
-    let registry = skill_registry.ok_or("Skill registry not available")?;
+) -> ToolResult {
+    let registry = skill_registry.ok_or(ToolError::Unavailable("Skill registry"))?;
     ensure_not_frozen(registry)?;
-    let name = input["name"].as_str().ok_or("Missing 'name' parameter")?;
-    let path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
+    let name = input["name"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("name"))?;
+    let path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
 
     // Same-turn fallback (see tool_skill_evolve_update).
     let skill_owned;
@@ -266,15 +297,14 @@ pub(super) async fn tool_skill_evolve_remove_file(
                 registry.skills_dir(),
                 name,
             )
-            .map_err(|e| format!("Skill '{name}' not found: {e}"))?;
+            .map_err(|_| skill_not_found(name))?;
             &skill_owned
         }
     };
 
-    match librefang_skills::evolution::remove_supporting_file(skill, path) {
-        Ok(result) => serde_json::to_string(&result).map_err(|e| e.to_string()),
-        Err(e) => Err(format!("Failed to remove file: {e}")),
-    }
+    let result = librefang_skills::evolution::remove_supporting_file(skill, path)
+        .map_err(ToolError::upstream)?;
+    Ok(serde_json::to_string(&result)?)
 }
 
 /// Read a companion file from an installed skill directory.
@@ -287,54 +317,62 @@ pub(super) async fn tool_skill_read_file(
     input: &serde_json::Value,
     skill_registry: Option<&SkillRegistry>,
     allowed_skills: Option<&[String]>,
-) -> Result<String, String> {
-    let registry = skill_registry.ok_or("Skill registry not available")?;
-    let skill_name = input["skill"].as_str().ok_or("Missing 'skill' parameter")?;
-    let rel_path = input["path"].as_str().ok_or("Missing 'path' parameter")?;
+) -> ToolResult {
+    let registry = skill_registry.ok_or(ToolError::Unavailable("Skill registry"))?;
+    let skill_name = input["skill"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("skill"))?;
+    let rel_path = input["path"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("path"))?;
 
     // Enforce agent skill allowlist: if the agent specifies allowed skills
     // (non-empty list), only those skills can be read. Empty = all allowed.
     if let Some(allowed) = allowed_skills {
         if !allowed.is_empty() && !allowed.iter().any(|s| s == skill_name) {
-            return Err(format!(
+            return Err(ToolError::PermissionDenied(format!(
                 "Access denied: agent is not allowed to access skill '{skill_name}'"
-            ));
+            )));
         }
     }
 
     // Reject absolute paths early — Path::join replaces the base when given
     // an absolute path, which would bypass the skill directory containment.
     if std::path::Path::new(rel_path).is_absolute() {
-        return Err("Access denied: absolute paths are not allowed".to_string());
+        return Err(ToolError::PermissionDenied(
+            "Access denied: absolute paths are not allowed".to_string(),
+        ));
     }
 
     // Look up the skill
     let skill = registry
         .get(skill_name)
-        .ok_or_else(|| format!("Skill '{}' not found", skill_name))?;
+        .ok_or_else(|| skill_not_found(skill_name))?;
 
     // Resolve the path relative to the skill directory
     let requested = skill.path.join(rel_path);
     let canonical = requested
         .canonicalize()
-        .map_err(|e| format!("File not found: {}", e))?;
+        .map_err(|e| ToolError::upstream_msg(format!("File not found: {e}")))?;
     let skill_root = skill
         .path
         .canonicalize()
-        .map_err(|e| format!("Skill directory error: {}", e))?;
+        .map_err(|e| ToolError::upstream_msg(format!("Skill directory error: {e}")))?;
 
     // Security: ensure the resolved path is within the skill directory
     if !canonical.starts_with(&skill_root) {
-        return Err(format!(
-            "Access denied: '{}' is outside the skill directory",
-            rel_path
-        ));
+        return Err(ToolError::PermissionDenied(format!(
+            "Access denied: '{rel_path}' is outside the skill directory"
+        )));
     }
 
     // Read the file
     let content = tokio::fs::read_to_string(&canonical)
         .await
-        .map_err(|e| format!("Failed to read '{}': {}", rel_path, e))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to read '{rel_path}': {e}"),
+            source: Some(Box::new(e)),
+        })?;
 
     // Fire-and-forget usage tracking — only count when the agent actually
     // loads the skill's core prompt content, not every supporting file

--- a/crates/librefang-runtime/src/tool_runner/system.rs
+++ b/crates/librefang-runtime/src/tool_runner/system.rs
@@ -1,11 +1,25 @@
 //! System info tools: location lookup and clock readout.
+//!
+//! `tool_location_get` migrated from `Result<String, String>` to
+//! `Result<String, ToolError>` (#3576). All failures are external HTTP / parse
+//! failures, mapped to `ToolError::Upstream`. The typed `reqwest::Error`s
+//! (build / send / json) keep their original prefixed message AND preserve the
+//! error on the `source()` chain (consistent with how the sibling slices wrap
+//! typed errors); the two non-`Error` API-level failures use `upstream_msg`.
+//! `Upstream`'s Display is the bare message, so the exact strings are
+//! preserved. `tool_system_time` is infallible (returns `String`), unchanged.
+
+use super::error::{ToolError, ToolResult};
 
 /// Look up approximate location via ip-api.com.
-pub(super) async fn tool_location_get() -> Result<String, String> {
+pub(super) async fn tool_location_get() -> ToolResult {
     let client = crate::http_client::proxied_client_builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()
-        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Failed to create HTTP client: {e}"),
+            source: Some(Box::new(e)),
+        })?;
 
     // Use ip-api.com (free, no API key, JSON response)
     let resp = client
@@ -13,20 +27,28 @@ pub(super) async fn tool_location_get() -> Result<String, String> {
         .header("User-Agent", "LibreFang/0.1")
         .send()
         .await
-        .map_err(|e| format!("Location request failed: {e}"))?;
+        .map_err(|e| ToolError::Upstream {
+            message: format!("Location request failed: {e}"),
+            source: Some(Box::new(e)),
+        })?;
 
     if !resp.status().is_success() {
-        return Err(format!("Location API returned {}", resp.status()));
+        return Err(ToolError::upstream_msg(format!(
+            "Location API returned {}",
+            resp.status()
+        )));
     }
 
-    let body: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse location response: {e}"))?;
+    let body: serde_json::Value = resp.json().await.map_err(|e| ToolError::Upstream {
+        message: format!("Failed to parse location response: {e}"),
+        source: Some(Box::new(e)),
+    })?;
 
     if body["status"].as_str() != Some("success") {
         let msg = body["message"].as_str().unwrap_or("Unknown error");
-        return Err(format!("Location lookup failed: {msg}"));
+        return Err(ToolError::upstream_msg(format!(
+            "Location lookup failed: {msg}"
+        )));
     }
 
     let result = serde_json::json!({
@@ -41,7 +63,7 @@ pub(super) async fn tool_location_get() -> Result<String, String> {
         "ip": body["query"],
     });
 
-    serde_json::to_string_pretty(&result).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 /// Return current date, time, timezone, and Unix epoch.

--- a/crates/librefang-runtime/src/tool_runner/task.rs
+++ b/crates/librefang-runtime/src/tool_runner/task.rs
@@ -4,28 +4,9 @@
 //! (#3576) — third slice after `tool_runner::{cron, schedule}`.
 
 use super::error::{ToolError, ToolResult};
-use super::require_kernel_typed;
+use super::{caller_agent_id_missing, require_kernel_typed};
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
-
-/// `ToolError` for a `task_*` tool reached with no caller agent id. Same
-/// rationale as `tool_runner::cron::caller_agent_id_missing`: the MCP HTTP
-/// route legitimately passes `None`, which is user-recoverable input, so it
-/// surfaces as `MissingParameter` (→ 400) rather than `Internal`; the tool
-/// name is preserved on the tracing channel for operators.
-//
-// Note: cron, schedule (#5720), and task each carry a local copy of this
-// 6-line helper. Hoisting it to a shared `tool_runner` util is the obvious
-// dedup once those slices have all landed on `main`; doing it here would
-// conflict with the still-open #5720, so it is flagged for a follow-up rather
-// than deferred silently.
-fn caller_agent_id_missing(tool: &'static str) -> ToolError {
-    tracing::warn!(
-        tool,
-        "caller agent_id missing — surfaced as MissingParameter to the LLM"
-    );
-    ToolError::MissingParameter("agent_id")
-}
 
 pub(super) async fn tool_task_post(
     input: &serde_json::Value,

--- a/crates/librefang-runtime/src/tool_runner/task.rs
+++ b/crates/librefang-runtime/src/tool_runner/task.rs
@@ -1,37 +1,60 @@
 //! Cross-agent task board tools backed by `KernelHandle::task_*`.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576) — third slice after `tool_runner::{cron, schedule}`.
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
+
+/// `ToolError` for a `task_*` tool reached with no caller agent id. Same
+/// rationale as `tool_runner::cron::caller_agent_id_missing`: the MCP HTTP
+/// route legitimately passes `None`, which is user-recoverable input, so it
+/// surfaces as `MissingParameter` (→ 400) rather than `Internal`; the tool
+/// name is preserved on the tracing channel for operators.
+//
+// Note: cron, schedule (#5720), and task each carry a local copy of this
+// 6-line helper. Hoisting it to a shared `tool_runner` util is the obvious
+// dedup once those slices have all landed on `main`; doing it here would
+// conflict with the still-open #5720, so it is flagged for a follow-up rather
+// than deferred silently.
+fn caller_agent_id_missing(tool: &'static str) -> ToolError {
+    tracing::warn!(
+        tool,
+        "caller agent_id missing — surfaced as MissingParameter to the LLM"
+    );
+    ToolError::MissingParameter("agent_id")
+}
 
 pub(super) async fn tool_task_post(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let title = input["title"].as_str().ok_or("Missing 'title' parameter")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let title = input["title"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("title"))?;
     let description = input["description"]
         .as_str()
-        .ok_or("Missing 'description' parameter")?;
+        .ok_or(ToolError::MissingParameter("description"))?;
     let assigned_to = input["assigned_to"].as_str();
     let task_id = kh
         .task_post(title, description, assigned_to, caller_agent_id)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Task created with ID: {task_id}"))
 }
 
 pub(super) async fn tool_task_claim(
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let agent_id = caller_agent_id.ok_or("task_claim requires a calling agent context")?;
-    match kh.task_claim(agent_id).await.map_err(|e| e.to_string())? {
-        Some(task) => {
-            serde_json::to_string_pretty(&task).map_err(|e| format!("Serialize error: {e}"))
-        }
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("task_claim"))?;
+    match kh.task_claim(agent_id).await.map_err(ToolError::upstream)? {
+        Some(task) => Ok(serde_json::to_string_pretty(&task)?),
         None => Ok("No tasks available.".to_string()),
     }
 }
@@ -40,43 +63,43 @@ pub(super) async fn tool_task_complete(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let agent_id = caller_agent_id.ok_or("task_complete requires a calling agent context")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("task_complete"))?;
     let task_id = input["task_id"]
         .as_str()
-        .ok_or("Missing 'task_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("task_id"))?;
     let result = input["result"]
         .as_str()
-        .ok_or("Missing 'result' parameter")?;
+        .ok_or(ToolError::MissingParameter("result"))?;
     kh.task_complete(agent_id, task_id, result)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(format!("Task {task_id} marked as completed."))
 }
 
 pub(super) async fn tool_task_list(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let status = input["status"].as_str();
-    let tasks = kh.task_list(status).await.map_err(|e| e.to_string())?;
+    let tasks = kh.task_list(status).await.map_err(ToolError::upstream)?;
     if tasks.is_empty() {
         return Ok("No tasks found.".to_string());
     }
-    serde_json::to_string_pretty(&tasks).map_err(|e| format!("Serialize error: {e}"))
+    Ok(serde_json::to_string_pretty(&tasks)?)
 }
 
 pub(super) async fn tool_task_status(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let task_id = input["task_id"]
         .as_str()
-        .ok_or("Missing 'task_id' parameter")?;
-    match kh.task_get(task_id).await.map_err(|e| e.to_string())? {
+        .ok_or(ToolError::MissingParameter("task_id"))?;
+    match kh.task_get(task_id).await.map_err(ToolError::upstream)? {
         Some(task) => {
             // Project to the same six columns comms_task_status returns from
             // the bridge SQL — keeps the native tool's contract tight even if
@@ -89,8 +112,57 @@ pub(super) async fn tool_task_status(
                 "created_at":   task.get("created_at").cloned().unwrap_or(serde_json::Value::Null),
                 "completed_at": task.get("completed_at").cloned().unwrap_or(serde_json::Value::Null),
             });
-            serde_json::to_string_pretty(&projected).map_err(|e| format!("Serialize error: {e}"))
+            Ok(serde_json::to_string_pretty(&projected)?)
         }
+        // Behaviour preserved from the pre-#3576 contract: a missing task is a
+        // readable success message, NOT a `NotFound` error (see
+        // `test_task_status_not_found_returns_message`).
         None => Ok(format!("Task '{task_id}' not found.")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Boundary tests that run BEFORE any kernel call. Kernel-roundtrip paths
+    //! (success, not-found message, projection) are covered against the
+    //! `CapturingKernel` stub in `tests/tool_runner_forwarding_task_cron.rs`.
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn task_post_without_kernel_returns_unavailable() {
+        let r = tool_task_post(&json!({}), None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn task_claim_without_kernel_returns_unavailable() {
+        let r = tool_task_claim(None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn task_complete_without_kernel_returns_unavailable() {
+        let r = tool_task_complete(&json!({}), None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn task_list_without_kernel_returns_unavailable() {
+        let r = tool_task_list(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn task_status_without_kernel_returns_unavailable() {
+        let r = tool_task_status(&json!({}), None).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[test]
+    fn caller_agent_id_missing_surfaces_as_missing_parameter() {
+        let e = caller_agent_id_missing("task_claim");
+        assert!(matches!(e, ToolError::MissingParameter("agent_id")));
+        assert!(e.to_string().contains("agent_id"));
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -688,6 +688,56 @@ async fn agent_send_distinct_keys_produce_isolated_dispatch() {
     );
 }
 
+/// Inter-agent call-depth quota maps to `PermissionDenied`, not `Upstream`.
+/// `Upstream` lifts to `LibreFangError::ToolExecution` (HTTP 5xx) which would
+/// mislead caller retry/circuit-break logic into treating a self-imposed
+/// kernel-policy quota as a transient infra crash; `PermissionDenied` lifts
+/// to `CapabilityDenied` (HTTP 403), which is the honest semantic for a
+/// "you can't go any deeper" limit. The rendered message and the
+/// `Use the task queue instead.` recovery hint are preserved on the wire.
+#[tokio::test]
+async fn agent_send_depth_exceeded_is_permission_denied() {
+    use super::error::ToolError;
+    use super::AGENT_CALL_DEPTH;
+
+    let cap = Arc::new(DispatchCapture::default());
+    let kernel: Arc<dyn KernelHandle> = cap.clone();
+    let input = serde_json::json!({ "agent_id": "target", "message": "hi" });
+
+    // DispatchCapture::max_agent_call_depth() returns 10; setting the
+    // task-local depth to 10 reaches the `>= max_depth` branch.
+    let result = AGENT_CALL_DEPTH
+        .scope(std::cell::Cell::new(10), async {
+            super::agent::tool_agent_send(&input, Some(&kernel), Some("parent-agent")).await
+        })
+        .await;
+
+    let err = result.expect_err("depth >= max must short-circuit before dispatch");
+    match &err {
+        ToolError::PermissionDenied(msg) => {
+            assert!(
+                msg.contains("Inter-agent call depth exceeded"),
+                "message text must survive (LLM relies on the recovery hint), got: {msg}"
+            );
+            assert!(
+                msg.contains("task queue"),
+                "recovery hint must survive, got: {msg}"
+            );
+        }
+        other => panic!(
+            "expected PermissionDenied (→ HTTP 403 CapabilityDenied), got {other:?} \
+             — Upstream would map to 5xx and mislead retry logic"
+        ),
+    }
+
+    // Dispatch must NOT have been reached.
+    let calls = cap.calls.lock().unwrap();
+    assert!(
+        calls.is_empty(),
+        "depth-exceeded must short-circuit before any send_to_agent_* arm, got: {calls:?}"
+    );
+}
+
 // ── channel_send mirror tests ────────────────────────────────────────────
 
 /// A minimal kernel for mirror tests.

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -227,7 +227,8 @@ async fn test_tool_a2a_send_blocks_secret_in_message() {
     });
     let err = tool_a2a_send(&input, Some(&kernel))
         .await
-        .expect_err("a2a_send must reject tainted message");
+        .expect_err("a2a_send must reject tainted message")
+        .to_string(); // #3576: Err is now ToolError; assert via its Display.
     assert!(
         err.contains("taint") || err.contains("violation"),
         "expected taint violation, got: {err}"

--- a/crates/librefang-runtime/src/tool_runner/tests/policy.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/policy.rs
@@ -589,7 +589,11 @@ async fn test_schedule_tools_without_kernel() {
     )
     .await;
     assert!(result.is_error);
-    assert!(result.content.contains("Kernel handle not available"));
+    // #3576: schedule_* now goes through `require_kernel_typed`, which yields
+    // `ToolError::Unavailable("Kernel handle")` rendered as "Kernel handle
+    // unavailable" (the old `require_kernel` string was "Kernel handle not
+    // available ..."). shell.rs still asserts the old text until shell migrates.
+    assert!(result.content.contains("Kernel handle unavailable"));
 }
 
 // ─── Canvas / A2UI tests ────────────────────────────────────────

--- a/crates/librefang-runtime/src/tool_runner/tests/policy.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/policy.rs
@@ -519,7 +519,9 @@ async fn test_media_tools_honor_named_workspace_prefixes() {
          no named-workspace prefixes are provided, got: {:?}",
         denied
     );
-    let err = denied.unwrap_err();
+    // #3576: Err is now ToolError; assert via its Display (the sandbox reason
+    // is preserved inside InvalidParameter).
+    let err = denied.unwrap_err().to_string();
     assert!(
         err.contains("resolves outside workspace") || err.contains("Access denied"),
         "expected sandbox rejection, got: {err}"

--- a/crates/librefang-runtime/src/tool_runner/tests/policy.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/policy.rs
@@ -1421,7 +1421,8 @@ fn test_goal_update_missing_kernel() {
     });
     let result = tool_goal_update(&input, None);
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Kernel handle"));
+    // #3576: Err is now ToolError; assert via its Display.
+    assert!(result.unwrap_err().to_string().contains("Kernel handle"));
 }
 
 #[test]
@@ -1440,7 +1441,7 @@ fn test_goal_update_no_fields() {
     });
     let result = tool_goal_update(&input, None);
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("At least one"));
+    assert!(result.unwrap_err().to_string().contains("At least one"));
 }
 
 #[test]
@@ -1451,7 +1452,7 @@ fn test_goal_update_invalid_status() {
     });
     let result = tool_goal_update(&input, None);
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Invalid status"));
+    assert!(result.unwrap_err().to_string().contains("Invalid status"));
 }
 
 /// Mock kernel that validates capability inheritance in spawn_agent_checked.

--- a/crates/librefang-runtime/src/tool_runner/tests/shell.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/shell.rs
@@ -761,7 +761,10 @@ async fn test_agent_tools_without_kernel() {
     )
     .await;
     assert!(result.is_error);
-    assert!(result.content.contains("Kernel handle not available"));
+    // #3576: require_kernel_typed renders as "Kernel handle unavailable"
+    // (ToolError::Unavailable) rather than the old "Kernel handle not
+    // available" string.
+    assert!(result.content.contains("Kernel handle unavailable"));
 }
 
 #[tokio::test]

--- a/crates/librefang-runtime/src/tool_runner/tests/skills.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/skills.rs
@@ -128,7 +128,7 @@ async fn skill_read_file_rejects_unknown_skill() {
 
     let input = serde_json::json!({ "skill": "nope", "path": "f.txt" });
     let result = tool_skill_read_file(&input, Some(&registry), None).await;
-    assert!(result.unwrap_err().contains("not found"));
+    assert!(result.unwrap_err().to_string().contains("not found"));
 }
 
 #[tokio::test]
@@ -143,7 +143,7 @@ async fn skill_read_file_rejects_absolute_path() {
         .into_owned();
     let input = serde_json::json!({ "skill": "abs", "path": abs_path });
     let result = tool_skill_read_file(&input, Some(&registry), None).await;
-    assert!(result.unwrap_err().contains("absolute paths"));
+    assert!(result.unwrap_err().to_string().contains("absolute paths"));
 }
 
 #[tokio::test]
@@ -155,7 +155,7 @@ async fn skill_read_file_enforces_allowlist() {
     let allowed = vec!["other-skill".to_string()];
     let input = serde_json::json!({ "skill": "secret", "path": "data.txt" });
     let result = tool_skill_read_file(&input, Some(&registry), Some(&allowed)).await;
-    assert!(result.unwrap_err().contains("not allowed"));
+    assert!(result.unwrap_err().to_string().contains("not allowed"));
 
     // Empty allowlist means all skills are accessible
     let empty: Vec<String> = vec![];
@@ -582,7 +582,8 @@ async fn test_evolve_tools_rejected_when_registry_frozen() {
     });
     let err = tool_skill_evolve_create(&input, Some(&registry), None)
         .await
-        .expect_err("must reject under freeze");
+        .expect_err("must reject under freeze")
+        .to_string();
     assert!(
         err.contains("frozen") || err.contains("Stable"),
         "error must mention Stable/frozen, got: {err}"
@@ -590,7 +591,8 @@ async fn test_evolve_tools_rejected_when_registry_frozen() {
 
     let err = tool_skill_evolve_delete(&serde_json::json!({ "name": "gated" }), Some(&registry))
         .await
-        .expect_err("delete must reject under freeze");
+        .expect_err("delete must reject under freeze")
+        .to_string();
     assert!(err.contains("frozen") || err.contains("Stable"));
 
     let err = tool_skill_evolve_write_file(
@@ -602,7 +604,8 @@ async fn test_evolve_tools_rejected_when_registry_frozen() {
         Some(&registry),
     )
     .await
-    .expect_err("write_file must reject under freeze");
+    .expect_err("write_file must reject under freeze")
+    .to_string();
     assert!(err.contains("frozen") || err.contains("Stable"));
 }
 

--- a/crates/librefang-runtime/src/tool_runner/web_legacy.rs
+++ b/crates/librefang-runtime/src/tool_runner/web_legacy.rs
@@ -1,37 +1,60 @@
 //! Legacy `web_fetch` / `web_search` fallbacks used when the agent's
 //! `WebToolsContext` is unavailable (e.g. tests, REST/MCP bridges that
 //! don't thread one through).
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). Missing params -> `MissingParameter`; the HTTP/transport
+//! (`reqwest::Error`) failures -> `ToolError::Upstream` via `fetch_err`, which
+//! keeps a stage-identifying prefix on the message AND the typed error on the
+//! `source()` chain; the 10 MB response cap -> `upstream_msg`.
 
+use super::error::{ToolError, ToolResult};
 use crate::web_search::parse_ddg_results;
 use tracing::debug;
+
+/// Wrap a transport failure in `ToolError::Upstream`, keeping a stage prefix on
+/// the rendered message and the typed error on the `source()` chain.
+fn fetch_err<E>(prefix: &str, e: E) -> ToolError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    ToolError::Upstream {
+        message: format!("{prefix}: {e}"),
+        source: Some(Box::new(e)),
+    }
+}
 
 /// Legacy web fetch (no SSRF protection, no readability). Used when WebToolsContext is unavailable.
 pub(super) async fn tool_web_fetch_legacy(
     input: &serde_json::Value,
     spill_threshold: u64,
     max_artifact_bytes: u64,
-) -> Result<String, String> {
-    let url = input["url"].as_str().ok_or("Missing 'url' parameter")?;
+) -> ToolResult {
+    let url = input["url"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("url"))?;
     let client = crate::http_client::proxied_client_builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
-        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+        .map_err(|e| fetch_err("Failed to create HTTP client", e))?;
     let resp = client
         .get(url)
         .send()
         .await
-        .map_err(|e| format!("HTTP request failed: {e}"))?;
+        .map_err(|e| fetch_err("HTTP request failed", e))?;
     let status = resp.status();
     // Reject responses larger than 10MB to prevent memory exhaustion
     if let Some(len) = resp.content_length() {
         if len > 10 * 1024 * 1024 {
-            return Err(format!("Response too large: {len} bytes (max 10MB)"));
+            return Err(ToolError::upstream_msg(format!(
+                "Response too large: {len} bytes (max 10MB)"
+            )));
         }
     }
     let body = resp
         .text()
         .await
-        .map_err(|e| format!("Failed to read response body: {e}"))?;
+        .map_err(|e| fetch_err("Failed to read response body", e))?;
     // Artifact spill: if the body exceeds the configured threshold, write it
     // to the artifact store and return a compact stub with a handle.  On write
     // failure (including per-artifact size cap exceeded), fall through to the
@@ -62,8 +85,10 @@ pub(super) async fn tool_web_fetch_legacy(
 }
 
 /// Legacy web search via DuckDuckGo HTML only. Used when WebToolsContext is unavailable.
-pub(super) async fn tool_web_search_legacy(input: &serde_json::Value) -> Result<String, String> {
-    let query = input["query"].as_str().ok_or("Missing 'query' parameter")?;
+pub(super) async fn tool_web_search_legacy(input: &serde_json::Value) -> ToolResult {
+    let query = input["query"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("query"))?;
     let max_results = input["max_results"].as_u64().unwrap_or(5) as usize;
 
     debug!(query, "Executing web search via DuckDuckGo HTML");
@@ -71,7 +96,7 @@ pub(super) async fn tool_web_search_legacy(input: &serde_json::Value) -> Result<
     let client = crate::http_client::proxied_client_builder()
         .timeout(std::time::Duration::from_secs(15))
         .build()
-        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+        .map_err(|e| fetch_err("Failed to create HTTP client", e))?;
 
     let resp = client
         .get("https://html.duckduckgo.com/html/")
@@ -79,12 +104,12 @@ pub(super) async fn tool_web_search_legacy(input: &serde_json::Value) -> Result<
         .header("User-Agent", "Mozilla/5.0 (compatible; LibreFangAgent/0.1)")
         .send()
         .await
-        .map_err(|e| format!("Search request failed: {e}"))?;
+        .map_err(|e| fetch_err("Search request failed", e))?;
 
     let body = resp
         .text()
         .await
-        .map_err(|e| format!("Failed to read search response: {e}"))?;
+        .map_err(|e| fetch_err("Failed to read search response", e))?;
 
     // Parse DuckDuckGo HTML results
     let results = parse_ddg_results(&body, max_results);
@@ -105,4 +130,21 @@ pub(super) async fn tool_web_search_legacy(input: &serde_json::Value) -> Result<
     }
 
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn web_fetch_legacy_missing_url_is_missing_parameter() {
+        let r = tool_web_fetch_legacy(&serde_json::json!({}), 0, 0).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("url"))));
+    }
+
+    #[tokio::test]
+    async fn web_search_legacy_missing_query_is_missing_parameter() {
+        let r = tool_web_search_legacy(&serde_json::json!({})).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("query"))));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/wiki.rs
+++ b/crates/librefang-runtime/src/tool_runner/wiki.rs
@@ -1,6 +1,12 @@
 //! Memory-wiki tools (issue #3329).
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). The per-user ACL gate (`enforce_memory_acl`, shared and still
+//! `Result<_, String>`) returns only its Deny message on `Err`, so it maps to
+//! `ToolError::PermissionDenied`; the message text is preserved verbatim.
 
-use super::{enforce_memory_acl, require_kernel, MemoryAclOp};
+use super::error::{ToolError, ToolResult};
+use super::{enforce_memory_acl, require_kernel_typed, MemoryAclOp};
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
@@ -16,9 +22,11 @@ pub(super) fn tool_wiki_get(
     kernel: Option<&Arc<dyn KernelHandle>>,
     sender_id: Option<&str>,
     channel: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let topic = input["topic"].as_str().ok_or("Missing 'topic' parameter")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let topic = input["topic"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("topic"))?;
     // #5139: gate the read on the per-user ACL before hitting the vault.
     enforce_memory_acl(
         kernel,
@@ -26,8 +34,9 @@ pub(super) fn tool_wiki_get(
         channel,
         MemoryAclOp::Read,
         WIKI_NAMESPACE,
-    )?;
-    let value = kh.wiki_get(topic).map_err(|e| e.to_string())?;
+    )
+    .map_err(ToolError::PermissionDenied)?;
+    let value = kh.wiki_get(topic).map_err(ToolError::upstream)?;
     Ok(serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()))
 }
 
@@ -36,9 +45,11 @@ pub(super) fn tool_wiki_search(
     kernel: Option<&Arc<dyn KernelHandle>>,
     sender_id: Option<&str>,
     channel: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let query = input["query"].as_str().ok_or("Missing 'query' parameter")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let query = input["query"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("query"))?;
     let limit = input
         .get("limit")
         .and_then(|v| v.as_u64())
@@ -51,8 +62,9 @@ pub(super) fn tool_wiki_search(
         channel,
         MemoryAclOp::Read,
         WIKI_NAMESPACE,
-    )?;
-    let value = kh.wiki_search(query, limit).map_err(|e| e.to_string())?;
+    )
+    .map_err(ToolError::PermissionDenied)?;
+    let value = kh.wiki_search(query, limit).map_err(ToolError::upstream)?;
     Ok(serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()))
 }
 
@@ -62,10 +74,14 @@ pub(super) fn tool_wiki_write(
     caller_agent_id: Option<&str>,
     sender_id: Option<&str>,
     channel: Option<&str>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
-    let topic = input["topic"].as_str().ok_or("Missing 'topic' parameter")?;
-    let body = input["body"].as_str().ok_or("Missing 'body' parameter")?;
+) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
+    let topic = input["topic"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("topic"))?;
+    let body = input["body"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("body"))?;
     let force = input
         .get("force")
         .and_then(|v| v.as_bool())
@@ -78,7 +94,8 @@ pub(super) fn tool_wiki_write(
         channel,
         MemoryAclOp::Write,
         WIKI_NAMESPACE,
-    )?;
+    )
+    .map_err(ToolError::PermissionDenied)?;
 
     // Provenance is constructed kernel-side rather than left to the LLM:
     // (1) every write is required to carry an agent attribution per #3329's
@@ -103,6 +120,30 @@ pub(super) fn tool_wiki_write(
 
     let value = kh
         .wiki_write(topic, body, provenance, force)
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
     Ok(serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn wiki_get_without_kernel_returns_unavailable() {
+        let r = tool_wiki_get(&json!({"topic": "x"}), None, None, None);
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[test]
+    fn wiki_search_without_kernel_returns_unavailable() {
+        let r = tool_wiki_search(&json!({"query": "x"}), None, None, None);
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[test]
+    fn wiki_write_without_kernel_returns_unavailable() {
+        let r = tool_wiki_write(&json!({"topic": "x", "body": "y"}), None, None, None, None);
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/workflow.rs
+++ b/crates/librefang-runtime/src/tool_runner/workflow.rs
@@ -1,6 +1,15 @@
 //! Workflow execution tools — run / list / status / start / cancel / describe.
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576). Missing params -> `MissingParameter`; bad `input` object / bad
+//! `_artifact` ref / non-UUID run_id -> `InvalidParameter`; unknown run/workflow
+//! -> `NotFound`; kernel ops (`KernelOpError`) -> `ToolError::upstream`; JSON
+//! serialization via `?`. The `prepare_workflow_input` /
+//! `resolve_workflow_input_artifacts` / `build_workflow_run_result` helpers keep
+//! their `Result<_, String>` / infallible shapes (shared, unit-tested directly).
 
-use super::require_kernel;
+use super::error::{ToolError, ToolResult};
+use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
@@ -117,21 +126,26 @@ pub(super) fn build_workflow_run_result(
 pub(super) async fn tool_workflow_run(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
+) -> ToolResult {
     let workflow_id = input["workflow_id"]
         .as_str()
-        .ok_or("Missing 'workflow_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("workflow_id"))?;
 
     // Resolve any {"_artifact": "sha256:..."} references in the input
     // object before serializing for the workflow engine (#4982 — gap 3
     // / file & image input). See `resolve_workflow_input_artifacts`.
-    let input_str = prepare_workflow_input(input.get("input"))?;
+    let input_str = prepare_workflow_input(input.get("input")).map_err(|reason| {
+        ToolError::InvalidParameter {
+            name: "input",
+            reason,
+        }
+    })?;
 
-    let kh = require_kernel(kernel)?;
+    let kh = require_kernel_typed(kernel)?;
     let (run_id, output) = kh
         .run_workflow(workflow_id, &input_str)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
 
     // Fetch the structured run summary so the caller gets {step_outputs,
     // output_json?} alongside the final output string (#4982 — gap 3 /
@@ -142,10 +156,8 @@ pub(super) async fn tool_workflow_run(
     Ok(build_workflow_run_result(&run_id, &output, summary.as_ref()).to_string())
 }
 
-pub(super) async fn tool_workflow_list(
-    kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
-    let kh = require_kernel(kernel)?;
+pub(super) async fn tool_workflow_list(kernel: Option<&Arc<dyn KernelHandle>>) -> ToolResult {
+    let kh = require_kernel_typed(kernel)?;
     let mut summaries = kh.list_workflows().await;
     // Sort by name for deterministic LLM prompt output (#3298).
     summaries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -161,28 +173,32 @@ pub(super) async fn tool_workflow_list(
             })
         })
         .collect();
-    serde_json::to_string(&json_array)
-        .map_err(|e| format!("Failed to serialize workflow list: {e}"))
+    Ok(serde_json::to_string(&json_array)?)
 }
 
 pub(super) async fn tool_workflow_status(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
+) -> ToolResult {
     let run_id = input["run_id"]
         .as_str()
-        .ok_or("Missing 'run_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("run_id"))?;
 
     // Validate UUID format before calling kernel — returns a clear error
     // rather than silently returning not-found for a malformed id.
-    uuid::Uuid::parse_str(run_id)
-        .map_err(|_| format!("Invalid run_id — must be a UUID: {run_id}"))?;
+    uuid::Uuid::parse_str(run_id).map_err(|_| ToolError::InvalidParameter {
+        name: "run_id",
+        reason: format!("must be a UUID: {run_id}"),
+    })?;
 
-    let kh = require_kernel(kernel)?;
+    let kh = require_kernel_typed(kernel)?;
     let summary = kh
         .get_workflow_run(run_id)
         .await
-        .ok_or_else(|| format!("workflow run not found: {run_id}"))?;
+        .ok_or_else(|| ToolError::NotFound {
+            kind: "Workflow run",
+            id: run_id.to_string(),
+        })?;
 
     // Mirror the run_workflow tool's structured shape: alongside the raw
     // `output` string, surface a parsed `output_json` when applicable and
@@ -219,7 +235,7 @@ pub(super) async fn tool_workflow_status(
     if let Some(json) = output_json {
         body["output_json"] = json;
     }
-    serde_json::to_string(&body).map_err(|e| format!("Failed to serialize workflow status: {e}"))
+    Ok(serde_json::to_string(&body)?)
 }
 
 pub(super) async fn tool_workflow_start(
@@ -227,16 +243,21 @@ pub(super) async fn tool_workflow_start(
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
     caller_session_id: Option<librefang_types::agent::SessionId>,
-) -> Result<String, String> {
+) -> ToolResult {
     let workflow_id = input["workflow_id"]
         .as_str()
-        .ok_or("Missing 'workflow_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("workflow_id"))?;
 
     // Resolve `_artifact` refs in the input object before serializing
     // (#4982 — gap 3 / file & image input).
-    let input_str = prepare_workflow_input(input.get("input"))?;
+    let input_str = prepare_workflow_input(input.get("input")).map_err(|reason| {
+        ToolError::InvalidParameter {
+            name: "input",
+            reason,
+        }
+    })?;
 
-    let kh = require_kernel(kernel)?;
+    let kh = require_kernel_typed(kernel)?;
 
     // Forward caller context so the kernel can register the workflow on
     // its async-task tracker (#4983) and inject a `TaskCompletionEvent`
@@ -252,7 +273,7 @@ pub(super) async fn tool_workflow_start(
             session_id_str.as_deref(),
         )
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
 
     Ok(serde_json::json!({ "run_id": run_id }).to_string())
 }
@@ -260,19 +281,21 @@ pub(super) async fn tool_workflow_start(
 pub(super) async fn tool_workflow_cancel(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
+) -> ToolResult {
     let run_id = input["run_id"]
         .as_str()
-        .ok_or("Missing 'run_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("run_id"))?;
 
     // Validate UUID format before calling kernel.
-    uuid::Uuid::parse_str(run_id)
-        .map_err(|_| format!("Invalid run_id — must be a UUID: {run_id}"))?;
+    uuid::Uuid::parse_str(run_id).map_err(|_| ToolError::InvalidParameter {
+        name: "run_id",
+        reason: format!("must be a UUID: {run_id}"),
+    })?;
 
-    let kh = require_kernel(kernel)?;
+    let kh = require_kernel_typed(kernel)?;
     kh.cancel_workflow_run(run_id)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(ToolError::upstream)?;
 
     Ok(serde_json::json!({
         "run_id": run_id,
@@ -288,16 +311,19 @@ pub(super) async fn tool_workflow_cancel(
 pub(super) async fn tool_workflow_describe(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
-) -> Result<String, String> {
+) -> ToolResult {
     let workflow_id = input["workflow_id"]
         .as_str()
-        .ok_or("Missing 'workflow_id' parameter")?;
+        .ok_or(ToolError::MissingParameter("workflow_id"))?;
 
-    let kh = require_kernel(kernel)?;
-    let description = kh
-        .describe_workflow(workflow_id)
-        .await
-        .ok_or_else(|| format!("workflow not found: {workflow_id}"))?;
+    let kh = require_kernel_typed(kernel)?;
+    let description =
+        kh.describe_workflow(workflow_id)
+            .await
+            .ok_or_else(|| ToolError::NotFound {
+                kind: "Workflow",
+                id: workflow_id.to_string(),
+            })?;
 
     let input_schema: Vec<serde_json::Value> = description
         .input_schema
@@ -315,12 +341,11 @@ pub(super) async fn tool_workflow_describe(
         })
         .collect();
 
-    serde_json::to_string(&serde_json::json!({
+    Ok(serde_json::to_string(&serde_json::json!({
         "id": description.id,
         "name": description.name,
         "description": description.description,
         "step_names": description.step_names,
         "input_schema": input_schema,
-    }))
-    .map_err(|e| format!("Failed to serialize workflow description: {e}"))
+    }))?)
 }

--- a/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
+++ b/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
@@ -631,3 +631,85 @@ async fn test_cron_cancel_missing_job_id_renders_as_missing_parameter() {
 fn cancel_was_never_called(calls: &CapturedCalls) -> bool {
     calls.cron_cancel.lock().unwrap().is_empty()
 }
+
+// schedule_delete ownership coverage (#3576 second-slice migration). The
+// natural-language `schedule_delete` shares `KernelHandle::cron_cancel` with
+// `cron_cancel`, which cancels by UUID with no ownership filtering. These pin
+// that `schedule_delete` enforces the same tool-layer ownership guard as
+// `cron_cancel` — previously it did not, so it was a bypass.
+
+#[tokio::test]
+async fn test_schedule_delete_succeeds_when_caller_owns_the_job() {
+    let (kernel, calls) = CapturingKernel::new();
+    kernel.set_cron_list_response(vec![json!({"id": "sched-99"})]);
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, Some("agent-1"));
+    let result = execute_tool_raw("s1", "schedule_delete", &json!({"id": "sched-99"}), &ctx).await;
+
+    assert!(
+        !result.is_error,
+        "schedule_delete should succeed when caller owns the job: {}",
+        result.content
+    );
+    let cancel_calls = calls.cron_cancel.lock().unwrap();
+    assert_eq!(cancel_calls.len(), 1);
+    assert_eq!(cancel_calls[0], "sched-99");
+}
+
+#[tokio::test]
+async fn test_schedule_delete_unowned_job_renders_as_not_found() {
+    // Regression: before #3576's second slice, schedule_delete called
+    // cron_cancel directly with no ownership check, so any agent could delete
+    // another agent's job by UUID. It must now collapse unowned/missing into
+    // NotFound and never reach the kernel.
+    let (kernel, calls) = CapturingKernel::new();
+    kernel.set_cron_list_response(vec![json!({"id": "sched-mine"})]);
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, Some("agent-1"));
+    let result = execute_tool_raw(
+        "s2",
+        "schedule_delete",
+        &json!({"id": "sched-other-agents"}),
+        &ctx,
+    )
+    .await;
+
+    assert!(
+        result.is_error,
+        "schedule_delete on unowned job must error: {}",
+        result.content
+    );
+    assert!(
+        result
+            .content
+            .contains("Schedule 'sched-other-agents' not found"),
+        "expected NotFound display, got: {}",
+        result.content
+    );
+    assert!(
+        cancel_was_never_called(&calls),
+        "schedule_delete must NOT reach the kernel when the caller doesn't own the job"
+    );
+}
+
+#[tokio::test]
+async fn test_schedule_delete_missing_id_renders_as_missing_parameter() {
+    let (kernel, _calls) = CapturingKernel::new();
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, Some("agent-1"));
+    let result = execute_tool_raw("s3", "schedule_delete", &json!({}), &ctx).await;
+
+    assert!(
+        result.is_error,
+        "schedule_delete without id must error: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("Missing required parameter 'id'"),
+        "expected MissingParameter display, got: {}",
+        result.content
+    );
+}


### PR DESCRIPTION
## What

Migrates **every** `tool_runner` tool function from the stringly-typed `Result<String, String>` to the structured `Result<String, ToolError>` (#3576), continuing the pattern from the cron first-slice (#5258). One PR, one commit per tool family, so history is reviewable file-by-file.

Tool families migrated:

`schedule` · `task` · `knowledge` · `event_publish` · `goal_update` · `a2a` · `location_get` · `wiki` · `hand` · `canvas` · `docker_exec` · `shell_exec` · `image_analyze` · `web_*_legacy` · `file_read/write/list/apply_patch` · `process_*` · `agent_*` · `skill_*` (evolve + read_file) · `workflow_*` · `media_*` (describe/transcribe/image/video/music/tts/stt)

(Supersedes the 15 separate PRs #5720–#5736, closed in favour of this one after maintainer feedback that splitting created an unnecessary review surface.)

## Conventions (consistent across every family)

- `require_kernel` → `require_kernel_typed` (`Unavailable("Kernel handle")`); other missing subsystems (media engine/drivers, TTS, process manager, skill registry, docker, workspace context) → `Unavailable`.
- Absent params → `MissingParameter`; bad values / sandbox-escape / parse / non-UUID / unknown-model / bad-format → `InvalidParameter` (message preserved).
- Typed downstream errors (`KernelOpError`, `io::Error`, `reqwest::Error`, `SkillError`) → `ToolError::upstream` / `Upstream { message, source }` (prefix + `source()` chain preserved where practical).
- Stringly-typed downstream surfaces (`A2aClient`, `ProcessManager`, `MediaDriver`/engine, `apply_patch`, shared `resolve_file_path_ext` / `enforce_memory_acl` / `prepare_workflow_input`) → `upstream_msg` / `InvalidParameter` / `PermissionDenied`, message verbatim. Those shared helpers keep their `Result<_, String>` shape (still called by code outside the migrated set).
- Security-contract messages preserved on the wire: a2a SSRF / taint / trusted-agent gate, wiki + memory ACL `Access denied`, skill freeze + read-file containment, shell `[interrupted]` / timeout, schedule/cron ownership `NotFound`, agent self-send + taint guards.
- Each dispatch arm narrows back to `Result<String, String>` with `.map_err(|e| e.to_string())` — a temporary bridge until the dispatch return type itself is lifted (follow-up).

## Included security fix (called out, not silent)

`schedule_delete` previously called `KernelHandle::cron_cancel` with **no ownership check** while the sibling `cron_cancel` tool enforces one — a cross-agent bypass (any agent could cancel another's job by UUID). This PR adds the same ownership guard, threading `caller_agent_id` through. Covered by integration tests.

## Tests

- Boundary unit tests added per family (no-kernel → `Unavailable`, missing-param → `MissingParameter`, validation variants).
- Existing direct-call tests that asserted the old `String` errors updated to read the `ToolError` `Display` (`.to_string()`) — goal_update, a2a-taint, image/skill sandbox, agent no-kernel, schedule frozen; substrings preserved.
- Tests going through `execute_tool_raw` (assert on `result.content`) are unchanged — the dispatch boundary still yields a `String`.

## Verification (Docker; host has no native toolchain)

Ran in the repo's `Dockerfile.rust-dev` image with isolated `CARGO_HOME` / `CARGO_TARGET_DIR` volumes:

- `cargo test -p librefang-runtime --lib tool_runner::` → **293 passed, 0 failed**
- `cargo test -p librefang-runtime --test tool_runner_forwarding_task_cron --test tool_runner_memory_acl --test tool_runner_agent_event --test tool_runner_workflow_readonly --test tool_runner_workflow_write` → all passed
- `rustfmt --check` on all changed files → clean
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` → clean

## Out of scope

- `channel_send` is intentionally left for a follow-up (it overlaps with open PR #5282; migrating it now would conflict).
- The dispatch-return-type lift (dropping the per-arm `.map_err`) and hoisting the duplicated `caller_agent_id_missing` helper to a shared util are follow-ups now that all submodules have migrated.
