### PR TITLE
feat(mcp): persist /api/mcp/servers writes to a DB store via mcp_runtime_store (#6113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 _8 PRs from 2 contributors since v2026.6.10-beta.17._
 
+### Added
+
+- **mcp/api: `mcp_runtime_store = "db"` persists `/api/mcp/servers` writes to SQLite instead of `config.toml`, so MCP servers can be managed at runtime when the config file is read-only** (#6113) (@houko).
+  #6106 added the DB-backed `mcp_server_configs` store and a boot-time merge, but the API write-path (`POST` / `PUT` / `DELETE /api/mcp/servers`, the taint patch) and the read-path still only saw `config.toml`, so a DB-managed server was invisible to the API and could not be added at all when `config.toml` was a read-only Kubernetes ConfigMap (the #6021 motivation).
+  The new `config.toml: mcp_runtime_store` knob (default `file`, byte-for-byte the prior behaviour) routes writes to the store when set to `db`.
+  The boot overlay and `reload_mcp_servers` now share one `McpConfigStore::merge_over` helper — previously the hot-reload path dropped DB-backed servers the boot merge had applied — and the handlers read the effective (file + DB) set, so DB-backed servers are listed, fetched, updated, and deleted like file-backed ones and take effect without a restart.
+  Tests: `mcp_config_store::tests::merge_over_*` and the `mcp_runtime_store_db_test` API integration suite.
+
 ### Fixed
 
 - **llm-drivers(deepseek): recognise `deepseek-v4-pro` as a thinking-with-tools model so its `reasoning_content` is echoed back** (@DaBlitzStein).

--- a/crates/librefang-api/src/routes/skills/mcp.rs
+++ b/crates/librefang-api/src/routes/skills/mcp.rs
@@ -1,5 +1,103 @@
 use super::*;
 
+/// Snapshot the kernel's *effective* MCP server set (file `[[mcp_servers]]`
+/// merged with the DB-backed `mcp_server_configs` overlay) — the list the
+/// kernel actually runs. Read and existence/duplicate checks MUST use this
+/// rather than `config_ref().mcp_servers` (file-only), otherwise servers
+/// persisted with `mcp_runtime_store = "db"` (#6113) are invisible to the API
+/// and cannot be updated or deleted. Returns an owned `Vec` so the `!Send`
+/// `std::sync::RwLock` guard is never held across an `.await`.
+fn effective_mcp_servers_snapshot(
+    state: &Arc<AppState>,
+) -> Vec<librefang_types::config::McpServerConfigEntry> {
+    state
+        .kernel
+        .effective_mcp_servers_ref()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
+/// Persist an MCP server upsert according to `config.mcp_runtime_store`, then
+/// make it effective without a restart. `File` (default) rewrites
+/// `config.toml` and runs a full config reload — byte-for-byte the pre-#6113
+/// behaviour. `Db` writes the SQLite `mcp_server_configs` table, leaving
+/// `config.toml` untouched (for read-only `config.toml` deployments, the
+/// #6021 motivation), then re-runs the MCP merge so the new row connects
+/// immediately. Returns the reload-status string for the response body, or a
+/// ready-to-return error tuple.
+async fn persist_mcp_upsert(
+    state: &Arc<AppState>,
+    entry: &librefang_types::config::McpServerConfigEntry,
+) -> Result<&'static str, (StatusCode, Json<serde_json::Value>)> {
+    match state.kernel.config_ref().mcp_runtime_store {
+        librefang_types::config::McpRuntimeStore::File => {
+            let config_path = state.kernel.home_dir().join("config.toml");
+            if let Err(e) = upsert_mcp_server_config(&config_path, entry) {
+                return Err(ApiErrorResponse::internal_scrub(e).into_json_tuple());
+            }
+            Ok(reload_via_config(state).await)
+        }
+        librefang_types::config::McpRuntimeStore::Db => {
+            let store =
+                librefang_memory::McpConfigStore::new(state.kernel.memory_substrate().pool());
+            if let Err(e) = store.upsert(entry) {
+                return Err(ApiErrorResponse::internal_scrub(e.to_string()).into_json_tuple());
+            }
+            Ok(reload_via_mcp(state).await)
+        }
+    }
+}
+
+/// Delete counterpart of [`persist_mcp_upsert`] — removes the entry from the
+/// configured store and re-applies the effective set.
+async fn persist_mcp_delete(
+    state: &Arc<AppState>,
+    name: &str,
+) -> Result<&'static str, (StatusCode, Json<serde_json::Value>)> {
+    match state.kernel.config_ref().mcp_runtime_store {
+        librefang_types::config::McpRuntimeStore::File => {
+            let config_path = state.kernel.home_dir().join("config.toml");
+            if let Err(e) = remove_mcp_server_config(&config_path, name) {
+                return Err(ApiErrorResponse::internal_scrub(e).into_json_tuple());
+            }
+            Ok(reload_via_config(state).await)
+        }
+        librefang_types::config::McpRuntimeStore::Db => {
+            let store =
+                librefang_memory::McpConfigStore::new(state.kernel.memory_substrate().pool());
+            if let Err(e) = store.delete(name) {
+                return Err(ApiErrorResponse::internal_scrub(e.to_string()).into_json_tuple());
+            }
+            Ok(reload_via_mcp(state).await)
+        }
+    }
+}
+
+/// Full config reload (`File` store path). Maps the plan to the response's
+/// `reload` status string.
+async fn reload_via_config(state: &Arc<AppState>) -> &'static str {
+    match state.kernel.reload_config().await {
+        Ok(plan) => {
+            if plan.restart_required {
+                "applied_partial"
+            } else {
+                "applied"
+            }
+        }
+        Err(_) => "saved_reload_failed",
+    }
+}
+
+/// MCP-only reload (`Db` store path) — re-runs the file+DB merge and connects
+/// new servers without re-reading `config.toml`.
+async fn reload_via_mcp(state: &Arc<AppState>) -> &'static str {
+    match state.kernel.clone().reload_mcp_servers().await {
+        Ok(_) => "applied",
+        Err(_) => "saved_reload_failed",
+    }
+}
+
 /// GET /api/mcp/taint-rules — List configured `[[taint_rules]]`.
 ///
 /// Issue #3050 follow-up: the dashboard `TaintPolicyEditor` references
@@ -58,11 +156,9 @@ pub async fn list_mcp_servers(State(state): State<Arc<AppState>>) -> impl IntoRe
         .collect();
     drop(auth_states);
 
-    // Get configured servers from config
-    let config_servers: Vec<serde_json::Value> = state
-        .kernel
-        .config_ref()
-        .mcp_servers
+    // Effective set = file `[[mcp_servers]]` + DB overlay (#6113), so
+    // DB-backed servers are listed too.
+    let config_servers: Vec<serde_json::Value> = effective_mcp_servers_snapshot(&state)
         .iter()
         .map(|s| {
             let transport = s.transport.as_ref().map(serialize_mcp_transport);
@@ -156,12 +252,10 @@ pub async fn get_mcp_server(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    // Find the configured entry by name — use config_snapshot() because
-    // the result is held across an .await below.
-    let cfg = state.kernel.config_snapshot();
-    let entry = cfg.mcp_servers.iter().find(|s| s.name == name);
-
-    let entry = match entry {
+    // Find the entry in the effective set (file + DB overlay, #6113). Owned
+    // snapshot so the borrow is safe to hold across the .await below.
+    let servers = effective_mcp_servers_snapshot(&state);
+    let entry = match servers.iter().find(|s| s.name == name) {
         Some(e) => e,
         None => {
             return ApiErrorResponse::not_found(format!("MCP server '{}' not found", name))
@@ -260,10 +354,7 @@ pub async fn add_mcp_server(
         // the vault would already hold credentials for a server the caller never
         // managed to register. Reject first, side-effect second.
         let prospective_name = entry.id.clone();
-        if state
-            .kernel
-            .config_ref()
-            .mcp_servers
+        if effective_mcp_servers_snapshot(&state)
             .iter()
             .any(|s| s.name == prospective_name)
         {
@@ -311,10 +402,7 @@ pub async fn add_mcp_server(
     };
 
     // Check for duplicate name
-    if state
-        .kernel
-        .config_ref()
-        .mcp_servers
+    if effective_mcp_servers_snapshot(&state)
         .iter()
         .any(|s| s.name == name)
     {
@@ -322,22 +410,10 @@ pub async fn add_mcp_server(
             .into_json_tuple();
     }
 
-    // Persist to config.toml
-    let config_path = state.kernel.home_dir().join("config.toml");
-    if let Err(e) = upsert_mcp_server_config(&config_path, &entry) {
-        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
-    }
-
-    // Trigger config reload
-    let reload_status = match state.kernel.reload_config().await {
-        Ok(plan) => {
-            if plan.restart_required {
-                "applied_partial"
-            } else {
-                "applied"
-            }
-        }
-        Err(_) => "saved_reload_failed",
+    // Persist per `mcp_runtime_store` (config.toml or DB) and apply.
+    let reload_status = match persist_mcp_upsert(&state, &entry).await {
+        Ok(status) => status,
+        Err(resp) => return resp,
     };
 
     // Establish connection to the newly added server in the background.
@@ -393,11 +469,8 @@ pub async fn update_mcp_server(
     Json(mut body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
-    // Ensure the entry exists
-    if !state
-        .kernel
-        .config_ref()
-        .mcp_servers
+    // Ensure the entry exists (effective set = file + DB overlay, #6113)
+    if !effective_mcp_servers_snapshot(&state)
         .iter()
         .any(|s| s.name == name)
     {
@@ -428,27 +501,14 @@ pub async fn update_mcp_server(
         }
     };
 
-    // Persist — upsert replaces an existing entry with the same name
-    let config_path = state.kernel.home_dir().join("config.toml");
-    if let Err(e) = upsert_mcp_server_config(&config_path, &entry) {
-        // Scrub the config-write error (audit: rusqlite-errors-leak):
-        // the helper string carries io / TOML-parse detail. Full error
-        // logged; client sees the generic body.
-        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
-    }
     // Drop ErrorTranslator before .await — FluentBundle is !Send and cannot
     // be held across an async suspension point.
     drop(t);
 
-    let reload_status = match state.kernel.reload_config().await {
-        Ok(plan) => {
-            if plan.restart_required {
-                "applied_partial"
-            } else {
-                "applied"
-            }
-        }
-        Err(_) => "saved_reload_failed",
+    // Persist per `mcp_runtime_store` (config.toml or DB) and apply.
+    let reload_status = match persist_mcp_upsert(&state, &entry).await {
+        Ok(status) => status,
+        Err(resp) => return resp,
     };
 
     // Disconnect the old connection so connect_mcp_servers picks up the new config.
@@ -497,12 +557,9 @@ pub async fn patch_mcp_server_taint(
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
 
     // Locate and clone the existing entry so we mutate a fresh copy that's
-    // safe to pass to upsert_mcp_server_config without touching the live
-    // config until persistence succeeds.
-    let mut entry = match state
-        .kernel
-        .config_ref()
-        .mcp_servers
+    // safe to pass to persist_mcp_upsert without touching the live config
+    // until persistence succeeds. Effective set = file + DB overlay (#6113).
+    let mut entry = match effective_mcp_servers_snapshot(&state)
         .iter()
         .find(|s| s.name == name)
         .cloned()
@@ -523,26 +580,14 @@ pub async fn patch_mcp_server_taint(
         entry.taint_policy = Some(policy);
     }
 
-    let config_path = state.kernel.home_dir().join("config.toml");
-    if let Err(e) = upsert_mcp_server_config(&config_path, &entry) {
-        // Scrub the config-write error (audit: rusqlite-errors-leak):
-        // the helper string carries io / TOML-parse detail. Full error
-        // logged; client sees the generic body.
-        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
-    }
     // Drop ErrorTranslator before .await — FluentBundle is !Send and cannot
     // be held across an async suspension point.
     drop(t);
 
-    let reload_status = match state.kernel.reload_config().await {
-        Ok(plan) => {
-            if plan.restart_required {
-                "applied_partial"
-            } else {
-                "applied"
-            }
-        }
-        Err(_) => "saved_reload_failed",
+    // Persist per `mcp_runtime_store` (config.toml or DB) and apply.
+    let reload_status = match persist_mcp_upsert(&state, &entry).await {
+        Ok(status) => status,
+        Err(resp) => return resp,
     };
 
     // Reconnect so the new taint_policy snapshot reaches the live
@@ -590,41 +635,31 @@ pub async fn delete_mcp_server(
     lang: Option<axum::Extension<RequestLanguage>>,
 ) -> impl IntoResponse {
     let t = ErrorTranslator::new(super::resolve_lang(lang.as_ref()));
-    // Ensure the entry exists
-    if !state
-        .kernel
-        .config_ref()
-        .mcp_servers
-        .iter()
-        .any(|s| s.name == name)
-    {
-        return ApiErrorResponse::not_found(
-            t.t_args("api-error-mcp-not-found", &[("name", &name)]),
-        )
-        .into_json_tuple();
-    }
-
-    // Resolve server URL before removing config (needed for vault cleanup)
-    let server_url = state
-        .kernel
-        .config_ref()
-        .mcp_servers
+    // Ensure the entry exists in the effective set (file + DB overlay, #6113),
+    // and resolve its URL before removal (needed for vault cleanup).
+    let server_url = match effective_mcp_servers_snapshot(&state)
         .iter()
         .find(|s| s.name == name)
-        .and_then(|s| match &s.transport {
+    {
+        Some(s) => match &s.transport {
             Some(librefang_types::config::McpTransportEntry::Http { url }) => Some(url.clone()),
             Some(librefang_types::config::McpTransportEntry::Sse { url }) => Some(url.clone()),
             _ => None,
-        });
-
-    let config_path = state.kernel.home_dir().join("config.toml");
-    if let Err(e) = remove_mcp_server_config(&config_path, &name) {
-        // Scrub the config-write error (audit: rusqlite-errors-leak):
-        // the helper string carries io / TOML-parse detail. Full error
-        // logged; client sees the generic body.
-        return ApiErrorResponse::internal_scrub(e).into_json_tuple();
-    }
+        },
+        None => {
+            return ApiErrorResponse::not_found(
+                t.t_args("api-error-mcp-not-found", &[("name", &name)]),
+            )
+            .into_json_tuple();
+        }
+    };
     drop(t);
+
+    // Persist the removal per `mcp_runtime_store` (config.toml or DB) and apply.
+    let reload_status = match persist_mcp_delete(&state, &name).await {
+        Ok(status) => status,
+        Err(resp) => return resp,
+    };
 
     // Clean up OAuth vault tokens, auth state, and live connections.
     //
@@ -671,17 +706,6 @@ pub async fn delete_mcp_server(
         .lock()
         .await
         .retain(|c| c.name() != name);
-
-    let reload_status = match state.kernel.reload_config().await {
-        Ok(plan) => {
-            if plan.restart_required {
-                "applied_partial"
-            } else {
-                "applied"
-            }
-        }
-        Err(_) => "saved_reload_failed",
-    };
 
     state.kernel.audit().record(
         "system",
@@ -773,10 +797,7 @@ pub async fn reconnect_mcp_server_handler(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    let configured = state
-        .kernel
-        .config_ref()
-        .mcp_servers
+    let configured = effective_mcp_servers_snapshot(&state)
         .iter()
         .any(|s| s.name == name);
     if !configured {

--- a/crates/librefang-api/tests/config_schema_overlay.rs
+++ b/crates/librefang-api/tests/config_schema_overlay.rs
@@ -200,6 +200,7 @@ fn every_kernel_config_struct_field_is_exposed_via_overlay() {
     const EXCLUDED: &[&str] = &[
         // Dedicated pages render these directly.
         "mcp_servers",          // /mcp-servers
+        "mcp_runtime_store",    // /mcp-servers (MCP write-target selector, #6113)
         "users",                // /users
         "bindings",             // /agents
         "provider_api_keys",    // /providers (sensitive too)

--- a/crates/librefang-api/tests/mcp_runtime_store_db_test.rs
+++ b/crates/librefang-api/tests/mcp_runtime_store_db_test.rs
@@ -1,0 +1,147 @@
+//! #6113 — `mcp_runtime_store = "db"` routes `POST/DELETE /api/mcp/servers`
+//! writes to the SQLite `mcp_server_configs` table instead of `config.toml`,
+//! and the read path lists DB-backed servers via the effective set (file
+//! `[[mcp_servers]]` merged with the DB overlay).
+//!
+//! This is what lets MCP servers be managed at runtime when `config.toml` is
+//! read-only — the Kubernetes ConfigMap motivation behind #6021. The default
+//! (`file`) behaviour is covered by the existing config.toml-backed paths and
+//! is intentionally not exercised here.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use librefang_api::routes::{self, AppState};
+use librefang_testing::{MockKernelBuilder, TestAppState};
+use librefang_types::config::McpRuntimeStore;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+struct Harness {
+    app: axum::Router,
+    state: Arc<AppState>,
+    _test: TestAppState,
+}
+
+/// Boot a real kernel with `mcp_runtime_store = Db` and mount the skills
+/// router (which owns `/mcp/servers`).
+fn boot_db_mode() -> Harness {
+    let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(|cfg| {
+        cfg.mcp_runtime_store = McpRuntimeStore::Db;
+    }));
+    let state = test.state.clone();
+    let app = routes::skills::router().with_state(state.clone());
+    Harness {
+        app,
+        state,
+        _test: test,
+    }
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .expect("read body");
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::json!(null))
+}
+
+fn add_server_request(name: &str) -> Request<Body> {
+    // `false` is a stdio command that exits immediately; the connect attempt
+    // fails fast and gracefully, but the entry is still persisted and added to
+    // the effective set (which `reload_mcp_servers` updates before connecting).
+    let body = serde_json::json!({
+        "name": name,
+        "transport": { "type": "stdio", "command": "false", "args": [] },
+    });
+    Request::builder()
+        .method(Method::POST)
+        .uri("/mcp/servers")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn db_mode_post_persists_to_store_not_config_toml_and_lists_via_effective_set() {
+    let h = boot_db_mode();
+    let home = h.state.kernel.home_dir().to_path_buf();
+
+    let resp = h
+        .app
+        .clone()
+        .oneshot(add_server_request("db-srv"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "add should succeed in db mode"
+    );
+
+    // The SQLite store holds the row.
+    let store = librefang_memory::McpConfigStore::new(h.state.kernel.memory_substrate().pool());
+    assert!(
+        store.get("db-srv").unwrap().is_some(),
+        "entry must be persisted to the mcp_server_configs table"
+    );
+
+    // config.toml was NOT written with the server (the whole point of db mode).
+    let cfg_toml = home.join("config.toml");
+    if cfg_toml.exists() {
+        let txt = std::fs::read_to_string(&cfg_toml).unwrap();
+        assert!(
+            !txt.contains("db-srv"),
+            "db mode must not write the server to config.toml, got:\n{txt}"
+        );
+    }
+
+    // GET lists it via the effective set (file + DB overlay).
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/mcp/servers")
+        .body(Body::empty())
+        .unwrap();
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let listed = json
+        .get("configured")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .any(|s| s.get("name").and_then(|n| n.as_str()) == Some("db-srv"))
+        })
+        .unwrap_or(false);
+    assert!(
+        listed,
+        "a DB-backed server must be visible in the listing, got:\n{json}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn db_mode_delete_removes_from_store() {
+    let h = boot_db_mode();
+
+    let resp = h
+        .app
+        .clone()
+        .oneshot(add_server_request("doomed"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let store = librefang_memory::McpConfigStore::new(h.state.kernel.memory_substrate().pool());
+    assert!(store.get("doomed").unwrap().is_some());
+
+    let req = Request::builder()
+        .method(Method::DELETE)
+        .uri("/mcp/servers/doomed")
+        .body(Body::empty())
+        .unwrap();
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "delete should succeed");
+
+    assert!(
+        store.get("doomed").unwrap().is_none(),
+        "delete must remove the row from the DB store"
+    );
+}

--- a/crates/librefang-kernel/src/config_reload.rs
+++ b/crates/librefang-kernel/src/config_reload.rs
@@ -426,6 +426,16 @@ pub fn build_reload_plan_with_caps(
         plan.hot_actions.push(HotAction::ReloadMcpServers);
     }
 
+    // `mcp_runtime_store` only selects where the next `/api/mcp/servers` write
+    // lands; it is read live from `config_ref()` by the handler, so a change
+    // needs no reload action — noop (#6113).
+    if old.mcp_runtime_store != new.mcp_runtime_store {
+        plan.noop_changes.push(format!(
+            "mcp_runtime_store: {:?} -> {:?} (effective on next /api/mcp/servers write)",
+            old.mcp_runtime_store, new.mcp_runtime_store
+        ));
+    }
+
     // Top-level [[taint_rules]] registry — hot-reloadable via the shared
     // `taint_rules_swap`. Tracked separately from `mcp_servers` because
     // operators commonly tune rule sets without touching MCP server config.
@@ -922,6 +932,7 @@ pub fn classified_reload_fields() -> std::collections::BTreeSet<&'static str> {
         "webhook_triggers",
         "extensions",
         "mcp_servers",
+        "mcp_runtime_store",
         "taint_rules",
         "a2a",
         "fallback_providers",

--- a/crates/librefang-kernel/src/kernel/boot.rs
+++ b/crates/librefang-kernel/src/kernel/boot.rs
@@ -963,35 +963,25 @@ impl LibreFangKernel {
             config
         };
         // DB rows override file entries by name; empty table is a no-op (supports K8s read-only ConfigMaps, #6021).
-        let mut all_mcp_servers = config.mcp_servers.clone();
-        {
+        // Shared `merge_over` keeps this overlay byte-identical to the hot-reload path (#6113).
+        let all_mcp_servers = {
             let mcp_config_store = librefang_memory::McpConfigStore::new(memory.pool());
-            match mcp_config_store.load_all() {
-                Ok(db_servers) if !db_servers.is_empty() => {
-                    let mut overridden = 0usize;
-                    let mut added = 0usize;
-                    for db_srv in db_servers {
-                        if let Some(slot) =
-                            all_mcp_servers.iter_mut().find(|s| s.name == db_srv.name)
-                        {
-                            *slot = db_srv;
-                            overridden += 1;
-                        } else {
-                            all_mcp_servers.push(db_srv);
-                            added += 1;
-                        }
+            match mcp_config_store.merge_over(config.mcp_servers.clone()) {
+                Ok((merged, added, overridden)) => {
+                    if added > 0 || overridden > 0 {
+                        info!(
+                            "MCP config (DB): {added} added, {overridden} overridden from \
+                             mcp_server_configs"
+                        );
                     }
-                    info!(
-                        "MCP config (DB): {added} added, {overridden} overridden from \
-                         mcp_server_configs"
-                    );
+                    merged
                 }
-                Ok(_) => {}
                 Err(e) => {
                     warn!("Failed to load DB-backed MCP server configs: {e}");
+                    config.mcp_servers.clone()
                 }
             }
-        }
+        };
 
         // Initialize MCP health monitor.
         // [health_check] section overrides [extensions] when explicitly set (non-default).

--- a/crates/librefang-kernel/src/kernel/mcp_setup.rs
+++ b/crates/librefang-kernel/src/kernel/mcp_setup.rs
@@ -330,8 +330,23 @@ impl LibreFangKernel {
         //    after `registry_sync`). Atomic swap — readers never blocked.
         let catalog_count = self.mcp_catalog_reload(&cfg.home_dir);
 
-        // 2. Effective server list == config.mcp_servers (no merge needed).
-        let new_configs = cfg.mcp_servers.clone();
+        // 2. Effective server list = config.mcp_servers merged with the
+        //    DB-backed `mcp_server_configs` table (DB wins by name), mirroring
+        //    the boot-time overlay via the shared `merge_over` helper. Without
+        //    this, a runtime DB write (`mcp_runtime_store = "db"`, #6113) would
+        //    only take effect after a restart, and a hot-reload would drop the
+        //    DB-backed servers the boot merge had applied. Empty table = the
+        //    file-only list, unchanged.
+        let new_configs = {
+            let store = librefang_memory::McpConfigStore::new(self.memory.substrate.pool());
+            match store.merge_over(cfg.mcp_servers.clone()) {
+                Ok((merged, _added, _overridden)) => merged,
+                Err(e) => {
+                    warn!("reload_mcp_servers: failed to merge DB-backed MCP configs: {e}");
+                    cfg.mcp_servers.clone()
+                }
+            }
+        };
 
         // 3. Find servers that aren't already connected
         let already_connected: Vec<String> = self

--- a/crates/librefang-memory/src/mcp_config_store.rs
+++ b/crates/librefang-memory/src/mcp_config_store.rs
@@ -92,6 +92,30 @@ impl McpConfigStore {
         Ok(result)
     }
 
+    /// Merge the DB-backed entries over a file-backed `base` list by `name`:
+    /// a DB row with the same name replaces the file entry, a DB-only name is
+    /// appended, and an empty table is a no-op. Returns `(merged, added,
+    /// overridden)`. This is the single source of the DB-wins merge shared by
+    /// the boot-time overlay and the hot-reload path, so both agree on the
+    /// effective MCP server set (#6113).
+    pub fn merge_over(
+        &self,
+        mut base: Vec<McpServerConfigEntry>,
+    ) -> LibreFangResult<(Vec<McpServerConfigEntry>, usize, usize)> {
+        let mut added = 0usize;
+        let mut overridden = 0usize;
+        for db_srv in self.load_all()? {
+            if let Some(slot) = base.iter_mut().find(|s| s.name == db_srv.name) {
+                *slot = db_srv;
+                overridden += 1;
+            } else {
+                base.push(db_srv);
+                added += 1;
+            }
+        }
+        Ok((base, added, overridden))
+    }
+
     /// Delete an MCP server config by name. Returns true if a row was deleted.
     pub fn delete(&self, name: &str) -> LibreFangResult<bool> {
         let c = self.pool.get().map_err(LibreFangError::memory)?;
@@ -217,5 +241,46 @@ mod tests {
         let store = in_memory_store();
         assert_eq!(store.count().unwrap(), 0);
         assert!(store.load_all().unwrap().is_empty());
+    }
+
+    #[test]
+    fn merge_over_empty_table_is_a_noop() {
+        // The boot/hot-reload merge must leave a file-only list untouched when
+        // the DB is empty (the K8s read-only-ConfigMap baseline, #6021/#6113).
+        let store = in_memory_store();
+        let base = vec![sample_entry("file-a", "a"), sample_entry("file-b", "b")];
+        let (merged, added, overridden) = store.merge_over(base.clone()).unwrap();
+        assert_eq!(added, 0);
+        assert_eq!(overridden, 0);
+        let names: Vec<String> = merged.into_iter().map(|e| e.name).collect();
+        assert_eq!(names, vec!["file-a", "file-b"]);
+    }
+
+    #[test]
+    fn merge_over_db_overrides_by_name_and_appends_new() {
+        // DB row with a matching name replaces the file entry in place; a
+        // DB-only name is appended. This is the single merge shared by the
+        // boot overlay and `reload_mcp_servers` (#6113).
+        let store = in_memory_store();
+        store.upsert(&sample_entry("shared", "db-version")).unwrap();
+        store.upsert(&sample_entry("db-only", "db")).unwrap();
+
+        let base = vec![
+            sample_entry("shared", "file-version"),
+            sample_entry("file-only", "f"),
+        ];
+        let (merged, added, overridden) = store.merge_over(base).unwrap();
+
+        assert_eq!(added, 1, "db-only is appended");
+        assert_eq!(overridden, 1, "shared is replaced by the DB row");
+        // file-only stays; shared now carries the DB transport command.
+        let shared = merged.iter().find(|e| e.name == "shared").unwrap();
+        match &shared.transport {
+            Some(McpTransportEntry::Stdio { command, .. }) => assert_eq!(command, "db-version"),
+            other => panic!("unexpected transport: {other:?}"),
+        }
+        assert!(merged.iter().any(|e| e.name == "file-only"));
+        assert!(merged.iter().any(|e| e.name == "db-only"));
+        assert_eq!(merged.len(), 3);
     }
 }

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -3018,6 +3018,21 @@ impl Default for TriggersConfig {
     }
 }
 
+/// Selects where runtime `/api/mcp/servers` writes are persisted.
+/// See [`KernelConfig::mcp_runtime_store`].
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum McpRuntimeStore {
+    /// Persist writes to `config.toml` (pre-#6113 behaviour). Default.
+    #[default]
+    File,
+    /// Persist writes to the SQLite `mcp_server_configs` table, leaving
+    /// `config.toml` untouched — for read-only `config.toml` deployments.
+    Db,
+}
+
 /// Top-level kernel configuration.
 #[derive(Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
@@ -3235,6 +3250,16 @@ pub struct KernelConfig {
     /// MCP server configurations for external tool integration.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mcp_servers: Vec<McpServerConfigEntry>,
+    /// Where the `POST/PUT/DELETE /api/mcp/servers` handlers persist a
+    /// runtime change. `file` (the default) rewrites `config.toml`, preserving
+    /// the pre-#6113 behaviour. `db` writes the SQLite `mcp_server_configs`
+    /// table instead and leaves `config.toml` untouched, so MCP servers can be
+    /// managed at runtime when `config.toml` is read-only (e.g. a Kubernetes
+    /// ConfigMap — the #6021 motivation). The boot merge already lets DB rows
+    /// override the file-backed list by name; this knob only selects the write
+    /// target. Changing it takes effect on the next write — no restart needed.
+    #[serde(default)]
+    pub mcp_runtime_store: McpRuntimeStore,
     /// Reusable named taint rule sets referenced by
     /// [`McpTaintToolPolicy::rule_sets`]. Each entry defines a group of
     /// taint rules with a severity action (block / warn / log) that the
@@ -6147,6 +6172,7 @@ impl Default for KernelConfig {
             users: Vec::new(),
             channel_role_mapping: ChannelRoleMapping::default(),
             mcp_servers: Vec::new(),
+            mcp_runtime_store: McpRuntimeStore::default(),
             taint_rules: Vec::new(),
             a2a: None,
             usage_footer: UsageFooterMode::default(),

--- a/docs/operations/config-reload.md
+++ b/docs/operations/config-reload.md
@@ -175,6 +175,7 @@ classified differently — the row note spells out which is which.
 |---|---|---|
 | `extensions` | H | Extensions & integrations config — reloads extensions. |
 | `mcp_servers` | H | MCP server list — reconnects MCP clients. |
+| `mcp_runtime_store` | N | Selects where `/api/mcp/servers` writes land (`file` → config.toml, `db` → SQLite `mcp_server_configs`). Read live by the handler; effective on the next write. |
 | `taint_rules` | H | Named taint rule sets pushed into the shared swap (see field note: already-connected servers pick them up on next scan, not via reconnect). |
 | `a2a` | H | Agent-to-Agent protocol config. |
 | `skills` | H | Skills config (bundled + user-installed) — reloads registry. |


### PR DESCRIPTION
## Summary

Closes #6113 (follow-up to #6021 / #6106).

#6106 landed the SQLite `mcp_server_configs` store and a boot-time merge (DB rows override file `[[mcp_servers]]` by name), but stopped there: the API write-path (`POST` / `PUT` / `DELETE /api/mcp/servers` and the taint patch) and the read-path still only saw `config.toml`. Two consequences:

- A DB-managed MCP server was **invisible to the API** — `GET /api/mcp/servers` and `GET /api/mcp/servers/{name}` read `config_ref().mcp_servers` (file-only), not the effective set the kernel actually runs.
- In the motivating Kubernetes case (#6021) where `config.toml` is a read-only ConfigMap, **every write failed**: the handlers `upsert_mcp_server_config(config.toml, …)` onto a read-only file.

This PR wires the store to the API behind an opt-in knob, and fixes the latent invisibility.

## Change

- **New config knob** `mcp_runtime_store` (`librefang-types`): `file` (default, byte-for-byte the prior behaviour) or `db`. When `db`, `add` / `update` / `delete` / taint-patch persist to `McpConfigStore` and leave `config.toml` untouched. Classified `N` (read-live) in `build_reload_plan` + `docs/operations/config-reload.md`.
- **Shared merge** `McpConfigStore::merge_over` (`librefang-memory`): the DB-wins overlay is now one helper used by both the boot merge (`boot.rs`) and `reload_mcp_servers` (`mcp_setup.rs`). Previously the hot-reload path rebuilt the effective set from `config.mcp_servers` only, silently **dropping the DB-backed servers the boot merge had applied** — fixed here so a runtime `db` write (and hot-reload generally) stays consistent with boot.
- **Reads use the effective set**: `list` / `get` / existence / duplicate checks in `routes/skills/mcp.rs` now read `effective_mcp_servers_ref()` (file + DB) instead of `config_ref().mcp_servers`, so DB-backed servers are listed, fetched, updated, and deleted like file-backed ones. In `file` mode with no DB rows this is identical to before.
- The `db` write-path re-runs `reload_mcp_servers` (not a config.toml diff), so a new/removed server takes effect without a restart.

## Scope

Single coherent unit: the store↔API wiring for #6113. CLI rewiring and a `config.toml` → DB import helper remain the other follow-ups noted on #6113.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-types -p librefang-memory -p librefang-kernel -p librefang-api --all-targets -- -D warnings` — 0 warnings.
- `cargo test -p librefang-memory mcp_config_store` — 8 passed (incl. new `merge_over_empty_table_is_a_noop`, `merge_over_db_overrides_by_name_and_appends_new`).
- `cargo test -p librefang-kernel --lib doc_reload_table_matches_classified_reload_fields every_config_field_is_reload_classified` — 2 passed (new field classified + documented).
- `cargo test -p librefang-api --test mcp_runtime_store_db_test` — 2 passed: `db` POST persists to the store, not `config.toml`, and lists via the effective set; `db` DELETE removes the row.
- `cargo test -p librefang-api --test dead_route_audit_test --test openapi_path_coverage_test` — pass (route shape unchanged).
