### PR TITLE
feat(channels,xtask): just dev --docker + TELEGRAM_LOG tracing

### DIFF
--- a/justfile
+++ b/justfile
@@ -185,6 +185,7 @@ doctor *ARGS:
     cargo xtask doctor {{ARGS}}
 
 # Start dev environment (daemon + dashboard hot reload)
+# Pass `--docker` to run daemon + sidecar binaries inside the librefang-rust-dev container with host ~/.librefang mounted in.
 dev *ARGS:
     cargo xtask dev {{ARGS}}
 

--- a/justfile
+++ b/justfile
@@ -276,7 +276,7 @@ _dev-docker *ARGS:
 
     # Forward provider keys from the host environment if they're set, so the agent inside the container can answer.
     HOST_ENV_ARGS=()
-    for k in OPENAI_API_KEY ANTHROPIC_API_KEY GROQ_API_KEY GOOGLE_API_KEY GEMINI_API_KEY DEEPSEEK_API_KEY TELEGRAM_BOT_TOKEN; do
+    for k in OPENAI_API_KEY ANTHROPIC_API_KEY GROQ_API_KEY GOOGLE_API_KEY GEMINI_API_KEY DEEPSEEK_API_KEY TELEGRAM_BOT_TOKEN TELEGRAM_LOG; do
       if [ -n "${!k:-}" ]; then
         HOST_ENV_ARGS+=(-e "${k}")
       fi

--- a/justfile
+++ b/justfile
@@ -190,12 +190,17 @@ doctor *ARGS:
 dev *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Branch on --docker before the recipe tries to invoke cargo, so hosts without a Rust toolchain can still run the docker workflow.
+    # Explicit --docker → docker mode.
     for arg in {{ARGS}}; do
       if [ "$arg" = "--docker" ]; then
         exec just _dev-docker {{ARGS}}
       fi
     done
+    # No --docker but no host cargo either → auto-fall-back to docker mode rather than dying with a confusing `sh: cargo: not found`. Notify so the operator knows what's happening.
+    if ! command -v cargo >/dev/null 2>&1; then
+      echo "Host has no cargo on PATH; falling back to --docker mode. Run 'mise install rust' to use the native path instead."
+      exec just _dev-docker --docker {{ARGS}}
+    fi
     exec cargo xtask dev {{ARGS}}
 
 # Pure-shell docker workflow invoked from `just dev --docker`. Not meant to be called directly — use `just dev --docker` so the args parse the same way as the native path.

--- a/justfile
+++ b/justfile
@@ -185,9 +185,83 @@ doctor *ARGS:
     cargo xtask doctor {{ARGS}}
 
 # Start dev environment (daemon + dashboard hot reload)
-# Pass `--docker` to run daemon + sidecar binaries inside the librefang-rust-dev container with host ~/.librefang mounted in.
+# Pass `--docker` to run daemon + sidecar binaries inside the librefang-rust-dev container with host ~/.librefang mounted in. Requires a host Rust toolchain (cargo + xtask). If the host has no Rust installed, use `just dev-docker` instead — it's a pure-shell wrapper around the same docker workflow.
 dev *ARGS:
     cargo xtask dev {{ARGS}}
+
+# Pure-shell dev-in-docker entry point. Identical workflow to `just dev --docker` but requires NO host Rust toolchain — daemon and sidecar binaries are built and run entirely inside the librefang-rust-dev container, with host ~/.librefang/ bind-mounted in so config edits on the host are immediately visible. Use this on a fresh macOS / Linux host where `mise install rust` hasn't been run yet.
+#   PORT       daemon port (default 4545; also forwarded to host)
+#   IMAGE_TAG  override the dev image tag (default librefang-rust-dev:latest)
+dev-docker PORT="4545" IMAGE_TAG="librefang-rust-dev:latest":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HOME_LIBREFANG="${HOME}/.librefang"
+    mkdir -p "$HOME_LIBREFANG"
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+    # Build the dev image if it isn't on the host yet (one-time, ~5 minutes).
+    if ! docker image inspect {{IMAGE_TAG}} >/dev/null 2>&1; then
+      echo "Building {{IMAGE_TAG}} from Dockerfile.rust-dev (one-time, ~5 minutes)..."
+      docker build -t {{IMAGE_TAG}} -f "${REPO_ROOT}/Dockerfile.rust-dev" "${REPO_ROOT}"
+    fi
+
+    # Compile daemon + Rust Telegram sidecar into the librefang-target named volume.
+    echo "Building librefang-cli + librefang-sidecar-telegram inside the container..."
+    docker run --rm \
+      -v "${REPO_ROOT}:/work" \
+      -v librefang-cargo:/cargo -v librefang-target:/target \
+      -e CARGO_HOME=/cargo -e CARGO_TARGET_DIR=/target \
+      -w /work {{IMAGE_TAG}} \
+      sh -c 'export PATH=/usr/local/cargo/bin:$PATH && \
+             cargo build --release -p librefang-cli && \
+             cargo build --release --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml'
+
+    # Bootstrap ~/.librefang/config.toml if missing.
+    if [ ! -f "${HOME_LIBREFANG}/config.toml" ]; then
+      echo "Bootstrapping ${HOME_LIBREFANG}/config.toml via 'librefang init --quick'..."
+      docker run --rm \
+        -v "${REPO_ROOT}:/work" \
+        -v "${HOME_LIBREFANG}:/root/.librefang" \
+        -v librefang-target:/target \
+        -w /work {{IMAGE_TAG}} \
+        /target/release/librefang init --quick || \
+        echo "warn: 'librefang init --quick' exited non-zero, continuing"
+      cat <<'NOTE'
+
+      Edit ~/.librefang/config.toml to add the Rust Telegram sidecar:
+
+        [[sidecar_channels]]
+        name = "telegram"
+        command = "/target/release/librefang-sidecar-telegram"
+        channel_type = "telegram"
+        [sidecar_channels.secrets]
+        TELEGRAM_BOT_TOKEN = "<your-token>"
+
+      Note `command` is the in-container path; the binary lives in the
+      librefang-target named volume mounted at /target inside the daemon.
+
+      Reference: https://docs.librefang.ai/architecture/rust-telegram-sidecar
+    NOTE
+    fi
+
+    # Pre-clean any stale container (orphan from a previous `--rm` that didn't fire).
+    docker rm -f librefang-dev >/dev/null 2>&1 || true
+
+    echo
+    echo "Starting daemon in container on port {{PORT}}..."
+    echo "  Host repo    ↔ /work"
+    echo "  ~/.librefang ↔ /root/.librefang"
+    echo "  binaries     ↔ named volume librefang-target (/target)"
+    echo
+    docker run -it --rm --name librefang-dev \
+      -v "${REPO_ROOT}:/work" \
+      -v "${HOME_LIBREFANG}:/root/.librefang" \
+      -v librefang-cargo:/cargo -v librefang-target:/target \
+      -e CARGO_HOME=/cargo -e CARGO_TARGET_DIR=/target \
+      -e LIBREFANG_PORT={{PORT}} \
+      -p {{PORT}}:{{PORT}} \
+      -w /work {{IMAGE_TAG}} \
+      /target/release/librefang start --foreground
 
 # Database management (info, backup, reset)
 db *ARGS:

--- a/justfile
+++ b/justfile
@@ -184,34 +184,56 @@ clean-all *ARGS:
 doctor *ARGS:
     cargo xtask doctor {{ARGS}}
 
-# Start dev environment (daemon + dashboard hot reload)
-# Pass `--docker` to run daemon + sidecar binaries inside the librefang-rust-dev container with host ~/.librefang mounted in. Requires a host Rust toolchain (cargo + xtask). If the host has no Rust installed, use `just dev-docker` instead — it's a pure-shell wrapper around the same docker workflow.
+# Start dev environment.
+# Native mode (default):   builds librefang-cli on host, starts daemon + dashboard with cargo-watch hot-reload. Requires host Rust toolchain.
+# Docker mode (--docker):  builds daemon + Rust sidecar binaries inside the librefang-rust-dev container, mounts host ~/.librefang/ in, forwards port 4545. Requires NO host Rust toolchain. Pass `--docker --port 4646` to change the port.
 dev *ARGS:
-    cargo xtask dev {{ARGS}}
-
-# Pure-shell dev-in-docker entry point. Identical workflow to `just dev --docker` but requires NO host Rust toolchain — daemon and sidecar binaries are built and run entirely inside the librefang-rust-dev container, with host ~/.librefang/ bind-mounted in so config edits on the host are immediately visible. Use this on a fresh macOS / Linux host where `mise install rust` hasn't been run yet.
-#   PORT       daemon port (default 4545; also forwarded to host)
-#   IMAGE_TAG  override the dev image tag (default librefang-rust-dev:latest)
-dev-docker PORT="4545" IMAGE_TAG="librefang-rust-dev:latest":
     #!/usr/bin/env bash
     set -euo pipefail
+    # Branch on --docker before the recipe tries to invoke cargo, so hosts without a Rust toolchain can still run the docker workflow.
+    for arg in {{ARGS}}; do
+      if [ "$arg" = "--docker" ]; then
+        exec just _dev-docker {{ARGS}}
+      fi
+    done
+    exec cargo xtask dev {{ARGS}}
+
+# Pure-shell docker workflow invoked from `just dev --docker`. Not meant to be called directly — use `just dev --docker` so the args parse the same way as the native path.
+# Builds daemon + Rust Telegram sidecar inside librefang-rust-dev:latest, bind-mounts host ~/.librefang/ at /root/.librefang/ for config persistence, forwards port 4545 (or the value of `--port <n>`) to the host. Dashboard / cargo-watch are not started — both belong on the host alongside the editor.
+_dev-docker *ARGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PORT=4545
+    IMAGE_TAG="librefang-rust-dev:latest"
+    # Strip --docker and parse --port <n> / --image <tag> if present.
+    args=({{ARGS}})
+    skip_next=0
+    for i in "${!args[@]}"; do
+      if [ "$skip_next" = "1" ]; then skip_next=0; continue; fi
+      case "${args[$i]}" in
+        --docker) ;;
+        --port)  PORT="${args[$((i+1))]}"; skip_next=1 ;;
+        --image) IMAGE_TAG="${args[$((i+1))]}"; skip_next=1 ;;
+        *) ;;
+      esac
+    done
     HOME_LIBREFANG="${HOME}/.librefang"
     mkdir -p "$HOME_LIBREFANG"
     REPO_ROOT="$(git rev-parse --show-toplevel)"
 
     # Build the dev image if it isn't on the host yet (one-time, ~5 minutes).
-    if ! docker image inspect {{IMAGE_TAG}} >/dev/null 2>&1; then
-      echo "Building {{IMAGE_TAG}} from Dockerfile.rust-dev (one-time, ~5 minutes)..."
-      docker build -t {{IMAGE_TAG}} -f "${REPO_ROOT}/Dockerfile.rust-dev" "${REPO_ROOT}"
+    if ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
+      echo "Building $IMAGE_TAG from Dockerfile.rust-dev (one-time, ~5 minutes)..."
+      docker build -t "$IMAGE_TAG" -f "${REPO_ROOT}/Dockerfile.rust-dev" "${REPO_ROOT}"
     fi
 
     # Compile daemon + Rust Telegram sidecar into the librefang-target named volume.
-    echo "Building librefang-cli + librefang-sidecar-telegram inside the container..."
+    echo "Building librefang-cli + librefang-sidecar-telegram inside the container (warm cache: ~30s, cold: ~10 min)..."
     docker run --rm \
       -v "${REPO_ROOT}:/work" \
       -v librefang-cargo:/cargo -v librefang-target:/target \
       -e CARGO_HOME=/cargo -e CARGO_TARGET_DIR=/target \
-      -w /work {{IMAGE_TAG}} \
+      -w /work "$IMAGE_TAG" \
       sh -c 'export PATH=/usr/local/cargo/bin:$PATH && \
              cargo build --release -p librefang-cli && \
              cargo build --release --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml'
@@ -223,44 +245,57 @@ dev-docker PORT="4545" IMAGE_TAG="librefang-rust-dev:latest":
         -v "${REPO_ROOT}:/work" \
         -v "${HOME_LIBREFANG}:/root/.librefang" \
         -v librefang-target:/target \
-        -w /work {{IMAGE_TAG}} \
+        -w /work "$IMAGE_TAG" \
         /target/release/librefang init --quick || \
         echo "warn: 'librefang init --quick' exited non-zero, continuing"
       cat <<'NOTE'
 
-      Edit ~/.librefang/config.toml to add the Rust Telegram sidecar:
+    Edit ~/.librefang/config.toml to add the Rust Telegram sidecar:
 
-        [[sidecar_channels]]
-        name = "telegram"
-        command = "/target/release/librefang-sidecar-telegram"
-        channel_type = "telegram"
-        [sidecar_channels.secrets]
-        TELEGRAM_BOT_TOKEN = "<your-token>"
+      [[sidecar_channels]]
+      name = "telegram"
+      command = "/target/release/librefang-sidecar-telegram"
+      channel_type = "telegram"
+      [sidecar_channels.secrets]
+      TELEGRAM_BOT_TOKEN = "<your-token>"
 
-      Note `command` is the in-container path; the binary lives in the
-      librefang-target named volume mounted at /target inside the daemon.
+    Note `command =` is the in-container path; the binary lives in the
+    librefang-target named volume mounted at /target inside the daemon.
 
-      Reference: https://docs.librefang.ai/architecture/rust-telegram-sidecar
+    Reference: https://docs.librefang.ai/architecture/rust-telegram-sidecar
     NOTE
     fi
 
     # Pre-clean any stale container (orphan from a previous `--rm` that didn't fire).
     docker rm -f librefang-dev >/dev/null 2>&1 || true
 
+    # Forward provider keys from the host environment if they're set, so the agent inside the container can answer.
+    HOST_ENV_ARGS=()
+    for k in OPENAI_API_KEY ANTHROPIC_API_KEY GROQ_API_KEY GOOGLE_API_KEY GEMINI_API_KEY DEEPSEEK_API_KEY TELEGRAM_BOT_TOKEN; do
+      if [ -n "${!k:-}" ]; then
+        HOST_ENV_ARGS+=(-e "${k}")
+      fi
+    done
+
     echo
-    echo "Starting daemon in container on port {{PORT}}..."
+    echo "Starting daemon in container on port ${PORT}..."
     echo "  Host repo    ↔ /work"
     echo "  ~/.librefang ↔ /root/.librefang"
     echo "  binaries     ↔ named volume librefang-target (/target)"
+    if [ ${#HOST_ENV_ARGS[@]} -gt 0 ]; then
+      forwarded=$(printf ' %s' "${HOST_ENV_ARGS[@]}" | tr -s ' ' | sed 's/-e //g')
+      echo "  forwarding host env: ${forwarded}"
+    fi
     echo
     docker run -it --rm --name librefang-dev \
       -v "${REPO_ROOT}:/work" \
       -v "${HOME_LIBREFANG}:/root/.librefang" \
       -v librefang-cargo:/cargo -v librefang-target:/target \
       -e CARGO_HOME=/cargo -e CARGO_TARGET_DIR=/target \
-      -e LIBREFANG_PORT={{PORT}} \
-      -p {{PORT}}:{{PORT}} \
-      -w /work {{IMAGE_TAG}} \
+      -e LIBREFANG_PORT=${PORT} \
+      "${HOST_ENV_ARGS[@]}" \
+      -p ${PORT}:${PORT} \
+      -w /work "$IMAGE_TAG" \
       /target/release/librefang start --foreground
 
 # Database management (info, backup, reset)

--- a/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
@@ -20,6 +20,28 @@ const ALLOWED_UPDATES: &[&str] = &["message", "edited_message", "callback_query"
 const MAX_BACKOFF_SECS: u64 = 300;
 const STREAM_EDIT_INTERVAL_MS: u64 = 1000;
 
+/// Cached state of the `TELEGRAM_LOG` env var. When non-empty AND not `"off"` / `"0"`, the adapter emits one-line happy-path traces to stderr (which the supervisor captures into the daemon's main log) for every inbound update and every outbound command. Errors always log regardless.
+static HAPPY_PATH_LOG: once_cell::sync::Lazy<bool> = once_cell::sync::Lazy::new(|| {
+    std::env::var("TELEGRAM_LOG")
+        .ok()
+        .map(|v| {
+            let t = v.trim();
+            !t.is_empty() && t != "0" && !t.eq_ignore_ascii_case("off")
+        })
+        .unwrap_or(false)
+});
+
+/// Emit a one-line trace to stderr if `TELEGRAM_LOG` is enabled. Argument is a closure so the format work is skipped when logging is off.
+fn trace(args: std::fmt::Arguments<'_>) {
+    if *HAPPY_PATH_LOG {
+        eprintln!("[telegram] {args}");
+    }
+}
+
+macro_rules! tg_trace {
+    ($($arg:tt)*) => { trace(format_args!($($arg)*)) };
+}
+
 pub struct TelegramAdapter {
     client: Arc<BotClient>,
     allowlist: AllowList,
@@ -136,12 +158,21 @@ impl SidecarAdapter for TelegramAdapter {
         let thread_id = Self::parse_thread_id(cmd.thread_id.as_deref());
 
         if let Some(content) = cmd.content {
+            let tag = content
+                .as_object()
+                .and_then(|o| o.keys().next().cloned())
+                .unwrap_or_else(|| "?".into());
+            tg_trace!("on_send chat={chat_id} content={tag}");
             dispatch_content(&self.client, chat_id, &content, thread_id)
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?;
             return Ok(());
         }
         // Legacy text-only fallback.
+        tg_trace!(
+            "on_send chat={chat_id} content=Text(legacy) len={}",
+            cmd.text.len()
+        );
         send_text(&self.client, chat_id, &cmd.text, thread_id)
             .await
             .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?;
@@ -156,6 +187,7 @@ impl SidecarAdapter for TelegramAdapter {
             Command::Send(s) => self.on_send(s).await,
             Command::Typing(t) => {
                 if let Some(chat_id) = Self::parse_chat_id(&t.channel_id) {
+                    tg_trace!("on_command Typing chat={chat_id}");
                     let _ = self.client.send_chat_action(chat_id, "typing").await;
                 }
                 Ok(())
@@ -167,6 +199,10 @@ impl SidecarAdapter for TelegramAdapter {
                 let Ok(message_id) = r.message_id.parse::<i64>() else {
                     return Ok(());
                 };
+                tg_trace!(
+                    "on_command Reaction chat={chat_id} msg={message_id} reaction={}",
+                    r.reaction
+                );
                 let emojis = map_reaction(&r.reaction, self.clear_done_reaction);
                 let reactions: Vec<Value> = emojis
                     .into_iter()
@@ -182,6 +218,7 @@ impl SidecarAdapter for TelegramAdapter {
                 let Some(chat_id) = Self::parse_chat_id(&i.channel_id) else {
                     return Ok(());
                 };
+                tg_trace!("on_command Interactive chat={chat_id}");
                 let payload = serde_json::to_value(&i.message)?;
                 let content_value = json!({ "Interactive": payload });
                 dispatch_content(&self.client, chat_id, &content_value, None)
@@ -194,6 +231,10 @@ impl SidecarAdapter for TelegramAdapter {
                     return Ok(());
                 };
                 let thread_id = Self::parse_thread_id(s.thread_id.as_deref());
+                tg_trace!(
+                    "on_command StreamStart chat={chat_id} stream_id={}",
+                    s.stream_id
+                );
                 // Send an empty placeholder so we have a message_id to edit later. Telegram edits a message by id alone, so we don't carry thread_id on the state.
                 let res = self
                     .client
@@ -226,8 +267,10 @@ impl SidecarAdapter for TelegramAdapter {
                     let chat_id = state.chat_id;
                     let message_id = state.message_id;
                     let body = crate::format::format_and_sanitize(&state.buf);
+                    let buf_len = state.buf.len();
                     state.last_edit = Instant::now();
                     drop(map);
+                    tg_trace!("StreamDelta edit chat={chat_id} msg={message_id} buf_len={buf_len}");
                     Self::edit_with_fallback(&self.client, chat_id, message_id, &body).await;
                 }
                 Ok(())
@@ -237,6 +280,12 @@ impl SidecarAdapter for TelegramAdapter {
                 let Some(state) = map.remove(&e.stream_id) else {
                     return Ok(());
                 };
+                tg_trace!(
+                    "on_command StreamEnd chat={} msg={} buf_len={}",
+                    state.chat_id,
+                    state.message_id,
+                    state.buf.len()
+                );
                 let body = crate::format::format_and_sanitize(&state.buf);
                 let chat_id = state.chat_id;
                 let message_id = state.message_id;
@@ -261,8 +310,26 @@ impl SidecarAdapter for TelegramAdapter {
                 Ok(resp) => {
                     // Reset backoff on a successful round.
                     backoff = Duration::from_secs(1);
+                    if !resp.result.is_empty() {
+                        tg_trace!(
+                            "getUpdates -> {} updates (next offset {})",
+                            resp.result.len(),
+                            offset
+                        );
+                    }
                     for upd in &resp.result {
                         offset = upd.update_id + 1;
+                        let kind = if upd.message.is_some() {
+                            "message"
+                        } else if upd.edited_message.is_some() {
+                            "edited_message"
+                        } else if upd.callback_query.is_some() {
+                            "callback_query"
+                        } else if upd.poll_answer.is_some() {
+                            "poll_answer"
+                        } else {
+                            "unknown"
+                        };
                         // Access control — extract a sender for every update kind the adapter emits, including poll_answer (otherwise the allowlist would silently let any Telegram user vote in the bot's polls and have the PollAnswer event reach the agent).
                         let sender = if let Some(msg) = &upd.message {
                             Some(extract_sender(msg))
@@ -280,11 +347,22 @@ impl SidecarAdapter for TelegramAdapter {
                                 .allowlist
                                 .permits(&sender.user_id, sender.username.as_deref())
                             {
+                                tg_trace!(
+                                    "update {} {kind} dropped by allowlist user={}",
+                                    upd.update_id,
+                                    sender.user_id
+                                );
                                 continue;
                             }
                         }
                         if let Some(event) = update_to_event(&self.client, upd).await {
+                            tg_trace!("emit {kind} update_id={}", upd.update_id);
                             emit(event);
+                        } else {
+                            tg_trace!(
+                                "update {} {kind} produced no event (unsupported variant)",
+                                upd.update_id
+                            );
                         }
                     }
                 }

--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -16,9 +16,18 @@ pub struct DevArgs {
     /// Build in release mode
     #[arg(long)]
     pub release: bool,
+
+    /// Run the daemon (and sidecar binaries) inside the `librefang-rust-dev` container instead of natively.
+    ///
+    /// Host's `~/.librefang/` is bind-mounted into the container so config edits on the host are immediately visible to the daemon; cargo caches live in named volumes (`librefang-cargo`, `librefang-target`) so a first-run install of Rust on the host isn't required, and a Linux binary is produced regardless of the host OS. Dashboard and cargo-watch are skipped — both make more sense run on the host alongside the editor.
+    #[arg(long)]
+    pub docker: bool,
 }
 
 pub fn run(args: DevArgs) -> Result<(), Box<dyn std::error::Error>> {
+    if args.docker {
+        return run_docker(&args);
+    }
     let root = repo_root();
 
     // Kill stale processes on relevant ports
@@ -507,6 +516,166 @@ fn get_pids_on_port(port: u16) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Run the dev daemon (and sidecar binaries) inside the `librefang-rust-dev` container.
+///
+/// Layout inside the container:
+/// - `/work` ↔ host repo root (read-write — `cargo` writes lockfile updates back).
+/// - `/root/.librefang` ↔ host `~/.librefang` (so config / vault / logs persist on host).
+/// - `/cargo` ← named volume `librefang-cargo` (CARGO_HOME).
+/// - `/target` ← named volume `librefang-target` (CARGO_TARGET_DIR).
+///
+/// Binaries live at `/target/release/librefang` and `/target/release/librefang-sidecar-telegram`; reference them by the in-container path in `~/.librefang/config.toml`.
+fn run_docker(args: &DevArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let root = repo_root();
+    let home = librefang_home();
+
+    // Daemon needs the dir to exist before we can mount it.
+    std::fs::create_dir_all(&home)?;
+
+    // Build the dev image if it's not on the host yet (one-time, ~5 min).
+    let image_present = Command::new("docker")
+        .args(["image", "inspect", "librefang-rust-dev:latest"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !image_present {
+        println!("Building librefang-rust-dev:latest image (one-time, ~5 minutes)...");
+        let status = Command::new("docker")
+            .args([
+                "build",
+                "-t",
+                "librefang-rust-dev:latest",
+                "-f",
+                "Dockerfile.rust-dev",
+                ".",
+            ])
+            .current_dir(&root)
+            .status()?;
+        if !status.success() {
+            return Err("`docker build` of librefang-rust-dev:latest failed".into());
+        }
+    }
+
+    // Step 1: compile librefang-cli + librefang-sidecar-telegram into the named-volume target dir. This is a separate `docker run --rm` (no tty) so the long build doesn't share a process group with the interactive daemon below.
+    println!("Building daemon + Rust Telegram sidecar inside the dev container...");
+    let root_str = root.display().to_string();
+    let build_status = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "-v",
+            &format!("{root_str}:/work"),
+            "-v",
+            "librefang-cargo:/cargo",
+            "-v",
+            "librefang-target:/target",
+            "-e",
+            "CARGO_HOME=/cargo",
+            "-e",
+            "CARGO_TARGET_DIR=/target",
+            "-w",
+            "/work",
+            "librefang-rust-dev:latest",
+            "sh",
+            "-c",
+            "export PATH=/usr/local/cargo/bin:$PATH && \
+             cargo build --release -p librefang-cli && \
+             cargo build --release --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml",
+        ])
+        .status()?;
+    if !build_status.success() {
+        return Err("Container build of librefang-cli / librefang-sidecar-telegram failed".into());
+    }
+
+    // Auto-init: run `librefang init --quick` inside the container if the operator's `~/.librefang/config.toml` doesn't exist yet. This produces a starter config keyed off the in-container binary paths.
+    let host_config = home.join("config.toml");
+    if !host_config.exists() {
+        println!(
+            "No config.toml at {} — bootstrapping with `librefang init --quick`...",
+            host_config.display()
+        );
+        let init_status = Command::new("docker")
+            .args([
+                "run",
+                "--rm",
+                "-v",
+                &format!("{root_str}:/work"),
+                "-v",
+                &format!("{}:/root/.librefang", home.display()),
+                "-v",
+                "librefang-target:/target",
+                "-w",
+                "/work",
+                "librefang-rust-dev:latest",
+                "/target/release/librefang",
+                "init",
+                "--quick",
+            ])
+            .status()?;
+        if !init_status.success() {
+            eprintln!("Warning: `librefang init --quick` exited non-zero; continuing.");
+        }
+        println!(
+            "Edit {} to add `[[sidecar_channels]]` entries — see\n  https://docs.librefang.ai/architecture/rust-telegram-sidecar\nfor the Rust Telegram sidecar config (use `command = \"/target/release/librefang-sidecar-telegram\"`).",
+            host_config.display()
+        );
+    }
+
+    // Step 2: start the daemon in the foreground with stdin/stdout attached so the operator sees logs live and ctrl-c stops it. Remove any stale `librefang-dev` container first — `--rm` covers clean exits, but a docker-daemon crash can leave an orphan that would fail with `name already in use`.
+    let _ = Command::new("docker")
+        .args(["rm", "-f", "librefang-dev"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    let port = args.port;
+    println!("\nStarting daemon in container on port {port}...");
+    println!("  Host repo  ↔ /work");
+    println!("  ~/.librefang ↔ /root/.librefang");
+    println!("  cargo cache ↔ named volume librefang-cargo");
+    println!("  binaries    ↔ named volume librefang-target");
+    println!();
+    let port_map = format!("{port}:{port}");
+    let port_env = format!("LIBREFANG_PORT={port}");
+    let home_mount = format!("{}:/root/.librefang", home.display());
+    let work_mount = format!("{root_str}:/work");
+    let docker_args: Vec<&str> = vec![
+        "run",
+        "-it",
+        "--rm",
+        "--name",
+        "librefang-dev",
+        "-v",
+        &work_mount,
+        "-v",
+        &home_mount,
+        "-v",
+        "librefang-cargo:/cargo",
+        "-v",
+        "librefang-target:/target",
+        "-e",
+        "CARGO_HOME=/cargo",
+        "-e",
+        "CARGO_TARGET_DIR=/target",
+        "-e",
+        &port_env,
+        "-p",
+        &port_map,
+        "-w",
+        "/work",
+        "librefang-rust-dev:latest",
+        "/target/release/librefang",
+        "start",
+        "--foreground",
+    ];
+    let status = Command::new("docker").args(&docker_args).status()?;
+    if !status.success() {
+        return Err(format!("daemon container exited with status {status:?}").into());
+    }
+    Ok(())
 }
 
 /// Resolve the LibreFang home directory (mirrors kernel logic).


### PR DESCRIPTION
## What

Two follow-ups to #5831 (the Rust Telegram sidecar):

1. **`just dev --docker`** — run daemon + sidecar binaries inside the `librefang-rust-dev:latest` container with host `~/.librefang/` bind-mounted in.
   On a fresh host without a Rust toolchain (the common case for operators trying the sidecar without `mise install rust`), `just dev` auto-falls-back to docker mode rather than dying with `sh: cargo: not found`.
2. **`TELEGRAM_LOG`-gated happy-path tracing** in the Rust Telegram sidecar so operators can see each step of inbound update → emit and on_send / on_command without having to wait for an error.

## `just dev` / `just dev --docker`

| Invocation | Behaviour |
|---|---|
| `just dev` (host has cargo) | Native: `cargo xtask dev` — daemon + dashboard + cargo-watch (unchanged) |
| `just dev` (no host cargo) | Auto-falls-back to docker mode with a one-line notice |
| `just dev --docker` | Explicit docker mode |
| `just dev --docker --port 4646` | Custom port forwarded to host |
| `just dev --docker --image my-tag` | Custom image |

Docker mode:

- Builds `librefang-rust-dev:latest` from `Dockerfile.rust-dev` if absent (one-time, ~5 min).
- Compiles `librefang-cli` + `librefang-sidecar-telegram` against the named-volume `librefang-target` so the host's main worktree `target/` is never touched.
- Bootstraps `~/.librefang/config.toml` via `librefang init --quick` if missing.
- Runs the daemon foreground in an `-it --rm` container with:
  - host `<repo>` ↔ `/work`
  - host `~/.librefang` ↔ `/root/.librefang`
  - named volumes `librefang-cargo` ↔ `/cargo`, `librefang-target` ↔ `/target`
  - port 4545 forwarded
- Forwards `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GROQ_API_KEY` / `GOOGLE_API_KEY` / `GEMINI_API_KEY` / `DEEPSEEK_API_KEY` / `TELEGRAM_BOT_TOKEN` / `TELEGRAM_LOG` from host env when set.

Two entry layers:

- `cargo xtask dev --docker` in `xtask/src/dev.rs` for hosts that have cargo.
- A pure-shell `_dev-docker` recipe in `justfile` (hidden, dispatched from `just dev`) for hosts that don't.

The multi-line shell recipe is flagged by the justfile preamble as a smell, but the whole point is to work *before* cargo is available. Documented inline.

## TELEGRAM_LOG happy-path tracing

Default off. Set `TELEGRAM_LOG=debug` (or anything non-empty other than `off` / `0`) before `just dev` and the sidecar emits one-line `[telegram] …` traces to stderr (which the supervisor captures into the daemon's main log):

- produce loop: `getUpdates -> N updates (next offset O)` per non-empty batch.
- per update: `emit message update_id=…`, `update X dropped by allowlist user=…`, `update X kind produced no event`.
- on_send: `on_send chat=… content=<tag>` or `content=Text(legacy) len=…`.
- on_command: Typing / Reaction / Interactive / StreamStart / StreamDelta / StreamEnd each get one-line traces with chat_id, message_id, buf_len etc.

Gating is a cached `Lazy<bool>` so the hot path pays one atomic load + a branch when disabled — no format work is performed.

Errors (`getUpdates` backoff, `stream edit failed`, `stream edit (plain fallback) failed`) continue to log unconditionally so the gate only suppresses HAPPY-path noise, never failures.

## Verification

Inside `librefang-rust-dev:latest` named-volume container:

- `cargo test` → 41 passed, 0 failed.
- `cargo clippy --all-targets -- -D warnings` → clean.
- `cargo fmt --check` → clean.
- `cargo build --release` → 7.9 MB stripped binary.

Live verification on a no-Rust macOS host:

- `just dev` (no `--docker` flag, no host cargo) → notice + falls back to docker mode → daemon comes up → Telegram bot receives message → agent runs gemma4 via Ollama on host (`http://host.docker.internal:11434`) → reply round-trips successfully (5640 input tokens, 227 output tokens).
- `TELEGRAM_LOG=debug just dev` → `[telegram] getUpdates -> 1 updates`, `[telegram] emit message update_id=…`, `[telegram] on_send chat=… content=Text` all show up next to the daemon's `DEBUG Received message from sidecar adapter=telegram user=…` lines.

## Out of scope (deliberate)

- Dashboard hot reload / cargo-watch in docker mode — both make more sense run on the host alongside the editor; the host can `pnpm dev` against the forwarded `:4545` separately.
- Live host-target writes from docker mode — binaries live in `librefang-target` named volume, not the host workspace `target/`. The CLAUDE.md rule about target/ contention is honoured.
