### PR TITLE
fix(runtime): tolerate <think> preamble in history_fold summary parsing (#6009)

### DIFF
--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -1732,15 +1732,17 @@ mod tests {
         let input = "<think>\nThe tool listed files. I'll summarise each one.\n</think>\n\
                      [{\"id\":\"toolu_1\",\"summary\":\"Listed files.\"}]";
         let out = parse_labeled_summaries(input).expect("should parse past <think> preamble");
-        assert_eq!(out.get("toolu_1").map(String::as_str), Some("Listed files."));
+        assert_eq!(
+            out.get("toolu_1").map(String::as_str),
+            Some("Listed files.")
+        );
     }
 
     #[test]
     fn parse_labeled_summaries_tolerates_think_preamble_then_json_fence() {
         let input = "<think>reasoning across\nmultiple lines</think>\n\
                      ```json\n[{\"id\":\"toolu_2\",\"summary\":\"Read config.\"}]\n```";
-        let out = parse_labeled_summaries(input)
-            .expect("should strip think block then json fence");
+        let out = parse_labeled_summaries(input).expect("should strip think block then json fence");
         assert_eq!(out.get("toolu_2").map(String::as_str), Some("Read config."));
     }
 

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -640,12 +640,8 @@ async fn summarise_batch(
 /// because some providers (notably reasoning-tier models) still emit
 /// fenced output even when told not to.
 fn parse_labeled_summaries(text: &str) -> Result<BTreeMap<String, String>, String> {
-    // Thinking-by-default models (e.g. deepseek-v4-flash) prepend a
-    // `<think>…</think>` reasoning block even when the fold request sets
-    // `thinking: None` — the provider enables it server-side and we have
-    // no signal to suppress it (#6009).  Strip that preamble before the
-    // fence/JSON parse so the trailing JSON array is the parsable body
-    // instead of `<think>` arriving at column 1.
+    // Thinking-by-default models (e.g. deepseek-v4-flash) prepend a `<think>…</think>` reasoning block even when the fold request sets `thinking: None` — the provider enables it server-side and we have no signal to suppress it (#6009).
+    // Strip that preamble before the fence/JSON parse so the trailing JSON array is the parsable body instead of `<think>` arriving at column 1.
     let stripped = strip_think_preamble(text.trim());
     let body = strip_code_fence(stripped.trim()).unwrap_or_else(|| stripped.trim().to_string());
     let value: serde_json::Value =
@@ -697,17 +693,12 @@ fn strip_code_fence(s: &str) -> Option<String> {
     Some(body.trim().to_string())
 }
 
-/// Strip a single leading `<think>…</think>` reasoning preamble (and any
-/// surrounding whitespace) if present, returning the remainder.  Returns the
-/// input unchanged when there is no leading think block.
+/// Strip a single leading `<think>…</think>` reasoning preamble (and any surrounding whitespace) if present, returning the remainder.
+/// Returns the input unchanged when there is no leading think block.
 ///
-/// Thinking-by-default models emit this prefix ahead of the requested JSON
-/// even when the fold request set `thinking: None` (#6009).  The opening tag
-/// is matched case-insensitively (`<think>`, `<THINK>`) and the block may span
-/// multiple lines; matching is non-greedy (stops at the first `</think>`) so a
-/// JSON payload that happens to mention `</think>` later is unaffected.  Only a
-/// *leading* block is stripped — a `<think>` appearing after other content is
-/// left alone, since the parser only needs the body to begin with JSON.
+/// Thinking-by-default models emit this prefix ahead of the requested JSON even when the fold request set `thinking: None` (#6009).
+/// The opening tag is matched case-insensitively (`<think>`, `<THINK>`) and the block may span multiple lines; matching is non-greedy (stops at the first `</think>`) so a JSON payload that happens to mention `</think>` later is unaffected.
+/// Only a *leading* block is stripped — a `<think>` appearing after other content is left alone, since the parser only needs the body to begin with JSON.
 fn strip_think_preamble(s: &str) -> String {
     let trimmed = s.trim_start();
     let lower = trimmed.to_ascii_lowercase();
@@ -1734,9 +1725,8 @@ mod tests {
         assert_eq!(strip_think_preamble(input), input);
     }
 
-    /// Regression for #6009: thinking-by-default fold models (deepseek-v4-flash)
-    /// prepend a `<think>…</think>` block to the requested JSON. The parser
-    /// must strip it instead of degrading to the raw bulk-summary fallback.
+    /// Regression for #6009: thinking-by-default fold models (deepseek-v4-flash) prepend a `<think>…</think>` block to the requested JSON.
+    /// The parser must strip it instead of degrading to the raw bulk-summary fallback.
     #[test]
     fn parse_labeled_summaries_tolerates_think_preamble() {
         let input = "<think>\nThe tool listed files. I'll summarise each one.\n</think>\n\

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -640,7 +640,14 @@ async fn summarise_batch(
 /// because some providers (notably reasoning-tier models) still emit
 /// fenced output even when told not to.
 fn parse_labeled_summaries(text: &str) -> Result<BTreeMap<String, String>, String> {
-    let body = strip_code_fence(text.trim()).unwrap_or_else(|| text.trim().to_string());
+    // Thinking-by-default models (e.g. deepseek-v4-flash) prepend a
+    // `<think>…</think>` reasoning block even when the fold request sets
+    // `thinking: None` — the provider enables it server-side and we have
+    // no signal to suppress it (#6009).  Strip that preamble before the
+    // fence/JSON parse so the trailing JSON array is the parsable body
+    // instead of `<think>` arriving at column 1.
+    let stripped = strip_think_preamble(text.trim());
+    let body = strip_code_fence(stripped.trim()).unwrap_or_else(|| stripped.trim().to_string());
     let value: serde_json::Value =
         serde_json::from_str(&body).map_err(|e| format!("JSON parse failed: {e}"))?;
     // Accept both the documented JSON-array shape AND a bare single
@@ -688,6 +695,36 @@ fn strip_code_fence(s: &str) -> Option<String> {
     let inner = after_open.trim_start_matches(['\n', '\r', ' ']);
     let body = inner.strip_suffix("```").unwrap_or(inner);
     Some(body.trim().to_string())
+}
+
+/// Strip a single leading `<think>…</think>` reasoning preamble (and any
+/// surrounding whitespace) if present, returning the remainder.  Returns the
+/// input unchanged when there is no leading think block.
+///
+/// Thinking-by-default models emit this prefix ahead of the requested JSON
+/// even when the fold request set `thinking: None` (#6009).  The opening tag
+/// is matched case-insensitively (`<think>`, `<THINK>`) and the block may span
+/// multiple lines; matching is non-greedy (stops at the first `</think>`) so a
+/// JSON payload that happens to mention `</think>` later is unaffected.  Only a
+/// *leading* block is stripped — a `<think>` appearing after other content is
+/// left alone, since the parser only needs the body to begin with JSON.
+fn strip_think_preamble(s: &str) -> String {
+    let trimmed = s.trim_start();
+    let lower = trimmed.to_ascii_lowercase();
+    if !lower.starts_with("<think>") {
+        return s.to_string();
+    }
+    match lower.find("</think>") {
+        Some(close) => {
+            let after = &trimmed[close + "</think>".len()..];
+            after.trim_start().to_string()
+        }
+        // Unterminated `<think>` (model was truncated before closing the
+        // tag) — nothing parsable follows, so hand the original text on and
+        // let the JSON parse surface the failure as before rather than
+        // silently swallowing everything.
+        None => s.to_string(),
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1669,6 +1706,59 @@ mod tests {
     fn strip_code_fence_returns_none_when_unfenced() {
         assert!(strip_code_fence("plain text").is_none());
         assert!(strip_code_fence("[1,2,3]").is_none());
+    }
+
+    #[test]
+    fn strip_think_preamble_removes_leading_block() {
+        let input = "<think>\nlet me reason about this...\n</think>\n[{\"id\":\"x\"}]";
+        assert_eq!(strip_think_preamble(input), "[{\"id\":\"x\"}]");
+    }
+
+    #[test]
+    fn strip_think_preamble_is_case_insensitive() {
+        let input = "<THINK>reasoning</THINK>\n{\"id\":\"x\"}";
+        assert_eq!(strip_think_preamble(input), "{\"id\":\"x\"}");
+    }
+
+    #[test]
+    fn strip_think_preamble_noop_without_block() {
+        assert_eq!(strip_think_preamble("[{\"id\":\"x\"}]"), "[{\"id\":\"x\"}]");
+        assert_eq!(strip_think_preamble("plain text"), "plain text");
+    }
+
+    #[test]
+    fn strip_think_preamble_leaves_unterminated_block() {
+        // No closing tag — return unchanged so the JSON parse surfaces the
+        // failure rather than swallowing the whole (truncated) response.
+        let input = "<think>truncated reasoning with no close";
+        assert_eq!(strip_think_preamble(input), input);
+    }
+
+    /// Regression for #6009: thinking-by-default fold models (deepseek-v4-flash)
+    /// prepend a `<think>…</think>` block to the requested JSON. The parser
+    /// must strip it instead of degrading to the raw bulk-summary fallback.
+    #[test]
+    fn parse_labeled_summaries_tolerates_think_preamble() {
+        let input = "<think>\nThe tool listed files. I'll summarise each one.\n</think>\n\
+                     [{\"id\":\"toolu_1\",\"summary\":\"Listed files.\"}]";
+        let out = parse_labeled_summaries(input).expect("should parse past <think> preamble");
+        assert_eq!(out.get("toolu_1").map(String::as_str), Some("Listed files."));
+    }
+
+    #[test]
+    fn parse_labeled_summaries_tolerates_think_preamble_then_json_fence() {
+        let input = "<think>reasoning across\nmultiple lines</think>\n\
+                     ```json\n[{\"id\":\"toolu_2\",\"summary\":\"Read config.\"}]\n```";
+        let out = parse_labeled_summaries(input)
+            .expect("should strip think block then json fence");
+        assert_eq!(out.get("toolu_2").map(String::as_str), Some("Read config."));
+    }
+
+    #[test]
+    fn parse_labeled_summaries_still_parses_plain_json() {
+        let input = "[{\"id\":\"toolu_3\",\"summary\":\"Ran tests.\"}]";
+        let out = parse_labeled_summaries(input).expect("plain JSON should still parse");
+        assert_eq!(out.get("toolu_3").map(String::as_str), Some("Ran tests."));
     }
 
     /// Regression for #5203: a verbose-JSON fold model that pretty-prints


### PR DESCRIPTION
## Root cause

`history_fold` consistently degraded to the bulk-summary fallback when a
thinking-by-default model (e.g. `deepseek-v4-flash`) was the fold aux model.

`summarise_batch` builds its `CompletionRequest` with `thinking: None`
(`history_fold.rs` ~L596), but for these models the provider enables extended
thinking server-side regardless — there is no `thinking: disabled` signal to
send. The response text therefore arrives as:

```
<think>
…(reasoning block)…
</think>
[{"id":"toolu_xyz","summary":"…"}]
```

`parse_labeled_summaries` ran `strip_code_fence(text.trim())` then
`serde_json::from_str`. `strip_code_fence` only matches markdown fences, so
`<think>` reached the JSON parser at column 1 and `from_str` failed with
`expected value at line 1 column 1`. `summarise_batch` then fell back to the
raw-bulk-summary path, which corrupts the fold entry: the agent reads a raw
thinking block as if it were a structured per-tool summary.

## Fix

A minimal, parser-side defensive strip — the same shape as the existing
`strip_code_fence` model. New helper `strip_think_preamble` removes a single
*leading* `<think>…</think>` block (case-insensitive tag, possibly multi-line,
non-greedy on the first `</think>`) plus surrounding whitespace, then parsing
proceeds as before.

Order in `parse_labeled_summaries`: **strip think → strip code fence → parse**,
so it is robust to:
- no think block (no-op, plain JSON still parses),
- `<think>…</think>` directly followed by JSON,
- `<think>…</think>` followed by a ` ```json ` fence,
- whitespace / newlines between any of the above.

An unterminated `<think>` (truncated response) is left unchanged so the JSON
parse surfaces the failure as before rather than silently swallowing the whole
response.

The request construction (`thinking: None`, `response_format`, token budget)
and the fallback semantics are **unchanged** — only the parser is made
tolerant.

## Tests

Added to the existing `tests` module in `history_fold.rs`, following the
`strip_code_fence_*` patterns:

- `strip_think_preamble_removes_leading_block`
- `strip_think_preamble_is_case_insensitive`
- `strip_think_preamble_noop_without_block`
- `strip_think_preamble_leaves_unterminated_block`
- `parse_labeled_summaries_tolerates_think_preamble`
- `parse_labeled_summaries_tolerates_think_preamble_then_json_fence`
- `parse_labeled_summaries_still_parses_plain_json`

## Verification

- No new dependency (plain string ops, matching `strip_code_fence`).
- Not compiled/tested locally (no native toolchain in this environment); CI is
  the gate for `cargo check --workspace --lib`, clippy, and the runtime unit
  tests.

Closes #6009
