### PR TITLE
fix(ci): unbreak main — agent channels in ApiDoc + fmt + secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,7 +175,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "929b5531f933164784179610dc6d44c9e4fe5e28",
         "is_verified": false,
-        "line_number": 1721
+        "line_number": 1722
       }
     ],
     "articles/hello-librefang.md": [
@@ -600,14 +600,14 @@
         "filename": "crates/librefang-api/src/routes/agents.rs",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 7293
+        "line_number": 7504
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/src/routes/agents.rs",
         "hashed_secret": "4835254aab9494e03d8b72e816719a4914612587",
         "is_verified": false,
-        "line_number": 7302
+        "line_number": 7513
       }
     ],
     "crates/librefang-api/src/routes/config.rs": [
@@ -641,7 +641,7 @@
         "filename": "crates/librefang-api/src/routes/registry.rs",
         "hashed_secret": "4e5111dafe7d9739f9228906d90cf421d5ec5371",
         "is_verified": false,
-        "line_number": 439
+        "line_number": 453
       }
     ],
     "crates/librefang-api/src/routes/terminal.rs": [
@@ -905,6 +905,15 @@
         "hashed_secret": "17bb10d3f44323963c21bf3c97341ebb5accf05e",
         "is_verified": false,
         "line_number": 38
+      }
+    ],
+    "crates/librefang-api/tests/agent_channels_routes_test.rs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "crates/librefang-api/tests/agent_channels_routes_test.rs",
+        "hashed_secret": "17bb10d3f44323963c21bf3c97341ebb5accf05e",
+        "is_verified": false,
+        "line_number": 59
       }
     ],
     "crates/librefang-api/tests/agent_identity_registry_test.rs": [
@@ -1433,7 +1442,7 @@
         "filename": "crates/librefang-channels/src/sidecar.rs",
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_verified": false,
-        "line_number": 2680
+        "line_number": 2684
       }
     ],
     "crates/librefang-cli/src/main.rs": [
@@ -1776,6 +1785,15 @@
         "hashed_secret": "1a37d41260f96724ee881be5e261b4d043f0626b",
         "is_verified": false,
         "line_number": 40
+      }
+    ],
+    "crates/librefang-kernel/tests/attachment_session_isolation_test.rs": [
+      {
+        "type": "Secret Keyword",
+        "filename": "crates/librefang-kernel/tests/attachment_session_isolation_test.rs",
+        "hashed_secret": "17bb10d3f44323963c21bf3c97341ebb5accf05e",
+        "is_verified": false,
+        "line_number": 69
       }
     ],
     "crates/librefang-kernel/tests/audit_retention_test.rs": [
@@ -2405,7 +2423,7 @@
         "filename": "crates/librefang-runtime/src/host_functions.rs",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 1795
+        "line_number": 1796
       }
     ],
     "crates/librefang-runtime/src/model_catalog.rs": [
@@ -2766,35 +2784,35 @@
         "filename": "crates/librefang-types/src/taint.rs",
         "hashed_secret": "928736a4122f1d25099ce7ef3e4aedcb8a96965f",
         "is_verified": false,
-        "line_number": 638
+        "line_number": 649
       },
       {
         "type": "Hex High Entropy String",
         "filename": "crates/librefang-types/src/taint.rs",
         "hashed_secret": "244f421f896bdcdd2784dccf4eaf7c8dfd5189b5",
         "is_verified": false,
-        "line_number": 647
+        "line_number": 658
       },
       {
         "type": "Hex High Entropy String",
         "filename": "crates/librefang-types/src/taint.rs",
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_verified": false,
-        "line_number": 656
+        "line_number": 667
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "crates/librefang-types/src/taint.rs",
         "hashed_secret": "0b1c50013102143e9b56177c69d158375cb2cc5c",
         "is_verified": false,
-        "line_number": 666
+        "line_number": 677
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "crates/librefang-types/src/taint.rs",
         "hashed_secret": "ee333313f1b6a2ecff54d01edf73f965d161d1b3",
         "is_verified": false,
-        "line_number": 860
+        "line_number": 871
       }
     ],
     "crates/librefang-types/src/tool_exec.rs": [
@@ -4038,5 +4056,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-26T10:16:51Z"
+  "generated_at": "2026-05-28T10:47:44Z"
 }

--- a/crates/librefang-api/src/openapi.rs
+++ b/crates/librefang-api/src/openapi.rs
@@ -85,6 +85,8 @@ use crate::types;
         routes::set_agent_skills,
         routes::get_agent_mcp_servers,
         routes::set_agent_mcp_servers,
+        routes::get_agent_channels,
+        routes::set_agent_channels,
         routes::update_agent_identity,
         routes::patch_agent_config,
         routes::patch_hand_agent_runtime_config,

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -577,10 +577,7 @@ pub async fn populate_sidecar_schema_cache() {
                         fields = fallback.fields.len(),
                         "sidecar --describe failed; using compile-time fallback schema"
                     );
-                    schema_cache()
-                        .write()
-                        .unwrap()
-                        .insert(entry.name, fallback);
+                    schema_cache().write().unwrap().insert(entry.name, fallback);
                 } else {
                     tracing::warn!(
                         adapter = entry.name,

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -3479,23 +3479,16 @@ async fn dispatch_message(
             // kernel's `MediaEngine`.  Inline `Image` blocks (base64
             // fallback when the save failed) have no on-disk path, so
             // skip description for those.
-            let saved_image: Option<(std::path::PathBuf, String)> = blocks
-                .iter()
-                .find_map(|b| {
-                    if let ContentBlock::ImageFile { path, media_type } = b {
-                        Some((
-                            std::path::PathBuf::from(path),
-                            media_type.clone(),
-                        ))
-                    } else {
-                        None
-                    }
-                });
+            let saved_image: Option<(std::path::PathBuf, String)> = blocks.iter().find_map(|b| {
+                if let ContentBlock::ImageFile { path, media_type } = b {
+                    Some((std::path::PathBuf::from(path), media_type.clone()))
+                } else {
+                    None
+                }
+            });
             let mut final_blocks = blocks;
             if let Some(ref saved) = saved_image {
-                if let Some(desc_block) =
-                    maybe_describe_inbound_image(handle, Some(saved)).await
-                {
+                if let Some(desc_block) = maybe_describe_inbound_image(handle, Some(saved)).await {
                     // Prepend the description so the model reads context
                     // before the raw image bytes.
                     final_blocks.insert(0, desc_block);

--- a/crates/librefang-runtime-media/src/media_understanding.rs
+++ b/crates/librefang-runtime-media/src/media_understanding.rs
@@ -111,9 +111,7 @@ impl MediaEngine {
         );
 
         let description = match provider {
-            "anthropic" => {
-                anthropic_describe_image(model, &image_bytes, mime_type).await?
-            }
+            "anthropic" => anthropic_describe_image(model, &image_bytes, mime_type).await?,
             "openai" | "groq" => {
                 let (api_url, api_key) = openai_vision_provider_config(provider)?;
                 openai_describe_image(&api_url, &api_key, model, &image_bytes, mime_type).await?
@@ -391,7 +389,9 @@ fn openai_vision_provider_config(provider: &str) -> Result<(String, String), Str
             "https://api.groq.com/openai/v1/chat/completions".into(),
             std::env::var("GROQ_API_KEY").map_err(|_| "GROQ_API_KEY not set")?,
         )),
-        other => Err(format!("No OpenAI-compatible vision config for provider: {other}")),
+        other => Err(format!(
+            "No OpenAI-compatible vision config for provider: {other}"
+        )),
     }
 }
 
@@ -406,8 +406,7 @@ async fn anthropic_describe_image(
 ) -> Result<String, String> {
     use base64::Engine;
 
-    let api_key = std::env::var("ANTHROPIC_API_KEY")
-        .map_err(|_| "ANTHROPIC_API_KEY not set")?;
+    let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| "ANTHROPIC_API_KEY not set")?;
 
     let image_b64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
 
@@ -1209,7 +1208,10 @@ mod tests {
             "claude-sonnet-4-20250514"
         );
         assert_eq!(default_vision_model("openai"), "gpt-4o");
-        assert_eq!(default_vision_model("groq"), "meta-llama/llama-4-scout-17b-16e-instruct");
+        assert_eq!(
+            default_vision_model("groq"),
+            "meta-llama/llama-4-scout-17b-16e-instruct"
+        );
         assert_eq!(default_vision_model("gemini"), "gemini-2.5-flash");
         assert_eq!(default_vision_model("unknown"), "unknown");
     }
@@ -1257,7 +1259,9 @@ mod tests {
         let result = engine.describe_image(&attachment).await;
         assert!(result.is_err());
         assert!(
-            result.unwrap_err().contains("URL-based image source not supported"),
+            result
+                .unwrap_err()
+                .contains("URL-based image source not supported"),
             "URL source must be rejected"
         );
     }

--- a/crates/librefang-runtime/src/tool_runner/hand.rs
+++ b/crates/librefang-runtime/src/tool_runner/hand.rs
@@ -155,10 +155,7 @@ pub(super) async fn tool_hand_status(
     let kh = require_kernel_typed(kernel)?;
     let hand_id = validate_required_string(input, "hand_id")?;
 
-    let result = kh
-        .hand_status(hand_id)
-        .await
-        .map_err(ToolError::upstream)?;
+    let result = kh.hand_status(hand_id).await.map_err(ToolError::upstream)?;
 
     let icon = result["icon"].as_str().unwrap_or("");
     let name = sanitize_value(&result["name"], 80);


### PR DESCRIPTION
## Problem

The default branch HEAD `dd1de430` has **6 failing required checks**, all root-caused to today's batch of merges:

| Failing check | Root cause |
|---|---|
| Workspace coverage (llvm-cov) | `openapi_path_coverage_test::every_annotated_handler_is_in_openapi` panics — #5738's `get_agent_channels` / `set_agent_channels` carry `#[utoipa::path]` but are missing from `ApiDoc::paths(...)`. |
| Test / Ubuntu (shard 2/4) | same |
| Test / Windows (shard 2/2) | same |
| Test / macOS | same |
| Quality (`cargo fmt`) | Format drift in 4 files: `routes/channels.rs:577`, `channels/bridge.rs:3479`, `tool_runner/hand.rs:155`, `runtime-media/media_understanding.rs` (lines 111 / 391 / 406 / 1209 / 1257). |
| detect-secrets scan | Baseline does not yet contain entries for two new test files (`agent_channels_routes_test.rs` from #5738, `attachment_session_isolation_test.rs` from #5334) — their scanner-flagged strings (test-fixture tokens) need to be baselined. |

## Fix

1. **`crates/librefang-api/src/openapi.rs`** — register the two channels handlers in `ApiDoc::paths(...)` immediately after their `agent_mcp_servers` siblings:
   ```rust
   routes::get_agent_mcp_servers,
   routes::set_agent_mcp_servers,
   routes::get_agent_channels,      // NEW
   routes::set_agent_channels,      // NEW
   routes::update_agent_identity,
   ```
2. **`cargo fmt`** — rewrap the 4 drifted files.
3. **`.secrets.baseline`** — refreshed via `detect-secrets scan` so the two new test files' fixture strings are recorded.

## Verification

```
$ cargo check -p librefang-api --lib --tests
Finished `dev` profile [unoptimized + debuginfo] target(s) in 31.76s
```

Confirms the openapi addition compiles and the existing tests still type-check against the new path list (the integration test that was panicking on `main` was *compiling* fine; it failed at runtime asserting the handler set, which is what this PR addresses).
