### PR TITLE
style: cargo fmt recently-merged code (repair main Quality fmt)

### DIFF
--- a/crates/librefang-api/tests/memory_routes_integration.rs
+++ b/crates/librefang-api/tests/memory_routes_integration.rs
@@ -515,7 +515,11 @@ async fn no_auth_loopback_memory_write_is_not_forbidden() {
         StatusCode::FORBIDDEN,
         "no-auth loopback write must be Owner-attributed, not Viewer-denied"
     );
-    assert_ne!(status, StatusCode::UNAUTHORIZED, "loopback no-auth must bypass");
+    assert_ne!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "loopback no-auth must bypass"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/librefang-kernel/src/goal_runner.rs
+++ b/crates/librefang-kernel/src/goal_runner.rs
@@ -540,7 +540,11 @@ mod tests {
         assert_eq!(stored.status, GoalStatus::InProgress);
     }
 
-    fn mk_state(goal_id: GoalId, agent_id: AgentId, max_iterations: u32) -> Arc<Mutex<GoalRunState>> {
+    fn mk_state(
+        goal_id: GoalId,
+        agent_id: AgentId,
+        max_iterations: u32,
+    ) -> Arc<Mutex<GoalRunState>> {
         Arc::new(Mutex::new(GoalRunState {
             goal_id,
             agent_id,
@@ -563,12 +567,27 @@ mod tests {
         let (_tx, rx) = watch::channel(false);
         let state = mk_state(goal.id, agent_id, 10);
 
-        let send = |_a: AgentId, _p: String| async move { Ok("stuck\nGOAL_BLOCKED: need a key".to_string()) };
-        run_loop(goal.id, agent_id, 10, substrate.clone(), send, state.clone(), Arc::new(AtomicBool::new(false)), rx).await;
+        let send = |_a: AgentId, _p: String| async move {
+            Ok("stuck\nGOAL_BLOCKED: need a key".to_string())
+        };
+        run_loop(
+            goal.id,
+            agent_id,
+            10,
+            substrate.clone(),
+            send,
+            state.clone(),
+            Arc::new(AtomicBool::new(false)),
+            rx,
+        )
+        .await;
 
         assert_eq!(state.lock().await.phase, GoalRunPhase::Stopped);
         // Blocked must NOT mark the goal completed.
-        assert_eq!(load_goal(&substrate, goal.id).unwrap().status, GoalStatus::InProgress);
+        assert_eq!(
+            load_goal(&substrate, goal.id).unwrap().status,
+            GoalStatus::InProgress
+        );
     }
 
     #[tokio::test]
@@ -586,7 +605,17 @@ mod tests {
             #[allow(unreachable_code)]
             Ok(String::new())
         };
-        run_loop(goal.id, agent_id, 10, substrate.clone(), send, state.clone(), Arc::new(AtomicBool::new(true)), rx).await;
+        run_loop(
+            goal.id,
+            agent_id,
+            10,
+            substrate.clone(),
+            send,
+            state.clone(),
+            Arc::new(AtomicBool::new(true)),
+            rx,
+        )
+        .await;
 
         let s = state.lock().await;
         assert_eq!(s.phase, GoalRunPhase::Stopped);
@@ -608,7 +637,17 @@ mod tests {
             #[allow(unreachable_code)]
             Ok(String::new())
         };
-        run_loop(goal.id, agent_id, 10, substrate.clone(), send, state.clone(), Arc::new(AtomicBool::new(false)), rx).await;
+        run_loop(
+            goal.id,
+            agent_id,
+            10,
+            substrate.clone(),
+            send,
+            state.clone(),
+            Arc::new(AtomicBool::new(false)),
+            rx,
+        )
+        .await;
 
         assert_eq!(state.lock().await.phase, GoalRunPhase::Stopped);
     }
@@ -631,10 +670,23 @@ mod tests {
                 librefang_channels::message_journal::RATE_LIMIT_DEFER_MARKER
             ))
         };
-        run_loop(goal.id, agent_id, 100, substrate.clone(), send, state.clone(), Arc::new(AtomicBool::new(false)), rx).await;
+        run_loop(
+            goal.id,
+            agent_id,
+            100,
+            substrate.clone(),
+            send,
+            state.clone(),
+            Arc::new(AtomicBool::new(false)),
+            rx,
+        )
+        .await;
 
         let s = state.lock().await;
         assert_eq!(s.phase, GoalRunPhase::RateLimited);
-        assert!(s.iteration < 100, "must trip the breaker, not run to the cap");
+        assert!(
+            s.iteration < 100,
+            "must trip the breaker, not run to the cap"
+        );
     }
 }

--- a/crates/librefang-memory/src/proactive.rs
+++ b/crates/librefang-memory/src/proactive.rs
@@ -615,7 +615,9 @@ impl ProactiveMemoryStore {
         // Read-only listing: a polled list/get must not bump access_count /
         // accessed_at, or the decay engine would never see these memories as
         // idle (#5839).
-        let frags = self.semantic.recall_readonly("", RECALL_CAP, Some(filter))?;
+        let frags = self
+            .semantic
+            .recall_readonly("", RECALL_CAP, Some(filter))?;
 
         let mut items: Vec<MemoryItem> = frags
             .into_iter()

--- a/crates/librefang-runtime/src/context_engine/sidecar.rs
+++ b/crates/librefang-runtime/src/context_engine/sidecar.rs
@@ -645,7 +645,12 @@ while True:
     /// given per-request timeout. `StubEngine` is the inner/fallback engine and
     /// leaves the window untouched, so a fallback is observable as "messages
     /// unchanged".
-    fn spawn_with(py: &str, dir: &std::path::Path, body: &str, timeout_secs: u64) -> SidecarContextEngine {
+    fn spawn_with(
+        py: &str,
+        dir: &std::path::Path,
+        body: &str,
+        timeout_secs: u64,
+    ) -> SidecarContextEngine {
         let script = dir.join("s.py");
         std::fs::write(&script, body).unwrap();
         SidecarContextEngine::spawn(
@@ -673,15 +678,25 @@ while True:
         let slow = "import sys, time\nwhile True:\n    if not sys.stdin.readline():\n        break\n    time.sleep(30)\n";
         let engine = spawn_with(py, dir_t.path(), slow, 1);
         let mut m = vec![Message::user("hi")];
-        engine.assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000).await.unwrap();
-        assert_eq!(m.len(), 1, "timeout must fall back to inner (window unchanged)");
+        engine
+            .assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000)
+            .await
+            .unwrap();
+        assert_eq!(
+            m.len(),
+            1,
+            "timeout must fall back to inner (window unchanged)"
+        );
 
         // (b) Error reply: sidecar returns {"id":N,"error":"boom"}.
         let dir_e = tempfile::tempdir().unwrap();
         let err = "import sys, json\nwhile True:\n    line = sys.stdin.readline()\n    if not line:\n        break\n    line = line.strip()\n    if not line:\n        continue\n    rid = json.loads(line).get(\"id\")\n    sys.stdout.write(json.dumps({\"id\": rid, \"error\": \"boom\"}) + \"\\n\")\n    sys.stdout.flush()\n";
         let engine = spawn_with(py, dir_e.path(), err, 5);
         let mut m = vec![Message::user("hi")];
-        engine.assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000).await.unwrap();
+        engine
+            .assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000)
+            .await
+            .unwrap();
         assert_eq!(m.len(), 1, "error reply must fall back");
 
         // (c) Malformed reply: `messages` is a string, not an array.
@@ -689,7 +704,10 @@ while True:
         let bad = "import sys, json\nwhile True:\n    line = sys.stdin.readline()\n    if not line:\n        break\n    line = line.strip()\n    if not line:\n        continue\n    rid = json.loads(line).get(\"id\")\n    sys.stdout.write(json.dumps({\"id\": rid, \"ok\": {\"messages\": \"not-an-array\"}}) + \"\\n\")\n    sys.stdout.flush()\n";
         let engine = spawn_with(py, dir_m.path(), bad, 5);
         let mut m = vec![Message::user("hi")];
-        engine.assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000).await.unwrap();
+        engine
+            .assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000)
+            .await
+            .unwrap();
         assert_eq!(m.len(), 1, "malformed reply must fall back");
     }
 
@@ -704,7 +722,10 @@ while True:
         let dir = tempfile::tempdir().unwrap();
         let engine = spawn_with(py, dir.path(), "import sys\nsys.exit(0)\n", 5);
         let mut m = vec![Message::user("hi")];
-        engine.assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000).await.unwrap();
+        engine
+            .assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000)
+            .await
+            .unwrap();
         assert_eq!(m.len(), 1, "dead sidecar must fall back to inner");
     }
 
@@ -723,7 +744,10 @@ while True:
         let body = "import sys, json\nwhile True:\n    line = sys.stdin.readline()\n    if not line:\n        break\n    line = line.strip()\n    if not line:\n        continue\n    rid = json.loads(line).get(\"id\")\n    win = [{\"role\": \"user\", \"content\": [{\"type\": \"tool_result\", \"tool_use_id\": \"orphan\", \"content\": \"x\"}]}]\n    sys.stdout.write(json.dumps({\"id\": rid, \"ok\": {\"messages\": win, \"recovery\": \"None\"}}) + \"\\n\")\n    sys.stdout.flush()\n";
         let engine = spawn_with(py, dir.path(), body, 5);
         let mut m = vec![Message::user("first")];
-        engine.assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000).await.unwrap();
+        engine
+            .assemble(AgentId(uuid::Uuid::nil()), &mut m, "sys", &[], 1000)
+            .await
+            .unwrap();
         // The orphan tool_result must not survive into the prompt.
         let has_orphan = m.iter().any(|msg| {
             if let MessageContent::Blocks(blocks) = &msg.content {
@@ -732,6 +756,9 @@ while True:
                 false
             }
         });
-        assert!(!has_orphan, "validate_and_repair must drop the orphan tool_result");
+        assert!(
+            !has_orphan,
+            "validate_and_repair must drop the orphan tool_result"
+        );
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/wasm_skill.rs
+++ b/crates/librefang-runtime/src/tool_runner/wasm_skill.rs
@@ -159,10 +159,7 @@ pub async fn execute_wasm_skill(
     // surfaces for the Python/Node runtimes). Detect that envelope so the
     // shared dispatch arm reports it to the agent as an error rather than a
     // success — keeping `is_error` consistent across all skill runtimes.
-    let is_error = result
-        .output
-        .get("error")
-        .is_some_and(|v| !v.is_null());
+    let is_error = result.output.get("error").is_some_and(|v| !v.is_null());
 
     Ok(SkillToolResult {
         output: result.output,


### PR DESCRIPTION
## Problem

`main` fails the Quality job's `cargo fmt --check` step, which fails Quality on **every open PR**. The unformatted blocks were merged via #5835, #5839, #5848, and #5849 — method chains and multi-line statements that rustfmt collapses/reflows (the PRs were verified with clippy + scoped tests but `cargo fmt --check` was missed on those).

## Fix

Pure `cargo fmt` output across the five affected files (no logic change):
- `crates/librefang-runtime/src/tool_runner/wasm_skill.rs`
- `crates/librefang-runtime/src/context_engine/sidecar.rs`
- `crates/librefang-kernel/src/goal_runner.rs`
- `crates/librefang-memory/src/proactive.rs`
- `crates/librefang-api/tests/memory_routes_integration.rs`

## Verification

`cargo fmt --check` on the result → clean (0 diffs), run in the dev container.
