### PR TITLE
fix(security/channels): enforce cross-chat dispatch guard through the /mcp bridge (#6117)

### DIFF
--- a/crates/librefang-api/src/routes/network.rs
+++ b/crates/librefang-api/src/routes/network.rs
@@ -1419,6 +1419,22 @@ pub async fn mcp_http(
         .and_then(|s| s.parse::<librefang_types::agent::AgentId>().ok())
         .and_then(|id| state.kernel.agent_registry().get(id));
 
+    // #6117: inbound peer scope of the turn that spawned the subprocess driver,
+    // forwarded by `claude-code`'s `write_mcp_config` on the bridge connection.
+    // Rehydrated into `ToolExecContext` below so `channel_send` rejects a
+    // cross-chat recipient mismatch on the same channel. External MCP clients
+    // that omit these headers run unguarded (the guard no-ops on `None`).
+    let header_str = |name: &str| -> Option<String> {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string)
+            .filter(|s| !s.is_empty())
+    };
+    let current_peer_jid = header_str("x-librefang-current-peer-jid");
+    let current_channel = header_str("x-librefang-current-channel");
+    let current_chat_id = header_str("x-librefang-current-chat-id");
+
     // Check if this is a tools/call that needs real execution
     let method = request["method"].as_str().unwrap_or("");
     if method == "tools/call" {
@@ -1517,9 +1533,9 @@ pub async fn mcp_http(
             docker_opt,
             Some(state.kernel.processes()),
             None, // process_registry (network bridge doesn't run agent tools)
-            None, // sender_id (MCP HTTP has no sender context)
-            None, // channel
-            None, // chat_id (MCP HTTP has no conversation context either)
+            current_peer_jid.as_deref(), // sender_id (X-LibreFang-Current-Peer-Jid, #6117)
+            current_channel.as_deref(), // channel (X-LibreFang-Current-Channel, #6117)
+            current_chat_id.as_deref(), // chat_id (X-LibreFang-Current-Chat-Id, #6117)
             None, // checkpoint_manager (network bridge doesn't run agent tools)
             None, // interrupt (MCP HTTP calls have no session-scoped cancellation)
             None, // session_id (MCP HTTP is not tied to a live session)

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2668,11 +2668,8 @@ async fn test_mcp_http_rehydrates_caller_context_from_agent_header() {
     );
 }
 
-/// #6117: a `channel_send` call routed through the `/mcp` bridge must honour
-/// the cross-chat guard using the peer scope forwarded on the bridge headers
-/// (`X-LibreFang-Current-Peer-Jid` / `-Channel` / `-Chat-Id`). Before the fix
-/// `mcp_http` hardcoded sender_id/channel/chat_id to `None`, so the guard had
-/// no peer to validate against and a mis-targeted recipient leaked.
+/// #6117: a `channel_send` call routed through the `/mcp` bridge must honour the cross-chat guard using the peer scope forwarded on the bridge headers (`X-LibreFang-Current-Peer-Jid` / `-Channel` / `-Chat-Id`).
+/// Before the fix `mcp_http` hardcoded sender_id/channel/chat_id to `None`, so the guard had no peer to validate against and a mis-targeted recipient leaked.
 const MCP_CHANNEL_MANIFEST: &str = r#"
 name = "mcp-channel-agent"
 version = "0.1.0"

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -2668,6 +2668,101 @@ async fn test_mcp_http_rehydrates_caller_context_from_agent_header() {
     );
 }
 
+/// #6117: a `channel_send` call routed through the `/mcp` bridge must honour
+/// the cross-chat guard using the peer scope forwarded on the bridge headers
+/// (`X-LibreFang-Current-Peer-Jid` / `-Channel` / `-Chat-Id`). Before the fix
+/// `mcp_http` hardcoded sender_id/channel/chat_id to `None`, so the guard had
+/// no peer to validate against and a mis-targeted recipient leaked.
+const MCP_CHANNEL_MANIFEST: &str = r#"
+name = "mcp-channel-agent"
+version = "0.1.0"
+description = "Integration test agent for /mcp channel_send guard"
+author = "test"
+module = "builtin:chat"
+
+[model]
+provider = "ollama"
+model = "test-model"
+system_prompt = "You are a test agent."
+
+[capabilities]
+tools = ["channel_send"]
+"#;
+
+async fn call_mcp_channel_send(
+    server: &TestServer,
+    agent_id: &str,
+    recipient: &str,
+    peer_headers: Option<(&str, &str)>,
+) -> serde_json::Value {
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(format!("{}/mcp", server.base_url))
+        .header("X-LibreFang-Agent-Id", agent_id)
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "channel_send",
+                "arguments": {"channel": "whatsapp", "recipient": recipient, "message": "hi"},
+            },
+        }));
+    if let Some((peer, channel)) = peer_headers {
+        req = req
+            .header("X-LibreFang-Current-Peer-Jid", peer)
+            .header("X-LibreFang-Current-Channel", channel);
+    }
+    let resp = req.send().await.expect("mcp request send");
+    assert_eq!(resp.status(), 200);
+    resp.json().await.expect("mcp body parse")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mcp_http_channel_send_cross_chat_guard_uses_peer_headers() {
+    let server = start_test_server().await;
+    let client = reqwest::Client::new();
+    let spawn = client
+        .post(format!("{}/api/agents", server.base_url))
+        .json(&serde_json::json!({"manifest_toml": MCP_CHANNEL_MANIFEST}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(spawn.status(), 201);
+    let agent_id = spawn.json::<serde_json::Value>().await.unwrap()["agent_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Inbound turn from `owner-jid` on `whatsapp`; the model targets a stranger
+    // on the SAME channel → the guard must reject it before any send.
+    let body = call_mcp_channel_send(
+        &server,
+        &agent_id,
+        "stranger-jid",
+        Some(("owner-jid", "whatsapp")),
+    )
+    .await;
+    let content = body["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        body["result"]["isError"].as_bool().unwrap_or(false),
+        "cross-chat send must be an error: {content}"
+    );
+    assert!(
+        content.contains("Cross-chat dispatch is forbidden"),
+        "expected the cross-chat guard message, got: {content}"
+    );
+
+    // Same mis-targeted send WITHOUT peer headers (e.g. an external MCP client):
+    // the guard no-ops, so the failure — if any — must NOT be the guard's.
+    let body = call_mcp_channel_send(&server, &agent_id, "stranger-jid", None).await;
+    let content = body["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        !content.contains("Cross-chat dispatch is forbidden"),
+        "without peer headers the guard must not fire: {content}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_mcp_http_invalid_agent_header_falls_back_to_unauthenticated() {
     // An unparseable or unknown agent ID must degrade gracefully to

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -826,6 +826,8 @@ impl LibreFangKernel {
                 session_id: None,
                 step_id: None,
                 reasoning_echo_policy: echo_policy,
+
+                ..Default::default()
             };
             let (complexity, routed_model) = router.select_model(&probe);
             // Check if the routed model's provider has a valid API key.

--- a/crates/librefang-kernel/src/kernel/assistant_routing.rs
+++ b/crates/librefang-kernel/src/kernel/assistant_routing.rs
@@ -108,6 +108,8 @@ impl LibreFangKernel {
             // for the empty-string id and the driver's fallback handles
             // the actual model the driver substitutes.
             reasoning_echo_policy: self.lookup_reasoning_echo_policy(""),
+
+            ..Default::default()
         };
 
         let result = match tokio::time::timeout(

--- a/crates/librefang-kernel/src/kernel/session_ops.rs
+++ b/crates/librefang-kernel/src/kernel/session_ops.rs
@@ -1232,6 +1232,7 @@ async fn build_session_summary(
         session_id: Some(session_id.0.to_string()),
         step_id: None,
         reasoning_echo_policy: echo_policy,
+        ..Default::default()
     };
 
     invoke_summary_driver(
@@ -1696,6 +1697,8 @@ mod session_summary_tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: Default::default(),
+
+            ..Default::default()
         }
     }
 

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -792,6 +792,8 @@ impl LibreFangKernel {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: echo_policy,
+
+            ..Default::default()
         };
 
         let start = std::time::Instant::now();

--- a/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
+++ b/crates/librefang-kernel/src/kernel/triggers_and_workflow.rs
@@ -99,6 +99,7 @@ impl LibreFangKernel {
                 session_id: Some(session_id.0.to_string()),
                 step_id: None,
                 reasoning_echo_policy: echo_policy,
+                ..Default::default()
             };
 
             let resp = match tokio::time::timeout(
@@ -185,6 +186,8 @@ impl LibreFangKernel {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: echo_policy,
+
+            ..Default::default()
         };
 
         let result = match tokio::time::timeout(

--- a/crates/librefang-kernel/src/skill_workshop/llm_review.rs
+++ b/crates/librefang-kernel/src/skill_workshop/llm_review.rs
@@ -139,6 +139,8 @@ pub async fn review_candidate(
         session_id: attribution.session_id.map(str::to_string),
         step_id: attribution.candidate_id.map(str::to_string),
         reasoning_echo_policy,
+
+        ..Default::default()
     };
 
     let response = match driver.complete(request).await {

--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -362,6 +362,38 @@ pub struct CompletionRequest {
     /// wire as `x-librefang-step-id`. `None` for callers that don't
     /// distinguish between steps.
     pub step_id: Option<String>,
+    /// Inbound peer identity for the turn that triggered this LLM call.
+    ///
+    /// Identifies the user / contact whose message the agent is currently
+    /// responding to (a WhatsApp / Telegram JID, an email address, …). Drivers
+    /// that spawn a subprocess and re-expose LibreFang's tool surface through
+    /// an MCP bridge (notably `claude-code`) forward it as
+    /// `x-librefang-current-peer-jid` so the bridge endpoint can rehydrate
+    /// `ToolExecContext::sender_id` — which `channel_send` uses (as the DM
+    /// fallback) to reject cross-chat recipient mismatches on the same channel
+    /// (#6117). `None` for out-of-band callers (cron, automation triggers,
+    /// compaction, routing probes) with no inbound peer scope.
+    pub sender_user_id: Option<String>,
+    /// Inbound channel for the turn that triggered this LLM call.
+    ///
+    /// Paired with [`Self::sender_user_id`]: the channel name (`"whatsapp"`,
+    /// `"telegram"`, `"email"`, …) the peer reached the agent through.
+    /// Forwarded by subprocess drivers as `x-librefang-current-channel` so the
+    /// `channel_send` guard scopes the cross-chat check to the **same**
+    /// channel — a different-channel dispatch stays allowed; only intra-channel
+    /// re-targeting is the cross-chat-leak pattern. `None` out-of-band.
+    pub sender_channel: Option<String>,
+    /// Platform conversation id (Telegram chat_id, WhatsApp group jid, …) the
+    /// inbound turn arrived on.
+    ///
+    /// Distinct from [`Self::sender_user_id`] for **group chats** — there the
+    /// chat id is the conversation while `sender_user_id` is the individual
+    /// speaker; they coincide in DMs. Forwarded as `x-librefang-current-chat-id`
+    /// so the bridge can rehydrate `ToolExecContext::chat_id`; the cross-chat
+    /// guard compares the outbound `recipient` against this value (with
+    /// `sender_user_id` as DM fallback) so legitimate group replies pass.
+    /// `None` out-of-band.
+    pub sender_chat_id: Option<String>,
     /// How the OpenAI-compat driver should handle `reasoning_content` on
     /// historical assistant turns for this request's model.
     ///
@@ -1016,6 +1048,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let response = driver.stream(request, tx).await.unwrap();
@@ -1083,6 +1117,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let err = driver.stream(request, tx).await.unwrap_err();
         assert!(

--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -364,34 +364,20 @@ pub struct CompletionRequest {
     pub step_id: Option<String>,
     /// Inbound peer identity for the turn that triggered this LLM call.
     ///
-    /// Identifies the user / contact whose message the agent is currently
-    /// responding to (a WhatsApp / Telegram JID, an email address, …). Drivers
-    /// that spawn a subprocess and re-expose LibreFang's tool surface through
-    /// an MCP bridge (notably `claude-code`) forward it as
-    /// `x-librefang-current-peer-jid` so the bridge endpoint can rehydrate
-    /// `ToolExecContext::sender_id` — which `channel_send` uses (as the DM
-    /// fallback) to reject cross-chat recipient mismatches on the same channel
-    /// (#6117). `None` for out-of-band callers (cron, automation triggers,
-    /// compaction, routing probes) with no inbound peer scope.
+    /// Identifies the user / contact whose message the agent is currently responding to (a WhatsApp / Telegram JID, an email address, …).
+    /// Drivers that spawn a subprocess and re-expose LibreFang's tool surface through an MCP bridge (notably `claude-code`) forward it as `x-librefang-current-peer-jid` so the bridge endpoint can rehydrate `ToolExecContext::sender_id` — which `channel_send` uses (as the DM fallback) to reject cross-chat recipient mismatches on the same channel (#6117).
+    /// `None` for out-of-band callers (cron, automation triggers, compaction, routing probes) with no inbound peer scope.
     pub sender_user_id: Option<String>,
     /// Inbound channel for the turn that triggered this LLM call.
     ///
-    /// Paired with [`Self::sender_user_id`]: the channel name (`"whatsapp"`,
-    /// `"telegram"`, `"email"`, …) the peer reached the agent through.
-    /// Forwarded by subprocess drivers as `x-librefang-current-channel` so the
-    /// `channel_send` guard scopes the cross-chat check to the **same**
-    /// channel — a different-channel dispatch stays allowed; only intra-channel
-    /// re-targeting is the cross-chat-leak pattern. `None` out-of-band.
+    /// Paired with [`Self::sender_user_id`]: the channel name (`"whatsapp"`, `"telegram"`, `"email"`, …) the peer reached the agent through.
+    /// Forwarded by subprocess drivers as `x-librefang-current-channel` so the `channel_send` guard scopes the cross-chat check to the **same** channel — a different-channel dispatch stays allowed; only intra-channel re-targeting is the cross-chat-leak pattern.
+    /// `None` out-of-band.
     pub sender_channel: Option<String>,
-    /// Platform conversation id (Telegram chat_id, WhatsApp group jid, …) the
-    /// inbound turn arrived on.
+    /// Platform conversation id (Telegram chat_id, WhatsApp group jid, …) the inbound turn arrived on.
     ///
-    /// Distinct from [`Self::sender_user_id`] for **group chats** — there the
-    /// chat id is the conversation while `sender_user_id` is the individual
-    /// speaker; they coincide in DMs. Forwarded as `x-librefang-current-chat-id`
-    /// so the bridge can rehydrate `ToolExecContext::chat_id`; the cross-chat
-    /// guard compares the outbound `recipient` against this value (with
-    /// `sender_user_id` as DM fallback) so legitimate group replies pass.
+    /// Distinct from [`Self::sender_user_id`] for **group chats** — there the chat id is the conversation while `sender_user_id` is the individual speaker; they coincide in DMs.
+    /// Forwarded as `x-librefang-current-chat-id` so the bridge can rehydrate `ToolExecContext::chat_id`; the cross-chat guard compares the outbound `recipient` against this value (with `sender_user_id` as DM fallback) so legitimate group replies pass.
     /// `None` out-of-band.
     pub sender_chat_id: Option<String>,
     /// How the OpenAI-compat driver should handle `reasoning_content` on

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -1700,6 +1700,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_request = build_anthropic_request(&request);
         assert_eq!(api_request.tools.len(), 2);
@@ -1742,6 +1744,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_request = build_anthropic_request(&request);
         assert!(api_request.tools[0].cache_control.is_none());
@@ -1792,6 +1796,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_request = build_anthropic_request(&request);
         // Trailing 3 must carry the marker.
@@ -1846,6 +1852,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_request = build_anthropic_request(&request);
         // Last 2 messages carry the marker.
@@ -1897,6 +1905,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_request = build_anthropic_request(&request);
         let last = api_request.messages.last().expect("has last message");
@@ -1937,6 +1947,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_request = build_anthropic_request(&request);
         let system = api_request.system.expect("system field set");
@@ -1981,6 +1993,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         // HTTP-layer header gate.
         assert!(request_uses_1h_cache(&request));
@@ -2027,6 +2041,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         assert!(!request_uses_1h_cache(&request));
         let api_request = build_anthropic_request(&request);
@@ -2063,6 +2079,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_request = build_anthropic_request(&request);
         let last = api_request.messages.last().expect("has last message");
@@ -2184,6 +2202,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_request = build_anthropic_request(&request);
         let mut total = 0usize;
@@ -2278,6 +2298,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_request = build_anthropic_request(&request);
         assert!(api_request.tools.is_empty());
@@ -2317,6 +2339,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         }
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -1300,6 +1300,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         assert_eq!(api_req.model, "gpt-4o");
@@ -1342,6 +1344,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         assert_eq!(api_req.instructions.as_deref(), Some("System prompt."));
@@ -1375,6 +1379,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         let instructions = api_req.instructions.expect("instructions");
@@ -1417,6 +1423,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let api_req = ChatGptDriver::build_responses_request(&req);
         let instructions = api_req.instructions.expect("instructions");

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -335,6 +335,14 @@ impl ClaudeCodeDriver {
     fn write_mcp_config(
         bridge: &McpBridgeConfig,
         agent_id: Option<&str>,
+        // #6117: inbound peer scope of the current turn. Forwarded on the
+        // bridge connection so `/mcp` can rehydrate `ToolExecContext`'s
+        // sender_id / channel / chat_id and `channel_send` can reject a
+        // cross-chat recipient mismatch on the same channel. `None` for
+        // out-of-band turns (cron, triggers) — those run the bridge unguarded.
+        peer_jid: Option<&str>,
+        peer_channel: Option<&str>,
+        peer_chat_id: Option<&str>,
     ) -> std::io::Result<PathBuf> {
         let path =
             std::env::temp_dir().join(format!("librefang-mcp-{}.json", uuid::Uuid::new_v4()));
@@ -362,6 +370,19 @@ impl ClaudeCodeDriver {
                 headers.insert("X-LibreFang-Agent-Id".to_string(), serde_json::json!(id));
             }
         }
+        // #6117: forward the turn's inbound peer scope. The bridge endpoint
+        // (`routes/network.rs::mcp_http`) reads these back into
+        // `ToolExecContext` so `channel_send` enforces the cross-chat guard.
+        let mut insert_nonempty = |key: &str, val: Option<&str>| {
+            if let Some(v) = val {
+                if !v.is_empty() {
+                    headers.insert(key.to_string(), serde_json::json!(v));
+                }
+            }
+        };
+        insert_nonempty("X-LibreFang-Current-Peer-Jid", peer_jid);
+        insert_nonempty("X-LibreFang-Current-Channel", peer_channel);
+        insert_nonempty("X-LibreFang-Current-Chat-Id", peer_chat_id);
 
         let mut server = serde_json::json!({
             "type": "http",
@@ -865,7 +886,13 @@ impl LlmDriver for ClaudeCodeDriver {
 
         if !request.tools.is_empty() {
             if let Some(ref bridge) = self.mcp_bridge {
-                match Self::write_mcp_config(bridge, request.agent_id.as_deref()) {
+                match Self::write_mcp_config(
+                    bridge,
+                    request.agent_id.as_deref(),
+                    request.sender_user_id.as_deref(),
+                    request.sender_channel.as_deref(),
+                    request.sender_chat_id.as_deref(),
+                ) {
                     Ok(path) => prepared.mcp_config_path = Some(path),
                     Err(e) => {
                         prepared.cleanup();
@@ -1148,7 +1175,13 @@ impl LlmDriver for ClaudeCodeDriver {
 
         if !request.tools.is_empty() {
             if let Some(ref bridge) = self.mcp_bridge {
-                match Self::write_mcp_config(bridge, request.agent_id.as_deref()) {
+                match Self::write_mcp_config(
+                    bridge,
+                    request.agent_id.as_deref(),
+                    request.sender_user_id.as_deref(),
+                    request.sender_channel.as_deref(),
+                    request.sender_chat_id.as_deref(),
+                ) {
                     Ok(path) => prepared.mcp_config_path = Some(path),
                     Err(e) => {
                         prepared.cleanup();
@@ -1786,6 +1819,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -1835,6 +1870,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -1901,6 +1938,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -1983,6 +2022,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let prompt = ClaudeCodeDriver::build_prompt(&request);
@@ -2998,6 +3039,8 @@ mod tests {
             session_id: Some("sess-xyz".to_string()),
             step_id: Some("step-001".to_string()),
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         ClaudeCodeDriver::apply_caller_trace_envs(&mut cmd, &request);
         let envs: std::collections::HashMap<_, _> = cmd
@@ -3056,6 +3099,8 @@ mod tests {
             session_id: Some(String::new()),
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         ClaudeCodeDriver::apply_caller_trace_envs(&mut cmd, &request);
         let envs: std::collections::HashMap<_, _> = cmd
@@ -3099,7 +3144,9 @@ mod tests {
             base_url: "http://127.0.0.1:4545".to_string(),
             api_key: Some("secret-key".to_string()),
         };
-        let path = ClaudeCodeDriver::write_mcp_config(&bridge, Some("agent-1234")).unwrap();
+        let path =
+            ClaudeCodeDriver::write_mcp_config(&bridge, Some("agent-1234"), None, None, None)
+                .unwrap();
         let written = std::fs::read_to_string(&path).unwrap();
         let _ = std::fs::remove_file(&path);
         let cfg: serde_json::Value = serde_json::from_str(&written).unwrap();
@@ -3119,13 +3166,60 @@ mod tests {
             base_url: "http://127.0.0.1:4545".to_string(),
             api_key: Some("secret-key".to_string()),
         };
-        let path = ClaudeCodeDriver::write_mcp_config(&bridge, None).unwrap();
+        let path = ClaudeCodeDriver::write_mcp_config(&bridge, None, None, None, None).unwrap();
         let written = std::fs::read_to_string(&path).unwrap();
         let _ = std::fs::remove_file(&path);
         let cfg: serde_json::Value = serde_json::from_str(&written).unwrap();
         let headers = &cfg["mcpServers"]["librefang"]["headers"];
         assert_eq!(headers["X-API-Key"], "secret-key");
         assert!(headers.get("X-LibreFang-Agent-Id").is_none());
+    }
+
+    #[test]
+    fn test_mcp_config_carries_current_peer_scope_headers() {
+        // #6117: the inbound peer scope of the turn is forwarded on the bridge
+        // connection so `/mcp` can rehydrate ToolExecContext and `channel_send`
+        // can reject a cross-chat recipient mismatch on the same channel.
+        let bridge = McpBridgeConfig {
+            base_url: "http://127.0.0.1:4545".to_string(),
+            api_key: None,
+        };
+        let path = ClaudeCodeDriver::write_mcp_config(
+            &bridge,
+            Some("agent-1234"),
+            Some("owner-jid"),
+            Some("whatsapp"),
+            Some("group-123"),
+        )
+        .unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+        let cfg: serde_json::Value = serde_json::from_str(&written).unwrap();
+        let headers = &cfg["mcpServers"]["librefang"]["headers"];
+        assert_eq!(headers["X-LibreFang-Current-Peer-Jid"], "owner-jid");
+        assert_eq!(headers["X-LibreFang-Current-Channel"], "whatsapp");
+        assert_eq!(headers["X-LibreFang-Current-Chat-Id"], "group-123");
+    }
+
+    #[test]
+    fn test_mcp_config_omits_peer_scope_headers_when_absent() {
+        // Out-of-band turns (cron, triggers) carry no peer scope → no peer
+        // headers, so the `/mcp` bridge runs `channel_send` unguarded exactly
+        // as before #6117.
+        let bridge = McpBridgeConfig {
+            base_url: "http://127.0.0.1:4545".to_string(),
+            api_key: Some("k".to_string()),
+        };
+        let path =
+            ClaudeCodeDriver::write_mcp_config(&bridge, Some("agent-1234"), None, None, None)
+                .unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+        let cfg: serde_json::Value = serde_json::from_str(&written).unwrap();
+        let headers = &cfg["mcpServers"]["librefang"]["headers"];
+        assert!(headers.get("X-LibreFang-Current-Peer-Jid").is_none());
+        assert!(headers.get("X-LibreFang-Current-Channel").is_none());
+        assert!(headers.get("X-LibreFang-Current-Chat-Id").is_none());
     }
 
     #[test]
@@ -3138,7 +3232,7 @@ mod tests {
             base_url: "http://127.0.0.1:4545".to_string(),
             api_key: None,
         };
-        let path = ClaudeCodeDriver::write_mcp_config(&bridge, None).unwrap();
+        let path = ClaudeCodeDriver::write_mcp_config(&bridge, None, None, None, None).unwrap();
         let written = std::fs::read_to_string(&path).unwrap();
         let _ = std::fs::remove_file(&path);
         let cfg: serde_json::Value = serde_json::from_str(&written).unwrap();

--- a/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
@@ -405,6 +405,8 @@ mod tests {
             session_id: Some("sess-xyz".to_string()),
             step_id: Some("step-001".to_string()),
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         CodexCliDriver::apply_caller_trace_envs(&mut cmd, &request);
         let envs: std::collections::HashMap<_, _> = cmd
@@ -464,6 +466,8 @@ mod tests {
             session_id: Some(String::new()),
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         CodexCliDriver::apply_caller_trace_envs(&mut cmd, &request);
         let envs: std::collections::HashMap<_, _> = cmd

--- a/crates/librefang-llm-drivers/src/drivers/fallback.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback.rs
@@ -558,6 +558,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         }
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
@@ -620,6 +620,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         }
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -1624,6 +1624,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let tools = convert_tools(&request);
@@ -1652,6 +1654,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let tools = convert_tools(&request);

--- a/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
@@ -466,6 +466,8 @@ mod tests {
             session_id: Some("sess-xyz".to_string()),
             step_id: Some("step-001".to_string()),
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         GeminiCliDriver::apply_caller_trace_envs(&mut cmd, &request);
         let envs: std::collections::HashMap<_, _> = cmd
@@ -525,6 +527,8 @@ mod tests {
             session_id: Some(String::new()),
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         GeminiCliDriver::apply_caller_trace_envs(&mut cmd, &request);
         let envs: std::collections::HashMap<_, _> = cmd

--- a/crates/librefang-llm-drivers/src/drivers/ollama.rs
+++ b/crates/librefang-llm-drivers/src/drivers/ollama.rs
@@ -1055,6 +1055,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         }
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -2981,6 +2981,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let oai = driver.build_request(&req).expect("build_request");
         let assistant_msg = oai
@@ -3034,6 +3036,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let oai = driver.build_request(&req).expect("build_request");
         let assistant_msg = oai
@@ -3090,6 +3094,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let oai = driver.build_request(&req).expect("build_request");
         let assistant_msg = oai
@@ -3149,6 +3155,8 @@ mod tests {
                 step_id: None,
                 reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(
                 ),
+
+                ..Default::default()
             };
             let oai = driver.build_request(&req).expect("build_request");
             let assistant_msg = oai
@@ -3212,6 +3220,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: policy,
+
+            ..Default::default()
         }
     }
 
@@ -3311,6 +3321,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: policy,
+
+            ..Default::default()
         };
         let driver = OpenAIDriver::new(String::new(), "https://example.com/v1".to_string());
 
@@ -3963,6 +3975,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let wire = driver.build_request(&request).expect("build");
         let user = wire
@@ -4047,6 +4061,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         // preprocess should succeed and leave the image block unchanged.
@@ -4098,6 +4114,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let err = driver
@@ -4141,6 +4159,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         // IMAGE/jpeg does NOT start with "image/" so the guard is NOT triggered.

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -1146,6 +1146,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);
@@ -1200,6 +1202,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);
@@ -1281,6 +1285,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);
@@ -1387,6 +1393,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);
@@ -1436,6 +1444,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
 
         let prepared = QwenCodeDriver::build_prompt(&request);
@@ -1676,6 +1686,8 @@ mod tests {
             session_id: Some("sess-xyz".to_string()),
             step_id: Some("step-001".to_string()),
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         QwenCodeDriver::apply_caller_trace_envs(&mut cmd, &request);
         let envs: std::collections::HashMap<_, _> = cmd
@@ -1735,6 +1747,8 @@ mod tests {
             session_id: Some(String::new()),
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         QwenCodeDriver::apply_caller_trace_envs(&mut cmd, &request);
         let envs: std::collections::HashMap<_, _> = cmd

--- a/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
+++ b/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
@@ -376,6 +376,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         }
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/trace_headers.rs
+++ b/crates/librefang-llm-drivers/src/drivers/trace_headers.rs
@@ -251,6 +251,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         }
     }
 

--- a/crates/librefang-llm-drivers/tests/anthropic_trace_headers.rs
+++ b/crates/librefang-llm-drivers/tests/anthropic_trace_headers.rs
@@ -35,6 +35,8 @@ fn request_with_trace_ids(
         session_id: session_id.map(String::from),
         step_id: step_id.map(String::from),
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 

--- a/crates/librefang-llm-drivers/tests/bedrock_trace_headers.rs
+++ b/crates/librefang-llm-drivers/tests/bedrock_trace_headers.rs
@@ -58,6 +58,8 @@ fn request_with_trace_ids(
         session_id: session_id.map(String::from),
         step_id: step_id.map(String::from),
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 

--- a/crates/librefang-llm-drivers/tests/chatgpt_trace_headers.rs
+++ b/crates/librefang-llm-drivers/tests/chatgpt_trace_headers.rs
@@ -37,6 +37,8 @@ fn request_with_trace_ids(
         session_id: session_id.map(String::from),
         step_id: step_id.map(String::from),
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 

--- a/crates/librefang-llm-drivers/tests/common/mod.rs
+++ b/crates/librefang-llm-drivers/tests/common/mod.rs
@@ -86,6 +86,8 @@ pub fn simple_request(model: &str) -> CompletionRequest {
         session_id: None,
         step_id: None,
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 
@@ -118,6 +120,8 @@ pub fn request_with_tools(model: &str) -> CompletionRequest {
         session_id: None,
         step_id: None,
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 
@@ -140,6 +144,8 @@ pub fn request_with_temperature(model: &str, temp: f32) -> CompletionRequest {
         session_id: None,
         step_id: None,
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 
@@ -162,6 +168,8 @@ pub fn o_series_request() -> CompletionRequest {
         session_id: None,
         step_id: None,
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 

--- a/crates/librefang-llm-drivers/tests/copilot_trace_headers.rs
+++ b/crates/librefang-llm-drivers/tests/copilot_trace_headers.rs
@@ -44,6 +44,8 @@ fn request_with_trace_ids(
         session_id: session_id.map(String::from),
         step_id: step_id.map(String::from),
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 

--- a/crates/librefang-llm-drivers/tests/gemini_trace_headers.rs
+++ b/crates/librefang-llm-drivers/tests/gemini_trace_headers.rs
@@ -35,6 +35,8 @@ fn request_with_trace_ids(
         session_id: session_id.map(String::from),
         step_id: step_id.map(String::from),
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 

--- a/crates/librefang-llm-drivers/tests/openai_trace_headers.rs
+++ b/crates/librefang-llm-drivers/tests/openai_trace_headers.rs
@@ -34,6 +34,8 @@ fn request_with_trace_ids(
         session_id: session_id.map(String::from),
         step_id: step_id.map(String::from),
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 

--- a/crates/librefang-llm-drivers/tests/shared_rate_guard_integration.rs
+++ b/crates/librefang-llm-drivers/tests/shared_rate_guard_integration.rs
@@ -104,6 +104,8 @@ fn simple_request(model: &str) -> CompletionRequest {
         session_id: None,
         step_id: None,
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 

--- a/crates/librefang-llm-drivers/tests/vertex_ai_trace_headers.rs
+++ b/crates/librefang-llm-drivers/tests/vertex_ai_trace_headers.rs
@@ -36,6 +36,8 @@ fn request_with_trace_ids(
         session_id: session_id.map(String::from),
         step_id: step_id.map(String::from),
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     }
 }
 

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -1106,6 +1106,12 @@ pub async fn run_agent_loop(
             agent_id: Some(agent_id_str.clone()),
             session_id: Some(session.id.to_string()),
             step_id: Some(iteration.to_string()),
+            // #6117: forward the turn's inbound peer scope so subprocess
+            // drivers (claude-code) can re-expose it to the /mcp bridge and
+            // `channel_send` can reject cross-chat dispatch.
+            sender_user_id: sender_user_id.clone(),
+            sender_channel: sender_channel.clone(),
+            sender_chat_id: sender_chat_id.clone(),
             reasoning_echo_policy,
         };
         // The stripped-tools request has been built; restore tools for any

--- a/crates/librefang-runtime/src/agent_loop/run_streaming.rs
+++ b/crates/librefang-runtime/src/agent_loop/run_streaming.rs
@@ -743,6 +743,12 @@ pub async fn run_agent_loop_streaming(
             agent_id: Some(agent_id_str.clone()),
             session_id: Some(session.id.to_string()),
             step_id: Some(iteration.to_string()),
+            // #6117: forward the turn's inbound peer scope so subprocess
+            // drivers (claude-code) can re-expose it to the /mcp bridge and
+            // `channel_send` can reject cross-chat dispatch.
+            sender_user_id: sender_user_id.clone(),
+            sender_channel: sender_channel.clone(),
+            sender_chat_id: sender_chat_id.clone(),
             reasoning_echo_policy,
         };
         // The stripped-tools request has been built; restore tools for any

--- a/crates/librefang-runtime/src/agent_loop/web_augment.rs
+++ b/crates/librefang-runtime/src/agent_loop/web_augment.rs
@@ -116,6 +116,8 @@ async fn generate_search_queries(
         session_id: None,
         step_id: None,
         reasoning_echo_policy,
+
+        ..Default::default()
     };
 
     let response =

--- a/crates/librefang-runtime/src/aux_client.rs
+++ b/crates/librefang-runtime/src/aux_client.rs
@@ -407,6 +407,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         resolution.driver.complete(req).await.unwrap();
         assert_eq!(primary_calls.1.load(Ordering::SeqCst), 1);
@@ -545,6 +547,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         };
         let out = res.driver.complete(req).await.unwrap();
         match &out.content[0] {

--- a/crates/librefang-runtime/src/compactor.rs
+++ b/crates/librefang-runtime/src/compactor.rs
@@ -719,6 +719,8 @@ async fn summarize_messages(
         session_id: None,
         step_id: None,
         reasoning_echo_policy,
+
+        ..Default::default()
     };
 
     // Retry logic for transient failures
@@ -851,6 +853,8 @@ async fn summarize_in_chunks(
         session_id: None,
         step_id: None,
         reasoning_echo_policy,
+
+        ..Default::default()
     };
 
     match driver.complete(merge_request).await {

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -678,6 +678,8 @@ async fn summarise_batch(
         session_id: None,
         step_id: None,
         reasoning_echo_policy,
+
+        ..Default::default()
     };
 
     let response = driver

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -565,6 +565,8 @@ impl LlmMemoryExtractor {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: self.echo_policy_for(model),
+
+            ..Default::default()
         };
 
         let response = self.driver.complete(request).await.map_err(|e| {
@@ -688,6 +690,8 @@ impl MemoryExtractor for LlmMemoryExtractor {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: self.echo_policy(),
+
+            ..Default::default()
         };
 
         match self.driver.complete(request).await {

--- a/crates/librefang-runtime/src/routing.rs
+++ b/crates/librefang-runtime/src/routing.rs
@@ -203,6 +203,8 @@ mod tests {
             session_id: None,
             step_id: None,
             reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+            ..Default::default()
         }
     }
 

--- a/crates/librefang-runtime/src/tool_runner/channel.rs
+++ b/crates/librefang-runtime/src/tool_runner/channel.rs
@@ -123,11 +123,18 @@ fn trim_opt_string(val: Option<&str>) -> Option<&str> {
     val.map(str::trim).filter(|s| !s.is_empty())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn tool_channel_send(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
     workspace_root: Option<&Path>,
     sender_id: Option<&str>,
+    // #6117: the current turn's inbound channel and platform conversation id
+    // (chat_id / group jid). Used to scope the cross-chat dispatch guard. Both
+    // `None` for out-of-band callers (cron, triggers, external MCP) — the guard
+    // no-ops, preserving the existing unrestricted behaviour for those paths.
+    sender_channel: Option<&str>,
+    sender_chat_id: Option<&str>,
     caller_agent_id: Option<&str>,
     additional_roots: &[&Path],
 ) -> Result<String, String> {
@@ -140,16 +147,50 @@ pub(super) async fn tool_channel_send(
         .trim()
         .to_string();
 
-    let recipient = input["recipient"]
+    // An explicitly-supplied recipient is the only cross-chat-leak vector — an
+    // auto-filled one (reply to the inbound peer) targets the current chat by
+    // construction. Keep the two apart so the guard below only scrutinises an
+    // explicit `recipient`.
+    let explicit_recipient = input["recipient"]
         .as_str()
         .map(str::trim)
-        .filter(|s| !s.is_empty())
+        .filter(|s| !s.is_empty());
+
+    let recipient = explicit_recipient
         .or(sender_id)
         .ok_or("Missing 'recipient' parameter. When replying to the original sender, recipient is auto-filled — ensure channel_send is called in response to a message.")?
         .trim();
 
     if recipient.is_empty() {
         return Err("Recipient cannot be empty".to_string());
+    }
+
+    // #6117 cross-chat dispatch guard (audio cross-chat leak 2026-05-19). When
+    // the model explicitly targets a recipient on the SAME channel the turn
+    // arrived on, it must match the current conversation. The comparison key is
+    // the platform conversation id (`sender_chat_id` — a Telegram chat_id,
+    // group jid, …), not the individual `sender_id`: in a group the legitimate
+    // reply target is the group, not the speaker. DMs (where chat_id coincides
+    // with the sender, or no chat_id is stamped) fall back to `sender_id`.
+    //
+    // A different-channel dispatch (e.g. emailing while replying to a WhatsApp
+    // peer) stays allowed — only intra-channel re-targeting is the leak. To
+    // legitimately reach a different contact, the agent uses `notify_owner`
+    // (kernel-mediated) or waits for that contact's own inbound message.
+    if let (Some(explicit), Some(turn_channel)) = (explicit_recipient, sender_channel) {
+        let expected_chat = sender_chat_id.or(sender_id);
+        if let Some(expected) = expected_chat {
+            let explicit = explicit.trim();
+            if !expected.is_empty()
+                && !turn_channel.is_empty()
+                && turn_channel.eq_ignore_ascii_case(&channel)
+                && !explicit.eq_ignore_ascii_case(expected)
+            {
+                return Err(format!(
+                    "channel_send recipient '{explicit}' does not match the current chat '{expected}' on channel '{channel}'. Cross-chat dispatch is forbidden — to reach a different contact use notify_owner, or wait for that contact's inbound message."
+                ));
+            }
+        }
     }
 
     let thread_id = trim_opt_string(input["thread_id"].as_str());

--- a/crates/librefang-runtime/src/tool_runner/channel.rs
+++ b/crates/librefang-runtime/src/tool_runner/channel.rs
@@ -178,13 +178,21 @@ pub(super) async fn tool_channel_send(
     // legitimately reach a different contact, the agent uses `notify_owner`
     // (kernel-mediated) or waits for that contact's own inbound message.
     if let (Some(explicit), Some(turn_channel)) = (explicit_recipient, sender_channel) {
-        let expected_chat = sender_chat_id.or(sender_id);
+        // Filter an empty `sender_chat_id` before the DM fallback: the
+        // in-process path stamps the raw metadata value (unlike the `/mcp`
+        // bridge, which drops empty headers), so `Some("")` must not mask the
+        // `sender_id` fallback and silently disable the guard.
+        let expected_chat = sender_chat_id.filter(|s| !s.is_empty()).or(sender_id);
         if let Some(expected) = expected_chat {
-            let explicit = explicit.trim();
+            // Compare the recipient case-SENSITIVELY: `send_channel_*` lookups
+            // are case-sensitive (#6078), so a case-insensitive match here would
+            // let `recipient = "OWNER"` pass while the send routes to a distinct
+            // case-sensitive chat. The channel match stays case-insensitive so
+            // the guard still fires when the model varies the channel's casing.
             if !expected.is_empty()
                 && !turn_channel.is_empty()
                 && turn_channel.eq_ignore_ascii_case(&channel)
-                && !explicit.eq_ignore_ascii_case(expected)
+                && explicit != expected
             {
                 return Err(format!(
                     "channel_send recipient '{explicit}' does not match the current chat '{expected}' on channel '{channel}'. Cross-chat dispatch is forbidden — to reach a different contact use notify_owner, or wait for that contact's inbound message."

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -1182,6 +1182,10 @@ pub async fn execute_tool_raw(
                 *kernel,
                 *workspace_root,
                 *sender_id,
+                // #6117: thread the turn's channel + conversation id so the
+                // cross-chat dispatch guard can scope its recipient check.
+                *channel,
+                *chat_id,
                 *caller_agent_id,
                 &extra_refs,
             )

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -246,9 +246,18 @@ async fn test_tool_channel_send_blocks_secret_in_text_message() {
         "recipient": "@user",
         "message": "here is the api_key=sk-abcdefghijklmnop",
     });
-    let err = tool_channel_send(&input, Some(&kernel), None, Some("test_user_id"), None, &[])
-        .await
-        .expect_err("channel_send must reject tainted message");
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        Some("test_user_id"),
+        None,
+        None,
+        None,
+        &[],
+    )
+    .await
+    .expect_err("channel_send must reject tainted message");
     assert!(
         err.contains("taint") || err.contains("violation"),
         "expected taint violation, got: {err}"
@@ -267,9 +276,18 @@ async fn test_tool_channel_send_blocks_secret_in_image_caption() {
         "image_url": "https://example.com/cat.png",
         "message": "see attached. token=sk-abcdefghijklmnop",
     });
-    let err = tool_channel_send(&input, Some(&kernel), None, Some("test_user_id"), None, &[])
-        .await
-        .expect_err("image caption must be sink-checked");
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        Some("test_user_id"),
+        None,
+        None,
+        None,
+        &[],
+    )
+    .await
+    .expect_err("image caption must be sink-checked");
     assert!(
         err.contains("taint") || err.contains("violation"),
         "expected taint violation, got: {err}"
@@ -288,9 +306,18 @@ async fn test_tool_channel_send_blocks_secret_in_poll_question() {
         "poll_question": "guess my api_key=sk-abcdefghijklmnop",
         "poll_options": ["yes", "no"],
     });
-    let err = tool_channel_send(&input, Some(&kernel), None, Some("test_user_id"), None, &[])
-        .await
-        .expect_err("poll question must be sink-checked");
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        Some("test_user_id"),
+        None,
+        None,
+        None,
+        &[],
+    )
+    .await
+    .expect_err("poll question must be sink-checked");
     assert!(
         err.contains("taint") || err.contains("violation"),
         "expected taint violation, got: {err}"
@@ -318,6 +345,8 @@ async fn test_tool_channel_send_auto_fills_recipient_from_sender_id() {
         None,
         Some("12345_telegram"),
         None,
+        None,
+        None,
         &[],
     )
     .await;
@@ -341,12 +370,165 @@ async fn test_tool_channel_send_requires_recipient_without_sender_id() {
         // recipient intentionally omitted
         "message": "Hello!",
     });
-    let err = tool_channel_send(&input, Some(&kernel), None, None, None, &[])
+    let err = tool_channel_send(&input, Some(&kernel), None, None, None, None, None, &[])
         .await
         .expect_err("channel_send must require recipient without sender_id");
     assert!(
         err.contains("Missing 'recipient'"),
         "Expected missing recipient error, got: {err}"
+    );
+}
+
+// ── #6117 cross-chat dispatch guard ───────────────────────────────────────
+//
+// The guard rejects an EXPLICIT `recipient` that targets a different chat on
+// the SAME channel the turn arrived on (the audio cross-chat leak 2026-05-19).
+// `ApprovalKernel` does not implement `send_channel_*`, so a send that passes
+// the guard fails later with a generic transport error — the assertions key on
+// the presence/absence of the guard's distinctive message, not on send success.
+
+const GUARD_MSG: &str = "Cross-chat dispatch is forbidden";
+
+fn guard_kernel() -> Arc<dyn KernelHandle> {
+    Arc::new(ApprovalKernel {
+        approval_requests: Arc::new(AtomicUsize::new(0)),
+        user_gate_override: None,
+    })
+}
+
+#[tokio::test]
+async fn channel_send_explicit_mismatch_same_channel_is_blocked() {
+    let kernel = guard_kernel();
+    let input = serde_json::json!({
+        "channel": "whatsapp",
+        "recipient": "stranger-jid",
+        "message": "leaked voice note",
+    });
+    // Turn arrived from `owner-jid` on `whatsapp`; model targets a stranger.
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        Some("owner-jid"), // sender_id
+        Some("whatsapp"),  // sender_channel
+        None,              // sender_chat_id (DM: falls back to sender_id)
+        Some("agent-x"),
+        &[],
+    )
+    .await
+    .expect_err("cross-chat dispatch must be blocked");
+    assert!(err.contains(GUARD_MSG), "expected guard error, got: {err}");
+    assert!(err.contains("stranger-jid") && err.contains("owner-jid"));
+}
+
+#[tokio::test]
+async fn channel_send_explicit_match_same_channel_passes_guard() {
+    let kernel = guard_kernel();
+    let input = serde_json::json!({
+        "channel": "whatsapp",
+        "recipient": "owner-jid",
+        "message": "legit reply",
+    });
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        Some("owner-jid"),
+        Some("whatsapp"),
+        None,
+        Some("agent-x"),
+        &[],
+    )
+    .await
+    .expect_err("send fails at the transport mock, not the guard");
+    assert!(
+        !err.contains(GUARD_MSG),
+        "recipient matches current chat; guard must NOT fire: {err}"
+    );
+}
+
+#[tokio::test]
+async fn channel_send_group_reply_to_chat_id_passes_guard() {
+    // Group chat: the legitimate reply target is the GROUP (chat_id), not the
+    // individual speaker (sender_id). Explicit recipient == chat_id must pass
+    // even though it differs from sender_id.
+    let kernel = guard_kernel();
+    let input = serde_json::json!({
+        "channel": "telegram",
+        "recipient": "group-123",
+        "message": "hi group",
+    });
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        Some("speaker-42"), // individual speaker
+        Some("telegram"),
+        Some("group-123"), // conversation id (the group)
+        Some("agent-x"),
+        &[],
+    )
+    .await
+    .expect_err("send fails at the transport mock, not the guard");
+    assert!(
+        !err.contains(GUARD_MSG),
+        "group reply to chat_id must pass the guard: {err}"
+    );
+}
+
+#[tokio::test]
+async fn channel_send_different_channel_passes_guard() {
+    // Replying on a DIFFERENT channel than the inbound turn is allowed — only
+    // intra-channel re-targeting is the leak pattern.
+    let kernel = guard_kernel();
+    let input = serde_json::json!({
+        "channel": "email",
+        "recipient": "someone@example.com",
+        "message": "cross-channel is fine",
+    });
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        Some("owner-jid"),
+        Some("whatsapp"), // inbound channel differs from the send channel
+        None,
+        Some("agent-x"),
+        &[],
+    )
+    .await
+    .expect_err("send fails at the transport mock, not the guard");
+    assert!(
+        !err.contains(GUARD_MSG),
+        "different-channel dispatch must pass the guard: {err}"
+    );
+}
+
+#[tokio::test]
+async fn channel_send_out_of_band_no_peer_scope_passes_guard() {
+    // Out-of-band callers (cron, triggers, external MCP) carry no peer scope —
+    // the guard no-ops so their existing unrestricted behaviour is preserved.
+    let kernel = guard_kernel();
+    let input = serde_json::json!({
+        "channel": "whatsapp",
+        "recipient": "anyone-jid",
+        "message": "scheduled broadcast",
+    });
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        None, // no sender_id
+        None, // no sender_channel
+        None, // no sender_chat_id
+        Some("agent-x"),
+        &[],
+    )
+    .await
+    .expect_err("send fails at the transport mock, not the guard");
+    assert!(
+        !err.contains(GUARD_MSG),
+        "out-of-band send must pass the guard: {err}"
     );
 }
 
@@ -987,6 +1169,8 @@ async fn test_channel_send_mirrors_to_channel_owner_session() {
         Some(&kernel),
         None,
         Some("99999"),
+        None,
+        None,
         Some("caller-agent-id"),
         &[],
     )
@@ -1038,6 +1222,8 @@ async fn test_channel_send_mirrors_when_caller_is_channel_owner() {
         Some(&kernel),
         None,
         Some("42"),
+        None,
+        None,
         Some("same-agent"),
         &[],
     )
@@ -1076,6 +1262,8 @@ async fn test_channel_send_succeeds_even_when_mirror_fails() {
         Some(&kernel),
         None,
         Some("77"),
+        None,
+        None,
         Some("caller-id"),
         &[],
     )

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -532,6 +532,58 @@ async fn channel_send_out_of_band_no_peer_scope_passes_guard() {
     );
 }
 
+#[tokio::test]
+async fn channel_send_explicit_case_variant_is_blocked() {
+    // `send_channel_*` lookups are case-sensitive (#6078), so a case-variant
+    // recipient is a DISTINCT chat and must be blocked — the guard compares the
+    // recipient case-sensitively rather than letting "OWNER-JID" pass as
+    // "owner-jid".
+    let kernel = guard_kernel();
+    let input = serde_json::json!({
+        "channel": "whatsapp",
+        "recipient": "OWNER-JID",
+        "message": "case bypass attempt",
+    });
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        Some("owner-jid"),
+        Some("whatsapp"),
+        None,
+        Some("agent-x"),
+        &[],
+    )
+    .await
+    .expect_err("case-variant recipient must be blocked");
+    assert!(err.contains(GUARD_MSG), "expected guard error, got: {err}");
+}
+
+#[tokio::test]
+async fn channel_send_empty_chat_id_falls_back_to_sender_id_guard() {
+    // An empty `sender_chat_id` (stamped raw on the in-process path) must not
+    // mask the `sender_id` DM fallback and silently disable the guard.
+    let kernel = guard_kernel();
+    let input = serde_json::json!({
+        "channel": "whatsapp",
+        "recipient": "stranger-jid",
+        "message": "leak via empty chat_id",
+    });
+    let err = tool_channel_send(
+        &input,
+        Some(&kernel),
+        None,
+        Some("owner-jid"),
+        Some("whatsapp"),
+        Some(""), // empty chat_id must fall back to sender_id, not disable the guard
+        Some("agent-x"),
+        &[],
+    )
+    .await
+    .expect_err("empty chat_id must still enforce via sender_id fallback");
+    assert!(err.contains(GUARD_MSG), "expected guard error, got: {err}");
+}
+
 // ── agent_send conversation_key routing tests ─────────────────────────────
 //
 // Verify that tool_agent_send routes to the correct KernelHandle method

--- a/crates/librefang-testing/src/tests.rs
+++ b/crates/librefang-testing/src/tests.rs
@@ -119,6 +119,8 @@ async fn test_mock_llm_driver_recording() {
         session_id: None,
         step_id: None,
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     };
 
     // First call
@@ -301,6 +303,8 @@ async fn test_mock_llm_driver_custom_tokens_and_stop_reason() {
         session_id: None,
         step_id: None,
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     };
 
     let resp = driver.complete(request).await.unwrap();
@@ -347,6 +351,8 @@ async fn test_failing_llm_driver() {
         session_id: None,
         step_id: None,
         reasoning_echo_policy: librefang_types::model_catalog::ReasoningEchoPolicy::default(),
+
+        ..Default::default()
     };
 
     let result = driver.complete(request).await;


### PR DESCRIPTION
## Summary

Fixes #6117. An agent's `channel_send` could dispatch a message to a *different* recipient than the current turn's inbound peer on the **same** channel, with no validation — a cross-chat confidentiality leak (observed live 2026-05-19: audio voice notes delivered to a stranger's WhatsApp chat).

The leak vector is the subprocess-driver `/mcp` bridge. `routes/network.rs::mcp_http` hardcoded `sender_id` / `channel` / `chat_id` to `None`, so `tool_channel_send` had no peer scope to validate against. A guard alone was not viable — the prerequisite peer-scope plumbing was absent on `main` (confirmed against the issue's feasibility note). This PR lands the full propagation chain plus the guard, reimplemented on current `main` (the prior attempt #5282 was closed and ~1 month stale).

## The propagation chain

- `CompletionRequest` gains `sender_user_id` / `sender_channel` / `sender_chat_id`, populated from the turn's existing manifest-metadata bindings in the agent loop (streaming + non-streaming). Out-of-band callers (cron, triggers, compaction, routing probes) leave them `None`.
- The `claude-code` driver forwards them on the bridge connection as `X-LibreFang-Current-Peer-Jid` / `-Channel` / `-Chat-Id`, mirroring the existing `X-LibreFang-Agent-Id` pattern in `write_mcp_config`.
- `mcp_http` reads those headers back into `ToolExecContext`.
- `tool_channel_send` enforces the guard.

## The guard

Rejects an **explicitly-targeted** recipient that does not match the current conversation on the **same** channel the turn arrived on.

- The comparison key is the conversation id (`sender_chat_id`), falling back to `sender_id` for DMs — so a legitimate group reply (recipient = group jid ≠ individual speaker) passes.
- An auto-filled recipient (reply to the inbound peer) is never scrutinised — only an explicit `recipient` can be the leak.
- A different-channel dispatch (e.g. emailing while replying to a WhatsApp peer) stays allowed; only intra-channel re-targeting is the leak.
- Out-of-band callers with no peer scope run unguarded, preserving existing behaviour. To legitimately reach a different contact, the agent uses `notify_owner` or waits for that contact's inbound message.

## Construction-site ripple

The new `CompletionRequest` fields default via the struct's existing `Default` derive, so the ~35 construction sites that carry no peer scope use `..Default::default()` rather than each spelling out three `None`s. Only the two agent-loop sites set real values.

## Tests

- `tool_runner::tests` — guard unit tests: same-channel mismatch DENIED; same-channel match passes; group reply to chat_id passes; cross-channel passes; out-of-band (no peer scope) passes.
- `claude_code` — `write_mcp_config` emits the peer headers when present, omits them when absent.
- `api_integration_test::test_mcp_http_channel_send_cross_chat_guard_uses_peer_headers` — end-to-end `/mcp` `tools/call` for `channel_send`: blocked with peer headers, unguarded without.

## Verification

- `cargo check --workspace --lib` — clean
- `cargo clippy --all-targets` on the changed crates — zero warnings
- `cargo test -p librefang-runtime` (tool_runner: 242 incl. guard tests), `-p librefang-llm-drivers` (driver header tests), `-p librefang-api --test api_integration_test` (the `/mcp` test), `-p librefang-kernel -p librefang-llm-driver -p librefang-testing --lib` (1238 passed, 0 failed)
