### PR TITLE
fix(audit): delimit all fields in the Merkle entry hash to close ambiguity

### DIFF
--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -152,10 +152,72 @@ pub struct AuditEntry {
 // Argument count exceeds clippy's default; folding the inputs into a
 // struct would either require building a temporary on every record/verify
 // call or change the on-disk hash inputs, both of which are strictly worse
-// than the readability cost of nine plain arguments. This is private and
-// purely additive — the previous six fields hash identically.
+// than the readability cost of nine plain arguments. As of the delimiter
+// fix this writes the v2 layout (all fields tagged); pre-fix entries are
+// verified via `compute_entry_hash_legacy`.
 #[allow(clippy::too_many_arguments)]
 fn compute_entry_hash(
+    seq: u64,
+    timestamp: &str,
+    agent_id: &str,
+    action: &AuditAction,
+    detail: &str,
+    outcome: &str,
+    user_id: Option<&UserId>,
+    channel: Option<&str>,
+    prev_hash: &str,
+) -> String {
+    // Every field is prefixed with a `\x1f`-delimited tag so byte content
+    // cannot be shifted across a field boundary without changing the digest.
+    // Without this, the free-form `agent_id` / `detail` / `outcome` strings
+    // were hashed back-to-back: `agent_id="a", detail="bc"` and
+    // `agent_id="ab", detail="c"` produced identical hashes, letting an
+    // attacker with `audit_entries` write access rewrite the field
+    // decomposition (e.g. reattribute an action to another agent) while
+    // keeping the stored hash — and thus the Merkle link — valid. The
+    // `user_id` / `channel` fields already used this scheme; this extends it
+    // to the original six. New entries are written with this (v2) layout;
+    // [`compute_entry_hash_legacy`] verifies entries written before the
+    // change (see `verify_integrity`).
+    let mut hasher = Sha256::new();
+    hasher.update(b"\x1fseq=");
+    hasher.update(seq.to_string().as_bytes());
+    hasher.update(b"\x1ftimestamp=");
+    hasher.update(timestamp.as_bytes());
+    hasher.update(b"\x1fagent_id=");
+    hasher.update(agent_id.as_bytes());
+    hasher.update(b"\x1faction=");
+    hasher.update(action.to_string().as_bytes());
+    hasher.update(b"\x1fdetail=");
+    hasher.update(detail.as_bytes());
+    hasher.update(b"\x1foutcome=");
+    hasher.update(outcome.as_bytes());
+    if let Some(uid) = user_id {
+        hasher.update(b"\x1fuser_id=");
+        hasher.update(uid.0.as_bytes());
+    }
+    if let Some(ch) = channel {
+        hasher.update(b"\x1fchannel=");
+        hasher.update(ch.as_bytes());
+    }
+    hasher.update(b"\x1fprev_hash=");
+    hasher.update(prev_hash.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Pre-delimiter (v1) hash layout: the original six fields concatenated with
+/// no separators, then the optionally-tagged `user_id` / `channel`, then a
+/// bare `prev_hash`. Retained only so `verify_integrity` can still validate
+/// entries written before the delimiter fix — never used to *write* new
+/// entries.
+///
+/// Falling back to this on verify does not weaken tamper-evidence: any edit
+/// that changes a stored hash still breaks the linked-list `prev_hash` chain
+/// (and, recomputed forward, the external anchor tip). The delimiter fix
+/// closes the one residual gap — a field reshuffle that left the hash
+/// unchanged — for every entry written under the v2 layout.
+#[allow(clippy::too_many_arguments)]
+fn compute_entry_hash_legacy(
     seq: u64,
     timestamp: &str,
     agent_id: &str,
@@ -832,7 +894,23 @@ impl AuditLog {
                 &entry.prev_hash,
             );
 
-            if recomputed != entry.hash {
+            // Accept the current (delimited, v2) layout, falling back to the
+            // pre-delimiter (v1) layout for entries written before the fix so
+            // an upgrade does not raise false tamper alarms on existing logs.
+            let matches = recomputed == entry.hash
+                || compute_entry_hash_legacy(
+                    entry.seq,
+                    &entry.timestamp,
+                    &entry.agent_id,
+                    &entry.action,
+                    &entry.detail,
+                    &entry.outcome,
+                    entry.user_id.as_ref(),
+                    entry.channel.as_deref(),
+                    &entry.prev_hash,
+                ) == entry.hash;
+
+            if !matches {
                 return Err(format!(
                     "hash mismatch at seq {}: expected {} but found {}",
                     entry.seq, recomputed, entry.hash

--- a/crates/librefang-runtime-audit/src/tests.rs
+++ b/crates/librefang-runtime-audit/src/tests.rs
@@ -1520,3 +1520,141 @@ fn audit_chain_holds_under_concurrent_record() {
         );
     }
 }
+
+#[test]
+fn delimited_hash_distinguishes_field_boundary_shifts() {
+    // The core fix: shifting bytes across the detail/outcome boundary (two
+    // adjacent free-form fields) must change the digest. Pre-fix (v1) these
+    // two decompositions collided — `detail="ab", outcome="c"` and
+    // `detail="a", outcome="bc"` both hashed "...abc..." — letting an
+    // attacker with audit_entries write access move text across the field
+    // boundary while keeping the stored hash (and thus the Merkle link) valid.
+    let v2_ab_c = compute_entry_hash(
+        1,
+        "2026-01-01T00:00:00Z",
+        "agent-1",
+        &AuditAction::ToolInvoke,
+        "ab",
+        "c",
+        None,
+        None,
+        "0",
+    );
+    let v2_a_bc = compute_entry_hash(
+        1,
+        "2026-01-01T00:00:00Z",
+        "agent-1",
+        &AuditAction::ToolInvoke,
+        "a",
+        "bc",
+        None,
+        None,
+        "0",
+    );
+    assert_ne!(
+        v2_ab_c, v2_a_bc,
+        "v2 must not collide across the detail/outcome split"
+    );
+
+    // Document the v1 weakness the fix addresses: legacy hashing DID collide.
+    let v1_ab_c = compute_entry_hash_legacy(
+        1,
+        "2026-01-01T00:00:00Z",
+        "agent-1",
+        &AuditAction::ToolInvoke,
+        "ab",
+        "c",
+        None,
+        None,
+        "0",
+    );
+    let v1_a_bc = compute_entry_hash_legacy(
+        1,
+        "2026-01-01T00:00:00Z",
+        "agent-1",
+        &AuditAction::ToolInvoke,
+        "a",
+        "bc",
+        None,
+        None,
+        "0",
+    );
+    assert_eq!(
+        v1_ab_c, v1_a_bc,
+        "legacy layout collided (this is the bug being fixed)"
+    );
+    // And v2 must differ from v1 for the same inputs (format actually changed).
+    assert_ne!(
+        v2_ab_c, v1_ab_c,
+        "v2 layout must differ from v1 for identical fields"
+    );
+}
+
+#[test]
+fn verify_integrity_accepts_legacy_hashed_entries() {
+    // An audit log written before the delimiter fix (rows hashed with the v1
+    // layout) must still verify after upgrade — no false tamper alarms.
+    let pool = Pool::builder()
+        .max_size(1)
+        .build(SqliteConnectionManager::memory())
+        .unwrap();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_entries (
+                seq INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                detail TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
+                prev_hash TEXT NOT NULL,
+                hash TEXT NOT NULL
+            )",
+        )
+        .unwrap();
+
+        // Two chained entries hashed with the LEGACY (v1) algorithm.
+        let genesis = "0".repeat(64);
+        let h0 = compute_entry_hash_legacy(
+            0,
+            "2026-01-01T00:00:00Z",
+            "agent-1",
+            &AuditAction::AgentSpawn,
+            "boot",
+            "ok",
+            None,
+            None,
+            &genesis,
+        );
+        let h1 = compute_entry_hash_legacy(
+            1,
+            "2026-01-01T00:00:01Z",
+            "agent-1",
+            &AuditAction::ShellExec,
+            "ls",
+            "ok",
+            None,
+            None,
+            &h0,
+        );
+        conn.execute(
+            "INSERT INTO audit_entries (seq, timestamp, agent_id, action, detail, outcome, user_id, channel, prev_hash, hash) VALUES (0,'2026-01-01T00:00:00Z','agent-1','AgentSpawn','boot','ok',NULL,NULL,?1,?2)",
+            rusqlite::params![genesis, h0],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO audit_entries (seq, timestamp, agent_id, action, detail, outcome, user_id, channel, prev_hash, hash) VALUES (1,'2026-01-01T00:00:01Z','agent-1','ShellExec','ls','ok',NULL,NULL,?1,?2)",
+            rusqlite::params![h0, h1],
+        )
+        .unwrap();
+    }
+
+    let log = AuditLog::with_db(pool.clone());
+    assert!(
+        log.verify_integrity().is_ok(),
+        "legacy-hashed entries must verify via the v1 fallback"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #5902.

`compute_entry_hash` fed `seq`, `timestamp`, `agent_id`, `action`, `detail`, `outcome` into SHA-256 back-to-back with no separators. Three are free-form (`agent_id`, `detail`, `outcome`), so adjacent fields could be re-split without changing the digest — `detail="ab", outcome="c"` and `detail="a", outcome="bc"` both hash `"...abc..."`. An attacker with `audit_entries` write access could rewrite an entry's field decomposition (move text out of `detail`, reattribute an action) while keeping the stored hash — and thus the Merkle link — valid, so `verify_integrity` still passed. The later `user_id` / `channel` fields already used `\x1f`-delimited tags; this extends the scheme to the original six (and `prev_hash`).

## Backward compatibility (no false tamper alarms on upgrade)

Changing the hash layout would normally invalidate every existing entry. To avoid that:

- `compute_entry_hash_legacy` preserves the exact pre-fix (v1) layout.
- `verify_integrity` accepts an entry whose stored hash matches **either** the new (v2) or legacy (v1) computation.
- New entries are always written with the delimited v2 layout.

The v1 fallback does not weaken tamper-evidence: any edit that changes a stored hash still breaks the linked-list `prev_hash` chain and, recomputed forward, the external anchor tip. The delimiter fix closes the one residual gap (a field reshuffle that left the hash unchanged) for every entry written under v2. No schema change.

## Verification

- `cargo test -p librefang-runtime-audit` — 33 passed, 0 failed (2 new).
- `cargo clippy -p librefang-runtime-audit --all-targets -- -D warnings` — clean.
- New tests: v2 distinguishes a `detail`/`outcome` boundary shift that v1 collided on; `verify_integrity` still accepts a chain of legacy-hashed rows loaded from SQLite.
