### PR TITLE
ci: merge_group support (prereq for merge queue) [stacked on #5943]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read
@@ -65,6 +66,21 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
+
+          # Merge queue: the queue branch is the last gate before main. A queued
+          # entry can batch several PRs, so a HEAD~1 diff is unreliable — instead
+          # force every route flag on and run the full suite on all platforms.
+          # This sidesteps the selective diff entirely.
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            {
+              echo "rust=true"; echo "docs=true"; echo "ci=true"; echo "install=true"
+              echo "full_run=true"; echo "full_test=true"
+              echo "skill_sdk=true"; echo "sidecar_rust=true"
+              echo "crates="
+            } >> "$GITHUB_OUTPUT"
+            echo "merge_group: forcing full run on all platforms"
+            exit 0
+          fi
 
           # Range: PR → base..head, push → just the pushed commit.
           if [ "$EVENT_NAME" = "pull_request" ]; then
@@ -567,7 +583,7 @@ jobs:
     needs: changes
     # PR-only: push to main already runs the full test matrix; the smoke
     # adds spawn-a-real-daemon coverage that the in-process tests miss.
-    if: github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true')
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -800,7 +816,7 @@ jobs:
   test-windows:
     name: Test / Windows (shard ${{ matrix.shard }}/2)
     needs: changes
-    if: github.event_name == 'push' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true')
+    if: (github.event_name == 'push' || github.event_name == 'merge_group') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true')
     runs-on: windows-latest
     timeout-minutes: 60
     strategy:
@@ -835,7 +851,7 @@ jobs:
   test-macos:
     name: Test / macOS
     needs: changes
-    if: github.event_name == 'push' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true')
+    if: (github.event_name == 'push' || github.event_name == 'merge_group') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true')
     runs-on: macos-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## What

Makes CI merge-queue-ready, so the `main` ruleset's `merge_queue` rule can be turned on safely.

GitHub's merge queue fires a `merge_group` event on a temporary queue branch and waits for the required checks to report there. If the workflows don't run on `merge_group`, the required checks never report and **every queued PR stalls forever**. This PR adds that support:

- **`merge_group` trigger** added to `ci.yml`.
- **`changes` short-circuits on `merge_group`** to force a full run on all platforms. A queued entry can batch several PRs, so a `HEAD~1` diff is unreliable — the queue is the last gate before `main`, so it runs everything rather than the selective per-PR routing.
- **Platform + smoke lanes fire in the queue**: `Test / Windows`, `Test / macOS` (push-only today) and `Live Integration Smoke` (PR-only today) now also run on `merge_group`, so the queue catches platform / smoke regressions before they land — the main point of having a queue.
- PR-hygiene checks (`No Build Artifacts`, `CHANGELOG Attribution`) stay PR-only; they're already satisfied by the time a PR enters the queue, and `CI Gate` treats their queue-time skip as passing.

## Stacked on #5943

This branches off `ci/fail-closed-gate-aarch64` and needs its `CI Gate` job. Rebase onto `main` and retarget the base once #5943 merges.

## Verification & caveat

- `ci.yml` parses (PyYAML); triggers are `push` / `pull_request` / `merge_group`; job count unchanged.
- **The `merge_group` path cannot be exercised by this PR's own `pull_request` CI** — that event only fires inside a live queue. So this lands on faith in the config, with a willingness to hotfix the first time the queue runs.

## Enablement sequence (do in order)

1. Merge #5943.
2. Switch the `main` ruleset required-status-checks to the single `CI Gate` context.
3. Merge this PR.
4. Add the `merge_queue` rule to the `main` ruleset. Watch the first queued PR; be ready to revert step 4 if anything stalls.

Opened as a **draft** — not to be merged until step 1/2 are done and step 4 is a deliberate, watched flip.
