### PR TITLE
feat(kernel,api,dashboard): configurable auto_evolve_mode (free/controlled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -637,6 +637,10 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
   The Android and `mini` variants are deliberately skipped (neither carries channels).
   `librefang update` therefore lands the binary at `~/.librefang/bin/librefang-sidecar-telegram` (`.exe` on Windows), and the daemon auto-resolves it: a sidecar channel whose `command` is empty or the bare stem `librefang-sidecar-telegram` is resolved against the daemon's own executable directory, then `~/.librefang/bin/`, then PATH; an absolute / relative path or any other program (`python3 -m …`) is treated as explicit operator intent and passed through unchanged.
   `install.sh` / `install.ps1` install the bundled binary when present and stay silent on older tarballs that lack it.
+- **agents: configurable `auto_evolve_mode` (`free` / `controlled`)** (#5828) (@DaBlitzStein) — a new per-agent manifest field and dashboard control governs how the background `auto_evolve` skill reviewer applies its proposals.
+  `free` (the default) applies `create` mutations directly, preserving the prior `auto_evolve = true` behavior; `controlled` routes proposed creations to the pending approval queue so an operator reviews each new skill before it loads.
+  Update / patch proposals are skipped with a warning in `controlled` mode because the pending queue is create-only.
+  Settable per agent in `agent.toml`, via `PATCH /api/agents/{id}/config`, or from the agent Skills tab in the dashboard.
 
 ### Fixed
 

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -308,6 +308,8 @@ export interface AgentItem {
   identity?: AgentIdentity;
   is_hand?: boolean;
   web_search_augmentation?: "off" | "auto" | "always";
+  auto_evolve?: boolean;
+  auto_evolve_mode?: "controlled" | "free";
   /** UUID of the parent agent that spawned this one, if any.
    *  Wire field emitted by `GET /api/agents` is `parent_agent_id`; the raw
    *  `AgentEntry` serde form is `parent`. Both are accepted so the type is
@@ -1248,6 +1250,10 @@ export interface AgentDetail {
   is_hand?: boolean;
   web_search_augmentation?: "off" | "auto" | "always";
   auto_evolve?: boolean;
+  /** Skill-evolution mutation policy. `free` (default) applies create
+   *  mutations directly; `controlled` routes create mutations to the
+   *  pending approval queue. */
+  auto_evolve_mode?: "controlled" | "free";
 }
 
 export async function getAgentDetail(agentId: string): Promise<AgentDetail> {
@@ -1308,6 +1314,7 @@ export async function patchAgentConfig(
     provider?: string;
     temperature?: number;
     web_search_augmentation?: "off" | "auto" | "always";
+    auto_evolve_mode?: "controlled" | "free";
   },
 ): Promise<ApiActionResponse> {
   return patch<ApiActionResponse>(

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -2006,7 +2006,8 @@ export async function getSupportingFile(name: string, path: string): Promise<Sup
 export type PendingCaptureSource =
   | { kind: "explicit_instruction"; trigger: string }
   | { kind: "user_correction"; trigger: string }
-  | { kind: "repeated_tool_pattern"; tools: string; repeat_count: number };
+  | { kind: "repeated_tool_pattern"; tools: string; repeat_count: number }
+  | { kind: "auto_evolve_review"; action: string; triggering_turn?: number | null };
 
 export interface PendingProvenance {
   user_message_excerpt: string;

--- a/crates/librefang-api/dashboard/src/components/PendingSkillsSection.tsx
+++ b/crates/librefang-api/dashboard/src/components/PendingSkillsSection.tsx
@@ -41,6 +41,14 @@ function sourceLabel(source: PendingCaptureSource): {
         label: "Repeated tool pattern",
         detail: `${source.tools} ×${source.repeat_count}`,
       };
+    case "auto_evolve_review":
+      return {
+        label: "Auto-evolve review",
+        detail:
+          source.triggering_turn != null
+            ? `${source.action} · turn ${source.triggering_turn}`
+            : source.action,
+      };
   }
 }
 

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
@@ -62,6 +62,7 @@ export type AgentConfigPatch = {
   api_key_env?: string;
   base_url?: string;
   web_search_augmentation?: "off" | "auto" | "always";
+  auto_evolve_mode?: "controlled" | "free";
 };
 
 export function useSpawnAgent() {

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -2371,6 +2371,45 @@ export function AgentsPage() {
                 </div>
               </section>
 
+              {/* Skill Evolution Mode */}
+              {detailAgent.auto_evolve && (
+                <section>
+                  <h4 className="text-sm font-semibold mb-2">
+                    {t("agents.skill_evolution", { defaultValue: "Skill Evolution" })}
+                  </h4>
+                  <div className="rounded-lg bg-main border border-border-subtle p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-sm">{t("agents.evolution_mode", { defaultValue: "Evolution Mode" })}</p>
+                        <p className="text-xs text-text-dim mt-0.5 leading-relaxed">
+                          {t("agents.evolution_mode_hint", { defaultValue: "Whether skill mutations require human approval or apply automatically" })}
+                        </p>
+                      </div>
+                      <select
+                        value={detailAgent.auto_evolve_mode || "free"}
+                        onChange={e => {
+                          const mode = e.target.value as "controlled" | "free";
+                          // auto_evolve_mode is a manifest-level setting, always
+                          // use the standard config PATCH (not hand-runtime).
+                          patchAgentConfigMutation.mutate(
+                            { agentId: detailAgent.id, config: { auto_evolve_mode: mode } },
+                            {
+                              onSuccess: async () => {
+                                await refreshDetailAgent(detailAgent.id, detailAgent.is_hand);
+                              },
+                            },
+                          );
+                        }}
+                        className="w-36 px-2 py-1 rounded-md border border-border-subtle bg-surface text-sm font-mono outline-none focus:border-brand text-right shrink-0"
+                      >
+                        <option value="controlled">{t("agents.evolution_controlled", { defaultValue: "Controlled" })}</option>
+                        <option value="free">{t("agents.evolution_free", { defaultValue: "Free" })}</option>
+                      </select>
+                    </div>
+                  </div>
+                </section>
+              )}
+
               {/* Capabilities */}
               {detailAgent.capabilities && (
                 <section>

--- a/crates/librefang-api/src/routes/agents/config.rs
+++ b/crates/librefang-api/src/routes/agents/config.rs
@@ -572,6 +572,9 @@ pub struct PatchAgentConfigRequest {
     /// Web search augmentation mode: "off", "auto", or "always".
     #[schema(value_type = Option<String>)]
     pub web_search_augmentation: Option<librefang_types::agent::WebSearchAugmentationMode>,
+    /// Auto-evolve mode: "controlled" (pending queue) or "free" (auto-apply).
+    #[schema(value_type = Option<String>)]
+    pub auto_evolve_mode: Option<librefang_types::agent::EvolutionMode>,
 }
 
 /// PATCH /api/agents/{id}/config — Hot-update agent name, description, system prompt, and identity.
@@ -834,6 +837,21 @@ pub async fn patch_agent_config(
             .kernel
             .agent_registry()
             .update_web_search_augmentation(agent_id, mode)
+            .is_err()
+        {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": t.t("api-error-agent-not-found")})),
+            );
+        }
+    }
+
+    // Update auto_evolve_mode (controlled / free)
+    if let Some(mode) = req.auto_evolve_mode {
+        if state
+            .kernel
+            .agent_registry()
+            .update_auto_evolve_mode(agent_id, mode)
             .is_err()
         {
             return (

--- a/crates/librefang-api/src/routes/agents/lifecycle.rs
+++ b/crates/librefang-api/src/routes/agents/lifecycle.rs
@@ -1070,6 +1070,7 @@ pub async fn get_agent(
             "mcp_servers_mode": mcp_servers_mode(&entry.manifest.mcp_servers),
             "fallback_models": entry.manifest.fallback_models,
             "auto_evolve": entry.manifest.auto_evolve,
+            "auto_evolve_mode": entry.manifest.auto_evolve_mode,
             "web_search_augmentation": entry.manifest.web_search_augmentation,
         })),
     )

--- a/crates/librefang-api/src/routes/agents/mod.rs
+++ b/crates/librefang-api/src/routes/agents/mod.rs
@@ -337,6 +337,8 @@ pub(crate) fn enrich_agent_json(
             "color": e.identity.color,
         },
         "web_search_augmentation": e.manifest.web_search_augmentation,
+        "auto_evolve": e.manifest.auto_evolve,
+        "auto_evolve_mode": e.manifest.auto_evolve_mode,
         "parent_agent_id": e.parent.as_ref().map(|p| p.to_string()),
         "children": e.children.iter().map(|c| c.to_string()).collect::<Vec<_>>(),
         "session_id": e.session_id.0.to_string(),

--- a/crates/librefang-api/tests/agents_routes_integration.rs
+++ b/crates/librefang-api/tests/agents_routes_integration.rs
@@ -1649,3 +1649,49 @@ async fn test_patch_agent_auto_evolve_persists() {
         body["auto_evolve"]
     );
 }
+
+// ---------------------------------------------------------------------------
+// PATCH /api/agents/{id}/config — auto_evolve_mode field
+//
+// Pins the contract: PATCHing auto_evolve_mode must persist and be reflected
+// in the subsequent GET, confirming the manifest field round-trips through
+// the registry. Default stays `free`.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_patch_agent_config_auto_evolve_mode() {
+    let h = boot(TEST_TOKEN).await;
+    let id = spawn_named(&h.state, "evolve-mode-test");
+
+    // PATCH to controlled
+    let (status, _) = send(
+        h.app.clone(),
+        patch_json(
+            &format!("/api/agents/{id}/config"),
+            serde_json::json!({"auto_evolve_mode": "controlled"}),
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}"))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["auto_evolve_mode"], "controlled");
+
+    // PATCH back to free
+    let (status, _) = send(
+        h.app.clone(),
+        patch_json(
+            &format!("/api/agents/{id}/config"),
+            serde_json::json!({"auto_evolve_mode": "free"}),
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}"))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["auto_evolve_mode"], "free");
+}

--- a/crates/librefang-cli/src/commands/skill.rs
+++ b/crates/librefang-cli/src/commands/skill.rs
@@ -922,6 +922,9 @@ pub(crate) fn cmd_skill_pending(sub: PendingCommands) {
                     librefang_kernel::skill_workshop::CaptureSource::RepeatedToolPattern {
                         ..
                     } => "tool_pattern",
+                    librefang_kernel::skill_workshop::CaptureSource::AutoEvolveReview {
+                        ..
+                    } => "auto_evolve",
                 };
                 println!(
                     "{:<38}  {:<18}  {:<22}  {}",

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -763,12 +763,18 @@ impl LibreFangKernel {
         let action = parsed["action"].as_str().unwrap_or("skip");
         let review_author = format!("reviewer:agent:{triggering_agent_id}");
 
-        // Resolve auto_evolve_mode from the agent's manifest. Controlled
-        // (default) routes all mutations through the pending queue for
-        // human approval; Free applies them directly.
-        let evolution_mode = kernel_weak
+        // Upgrade the kernel weak handle once and share it across every
+        // mutation branch below — the handle is needed for the manifest
+        // lookup, the registry read, the pending save, and the reload.
+        // A dropped kernel means the daemon is shutting down, so every
+        // branch treats it as a Permanent failure with uniform handling.
+        let kernel_arc = kernel_weak.as_ref().and_then(|w| w.upgrade());
+
+        // Resolve auto_evolve_mode from the agent's manifest. Free (the
+        // default) applies create mutations directly; Controlled routes
+        // create mutations through the pending approval queue.
+        let evolution_mode = kernel_arc
             .as_ref()
-            .and_then(|w| w.upgrade())
             .and_then(|kernel| {
                 kernel
                     .agents
@@ -778,78 +784,10 @@ impl LibreFangKernel {
             })
             .unwrap_or_default();
 
-        // Helper: lift an `Ok(result)` into a hot-reload + return.
+        // Helper: hot-reload the skill registry after a direct mutation.
         let do_reload = || {
-            if let Some(kernel) = kernel_weak.as_ref().and_then(|w| w.upgrade()) {
+            if let Some(kernel) = kernel_arc.as_ref() {
                 kernel.reload_skills();
-            }
-        };
-
-        // Helper: save a mutation as a pending candidate for human
-        // approval (Controlled mode). Builds a CandidateSkill from the
-        // reviewer's JSON fields and routes through the workshop's
-        // save_candidate pipeline (security scan, dedup, cap enforcement).
-        let save_as_pending = |action_label: &str,
-                               name: &str,
-                               description: &str,
-                               prompt_context: &str|
-         -> Result<(), ReviewError> {
-            let kernel = kernel_weak
-                .as_ref()
-                .and_then(|w| w.upgrade())
-                .ok_or_else(|| {
-                    ReviewError::Permanent("Kernel dropped before save_as_pending".to_string())
-                })?;
-            let candidate = crate::skill_workshop::candidate::CandidateSkill {
-                id: uuid::Uuid::new_v4().to_string(),
-                agent_id: triggering_agent_id.to_string(),
-                session_id: None,
-                captured_at: chrono::Utc::now(),
-                source: crate::skill_workshop::candidate::CaptureSource::ExplicitInstruction {
-                    trigger: format!("auto_evolve:{action_label}"),
-                },
-                name: name.to_string(),
-                description: description.to_string(),
-                prompt_context: prompt_context.to_string(),
-                provenance: crate::skill_workshop::candidate::Provenance {
-                    user_message_excerpt: safe_response_summary
-                        .chars()
-                        .take(crate::skill_workshop::candidate::PROVENANCE_EXCERPT_MAX_CHARS)
-                        .collect(),
-                    assistant_response_excerpt: Some(
-                        trace_summary
-                            .chars()
-                            .take(crate::skill_workshop::candidate::PROVENANCE_EXCERPT_MAX_CHARS)
-                            .collect(),
-                    ),
-                    turn_index: 0,
-                },
-            };
-            let skills_root = kernel.home_dir().join("skills");
-            match crate::skill_workshop::storage::save_candidate(&skills_root, &candidate, 50, None)
-            {
-                Ok(true) => {
-                    tracing::info!(
-                        skill = name,
-                        "Background review (controlled): pending candidate written for '{action_label}'"
-                    );
-                    Ok(())
-                }
-                Ok(false) => {
-                    tracing::debug!(
-                        skill = name,
-                        "Background review (controlled): candidate deduped or cap=0"
-                    );
-                    Ok(())
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        skill = name,
-                        error = %e,
-                        "Background review (controlled): failed to save pending candidate"
-                    );
-                    Err(ReviewError::Permanent(format!("save_as_pending: {e}")))
-                }
             }
         };
 
@@ -904,24 +842,26 @@ impl LibreFangKernel {
                     ReviewError::Permanent("Missing 'changelog' in update response".to_string())
                 })?;
 
-                // Controlled mode does not support updates yet — the
-                // pending queue only has CREATE semantics. Log and fall
-                // through to the direct path.
+                // Controlled mode does not yet support `update`. The pending
+                // queue is create-only — `approve_candidate` calls
+                // `evolution::create_skill`, so an approved "update" candidate
+                // would wrongly create a name-colliding skill rather than
+                // rewriting the existing one. Until the queue grows update
+                // semantics, skip rather than mis-apply.
                 if evolution_mode == librefang_types::agent::EvolutionMode::Controlled {
                     tracing::warn!(
                         skill = name,
-                        "Background skill review: controlled mode does not support \
-                         skill updates yet; applying directly"
+                        "Background skill review: controlled mode does not yet support \
+                         skill update; set auto_evolve_mode = \"free\" or apply the \
+                         change manually — skipping"
                     );
+                    return Ok(());
                 }
 
                 // Free mode: apply directly.
-                let kernel = kernel_weak
-                    .as_ref()
-                    .and_then(|w| w.upgrade())
-                    .ok_or_else(|| {
-                        ReviewError::Permanent("Kernel dropped before update".to_string())
-                    })?;
+                let kernel = kernel_arc.as_ref().ok_or_else(|| {
+                    ReviewError::Permanent("Kernel dropped before update".to_string())
+                })?;
                 let skill = {
                     let reg = kernel
                         .skills
@@ -967,14 +907,11 @@ impl LibreFangKernel {
             // where the reviewer identifies a specific sentence that's
             // wrong or outdated.
             //
-            // Design intent — patch stays on the DIRECT path intentionally:
-            // same rationale as the `update` arm above. A patch targets an
-            // already-approved skill; requiring human re-approval for every
-            // small textual fix would stall the incremental improvement loop
-            // without a meaningful security gain. The `evolution::patch_skill`
-            // call still runs the SkillVerifier scan (SecurityBlocked
-            // propagation is present in the match arm below), so malicious
-            // content cannot bypass the injection filter via the patch path.
+            // In `Free` mode this applies directly (the `evolution::patch_skill`
+            // call still runs the SkillVerifier scan, so malicious content
+            // cannot bypass the injection filter). In `Controlled` mode it is
+            // skipped — like `update`, the pending queue only has CREATE
+            // semantics, so there is no safe way to defer a patch for approval.
             "patch" => {
                 let name = name.ok_or_else(|| {
                     ReviewError::Permanent("Missing 'name' in patch response".to_string())
@@ -989,24 +926,24 @@ impl LibreFangKernel {
                     ReviewError::Permanent("Missing 'changelog' in patch response".to_string())
                 })?;
 
-                // Controlled mode does not support patches yet — the
-                // pending queue only has CREATE semantics. Log and fall
-                // through to the direct path.
+                // Controlled mode does not yet support `patch`. Same reason as
+                // `update`: the pending queue is create-only, so an approved
+                // patch candidate would create a name-colliding skill instead
+                // of editing the target. Skip rather than mis-apply.
                 if evolution_mode == librefang_types::agent::EvolutionMode::Controlled {
                     tracing::warn!(
                         skill = name,
-                        "Background skill review: controlled mode does not support \
-                         skill patches yet; applying directly"
+                        "Background skill review: controlled mode does not yet support \
+                         skill patch; set auto_evolve_mode = \"free\" or apply the \
+                         change manually — skipping"
                     );
+                    return Ok(());
                 }
 
                 // Free mode: apply directly.
-                let kernel = kernel_weak
-                    .as_ref()
-                    .and_then(|w| w.upgrade())
-                    .ok_or_else(|| {
-                        ReviewError::Permanent("Kernel dropped before patch".to_string())
-                    })?;
+                let kernel = kernel_arc.as_ref().ok_or_else(|| {
+                    ReviewError::Permanent("Kernel dropped before patch".to_string())
+                })?;
                 let skill = {
                     let reg = kernel
                         .skills
@@ -1065,19 +1002,14 @@ impl LibreFangKernel {
                     )
                 })?;
 
-                // Route through pending/ instead of creating the skill directly.
-                // This puts the LLM-proposed skill in the same approval queue as
-                // workshop-captured candidates — a human reviews it before it is
-                // loaded into the active registry.
-                let kernel = kernel_weak
-                    .as_ref()
-                    .and_then(|w| w.upgrade())
-                    .ok_or_else(|| {
-                        ReviewError::Permanent("Kernel dropped before pending save".to_string())
-                    })?;
-
                 // Read the agent's workshop config for cap / TTL settings.
-                // Fall back to the struct defaults when the agent entry is gone.
+                // These pending candidates land in the same pending/<agent>/
+                // dir the workshop manages, so the cap/TTL must match the
+                // workshop's. Fall back to struct defaults when the agent
+                // entry is gone.
+                let kernel = kernel_arc.as_ref().ok_or_else(|| {
+                    ReviewError::Permanent("Kernel dropped before pending save".to_string())
+                })?;
                 let workshop_cfg = kernel
                     .agents
                     .registry
@@ -1085,7 +1017,10 @@ impl LibreFangKernel {
                     .map(|e| e.manifest.skill_workshop)
                     .unwrap_or_default();
 
-                // Controlled mode: route creates through pending queue.
+                // Controlled mode: route creates through the pending queue.
+                // This puts the LLM-proposed skill in the same approval queue
+                // as workshop-captured candidates — a human reviews it before
+                // it is loaded into the active registry.
                 if evolution_mode == librefang_types::agent::EvolutionMode::Controlled {
                     let candidate = Self::build_reviewer_candidate(
                         triggering_agent_id,
@@ -1376,12 +1311,19 @@ impl LibreFangKernel {
     }
 
     /// Build the [`CandidateSkill`] that the background reviewer submits to the
-    /// pending queue when it decides to `create` a new skill.
+    /// pending queue when it decides to `create` a new skill in controlled mode.
     ///
     /// Extracted into its own method so the candidate-construction logic can be
     /// exercised in unit tests without spinning up a live kernel or LLM driver.
     /// The caller (`background_skill_review`) passes the already-sanitised
     /// summaries so this helper never touches raw agent output directly.
+    ///
+    /// The capture source is [`CaptureSource::AutoEvolveReview`] — not
+    /// `ExplicitInstruction` — so the dashboard labels it as an autonomous
+    /// reviewer proposal rather than a user-requested capture. The first
+    /// `REVIEWER_EXCERPT_MAX_CHARS` of `prompt_context` are lifted into
+    /// `assistant_response_excerpt` so an operator can see *why* the candidate
+    /// was proposed without opening the full body.
     pub(crate) fn build_reviewer_candidate(
         agent_id: AgentId,
         name: &str,
@@ -1389,13 +1331,18 @@ impl LibreFangKernel {
         prompt_context: &str,
         response_summary: &str,
     ) -> crate::skill_workshop::candidate::CandidateSkill {
+        /// Excerpt cap for the reviewer's proposed body shown in the dashboard.
+        const REVIEWER_EXCERPT_MAX_CHARS: usize = 500;
         crate::skill_workshop::candidate::CandidateSkill {
             id: uuid::Uuid::new_v4().to_string(),
             agent_id: agent_id.to_string(),
             session_id: None,
             captured_at: chrono::Utc::now(),
-            source: crate::skill_workshop::candidate::CaptureSource::ExplicitInstruction {
-                trigger: "auto_evolve_reviewer".to_string(),
+            source: crate::skill_workshop::candidate::CaptureSource::AutoEvolveReview {
+                action: "create".to_string(),
+                // TODO: thread turn_index from the session when the reviewer
+                // call carries it; 0/None until then.
+                triggering_turn: None,
             },
             name: name.to_string(),
             description: description.to_string(),
@@ -1405,7 +1352,13 @@ impl LibreFangKernel {
                     .chars()
                     .take(crate::skill_workshop::candidate::PROVENANCE_EXCERPT_MAX_CHARS)
                     .collect(),
-                assistant_response_excerpt: None,
+                assistant_response_excerpt: Some(
+                    prompt_context
+                        .chars()
+                        .take(REVIEWER_EXCERPT_MAX_CHARS)
+                        .collect(),
+                ),
+                // TODO: thread turn_index from the session context.
                 turn_index: 0,
             },
         }
@@ -1452,14 +1405,24 @@ mod tests {
         );
         assert_eq!(candidate.agent_id, agent_id.to_string());
         assert!(candidate.session_id.is_none());
-        assert!(candidate.provenance.assistant_response_excerpt.is_none());
+        // The reviewer's proposed body is lifted into the assistant excerpt so
+        // operators see why the candidate was proposed.
+        assert_eq!(
+            candidate.provenance.assistant_response_excerpt.as_deref(),
+            Some("# Cargo fmt\n\nRun `cargo fmt --all` before staging.")
+        );
         assert_eq!(candidate.provenance.turn_index, 0);
-        // Source must be ExplicitInstruction with the reviewer trigger tag.
+        // Source must be AutoEvolveReview tagged with the create action —
+        // NOT ExplicitInstruction (which would mislabel it as user-requested).
         match &candidate.source {
-            CaptureSource::ExplicitInstruction { trigger } => {
-                assert_eq!(trigger, "auto_evolve_reviewer");
+            CaptureSource::AutoEvolveReview {
+                action,
+                triggering_turn,
+            } => {
+                assert_eq!(action, "create");
+                assert!(triggering_turn.is_none());
             }
-            other => panic!("expected ExplicitInstruction source, got {other:?}"),
+            other => panic!("expected AutoEvolveReview source, got {other:?}"),
         }
         // Must be a valid UUID so the pending-queue storage path accepts it.
         uuid::Uuid::parse_str(&candidate.id).expect("candidate.id must be a valid UUID");
@@ -1483,6 +1446,134 @@ mod tests {
             PROVENANCE_EXCERPT_MAX_CHARS,
             "excerpt must be capped at PROVENANCE_EXCERPT_MAX_CHARS"
         );
+    }
+
+    // ── end-to-end mode-gating through background_skill_review ──────────────
+
+    use librefang_testing::MockLlmDriver;
+    use librefang_types::agent::{AgentManifest, EvolutionMode};
+    use librefang_types::config::{DefaultModelConfig, KernelConfig};
+
+    /// Boot a real kernel against a temp home and spawn one agent with the
+    /// requested `auto_evolve_mode`. Returns the kernel (wrapped in `Arc` so a
+    /// `Weak` can be handed to `background_skill_review`) and the agent id.
+    fn boot_kernel_with_mode(mode: EvolutionMode) -> (std::sync::Arc<LibreFangKernel>, AgentId) {
+        let tmp = tempdir().unwrap();
+        let home_dir = tmp.path().to_path_buf();
+        std::fs::create_dir_all(home_dir.join("data")).unwrap();
+        // Leak the TempDir so the on-disk home survives for the test body —
+        // dropping it would race the reload/save paths.
+        std::mem::forget(tmp);
+
+        let config = KernelConfig {
+            home_dir: home_dir.clone(),
+            data_dir: home_dir.join("data"),
+            ..KernelConfig::default()
+        };
+        let kernel = std::sync::Arc::new(
+            LibreFangKernel::boot_with_config(config).expect("kernel should boot"),
+        );
+        let agent_id = kernel
+            .spawn_agent_inner(
+                AgentManifest {
+                    name: "evolve-agent".to_string(),
+                    description: "auto-evolve test agent".to_string(),
+                    author: "test".to_string(),
+                    module: "builtin:chat".to_string(),
+                    auto_evolve_mode: mode,
+                    ..Default::default()
+                },
+                None,
+                None,
+                None,
+            )
+            .expect("agent should spawn");
+        (kernel, agent_id)
+    }
+
+    /// A reviewer JSON response asking to `create` a brand-new skill.
+    fn create_action_json(name: &str) -> String {
+        format!(
+            "```json\n{{\"action\": \"create\", \"name\": \"{name}\", \
+             \"description\": \"A skill proposed by the reviewer\", \
+             \"prompt_context\": \"# Auto Skill\\n\\nDo the thing.\", \
+             \"tags\": [\"auto\"]}}\n```"
+        )
+    }
+
+    /// Controlled mode: a reviewer `create` must land in the pending queue and
+    /// must NOT install a live skill.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn controlled_mode_create_routes_to_pending_not_live() {
+        let (kernel, agent_id) = boot_kernel_with_mode(EvolutionMode::Controlled);
+        let skills_dir = kernel.home_dir().join("skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        let driver = std::sync::Arc::new(MockLlmDriver::with_response(create_action_json(
+            "controlled_new_skill",
+        )));
+
+        LibreFangKernel::background_skill_review(
+            driver,
+            &skills_dir,
+            "trace summary",
+            "response summary",
+            Some(std::sync::Arc::downgrade(&kernel)),
+            agent_id,
+            &DefaultModelConfig::default(),
+        )
+        .await
+        .expect("review should succeed");
+
+        let pending = storage::list_pending(&skills_dir, &agent_id.to_string())
+            .expect("list_pending must succeed");
+        assert_eq!(
+            pending.len(),
+            1,
+            "controlled mode must write exactly one pending candidate"
+        );
+        assert_eq!(pending[0].name, "controlled_new_skill");
+        assert!(
+            !skills_dir.join("controlled_new_skill").exists(),
+            "controlled mode must NOT install a live skill before approval"
+        );
+
+        kernel.shutdown();
+    }
+
+    /// Free mode: a reviewer `create` must install a live skill directly and
+    /// must NOT leave anything in the pending queue.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn free_mode_create_installs_live_skill_not_pending() {
+        let (kernel, agent_id) = boot_kernel_with_mode(EvolutionMode::Free);
+        let skills_dir = kernel.home_dir().join("skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        let driver = std::sync::Arc::new(MockLlmDriver::with_response(create_action_json(
+            "free_new_skill",
+        )));
+
+        LibreFangKernel::background_skill_review(
+            driver,
+            &skills_dir,
+            "trace summary",
+            "response summary",
+            Some(std::sync::Arc::downgrade(&kernel)),
+            agent_id,
+            &DefaultModelConfig::default(),
+        )
+        .await
+        .expect("review should succeed");
+
+        assert!(
+            skills_dir.join("free_new_skill").exists(),
+            "free mode must install the skill directly into the registry dir"
+        );
+        let pending = storage::list_pending(&skills_dir, &agent_id.to_string()).unwrap_or_default();
+        assert!(
+            pending.is_empty(),
+            "free mode must NOT write a pending candidate"
+        );
+
+        kernel.shutdown();
     }
 
     // ── create action routes through save_candidate (pending queue) ─────────

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -609,7 +609,10 @@ impl LibreFangKernel {
             "- The approach involved 5+ steps that could benefit future similar tasks\n",
             "- The user's preferred method differs from the obvious approach\n",
             "- The agent used 3+ different tools in a sequence to accomplish a goal\n",
-            "- The conversation involved a multi-step procedure that could be reused\n\n",
+            "- The conversation involved a multi-step procedure that could be reused\n",
+            "- The agent used an existing skill but had to work around a limitation\n",
+            "- The agent discovered a better approach than what a skill prescribes\n",
+            "- Error handling or edge cases were found during execution\n\n",
             "Choose exactly ONE of these JSON responses:\n",
             "```json\n",
             "{\"action\": \"create\", \"name\": \"skill-name\", \"description\": \"one-line desc\", ",
@@ -760,10 +763,85 @@ impl LibreFangKernel {
         let action = parsed["action"].as_str().unwrap_or("skip");
         let review_author = format!("reviewer:agent:{triggering_agent_id}");
 
+        // Resolve auto_evolve_mode from the agent's manifest. Controlled
+        // (default) routes all mutations through the pending queue for
+        // human approval; Free applies them directly.
+        let evolution_mode = kernel_weak
+            .as_ref()
+            .and_then(|w| w.upgrade())
+            .and_then(|kernel| {
+                kernel
+                    .agents
+                    .registry
+                    .get(triggering_agent_id)
+                    .map(|e| e.manifest.auto_evolve_mode)
+            })
+            .unwrap_or_default();
+
         // Helper: lift an `Ok(result)` into a hot-reload + return.
         let do_reload = || {
             if let Some(kernel) = kernel_weak.as_ref().and_then(|w| w.upgrade()) {
                 kernel.reload_skills();
+            }
+        };
+
+        // Helper: save a mutation as a pending candidate for human
+        // approval (Controlled mode). Builds a CandidateSkill from the
+        // reviewer's JSON fields and routes through the workshop's
+        // save_candidate pipeline (security scan, dedup, cap enforcement).
+        let save_as_pending = |action_label: &str,
+                               name: &str,
+                               description: &str,
+                               prompt_context: &str|
+         -> Result<(), ReviewError> {
+            let kernel = kernel_weak
+                .as_ref()
+                .and_then(|w| w.upgrade())
+                .ok_or_else(|| {
+                    ReviewError::Permanent("Kernel dropped before save_as_pending".to_string())
+                })?;
+            let candidate = crate::skill_workshop::candidate::CandidateSkill {
+                id: uuid::Uuid::new_v4().to_string(),
+                agent_id: triggering_agent_id.to_string(),
+                session_id: None,
+                captured_at: chrono::Utc::now(),
+                source: crate::skill_workshop::candidate::CaptureSource::ExplicitInstruction {
+                    trigger: format!("auto_evolve:{action_label}"),
+                },
+                name: name.to_string(),
+                description: description.to_string(),
+                prompt_context: prompt_context.to_string(),
+                provenance: crate::skill_workshop::candidate::Provenance {
+                    user_message_excerpt: String::new(),
+                    assistant_response_excerpt: None,
+                    turn_index: 0,
+                },
+            };
+            let skills_root = kernel.home_dir().join("skills");
+            match crate::skill_workshop::storage::save_candidate(&skills_root, &candidate, 50, None)
+            {
+                Ok(true) => {
+                    tracing::info!(
+                        skill = name,
+                        "Background review (controlled): pending candidate written for '{action_label}'"
+                    );
+                    Ok(())
+                }
+                Ok(false) => {
+                    tracing::debug!(
+                        skill = name,
+                        "Background review (controlled): candidate deduped or cap=0"
+                    );
+                    Ok(())
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        skill = name,
+                        error = %e,
+                        "Background review (controlled): failed to save pending candidate"
+                    );
+                    Err(ReviewError::Permanent(format!("save_as_pending: {e}")))
+                }
             }
         };
 
@@ -818,6 +896,18 @@ impl LibreFangKernel {
                     ReviewError::Permanent("Missing 'changelog' in update response".to_string())
                 })?;
 
+                // Controlled mode does not support updates yet — the
+                // pending queue only has CREATE semantics. Log and fall
+                // through to the direct path.
+                if evolution_mode == librefang_types::agent::EvolutionMode::Controlled {
+                    tracing::warn!(
+                        skill = name,
+                        "Background skill review: controlled mode does not support \
+                         skill updates yet; applying directly"
+                    );
+                }
+
+                // Free mode: apply directly.
                 let kernel = kernel_weak
                     .as_ref()
                     .and_then(|w| w.upgrade())
@@ -849,7 +939,7 @@ impl LibreFangKernel {
                     Some(&review_author),
                 ) {
                     Ok(result) => {
-                        tracing::info!(skill = %result.skill_name, version = %result.version.as_deref().unwrap_or("?"), "💾 Background review: updated skill");
+                        tracing::info!(skill = %result.skill_name, version = %result.version.as_deref().unwrap_or("?"), "Background review (free): updated skill");
                         do_reload();
                         Ok(())
                     }
@@ -891,6 +981,18 @@ impl LibreFangKernel {
                     ReviewError::Permanent("Missing 'changelog' in patch response".to_string())
                 })?;
 
+                // Controlled mode does not support patches yet — the
+                // pending queue only has CREATE semantics. Log and fall
+                // through to the direct path.
+                if evolution_mode == librefang_types::agent::EvolutionMode::Controlled {
+                    tracing::warn!(
+                        skill = name,
+                        "Background skill review: controlled mode does not support \
+                         skill patches yet; applying directly"
+                    );
+                }
+
+                // Free mode: apply directly.
                 let kernel = kernel_weak
                     .as_ref()
                     .and_then(|w| w.upgrade())
@@ -924,7 +1026,7 @@ impl LibreFangKernel {
                     Some(&review_author),
                 ) {
                     Ok(result) => {
-                        tracing::info!(skill = %result.skill_name, version = %result.version.as_deref().unwrap_or("?"), "💾 Background review: patched skill");
+                        tracing::info!(skill = %result.skill_name, version = %result.version.as_deref().unwrap_or("?"), "Background review (free): patched skill");
                         do_reload();
                         Ok(())
                     }
@@ -975,45 +1077,85 @@ impl LibreFangKernel {
                     .map(|e| e.manifest.skill_workshop)
                     .unwrap_or_default();
 
-                let candidate = Self::build_reviewer_candidate(
-                    triggering_agent_id,
+                // Controlled mode: route creates through pending queue.
+                if evolution_mode == librefang_types::agent::EvolutionMode::Controlled {
+                    let candidate = Self::build_reviewer_candidate(
+                        triggering_agent_id,
+                        name,
+                        description,
+                        prompt_context,
+                        &safe_response_summary,
+                    );
+                    match crate::skill_workshop::storage::save_candidate(
+                        skills_dir,
+                        &candidate,
+                        workshop_cfg.max_pending,
+                        workshop_cfg.max_pending_age_days,
+                    ) {
+                        Ok(true) => {
+                            tracing::info!(
+                                skill = name,
+                                agent = %triggering_agent_id,
+                                "Background skill review: queued '{}' as pending draft for human approval",
+                                name
+                            );
+                            return Ok(());
+                        }
+                        Ok(false) => {
+                            tracing::debug!(
+                                skill = name,
+                                "Background skill review: pending save skipped (duplicate or max_pending=0)"
+                            );
+                            return Ok(());
+                        }
+                        Err(crate::skill_workshop::storage::WorkshopError::SecurityBlocked(msg)) => {
+                            return Err(ReviewError::Permanent(format!("security_blocked: {msg}")));
+                        }
+                        Err(crate::skill_workshop::storage::WorkshopError::Io(e)) => {
+                            return Err(ReviewError::Transient(format!("save_candidate io: {e}")));
+                        }
+                        Err(e) => {
+                            tracing::debug!(skill = name, error = %e, "Background skill review: pending save failed");
+                            return Err(ReviewError::Permanent(format!("save_candidate: {e}")));
+                        }
+                    }
+                }
+
+                // Free mode: apply directly.
+                let tags: Vec<String> = parsed["tags"]
+                    .as_array()
+                    .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                    .unwrap_or_default();
+                match librefang_skills::evolution::create_skill(
+                    skills_dir,
                     name,
                     description,
                     prompt_context,
-                    &safe_response_summary,
-                );
-
-                match crate::skill_workshop::storage::save_candidate(
-                    skills_dir,
-                    &candidate,
-                    workshop_cfg.max_pending,
-                    workshop_cfg.max_pending_age_days,
+                    tags,
+                    Some(&review_author),
                 ) {
-                    Ok(true) => {
+                    Ok(result) => {
                         tracing::info!(
                             skill = name,
-                            agent = %triggering_agent_id,
-                            "Background skill review: queued '{}' as pending draft for human approval",
-                            name
+                            "Background skill review (free): created skill '{}'",
+                            result.skill_name
                         );
+                        do_reload();
                         Ok(())
                     }
-                    Ok(false) => {
-                        tracing::debug!(
-                            skill = name,
-                            "Background skill review: pending save skipped (duplicate or max_pending=0)"
-                        );
+                    Err(librefang_skills::SkillError::AlreadyInstalled(_)) => {
+                        tracing::debug!(skill = name, "Skill already exists — skipping creation");
                         Ok(())
                     }
-                    Err(crate::skill_workshop::storage::WorkshopError::SecurityBlocked(msg)) => {
+                    Err(librefang_skills::SkillError::SecurityBlocked(msg)) => {
                         Err(ReviewError::Permanent(format!("security_blocked: {msg}")))
                     }
-                    Err(crate::skill_workshop::storage::WorkshopError::Io(e)) => {
-                        Err(ReviewError::Transient(format!("save_candidate io: {e}")))
+                    Err(librefang_skills::SkillError::Io(e)) => {
+                        Err(ReviewError::Transient(format!("create_skill io: {e}")))
                     }
                     Err(e) => {
-                        tracing::debug!(skill = name, error = %e, "Background skill review: pending save failed");
-                        Err(ReviewError::Permanent(format!("save_candidate: {e}")))
+                        tracing::debug!(skill = name, error = %e, "Background skill creation failed");
+                        Err(ReviewError::Permanent(format!("create_skill: {e}")))
                     }
                 }
             }

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -812,8 +812,16 @@ impl LibreFangKernel {
                 description: description.to_string(),
                 prompt_context: prompt_context.to_string(),
                 provenance: crate::skill_workshop::candidate::Provenance {
-                    user_message_excerpt: String::new(),
-                    assistant_response_excerpt: None,
+                    user_message_excerpt: safe_response_summary
+                        .chars()
+                        .take(crate::skill_workshop::candidate::PROVENANCE_EXCERPT_MAX_CHARS)
+                        .collect(),
+                    assistant_response_excerpt: Some(
+                        trace_summary
+                            .chars()
+                            .take(crate::skill_workshop::candidate::PROVENANCE_EXCERPT_MAX_CHARS)
+                            .collect(),
+                    ),
                     turn_index: 0,
                 },
             };
@@ -1108,7 +1116,9 @@ impl LibreFangKernel {
                             );
                             return Ok(());
                         }
-                        Err(crate::skill_workshop::storage::WorkshopError::SecurityBlocked(msg)) => {
+                        Err(crate::skill_workshop::storage::WorkshopError::SecurityBlocked(
+                            msg,
+                        )) => {
                             return Err(ReviewError::Permanent(format!("security_blocked: {msg}")));
                         }
                         Err(crate::skill_workshop::storage::WorkshopError::Io(e)) => {
@@ -1124,7 +1134,11 @@ impl LibreFangKernel {
                 // Free mode: apply directly.
                 let tags: Vec<String> = parsed["tags"]
                     .as_array()
-                    .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
                     .unwrap_or_default();
                 match librefang_skills::evolution::create_skill(
                     skills_dir,

--- a/crates/librefang-kernel/src/registry.rs
+++ b/crates/librefang-kernel/src/registry.rs
@@ -496,6 +496,20 @@ impl AgentRegistry {
         Ok(())
     }
 
+    /// Update an agent's auto_evolve_mode (Controlled / Free).
+    pub fn update_auto_evolve_mode(
+        &self,
+        id: AgentId,
+        mode: librefang_types::agent::EvolutionMode,
+    ) -> LibreFangResult<()> {
+        self.with_entry_mut(id, |entry| {
+            entry.manifest.auto_evolve_mode = mode;
+            entry.last_active = chrono::Utc::now();
+        })?;
+        self.notify_changed();
+        Ok(())
+    }
+
     /// Update an agent's schedule mode (Reactive / Periodic / Proactive /
     /// Continuous). Mutates the manifest only — the kernel-level wrapper
     /// `LibreFangKernel::set_agent_schedule` is what callers should use to

--- a/crates/librefang-kernel/src/skill_workshop/candidate.rs
+++ b/crates/librefang-kernel/src/skill_workshop/candidate.rs
@@ -71,6 +71,17 @@ pub enum CaptureSource {
         /// How many times the sequence was observed.
         repeat_count: u32,
     },
+    /// The background `auto_evolve` LLM reviewer proposed a skill mutation
+    /// while the agent runs in `controlled` mode, so it was routed to the
+    /// pending queue instead of being applied directly. Distinct from
+    /// `ExplicitInstruction` (which means the *user* asked for it) — these
+    /// are autonomous proposals from the reviewer pass.
+    AutoEvolveReview {
+        /// The reviewer action that produced this candidate (`"create"`).
+        action: String,
+        /// The session turn that triggered the review, when known.
+        triggering_turn: Option<u32>,
+    },
 }
 
 /// Conversation context the candidate was extracted from.

--- a/crates/librefang-kernel/src/skill_workshop/llm_review.rs
+++ b/crates/librefang-kernel/src/skill_workshop/llm_review.rs
@@ -166,6 +166,15 @@ fn build_user_prompt(hit: &HeuristicHit) -> String {
             tools,
             repeat_count,
         } => format!("repeated_tool_pattern: tools=[{tools}], count={repeat_count}"),
+        crate::skill_workshop::candidate::CaptureSource::AutoEvolveReview {
+            action,
+            triggering_turn,
+        } => format!(
+            "auto_evolve_review: action={action}, turn={}",
+            triggering_turn
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "?".to_string())
+        ),
     };
     let assistant_excerpt = hit
         .assistant_response_excerpt

--- a/crates/librefang-kernel/src/skill_workshop/storage.rs
+++ b/crates/librefang-kernel/src/skill_workshop/storage.rs
@@ -257,6 +257,7 @@ fn source_kind(source: &crate::skill_workshop::candidate::CaptureSource) -> &'st
         ExplicitInstruction { .. } => "explicit_instruction",
         UserCorrection { .. } => "user_correction",
         RepeatedToolPattern { .. } => "repeated_tool_pattern",
+        AutoEvolveReview { .. } => "auto_evolve_review",
     }
 }
 

--- a/crates/librefang-kernel/src/wizard.rs
+++ b/crates/librefang-kernel/src/wizard.rs
@@ -200,6 +200,7 @@ impl SetupWizard {
             auto_dream_min_sessions: None,
             show_progress: true,
             auto_evolve: true,
+            auto_evolve_mode: librefang_types::agent::EvolutionMode::default(),
             channel_overrides: None,
             max_history_messages: None,
             max_concurrent_invocations: None,

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -565,22 +565,25 @@ pub enum WebSearchAugmentationMode {
 ///
 /// Used alongside `auto_evolve = true` on `AgentManifest` to decide
 /// whether the background skill review pipeline applies mutations
-/// directly (free) or routes them through the pending queue for human
-/// approval (controlled). This is separate from `SkillWorkshopConfig`
-/// — the workshop handles passive capture from conversation turns,
-/// while `auto_evolve` + `EvolutionMode` govern the background LLM
-/// reviewer that runs after each turn.
+/// directly (free, the default) or routes proposed creations through
+/// the pending queue for human approval (controlled). This is separate
+/// from `SkillWorkshopConfig` — the workshop handles passive capture
+/// from conversation turns, while `auto_evolve` + `EvolutionMode` govern
+/// the background LLM reviewer that runs after each turn.
 #[derive(
     Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum EvolutionMode {
-    /// All mutations (create, update, patch) go through the pending
-    /// queue for human approval before taking effect.
+    /// `create` mutations route to the pending approval queue so an
+    /// operator reviews each proposed skill before it loads into the
+    /// active registry. `update`/`patch` are not yet supported in this
+    /// mode (the pending queue is create-only) and are skipped with a
+    /// warning rather than applied.
     Controlled,
     /// Mutations apply directly without approval. The agent evolves
-    /// autonomously. Default — preserves pre-existing behavior for
-    /// agents that already opted into `auto_evolve = true`.
+    /// autonomously. Default — preserves the prior behavior of agents
+    /// that already opted into `auto_evolve = true`.
     #[default]
     Free,
 }
@@ -1269,13 +1272,16 @@ pub struct AgentManifest {
     /// the background LLM budget or concurrency semaphore after a turn.
     #[serde(default = "default_true")]
     pub auto_evolve: bool,
-    /// Whether auto_evolve mutations require approval (`controlled`, default)
-    /// or apply directly (`free`). Only meaningful when `auto_evolve = true`.
+    /// Policy for how `auto_evolve` mutations are applied. Defaults to
+    /// `free`. Only meaningful when `auto_evolve = true`.
     ///
-    /// - `Controlled` (default): all mutations (create, update, patch) go
-    ///   through the pending queue for human approval before taking effect.
-    /// - `Free`: mutations apply directly without approval. The agent
+    /// - `Free` (default): mutations apply directly without approval,
+    ///   preserving the prior `auto_evolve = true` behavior — the agent
     ///   evolves autonomously.
+    /// - `Controlled`: `create` mutations route to the pending approval
+    ///   queue so an operator reviews each proposed skill before it loads.
+    ///   `update`/`patch` are not yet supported in controlled mode (the
+    ///   pending queue is create-only) and are skipped with a warning.
     #[serde(default)]
     pub auto_evolve_mode: EvolutionMode,
     /// Per-agent channel behavior overrides (dm_policy, group_policy, etc.).
@@ -3838,5 +3844,16 @@ model = "claude-3-haiku-20240307"
         }
         let w: W = toml::from_str(toml_str).unwrap();
         assert_eq!(w.auto_evolve_mode, EvolutionMode::Controlled);
+    }
+
+    #[test]
+    fn evolution_mode_rejects_unknown_variant() {
+        // An unrecognized mode must error rather than silently falling
+        // back to the default — a typo'd manifest should surface loudly.
+        let err = serde_json::from_str::<EvolutionMode>("\"semi-auto\"").unwrap_err();
+        assert!(
+            err.to_string().contains("unknown variant"),
+            "unknown auto_evolve_mode must error, got: {err}"
+        );
     }
 }

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -561,6 +561,30 @@ pub enum WebSearchAugmentationMode {
     Always,
 }
 
+/// Controls whether auto_evolve skill mutations require human approval.
+///
+/// Used alongside `auto_evolve = true` on `AgentManifest` to decide
+/// whether the background skill review pipeline applies mutations
+/// directly (free) or routes them through the pending queue for human
+/// approval (controlled). This is separate from `SkillWorkshopConfig`
+/// — the workshop handles passive capture from conversation turns,
+/// while `auto_evolve` + `EvolutionMode` govern the background LLM
+/// reviewer that runs after each turn.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum EvolutionMode {
+    /// All mutations (create, update, patch) go through the pending
+    /// queue for human approval before taking effect.
+    Controlled,
+    /// Mutations apply directly without approval. The agent evolves
+    /// autonomously. Default — preserves pre-existing behavior for
+    /// agents that already opted into `auto_evolve = true`.
+    #[default]
+    Free,
+}
+
 /// The current lifecycle state of an agent.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1245,6 +1269,15 @@ pub struct AgentManifest {
     /// the background LLM budget or concurrency semaphore after a turn.
     #[serde(default = "default_true")]
     pub auto_evolve: bool,
+    /// Whether auto_evolve mutations require approval (`controlled`, default)
+    /// or apply directly (`free`). Only meaningful when `auto_evolve = true`.
+    ///
+    /// - `Controlled` (default): all mutations (create, update, patch) go
+    ///   through the pending queue for human approval before taking effect.
+    /// - `Free`: mutations apply directly without approval. The agent
+    ///   evolves autonomously.
+    #[serde(default)]
+    pub auto_evolve_mode: EvolutionMode,
     /// Per-agent channel behavior overrides (dm_policy, group_policy, etc.).
     /// When set, these take priority over the channel-level `ChannelOverrides`
     /// for this specific agent. Follows the same pattern as `exec_policy`.
@@ -1562,6 +1595,7 @@ impl Default for AgentManifest {
             auto_dream_min_sessions: None,
             show_progress: true,
             auto_evolve: true,
+            auto_evolve_mode: EvolutionMode::default(),
             max_concurrent_invocations: None,
             channel_overrides: None,
             max_history_messages: None,

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -3814,4 +3814,29 @@ model = "claude-3-haiku-20240307"
             "explicit `session_mode = \"New\"` must error, not fall back to None / Persistent: {err}"
         );
     }
+
+    #[test]
+    fn evolution_mode_default_is_free() {
+        assert_eq!(EvolutionMode::default(), EvolutionMode::Free);
+    }
+
+    #[test]
+    fn evolution_mode_serde_roundtrip() {
+        for (variant, expected) in [
+            (EvolutionMode::Free, "\"free\""),
+            (EvolutionMode::Controlled, "\"controlled\""),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, expected);
+            let back: EvolutionMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
+        let toml_str = "auto_evolve_mode = \"controlled\"\n";
+        #[derive(serde::Deserialize)]
+        struct W {
+            auto_evolve_mode: EvolutionMode,
+        }
+        let w: W = toml::from_str(toml_str).unwrap();
+        assert_eq!(w.auto_evolve_mode, EvolutionMode::Controlled);
+    }
 }

--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -1645,6 +1645,7 @@ admin_role = "admin"
             auto_dream_min_sessions,
             show_progress,
             auto_evolve,
+            auto_evolve_mode,
             channel_overrides,
             max_concurrent_invocations,
             cache_context,

--- a/openapi.json
+++ b/openapi.json
@@ -13509,6 +13509,13 @@
               "null"
             ]
           },
+          "auto_evolve_mode": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Auto-evolve mode: \"controlled\" (pending queue) or \"free\" (auto-apply)."
+          },
           "avatar_url": {
             "type": [
               "string",

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-0baab49da9f4c5d5be0b78202d045dd89ca7253daecad5d2974a32fff3dd9b22  openapi.json
+c97cb45ec4e567c1daa5dcf2de98e62d57de0e50b34690bd2ad0b034f0109dfd  openapi.json


### PR DESCRIPTION
## Summary

Make a skill-evolving agent's autonomy configurable per agent via a new `auto_evolve_mode` (`EvolutionMode`) on `AgentManifest`, gating what the background skill-evolution reviewer is allowed to do when `auto_evolve` is on.

- **`free` (default)**: skill mutations apply directly — the agent evolves its own skills autonomously (`create` installs a live skill, `update` / `patch` modify in place via `librefang_skills::evolution::{update_skill,patch_skill}`).
- **`controlled`**: `create` routes to the skill-workshop pending queue for human approval (via `build_reviewer_candidate`, honoring `max_pending` / `max_pending_age_days`); `update` and `patch` of an existing live skill are **skipped with a `WARN`** rather than auto-applied (auto-patching a live skill without review is the riskier operation, so Controlled refuses it outright instead of silently queueing a hard-to-review diff).

Default is `free` so existing `auto_evolve` agents keep their current behavior; `controlled` is strictly opt-in.

## Key changes

- `crates/librefang-types/src/agent.rs` — `EvolutionMode { Free, Controlled }` (serde `snake_case`, default `Free`), field on `AgentManifest`, doc-comments, serde round-trip + unknown-variant-rejection tests.
- `crates/librefang-kernel/src/kernel/tools_and_skills.rs` — per-mode routing in the background reviewer's create/update/patch arms; `build_reviewer_candidate` tags provenance with the new `AutoEvolveReview` capture source and lifts a 500-char body excerpt; two end-to-end tests (`controlled` create → pending, `free` create → live).
- `crates/librefang-kernel/src/skill_workshop/{candidate,llm_review,storage}.rs`, `librefang-cli/src/main.rs`, dashboard `api.ts` / `PendingSkillsSection.tsx` — thread the new `AutoEvolveReview` `CaptureSource` variant through every exhaustive match (Rust + TS).
- `crates/librefang-api/src/routes/agents.rs` (+ `registry.rs`, `wizard.rs`) — GET/PATCH `auto_evolve_mode`.
- `crates/librefang-api/dashboard/src/pages/AgentsPage.tsx` + `lib/mutations/agents.ts` — Evolution Mode selector (shown when `auto_evolve` is on).
- `openapi.json` regenerated + `xtask/baselines/openapi.sha256` synced.
- `CHANGELOG.md` — `[Unreleased] → Added` entry (non-breaking).

## Verification

- `cargo check --workspace --lib` → clean.
- `cargo clippy -p librefang-types -p librefang-kernel -p librefang-api --lib -- -D warnings` → zero warnings.
- `cargo test -p librefang-types --lib` → passes (incl. `evolution_mode_default_is_free`, `_serde_roundtrip`, `_rejects_unknown_variant`).
- `cargo test -p librefang-kernel --lib` → the new mode-routing tests pass (`controlled_mode_create_routes_to_pending_not_live`, `free_mode_create_installs_live_skill_not_pending`, `build_reviewer_candidate_fields_are_populated`).
- `cargo test -p librefang-api --test agents_routes_integration test_patch_agent` → passes (incl. `test_patch_agent_config_auto_evolve_mode`, `test_patch_agent_auto_evolve_persists`).
- `cargo test -p librefang-api --test openapi_spec_test` → passes (openapi.json in sync).
- dashboard `pnpm run typecheck` → clean.

Branch rebased on current `main` (no merge commits, no stale base).

Refs #5819