### PR TITLE
refactor(memory): derive task_claim retry budget from pool size

### DIFF
--- a/crates/librefang-memory/src/substrate.rs
+++ b/crates/librefang-memory/src/substrate.rs
@@ -1038,6 +1038,12 @@ impl MemorySubstrate {
         agent_name: Option<&str>,
     ) -> LibreFangResult<Option<serde_json::Value>> {
         let conn = self.pool.clone();
+        // Derive the retry budget from the pool size instead of a magic number:
+        // at most `max_size` claimants can hold a connection (and thus contend
+        // on the CAS) at once — the rest block on `conn.get()` — so 2× that
+        // comfortably outlasts a full wave of rivals before yielding to the
+        // caller. Scales automatically when the pool is configured larger.
+        let max_claim_attempts = self.pool.max_size() as usize * 2;
         let agent_id = agent_id.to_string();
         let agent_name = agent_name.unwrap_or("").to_string();
 
@@ -1065,8 +1071,7 @@ impl MemorySubstrate {
             // bound caps the walk so pathological churn (claimants grabbing rows
             // faster than we SELECT) can't spin this blocking task forever — the
             // caller re-fires on its next invocation.
-            const MAX_CLAIM_ATTEMPTS: usize = 16;
-            for _ in 0..MAX_CLAIM_ATTEMPTS {
+            for _ in 0..max_claim_attempts {
                 let result = stmt.query_row(rusqlite::params![agent_id, agent_name], |row| {
                     Ok((
                         row.get::<_, String>(0)?,


### PR DESCRIPTION
## Summary

Addresses the non-blocking nit from the #5973 review: `MAX_CLAIM_ATTEMPTS`
in `task_claim` was a hardcoded `16`, not tied to the actual concurrency
surface.

## Change

Derive the retry budget from the connection pool's `max_size` — the real
upper bound on simultaneous CAS contenders, since extra claimants block on
`conn.get()` until a connection frees up:

```rust
let max_claim_attempts = self.pool.max_size() as usize * 2;
```

- Default pool size is `DEFAULT_POOL_SIZE = 8` -> budget `16`, **identical to
  the previous hardcoded value** — no behavior change on the default path.
- The budget now scales automatically when an operator configures a larger
  pool via `open_with_pool_size`, so the "claim past a lost CAS race" walk
  can't be starved by a bound that no longer matches the concurrency.

Single change in `librefang-memory`; the existing `task_claim` concurrency
tests (pool size 8 -> budget 16) continue to cover the loop unchanged.

## Verification

Local compile/test not possible here (no native cargo, no Docker daemon) —
CI is the gate (`cargo check --workspace --lib`, clippy, fmt, nextest).
Default-path behavior is unchanged (8 x 2 = 16).

Refs #5961.
