### PR TITLE
fix(kernel): use Option::zip for hand timestamp pairing (clippy)

### DIFF
--- a/crates/librefang-kernel/src/kernel/background_lifecycle.rs
+++ b/crates/librefang-kernel/src/kernel/background_lifecycle.rs
@@ -85,9 +85,7 @@ impl LibreFangKernel {
                         }
                     }
                 }
-                let timestamps = saved_hand
-                    .activated_at
-                    .and_then(|a| saved_hand.updated_at.map(|u| (a, u)));
+                let timestamps = saved_hand.activated_at.zip(saved_hand.updated_at);
                 match self.activate_hand_with_id(
                     &hand_id,
                     config,


### PR DESCRIPTION
## Problem

Current stable clippy (the workspace tracks rolling `stable` via `rust-toolchain.toml`) flags a deny-level `clippy::manual_option_zip` in the kernel:

```
error: manual implementation of `Option::zip`
  --> crates/librefang-kernel/src/kernel/background_lifecycle.rs:88
```

CI runs clippy on `stable`, so this turns the clippy lane red for every PR once the runner's stable rolls forward — a latent main-red unrelated to any feature work.

## Fix

```rust
- let timestamps = saved_hand
-     .activated_at
-     .and_then(|a| saved_hand.updated_at.map(|u| (a, u)));
+ let timestamps = saved_hand.activated_at.zip(saved_hand.updated_at);
```

Behaviour is identical — `Some((a, u))` only when both are `Some`, otherwise `None`.

## Verification

`cargo clippy -p librefang-kernel --lib -- -D warnings` — clean (run inside the repo `Dockerfile.rust-dev` image, isolated from the host `target/`).
