### PR TITLE
fix(channels): sidecar stderr read is unbounded — same OOM vector already capped for stdout

### DIFF
--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock, RwLock};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::{mpsc, oneshot, watch, Mutex};
 use tracing::{debug, error, info, warn};
@@ -817,9 +817,13 @@ async fn spawn_once(
     let stderr_name = ctx.name.clone();
     let mut stderr_translator = StderrTranslator::new(&ctx.command);
     tokio::spawn(async move {
-        let reader = BufReader::new(child_stderr);
-        let mut lines = reader.lines();
-        while let Ok(Some(line)) = lines.next_line().await {
+        // Read stderr with the SAME bounded reader as stdout. The unbounded
+        // `lines()` let a runaway adapter that writes to stderr without a
+        // newline grow the buffer without bound and OOM the daemon — the exact
+        // hazard the stdout path was capped against (MAX_EVENT_LINE_BYTES).
+        let mut reader = BufReader::new(child_stderr);
+        let mut line_buf: Vec<u8> = Vec::new();
+        while let Ok(Some(line)) = read_event_line(&mut reader, &mut line_buf).await {
             match stderr_translator.handle_line(&line) {
                 StderrAction::Warn(msg) => {
                     warn!(adapter = %stderr_name, "{msg}");


### PR DESCRIPTION
## Problem

The sidecar **stderr** reader used the unbounded `BufReader::lines()` / `next_line()`:

```rust
let reader = BufReader::new(child_stderr);
let mut lines = reader.lines();
while let Ok(Some(line)) = lines.next_line().await { ... }
```

The **stdout** path was deliberately switched to the bounded `read_event_line` (`read_capped_line` with `MAX_EVENT_LINE_BYTES` = 64 MiB) precisely because an external/untrusted adapter that writes bytes without a newline grows the reader's internal line buffer without bound and can OOM the daemon. The file's own header comment documents this hazard — but the mitigation was applied only to stdout; stderr had the same vulnerability.

## Fix

Read stderr through the same `read_event_line` bounded reader. An over-cap stderr line ends the stderr-logging task (the supervisor still manages the child) instead of growing memory without limit. Drops the now-unused `AsyncBufReadExt` import.

## Verification

```
cargo clippy -p librefang-channels --lib   # clean
```

The OOM path needs a child emitting a multi-MiB newline-free stderr stream to exercise (unsuitable for the unit lane); the fix reuses the already-proven stdout capping helper.

## How it was found

A 500-agent per-file scan of the workspace (one agent per source file).