### PR TITLE
fix(api): channel error truncation panics on multi-byte UTF-8 boundary

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -40,7 +40,7 @@ fn sanitize_channel_error(err: &str) -> String {
     } else {
         format!(
             "Something went wrong: please try again. (ref: {})",
-            &err[..err.len().min(80)]
+            safe_truncate_str(err, 80)
         )
     }
 }
@@ -2898,6 +2898,20 @@ mod tests {
         assert!(
             msg.contains("No pending approval matching 'deadbeef'"),
             "no-audit-hit branch must surface the not-found message verbatim, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn sanitize_channel_error_does_not_panic_on_multibyte_boundary() {
+        // The generic fallback used to slice the error at byte 80, which panics
+        // when byte 80 lands inside a multi-byte UTF-8 codepoint (localized
+        // provider errors, CJK, emoji). Build an error that hits the fallback
+        // branch, exceeds 80 bytes, and has a 2-byte char straddling byte 80.
+        let err = format!("{}é末", "x".repeat(79));
+        let out = sanitize_channel_error(&err);
+        assert!(
+            out.starts_with("Something went wrong"),
+            "must hit the fallback branch, got: {out}"
         );
     }
 


### PR DESCRIPTION
## Problem

`sanitize_channel_error`'s generic fallback built the user-facing ref string with a **byte** slice:

```rust
format!("Something went wrong: please try again. (ref: {})", &err[..err.len().min(80)])
```

`err` is an arbitrary LLM/driver error string. Slicing a `&str` at byte 80 panics — `byte index 80 is not a char boundary` — when the error exceeds 80 bytes and byte 80 lands inside a multi-byte UTF-8 codepoint (localized provider errors, emoji, accented Latin, CJK echoed back in the error). The panic aborts the channel dispatch task, dropping the user's reply and the error notification.

The rest of this file already uses the UTF-8-safe `safe_truncate_str` (imported at the top, used in ~9 other places) precisely to avoid this — the byte slice was an inconsistency.

## Fix

Use `safe_truncate_str(err, 80)`.

## Verification

```
cargo test -p librefang-api --lib sanitize_channel_error_does_not_panic   # passed
cargo clippy -p librefang-api --lib                                       # clean
```

`sanitize_channel_error_does_not_panic_on_multibyte_boundary` feeds a fallback-branch error longer than 80 bytes with a 2-byte char straddling byte 80 and asserts no panic.

## How it was found

A 500-agent per-file scan of the workspace (one agent per source file).