### PR TITLE
feat(channels,kernel): per-conversation agent routing for multi-agent groups (#5323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -822,6 +822,14 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Added
 
+- **channels(routing): per-conversation agent routing for multi-agent groups** (#5323) (@houko) — the AITL routing layer on top of #5671 PR-A's `agent` / `available_agents` schema.
+  When more than one agent serves a channel, a group message that names a specific non-default agent now reaches that agent instead of the channel default.
+  Two addressing paths: an explicit `@`-mention the adapter surfaces in `metadata["mention_names"]` (resolved against agent names/handles), and a non-default agent's declared `channel_overrides.group_trigger_patterns` alias matching the text — scored by a new deterministic per-agent attention scorer (`librefang_channels::bridge::best_alias_match`, reusing the compiled-regex cache) that the channel dispatch path consults before the previously non-deterministic "first available" fallback (closes layer (c) of #5294).
+  `ThreadKey` (the conversation-ownership claim key) grows three optional slices — `account_id` (multi-tenant: two bot accounts on one channel-type no longer collide, the unlanded #3419/#3420 fix), `chat_id` (two chats reusing a forum-topic id), and `peer_id` (per-sender stickiness so two users in one thread can talk to two different agents without contaminating each other) — all defaulting to `None`, reproducing the historical `(channel, thread)` key byte-for-byte.
+  A topic-less group now claims by chat id instead of bypassing the registry, and a live claim makes a follow-up sticky to the same agent without a fresh mention; an explicit address re-claims for the new agent, preserving the #3334 TTL semantics.
+  New per-channel `[channel_overrides]` knobs: `conversation_ownership_ttl_seconds` (default `600`) and `conversation_ownership_include_dms` (default `false`).
+  The Telegram / Discord / Slack / Matrix sidecar adapters now surface `mention_names` and a per-group `sender_user_id` so the bridge can route and scope per peer.
+  Additive and backward-compatible: single-agent channels and existing configs are unchanged.
 - **hands/registry: consume a Codeberg-hosted skill registry via `registry.registry_host`** (#6095) (@houko) — the registry sync path hardcoded GitHub's tarball/clone URLs.
   A new optional `registry_host` (full base URL, e.g. `https://codeberg.org`) derives the archive URL, git-clone URL, and tarball top-level prefix from that host; unset (default `None`) reproduces the exact GitHub URLs, so existing setups stay byte-identical and need no migration.
   GitHub and Forgejo/Codeberg differ in more than the host (archive path `/archive/refs/heads/main.tar.gz` vs `/archive/main.tar.gz`; prefix `librefang-registry-main/` vs `librefang-registry/`), handled in a small `registry_urls()` helper without a forge trait/enum.

--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -914,6 +914,38 @@ impl ChannelBridgeHandle for KernelBridgeAdapter {
             .unwrap_or_default()
     }
 
+    async fn route_assistant_by_metadata_for_channel(
+        &self,
+        channel_type: &str,
+        text: &str,
+    ) -> Option<AgentId> {
+        // Candidate set: every non-hand agent whose channel allowlist admits
+        // this channel (empty allowlist = all channels). Hand the per-agent
+        // alias lists to the channels-crate scorer, which reuses the compiled
+        // regex cache and picks the single clear winner deterministically.
+        let candidates: Vec<(AgentId, Vec<String>)> = self
+            .kernel
+            .agent_registry()
+            .list()
+            .into_iter()
+            .filter(|e| !e.is_hand)
+            .filter(|e| {
+                e.manifest.channels.is_empty()
+                    || e.manifest.channels.iter().any(|c| c == channel_type)
+            })
+            .map(|e| {
+                let patterns = e
+                    .manifest
+                    .channel_overrides
+                    .as_ref()
+                    .map(|ov| ov.group_trigger_patterns.clone())
+                    .unwrap_or_default();
+                (e.id, patterns)
+            })
+            .collect();
+        librefang_channels::bridge::best_alias_match(text, &candidates)
+    }
+
     async fn roster_upsert(
         &self,
         channel: &str,

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -305,6 +305,24 @@ pub trait ChannelBridgeHandle: Send + Sync {
         Vec::new()
     }
 
+    /// Pick the channel-eligible agent whose declared aliases
+    /// (`channel_overrides.group_trigger_patterns`) best match `text` (#5323).
+    ///
+    /// Scores every agent whose `manifest.channels` allows `channel_type`
+    /// (empty allowlist = all channels) by how many of its trigger patterns
+    /// match, and returns the single clear winner. Returns `None` when no
+    /// agent's alias matches or when the top score is tied (ambiguous — the
+    /// caller's deterministic binding/default chain decides instead). This is
+    /// the channel-path consultation of the per-agent attention scorer that
+    /// closes the non-deterministic "first available" fallback.
+    async fn route_assistant_by_metadata_for_channel(
+        &self,
+        _channel_type: &str,
+        _text: &str,
+    ) -> Option<AgentId> {
+        None
+    }
+
     /// Persist a group roster member to the kernel's persistent storage.
     async fn roster_upsert(
         &self,
@@ -2198,6 +2216,52 @@ fn compile_group_trigger_patterns(patterns: &[String]) -> Arc<CompiledGroupTrigg
     compiled
 }
 
+/// Pick the candidate agent whose declared group-trigger aliases best match
+/// `text` (#5323). Each candidate is `(agent_id, patterns)` where `patterns`
+/// is that agent's `channel_overrides.group_trigger_patterns`. Reuses the
+/// process-wide compiled-regex cache, so repeated calls on a busy group do not
+/// recompile.
+///
+/// Returns the single clear winner. Returns `None` when fewer than two
+/// candidates exist (nothing to disambiguate — the binding/default chain
+/// already routes a single agent), when no alias matches, or when the top
+/// score is tied (ambiguous: defer to the deterministic chain). The candidate
+/// order does not affect the result — ties resolve to `None` regardless of
+/// iteration order, so a `HashMap`-sourced candidate list stays deterministic.
+pub fn best_alias_match(text: &str, candidates: &[(AgentId, Vec<String>)]) -> Option<AgentId> {
+    if candidates.len() < 2 {
+        return None;
+    }
+    let mut best: Option<(AgentId, usize)> = None;
+    let mut tied = false;
+    for (id, patterns) in candidates {
+        if patterns.is_empty() {
+            continue;
+        }
+        let compiled = compile_group_trigger_patterns(patterns);
+        let Some(set) = compiled.regex_set.as_ref() else {
+            continue;
+        };
+        let score = set.matches(text).iter().count();
+        if score == 0 {
+            continue;
+        }
+        match best {
+            Some((_, b)) if score > b => {
+                best = Some((*id, score));
+                tied = false;
+            }
+            Some((_, b)) if score == b => tied = true,
+            Some(_) => {}
+            None => best = Some((*id, score)),
+        }
+    }
+    if tied {
+        return None;
+    }
+    best.map(|(id, _)| id)
+}
+
 fn text_content(message: &ChannelMessage) -> Option<&str> {
     match &message.content {
         ChannelContent::Text(text) => Some(text.as_str()),
@@ -2990,11 +3054,117 @@ async fn handle_send_error<F, Fut>(
 /// context, and fallback logic. Returns `Some(agent_id)` or `None` if no agents exist.
 ///
 /// Shared by `dispatch_message` and `dispatch_with_blocks` to ensure consistent routing.
+/// Outcome of routing one inbound message to an agent.
+struct RouteResolution {
+    /// Resolved agent, or `None` when no eligible agent exists.
+    agent_id: Option<AgentId>,
+    /// The message explicitly named this agent — an `@`-mention the adapter
+    /// surfaced, or a match against the agent's own declared alias. The
+    /// conversation-ownership gate treats an addressed dispatch as a re-claim
+    /// so a user can hand the thread from one agent to another mid-conversation
+    /// (#5323). A continuation that merely inherits the sticky holder is *not*
+    /// addressed.
+    addressed: bool,
+}
+
+impl RouteResolution {
+    fn none() -> Self {
+        Self {
+            agent_id: None,
+            addressed: false,
+        }
+    }
+    fn plain(id: AgentId) -> Self {
+        Self {
+            agent_id: Some(id),
+            addressed: false,
+        }
+    }
+    fn addressed(id: AgentId) -> Self {
+        Self {
+            agent_id: Some(id),
+            addressed: true,
+        }
+    }
+}
+
+/// Names the message explicitly `@`-mentioned, as surfaced by the adapter in
+/// `metadata["mention_names"]` (leading `@` optional). Empty when the adapter
+/// did not parse any mentions.
+fn mention_names(message: &ChannelMessage) -> Vec<String> {
+    message
+        .metadata
+        .get("mention_names")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.trim_start_matches('@').trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Whether the adapter flagged the bot's own handle as mentioned.
+fn platform_was_mentioned(message: &ChannelMessage) -> bool {
+    message
+        .metadata
+        .get("was_mentioned")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// True when `id` may serve `ct` — its `manifest.channels` allowlist either is
+/// empty (all channels) or contains the channel.
+async fn agent_allows_channel(
+    handle: &Arc<dyn ChannelBridgeHandle>,
+    id: AgentId,
+    ct: &str,
+) -> bool {
+    let allowlist = handle.agent_channel_allowlist(id).await;
+    allowlist.is_empty() || allowlist.iter().any(|c| c == ct)
+}
+
+/// Resolve a specific agent the group message addresses, ahead of the binding
+/// / default chain (#5323). Two ways a message names an agent:
+///
+/// 1. An explicit `@`-mention the adapter surfaced in `metadata["mention_names"]`
+///    that resolves to a channel-eligible agent.
+/// 2. A non-default agent's declared alias matching the text, scored by the
+///    per-agent attention scorer (`route_assistant_by_metadata_for_channel`).
+///
+/// Returns `None` when the message addresses no specific eligible agent.
+async fn resolve_addressed_agent(
+    message: &ChannelMessage,
+    handle: &Arc<dyn ChannelBridgeHandle>,
+) -> Option<AgentId> {
+    let ct = channel_type_str(&message.channel);
+
+    // 1. Explicit @-mention of a specific agent by name / handle.
+    for name in mention_names(message) {
+        if let Ok(Some(id)) = handle.find_agent_by_name(&name).await {
+            if agent_allows_channel(handle, id, ct).await {
+                return Some(id);
+            }
+        }
+    }
+
+    // 2. A (possibly non-default) eligible agent's alias matches the text.
+    let text = text_content(message)?;
+    handle
+        .route_assistant_by_metadata_for_channel(ct, text)
+        .await
+}
+
 async fn resolve_or_fallback(
     message: &ChannelMessage,
     handle: &Arc<dyn ChannelBridgeHandle>,
     router: &Arc<AgentRouter>,
-) -> Option<AgentId> {
+    thread_ownership: &Arc<crate::thread_ownership::ThreadOwnershipRegistry>,
+) -> RouteResolution {
+    let ct = channel_type_str(&message.channel);
+
     // Thread-based agent routing: if the adapter tagged this message with a
     // thread_route_agent, resolve that agent name first.
     let thread_route_agent_id = if let Some(agent_name) = message
@@ -3018,6 +3188,28 @@ async fn resolve_or_fallback(
     } else {
         None
     };
+
+    // Multi-agent group routing (#5323). An explicit @-mention or a
+    // non-default agent's alias takes priority over the binding/default chain
+    // and over the sticky holder, so a user can address agentB even while
+    // agentA holds the conversation. Only relevant for groups; DMs route to
+    // their single bound agent.
+    if thread_route_agent_id.is_none() && message.is_group {
+        if let Some(id) = resolve_addressed_agent(message, handle).await {
+            return RouteResolution::addressed(id);
+        }
+        // Sticky continuation: a live conversation-ownership claim for this
+        // (thread, peer) slice keeps the follow-up on the same agent even
+        // without a fresh mention, so the holder is not stranded by the
+        // default chain re-resolving to a different agent.
+        if let Some(key) = build_thread_key(message) {
+            if let Some(holder) = thread_ownership.current_holder(&key) {
+                if agent_allows_channel(handle, holder, ct).await {
+                    return RouteResolution::plain(holder);
+                }
+            }
+        }
+    }
 
     // Route to agent — use resolve_with_context to support account_id, guild_id, etc.
     let agent_id = if let Some(id) = thread_route_agent_id {
@@ -3049,14 +3241,23 @@ async fn resolve_or_fallback(
     };
 
     if let Some(id) = agent_id {
-        let allowlist = handle.agent_channel_allowlist(id).await;
-        if !allowlist.is_empty() {
-            let ct = channel_type_str(&message.channel);
-            if !allowlist.iter().any(|c| c == ct) {
-                return None;
-            }
+        if agent_allows_channel(handle, id, ct).await {
+            return RouteResolution::plain(id);
         }
-        return Some(id);
+        return RouteResolution::none();
+    }
+
+    // Attention scorer (#5323 step 4): before the non-deterministic
+    // "first available" tail, consult the per-agent alias scorer so a message
+    // that clearly names one channel-eligible agent reaches it deterministically
+    // rather than whichever agent happens to be listed first.
+    if let Some(text) = text_content(message) {
+        if let Some(id) = handle
+            .route_assistant_by_metadata_for_channel(ct, text)
+            .await
+        {
+            return RouteResolution::addressed(id);
+        }
     }
 
     // Fallback: try "assistant" agent, then first available agent
@@ -3070,12 +3271,8 @@ async fn resolve_or_fallback(
             .and_then(|agents| agents.first().map(|(id, _)| *id)),
     };
     if let Some(id) = fallback {
-        let allowlist = handle.agent_channel_allowlist(id).await;
-        if !allowlist.is_empty() {
-            let ct = channel_type_str(&message.channel);
-            if !allowlist.iter().any(|c| c == ct) {
-                return None;
-            }
+        if !agent_allows_channel(handle, id, ct).await {
+            return RouteResolution::none();
         }
         // Auto-set this as the user's default so future messages route
         // directly. Scope the cache entry to (channel, account_id) when we
@@ -3091,8 +3288,84 @@ async fn resolve_or_fallback(
             ),
             None => router.set_user_default(message.sender.platform_id.clone(), id),
         }
+        return RouteResolution::plain(id);
     }
-    fallback
+    RouteResolution::none()
+}
+
+/// Build the conversation-ownership key for this message (#5323).
+///
+/// `thread` is the platform forum-topic id when present, else the chat
+/// container id so a topic-less group still gets a stable claim. `account_id`
+/// keeps multi-tenant bots apart; `chat_id` distinguishes chats that reuse a
+/// topic id; `peer_id` scopes the claim to the individual sender. Returns
+/// `None` only when neither a thread nor a chat id is available.
+fn build_thread_key(message: &ChannelMessage) -> Option<crate::thread_ownership::ThreadKey> {
+    let ct = channel_type_str(&message.channel);
+    // For groups the bridge keys by `sender.platform_id` (= chat JID); for DMs
+    // that same field is the peer's id, which is also the conversation id.
+    let chat_id = message.sender.platform_id.as_str();
+    let thread = message
+        .thread_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(chat_id);
+    let account_id = message.metadata.get("account_id").and_then(|v| v.as_str());
+    let peer = sender_user_id(message);
+    crate::thread_ownership::ThreadKey::new(ct, thread).map(|k| {
+        k.with_account_id(account_id)
+            .with_chat_id(Some(chat_id))
+            .with_peer_id(Some(peer))
+    })
+}
+
+/// Conversation-ownership gate (#3334 / #5323). Returns `true` if `agent_id`
+/// may dispatch, `false` if another agent owns this conversation slice and the
+/// message did not explicitly re-address us. Shared by the text and multimodal
+/// dispatch paths.
+async fn conversation_ownership_allows(
+    message: &ChannelMessage,
+    thread_ownership: &Arc<crate::thread_ownership::ThreadOwnershipRegistry>,
+    overrides: Option<&ChannelOverrides>,
+    agent_id: AgentId,
+    addressed: bool,
+) -> bool {
+    let enabled = overrides
+        .map(|o| o.thread_ownership_enabled)
+        .unwrap_or(true);
+    if !enabled {
+        return true;
+    }
+    // DMs bypass the registry unless explicitly opted in (#5323 step 5).
+    let include_dms = overrides
+        .map(|o| o.conversation_ownership_include_dms)
+        .unwrap_or(false);
+    if !message.is_group && !include_dms {
+        return true;
+    }
+    let Some(key) = build_thread_key(message) else {
+        return true;
+    };
+    let ttl = std::time::Duration::from_secs(
+        overrides
+            .map(|o| o.conversation_ownership_ttl_seconds)
+            .unwrap_or(600),
+    );
+    // An explicit @-mention or a fresh address re-claims for the new agent.
+    let was_mentioned = platform_was_mentioned(message) || addressed;
+    match thread_ownership.decide_with_ttl(key, agent_id, was_mentioned, ttl) {
+        crate::thread_ownership::DispatchDecision::Allow { .. } => true,
+        crate::thread_ownership::DispatchDecision::Suppress { holder } => {
+            debug!(
+                channel = channel_type_str(&message.channel),
+                candidate = %agent_id,
+                holder = %holder,
+                "conversation_ownership: suppressing dispatch — another agent owns this conversation"
+            );
+            false
+        }
+    }
 }
 
 /// Dispatch a single incoming message — handles bot commands or routes to an agent.
@@ -3219,7 +3492,9 @@ async fn dispatch_message(
     }
 
     // Resolve target agent early so per-agent overrides can take priority
-    let early_agent_id = resolve_or_fallback(message, handle, router).await;
+    let resolution = resolve_or_fallback(message, handle, router, thread_ownership).await;
+    let early_agent_id = resolution.agent_id;
+    let agent_addressed = resolution.addressed;
 
     // Fetch overrides: agent-level (from agent.toml) wins, channel-level is fallback.
     // Per-instance adapter overrides (a sidecar's `[[sidecar_channels]]`
@@ -4233,37 +4508,20 @@ async fn dispatch_message(
         }
     };
 
-    // Thread-ownership gate (#3334). Only meaningful for group threads with
-    // a platform thread id; DMs and untreaded channels bypass entirely.
-    // An explicit @-mention re-claims the thread for the new agent.
-    if message.is_group
-        && overrides
-            .as_ref()
-            .map(|o| o.thread_ownership_enabled)
-            .unwrap_or(true)
+    // Conversation-ownership gate (#3334 / #5323). A topic-less group now
+    // claims by chat id, DMs can opt in, and the key is scoped per peer /
+    // account. An explicit @-mention or a fresh address re-claims for the new
+    // agent.
+    if !conversation_ownership_allows(
+        message,
+        thread_ownership,
+        overrides.as_ref(),
+        agent_id,
+        agent_addressed,
+    )
+    .await
     {
-        if let Some(thread_str) = message.thread_id.as_deref() {
-            if let Some(key) = crate::thread_ownership::ThreadKey::new(ct_str, thread_str) {
-                let was_mentioned = message
-                    .metadata
-                    .get("was_mentioned")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                match thread_ownership.decide(key, agent_id, was_mentioned) {
-                    crate::thread_ownership::DispatchDecision::Allow { .. } => {}
-                    crate::thread_ownership::DispatchDecision::Suppress { holder } => {
-                        debug!(
-                            channel = ct_str,
-                            thread_id = thread_str,
-                            candidate = %agent_id,
-                            holder = %holder,
-                            "thread_ownership: suppressing dispatch — another agent owns this thread"
-                        );
-                        return;
-                    }
-                }
-            }
-        }
+        return;
     }
 
     let channel_key = channel_type_str(&message.channel).to_string();
@@ -5676,7 +5934,8 @@ async fn dispatch_with_blocks(
     journal: Option<&crate::message_journal::MessageJournal>,
     thread_ownership: &Arc<crate::thread_ownership::ThreadOwnershipRegistry>,
 ) {
-    let agent_id = match resolve_or_fallback(message, handle, router).await {
+    let resolution = resolve_or_fallback(message, handle, router, thread_ownership).await;
+    let agent_id = match resolution.agent_id {
         Some(id) => id,
         None => {
             send_response(
@@ -5692,36 +5951,20 @@ async fn dispatch_with_blocks(
         }
     };
 
-    // Thread-ownership gate (#3334). Mirrors the text-path check in
-    // `dispatch_message`. Multimodal messages may not include a
-    // platform-level @-mention marker; treat absence as "no override".
-    if message.is_group
-        && overrides
-            .map(|o| o.thread_ownership_enabled)
-            .unwrap_or(true)
+    // Conversation-ownership gate (#3334 / #5323). Mirrors the text-path check
+    // in `dispatch_message`. Multimodal messages may not include a
+    // platform-level @-mention marker; the shared helper still honours a fresh
+    // address surfaced during resolution.
+    if !conversation_ownership_allows(
+        message,
+        thread_ownership,
+        overrides,
+        agent_id,
+        resolution.addressed,
+    )
+    .await
     {
-        if let Some(thread_str) = message.thread_id.as_deref() {
-            if let Some(key) = crate::thread_ownership::ThreadKey::new(ct_str, thread_str) {
-                let was_mentioned = message
-                    .metadata
-                    .get("was_mentioned")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                match thread_ownership.decide(key, agent_id, was_mentioned) {
-                    crate::thread_ownership::DispatchDecision::Allow { .. } => {}
-                    crate::thread_ownership::DispatchDecision::Suppress { holder } => {
-                        debug!(
-                            channel = ct_str,
-                            thread_id = thread_str,
-                            candidate = %agent_id,
-                            holder = %holder,
-                            "thread_ownership: suppressing block dispatch — another agent owns this thread"
-                        );
-                        return;
-                    }
-                }
-            }
-        }
+        return;
     }
 
     let channel_key = channel_type_str(&message.channel).to_string();
@@ -9593,5 +9836,84 @@ mod tests {
             "operator-typed `Custom(\"cron\")` must NOT collide with the \
              kernel's cron-fire SessionId after sanitize"
         );
+    }
+
+    // ── Multi-agent group routing (#5323) ──
+
+    #[test]
+    fn best_alias_match_picks_unique_winner() {
+        let a = AgentId::new();
+        let b = AgentId::new();
+        let candidates = vec![
+            (a, vec![r"(?i)\bfandango\b".to_string()]),
+            (b, vec![r"(?i)\bambrogio\b".to_string()]),
+        ];
+        // A non-default agent's alias routes to that agent, not the default.
+        assert_eq!(best_alias_match("ambrogio, ayúdame", &candidates), Some(b));
+        assert_eq!(best_alias_match("oye fandango", &candidates), Some(a));
+        // No alias matches -> defer to the binding/default chain.
+        assert_eq!(best_alias_match("hello there", &candidates), None);
+    }
+
+    #[test]
+    fn best_alias_match_tie_and_single_yield_none() {
+        let a = AgentId::new();
+        let b = AgentId::new();
+        // Both agents match -> ambiguous -> None (deterministic regardless of
+        // candidate order).
+        let tie = vec![
+            (a, vec![r"(?i)\bhelp\b".to_string()]),
+            (b, vec![r"(?i)\bhelp\b".to_string()]),
+        ];
+        assert_eq!(best_alias_match("i need help", &tie), None);
+        let tie_rev = vec![
+            (b, vec![r"(?i)\bhelp\b".to_string()]),
+            (a, vec![r"(?i)\bhelp\b".to_string()]),
+        ];
+        assert_eq!(best_alias_match("i need help", &tie_rev), None);
+        // Fewer than two candidates -> nothing to disambiguate.
+        let single = vec![(a, vec![r"(?i)\bhelp\b".to_string()])];
+        assert_eq!(best_alias_match("i need help", &single), None);
+    }
+
+    #[test]
+    fn build_thread_key_falls_back_to_chat_id_without_topic() {
+        let mut msg = group_thread_message("topic-1", false);
+        let k = build_thread_key(&msg).expect("key");
+        assert_eq!(k.thread, "topic-1");
+        assert_eq!(k.chat_id.as_deref(), Some("u1"));
+        // A topic-less group still gets a stable claim keyed by chat id.
+        msg.thread_id = None;
+        let k2 = build_thread_key(&msg).expect("key");
+        assert_eq!(k2.thread, "u1");
+    }
+
+    #[test]
+    fn build_thread_key_carries_account_and_peer() {
+        let mut msg = group_thread_message("t", false);
+        msg.metadata
+            .insert("account_id".into(), serde_json::json!("acct-1"));
+        msg.metadata
+            .insert(SENDER_USER_ID_KEY.into(), serde_json::json!("peer-9"));
+        let k = build_thread_key(&msg).expect("key");
+        assert_eq!(k.account_id.as_deref(), Some("acct-1"));
+        assert_eq!(k.peer_id.as_deref(), Some("peer-9"));
+    }
+
+    #[tokio::test]
+    async fn resolve_addressed_agent_routes_explicit_mention() {
+        let fandango = AgentId::new();
+        let ambrogio = AgentId::new();
+        let handle: std::sync::Arc<dyn ChannelBridgeHandle> = std::sync::Arc::new(MockHandle {
+            agents: Mutex::new(vec![
+                (fandango, "fandango".to_string()),
+                (ambrogio, "ambrogio".to_string()),
+            ]),
+        });
+        let mut msg = group_thread_message("t", false);
+        msg.metadata
+            .insert("mention_names".into(), serde_json::json!(["ambrogio"]));
+        // @ambrogio routes to ambrogio even though it is not the default.
+        assert_eq!(resolve_addressed_agent(&msg, &handle).await, Some(ambrogio));
     }
 }

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -305,16 +305,11 @@ pub trait ChannelBridgeHandle: Send + Sync {
         Vec::new()
     }
 
-    /// Pick the channel-eligible agent whose declared aliases
-    /// (`channel_overrides.group_trigger_patterns`) best match `text` (#5323).
+    /// Pick the channel-eligible agent whose declared aliases (`channel_overrides.group_trigger_patterns`) best match `text` (#5323).
     ///
-    /// Scores every agent whose `manifest.channels` allows `channel_type`
-    /// (empty allowlist = all channels) by how many of its trigger patterns
-    /// match, and returns the single clear winner. Returns `None` when no
-    /// agent's alias matches or when the top score is tied (ambiguous — the
-    /// caller's deterministic binding/default chain decides instead). This is
-    /// the channel-path consultation of the per-agent attention scorer that
-    /// closes the non-deterministic "first available" fallback.
+    /// Scores every agent whose `manifest.channels` allows `channel_type` (empty allowlist = all channels) by how many of its trigger patterns match, and returns the single clear winner.
+    /// Returns `None` when no agent's alias matches or when the top score is tied (ambiguous — the caller's deterministic binding/default chain decides instead).
+    /// This is the channel-path consultation of the per-agent attention scorer that closes the non-deterministic "first available" fallback.
     async fn route_assistant_by_metadata_for_channel(
         &self,
         _channel_type: &str,
@@ -2216,18 +2211,13 @@ fn compile_group_trigger_patterns(patterns: &[String]) -> Arc<CompiledGroupTrigg
     compiled
 }
 
-/// Pick the candidate agent whose declared group-trigger aliases best match
-/// `text` (#5323). Each candidate is `(agent_id, patterns)` where `patterns`
-/// is that agent's `channel_overrides.group_trigger_patterns`. Reuses the
-/// process-wide compiled-regex cache, so repeated calls on a busy group do not
-/// recompile.
+/// Pick the candidate agent whose declared group-trigger aliases best match `text` (#5323).
+/// Each candidate is `(agent_id, patterns)` where `patterns` is that agent's `channel_overrides.group_trigger_patterns`.
+/// Reuses the process-wide compiled-regex cache, so repeated calls on a busy group do not recompile.
 ///
-/// Returns the single clear winner. Returns `None` when fewer than two
-/// candidates exist (nothing to disambiguate — the binding/default chain
-/// already routes a single agent), when no alias matches, or when the top
-/// score is tied (ambiguous: defer to the deterministic chain). The candidate
-/// order does not affect the result — ties resolve to `None` regardless of
-/// iteration order, so a `HashMap`-sourced candidate list stays deterministic.
+/// Returns the single clear winner.
+/// Returns `None` when fewer than two candidates exist (nothing to disambiguate — the binding/default chain already routes a single agent), when no alias matches, or when the top score is tied (ambiguous: defer to the deterministic chain).
+/// The candidate order does not affect the result — ties resolve to `None` regardless of iteration order, so a `HashMap`-sourced candidate list stays deterministic.
 pub fn best_alias_match(text: &str, candidates: &[(AgentId, Vec<String>)]) -> Option<AgentId> {
     if candidates.len() < 2 {
         return None;
@@ -3058,12 +3048,9 @@ async fn handle_send_error<F, Fut>(
 struct RouteResolution {
     /// Resolved agent, or `None` when no eligible agent exists.
     agent_id: Option<AgentId>,
-    /// The message explicitly named this agent — an `@`-mention the adapter
-    /// surfaced, or a match against the agent's own declared alias. The
-    /// conversation-ownership gate treats an addressed dispatch as a re-claim
-    /// so a user can hand the thread from one agent to another mid-conversation
-    /// (#5323). A continuation that merely inherits the sticky holder is *not*
-    /// addressed.
+    /// The message explicitly named this agent — an `@`-mention the adapter surfaced, or a match against the agent's own declared alias.
+    /// The conversation-ownership gate treats an addressed dispatch as a re-claim so a user can hand the thread from one agent to another mid-conversation (#5323).
+    /// A continuation that merely inherits the sticky holder is *not* addressed.
     addressed: bool,
 }
 
@@ -3088,9 +3075,8 @@ impl RouteResolution {
     }
 }
 
-/// Names the message explicitly `@`-mentioned, as surfaced by the adapter in
-/// `metadata["mention_names"]` (leading `@` optional). Empty when the adapter
-/// did not parse any mentions.
+/// Names the message explicitly `@`-mentioned, as surfaced by the adapter in `metadata["mention_names"]` (leading `@` optional).
+/// Empty when the adapter did not parse any mentions.
 fn mention_names(message: &ChannelMessage) -> Vec<String> {
     message
         .metadata
@@ -3115,8 +3101,7 @@ fn platform_was_mentioned(message: &ChannelMessage) -> bool {
         .unwrap_or(false)
 }
 
-/// True when `id` may serve `ct` — its `manifest.channels` allowlist either is
-/// empty (all channels) or contains the channel.
+/// True when `id` may serve `ct` — its `manifest.channels` allowlist either is empty (all channels) or contains the channel.
 async fn agent_allows_channel(
     handle: &Arc<dyn ChannelBridgeHandle>,
     id: AgentId,
@@ -3126,13 +3111,11 @@ async fn agent_allows_channel(
     allowlist.is_empty() || allowlist.iter().any(|c| c == ct)
 }
 
-/// Resolve a specific agent the group message addresses, ahead of the binding
-/// / default chain (#5323). Two ways a message names an agent:
+/// Resolve a specific agent the group message addresses, ahead of the binding / default chain (#5323).
+/// Two ways a message names an agent:
 ///
-/// 1. An explicit `@`-mention the adapter surfaced in `metadata["mention_names"]`
-///    that resolves to a channel-eligible agent.
-/// 2. A non-default agent's declared alias matching the text, scored by the
-///    per-agent attention scorer (`route_assistant_by_metadata_for_channel`).
+/// 1. An explicit `@`-mention the adapter surfaced in `metadata["mention_names"]` that resolves to a channel-eligible agent.
+/// 2. A non-default agent's declared alias matching the text, scored by the per-agent attention scorer (`route_assistant_by_metadata_for_channel`).
 ///
 /// Returns `None` when the message addresses no specific eligible agent.
 async fn resolve_addressed_agent(
@@ -3295,11 +3278,9 @@ async fn resolve_or_fallback(
 
 /// Build the conversation-ownership key for this message (#5323).
 ///
-/// `thread` is the platform forum-topic id when present, else the chat
-/// container id so a topic-less group still gets a stable claim. `account_id`
-/// keeps multi-tenant bots apart; `chat_id` distinguishes chats that reuse a
-/// topic id; `peer_id` scopes the claim to the individual sender. Returns
-/// `None` only when neither a thread nor a chat id is available.
+/// `thread` is the platform forum-topic id when present, else the chat container id so a topic-less group still gets a stable claim.
+/// `account_id` keeps multi-tenant bots apart; `chat_id` distinguishes chats that reuse a topic id; `peer_id` scopes the claim to the individual sender.
+/// Returns `None` only when neither a thread nor a chat id is available.
 fn build_thread_key(message: &ChannelMessage) -> Option<crate::thread_ownership::ThreadKey> {
     let ct = channel_type_str(&message.channel);
     // For groups the bridge keys by `sender.platform_id` (= chat JID); for DMs
@@ -3320,10 +3301,9 @@ fn build_thread_key(message: &ChannelMessage) -> Option<crate::thread_ownership:
     })
 }
 
-/// Conversation-ownership gate (#3334 / #5323). Returns `true` if `agent_id`
-/// may dispatch, `false` if another agent owns this conversation slice and the
-/// message did not explicitly re-address us. Shared by the text and multimodal
-/// dispatch paths.
+/// Conversation-ownership gate (#3334 / #5323).
+/// Returns `true` if `agent_id` may dispatch, `false` if another agent owns this conversation slice and the message did not explicitly re-address us.
+/// Shared by the text and multimodal dispatch paths.
 async fn conversation_ownership_allows(
     message: &ChannelMessage,
     thread_ownership: &Arc<crate::thread_ownership::ThreadOwnershipRegistry>,

--- a/crates/librefang-channels/src/thread_ownership.rs
+++ b/crates/librefang-channels/src/thread_ownership.rs
@@ -8,24 +8,15 @@
 //! @-mention wins, sticky-TTL falls off, etc.). The user sees both agents
 //! reply, contradict each other, and run up cost.
 //!
-//! This module adds an in-memory single-process claim registry keyed by a
-//! `ThreadKey` with a TTL. The bridge consults it after routing and before
-//! dispatch, suppressing any agent that isn't the current claim holder. An
-//! explicit @-mention re-claims for the new agent.
+//! This module adds an in-memory single-process claim registry keyed by a `ThreadKey` with a TTL.
+//! The bridge consults it after routing and before dispatch, suppressing any agent that isn't the current claim holder.
+//! An explicit @-mention re-claims for the new agent.
 //!
-//! The key carries more than `(channel, thread)` (#5323): an optional
-//! `account_id` keeps two bot accounts on the same channel-type from
-//! colliding (multi-tenant), an optional `chat_id` distinguishes two chats
-//! that happen to share a forum-topic id, and an optional `peer_id` scopes a
-//! claim to one conversational partner so two users talking to two different
-//! agents in the same thread keep independent stickiness. All three extra
-//! slots default to `None`, which reproduces the original single-account
-//! `(channel, thread)` behaviour byte-for-byte.
+//! The key carries more than `(channel, thread)` (#5323): an optional `account_id` keeps two bot accounts on the same channel-type from colliding (multi-tenant), an optional `chat_id` distinguishes two chats that happen to share a forum-topic id, and an optional `peer_id` scopes a claim to one conversational partner so two users talking to two different agents in the same thread keep independent stickiness.
+//! All three extra slots default to `None`, which reproduces the original single-account `(channel, thread)` behaviour byte-for-byte.
 //!
-//! Multi-process / multi-daemon coordination (sharing the registry across
-//! processes via a forwarder API) is out of scope — see issue #3334. DMs
-//! bypass the registry unless `conversation_ownership_include_dms` is set on
-//! the channel override.
+//! Multi-process / multi-daemon coordination (sharing the registry across processes via a forwarder API) is out of scope — see issue #3334.
+//! DMs bypass the registry unless `conversation_ownership_include_dms` is set on the channel override.
 
 use dashmap::DashMap;
 use librefang_types::agent::AgentId;
@@ -40,36 +31,31 @@ pub const DEFAULT_TTL: Duration = Duration::from_secs(300);
 /// channel-type slug, the platform's thread identifier, and — when known —
 /// the bot account, chat, and conversational peer that further narrow it.
 ///
-/// `channel` and `thread` are mandatory; the remaining three are `None` on
-/// single-account installs and on adapters that do not surface them, which
-/// keeps the key equal to the historical `(channel, thread)` pair.
+/// `channel` and `thread` are mandatory; the remaining three are `None` on single-account installs and on adapters that do not surface them, which keeps the key equal to the historical `(channel, thread)` pair.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct ThreadKey {
     /// Adapter-qualified channel slug (e.g. `"slack"`, `"discord"`).
     pub channel: String,
-    /// Bot account this message reached, when the adapter is multi-tenant
-    /// (e.g. one Slack workspace id, one Telegram bot token slug). Two
-    /// accounts on the same channel-type never share a claim.
+    /// Bot account this message reached, when the adapter is multi-tenant (e.g. one Slack workspace id, one Telegram bot token slug).
+    /// Two accounts on the same channel-type never share a claim.
     pub account_id: Option<String>,
-    /// Chat / group / DM container id. Distinguishes two chats that reuse the
-    /// same platform-side `thread` id (rare but possible for forum topics).
+    /// Chat / group / DM container id.
+    /// Distinguishes two chats that reuse the same platform-side `thread` id (rare but possible for forum topics).
     pub chat_id: Option<String>,
-    /// Platform thread identifier (Slack `thread_ts`, Discord thread ID, a
-    /// forum-topic id, …). Callers without a forum topic pass the `chat_id`
-    /// here so a topic-less group still gets a stable claim. Empty string is
-    /// invalid; callers should not invoke the registry without a real thread.
+    /// Platform thread identifier (Slack `thread_ts`, Discord thread ID, a forum-topic id, …).
+    /// Callers without a forum topic pass the `chat_id` here so a topic-less group still gets a stable claim.
+    /// Empty string is invalid; callers should not invoke the registry without a real thread.
     pub thread: String,
-    /// Conversational partner (the individual sender). Scoping the claim to a
-    /// peer lets two users in the same thread talk to two different agents
-    /// without contaminating each other. `None` => thread-wide claim.
+    /// Conversational partner (the individual sender).
+    /// Scoping the claim to a peer lets two users in the same thread talk to two different agents without contaminating each other.
+    /// `None` => thread-wide claim.
     pub peer_id: Option<String>,
 }
 
 impl ThreadKey {
-    /// Build a key from a channel slug and thread id, leaving the
-    /// `account_id` / `chat_id` / `peer_id` slices unset. Trims whitespace;
-    /// both fields must be non-empty after trimming or the call is
-    /// meaningless. Use the `with_*` builders to narrow the key further.
+    /// Build a key from a channel slug and thread id, leaving the `account_id` / `chat_id` / `peer_id` slices unset.
+    /// Trims whitespace; both fields must be non-empty after trimming or the call is meaningless.
+    /// Use the `with_*` builders to narrow the key further.
     pub fn new(channel: &str, thread: &str) -> Option<Self> {
         let channel = channel.trim();
         let thread = thread.trim();
@@ -85,8 +71,8 @@ impl ThreadKey {
         })
     }
 
-    /// Narrow the key to a specific bot account. An empty / whitespace value
-    /// clears the slot rather than storing a meaningless empty string.
+    /// Narrow the key to a specific bot account.
+    /// An empty / whitespace value clears the slot rather than storing a meaningless empty string.
     pub fn with_account_id(mut self, account_id: Option<&str>) -> Self {
         self.account_id = normalize_opt(account_id);
         self
@@ -105,8 +91,7 @@ impl ThreadKey {
     }
 }
 
-/// Trim an optional string, collapsing empties to `None` so a blank metadata
-/// value never silently widens or splinters a key.
+/// Trim an optional string, collapsing empties to `None` so a blank metadata value never silently widens or splinters a key.
 fn normalize_opt(value: Option<&str>) -> Option<String> {
     value
         .map(str::trim)
@@ -195,10 +180,8 @@ impl ThreadOwnershipRegistry {
         self.decide_at(key, candidate, was_mentioned, Instant::now())
     }
 
-    /// Like `decide`, but use `ttl` for any claim this call creates or
-    /// refreshes instead of the registry default. Lets the bridge honour a
-    /// per-channel `conversation_ownership_ttl_seconds` override while every
-    /// channel keeps sharing one registry.
+    /// Like `decide`, but use `ttl` for any claim this call creates or refreshes instead of the registry default.
+    /// Lets the bridge honour a per-channel `conversation_ownership_ttl_seconds` override while every channel keeps sharing one registry.
     pub fn decide_with_ttl(
         &self,
         key: ThreadKey,

--- a/crates/librefang-channels/src/thread_ownership.rs
+++ b/crates/librefang-channels/src/thread_ownership.rs
@@ -8,14 +8,24 @@
 //! @-mention wins, sticky-TTL falls off, etc.). The user sees both agents
 //! reply, contradict each other, and run up cost.
 //!
-//! This module adds an in-memory single-process claim registry keyed
-//! `(channel, thread)` with a TTL. The bridge consults it after routing and
-//! before dispatch, suppressing any agent that isn't the current claim
-//! holder. An explicit @-mention re-claims for the new agent.
+//! This module adds an in-memory single-process claim registry keyed by a
+//! `ThreadKey` with a TTL. The bridge consults it after routing and before
+//! dispatch, suppressing any agent that isn't the current claim holder. An
+//! explicit @-mention re-claims for the new agent.
+//!
+//! The key carries more than `(channel, thread)` (#5323): an optional
+//! `account_id` keeps two bot accounts on the same channel-type from
+//! colliding (multi-tenant), an optional `chat_id` distinguishes two chats
+//! that happen to share a forum-topic id, and an optional `peer_id` scopes a
+//! claim to one conversational partner so two users talking to two different
+//! agents in the same thread keep independent stickiness. All three extra
+//! slots default to `None`, which reproduces the original single-account
+//! `(channel, thread)` behaviour byte-for-byte.
 //!
 //! Multi-process / multi-daemon coordination (sharing the registry across
 //! processes via a forwarder API) is out of scope — see issue #3334. DMs
-//! bypass the registry entirely (no overlap risk by definition).
+//! bypass the registry unless `conversation_ownership_include_dms` is set on
+//! the channel override.
 
 use dashmap::DashMap;
 use librefang_types::agent::AgentId;
@@ -26,21 +36,40 @@ use std::time::{Duration, Instant};
 /// the next agent to dispatch can take ownership.
 pub const DEFAULT_TTL: Duration = Duration::from_secs(300);
 
-/// Identity of a single (channel, thread) pair. Built per-message from the
-/// canonical channel-type slug and the platform's thread identifier.
+/// Identity of one ownership slice. Built per-message from the canonical
+/// channel-type slug, the platform's thread identifier, and — when known —
+/// the bot account, chat, and conversational peer that further narrow it.
+///
+/// `channel` and `thread` are mandatory; the remaining three are `None` on
+/// single-account installs and on adapters that do not surface them, which
+/// keeps the key equal to the historical `(channel, thread)` pair.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct ThreadKey {
     /// Adapter-qualified channel slug (e.g. `"slack"`, `"discord"`).
     pub channel: String,
-    /// Platform thread identifier (Slack `thread_ts`, Discord thread ID,
-    /// etc.). Empty string is invalid; callers should not invoke the
-    /// registry without a real thread.
+    /// Bot account this message reached, when the adapter is multi-tenant
+    /// (e.g. one Slack workspace id, one Telegram bot token slug). Two
+    /// accounts on the same channel-type never share a claim.
+    pub account_id: Option<String>,
+    /// Chat / group / DM container id. Distinguishes two chats that reuse the
+    /// same platform-side `thread` id (rare but possible for forum topics).
+    pub chat_id: Option<String>,
+    /// Platform thread identifier (Slack `thread_ts`, Discord thread ID, a
+    /// forum-topic id, …). Callers without a forum topic pass the `chat_id`
+    /// here so a topic-less group still gets a stable claim. Empty string is
+    /// invalid; callers should not invoke the registry without a real thread.
     pub thread: String,
+    /// Conversational partner (the individual sender). Scoping the claim to a
+    /// peer lets two users in the same thread talk to two different agents
+    /// without contaminating each other. `None` => thread-wide claim.
+    pub peer_id: Option<String>,
 }
 
 impl ThreadKey {
-    /// Build a key from a channel slug and thread id. Trims whitespace; both
-    /// fields must be non-empty after trimming or the call is meaningless.
+    /// Build a key from a channel slug and thread id, leaving the
+    /// `account_id` / `chat_id` / `peer_id` slices unset. Trims whitespace;
+    /// both fields must be non-empty after trimming or the call is
+    /// meaningless. Use the `with_*` builders to narrow the key further.
     pub fn new(channel: &str, thread: &str) -> Option<Self> {
         let channel = channel.trim();
         let thread = thread.trim();
@@ -49,9 +78,40 @@ impl ThreadKey {
         }
         Some(Self {
             channel: channel.to_string(),
+            account_id: None,
+            chat_id: None,
             thread: thread.to_string(),
+            peer_id: None,
         })
     }
+
+    /// Narrow the key to a specific bot account. An empty / whitespace value
+    /// clears the slot rather than storing a meaningless empty string.
+    pub fn with_account_id(mut self, account_id: Option<&str>) -> Self {
+        self.account_id = normalize_opt(account_id);
+        self
+    }
+
+    /// Narrow the key to a specific chat / group container.
+    pub fn with_chat_id(mut self, chat_id: Option<&str>) -> Self {
+        self.chat_id = normalize_opt(chat_id);
+        self
+    }
+
+    /// Narrow the key to a specific conversational peer.
+    pub fn with_peer_id(mut self, peer_id: Option<&str>) -> Self {
+        self.peer_id = normalize_opt(peer_id);
+        self
+    }
+}
+
+/// Trim an optional string, collapsing empties to `None` so a blank metadata
+/// value never silently widens or splinters a key.
+fn normalize_opt(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
 }
 
 /// One ownership record. Stored values are immutable — `extend` writes a new
@@ -135,6 +195,20 @@ impl ThreadOwnershipRegistry {
         self.decide_at(key, candidate, was_mentioned, Instant::now())
     }
 
+    /// Like `decide`, but use `ttl` for any claim this call creates or
+    /// refreshes instead of the registry default. Lets the bridge honour a
+    /// per-channel `conversation_ownership_ttl_seconds` override while every
+    /// channel keeps sharing one registry.
+    pub fn decide_with_ttl(
+        &self,
+        key: ThreadKey,
+        candidate: AgentId,
+        was_mentioned: bool,
+        ttl: Duration,
+    ) -> DispatchDecision {
+        self.decide_at_with_ttl(key, candidate, was_mentioned, Instant::now(), ttl)
+    }
+
     /// Test seam: like `decide` but with a caller-supplied `now`.
     pub fn decide_at(
         &self,
@@ -143,16 +217,34 @@ impl ThreadOwnershipRegistry {
         was_mentioned: bool,
         now: Instant,
     ) -> DispatchDecision {
+        self.decide_at_with_ttl(key, candidate, was_mentioned, now, self.default_ttl)
+    }
+
+    /// Test seam: like `decide_with_ttl` but with a caller-supplied `now`.
+    pub fn decide_at_with_ttl(
+        &self,
+        key: ThreadKey,
+        candidate: AgentId,
+        was_mentioned: bool,
+        now: Instant,
+        ttl: Duration,
+    ) -> DispatchDecision {
+        let ttl = if ttl.is_zero() {
+            Duration::from_secs(1)
+        } else {
+            ttl
+        };
         let mut entry = self.claims.entry(key).or_insert_with(|| Claim {
             agent_id: candidate,
             claimed_at: now,
-            ttl: self.default_ttl,
+            ttl,
         });
 
         // Existing entry path. Three cases: same holder (extend), expired
         // (take over), different live holder (suppress unless mentioned).
         if entry.agent_id == candidate {
             entry.claimed_at = now;
+            entry.ttl = ttl;
             return DispatchDecision::Allow {
                 agent_id: candidate,
             };
@@ -162,7 +254,7 @@ impl ThreadOwnershipRegistry {
             *entry = Claim {
                 agent_id: candidate,
                 claimed_at: now,
-                ttl: self.default_ttl,
+                ttl,
             };
             return DispatchDecision::Allow {
                 agent_id: candidate,
@@ -174,7 +266,7 @@ impl ThreadOwnershipRegistry {
             *entry = Claim {
                 agent_id: candidate,
                 claimed_at: now,
-                ttl: self.default_ttl,
+                ttl,
             };
             return DispatchDecision::Allow {
                 agent_id: candidate,
@@ -348,6 +440,73 @@ mod tests {
         match reg.decide_at(key("T2"), bob, false, now) {
             DispatchDecision::Allow { agent_id } => assert_eq!(agent_id, bob),
             other => panic!("expected Allow on disjoint thread, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn same_thread_distinct_account_id_does_not_collide() {
+        // Regression for #3419/#3420: two bot accounts on the same
+        // channel-type with an identical platform thread id must not share a
+        // claim.
+        let reg = ThreadOwnershipRegistry::new();
+        let alice = fresh_id();
+        let bob = fresh_id();
+        let now = Instant::now();
+        let k_a = key("T1").with_account_id(Some("acct-a"));
+        let k_b = key("T1").with_account_id(Some("acct-b"));
+        let _ = reg.decide_at(k_a.clone(), alice, false, now);
+        match reg.decide_at(k_b, bob, false, now) {
+            DispatchDecision::Allow { agent_id } => assert_eq!(agent_id, bob),
+            other => panic!("expected Allow across accounts, got {:?}", other),
+        }
+        // The first account's claim is untouched.
+        assert_eq!(reg.current_holder(&k_a), Some(alice));
+    }
+
+    #[test]
+    fn same_thread_distinct_peer_does_not_collide() {
+        // Per-peer stickiness (#5323): two users in the same thread can talk
+        // to two different agents without contaminating each other.
+        let reg = ThreadOwnershipRegistry::new();
+        let alice = fresh_id();
+        let bob = fresh_id();
+        let now = Instant::now();
+        let k_u1 = key("T1").with_peer_id(Some("user-1"));
+        let k_u2 = key("T1").with_peer_id(Some("user-2"));
+        let _ = reg.decide_at(k_u1.clone(), alice, false, now);
+        match reg.decide_at(k_u2.clone(), bob, false, now) {
+            DispatchDecision::Allow { agent_id } => assert_eq!(agent_id, bob),
+            other => panic!("expected Allow across peers, got {:?}", other),
+        }
+        assert_eq!(reg.current_holder(&k_u1), Some(alice));
+        assert_eq!(reg.current_holder(&k_u2), Some(bob));
+    }
+
+    #[test]
+    fn blank_optional_slices_collapse_to_none() {
+        // A blank metadata value must not splinter the key away from the
+        // unset form.
+        let bare = key("T1");
+        let blanked = key("T1")
+            .with_account_id(Some("  "))
+            .with_chat_id(Some(""))
+            .with_peer_id(None);
+        assert_eq!(bare, blanked);
+    }
+
+    #[test]
+    fn per_channel_ttl_overrides_default() {
+        // A 10s override expires the claim where the 300s default would not.
+        let reg = ThreadOwnershipRegistry::new();
+        let alice = fresh_id();
+        let bob = fresh_id();
+        let t0 = Instant::now();
+        let ttl = Duration::from_secs(10);
+        let _ = reg.decide_at_with_ttl(key("T1"), alice, false, t0, ttl);
+        let after_ttl = t0 + Duration::from_secs(11);
+        match reg.decide_at_with_ttl(key("T1"), bob, false, after_ttl, ttl) {
+            DispatchDecision::Allow { agent_id } => assert_eq!(agent_id, bob),
+            other => panic!("expected Allow after per-call TTL expiry, got {:?}", other),
         }
     }
 }

--- a/crates/librefang-types/src/config/mod.rs
+++ b/crates/librefang-types/src/config/mod.rs
@@ -394,6 +394,24 @@ admin_role = "admin"
         assert!(!ov.threading);
         assert!(ov.output_format.is_none());
         assert!(ov.model.is_none());
+        assert!(ov.thread_ownership_enabled);
+        assert_eq!(ov.conversation_ownership_ttl_seconds, 600);
+        assert!(!ov.conversation_ownership_include_dms);
+    }
+
+    #[test]
+    fn test_conversation_ownership_knobs_roundtrip() {
+        let toml_str = r#"
+            conversation_ownership_ttl_seconds = 120
+            conversation_ownership_include_dms = true
+        "#;
+        let ov: ChannelOverrides = toml::from_str(toml_str).unwrap();
+        assert_eq!(ov.conversation_ownership_ttl_seconds, 120);
+        assert!(ov.conversation_ownership_include_dms);
+        // Unset knobs keep their #5323 defaults.
+        let bare: ChannelOverrides = toml::from_str("").unwrap();
+        assert_eq!(bare.conversation_ownership_ttl_seconds, 600);
+        assert!(!bare.conversation_ownership_include_dms);
     }
 
     #[test]

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -225,10 +225,27 @@ pub struct ChannelOverrides {
     /// agent). DMs always bypass the registry. See #3334.
     #[serde(default = "default_thread_ownership_enabled")]
     pub thread_ownership_enabled: bool,
+    /// How long (in seconds) a conversation-ownership claim stays valid before
+    /// the next agent may take over a thread. Overrides the registry default
+    /// for this channel only. A value of `0` is clamped up to one second by
+    /// the registry. Default `600` (#5323). The refresh-on-holder and
+    /// re-claim-on-@-mention semantics from #3334 are unchanged.
+    #[serde(default = "default_conversation_ownership_ttl_seconds")]
+    pub conversation_ownership_ttl_seconds: u64,
+    /// When `true`, direct messages also participate in the conversation
+    /// ownership registry (keyed per peer), so a DM that rotates agents after
+    /// the TTL is held stable. Default `false`: DMs bypass the registry, the
+    /// historical behaviour (#3334).
+    #[serde(default)]
+    pub conversation_ownership_include_dms: bool,
 }
 
 fn default_thread_ownership_enabled() -> bool {
     true
+}
+
+fn default_conversation_ownership_ttl_seconds() -> u64 {
+    600
 }
 
 impl Default for ChannelOverrides {
@@ -261,6 +278,8 @@ impl Default for ChannelOverrides {
             auto_route_divergence_count: default_auto_route_divergence(),
             prefix_agent_name: PrefixStyle::Off,
             thread_ownership_enabled: true,
+            conversation_ownership_ttl_seconds: default_conversation_ownership_ttl_seconds(),
+            conversation_ownership_include_dms: false,
         }
     }
 }

--- a/sdk/python/librefang/sidecar/adapters/discord.py
+++ b/sdk/python/librefang/sidecar/adapters/discord.py
@@ -333,6 +333,26 @@ def parse_message_create(
         metadata["was_mentioned"] = True
     if account_id is not None:
         metadata["account_id"] = account_id
+    # Named mentions so the bridge can route a guild message to a specific
+    # non-default agent (#5323). Each mentioned user contributes its username
+    # and (when set) global display name; the bridge matches them against
+    # agent names/handles.
+    mention_names: list[str] = []
+    mentions_arr = d.get("mentions")
+    if isinstance(mentions_arr, list):
+        for m in mentions_arr:
+            if not isinstance(m, dict):
+                continue
+            for key in ("username", "global_name"):
+                val = m.get(key)
+                if isinstance(val, str) and val and val not in mention_names:
+                    mention_names.append(val)
+    if mention_names:
+        metadata["mention_names"] = mention_names
+    # Individual author so the registry can scope per-peer claims; the
+    # platform_id here is the channel, not the sender.
+    if is_group and isinstance(author_id, str) and author_id:
+        metadata["sender_user_id"] = author_id
 
     return protocol.message(
         user_id=channel_id,  # Rust adapter uses channel_id as platform_id

--- a/sdk/python/librefang/sidecar/adapters/matrix.py
+++ b/sdk/python/librefang/sidecar/adapters/matrix.py
@@ -1131,6 +1131,19 @@ class MatrixAdapter(SidecarAdapter):
                 metadata: dict[str, Any] = {}
                 if self.account_id is not None:
                     metadata["account_id"] = self.account_id
+                # Individual sender so the conversation-ownership registry can
+                # scope per-peer claims (the platform_id is the room, not the
+                # sender). #5323.
+                metadata["sender_user_id"] = sender
+                # Intentional mentions (MSC3952 `m.mentions`) so a multi-agent
+                # room can address a specific non-default agent (#5323).
+                mentioned = content.get("m.mentions")
+                if isinstance(mentioned, dict):
+                    user_ids = mentioned.get("user_ids")
+                    if isinstance(user_ids, list):
+                        names = [u for u in user_ids if isinstance(u, str) and u]
+                        if names:
+                            metadata["mention_names"] = names
                 ev = protocol.message(
                     user_id=room_id,
                     user_name=sender,

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -246,6 +246,26 @@ def parse_slack_event(
         metadata["was_mentioned"] = True
     if account_id is not None:
         metadata["account_id"] = account_id
+    # Named mentions so the bridge can route to a specific non-default agent
+    # in a multi-agent channel (#5323). Slack encodes mentions as
+    # `<@USERID>` or `<@USERID|handle>`; surface both the id and the optional
+    # handle and let the bridge match them against agent names/handles.
+    mention_names: list[str] = []
+    idx = 0
+    while True:
+        start = text.find("<@", idx)
+        if start == -1:
+            break
+        end = text.find(">", start)
+        if end == -1:
+            break
+        for part in text[start + 2:end].split("|", 1):
+            handle = part.strip()
+            if handle and handle not in mention_names:
+                mention_names.append(handle)
+        idx = end + 1
+    if mention_names:
+        metadata["mention_names"] = mention_names
 
     return protocol.message(
         # platform_id is the channel id (D… for DMs, C… for channels,

--- a/sdk/python/librefang/sidecar/adapters/telegram.py
+++ b/sdk/python/librefang/sidecar/adapters/telegram.py
@@ -1404,6 +1404,60 @@ class TelegramAdapter(SidecarAdapter):
             metadata={"user_id": str(uid), "sender_user_id": str(uid)},
         )
 
+    @staticmethod
+    def _extract_mentions(message: dict) -> list:
+        """`@`-mention handles in this message (#5323).
+
+        Telegram surfaces ``@username`` tokens as ``mention`` entities and
+        username-less user references as ``text_mention``. Entity offsets are
+        UTF-16 code-unit indices, so slice the text in UTF-16 to stay correct
+        when emoji or other astral characters precede the mention. The bridge
+        resolves these against agent names/handles to route a group message to
+        a specific non-default agent.
+        """
+        txt = message.get("text")
+        ents = message.get("entities")
+        if not isinstance(txt, str):
+            txt = message.get("caption")
+            ents = message.get("caption_entities")
+        if not isinstance(txt, str) or not isinstance(ents, list):
+            return []
+        utf16 = txt.encode("utf-16-le")
+        names: list = []
+        for e in ents:
+            etype = e.get("type")
+            if etype == "mention":
+                off, ln = e.get("offset"), e.get("length")
+                if isinstance(off, int) and isinstance(ln, int):
+                    frag = utf16[off * 2:(off + ln) * 2].decode(
+                        "utf-16-le", "ignore")
+                    handle = frag.lstrip("@").strip()
+                    if handle and handle not in names:
+                        names.append(handle)
+            elif etype == "text_mention":
+                uname = (e.get("user") or {}).get("username")
+                if uname and uname not in names:
+                    names.append(uname)
+        return names
+
+    def _message_metadata(self, message: dict, user_id: str,
+                          is_group: bool):
+        """Metadata that lets the bridge route and scope per-conversation.
+
+        ``sender_user_id`` is the individual sender (the group ``channel_id``
+        is the chat, not the user), so the conversation-ownership registry can
+        key per peer. ``mention_names`` carries any ``@``-mention so a specific
+        agent can be addressed in a multi-agent group (#5323). Returns ``None``
+        when there is nothing to attach so DMs keep their lean envelope.
+        """
+        meta: dict = {}
+        if is_group:
+            meta["sender_user_id"] = user_id
+        mentions = self._extract_mentions(message)
+        if mentions:
+            meta["mention_names"] = mentions
+        return meta or None
+
     def _update_to_event(self, update: dict):
         callback = update.get("callback_query")
         if callback:
@@ -1429,6 +1483,7 @@ class TelegramAdapter(SidecarAdapter):
             return None
         content = self._apply_reply(content, message)
         thread = message.get("message_thread_id")
+        is_group = chat.get("type") in ("group", "supergroup")
         return protocol.message(
             user_id=user_id,
             user_name=name,
@@ -1436,9 +1491,10 @@ class TelegramAdapter(SidecarAdapter):
             message_id=str(message.get("message_id", "")),
             channel_id=str(chat_id),
             username=username,
-            is_group=chat.get("type") in ("group", "supergroup"),
+            is_group=is_group,
             thread_id=str(thread) if thread is not None else None,
             platform="telegram",
+            metadata=self._message_metadata(message, user_id, is_group),
         )
 
     def _poll_once(self, emit, state: dict) -> None:

--- a/sdk/python/tests/test_telegram_adapter.py
+++ b/sdk/python/tests/test_telegram_adapter.py
@@ -160,6 +160,45 @@ def test_inbound_text_command_sender_allowed():
     assert sc["user_id"] == "-55" and sc["user_name"] == "Chan"
 
 
+def test_inbound_mentions_and_sender_user_id():
+    a = _adapter()
+    # "@ambrogio help me" in a supergroup: a mention entity is surfaced as a
+    # routable name, and the individual sender id is attached so the bridge
+    # can scope a per-peer conversation claim (#5323).
+    ev = a._update_to_event({
+        "message": {
+            "text": "@ambrogio help me",
+            "entities": [{"type": "mention", "offset": 0, "length": 9}],
+            "from": {"id": 42, "first_name": "Alice"},
+            "chat": {"id": -100123, "type": "supergroup"},
+            "message_id": 9,
+        },
+    })
+    meta = ev["params"]["metadata"]
+    assert meta["mention_names"] == ["ambrogio"]
+    assert meta["sender_user_id"] == "42"
+
+    # Emoji before the mention: entity offsets are UTF-16 code units, so the
+    # extractor must slice in UTF-16 to stay correct.
+    ev2 = a._update_to_event({
+        "message": {
+            "text": "😀 @ambrogio",
+            "entities": [{"type": "mention", "offset": 3, "length": 9}],
+            "from": {"id": 7, "first_name": "Bob"},
+            "chat": {"id": -100123, "type": "supergroup"},
+            "message_id": 10,
+        },
+    })
+    assert ev2["params"]["metadata"]["mention_names"] == ["ambrogio"]
+
+    # DM with no mentions: lean envelope, no metadata block.
+    dm = a._update_to_event({
+        "message": {"text": "hi", "from": {"id": 42, "first_name": "A"},
+                    "chat": {"id": 42, "type": "private"}, "message_id": 1},
+    })
+    assert dm["params"].get("metadata") is None
+
+
 def test_inbound_allowed_users_by_id_and_username():
     a = _adapter(ALLOWED_USERS="111, @Alice")
     mk = lambda f: {"message": {"text": "hi", "from": f,  # noqa: E731


### PR DESCRIPTION
## Summary

Closes the multi-agent-group routing gap in #5323: when more than one agent serves a channel, a group message that names a specific non-default agent now reaches that agent instead of always falling to the channel default, and the conversation stays sticky to it.

Built on top of #5671 PR-A (`SidecarChannelConfig.agent` + `available_agents`, merged in #6105), which adopted Model A. This is the AITL routing layer that PR-A's CHANGELOG entry anticipated ("`resolve_or_fallback`, dispatch … arrive in later PRs"). All five steps from the issue land in one PR.

## What changed (per issue step)

**Step 1 — `ThreadKey` reshape (`thread_ownership.rs`).** The conversation-ownership claim key grows three optional slices, all defaulting to `None` so the historical `(channel, thread)` key is reproduced byte-for-byte:
- `account_id` — two bot accounts on one channel-type no longer collide (the unlanded #3419/#3420 fix).
- `chat_id` — two chats reusing a forum-topic id stay distinct.
- `peer_id` — per-sender stickiness, so two users in one thread can talk to two different agents without contaminating each other.

`decide_with_ttl` lets the bridge pass a per-channel TTL while every channel shares one registry.

**Step 2 + 4 — multi-agent alias/mention routing (`bridge.rs`, `channel_bridge.rs`).** A new resolution step runs ahead of the binding/default chain for group messages:
- Explicit `@`-mention surfaced by the adapter in `metadata["mention_names"]`, resolved against agent names/handles (channel-eligibility enforced via the existing `manifest.channels` allowlist).
- A non-default agent's `channel_overrides.group_trigger_patterns` alias matching the message text, scored by a new deterministic per-agent attention scorer `librefang_channels::bridge::best_alias_match` (reuses the compiled-regex cache; ties → `None`).

The dispatch path also consults the scorer before the previously non-deterministic "first available" fallback, closing layer (c) of #5294. The kernel-side `route_assistant_by_metadata_for_channel` enumerates channel-eligible agents and delegates to the cached scorer (no new `regex` dependency added to `librefang-api`).

**Step 1b — claim-aware dispatch + `include_dms`.** A topic-less group now claims by `chat_id` instead of bypassing the registry (gap #5). A live claim makes a follow-up sticky to the same agent without a fresh mention; an explicit address re-claims for the new agent, preserving #3334's refresh/re-claim TTL semantics. The two duplicated gates (text + multimodal paths) are unified into one `conversation_ownership_allows` helper.

**Step 5 — config knobs (`ChannelOverrides`).** `conversation_ownership_ttl_seconds` (default `600`) and `conversation_ownership_include_dms` (default `false`).

**Step 3 — sidecar mention surfacing (Python).** Telegram (UTF-16-correct entity parsing), Discord, Slack, and Matrix now attach `mention_names` and a per-group `sender_user_id` so the bridge can route to a named agent and scope claims per peer. Telegram previously set no mention metadata at all.

## Design notes

- The issue proposed a `metadata.routing.handles` JSON convention; aliases were already refactored to typed `channel_overrides.group_trigger_patterns`, so this PR routes against agent **names** + those typed aliases rather than reintroducing the untyped bag. The "`ambrogio, ayúdame`" example from the issue works purely through the alias scorer on message text — no platform `@`-mention needed.
- Routing respects the per-agent `manifest.channels` allowlist (the mechanism `resolve_or_fallback` already enforced). The channel-side `available_agents` whitelist from #5671 remains schema-only ("not yet consulted") and its enforcement is the forthcoming `/agent` PR — out of scope here.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-channels -p librefang-api -p librefang-types --lib -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo test -p librefang-channels --lib` — 493 passed, incl. new `best_alias_match_*`, `build_thread_key_*`, `resolve_addressed_agent_routes_explicit_mention`, `same_thread_distinct_account_id_does_not_collide`, `same_thread_distinct_peer_does_not_collide`, `per_channel_ttl_overrides_default`.
- `cargo test -p librefang-types --lib config::` — 157 passed, incl. `test_conversation_ownership_knobs_roundtrip`.
- Python sidecar suites (telegram/discord/slack/matrix) — 288 passed, incl. new `test_inbound_mentions_and_sender_user_id` (covers the UTF-16 offset case).

Live LLM verification is not required — no LLM call path changed.

## Test-plan coverage (from the issue)

| Scenario | Covered by |
| --- | --- |
| `@agentB` in multi-agent group routes to B | `resolve_addressed_agent_routes_explicit_mention`, `best_alias_match_picks_unique_winner` |
| Follow-up from same peer (no mention) stays with B | sticky-holder branch in `resolve_or_fallback` |
| Another peer in same thread not contaminated | `same_thread_distinct_peer_does_not_collide` + per-peer `ThreadKey` |
| TTL expires → claim drops → re-evaluate | `per_channel_ttl_overrides_default` |
| Alias declared by non-default agentB routes to B | `best_alias_match_picks_unique_winner` |
| Topic-less group respects claim via chat_id | `build_thread_key_falls_back_to_chat_id_without_topic` |
| Same thread_id under different account_id no collision | `same_thread_distinct_account_id_does_not_collide` |
