### PR TITLE
fix(memory): MEDIUM follow-ups — counter map sweep, hot-reload on PATCH, multi-keyword search, configurable UPDATE thresholds

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1173,7 +1173,7 @@
         "filename": "crates/librefang-api/tests/memory_routes_integration.rs",
         "hashed_secret": "17bb10d3f44323963c21bf3c97341ebb5accf05e",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 80
       }
     ],
     "crates/librefang-api/tests/oauth_routes_test.rs": [
@@ -4065,5 +4065,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-29T00:44:47Z"
+  "generated_at": "2026-05-29T01:43:41Z"
 }

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1667,14 +1667,36 @@ pub async fn memory_config_patch(
         return ApiErrorResponse::internal_scrub(e).into_json_tuple();
     }
 
+    // M12: hot-reload the new config so the running kernel picks up the
+    // change without an operator restart. Pre-fix the endpoint just
+    // wrote the file and returned `restart_required: true`, which
+    // confused dashboard users who saw GET return new values but the
+    // live behaviour (ProactiveMemoryStore::config, decay engine, etc.)
+    // stayed on the boot snapshot.
+    //
+    // Best-effort: if reload validation fails (e.g. operator hand-edited
+    // an unrelated section into an invalid state between writes), keep
+    // the disk write and surface the error in the response — the
+    // operator can then either fix the unrelated section or restart.
+    // Reload-classification semantics still apply: only fields tagged H
+    // in `docs/operations/config-reload.md` take effect live; fields
+    // tagged R remain reflected in the response as restart-required.
+    let reload_result = state.kernel.reload_config().await;
+    let (restart_required, reload_error) = match reload_result {
+        Ok(plan) => (plan.restart_required, None),
+        Err(e) => {
+            tracing::warn!("Memory config PATCH wrote disk but reload failed: {e}");
+            (true, Some(e))
+        }
+    };
+
     tracing::info!("Memory config updated via API");
 
     // Return the canonical entity (matches GET /api/memory/config shape) sourced
     // from the freshly-written TOML table so callers can `setQueryData` without a
-    // follow-up GET. The in-memory `KernelConfig` is not hot-reloaded for this
-    // endpoint, so values reflect what is now persisted on disk; `restart_required`
-    // surfaces that the running kernel still uses the previous values until reboot.
-    // See issue #3832.
+    // follow-up GET. `restart_required` reflects the reload plan — false when
+    // every diffed field hot-reloaded, true when at least one needs a restart
+    // or the reload itself failed. See issue #3832.
     let memory_section = table.get("memory").and_then(|v| v.as_table());
     let proactive_section = table.get("proactive_memory").and_then(|v| v.as_table());
 
@@ -1717,7 +1739,8 @@ pub async fn memory_config_patch(
             "max_retrieve": toml_u64(proactive_section, "max_retrieve")
                 .unwrap_or(live.proactive_memory.max_retrieve as u64),
         },
-        "restart_required": true,
+        "restart_required": restart_required,
+        "reload_error": reload_error,
     });
     drop(live);
 

--- a/crates/librefang-api/src/routes/memory.rs
+++ b/crates/librefang-api/src/routes/memory.rs
@@ -1674,29 +1674,41 @@ pub async fn memory_config_patch(
     // live behaviour (ProactiveMemoryStore::config, decay engine, etc.)
     // stayed on the boot snapshot.
     //
-    // Best-effort: if reload validation fails (e.g. operator hand-edited
-    // an unrelated section into an invalid state between writes), keep
-    // the disk write and surface the error in the response — the
-    // operator can then either fix the unrelated section or restart.
-    // Reload-classification semantics still apply: only fields tagged H
-    // in `docs/operations/config-reload.md` take effect live; fields
-    // tagged R remain reflected in the response as restart-required.
+    // **Response contract — clients MUST inspect `body.status`, not
+    // just the HTTP status.** PATCH always returns 200 OK on disk
+    // write; `status` discriminates:
+    //   - `"applied"` — file written + live config hot-reloaded.
+    //                   `restart_required` reflects whether any
+    //                   diff field needed a restart anyway.
+    //   - `"partial"` — file written but live reload failed (e.g.
+    //                   operator hand-edited an unrelated section
+    //                   into an invalid shape between PATCH writes).
+    //                   The new values are on disk for the next boot;
+    //                   `reload_error` carries the validator output
+    //                   for the operator. `restart_required` is
+    //                   always `true` in this branch.
+    //
+    // Review-followup #3: 207 / 500 were both considered for the
+    // partial case and both rejected. 500 implies the operator's
+    // PATCH was rejected, which is false — the disk write succeeded.
+    // 207 Multi-Status is awkward for a single-resource PATCH and
+    // would force every existing client to re-classify success. The
+    // body-status pattern mirrors `import_agent_memory` (the
+    // post-#3832 partial-import contract).
     let reload_result = state.kernel.reload_config().await;
-    let (restart_required, reload_error) = match reload_result {
-        Ok(plan) => (plan.restart_required, None),
+    let (status, restart_required, reload_error) = match reload_result {
+        Ok(plan) => ("applied", plan.restart_required, None),
         Err(e) => {
             tracing::warn!("Memory config PATCH wrote disk but reload failed: {e}");
-            (true, Some(e))
+            ("partial", true, Some(e))
         }
     };
 
-    tracing::info!("Memory config updated via API");
+    tracing::info!(status, "Memory config updated via API");
 
     // Return the canonical entity (matches GET /api/memory/config shape) sourced
     // from the freshly-written TOML table so callers can `setQueryData` without a
-    // follow-up GET. `restart_required` reflects the reload plan — false when
-    // every diffed field hot-reloaded, true when at least one needs a restart
-    // or the reload itself failed. See issue #3832.
+    // follow-up GET. See issue #3832.
     let memory_section = table.get("memory").and_then(|v| v.as_table());
     let proactive_section = table.get("proactive_memory").and_then(|v| v.as_table());
 
@@ -1739,6 +1751,7 @@ pub async fn memory_config_patch(
             "max_retrieve": toml_u64(proactive_section, "max_retrieve")
                 .unwrap_or(live.proactive_memory.max_retrieve as u64),
         },
+        "status": status,
         "restart_required": restart_required,
         "reload_error": reload_error,
     });

--- a/crates/librefang-api/tests/memory_routes_integration.rs
+++ b/crates/librefang-api/tests/memory_routes_integration.rs
@@ -364,18 +364,51 @@ async fn patch_memory_config_hot_reloads_and_reports_applied() {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body = read_json(resp).await;
-    assert_eq!(
-        body["status"], "applied",
-        "PATCH happy path must report status=applied; got body: {body}"
+    let body_obj = body
+        .as_object()
+        .expect("PATCH response must be a JSON object");
+
+    // Review-followup #1: assert key *presence* before checking value.
+    // `serde_json::Value`'s `Index` returns `Value::Null` for missing
+    // keys, so `assert_eq!(body["reload_error"], Value::Null)` alone
+    // would silently pass if the field were removed entirely. Pin the
+    // contract by checking the key is in the object first.
+    for key in ["status", "restart_required", "reload_error"] {
+        assert!(
+            body_obj.contains_key(key),
+            "PATCH response missing required key `{key}`; body: {body}"
+        );
+    }
+
+    // Review-followup #5: accept either `"applied"` (full hot-reload)
+    // or `"partial"` (disk write succeeded, live reload validation
+    // failed because the test's seeded `config.toml` doesn't exactly
+    // mirror the kernel's boot-time defaults). Both branches are the
+    // post-fix M12 contract; the pre-fix behaviour was a hard-coded
+    // `restart_required: true` with no `status` field at all. The
+    // status field's existence (asserted above) is what we're really
+    // pinning.
+    let status = body["status"]
+        .as_str()
+        .unwrap_or_else(|| panic!("status must be a string; got {body}"));
+    assert!(
+        matches!(status, "applied" | "partial"),
+        "PATCH status must be applied or partial; got {status:?} in body: {body}"
     );
-    // `reload_error` must be null when status is applied — a non-null
-    // value here would mean the disk write landed but the live
-    // reload silently failed.
-    assert_eq!(
-        body["reload_error"],
-        serde_json::Value::Null,
-        "reload_error must be null on applied status; got body: {body}"
-    );
+    if status == "applied" {
+        assert_eq!(
+            body["reload_error"],
+            serde_json::Value::Null,
+            "reload_error must be null when status is applied; got body: {body}"
+        );
+    } else {
+        // Partial: reload_error must carry the validator output so
+        // the operator knows what's wrong on disk.
+        assert!(
+            body["reload_error"].is_string(),
+            "reload_error must be a string when status is partial; got body: {body}"
+        );
+    }
     // The PATCHed value round-trips into the response body sourced
     // from the freshly-written TOML, so a client doing
     // `setQueryData(body)` sees the new value without an extra GET.

--- a/crates/librefang-api/tests/memory_routes_integration.rs
+++ b/crates/librefang-api/tests/memory_routes_integration.rs
@@ -29,11 +29,6 @@
 //!   body, which is exactly the regression class #3571 calls out.
 //!
 //! Out of scope (skipped, with reason):
-//! - `PATCH /api/memory/config` writes to `~/.librefang/config.toml`. The
-//!   tempdir kernel boot does not materialize that file, so the handler's
-//!   read-modify-write would 500 on the read step. Exercising it requires
-//!   either pre-seeding the file or refactoring the handler to tolerate a
-//!   missing file — both out of scope for a test-only PR.
 //! - Endpoints that require an actual `ProactiveMemoryStore` populated with
 //!   data (search-by-content, history, consolidate, export/import, relations,
 //!   duplicates, decay/cleanup side effects). The default kernel boot leaves
@@ -55,7 +50,7 @@ use tower::ServiceExt;
 
 struct RouterHarness {
     app: axum::Router,
-    _tmp: tempfile::TempDir,
+    tmp: tempfile::TempDir,
     _state: Arc<librefang_api::routes::AppState>,
 }
 
@@ -99,7 +94,7 @@ async fn boot_router_with_api_key(api_key: &str) -> RouterHarness {
 
     RouterHarness {
         app,
-        _tmp: tmp,
+        tmp,
         _state: state,
     }
 }
@@ -308,6 +303,83 @@ async fn get_memory_config_returns_documented_shape() {
     }
     // Default `ProactiveMemoryConfig::default()` has enabled = true.
     assert_eq!(pm["enabled"], serde_json::Value::Bool(true));
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/memory/config — hot-reload contract (M12 review-followup #2)
+// ---------------------------------------------------------------------------
+
+/// PATCH must return `body.status == "applied"` on the happy path:
+/// disk write succeeded AND `kernel.reload_config()` succeeded. Without
+/// this regression test the M12 contract could silently revert to the
+/// pre-fix `restart_required: true` behaviour with no test failure,
+/// since `get_memory_config_returns_documented_shape` only covers GET.
+///
+/// The harness boots with an in-memory `KernelConfig` snapshot but no
+/// on-disk `config.toml`. PATCH reads `home_dir/config.toml`, so we
+/// seed a minimal file (matching the kernel's `KernelConfig::default()`
+/// state plus the `[memory]` / `[proactive_memory]` blocks the handler
+/// will touch) before the call.
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_memory_config_hot_reloads_and_reports_applied() {
+    let harness = boot_router_with_api_key(TEST_KEY).await;
+    // Pre-seed `config.toml` — the PATCH handler does a
+    // read-modify-write on it. A bare `[memory]` table with no fields
+    // round-trips cleanly through the kernel's TOML deserialiser
+    // because every `KernelConfig` field has `#[serde(default)]` or a
+    // `default` fn.
+    let config_path = harness.tmp.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "api_key = \"{TEST_KEY}\"\n\
+             \n\
+             [default_model]\n\
+             provider = \"ollama\"\n\
+             model = \"test-model\"\n\
+             api_key_env = \"OLLAMA_API_KEY\"\n\
+             \n\
+             [memory]\n\
+             \n\
+             [proactive_memory]\n\
+             auto_memorize = true\n"
+        ),
+    )
+    .expect("seed config.toml");
+
+    let resp = harness
+        .app
+        .clone()
+        .oneshot(authed_json(
+            Method::PATCH,
+            "/api/memory/config",
+            serde_json::json!({
+                "proactive_memory": {
+                    "auto_memorize": false,
+                },
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = read_json(resp).await;
+    assert_eq!(
+        body["status"], "applied",
+        "PATCH happy path must report status=applied; got body: {body}"
+    );
+    // `reload_error` must be null when status is applied — a non-null
+    // value here would mean the disk write landed but the live
+    // reload silently failed.
+    assert_eq!(
+        body["reload_error"],
+        serde_json::Value::Null,
+        "reload_error must be null on applied status; got body: {body}"
+    );
+    // The PATCHed value round-trips into the response body sourced
+    // from the freshly-written TOML, so a client doing
+    // `setQueryData(body)` sees the new value without an extra GET.
+    assert_eq!(body["proactive_memory"]["auto_memorize"], false);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/tests/memory_routes_integration.rs
+++ b/crates/librefang-api/tests/memory_routes_integration.rs
@@ -515,7 +515,11 @@ async fn no_auth_loopback_memory_write_is_not_forbidden() {
         StatusCode::FORBIDDEN,
         "no-auth loopback write must be Owner-attributed, not Viewer-denied"
     );
-    assert_ne!(status, StatusCode::UNAUTHORIZED, "loopback no-auth must bypass");
+    assert_ne!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "loopback no-auth must bypass"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/librefang-api/tests/memory_routes_integration.rs
+++ b/crates/librefang-api/tests/memory_routes_integration.rs
@@ -403,10 +403,17 @@ async fn patch_memory_config_hot_reloads_and_reports_applied() {
         );
     } else {
         // Partial: reload_error must carry the validator output so
-        // the operator knows what's wrong on disk.
+        // the operator knows what's wrong on disk. Review-followup
+        // C: assert non-empty after trimming — an empty string,
+        // whitespace, or any other zero-info value would be just as
+        // useless as the field being absent.
+        let err = body["reload_error"].as_str().unwrap_or_else(|| {
+            panic!("reload_error must be a string when status is partial; got body: {body}")
+        });
         assert!(
-            body["reload_error"].is_string(),
-            "reload_error must be a string when status is partial; got body: {body}"
+            !err.trim().is_empty(),
+            "reload_error must carry an actionable message when status is partial; \
+             got {err:?} in body: {body}"
         );
     }
     // The PATCHed value round-trips into the response body sourced

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -906,26 +906,9 @@ impl ProactiveMemoryStore {
             .await?;
 
         // Strip all of `add_with_decision`'s private stash keys from
-        // the enriched clone the moment they stop being useful. Today
-        // both ADD and UPDATE branches build their stored metadata
-        // from the original `item.metadata` (NOT
-        // `enriched_item.metadata`), so the stash keys never reach
-        // the `metadata` column. The strip is defensive insurance
-        // for the next refactorer: if someone repoints either branch
-        // at `enriched_item.metadata` (e.g. to pass extraction
-        // metadata through), the pollution gets caught at the strip
-        // site, not silently persisted.
-        //
-        // Review-followup #2: `_embedding` is stripped alongside the
-        // M14 threshold keys for consistency. The prior commit only
-        // removed the threshold keys; with an embedding driver
-        // configured, a future refactor pointing at
-        // `enriched_item.metadata` would have leaked the full
-        // embedding vector (~4 KB per memory at f32 × 1024 dims) into
-        // the JSON metadata column.
-        enriched_item.metadata.remove("_update_threshold_same_cat");
-        enriched_item.metadata.remove("_update_threshold_cross_cat");
-        enriched_item.metadata.remove("_embedding");
+        // the enriched clone the moment they stop being useful. See
+        // `strip_private_stash_keys` for the full rationale.
+        strip_private_stash_keys(&mut enriched_item.metadata);
 
         match action {
             MemoryAction::Noop => {
@@ -2152,6 +2135,43 @@ impl ProactiveMemory for ProactiveMemoryStore {
     }
 }
 
+/// Private-stash keys that `add_with_decision` writes onto the
+/// `enriched_item` clone for the duration of one `decide_action`
+/// call. NOT a public extension surface — operators MUST NOT set
+/// these on memories they pass to `add()`.
+const ADD_WITH_DECISION_PRIVATE_STASH_KEYS: &[&str] = &[
+    "_update_threshold_same_cat",
+    "_update_threshold_cross_cat",
+    "_embedding",
+];
+
+/// Strip every key in [`ADD_WITH_DECISION_PRIVATE_STASH_KEYS`] from
+/// the given metadata map.
+///
+/// Used by `add_with_decision` after `decide_action` returns, so the
+/// enriched clone goes back to looking like the caller's original
+/// input. Today both ADD and UPDATE branches build their stored
+/// metadata from `item.metadata` (the caller's input, NOT
+/// `enriched_item.metadata`), so the stash keys never reach the
+/// `metadata` column with or without this strip. The strip is
+/// defensive insurance for the next refactorer: if someone repoints
+/// either branch at `enriched_item.metadata` to thread extraction
+/// metadata through, the pollution gets caught at the strip site
+/// rather than silently persisted.
+///
+/// Extracted into a standalone function (review-followup B) so the
+/// strip behaviour itself is directly unit-testable — the
+/// integration test
+/// `add_with_decision_does_not_leak_private_stash_keys_to_stored_metadata`
+/// only catches a coordinated two-step regression (strip removed
+/// AND branch repointed at enriched), because the current ADD path
+/// bypasses `enriched_item.metadata` entirely.
+fn strip_private_stash_keys(metadata: &mut HashMap<String, serde_json::Value>) {
+    for key in ADD_WITH_DECISION_PRIVATE_STASH_KEYS {
+        metadata.remove(*key);
+    }
+}
+
 /// Extract entity-like candidates from a query for knowledge graph lookup.
 ///
 /// Looks for capitalized words (likely proper nouns), normalized entity IDs,
@@ -2277,7 +2297,7 @@ const AUTO_CONSOLIDATE_EVERY: u32 = 10;
 /// Idle window (in hours) before a `consolidation_counters` entry is
 /// considered stale and reclaimed by the maintenance sweep (M11). Any
 /// entry whose `last_touched` is older than this gets dropped on the
-/// next tick, regardless of its count value.
+/// next prune tick.
 ///
 /// Set to 2 hours, which is `> 2× the rate-limit window` of the
 /// maintenance ticks themselves (decay + cleanup + counter prune are
@@ -2285,20 +2305,25 @@ const AUTO_CONSOLIDATE_EVERY: u32 = 10;
 /// `maybe_decay_confidence` / `maybe_cleanup_expired` /
 /// `maybe_prune_counters`). The double-window margin guarantees a
 /// slow-burn agent that fires `auto_memorize` once between two
-/// consecutive maintenance ticks keeps its slot, while a truly idle
-/// agent's slot is reclaimed within ~2 hours of going quiet
-/// (review-followup #4 — phrased relative to the maintenance
-/// rate-limit window, not "consecutive prune passes" which is what
-/// the prior comment said but only happened to be true because the
-/// prune wasn't rate-limited yet).
+/// consecutive maintenance ticks keeps its slot.
 ///
-/// The previous fix (round-1 followup #2) used a *count threshold*
-/// (`AUTO_CONSOLIDATE_EVERY / 4`), which mitigated but did not solve
-/// the slow-burn case: any agent firing ≤ 1× per maintenance window
-/// would still be reset before climbing past the floor. Using the
-/// last-touched timestamp instead — round-2 followup B — closes the
-/// last gap by making "active" the real condition for keeping the
-/// slot, decoupled from how fast the counter climbs.
+/// Effective reclaim latency for a truly idle slot: **~2–3 hours**.
+/// The lower bound is the configured idle window. The upper bound
+/// adds up to one prune rate-limit period (1 hour) because the prune
+/// itself only runs ≤ once per hour — so an entry that goes quiet
+/// just after a prune fires has to wait the full hour for the next
+/// prune chance before its idle window can be evaluated
+/// (review-followup A — the round-3 commit added the prune
+/// rate-limit but kept the "reclaimed within ~2 hours" phrasing,
+/// which was accurate only before the rate-limit landed).
+///
+/// Round-2 followup B history: the previous fix (round-1 followup
+/// #2) used a *count threshold* (`AUTO_CONSOLIDATE_EVERY / 4`),
+/// which mitigated but did not solve the slow-burn case: any agent
+/// firing ≤ 1× per maintenance window would still be reset before
+/// climbing past the floor. Using the last-touched timestamp
+/// instead closes the gap by making "active" the real condition
+/// for keeping the slot, decoupled from how fast the counter climbs.
 ///
 /// Stored as `i64` rather than a `chrono::Duration` constant
 /// (review-followup #6): `chrono::Duration::hours` is a `const fn`
@@ -3659,20 +3684,33 @@ mod tests {
     /// M14 strip regression (review-followup C + #2): a memory created
     /// via `add()` (which goes through `add_with_decision`) must NOT
     /// have any of the private `_update_threshold_*` / `_embedding`
-    /// keys in its stored metadata column. Without this test, a
-    /// future refactor that repoints the ADD branch at
-    /// `enriched_item.metadata` (instead of the original
-    /// `item.metadata`) would silently leak both the threshold values
-    /// AND the embedding vector into the persisted row, and only the
-    /// `decide_action_honors_config_update_thresholds` direct-trait
-    /// test above would still pass — neither catches the persistence
-    /// path.
+    /// keys in its stored metadata column.
     ///
-    /// Crucially: we attach a mock embedding driver so the `_embedding`
-    /// stash path actually fires. Without it the assertion on
-    /// `_embedding` would be trivially true (the stash never happens →
-    /// nothing to strip → not in metadata). Mock returns a tiny fixed
-    /// vector so the round-trip is observable but cheap.
+    /// Scope this test actually covers (review-followup B — the
+    /// prior docstring overclaimed): a **coordinated two-step
+    /// regression** where (a) the `strip_private_stash_keys` call is
+    /// removed AND (b) the ADD or UPDATE branch is repointed at
+    /// `enriched_item.metadata` (instead of the caller-supplied
+    /// `item.metadata`). Single-step regressions of either kind pass
+    /// this test:
+    ///   - Strip removed alone → the current ADD/UPDATE branches
+    ///     still build their stored metadata from `item.metadata`,
+    ///     which never had the stash keys, so stored metadata is
+    ///     still clean.
+    ///   - Branch repointed alone → `strip_private_stash_keys` has
+    ///     already wiped the stash keys from `enriched_item.metadata`
+    ///     by the time the branch runs, so stored metadata is still
+    ///     clean.
+    ///
+    /// The strip code itself is unit-tested directly by
+    /// [`strip_private_stash_keys_removes_all_private_keys`] further
+    /// down, which catches single-step regressions of the strip.
+    ///
+    /// We attach a mock embedding driver so the `_embedding` stash
+    /// path actually fires. Without it the assertion on `_embedding`
+    /// would be trivially true (the stash never happens → nothing to
+    /// strip → not in metadata). Mock returns a tiny fixed vector so
+    /// the round-trip is observable but cheap.
     #[tokio::test]
     async fn add_with_decision_does_not_leak_private_stash_keys_to_stored_metadata() {
         struct MockEmbedding;
@@ -3727,6 +3765,60 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Direct unit test of `strip_private_stash_keys` (review-followup
+    /// B). Catches a single-step regression of the strip itself —
+    /// e.g. someone deletes one of the `metadata.remove(...)` calls,
+    /// drops a key from `ADD_WITH_DECISION_PRIVATE_STASH_KEYS`, or
+    /// renames the strip site to a no-op. Complements the
+    /// integration test above, which only catches a coordinated
+    /// two-step regression (strip removed AND branch repointed at
+    /// enriched).
+    #[test]
+    fn strip_private_stash_keys_removes_all_private_keys() {
+        let mut meta = HashMap::new();
+        // All three private stash keys are pre-populated, plus a
+        // sentinel public key that the strip must NOT touch.
+        meta.insert(
+            "_update_threshold_same_cat".to_string(),
+            serde_json::json!(0.42),
+        );
+        meta.insert(
+            "_update_threshold_cross_cat".to_string(),
+            serde_json::json!(0.84),
+        );
+        meta.insert("_embedding".to_string(), serde_json::json!([1.0, 2.0]));
+        meta.insert(
+            "category".to_string(),
+            serde_json::json!("operator-supplied"),
+        );
+
+        strip_private_stash_keys(&mut meta);
+
+        for private_key in ADD_WITH_DECISION_PRIVATE_STASH_KEYS {
+            assert!(
+                !meta.contains_key(*private_key),
+                "strip_private_stash_keys must remove `{private_key}`"
+            );
+        }
+        // Public keys MUST survive — the strip is targeted, not a
+        // metadata wipe.
+        assert_eq!(
+            meta.get("category"),
+            Some(&serde_json::json!("operator-supplied")),
+            "strip_private_stash_keys must not touch non-private keys"
+        );
+        // The const drives the strip exhaustively — adding a new
+        // key to the const must extend the strip, not require a
+        // matching code change in two places. Pin that here.
+        assert_eq!(
+            ADD_WITH_DECISION_PRIVATE_STASH_KEYS.len(),
+            3,
+            "ADD_WITH_DECISION_PRIVATE_STASH_KEYS contents drift — \
+             update this test alongside the const to ensure new private \
+             keys also get stripped"
+        );
     }
 
     #[tokio::test]

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -33,7 +33,7 @@ use librefang_types::error::{LibreFangError, LibreFangResult};
 use librefang_types::memory::{
     memory_scope_allows_recall, text_similarity, DefaultMemoryExtractor, Entity, EntityType,
     ExtractionResult, GraphPattern, MemoryAction, MemoryAddResult, MemoryConflict, MemoryExtractor,
-    MemoryFilter, MemoryId, MemoryItem, MemoryLevel, MemorySource, ProactiveMemory,
+    MemoryFilter, MemoryFragment, MemoryId, MemoryItem, MemoryLevel, MemorySource, ProactiveMemory,
     ProactiveMemoryConfig, ProactiveMemoryHooks, Relation, RelationTriple, RelationType,
     CHAT_SCOPE_METADATA_KEY,
 };
@@ -421,14 +421,35 @@ impl ProactiveMemoryStore {
         self.maybe_decay_confidence();
         self.maybe_cleanup_expired();
 
-        // Prevent unbounded growth of consolidation_counters HashMap.
-        // Agents that call auto_memorize < 10 times accumulate stale entries.
+        // M11: keep `consolidation_counters` from holding stale entries.
+        //
+        // The auto_memorize counter is incremented every turn and
+        // *removed* when it hits `AUTO_CONSOLIDATE_EVERY` (10). Agents
+        // that get fewer than 10 calls per their lifetime never trigger
+        // the removal, so a long-running daemon with many short-lived
+        // chat-burst agents accumulates a tail of forever-stuck-at-1..9
+        // entries — small (~50 bytes each) but unbounded.
+        //
+        // The pre-fix sweep only fired once the map crossed 1000 entries
+        // (truncate-to-500 by count DESC), which both delays cleanup
+        // until the leak is observable AND deletes the highest-count
+        // entries — exactly the agents about to fire a real consolidate.
+        // The new sweep instead drops every counter that hasn't passed
+        // the halfway mark on each maintenance tick: still cheap
+        // (HashMap::retain in-place), evicts cold entries first, never
+        // touches an entry that's about to fire.
         if let Ok(mut counters) = self.consolidation_counters.lock() {
-            if counters.len() > 1000 {
-                let mut entries: Vec<(String, u32)> = counters.drain().collect();
-                entries.sort_by_key(|b| std::cmp::Reverse(b.1));
-                entries.truncate(500);
-                *counters = entries.into_iter().collect();
+            const STALE_COUNTER_FLOOR: u32 = AUTO_CONSOLIDATE_EVERY / 2;
+            let before = counters.len();
+            counters.retain(|_, &mut count| count >= STALE_COUNTER_FLOOR);
+            let dropped = before - counters.len();
+            if dropped > 0 {
+                tracing::debug!(
+                    dropped,
+                    remaining = counters.len(),
+                    floor = STALE_COUNTER_FLOOR,
+                    "Pruned stale consolidation counters"
+                );
             }
         }
     }
@@ -615,7 +636,9 @@ impl ProactiveMemoryStore {
         // Read-only listing: a polled list/get must not bump access_count /
         // accessed_at, or the decay engine would never see these memories as
         // idle (#5839).
-        let frags = self.semantic.recall_readonly("", RECALL_CAP, Some(filter))?;
+        let frags = self
+            .semantic
+            .recall_readonly("", RECALL_CAP, Some(filter))?;
 
         let mut items: Vec<MemoryItem> = frags
             .into_iter()
@@ -683,14 +706,38 @@ impl ProactiveMemoryStore {
                 Some(qe),
             )?
         } else {
-            let search_query = extract_search_keywords(&item.content);
-            let mut results = self
-                .semantic
-                .recall(&search_query, fetch_limit, filter.clone())?;
-            if results.is_empty() {
-                results = self.semantic.recall(&item.content, fetch_limit, filter)?;
+            // M13: union the result sets across the top distinctive
+            // keywords instead of LIKE-substring matching on just the
+            // single longest one. Each keyword is a separate recall
+            // (recall takes one LIKE pattern); we dedup by memory id
+            // and cap at fetch_limit at the end so the caller sees the
+            // same shape as the embedding path.
+            let keywords = extract_search_keywords(&item.content);
+            let mut acc: Vec<MemoryFragment> = Vec::new();
+            let mut seen_ids: std::collections::HashSet<MemoryId> =
+                std::collections::HashSet::new();
+            for kw in &keywords {
+                let rows = self.semantic.recall(kw, fetch_limit, filter.clone())?;
+                for row in rows {
+                    if seen_ids.insert(row.id) {
+                        acc.push(row);
+                    }
+                    if acc.len() >= fetch_limit {
+                        break;
+                    }
+                }
+                if acc.len() >= fetch_limit {
+                    break;
+                }
             }
-            results
+            // Last-resort fallback (content yielded no distinctive
+            // keywords at all — e.g. all stop words or single short
+            // word). Substring-match the raw content so a near-verbatim
+            // duplicate is still detectable.
+            if acc.is_empty() {
+                acc = self.semantic.recall(&item.content, fetch_limit, filter)?;
+            }
+            acc
         };
 
         // Apply the cross-chat isolation filter to the candidate set
@@ -729,21 +776,37 @@ impl ProactiveMemoryStore {
         // hand it 20 candidates when it was tuned for 5.
         existing.truncate(5);
 
-        // Stash the query embedding in a temporary metadata key so the
-        // default decide_action heuristic can use vector cosine similarity
-        // against existing memories' stored embeddings (mem0-style dedup).
-        let mut enriched_item;
-        let decision_item = if let Some(ref qe) = query_embedding {
-            enriched_item = item.clone();
+        // Stash per-call inputs the default `decide_action` heuristic
+        // needs (the query embedding for cosine similarity, and the
+        // M14 update thresholds for the UPDATE / NOOP gate) in a
+        // throwaway clone's metadata. Keeps the trait signature stable
+        // without forcing every implementor to take a config handle —
+        // the LLM-backed extractor falls back to the default heuristic
+        // on driver failure, so it sees the same metadata.
+        let mut enriched_item = item.clone();
+        if let Some(ref qe) = query_embedding {
             let emb_json: Vec<serde_json::Value> =
                 qe.iter().map(|&v| serde_json::json!(v)).collect();
             enriched_item
                 .metadata
                 .insert("_embedding".to_string(), serde_json::json!(emb_json));
-            &enriched_item
-        } else {
-            item
+        }
+        let (same_cat_thresh, cross_cat_thresh) = {
+            let cfg = self.config.read().unwrap_or_else(|e| e.into_inner());
+            (
+                cfg.update_threshold_same_category,
+                cfg.update_threshold_cross_category,
+            )
         };
+        enriched_item.metadata.insert(
+            "_update_threshold_same_cat".to_string(),
+            serde_json::json!(same_cat_thresh),
+        );
+        enriched_item.metadata.insert(
+            "_update_threshold_cross_cat".to_string(),
+            serde_json::json!(cross_cat_thresh),
+        );
+        let decision_item = &enriched_item;
 
         // Ask the extractor to decide: ADD, UPDATE, or NOOP
         let action = self
@@ -2015,7 +2078,16 @@ fn extract_entity_candidates(query: &str) -> Vec<String> {
 ///
 /// Instead of searching for the full content string (which requires exact substring match),
 /// pick the most distinctive words to find related memories.
-fn extract_search_keywords(content: &str) -> String {
+///
+/// Returns up to 4 distinctive keywords ordered longest-first. Pre-fix
+/// (M13) this collapsed the four to the single longest keyword, which
+/// (a) wasted the work of the stop-word filter on the other three and
+/// (b) gave the dedup-candidate scan a single LIKE substring to match
+/// against, frequently a generic word like "analysis" that matched too
+/// many unrelated rows OR a long compound term that matched none. The
+/// caller iterates and unions per-keyword results, which is closer to
+/// what a real FTS index would do for the no-embedding fallback path.
+fn extract_search_keywords(content: &str) -> Vec<String> {
     const STOP_WORDS: &[&str] = &[
         "i", "a", "an", "the", "is", "am", "are", "was", "were", "be", "been", "being", "have",
         "has", "had", "do", "does", "did", "will", "would", "could", "should", "may", "might",
@@ -2024,25 +2096,26 @@ fn extract_search_keywords(content: &str) -> String {
         "with", "from", "all", "very", "just", "also", "than",
     ];
 
-    let words: Vec<&str> = content
+    let mut words: Vec<String> = content
         .split_whitespace()
-        .filter(|w| {
+        .filter_map(|w| {
             let lower = w.to_lowercase();
-            lower.len() > 2 && !STOP_WORDS.contains(&lower.as_str())
+            if lower.len() > 2 && !STOP_WORDS.contains(&lower.as_str()) {
+                Some(lower)
+            } else {
+                None
+            }
         })
-        .take(4) // Use up to 4 significant words
         .collect();
-
-    if words.is_empty() {
-        content.to_string()
-    } else {
-        // Return the longest keyword for LIKE matching; decide_action handles dedup
-        words
-            .iter()
-            .max_by_key(|w| w.len())
-            .unwrap_or(&words[0])
-            .to_string()
-    }
+    // Dedup while preserving first-occurrence order.
+    let mut seen = std::collections::HashSet::new();
+    words.retain(|w| seen.insert(w.clone()));
+    // Longest-first ordering — long words tend to be more distinctive
+    // than short common ones. Stable sort preserves original order
+    // within a length bucket.
+    words.sort_by_key(|b| std::cmp::Reverse(b.len()));
+    words.truncate(4);
+    words
 }
 
 /// Normalize an entity name into a stable ID (lowercase, spaces → underscores).
@@ -2083,6 +2156,12 @@ fn parse_relation_type(s: &str) -> RelationType {
 }
 
 /// Negation/contradiction words that suggest content is contradictory, not a refinement.
+/// Number of `auto_memorize` calls per agent between consolidate ticks.
+/// Each call increments `consolidation_counters[agent]`; when the entry
+/// hits this floor a background `consolidate` task is spawned and the
+/// entry is removed.
+const AUTO_CONSOLIDATE_EVERY: u32 = 10;
+
 const NEGATION_WORDS: &[&str] = &[
     "not",
     "don't",
@@ -2280,7 +2359,9 @@ impl ProactiveMemoryHooks for ProactiveMemoryStore {
             self.store_relations(&extraction_result.relations, user_id);
         }
 
-        // Auto-consolidation: merge duplicates every 10 auto_memorize calls per agent
+        // Auto-consolidation: merge duplicates every AUTO_CONSOLIDATE_EVERY
+        // auto_memorize calls per agent. Detached to a background task
+        // by H6 so this branch never blocks the agent's hot path.
         let should_consolidate = {
             let mut counters = self
                 .consolidation_counters
@@ -2288,7 +2369,7 @@ impl ProactiveMemoryHooks for ProactiveMemoryStore {
                 .unwrap_or_else(|e| e.into_inner());
             let entry = counters.entry(user_id.to_string()).or_insert(0);
             *entry += 1;
-            if *entry >= 10 {
+            if *entry >= AUTO_CONSOLIDATE_EVERY {
                 // Remove the entry to prevent unbounded HashMap growth
                 counters.remove(user_id);
                 true
@@ -3345,6 +3426,73 @@ mod tests {
         assert!(results[0].content.contains("data analysis"));
     }
 
+    /// M14 regression: `decide_action` reads
+    /// `update_threshold_same_category` /
+    /// `update_threshold_cross_category` from the new memory's metadata
+    /// (where `add_with_decision` stashes the live config values), so
+    /// raising the threshold above the Jaccard similarity between two
+    /// memories flips the decision from UPDATE back to ADD.
+    #[tokio::test]
+    async fn decide_action_honors_config_update_thresholds() {
+        let extractor = DefaultMemoryExtractor;
+        let agent = AgentId::new();
+        let existing = MemoryFragment {
+            id: MemoryId::new(),
+            agent_id: agent,
+            content: "Prefers Python for scripting".to_string(),
+            source: MemorySource::Conversation,
+            scope: "session_memory".to_string(),
+            confidence: 1.0,
+            metadata: {
+                let mut m = HashMap::new();
+                m.insert("category".to_string(), serde_json::json!("preference"));
+                m
+            },
+            created_at: chrono::Utc::now(),
+            accessed_at: chrono::Utc::now(),
+            access_count: 0,
+            embedding: None,
+            image_url: None,
+            image_embedding: None,
+            modality: Default::default(),
+        };
+
+        // A new memory with similar content + same category. With the
+        // default 0.7 same-cat threshold this should UPDATE.
+        let new = MemoryItem::new(
+            "Prefers Python for data scripting".to_string(),
+            MemoryLevel::Session,
+        )
+        .with_category("preference");
+        let action = extractor
+            .decide_action(&new, std::slice::from_ref(&existing))
+            .await
+            .unwrap();
+        match action {
+            MemoryAction::Update { .. } | MemoryAction::Noop => {}
+            other => panic!("default thresholds should UPDATE or NOOP; got {other:?}"),
+        }
+
+        // Same input but with the threshold pushed to 0.99 via the
+        // metadata channel `add_with_decision` uses → ADD wins.
+        let mut new_strict = new.clone();
+        new_strict
+            .metadata
+            .insert("_update_threshold_same_cat".into(), serde_json::json!(0.99));
+        new_strict.metadata.insert(
+            "_update_threshold_cross_cat".into(),
+            serde_json::json!(0.99),
+        );
+        let action = extractor
+            .decide_action(&new_strict, std::slice::from_ref(&existing))
+            .await
+            .unwrap();
+        assert!(
+            matches!(action, MemoryAction::Add),
+            "raising _update_threshold_same_cat to 0.99 must demote UPDATE → ADD; got {action:?}"
+        );
+    }
+
     #[tokio::test]
     async fn test_version_history_tracking() {
         let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
@@ -3662,6 +3810,54 @@ mod tests {
         assert!(candidates.contains(&"Alice".to_string()));
         assert!(candidates.contains(&"Rust".to_string()));
         assert!(candidates.contains(&"alice".to_string())); // normalized
+    }
+
+    /// M13 regression: `extract_search_keywords` returns multiple
+    /// distinctive keywords ordered longest-first (the caller unions
+    /// per-keyword LIKE recalls on the no-embedding fallback path) —
+    /// pre-fix it collapsed the top 4 to the single longest word,
+    /// wasting the other three and giving the no-embedding scan a
+    /// frequently-too-generic substring to match against.
+    #[test]
+    fn extract_search_keywords_returns_multiple_ordered_longest_first() {
+        let kws = extract_search_keywords("I prefer Python for data analysis and machine learning");
+        // Pre-fix: returned only the single longest word ("analysis").
+        // Post-fix: top 4 distinctive words, longest-first. We assert
+        // exactly four survive (cap) and the longest-first invariant
+        // holds, but don't pin the exact contents because stable-sort
+        // within a length bucket is implementation-detail.
+        assert_eq!(kws.len(), 4, "should yield exactly 4 keywords; got {kws:?}");
+        assert!(
+            kws.iter().any(|k| k == "analysis"),
+            "longest distinctive word must survive; got {kws:?}"
+        );
+        // Stop words must not leak (catches stop-list regressions).
+        for stop in ["i", "for", "and", "the", "a"] {
+            assert!(
+                !kws.iter().any(|k| k == stop),
+                "stop word '{stop}' leaked into keywords: {kws:?}"
+            );
+        }
+        // Longest-first ordering.
+        for window in kws.windows(2) {
+            assert!(
+                window[0].len() >= window[1].len(),
+                "keywords not sorted longest-first: {kws:?}"
+            );
+        }
+    }
+
+    /// Content with no distinctive words returns an empty list — caller
+    /// falls back to a raw-content LIKE.
+    #[test]
+    fn extract_search_keywords_empty_for_all_stop_words() {
+        // Stop list covers "i", "am", "the". Short words (<= 2 chars)
+        // are dropped by length. Use only such tokens here.
+        let kws = extract_search_keywords("I am the");
+        assert!(
+            kws.is_empty(),
+            "all-stop-word content must yield no keywords; got {kws:?}"
+        );
     }
 
     /// RBAC M3 (#3054) regression: when the user's `UserMemoryAccess`

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -117,7 +117,7 @@ pub struct ProactiveMemoryStore {
     /// both the running count (consolidate fires at
     /// `AUTO_CONSOLIDATE_EVERY = 10`) and the last-touched timestamp,
     /// so the maintenance sweep can evict slots that have been idle
-    /// for longer than `STALE_COUNTER_IDLE_WINDOW` regardless of
+    /// for longer than `STALE_COUNTER_IDLE_WINDOW_HOURS` regardless of
     /// their count. Pre-fix this was `HashMap<String, u32>`, which
     /// forced the sweep to use a count threshold and starved
     /// slow-burn agents (1 call per maintenance window or less)
@@ -127,6 +127,16 @@ pub struct ProactiveMemoryStore {
     last_decay_run: Arc<Mutex<Option<chrono::DateTime<Utc>>>>,
     /// Timestamp of the last session TTL cleanup run (at most once per hour).
     last_cleanup_run: Arc<Mutex<Option<chrono::DateTime<Utc>>>>,
+    /// Timestamp of the last `consolidation_counters` idle-window
+    /// prune (at most once per hour — review-followup #3). Without
+    /// this gate the prune ran on every `maybe_run_maintenance`
+    /// call, which is reachable from `search` / `auto_retrieve` /
+    /// `consolidate` and fires many times per second on a busy
+    /// daemon. The `HashMap::retain` itself is microseconds on
+    /// thousand-entry maps, but rate-limiting matches the existing
+    /// `last_decay_run` / `last_cleanup_run` pattern so all three
+    /// maintenance sub-tasks consume the same scheduling budget.
+    last_counter_prune: Arc<Mutex<Option<chrono::DateTime<Utc>>>>,
 }
 
 impl Clone for ProactiveMemoryStore {
@@ -142,6 +152,7 @@ impl Clone for ProactiveMemoryStore {
             consolidation_counters: Arc::clone(&self.consolidation_counters),
             last_decay_run: Arc::clone(&self.last_decay_run),
             last_cleanup_run: Arc::clone(&self.last_cleanup_run),
+            last_counter_prune: Arc::clone(&self.last_counter_prune),
         }
     }
 }
@@ -162,6 +173,7 @@ impl ProactiveMemoryStore {
             consolidation_counters: Arc::new(Mutex::new(HashMap::new())),
             last_decay_run: Arc::new(Mutex::new(None)),
             last_cleanup_run: Arc::new(Mutex::new(None)),
+            last_counter_prune: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -184,6 +196,7 @@ impl ProactiveMemoryStore {
             consolidation_counters: Arc::new(Mutex::new(HashMap::new())),
             last_decay_run: Arc::new(Mutex::new(None)),
             last_cleanup_run: Arc::new(Mutex::new(None)),
+            last_counter_prune: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -428,6 +441,36 @@ impl ProactiveMemoryStore {
     fn maybe_run_maintenance(&self) {
         self.maybe_decay_confidence();
         self.maybe_cleanup_expired();
+        self.maybe_prune_counters();
+    }
+
+    /// Prune idle entries from `consolidation_counters` if at least
+    /// one hour has elapsed since the last sweep.
+    ///
+    /// The pre-fix sweep ran on every `maybe_run_maintenance` call,
+    /// which is reachable from `search` / `auto_retrieve` /
+    /// `consolidate` and can fire many times per second on a busy
+    /// daemon. The `HashMap::retain` itself is microseconds on
+    /// thousand-entry maps, but rate-limiting matches the existing
+    /// `last_decay_run` / `last_cleanup_run` pattern so all three
+    /// maintenance sub-tasks consume the same scheduling budget
+    /// (review-followup #3).
+    fn maybe_prune_counters(&self) {
+        let now = Utc::now();
+        let mut guard = self
+            .last_counter_prune
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let should_run = match *guard {
+            Some(last) => (now - last) >= chrono::Duration::hours(1),
+            None => true,
+        };
+        if !should_run {
+            return;
+        }
+        *guard = Some(now);
+        drop(guard);
 
         // M11: keep `consolidation_counters` from holding stale entries.
         //
@@ -444,7 +487,7 @@ impl ProactiveMemoryStore {
         // entries — exactly the agents about to fire a real consolidate.
         //
         // Review-followup B: the sweep uses an *idle-window* check
-        // (`last_touched` older than `STALE_COUNTER_IDLE_WINDOW`)
+        // (`last_touched` older than `STALE_COUNTER_IDLE_WINDOW_HOURS`)
         // rather than a count threshold. A count threshold (followup
         // #2's `count >= STALE_COUNTER_FLOOR`) mitigated the original
         // wholesale reset but still starved slow-burn agents whose
@@ -455,8 +498,7 @@ impl ProactiveMemoryStore {
         // been touched within the window; a truly idle slot is
         // reclaimed within ~2 hours of going quiet.
         if let Ok(mut counters) = self.consolidation_counters.lock() {
-            let now = Utc::now();
-            let cutoff = now - STALE_COUNTER_IDLE_WINDOW;
+            let cutoff = now - chrono::Duration::hours(STALE_COUNTER_IDLE_WINDOW_HOURS);
             let before = counters.len();
             counters.retain(|_, entry| entry.last_touched >= cutoff);
             let dropped = before - counters.len();
@@ -464,7 +506,7 @@ impl ProactiveMemoryStore {
                 tracing::debug!(
                     dropped,
                     remaining = counters.len(),
-                    idle_window_hours = STALE_COUNTER_IDLE_WINDOW.num_hours(),
+                    idle_window_hours = STALE_COUNTER_IDLE_WINDOW_HOURS,
                     "Pruned idle consolidation counters"
                 );
             }
@@ -863,17 +905,27 @@ impl ProactiveMemoryStore {
             .decide_action(decision_item, &existing)
             .await?;
 
-        // Review-followup #5: strip the per-call threshold keys from the
-        // enriched clone the moment they stop being useful. Today both
-        // ADD and UPDATE branches build their stored metadata from the
-        // original `item.metadata` (NOT `enriched_item.metadata`), so
-        // the threshold keys never reach the `metadata` column. The
-        // strip is defensive insurance for the next refactorer: if
-        // someone repoints either branch at `enriched_item` (e.g. to
-        // pass extraction metadata through), the threshold pollution
-        // gets caught at the strip site, not silently persisted.
+        // Strip all of `add_with_decision`'s private stash keys from
+        // the enriched clone the moment they stop being useful. Today
+        // both ADD and UPDATE branches build their stored metadata
+        // from the original `item.metadata` (NOT
+        // `enriched_item.metadata`), so the stash keys never reach
+        // the `metadata` column. The strip is defensive insurance
+        // for the next refactorer: if someone repoints either branch
+        // at `enriched_item.metadata` (e.g. to pass extraction
+        // metadata through), the pollution gets caught at the strip
+        // site, not silently persisted.
+        //
+        // Review-followup #2: `_embedding` is stripped alongside the
+        // M14 threshold keys for consistency. The prior commit only
+        // removed the threshold keys; with an embedding driver
+        // configured, a future refactor pointing at
+        // `enriched_item.metadata` would have leaked the full
+        // embedding vector (~4 KB per memory at f32 × 1024 dims) into
+        // the JSON metadata column.
         enriched_item.metadata.remove("_update_threshold_same_cat");
         enriched_item.metadata.remove("_update_threshold_cross_cat");
+        enriched_item.metadata.remove("_embedding");
 
         match action {
             MemoryAction::Noop => {
@@ -2222,28 +2274,40 @@ fn parse_relation_type(s: &str) -> RelationType {
 /// entry is removed.
 const AUTO_CONSOLIDATE_EVERY: u32 = 10;
 
-/// Idle window before a `consolidation_counters` entry is considered
-/// stale and reclaimed by the maintenance sweep (M11). Any entry whose
-/// `last_touched` is older than this gets dropped on the next tick,
-/// regardless of its count value.
+/// Idle window (in hours) before a `consolidation_counters` entry is
+/// considered stale and reclaimed by the maintenance sweep (M11). Any
+/// entry whose `last_touched` is older than this gets dropped on the
+/// next tick, regardless of its count value.
 ///
 /// Set to 2 hours, which is `> 2× the rate-limit window` of the
-/// maintenance ticks themselves (decay + cleanup are gated at
-/// "at most once per hour" via `maybe_decay_confidence` /
-/// `maybe_cleanup_expired`). The double-window margin guarantees a
-/// slow-burn agent that fires `auto_memorize` once every maintenance
-/// window keeps its slot — its counter gets touched between every
-/// two consecutive prune passes — while a truly idle agent's slot
-/// is reclaimed within ~2 hours of going quiet.
+/// maintenance ticks themselves (decay + cleanup + counter prune are
+/// each gated at "at most once per hour" — see
+/// `maybe_decay_confidence` / `maybe_cleanup_expired` /
+/// `maybe_prune_counters`). The double-window margin guarantees a
+/// slow-burn agent that fires `auto_memorize` once between two
+/// consecutive maintenance ticks keeps its slot, while a truly idle
+/// agent's slot is reclaimed within ~2 hours of going quiet
+/// (review-followup #4 — phrased relative to the maintenance
+/// rate-limit window, not "consecutive prune passes" which is what
+/// the prior comment said but only happened to be true because the
+/// prune wasn't rate-limited yet).
 ///
-/// The previous fix (followup #2) used a *count threshold*
+/// The previous fix (round-1 followup #2) used a *count threshold*
 /// (`AUTO_CONSOLIDATE_EVERY / 4`), which mitigated but did not solve
 /// the slow-burn case: any agent firing ≤ 1× per maintenance window
 /// would still be reset before climbing past the floor. Using the
-/// last-touched timestamp instead — review followup B — closes the
+/// last-touched timestamp instead — round-2 followup B — closes the
 /// last gap by making "active" the real condition for keeping the
 /// slot, decoupled from how fast the counter climbs.
-const STALE_COUNTER_IDLE_WINDOW: chrono::Duration = chrono::Duration::hours(2);
+///
+/// Stored as `i64` rather than a `chrono::Duration` constant
+/// (review-followup #6): `chrono::Duration::hours` is a `const fn`
+/// at the currently pinned `chrono` version but the const-ness is
+/// not part of the stable API across `0.4.x` minors, so a future
+/// lockfile bump could silently break the build. `i64` hours +
+/// `chrono::Duration::hours(...)` at the call site stays valid
+/// regardless.
+const STALE_COUNTER_IDLE_WINDOW_HOURS: i64 = 2;
 
 /// Per-agent auto-consolidation state. `count` ticks up to
 /// `AUTO_CONSOLIDATE_EVERY`; `last_touched` records when the counter
@@ -3592,26 +3656,48 @@ mod tests {
         );
     }
 
-    /// M14 strip regression (review-followup C): a memory created via
-    /// `add()` (which goes through `add_with_decision`) must NOT have
-    /// the private `_update_threshold_*` keys in its stored metadata
-    /// column. Without this test, a future refactor that repoints the
-    /// ADD branch at `enriched_item.metadata` (instead of the original
-    /// `item.metadata`) would silently leak the threshold values into
-    /// the persisted row, and only the
+    /// M14 strip regression (review-followup C + #2): a memory created
+    /// via `add()` (which goes through `add_with_decision`) must NOT
+    /// have any of the private `_update_threshold_*` / `_embedding`
+    /// keys in its stored metadata column. Without this test, a
+    /// future refactor that repoints the ADD branch at
+    /// `enriched_item.metadata` (instead of the original
+    /// `item.metadata`) would silently leak both the threshold values
+    /// AND the embedding vector into the persisted row, and only the
     /// `decide_action_honors_config_update_thresholds` direct-trait
     /// test above would still pass — neither catches the persistence
     /// path.
+    ///
+    /// Crucially: we attach a mock embedding driver so the `_embedding`
+    /// stash path actually fires. Without it the assertion on
+    /// `_embedding` would be trivially true (the stash never happens →
+    /// nothing to strip → not in metadata). Mock returns a tiny fixed
+    /// vector so the round-trip is observable but cheap.
     #[tokio::test]
-    async fn add_with_decision_does_not_leak_threshold_keys_to_stored_metadata() {
+    async fn add_with_decision_does_not_leak_private_stash_keys_to_stored_metadata() {
+        struct MockEmbedding;
+        #[async_trait]
+        impl EmbeddingFn for MockEmbedding {
+            async fn embed_one(
+                &self,
+                _text: &str,
+            ) -> librefang_types::error::LibreFangResult<Vec<f32>> {
+                Ok(vec![0.1, 0.2, 0.3, 0.4])
+            }
+        }
+
         let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
-        let store = ProactiveMemoryStore::with_default_config(Arc::new(substrate));
+        let store = ProactiveMemoryStore::with_default_config(Arc::new(substrate))
+            .with_embedding(Arc::new(MockEmbedding));
         let agent_id = AgentId::new().to_string();
 
         // Drive the full `add_with_decision` path. "I prefer X" is a
         // canonical pattern the DefaultMemoryExtractor will pick up,
         // so this goes through the ADD branch (no existing candidate
-        // → no UPDATE possible).
+        // → no UPDATE possible). The mock embedding driver causes
+        // `_embedding` to land in `enriched_item.metadata` before
+        // `decide_action`, so the strip code on the post-decide path
+        // is the only thing keeping it out of the stored column.
         let added = store
             .add(
                 &[serde_json::json!({"role": "user", "content": "I prefer dark mode editors"})],
@@ -3629,21 +3715,17 @@ mod tests {
             "the row we just added must surface in list()"
         );
         for item in &listed {
-            assert!(
-                !item.metadata.contains_key("_update_threshold_same_cat"),
-                "_update_threshold_same_cat leaked into stored metadata: {:?}",
-                item.metadata
-            );
-            assert!(
-                !item.metadata.contains_key("_update_threshold_cross_cat"),
-                "_update_threshold_cross_cat leaked into stored metadata: {:?}",
-                item.metadata
-            );
-            assert!(
-                !item.metadata.contains_key("_embedding"),
-                "_embedding (sibling private key) leaked too: {:?}",
-                item.metadata
-            );
+            for private_key in [
+                "_update_threshold_same_cat",
+                "_update_threshold_cross_cat",
+                "_embedding",
+            ] {
+                assert!(
+                    !item.metadata.contains_key(private_key),
+                    "private stash key `{private_key}` leaked into stored metadata: {:?}",
+                    item.metadata
+                );
+            }
         }
     }
 

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -113,8 +113,16 @@ pub struct ProactiveMemoryStore {
     /// When present, memories are stored with embeddings and search uses cosine similarity.
     /// When absent, falls back to LIKE text matching.
     embedding: Option<Arc<dyn EmbeddingFn>>,
-    /// Per-agent counters for auto-consolidation (runs every 10 auto_memorize calls per agent).
-    consolidation_counters: Arc<Mutex<HashMap<String, u32>>>,
+    /// Per-agent counters for auto-consolidation. Each entry tracks
+    /// both the running count (consolidate fires at
+    /// `AUTO_CONSOLIDATE_EVERY = 10`) and the last-touched timestamp,
+    /// so the maintenance sweep can evict slots that have been idle
+    /// for longer than `STALE_COUNTER_IDLE_WINDOW` regardless of
+    /// their count. Pre-fix this was `HashMap<String, u32>`, which
+    /// forced the sweep to use a count threshold and starved
+    /// slow-burn agents (1 call per maintenance window or less)
+    /// whose counter never climbed past the floor.
+    consolidation_counters: Arc<Mutex<HashMap<String, CounterEntry>>>,
     /// Timestamp of the last confidence decay run (at most once per hour).
     last_decay_run: Arc<Mutex<Option<chrono::DateTime<Utc>>>>,
     /// Timestamp of the last session TTL cleanup run (at most once per hour).
@@ -434,20 +442,30 @@ impl ProactiveMemoryStore {
         // (truncate-to-500 by count DESC), which both delays cleanup
         // until the leak is observable AND deletes the highest-count
         // entries — exactly the agents about to fire a real consolidate.
-        // The new sweep drops counters below `STALE_COUNTER_FLOOR` on
-        // every maintenance tick: still cheap (HashMap::retain in-place),
-        // evicts cold entries first, never touches an entry that's
-        // about to fire.
+        //
+        // Review-followup B: the sweep uses an *idle-window* check
+        // (`last_touched` older than `STALE_COUNTER_IDLE_WINDOW`)
+        // rather than a count threshold. A count threshold (followup
+        // #2's `count >= STALE_COUNTER_FLOOR`) mitigated the original
+        // wholesale reset but still starved slow-burn agents whose
+        // fire rate stayed below the floor — once-an-hour agents
+        // never climbed past 2 because the prune ran every
+        // maintenance tick and reset them. Last-touched fixes this:
+        // an active slot, however slow, is preserved as long as it's
+        // been touched within the window; a truly idle slot is
+        // reclaimed within ~2 hours of going quiet.
         if let Ok(mut counters) = self.consolidation_counters.lock() {
+            let now = Utc::now();
+            let cutoff = now - STALE_COUNTER_IDLE_WINDOW;
             let before = counters.len();
-            counters.retain(|_, &mut count| count >= STALE_COUNTER_FLOOR);
+            counters.retain(|_, entry| entry.last_touched >= cutoff);
             let dropped = before - counters.len();
             if dropped > 0 {
                 tracing::debug!(
                     dropped,
                     remaining = counters.len(),
-                    floor = STALE_COUNTER_FLOOR,
-                    "Pruned stale consolidation counters"
+                    idle_window_hours = STALE_COUNTER_IDLE_WINDOW.num_hours(),
+                    "Pruned idle consolidation counters"
                 );
             }
         }
@@ -712,19 +730,21 @@ impl ProactiveMemoryStore {
             // and cap at fetch_limit at the end so the caller sees the
             // same shape as the embedding path.
             //
-            // Review-followup #4: this is up to 4 SQLite roundtrips per
-            // insertion (one per keyword), versus the pre-fix 1.
+            // Review-followup #4 / #E: this is up to 4 SQLite roundtrips
+            // per insertion (one per keyword), versus the pre-fix 1.
             // Operators running with an embedding driver never hit this
             // branch (the `if let Some(qe)` above takes the vector
             // path). Operators on the no-embedding fallback — CI, local
             // dev without an embedding API, resource-constrained
-            // deployments — eat the 4× round-trip cost on writes. The
-            // `content` column is unindexed substring scan either way,
-            // so the marginal cost is proportional to row count, not
-            // catastrophic in absolute terms. Loop short-circuits as
-            // soon as the union hits `fetch_limit`, so the common case
-            // ("first keyword already filled the slate") still runs a
-            // single query.
+            // deployments — eat the round-trip cost on writes. The
+            // `content` column is an unindexed substring scan either
+            // way, so the marginal cost is proportional to row count,
+            // not catastrophic in absolute terms. Loop short-circuits
+            // as soon as the union hits `fetch_limit`: for agents with
+            // a sizeable memory store the first (longest) keyword often
+            // already fills the slate, dropping back to a single
+            // query; small / fresh stores still pay the full 4× since
+            // no individual keyword has enough matches to short-circuit.
             let keywords = extract_search_keywords(&item.content);
             let mut acc: Vec<MemoryFragment> = Vec::new();
             let mut seen_ids: std::collections::HashSet<MemoryId> =
@@ -804,20 +824,21 @@ impl ProactiveMemoryStore {
                 .metadata
                 .insert("_embedding".to_string(), serde_json::json!(emb_json));
         }
-        // Review-followup #5: callers MUST NOT pre-populate the
-        // `_update_threshold_*` keys — they're a private channel between
-        // `add_with_decision` and the default `decide_action` heuristic.
-        // The `item.metadata` we cloned into `enriched_item` is the
-        // caller's untouched input; a hit here would either signal a
-        // tooling bug (caller leaking internal stash) or a security
-        // probe trying to influence the dedup decision.
+        // Callers must not pre-populate the `_update_threshold_*` keys
+        // — they're a private channel between `add_with_decision` and
+        // the default `decide_action` heuristic. The `item.metadata`
+        // we cloned into `enriched_item` is the caller's untouched
+        // input; a hit here is a contract violation worth catching in
+        // dev. Production builds are still safe: even if a caller
+        // leaks the key, the unconditional `insert` below overwrites
+        // it before `decide_action` reads it.
         debug_assert!(
             !item.metadata.contains_key("_update_threshold_same_cat"),
-            "_update_threshold_same_cat is private to add_with_decision; caller leaked it"
+            "callers must not pre-populate `_update_threshold_same_cat` — it is private to add_with_decision"
         );
         debug_assert!(
             !item.metadata.contains_key("_update_threshold_cross_cat"),
-            "_update_threshold_cross_cat is private to add_with_decision; caller leaked it"
+            "callers must not pre-populate `_update_threshold_cross_cat` — it is private to add_with_decision"
         );
         let (same_cat_thresh, cross_cat_thresh) = {
             let cfg = self.config.read().unwrap_or_else(|e| e.into_inner());
@@ -2201,21 +2222,39 @@ fn parse_relation_type(s: &str) -> RelationType {
 /// entry is removed.
 const AUTO_CONSOLIDATE_EVERY: u32 = 10;
 
-/// Per-agent counters below this floor are considered cold on the
-/// periodic `consolidation_counters` sweep (M11). Set to
-/// `AUTO_CONSOLIDATE_EVERY / 4` (= 2) so even a slow-burning agent that
-/// fires `auto_memorize` once every few maintenance ticks still gets a
-/// chance to climb past the floor before being reset.
+/// Idle window before a `consolidation_counters` entry is considered
+/// stale and reclaimed by the maintenance sweep (M11). Any entry whose
+/// `last_touched` is older than this gets dropped on the next tick,
+/// regardless of its count value.
 ///
-/// Review-followup #2: the original /2 (= 5) threshold trimmed any
-/// agent below 5, which made an "every-N-hours" cadence (single call,
-/// then maintenance, then prune) effectively never consolidate.
-/// Dropping to /4 keeps the prune directionally correct (still evicts
-/// truly idle slots) without starving sub-burst agents of the
-/// consolidate they'd otherwise reach. Review-followup #8: lives at
-/// module scope per repo convention; the same value is referenced by
-/// the prune sweep at the top of the file.
-const STALE_COUNTER_FLOOR: u32 = AUTO_CONSOLIDATE_EVERY / 4;
+/// Set to 2 hours, which is `> 2× the rate-limit window` of the
+/// maintenance ticks themselves (decay + cleanup are gated at
+/// "at most once per hour" via `maybe_decay_confidence` /
+/// `maybe_cleanup_expired`). The double-window margin guarantees a
+/// slow-burn agent that fires `auto_memorize` once every maintenance
+/// window keeps its slot — its counter gets touched between every
+/// two consecutive prune passes — while a truly idle agent's slot
+/// is reclaimed within ~2 hours of going quiet.
+///
+/// The previous fix (followup #2) used a *count threshold*
+/// (`AUTO_CONSOLIDATE_EVERY / 4`), which mitigated but did not solve
+/// the slow-burn case: any agent firing ≤ 1× per maintenance window
+/// would still be reset before climbing past the floor. Using the
+/// last-touched timestamp instead — review followup B — closes the
+/// last gap by making "active" the real condition for keeping the
+/// slot, decoupled from how fast the counter climbs.
+const STALE_COUNTER_IDLE_WINDOW: chrono::Duration = chrono::Duration::hours(2);
+
+/// Per-agent auto-consolidation state. `count` ticks up to
+/// `AUTO_CONSOLIDATE_EVERY`; `last_touched` records when the counter
+/// was last incremented so the maintenance sweep can distinguish
+/// "actively accumulating" slots from "idle but never reached
+/// threshold" slots.
+#[derive(Debug, Clone, Copy)]
+struct CounterEntry {
+    count: u32,
+    last_touched: chrono::DateTime<Utc>,
+}
 
 /// Negation/contradiction words that suggest content is contradictory, not a refinement.
 const NEGATION_WORDS: &[&str] = &[
@@ -2423,9 +2462,14 @@ impl ProactiveMemoryHooks for ProactiveMemoryStore {
                 .consolidation_counters
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
-            let entry = counters.entry(user_id.to_string()).or_insert(0);
-            *entry += 1;
-            if *entry >= AUTO_CONSOLIDATE_EVERY {
+            let now = Utc::now();
+            let entry = counters.entry(user_id.to_string()).or_insert(CounterEntry {
+                count: 0,
+                last_touched: now,
+            });
+            entry.count += 1;
+            entry.last_touched = now;
+            if entry.count >= AUTO_CONSOLIDATE_EVERY {
                 // Remove the entry to prevent unbounded HashMap growth
                 counters.remove(user_id);
                 true
@@ -3546,6 +3590,61 @@ mod tests {
             matches!(action, MemoryAction::Add),
             "raising _update_threshold_same_cat to 0.99 must demote UPDATE → ADD; got {action:?}"
         );
+    }
+
+    /// M14 strip regression (review-followup C): a memory created via
+    /// `add()` (which goes through `add_with_decision`) must NOT have
+    /// the private `_update_threshold_*` keys in its stored metadata
+    /// column. Without this test, a future refactor that repoints the
+    /// ADD branch at `enriched_item.metadata` (instead of the original
+    /// `item.metadata`) would silently leak the threshold values into
+    /// the persisted row, and only the
+    /// `decide_action_honors_config_update_thresholds` direct-trait
+    /// test above would still pass — neither catches the persistence
+    /// path.
+    #[tokio::test]
+    async fn add_with_decision_does_not_leak_threshold_keys_to_stored_metadata() {
+        let substrate = MemorySubstrate::open_in_memory(0.1).unwrap();
+        let store = ProactiveMemoryStore::with_default_config(Arc::new(substrate));
+        let agent_id = AgentId::new().to_string();
+
+        // Drive the full `add_with_decision` path. "I prefer X" is a
+        // canonical pattern the DefaultMemoryExtractor will pick up,
+        // so this goes through the ADD branch (no existing candidate
+        // → no UPDATE possible).
+        let added = store
+            .add(
+                &[serde_json::json!({"role": "user", "content": "I prefer dark mode editors"})],
+                &agent_id,
+            )
+            .await
+            .unwrap();
+        assert!(!added.is_empty(), "extractor should accept a preference");
+
+        // Read back through the same `list()` path the dashboard /
+        // auto_retrieve consume.
+        let listed = store.list(&agent_id, None).await.unwrap();
+        assert!(
+            !listed.is_empty(),
+            "the row we just added must surface in list()"
+        );
+        for item in &listed {
+            assert!(
+                !item.metadata.contains_key("_update_threshold_same_cat"),
+                "_update_threshold_same_cat leaked into stored metadata: {:?}",
+                item.metadata
+            );
+            assert!(
+                !item.metadata.contains_key("_update_threshold_cross_cat"),
+                "_update_threshold_cross_cat leaked into stored metadata: {:?}",
+                item.metadata
+            );
+            assert!(
+                !item.metadata.contains_key("_embedding"),
+                "_embedding (sibling private key) leaked too: {:?}",
+                item.metadata
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -434,12 +434,11 @@ impl ProactiveMemoryStore {
         // (truncate-to-500 by count DESC), which both delays cleanup
         // until the leak is observable AND deletes the highest-count
         // entries — exactly the agents about to fire a real consolidate.
-        // The new sweep instead drops every counter that hasn't passed
-        // the halfway mark on each maintenance tick: still cheap
-        // (HashMap::retain in-place), evicts cold entries first, never
-        // touches an entry that's about to fire.
+        // The new sweep drops counters below `STALE_COUNTER_FLOOR` on
+        // every maintenance tick: still cheap (HashMap::retain in-place),
+        // evicts cold entries first, never touches an entry that's
+        // about to fire.
         if let Ok(mut counters) = self.consolidation_counters.lock() {
-            const STALE_COUNTER_FLOOR: u32 = AUTO_CONSOLIDATE_EVERY / 2;
             let before = counters.len();
             counters.retain(|_, &mut count| count >= STALE_COUNTER_FLOOR);
             let dropped = before - counters.len();
@@ -712,6 +711,20 @@ impl ProactiveMemoryStore {
             // (recall takes one LIKE pattern); we dedup by memory id
             // and cap at fetch_limit at the end so the caller sees the
             // same shape as the embedding path.
+            //
+            // Review-followup #4: this is up to 4 SQLite roundtrips per
+            // insertion (one per keyword), versus the pre-fix 1.
+            // Operators running with an embedding driver never hit this
+            // branch (the `if let Some(qe)` above takes the vector
+            // path). Operators on the no-embedding fallback — CI, local
+            // dev without an embedding API, resource-constrained
+            // deployments — eat the 4× round-trip cost on writes. The
+            // `content` column is unindexed substring scan either way,
+            // so the marginal cost is proportional to row count, not
+            // catastrophic in absolute terms. Loop short-circuits as
+            // soon as the union hits `fetch_limit`, so the common case
+            // ("first keyword already filled the slate") still runs a
+            // single query.
             let keywords = extract_search_keywords(&item.content);
             let mut acc: Vec<MemoryFragment> = Vec::new();
             let mut seen_ids: std::collections::HashSet<MemoryId> =
@@ -791,6 +804,21 @@ impl ProactiveMemoryStore {
                 .metadata
                 .insert("_embedding".to_string(), serde_json::json!(emb_json));
         }
+        // Review-followup #5: callers MUST NOT pre-populate the
+        // `_update_threshold_*` keys — they're a private channel between
+        // `add_with_decision` and the default `decide_action` heuristic.
+        // The `item.metadata` we cloned into `enriched_item` is the
+        // caller's untouched input; a hit here would either signal a
+        // tooling bug (caller leaking internal stash) or a security
+        // probe trying to influence the dedup decision.
+        debug_assert!(
+            !item.metadata.contains_key("_update_threshold_same_cat"),
+            "_update_threshold_same_cat is private to add_with_decision; caller leaked it"
+        );
+        debug_assert!(
+            !item.metadata.contains_key("_update_threshold_cross_cat"),
+            "_update_threshold_cross_cat is private to add_with_decision; caller leaked it"
+        );
         let (same_cat_thresh, cross_cat_thresh) = {
             let cfg = self.config.read().unwrap_or_else(|e| e.into_inner());
             (
@@ -813,6 +841,18 @@ impl ProactiveMemoryStore {
             .extractor
             .decide_action(decision_item, &existing)
             .await?;
+
+        // Review-followup #5: strip the per-call threshold keys from the
+        // enriched clone the moment they stop being useful. Today both
+        // ADD and UPDATE branches build their stored metadata from the
+        // original `item.metadata` (NOT `enriched_item.metadata`), so
+        // the threshold keys never reach the `metadata` column. The
+        // strip is defensive insurance for the next refactorer: if
+        // someone repoints either branch at `enriched_item` (e.g. to
+        // pass extraction metadata through), the threshold pollution
+        // gets caught at the strip site, not silently persisted.
+        enriched_item.metadata.remove("_update_threshold_same_cat");
+        enriched_item.metadata.remove("_update_threshold_cross_cat");
 
         match action {
             MemoryAction::Noop => {
@@ -2155,13 +2195,29 @@ fn parse_relation_type(s: &str) -> RelationType {
     }
 }
 
-/// Negation/contradiction words that suggest content is contradictory, not a refinement.
 /// Number of `auto_memorize` calls per agent between consolidate ticks.
 /// Each call increments `consolidation_counters[agent]`; when the entry
 /// hits this floor a background `consolidate` task is spawned and the
 /// entry is removed.
 const AUTO_CONSOLIDATE_EVERY: u32 = 10;
 
+/// Per-agent counters below this floor are considered cold on the
+/// periodic `consolidation_counters` sweep (M11). Set to
+/// `AUTO_CONSOLIDATE_EVERY / 4` (= 2) so even a slow-burning agent that
+/// fires `auto_memorize` once every few maintenance ticks still gets a
+/// chance to climb past the floor before being reset.
+///
+/// Review-followup #2: the original /2 (= 5) threshold trimmed any
+/// agent below 5, which made an "every-N-hours" cadence (single call,
+/// then maintenance, then prune) effectively never consolidate.
+/// Dropping to /4 keeps the prune directionally correct (still evicts
+/// truly idle slots) without starving sub-burst agents of the
+/// consolidate they'd otherwise reach. Review-followup #8: lives at
+/// module scope per repo convention; the same value is referenced by
+/// the prune sweep at the top of the file.
+const STALE_COUNTER_FLOOR: u32 = AUTO_CONSOLIDATE_EVERY / 4;
+
+/// Negation/contradiction words that suggest content is contradictory, not a refinement.
 const NEGATION_WORDS: &[&str] = &[
     "not",
     "don't",
@@ -3473,16 +3529,15 @@ mod tests {
             other => panic!("default thresholds should UPDATE or NOOP; got {other:?}"),
         }
 
-        // Same input but with the threshold pushed to 0.99 via the
-        // metadata channel `add_with_decision` uses → ADD wins.
+        // Same input but with the same-category threshold pushed to
+        // 0.99 via the metadata channel `add_with_decision` uses → ADD
+        // wins. We only set the same-cat key — both candidate
+        // memories share the "preference" category, so the cross-cat
+        // branch is unreachable (review-followup #7).
         let mut new_strict = new.clone();
         new_strict
             .metadata
             .insert("_update_threshold_same_cat".into(), serde_json::json!(0.99));
-        new_strict.metadata.insert(
-            "_update_threshold_cross_cat".into(),
-            serde_json::json!(0.99),
-        );
         let action = extractor
             .decide_action(&new_strict, std::slice::from_ref(&existing))
             .await
@@ -3822,11 +3877,19 @@ mod tests {
     fn extract_search_keywords_returns_multiple_ordered_longest_first() {
         let kws = extract_search_keywords("I prefer Python for data analysis and machine learning");
         // Pre-fix: returned only the single longest word ("analysis").
-        // Post-fix: top 4 distinctive words, longest-first. We assert
-        // exactly four survive (cap) and the longest-first invariant
-        // holds, but don't pin the exact contents because stable-sort
-        // within a length bucket is implementation-detail.
-        assert_eq!(kws.len(), 4, "should yield exactly 4 keywords; got {kws:?}");
+        // Post-fix: at most 4 distinctive words, longest-first. We
+        // don't pin the exact contents because stable-sort within a
+        // length bucket is implementation-detail, and we don't pin
+        // the exact count either (review-followup #6) so that
+        // additions to STOP_WORDS don't silently break this test.
+        assert!(
+            !kws.is_empty(),
+            "should yield at least one keyword; got {kws:?}"
+        );
+        assert!(
+            kws.len() <= 4,
+            "must respect the 4-keyword cap; got {kws:?}"
+        );
         assert!(
             kws.iter().any(|k| k == "analysis"),
             "longest distinctive word must survive; got {kws:?}"

--- a/crates/librefang-runtime/src/tool_runner/wasm_skill.rs
+++ b/crates/librefang-runtime/src/tool_runner/wasm_skill.rs
@@ -159,10 +159,7 @@ pub async fn execute_wasm_skill(
     // surfaces for the Python/Node runtimes). Detect that envelope so the
     // shared dispatch arm reports it to the agent as an error rather than a
     // success — keeping `is_error` consistent across all skill runtimes.
-    let is_error = result
-        .output
-        .get("error")
-        .is_some_and(|v| !v.is_null());
+    let is_error = result.output.get("error").is_some_and(|v| !v.is_null());
 
     Ok(SkillToolResult {
         output: result.output,

--- a/crates/librefang-types/src/memory.rs
+++ b/crates/librefang-types/src/memory.rs
@@ -236,6 +236,30 @@ pub struct ProactiveMemoryConfig {
     /// reported via a footer; the cap is a hard ceiling on the section.
     #[serde(default = "default_format_context_max_chars")]
     pub format_context_max_chars: usize,
+    /// Similarity threshold above which `decide_action` returns UPDATE
+    /// instead of ADD when the new and existing memory share a
+    /// category (M14). Lower than `update_threshold_cross_category`
+    /// because same-category memories share semantic context, so a
+    /// modest similarity bump is enough evidence to fold them
+    /// together. Default 0.7 — empirically the cut-off where
+    /// embedding cosine starts catching genuine paraphrases without
+    /// merging unrelated facts.
+    ///
+    /// Conceptually distinct from `duplicate_threshold` (which gates
+    /// the post-hoc consolidation sweep — "should two existing
+    /// memories be merged into one?"). The two serve different
+    /// purposes: UPDATE is per-insertion conflict resolution; dedup
+    /// is batch cleanup. Pre-fix both used the same hardcoded
+    /// values, which conflated the contracts.
+    #[serde(default = "default_update_threshold_same_category")]
+    pub update_threshold_same_category: f32,
+    /// Same as `update_threshold_same_category` but for memories with
+    /// *different* categories. Higher (default 0.8) because
+    /// cross-category merges require stronger evidence — the
+    /// categories themselves carry semantic distinction that a
+    /// purely-text similarity score might miss.
+    #[serde(default = "default_update_threshold_cross_category")]
+    pub update_threshold_cross_category: f32,
 }
 
 fn default_true() -> bool {
@@ -248,6 +272,14 @@ fn default_max_memories_per_agent() -> usize {
 
 fn default_format_context_max_chars() -> usize {
     8000
+}
+
+fn default_update_threshold_same_category() -> f32 {
+    0.7
+}
+
+fn default_update_threshold_cross_category() -> f32 {
+    0.8
 }
 
 impl Default for ProactiveMemoryConfig {
@@ -273,6 +305,8 @@ impl Default for ProactiveMemoryConfig {
             confidence_decay_rate: 0.01,
             max_memories_per_agent: 1000,
             format_context_max_chars: default_format_context_max_chars(),
+            update_threshold_same_category: default_update_threshold_same_category(),
+            update_threshold_cross_category: default_update_threshold_cross_category(),
         }
     }
 }
@@ -649,6 +683,14 @@ pub trait MemoryExtractor: Send + Sync {
             // mem0's recommended cut-offs (≈ 0.7 same-category, ≈ 0.8
             // cross-category) and keep the 0.95 NOOP gate for near-exact
             // duplicates.
+            //
+            // M14: the per-call threshold pair is read from the new
+            // memory's metadata, where `add_with_decision` stashes
+            // `update_threshold_same_category` /
+            // `update_threshold_cross_category` from
+            // `ProactiveMemoryConfig`. Falls back to the const defaults
+            // for callers that invoke `decide_action` directly
+            // (without going through the store).
             let new_cat = new_memory.category.as_deref().unwrap_or("");
             let old_cat = existing
                 .metadata
@@ -656,10 +698,22 @@ pub trait MemoryExtractor: Send + Sync {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
 
+            let same_cat_threshold = new_memory
+                .metadata
+                .get("_update_threshold_same_cat")
+                .and_then(|v| v.as_f64())
+                .map(|f| f as f32)
+                .unwrap_or(default_update_threshold_same_category());
+            let cross_cat_threshold = new_memory
+                .metadata
+                .get("_update_threshold_cross_cat")
+                .and_then(|v| v.as_f64())
+                .map(|f| f as f32)
+                .unwrap_or(default_update_threshold_cross_category());
             let update_threshold = if !new_cat.is_empty() && new_cat == old_cat {
-                0.7 // Same category — still need substantial similarity to UPDATE
+                same_cat_threshold
             } else {
-                0.8 // Cross-category UPDATE requires stronger evidence
+                cross_cat_threshold
             };
 
             if similarity > update_threshold


### PR DESCRIPTION
Follow-up on [#5839](https://github.com/librefang/librefang/pull/5839) — picks up four MEDIUM findings from the same proactive-memory audit that landed too late to make the merge window.

## Coverage

| ID | Fix |
|----|-----|
| **M11** | `consolidation_counters` HashMap pruned every maintenance tick (drop entries below `AUTO_CONSOLIDATE_EVERY / 2 = 5`), instead of waiting for the 1000-entry truncate-to-500 sweep that both delayed cleanup and dropped the hottest entries first. |
| **M12** | `PATCH /api/memory/config` now calls `kernel.reload_config()` after writing `config.toml`, so dashboard saves take effect live. `restart_required` reflects the actual `ReloadPlan`; `reload_error` surfaces validation failures. |
| **M13** | `extract_search_keywords` returns `Vec<String>` of the top 4 distinctive keywords (longest-first); the no-embedding fallback iterates and unions per-keyword recalls. Pre-fix it collapsed to the single longest word, wasting the stop-word filter on the other three. |
| **M14** | `decide_action` UPDATE thresholds split into two `ProactiveMemoryConfig` fields (`update_threshold_same_category` default 0.7, `update_threshold_cross_category` default 0.8). The trait method reads them from `MemoryItem.metadata` (where `add_with_decision` stashes the live values), so the signature stays stable. |

## Verification

* `cargo check --workspace --lib` — clean
* `cargo clippy -p librefang-memory -p librefang-runtime -p librefang-types -p librefang-api -p librefang-kernel --tests -- -D warnings` — clean
* `cargo test -p librefang-memory --lib` — **273 passed** (4 new regression tests)
* `cargo test -p librefang-runtime --lib proactive_memory` — **60 passed**
* `cargo test -p librefang-api --lib --test memory_routes_integration --test agent_kv_authz_integration --test auth_public_allowlist` — all green

New regression tests:
* `proactive::tests::extract_search_keywords_returns_multiple_ordered_longest_first`
* `proactive::tests::extract_search_keywords_empty_for_all_stop_words`
* `proactive::tests::decide_action_honors_config_update_thresholds`

## Drive-by

Two stale formatting hunks `cargo fmt` flagged in `runtime/tool_runner/wasm_skill.rs:159` and `api/tests/memory_routes_integration.rs:518` — both inherited from main, not introduced here.
