### PR TITLE
fix(ci): regenerate stale openapi schema baseline to repair main red

### DIFF
--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-524797aa004a57056db6f91adc240a6c9a92a2ef9aab13e481092d6fb0f156af  openapi.json
+d5a6ba13220bb0662c10c0df2682bc9d3d03dc4cd75e7e7aa74e42a758cacea9  openapi.json


### PR DESCRIPTION
## Problem

The `OpenAPI Drift` CI job is failing on `main` (issue #5832), and because it runs on every push, every open PR inherits the red on its next CI run.

The job runs `git diff --quiet -- openapi.json sdk/ xtask/baselines/` on push events and fails when any generated artifact is out of sync with source.

## Root cause

The committed schema baseline hash was stale:

```
xtask/baselines/openapi.sha256
- 524797aa004a57056db6f91adc240a6c9a92a2ef9aab13e481092d6fb0f156af  openapi.json
+ d5a6ba13220bb0662c10c0df2682bc9d3d03dc4cd75e7e7aa74e42a758cacea9  openapi.json
```

`d5a6ba13…` is the actual sha256 of the committed `openapi.json`. A prior change regenerated and committed `openapi.json` without re-running `cargo xtask schema-check gen`, so the baseline hash was never updated to match.

`openapi.json` and the generated SDKs themselves are already in sync — running the full codegen pipeline produces a diff only in this one baseline file.

## Fix

Regenerated the baseline via the sanctioned pipeline (run inside the repo `Dockerfile.rust-dev` image, isolated from the host `target/`):

```
cargo xtask codegen --openapi      # no change — openapi.json already in sync
python3 scripts/codegen-sdks.py    # no change — SDKs already in sync (with rustfmt)
cargo xtask schema-check gen       # updates xtask/baselines/openapi.sha256
```

Only `xtask/baselines/openapi.sha256` changed.

## Verification

- Full codegen pipeline run in Docker; the only resulting diff is the baseline hash, now matching `shasum -a 256 openapi.json`.
- After committing, `git diff --quiet -- openapi.json sdk/ xtask/baselines/` is clean, which is exactly what the drift job checks.

Fixes #5832
