### PR TITLE
fix(runtime): move getpgrp to the x86_64-only seccomp block to unbreak aarch64

### DIFF
--- a/crates/librefang-runtime/src/plugin_runtime.rs
+++ b/crates/librefang-runtime/src/plugin_runtime.rs
@@ -970,7 +970,6 @@ fn apply_seccomp_allowlist(_allow_network: bool) -> bool {
         // it slipped past the locked-down round-trip test.
         libc::SYS_setpgid,
         libc::SYS_getpgid,
-        libc::SYS_getpgrp,
         libc::SYS_getsid,
         libc::SYS_setsid,
         // I/O multiplexing — universal variants
@@ -1049,6 +1048,10 @@ fn apply_seccomp_allowlist(_allow_network: bool) -> bool {
         libc::SYS_epoll_wait,
         libc::SYS_eventfd,
         libc::SYS_getdents,
+        // getpgrp is x86_64-only (aarch64 has no such syscall — glibc routes it
+        // through getpgid(0) there). dash reads the process group under job
+        // control when spawning external commands.
+        libc::SYS_getpgrp,
         libc::SYS_mkdir,
         libc::SYS_rmdir,
         libc::SYS_unlink,


### PR DESCRIPTION
## Problem

#5920 added job-control syscalls to the subprocess seccomp allowlist so `dash` can spawn external commands, but `libc::SYS_getpgrp` was placed in the **architecture-neutral** array.
`getpgrp` has no aarch64 syscall (glibc routes `getpgrp()` through `getpgid(0)` there), so `libc::SYS_getpgrp` is undefined on aarch64 and the crate fails to compile on aarch64-linux:

```
error: cannot find value `SYS_getpgrp` in module `libc`
  crates/librefang-runtime/src/plugin_runtime.rs (in the arch-neutral block)
```

CI's x86_64 Linux lane stayed green (the constant exists there), so this slipped through; it breaks Apple-Silicon Docker dev builds and any aarch64-linux target.

## Fix

Move `libc::SYS_getpgrp` into the existing `#[cfg(target_arch = "x86_64")]` block, next to the other x86_64-only legacy syscalls (`dup2`, `vfork`, `open`, `getdents`, …).
`setpgid`/`getpgid`/`getsid`/`setsid` exist on aarch64 and stay in the neutral array.

No behavior change on x86_64; restores aarch64-linux compilation.
