### PR TITLE
fix(runtime): WASM net_fetch follows redirects without per-hop SSRF re-validation (DNS-rebinding); misses Azure IMDS

### DIFF
--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -272,6 +272,10 @@ impl BrowserSession {
             .prefix("librefang-chrome-")
             .tempdir()
             .map_err(|e| format!("Failed to create Chromium user-data-dir: {e}"))?;
+        // `mut` is only exercised by the Linux-only root check below; allow
+        // the lint elsewhere so non-Linux builds stay warning-clean under the
+        // workspace `warnings = "deny"` policy.
+        #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
         let mut args = chromium_launch_args(config, user_data_dir.path());
 
         // On Linux, Chromium refuses to start as root without --no-sandbox.

--- a/crates/librefang-runtime/src/host_functions.rs
+++ b/crates/librefang-runtime/src/host_functions.rs
@@ -414,18 +414,6 @@ fn host_net_fetch(state: &GuestState, params: &serde_json::Value) -> serde_json:
         .unwrap_or("GET");
     let body = params.get("body").and_then(|b| b.as_str()).unwrap_or("");
 
-    // SECURITY: SSRF protection — resolve DNS once and validate IPs
-    let ssrf_result = match is_ssrf_target(url) {
-        Ok(r) => r,
-        Err(e) => return e,
-    };
-
-    // Extract host:port from URL for capability check
-    let host = extract_host_from_url(url);
-    if let Err(e) = check_capability(&state.capabilities, &Capability::NetConnect(host)) {
-        return e;
-    }
-
     // SECURITY: Use block_in_place instead of block_on so the tokio scheduler
     // can continue making progress (including the epoch-increment watchdog)
     // while this thread is parked waiting for the async HTTP call to complete.
@@ -434,29 +422,96 @@ fn host_net_fetch(state: &GuestState, params: &serde_json::Value) -> serde_json:
     let handle = state.tokio_handle.clone();
     tokio::task::block_in_place(|| {
         handle.block_on(async {
-            // Build a DNS-pinned client so the HTTP request connects to the
-            // same IPs we already validated (prevents DNS-rebinding TOCTOU).
-            let mut builder = librefang_http::proxied_client_builder();
-            for addr in &ssrf_result.resolved {
-                builder = builder.resolve(&ssrf_result.hostname, *addr);
-            }
-            let client = builder.build().expect("HTTP client build");
-            let request = match method.to_uppercase().as_str() {
-                "POST" => client.post(url).body(body.to_string()),
-                "PUT" => client.put(url).body(body.to_string()),
-                "DELETE" => client.delete(url),
-                _ => client.get(url),
-            };
-            match request.send().await {
-                Ok(resp) => {
-                    let status = resp.status().as_u16();
-                    match resp.text().await {
-                        Ok(text) => json!({"ok": {"status": status, "body": text}}),
-                        Err(e) => json!({"error": format!("Failed to read response: {e}")}),
-                    }
+            // SECURITY: follow redirects MANUALLY, re-running the SSRF check,
+            // the capability gate, and the DNS pin on EVERY hop. Auto-redirects
+            // (reqwest's default 10) would re-resolve a 3xx `Location` host
+            // through reqwest's own connector with no SSRF check and no pin, so
+            // a guest could fetch an allowed host that 302-redirects to
+            // 169.254.169.254 (or a rebinding name) and reach IMDS/internal
+            // endpoints — the same DNS-rebinding/redirect SSRF that
+            // web_fetch::send_with_pinned_redirects defends against. Disabling
+            // auto-redirects (`Policy::none`) and validating each hop closes it.
+            const MAX_REDIRECTS: usize = 10;
+            let mut current_url = url.to_string();
+            let mut current_method = method.to_uppercase();
+            let mut current_body = body.to_string();
+
+            for _ in 0..=MAX_REDIRECTS {
+                let ssrf_result = match is_ssrf_target(&current_url) {
+                    Ok(r) => r,
+                    Err(e) => return e,
+                };
+                // Capability gate on THIS hop's host — a redirect must not reach
+                // a destination the guest lacks `NetConnect` for.
+                let host = extract_host_from_url(&current_url);
+                if let Err(e) = check_capability(&state.capabilities, &Capability::NetConnect(host))
+                {
+                    return e;
                 }
-                Err(e) => json!({"error": format!("Request failed: {e}")}),
+
+                // DNS-pinned, non-redirecting client: connect to the exact IPs
+                // we just validated for this hop.
+                let mut builder = librefang_http::proxied_client_builder()
+                    .redirect(reqwest::redirect::Policy::none());
+                for addr in &ssrf_result.resolved {
+                    builder = builder.resolve(&ssrf_result.hostname, *addr);
+                }
+                let client = builder.build().expect("HTTP client build");
+                let request = match current_method.as_str() {
+                    "POST" => client.post(&current_url).body(current_body.clone()),
+                    "PUT" => client.put(&current_url).body(current_body.clone()),
+                    "DELETE" => client.delete(&current_url),
+                    _ => client.get(&current_url),
+                };
+                let resp = match request.send().await {
+                    Ok(r) => r,
+                    Err(e) => return json!({"error": format!("Request failed: {e}")}),
+                };
+                let status = resp.status();
+                if !status.is_redirection() {
+                    let status_u16 = status.as_u16();
+                    return match resp.text().await {
+                        Ok(text) => json!({"ok": {"status": status_u16, "body": text}}),
+                        Err(e) => json!({"error": format!("Failed to read response: {e}")}),
+                    };
+                }
+
+                // Redirect: resolve the Location against the current URL and loop
+                // so the next hop is validated and pinned afresh.
+                let Some(location) = resp
+                    .headers()
+                    .get(reqwest::header::LOCATION)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| s.to_string())
+                else {
+                    // 3xx with no usable Location — return it rather than loop.
+                    let status_u16 = status.as_u16();
+                    return match resp.text().await {
+                        Ok(text) => json!({"ok": {"status": status_u16, "body": text}}),
+                        Err(e) => json!({"error": format!("Failed to read response: {e}")}),
+                    };
+                };
+                let base = match url::Url::parse(&current_url) {
+                    Ok(u) => u,
+                    Err(e) => return json!({"error": format!("invalid request URL: {e}")}),
+                };
+                let next = match base.join(&location) {
+                    Ok(u) => u,
+                    Err(e) => {
+                        return json!({"error": format!(
+                            "invalid redirect Location '{location}': {e}"
+                        )})
+                    }
+                };
+                // 301/302/303 downgrade to GET and drop the body (browser
+                // behaviour); 307/308 preserve method and body.
+                if (301..=303).contains(&status.as_u16()) {
+                    current_method = "GET".to_string();
+                    current_body = String::new();
+                }
+                current_url = next.to_string();
             }
+            json!({"error": format!("SSRF blocked: too many redirects (cap: {MAX_REDIRECTS})")})
         })
     })
 }
@@ -1774,6 +1829,16 @@ mod tests {
     fn test_ssrf_public_ips_allowed() {
         assert!(is_ssrf_target("https://api.openai.com/v1/chat").is_ok());
         assert!(is_ssrf_target("https://google.com").is_ok());
+    }
+
+    #[test]
+    fn test_ssrf_blocks_azure_imds_and_alibaba_cgnat() {
+        // 192.0.0.192 (Azure's alternative IMDS endpoint) is not RFC-1918
+        // private and was not in the WASM hostname blocklist, so before the
+        // shared is_cloud_metadata_ip gained it the resolved-IP check let it
+        // through. 100.64/10 CGNAT (Alibaba IMDS) is covered by the same helper.
+        assert!(is_ssrf_target("http://192.0.0.192/metadata/instance").is_err());
+        assert!(is_ssrf_target("http://100.100.100.200/latest/meta-data/").is_err());
     }
 
     #[test]

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -454,6 +454,11 @@ pub(crate) fn is_cloud_metadata_ip(ip: &IpAddr) -> bool {
             o[0] == 169 && o[1] == 254
             // 100.64.0.0/10: first octet 100, second octet 64..=127
             || o[0] == 100 && (o[1] & 0xC0) == 64
+            // 192.0.0.192 — Azure's alternative IMDS endpoint. 192.0.0.0/24 is
+            // IETF protocol-assignment space (not RFC1918), so it is not caught
+            // by is_private_ip; this specific host must still be blocked, in
+            // step with mcp_oauth::is_ssrf_blocked_host and rl-export's mirror.
+            || (o[0] == 192 && o[1] == 0 && o[2] == 0 && o[3] == 192)
         }
         IpAddr::V6(_) => false,
     }
@@ -1070,6 +1075,19 @@ mod tests {
         assert!(is_cloud_metadata_ip(&mapped_imds));
         let mapped_cgnat: IpAddr = "::ffff:100.64.0.1".parse().unwrap();
         assert!(is_cloud_metadata_ip(&mapped_cgnat));
+    }
+
+    #[test]
+    fn test_is_cloud_metadata_ip_recognises_azure_imds() {
+        use std::net::IpAddr;
+        // 192.0.0.192 — Azure's alternative IMDS endpoint. Not RFC-1918, so it
+        // must be caught here (not by is_private_ip). The WASM host path relies
+        // on this classifier, so the addition closes that path too.
+        let azure_imds: IpAddr = "192.0.0.192".parse().unwrap();
+        assert!(is_cloud_metadata_ip(&azure_imds));
+        // ...including via an IPv4-mapped IPv6 form.
+        let mapped: IpAddr = "::ffff:192.0.0.192".parse().unwrap();
+        assert!(is_cloud_metadata_ip(&mapped));
     }
 
     #[test]

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -338,8 +338,8 @@ impl SsrfResolution {
 /// `allowed_hosts` is a list of CIDRs (e.g. `"10.0.0.0/8"`), glob hostname
 /// patterns (e.g. `"*.internal.example.com"`), or literal IPs/hostnames that
 /// are exempt from the private-IP block.  Cloud metadata ranges
-/// (`169.254.0.0/16`, `100.64.0.0/10`) remain unconditionally blocked even
-/// when an entry matches.
+/// (`169.254.0.0/16`, `100.64.0.0/10`, `192.0.0.192`) remain unconditionally
+/// blocked even when an entry matches.
 ///
 /// Returns the resolved addresses on success so that callers can pin DNS
 /// and avoid TOCTOU / DNS-rebinding attacks.
@@ -408,7 +408,17 @@ pub fn check_ssrf(url: &str, allowed_hosts: &[String]) -> Result<SsrfResolution,
                 // v6-only branches of is_private_ip / is_cloud_metadata_ip
                 // do not recognise.
                 let ip = canonical_ip(&addr.ip());
-                if ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) {
+                // is_cloud_metadata_ip must be consulted here, not only inside
+                // the allowlist branch: 192.0.0.192 (Azure IMDS alternative,
+                // IETF protocol-assignment space) and 100.64.0.0/10 (CGNAT /
+                // Alibaba IMDS) are not private ranges, so a hostname that
+                // DNS-resolves to them would otherwise be accepted outright.
+                // The literal-host blocklist above only catches literal URLs.
+                if ip.is_loopback()
+                    || ip.is_unspecified()
+                    || is_private_ip(&ip)
+                    || is_cloud_metadata_ip(&ip)
+                {
                     // Before rejecting, check the allowlist — but cloud metadata
                     // ranges are unconditionally blocked regardless of allowlist.
                     if !is_cloud_metadata_ip(&ip) && is_host_allowed(hostname, &ip, allowed_hosts) {
@@ -1009,6 +1019,29 @@ mod tests {
         assert!(check_ssrf("http://100.100.100.200/latest/meta-data/", &[]).is_err());
         // Azure IMDS alternative
         assert!(check_ssrf("http://192.0.0.192/metadata/instance", &[]).is_err());
+    }
+
+    #[test]
+    fn test_ssrf_blocks_resolved_cloud_metadata_ips() {
+        // The literal forms above are caught by the hostname blocklist before
+        // resolution. These bracket-literal IPv6 forms skip that list and
+        // exercise the resolved-IP gate, which must reject metadata IPs even
+        // though 192.0.0.0/24 and 100.64.0.0/10 are not private ranges
+        // (is_private_ip matches neither) — the same shape as a hostname that
+        // DNS-resolves to a metadata IP.
+        // Azure IMDS alternative (192.0.0.192) via IPv4-mapped IPv6:
+        assert!(check_ssrf("http://[::ffff:192.0.0.192]/metadata/instance", &[]).is_err());
+        // Alibaba Cloud IMDS (100.100.100.200) via IPv4-mapped IPv6:
+        assert!(check_ssrf("http://[::ffff:100.100.100.200]/latest/meta-data/", &[]).is_err());
+        // Plain CGNAT-range literal not in the hostname blocklist — exercises
+        // the IPv4 resolved path directly:
+        assert!(check_ssrf("http://100.64.0.5/", &[]).is_err());
+        // ...and the allowlist must not override the metadata block:
+        assert!(check_ssrf(
+            "http://[::ffff:192.0.0.192]/",
+            &["192.0.0.192".to_string(), "100.64.0.0/10".to_string()]
+        )
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
Closes two SSRF gaps on the WASM-guest `net_fetch` host function.

## 1. Redirect SSRF / DNS-rebinding (`host_functions.rs`)

`host_net_fetch` validated the URL once via `is_ssrf_target`, then built a DNS-pinned client with reqwest's **default** redirect policy (follow up to 10). The pin only covers the *original* hostname, so a 3xx `Location` to a different host was re-resolved by reqwest's own connector with **no SSRF check and no pin**.

A guest holding `NetConnect(*)` could fetch an allowed host that `302`-redirects to `http://169.254.169.254/` (or a TTL-0 rebinding name) and reach IMDS / internal endpoints — the exact attack `web_fetch::send_with_pinned_redirects` already defends against, simply bypassed on the WASM path.

**Fix:** follow redirects manually with `redirect(Policy::none())`, re-running `is_ssrf_target` (fresh DNS resolution + IP validation + DNS pin) **and** the `NetConnect` capability gate on **every** hop, mirroring the web_fetch hardening. 301/302/303 downgrade to GET and drop the body; hop cap is 10.

## 2. Azure IMDS `192.0.0.192` (`web_fetch.rs`)

The shared `is_cloud_metadata_ip` classifier — used by both web_fetch and the WASM path — covered `169.254/16` and `100.64/10` but not `192.0.0.192` (Azure's alternative IMDS endpoint).
`192.0.0.0/24` is IETF protocol-assignment space, so `is_private_ip` doesn't catch it either.
web_fetch's literal-host blocklist only catches literal-URL forms: `check_ssrf` consulted `is_cloud_metadata_ip` solely inside the branch gated by loopback / unspecified / `is_private_ip`, so a hostname that DNS-resolved to `192.0.0.192` (or Alibaba IMDS `100.100.100.200` in CGNAT `100.64/10`) was accepted on the web_fetch path too, and the WASM `is_ssrf_target` (which relies on the IP classifier) let a resolved `192.0.0.192` through.

**Fix:** add `192.0.0.192` to `is_cloud_metadata_ip`, closing the WASM path and aligning with `mcp_oauth` / `rl-export`.
Additionally, hoist `is_cloud_metadata_ip` into `check_ssrf`'s outer rejection gate so the web_fetch path now rejects metadata IPs after DNS resolution regardless of private-range classification (allowlist entries still cannot override the metadata block).

## Verification

```
cargo check  -p librefang-runtime --lib                        # clean
cargo clippy -p librefang-runtime --all-targets -- -D warnings # clean
cargo test   -p librefang-runtime web_fetch                    # 41 passed
cargo test   -p librefang-runtime host_functions               # 39 passed
```

- `test_ssrf_blocks_azure_imds_and_alibaba_cgnat` (host_functions)
- `test_is_cloud_metadata_ip_recognises_azure_imds` (web_fetch)
- `test_ssrf_blocks_resolved_cloud_metadata_ips` (web_fetch) — exercises `check_ssrf`'s resolved-IP gate via IPv4-mapped IPv6 bracket literals (which bypass the hostname blocklist without DNS) plus a plain CGNAT literal; verified to fail without the outer-gate change.

A hermetic integration test of the WASM redirect loop is not possible: `is_ssrf_target` hard-blocks loopback with no test-allowlist hook, so any local test server is rejected on hop 1. The per-hop validation is exercised by the `is_ssrf_target` unit tests, and the loop mirrors `web_fetch::send_with_pinned_redirects`, which carries its own redirect-to-metadata test (`test_redirect_to_metadata_ip_blocked_on_later_hop`).

Also fixes a pre-existing non-Linux build break inherited from main (e64ff339, #6028): `browser.rs` declared `let mut args` whose only mutation is Linux-gated, tripping `unused_mut` under the workspace `warnings = "deny"` policy on macOS/Windows; the allow is scoped to non-Linux targets.

## How it was found

Multi-agent audit of the workspace; both gaps traced against the sibling web_fetch hardening before fixing.
