### PR TITLE
fix(skills): ClawHub/Skillhub zip install bypasses the supply-chain audit (.pth RCE)

### DIFF
--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -772,6 +772,26 @@ impl ClawHubClient {
         // Step 7: Write skill.toml into tmp_dir
         openclaw_compat::write_librefang_manifest(&tmp_dir, &manifest)?;
 
+        // Step 8: Supply-chain audit on the staged bundle BEFORE promotion.
+        // The marketplace path runs this (marketplace.rs) but the ClawHub /
+        // Skillhub zip path previously did not, so a published bundle could ship
+        // e.g. an `evil.pth` (Python site-packages auto-exec → RCE) or a
+        // symlink escape and reach the live skill dir on install. Scanning
+        // `tmp_dir` keeps the stage-then-promote invariant: a malicious bundle
+        // is deleted and never promoted. (The audit honours
+        // LIBREFANG_SKIP_SUPPLY_CHAIN_AUDIT=1 internally for dev-mode.)
+        if let Err(violations) = crate::supply_chain::scan(&tmp_dir) {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            let summary = violations
+                .iter()
+                .map(|v| v.to_string())
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(SkillError::SecurityBlocked(format!(
+                "supply-chain audit failed for '{slug}': {summary}"
+            )));
+        }
+
         // Atomic promotion: remove the previous version (if any) and rename
         // the fully-prepared temp directory into the final skill directory.
         // If rename() fails the tmp dir is left behind; the next install will
@@ -1096,5 +1116,44 @@ mod tests {
             }),
         };
         assert_eq!(ClawHubClient::entry_version(&entry), "2.0.0");
+    }
+
+    #[tokio::test]
+    async fn install_rejects_bundle_with_pth_via_supply_chain_audit() {
+        use std::io::Write as _;
+        use zip::write::SimpleFileOptions;
+
+        // Build an in-memory zip: a valid SKILL.md plus a malicious `.pth`
+        // (Python site-packages auto-exec → RCE). The ClawHub/Skillhub zip
+        // path previously skipped the supply-chain audit the marketplace path
+        // runs, so this bundle reached disk. It must now be refused before the
+        // staged dir is promoted to the live skill directory.
+        let mut buf = Vec::new();
+        {
+            let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let opts = SimpleFileOptions::default();
+            zip.start_file("SKILL.md", opts).unwrap();
+            zip.write_all(b"---\nname: evil-skill\ndescription: test\n---\n# Evil\nBody\n")
+                .unwrap();
+            zip.start_file("evil.pth", opts).unwrap();
+            zip.write_all(b"import os\n").unwrap();
+            zip.finish().unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let client = ClawHubClient::new(dir.path().join("cache"));
+        let target = dir.path().join("skills");
+        std::fs::create_dir_all(&target).unwrap();
+
+        let err = client
+            .install_with_expected_sha256("evil-skill", &target, &buf, None)
+            .await
+            .expect_err("a bundle containing a .pth must be refused by the supply-chain audit");
+        assert!(
+            matches!(err, SkillError::SecurityBlocked(ref m) if m.contains("supply-chain")),
+            "expected a supply-chain SecurityBlocked error, got: {err:?}"
+        );
+        // The malicious bundle must NOT have been promoted to the live dir.
+        assert!(!target.join("evil-skill").exists());
     }
 }

--- a/crates/librefang-skills/src/clawhub.rs
+++ b/crates/librefang-skills/src/clawhub.rs
@@ -772,14 +772,7 @@ impl ClawHubClient {
         // Step 7: Write skill.toml into tmp_dir
         openclaw_compat::write_librefang_manifest(&tmp_dir, &manifest)?;
 
-        // Step 8: Supply-chain audit on the staged bundle BEFORE promotion.
-        // The marketplace path runs this (marketplace.rs) but the ClawHub /
-        // Skillhub zip path previously did not, so a published bundle could ship
-        // e.g. an `evil.pth` (Python site-packages auto-exec → RCE) or a
-        // symlink escape and reach the live skill dir on install. Scanning
-        // `tmp_dir` keeps the stage-then-promote invariant: a malicious bundle
-        // is deleted and never promoted. (The audit honours
-        // LIBREFANG_SKIP_SUPPLY_CHAIN_AUDIT=1 internally for dev-mode.)
+        // Step 8: Supply-chain audit before promotion — a rejected bundle never reaches the live skill dir.
         if let Err(violations) = crate::supply_chain::scan(&tmp_dir) {
             let _ = std::fs::remove_dir_all(&tmp_dir);
             let summary = violations
@@ -1123,11 +1116,7 @@ mod tests {
         use std::io::Write as _;
         use zip::write::SimpleFileOptions;
 
-        // Build an in-memory zip: a valid SKILL.md plus a malicious `.pth`
-        // (Python site-packages auto-exec → RCE). The ClawHub/Skillhub zip
-        // path previously skipped the supply-chain audit the marketplace path
-        // runs, so this bundle reached disk. It must now be refused before the
-        // staged dir is promoted to the live skill directory.
+        // zip with a valid SKILL.md and a .pth entry — triggers the supply-chain audit.
         let mut buf = Vec::new();
         {
             let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
@@ -1153,7 +1142,6 @@ mod tests {
             matches!(err, SkillError::SecurityBlocked(ref m) if m.contains("supply-chain")),
             "expected a supply-chain SecurityBlocked error, got: {err:?}"
         );
-        // The malicious bundle must NOT have been promoted to the live dir.
         assert!(!target.join("evil-skill").exists());
     }
 }


### PR DESCRIPTION
## Problem

`install_with_expected_sha256` — the single extraction path used by **both** `ClawHubClient::install` and `SkillhubClient::install` — extracted every zip entry guarded only by path-traversal checks, ran the manifest-capability and prompt-injection scans, then atomically promoted the staged dir to the live skill directory. It **never** called `supply_chain::scan`, which was invoked from exactly one place: the marketplace path.

So a published ClawHub/Skillhub bundle could ship e.g. an `evil.pth` (Python site-packages auto-exec → full-process **RCE**) — exactly what the `pth-import-hijack` rule exists to block — or a symlink escape, and it reached disk on install. The equivalent marketplace bundle was correctly refused, and the `supply_chain` module doc states the audit exists precisely so "a malicious bundle cannot reach disk … even when CI was bypassed (e.g. a direct `.zip` install)".

## Fix

After extraction into `tmp_dir` and before the atomic promotion, run `crate::supply_chain::scan(&tmp_dir)`; on violations, `remove_dir_all(&tmp_dir)` and return `SkillError::SecurityBlocked(...)`, mirroring the marketplace path. Scanning the **staging** dir (not the live dir) preserves the stage-then-promote invariant, so a malicious bundle never reaches the live directory. The audit honours `LIBREFANG_SKIP_SUPPLY_CHAIN_AUDIT=1` internally for dev-mode.

## Verification

```
cargo test -p librefang-skills --lib install_rejects_bundle_with_pth   # passed
cargo clippy -p librefang-skills --lib                                 # clean
```

`install_rejects_bundle_with_pth_via_supply_chain_audit` builds a zip with a valid `SKILL.md` plus an `evil.pth`, runs it through `install_with_expected_sha256`, and asserts a supply-chain `SecurityBlocked` error **and** that nothing was promoted to the live skill directory.

## How it was found

Multi-agent audit of the workspace; confirmed `supply_chain::scan` had a single caller (marketplace) and the zip path bypassed it.
