### PR TITLE
fix(runtime): tool_runner artifact — spawn_blocking, explicit errors, usize safe, zero-length reject

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/artifact.rs
+++ b/crates/librefang-runtime/src/tool_runner/artifact.rs
@@ -13,13 +13,44 @@ pub(super) async fn tool_read_artifact(
         .as_str()
         .ok_or("Missing required parameter 'handle'")?;
 
-    let offset = input["offset"].as_u64().unwrap_or(0) as usize;
-    let length = input["length"]
-        .as_u64()
-        .unwrap_or(4096)
-        .min(crate::artifact_store::MAX_READ_LENGTH as u64) as usize;
+    let offset: usize = match input.get("offset") {
+        Some(v) => v
+            .as_u64()
+            .ok_or_else(|| "Parameter 'offset' must be a non-negative integer".to_string())
+            .and_then(|n| {
+                usize::try_from(n)
+                    .map_err(|_| "Parameter 'offset' is too large for this platform".to_string())
+            })?,
+        None => 0,
+    };
 
-    let bytes = crate::artifact_store::read(handle, offset, length, artifact_dir)?;
+    let length: usize = match input.get("length") {
+        Some(v) => {
+            let n = v
+                .as_u64()
+                .ok_or_else(|| "Parameter 'length' must be a non-negative integer".to_string())
+                .and_then(|n| {
+                    usize::try_from(n).map_err(|_| {
+                        "Parameter 'length' is too large for this platform".to_string()
+                    })
+                })?;
+            if n == 0 {
+                return Err("Parameter 'length' must be greater than 0".to_string());
+            }
+            n
+        }
+        None => 4096,
+    };
+
+    let length = length.min(crate::artifact_store::MAX_READ_LENGTH);
+
+    let handle_owned = handle.to_string();
+    let dir_owned = artifact_dir.to_path_buf();
+    let bytes = tokio::task::spawn_blocking(move || {
+        crate::artifact_store::read(&handle_owned, offset, length, &dir_owned)
+    })
+    .await
+    .map_err(|e| format!("read_artifact task panicked: {e}"))??;
 
     if bytes.is_empty() {
         return Ok(format!(


### PR DESCRIPTION
## Type
- [x] Bug fix

## Summary

Hardens `tool_runner/artifact.rs`: async-safe I/O, explicit error messages, safe integer conversion, zero-length rejection.

## Changes

- Sync `artifact_store::read` wrapped in `tokio::task::spawn_blocking` — no blocking in async
- Bad offset/length returns explicit error instead of silent default
- `u64 as usize` replaced with `usize::try_from()` — safe on 32-bit
- `length=0` rejected with explicit error message

## Attribution
- [x] This PR preserves author attribution

## Testing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p librefang-runtime --lib` — 1795 passed, 0 failed

## Security
- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries