### PR TITLE
feat(goals): autonomous long-horizon goal runner

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -357,35 +357,35 @@
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "14b4007ff8fadc0587f923aa38acc6a1b36670da",
         "is_verified": false,
-        "line_number": 2708
+        "line_number": 2712
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "4dad82da373f06d95847d61ba3c5a1cdb5a94fe0",
         "is_verified": false,
-        "line_number": 2925
+        "line_number": 2929
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "5aa7d1e863b4cbed54c71b8ba1a6f4388efcadd0",
         "is_verified": false,
-        "line_number": 2930
+        "line_number": 2934
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "f91eb2a7b1c4be9f65c70eaaf47449c5cb788888",
         "is_verified": false,
-        "line_number": 3236
+        "line_number": 3240
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "cf678cab87dc1f7d1b95b964f15375e088461679",
         "is_verified": false,
-        "line_number": 3339
+        "line_number": 3343
       }
     ],
     "crates/librefang-api/dashboard/src/locales/zh.json": [
@@ -513,21 +513,21 @@
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "be0bbd80b4105d9030a3484201437d600f6fd1d0",
         "is_verified": false,
-        "line_number": 2665
+        "line_number": 2669
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "6e18c7516fd3fe2df687bc59ab10ffc5cee99a7b",
         "is_verified": false,
-        "line_number": 2887
+        "line_number": 2891
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "9d123ddd01a441bfe1d6c9f0bde50e2c7e6448fb",
         "is_verified": false,
-        "line_number": 3236
+        "line_number": 3240
       }
     ],
     "crates/librefang-api/dashboard/src/pages/Memory/index.test.tsx": [
@@ -4056,5 +4056,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-28T15:11:39Z"
+  "generated_at": "2026-05-28T18:51:31Z"
 }

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -3481,6 +3481,50 @@ export async function deleteGoal(goalId: string): Promise<ApiActionResponse> {
   return del<ApiActionResponse>(`/api/goals/${encodeURIComponent(goalId)}`);
 }
 
+// ── Goal runner — long-horizon autonomous execution (#5744) ──────────
+
+export interface GoalRunState {
+  goal_id: string;
+  agent_id: string;
+  phase: "running" | "finished" | "max_iterations_reached" | "rate_limited" | "stopped";
+  iteration: number;
+  max_iterations: number;
+  last_progress: number;
+  last_error?: string;
+  started_at: string;
+  updated_at: string;
+}
+
+/** Begin an autonomous run that drives the goal's assigned agent. */
+export async function startGoalRun(
+  goalId: string,
+  payload?: { max_iterations?: number }
+): Promise<{ ok: boolean; run: GoalRunState | null }> {
+  return post<{ ok: boolean; run: GoalRunState | null }>(
+    `/api/goals/${encodeURIComponent(goalId)}/start`,
+    payload ?? {}
+  );
+}
+
+/** Stop an active autonomous run for a goal. */
+export async function stopGoalRun(
+  goalId: string
+): Promise<{ ok: boolean; stopped: boolean }> {
+  return post<{ ok: boolean; stopped: boolean }>(
+    `/api/goals/${encodeURIComponent(goalId)}/stop`,
+    {}
+  );
+}
+
+/** Observe the autonomous run state for a goal. */
+export async function getGoalRun(
+  goalId: string
+): Promise<{ running: boolean; run?: GoalRunState }> {
+  return get<{ running: boolean; run?: GoalRunState }>(
+    `/api/goals/${encodeURIComponent(goalId)}/run`
+  );
+}
+
 // ── Network / Peers ──────────────────────────────────
 
 export interface NetworkStatusResponse {

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -234,6 +234,9 @@ export {
   createGoal,
   updateGoal,
   deleteGoal,
+  startGoalRun,
+  stopGoalRun,
+  getGoalRun,
   // hands
   activateHand,
   deactivateHand,

--- a/crates/librefang-api/dashboard/src/lib/mutations/goals.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/goals.ts
@@ -1,5 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { createGoal, updateGoal, deleteGoal } from "../http/client";
+import {
+  createGoal,
+  updateGoal,
+  deleteGoal,
+  startGoalRun,
+  stopGoalRun,
+} from "../http/client";
 import type { GoalItem } from "../../api";
 import { goalKeys } from "../queries/keys";
 
@@ -33,5 +39,30 @@ export function useDeleteGoal() {
   return useMutation({
     mutationFn: deleteGoal,
     onSuccess: () => qc.invalidateQueries({ queryKey: goalKeys.lists() }),
+  });
+}
+
+// Long-horizon autonomous runs (#5744).
+
+export function useStartGoalRun() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, maxIterations }: { id: string; maxIterations?: number }) =>
+      startGoalRun(id, maxIterations !== undefined ? { max_iterations: maxIterations } : undefined),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: goalKeys.run(id) });
+      qc.invalidateQueries({ queryKey: goalKeys.lists() });
+    },
+  });
+}
+
+export function useStopGoalRun() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => stopGoalRun(id),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: goalKeys.run(id) });
+      qc.invalidateQueries({ queryKey: goalKeys.lists() });
+    },
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/goals.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/goals.ts
@@ -1,10 +1,11 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
-import { listGoals, listGoalTemplates } from "../http/client";
+import { listGoals, listGoalTemplates, getGoalRun } from "../http/client";
 import { goalKeys } from "./keys";
 import { withOverrides, QueryOverrides } from "./options";
 
 const STALE_MS = 30_000;
 const TEMPLATE_STALE_MS = 300_000;
+const RUN_POLL_MS = 4_000;
 
 export const goalQueries = {
   list: () =>
@@ -21,6 +22,14 @@ export const goalQueries = {
       queryFn: listGoalTemplates,
       staleTime: TEMPLATE_STALE_MS,
     }),
+  run: (id: string) =>
+    queryOptions({
+      queryKey: goalKeys.run(id),
+      queryFn: () => getGoalRun(id),
+      // Poll while a run is active so the dashboard reflects live progress.
+      refetchInterval: RUN_POLL_MS,
+      refetchIntervalInBackground: false,
+    }),
 };
 
 export function useGoals(options: QueryOverrides = {}) {
@@ -29,4 +38,8 @@ export function useGoals(options: QueryOverrides = {}) {
 
 export function useGoalTemplates(options: QueryOverrides = {}) {
   return useQuery(withOverrides(goalQueries.templates(), options));
+}
+
+export function useGoalRun(id: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(goalQueries.run(id), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -296,6 +296,8 @@ export const goalKeys = {
   all: ["goals"] as const,
   lists: () => [...goalKeys.all, "list"] as const,
   templates: () => [...goalKeys.all, "templates"] as const,
+  runs: () => [...goalKeys.all, "run"] as const,
+  run: (id: string) => [...goalKeys.runs(), id] as const,
 };
 
 export const networkKeys = {

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -2584,6 +2584,10 @@
     "clear_all": "Clear All",
     "clear_all_confirm": "Delete all goals?",
     "clear_all_partial": "Deleted {{succeeded}}/{{total}} goals, failed {{failed}}.",
+    "run_start": "Run autonomously",
+    "run_stop": "Stop autonomous run",
+    "run_needs_agent": "Assign an agent to run this goal autonomously",
+    "run_active": "Running · iteration {{iteration}}/{{max}}",
     "help": "Goals is the strategic-planning surface — a tree of objectives the agent (or you) is working towards, with progress, status, and parent / child relationships. Templates seed common goal shapes; the tree view shows hierarchy and roll-up progress.\n\nHow to use this page:\n\n1. Create. \"Create goal\" opens a form for title, description, parent goal, and status. Or \"Pick template\" to apply a pre-built goal tree (e.g. \"ship a feature\", \"research a topic\").\n\n2. Track. Each node shows pending / in-progress / completed. Parent progress aggregates from children. Edit a node inline to flip its state or refine its description.\n\n3. Prune. \"Clear all\" wipes the tree (with a confirm) — useful when starting a new initiative.\n\nWhen to use it (vs. Scheduler / Workflows):\n\n  · Goals — what we want. Long-lived intentions, often agent-readable.\n  · Scheduler / Workflows — how it gets done. Concrete fires and steps.\n\nTypical scenarios:\n\n  · Giving an agent a long-term direction it can refer back to during planning.\n  · Tracking a multi-week project as a tree the human and the agent both see.\n\nThings to know:\n\n  · Templates are starting points — feel free to edit the tree after applying.\n  · Deleting a parent deletes its children. Confirm before \"Clear all\"."
   },
   "sessions": {

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -2541,6 +2541,10 @@
     "clear_all": "清空全部",
     "clear_all_confirm": "确认删除所有目标？",
     "clear_all_partial": "已删除 {{succeeded}}/{{total}} 个目标，失败 {{failed}} 个。",
+    "run_start": "自主执行",
+    "run_stop": "停止自主执行",
+    "run_needs_agent": "请先为该目标指派一个 agent 才能自主执行",
+    "run_active": "执行中 · 第 {{iteration}}/{{max}} 轮",
     "help": "Goals 是战略规划面——一棵 agent（或你）正在追的目标树，含进度、状态和父子关系。模板播种常见目标形状；树视图展示层级和向上汇总的进度。\n\n使用步骤：\n\n1. 创建。\"Create goal\" 打开表单填标题、描述、父目标、状态。或 \"Pick template\" 一次性铺开预置目标树（如 \"ship a feature\"、\"research a topic\"）。\n\n2. 跟踪。每个节点显示 pending / in-progress / completed。父节点进度由子节点汇总。点节点可内联编辑状态或描述。\n\n3. 清理。\"Clear all\" 整棵清空（带二次确认）——开新阶段时常用。\n\n跟 Scheduler / Workflows 的区别：\n\n  · Goals —— 想做什么。长期意图，可被 agent 读取。\n  · Scheduler / Workflows —— 怎么做。具体的触发与步骤。\n\n典型场景：\n\n  · 给 agent 一个长期方向，规划时可以参考。\n  · 跟踪一个跨周项目，人和 agent 都看同一棵树。\n\n注意事项：\n\n  · 模板是起点，应用后随便改。\n  · 删父节点会带走子节点，\"Clear all\" 前请确认。"
   },
   "sessions": {

--- a/crates/librefang-api/dashboard/src/pages/GoalsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/GoalsPage.test.tsx
@@ -2,23 +2,28 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { GoalsPage } from "./GoalsPage";
-import { useGoals, useGoalTemplates } from "../lib/queries/goals";
+import { useGoals, useGoalTemplates, useGoalRun } from "../lib/queries/goals";
 import {
   useCreateGoal,
   useUpdateGoal,
   useDeleteGoal,
+  useStartGoalRun,
+  useStopGoalRun,
 } from "../lib/mutations/goals";
 import type { GoalItem, GoalTemplate } from "../api";
 
 vi.mock("../lib/queries/goals", () => ({
   useGoals: vi.fn(),
   useGoalTemplates: vi.fn(),
+  useGoalRun: vi.fn(),
 }));
 
 vi.mock("../lib/mutations/goals", () => ({
   useCreateGoal: vi.fn(),
   useUpdateGoal: vi.fn(),
   useDeleteGoal: vi.fn(),
+  useStartGoalRun: vi.fn(),
+  useStopGoalRun: vi.fn(),
 }));
 
 vi.mock("react-i18next", async () => {
@@ -36,9 +41,12 @@ vi.mock("react-i18next", async () => {
 
 const useGoalsMock = useGoals as unknown as ReturnType<typeof vi.fn>;
 const useGoalTemplatesMock = useGoalTemplates as unknown as ReturnType<typeof vi.fn>;
+const useGoalRunMock = useGoalRun as unknown as ReturnType<typeof vi.fn>;
 const useCreateGoalMock = useCreateGoal as unknown as ReturnType<typeof vi.fn>;
 const useUpdateGoalMock = useUpdateGoal as unknown as ReturnType<typeof vi.fn>;
 const useDeleteGoalMock = useDeleteGoal as unknown as ReturnType<typeof vi.fn>;
+const useStartGoalRunMock = useStartGoalRun as unknown as ReturnType<typeof vi.fn>;
+const useStopGoalRunMock = useStopGoalRun as unknown as ReturnType<typeof vi.fn>;
 
 interface QueryShape<T> {
   data: T;
@@ -81,6 +89,8 @@ function setMutations(opts: {
   });
   useUpdateGoalMock.mockReturnValue({ mutateAsync: update, isPending: false });
   useDeleteGoalMock.mockReturnValue({ mutateAsync: del, isPending: false });
+  useStartGoalRunMock.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+  useStopGoalRunMock.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
   return { create, update, del };
 }
 
@@ -133,6 +143,9 @@ describe("GoalsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setMutations();
+    // GoalRunControl calls useGoalRun for every rendered goal; default to an
+    // idle (no active run) query so the control renders its start button.
+    useGoalRunMock.mockReturnValue(makeQuery({ running: false }));
   });
 
   it("renders the loading skeleton while goals are fetching", () => {

--- a/crates/librefang-api/dashboard/src/pages/GoalsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/GoalsPage.tsx
@@ -1,8 +1,14 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type GoalItem, type GoalTemplate } from "../api";
-import { useGoals, useGoalTemplates } from "../lib/queries/goals";
-import { useCreateGoal, useUpdateGoal, useDeleteGoal } from "../lib/mutations/goals";
+import { useGoals, useGoalTemplates, useGoalRun } from "../lib/queries/goals";
+import {
+  useCreateGoal,
+  useUpdateGoal,
+  useDeleteGoal,
+  useStartGoalRun,
+  useStopGoalRun,
+} from "../lib/mutations/goals";
 import { PageHeader } from "../components/ui/PageHeader";
 import { ListSkeleton } from "../components/ui/Skeleton";
 import { Card } from "../components/ui/Card";
@@ -10,7 +16,7 @@ import { Button } from "../components/ui/Button";
 import { Badge } from "../components/ui/Badge";
 import { useUIStore } from "../lib/store";
 import { toastErr } from "../lib/errors";
-import { Shield, Trash2, Edit2, Plus, Target, Rocket, Bot, Database, Users, AlertTriangle, Loader2, CheckCircle2, Clock, Play, ChevronDown, ChevronRight } from "lucide-react";
+import { Shield, Trash2, Edit2, Plus, Target, Rocket, Bot, Database, Users, AlertTriangle, Loader2, CheckCircle2, Clock, Play, Square, ChevronDown, ChevronRight } from "lucide-react";
 import { StaggerList } from "../components/ui/StaggerList";
 
 const TEMPLATE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -21,6 +27,90 @@ const TEMPLATE_ICONS: Record<string, React.ComponentType<{ className?: string }>
   users: Users,
   alert: AlertTriangle,
 };
+
+/**
+ * Start / stop the autonomous long-horizon run for a single goal (#5744).
+ * Only meaningful when the goal has an agent assigned — without one there is
+ * nothing to drive the loop, so the control prompts to assign an agent.
+ */
+function GoalRunControl({ goal }: { goal: GoalItem }) {
+  const { t } = useTranslation();
+  const addToast = useUIStore((s) => s.addToast);
+  const hasAgent = !!goal.agent_id;
+  // Poll the run state only while a run could be active; cheap GET otherwise.
+  const runQuery = useGoalRun(goal.id, { enabled: hasAgent });
+  const startMutation = useStartGoalRun();
+  const stopMutation = useStopGoalRun();
+
+  const run = runQuery.data?.run;
+  const isRunning = runQuery.data?.running === true && run?.phase === "running";
+
+  if (!hasAgent) {
+    return (
+      <button
+        type="button"
+        disabled
+        className="p-1.5 rounded-lg text-text-dim/40 cursor-not-allowed"
+        title={t("goals.run_needs_agent")}
+      >
+        <Play className="h-3.5 w-3.5" />
+      </button>
+    );
+  }
+
+  const onStart = async () => {
+    try {
+      await startMutation.mutateAsync({ id: goal.id });
+    } catch (err) {
+      addToast(toastErr(err, t("common.error")), "error");
+    }
+  };
+  const onStop = async () => {
+    try {
+      await stopMutation.mutateAsync(goal.id);
+    } catch (err) {
+      addToast(toastErr(err, t("common.error")), "error");
+    }
+  };
+
+  if (isRunning) {
+    return (
+      <button
+        type="button"
+        onClick={() => void onStop()}
+        disabled={stopMutation.isPending}
+        className="p-1.5 rounded-lg hover:bg-warning/10 text-warning transition-colors"
+        title={
+          run
+            ? t("goals.run_active", { iteration: run.iteration, max: run.max_iterations })
+            : t("goals.run_stop")
+        }
+      >
+        {stopMutation.isPending ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Square className="h-3.5 w-3.5" />
+        )}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void onStart()}
+      disabled={startMutation.isPending}
+      className="p-1.5 rounded-lg hover:bg-success/10 text-text-dim hover:text-success transition-colors"
+      title={t("goals.run_start")}
+    >
+      {startMutation.isPending ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : (
+        <Play className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}
 
 export function GoalsPage() {
   const { t } = useTranslation();
@@ -403,6 +493,7 @@ export function GoalsPage() {
                               </Badge>
                             </div>
                             <div className="flex items-center gap-1 shrink-0">
+                              {status !== "completed" && <GoalRunControl goal={r.goal} />}
                               <button onClick={() => handleStartEdit(r.goal)} className="p-1.5 rounded-lg hover:bg-brand/10 text-text-dim hover:text-brand transition-colors" title={t("common.edit")}>
                                 <Edit2 className="h-3.5 w-3.5" />
                               </button>

--- a/crates/librefang-api/src/routes/goals.rs
+++ b/crates/librefang-api/src/routes/goals.rs
@@ -17,6 +17,9 @@ pub fn router() -> axum::Router<std::sync::Arc<AppState>> {
             "/goals/{id}/children",
             axum::routing::get(get_goal_children),
         )
+        .route("/goals/{id}/run", axum::routing::get(get_goal_run))
+        .route("/goals/{id}/start", axum::routing::post(start_goal_run))
+        .route("/goals/{id}/stop", axum::routing::post(stop_goal_run))
 }
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -31,15 +34,14 @@ use crate::types::ApiErrorResponse;
 // Goals endpoints
 // ---------------------------------------------------------------------------
 
-/// The well-known shared-memory key for goals storage.
-const GOALS_KEY: &str = "__librefang_goals";
+/// The well-known shared-memory key for goals storage. Single source of truth
+/// lives in `librefang_types::goal` so the kernel goal runner reads/writes the
+/// same store (#5744).
+const GOALS_KEY: &str = librefang_types::goal::GOALS_STORAGE_KEY;
 
 /// Shared agent ID for goals KV storage.
 fn goals_shared_agent_id() -> AgentId {
-    AgentId(uuid::Uuid::from_bytes([
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x01,
-    ]))
+    librefang_types::goal::goals_storage_agent_id()
 }
 
 /// GET /api/goals — List all goals.
@@ -120,6 +122,124 @@ pub async fn get_goal_children(
             Json(serde_json::json!({"children": [], "total": 0, "error": format!("{e}")}))
         }
     }
+}
+
+/// GET /api/goals/{id}/run — Observe the autonomous run state for a goal.
+pub async fn get_goal_run(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let goal_id = match id.parse::<librefang_types::goal::GoalId>() {
+        Ok(g) => g,
+        Err(_) => return ApiErrorResponse::bad_request("Invalid goal id").into_json_tuple(),
+    };
+    match state.kernel.goal_run_state(goal_id) {
+        Some(run) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "running": true, "run": run })),
+        ),
+        None => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "running": false })),
+        ),
+    }
+}
+
+/// POST /api/goals/{id}/start — Begin an autonomous long-horizon run that
+/// drives the goal's assigned agent toward completion (#5744).
+///
+/// Optional body: `{ "max_iterations": <u32> }`.
+pub async fn start_goal_run(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    body: Option<Json<serde_json::Value>>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let goal_id = match id.parse::<librefang_types::goal::GoalId>() {
+        Ok(g) => g,
+        Err(_) => return ApiErrorResponse::bad_request("Invalid goal id").into_json_tuple(),
+    };
+
+    let arr = match state
+        .kernel
+        .memory_substrate()
+        .structured_get(goals_shared_agent_id(), GOALS_KEY)
+    {
+        Ok(Some(serde_json::Value::Array(arr))) => arr,
+        _ => Vec::new(),
+    };
+    let goal = match arr.iter().find(|g| g["id"].as_str() == Some(&id)) {
+        Some(g) => g.clone(),
+        None => {
+            return ApiErrorResponse::not_found(format!("Goal '{id}' not found")).into_json_tuple();
+        }
+    };
+    let agent_id = match goal["agent_id"]
+        .as_str()
+        .and_then(|s| s.parse::<uuid::Uuid>().ok())
+    {
+        Some(u) => AgentId(u),
+        None => {
+            return ApiErrorResponse::bad_request(
+                "Assign an agent to this goal before starting a run",
+            )
+            .into_json_tuple();
+        }
+    };
+
+    let max_iterations = body
+        .as_ref()
+        .and_then(|b| b.0.get("max_iterations"))
+        .and_then(|v| v.as_u64())
+        .map(|n| n as u32);
+
+    // Flip the goal to in_progress so the dashboard reflects the active run.
+    let _ = state.kernel.memory_substrate().structured_modify(
+        goals_shared_agent_id(),
+        GOALS_KEY,
+        |cur| {
+            let mut goals = match cur {
+                Some(serde_json::Value::Array(a)) => a,
+                _ => Vec::new(),
+            };
+            for g in goals.iter_mut() {
+                if g["id"].as_str() == Some(id.as_str()) {
+                    if let Some(o) = g.as_object_mut() {
+                        o.insert("status".into(), serde_json::json!("in_progress"));
+                        o.insert(
+                            "updated_at".into(),
+                            serde_json::json!(chrono::Utc::now().to_rfc3339()),
+                        );
+                    }
+                }
+            }
+            Ok((serde_json::Value::Array(goals), ()))
+        },
+    );
+
+    state
+        .kernel
+        .start_goal_run(goal_id, agent_id, max_iterations);
+    let run = state.kernel.goal_run_state(goal_id);
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "ok": true, "run": run })),
+    )
+}
+
+/// POST /api/goals/{id}/stop — Stop an active autonomous run for a goal.
+pub async fn stop_goal_run(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let goal_id = match id.parse::<librefang_types::goal::GoalId>() {
+        Ok(g) => g,
+        Err(_) => return ApiErrorResponse::bad_request("Invalid goal id").into_json_tuple(),
+    };
+    let stopped = state.kernel.stop_goal_run(goal_id);
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "ok": true, "stopped": stopped })),
+    )
 }
 
 /// POST /api/goals — Create a new goal.

--- a/crates/librefang-api/tests/goals_routes_integration.rs
+++ b/crates/librefang-api/tests/goals_routes_integration.rs
@@ -524,3 +524,57 @@ async fn concurrent_goal_creates_lose_no_writes_5138() {
     expected.sort();
     assert_eq!(titles, expected, "no individual goal may be clobbered");
 }
+
+// ---------------------------------------------------------------------------
+// POST /api/goals/{id}/start | /stop, GET /api/goals/{id}/run
+// Autonomous long-horizon goal runner (#5744).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goal_run_start_requires_assigned_agent() {
+    let h = boot().await;
+    let goal = create_goal(&h, serde_json::json!({"title": "No agent"})).await;
+    let id = goal["id"].as_str().unwrap();
+    let (status, body) =
+        json_request(&h, Method::POST, &format!("/api/goals/{id}/start"), None).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "starting a run for a goal with no assigned agent must 400: {body:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goal_run_start_then_stop_with_agent() {
+    let h = boot().await;
+    // A syntactically valid agent id; the run loop is aborted by stop() before
+    // it can complete a real agent turn, so no provider is needed.
+    let agent = "11111111-1111-1111-1111-111111111111";
+    let goal = create_goal(
+        &h,
+        serde_json::json!({"title": "Driveable", "agent_id": agent}),
+    )
+    .await;
+    let id = goal["id"].as_str().unwrap().to_string();
+
+    let (status, body) =
+        json_request(&h, Method::POST, &format!("/api/goals/{id}/start"), None).await;
+    assert_eq!(status, StatusCode::OK, "start failed: {body:?}");
+    assert_eq!(body["ok"].as_bool(), Some(true));
+    assert_eq!(body["run"]["phase"].as_str(), Some("running"));
+    assert_eq!(body["run"]["max_iterations"].as_u64(), Some(25));
+
+    // The run is observable via GET /run.
+    let (rs, run) = json_request(&h, Method::GET, &format!("/api/goals/{id}/run"), None).await;
+    assert_eq!(rs, StatusCode::OK);
+    assert_eq!(run["running"].as_bool(), Some(true));
+
+    // Stop the run.
+    let (ss, stop) = json_request(&h, Method::POST, &format!("/api/goals/{id}/stop"), None).await;
+    assert_eq!(ss, StatusCode::OK);
+    assert_eq!(stop["stopped"].as_bool(), Some(true));
+
+    // Stopping again reports no active run.
+    let (_s2, stop2) = json_request(&h, Method::POST, &format!("/api/goals/{id}/stop"), None).await;
+    assert_eq!(stop2["stopped"].as_bool(), Some(false));
+}

--- a/crates/librefang-kernel/src/goal_runner.rs
+++ b/crates/librefang-kernel/src/goal_runner.rs
@@ -1,0 +1,529 @@
+//! Long-horizon autonomous goal execution (#5744).
+//!
+//! The Goals system (CRUD + dashboard) tracks objectives but, on its own, is
+//! purely passive — nothing ever drives an agent toward a goal. The
+//! [`GoalRunner`] closes that gap: starting a run for a goal with an assigned
+//! agent spawns a bounded loop that repeatedly prompts the agent with the
+//! goal's context and parses the agent's reply for progress / completion
+//! markers, updating the goal in the shared memory store until the goal is
+//! done, the iteration cap is hit, an operator stops it, or the kernel shuts
+//! down.
+//!
+//! ## Why response markers instead of a tool
+//!
+//! The agent reports progress by ending its turn with structured lines:
+//!
+//! ```text
+//! GOAL_PROGRESS: 60
+//! GOAL_DONE          (optional — signals the goal is complete)
+//! GOAL_BLOCKED       (optional — signals it cannot proceed without input)
+//! ```
+//!
+//! This keeps the v1 runner entirely kernel-side: no new runtime tool, no
+//! tool-registry / capability-permission surgery. The parsing is forgiving
+//! (case-insensitive, last marker wins) so an agent that forgets the marker
+//! simply keeps iterating to the cap rather than failing.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use dashmap::DashMap;
+use tokio::sync::{watch, Mutex};
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+use librefang_memory::MemorySubstrate;
+use librefang_types::agent::AgentId;
+use librefang_types::goal::{
+    goals_storage_agent_id, Goal, GoalId, GoalRunPhase, GoalRunState, GoalStatus, GOALS_STORAGE_KEY,
+};
+
+use crate::background::{classify_tick_error, TickOutcome};
+
+/// Pause between iterations. Short — the agent turn itself dominates wall-clock;
+/// this just yields and lets shutdown / stop signals be observed promptly.
+const TICK_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Consecutive provider rate-limit ticks before the loop gives up, mirroring
+/// the background executor's circuit breaker (#5168) so a quota-exhausted
+/// provider does not get hammered on every iteration.
+const MAX_RATE_LIMIT_STREAK: u32 = 3;
+
+/// Result of parsing one agent reply for goal-control markers.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ParsedTick {
+    /// Progress value (0-100) if the agent emitted `GOAL_PROGRESS:`.
+    pub progress: Option<u8>,
+    /// The agent signalled completion (`GOAL_DONE`).
+    pub done: bool,
+    /// The agent signalled it is blocked (`GOAL_BLOCKED`).
+    pub blocked: bool,
+}
+
+/// Parse an agent reply for `GOAL_PROGRESS:` / `GOAL_DONE` / `GOAL_BLOCKED`
+/// markers. Case-insensitive; the last `GOAL_PROGRESS` line wins.
+pub fn parse_tick(reply: &str) -> ParsedTick {
+    let mut out = ParsedTick::default();
+    for line in reply.lines() {
+        let t = line.trim();
+        let upper = t.to_ascii_uppercase();
+        if let Some(rest) = upper.strip_prefix("GOAL_PROGRESS:") {
+            if let Ok(n) = rest.trim().parse::<u32>() {
+                out.progress = Some(n.min(100) as u8);
+            }
+        } else if upper.starts_with("GOAL_DONE") || upper.starts_with("GOAL_COMPLETE") {
+            out.done = true;
+        } else if upper.starts_with("GOAL_BLOCKED") {
+            out.blocked = true;
+        }
+    }
+    out
+}
+
+/// Build the per-iteration prompt that frames the goal for the agent.
+pub fn build_goal_prompt(goal: &Goal, iteration: u32, max_iterations: u32) -> String {
+    format!(
+        "[LONG-HORIZON GOAL] You are autonomously pursuing a goal across multiple turns.\n\
+         Goal: {title}\n\
+         Description: {description}\n\
+         Current progress: {progress}%\n\
+         Iteration: {iter} of {max}\n\n\
+         Take the next concrete action toward completing this goal. When you finish a \
+         step, end your reply with a line `GOAL_PROGRESS: <0-100>` reflecting overall \
+         completion. Add a line `GOAL_DONE` once the goal is fully achieved, or \
+         `GOAL_BLOCKED` if you cannot proceed without operator input.",
+        title = goal.title,
+        description = if goal.description.is_empty() {
+            "(none)"
+        } else {
+            &goal.description
+        },
+        progress = goal.progress,
+        iter = iteration + 1,
+        max = max_iterations,
+    )
+}
+
+/// Load the goal with `goal_id` from the shared goals store.
+fn load_goal(substrate: &MemorySubstrate, goal_id: GoalId) -> Option<Goal> {
+    let arr = match substrate.structured_get(goals_storage_agent_id(), GOALS_STORAGE_KEY) {
+        Ok(Some(serde_json::Value::Array(arr))) => arr,
+        _ => return None,
+    };
+    let target = goal_id.to_string();
+    arr.into_iter()
+        .find(|g| g.get("id").and_then(|v| v.as_str()) == Some(target.as_str()))
+        .and_then(|v| serde_json::from_value(v).ok())
+}
+
+/// Atomically patch a goal's progress / status / `updated_at` in the shared
+/// store. Uses `structured_modify` so concurrent writers (the API CRUD path)
+/// never lose this update to a last-writer-wins race.
+fn patch_goal(
+    substrate: &MemorySubstrate,
+    goal_id: GoalId,
+    progress: Option<u8>,
+    status: Option<GoalStatus>,
+) {
+    let target = goal_id.to_string();
+    let res =
+        substrate.structured_modify(goals_storage_agent_id(), GOALS_STORAGE_KEY, |existing| {
+            let mut arr = match existing {
+                Some(serde_json::Value::Array(arr)) => arr,
+                _ => Vec::new(),
+            };
+            for g in arr.iter_mut() {
+                if g.get("id").and_then(|v| v.as_str()) != Some(target.as_str()) {
+                    continue;
+                }
+                if let Some(obj) = g.as_object_mut() {
+                    if let Some(p) = progress {
+                        obj.insert("progress".into(), serde_json::json!(p));
+                    }
+                    if let Some(s) = status {
+                        obj.insert("status".into(), serde_json::json!(s.to_string()));
+                    }
+                    obj.insert("updated_at".into(), serde_json::json!(Utc::now()));
+                }
+                break;
+            }
+            Ok((serde_json::Value::Array(arr), ()))
+        });
+    if let Err(e) = res {
+        warn!(goal_id = %goal_id, "Failed to persist goal update: {e}");
+    }
+}
+
+/// A single in-flight goal run: the spawned loop task plus its observable state
+/// and a cooperative stop flag.
+struct RunHandle {
+    task: JoinHandle<()>,
+    state: Arc<Mutex<GoalRunState>>,
+    stop: Arc<AtomicBool>,
+}
+
+/// Registry + driver for autonomous goal runs. One [`GoalRunner`] lives on the
+/// kernel; it tracks at most one active run per goal.
+pub struct GoalRunner {
+    runs: Arc<DashMap<GoalId, RunHandle>>,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+impl GoalRunner {
+    /// Create a runner wired to the kernel shutdown signal.
+    pub fn new(shutdown_rx: watch::Receiver<bool>) -> Self {
+        Self {
+            runs: Arc::new(DashMap::new()),
+            shutdown_rx,
+        }
+    }
+
+    /// Whether a run is currently active for `goal_id`.
+    pub fn is_running(&self, goal_id: GoalId) -> bool {
+        self.runs
+            .get(&goal_id)
+            .is_some_and(|h| !h.task.is_finished())
+    }
+
+    /// Snapshot the observable state of a goal's run, if one exists.
+    pub fn state(&self, goal_id: GoalId) -> Option<GoalRunState> {
+        let handle = self.runs.get(&goal_id)?;
+        // try_lock avoids blocking the caller (an async HTTP handler) on a tick;
+        // a momentary contention just yields no snapshot this call.
+        handle.state.try_lock().ok().map(|s| s.clone())
+    }
+
+    /// Stop a goal's run if active. Returns whether a run was stopped.
+    pub fn stop(&self, goal_id: GoalId) -> bool {
+        if let Some((_, handle)) = self.runs.remove(&goal_id) {
+            handle.stop.store(true, Ordering::SeqCst);
+            handle.task.abort();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Start an autonomous run that drives `agent_id` toward `goal_id`.
+    ///
+    /// `send_message` performs one agent turn and yields the agent's reply text
+    /// (or an error string). The loop owns iteration counting, marker parsing,
+    /// goal persistence, and the rate-limit circuit breaker.
+    ///
+    /// Replaces any existing run for the same goal.
+    pub fn start<F, Fut>(
+        &self,
+        goal_id: GoalId,
+        agent_id: AgentId,
+        max_iterations: u32,
+        substrate: Arc<MemorySubstrate>,
+        send_message: F,
+    ) where
+        F: Fn(AgentId, String) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<String, String>> + Send + 'static,
+    {
+        // Replace any prior run for this goal.
+        self.stop(goal_id);
+
+        let now = Utc::now();
+        let state = Arc::new(Mutex::new(GoalRunState {
+            goal_id,
+            agent_id,
+            phase: GoalRunPhase::Running,
+            iteration: 0,
+            max_iterations,
+            last_progress: 0,
+            last_error: None,
+            started_at: now,
+            updated_at: now,
+        }));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let runs = self.runs.clone();
+        let shutdown_rx = self.shutdown_rx.clone();
+        let loop_state = state.clone();
+        let loop_stop = stop.clone();
+
+        let task = tokio::spawn(async move {
+            run_loop(
+                goal_id,
+                agent_id,
+                max_iterations,
+                substrate,
+                send_message,
+                loop_state,
+                loop_stop,
+                shutdown_rx,
+            )
+            .await;
+            // Self-cleanup: drop the registry entry once the loop ends so a
+            // stale handle does not linger (mirrors the background executor).
+            runs.remove(&goal_id);
+        });
+
+        self.runs.insert(goal_id, RunHandle { task, state, stop });
+        info!(goal_id = %goal_id, agent_id = %agent_id, max_iterations, "Goal run started");
+    }
+}
+
+/// The run loop body. Extracted as a free function so tests can drive it with a
+/// fake `send_message` and an in-memory substrate.
+#[allow(clippy::too_many_arguments)]
+async fn run_loop<F, Fut>(
+    goal_id: GoalId,
+    agent_id: AgentId,
+    max_iterations: u32,
+    substrate: Arc<MemorySubstrate>,
+    send_message: F,
+    state: Arc<Mutex<GoalRunState>>,
+    stop: Arc<AtomicBool>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) where
+    F: Fn(AgentId, String) -> Fut + Send + Sync,
+    Fut: std::future::Future<Output = Result<String, String>> + Send,
+{
+    let mut iteration: u32 = 0;
+    let mut rate_limit_streak: u32 = 0;
+    let final_phase = loop {
+        if stop.load(Ordering::SeqCst) {
+            break GoalRunPhase::Stopped;
+        }
+        if *shutdown_rx.borrow() {
+            break GoalRunPhase::Stopped;
+        }
+
+        let goal = match load_goal(&substrate, goal_id) {
+            Some(g) => g,
+            None => {
+                warn!(goal_id = %goal_id, "Goal vanished from store; ending run");
+                break GoalRunPhase::Finished;
+            }
+        };
+        if matches!(goal.status, GoalStatus::Completed | GoalStatus::Cancelled)
+            || goal.progress >= 100
+        {
+            break GoalRunPhase::Finished;
+        }
+        if iteration >= max_iterations {
+            break GoalRunPhase::MaxIterationsReached;
+        }
+
+        let prompt = build_goal_prompt(&goal, iteration, max_iterations);
+        debug!(goal_id = %goal_id, iteration, "Goal run: sending tick");
+
+        match send_message(agent_id, prompt).await {
+            Ok(reply) => {
+                rate_limit_streak = 0;
+                let parsed = parse_tick(&reply);
+                let new_status = if parsed.done {
+                    Some(GoalStatus::Completed)
+                } else {
+                    Some(GoalStatus::InProgress)
+                };
+                let new_progress = if parsed.done {
+                    Some(100)
+                } else {
+                    parsed.progress
+                };
+                patch_goal(&substrate, goal_id, new_progress, new_status);
+
+                {
+                    let mut s = state.lock().await;
+                    s.iteration = iteration + 1;
+                    if let Some(p) = new_progress {
+                        s.last_progress = p;
+                    }
+                    s.last_error = None;
+                    s.updated_at = Utc::now();
+                }
+
+                if parsed.done {
+                    break GoalRunPhase::Finished;
+                }
+                if parsed.blocked {
+                    info!(goal_id = %goal_id, "Goal run: agent reported blocked; ending run");
+                    break GoalRunPhase::Stopped;
+                }
+            }
+            Err(e) => {
+                match classify_tick_error(&e) {
+                    TickOutcome::RateLimited => {
+                        rate_limit_streak = rate_limit_streak.saturating_add(1);
+                        warn!(
+                            goal_id = %goal_id,
+                            consecutive_rate_limits = rate_limit_streak,
+                            "Goal run: tick failed on provider rate-limit",
+                        );
+                    }
+                    TickOutcome::Ok => {
+                        rate_limit_streak = 0;
+                    }
+                }
+                {
+                    let mut s = state.lock().await;
+                    s.last_error = Some(e);
+                    s.updated_at = Utc::now();
+                }
+                if rate_limit_streak >= MAX_RATE_LIMIT_STREAK {
+                    break GoalRunPhase::RateLimited;
+                }
+            }
+        }
+
+        iteration += 1;
+
+        tokio::select! {
+            _ = tokio::time::sleep(TICK_INTERVAL) => {}
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    break GoalRunPhase::Stopped;
+                }
+            }
+        }
+    };
+
+    {
+        let mut s = state.lock().await;
+        s.phase = final_phase;
+        s.updated_at = Utc::now();
+    }
+    info!(goal_id = %goal_id, phase = %final_phase, "Goal run ended");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tick_extracts_progress_done_blocked() {
+        let p = parse_tick("working...\nGOAL_PROGRESS: 60\nmore text");
+        assert_eq!(p.progress, Some(60));
+        assert!(!p.done);
+
+        let d = parse_tick("all set\ngoal_done");
+        assert!(d.done);
+
+        let b = parse_tick("stuck\nGOAL_BLOCKED: need a key");
+        assert!(b.blocked);
+
+        // Last progress wins; >100 clamps.
+        let m = parse_tick("GOAL_PROGRESS: 30\nGOAL_PROGRESS: 250");
+        assert_eq!(m.progress, Some(100));
+
+        // No markers → all default.
+        assert_eq!(parse_tick("just a normal reply"), ParsedTick::default());
+    }
+
+    fn seed_goal(substrate: &MemorySubstrate, goal: &Goal) {
+        substrate
+            .structured_set(
+                goals_storage_agent_id(),
+                GOALS_STORAGE_KEY,
+                serde_json::json!([serde_json::to_value(goal).unwrap()]),
+            )
+            .unwrap();
+    }
+
+    fn test_goal(agent_id: AgentId) -> Goal {
+        Goal {
+            id: GoalId::new(),
+            title: "Write a report".into(),
+            description: String::new(),
+            parent_id: None,
+            status: GoalStatus::InProgress,
+            progress: 0,
+            agent_id: Some(agent_id),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_loop_stops_and_completes_on_goal_done() {
+        let substrate = Arc::new(MemorySubstrate::open_in_memory(0.01).unwrap());
+        let agent_id = AgentId::new();
+        let goal = test_goal(agent_id);
+        seed_goal(&substrate, &goal);
+        let goal_id = goal.id;
+
+        let (_tx, rx) = watch::channel(false);
+        let state = Arc::new(Mutex::new(GoalRunState {
+            goal_id,
+            agent_id,
+            phase: GoalRunPhase::Running,
+            iteration: 0,
+            max_iterations: 10,
+            last_progress: 0,
+            last_error: None,
+            started_at: Utc::now(),
+            updated_at: Utc::now(),
+        }));
+
+        // Agent reports done on the first turn.
+        let send = |_a: AgentId, _p: String| async move { Ok("done\nGOAL_DONE".to_string()) };
+
+        run_loop(
+            goal_id,
+            agent_id,
+            10,
+            substrate.clone(),
+            send,
+            state.clone(),
+            Arc::new(AtomicBool::new(false)),
+            rx,
+        )
+        .await;
+
+        let s = state.lock().await;
+        assert_eq!(s.phase, GoalRunPhase::Finished);
+        let stored = load_goal(&substrate, goal_id).unwrap();
+        assert_eq!(stored.status, GoalStatus::Completed);
+        assert_eq!(stored.progress, 100);
+    }
+
+    #[tokio::test]
+    async fn run_loop_honors_max_iterations() {
+        let substrate = Arc::new(MemorySubstrate::open_in_memory(0.01).unwrap());
+        let agent_id = AgentId::new();
+        let goal = test_goal(agent_id);
+        seed_goal(&substrate, &goal);
+        let goal_id = goal.id;
+
+        let (_tx, rx) = watch::channel(false);
+        let state = Arc::new(Mutex::new(GoalRunState {
+            goal_id,
+            agent_id,
+            phase: GoalRunPhase::Running,
+            iteration: 0,
+            max_iterations: 2,
+            last_progress: 0,
+            last_error: None,
+            started_at: Utc::now(),
+            updated_at: Utc::now(),
+        }));
+
+        // Agent never finishes — always reports partial progress.
+        let send = |_a: AgentId, _p: String| async move { Ok("GOAL_PROGRESS: 10".to_string()) };
+
+        run_loop(
+            goal_id,
+            agent_id,
+            2,
+            substrate.clone(),
+            send,
+            state.clone(),
+            Arc::new(AtomicBool::new(false)),
+            rx,
+        )
+        .await;
+
+        let s = state.lock().await;
+        assert_eq!(s.phase, GoalRunPhase::MaxIterationsReached);
+        assert_eq!(s.iteration, 2);
+        // Goal stays in progress, not completed.
+        let stored = load_goal(&substrate, goal_id).unwrap();
+        assert_eq!(stored.status, GoalStatus::InProgress);
+    }
+}

--- a/crates/librefang-kernel/src/kernel/boot.rs
+++ b/crates/librefang-kernel/src/kernel/boot.rs
@@ -719,6 +719,9 @@ impl LibreFangKernel {
             config.max_concurrent_bg_llm,
             config.background.max_consecutive_rate_limits,
         );
+        // Autonomous long-horizon goal runner (#5744) — shares the kernel
+        // shutdown signal so active runs end cleanly on shutdown.
+        let goal_runner = crate::goal_runner::GoalRunner::new(supervisor.subscribe());
 
         // Initialize WASM sandbox engine (shared across all WASM agents)
         let wasm_sandbox = WasmSandbox::new()
@@ -1449,6 +1452,7 @@ impl LibreFangKernel {
                 },
                 trigger_engine,
                 background,
+                goal_runner,
                 cron_scheduler,
                 command_queue,
             ),

--- a/crates/librefang-kernel/src/kernel/goal_lifecycle.rs
+++ b/crates/librefang-kernel/src/kernel/goal_lifecycle.rs
@@ -1,0 +1,76 @@
+//! Kernel-side wiring for the autonomous goal runner (#5744).
+//!
+//! Bridges the standalone [`crate::goal_runner::GoalRunner`] to the live agent
+//! send path: each goal-run tick is an autonomous agent turn driven through
+//! `send_message_with_sender_context` with the reserved `"autonomous"` channel
+//! sentinel (same RBAC carve-out as the continuous / cron background loops).
+//!
+//! These are inherent helpers; the `KernelApi` trait methods (`start_goal_run`
+//! etc.) delegate here so the HTTP layer can reach them through
+//! `Arc<dyn KernelApi>`.
+
+use librefang_channels::types::SenderContext;
+use librefang_types::agent::AgentId;
+use librefang_types::goal::{GoalId, GoalRunState, DEFAULT_GOAL_MAX_ITERATIONS};
+
+use super::{LibreFangKernel, SYSTEM_CHANNEL_AUTONOMOUS};
+use crate::MemorySubsystemApi;
+
+impl LibreFangKernel {
+    /// Start an autonomous run that drives `agent_id` toward `goal_id`.
+    ///
+    /// Each tick is a full agent turn; the runner parses the agent's reply for
+    /// `GOAL_PROGRESS:` / `GOAL_DONE` markers and updates the goal until it is
+    /// complete, the iteration cap (`max_iterations`, default
+    /// [`DEFAULT_GOAL_MAX_ITERATIONS`]) is reached, an operator stops it, or the
+    /// kernel shuts down.
+    pub fn goal_run_start(&self, goal_id: GoalId, agent_id: AgentId, max_iterations: Option<u32>) {
+        let max = max_iterations.unwrap_or(DEFAULT_GOAL_MAX_ITERATIONS).max(1);
+        let substrate = self.substrate_ref().clone();
+
+        // The tick closure drives a real agent turn, which needs an owned
+        // `Arc<LibreFangKernel>`. Upgrade the self-handle (set right after the
+        // kernel is wrapped in `Arc` at boot).
+        let kernel = match self.self_handle.get().and_then(|w| w.upgrade()) {
+            Some(k) => k,
+            None => {
+                tracing::warn!(%goal_id, "Cannot start goal run: kernel self-handle unset");
+                return;
+            }
+        };
+
+        let send = move |aid: AgentId, msg: String| {
+            let k = kernel.clone();
+            async move {
+                // Trusted internal system path — reuse the autonomous-channel
+                // sentinel so the RBAC resolver applies the system carve-out
+                // (see background_lifecycle.rs).
+                let sender = SenderContext {
+                    channel: SYSTEM_CHANNEL_AUTONOMOUS.to_string(),
+                    user_id: aid.to_string(),
+                    display_name: SYSTEM_CHANNEL_AUTONOMOUS.to_string(),
+                    is_internal_system: true,
+                    ..Default::default()
+                };
+                match k.send_message_with_sender_context(aid, &msg, &sender).await {
+                    Ok(r) => Ok(r.response),
+                    Err(e) => Err(e.to_string()),
+                }
+            }
+        };
+
+        self.workflows
+            .goal_runner
+            .start(goal_id, agent_id, max, substrate, send);
+    }
+
+    /// Stop an active goal run. Returns whether a run was stopped.
+    pub fn goal_run_stop(&self, goal_id: GoalId) -> bool {
+        self.workflows.goal_runner.stop(goal_id)
+    }
+
+    /// Snapshot the observable state of a goal's run, if one is active.
+    pub fn goal_run_status(&self, goal_id: GoalId) -> Option<GoalRunState> {
+        self.workflows.goal_runner.state(goal_id)
+    }
+}

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -96,6 +96,7 @@ mod cron_script;
 // this file (#4683 landing zone). Extracted as `pub(super) async fn`
 // so the body can be edited and reviewed in isolation.
 mod cron_tick;
+mod goal_lifecycle;
 mod hands_lifecycle;
 mod llm_drivers;
 mod mcp_setup;

--- a/crates/librefang-kernel/src/kernel/subsystems/workflow.rs
+++ b/crates/librefang-kernel/src/kernel/subsystems/workflow.rs
@@ -11,6 +11,7 @@ use librefang_runtime::command_lane::CommandQueue;
 
 use crate::background::BackgroundExecutor;
 use crate::cron::CronScheduler;
+use crate::goal_runner::GoalRunner;
 use crate::triggers::TriggerEngine;
 use crate::workflow::{WorkflowEngine, WorkflowTemplateRegistry};
 
@@ -39,6 +40,8 @@ pub struct WorkflowSubsystem {
     pub(crate) triggers: TriggerEngine,
     /// Background agent executor.
     pub(crate) background: BackgroundExecutor,
+    /// Autonomous long-horizon goal runner (#5744).
+    pub(crate) goal_runner: GoalRunner,
     /// Cron job scheduler.
     pub(crate) cron_scheduler: CronScheduler,
     /// Command queue with lane-based concurrency control.
@@ -50,6 +53,7 @@ impl WorkflowSubsystem {
         engine: WorkflowEngine,
         triggers: TriggerEngine,
         background: BackgroundExecutor,
+        goal_runner: GoalRunner,
         cron_scheduler: CronScheduler,
         command_queue: CommandQueue,
     ) -> Self {
@@ -58,6 +62,7 @@ impl WorkflowSubsystem {
             template_registry: WorkflowTemplateRegistry::new(),
             triggers,
             background,
+            goal_runner,
             cron_scheduler,
             command_queue,
         }

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -111,6 +111,27 @@ pub trait KernelApi: KernelHandle + Send + Sync {
     fn web_tools(&self) -> &librefang_runtime::web_search::WebToolsContext;
     fn workflow_engine(&self) -> &WorkflowEngine;
 
+    // ====================================================================
+    // Autonomous goal runner (#5744)
+    // ====================================================================
+
+    /// Start a long-horizon autonomous run driving `agent_id` toward
+    /// `goal_id`. `max_iterations` bounds the run (default
+    /// [`librefang_types::goal::DEFAULT_GOAL_MAX_ITERATIONS`]).
+    fn start_goal_run(
+        &self,
+        goal_id: librefang_types::goal::GoalId,
+        agent_id: AgentId,
+        max_iterations: Option<u32>,
+    );
+    /// Stop an active goal run. Returns whether a run was stopped.
+    fn stop_goal_run(&self, goal_id: librefang_types::goal::GoalId) -> bool;
+    /// Snapshot the observable state of a goal's run, if one is active.
+    fn goal_run_state(
+        &self,
+        goal_id: librefang_types::goal::GoalId,
+    ) -> Option<librefang_types::goal::GoalRunState>;
+
     // `*_ref` accessors that expose internal state for mutation. These are
     // necessary for routes that need to read or mutate live kernel state
     // (model catalog, MCP wiring, event bus, …).
@@ -788,6 +809,24 @@ impl KernelApi for LibreFangKernel {
     }
     fn workflow_engine(&self) -> &WorkflowEngine {
         <Self as crate::WorkflowSubsystemApi>::engine_ref(self)
+    }
+
+    fn start_goal_run(
+        &self,
+        goal_id: librefang_types::goal::GoalId,
+        agent_id: AgentId,
+        max_iterations: Option<u32>,
+    ) {
+        self.goal_run_start(goal_id, agent_id, max_iterations);
+    }
+    fn stop_goal_run(&self, goal_id: librefang_types::goal::GoalId) -> bool {
+        self.goal_run_stop(goal_id)
+    }
+    fn goal_run_state(
+        &self,
+        goal_id: librefang_types::goal::GoalId,
+    ) -> Option<librefang_types::goal::GoalRunState> {
+        self.goal_run_status(goal_id)
     }
 
     fn command_queue_ref(&self) -> &librefang_runtime::command_lane::CommandQueue {

--- a/crates/librefang-kernel/src/lib.rs
+++ b/crates/librefang-kernel/src/lib.rs
@@ -20,6 +20,7 @@ pub mod cron;
 pub mod cron_delivery;
 pub mod error;
 pub mod event_bus;
+pub mod goal_runner;
 pub mod heartbeat;
 pub mod hooks;
 pub mod inbox;

--- a/crates/librefang-types/src/goal.rs
+++ b/crates/librefang-types/src/goal.rs
@@ -136,6 +136,85 @@ impl Goal {
 }
 
 // ---------------------------------------------------------------------------
+// Shared storage location
+// ---------------------------------------------------------------------------
+
+/// Well-known shared-memory key under which all goals are persisted as a
+/// single JSON array. Shared by the API CRUD routes and the kernel-side goal
+/// runner so both read and write the same store.
+pub const GOALS_STORAGE_KEY: &str = "__librefang_goals";
+
+/// The reserved sentinel agent ID that owns the goals KV entry. Goals are a
+/// global, cross-agent resource, so they live under a fixed ID rather than any
+/// real agent's namespace.
+pub fn goals_storage_agent_id() -> AgentId {
+    AgentId(Uuid::from_bytes([
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x01,
+    ]))
+}
+
+// ---------------------------------------------------------------------------
+// GoalRunState — long-horizon autonomous execution (#5744)
+// ---------------------------------------------------------------------------
+
+/// Lifecycle phase of an autonomous goal run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalRunPhase {
+    /// The runner loop is active and driving the assigned agent.
+    Running,
+    /// The goal reached `Completed`/`Cancelled` (or 100% progress); loop ended.
+    Finished,
+    /// The iteration cap was hit before the goal completed.
+    MaxIterationsReached,
+    /// The loop stopped on the provider rate-limit circuit breaker.
+    RateLimited,
+    /// An operator stopped the run.
+    Stopped,
+}
+
+impl std::fmt::Display for GoalRunPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GoalRunPhase::Running => write!(f, "running"),
+            GoalRunPhase::Finished => write!(f, "finished"),
+            GoalRunPhase::MaxIterationsReached => write!(f, "max_iterations_reached"),
+            GoalRunPhase::RateLimited => write!(f, "rate_limited"),
+            GoalRunPhase::Stopped => write!(f, "stopped"),
+        }
+    }
+}
+
+/// Default per-run iteration cap when a start request omits one. Bounds a
+/// long-horizon run so a goal the agent never marks done cannot loop forever.
+pub const DEFAULT_GOAL_MAX_ITERATIONS: u32 = 25;
+
+/// Observable state of a goal's autonomous run, surfaced via the API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoalRunState {
+    /// The goal being pursued.
+    pub goal_id: GoalId,
+    /// The agent driving the goal.
+    pub agent_id: AgentId,
+    /// Current lifecycle phase.
+    pub phase: GoalRunPhase,
+    /// Number of completed iterations (agent turns) so far.
+    pub iteration: u32,
+    /// Iteration cap for this run.
+    pub max_iterations: u32,
+    /// Last progress value (0-100) observed from the agent.
+    pub last_progress: u8,
+    /// Last error message, if the most recent tick failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    /// When the run started.
+    pub started_at: DateTime<Utc>,
+    /// When the most recent tick completed.
+    pub updated_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-524797aa004a57056db6f91adc240a6c9a92a2ef9aab13e481092d6fb0f156af  openapi.json
+d5a6ba13220bb0662c10c0df2682bc9d3d03dc4cd75e7e7aa74e42a758cacea9  openapi.json


### PR DESCRIPTION
Closes #5744.

## Problem

The Goals system shipped full CRUD + a dashboard, but goals were **purely passive**: `Goal.agent_id` was stored and never read, and nothing ever drove an agent toward a goal. There was no way to say "pursue this goal" and have an agent work it across turns — the gap #5744 describes.

## What this adds

A kernel-side **goal runner** that pursues a goal autonomously across many turns until it is done, capped, stopped, or the kernel shuts down.

### Runner (`crates/librefang-kernel/src/goal_runner.rs`)

`GoalRunner` spawns a bounded loop per goal. Each iteration:

1. Loads the goal from the shared store.
2. Frames it as a `[LONG-HORIZON GOAL]` prompt (title, description, current progress, iteration N of max).
3. Drives one agent turn.
4. Parses the reply for control markers — `GOAL_PROGRESS: <0-100>`, `GOAL_DONE`, `GOAL_BLOCKED` — and updates the goal via an atomic `structured_modify` (no lost-update race with the CRUD path).

The loop stops when the goal hits Completed/Cancelled or 100%, the iteration cap is reached (default 25), the agent reports blocked, an operator stops it, or the provider rate-limit circuit breaker trips (mirrors the background executor, #5168).

**Why response markers, not a new tool:** keeps v1 entirely kernel-side — no tool-registry / capability-permission surgery. Marker parsing is forgiving (case-insensitive, last-progress-wins); a turn with no marker just iterates to the cap.

### Wiring

- Ticks run through the existing autonomous-channel send path (`send_message_with_sender_context` with the reserved `"autonomous"` sentinel + `is_internal_system`) — the same RBAC carve-out the continuous / cron loops use.
- `KernelApi` gains `start_goal_run` / `stop_goal_run` / `goal_run_state`. The goals store key + sentinel agent id moved into `librefang_types::goal` as the single source of truth shared by the CRUD routes and the runner.
- New endpoints: `POST /api/goals/{id}/start` (requires an assigned agent; flips the goal to in_progress and returns run state), `POST /api/goals/{id}/stop`, `GET /api/goals/{id}/run`.
- Dashboard: a per-goal run/stop control on the Goals page that polls run state while active, plus query/mutation hooks and a hierarchical query key.

## Scope / follow-ups

This is a coherent v1, deliberately kernel-only. Natural follow-ups a maintainer may want to steer: a first-class `goal_update` runtime tool (instead of response markers), surfacing run history/telemetry, and resuming runs across daemon restarts. Happy to adjust the marker protocol or stop-condition policy.

## Verification

Rust run inside the repo `Dockerfile.rust-dev` image (isolated from the host `target/`); dashboard via pnpm:

- `cargo test -p librefang-kernel --lib goal_runner` — 3 passed (marker parsing; loop completes on `GOAL_DONE`; loop honors the iteration cap).
- `cargo test -p librefang-api --test goals_routes_integration goal_run` — 2 passed (`start` 400s without an assigned agent; start → run-state → stop happy path).
- `cargo check -p librefang-kernel -p librefang-api --lib` — clean.
- `cargo fmt --check` + `cargo clippy` (goal files) — clean.
- `pnpm typecheck` — clean; `pnpm lint` — no new warnings.
