### PR TITLE
fix(config): cover all per-agent override keys with a drift-guarded detector (#6)

### DIFF
--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -1515,4 +1515,176 @@ admin_role = "admin"
         .expect("toml parse");
         assert!(KernelConfig::detect_misplaced_per_agent_overrides(&raw).is_empty());
     }
+
+    #[test]
+    fn detect_misplaced_per_agent_overrides_flags_section_overrides_6() {
+        // The four section-overrides that #5476 originally missed:
+        // `thinking`, `exec_policy`, `max_history_messages`, and the
+        // tool-exec backend (both the `tool_exec` global-section spelling
+        // and the `tool_exec_backend` agent.toml spelling).
+        let raw: toml::Value = toml::from_str(
+            r#"
+            [agents.a.thinking]
+            enabled = true
+
+            [agents.a.exec_policy]
+            mode = "allowlist"
+
+            [agents.b]
+            max_history_messages = 80
+            tool_exec_backend = "ssh"
+
+            [agents.b.tool_exec]
+            kind = "ssh"
+            "#,
+        )
+        .expect("toml parse");
+        let found = KernelConfig::detect_misplaced_per_agent_overrides(&raw);
+        assert_eq!(
+            found,
+            vec![
+                ("a".to_string(), "exec_policy".to_string()),
+                ("a".to_string(), "thinking".to_string()),
+                ("b".to_string(), "max_history_messages".to_string()),
+                ("b".to_string(), "tool_exec".to_string()),
+                ("b".to_string(), "tool_exec_backend".to_string()),
+            ]
+        );
+    }
+
+    /// Drift guard (#6): every `AgentManifest` field that acts as a
+    /// per-agent override of a global `KernelConfig` section must be listed
+    /// in `PER_AGENT_OVERRIDE_KEYS`, so `detect_misplaced_per_agent_overrides`
+    /// emits the targeted "move this to agent.toml" warning for it.
+    ///
+    /// The original #5476 list was hand-maintained and silently drifted —
+    /// it covered only `proactive_memory` / `skill_workshop` / `compaction`
+    /// and missed `thinking`, `exec_policy`, `max_history_messages`, and the
+    /// tool-exec backend. This test makes that class of omission a compile
+    /// error: it exhaustively **destructures** `AgentManifest`, so adding a
+    /// field to the struct fails to compile here until the contributor
+    /// classifies it as either an override (→ add the config.toml-facing key
+    /// to `PER_AGENT_OVERRIDE_KEYS`) or non-override (→ list it in `OTHER`
+    /// below with the reason).
+    ///
+    /// We destructure rather than read a schema because `AgentManifest` does
+    /// not derive `JsonSchema` (it would cascade the derive onto ~15 nested
+    /// types) and a `serde_json::to_value(&default)` field walk would drop
+    /// every `skip_serializing_if = "Option::is_none"` field that defaults to
+    /// `None` — exactly the override fields we care about (`compaction`,
+    /// `tool_exec_backend`). The exhaustive pattern sees every field
+    /// regardless of serde attributes.
+    #[test]
+    fn per_agent_override_keys_cover_manifest_overrides_6() {
+        use super::validation::PER_AGENT_OVERRIDE_KEYS;
+        use crate::agent::AgentManifest;
+        use std::collections::BTreeSet;
+
+        // Exhaustive destructure: if a field is added to `AgentManifest`,
+        // this stops compiling until the new binding is added to exactly one
+        // of the two arms below. The bindings are otherwise unused.
+        #[allow(unused_variables)]
+        let AgentManifest {
+            // --- Per-agent overrides of a global KernelConfig section. ---
+            // Each maps to its config.toml-facing key in `expected_override_keys`.
+            proactive_memory,
+            skill_workshop,
+            compaction,
+            thinking,
+            exec_policy,
+            max_history_messages,
+            tool_exec_backend,
+
+            // --- OTHER: not a global-section override. -------------------
+            // These are agent-only settings with no matching global
+            // KernelConfig section to override (or are pure identity /
+            // wiring), so placing them under `[agents.x.…]` in config.toml
+            // is still a no-op but is intentionally NOT given the targeted
+            // #5476 warning — it falls through to the generic unknown-key
+            // pass instead. The detector is deliberately scoped to the
+            // overrides operators actually try to relocate.
+            name,
+            version,
+            description,
+            author,
+            module,
+            schedule,
+            session_mode,
+            model,
+            fallback_models,
+            resources,
+            priority,
+            capabilities,
+            profile,
+            tools,
+            skills,
+            skills_disabled,
+            mcp_servers,
+            channels,
+            mcp_disabled,
+            metadata,
+            tags,
+            routing,
+            autonomous,
+            pinned_model,
+            workspace,
+            generate_identity_files,
+            workspaces,
+            tool_allowlist,
+            tool_blocklist,
+            tools_disabled,
+            response_format,
+            enabled,
+            allowed_plugins,
+            inherit_parent_context,
+            context_injection,
+            is_hand,
+            web_search_augmentation,
+            auto_dream_enabled,
+            auto_dream_min_hours,
+            auto_dream_min_sessions,
+            show_progress,
+            auto_evolve,
+            channel_overrides,
+            max_concurrent_invocations,
+            cache_context,
+            triggers,
+            reconcile_orphans,
+            async_tasks,
+        } = AgentManifest::default();
+
+        // The config.toml-facing keys each override field should be flagged
+        // under. Most equal the manifest field name; `tool_exec_backend`
+        // also surfaces under the global section spelling `tool_exec`
+        // because that is what an operator copies from `[tool_exec]`.
+        let expected: BTreeSet<&str> = [
+            "proactive_memory",
+            "skill_workshop",
+            "compaction",
+            "thinking",
+            "exec_policy",
+            "max_history_messages",
+            "tool_exec",
+            "tool_exec_backend",
+        ]
+        .into_iter()
+        .collect();
+
+        let actual: BTreeSet<&str> = PER_AGENT_OVERRIDE_KEYS.iter().copied().collect();
+
+        let missing: Vec<&str> = expected.difference(&actual).copied().collect();
+        assert!(
+            missing.is_empty(),
+            "PER_AGENT_OVERRIDE_KEYS is missing override keys {missing:?}; \
+             an AgentManifest section-override field is not flagged by \
+             detect_misplaced_per_agent_overrides (#6)"
+        );
+
+        let stale: Vec<&str> = actual.difference(&expected).copied().collect();
+        assert!(
+            stale.is_empty(),
+            "PER_AGENT_OVERRIDE_KEYS lists keys {stale:?} that no longer map \
+             to an AgentManifest section-override field (renamed/removed?)"
+        );
+    }
 }

--- a/crates/librefang-types/src/config/validation.rs
+++ b/crates/librefang-types/src/config/validation.rs
@@ -45,6 +45,40 @@ const MANUAL_NESTED_ALIASES: &[(&str, &str)] = &[
     ("terminal", "trust_proxy_headers"),
 ];
 
+/// `[agents.<name>.<key>]` keys that a `config.toml` operator might write
+/// expecting a per-agent override, but which `KernelConfig` silently
+/// ignores because it has no `agents` field (#5476, #6). Each key here is
+/// a section that *is* honoured when placed in the agent's own `agent.toml`
+/// (or the `[agents.<name>]` table of a `HAND.toml`); the detector turns a
+/// silent no-op into a targeted "move this to agent.toml" warning.
+///
+/// These are the **config.toml-facing** names — what the operator types
+/// under `[agents.<name>.…]`. For most overrides that is also the
+/// `AgentManifest` field name, but two diverge:
+///   - `tool_exec` mirrors the global `[tool_exec]` section, while the
+///     manifest field is the scalar `tool_exec_backend`; both spellings
+///     are flagged so the operator is caught regardless of which one they
+///     copied.
+///   - `skill_workshop` has no global `KernelConfig` section at all — it is
+///     an agent-only feature whose documented surface is `[skill_workshop]`
+///     in `agent.toml`.
+///
+/// Do not hand-edit this list to track new `AgentManifest` fields: the
+/// `per_agent_override_keys_cover_manifest_overrides` test in
+/// `config/mod.rs` exhaustively destructures `AgentManifest` and fails the
+/// build if a newly-added field that overrides a global `KernelConfig`
+/// section is missing here (or if a stale key no longer maps to anything).
+pub(super) const PER_AGENT_OVERRIDE_KEYS: &[&str] = &[
+    "compaction",
+    "exec_policy",
+    "max_history_messages",
+    "proactive_memory",
+    "skill_workshop",
+    "thinking",
+    "tool_exec",
+    "tool_exec_backend",
+];
+
 /// Cached allowlists derived once from the schemars-emitted JSON Schema
 /// for `KernelConfig`. Built on first use and reused for the rest of the
 /// process.
@@ -252,12 +286,14 @@ impl KernelConfig {
     }
 
     /// Detect `[agents.<name>.<override_key>]` blocks placed in
-    /// `config.toml` (#5476).
+    /// `config.toml` (#5476, #6).
     ///
-    /// `KernelConfig` has no `agents` field — per-agent overrides for
-    /// `proactive_memory`, `skill_workshop`, and `compaction` live in
-    /// each agent's own `agent.toml` (or the `[agents.<name>]` section
-    /// of a `HAND.toml`), not in `config.toml`. The original #4870
+    /// `KernelConfig` has no `agents` field — per-agent overrides
+    /// (`proactive_memory`, `skill_workshop`, `compaction`, `thinking`,
+    /// `exec_policy`, `max_history_messages`, and the tool-exec backend;
+    /// the full set lives in [`PER_AGENT_OVERRIDE_KEYS`]) live in each
+    /// agent's own `agent.toml` (or the `[agents.<name>]` section of a
+    /// `HAND.toml`), not in `config.toml`. The original #4870
     /// issue body proposed the `config.toml` syntax in error, and the
     /// kernel silently accepted-and-ignored the block (the unknown
     /// top-level `agents` key was warned about generically, but the
@@ -272,13 +308,6 @@ impl KernelConfig {
     /// flagged — generic typos under `[agents]` fall through to the
     /// existing unknown-top-level warning.
     pub fn detect_misplaced_per_agent_overrides(raw: &toml::Value) -> Vec<(String, String)> {
-        // Keep this list in sync with the fields on `AgentManifest`
-        // that the kernel honours as per-agent overrides of a global
-        // `KernelConfig` section. Adding a new override here is a
-        // one-line update — the warning text below auto-includes it.
-        const PER_AGENT_OVERRIDE_KEYS: &[&str] =
-            &["proactive_memory", "skill_workshop", "compaction"];
-
         let Some(agents_tbl) = raw
             .as_table()
             .and_then(|t| t.get("agents"))


### PR DESCRIPTION
## Problem (#6)

`detect_misplaced_per_agent_overrides` (added in #5476 to turn a silent no-op into a targeted "this belongs in agent.toml" warning) hard-coded only three keys:

```rust
const PER_AGENT_OVERRIDE_KEYS: &[&str] = &["proactive_memory", "skill_workshop", "compaction"];
```

It missed at least four other `AgentManifest` fields that override a global `KernelConfig` section.
Writing any of them under `[agents.<name>.<key>]` in `config.toml` parses, silently drops, and gives the operator no targeted warning:

| config.toml key written under `[agents.x.…]` | AgentManifest field | global fallback site |
| --- | --- | --- |
| `thinking` | `thinking` | runtime `manifest.thinking` overrides global `[thinking]` |
| `exec_policy` | `exec_policy` | `kernel/spawn.rs` — `manifest.exec_policy.is_none()` → `cfg.exec_policy` |
| `max_history_messages` | `max_history_messages` | runtime resolution: manifest > `KernelConfig.max_history_messages` |
| `tool_exec` / `tool_exec_backend` | `tool_exec_backend` | `kernel/spawn.rs` — `manifest.tool_exec_backend` validated against global `cfg.tool_exec` |

The only drift guard was a `// keep this in sync with AgentManifest` comment — pure human discipline.

## Changes

- **Add the missing keys** to `PER_AGENT_OVERRIDE_KEYS`: `thinking`, `exec_policy`, `max_history_messages`, `tool_exec`, `tool_exec_backend`.
  Both tool-exec spellings are flagged: an operator might mirror the global `[tool_exec]` section name or the agent.toml `tool_exec_backend` scalar key — either way they get the warning.
- **Replace the comment with a compile-time drift guard** (`per_agent_override_keys_cover_manifest_overrides_6` in `config/mod.rs`).
  The test **exhaustively destructures `AgentManifest`**: adding a field to the struct stops this test compiling until the contributor classifies the new field into exactly one of two arms — a global-section override (→ add its config.toml-facing key to `PER_AGENT_OVERRIDE_KEYS`) or a non-override (→ list it with a reason).
  The test then asserts the expected override-key set equals `PER_AGENT_OVERRIDE_KEYS` in both directions (catches both a missing key and a stale/renamed one).

### Why not the schemars-intersection pattern used by `every_config_field_is_reload_classified`

That guard works by intersecting `KernelConfig`'s schema-derived field set with a classification table.
A naive "AgentManifest fields ∩ KernelConfig top-level fields" intersection does **not** capture this domain:

1. `AgentManifest` does not derive `JsonSchema`, and adding the derive would cascade onto ~15 nested types that also lack it — far out of scope for this fix.
2. `skill_workshop` has **no** global `KernelConfig` section at all (it is an agent-only feature whose documented surface is `[skill_workshop]` in agent.toml), so it would fall out of any intersection even though it is a legitimate misplaced-override key.
3. The tool-exec backend's manifest field is `tool_exec_backend` but the global section is `tool_exec` — a name mismatch an intersection can't bridge.
4. A `serde_json::to_value(&AgentManifest::default())` field walk would silently drop every `skip_serializing_if = "Option::is_none"` field defaulting to `None` — which includes the override fields `compaction` and `tool_exec_backend`.

The exhaustive-destructure pattern sidesteps all four: it sees every field regardless of serde attributes and needs no schema derive, while still failing the build the moment `AgentManifest` grows a field nobody classified.

## EXCLUDED keys (non-overrides) and why

The detector is deliberately scoped to overrides of a *global* `KernelConfig` section — generic typos under `[agents.x]` keep falling through to the existing unknown-top-level warning (preserving `detect_misplaced_per_agent_overrides_ignores_unrelated_agent_keys_5476`).
Every other `AgentManifest` field is excluded because it has no matching global section to override (it is agent-only config or pure identity/wiring): `name`, `version`, `model`, `capabilities`, `triggers`, `async_tasks`, `channel_overrides`, … (full list is the OTHER arm of the destructure).

## Verification

Scoped, in the repo's sanctioned Linux dev image (`Dockerfile.rust-dev`, named volumes — no host `target/` contention):

- `cargo check -p librefang-types --lib` — pass
- `cargo clippy -p librefang-types --lib -- -D warnings` — pass
- `cargo test -p librefang-types config::` — 139 passed; both new tests included:
  - `detect_misplaced_per_agent_overrides_flags_section_overrides_6`
  - `per_agent_override_keys_cover_manifest_overrides_6`
- `cargo fmt -p librefang-types -- --check` — pass

No kernel-side change required: `crates/librefang-kernel/src/config.rs` already calls this helper at load and on `POST /api/config/reload`; it now emits the targeted warning for the newly-covered keys automatically.

## Final per-agent override key set

`compaction`, `exec_policy`, `max_history_messages`, `proactive_memory`, `skill_workshop`, `thinking`, `tool_exec`, `tool_exec_backend`.

Closes #6.
