### PR TITLE
release: v2026.5.28-beta.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,78 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.5.28] - 2026-05-28
+
+_46 PRs from 5 contributors since v2026.5.25-beta.13._
+
+### Breaking Changes
+
+- Rust sidecar adapter SDK + AI-codegen-era rationale rewrite (#5821) (@houko)
+
+### Added
+
+- Per-agent channel allowlist (#5738) (@DaBlitzStein)
+- Implement describe_image() and wire ImageFile description through channel adapters (#5815) (@houko)
+- Rust sidecar adapter SDK + AI-codegen-era rationale rewrite (#5821) (@houko)
+
+### Fixed
+
+- Isolate attachment pre-inject per chat session — close cross-chat image leak (#5334) (@f-liva)
+- Make migrate path containment existence-independent (fixes #5716) (#5719) (@houko)
+- Repair discussion-to-issue backfill — gh api --jq doesn't take --arg (#5754) (@houko)
+- Tool_runner taint — unified SECRET_KEYS, substring match, header trim, single-pass normalization (#5762) (@leszek3737)
+- Tool_runner shell_safety — command injection hardening, quote-aware tokenizer (#5765) (@leszek3737)
+- Tool_runner definitions — ALWAYS_NATIVE complete, OnceLock caches, schema fixes, tool_name constants (#5771) (@leszek3737)
+- Tool_runner error — Upstream message preserved, MissingParameter String, ResourceNotFound 404 (#5772) (@leszek3737)
+- Tool_runner cron — sender_id override, TOCTOU reduction, HashSet lookup, empty job_id rejected (#5773) (@leszek3737)
+- Tool_runner dispatch — mutex split, fallback ACL, ACP args, spill wiring, snapshot ordering (#5774) (@leszek3737)
+- Tool_runner spill — config-based threshold, validation, fast-path (#5776) (@leszek3737)
+- Tool_runner wiki — limit cap, input validation, safe usize, caller_agent_id required (#5777) (@leszek3737)
+- Tool_runner meta — case-insensitive lookup, Cow optimization, deterministic sort (#5779) (@leszek3737)
+- Tool_runner task — typed deserialization, contextual errors, empty validation, status default (#5780) (@leszek3737)
+- Tool_runner notify — length limit, control char sanitization, PII removal (#5782) (@leszek3737)
+- Tool_runner hand — deterministic sort, empty id reject, config whitelist, output sanitization (#5784) (@leszek3737)
+- Tool_runner goal — progress type fix, range validation (#5785) (@leszek3737)
+- Tool_runner event — event_type validation, caller identity, reserved prefix guard (#5786) (@leszek3737)
+- Tool_runner a2a — session_id taint, SSRF diagnostics, zero-alloc agent check (#5787) (@leszek3737)
+- Tool_runner artifact — spawn_blocking, explicit errors, usize safe, zero-length reject (#5788) (@leszek3737)
+- Tool_runner channel — poll u8 safe, file size limit, email regex, mirror dedup, thread_id routing (#5789) (@leszek3737)
+- Skip bridge-side formatting for sidecar adapters (fixes #5795) (#5796) (@DaBlitzStein)
+- Return forward-slash relative path from registry/content on Windows (#5801) (@houko)
+- Make step timeout errors actionable with remediation guidance (#5806) (@houko)
+- Eliminate Instant subtraction that panics on Windows CI (fixes #5726) (#5808) (@houko)
+- Seed Feishu/Lark configure form when Python SDK is absent (#5809) (@houko)
+- Unbreak coverage build — thread session_id into two SessionWriter test stubs (#5816) (@houko)
+- Wiki.rs lifetime + shell.rs test arity after #5774/#5777 (#5818) (@houko)
+- Unbreak main — agent channels in ApiDoc + fmt + secrets baseline (#5820) (@houko)
+- Install gh CLI for release flow (#5826) (@houko)
+- Run `gh auth setup-git` to unblock git push from container (#5827) (@houko)
+- Override host-absolute credential helper path inside container (#5829) (@houko)
+
+### Changed
+
+- Migrate tool_runner tools to ToolError (#3576) (#5737) (@houko)
+
+<details>
+<summary>Documentation, maintenance, and other internal changes</summary>
+
+### Maintenance
+
+- Bump the cargo-minor-patch group with 4 updates (#5748) (@app/dependabot)
+- Bump wasmtime from 44.0.1 to 45.0.0 (#5749) (@app/dependabot)
+- Bump sysinfo from 0.38.4 to 0.39.2 (#5750) (@app/dependabot)
+- Bump which from 7.0.3 to 8.0.2 (#5751) (@app/dependabot)
+- Bump tikv-jemallocator from 0.6.1 to 0.7.0 (#5752) (@app/dependabot)
+- Bump the actions-minor-patch group with 4 updates (#5790) (@app/dependabot)
+- Bump actions/setup-python from 5 to 6 (#5791) (@app/dependabot)
+- Bump the web-minor-patch group in /web with 3 updates (#5810) (@app/dependabot)
+- Bump the dashboard-minor-patch group in /crates/librefang-api/dashboard with 7 updates (#5811) (@app/dependabot)
+- Bump globals from 15.15.0 to 17.6.0 in /crates/librefang-api/dashboard (#5812) (@app/dependabot)
+- Docker fallback for `just release` when cargo is missing (#5825) (@houko)
+
+</details>
+
+
 ## [2026.5.25] - 2026-05-25
 
 _308 PRs from 7 contributors since v2026.5.17-beta.12._

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,7 +4072,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-acp"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-tokio",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "async-trait",
  "axum",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "axum",
  "clap",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "librefang-types",
  "reqwest",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-import"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "librefang-llm-driver",
  "librefang-memory",
@@ -4453,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory-wiki"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "chrono",
  "librefang-kernel-handle",
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-rl-export"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-audit"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "chrono",
  "hex",
@@ -4659,7 +4659,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-media"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-sandbox-docker"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4712,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4740,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -11961,7 +11961,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.5.32263",
+  "version": "26.5.32294",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
     },
-    "version": "2026.5.25-beta.13"
+    "version": "2026.5.28-beta.14"
   },
   "paths": {
     "/.well-known/agent.json": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.5.25-beta.13",
+  "version": "2026.5.28-beta.14",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.5.25-beta.13",
+  "version": "2026.5.28-beta.14",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.5.25b13",
+    version="2026.5.28b14",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.5.25-beta.13"
+version = "2026.5.28-beta.14"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
<!-- release-tag:v2026.5.28-beta.14 -->
## Release v2026.5.28-beta.14

_46 PRs from 5 contributors since v2026.5.25-beta.13._

### Breaking Changes

- Rust sidecar adapter SDK + AI-codegen-era rationale rewrite (#5821) (@houko)

### Added

- Per-agent channel allowlist (#5738) (@DaBlitzStein)
- Implement describe_image() and wire ImageFile description through channel adapters (#5815) (@houko)
- Rust sidecar adapter SDK + AI-codegen-era rationale rewrite (#5821) (@houko)

### Fixed

- Isolate attachment pre-inject per chat session — close cross-chat image leak (#5334) (@f-liva)
- Make migrate path containment existence-independent (fixes #5716) (#5719) (@houko)
- Repair discussion-to-issue backfill — gh api --jq doesn't take --arg (#5754) (@houko)
- Tool_runner taint — unified SECRET_KEYS, substring match, header trim, single-pass normalization (#5762) (@leszek3737)
- Tool_runner shell_safety — command injection hardening, quote-aware tokenizer (#5765) (@leszek3737)
- Tool_runner definitions — ALWAYS_NATIVE complete, OnceLock caches, schema fixes, tool_name constants (#5771) (@leszek3737)
- Tool_runner error — Upstream message preserved, MissingParameter String, ResourceNotFound 404 (#5772) (@leszek3737)
- Tool_runner cron — sender_id override, TOCTOU reduction, HashSet lookup, empty job_id rejected (#5773) (@leszek3737)
- Tool_runner dispatch — mutex split, fallback ACL, ACP args, spill wiring, snapshot ordering (#5774) (@leszek3737)
- Tool_runner spill — config-based threshold, validation, fast-path (#5776) (@leszek3737)
- Tool_runner wiki — limit cap, input validation, safe usize, caller_agent_id required (#5777) (@leszek3737)
- Tool_runner meta — case-insensitive lookup, Cow optimization, deterministic sort (#5779) (@leszek3737)
- Tool_runner task — typed deserialization, contextual errors, empty validation, status default (#5780) (@leszek3737)
- Tool_runner notify — length limit, control char sanitization, PII removal (#5782) (@leszek3737)
- Tool_runner hand — deterministic sort, empty id reject, config whitelist, output sanitization (#5784) (@leszek3737)
- Tool_runner goal — progress type fix, range validation (#5785) (@leszek3737)
- Tool_runner event — event_type validation, caller identity, reserved prefix guard (#5786) (@leszek3737)
- Tool_runner a2a — session_id taint, SSRF diagnostics, zero-alloc agent check (#5787) (@leszek3737)
- Tool_runner artifact — spawn_blocking, explicit errors, usize safe, zero-length reject (#5788) (@leszek3737)
- Tool_runner channel — poll u8 safe, file size limit, email regex, mirror dedup, thread_id routing (#5789) (@leszek3737)
- Skip bridge-side formatting for sidecar adapters (fixes #5795) (#5796) (@DaBlitzStein)
- Return forward-slash relative path from registry/content on Windows (#5801) (@houko)
- Make step timeout errors actionable with remediation guidance (#5806) (@houko)
- Eliminate Instant subtraction that panics on Windows CI (fixes #5726) (#5808) (@houko)
- Seed Feishu/Lark configure form when Python SDK is absent (#5809) (@houko)
- Unbreak coverage build — thread session_id into two SessionWriter test stubs (#5816) (@houko)
- Wiki.rs lifetime + shell.rs test arity after #5774/#5777 (#5818) (@houko)
- Unbreak main — agent channels in ApiDoc + fmt + secrets baseline (#5820) (@houko)
- Install gh CLI for release flow (#5826) (@houko)
- Run `gh auth setup-git` to unblock git push from container (#5827) (@houko)
- Override host-absolute credential helper path inside container (#5829) (@houko)

### Changed

- Migrate tool_runner tools to ToolError (#3576) (#5737) (@houko)

<details>
<summary>Documentation, maintenance, and other internal changes</summary>

### Maintenance

- Bump the cargo-minor-patch group with 4 updates (#5748) (@app/dependabot)
- Bump wasmtime from 44.0.1 to 45.0.0 (#5749) (@app/dependabot)
- Bump sysinfo from 0.38.4 to 0.39.2 (#5750) (@app/dependabot)
- Bump which from 7.0.3 to 8.0.2 (#5751) (@app/dependabot)
- Bump tikv-jemallocator from 0.6.1 to 0.7.0 (#5752) (@app/dependabot)
- Bump the actions-minor-patch group with 4 updates (#5790) (@app/dependabot)
- Bump actions/setup-python from 5 to 6 (#5791) (@app/dependabot)
- Bump the web-minor-patch group in /web with 3 updates (#5810) (@app/dependabot)
- Bump the dashboard-minor-patch group in /crates/librefang-api/dashboard with 7 updates (#5811) (@app/dependabot)
- Bump globals from 15.15.0 to 17.6.0 in /crates/librefang-api/dashboard (#5812) (@app/dependabot)
- Docker fallback for `just release` when cargo is missing (#5825) (@houko)

</details>

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.5.25-beta.13...v2026.5.28-beta.14