### PR TITLE
fix(runtime): browser.rs fails to compile on non-Linux under deny-warnings

### DIFF
--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -272,6 +272,10 @@ impl BrowserSession {
             .prefix("librefang-chrome-")
             .tempdir()
             .map_err(|e| format!("Failed to create Chromium user-data-dir: {e}"))?;
+        // `args` is only mutated under `#[cfg(target_os = "linux")]` below
+        // (the root --no-sandbox path); on other platforms it stays immutable,
+        // so the `mut` would trip the workspace-wide `unused_mut` deny.
+        #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
         let mut args = chromium_launch_args(config, user_data_dir.path());
 
         // On Linux, Chromium refuses to start as root without --no-sandbox.

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -272,9 +272,6 @@ impl BrowserSession {
             .prefix("librefang-chrome-")
             .tempdir()
             .map_err(|e| format!("Failed to create Chromium user-data-dir: {e}"))?;
-        // `args` is only mutated under `#[cfg(target_os = "linux")]` below
-        // (the root --no-sandbox path); on other platforms it stays immutable,
-        // so the `mut` would trip the workspace-wide `unused_mut` deny.
         #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
         let mut args = chromium_launch_args(config, user_data_dir.path());
 


### PR DESCRIPTION
## Problem

`crates/librefang-runtime/src/browser.rs` does not compile on macOS or Windows when the workspace `[workspace.lints] warnings = "deny"` (Cargo.toml) is in effect.

In the Chromium launch path, `args` is declared `let mut args = …` but is only ever mutated inside the `#[cfg(target_os = "linux")]` root `--no-sandbox` branch:

```rust
let mut args = chromium_launch_args(config, user_data_dir.path());

#[cfg(target_os = "linux")]
{
    // … args.push("--no-sandbox") …
}
```

On any non-Linux target the binding is never mutated, so rustc emits `unused_mut`, which the workspace-wide deny promotes to a hard error. CI only exercises the deny set on Linux, so the break never showed up there — but a developer running `cargo check`/`cargo test` on macOS hits it immediately (it blocks every crate that depends on `librefang-runtime`).

## Fix

Gate the `mut` to the platform that actually uses it:

```rust
#[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
let mut args = chromium_launch_args(config, user_data_dir.path());
```

## Verification

- `cargo check`/`cargo test -p librefang-cli` (which transitively compiles `librefang-runtime`) now succeeds on macOS where it previously failed with the `unused_mut` deny.
- No behavioural change on Linux — the `mut` is still active there.

## How it was found

Surfaced while running a multi-agent audit of the workspace; it was the first compile barrier hit when building on macOS.