### PR TITLE
fix(kernel): finish Option::zip migration in kernel tests (clippy 1.96.0)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1722,21 +1722,21 @@
         "filename": "crates/librefang-kernel/src/kernel/tests.rs",
         "hashed_secret": "86a1932a93c72239442f6cd6296f4eb28d8a1730",
         "is_verified": false,
-        "line_number": 7668
+        "line_number": 7662
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-kernel/src/kernel/tests.rs",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 8803
+        "line_number": 8797
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-kernel/src/kernel/tests.rs",
         "hashed_secret": "96133e4265d7a277409c8094e5eff6a41934cf07",
         "is_verified": false,
-        "line_number": 9832
+        "line_number": 9826
       }
     ],
     "crates/librefang-kernel/src/mcp_oauth_provider.rs": [
@@ -4056,5 +4056,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-28T22:49:11Z"
+  "generated_at": "2026-05-28T23:33:44Z"
 }

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -2799,9 +2799,7 @@ system_prompt = "BASE PROMPT"
         .find(|s| s.hand_id == hand_id)
         .expect("hand_state.json must carry the persisted instance");
 
-    let timestamps = saved_hand
-        .activated_at
-        .and_then(|a| saved_hand.updated_at.map(|u| (a, u)));
+    let timestamps = saved_hand.activated_at.zip(saved_hand.updated_at);
     let instance = kernel
         .activate_hand_with_id(
             &saved_hand.hand_id,
@@ -2951,9 +2949,7 @@ system_prompt = "WORKER PROMPT"
         .into_iter()
         .find(|s| s.hand_id == hand_id)
         .expect("hand_state.json must carry the persisted instance");
-    let timestamps = saved_hand
-        .activated_at
-        .and_then(|a| saved_hand.updated_at.map(|u| (a, u)));
+    let timestamps = saved_hand.activated_at.zip(saved_hand.updated_at);
     let instance = kernel
         .activate_hand_with_id(
             &saved_hand.hand_id,
@@ -3145,9 +3141,7 @@ fn hand_runtime_override_survives_restart_via_activate_hand_with_id() {
 
     // Replay exactly what `start_background_agents` does for hand restoration,
     // minus the async prelude.
-    let timestamps = saved_hand
-        .activated_at
-        .and_then(|a| saved_hand.updated_at.map(|u| (a, u)));
+    let timestamps = saved_hand.activated_at.zip(saved_hand.updated_at);
     let restored_instance = kernel
         .activate_hand_with_id(
             &saved_hand.hand_id,


### PR DESCRIPTION
Completes the clippy 1.96.0 `manual_option_zip` cleanup.

The other two pieces this branch originally carried have since landed independently on `main`:
- openapi baseline drift → fixed by #5834
- `background_lifecycle.rs` `Option::zip` → fixed by #5845

But #5845 missed the **three identical occurrences in `crates/librefang-kernel/src/kernel/tests.rs`**. `main`'s own CI takes the `full_run` Quality path, but every PR takes the selective path (`clippy --all-targets --all-features -- -D warnings`), which lints test targets — so every open PR is red on Quality until these three are fixed.

This PR replaces them with the equivalent `saved_hand.activated_at.zip(saved_hand.updated_at)` (behavior identical — `Option::zip` returns `Some((a, b))` iff both are `Some`). `.secrets.baseline` line numbers regenerated for the edit-induced shift.
