### PR TITLE
fix(runtime): wiki.rs lifetime + shell.rs test arity after #5774/#5777

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/shell.rs
+++ b/crates/librefang-runtime/src/tool_runner/shell.rs
@@ -240,7 +240,7 @@ mod tests {
 
     #[tokio::test]
     async fn shell_exec_missing_command_is_missing_parameter() {
-        let r = tool_shell_exec(&json!({}), &[], None, None, None).await;
+        let r = tool_shell_exec(&json!({}), &[], None, None, None, None, None).await;
         assert!(matches!(r, Err(ToolError::MissingParameter("command"))));
     }
 
@@ -251,6 +251,8 @@ mod tests {
         let r = tool_shell_exec(
             &json!({"command": "echo \"unterminated"}),
             &[],
+            None,
+            None,
             None,
             None,
             None,

--- a/crates/librefang-runtime/src/tool_runner/wiki.rs
+++ b/crates/librefang-runtime/src/tool_runner/wiki.rs
@@ -29,7 +29,10 @@ fn format_output(value: &serde_json::Value) -> String {
 }
 
 /// Validate that a string parameter is not empty or whitespace-only.
-fn require_non_empty<'a>(val: &'a str, label: &str) -> Result<&'a str, ToolError> {
+///
+/// `label` is `&'static str` because `ToolError::InvalidParameter.name` is
+/// `&'static str` (every call site already passes a string literal).
+fn require_non_empty<'a>(val: &'a str, label: &'static str) -> Result<&'a str, ToolError> {
     let trimmed = val.trim();
     if trimmed.is_empty() {
         Err(ToolError::InvalidParameter {


### PR DESCRIPTION
## Problem

The default branch is red on the `Workspace coverage (llvm-cov)` job (and would be red on every full build) due to two compile errors introduced by yesterday's leszek3737 hardening merges:

```
error: lifetime may not live long enough
  --> crates/librefang-runtime/src/tool_runner/wiki.rs:36:19
32 | fn require_non_empty<'a>(val: &'a str, label: &str) -> Result<&'a str, ToolError> {
   |                                               - let's call the lifetime of this reference `'1`
...
36 |             name: label,
   |                   ^^^^^ this usage requires that `'1` must outlive `'static`

error[E0061]: this function takes 7 arguments but 5 arguments were supplied
   --> crates/librefang-runtime/src/tool_runner/shell.rs:243 (and :251)
```

`cargo check --workspace --lib` masked these — `wiki.rs` needs `--lib --tests` to surface (the bad path is inside the validator helper, but the lifetime constraint only fails when the unit-test target is being compiled too), and `shell.rs:243/251` are only triggered by the in-file `#[cfg(test)]` callers.

## Cause

- **#5777** (wiki) introduced `require_non_empty<'a>(val: &'a str, label: &str)` and passed `label` into `ToolError::InvalidParameter { name, .. }` where `name: &'static str`. All four call sites already pass string literals, so tightening the bound to `&'static str` is a no-op for callers.
- **#5774** (dispatch) added `process_registry: Option<&ProcessRegistry>` + `session_id: Option<String>` to `tool_shell_exec` and updated the production dispatch + the integration-test stubs, but missed the two `#[cfg(test)]` call sites inside `shell.rs` itself.

## Fix

- `wiki.rs:32` — `label: &str` → `label: &'static str` (with a doc-comment explaining why).
- `shell.rs:243, :251` — pass `None, None` for the two new params.

## Verification

```
$ cargo check -p librefang-runtime --lib --tests
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.22s
```

Same Docker dev-container path used in CLAUDE.md > Build & Verify (named volumes, isolated from the host `target/`). Local verification deliberately scoped `--lib --tests` together to cover both failure surfaces from above (the same lane the coverage job runs).
