### PR TITLE
release: v2026.6.11-beta.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.6.11] - 2026-06-11
+
+_8 PRs from 2 contributors since v2026.6.10-beta.17._
+
+### Fixed
+
+- Persist run state outside the state lock so GET /run never spuriously reports running:false (#6083) (@houko)
+- Inject embedded SDK into the sidecar --describe probe so the configure form isn't empty without pip install (#6085) (@houko)
+- Encode qrcode_img_content so the login QR is scannable (#6086) (@houko)
+
+<details>
+<summary>Documentation, maintenance, and other internal changes</summary>
+
+### Maintenance
+
+- Bump @whiskeysockets/baileys from 6.7.21 to 6.7.22 in /packages/whatsapp-gateway (#6077) (@app/dependabot)
+- Bump @types/react from 19.2.16 to 19.2.17 in /web in the web-minor-patch group (#6079) (@app/dependabot)
+- Bump the dashboard-minor-patch group in /crates/librefang-api/dashboard with 3 updates (#6080) (@app/dependabot)
+- Free runner disk space before nix build (#6082) (@houko)
+- Free runner disk space before the unit-test build (fixes ENOSPC on main) (#6089) (@houko)
+
+</details>
+
+
 ## [2026.6.10] - 2026-06-10
 
 _78 PRs from 6 contributors since v2026.5.31-beta.16._

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-acp"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-tokio",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "async-trait",
  "axum",
@@ -4523,7 +4523,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "axum",
  "clap",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "librefang-types",
  "reqwest",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-import"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "librefang-llm-driver",
  "librefang-memory",
@@ -4773,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4789,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4803,7 +4803,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4860,7 +4860,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory-wiki"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "chrono",
  "librefang-kernel-handle",
@@ -4876,7 +4876,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-rl-export"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-audit"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "chrono",
  "hex",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-media"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-sandbox-docker"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -5062,7 +5062,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-subprocess"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "metrics",
  "serde_json",
@@ -5074,7 +5074,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -12493,7 +12493,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.6.32117",
+  "version": "26.6.32128",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
     },
-    "version": "2026.6.10-beta.17"
+    "version": "2026.6.11-beta.18"
   },
   "paths": {
     "/.well-known/agent.json": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.6.10-beta.17",
+  "version": "2026.6.11-beta.18",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.6.10-beta.17",
+  "version": "2026.6.11-beta.18",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.6.10b17",
+    version="2026.6.11b18",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.6.10-beta.17"
+version = "2026.6.11-beta.18"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-19c78ad4b4c34aca835df5b3866f0cbab97acbd4bf78bb8c51a1cea8c34c2089  openapi.json
+073187682a836cee68697a7719ea12fe7617aa7ca7ace52d94a8465d3d34ab8e  openapi.json


### PR DESCRIPTION
<!-- release-tag:v2026.6.11-beta.18 -->
## Release v2026.6.11-beta.18

_8 PRs from 2 contributors since v2026.6.10-beta.17._

### Fixed

- Persist run state outside the state lock so GET /run never spuriously reports running:false (#6083) (@houko)
- Inject embedded SDK into the sidecar --describe probe so the configure form isn't empty without pip install (#6085) (@houko)
- Encode qrcode_img_content so the login QR is scannable (#6086) (@houko)

<details>
<summary>Documentation, maintenance, and other internal changes</summary>

### Maintenance

- Bump @whiskeysockets/baileys from 6.7.21 to 6.7.22 in /packages/whatsapp-gateway (#6077) (@app/dependabot)
- Bump @types/react from 19.2.16 to 19.2.17 in /web in the web-minor-patch group (#6079) (@app/dependabot)
- Bump the dashboard-minor-patch group in /crates/librefang-api/dashboard with 3 updates (#6080) (@app/dependabot)
- Free runner disk space before nix build (#6082) (@houko)
- Free runner disk space before the unit-test build (fixes ENOSPC on main) (#6089) (@houko)

</details>

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.6.10-beta.17...v2026.6.11-beta.18