### PR TITLE
fix(ci): refresh detect-secrets baseline for migrated Cloudflare account_id

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4050,7 +4050,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "web/workers/marketplace-worker/wrangler.toml",
-        "hashed_secret": "952f171c2975b07d40de194f1745c3dad8f9a3ce",
+        "hashed_secret": "abfc409c5d78e0b185b919c28eb7824214fec52c",
         "is_verified": false,
         "line_number": 20
       }
@@ -4059,7 +4059,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "web/workers/registry-worker/wrangler.toml",
-        "hashed_secret": "952f171c2975b07d40de194f1745c3dad8f9a3ce",
+        "hashed_secret": "abfc409c5d78e0b185b919c28eb7824214fec52c",
         "is_verified": false,
         "line_number": 22
       }


### PR DESCRIPTION
## Problem

The `secrets` (detect-secrets) job has been red on `main` since `fcfbd9e18` / #6092 ("migrate worker config to librefang Cloudflare account").

That PR changed the Cloudflare `account_id` in `web/workers/marketplace-worker/wrangler.toml` and `web/workers/registry-worker/wrangler.toml` from `3ee9bb524a4fb2a9d685ce1f82b52581` to `57449de851e4289a4407a73e66baaac9`.
detect-secrets fingerprints that value as a `Base64 High Entropy String`, so its baseline hash changed — but `.secrets.baseline` was not regenerated, so the CI re-scan no longer matches the committed baseline:

```
@@ web/workers/marketplace-worker/wrangler.toml
-        "hashed_secret": "952f171c2975b07d40de194f1745c3dad8f9a3ce",
+        "hashed_secret": "abfc409c5d78e0b185b919c28eb7824214fec52c",
@@ web/workers/registry-worker/wrangler.toml
-        "hashed_secret": "952f171c2975b07d40de194f1745c3dad8f9a3ce",
+        "hashed_secret": "abfc409c5d78e0b185b919c28eb7824214fec52c",
```

A Cloudflare account ID is a public account identifier, not a credential, so this is a false-positive class entry — the fix is to update the baseline, not to redact anything.

## Change

Update only the two `wrangler.toml` baseline entries to the rescanned hash `abfc409c…`.

The old hash `952f171c…` also appears on a third entry — `crates/librefang-runtime/src/plugin_manager/registry.rs` (an embedded registry pubkey).
That value was **not** changed by #6092 and CI's fresh scan still produces `952f171c…` for it, so that entry is deliberately left untouched (a blind global replace would have corrupted it).

## Verification

- `git diff` is exactly the two intended lines (`2 insertions(+), 2 deletions(-)`); `registry.rs` entry still carries `952f171c…`.
- `.secrets.baseline` re-parses as valid JSON.
- The new hashes match the exact values CI's re-scan reported in the failing run.
- `detect-secrets` is not installed locally, so the surgical edit reproduces CI's expected baseline (the strip-and-diff check ignores `generated_at` / `version` / `line_number`, so leaving `generated_at` as-is is fine).
