### PR TITLE
fix(dashboard): enable agent model Save on any field change (#5917)

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/agentModelPatch.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/agentModelPatch.test.ts
@@ -89,4 +89,36 @@ describe("buildModelConfigPatch", () => {
 
     expect(patch).toEqual({ provider: "anthropic", model: "claude-sonnet" });
   });
+
+  // temperature === 0 is the `??` vs `||` tripwire: with `|| MODEL_TEMPERATURE_DEFAULT`
+  // a persisted/explicit 0 collapses to 0.7 and these two assertions go red.
+  it("keeps an unchanged persisted temperature of 0 out of the patch", () => {
+    const persisted = { provider: "anthropic", model: "claude-sonnet", max_tokens: 4096, temperature: 0 };
+    const draft = seededDraft({ provider: "anthropic", model: "claude-sonnet", temperature: "0" });
+
+    const { patch } = buildModelConfigPatch(draft, persisted);
+
+    expect(patch).toEqual({});
+    expect(patch).not.toHaveProperty("temperature");
+  });
+
+  it("sends temperature: 0 when the user lowers an omitted (default 0.7) temperature to an explicit 0", () => {
+    // Backend omitted temperature, so the baseline is the default 0.7; "0" is a real change.
+    const persisted = { provider: "anthropic", model: "claude-sonnet" };
+    const draft = seededDraft({ provider: "anthropic", model: "claude-sonnet", temperature: "0" });
+
+    const { patch } = buildModelConfigPatch(draft, persisted);
+
+    expect(patch).toEqual({ temperature: 0 });
+  });
+
+  it("does not flag max_tokens as changed when the persisted value equals the default 4096", () => {
+    const persisted = { provider: "anthropic", model: "claude-sonnet", max_tokens: 4096, temperature: 0.7 };
+    const draft = seededDraft({ provider: "anthropic", model: "claude-sonnet" });
+
+    const { patch } = buildModelConfigPatch(draft, persisted);
+
+    expect(patch).toEqual({});
+    expect(patch).not.toHaveProperty("max_tokens");
+  });
 });

--- a/crates/librefang-api/dashboard/src/lib/agentModelPatch.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/agentModelPatch.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildModelConfigPatch,
+  MODEL_MAX_TOKENS_DEFAULT,
+  MODEL_TEMPERATURE_DEFAULT,
+} from "./agentModelPatch";
+
+// startModelEdit seeds the draft with these defaults when the backend omits
+// the field, so a draft that reflects "no user edit" carries the default string.
+const seededDraft = (over: Partial<{ provider: string; model: string; max_tokens: string; temperature: string }> = {}) => ({
+  provider: "anthropic",
+  model: "claude-sonnet",
+  max_tokens: String(MODEL_MAX_TOKENS_DEFAULT),
+  temperature: String(MODEL_TEMPERATURE_DEFAULT),
+  ...over,
+});
+
+describe("buildModelConfigPatch", () => {
+  it("provider-only change does NOT include max_tokens/temperature when backend omitted them (#5917 regression)", () => {
+    // Backend omits the optional fields; user only switches the provider/model.
+    const persisted = { provider: "openai", model: "gpt-4o" };
+    const draft = seededDraft({ provider: "anthropic", model: "claude-sonnet" });
+
+    const { patch } = buildModelConfigPatch(draft, persisted);
+
+    expect(patch).toEqual({ provider: "anthropic", model: "claude-sonnet" });
+    expect(patch).not.toHaveProperty("max_tokens");
+    expect(patch).not.toHaveProperty("temperature");
+  });
+
+  it("does not include max_tokens/temperature when the persisted value already equals the seeded default", () => {
+    const persisted = { provider: "openai", model: "gpt-4o", max_tokens: 4096, temperature: 0.7 };
+    const draft = seededDraft({ provider: "anthropic", model: "claude-sonnet" });
+
+    const { patch } = buildModelConfigPatch(draft, persisted);
+
+    expect(patch).toEqual({ provider: "anthropic", model: "claude-sonnet" });
+  });
+
+  it("includes a genuinely changed max_tokens", () => {
+    const persisted = { provider: "openai", model: "gpt-4o", max_tokens: 8000, temperature: 0.5 };
+    const draft = seededDraft({ provider: "openai", model: "gpt-4o", max_tokens: "12000", temperature: "0.5" });
+
+    const { patch } = buildModelConfigPatch(draft, persisted);
+
+    expect(patch).toEqual({ max_tokens: 12000 });
+  });
+
+  it("includes a genuinely changed temperature", () => {
+    const persisted = { provider: "openai", model: "gpt-4o", max_tokens: 8000, temperature: 0.5 };
+    const draft = seededDraft({ provider: "openai", model: "gpt-4o", max_tokens: "8000", temperature: "0.9" });
+
+    const { patch } = buildModelConfigPatch(draft, persisted);
+
+    expect(patch).toEqual({ temperature: 0.9 });
+  });
+
+  it("sends both provider and model together when either changes", () => {
+    const persisted = { provider: "openai", model: "gpt-4o", max_tokens: 4096, temperature: 0.7 };
+    const draft = seededDraft({ provider: "openai", model: "gpt-4o-mini" });
+
+    const { patch } = buildModelConfigPatch(draft, persisted);
+
+    expect(patch).toEqual({ provider: "openai", model: "gpt-4o-mini" });
+  });
+
+  it("returns no fields when nothing changed", () => {
+    const persisted = { provider: "openai", model: "gpt-4o", max_tokens: 4096, temperature: 0.7 };
+    const draft = seededDraft({ provider: "openai", model: "gpt-4o" });
+
+    const { patch } = buildModelConfigPatch(draft, persisted);
+
+    expect(patch).toEqual({});
+  });
+
+  it("returns null for invalid drafts", () => {
+    const persisted = { provider: "openai", model: "gpt-4o" };
+    expect(buildModelConfigPatch(seededDraft({ model: "" }), persisted).patch).toBeNull();
+    expect(buildModelConfigPatch(seededDraft({ max_tokens: "0" }), persisted).patch).toBeNull();
+    expect(buildModelConfigPatch(seededDraft({ temperature: "3" }), persisted).patch).toBeNull();
+    expect(buildModelConfigPatch(seededDraft({ max_tokens: "abc" }), persisted).patch).toBeNull();
+  });
+
+  it("treats an entirely-undefined persisted model as all-default baseline", () => {
+    // No model object at all: provider/model are the only real changes.
+    const draft = seededDraft({ provider: "anthropic", model: "claude-sonnet" });
+
+    const { patch } = buildModelConfigPatch(draft, undefined);
+
+    expect(patch).toEqual({ provider: "anthropic", model: "claude-sonnet" });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/agentModelPatch.ts
+++ b/crates/librefang-api/dashboard/src/lib/agentModelPatch.ts
@@ -1,0 +1,81 @@
+// Patch-builder for the agent "model" inline edit form on AgentsPage.
+//
+// AgentModelDetail.max_tokens / .temperature are optional: the backend omits
+// them when unset. startModelEdit seeds the draft with the same compiled
+// defaults the kernel uses (4096 / 0.7), so the persisted side MUST apply the
+// identical nullish defaults before comparing — otherwise a provider/model-only
+// edit would see the seeded default as a change and silently PATCH 4096 / 0.7
+// into an agent the user never touched. This module is the single source of
+// truth for that comparison baseline, shared by saveModelEdit and modelDirty's
+// regression test so the two cannot drift apart (the original #5917 defect).
+
+// Compiled kernel defaults surfaced in the edit form when the backend omits
+// the optional field. Keep in sync with the `?? 4096` / `?? 0.7` fallbacks in
+// AgentsPage's startModelEdit and modelDirty derivation.
+export const MODEL_MAX_TOKENS_DEFAULT = 4096;
+export const MODEL_TEMPERATURE_DEFAULT = 0.7;
+
+export interface PersistedModel {
+  provider?: string;
+  model?: string;
+  max_tokens?: number;
+  temperature?: number;
+}
+
+export interface ModelDraft {
+  provider: string;
+  model: string;
+  max_tokens: string;
+  temperature: string;
+}
+
+export interface ModelConfigPatch {
+  provider?: string;
+  model?: string;
+  max_tokens?: number;
+  temperature?: number;
+}
+
+export interface BuildModelConfigPatchResult {
+  /** null when the draft fails validation (caller should not submit). */
+  patch: ModelConfigPatch | null;
+}
+
+// Build the PATCH payload from the draft, including a field only when the user
+// actually changed it from its persisted (nullish-defaulted) value. Returns
+// `{ patch: null }` when the draft is invalid so the caller can bail without
+// re-implementing the validation.
+export function buildModelConfigPatch(
+  draft: ModelDraft,
+  persisted: PersistedModel | undefined,
+): BuildModelConfigPatchResult {
+  const trimmedProvider = draft.provider.trim();
+  const trimmedModel = draft.model.trim();
+  const parsedMaxTokens = parseInt(draft.max_tokens, 10);
+  const parsedTemperature = parseFloat(draft.temperature);
+
+  if (!trimmedProvider || !trimmedModel) return { patch: null };
+  if (isNaN(parsedMaxTokens) || parsedMaxTokens <= 0) return { patch: null };
+  if (isNaN(parsedTemperature) || parsedTemperature < 0 || parsedTemperature > 2) {
+    return { patch: null };
+  }
+
+  const patch: ModelConfigPatch = {};
+
+  const modelChanged = trimmedModel !== persisted?.model;
+  const providerChanged = trimmedProvider !== persisted?.provider;
+  if (modelChanged || providerChanged) {
+    patch.model = trimmedModel;
+    patch.provider = trimmedProvider;
+  }
+
+  // Same nullish-defaulted baseline as the modelDirty gate — see module doc.
+  if (parsedMaxTokens !== (persisted?.max_tokens ?? MODEL_MAX_TOKENS_DEFAULT)) {
+    patch.max_tokens = parsedMaxTokens;
+  }
+  if (parsedTemperature !== (persisted?.temperature ?? MODEL_TEMPERATURE_DEFAULT)) {
+    patch.temperature = parsedTemperature;
+  }
+
+  return { patch };
+}

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -702,6 +702,22 @@ export function AgentsPage() {
     [modelsQuery.data?.models, hiddenSet],
   );
 
+  // Single-model providers (e.g. a self-hosted Unsloth Studio endpoint that
+  // serves exactly one model) used to leave the Save button stuck disabled:
+  // switching provider clears modelDraft.model, and with only one option the
+  // user has nothing else to pick to repopulate it, so the !model.trim()
+  // validity gate never released. Auto-select the sole model so changing the
+  // provider (or any other field) is enough to enable Save. See #5917.
+  useEffect(() => {
+    if (!editingModel) return;
+    if (!modelDraft.provider.trim()) return;
+    if (modelsQuery.isLoading || modelDraft.model.trim()) return;
+    if (visibleModels.length === 1) {
+      const only = visibleModels[0].id;
+      setModelDraft(d => (d.model ? d : { ...d, model: only }));
+    }
+  }, [editingModel, modelDraft.provider, modelDraft.model, modelsQuery.isLoading, visibleModels]);
+
   const agents = agentsQuery.data?.agents ?? [];
   const visibleAgents = useMemo(
     () => showHandAgents ? agents : agents.filter(a => !a.is_hand),
@@ -755,15 +771,30 @@ export function AgentsPage() {
   const activeConfigMutation = detailAgent?.is_hand
     ? patchHandAgentRuntimeConfigMutation
     : patchAgentConfigMutation;
+  // Save enables when the draft is both valid AND differs from the persisted
+  // model in any field — Provider, Model, Max tokens, or Temperature. Earlier
+  // this gate checked validity only; combined with the provider-switch model
+  // reset that produced the #5917 symptom where Max-token / Temperature edits
+  // never lit Save. draftMaxTokens / draftTemperature mirror saveModelEdit's
+  // coercion so the dirty comparison matches what would actually be PATCHed.
+  const draftMaxTokens = parseInt(modelDraft.max_tokens, 10);
+  const draftTemperature = parseFloat(modelDraft.temperature);
+  const modelValid =
+    !!modelDraft.provider.trim()
+    && !!modelDraft.model.trim()
+    && !isNaN(draftMaxTokens)
+    && draftMaxTokens > 0
+    && !isNaN(draftTemperature)
+    && draftTemperature >= 0
+    && draftTemperature <= 2;
+  const currentModel = detailAgent?.model;
+  const modelDirty =
+    modelDraft.provider.trim() !== (currentModel?.provider ?? "")
+    || modelDraft.model.trim() !== (currentModel?.model ?? "")
+    || draftMaxTokens !== (currentModel?.max_tokens ?? 4096)
+    || draftTemperature !== (currentModel?.temperature ?? 0.7);
   const saveModelDisabled =
-    activeConfigMutation.isPending
-    || !modelDraft.provider.trim()
-    || !modelDraft.model.trim()
-    || isNaN(parseInt(modelDraft.max_tokens, 10))
-    || parseInt(modelDraft.max_tokens, 10) <= 0
-    || isNaN(parseFloat(modelDraft.temperature))
-    || parseFloat(modelDraft.temperature) < 0
-    || parseFloat(modelDraft.temperature) > 2;
+    activeConfigMutation.isPending || !modelValid || !modelDirty;
 
   const selectAgent = async (agent: AgentItem) => {
     setAgentTab("conversation");

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -27,6 +27,7 @@ import { useUIStore } from "../lib/store";
 import { toastErr } from "../lib/errors";
 import { filterVisible } from "../lib/hiddenModels";
 import { Search, Users, MessageCircle, X, Cpu, Wrench, Shield, Plus, Loader2, Pause, Play, Clock, Brain, Zap, FlaskConical, Trash2, Copy, RotateCcw, Pencil, Bot, Database, FileText, MoreHorizontal, Sparkles, ChevronDown, Check } from "lucide-react";
+import { buildModelConfigPatch, MODEL_MAX_TOKENS_DEFAULT, MODEL_TEMPERATURE_DEFAULT } from "../lib/agentModelPatch";
 import { truncateId } from "../lib/string";
 import { pickLatestSessionId } from "../lib/sessionSelector";
 import { getStatusVariant } from "../lib/status";
@@ -286,8 +287,8 @@ export function AgentsPage() {
     setModelDraft({
       provider: detailAgent?.model?.provider ?? "",
       model: detailAgent?.model?.model ?? "",
-      max_tokens: String(detailAgent?.model?.max_tokens ?? 4096),
-      temperature: String(detailAgent?.model?.temperature ?? 0.7),
+      max_tokens: String(detailAgent?.model?.max_tokens ?? MODEL_MAX_TOKENS_DEFAULT),
+      temperature: String(detailAgent?.model?.temperature ?? MODEL_TEMPERATURE_DEFAULT),
     });
     setEditingModel(true);
   }
@@ -421,27 +422,13 @@ export function AgentsPage() {
 
   function saveModelEdit() {
     if (!detailAgent) return;
-    const current = detailAgent.model;
-    const patch: { max_tokens?: number; model?: string; provider?: string; temperature?: number } = {};
-
-    const trimmedProvider = modelDraft.provider.trim();
-    const trimmedModel = modelDraft.model.trim();
-    const parsedMaxTokens = parseInt(modelDraft.max_tokens, 10);
-    const parsedTemperature = parseFloat(modelDraft.temperature);
-
-    if (!trimmedProvider || !trimmedModel) return;
-    if (isNaN(parsedMaxTokens) || parsedMaxTokens <= 0) return;
-    if (isNaN(parsedTemperature) || parsedTemperature < 0 || parsedTemperature > 2) return;
-
-    const modelChanged = trimmedModel !== current?.model;
-    const providerChanged = trimmedProvider !== current?.provider;
-
-    if (modelChanged || providerChanged) {
-      patch.model = trimmedModel;
-      patch.provider = trimmedProvider;
-    }
-    if (parsedMaxTokens !== current?.max_tokens) patch.max_tokens = parsedMaxTokens;
-    if (parsedTemperature !== current?.temperature) patch.temperature = parsedTemperature;
+    // buildModelConfigPatch validates the draft and includes a field only when
+    // the user changed it from its persisted (nullish-defaulted) value, using
+    // the same 4096 / 0.7 baseline as the modelDirty gate so the two can't drift
+    // (the #5917 follow-up: a provider-only edit must not write back defaults
+    // for max_tokens / temperature the backend had omitted).
+    const { patch } = buildModelConfigPatch(modelDraft, detailAgent.model);
+    if (!patch) return;
 
     if (Object.keys(patch).length === 0) {
       setEditingModel(false);
@@ -791,8 +778,8 @@ export function AgentsPage() {
   const modelDirty =
     modelDraft.provider.trim() !== (currentModel?.provider ?? "")
     || modelDraft.model.trim() !== (currentModel?.model ?? "")
-    || draftMaxTokens !== (currentModel?.max_tokens ?? 4096)
-    || draftTemperature !== (currentModel?.temperature ?? 0.7);
+    || draftMaxTokens !== (currentModel?.max_tokens ?? MODEL_MAX_TOKENS_DEFAULT)
+    || draftTemperature !== (currentModel?.temperature ?? MODEL_TEMPERATURE_DEFAULT);
   const saveModelDisabled =
     activeConfigMutation.isPending || !modelValid || !modelDirty;
 


### PR DESCRIPTION
## Problem

Closes #5917.

In the dashboard agent-detail model editor (Agents page → agent detail → Model card → edit), the **Save** button stayed disabled for any change other than the model dropdown.
Changing **Provider**, **Max tokens**, or **Temperature** did not enable Save, making it impossible to apply changes for a provider that serves only one model (e.g. a self-hosted Unsloth Studio endpoint).

### Root cause

`AgentsPage.tsx` had two interacting issues:

- The Provider `<select>` `onChange` clears `modelDraft.model` (`model: ""`) whenever the provider changes, by design — but the Model `<select>` never auto-selects when a provider exposes exactly one model.
  So for a single-model provider the model field stayed empty.
- The `saveModelDisabled` gate checked field **validity** only and included `!modelDraft.model.trim()`.
  With `model` stuck empty, that clause kept Save disabled, and the user had no second option to pick to repopulate it.

The combined effect: switching to a single-model provider, or editing only Max tokens / Temperature after a provider switch, left Save permanently disabled.

## Change

`crates/librefang-api/dashboard/src/pages/AgentsPage.tsx` only:

- **Auto-select the sole model** via a `useEffect`: when the model editor is open, a provider is chosen, models have loaded, and exactly one model is visible while `modelDraft.model` is empty, populate it.
  This directly unblocks single-model providers.
- **Recast the Save gate** from validity-only to validity **AND** dirtiness.
  `modelDirty` compares the draft against the persisted model across Provider / Model / Max tokens / Temperature (using the same `4096` / `0.7` baselines as `startModelEdit` and the same int/float coercion as `saveModelEdit`).
  Save now lights when any one of the four fields changes, and a no-op edit stays disabled.

No data-layer changes — the existing `patchAgentConfigMutation` / `patchHandAgentRuntimeConfigMutation` hooks are untouched, so the dashboard queries/mutations rule still holds.

### Before / after

- Disabled condition before: `isPending || !provider || !model || invalid(max_tokens) || invalid(temperature)` — validity only, and model could be wedged empty.
- Disabled condition after: `isPending || !modelValid || !modelDirty` — valid and actually changed; plus the single-model auto-select keeps `model` populated.

## Verification

Dashboard (`crates/librefang-api/dashboard`, pnpm):

- `pnpm typecheck` — clean.
- `pnpm exec eslint src/pages/AgentsPage.tsx` — no new warnings (the 2 remaining are pre-existing, unrelated lines).
- `pnpm test` — full suite shows the same 747 passed / 13 failed both with and without this change; the 13 failures are a pre-existing jsdom `localStorage`/zustand-persist isolation flake in `ApprovalsPage.test.tsx`, not introduced here.

`AgentsPage` has no colocated test harness today (no `AgentsPage.test.tsx`), and the change is a pure derivation over existing draft state.
A live UI smoke against a single-model provider is the remaining human check.
