### PR TITLE
ci(test): free runner disk space before the integration shard build (fixes ENOSPC on main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,8 +792,7 @@ jobs:
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
-      # ubuntu-latest leaves only ~14 GB free; the full-run path debug-compiles every workspace test binary via `cargo test --workspace --no-run` (each `tests/*.rs` is its own executable, plus dev-deps and librefang-desktop's large static archive), which overruns the disk — the runner dies with "No space left on device" mid-build (the full-run shards all do this build, so any one of them can flake on the margin, as shard 1 did on main).
-      # Reclaim ~25 GB by removing preinstalled toolchains this job never uses, mirroring the unit-test (#6089) and nix-build (#6081) fixes.
+      # ubuntu-latest leaves ~14 GB free; the full-run path compiles every workspace test binary and overruns the disk.
       - name: Free runner disk space
         if: steps.gate.outputs.skip != 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,6 +792,15 @@ jobs:
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
+      # ubuntu-latest leaves only ~14 GB free; the full-run path debug-compiles every workspace test binary via `cargo test --workspace --no-run` (each `tests/*.rs` is its own executable, plus dev-deps and librefang-desktop's large static archive), which overruns the disk — the runner dies with "No space left on device" mid-build (the full-run shards all do this build, so any one of them can flake on the margin, as shard 1 did on main).
+      # Reclaim ~25 GB by removing preinstalled toolchains this job never uses, mirroring the unit-test (#6089) and nix-build (#6081) fixes.
+      - name: Free runner disk space
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
+          sudo docker image prune --all --force
+          df -h /
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         if: steps.gate.outputs.skip != 'true'
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2


### PR DESCRIPTION
## Problem

`Test / Ubuntu (shard 1/4)` failed on `main` (run [27518045628](https://github.com/librefang/librefang/actions/runs/27518045628)) with the runner annotation:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/.../Worker_*.log'
```

This is not a test failure — the runner ran out of disk **mid-build**, before any test executed.

## Root cause

The `test-ubuntu` integration shard job's full-run path runs `cargo test --workspace --no-run`, which debug-compiles *every* workspace test binary (each `tests/*.rs` is its own executable, plus dev-dependencies and librefang-desktop's large static archive). `ubuntu-latest` leaves only ~14 GB free, and all four full-run shards do this same heavy build, so the disk sits right at the margin — shard 1/4 tipped over it.

This is the same class of failure that hit `Test / Unit (lib+bin)` in #6089 and `nix-build` in #6081. Both got a disk-free step; the integration shard lane — the last full-workspace Ubuntu build still exposed — did not.

## Fix

Add a `Free runner disk space` step to `test-ubuntu`, gated on the same selective-lane `skip` output as the rest of the job's steps. It removes preinstalled toolchains this job never uses (dotnet, Android SDK, GHC, CodeQL, docker images), reclaiming ~25 GB — identical to the step already in the unit job.

## Verification

- `ci.yml` still parses as valid YAML (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Step placement and `if:` gating match the surrounding gated steps; skipped (selective-lane non-1) shards do not run it.
