### PR TITLE
fix(workflow): make step timeout errors actionable with remediation guidance

### DIFF
--- a/crates/librefang-kernel/src/workflow.rs
+++ b/crates/librefang-kernel/src/workflow.rs
@@ -2516,7 +2516,7 @@ impl WorkflowEngine {
                         .await
                         .map_err(|_| {
                             format!(
-                                "Step '{}' timed out after {}s",
+                                "Step '{}' timed out after {}s; LLM steps generating long output often need more time — raise `timeout_secs` for this step in your workflow definition or switch to a faster model",
                                 step.name, step.timeout_secs
                             )
                         })?
@@ -2537,7 +2537,7 @@ impl WorkflowEngine {
                     }
                     Err(_) => {
                         warn!(
-                            "Step '{}' timed out (skipping) after {}s",
+                            "Step '{}' timed out (skipping) after {}s; raise `timeout_secs` for this step or use a faster model",
                             step.name, step.timeout_secs
                         );
                         Ok(None)
@@ -2589,7 +2589,7 @@ impl WorkflowEngine {
                             }
                         }
                         Err(_) => {
-                            last_err = format!("timed out after {}s", step.timeout_secs);
+                            last_err = format!("timed out after {}s; raise `timeout_secs` for this step or use a faster model", step.timeout_secs);
                             if attempt < *max_retries {
                                 let sleep_dur = compute_retry_backoff(
                                     &last_err,
@@ -4086,7 +4086,7 @@ impl WorkflowEngine {
                             }
                             Err(_) => {
                                 let error_msg = format!(
-                                    "FanOut step '{}' timed out after {}s",
+                                    "FanOut step '{}' timed out after {}s; raise `timeout_secs` for this step or use a faster model",
                                     step_name, fan_step.timeout_secs
                                 );
                                 warn!(%error_msg);
@@ -12118,6 +12118,110 @@ name = "topic"
         assert_eq!(
             pending[1].0.id, run_a,
             "A's pause is newer — it must come second"
+        );
+    }
+
+    // -- #5743: step timeout error must be actionable -----------------------
+
+    /// The Fail-mode timeout error message must tell the operator HOW to fix
+    /// the problem: it must name `timeout_secs` so they know which knob to
+    /// turn, and mention that slow/local LLMs generating long output are the
+    /// common cause.
+    #[tokio::test]
+    async fn step_timeout_fail_message_is_actionable() {
+        let step = WorkflowStep {
+            name: "evaluator".to_string(),
+            agent: StepAgent::ByName {
+                name: "test-agent".to_string(),
+            },
+            prompt_template: "Evaluate: {{input}}".to_string(),
+            mode: StepMode::Sequential,
+            // 1s so the test completes quickly
+            timeout_secs: 1,
+            error_mode: ErrorMode::Fail,
+            output_var: None,
+            inherit_context: None,
+            depends_on: vec![],
+            session_mode: None,
+        };
+        let agent_id = AgentId::default();
+        let run_id = WorkflowRunId::new();
+        let cancel_notify: Arc<DashMap<WorkflowRunId, Arc<tokio::sync::Notify>>> =
+            Arc::new(DashMap::new());
+
+        // send_message that never resolves — simulates a slow LLM
+        let send_message = |_: AgentId, _: String, _: Option<SessionMode>| async {
+            // Park forever; the step timeout will fire first.
+            std::future::pending::<Result<(String, u64, u64), String>>().await
+        };
+
+        let result = WorkflowEngine::execute_step_with_error_mode(
+            &step,
+            agent_id,
+            "test prompt".to_string(),
+            &send_message,
+            run_id,
+            &cancel_notify,
+        )
+        .await;
+
+        let err = result.expect_err("a never-resolving send_message must time out");
+        assert!(
+            err.contains("timeout_secs"),
+            "timeout error must mention `timeout_secs` so operators know the knob to raise; got: {err:?}"
+        );
+        assert!(
+            err.contains("evaluator"),
+            "timeout error must name the failing step; got: {err:?}"
+        );
+        assert!(
+            err.contains('1'),
+            "timeout error must include the step's timeout value; got: {err:?}"
+        );
+    }
+
+    /// Skip-mode timeout emits a warn-level log and returns Ok(None) rather
+    /// than an error, but the logged string should also mention `timeout_secs`
+    /// for consistency. We verify the return value is Ok(None).
+    #[tokio::test]
+    async fn step_timeout_skip_mode_returns_none() {
+        let step = WorkflowStep {
+            name: "skippable".to_string(),
+            agent: StepAgent::ByName {
+                name: "test-agent".to_string(),
+            },
+            prompt_template: "{{input}}".to_string(),
+            mode: StepMode::Sequential,
+            timeout_secs: 1,
+            error_mode: ErrorMode::Skip,
+            output_var: None,
+            inherit_context: None,
+            depends_on: vec![],
+            session_mode: None,
+        };
+        let agent_id = AgentId::default();
+        let run_id = WorkflowRunId::new();
+        let cancel_notify: Arc<DashMap<WorkflowRunId, Arc<tokio::sync::Notify>>> =
+            Arc::new(DashMap::new());
+
+        let send_message = |_: AgentId, _: String, _: Option<SessionMode>| async {
+            std::future::pending::<Result<(String, u64, u64), String>>().await
+        };
+
+        let result = WorkflowEngine::execute_step_with_error_mode(
+            &step,
+            agent_id,
+            "prompt".to_string(),
+            &send_message,
+            run_id,
+            &cancel_notify,
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            Ok(None),
+            "Skip-mode timeout must return Ok(None) so the workflow continues"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Actionable timeout errors**: rewrite all four step-timeout message sites in `workflow.rs` (`ErrorMode::Fail`, `ErrorMode::Skip` warn, `ErrorMode::Retry` last_err, and FanOut) to explain the common cause (slow/local LLMs generating long output) and tell the operator exactly which knob to turn (`timeout_secs` in the workflow definition, or switch to a faster model).
- **Unit tests**: add `step_timeout_fail_message_is_actionable` and `step_timeout_skip_mode_returns_none` in the `#[cfg(test)]` module of `workflow.rs`, each driving `execute_step_with_error_mode` with a `std::future::pending` send_message and a 1s step timeout to verify the new message shape and Skip-mode return value.
- **Template investigation**: the "Brainstorm & Action Plan" (`brainstorm`) template is a metadata-only entry in `web/public/registry.json` (no `steps` field, no `timeout_secs`). The actual TOML is served by the remote marketplace — it is **not** bundled in this repo, so no in-repo step timeout can be raised. Operators who hit the 120s limit on that template must override `timeout_secs` in their local copy of the workflow definition.

## Verification

- `cargo check --workspace --lib` clean in the Docker dev image.
- `cargo test -p librefang-kernel --lib` passed locally (exit 0); local Docker run was killed by a shared-volume lock, so final confirmation defers to CI.
- No existing test asserted on the old `"Step '...' timed out after Ns"` string (verified by grep across workspace).
- The separate `"workflow run timed out after Ns (agent-side default_timeout_secs)"` message in `workflow_runner.rs` / `async_task_tracker_runtime_test.rs` is untouched — that is a different layer.

## Not changed

- **Global `default_timeout()` value (120s)** was deliberately left at 120. Lowering it affects every workflow in the system and is a maintainer judgment call. The issue reporter is on Windows with a local/slow LLM — the 120s default may be fine for cloud models; raising it globally would hide misconfigured step agents. Recommend the maintainer decide separately.
- **Windows-runtime root cause**: the consistent timeout on Windows with a local model could not be reproduced here (Docker dev image is Linux-only). The actionable error message (criterion 2 from the issue) is addressed. If the model is consistently taking >120s, the reporter should raise `timeout_secs` for the `evaluator` step in their workflow, or use a hosted model.

## Open question for maintainers

Should `default_timeout()` be raised (e.g. 300s) for LLM steps? The current 120s is fine for fast hosted models but tight for local inference. This PR deliberately does not change it.
