### PR TITLE
fix(runtime): apply_patch files_moved counter incremented before the move write succeeds

### DIFF
--- a/crates/librefang-runtime/src/apply_patch.rs
+++ b/crates/librefang-runtime/src/apply_patch.rs
@@ -415,7 +415,6 @@ pub async fn apply_patch_ext(
                                         result.errors.push(err);
                                         continue;
                                     }
-                                    result.files_moved += 1;
                                     t
                                 }
                                 Err(e) => {
@@ -430,7 +429,13 @@ pub async fn apply_patch_ext(
                         match atomic_write(&target, &patched).await {
                             Ok(()) => {
                                 result.files_updated += 1;
+                                // Count the move only after the write to the new
+                                // path actually lands — previously the counter
+                                // was bumped while resolving the target, so a
+                                // failed write reported "1 moved" for a move that
+                                // never happened.
                                 if move_to.is_some() && target != resolved {
+                                    result.files_moved += 1;
                                     let _ = tokio::fs::remove_file(&resolved).await;
                                 }
                             }
@@ -841,6 +846,46 @@ mod tests {
             .unwrap();
         assert!(updated.contains("replaced"));
         assert!(!updated.contains("line2"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn move_is_not_counted_when_the_write_fails() {
+        let dir = std::env::temp_dir().join("librefang_patch_move_fail_test");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("src.txt"), "a\n").await.unwrap();
+        // Make the move target an existing directory so atomic_write's final
+        // rename onto it fails — exercising the write-failure path.
+        tokio::fs::create_dir_all(dir.join("dest")).await.unwrap();
+
+        let ops = vec![PatchOp::UpdateFile {
+            path: "src.txt".to_string(),
+            move_to: Some("dest".to_string()),
+            hunks: vec![Hunk {
+                context_before: vec![],
+                old_lines: vec!["a".to_string()],
+                new_lines: vec!["b".to_string()],
+                context_after: vec![],
+            }],
+        }];
+
+        let result = apply_patch(&ops, &dir, &[]).await;
+        // The write to the directory target fails, so nothing actually moved.
+        // Before the fix, files_moved was bumped while resolving the target and
+        // reported "1 moved" for a move that never happened.
+        assert_eq!(
+            result.files_moved, 0,
+            "no move should be counted when the write fails"
+        );
+        assert_eq!(result.files_updated, 0);
+        assert!(
+            !result.errors.is_empty(),
+            "the failed write should be recorded as an error"
+        );
+        // The source file must be left intact (not removed).
+        assert!(dir.join("src.txt").exists());
 
         let _ = tokio::fs::remove_dir_all(&dir).await;
     }


### PR DESCRIPTION
## Problem

In `apply_patch_ext`, an `UpdateFile` with `move_to` bumped `result.files_moved` **while resolving the destination path**, before `atomic_write` was attempted:

```rust
Ok(t) => {
    if let Some(err) = denied_readonly(&t, new_path) { ...; continue; }
    result.files_moved += 1;   // counted before any write
    t
}
...
match atomic_write(&target, &patched).await {
    Ok(()) => { result.files_updated += 1; ... }
    Err(e) => { result.errors.push(...); }   // files_moved already counted
}
```

If the write failed, `files_moved` was already 1 even though no move occurred, so `PatchResult::summary()` reported e.g. `"1 moved, 1 errors"` for a move that never happened — misleading the agent / UX about the side effect.

## Fix

Move the `result.files_moved += 1` increment into the `Ok(())` arm of the `atomic_write` match, gated on `move_to.is_some() && target != resolved` (the same condition that removes the old file), so the counter reflects a write that actually landed.

## Verification

```
cargo test -p librefang-runtime --lib apply_patch::tests   # 23 passed
```

`move_is_not_counted_when_the_write_fails` points the move at an existing directory so the final rename fails, and asserts `files_moved == 0`, `files_updated == 0`, an error is recorded, and the source file is left intact.

## How it was found

Multi-agent audit of the workspace.
