### PR TITLE
fix(kernel): describe_event panics on multi-byte Custom payload; correct false test-env safety claim

### DIFF
--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -79,14 +79,18 @@ impl Drop for EnvVarGuard {
 }
 
 fn set_test_env(key: &'static str, value: &str) -> EnvVarGuard {
-    // SAFETY: tests use unique env-var names per test function and are
-    // serialised by the single-threaded default test runner.  The guard
-    // removes the variable on drop so it never persists across tests.
+    // SAFETY: every caller is annotated `#[serial_test::serial(librefang_vault_key)]`,
+    // so no two env-mutating tests in this file run concurrently — process-global
+    // `set_var`/`remove_var` cannot race a `getenv` on another test thread. The
+    // guard removes the variable on drop so it never persists across tests.
+    // (The earlier claim that the default test runner is single-threaded was
+    // incorrect: `cargo test` runs tests across multiple threads in one process.)
     unsafe { std::env::set_var(key, value) };
     EnvVarGuard { key }
 }
 
 #[test]
+#[serial_test::serial(librefang_vault_key)]
 fn test_collect_rotation_key_specs_dedupes_primary_profile_key() {
     let _primary = set_test_env("LIBREFANG_TEST_ROTATION_PRIMARY_KEY_A", "key-1");
     let _secondary = set_test_env("LIBREFANG_TEST_ROTATION_SECONDARY_KEY_A", "key-2");
@@ -123,6 +127,7 @@ fn test_collect_rotation_key_specs_dedupes_primary_profile_key() {
 }
 
 #[test]
+#[serial_test::serial(librefang_vault_key)]
 fn test_collect_rotation_key_specs_prepends_distinct_primary_and_skips_missing_profiles() {
     let _secondary = set_test_env("LIBREFANG_TEST_ROTATION_SECONDARY_KEY_B", "key-2");
     let profiles = [

--- a/crates/librefang-kernel/src/triggers.rs
+++ b/crates/librefang-kernel/src/triggers.rs
@@ -1513,7 +1513,11 @@ fn describe_event(event: &Event) -> String {
                 let summary = {
                     let s = val.to_string();
                     if s.len() > 300 {
-                        format!("{}...", &s[..300])
+                        // `&s[..300]` panics when byte 300 lands inside a
+                        // multi-byte UTF-8 codepoint; Custom payloads are
+                        // operator/attacker-controlled. truncate_str snaps to a
+                        // char boundary (used the same way at line ~1404).
+                        format!("{}...", librefang_types::truncate_str(&s, 300))
                     } else {
                         s
                     }


### PR DESCRIPTION
Two issues in `librefang-kernel`.

## 1. `describe_event` panics on a multi-byte Custom payload (`triggers.rs`)

The `EventPayload::Custom` branch truncated the re-serialized JSON with a **byte** slice:

```rust
let s = val.to_string();
if s.len() > 300 { format!("{}...", &s[..300]) } else { s }
```

`serde_json::Value::to_string()` emits raw (non-escaped) UTF-8, so a Custom payload exceeding 300 bytes with a multi-byte char (emoji, CJK, …) straddling byte 300 makes `&s[..300]` panic — `byte index 300 is not a char boundary`. Custom payloads are operator/attacker-controlled and reach `describe_event` during trigger evaluation. Use the char-boundary-safe `librefang_types::truncate_str(&s, 300)` (already used ~100 lines up for ToolResult content).

## 2. False SAFETY claim on `set_test_env` (`kernel/tests.rs`)

The comment claimed the tests are "serialised by the single-threaded default test runner" — false: `cargo test` runs tests across multiple threads in one process, and process-global `set_var`/`remove_var` is a documented data race against any concurrent `getenv` (UB under Rust 2024 unsafe-env rules). The vault-key tests guard this with `#[serial_test::serial(librefang_vault_key)]`, but the two rotation-key tests relied solely on the wrong claim. Add them to the same serial group and correct the comment.

## Verification

```
cargo test -p librefang-kernel --lib test_collect_rotation_key_specs   # 2 passed
cargo clippy -p librefang-kernel --lib                                 # clean
```

## How it was found

A 500-agent per-file scan of the workspace (one agent per source file).