### PR TITLE
fix(runtime-sandbox-docker): exec timeout leaks docker process; bind-mount validation never runs

### DIFF
--- a/crates/librefang-runtime-sandbox-docker/src/lib.rs
+++ b/crates/librefang-runtime-sandbox-docker/src/lib.rs
@@ -288,8 +288,12 @@ pub async fn create_sandbox(
         cmd.arg("--tmpfs").arg(tmpfs_mount);
     }
 
-    // Mount workspace read-only
+    // Mount workspace read-only. SECURITY: validate the host path against the
+    // symlink-escape and blocked-path checks BEFORE handing it to `docker run`.
+    // Without this gate the checks were dead code and a `workspace` resolving
+    // through a symlink into e.g. /etc would still be mounted into the sandbox.
     let ws_str = workspace.display().to_string();
+    validate_bind_mount(&ws_str, &config.blocked_mounts)?;
     cmd.arg("-v").arg(format!("{ws_str}:{}:ro", config.workdir));
 
     // Working directory
@@ -339,6 +343,13 @@ pub async fn exec_in_sandbox(
 
     cmd.stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
+
+    // SIGKILL the `docker exec` client when the future is dropped — tokio does
+    // NOT kill the child on drop by default, so without this a timeout would
+    // leave the host-side `docker exec` process running past the deadline and
+    // leak one per timed-out call. (The in-container workload is bounded
+    // separately by the caller destroying the container.)
+    cmd.kill_on_drop(true);
 
     debug!(container = %container.container_id, "Executing in Docker sandbox");
 
@@ -780,6 +791,22 @@ mod tests {
         assert!(config.cap_add.is_empty());
         assert_eq!(config.tmpfs, vec!["/tmp:size=64m"]);
         assert_eq!(config.pids_limit, 100);
+    }
+
+    #[tokio::test]
+    async fn create_sandbox_rejects_blocked_workspace_mount() {
+        // `/etc` is a default blocked mount path. `create_sandbox` must refuse a
+        // workspace under it — and because `validate_bind_mount` runs before any
+        // `docker run`, this returns an error without shelling out to docker.
+        // The check used to be dead code: never invoked on the creation path.
+        let config = DockerSandboxConfig::default();
+        let err = create_sandbox(&config, "agent-1", std::path::Path::new("/etc/secret"))
+            .await
+            .expect_err("a blocked workspace mount must be rejected");
+        assert!(
+            err.contains("blocked"),
+            "expected a blocked-mount error, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two issues in the Docker sandbox (`librefang-runtime-sandbox-docker`).

## 1. Exec timeout leaks the `docker exec` process

`exec_in_sandbox` built a `tokio::process::Command` without `kill_on_drop`. When the exec timeout fired, the `cmd.output()` future was dropped — but **tokio does not kill the child on drop by default**, so the host-side `docker exec` client kept running past the deadline. Under repeated timeouts this leaks one host process per timed-out call and defeats the timeout the sandbox advertises.

**Fix:** `cmd.kill_on_drop(true)` so the dropped future SIGKILLs the client. (The in-container workload is bounded separately by the caller destroying the container.)

## 2. The workspace bind mount was never validated

`create_sandbox` constructed the workspace bind mount directly:

```rust
let ws_str = workspace.display().to_string();
cmd.arg("-v").arg(format!("{ws_str}:{}:ro", config.workdir));
```

It never called `validate_bind_mount` or consulted `config.blocked_mounts` — so the symlink-escape and blocked-path protections the crate implements and documents were **dead code** from the daemon's perspective (the only callers were tests and a no-op stub). A `workspace` resolving through a symlink into `/etc` etc. was still mounted.

**Fix:** call `validate_bind_mount(&ws_str, &config.blocked_mounts)?` before appending the `-v` argument, so the checks gate the mount `docker run` actually performs.

## Verification

```
cargo test -p librefang-runtime-sandbox-docker --lib   # 42 passed
cargo clippy -p librefang-runtime-sandbox-docker --lib  # clean
```

`create_sandbox_rejects_blocked_workspace_mount` asserts a workspace under `/etc` is rejected before any docker invocation. The exec kill-on-drop path needs a live container + real timeout to exercise and can't be unit-tested hermetically; `kill_on_drop(true)` is the standard tokio idiom for it.

## How it was found

Multi-agent audit of the workspace; confirmed `validate_bind_mount` had no production caller before fixing.
