### PR TITLE
fix(extensions): vault staging-file race across processes; OAuth deny hangs 5 minutes

### DIFF
--- a/crates/librefang-extensions/src/oauth.rs
+++ b/crates/librefang-extensions/src/oauth.rs
@@ -252,7 +252,7 @@ pub async fn run_pkce_flow(oauth: &OAuthTemplate, client_id: &str) -> ExtensionR
     }
 
     // Wait for callback
-    let (code_tx, code_rx) = oneshot::channel::<String>();
+    let (code_tx, code_rx) = oneshot::channel::<Result<String, String>>();
     let code_tx = Arc::new(Mutex::new(Some(code_tx)));
 
     // Spawn callback handler
@@ -298,6 +298,12 @@ pub async fn run_pkce_flow(oauth: &OAuthTemplate, client_id: &str) -> ExtensionR
                         );
                     }
                     if let Some(ref error) = query.error {
+                        // Provider denied / errored (state already verified
+                        // above). Signal the waiter so it fails fast with this
+                        // error instead of hanging until the 5-minute timeout.
+                        if let Some(tx) = code_tx.lock().await.take() {
+                            let _ = tx.send(Err(format!("OAuth error: {error}")));
+                        }
                         return axum::response::Html(format!(
                             "<h1>Error</h1><p>OAuth error: {error}</p>"
                         ));
@@ -308,7 +314,7 @@ pub async fn run_pkce_flow(oauth: &OAuthTemplate, client_id: &str) -> ExtensionR
                         // a replay against the live channel cannot succeed.
                         let mut guard = code_tx.lock().await;
                         if let Some(tx) = guard.take() {
-                            let _ = tx.send(code.clone());
+                            let _ = tx.send(Ok(code.clone()));
                             axum::response::Html(
                                 "<h1>Success!</h1><p>Authorization complete. You can close this tab.</p><script>window.close()</script>"
                                     .to_string(),
@@ -320,6 +326,12 @@ pub async fn run_pkce_flow(oauth: &OAuthTemplate, client_id: &str) -> ExtensionR
                             )
                         }
                     } else {
+                        // Callback arrived with neither `code` nor `error`
+                        // (state already verified). Signal so the waiter doesn't
+                        // hang until the timeout.
+                        if let Some(tx) = code_tx.lock().await.take() {
+                            let _ = tx.send(Err("No authorization code received".to_string()));
+                        }
                         axum::response::Html(
                             "<h1>Error</h1><p>No authorization code received.</p>".to_string(),
                         )
@@ -338,7 +350,8 @@ pub async fn run_pkce_flow(oauth: &OAuthTemplate, client_id: &str) -> ExtensionR
     let code = tokio::time::timeout(std::time::Duration::from_secs(300), code_rx)
         .await
         .map_err(|_| ExtensionError::OAuth("OAuth flow timed out after 5 minutes".to_string()))?
-        .map_err(|_| ExtensionError::OAuth("Callback channel closed".to_string()))?;
+        .map_err(|_| ExtensionError::OAuth("Callback channel closed".to_string()))?
+        .map_err(ExtensionError::OAuth)?;
 
     // Shut down callback server
     server_handle.abort();

--- a/crates/librefang-extensions/src/vault.rs
+++ b/crates/librefang-extensions/src/vault.rs
@@ -850,11 +850,19 @@ impl CredentialVault {
         output.extend_from_slice(VAULT_MAGIC);
         output.extend_from_slice(content.as_bytes());
 
-        // Atomic write to .tmp (mode 0600 on Unix) then rename over target.
-        let temp_path = self.path.with_extension("tmp");
-        {
+        // Atomic write to a PER-PROCESS staging file (mode 0600 on Unix) then
+        // rename over target. The in-process RwLock only serialises writers
+        // within one process; a fixed `vault.tmp` shared by two processes (e.g.
+        // a `librefang vault …` CLI run while the daemon is up) could truncate /
+        // clobber each other's half-written staging file before the rename,
+        // leaving a torn `vault.enc`. Mirror write_keyring_file: a unique
+        // per-process name opened with `create_new`, cleaned up on error.
+        let temp_path = self
+            .path
+            .with_extension(format!("tmp.{}", std::process::id()));
+        let write_result = (|| -> std::io::Result<()> {
             let mut opts = OpenOptions::new();
-            opts.write(true).create(true).truncate(true);
+            opts.write(true).create_new(true);
             #[cfg(unix)]
             {
                 use std::os::unix::fs::OpenOptionsExt;
@@ -863,8 +871,13 @@ impl CredentialVault {
             let mut f = opts.open(&temp_path)?;
             f.write_all(&output)?;
             f.sync_all()?;
+            drop(f);
+            std::fs::rename(&temp_path, &self.path)
+        })();
+        if let Err(e) = write_result {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(e.into());
         }
-        std::fs::rename(&temp_path, &self.path)?;
         // Enforce 0600 if a pre-existing file had looser perms.
         #[cfg(unix)]
         {
@@ -2096,6 +2109,31 @@ mod tests {
         // Remove
         assert!(vault2.remove("GITHUB_TOKEN").unwrap());
         assert!(vault2.get("GITHUB_TOKEN").is_none());
+    }
+
+    #[test]
+    fn save_uses_per_process_temp_and_leaves_no_staging_file() {
+        let (dir, mut vault) = test_vault();
+        let key = random_key();
+        vault.init_with_key(key.clone()).unwrap();
+        vault
+            .set("K".to_string(), Zeroizing::new("v".to_string()))
+            .unwrap();
+
+        assert!(vault.exists());
+        // No staging file is left behind — neither the old fixed `vault.tmp`
+        // (which two processes would collide on) nor this process's unique
+        // `vault.tmp.<pid>`, which must be renamed onto the target.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.starts_with("vault.tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "no staging files should remain, found {leftovers:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two independent robustness bugs in `librefang-extensions`.

## 1. Vault staging file races across processes (`vault.rs`)

`CredentialVault::save` staged the encrypted vault to a **fixed** `vault.tmp` opened with `create(true).truncate(true)`:

```rust
let temp_path = self.path.with_extension("tmp");
... opts.write(true).create(true).truncate(true) ...
std::fs::rename(&temp_path, &self.path)?;
```

The in-process `RwLock` only serialises writers within one process, so two processes touching the same vault (e.g. a `librefang vault …` CLI run while the daemon is up) both write the same `vault.tmp` and rename it — one can truncate/overwrite the other's half-written staging file, and the interleaved renames can leave a torn `vault.enc`. The codebase already fixed this exact pattern in `write_keyring_file` and `dotenv.rs::write_env_file`.

**Fix:** stage to a unique per-process `vault.tmp.<pid>` opened with `create_new(true)`, and remove the abandoned staging file on error — mirroring `write_keyring_file`.

## 2. OAuth deny/error hangs for 5 minutes (`oauth.rs`)

`run_pkce_flow`'s `/callback` handler rendered an error page on a provider `error` parameter (user clicked **Deny**, `access_denied`, …) but **never signalled** the `code_tx` oneshot, so the waiter blocked on `code_rx` until the full 300s timeout and then reported a generic "timed out" instead of the real provider error. The "no code received" branch hung the same way.

**Fix:** change the channel to `oneshot::Sender<Result<String, String>>` and signal `Err(provider_error)` on both branches — only **after** state/nonce are verified, so a forged bad-state callback still cannot abort a legitimate flow. The flow now fails fast and surfaces the actual provider error.

## Verification

```
cargo test -p librefang-extensions --lib vault::tests   # 48 passed
cargo clippy -p librefang-extensions --lib              # clean
```

`save_uses_per_process_temp_and_leaves_no_staging_file` asserts no `vault.tmp*` staging file remains after a save. The OAuth callback path needs a live local-server + browser-redirect simulation to integration-test; the change is a straightforward signal-on-error verified by compile + the existing flow tests.

## How it was found

Multi-agent audit of the workspace; both were cross-checked against the crate's own already-fixed siblings (`write_keyring_file`) before fixing.
