### PR TITLE
feat(dashboard): inline skill assignment on the agent Skills tab (#4917)

### DIFF
--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1437,6 +1437,45 @@ export async function updateAgentTools(agentId: string, payload: { capabilities_
   return put<AgentToolsResponse>(`/api/agents/${encodeURIComponent(agentId)}/tools`, payload);
 }
 
+/**
+ * Per-agent skill assignment, returned by `GET /api/agents/{id}/skills`.
+ *
+ * - `assigned`: the manifest allowlist (empty when `mode === "all"`).
+ * - `available`: every skill name in the daemon's registry — the pool the
+ *   inline assignment UI lets the operator add from.
+ * - `mode`: `"all"` (no allowlist; every registry skill is usable),
+ *   `"allowlist"` (manifest pins a specific set), or `"none"`
+ *   (`skills_disabled = true`; dispatch is off entirely).
+ * - `disabled`: mirrors the `none` mode as a boolean for convenience.
+ */
+export interface AgentSkillsResponse {
+  assigned: string[];
+  available: string[];
+  mode: "all" | "allowlist" | "none";
+  disabled: boolean;
+}
+
+export async function getAgentSkills(agentId: string): Promise<AgentSkillsResponse> {
+  return get<AgentSkillsResponse>(`/api/agents/${encodeURIComponent(agentId)}/skills`);
+}
+
+/**
+ * PUT /api/agents/{id}/skills — replace the agent's skill allowlist.
+ *
+ * An empty array clears the allowlist, switching the agent back to "all"
+ * mode (every registry skill available). A non-empty list is validated
+ * against the registry server-side; unknown names are rejected with a 4xx.
+ */
+export async function setAgentSkills(
+  agentId: string,
+  skills: string[],
+): Promise<{ status: string; skills: string[] }> {
+  return put<{ status: string; skills: string[] }>(
+    `/api/agents/${encodeURIComponent(agentId)}/skills`,
+    { skills },
+  );
+}
+
 export async function listAgents(
   opts: { includeHands?: boolean } = {},
 ): Promise<AgentItem[]> {

--- a/crates/librefang-api/dashboard/src/components/AgentSkillItem.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/AgentSkillItem.test.tsx
@@ -78,4 +78,50 @@ describe("AgentSkillItem", () => {
     await userEvent.click(screen.getByTestId("agent-skill-item"));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  // Issue #4917 — inline assignment. The same row now renders a trailing
+  // ✕ (remove) for assigned skills and a ＋ (add) for available ones.
+
+  it("renders a remove button and fires onRemove without bubbling to the row", async () => {
+    const onClick = vi.fn();
+    const onRemove = vi.fn();
+    render(
+      <AgentSkillItem
+        name="web-search"
+        action="remove"
+        onClick={onClick}
+        onRemove={onRemove}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("agent-skill-item-remove"));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    // stopPropagation must keep the row's onClick from also firing.
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("renders an add affordance and assigns via the row click", async () => {
+    const onClick = vi.fn();
+    render(
+      <AgentSkillItem name="writing-coach" action="add" onClick={onClick} />,
+    );
+    expect(screen.getByTestId("agent-skill-item-add")).toBeTruthy();
+    await userEvent.click(screen.getByTestId("agent-skill-item"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the remove button while busy", async () => {
+    const onRemove = vi.fn();
+    render(
+      <AgentSkillItem
+        name="web-search"
+        action="remove"
+        onRemove={onRemove}
+        busy
+      />,
+    );
+    const btn = screen.getByTestId("agent-skill-item-remove") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    await userEvent.click(btn);
+    expect(onRemove).not.toHaveBeenCalled();
+  });
 });

--- a/crates/librefang-api/dashboard/src/components/AgentSkillItem.tsx
+++ b/crates/librefang-api/dashboard/src/components/AgentSkillItem.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent } from "react";
-import { Sparkles } from "lucide-react";
+import { Plus, Sparkles, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 /**
@@ -15,6 +15,15 @@ import { useTranslation } from "react-i18next";
  * "installed" hint so the row still has a stable second line and the
  * grid layout doesn't jump.
  *
+ * Issue #4917: the tab gained inline assignment. The same row now serves
+ * two roles via the `action` prop:
+ *   - `"remove"` (assigned skills) — a trailing ✕ button that unassigns.
+ *   - `"add"` (available, not-yet-assigned skills) — a trailing ＋ button
+ *     that assigns. The whole row is the click target in this mode so the
+ *     hit area matches the old "click to open" affordance.
+ * With no `action` (or `"none"`) the row is the read-only display used by
+ * the "all" informational list.
+ *
  * Extracted into its own component so it can be unit-tested without
  * mounting the entire AgentsPage (which pulls in routing, multiple
  * queries, the manifest form, etc.).
@@ -22,10 +31,28 @@ import { useTranslation } from "react-i18next";
 export interface AgentSkillItemProps {
   name: string;
   description?: string;
+  /**
+   * Row click handler. In `"add"` mode this is the assign action (the whole
+   * row is clickable); in `"remove"` / display mode it is the optional
+   * navigate-to-detail affordance.
+   */
   onClick?: () => void;
+  /** Trailing-affordance variant. Defaults to `"none"` (display only). */
+  action?: "none" | "add" | "remove";
+  /** Click handler for the trailing ✕ in `"remove"` mode. */
+  onRemove?: () => void;
+  /** Disable the trailing affordance while a mutation is in flight. */
+  busy?: boolean;
 }
 
-export function AgentSkillItem({ name, description, onClick }: AgentSkillItemProps) {
+export function AgentSkillItem({
+  name,
+  description,
+  onClick,
+  action = "none",
+  onRemove,
+  busy = false,
+}: AgentSkillItemProps) {
   const { t } = useTranslation();
   const trimmedDescription = description?.trim();
   const subtitle = trimmedDescription && trimmedDescription.length > 0
@@ -48,7 +75,9 @@ export function AgentSkillItem({ name, description, onClick }: AgentSkillItemPro
       onKeyDown={handleKeyDown}
       role={onClick ? "button" : undefined}
       tabIndex={onClick ? 0 : undefined}
-      className="px-3 py-2.5 rounded-md border border-border-subtle bg-main/40 cursor-pointer hover:border-brand/40 transition-colors flex items-start justify-between gap-2"
+      className={`px-3 py-2.5 rounded-md border border-border-subtle bg-main/40 transition-colors flex items-start justify-between gap-2 ${
+        onClick ? "cursor-pointer hover:border-brand/40" : ""
+      } ${busy ? "opacity-50 pointer-events-none" : ""}`}
       data-testid="agent-skill-item"
     >
       <div className="min-w-0 flex-1">
@@ -66,7 +95,36 @@ export function AgentSkillItem({ name, description, onClick }: AgentSkillItemPro
           {subtitle}
         </div>
       </div>
-      <Sparkles className="w-3.5 h-3.5 text-brand/70 shrink-0 mt-0.5" />
+      {action === "remove" ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            // Don't let the click bubble to the row's onClick (navigate).
+            e.stopPropagation();
+            onRemove?.();
+          }}
+          disabled={busy}
+          aria-label={t("agents.detail.skill_remove", {
+            defaultValue: "Remove {{name}}",
+            name,
+          })}
+          title={t("agents.detail.skill_remove", {
+            defaultValue: "Remove {{name}}",
+            name,
+          })}
+          className="shrink-0 mt-0.5 rounded p-0.5 text-text-dim hover:text-red-400 hover:bg-red-400/10 transition-colors disabled:opacity-50"
+          data-testid="agent-skill-item-remove"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      ) : action === "add" ? (
+        <Plus
+          className="w-3.5 h-3.5 text-brand/70 shrink-0 mt-0.5"
+          data-testid="agent-skill-item-add"
+        />
+      ) : (
+        <Sparkles className="w-3.5 h-3.5 text-brand/70 shrink-0 mt-0.5" />
+      )}
     </div>
   );
 }

--- a/crates/librefang-api/dashboard/src/lib/http/client.ts
+++ b/crates/librefang-api/dashboard/src/lib/http/client.ts
@@ -132,6 +132,8 @@ export {
   // tools
   listTools,
   getAgentTools,
+  // per-agent skill assignment — read (#4917)
+  getAgentSkills,
   getAgentTemplateToml,
   // overview
   loadDashboardSnapshot,
@@ -194,6 +196,8 @@ export {
   clearHandAgentRuntimeConfig,
   resetAgentSession,
   updateAgentTools,
+  // per-agent skill assignment — write (#4917)
+  setAgentSkills,
   createAgentSession,
   switchAgentSession,
   deleteSession,

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents-skills.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents-skills.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import * as http from "../http/client";
+import { renderHook } from "@testing-library/react";
+import { useSetAgentSkills } from "./agents";
+import { agentKeys } from "../queries/keys";
+import { createQueryClientWrapper } from "../test/query-client";
+
+// Issue #4917 — inline skill assignment mutation. A PUT must invalidate the
+// per-agent skill read, the agent detail (skills / skills_mode are echoed on
+// it), and the agent list (row-level skill chips).
+
+vi.mock("../http/client", () => ({
+  setAgentSkills: vi.fn().mockResolvedValue({ status: "ok", skills: [] }),
+}));
+
+describe("useSetAgentSkills", () => {
+  it("PUTs the new allowlist and invalidates skills, detail, and lists", async () => {
+    const { queryClient, wrapper } = createQueryClientWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useSetAgentSkills(), { wrapper });
+
+    await result.current.mutateAsync({
+      agentId: "agent-1",
+      skills: ["web-search"],
+    });
+
+    expect(http.setAgentSkills).toHaveBeenCalledWith("agent-1", [
+      "web-search",
+    ]);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.skills("agent-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.detail("agent-1"),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: agentKeys.lists(),
+    });
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/agents.ts
@@ -25,6 +25,7 @@ import {
   sendAgentMessage,
   resetAgentSession,
   updateAgentTools,
+  setAgentSkills,
   getAgentTemplateToml,
 } from "../http/client";
 import type { AgentSchedulePatch, PromptExperiment, PromptVersion, SendAgentMessageOptions } from "../../api";
@@ -521,6 +522,37 @@ export function useUpdateAgentTools() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: agentKeys.detail(variables.agentId) });
       qc.invalidateQueries({ queryKey: agentKeys.tools(variables.agentId) });
+    },
+  });
+}
+
+/**
+ * PUT /agents/{id}/skills — replace the agent's skill allowlist (#4917).
+ *
+ * Powers the inline assignment UI on the Skills tab. An empty array clears
+ * the allowlist back to "all" mode; a non-empty list is validated against
+ * the registry server-side.
+ *
+ * Invalidates:
+ * - `agentKeys.skills(id)` — the tab's own read (assigned / mode).
+ * - `agentKeys.detail(id)` — `skills` and `skills_mode` are echoed on the
+ *   agent detail payload and rendered in the summary drawer.
+ * - `agentKeys.lists()` — the list row's skill summary chips.
+ */
+export function useSetAgentSkills() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      agentId,
+      skills,
+    }: {
+      agentId: string;
+      skills: string[];
+    }) => setAgentSkills(agentId, skills),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: agentKeys.skills(variables.agentId) });
+      qc.invalidateQueries({ queryKey: agentKeys.detail(variables.agentId) });
+      qc.invalidateQueries({ queryKey: agentKeys.lists() });
     },
   });
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/agents-skills.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents-skills.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useAgentSkills } from "./agents";
+import * as httpClient from "../http/client";
+import { agentKeys } from "./keys";
+import { createQueryClientWrapper } from "../test/query-client";
+
+// Issue #4917 — per-agent skill assignment query hook. The Skills tab on the
+// agent detail page reads { assigned, available, mode, disabled } from
+// GET /api/agents/{id}/skills through this hook.
+
+vi.mock("../http/client", () => ({
+  getAgentSkills: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useAgentSkills", () => {
+  it("is disabled (no fetch) when agentId is empty", () => {
+    const { result } = renderHook(() => useAgentSkills(""), {
+      wrapper: createQueryClientWrapper().wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(httpClient.getAgentSkills).not.toHaveBeenCalled();
+  });
+
+  it("fetches and caches under agentKeys.skills(id)", async () => {
+    const payload = {
+      assigned: ["web-search"],
+      available: ["web-search", "writing-coach"],
+      mode: "allowlist" as const,
+      disabled: false,
+    };
+    vi.mocked(httpClient.getAgentSkills).mockResolvedValue(payload);
+    const { queryClient, wrapper } = createQueryClientWrapper();
+
+    const { result } = renderHook(() => useAgentSkills("agent-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+    expect(httpClient.getAgentSkills).toHaveBeenCalledWith("agent-1");
+    expect(queryClient.getQueryData(agentKeys.skills("agent-1"))).toEqual(
+      payload,
+    );
+  });
+});

--- a/crates/librefang-api/dashboard/src/lib/queries/agents.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/agents.ts
@@ -12,6 +12,7 @@ import {
   loadAgentSession,
   listTools,
   getAgentTools,
+  getAgentSkills,
 } from "../http/client";
 import { agentKeys, toolKeys } from "./keys";
 import { withOverrides, type QueryOverrides } from "./options";
@@ -102,6 +103,12 @@ export const agentQueries = {
       queryFn: () => getAgentTools(agentId),
       enabled: !!agentId,
     }),
+  agentSkills: (agentId: string) =>
+    queryOptions({
+      queryKey: agentKeys.skills(agentId),
+      queryFn: () => getAgentSkills(agentId),
+      enabled: !!agentId,
+    }),
   toolsList: () =>
     queryOptions({
       queryKey: toolKeys.list(),
@@ -158,4 +165,8 @@ export function useTools(options: QueryOverrides = {}) {
 
 export function useAgentTools(agentId: string, options: QueryOverrides = {}) {
   return useQuery(withOverrides(agentQueries.agentTools(agentId), options));
+}
+
+export function useAgentSkills(agentId: string, options: QueryOverrides = {}) {
+  return useQuery(withOverrides(agentQueries.agentSkills(agentId), options));
 }

--- a/crates/librefang-api/dashboard/src/lib/queries/keys.ts
+++ b/crates/librefang-api/dashboard/src/lib/queries/keys.ts
@@ -43,6 +43,11 @@ export const agentKeys = {
     [...agentKeys.all, "experimentMetrics", experimentId] as const,
   tools: (agentId: string) =>
     [...agentKeys.all, "tools", agentId] as const,
+  // Per-agent skill assignment (#4917) — backs the inline assignment UI on
+  // the agent detail Skills tab. Distinct subtree from `tools` so a skill
+  // PUT only invalidates the skill read, not the tool read.
+  skills: (agentId: string) =>
+    [...agentKeys.all, "skills", agentId] as const,
 };
 
 export const toolKeys = {

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -60,6 +60,7 @@ import {
   useAgentStats,
   useAgentTemplates,
   useAgentTools,
+  useAgentSkills,
   useTools,
 } from "../lib/queries/agents";
 import {
@@ -74,6 +75,7 @@ import {
   useSpawnAgent,
   useSuspendAgent,
   useUpdateAgentTools,
+  useSetAgentSkills,
 } from "../lib/mutations/agents";
 
 /**
@@ -503,6 +505,14 @@ export function AgentsPage() {
   const tabAgentToolsQuery = useAgentTools(detailAgent?.id ?? "", {
     enabled: !!detailAgent && agentTab === "tools",
   });
+  // Per-agent skill assignment (#4917) — backs the inline assign/unassign
+  // UI on the Skills tab. Returns { assigned, available, mode, disabled };
+  // gated on the tab being open so we don't fetch the registry pool at
+  // page load.
+  const tabAgentSkillsQuery = useAgentSkills(detailAgent?.id ?? "", {
+    enabled: !!detailAgent && agentTab === "skills",
+  });
+  const setAgentSkillsMutation = useSetAgentSkills();
 
   useEffect(() => {
     if (agentTab !== "tools") {
@@ -1259,29 +1269,98 @@ export function AgentsPage() {
     );
   };
 
-  // ---------- Skills tab — 2-col card grid per design canvas
+  // ---------- Skills tab — inline assign/unassign per agent (#4917)
   const renderSkillsTab = (agent: AgentDetail) => {
+    // Source of truth is GET /api/agents/{id}/skills (tabAgentSkillsQuery),
+    // which returns { assigned, available, mode, disabled }. While it loads
+    // we fall back to the manifest fields echoed on the detail payload so the
+    // header/empty-state don't flash. Skill names are slug-shape ASCII IDs,
+    // so plain codepoint sort is stable across locales (#4940).
     const view = agent as AgentView;
-    // Sort alphabetically (#4940) — the backend returns the manifest's
-    // allowlist order, which is meaningless to humans scanning the tab.
-    // Skill names are slug-shape ASCII IDs, so plain codepoint sort is
-    // stable across locales (localeCompare would flip in tr-TR etc).
-    const skills: string[] = (
-      Array.isArray(view.skills)
-        ? view.skills
-        : Array.isArray(view.capabilities?.skills)
-          ? view.capabilities!.skills!
-          : []
-    )
+    const skillsData = tabAgentSkillsQuery.data;
+    const manifestSkills: string[] = Array.isArray(view.skills)
+      ? view.skills
+      : Array.isArray(view.capabilities?.skills)
+        ? view.capabilities!.skills!
+        : [];
+    const assigned: string[] = (skillsData?.assigned ?? manifestSkills)
       .slice()
       .sort();
-    // skills_mode: 'none' (skills_disabled), 'all' (no allowlist — uses
-    // every skill in the registry, the default), or 'allowlist' (manifest
-    // pinned a list). Each needs a different empty-state copy; the
-    // previous code collapsed them all to "0 installed".
-    const skillsMode = (agent as AgentDetail).skills_mode;
-    const usesAllSkills = skillsMode === "all" && skills.length === 0;
-    const skillsDisabled = skillsMode === "none";
+    const available: string[] = (skillsData?.available ?? []).slice().sort();
+    // skills_mode: 'none' (skills_disabled), 'all' (no allowlist — every
+    // registry skill usable, the default), or 'allowlist' (manifest pins a
+    // set). Prefer the live query's mode; fall back to the detail payload.
+    const skillsMode =
+      skillsData?.mode ?? (agent as AgentDetail).skills_mode;
+    const usesAllSkills = skillsMode === "all";
+    const skillsDisabled =
+      skillsData?.disabled ?? skillsMode === "none";
+    // Available skills not yet on the allowlist — the add pool in allowlist
+    // mode. Built from the registry list minus what's already assigned.
+    const assignedSet = new Set(assigned);
+    const addable = available.filter((s) => !assignedSet.has(s));
+    const mutating = setAgentSkillsMutation.isPending;
+    const skillsLoading =
+      tabAgentSkillsQuery.isLoading && !skillsData;
+
+    // Apply a new allowlist. Empty array clears it back to "all" mode.
+    const applySkills = (next: string[], toast: string) => {
+      if (!agent.id) return;
+      setAgentSkillsMutation.mutate(
+        { agentId: agent.id, skills: next },
+        {
+          onSuccess: async () => {
+            await refreshDetailAgent(agent.id, agent.is_hand);
+            addToast(toast, "success");
+          },
+          onError: (e) => {
+            addToast(
+              toastErr(
+                e,
+                t("agents.detail.skill_update_failed", {
+                  defaultValue: "Failed to update skills",
+                }),
+              ),
+              "error",
+            );
+          },
+        },
+      );
+    };
+    const addSkill = (name: string) =>
+      applySkills(
+        [...assigned, name],
+        t("agents.detail.skill_added", {
+          defaultValue: "Skill assigned",
+        }),
+      );
+    const removeSkill = (name: string) =>
+      applySkills(
+        assigned.filter((s) => s !== name),
+        t("agents.detail.skill_removed", {
+          defaultValue: "Skill removed",
+        }),
+      );
+    // "Customize" from all-mode: seed the allowlist with every available
+    // skill so the operator gets a concrete list to prune (an empty PUT
+    // would just stay in all-mode). Done with the assign mutation so the
+    // skill-registry validation runs server-side.
+    const customizeFromAll = () =>
+      applySkills(
+        available,
+        t("agents.detail.skill_customized", {
+          defaultValue: "Switched to a per-agent allowlist",
+        }),
+      );
+    // "Reset to all": clear the allowlist (empty PUT → all-mode).
+    const resetToAll = () =>
+      applySkills(
+        [],
+        t("agents.detail.skill_reset_all", {
+          defaultValue: "Reset to all available skills",
+        }),
+      );
+
     const autoEvolve = agent.auto_evolve !== false;
     const handleToggleAutoEvolve = () => {
       if (!agent.id) return;
@@ -1307,7 +1386,7 @@ export function AgentsPage() {
             {" · "}
             {usesAllSkills
               ? t("agents.detail.skills_all", { defaultValue: "all" })
-              : skills.length}
+              : assigned.length}
           </div>
           <Button
             variant="ghost"
@@ -1345,7 +1424,12 @@ export function AgentsPage() {
           </button>
         </div>
 
-        {skillsDisabled ? (
+        {skillsLoading ? (
+          <div className="rounded-md border border-border-subtle bg-main/40 p-4 flex items-center gap-2 text-[12px] text-text-dim">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            {t("agents.detail.skills_loading", { defaultValue: "Loading skills…" })}
+          </div>
+        ) : skillsDisabled ? (
           <div className="rounded-md border border-border-subtle bg-main/40 p-4 flex items-start gap-3">
             <X className="w-4 h-4 text-text-dim shrink-0 mt-0.5" />
             <div className="min-w-0 flex-1">
@@ -1360,36 +1444,103 @@ export function AgentsPage() {
             </div>
           </div>
         ) : usesAllSkills ? (
-          <div
-            onClick={() => navigate({ to: "/skills" })}
-            className="rounded-md border border-border-subtle bg-main/40 p-4 flex items-start gap-3 cursor-pointer hover:border-brand/40 transition-colors"
-          >
-            <Sparkles className="w-4 h-4 text-brand/80 shrink-0 mt-0.5" />
-            <div className="min-w-0 flex-1">
-              <div className="font-mono text-[12.5px] font-medium text-text-main">
-                {t("agents.detail.skills_all_title", { defaultValue: "Using all available skills" })}
+          <div className="flex flex-col gap-2.5">
+            <div className="rounded-md border border-border-subtle bg-main/40 p-3 flex items-start justify-between gap-3">
+              <div className="flex items-start gap-3 min-w-0">
+                <Sparkles className="w-4 h-4 text-brand/80 shrink-0 mt-0.5" />
+                <div className="min-w-0 flex-1">
+                  <div className="font-mono text-[12.5px] font-medium text-text-main">
+                    {t("agents.detail.skills_all_title", { defaultValue: "Using all available skills" })}
+                  </div>
+                  <div className="font-mono text-[10.5px] text-text-dim/80 mt-0.5">
+                    {t("agents.detail.skills_all_desc", {
+                      defaultValue: "manifest doesn't pin an allowlist — every skill in the registry is available",
+                    })}
+                  </div>
+                </div>
               </div>
-              <div className="font-mono text-[10.5px] text-text-dim/80 mt-0.5">
-                {t("agents.detail.skills_all_desc", {
-                  defaultValue: "manifest doesn't pin an allowlist — every skill in the registry is available",
-                })}
-              </div>
+              {available.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={customizeFromAll}
+                  disabled={mutating}
+                  data-testid="skills-customize-btn"
+                >
+                  {t("agents.detail.skills_customize", { defaultValue: "Customize" })}
+                </Button>
+              )}
             </div>
-          </div>
-        ) : skills.length === 0 ? (
-          <div className="rounded-md border border-border-subtle bg-main/40 p-4 text-[12px] text-text-dim italic">
-            {t("agents.detail.no_skills", { defaultValue: "No skills installed for this agent." })}
+            {available.length > 0 && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5" data-testid="skills-available-grid">
+                {available.map((s) => (
+                  <AgentSkillItem
+                    key={s}
+                    name={s}
+                    description={skillDescriptionByName.get(s)}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-            {skills.map((s) => (
-              <AgentSkillItem
-                key={s}
-                name={s}
-                description={skillDescriptionByName.get(s)}
-                onClick={() => navigate({ to: "/skills" })}
-              />
-            ))}
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between">
+                <div className="text-[10px] uppercase font-semibold tracking-[0.08em] text-text-dim/80">
+                  {t("agents.detail.skills_assigned", { defaultValue: "Assigned" })}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={resetToAll}
+                  disabled={mutating}
+                  data-testid="skills-reset-all-btn"
+                >
+                  {t("agents.detail.skills_reset_all", { defaultValue: "Reset to all" })}
+                </Button>
+              </div>
+              {assigned.length === 0 ? (
+                <div className="rounded-md border border-border-subtle bg-main/40 p-4 text-[12px] text-text-dim italic">
+                  {t("agents.detail.no_skills_assigned", {
+                    defaultValue: "No skills assigned — add from the list below, or reset to all.",
+                  })}
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5" data-testid="skills-assigned-grid">
+                  {assigned.map((s) => (
+                    <AgentSkillItem
+                      key={s}
+                      name={s}
+                      description={skillDescriptionByName.get(s)}
+                      action="remove"
+                      onRemove={() => removeSkill(s)}
+                      busy={mutating}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {addable.length > 0 && (
+              <div className="flex flex-col gap-1.5">
+                <div className="text-[10px] uppercase font-semibold tracking-[0.08em] text-text-dim/80">
+                  {t("agents.detail.skills_available", { defaultValue: "Available" })}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5" data-testid="skills-addable-grid">
+                  {addable.map((s) => (
+                    <AgentSkillItem
+                      key={s}
+                      name={s}
+                      description={skillDescriptionByName.get(s)}
+                      action="add"
+                      onClick={() => addSkill(s)}
+                      busy={mutating}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/crates/librefang-api/tests/agents_capabilities_files_integration.rs
+++ b/crates/librefang-api/tests/agents_capabilities_files_integration.rs
@@ -551,7 +551,10 @@ async fn test_skills_set_valid_allowlist_round_trip() {
     // Before assignment the agent uses every registry skill → mode "all".
     let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/skills"))).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["mode"], "all", "fresh agent should default to all: {body:?}");
+    assert_eq!(
+        body["mode"], "all",
+        "fresh agent should default to all: {body:?}"
+    );
     assert!(
         body["available"]
             .as_array()
@@ -567,7 +570,11 @@ async fn test_skills_set_valid_allowlist_round_trip() {
         ),
     )
     .await;
-    assert_eq!(status, StatusCode::OK, "valid allowlist must succeed: {body:?}");
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "valid allowlist must succeed: {body:?}"
+    );
     assert_eq!(body["skills"], serde_json::json!(["round_trip_skill"]));
 
     let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/skills"))).await;
@@ -593,7 +600,10 @@ async fn test_skills_set_valid_allowlist_round_trip() {
     .await;
     assert_eq!(status, StatusCode::OK);
     let (_status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/skills"))).await;
-    assert_eq!(body["mode"], "all", "empty PUT returns to all-mode: {body:?}");
+    assert_eq!(
+        body["mode"], "all",
+        "empty PUT returns to all-mode: {body:?}"
+    );
     assert_eq!(body["assigned"], serde_json::json!([]));
 }
 

--- a/crates/librefang-api/tests/agents_capabilities_files_integration.rs
+++ b/crates/librefang-api/tests/agents_capabilities_files_integration.rs
@@ -115,6 +115,34 @@ fn spawn_named(state: &Arc<AppState>, name: &str) -> AgentId {
         .expect("spawn_agent")
 }
 
+/// Drop a minimal `skill.toml` into `<home>/skills/<name>/` so the kernel's
+/// registry picks it up on the next `reload_skills()`. Mirrors the helper in
+/// `skills_routes_test.rs` / `librefang_skills::registry::tests::create_test_skill`
+/// so the schema matches what `SkillRegistry::load_all` accepts. Used by the
+/// valid-allowlist round-trip below — the empty / rejection cases need no real
+/// skill on disk, but exercising a successful non-empty assignment does.
+fn install_skill(home: &std::path::Path, name: &str) {
+    let skill_dir = home.join("skills").join(name);
+    std::fs::create_dir_all(&skill_dir).expect("mkdir skill dir");
+    let manifest = format!(
+        r#"[skill]
+name = "{name}"
+version = "0.1.0"
+description = "Test skill {name}"
+
+[runtime]
+type = "python"
+entry = "main.py"
+
+[[tools.provided]]
+name = "{name}_tool"
+description = "A test tool"
+input_schema = {{ type = "object" }}
+"#
+    );
+    std::fs::write(skill_dir.join("skill.toml"), manifest).expect("write skill.toml");
+}
+
 async fn send(app: axum::Router, req: Request<Body>) -> (StatusCode, serde_json::Value) {
     let resp = app.oneshot(req).await.expect("oneshot");
     let status = resp.status();
@@ -505,6 +533,68 @@ async fn test_skills_set_empty_then_read_round_trip() {
         body["available"].is_array(),
         "GET should advertise available skills: {body:?}"
     );
+}
+
+/// Skills (#4917): assigning a *valid* non-empty allowlist persists and reads
+/// back, and `mode` flips from "all" to "allowlist". This is the happy path
+/// the dashboard's inline assignment UI drives — the empty round-trip above
+/// only proves the clear/all path, not that a concrete skill survives a PUT.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_skills_set_valid_allowlist_round_trip() {
+    let h = boot().await;
+    // Seed a real skill so the kernel's registry validation accepts it.
+    install_skill(h._tmp.path(), "round_trip_skill");
+    h.state.kernel.reload_skills();
+
+    let id = spawn_named(&h.state, "skills-allowlist");
+
+    // Before assignment the agent uses every registry skill → mode "all".
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/skills"))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["mode"], "all", "fresh agent should default to all: {body:?}");
+    assert!(
+        body["available"]
+            .as_array()
+            .is_some_and(|a| a.iter().any(|v| v == "round_trip_skill")),
+        "seeded skill must surface in available: {body:?}"
+    );
+
+    let (status, body) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/skills"),
+            serde_json::json!({ "skills": ["round_trip_skill"] }),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "valid allowlist must succeed: {body:?}");
+    assert_eq!(body["skills"], serde_json::json!(["round_trip_skill"]));
+
+    let (status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/skills"))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["assigned"],
+        serde_json::json!(["round_trip_skill"]),
+        "GET must reflect the assigned allowlist: {body:?}"
+    );
+    assert_eq!(
+        body["mode"], "allowlist",
+        "a non-empty allowlist flips mode to allowlist: {body:?}"
+    );
+
+    // Clearing it returns to all-mode — the dashboard's "Reset to all".
+    let (status, _body) = send(
+        h.app.clone(),
+        put_json(
+            &format!("/api/agents/{id}/skills"),
+            serde_json::json!({ "skills": [] }),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (_status, body) = send(h.app.clone(), get(&format!("/api/agents/{id}/skills"))).await;
+    assert_eq!(body["mode"], "all", "empty PUT returns to all-mode: {body:?}");
+    assert_eq!(body["assigned"], serde_json::json!([]));
 }
 
 /// Skills: an unknown skill name in a non-empty allowlist is rejected by the


### PR DESCRIPTION
## Summary

Closes #4917.

The agent detail **Skills** tab was effectively read-only.
The "+" button navigated to the system-level `/skills` page (hub install / uninstall) instead of assigning an existing skill to *this* agent, `"all"` mode showed a generic "Using all available skills" card with no list of what "all" meant, and there was no inline way to toggle a skill on or off per agent — unlike the Tools / MCP tabs.

PR #5741 previously added the `auto_evolve` toggle to this tab but did **not** add inline assignment; this PR adds the assignment surface and preserves that toggle.

The backend already exposes `GET` / `PUT /api/agents/{id}/skills` (registered in `routes/agents.rs`, kernel-validated against the skill registry).
**No backend endpoint was added** — the gap was entirely the dashboard data layer plus the tab UI.

## Changes

Data layer (mirrors the existing per-agent capability pattern):

- `api.ts` — `AgentSkillsResponse` type + `getAgentSkills` / `setAgentSkills`.
- `lib/http/client.ts` — re-export both (read block / write block).
- `lib/queries/keys.ts` — `agentKeys.skills(id)`, its own subtree so a skill PUT does not invalidate the tool read.
- `lib/queries/agents.ts` — `agentSkills` query options + `useAgentSkills`, gated on the Skills tab being open so the registry pool is not fetched at page load.
- `lib/mutations/agents.ts` — `useSetAgentSkills`, invalidating `agentKeys.skills(id)` / `detail(id)` / `lists()` in `onSuccess`.

UI:

- `AgentSkillItem` — gained a `"remove"` variant (trailing ✕, `stopPropagation` so it doesn't fire the row click) and an `"add"` variant (trailing ＋, whole-row click target), plus a `busy` state that disables the affordance during a mutation. The existing display / `onClick` behaviour is unchanged.
- `AgentsPage` `renderSkillsTab` — now drives off the live query instead of the stale manifest echo:
  - **allowlist** mode: assigned skills with remove ✕, available-not-assigned skills with click-to-add, and a **Reset to all** action (empty PUT → all-mode).
  - **all** mode: lists available skills informationally with a **Customize** action that seeds the allowlist with every available skill so the operator has a concrete list to prune.
  - **none** mode: keeps the existing "skills disabled" message.
  - The `auto_evolve` toggle from #5741 and the **Install** button (which still routes to `/skills` — installing from a hub is a distinct action from assigning an already-installed skill) are preserved.

All API access stays in `lib/queries/` / `lib/mutations/` hooks per the dashboard data-layer rule; no inline `fetch()` / `api.*` was added to the page.

## Verification

- `pnpm typecheck` — clean.
- `pnpm exec eslint` on every changed file — 0 errors (3 warnings, all pre-existing in untouched code).
- New tests pass:
  - `AgentSkillItem.test.tsx` — remove fires `onRemove` without bubbling to the row; add affordance renders and assigns via row click; `busy` disables the remove button.
  - `lib/queries/agents-skills.test.tsx` — `useAgentSkills` disabled on empty id, caches under `agentKeys.skills(id)`.
  - `lib/mutations/agents-skills.test.tsx` — PUT payload + skills / detail / lists invalidation fan-out.
- Existing `lib/queries/agents.test.tsx` + `lib/mutations/agents.test.tsx` — still green (25 tests).
- `scripts/i18n-parity.mjs` — locales in parity.
- Backend integration test added in `agents_capabilities_files_integration.rs`: `test_skills_set_valid_allowlist_round_trip` seeds a real skill, asserts the fresh agent is `mode: "all"`, assigns the skill, reads it back as `mode: "allowlist"`, then clears it back to `"all"` — complementing the existing empty / rejection cases. Rust compile / test relies on CI per repo policy (no local `cargo`).

The full dashboard suite has 13 unrelated failures in `ApprovalsPage.test.tsx` (a cross-file `localStorage.setItem` isolation issue under parallel runs); `ApprovalsPage.test.tsx` passes 8/8 in isolation and is untouched by this PR.
