### PR TITLE
chore(release): bump version to 2026.5.31-beta.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.5.31] - 2026-05-31
+
+_15 PRs from 2 contributors since v2026.5.30-beta.15._
+
+### Added
+
+- Inline skill assignment on the agent Skills tab (#4917) (#5930) (@houko)
+- Port command-policy and message coalescing to sidecar channels (#5931) (@houko)
+- Propose evolved skill as PR to registry (#5932) (@houko)
+- Ship librefang-sidecar-telegram binary in release tarballs (#5937) (@houko)
+
+### Fixed
+
+- Tool_runner knowledge — confidence clamp, input validation, result limits, property bounds (#5767) (@leszek3737)
+- Tool_runner image — extension whitelist, 50MB limit, BMP i32, JPEG markers, PNG sig (#5768) (@leszek3737)
+- Enable agent model Save on any field change (#5917) (#5925) (@houko)
+- Empty mcp_servers = [] grants no MCP tools, not all (#5855) (#5928) (@houko)
+- Move getpgrp to the x86_64-only seccomp block to unbreak aarch64 (#5929) (@houko)
+- Patch rand (0.8.6/0.9.3) and link-preview-js (4.0.1) security advisories (#5934) (@houko)
+- Migrate ssh-backend to russh 0.61.1 (clears 5 RustSec advisories) (#5935) (@houko)
+
+### Changed
+
+- Migrate read_artifact to ToolError (error-contracts slice 2) (#5926) (@houko)
+
+<details>
+<summary>Documentation, maintenance, and other internal changes</summary>
+
+### Maintenance
+
+- Regression test for #5857 Windows provider-key path validation (#5927) (@houko)
+- Skip deleted (410 Gone) issues in auto-close reconciler (#5933) (@houko)
+- Rustfmt knowledge.rs to unbreak main Quality (post #5767) (#5938) (@houko)
+
+</details>
+
+
 ## [2026.5.30] - 2026-05-30
 
 _68 PRs from 5 contributors since v2026.5.28-beta.14._

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-acp"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-tokio",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -4523,7 +4523,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "axum",
  "clap",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "librefang-types",
  "reqwest",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-import"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4740,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4753,7 +4753,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "librefang-llm-driver",
  "librefang-memory",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory-wiki"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "chrono",
  "librefang-kernel-handle",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-rl-export"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4953,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-audit"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "chrono",
  "hex",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-media"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-sandbox-docker"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -5053,7 +5053,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-subprocess"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "metrics",
  "serde_json",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -12500,7 +12500,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.5.32315",
+  "version": "26.5.32326",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.5.30-beta.15",
+  "version": "2026.5.31-beta.16",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.5.30-beta.15",
+  "version": "2026.5.31-beta.16",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.5.30b15",
+    version="2026.5.31b16",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.5.30-beta.15"
+version = "2026.5.31-beta.16"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"


### PR DESCRIPTION
## What

Bump the workspace version from `2026.5.30-beta.15` to `2026.5.31-beta.16` and add the corresponding `CHANGELOG.md` section for the 15 PRs merged from 2 contributors since `v2026.5.30-beta.15`.

These are the standard release-bump artifacts (version files + generated changelog) that the `cargo xtask release` flow normally produces. The previous run was interrupted partway through (before commit/tag), so this PR carries the bump through the normal review flow instead.

## Changes

- `Cargo.toml`: workspace version `2026.5.30-beta.15` → `2026.5.31-beta.16`
- `Cargo.lock`: version propagation for workspace crates
- `CHANGELOG.md`: new `## [2026.5.31]` section (Added / Fixed / Changed / Maintenance), generated from merged PRs
- `crates/librefang-desktop/tauri.conf.json`, `packages/whatsapp-gateway/package.json`, `sdk/javascript/package.json`, `sdk/python/setup.py`, `sdk/rust/Cargo.toml`: version sync

No source / logic changes — version strings and changelog only.

## Follow-up

This bump goes through a PR rather than the release tool's auto-commit+tag path, so after merge the tag `v2026.5.31-beta.16` still needs to be cut to trigger the release CI (npm / PyPI / crates.io publish).
