### PR TITLE
fix(acp): permission bridge serializes all sessions, dropping approval events on broadcast lag

### DIFF
--- a/crates/librefang-acp/src/permission.rs
+++ b/crates/librefang-acp/src/permission.rs
@@ -50,11 +50,23 @@ pub(crate) async fn run_bridge<K: AcpKernel>(
     loop {
         match rx.recv().await {
             Ok(ApprovalEvent::Created(approval)) => {
-                // `approval` is now `Box<ApprovalRequest>`; unbox so
-                // `dispatch_pending`'s by-value signature still works.
-                if let Err(e) = dispatch_pending(&kernel, &sessions, &cx, *approval).await {
-                    warn!(error = %e, "ACP permission bridge: dispatch_pending failed");
-                }
+                // Dispatch each approval in its OWN task so the up-to-60s editor
+                // round-trip inside `dispatch_pending` does not block this recv
+                // loop. The bridge is one task per connection serving ALL
+                // multiplexed ACP sessions; if it blocked here, other sessions'
+                // `Created` events would pile up in the kernel broadcast (cap
+                // 256) and be dropped on lag — and the kernel fires `Created`
+                // exactly once per approval, so a dropped event hangs that
+                // session's approval indefinitely. `approval` is `Box`, unboxed
+                // into the task.
+                let kernel = Arc::clone(&kernel);
+                let sessions = Arc::clone(&sessions);
+                let cx = cx.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = dispatch_pending(&kernel, &sessions, &cx, *approval).await {
+                        warn!(error = %e, "ACP permission bridge: dispatch_pending failed");
+                    }
+                });
             }
             // `Resolved` events are emitted as a courtesy to other
             // subscribers (dashboards / TUI). The ACP side has nothing to

--- a/crates/librefang-acp/src/permission.rs
+++ b/crates/librefang-acp/src/permission.rs
@@ -50,15 +50,7 @@ pub(crate) async fn run_bridge<K: AcpKernel>(
     loop {
         match rx.recv().await {
             Ok(ApprovalEvent::Created(approval)) => {
-                // Dispatch each approval in its OWN task so the up-to-60s editor
-                // round-trip inside `dispatch_pending` does not block this recv
-                // loop. The bridge is one task per connection serving ALL
-                // multiplexed ACP sessions; if it blocked here, other sessions'
-                // `Created` events would pile up in the kernel broadcast (cap
-                // 256) and be dropped on lag — and the kernel fires `Created`
-                // exactly once per approval, so a dropped event hangs that
-                // session's approval indefinitely. `approval` is `Box`, unboxed
-                // into the task.
+                // Created fires once per approval; spawn so the ≤60s editor wait never stalls this drain loop.
                 let kernel = Arc::clone(&kernel);
                 let sessions = Arc::clone(&sessions);
                 let cx = cx.clone();
@@ -194,12 +186,6 @@ async fn dispatch_pending<K: AcpKernel>(
     })
     .map_err(AcpError::Transport)?;
 
-    // Serialize approvals — wait inline before processing the next
-    // broadcast event. Phase 1 prefers correctness over throughput;
-    // pending approvals queue in the broadcast (capacity 256). The
-    // serial path keeps tests deterministic and avoids spawning
-    // detached tasks whose runtime context (LocalSet vs not) can
-    // diverge between production and test harnesses.
     let (decision, remember) = match tokio::time::timeout(PERMISSION_TIMEOUT, rx).await {
         Ok(Ok(Ok(resp))) => decision_from_outcome(resp.outcome),
         Ok(Ok(Err(e))) => {


### PR DESCRIPTION
## Problem

The ACP permission bridge is a **single task per connection** that services **all** multiplexed ACP sessions. `run_bridge` awaited `dispatch_pending` **inline** in the recv loop, and `dispatch_pending` blocks up to `PERMISSION_TIMEOUT` (60s) waiting for the editor's `session/request_permission` response:

```rust
Ok(ApprovalEvent::Created(approval)) => {
    if let Err(e) = dispatch_pending(&kernel, &sessions, &cx, *approval).await { ... }  // blocks ≤60s
}
```

While one approval was pending, `Created` events for **other** sessions piled up in the kernel's `broadcast::channel(256)`; on overflow the loop only logged `Lagged` and continued. Since the kernel fires `Created` exactly once per approval (no periodic re-fire) and the bridge never re-queries `list_pending`, any dropped event left that session's approval **hanging until its own timeout** — a stuck editor on one session could starve approvals on every other session sharing the connection.

## Fix

Spawn each approval's `dispatch_pending` in its own `tokio::spawn` task (cloning the `Arc<K>` kernel, `Arc<SessionStore>`, and the cheaply-cloneable `ConnectionTo<Client>`), so the recv loop returns immediately to draining the broadcast and distinct sessions' approvals proceed in parallel. `AcpKernel: Send + Sync + 'static` already makes the spawn sound. Concurrency is naturally bounded by the human-gated approval rate and each task's 60s timeout.

## Verification

```
cargo check -p librefang-acp --lib   # ok
cargo clippy -p librefang-acp --lib  # clean
```

A hermetic test of the drain-while-pending behaviour needs a mock `ConnectionTo<Client>` (a concrete `agent_client_protocol` type) and a fake multi-session kernel, neither of which the crate's test harness provides; this is a standard spawn-instead-of-await concurrency fix.

## How it was found

Multi-agent audit of the workspace; traced the inline `.await` against the `broadcast(256)` cap and the once-only `Created` fire.
