### PR TITLE
fix(providers): keep custom providers across restarts, tolerate unknown tier

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -641,7 +641,7 @@
         "filename": "crates/librefang-api/src/routes/registry.rs",
         "hashed_secret": "4e5111dafe7d9739f9228906d90cf421d5ec5371",
         "is_verified": false,
-        "line_number": 453
+        "line_number": 470
       }
     ],
     "crates/librefang-api/src/routes/terminal.rs": [
@@ -2768,14 +2768,14 @@
         "filename": "crates/librefang-types/src/model_catalog.rs",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 562
+        "line_number": 589
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/model_catalog.rs",
         "hashed_secret": "ba4d38e2a7e8c718913887136d2526351d05cd69",
         "is_verified": false,
-        "line_number": 927
+        "line_number": 990
       }
     ],
     "crates/librefang-types/src/taint.rs": [
@@ -4056,5 +4056,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-28T15:11:39Z"
+  "generated_at": "2026-05-28T18:24:57Z"
 }

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -759,11 +759,15 @@ const EMPTY_MODEL: ModelEntry = {
   input_cost_per_m: "", output_cost_per_m: "",
 };
 
+// Values must match the backend `ModelTier` enum
+// (crates/librefang-types/src/model_catalog.rs). "reasoning" is NOT a tier —
+// it was rejected by the catalog TOML parser and made the provider silently
+// vanish (#5822); "frontier" is the real top-capability tier.
 const TIER_OPTIONS = [
   { value: "fast", label: "Fast" },
   { value: "balanced", label: "Balanced" },
   { value: "smart", label: "Smart" },
-  { value: "reasoning", label: "Reasoning" },
+  { value: "frontier", label: "Frontier" },
 ];
 
 function CreateProviderWizard({

--- a/crates/librefang-api/src/routes/registry.rs
+++ b/crates/librefang-api/src/routes/registry.rs
@@ -296,14 +296,31 @@ async fn create_registry_content(
         }
 
         let target_for_closure = target.clone();
+        // The trait method returns `()`; capture the load result via a
+        // surrounding `&mut Option<_>` (per the `model_catalog_update` contract).
+        let mut merge_result: Option<Result<usize, String>> = None;
+        let sink = &mut merge_result;
         state.kernel.model_catalog_update(&mut move |catalog| {
-            if let Err(e) = catalog.load_catalog_file(&target_for_closure) {
-                tracing::warn!("Failed to merge provider file into catalog: {e}");
-            }
+            *sink = Some(catalog.load_catalog_file(&target_for_closure));
             catalog.detect_auth();
         });
         // Invalidate cached LLM drivers — URLs/keys may have changed.
         state.kernel.clear_driver_cache();
+
+        // The file was written to disk but failed to load into the catalog.
+        // Previously this was swallowed as a `warn!`, so the dashboard saw a
+        // success while the provider silently never appeared (#5822). Roll
+        // back the unusable file — leaving it would also re-trigger the same
+        // parse warning on every daemon boot — and surface the error so the
+        // operator can correct the definition.
+        if let Some(Err(e)) = merge_result {
+            let _ = std::fs::remove_file(&target);
+            return ApiErrorResponse::bad_request(format!(
+                "Provider definition was rejected and not saved: {e}"
+            ))
+            .into_json_tuple()
+            .into_response();
+        }
 
         if api_key_to_save.is_some() {
             state.kernel.clone().spawn_key_validation();

--- a/crates/librefang-api/tests/registry_content_path_test.rs
+++ b/crates/librefang-api/tests/registry_content_path_test.rs
@@ -200,3 +200,94 @@ async fn registry_content_accepts_dotted_and_dashed_identifiers() {
         Some("providers/my.provider-name_1.toml")
     );
 }
+
+async fn get_json(app: &Router, path: &str) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .header(header::AUTHORIZATION, format!("Bearer {TEST_API_KEY}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let value: serde_json::Value =
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, value)
+}
+
+/// #5822: creating a custom provider whose model carries the out-of-vocabulary
+/// tier `"reasoning"` (which the dashboard used to offer) must succeed AND the
+/// model must actually load into the catalog. Previously the catalog TOML
+/// parser rejected the unknown tier, the merge was swallowed as a `warn!`, and
+/// the provider silently never appeared — the endpoint still returned 200, so
+/// asserting the status alone is not enough; we read the catalog back.
+#[tokio::test(flavor = "multi_thread")]
+async fn provider_with_reasoning_tier_model_loads_into_catalog() {
+    let h = boot().await;
+    let body = serde_json::json!({
+        "id": "myai-ds4",
+        "display_name": "My AI",
+        "api_key_env": "MYAI_DS4_API_KEY", // pragma: allowlist secret
+        "base_url": "https://example.invalid/v1",
+        "key_required": false,
+        "models": [{
+            "id": "myai-reasoner-x",
+            "display_name": "MyAI Reasoner X",
+            "tier": "reasoning",
+            "context_window": 128000,
+            "max_output_tokens": 8192,
+            "input_cost_per_m": 1.0,
+            "output_cost_per_m": 2.0
+        }]
+    });
+    let (status, resp) = post_json(&h.app, "/api/registry/content/provider", body).await;
+    assert_eq!(status, StatusCode::OK, "create must succeed: {resp}");
+
+    let (status, models) = get_json(&h.app, "/api/models").await;
+    assert_eq!(status, StatusCode::OK);
+    let raw = models.to_string();
+    assert!(
+        raw.contains("myai-reasoner-x"),
+        "the reasoning-tier model must be present in the catalog; got: {raw}"
+    );
+}
+
+/// A provider definition that fails to load into the catalog (here: a model
+/// whose `context_window` is the wrong TOML type) must be reported to the
+/// caller as a 400 — not swallowed as a success — and the rejected file must
+/// not be left behind on disk to break catalog parsing on every boot.
+#[tokio::test(flavor = "multi_thread")]
+async fn provider_rejected_by_catalog_returns_400_and_leaves_no_file() {
+    let h = boot().await;
+    let body = serde_json::json!({
+        "id": "broken-provider",
+        "display_name": "Broken",
+        "api_key_env": "BROKEN_PROVIDER_API_KEY", // pragma: allowlist secret
+        "base_url": "https://example.invalid/v1",
+        "key_required": false,
+        "models": [{
+            "id": "broken-model",
+            "display_name": "Broken Model",
+            "tier": "fast",
+            "context_window": "not-a-number",
+            "max_output_tokens": 8192,
+            "input_cost_per_m": 1.0,
+            "output_cost_per_m": 2.0
+        }]
+    });
+    let (status, resp) = post_json(&h.app, "/api/registry/content/provider", body).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a provider the catalog rejects must surface a 400, got {status} / {resp}"
+    );
+
+    let file = h.home_dir.join("providers").join("broken-provider.toml");
+    assert!(
+        !file.exists(),
+        "the rejected provider file must be rolled back, not left at {file:?}"
+    );
+}

--- a/crates/librefang-runtime/src/registry_sync.rs
+++ b/crates/librefang-runtime/src/registry_sync.rs
@@ -500,6 +500,37 @@ pub fn needs_sync(home_dir: &Path) -> bool {
     !home_dir.join("registry").join("providers").exists()
 }
 
+/// Name of the per-directory manifest recording which `.toml` files the
+/// registry sync installed. Pruning is gated on this set so user-created
+/// files (e.g. a custom provider added via the dashboard, #5823) are never
+/// deleted on restart — only files we previously synced *and* that upstream
+/// has since removed get cleaned up. The leading dot and lack of a `.toml`
+/// extension keep it out of both the sync and the catalog-load globs.
+const REGISTRY_MANAGED_MANIFEST: &str = ".registry-managed";
+
+/// Read the set of registry-managed `.toml` filenames recorded for `dest_dir`.
+///
+/// Returns an empty set when the manifest is absent (e.g. first run, or an
+/// install that predates the manifest) — which makes pruning a no-op until
+/// the next sync writes the manifest, erring on the side of keeping files.
+fn read_managed_manifest(dest_dir: &Path) -> std::collections::HashSet<String> {
+    std::fs::read_to_string(dest_dir.join(REGISTRY_MANAGED_MANIFEST))
+        .map(|s| {
+            s.lines()
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Persist the set of registry-managed filenames for `dest_dir`.
+fn write_managed_manifest(dest_dir: &Path, names: &std::collections::BTreeSet<String>) {
+    let body = names.iter().cloned().collect::<Vec<_>>().join("\n");
+    let _ = std::fs::write(dest_dir.join(REGISTRY_MANAGED_MANIFEST), body);
+}
+
 /// Sync flat .toml files (e.g. integrations/, providers/).
 fn sync_flat_files(src_dir: &Path, dest_dir: &Path, label: &str) {
     let entries = match std::fs::read_dir(src_dir) {
@@ -507,6 +538,8 @@ fn sync_flat_files(src_dir: &Path, dest_dir: &Path, label: &str) {
         Err(_) => return,
     };
 
+    // Filenames the registry currently ships — the new managed set.
+    let mut managed: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     let mut synced = 0;
     let mut updated = 0;
     let mut skipped = 0;
@@ -519,6 +552,7 @@ fn sync_flat_files(src_dir: &Path, dest_dir: &Path, label: &str) {
             Some(n) if n.ends_with(".toml") => n.to_string(),
             _ => continue,
         };
+        managed.insert(name.clone());
 
         let dest_file = dest_dir.join(&name);
         if dest_file.exists() {
@@ -542,24 +576,25 @@ fn sync_flat_files(src_dir: &Path, dest_dir: &Path, label: &str) {
         }
     }
 
-    // Remove local files that no longer exist in the registry source.
-    // This cleans up defunct providers/integrations after upstream pruning.
+    // Clean up defunct registry files after upstream pruning — but ONLY files
+    // we previously installed ourselves. A file that was registry-managed last
+    // sync (recorded in the manifest) and is gone from the source now is
+    // safe to delete; a file we never installed (a user's custom provider) is
+    // left untouched. This is the #5823 fix: the old logic deleted every local
+    // `.toml` absent from the source, wiping dashboard-created providers on
+    // every restart.
+    let previously_managed = read_managed_manifest(dest_dir);
     let mut removed = 0usize;
-    if let Ok(dest_entries) = std::fs::read_dir(dest_dir) {
-        for entry in dest_entries.flatten() {
-            let path = entry.path();
-            if !path.is_file() {
-                continue;
-            }
-            let name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(n) if n.ends_with(".toml") => n.to_string(),
-                _ => continue,
-            };
-            if !src_dir.join(&name).exists() && std::fs::remove_file(&path).is_ok() {
+    for name in &previously_managed {
+        if !managed.contains(name) {
+            let path = dest_dir.join(name);
+            if path.is_file() && std::fs::remove_file(&path).is_ok() {
                 removed += 1;
             }
         }
     }
+
+    write_managed_manifest(dest_dir, &managed);
 
     if synced > 0 || updated > 0 || removed > 0 || skipped > 0 {
         tracing::info!("{label} synced ({synced} new, {updated} updated, {removed} removed, {skipped} unchanged)");
@@ -733,6 +768,72 @@ mod tests {
     fn test_needs_sync_when_registry_cache_missing() {
         let tmp = tempfile::tempdir().unwrap();
         assert!(needs_sync(tmp.path()));
+    }
+
+    /// #5823: a dashboard-created custom provider lives only in the dest dir
+    /// and is absent from the registry source. It MUST survive a sync — the
+    /// old logic deleted every dest `.toml` not present in the source, so the
+    /// provider vanished on every `librefang stop && start`.
+    #[test]
+    fn sync_flat_files_preserves_user_created_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&dest).unwrap();
+
+        // Registry ships one provider; user added their own.
+        std::fs::write(src.join("openai.toml"), "id = \"openai\"").unwrap();
+        std::fs::write(dest.join("openai.toml"), "id = \"openai\"").unwrap();
+        std::fs::write(dest.join("my-custom.toml"), "id = \"my-custom\"").unwrap();
+
+        sync_flat_files(&src, &dest, "providers");
+
+        assert!(
+            dest.join("my-custom.toml").exists(),
+            "user-created provider must survive sync"
+        );
+        assert!(dest.join("openai.toml").exists());
+        // A second sync (simulating a restart) must still keep it.
+        sync_flat_files(&src, &dest, "providers");
+        assert!(
+            dest.join("my-custom.toml").exists(),
+            "user-created provider must survive repeated restarts"
+        );
+    }
+
+    /// The upstream-pruning cleanup is preserved: a file we previously synced
+    /// from the registry and that the registry no longer ships is removed —
+    /// but only because it was recorded in the managed manifest.
+    #[test]
+    fn sync_flat_files_prunes_only_previously_managed_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&dest).unwrap();
+
+        // First sync: registry ships two providers.
+        std::fs::write(src.join("alpha.toml"), "id = \"alpha\"").unwrap();
+        std::fs::write(src.join("beta.toml"), "id = \"beta\"").unwrap();
+        sync_flat_files(&src, &dest, "providers");
+        assert!(dest.join("alpha.toml").exists());
+        assert!(dest.join("beta.toml").exists());
+
+        // Upstream prunes beta; user has meanwhile added their own provider.
+        std::fs::remove_file(src.join("beta.toml")).unwrap();
+        std::fs::write(dest.join("mine.toml"), "id = \"mine\"").unwrap();
+        sync_flat_files(&src, &dest, "providers");
+
+        assert!(dest.join("alpha.toml").exists(), "still-shipped file kept");
+        assert!(
+            !dest.join("beta.toml").exists(),
+            "previously-managed, upstream-removed file is pruned"
+        );
+        assert!(
+            dest.join("mine.toml").exists(),
+            "never-managed user file is never pruned"
+        );
     }
 
     #[test]

--- a/crates/librefang-types/src/model_catalog.rs
+++ b/crates/librefang-types/src/model_catalog.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 /// A model's capability tier.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum ModelTier {
@@ -22,6 +22,33 @@ pub enum ModelTier {
     Local,
     /// User-defined custom models added at runtime.
     Custom,
+}
+
+impl<'de> Deserialize<'de> for ModelTier {
+    /// Deserialize leniently: an unrecognized tier string maps to
+    /// [`ModelTier::Custom`] rather than failing the whole file.
+    ///
+    /// Catalog files are loaded one-per-provider, and a single hard parse
+    /// error makes the entire provider vanish (see `from_sources` /
+    /// `load_catalog_file`). A dashboard or hand-edited file carrying an
+    /// out-of-vocabulary tier (e.g. `tier = "reasoning"`, #5822) must not
+    /// take the provider down with it — treat the unknown label as a custom
+    /// tier and keep the provider usable.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Ok(match raw.trim().to_ascii_lowercase().as_str() {
+            "frontier" => ModelTier::Frontier,
+            "smart" => ModelTier::Smart,
+            "balanced" => ModelTier::Balanced,
+            "fast" => ModelTier::Fast,
+            "local" => ModelTier::Local,
+            // "custom" and anything unrecognized collapse to Custom.
+            _ => ModelTier::Custom,
+        })
+    }
 }
 
 impl fmt::Display for ModelTier {
@@ -629,6 +656,42 @@ mod tests {
     #[test]
     fn test_model_tier_default() {
         assert_eq!(ModelTier::default(), ModelTier::Balanced);
+    }
+
+    #[test]
+    fn model_tier_deserializes_known_values() {
+        for (s, want) in [
+            ("frontier", ModelTier::Frontier),
+            ("smart", ModelTier::Smart),
+            ("balanced", ModelTier::Balanced),
+            ("fast", ModelTier::Fast),
+            ("local", ModelTier::Local),
+            ("custom", ModelTier::Custom),
+        ] {
+            let parsed: ModelTier = toml::from_str(&format!("tier = {s:?}"))
+                .map(|w: TierWrap| w.tier)
+                .unwrap_or_else(|e| panic!("{s} must parse: {e}"));
+            assert_eq!(parsed, want, "tier {s:?}");
+        }
+    }
+
+    /// #5822: an out-of-vocabulary tier (the dashboard once offered
+    /// `"reasoning"`) must NOT fail the parse — it collapses to `Custom` so
+    /// the provider stays loadable instead of silently vanishing.
+    #[test]
+    fn model_tier_deserializes_unknown_value_as_custom() {
+        let w: TierWrap = toml::from_str(r#"tier = "reasoning""#).expect("unknown tier must parse");
+        assert_eq!(w.tier, ModelTier::Custom);
+        let w2: TierWrap = toml::from_str(r#"tier = "totally-made-up""#).expect("must parse");
+        assert_eq!(w2.tier, ModelTier::Custom);
+        // Case-insensitive on the known set, too.
+        let w3: TierWrap = toml::from_str(r#"tier = "FRONTIER""#).expect("must parse");
+        assert_eq!(w3.tier, ModelTier::Frontier);
+    }
+
+    #[derive(Deserialize)]
+    struct TierWrap {
+        tier: ModelTier,
     }
 
     #[test]

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-524797aa004a57056db6f91adc240a6c9a92a2ef9aab13e481092d6fb0f156af  openapi.json
+d5a6ba13220bb0662c10c0df2682bc9d3d03dc4cd75e7e7aa74e42a758cacea9  openapi.json


### PR DESCRIPTION
Fixes three related custom-provider catalog bugs in the dashboard "add custom provider" flow.

## #5823 — custom providers deleted on restart

`registry_sync::sync_flat_files` pruned every `.toml` in `~/.librefang/providers/` that was absent from the registry source — which is exactly the set of user-created providers. So any provider added via the dashboard vanished on the next `librefang stop && start`.

The prune is now gated on a per-directory `.registry-managed` manifest. Only files we previously installed from the registry (recorded in the manifest) and that upstream has since removed are cleaned up. User-created files are never recorded there, so they are never deleted. The upstream-pruning cleanup the deletion was written for is preserved.

## #5822 — `tier = "reasoning"` silently dropped the provider

Creating a model with the tier `"reasoning"` (which the dashboard offered) failed the catalog TOML parse:

```
Failed to parse catalog file …/myai-ds4.toml: TOML parse error at line 8, column 8
8 | tier = "reasoning"
```

Catalog files load one-per-provider, and a hard parse error makes the whole provider vanish with only a `warn!`. Two changes:

- **`ModelTier` now deserializes leniently** — an unrecognized tier collapses to `Custom` instead of taking the provider down. Defense in depth for any future / hand-edited tier value, not just `"reasoning"`.
- **The dashboard tier dropdown** offered `"reasoning"`, which is not a `ModelTier` variant. Replaced it with `"frontier"` (the real top-capability tier) so the UI only emits values the backend models.

## Silent-failure surfacing

When a written provider file failed to merge into the catalog, `POST /api/registry/content/provider` swallowed the error as a `warn!` and returned 200 — the dashboard saw success while the provider never appeared (the "no errors shown on webui and no provider shown neither" in #5822). It now rolls back the unusable file (leaving it would re-trigger the parse warning on every boot) and returns a 400 with the parse error so the operator can correct the definition.

## Verification

Run inside the repo `Dockerfile.rust-dev` image (isolated from the host `target/`):

- `cargo test -p librefang-types --lib model_tier` — 5 passed (incl. unknown-tier→Custom, case-insensitive known values, serde round-trip).
- `cargo test -p librefang-runtime --lib sync_flat_files` — 2 passed (user file survives repeated restarts; only previously-managed, upstream-removed files pruned).
- `cargo test -p librefang-api --test registry_content_path_test` — 5 passed (reasoning-tier model loads into catalog; catalog-rejected provider returns 400 and leaves no file behind).
- `cargo fmt --check` clean for all three crates.

Fixes #5822
Fixes #5823
