### PR TITLE
fix(extensions): single-quote dotenv value panics credential resolution

### DIFF
--- a/crates/librefang-extensions/src/credentials.rs
+++ b/crates/librefang-extensions/src/credentials.rs
@@ -210,9 +210,13 @@ fn load_dotenv(path: &Path) -> Result<HashMap<String, String>, std::io::Error> {
         if let Some((key, value)) = line.split_once('=') {
             let key = key.trim();
             let mut value = value.trim().to_string();
-            // Strip surrounding quotes
-            if (value.starts_with('"') && value.ends_with('"'))
-                || (value.starts_with('\'') && value.ends_with('\''))
+            // Strip surrounding quotes. The `len() >= 2` guard is essential: a
+            // bare single quote char (`KEY="`) satisfies both starts_with and
+            // ends_with on the SAME byte, and `value[1..0]` would panic. This
+            // matches the guard in `dotenv.rs::parse_env_line`.
+            if value.len() >= 2
+                && ((value.starts_with('"') && value.ends_with('"'))
+                    || (value.starts_with('\'') && value.ends_with('\'')))
             {
                 value = value[1..value.len() - 1].to_string();
             }
@@ -270,6 +274,23 @@ SINGLE_QUOTED='single'
     fn load_dotenv_nonexistent() {
         let map = load_dotenv(Path::new("/nonexistent/.env")).unwrap();
         assert!(map.is_empty());
+    }
+
+    #[test]
+    fn load_dotenv_single_quote_char_does_not_panic() {
+        // A value that is a single quote character satisfies both starts_with
+        // and ends_with on the same byte; without the `len() >= 2` guard the
+        // `value[1..0]` slice panicked and took down the parsing process.
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        std::fs::write(&env_path, "DQUOTE=\"\nSQUOTE='\nOK=value\n").unwrap();
+
+        let map = load_dotenv(&env_path).unwrap();
+        // The lone quote char is kept verbatim (not stripped) and parsing
+        // continues to the following keys.
+        assert_eq!(map.get("DQUOTE").unwrap(), "\"");
+        assert_eq!(map.get("SQUOTE").unwrap(), "'");
+        assert_eq!(map.get("OK").unwrap(), "value");
     }
 
     // Tests that mutate process-wide env vars must run serially to avoid races


### PR DESCRIPTION
## Problem

`load_dotenv` strips surrounding quotes from a value:

```rust
if (value.starts_with('"') && value.ends_with('"'))
    || (value.starts_with('\'') && value.ends_with('\''))
{
    value = value[1..value.len() - 1].to_string();
}
```

There is no length guard. When a value is a **single quote character** — a line like `KEY="` or `KEY='` — `starts_with` and `ends_with` are satisfied by the *same* byte, so the branch runs with `value.len() == 1` and `value[1..0]` panics:

```
slice index starts at 1 but ends at 0
```

This is reachable from any caller that constructs a `CredentialResolver` over a user-controlled dotenv file, taking down whatever process (CLI command / API request) parses it.

The sibling parser `dotenv.rs::parse_env_line` already guards this exact case with `value.len() >= 2`; the two copies had diverged.

## Fix

Add the same `value.len() >= 2` guard before stripping quotes.

## Verification

New `load_dotenv_single_quote_char_does_not_panic` feeds lone double- and single-quote values plus a following key, and asserts no panic, the quote chars are kept verbatim, and parsing continues to the next key.

```
cargo test -p librefang-extensions --lib credentials::tests::load_dotenv   # 3 passed
cargo clippy -p librefang-extensions --lib   # clean
```

## How it was found

Multi-agent audit of the workspace; reproduced the panicking slice before fixing.
