### PR TITLE
ci(nix-build): free runner disk space before nix build

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -40,6 +40,19 @@ jobs:
           - librefang-desktop
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # ubuntu-latest leaves only ~14 GB free; the full workspace build plus
+      # its /nix/store closure exceeds that, the disk fills, and the
+      # nix-daemon gets killed mid-build ("Nix daemon disconnected
+      # unexpectedly"). Drop the preinstalled toolchains this job never
+      # touches (~25 GB) before building. See #6081.
+      - name: Free runner disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
+          sudo docker image prune --all --force
+          df -h /
+
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
         with:

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -41,11 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # ubuntu-latest leaves only ~14 GB free; the full workspace build plus
-      # its /nix/store closure exceeds that, the disk fills, and the
-      # nix-daemon gets killed mid-build ("Nix daemon disconnected
-      # unexpectedly"). Drop the preinstalled toolchains this job never
-      # touches (~25 GB) before building. See #6081.
+      # ubuntu-latest leaves only ~14 GB free; the full workspace build plus its /nix/store closure exceeds that, the disk fills, and the nix-daemon gets killed mid-build ("Nix daemon disconnected unexpectedly").
+      # Drop the preinstalled toolchains this job never touches (~25 GB) before building.
+      # See #6081.
       - name: Free runner disk space
         run: |
           df -h /


### PR DESCRIPTION
## Problem

On the push-to-main run for #6075 ([27277064565](https://github.com/librefang/librefang/actions/runs/27277064565)), both `nix build` matrix jobs died ~50 minutes in with `error: Nix daemon disconnected unexpectedly (maybe it crashed?)`.
After a `--failed` rerun, `librefang-desktop` passed but `librefang-cli` failed a second time with the identical signature, so this is systematic rather than a flake.
The same merge commit's CI run also hit `No space left on device` on another `ubuntu-latest` runner (`Test / Ubuntu (shard 2/4)`), pointing at disk exhaustion: `ubuntu-latest` leaves only ~14 GB free, the workspace's `/nix/store` build closure exceeds that, and the nix-daemon is killed when the disk fills.

## Change

- Add a `Free runner disk space` step to `.github/workflows/nix-build.yml` before the Nix install: remove preinstalled toolchains the job never uses (dotnet, Android SDK, GHC/ghcup, the CodeQL bundle, docker images), reclaiming roughly 25 GB.
- `df -h /` is printed before and after so future runs show actual headroom in the log.
- Plain `rm -rf` in a run step — no new third-party action dependency.

## Verification

- Workflow-only change; no Rust code touched, so `cargo check` / tests are not applicable.
- `.github/workflows/nix-build.yml` is in the workflow's own `paths` filter, so the push-to-main after merge triggers a full `nix build` of both matrix packages and validates the fix directly.

Closes #6081
