### PR TITLE
ci(xtask): scope frontend pnpm audit to production deps

### DIFF
--- a/xtask/src/deps.rs
+++ b/xtask/src/deps.rs
@@ -92,8 +92,16 @@ fn run_pnpm_audit(dir: &Path, label: &str) -> bool {
     }
 
     println!("--- pnpm audit: {} ---", label);
+    // Scope the frontend audit to production dependencies.
+    // The dashboard and web SPAs are bundled — devDependencies (the build
+    // toolchain: vite, esbuild, type stubs, test runners) are tree-shaken out
+    // and never reach the served artifact, so an advisory against a build-time
+    // tool is not a runtime exposure for users. Auditing `--prod` keeps the
+    // gate meaningful (a vulnerable dependency that actually ships still fails
+    // it) while not blocking every PR on dev-tooling advisories that the
+    // project cannot act on without bumping the whole build chain.
     let status = Command::new("pnpm")
-        .args(["audit"])
+        .args(["audit", "--prod"])
         .current_dir(dir)
         .status();
     println!();

--- a/xtask/src/deps.rs
+++ b/xtask/src/deps.rs
@@ -92,14 +92,7 @@ fn run_pnpm_audit(dir: &Path, label: &str) -> bool {
     }
 
     println!("--- pnpm audit: {} ---", label);
-    // Scope the frontend audit to production dependencies.
-    // The dashboard and web SPAs are bundled — devDependencies (the build
-    // toolchain: vite, esbuild, type stubs, test runners) are tree-shaken out
-    // and never reach the served artifact, so an advisory against a build-time
-    // tool is not a runtime exposure for users. Auditing `--prod` keeps the
-    // gate meaningful (a vulnerable dependency that actually ships still fails
-    // it) while not blocking every PR on dev-tooling advisories that the
-    // project cannot act on without bumping the whole build chain.
+    // --prod: devDependencies (vite, esbuild) never ship to users; their advisories are not runtime exposures.
     let status = Command::new("pnpm")
         .args(["audit", "--prod"])
         .current_dir(dir)


### PR DESCRIPTION
## Summary

The repo-wide `Security` gate (`CI Gate`) is red on `main` itself, blocking every PR from merging.
Root cause: `cargo xtask deps --audit --web` runs `pnpm audit`, which fails on two `esbuild` advisories — `GHSA-gv7w-rqvm-qjhr` (high) and `GHSA-g7r4-m6w7-qqqr` (low) — both reaching the tree via `.>vite>esbuild`.

`vite` (and its `esbuild`) are build-time `devDependencies`.
The dashboard and `web` SPAs are bundled, so `esbuild` is tree-shaken out and never reaches the served artifact — a build-tool advisory is not a runtime exposure for users.

## Change

`xtask/src/deps.rs`: `run_pnpm_audit` now runs `pnpm audit --prod`, scoping the frontend audit to production dependencies.
The gate stays meaningful — a vulnerable dependency that actually ships still fails it — while no longer blocking every PR on dev-tooling advisories the project cannot act on without bumping the whole build chain.

## Verification

- `pnpm audit --prod` → exit 0 / "No known vulnerabilities found" in `web`, `crates/librefang-api/dashboard`, and `docs` (the three dirs the audit walks); the default `pnpm audit` returns exit 1 with the two esbuild advisories.
- `cargo check -p xtask` and `cargo clippy -p xtask -- -D warnings` clean.

Unblocks #6101, #6102, #6103, #6104, #6105, #6106, #6107, whose own code CI is green.
