### PR TITLE
fix(kernel): empty mcp_servers = [] grants no MCP tools, not all (#5855)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1731,21 +1731,21 @@
         "filename": "crates/librefang-kernel/src/kernel/tests.rs",
         "hashed_secret": "86a1932a93c72239442f6cd6296f4eb28d8a1730",
         "is_verified": false,
-        "line_number": 7864
+        "line_number": 7938
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-kernel/src/kernel/tests.rs",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 8999
+        "line_number": 9073
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-kernel/src/kernel/tests.rs",
         "hashed_secret": "96133e4265d7a277409c8094e5eff6a41934cf07",
         "is_verified": false,
-        "line_number": 10028
+        "line_number": 10102
       }
     ],
     "crates/librefang-kernel/src/mcp_oauth_provider.rs": [
@@ -4065,5 +4065,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T10:36:19Z"
+  "generated_at": "2026-05-30T23:15:36Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -600,14 +600,14 @@
         "filename": "crates/librefang-api/src/routes/agents.rs",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 7562
+        "line_number": 7589
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/src/routes/agents.rs",
         "hashed_secret": "4835254aab9494e03d8b72e816719a4914612587",
         "is_verified": false,
-        "line_number": 7571
+        "line_number": 7598
       }
     ],
     "crates/librefang-api/src/routes/config.rs": [
@@ -1731,21 +1731,21 @@
         "filename": "crates/librefang-kernel/src/kernel/tests.rs",
         "hashed_secret": "86a1932a93c72239442f6cd6296f4eb28d8a1730",
         "is_verified": false,
-        "line_number": 7716
+        "line_number": 7864
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-kernel/src/kernel/tests.rs",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 8851
+        "line_number": 8999
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-kernel/src/kernel/tests.rs",
         "hashed_secret": "96133e4265d7a277409c8094e5eff6a41934cf07",
         "is_verified": false,
-        "line_number": 9880
+        "line_number": 10028
       }
     ],
     "crates/librefang-kernel/src/mcp_oauth_provider.rs": [
@@ -4065,5 +4065,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T10:19:39Z"
+  "generated_at": "2026-05-30T10:36:19Z"
 }

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -381,7 +381,7 @@
       "skills_search_placeholder": "Search installed skills…",
       "mcp_servers": "MCP Servers",
       "mcp_servers_placeholder": "Empty = all connected servers",
-      "mcp_servers_hint": "Empty = all configured MCP servers available.",
+      "mcp_servers_hint": "Empty = no MCP servers exposed. [\"*\"] = all connected servers. A named list = only those servers.",
       "mcp_servers_search_placeholder": "Search MCP servers…",
       "live_toml": "Live TOML Preview",
       "preview_toml": "TOML",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -381,7 +381,7 @@
       "skills_search_placeholder": "搜索已安装的技能…",
       "mcp_servers": "MCP 服务器",
       "mcp_servers_placeholder": "留空=可用全部已连接服务器",
-      "mcp_servers_hint": "留空=可使用全部已配置 MCP 服务器。",
+      "mcp_servers_hint": "留空=不暴露任何 MCP 服务器；[\"*\"]=全部已连接服务器；命名列表=仅这些服务器。",
       "mcp_servers_search_placeholder": "搜索 MCP 服务器…",
       "live_toml": "TOML 实时预览",
       "preview_toml": "TOML",

--- a/crates/librefang-api/src/routes/agents.rs
+++ b/crates/librefang-api/src/routes/agents.rs
@@ -2891,7 +2891,7 @@ pub async fn get_agent(
             "skills_disabled": entry.manifest.skills_disabled,
             "tools_disabled": entry.manifest.tools_disabled,
             "mcp_servers": entry.manifest.mcp_servers,
-            "mcp_servers_mode": if entry.manifest.mcp_servers.is_empty() { "all" } else { "allowlist" },
+            "mcp_servers_mode": mcp_servers_mode(&entry.manifest.mcp_servers),
             "fallback_models": entry.manifest.fallback_models,
             "auto_evolve": entry.manifest.auto_evolve,
             "web_search_augmentation": entry.manifest.web_search_augmentation,
@@ -4457,11 +4457,7 @@ pub async fn get_agent_mcp_servers(
             }
         }
     }
-    let mode = if entry.manifest.mcp_servers.is_empty() {
-        "all"
-    } else {
-        "allowlist"
-    };
+    let mode = mcp_servers_mode(&entry.manifest.mcp_servers);
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -5647,6 +5643,21 @@ fn skill_assignment_mode(manifest: &librefang_types::agent::AgentManifest) -> &'
     if manifest.skills_disabled {
         "none"
     } else if manifest.skills.is_empty() {
+        "all"
+    } else {
+        "allowlist"
+    }
+}
+
+/// Classify an agent's MCP server allowlist for display (#5855).
+///
+/// Mirrors the kernel semantics in `available_tools`: an empty list grants
+/// **no** MCP servers, `["*"]` grants all connected servers, anything else is
+/// a literal allowlist.
+fn mcp_servers_mode(mcp_servers: &[String]) -> &'static str {
+    if mcp_servers.is_empty() {
+        "none"
+    } else if mcp_servers.iter().any(|s| s == "*") {
         "all"
     } else {
         "allowlist"
@@ -7207,6 +7218,22 @@ mod tests {
         assert!(cloned.skills_disabled);
         assert_eq!(skill_assignment_mode(&cloned), "none");
         assert!(!cloned.tools.is_empty());
+    }
+
+    #[test]
+    fn test_mcp_servers_mode_classification() {
+        // #5855: empty allowlist is "none" (no servers), not "all".
+        assert_eq!(mcp_servers_mode(&[]), "none");
+        assert_eq!(mcp_servers_mode(&["*".to_string()]), "all");
+        assert_eq!(
+            mcp_servers_mode(&["server-a".to_string(), "*".to_string()]),
+            "all",
+            "a wildcard anywhere in the list means all servers"
+        );
+        assert_eq!(
+            mcp_servers_mode(&["server-a".to_string(), "server-b".to_string()]),
+            "allowlist"
+        );
     }
 
     #[test]

--- a/crates/librefang-api/tests/agents_capabilities_files_integration.rs
+++ b/crates/librefang-api/tests/agents_capabilities_files_integration.rs
@@ -545,8 +545,8 @@ async fn test_skills_unknown_name_rejected_4xx() {
     );
 }
 
-/// MCP servers: setting an empty allowlist (= all servers) succeeds and reads
-/// back as empty with mode "all".
+/// MCP servers: setting an empty allowlist (= no servers, #5855) succeeds and
+/// reads back as empty with mode "none".
 #[tokio::test(flavor = "multi_thread")]
 async fn test_mcp_servers_set_empty_then_read_round_trip() {
     let h = boot().await;
@@ -576,8 +576,8 @@ async fn test_mcp_servers_set_empty_then_read_round_trip() {
         "GET must reflect the empty allowlist: {body:?}"
     );
     assert_eq!(
-        body["mode"], "all",
-        "empty allowlist means all servers: {body:?}"
+        body["mode"], "none",
+        "empty allowlist means no MCP servers (#5855): {body:?}"
     );
 }
 

--- a/crates/librefang-api/tests/mcp_tools_list_allowlist_test.rs
+++ b/crates/librefang-api/tests/mcp_tools_list_allowlist_test.rs
@@ -96,6 +96,13 @@ fn register_agent_with_filters(
         description: "agent for /mcp tools/list filter regression".to_string(),
         author: "test".to_string(),
         module: "builtin:chat".to_string(),
+        // Opt into every connected MCP server. Since #5855, `mcp_servers = []`
+        // (the manifest default) means "no MCP servers", so the seeded MCP
+        // tools would be hidden before `tool_allowlist`/`tool_blocklist` ever
+        // ran. `["*"]` is the explicit "all servers" opt-in — this test
+        // exercises the tool-level filters, not the server allowlist, so the
+        // agent must see the full MCP catalogue first.
+        mcp_servers: vec!["*".to_string()],
         tool_allowlist: allowlist.iter().map(|s| s.to_string()).collect(),
         tool_blocklist: blocklist.iter().map(|s| s.to_string()).collect(),
         ..Default::default()

--- a/crates/librefang-cli/src/tui/screens/agents.rs
+++ b/crates/librefang-cli/src/tui/screens/agents.rs
@@ -1188,8 +1188,13 @@ fn draw_detail(f: &mut Frame, area: Rect, state: &AgentSelectState) {
                 ]));
             }
 
-            // MCP section
-            if detail.mcp_servers.is_empty() || detail.mcp_servers_mode == "all" {
+            // MCP section (#5855: empty allowlist = no servers, `["*"]` = all)
+            if detail.mcp_servers.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("  MCP:      "),
+                    Span::styled("[None]", Style::default().fg(theme::DIM)),
+                ]));
+            } else if detail.mcp_servers_mode == "all" {
                 lines.push(Line::from(vec![
                     Span::raw("  MCP:      "),
                     Span::styled("[All servers]", Style::default().fg(theme::GREEN)),

--- a/crates/librefang-kernel/src/kernel/mcp_summary.rs
+++ b/crates/librefang-kernel/src/kernel/mcp_summary.rs
@@ -4,9 +4,13 @@
 //! it without instantiating a full kernel.
 
 /// Build a deterministic cache key for the per-agent MCP allowlist; sorts and joins with `\x1f` so insertion-order variants share one entry.
+///
+/// An empty allowlist means "no MCP servers" (#5855), not "all"; it gets its
+/// own sentinel key so it never shares a cache slot with the explicit `["*"]`
+/// wildcard (which keys to `*`).
 pub(super) fn mcp_summary_cache_key(mcp_allowlist: &[String]) -> String {
     if mcp_allowlist.is_empty() {
-        return String::from("*");
+        return String::from("\x1fnone\x1f");
     }
     let mut sorted = mcp_allowlist.to_vec();
     sorted.sort();
@@ -36,6 +40,13 @@ pub(super) fn render_mcp_summary(
         return String::new();
     }
 
+    // #5855: an empty allowlist means "no MCP servers", so the agent's prompt
+    // must not advertise any. `["*"]` is the explicit "all servers" opt-in.
+    if mcp_allowlist.is_empty() {
+        return String::new();
+    }
+    let wildcard = mcp_allowlist.iter().any(|s| s == "*");
+
     let normalized: Vec<String> = mcp_allowlist
         .iter()
         .map(|s| librefang_runtime::mcp::normalize_name(s))
@@ -50,7 +61,7 @@ pub(super) fn render_mcp_summary(
             configured_servers.iter().map(String::as_str),
         ) {
             let normalized_server = librefang_runtime::mcp::normalize_name(server_name);
-            if !mcp_allowlist.is_empty() && !normalized.iter().any(|n| n == &normalized_server) {
+            if !wildcard && !normalized.iter().any(|n| n == &normalized_server) {
                 continue;
             }
             if let Some(raw_tool_name) =

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -5963,9 +5963,49 @@ fn mcp_disabled_false_preserves_mcp_tools() {
 // opted into any MCP server saw the union of all servers' tools, attempted to
 // call them, and the streaming loop exited after 3 consecutive tool failures.
 
-/// Register one tool each for two distinct global MCP servers, then assert the
-/// per-allowlist MCP tool set an agent with `mcp_servers = allowlist` resolves.
-fn mcp_tool_names_for_allowlist(test_name: &str, allowlist: Vec<String>) -> Vec<String> {
+/// Register a server name into the kernel's `effective_mcp_servers` snapshot
+/// so `resolve_mcp_server_from_known` can map a namespaced tool name back to
+/// its real owning server — the exact path `available_tools` and
+/// `render_mcp_summary` both take. Mirrors `seed_mcp_server` in
+/// `crates/librefang-api/tests/system_tools_sessions_test.rs`.
+fn register_mcp_server(kernel: &LibreFangKernel, server_name: &str) {
+    let entry = librefang_types::config::McpServerConfigEntry {
+        name: server_name.to_string(),
+        template_id: None,
+        transport: None,
+        timeout_secs: 30,
+        env: Vec::new(),
+        headers: Vec::new(),
+        oauth: None,
+        taint_scanning: true,
+        taint_policy: None,
+    };
+    kernel
+        .mcp
+        .effective_mcp_servers
+        .write()
+        .expect("effective_mcp_servers write lock not poisoned")
+        .push(entry);
+}
+
+/// Boot a kernel that has `servers` connected (registered in
+/// `effective_mcp_servers`) and `tools` in the global MCP tool map, spawn an
+/// agent with `mcp_servers = allowlist`, and return the agent's resolved MCP
+/// tool names.
+///
+/// Registering the servers — not just pushing tools — is load-bearing: the
+/// named-allowlist filter resolves each tool to its *real* owning server via
+/// `effective_mcp_servers`, then compares that server name to the allowlist by
+/// exact equality. An earlier revision resolved tools against the allowlist
+/// directly, which prefix-matched `mcp_server_x_*` under a `["server"]`
+/// allowlist; seeding the real servers here is what lets the test exercise the
+/// correct, summary-consistent algorithm.
+fn mcp_tool_names_for_servers(
+    test_name: &str,
+    servers: &[&str],
+    tools: &[&str],
+    allowlist: Vec<String>,
+) -> Vec<String> {
     let tmp = tempfile::tempdir().unwrap();
     let home = tmp.path().join(test_name);
     std::fs::create_dir_all(home.join("data")).unwrap();
@@ -5987,18 +6027,18 @@ fn mcp_tool_names_for_allowlist(test_name: &str, allowlist: Vec<String>) -> Vec<
     };
     let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
 
+    for server in servers {
+        register_mcp_server(&kernel, server);
+    }
     {
-        let mut tools = kernel.tools_ref().lock().unwrap();
-        tools.push(librefang_types::tool::ToolDefinition {
-            name: "mcp_server_x_do_thing".to_string(),
-            description: String::new(),
-            input_schema: serde_json::json!({}),
-        });
-        tools.push(librefang_types::tool::ToolDefinition {
-            name: "mcp_server_y_other_thing".to_string(),
-            description: String::new(),
-            input_schema: serde_json::json!({}),
-        });
+        let mut tool_guard = kernel.tools_ref().lock().unwrap();
+        for tool in tools {
+            tool_guard.push(librefang_types::tool::ToolDefinition {
+                name: (*tool).to_string(),
+                description: String::new(),
+                input_schema: serde_json::json!({}),
+            });
+        }
     }
     kernel
         .mcp
@@ -6013,6 +6053,17 @@ fn mcp_tool_names_for_allowlist(test_name: &str, allowlist: Vec<String>) -> Vec<
         .collect();
     kernel.shutdown();
     names
+}
+
+/// Register one tool each for two distinct global MCP servers, then assert the
+/// per-allowlist MCP tool set an agent with `mcp_servers = allowlist` resolves.
+fn mcp_tool_names_for_allowlist(test_name: &str, allowlist: Vec<String>) -> Vec<String> {
+    mcp_tool_names_for_servers(
+        test_name,
+        &["server_x", "server_y"],
+        &["mcp_server_x_do_thing", "mcp_server_y_other_thing"],
+        allowlist,
+    )
 }
 
 #[test]
@@ -6055,6 +6106,29 @@ fn explicit_mcp_servers_allowlist_filters_to_named_servers() {
         names,
         vec!["mcp_server_x_do_thing".to_string()],
         "mcp_servers = [\"server_x\"] must expose only server_x tools; got: {names:?}"
+    );
+}
+
+#[test]
+fn named_allowlist_does_not_leak_prefix_overlapping_server() {
+    // Prefix-collision regression: server `server` and server `server_x` share
+    // the `mcp_server_` namespace prefix. An agent allowlisting only `server`
+    // must NOT see `server_x`'s tools. Resolving each tool against the agent's
+    // allowlist directly (rather than the connected-server set) would make
+    // `mcp_server_x_bar` prefix-match `mcp_server_` and leak — a narrower
+    // recurrence of the #5855 cross-agent leak. `explicit_*` above uses
+    // server_x/server_y, whose prefixes do not overlap, so it cannot catch this.
+    let names = mcp_tool_names_for_servers(
+        "librefang-mcp-prefix-overlap-5855",
+        &["server", "server_x"],
+        &["mcp_server_foo", "mcp_server_x_bar"],
+        vec!["server".to_string()],
+    );
+    assert_eq!(
+        names,
+        vec!["mcp_server_foo".to_string()],
+        "mcp_servers = [\"server\"] must expose only server's tools, never the \
+         prefix-overlapping server_x; got: {names:?}"
     );
 }
 

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -5665,7 +5665,8 @@ fn mcp_summary_is_byte_identical_across_input_orders() {
         "mcp_filesystem_list_directory".to_string(),
     ];
 
-    let allowlist: Vec<String> = Vec::new();
+    // `["*"]` = all servers; exercises the multi-server render path (#5855).
+    let allowlist: Vec<String> = vec!["*".to_string()];
     let summary_a = super::render_mcp_summary(&order_a, &configured, &allowlist);
     let summary_b = super::render_mcp_summary(&order_b, &configured, &allowlist);
 
@@ -5694,7 +5695,7 @@ fn mcp_summary_inner_tool_list_is_sorted() {
         "mcp_github_close_pr".to_string(),
     ];
 
-    let allowlist: Vec<String> = Vec::new();
+    let allowlist: Vec<String> = vec!["*".to_string()];
     let summary = super::render_mcp_summary(&tools, &configured, &allowlist);
 
     // The inner list joined with ", " must appear in alphabetical order.
@@ -5725,7 +5726,15 @@ fn mcp_summary_cache_key_is_order_independent() {
         super::mcp_summary_cache_key(&order_b),
         "cache key must be insertion-order-independent"
     );
-    assert_eq!(super::mcp_summary_cache_key(&[]), "*");
+    // #5855: empty allowlist ("no servers") gets its own sentinel key, distinct
+    // from the explicit `["*"]` wildcard ("all servers", keyed `*`).
+    assert_eq!(super::mcp_summary_cache_key(&[]), "\x1fnone\x1f");
+    assert_eq!(super::mcp_summary_cache_key(&["*".to_string()]), "*");
+    assert_ne!(
+        super::mcp_summary_cache_key(&[]),
+        super::mcp_summary_cache_key(&["*".to_string()]),
+        "empty (none) and [\"*\"] (all) must not collide in the summary cache"
+    );
 }
 
 #[test]
@@ -5748,6 +5757,9 @@ fn available_tools_mcp_section_is_sorted_across_connect_orders() {
         description: "agent for mcp order regression".to_string(),
         author: "test".to_string(),
         module: "builtin:chat".to_string(),
+        // `["*"]` opts into all servers so this test exercises the multi-server
+        // sort path; an empty allowlist now means "no MCP tools" (#5855).
+        mcp_servers: vec!["*".to_string()],
         ..Default::default()
     };
     let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
@@ -5906,6 +5918,8 @@ fn mcp_disabled_false_preserves_mcp_tools() {
         author: "test".to_string(),
         module: "builtin:chat".to_string(),
         mcp_disabled: false,
+        // `["*"]` = all servers; empty would now yield zero MCP tools (#5855).
+        mcp_servers: vec!["*".to_string()],
         ..Default::default()
     };
     let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
@@ -5938,6 +5952,136 @@ fn mcp_disabled_false_preserves_mcp_tools() {
     kernel.shutdown();
 }
 
+// ─── mcp_servers allowlist semantics (#5855) ──────────────────────────────
+//
+// Empty `mcp_servers = []` must NOT leak every globally-connected server's
+// tools into the agent. The field is a real allowlist:
+//   []        → zero MCP tools
+//   ["*"]     → all connected servers
+//   ["a"]     → only server `a`
+// Before #5855 the empty case was read as a wildcard, so an agent that never
+// opted into any MCP server saw the union of all servers' tools, attempted to
+// call them, and the streaming loop exited after 3 consecutive tool failures.
+
+/// Register one tool each for two distinct global MCP servers, then assert the
+/// per-allowlist MCP tool set an agent with `mcp_servers = allowlist` resolves.
+fn mcp_tool_names_for_allowlist(test_name: &str, allowlist: Vec<String>) -> Vec<String> {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join(test_name);
+    std::fs::create_dir_all(home.join("data")).unwrap();
+    let cfg = KernelConfig {
+        home_dir: home.clone(),
+        data_dir: home.join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(cfg).expect("kernel should boot");
+
+    let manifest = AgentManifest {
+        name: "allowlist-agent".to_string(),
+        description: "agent under mcp_servers allowlist test".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        mcp_disabled: false,
+        mcp_servers: allowlist,
+        ..Default::default()
+    };
+    let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
+
+    {
+        let mut tools = kernel.tools_ref().lock().unwrap();
+        tools.push(librefang_types::tool::ToolDefinition {
+            name: "mcp_server_x_do_thing".to_string(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+        });
+        tools.push(librefang_types::tool::ToolDefinition {
+            name: "mcp_server_y_other_thing".to_string(),
+            description: String::new(),
+            input_schema: serde_json::json!({}),
+        });
+    }
+    kernel
+        .mcp
+        .mcp_generation
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+    let names: Vec<String> = kernel
+        .available_tools(agent_id)
+        .iter()
+        .filter(|t| t.name.starts_with("mcp_"))
+        .map(|t| t.name.clone())
+        .collect();
+    kernel.shutdown();
+    names
+}
+
+#[test]
+fn empty_mcp_servers_yields_no_mcp_tools() {
+    // The core leak: an unconfigured agent (mcp_servers = []) must see ZERO
+    // MCP tools even though two servers are connected globally.
+    let names = mcp_tool_names_for_allowlist("librefang-mcp-empty-allowlist-5855", vec![]);
+    assert!(
+        names.is_empty(),
+        "mcp_servers = [] must expose no MCP tools (#5855); leaked: {names:?}"
+    );
+}
+
+#[test]
+fn wildcard_mcp_servers_yields_all_mcp_tools() {
+    // ["*"] is the explicit opt-in to all connected servers.
+    let mut names = mcp_tool_names_for_allowlist(
+        "librefang-mcp-wildcard-allowlist-5855",
+        vec!["*".to_string()],
+    );
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "mcp_server_x_do_thing".to_string(),
+            "mcp_server_y_other_thing".to_string(),
+        ],
+        "mcp_servers = [\"*\"] must expose every connected server's tools (#5855)"
+    );
+}
+
+#[test]
+fn explicit_mcp_servers_allowlist_filters_to_named_servers() {
+    // ["server_x"] selects only server_x's tools — server_y stays hidden.
+    let names = mcp_tool_names_for_allowlist(
+        "librefang-mcp-named-allowlist-5855",
+        vec!["server_x".to_string()],
+    );
+    assert_eq!(
+        names,
+        vec!["mcp_server_x_do_thing".to_string()],
+        "mcp_servers = [\"server_x\"] must expose only server_x tools; got: {names:?}"
+    );
+}
+
+#[test]
+fn empty_mcp_allowlist_renders_empty_summary() {
+    // The prompt summary must mirror the tool list: an empty allowlist
+    // advertises no MCP servers, so the agent's prompt never names tools it
+    // cannot call (#5855).
+    let configured = vec!["filesystem".to_string(), "github".to_string()];
+    let tools = vec![
+        "mcp_filesystem_read_file".to_string(),
+        "mcp_github_create_issue".to_string(),
+    ];
+    let empty: Vec<String> = Vec::new();
+    assert_eq!(
+        super::render_mcp_summary(&tools, &configured, &empty),
+        "",
+        "empty mcp_servers must render an empty MCP summary (#5855)"
+    );
+    // Sanity: the same tools under `["*"]` DO render a non-empty summary.
+    let wildcard = vec!["*".to_string()];
+    assert!(
+        !super::render_mcp_summary(&tools, &configured, &wildcard).is_empty(),
+        "mcp_servers = [\"*\"] must render a non-empty summary"
+    );
+}
+
 #[test]
 fn mcp_disabled_hot_reload_takes_effect_without_respawn() {
     // After toggling mcp_disabled from false → true in a live manifest,
@@ -5961,6 +6105,8 @@ fn mcp_disabled_hot_reload_takes_effect_without_respawn() {
         author: "test".to_string(),
         module: "builtin:chat".to_string(),
         mcp_disabled: false,
+        // `["*"]` = all servers; empty would now yield zero MCP tools (#5855).
+        mcp_servers: vec!["*".to_string()],
         ..Default::default()
     };
     let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
@@ -6053,7 +6199,9 @@ fn mcp_disabled_produces_empty_mcp_summary() {
         "mcp_filesystem_read_file".to_string(),
         "mcp_github_create_issue".to_string(),
     ];
-    let allowlist: Vec<String> = Vec::new();
+    // `["*"]` = all servers; an empty allowlist would now render "" (#5855),
+    // which would defeat the "enabled produces non-empty summary" sanity check.
+    let allowlist: Vec<String> = vec!["*".to_string()];
 
     // Helper that mirrors the call-site gate exactly:
     //   `if mcp_tool_count > 0 && !mcp_disabled { build_mcp_summary(...) } else { "" }`

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -184,8 +184,10 @@ impl LibreFangKernel {
         }
 
         // Step 3: Add MCP tools (filtered by agent's MCP server allowlist,
-        // then by declared tools). Skip entirely when MCP is disabled.
-        if !mcp_disabled {
+        // then by declared tools). Skip entirely when MCP is disabled, or when
+        // the allowlist is empty — an empty list grants no servers (#5855), so
+        // there is nothing to add and no need to lock the global MCP tool map.
+        if !mcp_disabled && !mcp_allowlist.is_empty() {
             if let Ok(mcp_tools) = self.mcp.mcp_tools.lock() {
                 let configured_servers: Vec<String> = self
                     .mcp
@@ -193,7 +195,18 @@ impl LibreFangKernel {
                     .read()
                     .map(|servers| servers.iter().map(|s| s.name.clone()).collect())
                     .unwrap_or_default();
-                let mut mcp_candidates: Vec<ToolDefinition> = if mcp_allowlist.is_empty() {
+                // MCP allowlist semantics (#5855): the empty case is handled by
+                // the early `!mcp_allowlist.is_empty()` guard above (zero tools),
+                // so here the list is non-empty.
+                //   ["*"]        → all connected MCP servers (explicit opt-in).
+                //   ["a", "b"]   → only servers a and b.
+                // `mcp_tools` is a single global Vec populated by every connected
+                // server, so the previous "empty == wildcard" reading leaked one
+                // agent's servers into every other agent's prompt.
+                let mut mcp_candidates: Vec<ToolDefinition> = if mcp_allowlist
+                    .iter()
+                    .any(|s| s == "*")
+                {
                     mcp_tools.iter().cloned().collect()
                 } else {
                     let normalized: Vec<String> = mcp_allowlist

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -189,12 +189,6 @@ impl LibreFangKernel {
         // there is nothing to add and no need to lock the global MCP tool map.
         if !mcp_disabled && !mcp_allowlist.is_empty() {
             if let Ok(mcp_tools) = self.mcp.mcp_tools.lock() {
-                let configured_servers: Vec<String> = self
-                    .mcp
-                    .effective_mcp_servers
-                    .read()
-                    .map(|servers| servers.iter().map(|s| s.name.clone()).collect())
-                    .unwrap_or_default();
                 // MCP allowlist semantics (#5855): the empty case is handled by
                 // the early `!mcp_allowlist.is_empty()` guard above (zero tools),
                 // so here the list is non-empty.
@@ -203,33 +197,30 @@ impl LibreFangKernel {
                 // `mcp_tools` is a single global Vec populated by every connected
                 // server, so the previous "empty == wildcard" reading leaked one
                 // agent's servers into every other agent's prompt.
-                let mut mcp_candidates: Vec<ToolDefinition> = if mcp_allowlist
-                    .iter()
-                    .any(|s| s == "*")
-                {
-                    mcp_tools.iter().cloned().collect()
-                } else {
-                    let normalized: Vec<String> = mcp_allowlist
-                        .iter()
-                        .map(|s| librefang_runtime::mcp::normalize_name(s))
-                        .collect();
-                    mcp_tools
-                        .iter()
-                        .filter(|t| {
-                            librefang_runtime::mcp::resolve_mcp_server_from_known(
-                                &t.name,
-                                configured_servers.iter().map(String::as_str),
-                            )
-                            .map(|server| {
-                                let normalized_server =
-                                    librefang_runtime::mcp::normalize_name(server);
-                                normalized.iter().any(|n| n == &normalized_server)
+                let mut mcp_candidates: Vec<ToolDefinition> =
+                    if mcp_allowlist.iter().any(|s| s == "*") {
+                        mcp_tools.iter().cloned().collect()
+                    } else {
+                        // Resolve each tool's owning server against the agent's
+                        // own allowlist (not the global `effective_mcp_servers`
+                        // list). The allowlist is the authority for which servers
+                        // this agent may see, so filtering off it stays correct
+                        // even before/while server registration syncs — and
+                        // `resolve_mcp_server_from_known` longest-prefix matching
+                        // keeps `["server"]` from swallowing `server_x`'s tools.
+                        let allow: Vec<&str> = mcp_allowlist.iter().map(String::as_str).collect();
+                        mcp_tools
+                            .iter()
+                            .filter(|t| {
+                                librefang_runtime::mcp::resolve_mcp_server_from_known(
+                                    &t.name,
+                                    allow.iter().copied(),
+                                )
+                                .is_some()
                             })
-                            .unwrap_or(false)
-                        })
-                        .cloned()
-                        .collect()
-                };
+                            .cloned()
+                            .collect()
+                    };
                 // Sort MCP tools by name so connect / hot-reload order does not
                 // mutate the prompt prefix and invalidate provider cache (#3765).
                 mcp_candidates.sort_by(|a, b| a.name.cmp(&b.name));

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -201,22 +201,42 @@ impl LibreFangKernel {
                     if mcp_allowlist.iter().any(|s| s == "*") {
                         mcp_tools.iter().cloned().collect()
                     } else {
-                        // Resolve each tool's owning server against the agent's
-                        // own allowlist (not the global `effective_mcp_servers`
-                        // list). The allowlist is the authority for which servers
-                        // this agent may see, so filtering off it stays correct
-                        // even before/while server registration syncs — and
-                        // `resolve_mcp_server_from_known` longest-prefix matching
-                        // keeps `["server"]` from swallowing `server_x`'s tools.
-                        let allow: Vec<&str> = mcp_allowlist.iter().map(String::as_str).collect();
+                        // Resolve each tool to its *real* owning server using the
+                        // set of connected servers, then compare that server name
+                        // against the allowlist by exact (normalized) equality.
+                        // This mirrors `render_mcp_summary` exactly so the tool
+                        // list and the prompt's MCP summary never disagree.
+                        //
+                        // Resolving against the allowlist directly would be wrong:
+                        // `resolve_mcp_server_from_known` is a `mcp_{name}_` prefix
+                        // match, and its longest-prefix disambiguation only kicks
+                        // in when both `server` and `server_x` are in the candidate
+                        // set. With the allowlist (`["server"]`) as the candidate
+                        // set, `mcp_server_x_bar` would prefix-match `mcp_server_`
+                        // and leak server_x's tools into a server-scoped agent.
+                        let configured_servers: Vec<String> = self
+                            .mcp
+                            .effective_mcp_servers
+                            .read()
+                            .map(|servers| servers.iter().map(|s| s.name.clone()).collect())
+                            .unwrap_or_default();
+                        let normalized: Vec<String> = mcp_allowlist
+                            .iter()
+                            .map(|s| librefang_runtime::mcp::normalize_name(s))
+                            .collect();
                         mcp_tools
                             .iter()
                             .filter(|t| {
                                 librefang_runtime::mcp::resolve_mcp_server_from_known(
                                     &t.name,
-                                    allow.iter().copied(),
+                                    configured_servers.iter().map(String::as_str),
                                 )
-                                .is_some()
+                                .map(|server| {
+                                    let normalized_server =
+                                        librefang_runtime::mcp::normalize_name(server);
+                                    normalized.iter().any(|n| n == &normalized_server)
+                                })
+                                .unwrap_or(false)
                             })
                             .cloned()
                             .collect()

--- a/crates/librefang-types/src/agent.rs
+++ b/crates/librefang-types/src/agent.rs
@@ -1091,7 +1091,17 @@ pub struct AgentManifest {
     /// Explicitly disable all skills, overriding the empty-list = all-skills default.
     #[serde(default)]
     pub skills_disabled: bool,
-    /// MCP server allowlist (empty = all connected MCP servers available).
+    /// MCP server allowlist.
+    ///
+    /// - `[]` (empty / unset) → **no** MCP servers. The agent sees zero MCP
+    ///   tools and the MCP server summary is omitted from its prompt. This is
+    ///   a real allowlist, not a wildcard — an unconfigured agent must not
+    ///   silently inherit every globally-connected server's tools (#5855).
+    /// - `["*"]` → all connected MCP servers (explicit opt-in).
+    /// - `["a", "b"]` → only servers `a` and `b`.
+    ///
+    /// Use [`Self::mcp_disabled`] to additionally guarantee no MCP tools even
+    /// if `["*"]` or a non-empty list is set.
     #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
     pub mcp_servers: Vec<String>,
     /// Channel allowlist — restricts which configured channels this agent can
@@ -1100,7 +1110,9 @@ pub struct AgentManifest {
     #[serde(default, deserialize_with = "crate::serde_compat::vec_lenient")]
     pub channels: Vec<String>,
     /// Explicitly disable all MCP server tools for this agent. Mirrors
-    /// `skills_disabled` — `mcp_servers = []` means "all", this means "none".
+    /// `skills_disabled`. Since #5855, `mcp_servers = []` already means "no
+    /// servers", so this flag is the belt-and-braces guarantee: it forces zero
+    /// MCP tools even when `mcp_servers = ["*"]` or a non-empty allowlist is set.
     ///
     /// **Scope**: this flag hides MCP tools and the MCP server summary from
     /// *this agent's* LLM prompt only. MCP servers defined in `KernelConfig`

--- a/docs/src/app/agent/templates/page.mdx
+++ b/docs/src/app/agent/templates/page.mdx
@@ -444,7 +444,7 @@ tool_allowlist = ["web_search", "web_fetch", "file_read", "file_write"]
 tool_blocklist = ["shell_exec"]
 tools_disabled = false             # explicit master kill-switch — overrides everything else
 allowed_plugins = ["truncate", "redact"]   # plugin names; empty = all available plugins
-mcp_servers    = ["github", "linear"]     # MCP server names; empty = all connected servers
+mcp_servers    = ["github", "linear"]     # MCP server names; empty = no servers, ["*"] = all connected
 skills_disabled = false            # explicit master kill-switch for skills
 ```
 
@@ -454,7 +454,7 @@ skills_disabled = false            # explicit master kill-switch for skills
 | `tool_blocklist` | `Vec<string>` | `[]` | Tools this agent **may not** call. Applied **after** `tool_allowlist` so a name on both lists is denied. |
 | `tools_disabled` | bool | `false` | Master kill-switch — when `true`, the agent has zero tools regardless of allowlist / profile. |
 | `allowed_plugins` | `Vec<string>` | `[]` (= all plugins) | Plugin allowlist for this agent. |
-| `mcp_servers` | `Vec<string>` | `[]` (= all servers) | MCP server allowlist. Useful when one corp server has dangerous tools and you only want a few agents talking to it. |
+| `mcp_servers` | `Vec<string>` | `[]` (= **no** servers) | MCP server allowlist. `[]` exposes zero MCP tools; `["*"]` exposes all connected servers; a named list scopes to those servers. Useful when one corp server has dangerous tools and you only want a few agents talking to it. |
 | `skills_disabled` | bool | `false` | Master kill-switch for skills. |
 
 ### Identity & spawn behaviour

--- a/docs/src/app/architecture/manifest-mcp/page.mdx
+++ b/docs/src/app/architecture/manifest-mcp/page.mdx
@@ -13,7 +13,7 @@ and which crate is allowed to mutate which side.
 
 | Where | Type | What it holds |
 |---|---|---|
-| `AgentManifest.mcp_servers` | `Vec<String>` (server **names**) | Per-agent **allowlist**. Empty = "every configured server is visible to this agent". Lives in `agent.toml`. |
+| `AgentManifest.mcp_servers` | `Vec<String>` (server **names**) | Per-agent **allowlist**. Empty = "no servers visible to this agent"; `["*"]` = every configured server; a named list scopes to those servers (#5855). Lives in `agent.toml`. |
 | `KernelConfig.mcp_servers` | `Vec<McpServerConfigEntry>` (full configs) | Global **registry** of installed servers — transport, env, OAuth, taint policy, headers. Lives in `~/.librefang/config.toml`. |
 | `kernel.mcp.effective_mcp_servers` | `RwLock<Vec<McpServerConfigEntry>>` | Hot-reloadable runtime mirror of `KernelConfig.mcp_servers`. Bumped together with `mcp_generation` so cached prompt summaries invalidate atomically. |
 
@@ -36,13 +36,14 @@ render_mcp_summary(tool_names, configured_servers, mcp_allowlist)
 — `crates/librefang-kernel/src/kernel/prompt_context.rs:281`. The
 `configured_servers` argument is the registry snapshot
 (`effective_mcp_servers`); the `mcp_allowlist` argument is the agent's
-manifest field. An empty allowlist means every configured server is
-visible to this agent.
+manifest field. An empty allowlist means **no** server is visible to
+this agent; `["*"]` opts into every configured server (#5855).
 
 The same pattern is used elsewhere any time a per-agent view of MCP is
 needed (tool list rendering, route handlers): pull the registry
 snapshot, then filter through the manifest allowlist. **Never store the
-intersection.**
+intersection.** Since #5855 an empty allowlist resolves to **no** servers
+(not all); `["*"]` is the explicit opt-in to every configured server.
 
 ## Why the split is intentional
 


### PR DESCRIPTION
## Summary

Closes #5855.

An agent manifest with `mcp_servers = []` — which is the default for **any** agent that never set the field — was read as a wildcard, so the agent received every MCP tool from every globally-connected MCP server, not zero tools as the field name implies.

`mcp_tools` is a single global `Vec` populated by every connected server kernel-wide, so the "empty == all" branch yielded the union of all servers' tools regardless of which agent was being prepared.
This leaked one agent's MCP servers into every other agent's prompt: the model called tools it had no runtime access to, the calls failed, and after 3 consecutive failures the streaming loop exited with the user-facing "Something went wrong: please try again".

## Root cause

`crates/librefang-kernel/src/kernel/tools_and_skills.rs` (`available_tools`) had `if mcp_allowlist.is_empty() { mcp_tools.iter().cloned().collect() }` — empty allowlist meant "all global MCP tools".
The same empty-means-all reading existed in the prompt summary path (`render_mcp_summary` / `mcp_summary_cache_key`) and in the API `mcp_servers_mode` ("all") and TUI ("[All servers]") display surfaces.

## Fix

The MCP allowlist is now a real allowlist with an explicit wildcard escape hatch:

- `[]` (empty / unset) → zero MCP tools; the MCP server summary is omitted from the agent's prompt.
- `["*"]` → all connected MCP servers (explicit opt-in).
- `["a", "b"]` → only servers `a` and `b`.

`mcp_disabled = true` is unchanged and still forces zero MCP tools even when `["*"]` or a named list is set.

Fixed at every boundary that crosses the manifest field into the LLM prompt, so the tool list and the prompt summary stay consistent (a fix that touched only the tool list would still have advertised every server in the prompt summary):

- `available_tools` (tool list): empty → no MCP tools; also skips locking the global MCP tool map entirely for the now-common empty case.
- `render_mcp_summary` + `mcp_summary_cache_key`: empty → empty summary; empty ("none") and `["*"]` ("all") get distinct cache keys so they never collide in the per-agent summary cache.
- `routes/agents.rs`: new `mcp_servers_mode` helper used by `GET /api/agents/{id}` and `GET /api/agents/{id}/mcp_servers` — empty → `"none"`, `["*"]` → `"all"`, else `"allowlist"`.
- TUI agent detail (`tui/screens/agents.rs`): empty → `[None]`, `["*"]` → `[All servers]`.
- Doc-comments on `AgentManifest::mcp_servers` / `mcp_disabled`, plus `docs/.../agent/templates` and `docs/.../architecture/manifest-mcp`.

## Why not change the type to `Option<Vec<String>>`?

That would distinguish "field absent" (inherit all) from "explicitly `[]`" (none), but `mcp_servers: Vec<String>` with `#[serde(default)]` makes absent and `[]` indistinguishable today, and the type change ripples across many call sites (API responses, TUI, hands merge, persistence, serialization tests) in several crates.
The allowlist-with-`["*"]`-wildcard approach is exactly what the issue proposes, is self-consistent (the field becomes a true allowlist), and keeps the blast radius inside the MCP boundary.

## Hands composition (unchanged, verified)

`hands_lifecycle.rs` merges a hand's `mcp_servers` into spawned-agent manifests: when a hand declares servers and the agent didn't, the agent's manifest gets the hand's concrete list, so hand-granted MCP access is preserved.
Only the both-empty case changes — and that now correctly resolves to "no MCP tools".

## Tests

New (`crates/librefang-kernel/src/kernel/tests.rs`):

- `empty_mcp_servers_yields_no_mcp_tools` — the leak: two servers connected globally, agent with `mcp_servers = []` sees zero MCP tools.
- `wildcard_mcp_servers_yields_all_mcp_tools` — `["*"]` exposes every connected server's tools.
- `explicit_mcp_servers_allowlist_filters_to_named_servers` — `["server_x"]` exposes only server_x tools.
- `empty_mcp_allowlist_renders_empty_summary` — the prompt summary mirrors the tool list (empty → "", `["*"]` → non-empty).

New (`routes/agents.rs`): `test_mcp_servers_mode_classification`.

Updated to the new contract:

- `mcp_summary_cache_key_is_order_independent` — empty keys to a `\x1fnone\x1f` sentinel, `["*"]` keys to `*`, and the two must not collide.
- `mcp_summary_is_byte_identical_across_input_orders`, `mcp_summary_inner_tool_list_is_sorted`, `available_tools_mcp_section_is_sorted_across_connect_orders`, `mcp_disabled_false_preserves_mcp_tools`, `mcp_disabled_hot_reload_takes_effect_without_respawn`, `mcp_disabled_produces_empty_mcp_summary` — these exercised determinism / `mcp_disabled` and relied on empty == all to have tools present; migrated to `["*"]`.
- `test_mcp_servers_set_empty_then_read_round_trip` (`agents_capabilities_files_integration.rs`) — now asserts `mode == "none"`.

## Verification

The host has no native Rust toolchain (CLAUDE.md: don't run `cargo` locally), and Docker was skipped per the task (disk constrained), so compilation and the test run are delegated to CI.
Changes are scoped, and each edited boundary was reviewed for unused-variable / dead-branch clippy issues (the early empty-skip removes the previously-dead `vec![]` inner branch).

## Behaviour change / operator note

This is a behaviour change for any deployment that relied on `mcp_servers = []` meaning "all".
Such agents must now set `mcp_servers = ["*"]` to keep full MCP access.
Worth a release note.

## Out of scope

- CHANGELOG `[Unreleased]` entry: the pre-commit hook requires a `(@github-login)` attribution suffix and I don't have the maintainer's handle; please add the entry (and the matching zh doc mirrors under `docs/src/app/zh/...`) with your handle.
