### PR TITLE
refactor(runtime): migrate read_artifact to ToolError (error-contracts slice 2)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/artifact.rs
+++ b/crates/librefang-runtime/src/tool_runner/artifact.rs
@@ -113,12 +113,21 @@ mod tests {
 
     #[tokio::test]
     async fn read_artifact_missing_artifact_surfaces_as_upstream() {
-        // A well-formed but nonexistent handle: the lookup failure inside
-        // `artifact_store::read` (still `Result<_, String>`) is lifted onto the
-        // `Upstream` variant verbatim, not flattened into `Internal`.
+        // A well-formed but nonexistent handle (passes `ArtifactHandle::parse`'s
+        // `sha256:` + 64-hex check, then misses `path.exists()`): the not-found
+        // lookup failure inside `artifact_store::read` (still `Result<_, String>`)
+        // is lifted onto the `Upstream` variant verbatim, not flattened into
+        // `Internal`. Asserting the message keeps this on the not-found path —
+        // a bare-prefix handle would short-circuit in `parse` and exercise a
+        // different error entirely while still matching `Upstream`.
         let dir = std::env::temp_dir();
-        let r =
-            tool_read_artifact(&json!({"handle": "art_0000000000000000000000000000"}), &dir).await;
-        assert!(matches!(r, Err(ToolError::Upstream { .. })));
+        let handle = "sha256:".to_string() + &"0".repeat(64);
+        let r = tool_read_artifact(&json!({ "handle": handle }), &dir).await;
+        match r {
+            Err(ToolError::Upstream { message, .. }) => {
+                assert!(message.contains("not found"), "got: {message}");
+            }
+            other => panic!("expected ToolError::Upstream, got: {other:?}"),
+        }
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/artifact.rs
+++ b/crates/librefang-runtime/src/tool_runner/artifact.rs
@@ -1,4 +1,11 @@
 //! Artifact retrieval tool (#3347).
+//!
+//! Migrated from `Result<String, String>` to `Result<String, ToolError>`
+//! (#3576, slice 2). Completes the slice — `event` / `goal` / `sandbox` /
+//! `system` were already typed; this was the last `Result<String, String>`
+//! return in the group.
+
+use super::error::{ToolError, ToolResult};
 
 /// Implementation of the `read_artifact` tool.
 ///
@@ -8,34 +15,40 @@
 pub(super) async fn tool_read_artifact(
     input: &serde_json::Value,
     artifact_dir: &std::path::Path,
-) -> Result<String, String> {
+) -> ToolResult {
     let handle = input["handle"]
         .as_str()
-        .ok_or("Missing required parameter 'handle'")?;
+        .ok_or(ToolError::MissingParameter("handle"))?;
 
     let offset: usize = match input.get("offset") {
-        Some(v) => v
-            .as_u64()
-            .ok_or_else(|| "Parameter 'offset' must be a non-negative integer".to_string())
-            .and_then(|n| {
-                usize::try_from(n)
-                    .map_err(|_| "Parameter 'offset' is too large for this platform".to_string())
-            })?,
+        Some(v) => {
+            let n = v.as_u64().ok_or(ToolError::InvalidParameter {
+                name: "offset",
+                reason: "must be a non-negative integer".into(),
+            })?;
+            usize::try_from(n).map_err(|_| ToolError::InvalidParameter {
+                name: "offset",
+                reason: "is too large for this platform".into(),
+            })?
+        }
         None => 0,
     };
 
     let length: usize = match input.get("length") {
         Some(v) => {
-            let n = v
-                .as_u64()
-                .ok_or_else(|| "Parameter 'length' must be a non-negative integer".to_string())
-                .and_then(|n| {
-                    usize::try_from(n).map_err(|_| {
-                        "Parameter 'length' is too large for this platform".to_string()
-                    })
-                })?;
+            let n = v.as_u64().ok_or(ToolError::InvalidParameter {
+                name: "length",
+                reason: "must be a non-negative integer".into(),
+            })?;
+            let n = usize::try_from(n).map_err(|_| ToolError::InvalidParameter {
+                name: "length",
+                reason: "is too large for this platform".into(),
+            })?;
             if n == 0 {
-                return Err("Parameter 'length' must be greater than 0".to_string());
+                return Err(ToolError::InvalidParameter {
+                    name: "length",
+                    reason: "must be greater than 0".into(),
+                });
             }
             n
         }
@@ -50,7 +63,8 @@ pub(super) async fn tool_read_artifact(
         crate::artifact_store::read(&handle_owned, offset, length, &dir_owned)
     })
     .await
-    .map_err(|e| format!("read_artifact task panicked: {e}"))??;
+    .map_err(|e| ToolError::Internal(format!("read_artifact task panicked: {e}")))?
+    .map_err(ToolError::upstream_msg)?;
 
     if bytes.is_empty() {
         return Ok(format!(
@@ -63,4 +77,48 @@ pub(super) async fn tool_read_artifact(
         "[read_artifact: {handle} | offset={offset} | {} bytes read]\n{text}",
         bytes.len()
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn read_artifact_without_handle_returns_missing_parameter() {
+        let dir = std::env::temp_dir();
+        let r = tool_read_artifact(&json!({}), &dir).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("handle"))));
+    }
+
+    #[tokio::test]
+    async fn read_artifact_non_integer_offset_returns_invalid_parameter() {
+        let dir = std::env::temp_dir();
+        let r = tool_read_artifact(&json!({"handle": "h", "offset": "nope"}), &dir).await;
+        assert!(matches!(
+            r,
+            Err(ToolError::InvalidParameter { name: "offset", .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_artifact_zero_length_returns_invalid_parameter() {
+        let dir = std::env::temp_dir();
+        let r = tool_read_artifact(&json!({"handle": "h", "length": 0}), &dir).await;
+        assert!(matches!(
+            r,
+            Err(ToolError::InvalidParameter { name: "length", .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_artifact_missing_artifact_surfaces_as_upstream() {
+        // A well-formed but nonexistent handle: the lookup failure inside
+        // `artifact_store::read` (still `Result<_, String>`) is lifted onto the
+        // `Upstream` variant verbatim, not flattened into `Internal`.
+        let dir = std::env::temp_dir();
+        let r =
+            tool_read_artifact(&json!({"handle": "art_0000000000000000000000000000"}), &dir).await;
+        assert!(matches!(r, Err(ToolError::Upstream { .. })));
+    }
 }

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1320,9 +1320,12 @@ pub async fn execute_tool_raw(
 
         // Artifact retrieval tool — recovers content spilled to disk by the
         // artifact store when a tool result exceeded `spill_threshold_bytes`.
+        // (#3576: returns Result<String, ToolError>)
         "read_artifact" => {
             let artifact_dir = crate::artifact_store::default_artifact_storage_dir();
-            tool_read_artifact(input, &artifact_dir).await
+            tool_read_artifact(input, &artifact_dir)
+                .await
+                .map_err(|e| e.to_string())
         }
 
         // Canvas / A2UI tool (#3576: returns Result<String, ToolError>)

--- a/crates/librefang-runtime/src/tool_runner/tests/skills.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/skills.rs
@@ -652,8 +652,15 @@ async fn read_artifact_nonexistent_returns_error() {
     let fake = "sha256:".to_string() + &"b".repeat(64);
     let input = serde_json::json!({ "handle": fake });
     let result = tool_read_artifact(&input, dir.path()).await;
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("not found"));
+    // A well-formed but nonexistent handle: the lookup failure inside
+    // `artifact_store::read` is lifted verbatim onto the `Upstream` variant,
+    // carrying the original "artifact not found: …" message.
+    match result {
+        Err(crate::tool_runner::error::ToolError::Upstream { message, .. }) => {
+            assert!(message.contains("not found"), "got: {message}");
+        }
+        other => panic!("expected ToolError::Upstream, got: {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -661,8 +668,12 @@ async fn read_artifact_missing_handle_returns_error() {
     let dir = tempfile::TempDir::new().unwrap();
     let input = serde_json::json!({});
     let result = tool_read_artifact(&input, dir.path()).await;
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("handle"));
+    assert!(matches!(
+        result,
+        Err(crate::tool_runner::error::ToolError::MissingParameter(
+            "handle"
+        ))
+    ));
 }
 
 #[tokio::test]

--- a/docs/architecture/error-contracts.md
+++ b/docs/architecture/error-contracts.md
@@ -245,10 +245,16 @@ Smallest-blast-radius first. Each module is independently reviewable.
 
 1. **`tool_runner/cron.rs`** — 3 fns, 9 sites, 1 caller (`dispatch.rs`).
    The canonical first migration. **Done in this PR.**
-2. **`tool_runner/{event,artifact,goal,spill,notify,sandbox,system}.rs`** —
+2. **`tool_runner/{event,artifact,goal,sandbox,system}.rs`** —
    small, mostly-pure (no kernel handle plumbing beyond `require_kernel`).
+   **Done.** `spill.rs` / `notify.rs` were named in an earlier draft of this
+   list but never returned `Result<String, String>` — `spill.rs` is pure
+   config plumbing and `notify.rs` returns the unrelated
+   `librefang_types::tool::ToolResult` response struct, so neither is in this
+   migration's scope.
 3. **`tool_runner/{memory,a2a,task,process}.rs`** — kernel-handle-heavy, need
-   the `From<LibreFangError>` impl exercised.
+   the `From<LibreFangError>` impl exercised. Only `memory.rs` remains;
+   `a2a` / `task` / `process` are already typed.
 4. **`tool_runner/{shell,knowledge,image,meta,canvas,wiki,web_legacy,hand}.rs`** —
    the long tail. Each PR migrates one file + adds tests.
 5. **`tool_runner/{fs,dispatch}.rs`** — last, because `dispatch.rs` is the


### PR DESCRIPTION
## What

Migrates `tool_read_artifact` (`read_artifact` tool) from `Result<String, String>` to the typed `ToolResult` / `ToolError`, completing **slice 2** of the error-contracts migration tracked by #3576 and `docs/architecture/error-contracts.md`.

This was the last `Result<String, String>` return in the slice-2 group; `event.rs`, `goal.rs`, `sandbox.rs`, and `system.rs` were already typed in earlier slices.

## Changes

- `crates/librefang-runtime/src/tool_runner/artifact.rs` — `tool_read_artifact` now returns `ToolResult`, mapping each former string error onto an existing `ToolError` variant:
  - missing `handle` → `MissingParameter("handle")`
  - non-integer / out-of-range `offset`, non-integer / out-of-range / zero `length` → `InvalidParameter { name, reason }`
  - `spawn_blocking` join panic → `Internal`
  - `artifact_store::read` lookup failure → `Upstream` (message preserved verbatim — the store layer is still `Result<_, String>` and belongs to a deeper slice)
- `crates/librefang-runtime/src/tool_runner/dispatch.rs` — the `read_artifact` arm gains the same `.map_err(|e| e.to_string())` boundary shim every already-migrated arm uses, so the change does not cascade to the remaining sites.
- `docs/architecture/error-contracts.md` — corrects the migration order:
  - slice 2 marked **Done**; `spill.rs` / `notify.rs` removed from the slice-2 list (they never returned `Result<String, String>` — `spill.rs` is config plumbing, `notify.rs` returns `librefang_types::tool::ToolResult`, an unrelated response struct).
  - slice 3 annotated: only `memory.rs` remains; `a2a` / `task` / `process` are already typed on main.

## Tests

Four unit tests added in `artifact.rs` (none existed before), pinning each error path to its variant:

- `read_artifact_without_handle_returns_missing_parameter`
- `read_artifact_non_integer_offset_returns_invalid_parameter`
- `read_artifact_zero_length_returns_invalid_parameter`
- `read_artifact_missing_artifact_surfaces_as_upstream`

## Verification

Run in the repo's sanctioned `Dockerfile.rust-dev` image (named volumes, isolated from the host `target/`):

- `cargo fmt -p librefang-runtime -- --check` → **pass** (`FMT_OK`).
- `cargo clippy -p librefang-runtime --lib` / `cargo test -p librefang-runtime --lib tool_runner::artifact` could not complete **in the container only**: the image is `aarch64-unknown-linux-gnu` and the build hits a pre-existing, unrelated error in `plugin_runtime.rs:973` (`libc::SYS_getpgrp` is an x86-only legacy syscall constant, absent on aarch64-linux). That line is unchanged from `origin/main` and is outside this PR's scope. CI compiles `librefang-runtime` on **x86_64 Ubuntu**, where `SYS_getpgrp` resolves, so the clippy + test lanes are authoritative there.

The change is mechanical: it reuses `ToolError` variants exactly as the sibling `event.rs` / `sandbox.rs` files already do, plus the established dispatch-shim pattern.

## Scope

Partial — one slice of a multi-PR migration. `Refs #3576`, not `Closes`. The remaining ~177 sites continue under the umbrella issue per the order in `error-contracts.md`.

Refs #3576
