### PR TITLE
ci(todo-to-issue): ignore skill scaffolder template TODOs (#5982, #5983)

### DIFF
--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -18,10 +18,17 @@ jobs:
           LABEL: "good first issue,help wanted"
           AUTO_ASSIGN: false
           # Skip files that contain TODO markers inside string-literal code templates
-          # (e.g. plugin scaffolding) — those are placeholders for end users, not tasks.
+          # (e.g. plugin / skill scaffolding) — those are placeholders for end users,
+          # not tasks.
           #
           # After the #3710 god-crate split (#5053) the plugin_manager.rs file became
           # a directory (plugin_manager/{mod,scaffold,...}.rs); the scaffolder's TODO
           # strings now live in plugin_manager/scaffold.rs. Match the directory so
           # any future siblings (e.g. another templating module) are also covered.
-          IGNORE: crates/librefang-runtime/src/plugin_manager/
+          #
+          # The `librefang skill new` scaffolder embeds the same kind of
+          # `// TODO: Implement your skill logic here` markers in its Python / Node /
+          # WASM stub templates; those strings moved into commands/skill.rs during the
+          # cli/main.rs split (#5971), which re-triggered the false positives (#5982,
+          # #5983). Ignore that file too.
+          IGNORE: crates/librefang-runtime/src/plugin_manager/,crates/librefang-cli/src/commands/skill.rs


### PR DESCRIPTION
## Problem

The `todo-to-issue` action filed two false-positive issues — #5982 and #5983 — for `// TODO: Implement your skill logic here` markers.
Those markers are not tasks in our codebase: they live inside **string literals** in the `librefang skill new` scaffolder (`crates/librefang-cli/src/commands/skill.rs`), i.e. boilerplate written into the *end user's* freshly-generated Python / Node / WASM skill stub to show where they add their own logic.

The scaffolder templates moved into `commands/skill.rs` during the `cli/main.rs` split (#5971).
The scanner's `IGNORE` list already covers the equivalent plugin scaffolder (`crates/librefang-runtime/src/plugin_manager/`) but not the new skill path, so the markers were re-detected as fresh TODOs on merge and filed as issues.

## Fix

Add `crates/librefang-cli/src/commands/skill.rs` to the `todo-to-issue` `IGNORE` list, and expand the surrounding comment to document the skill scaffolder as a second template source.

Only the two template files in the repo contain these scaffold-stub TODO markers (`plugin_manager/scaffold.rs`, already ignored; `commands/skill.rs`, now ignored) — verified by grep, so this closes the recurrence without over-broad suppression of real TODOs.

## Verification

- CI-config-only change; no Rust touched.
- #5982 and #5983 already closed as the underlying false positives.

Refs #5982, #5983
