### PR TITLE
chore(just): docker fallback for `just release` when cargo is missing

### DIFF
--- a/justfile
+++ b/justfile
@@ -114,9 +114,9 @@ clean:
 sync-versions *ARGS:
     cargo xtask sync-versions {{ARGS}}
 
-# Cut a release
+# Cut a release (falls back to `librefang-rust-dev` container if cargo is missing)
 release *ARGS:
-    cargo xtask release {{ARGS}}
+    scripts/run-xtask.sh release {{ARGS}}
 
 # Generate CHANGELOG from merged PRs
 changelog *ARGS:

--- a/justfile
+++ b/justfile
@@ -115,8 +115,14 @@ sync-versions *ARGS:
     cargo xtask sync-versions {{ARGS}}
 
 # Cut a release (falls back to `librefang-rust-dev` container if cargo is missing)
+[unix]
 release *ARGS:
     scripts/run-xtask.sh release {{ARGS}}
+
+# Cut a release (Windows: requires a native Rust toolchain — the docker fallback used on Unix relies on bash, which cmd cannot exec)
+[windows]
+release *ARGS:
+    cargo xtask release {{ARGS}}
 
 # Generate CHANGELOG from merged PRs
 changelog *ARGS:

--- a/scripts/run-xtask.sh
+++ b/scripts/run-xtask.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+# Run `cargo xtask <subcmd> [args…]` natively if a Rust toolchain is on PATH,
+# otherwise fall back to the `librefang-rust-dev` container so contributors
+# on a host without rustup (typical macOS dev box) can still invoke xtask
+# recipes (e.g. `just release`) without first installing Rust.
+#
+# Forwarded credentials (mounted read-only into the container):
+#   ~/.gitconfig     — so `git commit` inside the container uses your identity
+#   ~/.ssh           — so `git push` via SSH works
+#   ~/.config/gh     — so `gh pr create` reuses your auth
+#
+# Cargo / build state lives in named volumes (librefang-cargo,
+# librefang-target) so dependencies compile once and survive across runs,
+# and the host's shared `target/` directory is NOT touched (the
+# Dockerfile.rust-dev comment + CLAUDE.md "Verifying without a native
+# toolchain (Docker)" section explain why that isolation matters).
+#
+# Tools the dev image does NOT ship that some xtask flows expect:
+#   gh          — release.rs uses it to open the version-bump PR
+#   claude      — release.rs uses it to polish the Dev.to article (optional;
+#                 release flow continues with raw changelog if missing)
+# If the flow you're running needs one of these, install it inside the
+# container by extending Dockerfile.rust-dev, or run that step natively
+# on the host after the build artifacts are produced.
+set -eu
+
+if command -v cargo >/dev/null 2>&1; then
+    exec cargo xtask "$@"
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+error: neither `cargo` nor `docker` is on PATH.
+
+Install one of:
+  - Rust toolchain (recommended): https://rustup.rs
+  - Docker:                       https://docs.docker.com/get-docker/
+EOF
+    exit 127
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+IMAGE="${LIBREFANG_RUST_IMAGE:-librefang-rust-dev:latest}"
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "info: building $IMAGE from Dockerfile.rust-dev (one-time, ~10 min)" >&2
+    docker build -t "$IMAGE" -f "$REPO_ROOT/Dockerfile.rust-dev" "$REPO_ROOT"
+fi
+
+set -- "$@"
+# Build the inner command string with proper quoting so args with spaces
+# survive the sh -c wrapper inside the container.
+inner_cmd='export PATH=/usr/local/cargo/bin:$PATH && exec cargo xtask'
+for arg in "$@"; do
+    # POSIX-safe single-quote escape: ' -> '\''
+    quoted=$(printf '%s' "$arg" | sed "s/'/'\\\\''/g")
+    inner_cmd="$inner_cmd '$quoted'"
+done
+
+mounts="-v $REPO_ROOT:/work"
+if [ -f "$HOME/.gitconfig" ]; then
+    mounts="$mounts -v $HOME/.gitconfig:/root/.gitconfig:ro"
+fi
+if [ -d "$HOME/.ssh" ]; then
+    mounts="$mounts -v $HOME/.ssh:/root/.ssh:ro"
+fi
+if [ -d "$HOME/.config/gh" ]; then
+    mounts="$mounts -v $HOME/.config/gh:/root/.config/gh:ro"
+fi
+
+# `-it` only when stdin is a tty — keeps the wrapper usable from CI / hooks.
+tty_flag=""
+if [ -t 0 ] && [ -t 1 ]; then
+    tty_flag="-it"
+fi
+
+# shellcheck disable=SC2086  # word-splitting on $mounts is intentional
+exec docker run --rm $tty_flag \
+    $mounts \
+    -v librefang-cargo:/cargo \
+    -v librefang-target:/target \
+    -e CARGO_HOME=/cargo \
+    -e CARGO_TARGET_DIR=/target \
+    -w /work \
+    "$IMAGE" \
+    sh -c "$inner_cmd"

--- a/scripts/run-xtask.sh
+++ b/scripts/run-xtask.sh
@@ -1,27 +1,26 @@
 #!/usr/bin/env sh
-# Run `cargo xtask <subcmd> [args…]` natively if a Rust toolchain is on PATH,
-# otherwise fall back to the `librefang-rust-dev` container so contributors
-# on a host without rustup (typical macOS dev box) can still invoke xtask
-# recipes (e.g. `just release`) without first installing Rust.
+# Run `cargo xtask <subcmd> [args…]` natively if a Rust toolchain is on PATH, otherwise fall back to the `librefang-rust-dev` container.
+# This lets contributors on a host without rustup (typical macOS dev box) invoke xtask recipes like `just release` without first installing Rust.
 #
-# Forwarded credentials (mounted read-only into the container):
-#   ~/.gitconfig     — so `git commit` inside the container uses your identity
-#   ~/.ssh           — so `git push` via SSH works
-#   ~/.config/gh     — so `gh pr create` reuses your auth
+# Mounts (read-only, into the container):
+#   ~/.gitconfig                — so `git commit` inside the container uses your identity.
+#   ~/.ssh                      — so `git push` over SSH works.
+#   ~/.config/gh                — so `gh` finds its hosts.yml (the token may live in the macOS keychain — see GH_TOKEN passthrough below).
+#   <main-repo>                 — when the caller is in a linked worktree, the main repo's checkout is mounted at the same absolute path it has on the host.
+#                                 Linked worktrees keep their `.git` as a text file pointing at `<main-repo>/.git/worktrees/<name>` — without this extra mount that absolute path doesn't exist inside the container and every `git` call fails.
 #
-# Cargo / build state lives in named volumes (librefang-cargo,
-# librefang-target) so dependencies compile once and survive across runs,
-# and the host's shared `target/` directory is NOT touched (the
-# Dockerfile.rust-dev comment + CLAUDE.md "Verifying without a native
-# toolchain (Docker)" section explain why that isolation matters).
+# Env-var passthrough:
+#   GH_TOKEN                    — if unset, this script tries `gh auth token` on the host (covers macOS where `gh` keeps the token in Keychain instead of `~/.config/gh/hosts.yml`) and forwards the value via `-e GH_TOKEN`.
+#                                 The value is read into this process's env only; it is never printed and is forwarded via the `-e VAR` form (no value on argv) so it does not appear in `ps`.
 #
-# Tools the dev image does NOT ship that some xtask flows expect:
-#   gh          — release.rs uses it to open the version-bump PR
-#   claude      — release.rs uses it to polish the Dev.to article (optional;
-#                 release flow continues with raw changelog if missing)
-# If the flow you're running needs one of these, install it inside the
-# container by extending Dockerfile.rust-dev, or run that step natively
-# on the host after the build artifacts are produced.
+# Caching:
+#   librefang-cargo / librefang-target named volumes hold `CARGO_HOME` / `CARGO_TARGET_DIR` so dependencies compile once and survive across runs.
+#   The host's shared `target/` is never touched — matches the isolation guarantee documented under "Verifying without a native toolchain (Docker)" in `CLAUDE.md`.
+#   Set `LIBREFANG_RUST_IMAGE_REBUILD=1` to force a fresh `docker build` (the wrapper otherwise reuses any locally cached `librefang-rust-dev:latest`, even if `Dockerfile.rust-dev` has changed since).
+#
+# Known gaps not worth solving in this script:
+#   `gh` and `claude` are not in the dev image — `release.rs` calls both. `claude` is best-effort (release continues without it). `gh` is checked with `gh --version` before use, so missing-`gh` skips the PR-create step and prints the command for the user to run on the host.
+#   Files written through the bind mount are root-owned on Linux hosts (Docker Desktop on macOS hides this via UID mapping). Add `--user "$(id -u):$(id -g)"` if that bites you; left out for now because the cargo named volume would also need world-writable perms.
 set -eu
 
 if command -v cargo >/dev/null 2>&1; then
@@ -40,24 +39,27 @@ EOF
 fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+GIT_COMMON_DIR_ABS="$(cd "$(git rev-parse --git-common-dir)" && pwd)"
+MAIN_REPO="$(dirname "$GIT_COMMON_DIR_ABS")"
 IMAGE="${LIBREFANG_RUST_IMAGE:-librefang-rust-dev:latest}"
 
-if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+if [ "${LIBREFANG_RUST_IMAGE_REBUILD:-}" = "1" ] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
     echo "info: building $IMAGE from Dockerfile.rust-dev (one-time, ~10 min)" >&2
     docker build -t "$IMAGE" -f "$REPO_ROOT/Dockerfile.rust-dev" "$REPO_ROOT"
 fi
 
-set -- "$@"
-# Build the inner command string with proper quoting so args with spaces
-# survive the sh -c wrapper inside the container.
+# Build the inner command with POSIX-safe single-quote escaping so args containing spaces or quotes survive the `sh -c` wrapper inside the container.
 inner_cmd='export PATH=/usr/local/cargo/bin:$PATH && exec cargo xtask'
 for arg in "$@"; do
-    # POSIX-safe single-quote escape: ' -> '\''
     quoted=$(printf '%s' "$arg" | sed "s/'/'\\\\''/g")
     inner_cmd="$inner_cmd '$quoted'"
 done
 
 mounts="-v $REPO_ROOT:/work"
+# Mount the main repo at its host path so the `.git` text-file pointer inside a linked worktree still resolves; skip when the worktree IS the main repo (would collide on the same target).
+if [ "$MAIN_REPO" != "$REPO_ROOT" ]; then
+    mounts="$mounts -v $MAIN_REPO:$MAIN_REPO"
+fi
 if [ -f "$HOME/.gitconfig" ]; then
     mounts="$mounts -v $HOME/.gitconfig:/root/.gitconfig:ro"
 fi
@@ -68,15 +70,30 @@ if [ -d "$HOME/.config/gh" ]; then
     mounts="$mounts -v $HOME/.config/gh:/root/.config/gh:ro"
 fi
 
-# `-it` only when stdin is a tty — keeps the wrapper usable from CI / hooks.
+# Pull the gh token out of the host's keychain (macOS) or wherever `gh auth token` finds it, so the container can authenticate even when `~/.config/gh/hosts.yml` carries no token.
+env_args=""
+if [ -z "${GH_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
+    GH_TOKEN=$(gh auth token 2>/dev/null || true)
+    if [ -n "$GH_TOKEN" ]; then
+        export GH_TOKEN
+    else
+        unset GH_TOKEN
+    fi
+fi
+if [ -n "${GH_TOKEN:-}" ]; then
+    env_args="$env_args -e GH_TOKEN"
+fi
+
+# `-it` only when stdin AND stdout are ttys — keeps the wrapper usable from CI / hooks where stdin is a pipe.
 tty_flag=""
 if [ -t 0 ] && [ -t 1 ]; then
     tty_flag="-it"
 fi
 
-# shellcheck disable=SC2086  # word-splitting on $mounts is intentional
+# shellcheck disable=SC2086  # word-splitting on $mounts / $env_args / $tty_flag is intentional.
 exec docker run --rm $tty_flag \
     $mounts \
+    $env_args \
     -v librefang-cargo:/cargo \
     -v librefang-target:/target \
     -e CARGO_HOME=/cargo \

--- a/scripts/run-xtask.sh
+++ b/scripts/run-xtask.sh
@@ -1,27 +1,33 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Run `cargo xtask <subcmd> [args…]` natively if a Rust toolchain is on PATH, otherwise fall back to the `librefang-rust-dev` container.
 # This lets contributors on a host without rustup (typical macOS dev box) invoke xtask recipes like `just release` without first installing Rust.
 #
+# Why bash, not /bin/sh: we build argv as arrays so that workspace paths containing spaces (e.g. `~/My Workspace/librefang`) survive being passed to `docker run -v`. POSIX sh has no arrays; string concat + unquoted word-splitting would break on the first space. Bash 3.2 is present on macOS by default and on every supported Linux distro.
+#
 # Mounts (read-only, into the container):
-#   ~/.gitconfig                — so `git commit` inside the container uses your identity.
-#   ~/.ssh                      — so `git push` over SSH works.
-#   ~/.config/gh                — so `gh` finds its hosts.yml (the token may live in the macOS keychain — see GH_TOKEN passthrough below).
-#   <main-repo>                 — when the caller is in a linked worktree, the main repo's checkout is mounted at the same absolute path it has on the host.
+#   ~/.gitconfig                → /home/dev/.gitconfig — so `git commit` inside the container uses your identity.
+#   ~/.ssh                      → /home/dev/.ssh       — so `git push` over SSH works.
+#   ~/.config/gh                → /home/dev/.config/gh — so `gh` finds its hosts.yml (the token may live in the macOS keychain — see GH_TOKEN passthrough below).
+#   <main-repo>                 — when the caller is in a linked worktree, the main repo's checkout is also mounted at its host absolute path.
 #                                 Linked worktrees keep their `.git` as a text file pointing at `<main-repo>/.git/worktrees/<name>` — without this extra mount that absolute path doesn't exist inside the container and every `git` call fails.
 #
+# In-container HOME is fixed at `/home/dev` (set via `-e HOME=/home/dev`) so the same mount layout works whether the container runs as root (macOS Docker Desktop) or as the host uid (Linux, see below). Docker auto-creates the bind-mount targets.
+#
 # Env-var passthrough:
-#   GH_TOKEN                    — if unset, this script tries `gh auth token` on the host (covers macOS where `gh` keeps the token in Keychain instead of `~/.config/gh/hosts.yml`) and forwards the value via `-e GH_TOKEN`.
-#                                 The value is read into this process's env only; it is never printed and is forwarded via the `-e VAR` form (no value on argv) so it does not appear in `ps`.
+#   GH_TOKEN                    — if unset on the host, this script tries `gh auth token` (covers macOS where `gh` keeps the token in Keychain instead of `~/.config/gh/hosts.yml`) and forwards the value via `-e GH_TOKEN`.
+#                                 The value is read into this process's env only; it is forwarded via the `-e VAR` form (no value on argv) so it does not appear in `ps`.
 #
 # Caching:
 #   librefang-cargo / librefang-target named volumes hold `CARGO_HOME` / `CARGO_TARGET_DIR` so dependencies compile once and survive across runs.
 #   The host's shared `target/` is never touched — matches the isolation guarantee documented under "Verifying without a native toolchain (Docker)" in `CLAUDE.md`.
 #   Set `LIBREFANG_RUST_IMAGE_REBUILD=1` to force a fresh `docker build` (the wrapper otherwise reuses any locally cached `librefang-rust-dev:latest`, even if `Dockerfile.rust-dev` has changed since).
 #
-# Known gaps not worth solving in this script:
-#   `gh` and `claude` are not in the dev image — `release.rs` calls both. `claude` is best-effort (release continues without it). `gh` is checked with `gh --version` before use, so missing-`gh` skips the PR-create step and prints the command for the user to run on the host.
-#   Files written through the bind mount are root-owned on Linux hosts (Docker Desktop on macOS hides this via UID mapping). Add `--user "$(id -u):$(id -g)"` if that bites you; left out for now because the cargo named volume would also need world-writable perms.
-set -eu
+# UID mapping (Linux only):
+#   On Linux hosts the container runs as the host uid:gid so generated files (CHANGELOG.md, Cargo.lock, openapi.json, …) end up owned by the contributor instead of root. The named volumes are chown'd once per host-uid the first time they're used (a marker file inside the volume avoids re-traversing on every run). On macOS Docker Desktop handles uid translation transparently, so the container keeps running as root and no chown is needed — same code path as before for that platform.
+#
+# Known gap not solved here:
+#   `gh` and `claude` are not in the dev image. `release.rs` guards `gh` with `gh --version` before use, so a missing `gh` skips the PR-create step and prints the command for the user to run on the host. `claude` is best-effort (release continues with the raw changelog).
+set -euo pipefail
 
 if command -v cargo >/dev/null 2>&1; then
     exec cargo xtask "$@"
@@ -42,62 +48,81 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 GIT_COMMON_DIR_ABS="$(cd "$(git rev-parse --git-common-dir)" && pwd)"
 MAIN_REPO="$(dirname "$GIT_COMMON_DIR_ABS")"
 IMAGE="${LIBREFANG_RUST_IMAGE:-librefang-rust-dev:latest}"
+GUEST_HOME=/home/dev
 
-if [ "${LIBREFANG_RUST_IMAGE_REBUILD:-}" = "1" ] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+if [[ "${LIBREFANG_RUST_IMAGE_REBUILD:-}" == "1" ]] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
     echo "info: building $IMAGE from Dockerfile.rust-dev (one-time, ~10 min)" >&2
     docker build -t "$IMAGE" -f "$REPO_ROOT/Dockerfile.rust-dev" "$REPO_ROOT"
+fi
+
+# Linux: chown named volumes to host uid:gid once, then run --user. macOS: no-op (Docker Desktop handles uid mapping; running as root inside is fine).
+user_args=()
+if [[ "$(uname -s)" == "Linux" ]]; then
+    host_uid=$(id -u)
+    host_gid=$(id -g)
+    marker="/cargo/.owned-by-${host_uid}"
+    if ! docker run --rm \
+            -v librefang-cargo:/cargo \
+            "$IMAGE" \
+            test -f "$marker" >/dev/null 2>&1; then
+        echo "info: chowning librefang-cargo + librefang-target volumes to ${host_uid}:${host_gid} (one-time)" >&2
+        docker run --rm \
+            --user 0:0 \
+            -v librefang-cargo:/cargo \
+            -v librefang-target:/target \
+            "$IMAGE" \
+            sh -c "chown -R ${host_uid}:${host_gid} /cargo /target && touch '$marker'"
+    fi
+    user_args=(--user "${host_uid}:${host_gid}")
 fi
 
 # Build the inner command with POSIX-safe single-quote escaping so args containing spaces or quotes survive the `sh -c` wrapper inside the container.
 inner_cmd='export PATH=/usr/local/cargo/bin:$PATH && exec cargo xtask'
 for arg in "$@"; do
-    quoted=$(printf '%s' "$arg" | sed "s/'/'\\\\''/g")
-    inner_cmd="$inner_cmd '$quoted'"
+    quoted=${arg//\'/\'\\\'\'}
+    inner_cmd+=" '$quoted'"
 done
 
-mounts="-v $REPO_ROOT:/work"
-# Mount the main repo at its host path so the `.git` text-file pointer inside a linked worktree still resolves; skip when the worktree IS the main repo (would collide on the same target).
-if [ "$MAIN_REPO" != "$REPO_ROOT" ]; then
-    mounts="$mounts -v $MAIN_REPO:$MAIN_REPO"
+mounts=(-v "$REPO_ROOT:/work")
+# Mount the main repo at its host path so the `.git` text-file pointer inside a linked worktree resolves; skip when the worktree IS the main repo (would collide on the same target).
+if [[ "$MAIN_REPO" != "$REPO_ROOT" ]]; then
+    mounts+=(-v "$MAIN_REPO:$MAIN_REPO")
 fi
-if [ -f "$HOME/.gitconfig" ]; then
-    mounts="$mounts -v $HOME/.gitconfig:/root/.gitconfig:ro"
+if [[ -f "$HOME/.gitconfig" ]]; then
+    mounts+=(-v "$HOME/.gitconfig:$GUEST_HOME/.gitconfig:ro")
 fi
-if [ -d "$HOME/.ssh" ]; then
-    mounts="$mounts -v $HOME/.ssh:/root/.ssh:ro"
+if [[ -d "$HOME/.ssh" ]]; then
+    mounts+=(-v "$HOME/.ssh:$GUEST_HOME/.ssh:ro")
 fi
-if [ -d "$HOME/.config/gh" ]; then
-    mounts="$mounts -v $HOME/.config/gh:/root/.config/gh:ro"
+if [[ -d "$HOME/.config/gh" ]]; then
+    mounts+=(-v "$HOME/.config/gh:$GUEST_HOME/.config/gh:ro")
 fi
 
-# Pull the gh token out of the host's keychain (macOS) or wherever `gh auth token` finds it, so the container can authenticate even when `~/.config/gh/hosts.yml` carries no token.
-env_args=""
-if [ -z "${GH_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
-    GH_TOKEN=$(gh auth token 2>/dev/null || true)
-    if [ -n "$GH_TOKEN" ]; then
-        export GH_TOKEN
-    else
-        unset GH_TOKEN
+# Pull the gh token out of the host's keychain (macOS) or wherever `gh auth token` finds it, so the container authenticates even when `~/.config/gh/hosts.yml` carries no token.
+env_args=(-e "HOME=$GUEST_HOME" -e CARGO_HOME=/cargo -e CARGO_TARGET_DIR=/target)
+if [[ -z "${GH_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
+    if token=$(gh auth token 2>/dev/null) && [[ -n "$token" ]]; then
+        export GH_TOKEN="$token"
     fi
 fi
-if [ -n "${GH_TOKEN:-}" ]; then
-    env_args="$env_args -e GH_TOKEN"
+if [[ -n "${GH_TOKEN:-}" ]]; then
+    env_args+=(-e GH_TOKEN)
 fi
 
 # `-it` only when stdin AND stdout are ttys — keeps the wrapper usable from CI / hooks where stdin is a pipe.
-tty_flag=""
-if [ -t 0 ] && [ -t 1 ]; then
-    tty_flag="-it"
+tty_args=()
+if [[ -t 0 && -t 1 ]]; then
+    tty_args=(-it)
 fi
 
-# shellcheck disable=SC2086  # word-splitting on $mounts / $env_args / $tty_flag is intentional.
-exec docker run --rm $tty_flag \
-    $mounts \
-    $env_args \
+# `${arr[@]+"${arr[@]}"}` guards the empty-array case — under `set -u` on bash 3.2 (macOS default) a bare `"${arr[@]}"` errors with "unbound variable" when the array has never been assigned a value. `mounts` and `env_args` are always non-empty so the guard is only needed on the optional ones.
+exec docker run --rm \
+    ${tty_args[@]+"${tty_args[@]}"} \
+    ${user_args[@]+"${user_args[@]}"} \
+    "${mounts[@]}" \
+    "${env_args[@]}" \
     -v librefang-cargo:/cargo \
     -v librefang-target:/target \
-    -e CARGO_HOME=/cargo \
-    -e CARGO_TARGET_DIR=/target \
     -w /work \
     "$IMAGE" \
     sh -c "$inner_cmd"

--- a/scripts/run-xtask.sh
+++ b/scripts/run-xtask.sh
@@ -25,11 +25,16 @@
 # UID mapping (Linux only):
 #   On Linux hosts the container runs as the host uid:gid so generated files (CHANGELOG.md, Cargo.lock, openapi.json, …) end up owned by the contributor instead of root. The named volumes are chown'd once per host-uid the first time they're used (a marker file inside the volume avoids re-traversing on every run). On macOS Docker Desktop handles uid translation transparently, so the container keeps running as root and no chown is needed — same code path as before for that platform.
 #
-# Known gap not solved here:
+# Forcing the docker path:
+#   Set `LIBREFANG_RUST_FORCE_DOCKER=1` to skip the native `cargo` short-circuit even when a host toolchain is available. Useful for reproducing a contributor's container behaviour from a machine that has cargo installed.
+#
+# Known gaps not solved here:
 #   `gh` and `claude` are not in the dev image. `release.rs` guards `gh` with `gh --version` before use, so a missing `gh` skips the PR-create step and prints the command for the user to run on the host. `claude` is best-effort (release continues with the raw changelog).
+#   `ssh-agent` does not cross the container boundary. The wrapper mounts `~/.ssh` read-only so on-disk keys work, but `$SSH_AUTH_SOCK` points at a host unix socket the container can't see — passphrase-protected keys that rely on the agent will block `git push` from inside the container. Run with `ssh-add -l` working on the host and an unencrypted key on disk, or push from the host afterwards.
+#   Windows: this script is bash-only; the `justfile` exposes `release` as `[unix]` + `[windows]`, where the Windows variant keeps the original `cargo xtask release` call and therefore still requires a native Rust toolchain on Windows. There is no docker fallback for cmd.exe.
 set -euo pipefail
 
-if command -v cargo >/dev/null 2>&1; then
+if [[ "${LIBREFANG_RUST_FORCE_DOCKER:-}" != "1" ]] && command -v cargo >/dev/null 2>&1; then
     exec cargo xtask "$@"
 fi
 


### PR DESCRIPTION
## Summary

`just release` previously failed with exit 127 on hosts without a Rust toolchain:

```
cargo xtask release
sh: cargo: command not found
error: recipe `release` failed on line 119 with exit code 127
```

Route the recipe through a new `scripts/run-xtask.sh` wrapper that execs `cargo xtask` natively when `cargo` is on PATH and otherwise runs it inside the existing `librefang-rust-dev` container (auto-building the image on first use), mounting the workspace plus the user's git / gh / ssh credentials so the release flow's subprocess calls still authenticate.

Cargo and target state live in named volumes (`librefang-cargo`, `librefang-target`) so deps compile once across runs and the host's shared `target/` is never touched — same isolation pattern documented under "Verifying without a native toolchain (Docker)" in `CLAUDE.md`. Set `LIBREFANG_RUST_IMAGE_REBUILD=1` to force a fresh image build when `Dockerfile.rust-dev` changes, or `LIBREFANG_RUST_FORCE_DOCKER=1` to exercise the docker path from a host that has cargo (verification).

## Why bash, not /bin/sh

We build argv as arrays so that workspace paths containing spaces (e.g. `~/My Workspace/librefang`) survive being passed to `docker run -v`. POSIX sh has no arrays; the original string-concat + unquoted word-split version would have broken on the first space. Bash 3.2 (macOS default) is supported via the `${arr[@]+"${arr[@]}"}` guard for empty arrays under `set -u`.

## Linked-worktree handling

The project mandates all work happen in linked worktrees, where `<worktree>/.git` is a text file pointing at `<main-repo>/.git/worktrees/<name>` (an absolute host path). The wrapper also bind-mounts the main repo at its host path when the caller is in a linked worktree, so the pointer resolves; the extra mount is skipped when the caller is already in the main worktree to avoid a target collision.

## Linux UID mapping

On Linux hosts the container runs as the host `uid:gid` so generated files (CHANGELOG.md, Cargo.lock, openapi.json, …) end up owned by the contributor instead of root. The `librefang-cargo` / `librefang-target` named volumes are chown'd to the host uid once per uid (a marker file inside the volume avoids re-traversing on every run). macOS Docker Desktop handles uid translation natively, so the `--user` flag is not added there and the existing behaviour is preserved.

## In-container HOME

HOME is fixed at `/home/dev` (`-e HOME=/home/dev`) and credentials mount under that path. This keeps the layout identical whether the container runs as root (macOS) or as the host uid (Linux) — no per-platform mount-path branching needed.

## gh on macOS

`gh` on macOS keeps the token in Keychain, not in `~/.config/gh/hosts.yml`, so mounting that directory alone left the container unauthenticated. If `GH_TOKEN` is unset on the host, the wrapper runs `gh auth token` on the host and forwards the value via `-e GH_TOKEN` (no value on argv, so the token does not appear in `ps`).

## Per-platform recipe

The `release` recipe is now `[unix]` (docker fallback via `run-xtask.sh`) + `[windows]` (keeps the original `cargo xtask release` call). The wrapper is bash-only, so on Windows there is no docker fallback — a Windows contributor without a Rust toolchain gets the same cargo-not-found error they had before this PR. This avoids replacing one cryptic error (sh-not-found from cmd.exe trying to exec a bash script) with another.

## Known gaps not solved here

- `gh` and `claude` are not in the dev image; `release.rs` guards `gh` with `gh --version` before use, so a missing `gh` skips the PR-create step and prints the command for the user to run on the host. `claude` is best-effort (release continues with the raw changelog).
- `ssh-agent` does not cross the container boundary. The wrapper mounts `~/.ssh` read-only so on-disk keys work, but `$SSH_AUTH_SOCK` points at a host unix socket the container can't see — passphrase-protected keys that rely on the agent will block `git push` from inside the container. Use an unencrypted on-disk key for the docker path, or push from the host afterwards.
- Windows: no docker fallback (see above).

## Scope

Only the `release` recipe is rewired. The wrapper is reusable, so other `cargo xtask …` recipes can opt in incrementally — left out of this PR to keep the diff focused. `Dockerfile.rust-dev` is **not** modified.

## Test plan

- [x] `bash -n scripts/run-xtask.sh` — bash syntax clean.
- [x] `just --dry-run release …` — recipe expands to `scripts/run-xtask.sh release …` on this Unix host.
- [x] `just --list` shows only the `[unix]` variant on macOS.
- [x] `PATH=/usr/bin:/bin scripts/run-xtask.sh release --dry-run` (no cargo, no docker) — prints the install-one-of message and exits 127.
- [x] `PATH=/opt/homebrew/bin:/usr/bin:/bin scripts/run-xtask.sh --help` (no cargo, docker present) — wrapper builds xtask inside the container and emits the full help.
- [x] `scripts/run-xtask.sh release --dry-run --no-confirm --channel rc` from a linked worktree — reaches the real preflight inside the container and bails on the correct condition (`Error: must be on 'main' branch (currently on 'release-docker-fallback')`).
- [x] `docker run … alpine/git status` on the same mounts — produces real git output instead of "fatal: not a git repository".
- [x] Spaced-HOME stub test: `HOME='/var/.../spaced home.iGv'` produces `[ARG].../spaced home.iGv/.gitconfig:/home/dev/.gitconfig:ro` as a single argv element.
- [x] Args-with-spaces stub test: `release --foo "bar baz"` arrives in the inner sh -c as `'release' '--foo' 'bar baz'`.
- [x] Cargo-stub test: with a fake `cargo` on PATH, the default invocation hits the native short-circuit (sees `[CARGO] xtask release --help` from the stub).
- [x] `LIBREFANG_RUST_FORCE_DOCKER=1` with the same fake cargo — bypasses the short-circuit and engages the docker fallback (rustup channel sync appears).
- [ ] Reviewer on a Linux host confirms the one-time chown banner appears on first run, subsequent runs are silent, and generated artefacts land owned by the contributor uid not root.
- [ ] Reviewer with a real native cargo confirms `just release` is unchanged from the pre-PR behaviour on the cargo-present path.
