### PR TITLE
fix(runtime): history fold preserves tool-result content on omit AND parse failure (#5978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -651,8 +651,9 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
   Regression tests: `router::tests::sidecar_default_does_not_collide_across_bots` (two sidecars register under distinct `telegram:<name>` keys, no last-writer-wins collision) and `sidecar::tests::test_sidecar_stamps_account_id_from_adapter_name` (a real sidecar subprocess stamps `account_id` from the config name, not the `ready`-event account, and preserves an adapter-supplied one).
 
 - **runtime(history-fold): preserve omitted tool-result content instead of substituting an "unavailable" stub** (#5978) (@DaBlitzStein).
-  The fold's apply loop unconditionally replaced every omitted tool result with the `[summarisation unavailable]` fallback string, so a recalled memory tool result lost its content and the agent re-issued `memory_recall` forever, an endless loop that drained tokens.
-  Omitted results now keep their preview-truncated original content, breaking the loop while still bounding the folded size.
+  The fold's apply loop discarded the real tool result in two cases — an id the model silently omitted from an otherwise-valid batch, and a response that could not be parsed as `[{id,summary}]` JSON at all (the latter was dumped verbatim over every stale block as a "bulk summary").
+  Either way a recalled memory tool result lost its content, the agent read it as "no answer yet", and re-issued `memory_recall` forever — an endless loop that drained tokens (verified live: a Moonshot/Kimi response that failed the JSON parse triggered exactly this).
+  Both cases now keep each block's preview-truncated original content, breaking the loop while still bounding the folded size; the raw unparseable response is no longer applied as a bulk summary.
 
 - **kernel(cron): day-of-week now follows the POSIX convention (`0` and `7` both mean Sunday)** instead of the `cron` crate's 1-7 mapping (#5966) (@DaBlitzStein).
   Sunday-only schedules like `0 16 * * 0` were previously rejected as unschedulable, and numeric weekday ranges such as `1-5` silently shifted by one day (firing Sun-Thu instead of Mon-Fri).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -650,6 +650,10 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
   Registration key and resolution key now both derive from `SidecarChannelConfig::name`, so they line up.
   Regression tests: `router::tests::sidecar_default_does_not_collide_across_bots` (two sidecars register under distinct `telegram:<name>` keys, no last-writer-wins collision) and `sidecar::tests::test_sidecar_stamps_account_id_from_adapter_name` (a real sidecar subprocess stamps `account_id` from the config name, not the `ready`-event account, and preserves an adapter-supplied one).
 
+- **runtime(history-fold): preserve omitted tool-result content instead of substituting an "unavailable" stub** (#5978) (@DaBlitzStein).
+  The fold's apply loop unconditionally replaced every omitted tool result with the `[summarisation unavailable]` fallback string, so a recalled memory tool result lost its content and the agent re-issued `memory_recall` forever, an endless loop that drained tokens.
+  Omitted results now keep their preview-truncated original content, breaking the loop while still bounding the folded size.
+
 - **kernel(cron): day-of-week now follows the POSIX convention (`0` and `7` both mean Sunday)** instead of the `cron` crate's 1-7 mapping (#5966) (@DaBlitzStein).
   Sunday-only schedules like `0 16 * * 0` were previously rejected as unschedulable, and numeric weekday ranges such as `1-5` silently shifted by one day (firing Sun-Thu instead of Mon-Fri).
   The 5/6-field expression is now remapped at the single conversion site before it reaches the crate, so `0`/`7` resolve to Sunday and `1-5` fires Monday through Friday as written.

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -83,7 +83,22 @@ const FOLD_PREFIX: &str = "[history-fold]";
 const FOLD_PREVIEW_CHARS: usize = 500;
 
 /// Static-stub text used when the aux-LLM summarisation call fails outright.
-const FALLBACK_SUMMARY: &str = "[summarisation unavailable]";
+///
+/// Explicitly tells the model the call genuinely failed so it does NOT
+/// re-issue the identical tool call.  Only applied when the whole batched
+/// summariser call failed (network/empty) — see `bulk_fallback`.  For the
+/// narrower case where the model simply *omitted* one id from an otherwise
+/// successful batch, the original tool result is preserved instead (see the
+/// `[result preserved — summarisation omitted]` branch in the apply loop) so
+/// the model never reads a folded block as "result not available yet" and
+/// retries (issue #5978).
+const FALLBACK_SUMMARY: &str = "[summarisation unavailable — do not retry this tool call]";
+
+/// Marker prefixing a fold block whose id the summariser omitted from an
+/// otherwise-successful batch.  The original tool result is preserved
+/// (preview-truncated) after this marker so the model sees what the tool
+/// returned and does not re-issue the identical call (issue #5978).
+const OMITTED_SUMMARY_PREFIX: &str = "[result preserved — summarisation omitted]";
 
 /// Hard cap on `max_tokens` requested from the summariser.  Several
 /// providers (Groq Llama-3.1, Cerebras, older Anthropic SKUs) reject
@@ -282,7 +297,7 @@ pub async fn fold_stale_tool_results(
             if !missing.is_empty() {
                 warn!(
                     missing_ids = ?missing,
-                    "history_fold: model omitted summaries for some stale tool_use_ids — those blocks fall back to the static stub"
+                    "history_fold: model omitted summaries for some stale tool_use_ids — those blocks preserve a preview-truncated copy of the original tool result (issue #5978)"
                 );
             }
             (map, None)
@@ -320,12 +335,37 @@ pub async fn fold_stale_tool_results(
                     ..
                 } = block
                 {
-                    let summary = summaries_by_id
-                        .get(tool_use_id)
-                        .cloned()
-                        .or_else(|| bulk_fallback.clone())
-                        .unwrap_or_else(|| FALLBACK_SUMMARY.to_string());
-                    let new_content = format!("{FOLD_PREFIX} {summary}");
+                    // Resolve the new folded content for this block:
+                    //   1. model-returned per-id summary (happy path), OR
+                    //   2. bulk fallback — either the raw non-JSON response
+                    //      (Parse failure) or the static stub (call failure), OR
+                    //   3. neither: the batched call *succeeded* but the model
+                    //      silently omitted this id.  Previously this fell back
+                    //      to FALLBACK_SUMMARY, discarding the real prior tool
+                    //      result — the model then read the block as "result
+                    //      not available yet" and re-issued the identical call,
+                    //      producing the endless memory_recall loop in #5978.
+                    //      Instead, PRESERVE a preview-truncated copy of the
+                    //      ORIGINAL `content` (still intact at this point — the
+                    //      apply loop has not overwritten it yet) so the model
+                    //      sees what the tool returned and does not retry.
+                    let new_content = if let Some(summary) =
+                        summaries_by_id.get(tool_use_id).cloned()
+                    {
+                        format!("{FOLD_PREFIX} {summary}")
+                    } else if let Some(bulk) = bulk_fallback.clone() {
+                        format!("{FOLD_PREFIX} {bulk}")
+                    } else {
+                        // Omitted id from an otherwise-successful batch:
+                        // preserve the original result, preview-truncated.
+                        let preview: String = content.chars().take(FOLD_PREVIEW_CHARS).collect();
+                        let ellipsis = if content.chars().count() > FOLD_PREVIEW_CHARS {
+                            "…"
+                        } else {
+                            ""
+                        };
+                        format!("{FOLD_PREFIX} {OMITTED_SUMMARY_PREFIX} {preview}{ellipsis}")
+                    };
                     if *content != new_content {
                         *content = new_content.clone();
                         result.rewrites.insert(tool_use_id.clone(), new_content);
@@ -530,7 +570,11 @@ async fn summarise_batch(
          Capture what the tool did and what it returned, omitting raw data. \
          Output ONLY a JSON array of objects with this shape: \
          [{\"id\":\"<tool_use_id>\",\"summary\":\"...\"}]. \
-         Echo every id verbatim. No preamble, no markdown fences.\n\n\
+         You MUST return exactly one object for EVERY id listed below, in the \
+         same order, even when a result is empty, an error, or trivial — in \
+         that case summarise it as such (e.g. \"returned no output\" or \
+         \"errored: <reason>\") rather than omitting the id. Never skip, merge, \
+         or drop an id. Echo every id verbatim. No preamble, no markdown fences.\n\n\
          Results:\n",
     );
     for b in blocks {
@@ -1490,14 +1534,18 @@ mod tests {
     }
 
     /// JSON parse succeeds but every returned `id` is bogus (no overlap
-    /// with stale `tool_use_id`s).  The Ok-path runs, the per-block
-    /// apply loop finds no matching summary, every block falls back to
-    /// the static stub.  `groups_used_fallback` stays 0 (the aux-LLM
-    /// call itself succeeded — the operator-visible drift is surfaced
-    /// via the unmatched-ids warn, not this counter).
+    /// with stale `tool_use_id`s).  The Ok-path runs, the per-block apply
+    /// loop finds no matching summary AND there is no `bulk_fallback`
+    /// (the call succeeded), so every block lands on the omitted-id
+    /// preservation branch (issue #5978): the ORIGINAL tool result is
+    /// kept, preview-truncated, NOT the static stub.  This prevents the
+    /// model from reading the fold as "result not available yet" and
+    /// re-issuing the identical call.  `groups_used_fallback` stays 0
+    /// (the aux-LLM call itself succeeded — the operator-visible drift
+    /// is surfaced via the unmatched-ids warn, not this counter).
     #[tokio::test]
-    async fn parse_succeeds_but_all_ids_bogus_falls_back_per_block() {
-        let messages = build_history(10); // tid_0..tid_9
+    async fn parse_succeeds_but_all_ids_bogus_preserves_original_content() {
+        let messages = build_history(10); // tid_0..tid_9, content "output of turn N"
         let bogus = r#"[{"id":"not_a_real_id","summary":"won't match anything"}]"#;
         let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(bogus.to_string()));
 
@@ -1514,18 +1562,20 @@ mod tests {
         )
         .await;
 
-        // Ok-path → aux-call-failure counter stays 0 even though every
-        // block ended up on the static stub.
+        // Ok-path → aux-call-failure counter stays 0.
         assert_eq!(result.groups_used_fallback, 0);
-        // But every folded block should carry the static FALLBACK_SUMMARY
-        // marker, not arbitrary text.
-        let stale_count = out
+        // Every folded block must carry the omitted-id preservation marker
+        // plus a copy of the ORIGINAL tool result — and must NOT carry the
+        // "summarisation unavailable" static stub.
+        let preserved_count = out
             .iter()
             .filter(|m| match &m.content {
                 MessageContent::Blocks(blocks) => blocks.iter().any(|b| match b {
                     ContentBlock::ToolResult { content, .. } => {
                         content.starts_with(FOLD_PREFIX)
-                            && content.contains("summarisation unavailable")
+                            && content.contains(OMITTED_SUMMARY_PREFIX)
+                            && content.contains("output of turn")
+                            && !content.contains("summarisation unavailable")
                     }
                     _ => false,
                 }),
@@ -1533,10 +1583,155 @@ mod tests {
             })
             .count();
         assert!(
-            stale_count >= 8,
-            "every stale block must carry the static fallback stub when no \
-             returned id matches; saw {stale_count}"
+            preserved_count >= 8,
+            "every stale block must preserve its original tool result when no \
+             returned id matches (issue #5978); saw {preserved_count}"
         );
+    }
+
+    /// Issue #5978 regression: when the summariser returns a valid batch
+    /// but OMITS one stale id, that block must preserve a preview-truncated
+    /// copy of its ORIGINAL tool result — never the static
+    /// `[summarisation unavailable]` stub, which the model reads as "result
+    /// not available yet" and re-issues the identical call (the endless
+    /// memory_recall loop).
+    #[tokio::test]
+    async fn omitted_ids_preserve_original_content() {
+        // build_history(10) with fold_after=2 → stale ids tid_0..tid_7,
+        // each with content "output of turn N".  The response below names
+        // tid_0..tid_6 but DELIBERATELY omits tid_7.
+        let messages = build_history(10);
+        let json = r#"[
+            {"id":"tid_0","summary":"s0"},
+            {"id":"tid_1","summary":"s1"},
+            {"id":"tid_2","summary":"s2"},
+            {"id":"tid_3","summary":"s3"},
+            {"id":"tid_4","summary":"s4"},
+            {"id":"tid_5","summary":"s5"},
+            {"id":"tid_6","summary":"s6"}
+        ]"#;
+        let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(json.to_string()));
+
+        let (out, _result) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+
+        // The omitted tid_7 block must keep a copy of its original result.
+        let tid_7_content = out.iter().find_map(|m| match &m.content {
+            MessageContent::Blocks(blocks) => blocks.iter().find_map(|b| match b {
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } if tool_use_id == "tid_7" => Some(content.clone()),
+                _ => None,
+            }),
+            _ => None,
+        });
+        let content = tid_7_content.expect("tid_7 ToolResult must survive fold");
+        assert!(
+            content.contains("output of turn 7"),
+            "omitted id must preserve a substring of the ORIGINAL tool result, got: {content:?}"
+        );
+        assert!(
+            !content.contains("summarisation unavailable"),
+            "omitted id must NOT carry the static FALLBACK_SUMMARY stub, got: {content:?}"
+        );
+        assert!(
+            content.contains(OMITTED_SUMMARY_PREFIX),
+            "omitted id must carry the preservation marker, got: {content:?}"
+        );
+
+        // A named id (tid_0) must still receive its model summary.
+        let tid_0_content = out.iter().find_map(|m| match &m.content {
+            MessageContent::Blocks(blocks) => blocks.iter().find_map(|b| match b {
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } if tool_use_id == "tid_0" => Some(content.clone()),
+                _ => None,
+            }),
+            _ => None,
+        });
+        assert_eq!(
+            tid_0_content.as_deref(),
+            Some("[history-fold] s0"),
+            "named ids must still receive their per-id model summary"
+        );
+    }
+
+    /// Issue #5978 regression (negative assertion): the FALLBACK_SUMMARY
+    /// text must NOT appear in any block whose id was merely omitted from
+    /// an otherwise-successful batch.  Belt-and-suspenders companion to
+    /// `omitted_ids_preserve_original_content`.
+    #[tokio::test]
+    async fn omitted_ids_do_not_carry_fallback_summary_string() {
+        let messages = build_history(10); // stale tid_0..tid_7
+                                          // Name only tid_0; tid_1..tid_7 are all omitted.
+        let json = r#"[{"id":"tid_0","summary":"only one named"}]"#;
+        let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(json.to_string()));
+
+        let (out, _result) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+
+        // No folded block may carry the static "summarisation unavailable"
+        // stub — every omitted id preserves its original content instead.
+        let any_fallback = out.iter().any(|m| match &m.content {
+            MessageContent::Blocks(blocks) => blocks.iter().any(|b| match b {
+                ContentBlock::ToolResult { content, .. } => {
+                    content.contains("summarisation unavailable")
+                }
+                _ => false,
+            }),
+            _ => false,
+        });
+        assert!(
+            !any_fallback,
+            "no omitted-id block may carry the FALLBACK_SUMMARY stub (issue #5978)"
+        );
+
+        // And the omitted blocks must preserve their original results.
+        for i in 1..=7 {
+            let id = format!("tid_{i}");
+            let content = out
+                .iter()
+                .find_map(|m| match &m.content {
+                    MessageContent::Blocks(blocks) => blocks.iter().find_map(|b| match b {
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                            ..
+                        } if *tool_use_id == id => Some(content.clone()),
+                        _ => None,
+                    }),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            assert!(
+                content.contains(&format!("output of turn {i}")),
+                "omitted {id} must preserve its original result, got: {content:?}"
+            );
+        }
     }
 
     /// `apply_fold_rewrites` must walk a separate message list (typically

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -302,13 +302,23 @@ pub async fn fold_stale_tool_results(
             }
             (map, None)
         }
-        Err(BatchSummariseFailure::Parse { raw, error }) => {
+        Err(BatchSummariseFailure::Parse { error }) => {
+            // The aux model returned a body we could not parse as the
+            // expected `[{id,summary}]` JSON.  Do NOT dump the raw non-JSON
+            // text over every stale tool result as a bulk summary — that is
+            // exactly the #5978 failure: a `memory_recall` result gets
+            // overwritten with garbage, the model reads it as "no answer"
+            // and re-issues the identical call forever (verified live,
+            // session 81620c15).  Treat it like a fully-omitted batch:
+            // an empty map + `None` bulk fallback routes every stale block
+            // into the content-preserving branch below, so each keeps a
+            // preview-truncated copy of its own original result.
             warn!(
                 count = stale_count,
                 error = %error,
-                "history_fold: JSON parse failed — applying raw response as bulk summary"
+                "history_fold: JSON parse failed — preserving preview-truncated original tool results (issue #5978)"
             );
-            (BTreeMap::new(), Some(raw))
+            (BTreeMap::new(), None)
         }
         Err(err) => {
             warn!(
@@ -337,18 +347,21 @@ pub async fn fold_stale_tool_results(
                 {
                     // Resolve the new folded content for this block:
                     //   1. model-returned per-id summary (happy path), OR
-                    //   2. bulk fallback — either the raw non-JSON response
-                    //      (Parse failure) or the static stub (call failure), OR
+                    //   2. bulk fallback — the static stub, used only when the
+                    //      aux call itself failed (network / empty body), OR
                     //   3. neither: the batched call *succeeded* but the model
-                    //      silently omitted this id.  Previously this fell back
-                    //      to FALLBACK_SUMMARY, discarding the real prior tool
-                    //      result — the model then read the block as "result
-                    //      not available yet" and re-issued the identical call,
-                    //      producing the endless memory_recall loop in #5978.
-                    //      Instead, PRESERVE a preview-truncated copy of the
-                    //      ORIGINAL `content` (still intact at this point — the
-                    //      apply loop has not overwritten it yet) so the model
-                    //      sees what the tool returned and does not retry.
+                    //      silently omitted this id, OR the response could not
+                    //      be parsed as JSON at all (Parse failure → empty map
+                    //      + `None` fallback, so every block lands here).
+                    //      Previously both of those fell back to a stub that
+                    //      discarded the real prior tool result — the model
+                    //      then read the block as "result not available yet"
+                    //      and re-issued the identical call, producing the
+                    //      endless memory_recall loop in #5978.  Instead,
+                    //      PRESERVE a preview-truncated copy of the ORIGINAL
+                    //      `content` (still intact at this point — the apply
+                    //      loop has not overwritten it yet) so the model sees
+                    //      what the tool returned and does not retry.
                     let new_content = if let Some(summary) =
                         summaries_by_id.get(tool_use_id).cloned()
                     {
@@ -533,13 +546,16 @@ fn is_already_folded(msg: &Message) -> bool {
     }
 }
 
-/// Failure modes for the batched summariser.  `Parse` retains the raw
-/// model response so the caller can fall back to Option-1 bulk-summary
-/// semantics instead of wasting the round-trip.
+/// Failure modes for the batched summariser.  All three are handled by
+/// preserving the stale blocks' original content rather than substituting a
+/// summary: `Call` / `Empty` fall back to the static stub, while `Parse`
+/// (an unparseable response) keeps each block's own preview-truncated
+/// original — dumping the raw non-JSON text as a bulk summary is the #5978
+/// memory_recall loop, so the raw body is intentionally not retained.
 enum BatchSummariseFailure {
     Call(String),
     Empty,
-    Parse { raw: String, error: String },
+    Parse { error: String },
 }
 
 impl std::fmt::Display for BatchSummariseFailure {
@@ -547,7 +563,7 @@ impl std::fmt::Display for BatchSummariseFailure {
         match self {
             BatchSummariseFailure::Call(e) => write!(f, "LLM call failed: {e}"),
             BatchSummariseFailure::Empty => write!(f, "LLM returned empty response"),
-            BatchSummariseFailure::Parse { error, .. } => write!(f, "{error}"),
+            BatchSummariseFailure::Parse { error } => write!(f, "{error}"),
         }
     }
 }
@@ -673,10 +689,7 @@ async fn summarise_batch(
         return Err(BatchSummariseFailure::Empty);
     }
 
-    parse_labeled_summaries(&raw).map_err(|error| BatchSummariseFailure::Parse {
-        raw: raw.clone(),
-        error,
-    })
+    parse_labeled_summaries(&raw).map_err(|error| BatchSummariseFailure::Parse { error })
 }
 
 /// Parse the batched-call response into a `tool_use_id → summary` map.
@@ -1490,8 +1503,14 @@ mod tests {
     /// behaviour identical to the pre-#4866 single-group fast-path so
     /// existing call sites that rely on `messages_replaced > 0` still
     /// signal correctly.
+    /// Companion to `parse_failure_preserves_original_per_block_content`,
+    /// exercising the *pure-prose* Parse variant (`serde_json::from_str`
+    /// fails outright, vs a valid array with no `{id,summary}` pairs).  Both
+    /// route to the same arm: the raw response is NOT applied as a bulk
+    /// summary (that was the #5978 loop) — every stale block keeps its own
+    /// preview-truncated original.
     #[tokio::test]
-    async fn parse_failure_falls_back_to_raw_response_as_bulk_summary() {
+    async fn parse_failure_does_not_apply_raw_response_as_bulk_summary() {
         let messages = build_history(10);
         let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(
             "not json at all — just prose the model produced".to_string(),
@@ -1516,21 +1535,45 @@ mod tests {
         // observability: an operator chasing "why is fold falling back"
         // can distinguish "aux unreachable" from "model produced prose".
         assert_eq!(result.groups_used_fallback, 0);
-        // Every stale block should carry the raw response prose.
-        let all_stale_carry_raw_prose =
+        // No stale block may carry the raw prose as a bulk summary — that
+        // overwrites the real tool result and re-triggers the loop (#5978).
+        let any_carries_raw_prose =
             out.iter()
                 .filter(|m| has_folded_tool_result(m))
-                .all(|m| match &m.content {
-                    MessageContent::Blocks(blocks) => blocks.iter().all(|b| match b {
+                .any(|m| match &m.content {
+                    MessageContent::Blocks(blocks) => blocks.iter().any(|b| match b {
                         ContentBlock::ToolResult { content, .. } => content.contains("just prose"),
-                        _ => true,
+                        _ => false,
                     }),
                     _ => false,
                 });
         assert!(
-            all_stale_carry_raw_prose,
-            "parse failure must apply the raw response as bulk summary, not the static stub"
+            !any_carries_raw_prose,
+            "parse failure must NOT apply the raw response as a bulk summary (issue #5978)"
         );
+        // Instead every stale block preserves its own original result.
+        for i in 0..=7 {
+            let id = format!("tid_{i}");
+            let content = out
+                .iter()
+                .find_map(|m| match &m.content {
+                    MessageContent::Blocks(blocks) => blocks.iter().find_map(|b| match b {
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                            ..
+                        } if *tool_use_id == id => Some(content.clone()),
+                        _ => None,
+                    }),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            assert!(
+                content.contains(&format!("output of turn {i}"))
+                    && content.contains(OMITTED_SUMMARY_PREFIX),
+                "{id} must preserve its preview-truncated original, got: {content:?}"
+            );
+        }
     }
 
     /// JSON parse succeeds but every returned `id` is bogus (no overlap
@@ -1730,6 +1773,86 @@ mod tests {
             assert!(
                 content.contains(&format!("output of turn {i}")),
                 "omitted {id} must preserve its original result, got: {content:?}"
+            );
+        }
+    }
+
+    /// Issue #5978 (live-verified, session 81620c15): when the aux model's
+    /// batched-summary response cannot be parsed as `[{id,summary}]` JSON at
+    /// all (here a valid array with no `{id,summary}` pairs → the exact live
+    /// "JSON entries did not contain any {id,summary} pairs" error), the fold
+    /// must NOT overwrite every stale tool result with the raw non-JSON
+    /// response as a bulk summary.  Doing so destroyed the real memory_recall
+    /// result, the model read it as "no answer", and re-issued the identical
+    /// call until the loop guard blocked it forever.  Each stale block must
+    /// instead keep a preview-truncated copy of its OWN original content, and
+    /// every `tool_use_id` must survive (pairing invariant).
+    #[tokio::test]
+    async fn parse_failure_preserves_original_per_block_content() {
+        let messages = build_history(10); // stale tid_0..tid_7
+        let ids_before: Vec<String> = messages.iter().flat_map(tool_use_ids_in).collect();
+
+        // Valid JSON, but no entry carries the {id,summary} shape — this is
+        // the precise failure fandangorodelo hit, routed to the Parse arm.
+        let raw = r#"[{"foo":"bar"},{"baz":42}]"#;
+        let driver: Arc<dyn LlmDriver> = Arc::new(OkDriver(raw.to_string()));
+
+        let (out, _result) = fold_stale_tool_results(
+            messages,
+            FoldConfig {
+                fold_after_turns: 2,
+                min_batch_size: 1,
+            },
+            "test-model",
+            None,
+            driver,
+            librefang_types::model_catalog::ReasoningEchoPolicy::None,
+        )
+        .await;
+
+        // Pairing invariant: no tool_use_id may be dropped by the fold.
+        let ids_after: Vec<String> = out.iter().flat_map(tool_use_ids_in).collect();
+        assert_eq!(
+            ids_before, ids_after,
+            "fold must preserve every tool_use_id on a parse failure (pairing invariant)"
+        );
+
+        for i in 0..=7 {
+            let id = format!("tid_{i}");
+            let content = out
+                .iter()
+                .find_map(|m| match &m.content {
+                    MessageContent::Blocks(blocks) => blocks.iter().find_map(|b| match b {
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                            ..
+                        } if *tool_use_id == id => Some(content.clone()),
+                        _ => None,
+                    }),
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("{id} ToolResult must survive fold"));
+
+            // Must preserve the ORIGINAL result, not the raw garbage response.
+            assert!(
+                content.contains(&format!("output of turn {i}")),
+                "{id} must preserve its original result on parse failure, got: {content:?}"
+            );
+            // Must NOT dump the raw non-JSON response as a bulk summary.
+            assert!(
+                !content.contains("foo") && !content.contains("baz"),
+                "{id} must NOT carry the raw unparsed response as a bulk summary, got: {content:?}"
+            );
+            // Must NOT carry the static call-failure stub either.
+            assert!(
+                !content.contains("summarisation unavailable"),
+                "{id} must NOT carry the FALLBACK_SUMMARY stub on a parse failure, got: {content:?}"
+            );
+            // Must carry the preservation marker.
+            assert!(
+                content.contains(OMITTED_SUMMARY_PREFIX),
+                "{id} must carry the preservation marker, got: {content:?}"
             );
         }
     }


### PR DESCRIPTION
Closes #5978.

## Problem

The history-fold apply loop lost real tool-result content in two ways, and both drove an endless `memory_recall` re-issue loop on a live Moonshot/Kimi deployment (session 81620c15):

1. **Omitted ids.** When the aux summariser returned a valid batch but simply *omitted* one id, the apply loop substituted the `[summarisation unavailable]` fallback string for that result — discarding content that was still on hand.
2. **Total parse failure.** When the aux model returned a body that did not parse as the expected `[{id,summary}]` JSON, the loop dumped that raw, unparseable text verbatim over **every** stale tool result as a "bulk summary".

Either way, a recalled `memory_recall` result lost its content on fold, the agent saw garbage/"unavailable" where its answer used to be, and re-issued `memory_recall` — forever (until the loop guard blocked it; see the companion #5979).

## Relationship to #6009

#6009 (merged) fixes the *specific live trigger* of case 2: thinking-by-default fold models prepend a `<think>…</think>` block, which made the JSON parse fail. With `<think>` stripped, the kimi deployment no longer hits the parse failure.

This PR is complementary, not redundant: it makes the apply loop safe for **any** parse failure (truly malformed JSON, a different non-JSON preamble, a truncated body), so a future fold-model quirk can no longer dump raw text over every stale result and restart the loop. The omitted-id case (#1) is independent of #6009 entirely.

## Fix

Both paths now retain each stale block's **preview-truncated original content**:

- The omitted-id case keeps the original result instead of the `[summarisation unavailable]` stub.
- The Parse-failure arm is routed through that same content-preserving branch (empty map + no bulk fallback), so each block keeps its own truncated original instead of the raw non-JSON body. The now-dead `BatchSummariseFailure::Parse.raw` field is dropped.

Genuine network failures (Call/Empty) still use the static stub — there is no per-block original to recover there.

## Scope

`crates/librefang-runtime/src/history_fold.rs` only. The loop-guard hardening (`tool_call.rs`) is the companion PR #5992 (#5979). Rebased on current `main` (includes #6009); no textual overlap — #6009 changes the parser (`parse_labeled_summaries`), this changes the apply loop.

## Verification

Unit tests in `history_fold.rs`, all passing:
- `omitted_ids_preserve_original_content` / `omitted_ids_do_not_carry_fallback_summary_string` — omitted-id preservation.
- `parse_failure_preserves_original_per_block_content` / `parse_failure_does_not_apply_raw_response_as_bulk_summary` — parse-failure preservation (replaces the test that codified the old bulk-summary behavior).

`cargo test -p librefang-runtime --lib` (history_fold suite), `cargo clippy -p librefang-runtime --all-targets -- -D warnings`, `cargo fmt --check`: clean.