### PR TITLE
fix(runtime): tool_runner spill — config-based threshold, validation, fast-path

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/spill.rs
+++ b/crates/librefang-runtime/src/tool_runner/spill.rs
@@ -9,18 +9,21 @@ pub(crate) fn resolve_spill_config(
     spill_threshold_bytes: u64,
     max_artifact_bytes: u64,
 ) -> (u64, u64) {
-    (
-        if spill_threshold_bytes == 0 {
-            16_384 // ToolResultsConfig::default().spill_threshold_bytes
-        } else {
-            spill_threshold_bytes
-        },
-        if max_artifact_bytes == 0 {
-            crate::artifact_store::DEFAULT_MAX_ARTIFACT_BYTES
-        } else {
-            max_artifact_bytes
-        },
-    )
+    let threshold = if spill_threshold_bytes == 0 {
+        librefang_types::config::ToolResultsConfig::default().spill_threshold_bytes
+    } else {
+        spill_threshold_bytes
+    };
+    let max = if max_artifact_bytes == 0 {
+        crate::artifact_store::DEFAULT_MAX_ARTIFACT_BYTES
+    } else {
+        max_artifact_bytes
+    };
+    if threshold > max {
+        (max, max)
+    } else {
+        (threshold, max)
+    }
 }
 
 /// Apply artifact spill to a tool-result string, returning a compact stub
@@ -33,10 +36,12 @@ pub(super) fn spill_or_passthrough(
     threshold: u64,
     max_artifact: u64,
 ) -> String {
-    let bytes = body.as_bytes();
+    if body.len() as u64 <= threshold {
+        return body;
+    }
     if let Some(stub) = crate::artifact_store::maybe_spill(
         tool_name,
-        bytes,
+        body.as_bytes(),
         threshold,
         max_artifact,
         &crate::artifact_store::default_artifact_storage_dir(),


### PR DESCRIPTION
## Type
- [x] Bug fix
- [x] Refactor / Performance

## Summary

Fixes 3 issues in `tool_runner/spill.rs`: replaces magic number, adds threshold validation, adds early-return fast-path.

## Changes

- Hardcoded `16_384` replaced with `ToolResultsConfig::default().spill_threshold_bytes` — single source of truth
- `resolve_spill_config` clamps `threshold` to `max` when threshold > max
- `spill_or_passthrough` returns early when `body.len() <= threshold` — skips storage dir allocation

## Attribution
- [x] This PR preserves author attribution

## Testing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p librefang-runtime --lib` — 1795 passed, 0 failed

## Security
- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries