### PR TITLE
feat(types,kernel,api): per-agent channel allowlist

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -1937,6 +1937,14 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .and_then(|entry| entry.manifest.channel_overrides.clone())
     }
 
+    async fn agent_channel_allowlist(&self, agent_id: AgentId) -> Vec<String> {
+        self.kernel
+            .agent_registry()
+            .get(agent_id)
+            .map(|entry| entry.manifest.channels.clone())
+            .unwrap_or_default()
+    }
+
     async fn authorize_channel_user(
         &self,
         channel_type: &str,

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -141,6 +141,10 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             axum::routing::get(get_agent_mcp_servers).put(set_agent_mcp_servers),
         )
         .route(
+            "/agents/{id}/channels",
+            axum::routing::get(get_agent_channels).put(set_agent_channels),
+        )
+        .route(
             "/agents/{id}/identity",
             axum::routing::patch(update_agent_identity),
         )
@@ -4399,6 +4403,111 @@ pub async fn set_agent_mcp_servers(
         Ok(()) => (
             StatusCode::OK,
             Json(serde_json::json!({"status": "ok", "mcp_servers": servers})),
+        ),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(
+                serde_json::json!({"error": t.t_args("api-error-generic", &[("error", &e.to_string())])}),
+            ),
+        ),
+    }
+}
+
+/// GET /api/agents/{id}/channels — Get an agent's channel allowlist info.
+#[utoipa::path(
+    get,
+    path = "/api/agents/{id}/channels",
+    tag = "agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    responses(
+        (status = 200, description = "Get an agent's channel allowlist info", body = crate::types::JsonObject)
+    )
+)]
+pub async fn get_agent_channels(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+) -> impl IntoResponse {
+    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    let agent_id: AgentId = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": t.t("api-error-agent-invalid-id")})),
+            )
+        }
+    };
+    let entry = match state.kernel.agent_registry().get(agent_id) {
+        Some(e) => e,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
+            )
+        }
+    };
+    let available: Vec<String> = state
+        .kernel
+        .config_ref()
+        .sidecar_channels
+        .iter()
+        .map(|sc| sc.channel_type.clone().unwrap_or_else(|| sc.name.clone()))
+        .collect();
+    let mode = if entry.manifest.channels.is_empty() {
+        "all"
+    } else {
+        "allowlist"
+    };
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "assigned": entry.manifest.channels,
+            "available": available,
+            "mode": mode,
+        })),
+    )
+}
+
+/// PUT /api/agents/{id}/channels — Update an agent's channel allowlist.
+#[utoipa::path(
+    put,
+    path = "/api/agents/{id}/channels",
+    tag = "agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    request_body(content = crate::types::JsonArray, description = "Array of channel_type strings"),
+    responses(
+        (status = 200, description = "Update an agent's channel allowlist", body = crate::types::JsonObject)
+    )
+)]
+pub async fn set_agent_channels(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    let agent_id: AgentId = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": t.t("api-error-agent-invalid-id")})),
+            )
+        }
+    };
+    let channels: Vec<String> = body["channels"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    match state.kernel.set_agent_channels(agent_id, channels.clone()) {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"status": "ok", "channels": channels})),
         ),
         Err(e) => (
             StatusCode::BAD_REQUEST,

--- a/crates/librefang-api/tests/agent_channels_routes_test.rs
+++ b/crates/librefang-api/tests/agent_channels_routes_test.rs
@@ -1,0 +1,266 @@
+//! Integration tests for the `/api/agents/{id}/channels` route family.
+//!
+//! Refs #4961 — per-agent channel allowlist. Tests exercise the production
+//! router (`server::build_router`) with `tower::ServiceExt::oneshot`, so the
+//! real auth middleware, route registration, and handler logic are in play.
+//! No real LLM calls — every test is hermetic.
+//!
+//! Routes covered:
+//!   GET /api/agents/{id}/channels   (default shape, populated allowlist)
+//!   PUT /api/agents/{id}/channels   (set + read-back, clear, bad id 400,
+//!                                    unknown agent 404)
+//!
+//! Run: cargo test -p librefang-api --test agent_channels_routes_test
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use librefang_api::routes::AppState;
+use librefang_api::server;
+use librefang_kernel::LibreFangKernel;
+use librefang_types::agent::{AgentId, AgentManifest};
+use librefang_types::config::{DefaultModelConfig, KernelConfig};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+struct Harness {
+    app: axum::Router,
+    state: Arc<AppState>,
+    _tmp: tempfile::TempDir,
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.state.kernel.shutdown();
+    }
+}
+
+const TEST_TOKEN: &str = "test-secret";
+
+async fn boot() -> Harness {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    librefang_kernel::registry_sync::sync_registry(
+        tmp.path(),
+        librefang_kernel::registry_sync::DEFAULT_CACHE_TTL_SECS,
+        "",
+    );
+
+    let config = KernelConfig {
+        home_dir: tmp.path().to_path_buf(),
+        data_dir: tmp.path().join("data"),
+        api_key: TEST_TOKEN.to_string(),
+        default_model: DefaultModelConfig {
+            provider: "ollama".to_string(),
+            model: "test-model".to_string(),
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            base_url: None,
+            message_timeout_secs: 300,
+            extra_params: std::collections::HashMap::new(),
+            cli_profile_dirs: Vec::new(),
+        },
+        ..KernelConfig::default()
+    };
+
+    let kernel = LibreFangKernel::boot_with_config(config).expect("kernel boot");
+    let kernel = Arc::new(kernel);
+    kernel.set_self_handle();
+
+    let (app, state) = server::build_router(kernel, "127.0.0.1:0".parse().expect("addr")).await;
+
+    Harness {
+        app,
+        state,
+        _tmp: tmp,
+    }
+}
+
+fn spawn_named(state: &Arc<AppState>, name: &str) -> AgentId {
+    let manifest = AgentManifest {
+        name: name.to_string(),
+        ..AgentManifest::default()
+    };
+    state
+        .kernel
+        .spawn_agent_typed(manifest)
+        .expect("spawn_agent")
+}
+
+async fn send(app: axum::Router, req: Request<Body>) -> (StatusCode, serde_json::Value) {
+    let resp = app.oneshot(req).await.expect("oneshot");
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let json = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, json)
+}
+
+fn get(path: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn put_json(path: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method(Method::PUT)
+        .uri(path)
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// GET /api/agents/{id}/channels on a freshly spawned agent must return the
+/// backward-compatible default: empty assigned list and mode = "all".
+#[tokio::test(flavor = "multi_thread")]
+async fn get_channels_default_shape() {
+    let h = boot().await;
+    let id = spawn_named(&h.state, "chan-default");
+
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/channels"))).await;
+
+    assert_eq!(status, StatusCode::OK, "body={body:?}");
+    assert_eq!(
+        body["assigned"],
+        serde_json::json!([]),
+        "fresh agent must have empty assigned list"
+    );
+    assert_eq!(body["mode"], "all", "empty assigned must yield mode=all");
+    assert!(
+        body["available"].is_array(),
+        "available must be an array (may be empty when no sidecars configured)"
+    );
+}
+
+/// PUT then GET round-trip: setting a non-empty allowlist is reflected on read-back.
+#[tokio::test(flavor = "multi_thread")]
+async fn put_channels_roundtrip() {
+    let h = boot().await;
+    let id = spawn_named(&h.state, "chan-roundtrip");
+
+    let (put_status, put_body) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/channels"),
+            serde_json::json!({"channels": ["telegram", "discord"]}),
+        ),
+    )
+    .await;
+
+    assert_eq!(put_status, StatusCode::OK, "PUT body={put_body:?}");
+    assert_eq!(put_body["status"], "ok");
+
+    let (get_status, get_body) =
+        send(h.app.clone(), get(&format!("/api/agents/{id}/channels"))).await;
+
+    assert_eq!(get_status, StatusCode::OK, "GET body={get_body:?}");
+    let assigned = get_body["assigned"].as_array().expect("assigned array");
+    let mut names: Vec<&str> = assigned.iter().filter_map(|v| v.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, vec!["discord", "telegram"]);
+    assert_eq!(get_body["mode"], "allowlist");
+}
+
+/// PUT an empty channels array must clear the allowlist and revert to mode=all.
+#[tokio::test(flavor = "multi_thread")]
+async fn put_channels_clear_allowlist() {
+    let h = boot().await;
+    let id = spawn_named(&h.state, "chan-clear");
+
+    // First set a non-empty allowlist.
+    send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/channels"),
+            serde_json::json!({"channels": ["slack"]}),
+        ),
+    )
+    .await;
+
+    // Then clear it.
+    let (put_status, _) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/channels"),
+            serde_json::json!({"channels": []}),
+        ),
+    )
+    .await;
+    assert_eq!(put_status, StatusCode::OK);
+
+    let (get_status, get_body) =
+        send(h.app.clone(), get(&format!("/api/agents/{id}/channels"))).await;
+    assert_eq!(get_status, StatusCode::OK, "GET body={get_body:?}");
+    assert_eq!(
+        get_body["assigned"],
+        serde_json::json!([]),
+        "allowlist should be empty after clear"
+    );
+    assert_eq!(get_body["mode"], "all");
+}
+
+/// GET or PUT with a non-UUID agent ID must return 400.
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_bad_agent_id_returns_400() {
+    let h = boot().await;
+
+    let (get_status, _) = send(h.app.clone(), get("/api/agents/not-a-uuid/channels")).await;
+    assert_eq!(get_status, StatusCode::BAD_REQUEST, "GET must be 400");
+
+    let (put_status, _) = send(
+        h.app.clone(),
+        put_json(
+            "/api/agents/not-a-uuid/channels",
+            serde_json::json!({"channels": ["telegram"]}),
+        ),
+    )
+    .await;
+    assert_eq!(put_status, StatusCode::BAD_REQUEST, "PUT must be 400");
+}
+
+/// GET with a valid UUID that doesn't exist must return 404.
+/// PUT with a valid UUID that doesn't exist returns 400 (agent-not-found
+/// error propagated through the kernel, consistent with set_agent_skills /
+/// set_agent_mcp_servers which also return 400 for all kernel errors).
+#[tokio::test(flavor = "multi_thread")]
+async fn channels_unknown_agent_returns_error() {
+    let h = boot().await;
+    let unknown = AgentId::new();
+
+    let (get_status, _) = send(
+        h.app.clone(),
+        get(&format!("/api/agents/{unknown}/channels")),
+    )
+    .await;
+    assert_eq!(get_status, StatusCode::NOT_FOUND, "GET must be 404");
+
+    let (put_status, _) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{unknown}/channels"),
+            serde_json::json!({"channels": ["telegram"]}),
+        ),
+    )
+    .await;
+    assert_eq!(
+        put_status,
+        StatusCode::BAD_REQUEST,
+        "PUT must be 400 (kernel error)"
+    );
+}

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -292,6 +292,14 @@ pub trait ChannelBridgeHandle: Send + Sync {
         None
     }
 
+    /// Return the agent's channel allowlist (`manifest.channels`).
+    ///
+    /// Empty = all channels permitted (backward-compatible default).
+    /// Non-empty = only the listed `channel_type` strings are allowed.
+    async fn agent_channel_allowlist(&self, _agent_id: AgentId) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Already-escaped regex patterns from `channel_overrides.group_trigger_patterns`; callers must not re-escape.
     async fn get_agent_group_trigger_patterns(&self, _agent_id: AgentId) -> Vec<String> {
         Vec::new()
@@ -2999,6 +3007,13 @@ async fn resolve_or_fallback(
     };
 
     if let Some(id) = agent_id {
+        let allowlist = handle.agent_channel_allowlist(id).await;
+        if !allowlist.is_empty() {
+            let ct = channel_type_str(&message.channel);
+            if !allowlist.iter().any(|c| c == ct) {
+                return None;
+            }
+        }
         return Some(id);
     }
 
@@ -3013,6 +3028,13 @@ async fn resolve_or_fallback(
             .and_then(|agents| agents.first().map(|(id, _)| *id)),
     };
     if let Some(id) = fallback {
+        let allowlist = handle.agent_channel_allowlist(id).await;
+        if !allowlist.is_empty() {
+            let ct = channel_type_str(&message.channel);
+            if !allowlist.iter().any(|c| c == ct) {
+                return None;
+            }
+        }
         // Auto-set this as the user's default so future messages route
         // directly. Scope the cache entry to (channel, account_id) when we
         // know the bot identity, otherwise we would re-introduce the #5672

--- a/crates/librefang-kernel/src/kernel/agent_state.rs
+++ b/crates/librefang-kernel/src/kernel/agent_state.rs
@@ -528,6 +528,36 @@ impl LibreFangKernel {
         Ok(())
     }
 
+    /// Update an agent's channel allowlist. Empty = all channels (backward compat).
+    pub fn set_agent_channels(&self, agent_id: AgentId, channels: Vec<String>) -> KernelResult<()> {
+        // Snapshot previous channel list for rollback on DB persist failure.
+        let prev_channels = self
+            .agents
+            .registry
+            .get(agent_id)
+            .map(|e| e.manifest.channels.clone());
+
+        self.agents
+            .registry
+            .update_channels(agent_id, channels.clone())
+            .map_err(KernelError::LibreFang)?;
+
+        if let Some(entry) = self.agents.registry.get(agent_id) {
+            if let Err(e) = self.memory.substrate.save_agent(&entry) {
+                if let Some(p_channels) = prev_channels {
+                    let _ = self.agents.registry.update_channels(agent_id, p_channels);
+                }
+                return Err(KernelError::LibreFang(e));
+            }
+        }
+
+        // Persist manifest to disk so the change survives a daemon restart.
+        self.persist_manifest_to_disk(agent_id);
+
+        info!(agent_id = %agent_id, channels = ?channels, "Agent channel allowlist updated");
+        Ok(())
+    }
+
     /// Update an agent's schedule mode and restart its background loop so
     /// the change takes effect immediately, without a daemon restart.
     ///

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -279,6 +279,7 @@ pub trait KernelApi: KernelHandle + Send + Sync {
     fn update_manifest(&self, agent_id: AgentId, new_manifest: AgentManifest) -> KernelResult<()>;
     fn set_agent_skills(&self, agent_id: AgentId, skills: Vec<String>) -> KernelResult<()>;
     fn set_agent_mcp_servers(&self, agent_id: AgentId, servers: Vec<String>) -> KernelResult<()>;
+    fn set_agent_channels(&self, agent_id: AgentId, channels: Vec<String>) -> KernelResult<()>;
     /// Update an agent's schedule mode and restart its background loop so
     /// the change takes effect immediately, without a daemon restart.
     /// See [`LibreFangKernel::set_agent_schedule`] for the full contract.
@@ -1004,6 +1005,9 @@ impl KernelApi for LibreFangKernel {
     }
     fn set_agent_mcp_servers(&self, agent_id: AgentId, servers: Vec<String>) -> KernelResult<()> {
         Self::set_agent_mcp_servers(self, agent_id, servers)
+    }
+    fn set_agent_channels(&self, agent_id: AgentId, channels: Vec<String>) -> KernelResult<()> {
+        Self::set_agent_channels(self, agent_id, channels)
     }
     fn set_agent_schedule(
         self: Arc<Self>,

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -539,6 +539,16 @@ impl AgentRegistry {
         Ok(())
     }
 
+    /// Update an agent's channel allowlist.
+    pub fn update_channels(&self, id: AgentId, channels: Vec<String>) -> LibreFangResult<()> {
+        self.with_entry_mut(id, |entry| {
+            entry.manifest.channels = channels;
+            entry.last_active = chrono::Utc::now();
+        })?;
+        self.notify_changed();
+        Ok(())
+    }
+
     /// Update an agent's MCP server allowlist.
     pub fn update_mcp_servers(&self, id: AgentId, servers: Vec<String>) -> LibreFangResult<()> {
         self.with_entry_mut(id, |entry| {

--- a/crates/librefang-kernel/src/wizard.rs
+++ b/crates/librefang-kernel/src/wizard.rs
@@ -171,6 +171,7 @@ impl SetupWizard {
             skills: intent.skills.clone(),
             skills_disabled: false,
             mcp_servers: vec![],
+            channels: vec![],
             mcp_disabled: false,
             metadata: HashMap::new(),
             tags: vec![],

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -1089,6 +1089,11 @@ pub struct AgentManifest {
     /// MCP server allowlist (empty = all connected MCP servers available).
     #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
     pub mcp_servers: Vec<String>,
+    /// Channel allowlist — restricts which configured channels this agent can
+    /// receive messages from. Uses the `channel_type` string (e.g. `"telegram"`,
+    /// `"discord"`, `"slack"`). Empty = all channels (backward-compatible default).
+    #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
+    pub channels: Vec<String>,
     /// Explicitly disable all MCP server tools for this agent. Mirrors
     /// `skills_disabled` — `mcp_servers = []` means "all", this means "none".
     ///
@@ -1513,6 +1518,7 @@ impl Default for AgentManifest {
             skills: Vec::new(),
             skills_disabled: false,
             mcp_servers: Vec::new(),
+            channels: Vec::new(),
             mcp_disabled: false,
             metadata: HashMap::new(),
             tags: Vec::new(),


### PR DESCRIPTION
## Summary

Add `channels` field to `AgentManifest` restricting which configured channels an agent can use. Empty list = all channels (backward-compatible default).

- Uses `channel_type` namespace consistently (not display names) — fixes the namespace mismatch from #4961
- Bridge enforcement in `resolve_or_fallback` for both primary and fallback agent paths
- `GET/PUT /api/agents/{id}/channels` endpoints with persist-to-disk
- No scope creep: no template/workspace changes

Supersedes #4961.

## Files changed (9)

- `agent.rs` — `channels: Vec<String>` with `vec_lenient` deserializer
- `registry.rs` — `update_channels()` method
- `kernel_api.rs` — trait + delegation
- `agent_state.rs` — `set_agent_channels` with rollback on DB failure
- `wizard.rs` — default in struct literal
- `bridge.rs` — `agent_channel_allowlist` trait method + enforcement
- `channel_bridge.rs` — `KernelBridgeAdapter` impl
- `routes/agents.rs` — GET/PUT handlers + router registration
- `agent_channels_routes_test.rs` — 5 integration tests

## Test plan

- [ ] `cargo check --workspace --lib` clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo test -p librefang-api --test agent_channels_routes_test` — 5/5 pass
- [ ] GET returns `{ assigned: [], available: [...], mode: "all" }` for default agent
- [ ] PUT channels → GET returns updated list with `mode: "allowlist"`
- [ ] Bridge filters inbound messages for agents with non-matching allowlist