### PR TITLE
fix(runtime,kernel): redact images for text-only models via catalog supports_vision (#6010)

### DIFF
--- a/crates/librefang-kernel-handle/src/catalog_query.rs
+++ b/crates/librefang-kernel-handle/src/catalog_query.rs
@@ -24,6 +24,22 @@ pub trait CatalogQuery: Send + Sync {
         librefang_types::model_catalog::ReasoningEchoPolicy::None
     }
 
+    /// Whether the given model supports vision (image) input, resolved from
+    /// the model catalog's effective capabilities (#6010). Consulted at
+    /// request-build time to decide whether image content blocks may be sent
+    /// to the model or must be redacted to a text placeholder first —
+    /// text-only OpenAI-compatible models reject image content parts with
+    /// HTTP 400 (`unknown variant image_url, expected text`).
+    ///
+    /// Default impl returns `true` (fail open) so non-overriding mocks and
+    /// stubs keep sending images unchanged. The real kernel impl applies user
+    /// capability overrides (#4745) via `effective_capabilities` and also
+    /// fails open on a catalog miss, so vision-capable models are never
+    /// degraded.
+    fn supports_vision_for(&self, _model: &str) -> bool {
+        true
+    }
+
     /// Resolve the effective proactive-memory `extraction_model` for the
     /// agent identified by `agent_id` (#5475). Looks at the agent's
     /// manifest `[proactive_memory] extraction_model` and falls back to

--- a/crates/librefang-kernel-handle/src/tests.rs
+++ b/crates/librefang-kernel-handle/src/tests.rs
@@ -233,3 +233,15 @@ fn catalog_query_default_returns_none() {
         ReasoningEchoPolicy::None
     );
 }
+
+#[test]
+fn catalog_query_supports_vision_defaults_to_true() {
+    // #6010: a stub/mock that doesn't override `supports_vision_for` must
+    // report `true` (fail open), so test fixtures and any handle without a
+    // catalog wired keep sending image content blocks unchanged. Only the
+    // real kernel impl, which consults the model catalog, can return `false`.
+    let stub = StubKernel;
+    assert!(stub.supports_vision_for("deepseek-v4"));
+    assert!(stub.supports_vision_for("gpt-4o"));
+    assert!(stub.supports_vision_for("anything-else"));
+}

--- a/crates/librefang-kernel/src/kernel/handles/catalog_query.rs
+++ b/crates/librefang-kernel/src/kernel/handles/catalog_query.rs
@@ -26,11 +26,28 @@ impl LibreFangKernel {
             .map(|entry| entry.reasoning_echo_policy)
             .unwrap_or_default()
     }
+
+    /// Inherent mirror of [`kernel_handle::CatalogQuery::supports_vision_for`]
+    /// (#6010). Resolves the model's effective vision capability from the
+    /// catalog, honouring user capability overrides (#4745) via
+    /// `effective_capabilities`. Fails open (`true`) on a catalog miss so an
+    /// unknown / user-defined model is never silently stripped of image input.
+    pub(crate) fn lookup_supports_vision(&self, model: &str) -> bool {
+        let catalog = self.model_catalog_ref().load();
+        catalog
+            .find_model(model)
+            .map(|m| catalog.effective_capabilities(m).supports_vision)
+            .unwrap_or(true)
+    }
 }
 
 impl kernel_handle::CatalogQuery for LibreFangKernel {
     fn reasoning_echo_policy_for(&self, model: &str) -> ReasoningEchoPolicy {
         self.lookup_reasoning_echo_policy(model)
+    }
+
+    fn supports_vision_for(&self, model: &str) -> bool {
+        self.lookup_supports_vision(model)
     }
 
     /// Resolve the per-agent `extraction_model` for proactive memory

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -295,6 +295,39 @@ fn build_sender_prefix(manifest: &AgentManifest, sender_user_id: Option<&str>) -
     Some(format!("[{}]: ", sanitize_sender_label(raw)))
 }
 
+/// Replace every `Image` / `ImageFile` content block in `messages` with a
+/// short text placeholder, leaving all other blocks and messages untouched
+/// (#6010).
+///
+/// Called only when the target model has no vision support. Text-only
+/// OpenAI-compatible models reject image content parts with HTTP 400
+/// (`unknown variant image_url, expected text`), which previously broke any
+/// channel/sidecar bot whose default agent ran a text-only model the moment a
+/// user sent a photo. Redacting upstream of the driver covers *every* entry
+/// path (WebUI, channels, sidecars, triggers), not just the OpenAI driver.
+///
+/// Pure function: the caller passes a clone, so the live session history is
+/// never mutated and the vision path stays byte-identical to before.
+fn redact_images_for_text_only(mut messages: Vec<Message>, model: &str) -> Vec<Message> {
+    let placeholder = format!("[image omitted: model `{model}` has no vision support]");
+    for msg in &mut messages {
+        if let MessageContent::Blocks(blocks) = &mut msg.content {
+            for block in blocks.iter_mut() {
+                if matches!(
+                    block,
+                    ContentBlock::Image { .. } | ContentBlock::ImageFile { .. }
+                ) {
+                    *block = ContentBlock::Text {
+                        text: placeholder.clone(),
+                        provider_metadata: None,
+                    };
+                }
+            }
+        }
+    }
+    messages
+}
+
 /// Run the agent execution loop for a single user message.
 ///
 /// This is the core of LibreFang: it loads session context, recalls memories,
@@ -1008,11 +1041,27 @@ pub async fn run_agent_loop(
             .map(|k| k.reasoning_echo_policy_for(&api_model))
             .unwrap_or_default();
 
+        // Catalog-driven vision-capability gate (#6010). When the target model
+        // has no vision support, image content blocks are redacted to a text
+        // placeholder before the request is built — text-only OpenAI-compatible
+        // models otherwise reject `image_url` content parts with HTTP 400. Fails
+        // open (no kernel handle wired, or catalog miss) so vision and unknown
+        // models keep sending images unchanged.
+        let supports_vision = kernel
+            .as_ref()
+            .map(|k| k.supports_vision_for(&api_model))
+            .unwrap_or(true);
+        let request_messages = if supports_vision {
+            messages.clone()
+        } else {
+            redact_images_for_text_only(messages.clone(), &api_model)
+        };
+
         // Wrap messages once per turn — call_with_retry's `request.clone()`
         // becomes a refcount bump instead of a deep clone of the history (#3766).
         let request = CompletionRequest {
             model: api_model,
-            messages: std::sync::Arc::new(messages.clone()),
+            messages: std::sync::Arc::new(request_messages),
             tools: tools_cache.get(available_tools, &session_loaded_tools),
             max_tokens: manifest.model.max_tokens,
             temperature: manifest.model.temperature,

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -308,7 +308,7 @@ fn build_sender_prefix(manifest: &AgentManifest, sender_user_id: Option<&str>) -
 ///
 /// Pure function: the caller passes a clone, so the live session history is
 /// never mutated and the vision path stays byte-identical to before.
-fn redact_images_for_text_only(mut messages: Vec<Message>, model: &str) -> Vec<Message> {
+pub(super) fn redact_images_for_text_only(mut messages: Vec<Message>, model: &str) -> Vec<Message> {
     let placeholder = format!("[image omitted: model `{model}` has no vision support]");
     for msg in &mut messages {
         if let MessageContent::Blocks(blocks) = &mut msg.content {

--- a/crates/librefang-runtime/src/agent_loop/run_streaming.rs
+++ b/crates/librefang-runtime/src/agent_loop/run_streaming.rs
@@ -681,10 +681,21 @@ pub async fn run_agent_loop_streaming(
             .map(|k| k.reasoning_echo_policy_for(&api_model))
             .unwrap_or_default();
 
+        // Mirror the non-streaming vision gate (#6010): redact image blocks for text-only models before building the request.
+        let supports_vision = kernel
+            .as_ref()
+            .map(|k| k.supports_vision_for(&api_model))
+            .unwrap_or(true);
+        let request_messages = if supports_vision {
+            messages.clone()
+        } else {
+            super::redact_images_for_text_only(messages.clone(), &api_model)
+        };
+
         // Same Arc-wrap as the non-streaming hot path (#3766).
         let request = CompletionRequest {
             model: api_model,
-            messages: std::sync::Arc::new(messages.clone()),
+            messages: std::sync::Arc::new(request_messages),
             tools: tools_cache.get(available_tools, &session_loaded_tools),
             max_tokens: manifest.model.max_tokens,
             temperature: manifest.model.temperature,

--- a/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
@@ -1610,3 +1610,113 @@ async fn test_normal_turn_auto_memorizes_proactive_memory_control() {
         "normal turn should auto_memorize the preference fixture"
     );
 }
+
+// --- #6010: redact_images_for_text_only ---
+
+#[test]
+fn redact_images_for_text_only_replaces_image_and_imagefile_blocks() {
+    use super::super::redact_images_for_text_only;
+    use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+
+    let messages = vec![
+        // Plain text user message — must be left untouched.
+        Message {
+            role: Role::User,
+            content: MessageContent::Text("hello".to_string()),
+            pinned: false,
+            timestamp: None,
+        },
+        // Mixed block message: a Text block, an inline Image, and an
+        // on-disk ImageFile. Both image variants must be redacted; the
+        // Text block and surrounding structure must survive.
+        Message {
+            role: Role::User,
+            content: MessageContent::Blocks(vec![
+                ContentBlock::Text {
+                    text: "what is in this photo?".to_string(),
+                    provider_metadata: None,
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: "aGVsbG8=".to_string(),
+                },
+                ContentBlock::ImageFile {
+                    media_type: "image/jpeg".to_string(),
+                    path: "/tmp/photo.jpg".to_string(),
+                },
+            ]),
+            pinned: false,
+            timestamp: None,
+        },
+    ];
+
+    let out = redact_images_for_text_only(messages, "deepseek-v4");
+
+    // First message untouched.
+    assert!(matches!(
+        &out[0].content,
+        MessageContent::Text(t) if t == "hello"
+    ));
+
+    let blocks = match &out[1].content {
+        MessageContent::Blocks(b) => b,
+        other => panic!("expected Blocks, got {other:?}"),
+    };
+    assert_eq!(blocks.len(), 3, "block count must be preserved");
+    // Original text block survives verbatim.
+    assert!(matches!(
+        &blocks[0],
+        ContentBlock::Text { text, .. } if text == "what is in this photo?"
+    ));
+    // No image block of either variant may remain.
+    assert!(
+        !blocks
+            .iter()
+            .any(|b| matches!(b, ContentBlock::Image { .. } | ContentBlock::ImageFile { .. })),
+        "all image blocks must be redacted"
+    );
+    // The two image slots became text placeholders mentioning the model.
+    for idx in [1usize, 2usize] {
+        match &blocks[idx] {
+            ContentBlock::Text { text, .. } => {
+                assert!(
+                    text.contains("image omitted") && text.contains("deepseek-v4"),
+                    "redacted placeholder must mention omission + model, got {text:?}"
+                );
+            }
+            other => panic!("expected redacted Text placeholder, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn redact_images_for_text_only_is_noop_without_images() {
+    use super::super::redact_images_for_text_only;
+    use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+
+    let messages = vec![Message {
+        role: Role::Assistant,
+        content: MessageContent::Blocks(vec![
+            ContentBlock::Text {
+                text: "sure".to_string(),
+                provider_metadata: None,
+            },
+            ContentBlock::ToolUse {
+                id: "call_1".to_string(),
+                name: "search".to_string(),
+                input: serde_json::json!({"q": "x"}),
+                provider_metadata: None,
+            },
+        ]),
+        pinned: false,
+        timestamp: None,
+    }];
+    let original = messages.clone();
+    let out = redact_images_for_text_only(messages, "gpt-4o");
+    // Non-image content is structurally unchanged.
+    assert_eq!(
+        format!("{:?}", out[0].content),
+        format!("{:?}", original[0].content),
+        "messages without image blocks must pass through unchanged"
+    );
+}

--- a/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
@@ -1670,9 +1670,10 @@ fn redact_images_for_text_only_replaces_image_and_imagefile_blocks() {
     ));
     // No image block of either variant may remain.
     assert!(
-        !blocks
-            .iter()
-            .any(|b| matches!(b, ContentBlock::Image { .. } | ContentBlock::ImageFile { .. })),
+        !blocks.iter().any(|b| matches!(
+            b,
+            ContentBlock::Image { .. } | ContentBlock::ImageFile { .. }
+        )),
         "all image blocks must be redacted"
     );
     // The two image slots became text placeholders mentioning the model.


### PR DESCRIPTION
## Problem

A channel/sidecar bot whose default agent runs a **text-only** model (e.g.
DeepSeek `deepseek-v4`, `supports_vision = false`) breaks the moment a user
sends a photo. The OpenAI-compatible API rejects image content parts with
HTTP 400:

```
unknown variant `image_url`, expected `text`
```

The channel layer downloads the image and prepends a textual `[media]`
description, but it does **not** strip the `ContentBlock::Image` / `ImageFile`
block, so the image still reaches the driver, is inlined as a `data:` URL, and
400s the whole turn. This affects every entry path with a text-only default
agent (WebUI, channels, sidecars, triggers).

## Approach (authoritative, catalog-driven)

The previous revision of this PR used a driver-local name deny-list in
`openai.rs`. That was rejected by the maintainer as non-authoritative. This
revision moves the gate to the model catalog and redacts upstream of the
driver, so it covers **all** entry paths and **all** OpenAI-compatible drivers,
respects user capability overrides, and never hard-codes provider names.

LibreFang's authoritative vision flag is the model catalog's
`effective_capabilities().supports_vision`, which already honours user
overrides (#4745). This is surfaced to request-build time via the same
`CatalogQuery` trait that #4842 used to thread `reasoning_echo_policy`.

## Changes

1. **`CatalogQuery::supports_vision_for(model) -> bool`** — new trait method
   mirroring `reasoning_echo_policy_for`, with a default body returning `true`
   (fail open) so non-overriding mocks/stubs keep sending images unchanged.
   `crates/librefang-kernel-handle/src/catalog_query.rs`

2. **Kernel override** — resolves the flag from the catalog, honouring user
   overrides via `effective_capabilities`, fails open on a catalog miss
   (`unwrap_or(true)`), using the same catalog accessor as
   `lookup_reasoning_echo_policy` and the same call shape as `ws.rs`.
   `crates/librefang-kernel/src/kernel/handles/catalog_query.rs`

3. **Agent-loop gate** — at the request-build site in `run_agent_loop`, look up
   `supports_vision` via the kernel handle (same `kernel.as_ref().map(|k| …)`
   pattern as the adjacent `reasoning_echo_policy` lookup). When
   `!supports_vision`, redact image blocks to a text placeholder via a small
   pure helper `redact_images_for_text_only(messages, model)` **before**
   building the request. The vision path is byte-identical to before.
   `crates/librefang-runtime/src/agent_loop/mod.rs`

4. **`openai.rs` reverted** to `main` — the driver again serializes images
   unconditionally; the gate now lives upstream.

### Why this is correct

- **Authoritative**: capability comes from the catalog
  (`effective_capabilities().supports_vision`), not a name heuristic.
- **Respects user overrides (#4745)**: `effective_capabilities` applies the
  per-model override, so an operator who force-enables vision on a
  mis-declared model keeps sending images.
- **Covers all paths**: redaction happens in the shared agent loop, so every
  inbound surface (WebUI, channels, sidecars, triggers) is protected, not just
  the OpenAI driver / a known family list.
- **Fails open**: no kernel handle wired, or a catalog miss → images are sent
  unchanged, so vision and unknown models are never degraded.

## Tests

- `crates/librefang-kernel-handle/src/tests.rs` —
  `catalog_query_supports_vision_defaults_to_true`: a stub that doesn't
  override the method returns `true` (mirrors the existing
  `catalog_query_default_returns_none` test).
- `crates/librefang-runtime/src/agent_loop/tests/utilities.rs` —
  `redact_images_for_text_only_replaces_image_and_imagefile_blocks`: both
  `Image` and `ImageFile` blocks become text placeholders that mention the
  model; text/other blocks and block counts are preserved.
  `redact_images_for_text_only_is_noop_without_images`: messages without image
  blocks pass through structurally unchanged.

## Verification

Local compilation/tests were not possible in this environment (no native
`cargo`/`rustc`, no reliable Docker). The change follows the existing
`reasoning_echo_policy_for` precedent and `ws.rs` catalog-call shape, and is
left for CI to compile and run as the gate.

Closes #6010
