### PR TITLE
fix(llm-drivers): unbounded Vec growth from attacker-controlled streamed tool-call index (OOM)

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -91,6 +91,12 @@ const REFRESH_BUFFER_SECS: u64 = 3600; // 1 hour
 /// Hard timeout for OAuth refresh requests after explicit auth failures.
 const TOKEN_REFRESH_TIMEOUT_SECS: u64 = 15;
 
+/// Upper bound on streamed tool-call slots a single response may allocate. The
+/// accumulator is grown densely up to the SSE `output_index`; without a cap a
+/// hostile or buggy endpoint (or proxy) could send an enormous index and OOM
+/// the daemon. No real response carries this many parallel tool calls.
+const MAX_STREAMED_TOOL_CALLS: usize = 256;
+
 // ── Responses API request/response types ──────────────────────────────
 
 /// A single input item for the Responses API.
@@ -629,6 +635,17 @@ impl ChatGptDriver {
                                     .and_then(|v| v.as_u64())
                                     .unwrap_or(tool_accum.len() as u64)
                                     as usize;
+                                // Cap attacker-controlled index before growing
+                                // the dense accumulator (OOM guard). `line_buf`
+                                // is already advanced, so skipping this event is
+                                // safe.
+                                if output_index >= MAX_STREAMED_TOOL_CALLS {
+                                    warn!(
+                                        output_index,
+                                        "Ignoring function_call item with out-of-range output_index"
+                                    );
+                                    continue;
+                                }
 
                                 // Ensure tool_accum is large enough
                                 while tool_accum.len() <= output_index {

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -91,10 +91,9 @@ const REFRESH_BUFFER_SECS: u64 = 3600; // 1 hour
 /// Hard timeout for OAuth refresh requests after explicit auth failures.
 const TOKEN_REFRESH_TIMEOUT_SECS: u64 = 15;
 
-/// Upper bound on streamed tool-call slots a single response may allocate. The
-/// accumulator is grown densely up to the SSE `output_index`; without a cap a
-/// hostile or buggy endpoint (or proxy) could send an enormous index and OOM
-/// the daemon. No real response carries this many parallel tool calls.
+/// Upper bound on streamed tool-call slots a single response may allocate.
+/// The accumulator is grown densely up to the SSE `output_index`; without a cap a hostile or buggy endpoint (or proxy) could send an enormous index and OOM the daemon.
+/// No real response carries this many parallel tool calls.
 const MAX_STREAMED_TOOL_CALLS: usize = 256;
 
 // ── Responses API request/response types ──────────────────────────────
@@ -635,10 +634,7 @@ impl ChatGptDriver {
                                     .and_then(|v| v.as_u64())
                                     .unwrap_or(tool_accum.len() as u64)
                                     as usize;
-                                // Cap attacker-controlled index before growing
-                                // the dense accumulator (OOM guard). `line_buf`
-                                // is already advanced, so skipping this event is
-                                // safe.
+                                // skip: line_buf is already past this event so `continue` is safe
                                 if output_index >= MAX_STREAMED_TOOL_CALLS {
                                     warn!(
                                         output_index,

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -16,12 +16,9 @@ use std::collections::{BTreeMap, HashMap};
 use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
-/// Upper bound on the number of streamed tool-call slots a single response may
-/// allocate. The accumulator is grown densely up to the `index` reported in
-/// each SSE delta, and this driver talks to arbitrary user-configured base URLs
-/// (Ollama, LiteLLM, custom gateways), so a hostile or buggy endpoint could
-/// send an enormous `index` and OOM the daemon. No real response carries
-/// anywhere near this many parallel tool calls.
+/// Upper bound on the number of streamed tool-call slots a single response may allocate.
+/// The accumulator is grown densely up to the `index` reported in each SSE delta, and this driver talks to arbitrary user-configured base URLs (Ollama, LiteLLM, custom gateways), so a hostile or buggy endpoint could send an enormous `index` and OOM the daemon.
+/// No real response carries anywhere near this many parallel tool calls.
 const MAX_STREAMED_TOOL_CALLS: usize = 256;
 
 /// OpenAI-compatible API driver.
@@ -1980,8 +1977,6 @@ impl LlmDriver for OpenAIDriver {
                         if let Some(calls) = delta["tool_calls"].as_array() {
                             for call in calls {
                                 let idx = call["index"].as_u64().unwrap_or(0) as usize;
-                                // Cap attacker-controlled index before growing
-                                // the dense accumulator (OOM guard).
                                 if idx >= MAX_STREAMED_TOOL_CALLS {
                                     warn!(
                                         index = idx,
@@ -4203,8 +4198,7 @@ mod tests {
         format!("http://{addr}")
     }
 
-    /// Spawn a minimal server that answers any request with the given raw SSE
-    /// body as `text/event-stream`, then closes the socket.
+    /// Spawn a minimal server that answers any request with the given raw SSE body as `text/event-stream`, then closes the socket.
     async fn spawn_sse_server(sse_body: String) -> String {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
@@ -4227,10 +4221,6 @@ mod tests {
         format!("http://{addr}")
     }
 
-    // A hostile/buggy endpoint can put any `index` on a streamed tool_call
-    // delta. The accumulator is grown densely up to that index, so an enormous
-    // value would OOM the daemon. The driver must drop deltas whose index is
-    // out of range (>= MAX_STREAMED_TOOL_CALLS) rather than allocate up to it.
     #[tokio::test]
     async fn streamed_tool_call_with_out_of_range_index_is_dropped() {
         let bad_index = MAX_STREAMED_TOOL_CALLS; // first out-of-range value

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -16,6 +16,14 @@ use std::collections::{BTreeMap, HashMap};
 use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
+/// Upper bound on the number of streamed tool-call slots a single response may
+/// allocate. The accumulator is grown densely up to the `index` reported in
+/// each SSE delta, and this driver talks to arbitrary user-configured base URLs
+/// (Ollama, LiteLLM, custom gateways), so a hostile or buggy endpoint could
+/// send an enormous `index` and OOM the daemon. No real response carries
+/// anywhere near this many parallel tool calls.
+const MAX_STREAMED_TOOL_CALLS: usize = 256;
+
 /// OpenAI-compatible API driver.
 pub struct OpenAIDriver {
     api_key: Zeroizing<String>,
@@ -1972,6 +1980,15 @@ impl LlmDriver for OpenAIDriver {
                         if let Some(calls) = delta["tool_calls"].as_array() {
                             for call in calls {
                                 let idx = call["index"].as_u64().unwrap_or(0) as usize;
+                                // Cap attacker-controlled index before growing
+                                // the dense accumulator (OOM guard).
+                                if idx >= MAX_STREAMED_TOOL_CALLS {
+                                    warn!(
+                                        index = idx,
+                                        "Ignoring tool_call delta with out-of-range index"
+                                    );
+                                    continue;
+                                }
 
                                 // Ensure tool_accum has enough entries
                                 while tool_accum.len() <= idx {
@@ -4184,6 +4201,74 @@ mod tests {
             }
         });
         format!("http://{addr}")
+    }
+
+    /// Spawn a minimal server that answers any request with the given raw SSE
+    /// body as `text/event-stream`, then closes the socket.
+    async fn spawn_sse_server(sse_body: String) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 8192];
+                let _ = sock.read(&mut buf).await;
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    sse_body.len(),
+                    sse_body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.flush().await;
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    // A hostile/buggy endpoint can put any `index` on a streamed tool_call
+    // delta. The accumulator is grown densely up to that index, so an enormous
+    // value would OOM the daemon. The driver must drop deltas whose index is
+    // out of range (>= MAX_STREAMED_TOOL_CALLS) rather than allocate up to it.
+    #[tokio::test]
+    async fn streamed_tool_call_with_out_of_range_index_is_dropped() {
+        let bad_index = MAX_STREAMED_TOOL_CALLS; // first out-of-range value
+        let sse_body = format!(
+            "data: {{\"choices\":[{{\"delta\":{{\"tool_calls\":[{{\"index\":{bad_index},\"id\":\"call_evil\",\"function\":{{\"name\":\"evil\",\"arguments\":\"{{}}\"}}}}]}}}}]}}\n\
+             data: {{\"choices\":[{{\"delta\":{{\"content\":\"ok\"}}}}]}}\n\
+             data: {{\"choices\":[{{\"delta\":{{}},\"finish_reason\":\"stop\"}}],\"usage\":{{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}}}\n\
+             data: [DONE]\n"
+        );
+        let base = spawn_sse_server(sse_body).await;
+        let driver = OpenAIDriver::new("test-key".to_string(), base);
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let resp = driver
+            .stream(transport_retry_request(), tx)
+            .await
+            .expect("stream must complete instead of OOMing on a huge tool index");
+
+        let mut events = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            events.push(ev);
+        }
+        // The out-of-range tool call is dropped: no ToolUseStart is emitted and
+        // the final response carries no tool-call content block.
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, StreamEvent::ToolUseStart { .. })),
+            "out-of-range tool index must not start a tool call"
+        );
+        assert!(
+            !resp
+                .content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolUse { .. })),
+            "out-of-range tool index must not appear in the response"
+        );
+        assert_eq!(resp.text(), "ok");
     }
 
     fn transport_retry_request() -> librefang_llm_driver::CompletionRequest {


### PR DESCRIPTION
## Problem

Both streaming drivers grow a **dense** `Vec` accumulator up to the tool-call index reported in each SSE delta:

```rust
// openai.rs
let idx = call["index"].as_u64().unwrap_or(0) as usize;
while tool_accum.len() <= idx { tool_accum.push((String::new(), String::new(), String::new())); }

// chatgpt.rs (response.output_item.added)
let output_index = event.get("output_index").and_then(|v| v.as_u64()).unwrap_or(tool_accum.len() as u64) as usize;
while tool_accum.len() <= output_index { tool_accum.push((..)); }
```

`idx` / `output_index` is read straight from the streamed provider response with **no upper bound**. These drivers connect to **arbitrary user-configured base URLs** (Ollama, LiteLLM, custom gateways, MITM'd proxies), so a single SSE delta carrying `"index": 1000000000000` drives the loop to allocate that many tuples — gigabytes — and aborts the daemon. A merely buggy endpoint hits the same path.

## Fix

Add `const MAX_STREAMED_TOOL_CALLS: usize = 256;` to each driver and **skip** any delta whose index is out of range before growing the accumulator (with a `warn!`). No real response carries anywhere near 256 parallel tool calls.

The ChatGPT `response.function_call_arguments.delta` arm already guarded with `if output_index < tool_accum.len()` and never grows, so only the `response.output_item.added` arm needed the cap.

## Verification

New `#[tokio::test] streamed_tool_call_with_out_of_range_index_is_dropped` (openai.rs) streams a real `text/event-stream` body whose tool_call uses an out-of-range index and asserts the stream completes, emits no `ToolUseStart`, and yields no tool-call content block:

```
cargo test -p librefang-llm-drivers --lib streamed_tool_call_with_out_of_range_index
test result: ok. 1 passed
cargo clippy -p librefang-llm-drivers --lib   # clean
```

The ChatGPT streaming path needs live OAuth session state that makes a hermetic unit test impractical; its guard is identical in shape to the tested OpenAI one.

## How it was found

Multi-agent audit of the workspace; both sites verified against the real streaming loops before fixing.