### PR TITLE
fix(dashboard/agents): stage Skills-tab edits behind a Save button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -801,6 +801,10 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
   Under load a `GET /run` landing inside that write window lost the `try_lock` and surfaced a live run as not running — a dashboard `/run` poll would flicker "stopped", and the `goal_run_start_then_stop_with_agent` integration test flaked on it.
   The loop now updates the in-memory state under the lock, releases it, and persists the cloned snapshot outside the lock; `state` is written only by the single loop task, so the snapshot stays consistent.
   This shrinks the lock hold to a few synchronous field writes, so `try_lock` no longer realistically contends.
+- **fix(dashboard/agents): stage agent Skills-tab edits behind a Save button instead of persisting on every click** (#6041) (@DaBlitzStein).
+  The Skills tab fired `PUT /api/agents/{id}/skills` immediately on every add / remove / Customize / Reset-to-all, with no Save button and no way to back out — unlike the Tools tab, which stages a draft and only writes on Save.
+  Skills now mirrors Tools: edits stage into a local `skillsDraft`, a Save button (disabled until dirty) issues the single PUT, and switching tabs discards the draft.
+
 - **channels: stop silently swallowing an upgraded operator's channel config, and explain why the WeChat/etc. configure form is empty** (@houko).
   After the channel → sidecar migration (#5317–#5459) the in-process `[channels.<vendor>]` config blocks were removed from `ChannelsConfig`, so an operator upgrading from a pre-migration build lost every configured channel on first boot: the old block deserialised into nothing, the dashboard channels page (which only renders `configured` rows) showed the WeChat card vanishing, and the only signal was a generic "Unknown config field (ignored)" log that never mentioned sidecars.
   Re-adding the channel then failed just as quietly — the configure form is schema-driven off `python3 -m librefang.sidecar.adapters.<name> --describe`, which fails when the Python sidecar SDK is not installed (and a pre-migration WeChat ran in-process Rust, so an upgrader never had it), leaving the Add-picker drawer blank with no inputs and no explanation.

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -220,6 +220,11 @@ export function AgentsPage() {
   // five sections (Conversation / Memory / Skills / Schedule / Logs).
   const [toolsDraft, setToolsDraft] = useState<string[] | null>(null);
   const [expandedToolGroup, setExpandedToolGroup] = useState<string | null>(null);
+  // Skills tab draft — mirrors `toolsDraft`. Holds the staged per-agent skill
+  // allowlist; `null` = pristine (no edits). Add/remove/customize/reset only
+  // mutate this local draft, so nothing persists until the Save button fires
+  // the PUT — leaving the tab discards the draft (the "change your mind" path).
+  const [skillsDraft, setSkillsDraft] = useState<string[] | null>(null);
   const [agentTab, setAgentTab] = useState<
     "conversation" | "memory" | "skills" | "tools" | "schedule" | "logs"
   >("conversation");
@@ -514,6 +519,22 @@ export function AgentsPage() {
       setToolsDraft([...declared]);
     }
   }, [agentTab, tabAgentToolsQuery.data]);
+
+  // Seed / reset the Skills draft, same shape as the Tools effect above.
+  // Only an allowlist-mode agent (a pinned set) seeds the draft; "all" mode
+  // leaves it null so the all-view renders until the operator customizes.
+  useEffect(() => {
+    if (agentTab !== "skills") {
+      setSkillsDraft(null);
+      return;
+    }
+    const data = tabAgentSkillsQuery.data;
+    if (!data) return;
+    const pinned = data.mode === "allowlist" ? (data.assigned ?? []) : [];
+    if (pinned.length > 0 && skillsDraft === null) {
+      setSkillsDraft([...pinned]);
+    }
+  }, [agentTab, tabAgentSkillsQuery.data]);
 
   // Per-agent session list — Conversation tab uses this directly. The
   // global /api/sessions used previously was paginated to 50, so the
@@ -1301,7 +1322,7 @@ export function AgentsPage() {
       : Array.isArray(view.capabilities?.skills)
         ? view.capabilities!.skills!
         : [];
-    const assigned: string[] = (skillsData?.assigned ?? manifestSkills)
+    const serverAssigned: string[] = (skillsData?.assigned ?? manifestSkills)
       .slice()
       .sort();
     const available: string[] = (skillsData?.available ?? []).slice().sort();
@@ -1310,26 +1331,59 @@ export function AgentsPage() {
     // set). Prefer the live query's mode; fall back to the detail payload.
     const skillsMode =
       skillsData?.mode ?? (agent as AgentDetail).skills_mode;
-    const usesAllSkills = skillsMode === "all";
     const skillsDisabled =
       skillsData?.disabled ?? skillsMode === "none";
-    // Available skills not yet on the allowlist — the add pool in allowlist
-    // mode. Built from the registry list minus what's already assigned.
-    const assignedSet = new Set(assigned);
-    const addable = available.filter((s) => !assignedSet.has(s));
+    // The persisted allowlist as the server currently has it: the pinned set
+    // in allowlist mode, empty in all-mode (an empty allowlist === all-mode on
+    // write). `draft` is the locally-staged copy — `skillsDraft` is null until
+    // the first edit, so nothing is persisted until Save. Mirrors `toolsDraft`.
+    const persisted: string[] =
+      skillsMode === "allowlist" ? serverAssigned : [];
+    const assigned: string[] = (skillsDraft ?? persisted).slice().sort();
+    const draftSet = new Set(assigned);
+    const isDirty =
+      skillsDraft !== null &&
+      (assigned.length !== persisted.length ||
+        assigned.some((s) => !persisted.includes(s)));
+    // Render the "using all skills" view only when the persisted state is
+    // all-mode AND there are no staged edits — once the operator customizes,
+    // the allowlist editor takes over (mirrors the Tools tab's `usesAll`).
+    const usesAllSkills = persisted.length === 0 && !isDirty;
+    // Available skills not yet on the (draft) allowlist — the add pool.
+    const addable = available.filter((s) => !draftSet.has(s));
     const mutating = setAgentSkillsMutation.isPending;
     const skillsLoading =
       tabAgentSkillsQuery.isLoading && !skillsData;
 
-    // Apply a new allowlist. Empty array clears it back to "all" mode.
-    const applySkills = (next: string[], toast: string) => {
+    // Every edit stages into `skillsDraft`; the server is only touched on Save.
+    const addSkill = (name: string) =>
+      setSkillsDraft((prev) => {
+        const base = prev ?? persisted;
+        return base.includes(name) ? base : [...base, name];
+      });
+    const removeSkill = (name: string) =>
+      setSkillsDraft((prev) => (prev ?? persisted).filter((s) => s !== name));
+    // "Customize" from all-mode: seed the allowlist with every available skill
+    // so the operator gets a concrete list to prune (saving an empty allowlist
+    // would just stay in all-mode).
+    const customizeFromAll = () => setSkillsDraft([...available]);
+    // "Reset to all": stage an empty allowlist (an empty PUT → all-mode on Save).
+    const resetToAll = () => setSkillsDraft([]);
+    // Persist the staged allowlist. Empty array clears it back to "all" mode.
+    const handleSaveSkills = () => {
       if (!agent.id) return;
       setAgentSkillsMutation.mutate(
-        { agentId: agent.id, skills: next },
+        { agentId: agent.id, skills: assigned },
         {
           onSuccess: async () => {
             await refreshDetailAgent(agent.id, agent.is_hand);
-            addToast(toast, "success");
+            setSkillsDraft(null);
+            addToast(
+              t("agents.detail.skills_saved", {
+                defaultValue: "Saved to agent.toml",
+              }),
+              "success",
+            );
           },
           onError: (e) => {
             addToast(
@@ -1345,39 +1399,6 @@ export function AgentsPage() {
         },
       );
     };
-    const addSkill = (name: string) =>
-      applySkills(
-        [...assigned, name],
-        t("agents.detail.skill_added", {
-          defaultValue: "Skill assigned",
-        }),
-      );
-    const removeSkill = (name: string) =>
-      applySkills(
-        assigned.filter((s) => s !== name),
-        t("agents.detail.skill_removed", {
-          defaultValue: "Skill removed",
-        }),
-      );
-    // "Customize" from all-mode: seed the allowlist with every available
-    // skill so the operator gets a concrete list to prune (an empty PUT
-    // would just stay in all-mode). Done with the assign mutation so the
-    // skill-registry validation runs server-side.
-    const customizeFromAll = () =>
-      applySkills(
-        available,
-        t("agents.detail.skill_customized", {
-          defaultValue: "Switched to a per-agent allowlist",
-        }),
-      );
-    // "Reset to all": clear the allowlist (empty PUT → all-mode).
-    const resetToAll = () =>
-      applySkills(
-        [],
-        t("agents.detail.skill_reset_all", {
-          defaultValue: "Reset to all available skills",
-        }),
-      );
 
     const autoEvolve = agent.auto_evolve !== false;
     const handleToggleAutoEvolve = () => {
@@ -1559,6 +1580,21 @@ export function AgentsPage() {
                 </div>
               </div>
             )}
+          </div>
+        )}
+
+        {!skillsLoading && !skillsDisabled && (
+          <div className="flex justify-end mt-2">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleSaveSkills}
+              disabled={!isDirty || mutating}
+            >
+              {mutating
+                ? t("common.saving", { defaultValue: "Saving..." })
+                : t("common.save", { defaultValue: "Save" })}
+            </Button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Closes #6041.

The agent **Skills** tab persisted every change immediately (`PUT /api/agents/{id}/skills` on each add / remove / Customize / Reset-to-all) with no Save button and no way to back out — inconsistent with the sibling **Tools** tab, which stages a draft and only writes on **Save**. A misclick (or "Reset to all") was instantly written to `agent.toml`.

This makes Skills mirror Tools exactly.

## Change

All in `crates/librefang-api/dashboard/src/pages/AgentsPage.tsx`:

- Added a `skillsDraft: string[] | null` state next to the existing `toolsDraft` (`null` = pristine, otherwise the staged allowlist).
- Added a draft-sync `useEffect` mirroring the Tools one: seeds the draft from the persisted allowlist when an allowlist-mode agent's Skills tab opens; resets to `null` when leaving the tab (so the draft is discarded).
- `renderSkillsTab`: add / remove / Customize / Reset-to-all now only mutate `skillsDraft` — no network call. The view derives `isDirty`/`usesAllSkills` from the draft, so pending edits are visible before saving.
- Added a bottom **Save** button (disabled until `isDirty`) that issues the single `setAgentSkillsMutation` PUT, then clears the draft on success. An empty allowlist still saves as all-mode (unchanged write semantics).
- **Auto-evolve** stays an immediate toggle — it's a separate boolean, not part of the skill allowlist.

No changes to `src/lib/queries`, `src/lib/mutations`, or `src/api.ts`; the mutation hook (`useSetAgentSkills`) and its invalidation are reused as-is.

## Verification

- `pnpm typecheck` — clean.
- `pnpm lint src/pages/AgentsPage.tsx` — 0 errors. The one new `react-hooks/exhaustive-deps` warning on the skills `useEffect` is the same intentional pattern as the existing `toolsDraft` effect (the draft is deliberately excluded to avoid re-seeding); the lint policy allows warnings.
- `pnpm test --run` — skills + key-factory suites green (`agents-skills.test.tsx`, `queries/agents-skills.test.tsx`, `keys.test.ts`: 42 passed). `pnpm build` succeeds.
- Pre-existing, unrelated: `src/pages/ModelsPage.test.tsx` fails in isolation on `main` too (zustand `localStorage.setItem` throwing under jsdom) — untouched by this PR (diff is one file). Flagged separately, not bundled here.

## Notes

Manual browser click-through was not performed in this environment; behavior is asserted via typecheck/lint/build and by structural parity with the already-shipped Tools-tab Save flow.