### PR TITLE
fix(runtime): unbreak coverage build — thread session_id into two SessionWriter test stubs

### DIFF
--- a/crates/librefang-runtime/tests/proactive_memory_extraction_model_override.rs
+++ b/crates/librefang-runtime/tests/proactive_memory_extraction_model_override.rs
@@ -212,6 +212,7 @@ impl librefang_kernel_handle::SessionWriter for OverrideKernel {
     fn inject_attachment_blocks(
         &self,
         _: librefang_types::agent::AgentId,
+        _: librefang_types::agent::SessionId,
         _: Vec<librefang_types::message::ContentBlock>,
     ) {
     }

--- a/crates/librefang-runtime/tests/tool_runner_memory_isolation.rs
+++ b/crates/librefang-runtime/tests/tool_runner_memory_isolation.rs
@@ -247,6 +247,7 @@ impl librefang_kernel_handle::SessionWriter for IsolationKernel {
     fn inject_attachment_blocks(
         &self,
         _agent_id: librefang_types::agent::AgentId,
+        _session_id: librefang_types::agent::SessionId,
         _blocks: Vec<librefang_types::message::ContentBlock>,
     ) {
     }


### PR DESCRIPTION
## Problem

`main` is red on the **Workspace coverage (llvm-cov)** job:

```
error[E0050]: method `inject_attachment_blocks` has 3 parameters
but the declaration in trait `inject_attachment_blocks` has 4
  --> crates/librefang-runtime/tests/proactive_memory_extraction_model_override.rs:213:9
```

#5334 added a `session_id: SessionId` parameter to
`SessionWriter::inject_attachment_blocks` (between `agent_id` and `blocks`)
and updated the production impl plus most test kernels, but missed two
integration-test stub impls. The crate **lib** compiles, so a
`cargo check --lib` does not catch it — only the `--tests` targets (and the
coverage job, which builds all targets) fail.

## Fix

Add the missing `session_id` parameter to the two stubs so they match the
trait and the other 17 implementors:

- `crates/librefang-runtime/tests/tool_runner_memory_isolation.rs`
- `crates/librefang-runtime/tests/proactive_memory_extraction_model_override.rs`

Both are no-op stubs; the parameter is bound as `_` / `_session_id`.

## Verification

A repo-wide scan of all `inject_attachment_blocks` implementors confirms these
two were the only remaining 3-parameter stubs; all others (production
`session_writer.rs`, the other test kernels, `host_functions.rs`,
`tool_runner/tests/*`) already carry the 4-parameter signature.

Local Docker verification was blocked by a full Docker VM disk, so this relies
on CI — the same **Workspace coverage (llvm-cov)** job that flagged the
breakage, plus the Ubuntu integration shards, gate this PR.
