### PR TITLE
feat(channels): port command-policy and message coalescing to sidecar channels

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1442,7 +1442,7 @@
         "filename": "crates/librefang-channels/src/sidecar.rs",
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_verified": false,
-        "line_number": 2759
+        "line_number": 2781
       }
     ],
     "crates/librefang-cli/src/main.rs": [
@@ -4065,5 +4065,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T10:40:38Z"
+  "generated_at": "2026-05-30T16:13:59Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1442,7 +1442,7 @@
         "filename": "crates/librefang-channels/src/sidecar.rs",
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_verified": false,
-        "line_number": 2709
+        "line_number": 2759
       }
     ],
     "crates/librefang-cli/src/main.rs": [
@@ -2731,28 +2731,28 @@
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 2813
+        "line_number": 2869
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "e84fc93286dec77fb75fbe036dff86318eb3503e",
         "is_verified": false,
-        "line_number": 3702
+        "line_number": 3758
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "c6c914a1fb807d140dfafbe0139614358330e43f",
         "is_verified": false,
-        "line_number": 3717
+        "line_number": 3773
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "6baf51b50e44bb41da5fb5dc6dbbb801217ffd32",
         "is_verified": false,
-        "line_number": 4379
+        "line_number": 4435
       }
     ],
     "crates/librefang-types/src/config/version.rs": [
@@ -4065,5 +4065,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T10:19:39Z"
+  "generated_at": "2026-05-30T10:40:38Z"
 }

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -4209,9 +4209,25 @@
     "SidecarChannelConfig": {
       "description": "Configuration for a sidecar channel adapter (external process-based).\n\nSidecar adapters allow external processes written in any language to act as channel adapters. Communication uses newline-delimited JSON over stdin/stdout.\n\nConfigure in config.toml: ```toml [[sidecar_channels]] name = \"my-telegram\" command = \"python3\" args = [\"-m\", \"librefang.sidecar.adapters.telegram\"] env = { TELEGRAM_BOT_TOKEN = \"xxx\" } ```",
       "properties": {
+        "allowed_commands": {
+          "default": [],
+          "description": "Whitelist of built-in command names (without the leading `/`) consulted when `command_policy = \"allowlist\"`. Entries may be written with or without a leading slash.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "args": {
           "default": [],
           "description": "Arguments to pass to the command.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "blocked_commands": {
+          "default": [],
+          "description": "Blacklist of built-in command names (without the leading `/`) consulted when `command_policy = \"blocklist\"`. Entries may be written with or without a leading slash.",
           "items": {
             "type": "string"
           },
@@ -4228,6 +4244,15 @@
         "command": {
           "description": "Command to execute (e.g., \"python3\", \"/usr/local/bin/my-adapter\").",
           "type": "string"
+        },
+        "command_policy": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/SidecarCommandPolicy"
+            }
+          ],
+          "default": "allow",
+          "description": "Built-in slash-command policy for this channel (#5841). Ports the in-process `disable_commands` / `allowed_commands` / `blocked_commands` gating to sidecars. Defaults to `allow` so existing configs keep honouring every command. A rejected command is forwarded to the agent as plain text, never answered with an \"unknown command\" error."
         },
         "default_agent": {
           "default": null,
@@ -4249,6 +4274,13 @@
           "default": 256,
           "description": "Bounded inbound message buffer (also the backpressure point).",
           "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "message_coalesce_window_ms": {
+          "default": 0,
+          "description": "Inbound message-coalescing window in milliseconds (#5841 / #4441). When > 0, messages from the same sender arriving within the window are buffered and dispatched as a single batched context, so a user who forwards several messages in rapid succession produces one agent invocation instead of racing concurrent ones on the same session. Default `0` (disabled).",
+          "format": "uint64",
           "minimum": 0.0,
           "type": "integer"
         },
@@ -4318,6 +4350,39 @@
         "name"
       ],
       "type": "object"
+    },
+    "SidecarCommandPolicy": {
+      "description": "Built-in slash-command policy for a sidecar channel.\n\nPorts the in-process `[channels.<name>.overrides]` command gating (`disable_commands` / `allowed_commands` / `blocked_commands`, #2063) to the sidecar architecture (#5841). A command that the policy rejects is **not** answered with an error — it is forwarded to the agent as plain text, so public-facing bots never reveal the existence of an internal command system to end users.",
+      "oneOf": [
+        {
+          "description": "All built-in slash commands are honoured (current default behaviour — preserves backward compatibility).",
+          "enum": [
+            "allow"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "All built-in slash commands are disabled; any leading-slash text is forwarded to the agent as normal content. Use for public-facing bots where end users must not be able to switch agents or reset sessions.",
+          "enum": [
+            "disable"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Only the commands in `allowed_commands` are honoured; everything else is forwarded as plain text.",
+          "enum": [
+            "allowlist"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Every command except those in `blocked_commands` is honoured; the blocked ones are forwarded as plain text.",
+          "enum": [
+            "blocklist"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "SidecarOverflowPolicy": {
       "description": "Backpressure policy when the bounded inbound message buffer is full.\n\nSelected via [`SidecarChannelConfig::overflow`].",

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1112,15 +1112,20 @@ fn flush_debounced(
                 }
             }
 
-            let overrides = channel_handle
-                .channel_overrides(
-                    ct_str,
-                    merged_msg
-                        .metadata
-                        .get("account_id")
-                        .and_then(|v| v.as_str()),
-                )
-                .await;
+            let overrides = match adapter.channel_overrides() {
+                Some(ov) => Some(ov),
+                None => {
+                    channel_handle
+                        .channel_overrides(
+                            ct_str,
+                            merged_msg
+                                .metadata
+                                .get("account_id")
+                                .and_then(|v| v.as_str()),
+                        )
+                        .await
+                }
+            };
             let channel_default_format = default_output_format_for_channel(ct_str);
             let output_format = overrides
                 .as_ref()
@@ -1337,7 +1342,14 @@ impl BridgeManager {
         let mut shutdown = self.shutdown_rx.clone();
 
         let ct_str = channel_type_str(&adapter.channel_type()).to_string();
-        let overrides = handle.channel_overrides(&ct_str, None).await;
+        // Per-instance overrides carried by the adapter (e.g. a sidecar's
+        // `[[sidecar_channels]]` command-policy / coalescing block, #5841)
+        // win over the kernel-level channel-type lookup, which cannot tell
+        // two same-`channel_type` sidecars apart.
+        let overrides = match adapter.channel_overrides() {
+            Some(ov) => Some(ov),
+            None => handle.channel_overrides(&ct_str, None).await,
+        };
         let debounce_ms = overrides
             .as_ref()
             .map(|o| o.message_debounce_ms)
@@ -3210,12 +3222,22 @@ async fn dispatch_message(
     let early_agent_id = resolve_or_fallback(message, handle, router).await;
 
     // Fetch overrides: agent-level (from agent.toml) wins, channel-level is fallback.
-    let channel_overrides = handle
-        .channel_overrides(
-            ct_str,
-            message.metadata.get("account_id").and_then(|v| v.as_str()),
-        )
-        .await;
+    // Per-instance adapter overrides (a sidecar's `[[sidecar_channels]]`
+    // command-policy / coalescing block, #5841) take the channel-level slot
+    // when present — they are keyed to this exact adapter, whereas the
+    // kernel lookup is keyed only by `channel_type` and cannot distinguish
+    // two sidecars sharing a `channel_type`.
+    let channel_overrides = match adapter.channel_overrides() {
+        Some(ov) => Some(ov),
+        None => {
+            handle
+                .channel_overrides(
+                    ct_str,
+                    message.metadata.get("account_id").and_then(|v| v.as_str()),
+                )
+                .await
+        }
+    };
     let overrides = if let Some(aid) = early_agent_id {
         handle
             .agent_channel_overrides(aid)

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -1248,6 +1248,51 @@ pub struct SidecarAdapter {
     typing_rx: Arc<std::sync::Mutex<Option<mpsc::Receiver<TypingEvent>>>>,
     /// Supervision tunables snapshotted from config at construction.
     sup: SupCfg,
+    /// Per-instance channel behaviour overrides built from the
+    /// `[[sidecar_channels]]` block — command policy + message
+    /// coalescing (#5841). `None` when the block carries no such
+    /// settings, so the bridge falls back to kernel-resolved overrides.
+    overrides: Option<librefang_types::config::ChannelOverrides>,
+}
+
+/// Translate the command-policy + coalescing fields of a
+/// `[[sidecar_channels]]` block into the `ChannelOverrides` the bridge
+/// already understands (#5841). Returns `None` when every field is at
+/// its default, so a plain sidecar config produces no override and the
+/// bridge keeps falling back to the kernel-level lookup.
+fn overrides_from_sidecar_config(
+    config: &librefang_types::config::SidecarChannelConfig,
+) -> Option<librefang_types::config::ChannelOverrides> {
+    use librefang_types::config::SidecarCommandPolicy;
+
+    let policy = config.command_policy;
+    let coalesce_ms = config.message_coalesce_window_ms;
+
+    let has_command_policy = policy != SidecarCommandPolicy::Allow;
+    if !has_command_policy && coalesce_ms == 0 {
+        return None;
+    }
+
+    let mut ov = librefang_types::config::ChannelOverrides::default();
+    // Map the sidecar policy enum onto the existing boolean / list
+    // fields `is_command_allowed` consults. Precedence inside the bridge
+    // is `disable_commands` > `allowed_commands` > `blocked_commands`, so
+    // exactly one of the three is populated per policy variant.
+    match policy {
+        SidecarCommandPolicy::Allow => {}
+        SidecarCommandPolicy::Disable => ov.disable_commands = true,
+        SidecarCommandPolicy::Allowlist => {
+            ov.allowed_commands = config.allowed_commands.clone();
+        }
+        SidecarCommandPolicy::Blocklist => {
+            ov.blocked_commands = config.blocked_commands.clone();
+        }
+    }
+    // The bridge's debouncer keys off `message_debounce_ms`; the
+    // sidecar-facing name is `message_coalesce_window_ms`, matching the
+    // pre-migration `[[channels.telegram]]` field operators knew (#4441).
+    ov.message_debounce_ms = coalesce_ms;
+    Some(ov)
 }
 
 impl SidecarAdapter {
@@ -1284,6 +1329,7 @@ impl SidecarAdapter {
             typing_tx,
             typing_rx: Arc::new(std::sync::Mutex::new(Some(typing_rx))),
             sup: SupCfg::from_config(config),
+            overrides: overrides_from_sidecar_config(config),
         }
     }
 
@@ -1312,6 +1358,10 @@ impl ChannelAdapter for SidecarAdapter {
 
     fn channel_type(&self) -> ChannelType {
         self.channel_type.clone()
+    }
+
+    fn channel_overrides(&self) -> Option<librefang_types::config::ChannelOverrides> {
+        self.overrides.clone()
     }
 
     async fn start(
@@ -2754,6 +2804,98 @@ mod tests {
             }))
             .unwrap();
         assert_eq!(c.default_agent.as_deref(), Some("fandangorodelo"));
+    }
+
+    // #5841 — command-policy + message-coalescing ported to sidecars.
+    // `overrides_from_sidecar_config` projects the sidecar-facing fields
+    // onto the `ChannelOverrides` the bridge already consults
+    // (`is_command_allowed`, debouncer setup).
+    fn cfg_json(value: serde_json::Value) -> librefang_types::config::SidecarChannelConfig {
+        serde_json::from_value(value).expect("SidecarChannelConfig from json")
+    }
+
+    #[test]
+    fn overrides_none_for_plain_sidecar_config_5841() {
+        // A default sidecar (allow-all, no coalescing) carries no
+        // override, so the bridge keeps falling back to the kernel lookup.
+        let c = cfg("telegram", "python3", vec![]);
+        assert!(super::overrides_from_sidecar_config(&c).is_none());
+    }
+
+    #[test]
+    fn overrides_disable_maps_to_disable_commands_5841() {
+        let c = cfg_json(serde_json::json!({
+            "name": "afina-sales-bot",
+            "command": "python3",
+            "command_policy": "disable",
+        }));
+        let ov = super::overrides_from_sidecar_config(&c).expect("override built");
+        assert!(ov.disable_commands);
+        assert!(ov.allowed_commands.is_empty());
+        assert!(ov.blocked_commands.is_empty());
+        assert_eq!(ov.message_debounce_ms, 0);
+    }
+
+    #[test]
+    fn overrides_allowlist_maps_to_allowed_commands_5841() {
+        let c = cfg_json(serde_json::json!({
+            "name": "bot",
+            "command": "python3",
+            "command_policy": "allowlist",
+            "allowed_commands": ["start", "/help"],
+        }));
+        let ov = super::overrides_from_sidecar_config(&c).expect("override built");
+        assert!(!ov.disable_commands);
+        assert_eq!(ov.allowed_commands, vec!["start", "/help"]);
+        assert!(ov.blocked_commands.is_empty());
+    }
+
+    #[test]
+    fn overrides_blocklist_maps_to_blocked_commands_5841() {
+        let c = cfg_json(serde_json::json!({
+            "name": "bot",
+            "command": "python3",
+            "command_policy": "blocklist",
+            "blocked_commands": ["new", "reboot", "agent"],
+        }));
+        let ov = super::overrides_from_sidecar_config(&c).expect("override built");
+        assert!(!ov.disable_commands);
+        assert!(ov.allowed_commands.is_empty());
+        assert_eq!(ov.blocked_commands, vec!["new", "reboot", "agent"]);
+    }
+
+    #[test]
+    fn overrides_coalesce_window_maps_to_debounce_ms_5841() {
+        // Coalescing alone (policy left at the allow default) still yields
+        // an override so the bridge's debouncer turns on.
+        let c = cfg_json(serde_json::json!({
+            "name": "bot",
+            "command": "python3",
+            "message_coalesce_window_ms": 3000,
+        }));
+        let ov = super::overrides_from_sidecar_config(&c).expect("override built");
+        // Allow policy leaves every command-gating field untouched.
+        assert!(!ov.disable_commands);
+        assert!(ov.allowed_commands.is_empty());
+        assert!(ov.blocked_commands.is_empty());
+        assert_eq!(ov.message_debounce_ms, 3000);
+    }
+
+    #[test]
+    fn adapter_exposes_built_overrides_5841() {
+        // The trait method the bridge calls returns the built overrides.
+        let c = cfg_json(serde_json::json!({
+            "name": "bot",
+            "command": "python3",
+            "command_policy": "disable",
+            "message_coalesce_window_ms": 1500,
+        }));
+        let adapter = SidecarAdapter::new(&c, std::path::PathBuf::from("/tmp"));
+        let ov = adapter
+            .channel_overrides()
+            .expect("adapter carries overrides");
+        assert!(ov.disable_commands);
+        assert_eq!(ov.message_debounce_ms, 1500);
     }
 
     #[test]

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -1282,9 +1282,31 @@ fn overrides_from_sidecar_config(
         SidecarCommandPolicy::Allow => {}
         SidecarCommandPolicy::Disable => ov.disable_commands = true,
         SidecarCommandPolicy::Allowlist => {
-            ov.allowed_commands = config.allowed_commands.clone();
+            // Fail closed: `allowlist` is an explicit default-deny intent. An
+            // empty list means "honour no commands", so it must deny all, not
+            // fall through to the allow-everything path `is_command_allowed`
+            // takes when `allowed_commands` is empty. Map empty-allowlist onto
+            // `disable_commands` (the highest-precedence deny) instead.
+            if config.allowed_commands.is_empty() {
+                warn!(
+                    channel = %config.name,
+                    "command_policy = \"allowlist\" with an empty allowed_commands list — denying all commands (fail-closed)"
+                );
+                ov.disable_commands = true;
+            } else {
+                ov.allowed_commands = config.allowed_commands.clone();
+            }
         }
         SidecarCommandPolicy::Blocklist => {
+            // An empty blocklist legitimately means "allow all, block nothing"
+            // — intuitive and harmless — but it usually signals a forgotten
+            // list, so surface it rather than silently allowing everything.
+            if config.blocked_commands.is_empty() {
+                warn!(
+                    channel = %config.name,
+                    "command_policy = \"blocklist\" with an empty blocked_commands list — all commands remain allowed"
+                );
+            }
             ov.blocked_commands = config.blocked_commands.clone();
         }
     }
@@ -2847,6 +2869,26 @@ mod tests {
         let ov = super::overrides_from_sidecar_config(&c).expect("override built");
         assert!(!ov.disable_commands);
         assert_eq!(ov.allowed_commands, vec!["start", "/help"]);
+        assert!(ov.blocked_commands.is_empty());
+    }
+
+    #[test]
+    fn overrides_allowlist_empty_fails_closed_5841() {
+        // Regression (#5931): `allowlist` with an empty / omitted list is an
+        // explicit default-deny intent and must deny ALL commands, not fall
+        // through to the allow-everything path. It maps to `disable_commands`,
+        // the highest-precedence deny `is_command_allowed` honours.
+        let c = cfg_json(serde_json::json!({
+            "name": "public-bot",
+            "command": "python3",
+            "command_policy": "allowlist",
+        }));
+        let ov = super::overrides_from_sidecar_config(&c).expect("override built");
+        assert!(
+            ov.disable_commands,
+            "empty allowlist must fail closed (deny all)"
+        );
+        assert!(ov.allowed_commands.is_empty());
         assert!(ov.blocked_commands.is_empty());
     }
 

--- a/crates/librefang-channels/src/types.rs
+++ b/crates/librefang-channels/src/types.rs
@@ -950,6 +950,22 @@ pub trait ChannelAdapter: Send + Sync {
     fn account_id(&self) -> Option<&str> {
         None
     }
+
+    /// Per-instance channel behaviour overrides carried by the adapter
+    /// itself, rather than resolved kernel-side by channel type (#5841).
+    ///
+    /// Sidecar adapters build this from their `[[sidecar_channels]]`
+    /// block so that two adapters sharing the same `channel_type`
+    /// (e.g. two Telegram bots) can carry distinct command-policy and
+    /// message-coalescing settings — a channel-type-keyed lookup cannot
+    /// tell them apart. The bridge prefers this over the kernel-level
+    /// `channel_overrides(channel_type, …)` lookup when present.
+    ///
+    /// Default `None`: adapters with no per-instance overrides fall back
+    /// to the kernel-resolved overrides.
+    fn channel_overrides(&self) -> Option<librefang_types::config::ChannelOverrides> {
+        None
+    }
 }
 
 /// Split a message into chunks of at most `max_len` characters,

--- a/crates/librefang-channels/tests/bridge_integration_test.rs
+++ b/crates/librefang-channels/tests/bridge_integration_test.rs
@@ -15,6 +15,7 @@ use librefang_channels::types::{
     ChannelAdapter, ChannelContent, ChannelMessage, ChannelType, ChannelUser,
 };
 use librefang_types::agent::AgentId;
+use librefang_types::config::ChannelOverrides;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -54,12 +55,27 @@ struct MockAdapter {
     /// Captures all messages sent via send().
     sent: Arc<Mutex<Vec<(String, String)>>>,
     shutdown_tx: watch::Sender<bool>,
+    /// Per-instance overrides the bridge reads via `channel_overrides()`.
+    /// `None` mirrors a sidecar with no command policy (allow-all fallback).
+    overrides: Option<ChannelOverrides>,
 }
 
 impl MockAdapter {
     /// Create a new mock adapter. Returns (adapter, sender) — use the sender
     /// to inject test messages into the adapter's stream.
     fn new(name: &str, channel_type: ChannelType) -> (Arc<Self>, mpsc::Sender<ChannelMessage>) {
+        Self::new_with_overrides(name, channel_type, None)
+    }
+
+    /// Like `new`, but the adapter carries per-instance `ChannelOverrides`
+    /// (as a sidecar built from `[[sidecar_channels]]` would). The bridge
+    /// prefers these over the kernel-level lookup, so command-policy gating
+    /// can be exercised end-to-end.
+    fn new_with_overrides(
+        name: &str,
+        channel_type: ChannelType,
+        overrides: Option<ChannelOverrides>,
+    ) -> (Arc<Self>, mpsc::Sender<ChannelMessage>) {
         let (tx, rx) = mpsc::channel(256);
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
 
@@ -69,6 +85,7 @@ impl MockAdapter {
             rx: Mutex::new(Some(rx)),
             sent: Arc::new(Mutex::new(Vec::new())),
             shutdown_tx,
+            overrides,
         });
         (adapter, tx)
     }
@@ -136,6 +153,10 @@ impl ChannelAdapter for MockAdapter {
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let _ = self.shutdown_tx.send(true);
         Ok(())
+    }
+
+    fn channel_overrides(&self) -> Option<ChannelOverrides> {
+        self.overrides.clone()
     }
 }
 
@@ -400,6 +421,89 @@ async fn test_bridge_dispatch_agent_select_command() {
     // Verify router was updated — user42 should now route to agent_id
     let resolved = router.resolve(&ChannelType::Telegram, "user42", None);
     assert_eq!(resolved, Some(agent_id));
+
+    manager.stop().await;
+}
+
+/// Regression (#5931): a sidecar with `command_policy = "allowlist"` and an
+/// empty `allowed_commands` must FAIL CLOSED — every command is gated, not
+/// allowed. We build the overrides through the real `SidecarAdapter` so the
+/// `overrides_from_sidecar_config` mapping is exercised end-to-end, then drive
+/// a `/agent coder` command through the live bridge dispatch path and assert
+/// it was NOT honoured (router unchanged) and was instead forwarded to the
+/// agent as plain text (`/agent coder`).
+#[tokio::test]
+async fn test_bridge_allowlist_empty_fails_closed_gates_command_5931() {
+    use librefang_channels::sidecar::SidecarAdapter;
+    use librefang_channels::types::ChannelAdapter as _;
+
+    // The real sidecar config → overrides path: allowlist + empty list.
+    let sidecar_cfg: librefang_types::config::SidecarChannelConfig =
+        serde_json::from_value(serde_json::json!({
+            "name": "public-bot",
+            "command": "true",
+            "command_policy": "allowlist",
+        }))
+        .expect("SidecarChannelConfig from json");
+    let sidecar = SidecarAdapter::new(&sidecar_cfg, std::env::temp_dir());
+    let overrides = sidecar
+        .channel_overrides()
+        .expect("allowlist policy yields per-instance overrides");
+    assert!(
+        overrides.disable_commands,
+        "empty allowlist must map to disable_commands (fail-closed)"
+    );
+
+    let agent_id = AgentId::new();
+    let handle = Arc::new(MockHandle::new(vec![(agent_id, "coder".to_string())]));
+    let router = Arc::new(AgentRouter::new());
+    // Pre-route the user so the forwarded text has somewhere to land.
+    router.set_user_default("user42".to_string(), agent_id);
+
+    let (adapter, tx) =
+        MockAdapter::new_with_overrides("public-bot", ChannelType::Telegram, Some(overrides));
+    let adapter_ref = adapter.clone();
+
+    let mut manager = BridgeManager::new(handle.clone(), router.clone());
+    manager.start_adapter(adapter.clone()).await.unwrap();
+
+    // A privileged command an end user must not be able to run on a public bot.
+    tx.send(make_command_msg(
+        ChannelType::Telegram,
+        "user42",
+        "agent",
+        vec!["coder"],
+    ))
+    .await
+    .unwrap();
+
+    wait_until("gated command forwarded as text", || {
+        !adapter_ref.get_sent().is_empty()
+    })
+    .await;
+
+    // The command was GATED: it was forwarded to the agent verbatim, not
+    // executed as a `/agent` switch (which would have replied with a selection
+    // confirmation).
+    let sent = adapter_ref.get_sent();
+    assert_eq!(sent.len(), 1, "expected exactly one reply, got {sent:?}");
+    assert_eq!(
+        sent[0].1, "Echo: /agent coder",
+        "blocked command must be forwarded to the agent as plain text, got: {}",
+        sent[0].1
+    );
+    assert!(
+        !sent[0].1.contains("Now talking to agent"),
+        "command must NOT have been honoured as an agent switch: {}",
+        sent[0].1
+    );
+
+    // The agent received the raw slash text, confirming it was treated as input.
+    {
+        let received = handle.received.lock().unwrap();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].1, "/agent coder");
+    }
 
     manager.stop().await;
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -2222,6 +2222,36 @@ pub enum SidecarOverflowPolicy {
     DropNewest,
 }
 
+/// Built-in slash-command policy for a sidecar channel.
+///
+/// Ports the in-process `[channels.<name>.overrides]` command gating
+/// (`disable_commands` / `allowed_commands` / `blocked_commands`, #2063)
+/// to the sidecar architecture (#5841). A command that the policy
+/// rejects is **not** answered with an error — it is forwarded to the
+/// agent as plain text, so public-facing bots never reveal the
+/// existence of an internal command system to end users.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SidecarCommandPolicy {
+    /// All built-in slash commands are honoured (current default
+    /// behaviour — preserves backward compatibility).
+    #[default]
+    Allow,
+    /// All built-in slash commands are disabled; any leading-slash text
+    /// is forwarded to the agent as normal content. Use for
+    /// public-facing bots where end users must not be able to switch
+    /// agents or reset sessions.
+    Disable,
+    /// Only the commands in `allowed_commands` are honoured; everything
+    /// else is forwarded as plain text.
+    Allowlist,
+    /// Every command except those in `blocked_commands` is honoured; the
+    /// blocked ones are forwarded as plain text.
+    Blocklist,
+}
+
 /// Configuration for a sidecar channel adapter (external process-based).
 ///
 /// Sidecar adapters allow external processes written in any language to act as
@@ -2290,6 +2320,32 @@ pub struct SidecarChannelConfig {
     /// What to do when `message_buffer` is full.
     #[serde(default)]
     pub overflow: SidecarOverflowPolicy,
+    /// Built-in slash-command policy for this channel (#5841). Ports the
+    /// in-process `disable_commands` / `allowed_commands` /
+    /// `blocked_commands` gating to sidecars. Defaults to `allow` so
+    /// existing configs keep honouring every command. A rejected command
+    /// is forwarded to the agent as plain text, never answered with an
+    /// "unknown command" error.
+    #[serde(default)]
+    pub command_policy: SidecarCommandPolicy,
+    /// Whitelist of built-in command names (without the leading `/`)
+    /// consulted when `command_policy = "allowlist"`. Entries may be
+    /// written with or without a leading slash.
+    #[serde(default)]
+    pub allowed_commands: Vec<String>,
+    /// Blacklist of built-in command names (without the leading `/`)
+    /// consulted when `command_policy = "blocklist"`. Entries may be
+    /// written with or without a leading slash.
+    #[serde(default)]
+    pub blocked_commands: Vec<String>,
+    /// Inbound message-coalescing window in milliseconds (#5841 / #4441).
+    /// When > 0, messages from the same sender arriving within the window
+    /// are buffered and dispatched as a single batched context, so a user
+    /// who forwards several messages in rapid succession produces one
+    /// agent invocation instead of racing concurrent ones on the same
+    /// session. Default `0` (disabled).
+    #[serde(default)]
+    pub message_coalesce_window_ms: u64,
 }
 
 fn default_sidecar_restart() -> bool {
@@ -7008,6 +7064,58 @@ impl Default for ToolResultsConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sidecar_command_policy_and_coalesce_defaults_are_backward_compatible() {
+        // A minimal sidecar block (no command-policy / coalescing keys)
+        // must deserialize to the permissive defaults so existing configs
+        // keep honouring every command and run with coalescing off.
+        let toml_str = r#"
+            name = "telegram"
+            command = "python3"
+        "#;
+        let cfg: SidecarChannelConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.command_policy, SidecarCommandPolicy::Allow);
+        assert!(cfg.allowed_commands.is_empty());
+        assert!(cfg.blocked_commands.is_empty());
+        assert_eq!(cfg.message_coalesce_window_ms, 0);
+    }
+
+    #[test]
+    fn sidecar_command_policy_disable_parses() {
+        let toml_str = r#"
+            name = "afina-sales-bot"
+            command = "python3"
+            command_policy = "disable"
+            message_coalesce_window_ms = 3000
+        "#;
+        let cfg: SidecarChannelConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.command_policy, SidecarCommandPolicy::Disable);
+        assert_eq!(cfg.message_coalesce_window_ms, 3000);
+    }
+
+    #[test]
+    fn sidecar_command_policy_allowlist_and_blocklist_parse() {
+        let allow = r#"
+            name = "bot"
+            command = "python3"
+            command_policy = "allowlist"
+            allowed_commands = ["start", "/help"]
+        "#;
+        let cfg: SidecarChannelConfig = toml::from_str(allow).unwrap();
+        assert_eq!(cfg.command_policy, SidecarCommandPolicy::Allowlist);
+        assert_eq!(cfg.allowed_commands, vec!["start", "/help"]);
+
+        let block = r#"
+            name = "bot"
+            command = "python3"
+            command_policy = "blocklist"
+            blocked_commands = ["new", "reboot", "agent"]
+        "#;
+        let cfg: SidecarChannelConfig = toml::from_str(block).unwrap();
+        assert_eq!(cfg.command_policy, SidecarCommandPolicy::Blocklist);
+        assert_eq!(cfg.blocked_commands, vec!["new", "reboot", "agent"]);
+    }
 
     #[test]
     fn test_session_config_defaults_backward_compatible() {


### PR DESCRIPTION
## Summary

Ports two per-channel overrides that the in-process Telegram adapter had but the sidecar architecture dropped (#5241), so sidecar operators can replicate them again.

Closes #5841.

### 1. Command policy — `command_policy` on `[[sidecar_channels]]`

Re-exposes the in-process `disable_commands` / `allowed_commands` / `blocked_commands` gating (#2063) on sidecar channels:

```toml
[[sidecar_channels]]
name = "afina-sales-bot"
command = "python3"
args = ["-m", "librefang.sidecar.adapters.telegram"]
channel_type = "telegram"
command_policy = "disable"      # allow (default) | disable | allowlist | blocklist
# allowed_commands = ["start"]  # used when command_policy = "allowlist"
# blocked_commands = ["new", "reboot", "agent"]  # used when command_policy = "blocklist"
```

A rejected command is **forwarded to the agent as plain text**, never answered with an "unknown command" error — preserving the #2063 behaviour public-facing / customer-service bots rely on.
A non-technical end user who types `/new` or `/reboot` no longer triggers a session reset.

### 2. Inbound coalescing — `message_coalesce_window_ms`

Re-exposes the inbound debounce window (#4441):

```toml
[[sidecar_channels]]
name = "afina-sales-bot"
message_coalesce_window_ms = 3000   # buffer inbound messages; dispatch once window expires
```

Messages from one sender arriving within the window are buffered and dispatched as a single batched context, so a user forwarding several messages in rapid succession produces one agent invocation instead of racing concurrent ones on the same session (the "Sorry, something went wrong" regression in the issue).

## Implementation

Reuses the gating the bridge already has — the inbound `is_command_allowed` check (`bridge.rs`) and the `MessageDebouncer`.
The only gap was a config path to feed them for sidecars, since `KernelBridgeAdapter::channel_overrides()` returns `None` for sidecar channels.

- `SidecarChannelConfig` gains `command_policy: SidecarCommandPolicy`, `allowed_commands`, `blocked_commands`, `message_coalesce_window_ms` — all `#[serde(default)]`, backward-compatible.
- `SidecarAdapter` builds a `ChannelOverrides` from its block (`overrides_from_sidecar_config`) and exposes it via a new `ChannelAdapter::channel_overrides()` default trait method (default `None`).
- The bridge prefers that per-instance override over the kernel-level `channel_overrides(channel_type, …)` lookup at all three resolution sites (debouncer setup in `start_adapter`, `dispatch_message`, and the coalesced-media flush path). The kernel lookup is keyed only by `channel_type` and cannot distinguish two sidecars sharing a `channel_type` (e.g. two Telegram bots); a per-adapter override can.
- `command_policy` maps onto the existing `is_command_allowed` boolean/list fields; `message_coalesce_window_ms` maps onto the debouncer's `message_debounce_ms`. Gating happens uniformly kernel-side, so **no Python sidecar change is needed** — the adapter still emits the command, the bridge forwards it as text when policy rejects it.

## Tests

- `librefang-types` (`config/types.rs`): serde defaults are backward-compatible (allow policy, coalescing off); `disable` / `allowlist` / `blocklist` blocks parse with their command lists.
- `librefang-channels` (`sidecar.rs`): `overrides_from_sidecar_config` maps each policy variant and the coalesce window correctly, returns `None` for a plain config (so the kernel fallback still applies), and `SidecarAdapter::channel_overrides()` surfaces the built overrides.

## Verification

Run in the sanctioned Docker dev image (`Dockerfile.rust-dev`, named volumes — host `target/` untouched):

- `cargo test -p librefang-types -p librefang-channels --lib` — 1333 pass (6 new in channels, 3 new in types)
- `cargo clippy -p librefang-types -p librefang-channels --all-targets -- -D warnings` — clean
- `cargo fmt -p librefang-types -p librefang-channels -- --check` — clean

## Notes / deferred

- The kernel-config golden fixture (`kernel_config_schema.golden.json`) was updated **by hand** to mirror the deterministic schemars output (new `command_policy` / `allowed_commands` / `blocked_commands` / `message_coalesce_window_ms` properties + the `SidecarCommandPolicy` definition). The automated regen test lives in `librefang-api`, whose build currently hits a pre-existing aarch64-Linux `libc::SYS_getpgrp` break in `librefang-runtime` (unrelated to this change; `SYS_getpgrp` is x86-only). The golden assertion `kernel_config_schema_matches_golden_fixture` is itself `#[ignore]`d on `main` for separate pre-existing drift, so CI does not gate on the fixture yet — but please re-run `cargo test -p librefang-api --test config_schema_golden -- --ignored regenerate_golden --nocapture` on an x86_64 host to confirm a byte-match if convenient.
- No CHANGELOG entry added (no `[Unreleased]` section exists on `main` and the attribution guard expects `(@user)`); add one on merge.
- No dashboard form for these fields — they are TOML-only, matching the issue's proposed config shape. Adding a dashboard surface would be a separate change in the dashboard domain.
