### PR TITLE
fix(channels): propagate per-sidecar account_id for multi-bot isolation (#5955)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -640,6 +640,13 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ### Fixed
 
+- **security(channels): propagate per-sidecar `account_id` so multi-bot Telegram isolation actually engages** (#5955) (@nevgenov).
+  Multi-instance sidecar setups (several `[[sidecar_channels]]` of `channel_type = "telegram"`) regressed the #5688 per-bot isolation because the daemon never propagated the operator-known `SidecarChannelConfig::name` as `account_id`, leaving the #5688 guards as dead code for sidecars.
+  Two manifestations, one root: the daemon registration hardcoded `account_id = None`, so every sidecar's `default_agent` collided on the bare `channel_defaults["telegram"]` key (last-booted bot answered in every bot); and the sidecar reader loop stamped `channel_id` / `platform` / `sender_username` into per-message metadata but never `account_id`, so `dispatch_message` always took the global `set_user_default` branch and a `/agent <name>` selection in bot-A leaked to bot-B for the same platform user.
+  The registration now qualifies each sidecar under its own `name` (`channel_bridge.rs`), and the reader loop stamps `metadata["account_id"]` from the same adapter name via `entry().or_insert_with(...)` so an adapter that already supplies its own `account_id` (dingtalk / email / google_chat) is preserved (`sidecar.rs`).
+  Registration key and resolution key now both derive from `SidecarChannelConfig::name`, so they line up.
+  Regression tests: `router::tests::sidecar_default_does_not_collide_across_bots` (two sidecars register under distinct `telegram:<name>` keys, no last-writer-wins collision) and `sidecar::tests::test_sidecar_stamps_account_id_from_adapter_name` (a real sidecar subprocess stamps `account_id` from the config name, not the `ready`-event account, and preserves an adapter-supplied one).
+
 - **kernel(cron): day-of-week now follows the POSIX convention (`0` and `7` both mean Sunday)** instead of the `cron` crate's 1-7 mapping (#5966) (@DaBlitzStein).
   Sunday-only schedules like `0 16 * * 0` were previously rejected as unschedulable, and numeric weekday ranges such as `1-5` silently shifted by one day (firing Sun-Thu instead of Mon-Fri).
   The 5/6-field expression is now remapped at the single conversion site before it reaches the crate, so `0`/`7` resolve to Sunday and `1-5` fires Monday through Friday as written.

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2509,11 +2509,17 @@ pub async fn start_channel_bridge_with_config(
         started_at: Instant::now(),
     };
 
-    // (adapter, default_agent_name, account_id) — `account_id` is
-    // always None because `SidecarChannelConfig` carries no such
-    // field (sidecars surface their own per-instance id via env
-    // vars like `TEAMS_ACCOUNT_ID`). The triple stays for the
-    // downstream router-population loop's signature.
+    // (adapter, default_agent_name, account_id) — `account_id` is the
+    // sidecar's config `name`, which qualifies the per-bot routing key
+    // (#5955). Two Telegram sidecars share the `"telegram"` channel
+    // type, so without a distinct `account_id` the downstream
+    // router-population loop would key both under the bare `"telegram"`
+    // default (last-writer-wins) and the `metadata["account_id"]`
+    // resolution path in `bridge.rs` would collapse a `/agent`
+    // selection across every bot of the same platform. The sidecar
+    // reader loop stamps the matching `metadata["account_id"]` from the
+    // same `name` (`librefang-channels/src/sidecar.rs`), so the
+    // registration key and the resolution key line up.
     #[allow(clippy::type_complexity)]
     let mut adapters: Vec<(Arc<dyn ChannelAdapter>, Option<String>, Option<String>)> = Vec::new();
 
@@ -2547,7 +2553,17 @@ pub async fn start_channel_bridge_with_config(
         // the non-deterministic "first available agent" branch in
         // `resolve_or_fallback`, silently routing traffic to whichever agent
         // happens to be first in the registry iteration order.
-        adapters.push((adapter, sidecar_config.default_agent.clone(), None));
+        // #5955 — qualify each sidecar under its own `name` so per-bot
+        // isolation (PR #5688) actually engages. `None` here keyed every
+        // Telegram sidecar under the bare `"telegram"` default, so the
+        // last-registered bot won every chat and `/agent` selections
+        // leaked across bots. Must match the `metadata["account_id"]`
+        // the sidecar reader loop stamps from the same `name`.
+        adapters.push((
+            adapter,
+            sidecar_config.default_agent.clone(),
+            Some(sidecar_config.name.clone()),
+        ));
     }
 
     if adapters.is_empty() {

--- a/crates/librefang-channels/src/router.rs
+++ b/crates/librefang-channels/src/router.rs
@@ -1027,4 +1027,62 @@ mod tests {
             Some(agent)
         );
     }
+
+    /// Regression test for #5955: two Telegram sidecars that share the
+    /// `"telegram"` channel type but carry distinct config `name`s must
+    /// register under distinct `"telegram:<name>"` channel-default keys,
+    /// not collide on the bare `"telegram"` key (last-writer-wins).
+    ///
+    /// This reproduces the exact key-building the daemon performs in
+    /// `librefang-api/src/channel_bridge.rs`: with `account_id = Some(name)`
+    /// the key is `"<channel>:<name>"`; the buggy `account_id = None` path
+    /// collapsed both sidecars onto `"<channel>"`, so whichever sidecar
+    /// registered last won every chat. We assert each bot resolves to its
+    /// own default independently.
+    #[test]
+    fn sidecar_default_does_not_collide_across_bots() {
+        let router = AgentRouter::new();
+        let agent_a = AgentId::new();
+        let agent_b = AgentId::new();
+
+        // Mirror channel_bridge.rs: account_id = Some(sidecar.name) ⇒
+        // key = "telegram:<name>".
+        let ct = ChannelType::Telegram;
+        for (name, agent) in [("bot-a", agent_a), ("bot-b", agent_b)] {
+            let channel_key = format!("{}:{}", channel_type_to_str(&ct), name);
+            router.set_channel_default_with_name(channel_key, agent, name.to_string());
+        }
+
+        // Each bot's qualified key resolves to its own default — no
+        // last-writer-wins collision.
+        assert_eq!(
+            router.channel_default("telegram:bot-a"),
+            Some(agent_a),
+            "bot-a must keep its own channel default"
+        );
+        assert_eq!(
+            router.channel_default("telegram:bot-b"),
+            Some(agent_b),
+            "bot-b must keep its own channel default — not bot-a's, and \
+             not lost to a bare `telegram` collision"
+        );
+        // The configured names are preserved per-bot too (used by the
+        // reply-precheck bot-name lookup in bridge.rs).
+        assert_eq!(
+            router.channel_default_name("telegram:bot-a").as_deref(),
+            Some("bot-a")
+        );
+        assert_eq!(
+            router.channel_default_name("telegram:bot-b").as_deref(),
+            Some("bot-b")
+        );
+        // The bare `"telegram"` key was never written under the fixed
+        // keying, so it does not silently shadow either bot.
+        assert_eq!(
+            router.channel_default("telegram"),
+            None,
+            "no sidecar should claim the unqualified `telegram` default \
+             when each carries a distinct account_id"
+        );
+    }
 }

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -977,6 +977,28 @@ async fn spawn_once(
                                             serde_json::Value::String(h),
                                         );
                                     }
+                                    // #5955 — stamp the per-bot account id so
+                                    // the bridge's `metadata["account_id"]`
+                                    // resolution computes the qualified
+                                    // `<channel>:<account_id>` routing key that
+                                    // matches the per-sidecar registration key
+                                    // seeded in `channel_bridge.rs` (which keys
+                                    // off the sidecar's config `name`). Without
+                                    // this, every Telegram sidecar collapses to
+                                    // the bare `"telegram"` key, so a `/agent`
+                                    // selection in bot-A leaks to bot-B for the
+                                    // same platform user. Use `or_insert` so an
+                                    // adapter that already supplies its own
+                                    // `account_id` in the message metadata
+                                    // (dingtalk / email / google_chat) is not
+                                    // overwritten.
+                                    metadata
+                                        .entry("account_id".to_string())
+                                        .or_insert_with(|| {
+                                            serde_json::Value::String(
+                                                adapter_name.clone(),
+                                            )
+                                        });
                                     if !params.group_members.is_empty() {
                                         if let Ok(v) = serde_json::to_value(
                                             &params.group_members,
@@ -3426,6 +3448,73 @@ mod tests {
             !msg.metadata.contains_key("username"),
             "the dead `username` key must not be written"
         );
+        adapter.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sidecar_stamps_account_id_from_adapter_name() {
+        // Regression for #5955: the reader must stamp
+        // `metadata["account_id"]` from the sidecar's config `name` so
+        // the bridge computes the per-bot `"<channel>:<account_id>"`
+        // routing key matching the registration key seeded in
+        // `channel_bridge.rs`. Without it, every Telegram sidecar
+        // collapses to the bare `"telegram"` key and a `/agent`
+        // selection in one bot leaks to every other bot. The stamp must
+        // key off the adapter NAME (the config name), NOT the
+        // `ready`-event `account_id`, so the registration key and the
+        // resolution key line up. And an adapter that supplies its own
+        // `account_id` in the message metadata must be preserved.
+        let python = match which_python() {
+            Some(p) => p,
+            None => return,
+        };
+        // The `ready` event advertises a DIFFERENT account_id than the
+        // config name, to prove the stamp uses the name, not the ready
+        // account. First message omits account_id (must be stamped with
+        // the adapter name "bot-a"); second supplies its own ("own-acct",
+        // must be preserved).
+        let script = concat!(
+            "import sys,json;",
+            "print(json.dumps({'method':'ready','params':",
+            "{'capabilities':[],'account_id':'ready-acct'}}),flush=True);",
+            "print(json.dumps({'method':'message','params':",
+            "{'user_id':'u','user_name':'n','text':'one'}}),flush=True);",
+            "print(json.dumps({'method':'message','params':",
+            "{'user_id':'u','user_name':'n','text':'two',",
+            "'metadata':{'account_id':'own-acct'}}}),flush=True);",
+            "sys.exit(0)"
+        );
+        let config = cfg(
+            "bot-a",
+            &python,
+            vec!["-u".to_string(), "-c".to_string(), script.to_string()],
+        );
+        let adapter = SidecarAdapter::new(&config, std::env::temp_dir());
+        let mut stream = adapter.start().await.unwrap();
+        use futures::StreamExt;
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(30), stream.next())
+            .await
+            .expect("timed out waiting for first message")
+            .expect("stream ended before first message");
+        assert_eq!(
+            first.metadata.get("account_id").and_then(|v| v.as_str()),
+            Some("bot-a"),
+            "account_id must be stamped from the adapter (config) name, \
+             not the ready-event account_id"
+        );
+
+        let second = tokio::time::timeout(std::time::Duration::from_secs(30), stream.next())
+            .await
+            .expect("timed out waiting for second message")
+            .expect("stream ended before second message");
+        assert_eq!(
+            second.metadata.get("account_id").and_then(|v| v.as_str()),
+            Some("own-acct"),
+            "an adapter-supplied account_id in message metadata must be \
+             preserved, not overwritten by the adapter name"
+        );
+
         adapter.stop().await.unwrap();
     }
 


### PR DESCRIPTION
## Summary

Fixes the SECURITY regression in #5955: a `/agent <name>` selection in one Telegram bot leaks to every other bot for the same platform user, and every multi-bot sidecar setup routes all traffic to the last-booted agent.

Both symptoms share **one root**: the daemon never propagated the operator-known `SidecarChannelConfig::name` as `account_id`, so the per-bot isolation guards added in #5688 are dead code for sidecar adapters (the trait-default `SidecarAdapter::account_id()` is `None`, and neither the registration path nor the reader loop fell back to the config `name`).

## Two-site root cause and fix

### Site A — daemon registration hardcoded `None`

`crates/librefang-api/src/channel_bridge.rs::start_channel_bridge_with_config` pushed each sidecar adapter as `(adapter, default_agent, None)`. With `account_id = None`, the downstream router-population loop keyed every Telegram sidecar's `default_agent` under the bare `channel_defaults["telegram"]` key (`set_channel_default_with_name`, last-writer-wins), so the last sidecar to boot became the de-facto router for every bot.

Fix: pass `Some(sidecar_config.name.clone())` so each sidecar registers under a distinct `"telegram:<name>"` key. Also corrected the stale comment that claimed `SidecarChannelConfig` "carries no such field" — it has `.name`.

### Site B — sidecar reader loop never stamped `account_id`

`crates/librefang-channels/src/sidecar.rs` (reader loop) stamps `channel_id`, `platform`, `sender_username`, `group_members`, `group_participants` into per-message `metadata` but never `account_id`. `bridge.rs::dispatch_message` (the #5688 fix) only takes the per-bot `set_user_default_for_channel` branch when `metadata["account_id"]` is present; otherwise it falls through to the global `set_user_default`, so a `/agent` override sticks to `user_id` alone and leaks across bots.

Fix: stamp `metadata["account_id"]` from the adapter (config) name via `entry().or_insert_with(...)`, mirroring the bare-string-key style of the surrounding inserts. `or_insert` preserves an `account_id` an adapter already supplies in its message metadata (dingtalk / email / google_chat).

### Consistency

The registration key (Site A) and the resolution key (Site B) both derive from `SidecarChannelConfig::name`: Site A registers under `"telegram:<name>"`, and Site B stamps `metadata["account_id"] = <name>` so `bridge.rs` recomputes `"telegram:" + metadata["account_id"]` = the same key. The stamp deliberately keys off the config name, NOT the `ready`-event `account_id`, so the two sides line up.

## Regression tests (no live daemon)

- `crates/librefang-channels/src/router.rs::tests::sidecar_default_does_not_collide_across_bots` — replicates the daemon's exact key-building for two sidecars with distinct `name`s; asserts `channel_default("telegram:bot-a")` and `("telegram:bot-b")` resolve independently, the per-bot names are preserved, and the bare `"telegram"` key is never shadowed. Targets the registration keying (Site A), which the existing `#5688` test `user_default_does_not_leak_across_bots` does not cover (it passes `"telegram:bot-a"` keys directly to the resolver).
- `crates/librefang-channels/src/sidecar.rs::tests::test_sidecar_stamps_account_id_from_adapter_name` — spawns a real sidecar subprocess (gated on `which_python()`, mirroring `test_sidecar_username_folds_to_sender_username_metadata`); the child emits a `ready` carrying a *different* `account_id` than the config name, then two messages. Asserts the first message (no `account_id`) is stamped with the adapter name `"bot-a"` (not the `ready` account `"ready-acct"`), and the second (own `account_id = "own-acct"`) is preserved. Targets the metadata population (Site B).

## Verification

No native Rust toolchain on this host (and the dev Docker image is unavailable), so compilation/test verification is the **CI gate**:

- Site A: tuple element type unchanged (`Option<String>`); `sidecar_config.name` is a `String`.
- Site B: `metadata` is `HashMap<String, serde_json::Value>`; `entry(String).or_insert_with(|| serde_json::Value::String(adapter_name.clone()))`; `adapter_name` (`ctx.name.clone()`) is used by-ref afterwards, so the clone does not move it.
- Tests use only public APIs and the same imports as the adjacent existing tests.
- Broad scan: no other `adapters.push(... None)` site, and no API integration test asserts the old bare-key behaviour. No config-struct change, so the kernel-config golden fixture is untouched.

## Scope

One PR ↔ one issue. The reporter also flagged that `PUT /api/agents/{id}/channels` expects channel **type** not channel **name** (so per-agent allowlist can't scope to a single bot) — that is a separate concern in a different route domain and is intentionally not bundled here.

Closes #5955
