### PR TITLE
ci(todo-to-issue): ignore .github self-scan that spawns false-positive issues

### DIFF
--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -27,8 +27,20 @@ jobs:
           # any future siblings (e.g. another templating module) are also covered.
           #
           # The `librefang skill new` scaffolder embeds the same kind of
-          # `// TODO: Implement your skill logic here` markers in its Python / Node /
+          # `// T-O-D-O: Implement your skill logic here` markers in its Python / Node /
           # WASM stub templates; those strings moved into commands/skill.rs during the
           # cli/main.rs split (#5971), which re-triggered the false positives (#5982,
           # #5983). Ignore that file too.
-          IGNORE: crates/librefang-runtime/src/plugin_manager/,crates/librefang-cli/src/commands/skill.rs
+          #
+          # NOTE on the token spelling above: it is deliberately hyphenated so this
+          # workflow's own comment never contains a literal scanner marker. The action
+          # matches its markers via `re.match` on each changed file's path, so it would
+          # otherwise scan THIS file and raise garbled false-positive issues from its own
+          # comments (#5982, #5983, #5997, #5998, #5999). The `.github/` IGNORE entry
+          # below now also excludes this file from the scan; the hyphenation is
+          # defense-in-depth in case the IGNORE list is ever edited.
+          #
+          # `.github/` ignores the workflow/config directory itself (re.match anchors at
+          # the path start, and diff paths are repo-root-relative without a leading slash,
+          # e.g. `.github/workflows/todo-to-issue.yml`).
+          IGNORE: .github/,crates/librefang-runtime/src/plugin_manager/,crates/librefang-cli/src/commands/skill.rs


### PR DESCRIPTION
## Root cause

`.github/workflows/todo-to-issue.yml` runs `alstr/todo-to-issue-action`, which
scans changed files for `// TODO:` markers and opens a GitHub issue per marker.
The action's `IGNORE` list skipped the scaffolder template files
(`plugin_manager/`, `commands/skill.rs`) whose TODO strings are end-user
placeholders, not tasks.

The problem: the workflow's **own comment block** contained the literal example
text `// TODO: Implement your skill logic here` (used to explain *why* those
files are ignored). The action's `_should_ignore` matches `IGNORE` entries with
`re.match` against each changed file's repo-root-relative path
(`TodoParser.py`, pinned commit `64aca8f`), but `.github/` itself was **not** in
the list — so on every push that touched this workflow, the action scanned the
workflow file, matched the example marker inside its own comments, and opened a
series of garbled false-positive issues whose titles are fragments of that
comment: **#5982, #5983, #5997, #5998, #5999**. A self-referential
false-positive loop.

## Fix (defense-in-depth, both layers)

1. **Add `.github/` to `IGNORE`** (kept the two existing entries). The action
   matches via `re.match` anchored at the start of each diff path, and diff
   paths are repo-root-relative with no leading slash
   (e.g. `.github/workflows/todo-to-issue.yml`), so `.github/` excludes the
   whole workflow/config directory from the scan. This is the primary,
   robust fix — verified against the action's source at the pinned SHA.
2. **Neutralize the literal marker in the comment** — rewrote the example token
   as `// T-O-D-O: Implement your skill logic here` so the comment can never
   contain a real scanner marker even if the `IGNORE` list is later edited.
   Added a NOTE explaining the hyphenation and the `.github/` entry.

Legitimate scanning of real source TODOs is unchanged — the action still runs;
only the self-scan of `.github/` is excluded.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open(...))"` → YAML well-formed;
  `IGNORE = .github/,crates/librefang-runtime/src/plugin_manager/,crates/librefang-cli/src/commands/skill.rs`.
- `grep -E 'TODO:'` on the file → no literal marker remains (only `T-O-D-O:`).
- `re.match(r'.github/', '.github/workflows/todo-to-issue.yml')` → matches;
  `re.match(r'.github/', 'crates/foo/bar.rs')` → does not match (no false
  exclusion of real source).

No Rust toolchain involved — this is a workflow YAML change only.

## Follow-up

The spurious bot-created issues #5997, #5998, #5999 (and #5982, #5983 if still
open) should be closed as false positives.
