### PR TITLE
fix(runtime): allow unused_mut on chromium launch args off-Linux

### DIFF
--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -272,6 +272,8 @@ impl BrowserSession {
             .prefix("librefang-chrome-")
             .tempdir()
             .map_err(|e| format!("Failed to create Chromium user-data-dir: {e}"))?;
+        // `mut` is only exercised by the Linux root/--no-sandbox branch below.
+        #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
         let mut args = chromium_launch_args(config, user_data_dir.path());
 
         // On Linux, Chromium refuses to start as root without --no-sandbox.


### PR DESCRIPTION
## Problem

Main CI is red on the macOS and both Windows test lanes since #6028 (e64ff3398): the `-D warnings` test compile fails with

```
error: variable does not need to be mutable
   --> crates/librefang-runtime/src/browser.rs:275:13
```

The `mut` on `args` in `BrowserSession::launch` is only exercised by the `#[cfg(target_os = "linux")]` root/`--no-sandbox` branch, so the Linux lane passes while macOS/Windows reject the unused `mut`.

## Change

- Add `#[cfg_attr(not(target_os = "linux"), allow(unused_mut))]` on the binding.
On Linux the attribute expands to nothing, leaving the code byte-identical to what the green Linux lane already compiles.

## Verification

- `cargo check -p librefang-runtime --lib` on macOS (aarch64-apple-darwin, the previously failing platform): clean.
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` on macOS: clean.

Failing run for reference: https://github.com/librefang/librefang/actions/runs/27222313636