### PR TITLE
feat(api,dashboard): expose auto_evolve toggle in Skills tab

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1247,6 +1247,7 @@ export interface AgentDetail {
   thinking?: { budget_tokens?: number; stream_thinking?: boolean };
   is_hand?: boolean;
   web_search_augmentation?: "off" | "auto" | "always";
+  auto_evolve?: boolean;
 }
 
 export async function getAgentDetail(agentId: string): Promise<AgentDetail> {

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
@@ -150,6 +150,7 @@ export function usePatchAgent() {
         provider?: string;
         mcp_servers?: string[];
         schedule?: AgentSchedulePatch;
+        auto_evolve?: boolean;
       };
     }) => patchAgent(agentId, body),
     onSuccess: (_data, variables) => {

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -1290,9 +1290,9 @@ export function AgentsPage() {
         {
           onSuccess: () => {
             addToast(
-              t("agents.detail.auto_evolve_saved", {
-                defaultValue: !autoEvolve ? "Auto-evolve enabled" : "Auto-evolve disabled",
-              }),
+              !autoEvolve
+                ? t("agents.detail.auto_evolve_enabled", { defaultValue: "Auto-evolve enabled" })
+                : t("agents.detail.auto_evolve_disabled", { defaultValue: "Auto-evolve disabled" }),
               "success",
             );
           },

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -1282,6 +1282,23 @@ export function AgentsPage() {
     const skillsMode = (agent as AgentDetail).skills_mode;
     const usesAllSkills = skillsMode === "all" && skills.length === 0;
     const skillsDisabled = skillsMode === "none";
+    const autoEvolve = agent.auto_evolve !== false;
+    const handleToggleAutoEvolve = () => {
+      if (!agent.id) return;
+      patchAgentMutation.mutate(
+        { agentId: agent.id, body: { auto_evolve: !autoEvolve } },
+        {
+          onSuccess: () => {
+            addToast(
+              t("agents.detail.auto_evolve_saved", {
+                defaultValue: !autoEvolve ? "Auto-evolve enabled" : "Auto-evolve disabled",
+              }),
+              "success",
+            );
+          },
+        },
+      );
+    };
     return (
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
@@ -1301,6 +1318,33 @@ export function AgentsPage() {
             {t("agents.detail.install_skill", { defaultValue: "Install" })}
           </Button>
         </div>
+
+        <div className="flex items-center justify-between px-3 py-2 rounded-md border border-border-subtle bg-main/40">
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[12px] font-medium text-text-main">
+              {t("agents.detail.auto_evolve_label", { defaultValue: "Auto-evolve" })}
+            </div>
+            <div className="font-mono text-[10px] text-text-dim/70 mt-0.5">
+              {t("agents.detail.auto_evolve_desc", {
+                defaultValue: "Background skill evolution review after each turn",
+              })}
+            </div>
+          </div>
+          <button
+            onClick={handleToggleAutoEvolve}
+            disabled={patchAgentMutation.isPending}
+            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none ${
+              autoEvolve ? "bg-brand" : "bg-text-dim/30"
+            } ${patchAgentMutation.isPending ? "opacity-50" : ""}`}
+          >
+            <span
+              className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                autoEvolve ? "translate-x-4" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+
         {skillsDisabled ? (
           <div className="rounded-md border border-border-subtle bg-main/40 p-4 flex items-start gap-3">
             <X className="w-4 h-4 text-text-dim shrink-0 mt-0.5" />

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -2877,6 +2877,7 @@ pub async fn get_agent(
             "mcp_servers": entry.manifest.mcp_servers,
             "mcp_servers_mode": if entry.manifest.mcp_servers.is_empty() { "all" } else { "allowlist" },
             "fallback_models": entry.manifest.fallback_models,
+            "auto_evolve": entry.manifest.auto_evolve,
             "web_search_augmentation": entry.manifest.web_search_augmentation,
         })),
     )
@@ -4830,6 +4831,13 @@ pub async fn patch_agent(
                 );
             }
         }
+    }
+
+    if let Some(auto_evolve) = body.get("auto_evolve").and_then(|v| v.as_bool()) {
+        let _ = state
+            .kernel
+            .agent_registry()
+            .update_auto_evolve(agent_id, auto_evolve);
     }
 
     // Persist updated entry to SQLite (skipped when the schedule branch

--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -1582,3 +1582,69 @@ async fn test_set_mode_invalid_id_returns_400() {
     assert_eq!(status, StatusCode::BAD_REQUEST, "body={body:?}");
     assert_eq!(body["code"], "invalid_agent_id");
 }
+
+// ---------------------------------------------------------------------------
+// PATCH /api/agents/{id} — auto_evolve field
+//
+// Pins the contract: toggling auto_evolve off via PATCH must be reflected
+// by the subsequent GET, confirming the field is persisted and serialised in
+// the agent response.
+// ---------------------------------------------------------------------------
+
+/// PATCH `{"auto_evolve": false}` then GET — the response must contain
+/// `auto_evolve: false`.  Also verifies round-trip back to `true`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_agent_auto_evolve_persists() {
+    let h = boot(TEST_TOKEN).await;
+    let id = spawn_named(&h.state, "auto-evolve-target");
+
+    // Default: auto_evolve should be true on a freshly spawned agent.
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{}", id))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["auto_evolve"], true,
+        "expected auto_evolve=true by default, got {:?}",
+        body["auto_evolve"]
+    );
+
+    // PATCH auto_evolve to false.
+    let (status, _) = send(
+        h.app.clone(),
+        patch_json(
+            &format!("/api/agents/{}", id),
+            serde_json::json!({"auto_evolve": false}),
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Read-after-write — GET must reflect the new value.
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{}", id))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["auto_evolve"], false,
+        "expected auto_evolve=false after PATCH, got {:?}",
+        body["auto_evolve"]
+    );
+
+    // Round-trip: restore auto_evolve to true.
+    let (status, _) = send(
+        h.app.clone(),
+        patch_json(
+            &format!("/api/agents/{}", id),
+            serde_json::json!({"auto_evolve": true}),
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{}", id))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["auto_evolve"], true,
+        "expected auto_evolve=true after re-enable PATCH, got {:?}",
+        body["auto_evolve"]
+    );
+}

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -499,15 +499,6 @@ impl AgentRegistry {
     /// Update an agent's schedule mode (Reactive / Periodic / Proactive /
     /// Continuous). Mutates the manifest only — the kernel-level wrapper
     /// `LibreFangKernel::set_agent_schedule` is what callers should use to
-    pub fn update_auto_evolve(&self, id: AgentId, auto_evolve: bool) -> LibreFangResult<()> {
-        self.with_entry_mut(id, |entry| {
-            entry.manifest.auto_evolve = auto_evolve;
-            entry.last_active = chrono::Utc::now();
-        })?;
-        self.notify_changed();
-        Ok(())
-    }
-
     /// also stop the prior background loop and start the new one so the
     /// runtime actually reflects the change without a daemon restart.
     pub fn update_schedule(
@@ -562,6 +553,16 @@ impl AgentRegistry {
     pub fn update_mcp_servers(&self, id: AgentId, servers: Vec<String>) -> LibreFangResult<()> {
         self.with_entry_mut(id, |entry| {
             entry.manifest.mcp_servers = servers;
+            entry.last_active = chrono::Utc::now();
+        })?;
+        self.notify_changed();
+        Ok(())
+    }
+
+    /// Update an agent's `auto_evolve` flag.
+    pub fn update_auto_evolve(&self, id: AgentId, auto_evolve: bool) -> LibreFangResult<()> {
+        self.with_entry_mut(id, |entry| {
+            entry.manifest.auto_evolve = auto_evolve;
             entry.last_active = chrono::Utc::now();
         })?;
         self.notify_changed();

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -499,6 +499,15 @@ impl AgentRegistry {
     /// Update an agent's schedule mode (Reactive / Periodic / Proactive /
     /// Continuous). Mutates the manifest only — the kernel-level wrapper
     /// `LibreFangKernel::set_agent_schedule` is what callers should use to
+    pub fn update_auto_evolve(&self, id: AgentId, auto_evolve: bool) -> LibreFangResult<()> {
+        self.with_entry_mut(id, |entry| {
+            entry.manifest.auto_evolve = auto_evolve;
+            entry.last_active = chrono::Utc::now();
+        })?;
+        self.notify_changed();
+        Ok(())
+    }
+
     /// also stop the prior background loop and start the new one so the
     /// runtime actually reflects the change without a daemon restart.
     pub fn update_schedule(


### PR DESCRIPTION
## Summary

Expose the existing `auto_evolve` manifest field in the API and dashboard:

- Add `auto_evolve` to `GET /api/agents/{id}` response
- Add `auto_evolve` to `PATCH /api/agents/{id}` handler (via `update_auto_evolve` on `AgentRegistry`)
- Add toggle switch in the Skills tab of agent detail panel — instant save via PATCH
- `pnpm typecheck` zero errors, `cargo check` clean

## Test plan

- [ ] Open agent detail → Skills tab → auto-evolve toggle visible
- [ ] Toggle off → toast "Auto-evolve disabled" → API returns `auto_evolve: false`
- [ ] Toggle on → toast "Auto-evolve enabled" → API returns `auto_evolve: true`
- [ ] `cargo check --workspace --lib` clean
- [ ] `pnpm typecheck` zero errors

Refs: #5675