### PR TITLE
fix(api): return forward-slash relative path from registry/content on Windows

### DIFF
--- a/crates/librefang-api/src/routes/registry.rs
+++ b/crates/librefang-api/src/routes/registry.rs
@@ -326,11 +326,25 @@ async fn create_registry_content(
         .unwrap_or_else(|_| {
             std::path::PathBuf::from(target.file_name().unwrap_or(target.as_os_str()))
         });
+    // Render with forward-slash separators regardless of host OS — this
+    // is a JSON API response and the dashboard / SDKs expect a
+    // platform-independent shape (`providers/openai.toml`, not
+    // `providers\openai.toml`). `Path::display()` uses the platform
+    // separator, which produced backslashes on Windows and broke the
+    // `registry_content_path_test` regression tests.
+    let relative_path_str = relative_path
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => s.to_str(),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/");
     Json(serde_json::json!({
         "ok": true,
         "content_type": content_type,
         "identifier": identifier,
-        "path": relative_path.display().to_string(),
+        "path": relative_path_str,
     }))
     .into_response()
 }


### PR DESCRIPTION
## Summary

Fixes the Windows CI failure on `main` (run [26407058140](https://github.com/librefang/librefang/actions/runs/26407058140)) where two `registry_content_path_test` cases panicked on the Windows shards.

`POST /api/registry/content/<type>` rendered its response `path` field with `relative_path.display().to_string()`. `Path::display()` uses the host separator, so on Windows the response was `providers\openai.toml` instead of the canonical API-contract `providers/openai.toml`.

Failing tests on `windows-latest`:

- `librefang-api::registry_content_path_test::registry_content_path_is_relative_not_absolute` (asserts `Some("providers/test-provider-abs-path-leak.toml")`)
- `librefang-api::registry_content_path_test::registry_content_accepts_dotted_and_dashed_identifiers` (asserts `Some("providers/my.provider-name_1.toml")`)

## Fix

Replace the `display()` rendering with an explicit forward-slash join of the `Normal` path components. The relative path is built by `target.strip_prefix(home_dir)`, so the components are always `Normal` (no `..`, no root, no prefix), and component names cannot contain a separator on any platform — making the join lossless.

Behaviour on Unix is unchanged (`display()` already emits `/`); only the Windows backslash case is corrected.

## Scope

Other `display().to_string()` call sites in `crates/librefang-api/src/routes/` return **absolute** on-disk paths (`home_dir`, plugin file paths via `plugins.rs`, etc.). Those are intentionally OS-native — the dashboard renders them verbatim and no test pins a forward-slash form. Out of scope for this PR.

The Ubuntu shard 2/4 failure in the same CI run (`No space left on device` on the runner's `_diag` directory) is a GitHub infrastructure issue, not a code regression — unaffected by this change.

## Verification

- Compile/test was not run locally: this host has no native cargo and the sanctioned `Dockerfile.rust-dev` flow was blocked because the local container runtime (OrbStack) would not launch from the agent shell. The change is platform-agnostic source — Linux/macOS behaviour is byte-identical to before — so the CI Windows shard is the actual verdict for the fix.
- The two existing regression tests already encode the expected contract; CI on this branch will confirm both pass on Windows shard 1/2 (and continue to pass on every other shard).

## Out-of-scope follow-ups

None.
