### PR TITLE
fix(channels): preserve caller-supplied channel name case in channel_send (#6078)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -785,6 +785,8 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ### Fixed
 
+- **channels: `channel_send` no longer lowercases the caller-supplied channel name, so capitalized sidecars are reachable again** (@houko). The `channel` tool argument was force-lowercased before the kernel's case-sensitive `send_channel_*` lookup, while channel adapters register under their config name with original case — so an agent calling `channel_send(channel="bot-A", …)` looked up `bot-a` and failed with a not-found error for any sidecar whose name carried uppercase (a latent regression since the case-preserving registration in #5996). The name is now passed through verbatim (still trimmed). Closes #6078.
+
 - **channels: the dashboard configure form is no longer empty for sidecar adapters when `librefang-sdk` is not pip-installed** (@houko).
   The Add-a-channel form is schema-driven off `python3 -m librefang.sidecar.adapters.<name> --describe`, but the boot-time probe (`routes/sidecar_describe.rs::describe_sidecar`) spawned the interpreter without the binary-embedded SDK on `PYTHONPATH` — unlike the live channel-spawn path, which has injected the embedded copy since the SDK was bundled.
   So on a fresh host with only `python3` (no `pip install librefang-sdk`), `--describe` failed with `ModuleNotFoundError`, and every adapter without a hand-maintained `static_fields` fallback (telegram, ntfy, gotify, mastodon, …) rendered a blank configure drawer — even though the adapter source ships embedded in the daemon binary.

--- a/crates/librefang-runtime/src/tool_runner/channel.rs
+++ b/crates/librefang-runtime/src/tool_runner/channel.rs
@@ -133,11 +133,7 @@ pub(super) async fn tool_channel_send(
 ) -> Result<String, String> {
     let kh = require_kernel(kernel)?;
 
-    // Preserve the caller-supplied channel name verbatim (#6078). Channel
-    // adapters register under their config name with original case
-    // (`channel_bridge`), and the kernel's `send_channel_*` lookups are
-    // case-sensitive. Lowercasing here broke `channel_send` for any sidecar
-    // whose name carries uppercase (e.g. `bot-A`).
+    // Kernel `send_channel_*` lookups are case-sensitive; adapters register with original case (#6078).
     let channel = input["channel"]
         .as_str()
         .ok_or("Missing 'channel' parameter")?

--- a/crates/librefang-runtime/src/tool_runner/channel.rs
+++ b/crates/librefang-runtime/src/tool_runner/channel.rs
@@ -133,11 +133,16 @@ pub(super) async fn tool_channel_send(
 ) -> Result<String, String> {
     let kh = require_kernel(kernel)?;
 
+    // Preserve the caller-supplied channel name verbatim (#6078). Channel
+    // adapters register under their config name with original case
+    // (`channel_bridge`), and the kernel's `send_channel_*` lookups are
+    // case-sensitive. Lowercasing here broke `channel_send` for any sidecar
+    // whose name carries uppercase (e.g. `bot-A`).
     let channel = input["channel"]
         .as_str()
         .ok_or("Missing 'channel' parameter")?
         .trim()
-        .to_lowercase();
+        .to_string();
 
     let recipient = input["recipient"]
         .as_str()


### PR DESCRIPTION
## Summary

`channel_send` force-lowercased the `channel` argument before the kernel's case-sensitive `send_channel_*` lookup, while channel adapters register under their config name with original case. Any sidecar whose name carries uppercase (e.g. `bot-A`) became unreachable — a latent regression since the case-preserving registration in #5996.

## Change

Pass the channel name through verbatim (still trimmed) in `crates/librefang-runtime/src/tool_runner/channel.rs`.

## Behaviour note

Channel matching is now case-sensitive (was effectively lowercase-only). Operators who registered an uppercase sidecar and worked around the bug by calling `channel_send` with a lowercased name must use the exact registered case. Already-matching setups are unaffected.

## Test plan

- `cargo build -p librefang-runtime`
- `cargo clippy -p librefang-runtime -- -D warnings`

Closes #6078
