### PR TITLE
style(runtime): rustfmt knowledge.rs to unbreak main Quality (post #5767)

### DIFF
--- a/crates/librefang-runtime/src/tool_runner/knowledge.rs
+++ b/crates/librefang-runtime/src/tool_runner/knowledge.rs
@@ -75,9 +75,7 @@ pub(super) async fn tool_knowledge_add_entity(
                 .take(MAX_PROPERTY_COUNT)
                 .map(|(k, v)| {
                     let capped = if let Some(s) = v.as_str() {
-                        serde_json::Value::String(
-                            s.chars().take(MAX_PROPERTY_VALUE_LEN).collect(),
-                        )
+                        serde_json::Value::String(s.chars().take(MAX_PROPERTY_VALUE_LEN).collect())
                     } else {
                         v.clone()
                     };
@@ -127,9 +125,7 @@ pub(super) async fn tool_knowledge_add_relation(
                 .take(MAX_PROPERTY_COUNT)
                 .map(|(k, v)| {
                     let capped = if let Some(s) = v.as_str() {
-                        serde_json::Value::String(
-                            s.chars().take(MAX_PROPERTY_VALUE_LEN).collect(),
-                        )
+                        serde_json::Value::String(s.chars().take(MAX_PROPERTY_VALUE_LEN).collect())
                     } else {
                         v.clone()
                     };
@@ -207,7 +203,11 @@ pub(super) async fn tool_knowledge_query(
 
     let shown = matches.len().min(limit);
     let mut output = String::with_capacity(256 * shown);
-    output.push_str(&format!("Found {} match(es) (showing {}):\n", matches.len(), shown));
+    output.push_str(&format!(
+        "Found {} match(es) (showing {}):\n",
+        matches.len(),
+        shown
+    ));
     for m in matches.iter().take(limit) {
         use std::fmt::Write;
         let _ = write!(


### PR DESCRIPTION
## Problem

`main` (`Test / Quality`) is red: the `cargo xtask fmt` check fails on `crates/librefang-runtime/src/tool_runner/knowledge.rs` at three spots.

The break landed with the squash-merge of #5767 (`fix(runtime): knowledge confidence clamp …`). The merged tree was not rustfmt-clean — likely a rebase/merge edit (the `Found … (showing …)` header wording differs from the original PR diff) reintroduced formatting drift that the contributor PR's own CI did not surface.

The immediately prior main commit (`f772ddff`) had `Quality = success`; `9448034f` (#5767) is `Quality = failure`.

## Fix

Apply exactly what `rustfmt` requests (verbatim from the failing CI log), no logic change:

- Two `serde_json::Value::String(s.chars().take(MAX_PROPERTY_VALUE_LEN).collect())` calls collapsed back onto one line.
- The `output.push_str(&format!("Found {} match(es) (showing {}):\n", matches.len(), shown))` call wrapped across lines.

`git diff --stat`: 1 file, 7 insertions / 7 deletions — formatting only.

## Verification

- Edits are byte-for-byte the canonical output shown in the failed `Quality` run (`cargo xtask fmt`).
- rustfmt is not installed on the author's host (toolchain runs via Docker); the `Quality` job on this PR re-runs `cargo xtask fmt` and is the authoritative check.
