### PR TITLE
ci(test): free runner disk space before the unit-test build (fixes ENOSPC on main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,6 +721,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # ubuntu-latest leaves only ~14 GB free; a full-workspace `cargo nextest
+      # run --workspace` debug-compiles every lib+bin target (librefang-desktop's
+      # static archive alone is large) and overruns it — the linker dies with
+      # "No space left on device". Reclaim ~25 GB by removing preinstalled
+      # toolchains this job never uses, mirroring the nix-build job's fix (#6081).
+      - name: Free runner disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
+          sudo docker image prune --all --force
+          df -h /
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,11 +721,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # ubuntu-latest leaves only ~14 GB free; a full-workspace `cargo nextest
-      # run --workspace` debug-compiles every lib+bin target (librefang-desktop's
-      # static archive alone is large) and overruns it — the linker dies with
-      # "No space left on device". Reclaim ~25 GB by removing preinstalled
-      # toolchains this job never uses, mirroring the nix-build job's fix (#6081).
+      # ubuntu-latest leaves only ~14 GB free; a full-workspace `cargo nextest run --workspace` debug-compiles every lib+bin target (librefang-desktop's static archive alone is large) and overruns it — the linker dies with "No space left on device".
+      # Reclaim ~25 GB by removing preinstalled toolchains this job never uses, mirroring the nix-build job's fix (#6081).
       - name: Free runner disk space
         run: |
           df -h /


### PR DESCRIPTION
## Problem

`Test / Unit (lib+bin)` failed on the push-to-main run after #6083 merged — **not a test failure**, a disk-full failure:

```
rustc-LLVM ERROR: IO failure on output stream: No space left on device
error: failed to build archive at `.../liblibrefang_desktop.a`: No space left on device (os error 28)
```

The job's full-run path is `cargo nextest run --workspace -E 'kind(lib) | kind(bin)'`, which debug-compiles **every** lib+bin target in the workspace (including `librefang-desktop`'s large static archive).
`ubuntu-latest` leaves only ~14 GB free, the build overruns it, and the linker dies before any test runs.
The job had **no disk-cleanup step**.

#6081 already added exactly this cleanup to the **nix-build** job, but it only touched `nix-build.yml` — the Unit job stayed exposed and is the one that just took down main.

## Fix

Add a `Free runner disk space` step (right after checkout) to the Unit job, identical to #6081's: delete preinstalled toolchains the job never uses (dotnet, Android SDK, GHC, CodeQL, docker images), reclaiming ~25 GB before the build, and print `df -h /` before and after so the reclaimed space shows in the log.

## Scope / notes

- Targeted at the one job that has actually hit ENOSPC. Over the last 12 main CI runs, the Unit job is the only one that failed on disk; the 4 Ubuntu test shards, Quality, Security, and Build all stayed green, so they are intentionally left untouched (no evidence they need it yet).
- If those jobs start hitting ENOSPC too, the same step applies — at that point it would be worth extracting it into a small composite action instead of a third copy (this is the second copy after #6081).

## Verification

- `ci.yml` still parses as valid YAML (`python -c "import yaml; yaml.safe_load(...)"`).
- The step is byte-identical to the one already running in `nix-build.yml` (#6081), which has been exercising it on the same runner image.
