### PR TITLE
fix(bedrock): account prompt-cache tokens in usage normalization

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/bedrock.rs
+++ b/crates/librefang-llm-drivers/src/drivers/bedrock.rs
@@ -244,6 +244,13 @@ struct BedrockResponseToolUse {
 struct BedrockUsage {
     input_tokens: u64,
     output_tokens: u64,
+    // Prompt-cache counters from the Converse API. Like Anthropic native,
+    // `input_tokens` reports NEW input only with these as separate buckets;
+    // absent for models / requests without caching, so default to 0.
+    #[serde(default)]
+    cache_read_input_tokens: u64,
+    #[serde(default)]
+    cache_write_input_tokens: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -707,13 +714,16 @@ fn convert_response(resp: ConverseResponse) -> Result<CompletionResponse, LlmErr
         stop_reason,
         tool_calls,
         usage: TokenUsage {
-            input_tokens: resp.usage.input_tokens,
+            // Normalize to the workspace convention (see TokenUsage docs and
+            // anthropic.rs): `input_tokens` = TOTAL prompt including cached.
+            // Bedrock Converse reports `inputTokens` as NEW input only with
+            // cacheRead / cacheWrite as separate buckets, so fold them in.
+            input_tokens: resp.usage.input_tokens
+                + resp.usage.cache_read_input_tokens
+                + resp.usage.cache_write_input_tokens,
             output_tokens: resp.usage.output_tokens,
-            // Bedrock Converse API does not yet expose prompt-cache token
-            // counters separately, so report zero — the agent loop treats
-            // missing cache stats the same as no caching.
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: resp.usage.cache_write_input_tokens,
+            cache_read_input_tokens: resp.usage.cache_read_input_tokens,
         },
         actual_provider: None,
     })
@@ -980,6 +990,8 @@ mod tests {
             usage: BedrockUsage {
                 input_tokens: 10,
                 output_tokens: 5,
+                cache_read_input_tokens: 0,
+                cache_write_input_tokens: 0,
             },
         };
         let result = convert_response(resp).unwrap();
@@ -987,6 +999,35 @@ mod tests {
         assert_eq!(result.usage.input_tokens, 10);
         assert_eq!(result.usage.output_tokens, 5);
         assert!(matches!(result.stop_reason, StopReason::EndTurn));
+    }
+
+    #[test]
+    fn test_convert_response_folds_cache_tokens_into_input() {
+        // Converse reports inputTokens as NEW input only; cacheRead/cacheWrite
+        // are separate. Normalize input_tokens to the total prompt and surface
+        // the buckets so metering applies cache pricing.
+        let resp = ConverseResponse {
+            output: ConverseOutput {
+                message: BedrockResponseMessage {
+                    role: "assistant".to_string(),
+                    content: vec![BedrockResponseContent::Text {
+                        text: "Hi".to_string(),
+                    }],
+                },
+            },
+            stop_reason: "end_turn".to_string(),
+            usage: BedrockUsage {
+                input_tokens: 20,
+                output_tokens: 5,
+                cache_read_input_tokens: 70,
+                cache_write_input_tokens: 10,
+            },
+        };
+        let result = convert_response(resp).unwrap();
+        // 20 new + 70 read + 10 write = 100 total prompt.
+        assert_eq!(result.usage.input_tokens, 100);
+        assert_eq!(result.usage.cache_read_input_tokens, 70);
+        assert_eq!(result.usage.cache_creation_input_tokens, 10);
     }
 
     #[test]
@@ -1008,6 +1049,8 @@ mod tests {
             usage: BedrockUsage {
                 input_tokens: 15,
                 output_tokens: 8,
+                cache_read_input_tokens: 0,
+                cache_write_input_tokens: 0,
             },
         };
         let result = convert_response(resp).unwrap();


### PR DESCRIPTION
## Summary

Fixes #5878.

`BedrockUsage` deserialized only `inputTokens`/`outputTokens`, and `convert_response` hardcoded both cache buckets to 0 with a comment claiming the Converse API does not expose cache counters. It does: `cacheReadInputTokens` and `cacheWriteInputTokens` are reported separately, and `inputTokens` is NEW input only (same shape as Anthropic native). With prompt caching active, total input was undercounted (cached tokens vanished entirely) and cache pricing could never apply.

## Changes

- Add `#[serde(default)] cache_read_input_tokens` / `cache_write_input_tokens` to `BedrockUsage`.
- Normalize in `convert_response` to the workspace `TokenUsage` convention (`input_tokens` = TOTAL prompt including cached), mirroring `anthropic.rs`:
  - `input_tokens = inputTokens + cacheRead + cacheWrite`
  - `cache_read_input_tokens = cacheRead`
  - `cache_creation_input_tokens = cacheWrite`

## Verification

- `cargo test -p librefang-llm-drivers --lib bedrock` — 29 passed, 0 failed (includes new `test_convert_response_folds_cache_tokens_into_input`).
- `cargo clippy -p librefang-llm-drivers --lib -- -D warnings` — clean.

Live Bedrock round-trip is human-only per `CLAUDE.md`; the wire-shape parsing is covered by the unit test.
