### PR TITLE
fix(api): enforce RBAC on session auth path; offload workflow template write

### DIFF
--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -210,6 +210,44 @@ fn user_role_allows_request(role: UserRole, method: &axum::http::Method, path: &
     false
 }
 
+/// Build the 403 response for an RBAC denial and record it in the audit log.
+///
+/// Shared by the session-token and per-user-API-key auth branches so both
+/// enforce `user_role_allows_request` identically — previously only the
+/// per-user-key branch gated, while a session token was trusted with no
+/// role check (latent: all sessions are Owner today, but a future
+/// SSO-mapped non-Owner session would have bypassed Owner-only writes).
+fn rbac_denied_response(
+    auth_state: &AuthState,
+    method: &axum::http::Method,
+    path: &str,
+    role: UserRole,
+    user_id: UserId,
+    lang: &'static str,
+) -> Response<Body> {
+    if let Some(ref audit) = auth_state.audit_log {
+        audit.record_with_context(
+            "system",
+            librefang_kernel::audit::AuditAction::PermissionDenied,
+            format!("{method} {path}"),
+            format!("role={role}"),
+            Some(user_id),
+            Some("api".to_string()),
+        );
+    }
+    Response::builder()
+        .status(StatusCode::FORBIDDEN)
+        .header("content-type", "application/json")
+        .header("content-language", lang)
+        .body(Body::from(
+            serde_json::json!({
+                "error": format!("Role '{role}' is not allowed to access this endpoint")
+            })
+            .to_string(),
+        ))
+        .unwrap_or_default()
+}
+
 /// Pull a caller-provided token from the standard locations the auth path
 /// understands. Precedence (matches the non-loopback flow at `auth(...)`):
 ///   1. `Authorization: Bearer <x>`
@@ -1449,6 +1487,16 @@ pub async fn auth(
             if let (Some(name), Some(role_str)) = (session.user_name, session.user_role) {
                 let role = UserRole::from_str_role(&role_str);
                 let user_id = UserId::from_name(&name);
+                // Enforce the same RBAC gate as the per-user-API-key branch:
+                // a session's role must be allowed to reach this endpoint.
+                if !user_role_allows_request(role, &method, path) {
+                    let lang = request
+                        .extensions()
+                        .get::<RequestLanguage>()
+                        .map(|rl| rl.0)
+                        .unwrap_or(i18n::DEFAULT_LANGUAGE);
+                    return rbac_denied_response(&auth_state, &method, path, role, user_id, lang);
+                }
                 request.extensions_mut().insert(AuthenticatedApiUser {
                     name,
                     role,
@@ -1465,41 +1513,23 @@ pub async fn auth(
             .cloned()
         {
             if !user_role_allows_request(user.role, &method, path) {
-                // RBAC M5: surface the denial in the hash-chained audit
-                // log so an operator can correlate 403s with the user
-                // who tripped them. Best-effort — we do not have a
-                // direct kernel handle in the middleware extension so
-                // we read it back via the `audit_log_handle` injected
-                // into AuthState at server build time.
-                if let Some(ref audit) = auth_state.audit_log {
-                    audit.record_with_context(
-                        "system",
-                        librefang_kernel::audit::AuditAction::PermissionDenied,
-                        format!("{} {}", method, path),
-                        format!("role={}", user.role),
-                        Some(user.user_id),
-                        Some("api".to_string()),
-                    );
-                }
+                // RBAC M5: `rbac_denied_response` surfaces the denial in the
+                // hash-chained audit log (best-effort via the `audit_log`
+                // handle injected into AuthState at server build time) and
+                // returns the localized 403. Shared with the session branch.
                 let lang = request
                     .extensions()
                     .get::<RequestLanguage>()
                     .map(|rl| rl.0)
                     .unwrap_or(i18n::DEFAULT_LANGUAGE);
-                return Response::builder()
-                    .status(StatusCode::FORBIDDEN)
-                    .header("content-type", "application/json")
-                    .header("content-language", lang)
-                    .body(Body::from(
-                        serde_json::json!({
-                            "error": format!(
-                                "Role '{}' is not allowed to access this endpoint",
-                                user.role
-                            )
-                        })
-                        .to_string(),
-                    ))
-                    .unwrap_or_default();
+                return rbac_denied_response(
+                    &auth_state,
+                    &method,
+                    path,
+                    user.role,
+                    user.user_id,
+                    lang,
+                );
             }
 
             request.extensions_mut().insert(AuthenticatedApiUser {

--- a/crates/librefang-api/src/routes/workflows.rs
+++ b/crates/librefang-api/src/routes/workflows.rs
@@ -2066,13 +2066,13 @@ pub async fn save_workflow_as_template(
 
     // Persist template to TOML file under the active kernel home directory.
     let templates_dir = state.kernel.home_dir().join("workflows").join("templates");
-    if let Err(e) = std::fs::create_dir_all(&templates_dir) {
+    if let Err(e) = tokio::fs::create_dir_all(&templates_dir).await {
         warn!("Failed to create templates directory: {e}");
     } else {
         let toml_path = templates_dir.join(format!("{}.toml", &template.id));
         match toml::to_string_pretty(&template) {
             Ok(toml_str) => {
-                if let Err(e) = std::fs::write(&toml_path, toml_str) {
+                if let Err(e) = tokio::fs::write(&toml_path, toml_str).await {
                     warn!(
                         path = %toml_path.display(),
                         "Failed to write template file: {e}"


### PR DESCRIPTION
## Summary

Two low-severity `librefang-api` fixes, plus a re-evaluated non-issue documented below.

Closes #5904, closes #5905.

## Changes

### RBAC gate on the session auth path (#5904)
The dashboard session-token branch in `middleware.rs` rebuilt `AuthenticatedApiUser` from the session's role and returned **without** calling `user_role_allows_request`, while the per-user-API-key branch did gate. Latent today (every session is minted as Owner), but the contract "session role is enforced at the HTTP layer" was false — a future SSO-mapped non-Owner session would have bypassed the Owner-only-write gate (config writes, user management, shutdown, TOTP enrollment).

- Extract the audit + localized 403 into a shared `rbac_denied_response` helper.
- Gate the session branch with `user_role_allows_request`, returning the helper on denial.
- The per-user-key branch now uses the same helper (de-dups the identical block).

### Offload workflow template write (#5905)
`save_workflow_as_template` did blocking `std::fs::create_dir_all` + `write` of the template TOML on the tokio runtime; switched to `tokio::fs`.

## Re-evaluated non-issue (no change)

The audit flagged an A2A-discover SSRF TOCTOU (the `is_url_safe_for_ssrf` pre-check resolves separately from the fetch). This is **not** exploitable: `A2aClient::discover` builds its client via `build_client_for_url`, which runs `check_ssrf` and `resolution.pin_dns(builder)` to pin the connection to the validated IPs (`crates/librefang-runtime/src/a2a.rs:947-983`, Bug #3563), with redirect `Policy::none()`. The resolution that connects is the one that is validated — there is no rebind window. The network.rs pre-check is redundant defense-in-depth.

## Verification

- `cargo check -p librefang-api --lib` — clean.
- `cargo clippy -p librefang-api --lib -- -D warnings` — clean.
- `cargo test -p librefang-api --lib middleware` — 60 passed.
- `cargo test -p librefang-api --test authz_routes_integration --test auth_public_allowlist` — 10 + 12 passed (no auth-flow regression).
