### PR TITLE
chore(workers): migrate worker config to librefang Cloudflare account

### DIFF
--- a/web/workers/marketplace-worker/wrangler.toml
+++ b/web/workers/marketplace-worker/wrangler.toml
@@ -1,12 +1,12 @@
 name = "librefang-marketplace"
 main = "index.js"
 compatibility_date = "2025-01-01"
-account_id = "3ee9bb524a4fb2a9d685ce1f82b52581"
+account_id = "57449de851e4289a4407a73e66baaac9"
 
 [[d1_databases]]
 binding = "DB"
 database_name = "librefang-marketplace"
-database_id = "91df0bc6-e658-4463-9eba-22d5476d420a"
+database_id = "1bbf40ca-963b-4b94-b65d-062b9e7bbb42"
 
 [vars]
 GITHUB_CLIENT_ID = "Iv1.3683b4ad4a41e982"
@@ -17,7 +17,7 @@ GITHUB_CLIENT_ID = "Iv1.3683b4ad4a41e982"
 # Until both are set, /v1/pubkey and /v1/download/.../signature return 503,
 # new versions are stored without bundle_sig (NULL), and existing endpoints
 # remain fully functional.
-REGISTRY_PUBLIC_KEY = "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0="
+REGISTRY_PUBLIC_KEY = "joY8IYrUbbACfKRyp2CTcEbcEty8wcBwP1MTxU+vjaM="
 
 # Weekly stats aggregation
 [triggers]

--- a/web/workers/registry-worker/wrangler.toml
+++ b/web/workers/registry-worker/wrangler.toml
@@ -1,12 +1,12 @@
 name = "librefang-registry"
 main = "index.js"
 compatibility_date = "2025-01-01"
-account_id = "3ee9bb524a4fb2a9d685ce1f82b52581"
+account_id = "57449de851e4289a4407a73e66baaac9"
 
 [[d1_databases]]
 binding = "DB"
 database_name = "librefang-marketplace"
-database_id = "91df0bc6-e658-4463-9eba-22d5476d420a"
+database_id = "1bbf40ca-963b-4b94-b65d-062b9e7bbb42"
 
 # Daily registry refresh at UTC 02:00
 [triggers]
@@ -19,4 +19,4 @@ crons = ["0 2 * * *"]
 # Until both are set, the signing endpoints return 503 and the cron refresh
 # skips signing — the existing /api/registry path remains fully functional.
 [vars]
-REGISTRY_PUBLIC_KEY = "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0="
+REGISTRY_PUBLIC_KEY = "joY8IYrUbbACfKRyp2CTcEbcEty8wcBwP1MTxU+vjaM="

--- a/web/workers/stats-worker/wrangler.toml
+++ b/web/workers/stats-worker/wrangler.toml
@@ -1,12 +1,12 @@
 name = "librefang-github-stats"
 main = "index.js"
 compatibility_date = "2025-01-01"
-account_id = "3ee9bb524a4fb2a9d685ce1f82b52581"
+account_id = "57449de851e4289a4407a73e66baaac9"
 
 [[d1_databases]]
 binding = "DB"
 database_name = "librefang-marketplace"
-database_id = "91df0bc6-e658-4463-9eba-22d5476d420a"
+database_id = "1bbf40ca-963b-4b94-b65d-062b9e7bbb42"
 
 # Runs daily at UTC 00:00
 [triggers]

--- a/web/workers/visit-counter-worker/wrangler.toml
+++ b/web/workers/visit-counter-worker/wrangler.toml
@@ -5,4 +5,4 @@ compatibility_date = "2025-01-01"
 [[d1_databases]]
 binding = "DB"
 database_name = "librefang-marketplace"
-database_id = "91df0bc6-e658-4463-9eba-22d5476d420a"
+database_id = "1bbf40ca-963b-4b94-b65d-062b9e7bbb42"


### PR DESCRIPTION
## What

Point the Cloudflare Worker configs at the new **librefang** Cloudflare account after the cross-account migration.

- `account_id` -> librefang account (`57449de851e4289a4407a73e66baaac9`)
- D1 `database_id` -> migrated database (`1bbf40ca-963b-4b94-b65d-062b9e7bbb42`)
- `REGISTRY_PUBLIC_KEY` -> rotated Ed25519 signing key

Affects `marketplace-worker`, `stats-worker`, `visit-counter-worker`, `registry-worker`.

## Why

`librefang.ai`, all workers, D1, and KV have been migrated from the previous Cloudflare account to the dedicated librefang account. The workers are already deployed and serving there; this updates the repo so `deploy-worker.yml` targets the new account too.

## Follow-up after merge

Repoint the repo Actions secrets, otherwise CI keeps deploying to the old account:

- `CLOUDFLARE_ACCOUNT_ID` -> `57449de851e4289a4407a73e66baaac9`
- `CLOUDFLARE_API_TOKEN` -> a token scoped to the librefang account (Workers + Pages)
