### PR TITLE
fix(run-xtask): override host-absolute credential helper path inside container

### DIFF
--- a/scripts/run-xtask.sh
+++ b/scripts/run-xtask.sh
@@ -82,9 +82,11 @@ if [[ "$(uname -s)" == "Linux" ]]; then
 fi
 
 # Build the inner command with POSIX-safe single-quote escaping so args containing spaces or quotes survive the `sh -c` wrapper inside the container.
-# `gh auth setup-git` (when GH_TOKEN is present) wires gh in as the git credential helper, so `git push` against https://github.com URLs authenticates via the forwarded token instead of dropping to an interactive HTTPS username prompt. Stderr is silenced because gh prints a banner; we only care about its side effect.
+# Synthesize a container-side gitconfig that `[include]`s the host's gitconfig (mounted at /tmp/host.gitconfig — see mounts below) for user.*/alias.* AND then overrides any `credential.helper` that hard-codes a host-only absolute path. The double `helper =` form first clears (resets) the included value, then installs a relative `!gh auth git-credential` that resolves in both /usr/bin/gh (container) and /opt/homebrew/bin/gh (macOS host PATH). This subsumes the previous `gh auth setup-git` call from #5827 — setup-git tried to write /home/dev/.gitconfig, but that path was mounted :ro from the host, so the write silently failed and the host helper kept winning. Direct synthesis at a writeable path is the only reliable fix.
 inner_cmd='export PATH=/usr/local/cargo/bin:$PATH'
-inner_cmd+=' && if [ -n "${GH_TOKEN:-}" ]; then gh auth setup-git 2>/dev/null || true; fi'
+inner_cmd+=' && if [ -f /tmp/host.gitconfig ]; then'
+inner_cmd+=' printf "[include]\n\tpath = /tmp/host.gitconfig\n[credential]\n\thelper =\n\thelper = !gh auth git-credential\n" > /home/dev/.gitconfig;'
+inner_cmd+=' fi'
 inner_cmd+=' && exec cargo xtask'
 for arg in "$@"; do
     quoted=${arg//\'/\'\\\'\'}
@@ -96,8 +98,9 @@ mounts=(-v "$REPO_ROOT:/work")
 if [[ "$MAIN_REPO" != "$REPO_ROOT" ]]; then
     mounts+=(-v "$MAIN_REPO:$MAIN_REPO")
 fi
+# Mount the host gitconfig at a side path (NOT directly at $GUEST_HOME/.gitconfig). The inner_cmd above writes a real gitconfig at $GUEST_HOME/.gitconfig that includes this one for user/alias settings but overrides any host-absolute-path credential helper. Mounting directly at $GUEST_HOME/.gitconfig:ro would block both the override and any in-container `git config` from working.
 if [[ -f "$HOME/.gitconfig" ]]; then
-    mounts+=(-v "$HOME/.gitconfig:$GUEST_HOME/.gitconfig:ro")
+    mounts+=(-v "$HOME/.gitconfig:/tmp/host.gitconfig:ro")
 fi
 if [[ -d "$HOME/.ssh" ]]; then
     mounts+=(-v "$HOME/.ssh:$GUEST_HOME/.ssh:ro")


### PR DESCRIPTION
## Summary

Direct follow-up to #5827. That PR ran `gh auth setup-git` inside the container to wire gh in as git's credential helper, but on a real run from a cargo-less macOS host the `git push` step still failed:

```
Error: git push -u origin chore/bump-version-… failed:
  /opt/homebrew/bin/gh auth git-credential get: 1: /opt/homebrew/bin/gh: not found
  /opt/homebrew/bin/gh auth git-credential erase: 1: /opt/homebrew/bin/gh: not found
remote: Invalid username or token. Password authentication is not supported for Git operations.
```

## Root cause

Two-layer interaction:

1. On macOS, `gh auth setup-git` writes `credential.helper = !/opt/homebrew/bin/gh auth git-credential` into `~/.gitconfig` — an absolute path.
2. The wrapper bind-mounts `~/.gitconfig` directly at `/home/dev/.gitconfig:ro`. Inside the container that helper points at a host-only path; gh is at `/usr/bin/gh` there.

#5827's in-container `gh auth setup-git` tried to rewrite `/home/dev/.gitconfig`, but the mount was read-only, so the write silently failed (`|| true`). The host helper kept winning, every `git push` blew up at the credential get/erase step, and the GitHub remote rejected the resulting empty token.

## Fix

- Move the host gitconfig mount to a side path (`/tmp/host.gitconfig`) so `/home/dev/.gitconfig` is writeable.
- Synthesize `/home/dev/.gitconfig` at container startup that `[include]`s the host config (for `user.*` / `alias.*`) and then overrides credential.helper using the double-`helper =` form: an empty `helper =` resets the included value, then a relative `!gh auth git-credential` is installed. The relative form resolves via PATH in both environments (`/usr/bin/gh` in the container, `/opt/homebrew/bin/gh` in the host shell where the same script ran natively before).
- Drop the now-redundant `gh auth setup-git` invocation from #5827.

## Test plan

- [x] `bash -n scripts/run-xtask.sh` — syntax clean.
- [x] Reproduced the failure mode with a fake host gitconfig containing `credential.helper = !/opt/homebrew/bin/gh auth git-credential`, ran the synthesis step inside `librefang-rust-dev:latest`, and confirmed `git config --get-all credential.helper` now shows the host value, an empty reset, and our relative override — git applies values left of the empty reset and then re-accumulates, so only the relative `!gh` is live for actual push operations.
- [ ] Reviewer reruns `just release` from a cargo-less macOS host whose `~/.gitconfig` has the standard `gh auth setup-git` output, and confirms `git push` no longer hits the credential-helper-not-found error.
