### PR TITLE
fix(runtime-audit): trim/prune drop in-memory entries even when the SQLite DELETE fails

### DIFF
--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -1230,14 +1230,7 @@ impl AuditLog {
             return 0;
         }
 
-        // Update the in-memory chain anchor BEFORE draining so a verify
-        // racing against this prune (blocked on the entries lock) sees a
-        // consistent (anchor, first_survivor) pair on the next acquire.
         let new_anchor = entries[drop_count - 1].hash.clone();
-        {
-            let mut anchor = self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
-            *anchor = Some(new_anchor);
-        }
 
         // Persist: delete the same prefix from SQLite using `seq` rather
         // than `timestamp` so DB and in-memory share one source of truth
@@ -1276,6 +1269,18 @@ impl AuditLog {
             }
         }
 
+        // Mutate in-memory state only after the DB delete succeeded
+        // (mirrors `AuditLog::trim`). Order matters: anchor before drain
+        // so a verify racing against this prune (blocked on the entries
+        // lock) sees a consistent (anchor, first_survivor) pair on the
+        // next acquire. Advancing the anchor before the DB block would
+        // leave a failed DELETE with un-drained entries whose
+        // `entries[0].prev_hash` no longer matches the anchor —
+        // verify_integrity would then raise a spurious "chain break".
+        {
+            let mut anchor = self.chain_anchor.lock().unwrap_or_else(|e| e.into_inner());
+            *anchor = Some(new_anchor);
+        }
         entries.drain(..drop_count);
 
         // Refresh the external anchor file's `seq` column so the next

--- a/crates/librefang-runtime-audit/src/lib.rs
+++ b/crates/librefang-runtime-audit/src/lib.rs
@@ -1129,12 +1129,33 @@ impl AuditLog {
             // caller) re-anchors against the chain_anchor we set below.
             entries[total - 1].seq + 1
         };
+        // Persist-before-mutate: only drop the in-memory prefix if the DB
+        // delete actually succeeded. If `db.get()` or the `DELETE` fails and we
+        // trimmed memory anyway, a restart would reload the un-deleted rows —
+        // resurrecting the entries retention was supposed to remove and
+        // desyncing the anchor seq from the DB. On failure, keep memory intact
+        // and report nothing dropped so the trim retries on the next tick.
         if let Some(ref db) = self.db {
-            if let Ok(conn) = db.get() {
-                let _ = conn.execute(
-                    "DELETE FROM audit_entries WHERE seq < ?1",
-                    rusqlite::params![first_survivor_seq as i64],
-                );
+            match db.get() {
+                Ok(conn) => {
+                    if let Err(e) = conn.execute(
+                        "DELETE FROM audit_entries WHERE seq < ?1",
+                        rusqlite::params![first_survivor_seq as i64],
+                    ) {
+                        tracing::error!(
+                            "Audit trim DELETE failed ({e}); keeping the in-memory window \
+                             consistent with the DB — retrying on the next trim tick"
+                        );
+                        return TrimReport::default();
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Audit trim could not acquire a DB connection ({e}); keeping the \
+                         in-memory window consistent with the DB — retrying on the next tick"
+                    );
+                    return TrimReport::default();
+                }
             }
         }
 
@@ -1228,12 +1249,30 @@ impl AuditLog {
         } else {
             entries[total - 1].seq + 1
         };
+        // Persist-before-mutate: keep the in-memory window only if the DB
+        // delete succeeded (see AuditLog::trim). On failure, leave memory and
+        // the DB consistent and report nothing pruned so the next prune retries.
         if let Some(ref db) = self.db {
-            if let Ok(conn) = db.get() {
-                let _ = conn.execute(
-                    "DELETE FROM audit_entries WHERE seq < ?1",
-                    rusqlite::params![first_survivor_seq as i64],
-                );
+            match db.get() {
+                Ok(conn) => {
+                    if let Err(e) = conn.execute(
+                        "DELETE FROM audit_entries WHERE seq < ?1",
+                        rusqlite::params![first_survivor_seq as i64],
+                    ) {
+                        tracing::error!(
+                            "Audit prune DELETE failed ({e}); keeping the in-memory window \
+                             consistent with the DB — retrying on the next prune"
+                        );
+                        return 0;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Audit prune could not acquire a DB connection ({e}); keeping the \
+                         in-memory window consistent with the DB — retrying on the next prune"
+                    );
+                    return 0;
+                }
             }
         }
 

--- a/crates/librefang-runtime-audit/src/tests.rs
+++ b/crates/librefang-runtime-audit/src/tests.rs
@@ -1225,6 +1225,67 @@ fn test_prune_drops_all_persists_consistently_across_restart() {
 }
 
 #[test]
+fn prune_keeps_memory_consistent_when_db_delete_fails() {
+    let pool = Pool::builder()
+        .max_size(1)
+        .build(SqliteConnectionManager::memory())
+        .unwrap();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_entries (
+                seq INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                detail TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
+                prev_hash TEXT NOT NULL,
+                hash TEXT NOT NULL
+            )",
+        )
+        .unwrap();
+    }
+
+    let log = AuditLog::with_db(pool.clone());
+    let now = chrono::Utc::now();
+    let old = now - chrono::Duration::days(2);
+    push_aged_entry(&log, "a", AuditAction::ToolInvoke, "old1", "ok", old);
+    push_aged_entry(&log, "a", AuditAction::ToolInvoke, "old2", "ok", old);
+    push_aged_entry(&log, "a", AuditAction::ToolInvoke, "recent", "ok", now);
+    assert_eq!(log.len(), 3);
+
+    // Break the DB so the prune's DELETE fails.
+    pool.get()
+        .unwrap()
+        .execute_batch("DROP TABLE audit_entries")
+        .unwrap();
+
+    let pruned = log.prune(1);
+
+    // The DELETE failed, so nothing is pruned and the in-memory window is
+    // preserved — memory and DB stay consistent and the prune retries next time.
+    assert_eq!(
+        pruned, 0,
+        "no rows should be pruned when the DB delete fails"
+    );
+    assert_eq!(
+        log.len(),
+        3,
+        "in-memory window must be preserved on DB failure"
+    );
+    // Regression: prune used to advance chain_anchor BEFORE the DB delete, so
+    // a failed DELETE left the entries un-drained but the anchor pointing past
+    // them — verify_integrity then raised a spurious "chain break" forever.
+    assert!(
+        log.verify_integrity().is_ok(),
+        "verify_integrity must still pass after a failed prune (anchor must not advance)"
+    );
+}
+
+#[test]
 fn test_anchor_write_atomic_rename_on_record() {
     let (log, _db, anchor_path) = setup_anchored_log();
     log.record("agent-1", AuditAction::ToolInvoke, "first", "ok");

--- a/crates/librefang-runtime-audit/src/tests.rs
+++ b/crates/librefang-runtime-audit/src/tests.rs
@@ -603,6 +603,66 @@ fn test_trim_drops_old_entries_by_action() {
 }
 
 #[test]
+fn trim_keeps_memory_consistent_when_db_delete_fails() {
+    let pool = Pool::builder()
+        .max_size(1)
+        .build(SqliteConnectionManager::memory())
+        .unwrap();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_entries (
+                seq INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                detail TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                user_id TEXT,
+                channel TEXT,
+                prev_hash TEXT NOT NULL,
+                hash TEXT NOT NULL
+            )",
+        )
+        .unwrap();
+    }
+
+    let log = AuditLog::with_db(pool.clone());
+    let now = chrono::Utc::now();
+    let old = now - chrono::Duration::days(2);
+    push_aged_entry(&log, "a", AuditAction::ToolInvoke, "old1", "ok", old);
+    push_aged_entry(&log, "a", AuditAction::ToolInvoke, "old2", "ok", old);
+    push_aged_entry(&log, "a", AuditAction::ToolInvoke, "recent", "ok", now);
+    assert_eq!(log.len(), 3);
+
+    // Break the DB so the trim's DELETE fails.
+    pool.get()
+        .unwrap()
+        .execute_batch("DROP TABLE audit_entries")
+        .unwrap();
+
+    let mut policy = AuditRetentionConfig::default();
+    policy
+        .retention_days_by_action
+        .insert("ToolInvoke".to_string(), 1);
+    let report = log.trim(&policy, now);
+
+    // The DELETE failed, so nothing is trimmed and the in-memory window is
+    // preserved — memory and DB stay consistent and the trim retries next tick.
+    // Before the fix, memory was drained anyway and the anchor advanced, so a
+    // restart resurrected the "dropped" rows and verify_integrity broke.
+    assert_eq!(
+        report.total_dropped, 0,
+        "no rows should be dropped when the DB delete fails"
+    );
+    assert_eq!(
+        log.len(),
+        3,
+        "in-memory window must be preserved on DB failure"
+    );
+}
+
+#[test]
 fn test_trim_preserves_chain_via_anchor() {
     let log = AuditLog::new();
     let now = chrono::Utc::now();


### PR DESCRIPTION
## Problem

`trim()` and `prune()` discarded the result of `DELETE FROM audit_entries` (and ignored a failed `db.get()`), then **unconditionally** drained the in-memory prefix and advanced `chain_anchor`:

```rust
if let Some(ref db) = self.db {
    if let Ok(conn) = db.get() {
        let _ = conn.execute("DELETE FROM audit_entries WHERE seq < ?1", ...);  // error ignored
    }
}
entries.drain(..drop_count);   // memory trimmed regardless of DB outcome
```

If the delete failed, memory was trimmed but the DB still held the "dropped" rows, so on the next boot `with_db` reloaded the full un-deleted set:

1. entries the retention policy was supposed to remove **reappeared** — defeating the very `RetentionTrim` the log was recording;
2. the in-memory length no longer matched the anchor seq, surfacing as a spurious `audit anchor mismatch` on the next verify.

The failure was swallowed with no log, so an operator got no signal that retention silently failed.

## Fix

Capture the DELETE / connection result and only drain memory + advance the anchor when it succeeded (persist-before-mutate, mirroring the INSERT path). On failure, log at `ERROR` and report nothing dropped (`TrimReport::default()` / `0`) so memory and the DB stay consistent and the trim/prune retries on the next tick.

## Verification

```
cargo test -p librefang-runtime-audit --lib   # 34 passed
cargo clippy -p librefang-runtime-audit --lib  # clean
```

`trim_keeps_memory_consistent_when_db_delete_fails` records three DB-backed entries, drops the `audit_entries` table to force the DELETE to fail, and asserts the trim reports 0 dropped and the in-memory window is preserved.

## Out of scope (flagged)

A sibling finding: the soft-cap drain in `record_with_context` writes the anchor `seq` from the (separately capped) in-memory length rather than the DB row count, so after a restart that reloads all rows the seq can diverge and `verify_integrity` fails. Correcting that is a change to the anchor/DB seq-**accounting model** of a tamper-detection system and warrants a dedicated, carefully-reviewed PR rather than being bundled with this localized retention fix.

## How it was found

Multi-agent audit of the workspace.
