### PR TITLE
test(api): regression test for #5857 Windows provider-key path validation

### DIFF
--- a/crates/librefang-api/src/routes/skills.rs
+++ b/crates/librefang-api/src/routes/skills.rs
@@ -6611,6 +6611,56 @@ mod tests {
             "secrets.env must not be created on validation error"
         );
     }
+
+    /// Regression for #5857: on Windows the dashboard "save provider key"
+    /// action failed with `unsafe path 'C:\Users\root\.librefang\secrets.env'`.
+    /// `validate_static_file_path` (the gate on every secrets.env / config.toml
+    /// write) used to reject `Component::Prefix(_)` alongside `ParentDir`, and a
+    /// Windows absolute path always carries a drive-letter prefix — so every
+    /// legitimate, server-constructed `home_dir().join("secrets.env")` tripped
+    /// the check. PR #1770 narrowed the rejection to `ParentDir` only; this
+    /// asserts the drive-letter prefix is accepted so the rejection cannot be
+    /// re-added without failing the Windows CI shard.
+    #[cfg(windows)]
+    #[test]
+    fn validate_static_file_path_accepts_windows_drive_prefix() {
+        let path = std::path::Path::new(r"C:\Users\root\.librefang\secrets.env");
+        // Sanity: the host parser really does emit a drive-letter prefix here,
+        // otherwise the assertion below would pass vacuously.
+        assert!(
+            path.components()
+                .any(|c| matches!(c, std::path::Component::Prefix(_))),
+            "test precondition: Windows path must carry a Component::Prefix",
+        );
+        assert!(
+            validate_static_file_path(path, "secrets.env").is_ok(),
+            "a server-constructed Windows absolute secrets.env path must validate; \
+             rejecting Component::Prefix re-introduces #5857",
+        );
+    }
+
+    /// Platform-independent companion to the #5857 guard above. The Windows
+    /// `Prefix` component is unreachable on a Unix test host, but the contract —
+    /// "reject `..`, accept everything else for the fixed filename" — is the
+    /// same on every platform and must hold for the boot-time path shape the
+    /// daemon actually constructs (`home_dir().join("secrets.env")`).
+    #[test]
+    fn validate_static_file_path_rejects_parent_dir_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let good = tmp.path().join("secrets.env");
+        assert!(
+            validate_static_file_path(&good, "secrets.env").is_ok(),
+            "an absolute, traversal-free secrets.env path must validate",
+        );
+
+        let traversal = tmp.path().join("..").join("secrets.env");
+        let err = validate_static_file_path(&traversal, "secrets.env")
+            .expect_err("a `..` component must be rejected");
+        assert!(
+            err.contains("unsafe path"),
+            "rejection message should flag the unsafe path, got: {err}",
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes #5857.

The issue reports that on Windows the dashboard "configure provider key" action (search `zhipu`, save key) fails with:

```
Failed to write secrets.env: unsafe path 'C:\Users\root\.librefang\secrets.env'
```

### Root cause

`validate_static_file_path` (`crates/librefang-api/src/routes/skills.rs`) — the shared gate on every secrets and `config.toml` write path (`set_provider_key`, the registry catalog save, and `config/set`) — used to reject `Component::Prefix(_)` alongside `Component::ParentDir`.
Every Windows absolute path carries a drive-letter prefix (`C:`), so the legitimate, server-constructed `home_dir().join(...)` write target was rejected on every save.

**The behavioral fix already landed** in PR #1770 (`51a05581`, 2026-03-28), which narrowed the rejection to `ParentDir` only.
All three validation sites (`skills.rs`, `config.rs`, `providers.rs`) currently allow drive-letter prefixes on `main`.

The reporter's binary is version `2026.3.2201` — a build from ~2026-03-22, which falls inside the buggy window (after #1260 introduced the check on 2026-03-20, before #1770 fixed it on 2026-03-28).
The commit hash they pasted (`edd19966`, 2026-05-29) is the latest `main` commit they viewed, not what their installed binary was built from.
Upgrading past the 2026-03-28 fix resolves the report.

### What this PR adds

PR #1770 shipped the fix but added **no test**, leaving the contract unguarded against re-introduction (a future "security hardening" could re-add the `Prefix(_)` rejection and silently break Windows again).
No existing test invokes `validate_static_file_path` at all.

Two regression tests on that helper:

- `validate_static_file_path_accepts_windows_drive_prefix` (`#[cfg(windows)]`) reproduces #5857 exactly: a `C:\Users\root\.librefang\secrets.env` path carrying a real `Component::Prefix("C:")` must validate.
  Runs on the Windows CI shard; would have caught the original regression.
- `validate_static_file_path_rejects_parent_dir_only` is the platform-independent companion: a traversal-free absolute path is accepted, a `..` component is rejected with the `unsafe path` message.

The Windows assertion is `#[cfg(windows)]`-gated because on a Unix host the same string parses as a single `Normal` component with no drive prefix — verified empirically.

## Verification

- `validate_static_file_path` logic and the test assertions were validated with a standalone mirror compiled under the repo dev image (`Dockerfile.rust-dev`): traversal-free path accepted, `..` rejected with `unsafe path`, and `C:\...` confirmed to carry no `Prefix` component on Unix (so the Windows assertion is correctly gated).
- `rustfmt --check` on the edited file shows zero diffs in the added region (lines 6000–6999).
- The full `librefang-api` crate could not be compiled on the local aarch64 dev image due to a pre-existing, unrelated `libc::SYS_getpgrp` error in `librefang-runtime` on aarch64 (CI runs x86_64 Linux + a Windows shard, where both new tests compile and run). The change is confined to a test module in `librefang-api`.
