### PR TITLE
fix(runtime): tool_runner knowledge — confidence clamp, input validation, result limits, property bounds

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/knowledge.rs
+++ b/crates/librefang-runtime/src/tool_runner/knowledge.rs
@@ -11,9 +11,13 @@ use super::require_kernel_typed;
 use crate::kernel_handle::prelude::*;
 use std::sync::Arc;
 
+const MAX_PROPERTY_COUNT: usize = 50;
+const MAX_PROPERTY_VALUE_LEN: usize = 4096;
+
 fn parse_entity_type(s: &str) -> librefang_types::memory::EntityType {
     use librefang_types::memory::EntityType;
-    match s.to_lowercase().as_str() {
+    let lower = s.to_lowercase();
+    match lower.as_str() {
         "person" => EntityType::Person,
         "organization" | "org" => EntityType::Organization,
         "project" => EntityType::Project,
@@ -22,13 +26,14 @@ fn parse_entity_type(s: &str) -> librefang_types::memory::EntityType {
         "location" => EntityType::Location,
         "document" | "doc" => EntityType::Document,
         "tool" => EntityType::Tool,
-        other => EntityType::Custom(other.to_string()),
+        _ => EntityType::Custom(s.to_string()),
     }
 }
 
 fn parse_relation_type(s: &str) -> librefang_types::memory::RelationType {
     use librefang_types::memory::RelationType;
-    match s.to_lowercase().as_str() {
+    let lower = s.to_lowercase();
+    match lower.as_str() {
         "works_at" | "worksat" => RelationType::WorksAt,
         "knows_about" | "knowsabout" | "knows" => RelationType::KnowsAbout,
         "related_to" | "relatedto" | "related" => RelationType::RelatedTo,
@@ -39,7 +44,7 @@ fn parse_relation_type(s: &str) -> librefang_types::memory::RelationType {
         "part_of" | "partof" => RelationType::PartOf,
         "uses" => RelationType::Uses,
         "produces" => RelationType::Produces,
-        other => RelationType::Custom(other.to_string()),
+        _ => RelationType::Custom(s.to_string()),
     }
 }
 
@@ -48,20 +53,42 @@ pub(super) async fn tool_knowledge_add_entity(
     kernel: Option<&Arc<dyn KernelHandle>>,
 ) -> ToolResult {
     let kh = require_kernel_typed(kernel)?;
-    let name = input["name"]
+
+    let name_raw = input["name"]
         .as_str()
         .ok_or(ToolError::MissingParameter("name"))?;
+    let name = name_raw.trim();
+    if name.is_empty() {
+        return Err(ToolError::InvalidParameter {
+            name: "name",
+            reason: "must not be empty".to_string(),
+        });
+    }
     let entity_type_str = input["entity_type"]
         .as_str()
         .ok_or(ToolError::MissingParameter("entity_type"))?;
-    let properties = input
+    let properties: std::collections::HashMap<String, serde_json::Value> = input
         .get("properties")
         .and_then(|v| v.as_object())
-        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .map(|m| {
+            m.iter()
+                .take(MAX_PROPERTY_COUNT)
+                .map(|(k, v)| {
+                    let capped = if let Some(s) = v.as_str() {
+                        serde_json::Value::String(
+                            s.chars().take(MAX_PROPERTY_VALUE_LEN).collect(),
+                        )
+                    } else {
+                        v.clone()
+                    };
+                    (k.clone(), capped)
+                })
+                .collect()
+        })
         .unwrap_or_default();
 
     let entity = librefang_types::memory::Entity {
-        id: String::new(), // kernel/store assigns a real ID
+        id: String::new(),
         entity_type: parse_entity_type(entity_type_str),
         name: name.to_string(),
         properties,
@@ -90,11 +117,26 @@ pub(super) async fn tool_knowledge_add_relation(
     let target = input["target"]
         .as_str()
         .ok_or(ToolError::MissingParameter("target"))?;
-    let confidence = input["confidence"].as_f64().unwrap_or(1.0) as f32;
-    let properties = input
+    let confidence_raw = input["confidence"].as_f64().unwrap_or(1.0) as f32;
+    let confidence = confidence_raw.clamp(0.0, 1.0);
+    let properties: std::collections::HashMap<String, serde_json::Value> = input
         .get("properties")
         .and_then(|v| v.as_object())
-        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .map(|m| {
+            m.iter()
+                .take(MAX_PROPERTY_COUNT)
+                .map(|(k, v)| {
+                    let capped = if let Some(s) = v.as_str() {
+                        serde_json::Value::String(
+                            s.chars().take(MAX_PROPERTY_VALUE_LEN).collect(),
+                        )
+                    } else {
+                        v.clone()
+                    };
+                    (k.clone(), capped)
+                })
+                .collect()
+        })
         .unwrap_or_default();
 
     let relation = librefang_types::memory::Relation {
@@ -120,17 +162,33 @@ pub(super) async fn tool_knowledge_query(
     kernel: Option<&Arc<dyn KernelHandle>>,
 ) -> ToolResult {
     let kh = require_kernel_typed(kernel)?;
-    let source = input["source"].as_str().map(|s| s.to_string());
-    let target = input["target"].as_str().map(|s| s.to_string());
+    let source = input["source"]
+        .as_str()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let target = input["target"]
+        .as_str()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
     let relation = input["relation"].as_str().map(parse_relation_type);
-    // Cap depth to prevent LLM-triggered DoS via exponential graph
-    // traversal. Knowledge graphs rarely benefit from depth > 5 and
-    // the backend traversal is O(branching_factor^depth).
+
+    if source.is_none() && target.is_none() && relation.is_none() {
+        return Err(ToolError::InvalidParameter {
+            name: "source/target/relation",
+            reason: "at least one of 'source', 'target', or 'relation' is required".to_string(),
+        });
+    }
+
     const MAX_KNOWLEDGE_DEPTH: u64 = 10;
+    const DEFAULT_RESULT_LIMIT: usize = 50;
     let max_depth = input["max_depth"]
         .as_u64()
         .unwrap_or(1)
         .min(MAX_KNOWLEDGE_DEPTH) as u32;
+    let limit = input["limit"]
+        .as_u64()
+        .unwrap_or(DEFAULT_RESULT_LIMIT as u64)
+        .min(DEFAULT_RESULT_LIMIT as u64 * 2) as usize;
 
     let pattern = librefang_types::memory::GraphPattern {
         source,
@@ -147,9 +205,13 @@ pub(super) async fn tool_knowledge_query(
         return Ok("No matching knowledge graph entries found.".to_string());
     }
 
-    let mut output = format!("Found {} match(es):\n", matches.len());
-    for m in &matches {
-        output.push_str(&format!(
+    let shown = matches.len().min(limit);
+    let mut output = String::with_capacity(256 * shown);
+    output.push_str(&format!("Found {} match(es) (showing {}):\n", matches.len(), shown));
+    for m in matches.iter().take(limit) {
+        use std::fmt::Write;
+        let _ = write!(
+            output,
             "\n  {} ({:?}) --[{:?} ({:.0}%)]--> {} ({:?})",
             m.source.name,
             m.source.entity_type,
@@ -157,7 +219,7 @@ pub(super) async fn tool_knowledge_query(
             m.relation.confidence * 100.0,
             m.target.name,
             m.target.entity_type,
-        ));
+        );
     }
     Ok(output)
 }


### PR DESCRIPTION
## Type
- [x] Bug fix

## Summary

Hardens `tool_runner/knowledge.rs` with 7 fixes: confidence range check, empty input rejection, result limiting, property bounds, conditional lowercase, pre-allocated output.

## Changes

- Confidence clamped to 0.0–1.0 via `.clamp(0.0, 1.0)`
- Query strings trimmed and empty values rejected
- `DEFAULT_RESULT_LIMIT = 50`, configurable via `limit` param, capped at 2x default
- Properties bounded: max 50 keys, string values capped at 4096 chars
- `to_lowercase()` called once into binding — `Custom` variant preserves original case
- `String::with_capacity` + `write!` replaces `format!` + `push_str` in loop

## Attribution
- [x] This PR preserves author attribution

## Testing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p librefang-runtime --lib` — 1795 passed, 0 failed

## Security
- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries