### PR TITLE
fix(skills): assign approved workshop skill to the creating agent (#5989)

### DIFF
--- a/crates/librefang-api/src/routes/skills/skill.rs
+++ b/crates/librefang-api/src/routes/skills/skill.rs
@@ -354,6 +354,15 @@ pub async fn approve_pending_candidate(
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> impl IntoResponse {
     let skills_root = state.kernel.home_dir().join("skills");
+    // Capture the creating agent id BEFORE promotion: `approve_candidate`
+    // deletes the pending TOML on success, after which `agent_id` is no
+    // longer recoverable. Best-effort — a read failure here must not block
+    // the approve (auto-assign is a convenience, not a precondition).
+    let creator_agent_id =
+        match librefang_kernel::skill_workshop::storage::load_candidate(&skills_root, &id) {
+            Ok(c) => Some(c.agent_id),
+            Err(_) => None,
+        };
     match librefang_kernel::skill_workshop::storage::approve_candidate(
         &skills_root,
         &skills_root,
@@ -364,6 +373,12 @@ pub async fn approve_pending_candidate(
             // `skills_root`; refresh the in-memory registry so the next
             // turn's prompt build sees the new skill.
             state.kernel.reload_skills();
+            // Auto-assign the promoted skill to the agent that produced it
+            // so the workshop loop (capture → review → approve → use)
+            // closes without a manual `agent.toml` edit (#5989). Best-effort:
+            // logs and continues if the agent was deleted between capture
+            // and approval, so the approve still returns 200.
+            assign_skill_to_creator(&state, creator_agent_id.as_deref(), &result.skill_name);
             (
                 StatusCode::OK,
                 Json(serde_json::json!({
@@ -452,17 +467,27 @@ pub async fn approve_pending_candidate(
                 // cleanup beat us to the row), not a failure.
                 match librefang_kernel::skill_workshop::storage::reject_candidate(&skills_root, &id)
                 {
-                    Ok(()) | Err(librefang_kernel::skill_workshop::WorkshopError::NotFound(_)) => (
-                        StatusCode::OK,
-                        Json(serde_json::json!({
-                            "status": "already_promoted",
-                            "candidate_id": id,
-                            "skill_name": skill_name,
-                            "message": format!(
-                                "Active skill '{skill_name}' already exists with the same body; pending entry cleared.",
-                            ),
-                        })),
-                    ),
+                    Ok(()) | Err(librefang_kernel::skill_workshop::WorkshopError::NotFound(_)) => {
+                        // Idempotent re-approval: the skill was already
+                        // promoted, but the creating agent may not have been
+                        // assigned on the first pass (e.g. it didn't exist
+                        // yet, or assignment failed). Re-run the best-effort
+                        // assign so phantom recovery converges to the same
+                        // end state — `assign_skill_to_creator` is a no-op
+                        // when the skill is already live on the allowlist.
+                        assign_skill_to_creator(&state, creator_agent_id.as_deref(), &skill_name);
+                        (
+                            StatusCode::OK,
+                            Json(serde_json::json!({
+                                "status": "already_promoted",
+                                "candidate_id": id,
+                                "skill_name": skill_name,
+                                "message": format!(
+                                    "Active skill '{skill_name}' already exists with the same body; pending entry cleared.",
+                                ),
+                            })),
+                        )
+                    }
                     Err(e) => {
                         // Scrub the raw storage error (audit:
                         // rusqlite-errors-leak); operator context in
@@ -495,6 +520,65 @@ pub async fn approve_pending_candidate(
             Json(serde_json::json!({"error": format!("promotion rejected: {e}")})),
         ),
         Err(e) => ApiErrorResponse::internal_scrub(e).into_json_tuple(),
+    }
+}
+
+/// Append a freshly-promoted workshop skill to its creating agent's
+/// allowlist (#5989). Best-effort and idempotent:
+///
+/// * `agent_id` is `None` / unparseable / no longer in the registry →
+///   log a WARN and return; the caller's approve still succeeds.
+/// * skill already on the allowlist AND not hidden by `skills_disabled`
+///   → no-op (no redundant DB write).
+/// * otherwise append the skill and route through `set_agent_skills`,
+///   which clears `skills_disabled` so the new skill is live, persists
+///   the manifest, and invalidates the agent's cached tool list.
+fn assign_skill_to_creator(state: &Arc<AppState>, agent_id: Option<&str>, skill_name: &str) {
+    let Some(agent_id) = agent_id else {
+        tracing::warn!(
+            %skill_name,
+            "skill_workshop: approved candidate had no recoverable agent_id; \
+             skipping auto-assign (skill promoted, assign manually if needed)"
+        );
+        return;
+    };
+    let Ok(agent_id) = agent_id.parse::<librefang_types::agent::AgentId>() else {
+        tracing::warn!(
+            %agent_id,
+            %skill_name,
+            "skill_workshop: candidate agent_id is not a valid AgentId; skipping auto-assign"
+        );
+        return;
+    };
+    let Some(entry) = state.kernel.agent_registry().get(agent_id) else {
+        tracing::warn!(
+            %agent_id,
+            %skill_name,
+            "skill_workshop: creating agent no longer exists; skipping auto-assign \
+             (skill promoted successfully)"
+        );
+        return;
+    };
+
+    let already_listed = entry.manifest.skills.iter().any(|s| s == skill_name);
+    // Re-run the assign when the skill is present but hidden by
+    // `skills_disabled` so the flag is cleared and the skill goes live.
+    if already_listed && !entry.manifest.skills_disabled {
+        return;
+    }
+
+    let mut skills = entry.manifest.skills.clone();
+    if !already_listed {
+        skills.push(skill_name.to_string());
+    }
+    if let Err(e) = state.kernel.set_agent_skills(agent_id, skills) {
+        tracing::warn!(
+            %agent_id,
+            %skill_name,
+            error = %e,
+            "skill_workshop: failed to auto-assign promoted skill to creating agent \
+             (skill promoted successfully; assign manually)"
+        );
     }
 }
 

--- a/crates/librefang-api/tests/skill_workshop_pending_routes_test.rs
+++ b/crates/librefang-api/tests/skill_workshop_pending_routes_test.rs
@@ -460,7 +460,10 @@ fn agent_skills(h: &Harness, agent_id: &str) -> (Vec<String>, bool) {
         .agent_registry()
         .get(id)
         .expect("agent must still be registered");
-    (entry.manifest.skills.clone(), entry.manifest.skills_disabled)
+    (
+        entry.manifest.skills.clone(),
+        entry.manifest.skills_disabled,
+    )
 }
 
 /// Approving a candidate whose `agent_id` resolves to a live agent must

--- a/crates/librefang-api/tests/skill_workshop_pending_routes_test.rs
+++ b/crates/librefang-api/tests/skill_workshop_pending_routes_test.rs
@@ -418,6 +418,155 @@ async fn pending_approve_name_collision_with_different_body_returns_409() {
 }
 
 // ---------------------------------------------------------------------------
+// Auto-assign promoted skill to the creating agent (#5989)
+// ---------------------------------------------------------------------------
+
+/// Register a real agent in the harness's registry so the approve path
+/// can resolve `CandidateSkill.agent_id` and append the promoted skill to
+/// its allowlist. Returns the agent's id as the canonical UUID string the
+/// candidate fixture must carry.
+fn register_agent(h: &Harness, name: &str) -> String {
+    use librefang_types::agent::{AgentEntry, AgentId};
+    let agent_id = AgentId::new();
+    let manifest = librefang_types::agent::AgentManifest {
+        name: name.to_string(),
+        // Start with an empty allowlist so the assertions exercise the
+        // append. (Empty also means "all skills" at runtime, but we
+        // assert on the raw manifest list — what the operator edits in
+        // agent.toml — so the append is observable.)
+        skills: Vec::new(),
+        skills_disabled: false,
+        ..Default::default()
+    };
+    let entry = AgentEntry {
+        id: agent_id,
+        name: name.to_string(),
+        manifest,
+        ..Default::default()
+    };
+    h.state
+        .kernel
+        .agent_registry()
+        .register(entry)
+        .expect("register agent");
+    agent_id.0.to_string()
+}
+
+fn agent_skills(h: &Harness, agent_id: &str) -> (Vec<String>, bool) {
+    let id: librefang_types::agent::AgentId = agent_id.parse().expect("parse agent id");
+    let entry = h
+        .state
+        .kernel
+        .agent_registry()
+        .get(id)
+        .expect("agent must still be registered");
+    (entry.manifest.skills.clone(), entry.manifest.skills_disabled)
+}
+
+/// Approving a candidate whose `agent_id` resolves to a live agent must
+/// append the promoted skill to that agent's allowlist and clear
+/// `skills_disabled`, so the workshop loop closes without a manual
+/// `agent.toml` edit.
+#[tokio::test(flavor = "multi_thread")]
+async fn pending_approve_assigns_skill_to_creating_agent() {
+    let h = boot().await;
+    let agent = register_agent(&h, "creator_agent");
+    let id = "f1f1f1f1-0000-0000-0000-000000000001";
+    let root = skills_root(&h);
+    storage::save_candidate(&root, &fixture_candidate(&agent, id), 20, None).unwrap();
+
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        &format!("/api/skills/pending/{id}/approve"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert_eq!(body["skill_name"], "fmt_before_commit");
+
+    let (skills, disabled) = agent_skills(&h, &agent);
+    assert!(
+        skills.contains(&"fmt_before_commit".to_string()),
+        "promoted skill must be appended to the creating agent's allowlist: {skills:?}"
+    );
+    assert!(
+        !disabled,
+        "skills_disabled must be cleared so the new skill is live"
+    );
+}
+
+/// Re-approving the same skill for the same agent (phantom-pending
+/// recovery → `already_promoted`) must be idempotent: the skill appears
+/// exactly once on the allowlist, no duplicate entry.
+#[tokio::test(flavor = "multi_thread")]
+async fn pending_approve_assignment_is_idempotent() {
+    let h = boot().await;
+    let agent = register_agent(&h, "creator_agent");
+    let first_id = "f2f2f2f2-0000-0000-0000-000000000001";
+    let second_id = "f2f2f2f2-0000-0000-0000-000000000002";
+    let root = skills_root(&h);
+
+    storage::save_candidate(&root, &fixture_candidate(&agent, first_id), 20, None).unwrap();
+    let (status, _) = json_request(
+        &h,
+        Method::POST,
+        &format!("/api/skills/pending/{first_id}/approve"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "first approve must succeed");
+
+    // Re-stage a same-named candidate to mimic the phantom-pending case
+    // (active skill already exists; pending re-approved). The assignment
+    // must not double-append the skill name.
+    storage::save_candidate(&root, &fixture_candidate(&agent, second_id), 20, None).unwrap();
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        &format!("/api/skills/pending/{second_id}/approve"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "re-approve must succeed: {body:?}");
+
+    let (skills, _) = agent_skills(&h, &agent);
+    let occurrences = skills.iter().filter(|s| *s == "fmt_before_commit").count();
+    assert_eq!(
+        occurrences, 1,
+        "re-approval must not duplicate the skill on the allowlist: {skills:?}"
+    );
+}
+
+/// Auto-assign is best-effort: when the creating agent was deleted
+/// between capture and approval (its `agent_id` no longer resolves), the
+/// approve must still promote the skill and return 200 — assignment is a
+/// convenience, not a hard precondition.
+#[tokio::test(flavor = "multi_thread")]
+async fn pending_approve_succeeds_when_creating_agent_gone() {
+    let h = boot().await;
+    // A well-formed UUID that was never registered in the harness.
+    let agent = "deadbeef-0000-0000-0000-000000000000";
+    let id = "f3f3f3f3-0000-0000-0000-000000000001";
+    let root = skills_root(&h);
+    storage::save_candidate(&root, &fixture_candidate(agent, id), 20, None).unwrap();
+
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        &format!("/api/skills/pending/{id}/approve"),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "approve must succeed even when the creating agent is gone: {body:?}"
+    );
+    assert_eq!(body["status"], "approved");
+    assert!(
+        root.join("fmt_before_commit").join("skill.toml").exists(),
+        "skill must still be promoted when the agent can't be resolved"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // POST /api/skills/pending/{id}/reject
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #5989.

Approving a pending skill-workshop candidate (`POST /api/skills/pending/{id}/approve`, and by extension the CLI / dashboard, which share this route) promoted the skill into the registry via `reload_skills()` but never touched any agent's allowlist. The teaching agent — whose id is recorded on `CandidateSkill.agent_id` — therefore could not use the skill it produced until an operator manually edited `agent.toml` and added the name to `skills = [...]`.

This PR closes the workshop loop (capture → review → approve → use) by auto-assigning the promoted skill to its creating agent on approval.

## Root cause

`approve_pending_candidate` in `crates/librefang-api/src/routes/skills/skill.rs` called `state.kernel.reload_skills()` (global loadability) but had no follow-up that read `CandidateSkill.agent_id` and appended the skill to that agent's `manifest.skills`. The `agent_id` was available on the candidate but unused for assignment.

## Fix

In `approve_pending_candidate`:

- Read `CandidateSkill.agent_id` via `storage::load_candidate` **before** calling `approve_candidate` (which deletes the pending TOML on success, after which `agent_id` is unrecoverable). Best-effort: a read failure yields `None` and does not block the approve.
- After promotion + `reload_skills()`, call a new best-effort helper `assign_skill_to_creator`:
  - `None` / unparseable id / agent no longer in the registry → log a `WARN` and return; the approve still returns 200 (auto-assign is a convenience, not a precondition).
  - skill already on the allowlist AND `skills_disabled` is already false → no-op (no redundant DB write).
  - otherwise append the skill (idempotent — no duplicate if already present) and route through the existing `kernel.set_agent_skills`, which clears `skills_disabled` so the skill is live, persists the manifest (`save_agent` upsert), and invalidates the agent's cached tool list.
- The phantom-pending recovery branch (`already_promoted`) also re-runs the assign so re-approval converges to the same end state (e.g. the agent didn't exist on the first pass but was recreated later).

Reuses the existing `kernel.set_agent_skills` path rather than inventing a new registry method, so manifest persistence, skill-name validation (the promoted skill is registered by the preceding `reload_skills()`), rollback, and cache invalidation all stay consistent with the `PUT /api/agents/{id}/skills` route.

## Tests

Added three `#[tokio::test]` cases to `crates/librefang-api/tests/skill_workshop_pending_routes_test.rs` (same `TestAppState` + `tower::oneshot` harness as the existing approve tests):

- `pending_approve_assigns_skill_to_creating_agent` — register a real agent, approve a candidate carrying that `agent_id`, assert the promoted skill is appended to the agent's allowlist and `skills_disabled` is cleared.
- `pending_approve_assignment_is_idempotent` — re-approve the same skill (phantom-pending path) and assert the skill appears exactly once on the allowlist.
- `pending_approve_succeeds_when_creating_agent_gone` — approve a candidate whose `agent_id` was never registered; assert the approve still returns 200 and the skill is still promoted.

## Scope

This is the targeted slice of the broader #5844 (approval + assignment). It does NOT implement #5844's diff-review flow for skill *updates* — only the assign-on-approve behaviour #5989 asks for.

## Verification

No local compile/test: this environment has no native `cargo`/`rustfmt` and no usable Docker, so I could not build or run the suite locally. CI is the gate — the new integration tests run in the `Test / Ubuntu` lanes and the fmt/clippy checks run in CI.
