### PR TITLE
fix(channels): skip Markdown→HTML conversion for sidecar adapters (#5795)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -641,7 +641,7 @@
         "filename": "crates/librefang-api/src/routes/registry.rs",
         "hashed_secret": "4e5111dafe7d9739f9228906d90cf421d5ec5371",
         "is_verified": false,
-        "line_number": 439
+        "line_number": 453
       }
     ],
     "crates/librefang-api/src/routes/terminal.rs": [
@@ -1433,7 +1433,7 @@
         "filename": "crates/librefang-channels/src/sidecar.rs",
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_verified": false,
-        "line_number": 2680
+        "line_number": 2692
       }
     ],
     "crates/librefang-cli/src/main.rs": [
@@ -4038,5 +4038,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-26T10:16:51Z"
+  "generated_at": "2026-05-27T23:25:26Z"
 }

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -2727,6 +2727,11 @@ async fn resolve_prefix_chunk(
 }
 
 /// Send a response, applying output formatting and optional threading.
+///
+/// Formatting is skipped when `adapter.owns_formatting()` returns `true` (e.g.
+/// sidecar adapters such as Telegram and Matrix). Those adapters apply their own
+/// Markdown→HTML conversion internally; pre-converting here would cause
+/// double-escaping and visible raw HTML tags on the platform. See issue #5795.
 async fn send_response(
     adapter: &dyn ChannelAdapter,
     user: &ChannelUser,
@@ -2740,7 +2745,13 @@ async fn send_response(
         text_len = text.len(),
         "Sending response to channel"
     );
-    let formatted = formatter::format_for_channel(&text, output_format);
+    // Sidecar adapters own formatting — forward raw Markdown.
+    // In-process adapters receive the channel-converted form.
+    let formatted = if adapter.owns_formatting() {
+        text
+    } else {
+        formatter::format_for_channel(&text, output_format)
+    };
     let content = ChannelContent::Text(formatted);
 
     let result = if let Some(tid) = thread_id {
@@ -6940,6 +6951,12 @@ mod tests {
             OutputFormat::PlainText
         );
     }
+
+    // Regression tests for #5795 (double formatting on sidecar paths) live in
+    // crates/librefang-channels/tests/bridge_integration_test.rs — the
+    // channel-policy pre-commit hook scans src/*.rs and would flag a test-only
+    // adapter impl here as an in-process adapter violation.  The tests/ directory
+    // is outside src/ and is not subject to that policy check.
 
     #[test]
     fn test_apply_agent_prefix_off_is_identity() {

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -1674,6 +1674,18 @@ impl ChannelAdapter for SidecarAdapter {
         self.has_cap("streaming")
     }
 
+    /// Sidecar adapters own Markdown→platform formatting internally.
+    ///
+    /// The Python/JS sidecar process applies its own `markdown_to_*_html`
+    /// conversion (e.g. `telegram.py:_format_and_sanitize`,
+    /// `matrix.py:markdown_to_matrix_html`). The daemon must forward raw
+    /// agent Markdown — not pre-converted HTML — to avoid double-escaping
+    /// (`<b>bold</b>` → `&lt;b&gt;bold&lt;/b&gt;` → literal tags rendered
+    /// by Telegram / Matrix). See issue #5795.
+    fn owns_formatting(&self) -> bool {
+        true
+    }
+
     async fn send_streaming(
         &self,
         user: &ChannelUser,
@@ -2804,6 +2816,14 @@ mod tests {
         // already taken.
         assert!(a.typing_events().is_some());
         assert!(a.typing_events().is_none(), "receiver handed out once");
+
+        // Regression: #5795 — sidecar adapters must own formatting so the
+        // bridge does not pre-convert Markdown to HTML before forwarding.
+        assert!(
+            a.owns_formatting(),
+            "SidecarAdapter must return owns_formatting() = true so send_response \
+             skips format_for_channel and forwards raw Markdown to the sidecar process"
+        );
     }
 
     #[tokio::test]

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -941,6 +941,25 @@ pub trait ChannelAdapter: Send + Sync {
     fn account_id(&self) -> Option<&str> {
         None
     }
+
+    /// Whether this adapter owns Markdown→platform formatting internally.
+    ///
+    /// When `true`, `send_response` in the bridge forwards the raw agent
+    /// Markdown directly to the adapter without applying `format_for_channel`.
+    /// The adapter (or its sidecar process) is then solely responsible for
+    /// converting Markdown to the platform's native markup.
+    ///
+    /// Sidecar adapters (Telegram, Matrix, WeCom, …) return `true` because
+    /// their Python/JS process applies its own `markdown_to_*_html` pass.
+    /// Sending pre-converted HTML to the sidecar would cause double-escaping
+    /// (e.g. `<b>bold</b>` → `&lt;b&gt;bold&lt;/b&gt;`) and show literal
+    /// HTML tags to end users.
+    ///
+    /// In-process adapters (Slack, custom webhook adapters) return the default
+    /// `false` and receive formatted output from the bridge as before.
+    fn owns_formatting(&self) -> bool {
+        false
+    }
 }
 
 /// Split a message into chunks of at most `max_len` characters,

--- a/crates/librefang-channels/tests/bridge_integration_test.rs
+++ b/crates/librefang-channels/tests/bridge_integration_test.rs
@@ -140,6 +140,89 @@ impl ChannelAdapter for MockAdapter {
 }
 
 // ---------------------------------------------------------------------------
+// Sidecar Mock Adapter — like MockAdapter but owns_formatting() = true
+//
+// Used by the #5795 regression test to verify that the bridge forwards
+// raw Markdown to sidecar adapters instead of pre-converting to HTML.
+// ---------------------------------------------------------------------------
+
+struct SidecarMockAdapter {
+    name: String,
+    channel_type: ChannelType,
+    rx: Mutex<Option<mpsc::Receiver<ChannelMessage>>>,
+    sent: Arc<Mutex<Vec<(String, String)>>>,
+    shutdown_tx: watch::Sender<bool>,
+}
+
+impl SidecarMockAdapter {
+    fn new(name: &str, channel_type: ChannelType) -> (Arc<Self>, mpsc::Sender<ChannelMessage>) {
+        let (tx, rx) = mpsc::channel(256);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let adapter = Arc::new(Self {
+            name: name.to_string(),
+            channel_type,
+            rx: Mutex::new(Some(rx)),
+            sent: Arc::new(Mutex::new(Vec::new())),
+            shutdown_tx,
+        });
+        (adapter, tx)
+    }
+
+    fn get_sent(&self) -> Vec<(String, String)> {
+        self.sent.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ChannelAdapter for SidecarMockAdapter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn channel_type(&self) -> ChannelType {
+        self.channel_type.clone()
+    }
+
+    /// Sidecar adapters own Markdown→HTML formatting — the bridge must NOT
+    /// pre-convert before forwarding. See issue #5795.
+    fn owns_formatting(&self) -> bool {
+        true
+    }
+
+    async fn start(
+        &self,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = ChannelMessage> + Send>>,
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
+        let rx = self
+            .rx
+            .lock()
+            .unwrap()
+            .take()
+            .expect("start() called more than once");
+        let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+        Ok(Box::pin(stream))
+    }
+
+    async fn send(
+        &self,
+        user: &ChannelUser,
+        content: ChannelContent,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if let ChannelContent::Text(t) = content {
+            self.sent.lock().unwrap().push((user.platform_id.clone(), t));
+        }
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let _ = self.shutdown_tx.send(true);
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Mock Kernel Handle — echoes messages, serves agent lists
 // ---------------------------------------------------------------------------
 
@@ -2546,6 +2629,110 @@ async fn test_approval_listener_binding_respects_account_id_scope() {
     assert!(
         sent_b.is_empty(),
         "bot-b has no matching binding (account_id mismatch); approval must not leak there, got: {sent_b:?}"
+    );
+
+    manager.stop().await;
+}
+
+// ---------------------------------------------------------------------------
+// Regression: #5795 — double formatting on non-streaming sidecar paths
+// ---------------------------------------------------------------------------
+//
+// Before the fix, send_response always called format_for_channel regardless
+// of whether the adapter owned formatting.  For Telegram (TelegramHtml format),
+// "**bold**" was converted to "<b>bold</b>" before reaching the Python sidecar,
+// which then HTML-escaped it to "&lt;b&gt;bold&lt;/b&gt;" — making literal
+// HTML tags visible on the platform.
+//
+// The fix: ChannelAdapter::owns_formatting() (default false).  SidecarAdapter
+// overrides to true.  send_response forwards raw Markdown when true.
+//
+// These tests verify the end-to-end bridge dispatch path: inject a Markdown
+// message, let the MockHandle echo it back, and assert what the adapter receives.
+
+/// Sidecar adapter (owns_formatting = true, Telegram channel):
+/// the bridge must forward the raw Markdown echo — not pre-converted HTML.
+/// Regression guard for #5795.
+#[tokio::test]
+async fn test_bridge_sidecar_adapter_receives_raw_markdown_not_html() {
+    let agent_id = AgentId::new();
+    let handle = Arc::new(MockHandle::new(vec![(agent_id, "echo-bot".to_string())]));
+    let router = Arc::new(AgentRouter::new());
+    router.set_user_default("tg-user".to_string(), agent_id);
+
+    // SidecarMockAdapter: owns_formatting() = true, Telegram channel type.
+    // The bridge picks TelegramHtml as the default format for "telegram",
+    // but must skip it because the adapter signals it owns formatting.
+    let (adapter, tx) = SidecarMockAdapter::new("telegram-sidecar", ChannelType::Telegram);
+    let adapter_ref = adapter.clone();
+
+    let mut manager = BridgeManager::new(handle.clone(), router);
+    manager.start_adapter(adapter.clone()).await.unwrap();
+
+    // Inject a message with Markdown bold syntax.
+    tx.send(make_text_msg(ChannelType::Telegram, "tg-user", "**bold**"))
+        .await
+        .unwrap();
+
+    wait_until("sidecar echo dispatched", || {
+        !adapter_ref.get_sent().is_empty()
+    })
+    .await;
+
+    let sent = adapter_ref.get_sent();
+    assert_eq!(sent.len(), 1, "expected one response from sidecar adapter");
+
+    let received_text = &sent[0].1;
+    // The MockHandle echoes: "Echo: **bold**"
+    // With the fix:    sidecar receives "Echo: **bold**" (raw Markdown)
+    // Without the fix: sidecar receives "Echo: <b>bold</b>" (pre-converted HTML)
+    assert!(
+        !received_text.contains("<b>"),
+        "sidecar adapter must not receive pre-converted HTML — double-formatting regression (#5795); got: {received_text:?}"
+    );
+    assert!(
+        received_text.contains("**bold**"),
+        "sidecar adapter must receive raw Markdown **bold** syntax; got: {received_text:?}"
+    );
+
+    manager.stop().await;
+}
+
+/// In-process adapter (owns_formatting = false, Slack channel):
+/// the bridge converts Markdown to Slack mrkdwn before sending.
+/// Verifies we did not regress in-process adapters while fixing #5795.
+#[tokio::test]
+async fn test_bridge_in_process_adapter_converts_markdown_to_channel_format() {
+    let agent_id = AgentId::new();
+    let handle = Arc::new(MockHandle::new(vec![(agent_id, "slack-bot".to_string())]));
+    let router = Arc::new(AgentRouter::new());
+    router.set_user_default("slack-user".to_string(), agent_id);
+
+    // Standard MockAdapter: owns_formatting() = false (default), Slack channel.
+    // The bridge converts "**bold**" → "*bold*" (Slack mrkdwn) before sending.
+    let (adapter, tx) = MockAdapter::new("slack-adapter", ChannelType::Slack);
+    let adapter_ref = adapter.clone();
+
+    let mut manager = BridgeManager::new(handle.clone(), router);
+    manager.start_adapter(adapter.clone()).await.unwrap();
+
+    tx.send(make_text_msg(ChannelType::Slack, "slack-user", "**bold**"))
+        .await
+        .unwrap();
+
+    wait_until("slack echo dispatched", || {
+        !adapter_ref.get_sent().is_empty()
+    })
+    .await;
+
+    let sent = adapter_ref.get_sent();
+    assert_eq!(sent.len(), 1, "expected one response from in-process adapter");
+
+    let received_text = &sent[0].1;
+    // MockHandle echoes "Echo: **bold**"; Slack format converts ** → *
+    assert!(
+        !received_text.contains("**bold**"),
+        "in-process Slack adapter must not receive raw Markdown **; got: {received_text:?}"
     );
 
     manager.stop().await;


### PR DESCRIPTION
## Root cause

`bridge.rs:send_response()` (line 2730) always called `format_for_channel(text, output_format)` before forwarding to the adapter. For Telegram (default format `TelegramHtml`) and Matrix, this converted `**bold**` → `<b>bold</b>`. The Python sidecar then applied its own `markdown_to_*_html` pass whose first step is `_escape_html`, converting `<` → `&lt;`. Telegram/Matrix received `&lt;b&gt;bold&lt;/b&gt;` with `parse_mode=HTML` and rendered literal tags.

The sidecar contract (`telegram.py:617`): "Daemon sends raw agent Markdown; the sidecar owns formatting now." This was never honoured by `send_response`.

Streaming was not affected because raw deltas bypass `format_for_channel` entirely.

## Affected non-streaming paths (all fixed)

- Bot commands (`/help`, `/model`, etc.)
- Error messages
- Auto-reply responses
- Multimodal responses (images, files, voice)
- Rate-limited responses
- Streaming fallback (when streaming fails)
- Access-denied messages

## Approach chosen

**Approach A**: add `fn owns_formatting(&self) -> bool` to `ChannelAdapter` trait (default `false`). `SidecarAdapter` overrides to `true`. `send_response` skips `format_for_channel` when the adapter owns formatting.

Chosen over Approach B (`OutputFormat::Markdown` for sidecars) because:
- Semantically correct — the method expresses the architectural contract, not just the format
- Catches all future sidecar adapters automatically via the override in `SidecarAdapter`
- Does not require threading the format decision through call sites that derive `output_format` from the channel type string

## Changes

- `crates/librefang-channels/src/types.rs`: add `owns_formatting()` to `ChannelAdapter` trait (default `false`) with doc comment explaining the sidecar contract
- `crates/librefang-channels/src/sidecar.rs`: override `owns_formatting()` → `true` in `SidecarAdapter`; extend `test_cap_gated_methods_default_without_ready` to assert `owns_formatting() == true`
- `crates/librefang-channels/src/bridge.rs`: `send_response` skips `format_for_channel` when `adapter.owns_formatting()` is `true`
- `crates/librefang-channels/tests/bridge_integration_test.rs`: add `SidecarMockAdapter` (owns_formatting = true) and two end-to-end regression tests:
  - `test_bridge_sidecar_adapter_receives_raw_markdown_not_html` — Telegram sidecar gets raw `**bold**`, not `<b>bold</b>`
  - `test_bridge_in_process_adapter_converts_markdown_to_channel_format` — Slack in-process adapter still gets converted mrkdwn

## Verification

`cargo check --workspace --lib` and `cargo test -p librefang-channels` were not runnable locally (no native toolchain; Docker volume out of disk space). The code was verified structurally:
- Hook: pre-commit passed (channel-policy, detect-secrets, CHANGELOG checks)
- CI will run `cargo nextest run --workspace -E 'kind(lib) | kind(bin)'` and the integration test shard

Fixes #5795
