### PR TITLE
fix(channels): route attachment download through the redirect-revalidating client

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -5148,7 +5148,13 @@ async fn download_file_to_blocks(
         }]);
     }
 
-    let client = crate::http_client::new_client();
+    // Use the redirect-revalidating client: `new_client()` follows up to 10
+    // redirects with NO per-hop SSRF check, so a forged attachment URL on a
+    // public host could `302` to `http://169.254.169.254/...` and bypass the
+    // entry-time `validate_url_scheme` guard. `safe_fetch_client()` re-runs
+    // `validate_url_for_fetch` on every redirect target (cap 5), matching the
+    // image path (`fetch_url_bytes`).
+    let client = crate::http_client::safe_fetch_client();
     let mut req = client.get(url).timeout(std::time::Duration::from_secs(60));
     for (name, value) in extra_headers {
         req = req.header(name.as_str(), value.as_str());


### PR DESCRIPTION
## Summary

Fixes #5883.

`download_file_to_blocks` validated the initial attachment URL with `validate_url_scheme` (which delegates to the full `validate_url_for_fetch` SSRF guard) but then fetched it with `crate::http_client::new_client()`, which follows up to 10 redirects with **no** per-hop SSRF check. A forged inbound `File` attachment pointing at an attacker-controlled public host could `302 Location: http://169.254.169.254/...` (or a loopback service) and have the redirect body streamed to disk and base64'd into the agent's LLM context — bypassing the entry-time guard.

## Changes

- Switch the download client to `crate::http_client::safe_fetch_client()`, whose `redirect::Policy::custom` re-runs `validate_url_for_fetch` on every redirect target (cap 5). This is the same client the image path (`fetch_url_bytes`) already uses.

## Verification

- `cargo check -p librefang-channels --lib` — clean.
- `cargo clippy -p librefang-channels --lib -- -D warnings` — clean.
- `cargo test -p librefang-channels --lib http_client` — 26 passed; the redirect-bypass behavior is covered by the existing `fetch_url_bytes_refuses_redirect_to_private_host` regression test (the download now uses the same revalidating client). A download-path-specific test can't bind a private host because `validate_url_for_fetch` refuses `127.0.0.1` (which is why wiremock-based tests use the `fetch_url_bytes_unchecked` escape hatch).

## Note on the cluster

The audit grouped this with #5870-area web_fetch redirect pinning (issue 010) and the A2A discover TOCTOU (issue 023). Issue 010 lives in `librefang-runtime` and needs a manual redirect loop to pin each hop to its validated IP — a substantially different and riskier change — so it is sent as its own focused PR rather than bundled here. Issue 023 is low-severity and out of this round's scope.
