### PR TITLE
fix(kernel): reserve the global USD budget on the streaming dispatch path

### DIFF
--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -1905,15 +1905,48 @@ impl LibreFangKernel {
         // to a healthy slot. See the ephemeral-path explanation
         // above for the full rationale.
 
+        // Reserve the global USD budget up front, mirroring the
+        // non-streaming path (#3616). Without this hold, N concurrent
+        // streaming turns all observe the same pre-call total and only the
+        // post-call `check_all_and_record` gate runs, so the global `[budget]`
+        // cap can be overshot under concurrency. The reservation is held for
+        // the duration of the spawned task and settled/released alongside the
+        // token reservation below.
+        let estimated_usd = {
+            let max_out = entry.manifest.model.max_tokens as u64;
+            let est_in = max_out;
+            let catalog = self.llm.model_catalog.load();
+            MeteringEngine::estimate_cost_with_catalog(
+                &catalog,
+                &entry.manifest.model.model,
+                est_in,
+                max_out,
+                0,
+                0,
+            )
+        };
+        let usd_reservation = self
+            .metering
+            .engine
+            .reserve_global_budget(&self.current_budget(), estimated_usd)
+            .map_err(KernelError::LibreFang)?;
+
         // Pre-charge the estimated token budget atomically to prevent the
         // TOCTOU race (#3736).  The reservation is settled inside the spawned
         // task after the LLM call completes.
         let estimated_tokens = entry.manifest.model.max_tokens as u64;
-        let token_reservation = self
+        let token_reservation = match self
             .agents
             .scheduler
             .check_quota_and_reserve(agent_id, estimated_tokens)
-            .map_err(KernelError::LibreFang)?;
+        {
+            Ok(r) => r,
+            Err(e) => {
+                // Roll back the USD reservation — the call never dispatched.
+                usd_reservation.release();
+                return Err(KernelError::LibreFang(e));
+            }
+        };
 
         let is_wasm = entry.manifest.module.starts_with("wasm:");
         let is_python = entry.manifest.module.starts_with("python:");
@@ -1961,6 +1994,9 @@ impl LibreFangKernel {
                             token_reservation,
                             &result.total_usage,
                         );
+                        // Release the global USD hold — non-LLM modules incur
+                        // no provider cost, so there is nothing to settle.
+                        usd_reservation.release();
                         let _ = kernel_clone
                             .agents
                             .registry
@@ -1975,6 +2011,7 @@ impl LibreFangKernel {
                             .agents
                             .scheduler
                             .release_reservation(agent_id, token_reservation);
+                        usd_reservation.release();
                         kernel_clone.agents.supervisor.record_panic();
                         warn!(agent_id = %agent_id, error = %e, "Non-LLM agent failed");
                         Err(e)
@@ -2830,6 +2867,10 @@ impl LibreFangKernel {
                         token_reservation,
                         &result.total_usage,
                     );
+                    // Settle the global USD hold (#3616) — actual spend is
+                    // recorded via `check_all_and_record`; this frees the
+                    // pre-call ceiling that throttled concurrent fires.
+                    usd_reservation.settle();
                     // Record tool calls for rate limiting
                     let tool_count = result.decision_traces.len() as u32;
                     kernel_clone
@@ -3060,6 +3101,7 @@ impl LibreFangKernel {
                         .agents
                         .scheduler
                         .release_reservation(agent_id, token_reservation);
+                    usd_reservation.release();
                     kernel_clone.agents.supervisor.record_panic();
                     warn!(agent_id = %agent_id, error = %e, "Streaming agent loop failed");
                     // Lifecycle: emit TurnFailed before cleanup so subscribers


### PR DESCRIPTION
## Summary

Fixes #5868.

The non-streaming dispatch path reserves the global USD budget up front via `reserve_global_budget` (#3616), so concurrent fires cannot all observe the same pre-call total and collectively overshoot the `[budget]` cap.
The streaming path — `send_message_streaming_with_sender_and_opts`, used by the dashboard `/message/stream` endpoint, the primary user-facing path — reserved only the per-agent token quota and **never** the USD budget. So N concurrent streaming turns all passed the post-call-only `check_all_and_record` gate before any recorded, and the global cost cap could be overshot under concurrency.

## Changes

In `send_message_streaming_with_sender_and_opts`:

- Compute `estimated_usd` and call `reserve_global_budget(&self.current_budget(), estimated_usd)` before the token reservation (same estimate block as the non-streaming path).
- If the token-quota check then fails, `release()` the USD reservation before returning.
- Move the reservation into the spawned task; `settle()` it next to the token `settle_reservation` on success, `release()` it next to `release_reservation` on the error branch.
- wasm/python (non-LLM) branch `release()`s the hold — those modules incur no provider cost.

`MeteringReservation`'s `Drop` impl still frees the slot defensively on any path that neither settles nor releases.

## Verification

- `cargo check -p librefang-kernel --lib` — clean.
- `cargo clippy -p librefang-kernel --lib -- -D warnings` — clean.
- `cargo test -p librefang-kernel-metering` — 37 passed (reservation ledger semantics unchanged).

End-to-end overshoot-under-concurrency behavior exercises the real LLM streaming call path, which is human-only verification per `CLAUDE.md` (live daemon on :4545). The change is a structural mirror of the already-tested non-streaming reservation path.
