### PR TITLE
fix(dockerfile-rust-dev): install gh CLI for release flow

### DIFF
--- a/Dockerfile.rust-dev
+++ b/Dockerfile.rust-dev
@@ -67,8 +67,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsecret-1-dev \
     perl \
     ca-certificates \
-    curl \
-    gnupg \
     libwebkit2gtk-4.1-dev \
     libgtk-3-dev \
     libayatana-appindicator3-dev \
@@ -76,8 +74,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     patchelf \
     && rm -rf /var/lib/apt/lists/*
 
-# GitHub CLI (`gh`) — required by `cargo xtask release` (changelog generation hard-fails with "gh CLI required" at xtask/src/changelog.rs:421 if absent) and by `cargo xtask changelog`. Installed from GitHub's official apt repo per https://github.com/cli/cli/blob/trunk/docs/install_linux.md so the version tracks upstream stable rather than whatever Debian's archive carries. The release wrapper at scripts/run-xtask.sh forwards `GH_TOKEN` from the host (pulled out of the macOS Keychain when needed) so this `gh` authenticates without re-running `gh auth login` inside the container.
-RUN install -d -m 0755 /etc/apt/keyrings \
+# GitHub CLI (`gh`) — required by `cargo xtask release` (changelog generation hard-fails with "gh CLI required" at xtask/src/changelog.rs:421 if absent) and by `cargo xtask changelog`; also used by `release.rs` for the version-bump PR and by `cargo xtask contributors` for the GitHub-API-backed contributor list. Installed from GitHub's official apt repo per https://github.com/cli/cli/blob/trunk/docs/install_linux.md so the version tracks upstream stable rather than whatever Debian's archive carries. The release wrapper at scripts/run-xtask.sh forwards `GH_TOKEN` from the host (pulled out of the macOS Keychain when needed) so this `gh` authenticates without re-running `gh auth login` inside the container.
+# `curl` + `gnupg` are bootstrap deps for the apt-key fetch only — they live in this RUN block (not the Tauri/system-deps block above) so the layer that needs them is the same layer that consumes them, and a future change to the system-deps list doesn't invalidate the gh layer.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl gnupg \
+    && install -d -m 0755 /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \

--- a/Dockerfile.rust-dev
+++ b/Dockerfile.rust-dev
@@ -67,11 +67,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsecret-1-dev \
     perl \
     ca-certificates \
+    curl \
+    gnupg \
     libwebkit2gtk-4.1-dev \
     libgtk-3-dev \
     libayatana-appindicator3-dev \
     librsvg2-dev \
     patchelf \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (`gh`) — required by `cargo xtask release` (changelog generation hard-fails with "gh CLI required" at xtask/src/changelog.rs:421 if absent) and by `cargo xtask changelog`. Installed from GitHub's official apt repo per https://github.com/cli/cli/blob/trunk/docs/install_linux.md so the version tracks upstream stable rather than whatever Debian's archive carries. The release wrapper at scripts/run-xtask.sh forwards `GH_TOKEN` from the host (pulled out of the macOS Keychain when needed) so this `gh` authenticates without re-running `gh auth login` inside the container.
+RUN install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 # The wrapper mounts the workspace and sets CARGO_HOME to /usr/local/cargo


### PR DESCRIPTION
## Summary

Follow-up to #5825. With cargo missing on the host, `just release` now routes through `scripts/run-xtask.sh` into `librefang-rust-dev`. But the release flow hard-fails inside the container before it can produce anything useful:

```
Generating changelog...
Generating changelog: 2026.5.28 (since v2026.5.25-beta.13)
Error: gh CLI required
error: recipe `release` failed on line 120 with exit code 1
```

The hard-require is at `xtask/src/changelog.rs:421-422`:

```rust
if Command::new("gh").arg("--version").output().is_err() {
    return Err("gh CLI required".into());
}
```

`cargo xtask changelog` (the recipe `just changelog`) hits the same path. #5825's PR body listed missing `gh` as a "known gap" but the gap turned out to bite the release flow's first real step, not just the final PR-create step — install it.

## What changed

Add an apt entry for GitHub's official `cli.github.com` repo (per https://github.com/cli/cli/blob/trunk/docs/install_linux.md) and install `gh` in a separate `RUN` so the layer is independent of the existing system-deps layer. Tracks upstream stable rather than whatever Debian's archive carries.

`curl` and `gnupg` (apt-key fetch bootstrap deps) live in the same `RUN` as the gh install — they're consumed only by the keyring fetch and don't belong with the Tauri/system-deps group above. Side benefit: a future change to the system-deps list won't invalidate the gh layer cache.

## Blast radius (xtask call sites that gain `gh` access)

The trigger was `changelog.rs:421`'s hard-fail, but the same image gates several other xtask paths that all gracefully degrade today and become usable inside the container after this PR:

- `xtask/src/changelog.rs:70` — PR enumeration for the changelog body.
- `xtask/src/release.rs:321/696/989/1014` — version-bump branch creation, PR open, PR labelling.
- `xtask/src/release.rs:965` — `gh --version` guard around the PR-create step (was the only "known gap" called out in #5825 but the changelog path is hit first).
- `xtask/src/contributors.rs:35/185` — GitHub-API-backed contributor list for `just contributors`.
- `xtask/src/setup.rs:104` / `xtask/src/doctor.rs:89` — onboarding / diagnostic checks that flag missing `gh`; now satisfied inside the container.

## Image-size impact

`gh` 2.93.0 arm64 ≈ 14 MB unpacked. Single-digit-MB delta on a 3.1 GB image.

## Test plan

- [x] `docker build -t librefang-rust-dev:latest -f Dockerfile.rust-dev .` — succeeds; `apt` finds the GitHub repo, gh 2.93.0 installs cleanly on arm64.
- [x] `docker run --rm librefang-rust-dev:latest gh --version` — prints `gh version 2.93.0 (2026-05-27)`.
- [x] Rebuilt after moving curl/gnupg into the gh RUN block — still installs cleanly, gh still works.
- [ ] Reviewer (or original reporter) reruns `LIBREFANG_RUST_IMAGE_REBUILD=1 just release …` from a cargo-less host and confirms the changelog step now proceeds past the gh-required gate.

## Activating locally

Existing contributors with a cached `librefang-rust-dev:latest` need to force a rebuild once:

```
LIBREFANG_RUST_IMAGE_REBUILD=1 just release …
```

(The `LIBREFANG_RUST_IMAGE_REBUILD` escape hatch was added in #5825.)
