### PR TITLE
fix(run-xtask): run `gh auth setup-git` to unblock git push from container

### DIFF
--- a/scripts/run-xtask.sh
+++ b/scripts/run-xtask.sh
@@ -82,7 +82,10 @@ if [[ "$(uname -s)" == "Linux" ]]; then
 fi
 
 # Build the inner command with POSIX-safe single-quote escaping so args containing spaces or quotes survive the `sh -c` wrapper inside the container.
-inner_cmd='export PATH=/usr/local/cargo/bin:$PATH && exec cargo xtask'
+# `gh auth setup-git` (when GH_TOKEN is present) wires gh in as the git credential helper, so `git push` against https://github.com URLs authenticates via the forwarded token instead of dropping to an interactive HTTPS username prompt. Stderr is silenced because gh prints a banner; we only care about its side effect.
+inner_cmd='export PATH=/usr/local/cargo/bin:$PATH'
+inner_cmd+=' && if [ -n "${GH_TOKEN:-}" ]; then gh auth setup-git 2>/dev/null || true; fi'
+inner_cmd+=' && exec cargo xtask'
 for arg in "$@"; do
     quoted=${arg//\'/\'\\\'\'}
     inner_cmd+=" '$quoted'"


### PR DESCRIPTION
## Summary

Follow-up to #5825 and #5826. With those landed, `just release` inside the dev container now runs `gh` successfully (changelog generation, PR creation, etc.). But the version-bump `git push` step still blocks on an interactive HTTPS prompt:

```
Committing version bump...
Creating release branch 'chore/bump-version-2026.5.28-beta.14'...
Tag v2026.5.28-beta.14 will be created when PR merges.
Username for 'https://github.com':
```

#5825 forwarded `GH_TOKEN` into the container so gh authenticates without the host's Keychain. But `git push` doesn't read `GH_TOKEN` — it goes through git's credential system, which is unconfigured inside the container, so it falls back to prompting on stdin.

## Fix

Before invoking xtask, run `gh auth setup-git` (when `GH_TOKEN` is present) so gh wires itself in as the git credential helper. From then on `git push` over `https://github.com` URLs authenticates via the forwarded token — no interactive prompt, no leaked password in the container, no Keychain dependency from inside Docker. The guard is a no-op when `GH_TOKEN` is unset (e.g. a host where gh isn't installed), preserving the previous behaviour for that path.

Stderr is silenced because gh prints a one-line banner on success; the side effect (writing the credential helper config) is what we want.

## Test plan

- [x] `bash -n scripts/run-xtask.sh` — syntax clean.
- [x] Stub-docker test confirms the inner `sh -c` now expands to `export PATH=… && if [ -n "${GH_TOKEN:-}" ]; then gh auth setup-git 2>/dev/null || true; fi && exec cargo xtask 'release' '--foo'`.
- [ ] Reviewer reruns `just release` from a cargo-less macOS host and confirms it no longer blocks on `Username for 'https://github.com':` at the version-bump push.

## Why not bundle this into #5825

#5825 was already growing — adding git-credential plumbing would have stretched it further. The gap only surfaces once the rest of the chain works (need #5826's gh to even get to the push step), so cutting it as a focused follow-up keeps each diff small enough to audit.
