### PR TITLE
fix(cli): auto-update script TOCTOU/symlink exec; skill-install path traversal

### DIFF
--- a/crates/librefang-cli/src/commands/maintenance.rs
+++ b/crates/librefang-cli/src/commands/maintenance.rs
@@ -810,12 +810,38 @@ pub(crate) fn write_update_script(contents: &str, extension: &str) -> Result<Pat
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
         .unwrap_or(0);
-    let path = std::env::temp_dir().join(format!(
+    // SECURITY: this script is `sh`-exec'd right after. Stage it in a per-user
+    // 0700 directory instead of the world-writable shared temp dir, and create
+    // the file atomically with `create_new` + mode 0600. The previous
+    // `fs::write` + later `restrict_file_permissions` (a) followed a pre-planted
+    // symlink at the predictable `librefang-update-<pid>-<millis>` path and
+    // (b) left a default-umask window a local attacker on a shared host could
+    // race to swap the contents before they ran. `create_new` refuses an
+    // existing path / dangling symlink and never follows one.
+    let dir = cli_librefang_home().join("updates");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create updater dir: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+    }
+    let path = dir.join(format!(
         "librefang-update-{}-{unique}.{extension}",
         std::process::id()
     ));
-    std::fs::write(&path, contents).map_err(|e| format!("Failed to write updater script: {e}"))?;
-    restrict_file_permissions(&path);
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut f = opts
+        .open(&path)
+        .map_err(|e| format!("Failed to create updater script: {e}"))?;
+    use std::io::Write as _;
+    f.write_all(contents.as_bytes())
+        .map_err(|e| format!("Failed to write updater script: {e}"))?;
     Ok(path)
 }
 

--- a/crates/librefang-cli/src/commands/skill.rs
+++ b/crates/librefang-cli/src/commands/skill.rs
@@ -9,6 +9,26 @@ use crate::commands::prelude::*;
 // Skill commands
 // ---------------------------------------------------------------------------
 
+/// Validate that a skill name from an (untrusted) manifest is safe to use as a
+/// single path component under the skills directory.
+///
+/// `dest = skills_dir.join(name)` with `Path::join` treats an absolute `name`
+/// as a full replacement and lets `..` escape the base, so a package with
+/// `name = "../../.librefang/config.toml"` would write outside `skills_dir`.
+/// Require the name to be exactly one normal path component.
+fn validate_skill_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("skill name is empty".to_string());
+    }
+    let mut comps = std::path::Path::new(name).components();
+    match (comps.next(), comps.next()) {
+        (Some(std::path::Component::Normal(c)), None) if c == std::ffi::OsStr::new(name) => Ok(()),
+        _ => Err(format!(
+            "unsafe skill name '{name}': must be a single path component (no '/', '\\', '..' or absolute path)"
+        )),
+    }
+}
+
 /// Resolve the skills directory: global or per-hand workspace.
 pub(crate) fn resolve_skills_dir(hand: Option<&str>) -> PathBuf {
     let home = librefang_home();
@@ -42,6 +62,10 @@ pub(crate) fn cmd_skill_install(source: &str, hand: Option<&str>) {
                 println!("Detected OpenClaw skill format. Converting...");
                 match librefang_skills::openclaw_compat::convert_openclaw_skill(&source_path) {
                     Ok(manifest) => {
+                        if let Err(e) = validate_skill_name(&manifest.skill.name) {
+                            eprintln!("Refusing to install skill: {e}");
+                            std::process::exit(1);
+                        }
                         let dest = skills_dir.join(&manifest.skill.name);
                         // Copy skill directory
                         copy_dir_recursive(&source_path, &dest);
@@ -82,6 +106,10 @@ pub(crate) fn cmd_skill_install(source: &str, hand: Option<&str>) {
                 std::process::exit(1);
             });
 
+        if let Err(e) = validate_skill_name(&manifest.skill.name) {
+            eprintln!("Refusing to install skill: {e}");
+            std::process::exit(1);
+        }
         let dest = skills_dir.join(&manifest.skill.name);
         copy_dir_recursive(&source_path, &dest);
         if let Some(h) = hand {
@@ -981,5 +1009,27 @@ pub(crate) fn cmd_skill_pending(sub: PendingCommands) {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_skill_name;
+
+    #[test]
+    fn validate_skill_name_accepts_plain_names() {
+        assert!(validate_skill_name("my-skill").is_ok());
+        assert!(validate_skill_name("Skill_1.2").is_ok());
+    }
+
+    #[test]
+    fn validate_skill_name_rejects_path_traversal_and_absolute() {
+        // These would let `skills_dir.join(name)` escape the skills directory.
+        assert!(validate_skill_name("").is_err());
+        assert!(validate_skill_name("..").is_err());
+        assert!(validate_skill_name("../../.librefang/config.toml").is_err());
+        assert!(validate_skill_name("a/b").is_err());
+        assert!(validate_skill_name("/etc/passwd").is_err());
+        assert!(validate_skill_name("foo/").is_err());
     }
 }


### PR DESCRIPTION
Two security bugs in the CLI.

## 1. Auto-update writes the installer to a predictable shared temp path, then execs it (TOCTOU / symlink)

`write_update_script` downloaded the remote installer and wrote it to a predictable, world-readable shared temp path — `librefang-update-<pid>-<millis>.sh` — with `fs::write` (follows symlinks, default umask), and only chmod'd `0600` **after** the write. `run_official_update` then `sh`-exec'd it.

On a shared host a local attacker can pre-create that path as a symlink (the write follows it) or win the race between `fs::write` and the post-hoc chmod to substitute the contents — running arbitrary commands as the updating user.

**Fix:** stage the script in a per-user `0700` directory under `cli_librefang_home()/updates` and create it atomically with `OpenOptions::create_new(true)` + `mode(0o600)`, which refuses an existing path / dangling symlink and never follows one.

## 2. Skill install joins an attacker-controlled name into the destination path (traversal)

Local skill install derived the destination by joining the untrusted `skill.toml` `name` field directly: `skills_dir.join(&manifest.skill.name)`. `Path::join` lets an absolute component replace the base and `..` escape it, so a package with `name = "../../.librefang/config.toml"` (or an absolute path) wrote/overwrote files **outside** the skills directory. The same unvalidated join was on both the standard and OpenClaw install paths.

**Fix:** add `validate_skill_name`, which requires the name to be exactly one normal path component (no `/`, platform separator, `..`, or absolute prefix), and call it on both paths before the join.

## Verification

```
cargo test -p librefang-cli --bins validate_skill_name   # 2 passed
cargo clippy -p librefang-cli --bins                     # clean
```

`validate_skill_name_rejects_path_traversal_and_absolute` covers `..`, `../../…`, `a/b`, `/etc/passwd`, and empty. The updater atomic-create path is a standard `create_new` + `0600` idiom; exercising the symlink race needs a shared-fs setup unsuitable for the unit lane.

## How it was found

Multi-agent audit of the workspace.
