### PR TITLE
fix(channels): skip bridge-side formatting for sidecar adapters (fixes #5795)

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -2740,7 +2740,11 @@ async fn send_response(
         text_len = text.len(),
         "Sending response to channel"
     );
-    let formatted = formatter::format_for_channel(&text, output_format);
+    let formatted = if adapter.owns_formatting() {
+        text
+    } else {
+        formatter::format_for_channel(&text, output_format)
+    };
     let content = ChannelContent::Text(formatted);
 
     let result = if let Some(tid) = thread_id {

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -1670,6 +1670,10 @@ impl ChannelAdapter for SidecarAdapter {
         .await
     }
 
+    fn owns_formatting(&self) -> bool {
+        true
+    }
+
     fn supports_streaming(&self) -> bool {
         self.has_cap("streaming")
     }

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -880,6 +880,15 @@ pub trait ChannelAdapter: Send + Sync {
         self.send(user, content).await
     }
 
+    /// Whether this adapter owns message formatting (Markdown → platform-native).
+    ///
+    /// Sidecar adapters return `true` because the Python sidecar process
+    /// applies its own `markdown_to_*` conversion. The Rust bridge must
+    /// send raw Markdown to avoid double-formatting.
+    fn owns_formatting(&self) -> bool {
+        false
+    }
+
     /// Whether this adapter supports streaming output (progressive message updates).
     ///
     /// When true, the bridge will use `send_streaming()` instead of `send()` for


### PR DESCRIPTION
## Summary

Sidecar adapters (Telegram, Matrix, etc.) apply their own Markdown-to-platform-native conversion. The Rust bridge was also calling `format_for_channel()` on non-streaming paths, causing **double formatting**: Markdown→HTML in Rust, then the sidecar's `_escape_html()` converted the HTML tags to `&lt;`/`&gt;` entities, making them display as literal `<b>bold</b>` text.

The streaming path was already correct — raw deltas bypass `format_for_channel()`.

## Changes (3 files, 18 lines)

- **`types.rs`**: Add `owns_formatting()` to `ChannelAdapter` trait (default `false`). Sidecars that do their own formatting return `true`.
- **`sidecar.rs`**: `SidecarAdapter` returns `true` for `owns_formatting()`.
- **`bridge.rs`**: `send_response()` skips `format_for_channel()` when `adapter.owns_formatting()` is `true`, sending raw Markdown for the sidecar to convert.

## Root cause

Documented in the sidecar itself at `telegram.py:617`: *"Daemon sends raw agent Markdown; the sidecar owns formatting now."* But `send_response` was not updated after the sidecar migration — it still called `format_for_channel()`.

## Affected paths (non-streaming)

Bot commands, error messages, auto-reply, multimodal responses, rate-limit messages, streaming fallback, access denied.

## Test plan

- [ ] `cargo check --workspace --lib` clean
- [ ] `cargo clippy -p librefang-channels --all-targets -- -D warnings` clean
- [ ] Send `/help` to Telegram bot → no raw HTML tags visible
- [ ] Send a message that triggers non-streaming response → formatting renders correctly
- [ ] Streaming responses continue to work (unchanged path)

Fixes: #5795