### PR TITLE
perf: offload blocking filesystem/zip IO off the tokio runtime

### DIFF
--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -6450,7 +6450,7 @@ pub async fn upload_file(
         .config_ref()
         .channels
         .effective_file_download_dir();
-    if let Err(e) = std::fs::create_dir_all(&upload_dir) {
+    if let Err(e) = tokio::fs::create_dir_all(&upload_dir).await {
         tracing::warn!("Failed to create upload dir: {e}");
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -6459,7 +6459,7 @@ pub async fn upload_file(
     }
 
     let file_path = upload_dir.join(&file_id);
-    if let Err(e) = std::fs::write(&file_path, &body) {
+    if let Err(e) = tokio::fs::write(&file_path, &body).await {
         tracing::warn!("Failed to write upload: {e}");
         return (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/librefang-api/src/routes/backup.rs
+++ b/crates/librefang-api/src/routes/backup.rs
@@ -467,103 +467,57 @@ pub async fn delete_backup(
     (StatusCode::NO_CONTENT, Json(serde_json::json!(null)))
 }
 
-/// POST /api/restore — Restore kernel state from a backup archive.
-///
-/// Accepts a JSON body with `{"filename": "librefang_backup_20260315_120000.zip"}`.
-/// The file must exist in `<home_dir>/backups/`.
-///
-/// **Warning**: This overwrites existing state files. The daemon should be
-/// restarted after a restore for all changes to take effect.
-#[utoipa::path(post, path = "/api/restore", tag = "system", request_body = crate::types::JsonObject, responses((status = 200, description = "Backup restored", body = crate::types::JsonObject)))]
-pub async fn restore_backup(
-    State(state): State<Arc<AppState>>,
-    lang: Option<axum::Extension<RequestLanguage>>,
-    Json(req): Json<serde_json::Value>,
-) -> impl IntoResponse {
-    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
-    let filename = match req.get("filename").and_then(|v| v.as_str()) {
-        Some(f) => f.to_string(),
-        None => {
-            return ApiErrorResponse::bad_request(t.t("api-error-backup-missing-filename"))
-                .into_json_tuple();
-        }
-    };
+/// Categorised failure mode for `restore_backup_blocking`, mapped 1:1 onto
+/// the original handler's distinct ApiErrorResponse branches so the
+/// translated client-facing message stays identical after the
+/// spawn_blocking refactor.
+enum RestoreError {
+    Open(String),
+    InvalidArchive(String),
+    MissingManifest,
+}
 
-    // Sanitize
-    if is_invalid_backup_filename(&filename) {
-        return ApiErrorResponse::bad_request(t.t("api-error-backup-invalid-filename"))
-            .into_json_tuple();
-    }
-    if !filename.ends_with(".zip") {
-        return ApiErrorResponse::bad_request(t.t("api-error-backup-must-be-zip"))
-            .into_json_tuple();
-    }
+/// Result of a successful restore extraction.
+struct RestoreOutcome {
+    restored: Vec<String>,
+    errors: Vec<String>,
+    manifest: Option<BackupManifest>,
+}
 
-    let home_dir = &state.kernel.home_dir();
-    let backups_dir = home_dir.join("backups");
-    let backup_path = match find_backup_path(&backups_dir, &filename) {
-        Ok(Some(path)) => path,
-        Ok(None) => {
-            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found"))
-                .into_json_tuple();
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found"))
-                .into_json_tuple();
-        }
-        Err(e) => {
-            return ApiErrorResponse::internal(
-                t.t_args("api-error-backup-open-failed", &[("error", &e.to_string())]),
-            )
-            .into_json_tuple();
-        }
-    };
+/// Sync, blocking implementation of `restore_backup`: opens the zip,
+/// validates the manifest, and extracts every entry into `home_dir`.
+/// Must be dispatched via `tokio::task::spawn_blocking` — the
+/// decompress-and-write loop otherwise stalls the axum/tokio worker for
+/// the full archive (each entry is buffered into a `Vec<u8>` then written),
+/// matching the `create_backup_blocking` contract above.
+fn restore_backup_blocking(
+    backup_path: std::path::PathBuf,
+    home_dir: std::path::PathBuf,
+) -> Result<RestoreOutcome, RestoreError> {
+    let file = std::fs::File::open(&backup_path).map_err(|e| RestoreError::Open(e.to_string()))?;
+    let mut archive =
+        zip::ZipArchive::new(file).map_err(|e| RestoreError::InvalidArchive(e.to_string()))?;
 
-    // Open zip
-    let file = match std::fs::File::open(&backup_path) {
-        Ok(f) => f,
-        Err(e) => {
-            return ApiErrorResponse::internal(
-                t.t_args("api-error-backup-open-failed", &[("error", &e.to_string())]),
-            )
-            .into_json_tuple();
-        }
-    };
-    let mut archive = match zip::ZipArchive::new(file) {
-        Ok(a) => a,
-        Err(e) => {
-            return ApiErrorResponse::bad_request(t.t_args(
-                "api-error-backup-invalid-archive",
-                &[("error", &e.to_string())],
-            ))
-            .into_json_tuple();
-        }
-    };
-
-    // Validate manifest
-    let manifest: Option<BackupManifest> = {
-        match archive.by_name("manifest.json") {
-            Ok(mut entry) => {
-                let mut buf = String::new();
-                if std::io::Read::read_to_string(&mut entry, &mut buf).is_ok() {
-                    serde_json::from_str(&buf).ok()
-                } else {
-                    None
-                }
+    // Validate manifest before touching the filesystem.
+    let manifest: Option<BackupManifest> = match archive.by_name("manifest.json") {
+        Ok(mut entry) => {
+            let mut buf = String::new();
+            if std::io::Read::read_to_string(&mut entry, &mut buf).is_ok() {
+                serde_json::from_str(&buf).ok()
+            } else {
+                None
             }
-            Err(_) => None,
         }
+        Err(_) => None,
     };
-
     if manifest.is_none() {
-        return ApiErrorResponse::bad_request(t.t("api-error-backup-missing-manifest"))
-            .into_json_tuple();
+        return Err(RestoreError::MissingManifest);
     }
 
     let mut restored: Vec<String> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
 
-    // Extract all files to home_dir, skipping manifest.json itself
+    // Extract all files to home_dir, skipping manifest.json itself.
     for i in 0..archive.len() {
         let mut entry = match archive.by_index(i) {
             Ok(e) => e,
@@ -613,6 +567,110 @@ pub async fn restore_backup(
         }
         restored.push(entry_name.to_string_lossy().to_string());
     }
+
+    Ok(RestoreOutcome {
+        restored,
+        errors,
+        manifest,
+    })
+}
+
+/// POST /api/restore — Restore kernel state from a backup archive.
+///
+/// Accepts a JSON body with `{"filename": "librefang_backup_20260315_120000.zip"}`.
+/// The file must exist in `<home_dir>/backups/`.
+///
+/// **Warning**: This overwrites existing state files. The daemon should be
+/// restarted after a restore for all changes to take effect.
+#[utoipa::path(post, path = "/api/restore", tag = "system", request_body = crate::types::JsonObject, responses((status = 200, description = "Backup restored", body = crate::types::JsonObject)))]
+pub async fn restore_backup(
+    State(state): State<Arc<AppState>>,
+    lang: Option<axum::Extension<RequestLanguage>>,
+    Json(req): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+    let filename = match req.get("filename").and_then(|v| v.as_str()) {
+        Some(f) => f.to_string(),
+        None => {
+            return ApiErrorResponse::bad_request(t.t("api-error-backup-missing-filename"))
+                .into_json_tuple();
+        }
+    };
+
+    // Sanitize
+    if is_invalid_backup_filename(&filename) {
+        return ApiErrorResponse::bad_request(t.t("api-error-backup-invalid-filename"))
+            .into_json_tuple();
+    }
+    if !filename.ends_with(".zip") {
+        return ApiErrorResponse::bad_request(t.t("api-error-backup-must-be-zip"))
+            .into_json_tuple();
+    }
+
+    let home_dir = state.kernel.home_dir().to_path_buf();
+    let backups_dir = home_dir.join("backups");
+    let backup_path = match find_backup_path(&backups_dir, &filename) {
+        Ok(Some(path)) => path,
+        Ok(None) => {
+            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found"))
+                .into_json_tuple();
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return ApiErrorResponse::not_found(t.t("api-error-backup-not-found"))
+                .into_json_tuple();
+        }
+        Err(e) => {
+            return ApiErrorResponse::internal(
+                t.t_args("api-error-backup-open-failed", &[("error", &e.to_string())]),
+            )
+            .into_json_tuple();
+        }
+    };
+
+    // Drop the `!Send` ErrorTranslator before the spawn_blocking `.await`
+    // (the axum Handler bound rejects a non-Send future). Each error branch
+    // below reconstructs it after the await, like `create_backup`.
+    drop(t);
+
+    // Dispatch the blocking open + decompress + write loop onto a blocking
+    // thread so it does not stall the axum/tokio worker (refs
+    // blocking-fs-on-executor).
+    let result =
+        tokio::task::spawn_blocking(move || restore_backup_blocking(backup_path, home_dir)).await;
+
+    let outcome = match result {
+        Ok(Ok(o)) => o,
+        Ok(Err(RestoreError::Open(msg))) => {
+            let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+            return ApiErrorResponse::internal(
+                t.t_args("api-error-backup-open-failed", &[("error", &msg)]),
+            )
+            .into_json_tuple();
+        }
+        Ok(Err(RestoreError::InvalidArchive(msg))) => {
+            let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+            return ApiErrorResponse::bad_request(
+                t.t_args("api-error-backup-invalid-archive", &[("error", &msg)]),
+            )
+            .into_json_tuple();
+        }
+        Ok(Err(RestoreError::MissingManifest)) => {
+            let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+            return ApiErrorResponse::bad_request(t.t("api-error-backup-missing-manifest"))
+                .into_json_tuple();
+        }
+        Err(join_err) => {
+            let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
+            return ApiErrorResponse::internal(t.t_args(
+                "api-error-backup-open-failed",
+                &[("error", &format!("restore task join: {join_err}"))],
+            ))
+            .into_json_tuple();
+        }
+    };
+    let restored = outcome.restored;
+    let errors = outcome.errors;
+    let manifest = outcome.manifest;
 
     let total_restored = restored.len();
     tracing::info!(

--- a/crates/librefang-api/src/routes/media.rs
+++ b/crates/librefang-api/src/routes/media.rs
@@ -420,12 +420,12 @@ pub async fn transcribe_audio(
         .config_ref()
         .channels
         .effective_file_download_dir();
-    if let Err(e) = std::fs::create_dir_all(&upload_dir) {
+    if let Err(e) = tokio::fs::create_dir_all(&upload_dir).await {
         return ApiErrorResponse::internal_scrub(e).into_response();
     }
     let file_id = uuid::Uuid::new_v4().to_string();
     let file_path = upload_dir.join(&file_id);
-    if let Err(e) = std::fs::write(&file_path, &body) {
+    if let Err(e) = tokio::fs::write(&file_path, &body).await {
         return ApiErrorResponse::internal_scrub(e).into_response();
     }
 
@@ -441,7 +441,7 @@ pub async fn transcribe_audio(
     match state.kernel.media().transcribe_audio(&attachment).await {
         Ok(result) => {
             // Clean up temp file
-            let _ = std::fs::remove_file(&file_path);
+            let _ = tokio::fs::remove_file(&file_path).await;
             Json(serde_json::json!({
                 "text": result.description,
                 "provider": result.provider,
@@ -450,7 +450,7 @@ pub async fn transcribe_audio(
             .into_response()
         }
         Err(e) => {
-            let _ = std::fs::remove_file(&file_path);
+            let _ = tokio::fs::remove_file(&file_path).await;
             ApiErrorResponse::internal_scrub(e).into_response()
         }
     }

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -5363,8 +5363,22 @@ async fn download_file_to_blocks(
         // addition to the saved-path block. The path block is preserved
         // so tools that legitimately want raw bytes (media_transcribe,
         // custom file readers) still work.
-        let mut blocks =
-            crate::attachment_enrich::enrich_saved_file(&file_path, &media_type, filename);
+        // enrich_saved_file does blocking std::fs reads and CPU-bound PDF
+        // text extraction (pdf_extract), which can stall the tokio worker for
+        // a large/complex document — offload it (refs blocking-fs-on-executor).
+        let mut blocks = {
+            let file_path = file_path.clone();
+            let media_type = media_type.clone();
+            let filename = filename.to_string();
+            tokio::task::spawn_blocking(move || {
+                crate::attachment_enrich::enrich_saved_file(&file_path, &media_type, &filename)
+            })
+            .await
+            .unwrap_or_else(|e| {
+                warn!("attachment enrichment task failed to join: {e}");
+                Vec::new()
+            })
+        };
         blocks.push(ContentBlock::Text {
             text: format!("{FILE_SAVED_BLOCK_PREFIX}{filename}] saved to {path_str}"),
             provider_metadata: None,

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -627,65 +627,85 @@ impl ClawHubClient {
         let seq = STAGING_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let skill_dir = resolve_skill_dir(target_dir, slug)?;
         let tmp_dir = target_dir.join(format!(".staging-{}-{}-{}", slug, std::process::id(), seq));
-        // Defensive: clean up if a path collision somehow occurred.
-        if tmp_dir.exists() {
-            let _ = std::fs::remove_dir_all(&tmp_dir);
-        }
-        std::fs::create_dir_all(&tmp_dir)?;
+        // Extraction — tmp-dir setup, zip decompression, and per-entry writes
+        // — is blocking and, for a zip skill, unbounded in size. Offload it to
+        // a blocking thread so it does not stall the tokio worker for the full
+        // archive (refs blocking-fs-on-executor). Returns `is_skillmd`, which
+        // the conversion step below needs.
+        let is_skillmd = {
+            let tmp_dir = tmp_dir.clone();
+            let bytes = bytes.to_vec();
+            let slug = slug.to_string();
+            tokio::task::spawn_blocking(move || -> Result<bool, SkillError> {
+                // Defensive: clean up if a path collision somehow occurred.
+                if tmp_dir.exists() {
+                    let _ = std::fs::remove_dir_all(&tmp_dir);
+                }
+                std::fs::create_dir_all(&tmp_dir)?;
 
-        // Detect content type and extract accordingly
-        let content_str = String::from_utf8_lossy(bytes);
-        let is_skillmd = content_str.trim_start().starts_with("---");
+                // Detect content type and extract accordingly
+                let content_str = String::from_utf8_lossy(&bytes);
+                let is_skillmd = content_str.trim_start().starts_with("---");
 
-        if is_skillmd {
-            let skill_md_path = resolve_skill_child_path(&tmp_dir, Path::new("SKILL.md"))?;
-            std::fs::write(skill_md_path, bytes)?;
-        } else if bytes.len() >= 4 && bytes[0] == 0x50 && bytes[1] == 0x4b {
-            // Zip archive — extract all files
-            let cursor = std::io::Cursor::new(bytes);
-            match zip::ZipArchive::new(cursor) {
-                Ok(mut archive) => {
-                    for i in 0..archive.len() {
-                        let mut file = match archive.by_index(i) {
-                            Ok(f) => f,
-                            Err(e) => {
-                                warn!(index = i, error = %e, "Skipping zip entry");
-                                continue;
+                if is_skillmd {
+                    let skill_md_path = resolve_skill_child_path(&tmp_dir, Path::new("SKILL.md"))?;
+                    std::fs::write(skill_md_path, &bytes)?;
+                } else if bytes.len() >= 4 && bytes[0] == 0x50 && bytes[1] == 0x4b {
+                    // Zip archive — extract all files
+                    let cursor = std::io::Cursor::new(&bytes);
+                    match zip::ZipArchive::new(cursor) {
+                        Ok(mut archive) => {
+                            for i in 0..archive.len() {
+                                let mut file = match archive.by_index(i) {
+                                    Ok(f) => f,
+                                    Err(e) => {
+                                        warn!(index = i, error = %e, "Skipping zip entry");
+                                        continue;
+                                    }
+                                };
+                                let Some(enclosed_name) = file.enclosed_name() else {
+                                    warn!("Skipping zip entry with unsafe path");
+                                    continue;
+                                };
+                                let out_path =
+                                    match resolve_skill_child_path(&tmp_dir, &enclosed_name) {
+                                        Ok(path) => path,
+                                        Err(e) => {
+                                            warn!(index = i, error = %e, "Skipping zip entry with unsafe path");
+                                            continue;
+                                        }
+                                    };
+                                if file.is_dir() {
+                                    std::fs::create_dir_all(&out_path)?;
+                                } else {
+                                    if let Some(parent) = out_path.parent() {
+                                        std::fs::create_dir_all(parent)?;
+                                    }
+                                    let mut out_file = std::fs::File::create(&out_path)?;
+                                    std::io::copy(&mut file, &mut out_file)?;
+                                }
                             }
-                        };
-                        let Some(enclosed_name) = file.enclosed_name() else {
-                            warn!("Skipping zip entry with unsafe path");
-                            continue;
-                        };
-                        let out_path = match resolve_skill_child_path(&tmp_dir, &enclosed_name) {
-                            Ok(path) => path,
-                            Err(e) => {
-                                warn!(index = i, error = %e, "Skipping zip entry with unsafe path");
-                                continue;
-                            }
-                        };
-                        if file.is_dir() {
-                            std::fs::create_dir_all(&out_path)?;
-                        } else {
-                            if let Some(parent) = out_path.parent() {
-                                std::fs::create_dir_all(parent)?;
-                            }
-                            let mut out_file = std::fs::File::create(&out_path)?;
-                            std::io::copy(&mut file, &mut out_file)?;
+                            info!(slug, entries = archive.len(), "Extracted skill zip");
+                        }
+                        Err(e) => {
+                            warn!(slug, error = %e, "Failed to read zip, saving raw");
+                            let zip_path =
+                                resolve_skill_child_path(&tmp_dir, Path::new("skill.zip"))?;
+                            std::fs::write(zip_path, &bytes)?;
                         }
                     }
-                    info!(slug, entries = archive.len(), "Extracted skill zip");
+                } else {
+                    let package_path =
+                        resolve_skill_child_path(&tmp_dir, Path::new("package.json"))?;
+                    std::fs::write(package_path, &bytes)?;
                 }
-                Err(e) => {
-                    warn!(slug, error = %e, "Failed to read zip, saving raw");
-                    let zip_path = resolve_skill_child_path(&tmp_dir, Path::new("skill.zip"))?;
-                    std::fs::write(zip_path, bytes)?;
-                }
-            }
-        } else {
-            let package_path = resolve_skill_child_path(&tmp_dir, Path::new("package.json"))?;
-            std::fs::write(package_path, bytes)?;
-        }
+                Ok(is_skillmd)
+            })
+            .await
+            .map_err(|e| {
+                SkillError::Io(std::io::Error::other(format!("extract task join: {e}")))
+            })??
+        };
 
         // Step 2-3: Detect format and convert (operate on tmp_dir throughout)
         let mut all_warnings = Vec::new();


### PR DESCRIPTION
## Summary

Cluster of blocking-IO-on-the-tokio-runtime defects. Several async handlers ran synchronous `std::fs` / zip work directly on tokio worker threads, stalling every other request scheduled on that worker for the duration (and, for the unbounded zip/PDF cases, enabling a single large input to monopolize a worker).

Closes #5887, closes #5888, closes #5889, closes #5890, closes #5891.

## Changes

| Site | Crate | Fix |
|------|-------|-----|
| `restore_backup` (#5887) | librefang-api | Open zip + manifest validation + decompress-and-write loop extracted into `restore_backup_blocking` dispatched via `spawn_blocking`, mirroring the existing `create_backup_blocking` pattern. The `!Send` `ErrorTranslator` is dropped before the `.await` and reconstructed per error branch. |
| `install_with_expected_sha256` (#5888) | librefang-skills | tmp-dir setup + zip extraction (unbounded per-entry decompress + writes) moved into `spawn_blocking`, returning `is_skillmd` for the downstream conversion. |
| `download_file_to_blocks` (#5889) | librefang-channels | `enrich_saved_file` (blocking `std::fs` read + CPU-bound `pdf_extract`) moved into `spawn_blocking`; best-effort fallback to no enrichment blocks on join failure. |
| `transcribe_audio` (#5890) | librefang-api | `std::fs` `create_dir_all`/`write`/`remove_file` → `tokio::fs` equivalents. |
| `upload_file` (#5891) | librefang-api | `std::fs` `create_dir_all`/`write` → `tokio::fs`. |

All are behavior-preserving offloads — no change to what is read/written, only where the blocking work runs.

## Verification

- `cargo check -p librefang-api -p librefang-skills -p librefang-channels --lib` — clean.
- `cargo clippy -p librefang-api -p librefang-skills -p librefang-channels --lib -- -D warnings` — clean.
- `cargo test -p librefang-api --test pairing_backup_extra_test` — 18 passed (exercises backup/restore round-trips).
- `cargo test -p librefang-channels --lib attachment_enrich` — 13 passed (`enrich_saved_file` logic unchanged).
