### PR TITLE
ci: skip deleted (410 Gone) issues in auto-close reconciler

### DIFF
--- a/.github/workflows/auto-close-resolved-issues.yml
+++ b/.github/workflows/auto-close-resolved-issues.yml
@@ -145,7 +145,12 @@ jobs:
                 });
                 issue = r.data;
               } catch (e) {
-                if (e.status === 404) { skipped.push(`#${num} (not found)`); continue; }
+                // 404 = never existed; 410 = existed but was deleted (Gone).
+                // Both mean "no issue to act on" — skip rather than crash the run.
+                if (e.status === 404 || e.status === 410) {
+                  skipped.push(`#${num} (${e.status === 410 ? 'deleted' : 'not found'})`);
+                  continue;
+                }
                 throw e;
               }
 


### PR DESCRIPTION
## Problem

The `Auto-close Resolved Issues` scheduled workflow has been failing on `main`. The latest run errored with:

```
##[error]Unhandled error: HttpError: This issue was deleted
status: '410'
```

In the `reconcile` job, `github.rest.issues.get()` is wrapped in a `try/catch` that only handles `404` (issue never existed). When a recent commit references an issue that was later **deleted**, GitHub's API returns `410 Gone`, which falls through to the `throw e` rethrow and crashes the entire daily run before any other referenced issue is processed.

This is automation-only noise — it does not affect build/test CI (`CI`, `Coverage`, `Docker Build`, `Nix Build`, `cargo-deny` are all green on `main`) — but it leaves a persistent red mark on the default branch and silently disables the stale-issue safety net.

## Fix

Treat `410` the same as `404`: record the reference as skipped and `continue`, so a single deleted-issue reference no longer fails the run.

```js
if (e.status === 404 || e.status === 410) {
  skipped.push(`#${num} (${e.status === 410 ? 'deleted' : 'not found'})`);
  continue;
}
throw e;
```

The later `listComments` / `listEvents` calls are unaffected because the deleted issue is now skipped before they run.

## Verification

Workflow-only change (no Rust touched). YAML edit is confined to the `github-script` body; the `404 || 410` branch mirrors the existing `404` skip path. The next scheduled run (or a `workflow_dispatch` dry-run) will exercise it against live data.
