### PR TITLE
feat(cli): localize CLI console output, TUI launcher, and support auto system locale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10474,7 +10474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "async-compression",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "http",

--- a/crates/librefang-cli/locales/en/main.ftl
+++ b/crates/librefang-cli/locales/en/main.ftl
@@ -803,3 +803,57 @@ doctor-section-daemon-health =
 doctor-check-daemon-mcp-status = MCP servers: { $configured } configured, { $connected } connected
 doctor-check-daemon-mcp-health = MCP server health: { $healthy }/{ $total } healthy
 
+doctor-suggest-groq = https://console.groq.com       (free, fast)
+doctor-suggest-gemini = https://aistudio.google.com    (free tier)
+doctor-suggest-deepseek = https://platform.deepseek.com  (low cost)
+
+desktop-install-launched = Desktop app launched.
+desktop-install-launch-fail = Failed to launch { $path }: { $error }
+desktop-install-launch-fail-generic = Failed to launch desktop app: { $error }
+desktop-install-not-installed = LibreFang Desktop is not installed.
+desktop-install-prompt =   Download and install it now? [Y/n] 
+desktop-install-skipped = Skipped. You can install it later:
+desktop-install-skipped-brew =   brew install --cask librefang   (macOS)
+desktop-install-skipped-manual =   Or download from https://github.com/librefang/librefang/releases
+desktop-install-fetching = Fetching latest release info...
+desktop-install-unsupported = Unsupported platform for automatic desktop install.
+desktop-install-download-manual = Download manually: https://github.com/librefang/librefang/releases
+desktop-install-github-fail = Failed to reach GitHub: { $error }
+desktop-install-parse-fail = Failed to parse release info: { $error }
+desktop-install-kv-asset = Asset
+desktop-install-downloading = Downloading...
+desktop-install-download-fail = Download failed: { $error }
+desktop-install-download-complete = Download complete.
+desktop-install-installing = Installing...
+desktop-install-success = LibreFang Desktop installed successfully.
+desktop-install-fail = Installation failed: { $error }
+desktop-install-running-installer = Running installer...
+
+doctor-audit-vault-key-unset = LIBREFANG_VAULT_KEY not set — vault encryption disabled.
+doctor-audit-vault-key-invalid-base64 = LIBREFANG_VAULT_KEY is not valid base64: { $error }
+doctor-audit-vault-key-invalid-base64-hint = Generate one with: openssl rand -base64 32
+doctor-audit-vault-key-wrong-length = LIBREFANG_VAULT_KEY decodes to { $count } bytes; must be exactly 32. Note that 32 ASCII characters is NOT 32 bytes after base64 decode.
+doctor-audit-vault-key-wrong-length-hint = Generate a fresh 32-byte key: openssl rand -base64 32 (44-char output)
+doctor-audit-vault-key-ok = LIBREFANG_VAULT_KEY decodes to 32 bytes.
+
+doctor-audit-api-listen-no-config = config.toml not found — skipping api_listen check.
+doctor-audit-api-listen-invalid-toml = config.toml is not valid TOML: { $error }
+doctor-audit-api-listen-invalid-toml-hint = Edit ~/.librefang/config.toml or run `librefang doctor --repair`.
+doctor-audit-api-listen-unset = api_listen not set in config — kernel will use the default.
+doctor-audit-api-listen-invalid-addr = api_listen `{ $address }` is not a valid socket address: { $error }
+doctor-audit-api-listen-invalid-addr-hint = Use `host:port` form, e.g. `127.0.0.1:4545` or `[::1]:4545`.
+doctor-audit-api-listen-port-zero = api_listen `{ $address }` uses port 0 (OS-assigned ephemeral); clients can't discover the daemon URL after bind.
+doctor-audit-api-listen-port-zero-hint = Pick an explicit port (default 4545), e.g. `127.0.0.1:4545`.
+doctor-audit-api-listen-privileged = api_listen port { $port } is privileged (<1024); daemon will fail to bind without root.
+doctor-audit-api-listen-privileged-hint = Use a port >= 1024 (default 4545) unless you intentionally need root.
+doctor-audit-api-listen-ok = api_listen `{ $address }` parses cleanly.
+
+doctor-audit-config-not-found = { $path } does not exist.
+doctor-audit-config-not-found-hint = Run `librefang init` to create a default config.
+doctor-audit-config-read-fail = Failed to read { $path }: { $error }
+doctor-audit-config-ok = { $path } parses as TOML.
+doctor-audit-config-syntax-error = { $path } has TOML syntax errors: { $error }
+doctor-audit-config-syntax-error-hint = Edit { $path } or restore from a backup.
+
+
+

--- a/crates/librefang-cli/locales/en/main.ftl
+++ b/crates/librefang-cli/locales/en/main.ftl
@@ -887,6 +887,12 @@ launcher-help-title = All commands
 launcher-help-subtitle =   — q/Esc to go back
 launcher-help-hints = ↑↓/jk scroll  PgUp/PgDn  g/G top/bottom  q back
 
-
+# CLI shared UI strings
+ui-brand-tagline = The open-source agent operating system
+ui-label-hint = hint:
+ui-label-next-steps = Next steps
+ui-label-fix = fix:
+ui-label-try = try:
+ui-provider-not-set = { $env_var } not set
 
 

--- a/crates/librefang-cli/locales/en/main.ftl
+++ b/crates/librefang-cli/locales/en/main.ftl
@@ -62,6 +62,14 @@ label-id = ID
 label-active-agents = Active agents
 label-pairing-code = Pairing code
 label-expires = Expires
+label-yes = yes
+label-not-loaded = not loaded
+label-current = Current
+label-channel = Channel
+label-binary = Binary
+label-latest = Latest
+label-target = Target
+label-installed = Installed
 
 # --- Hints ---
 hint-open-dashboard = Open the dashboard in your browser, or run `librefang chat`
@@ -402,3 +410,396 @@ reset-fail = Failed to remove { $path }: { $error }
 # --- Logs ---
 log-following = --- Following { $path } (Ctrl+C to stop) ---
 log-path-hint = Log file: { $path }
+
+# --- Extracted from Rust sources ---
+init-upgrade-existing = Existing installation detected — running upgrade to preserve your settings.
+init-upgrade-fresh-hint = To start fresh, remove ~/.librefang/config.toml and run `librefang init` again.
+init-upgrade-no-config = Nothing to upgrade — no config.toml found. Run `librefang init` first.
+init-upgrade-registry-synced = Registry synced
+init-upgrade-registry-failed = Registry sync failed (network issue?) — continuing with cached content
+init-upgrade-config-up-to-date = Config is already up to date — no new fields added
+init-upgrade-sections-added = Added { $count } new config section(s):
+init-upgrade-legacy-openclaw = Legacy ~/.openclaw installation detected.
+init-upgrade-legacy-openclaw-hint = Run `librefang migrate --from openclaw` to migrate your data.
+init-upgrade-approval-warning = Your require_approval list only contains "shell_exec". File operations (file_write, file_delete) now require approval by default.
+init-upgrade-approval-hint = To enable: add "file_write" and "file_delete" to require_approval in config.toml
+init-upgrade-success-summary = Upgrade complete!
+init-upgrade-title = Upgrading LibreFang installation
+init-upgrade-progress-label = Upgrading
+init-upgrade-backing-up = Backing up config
+init-upgrade-backup-success = Backed up config to backups/{ $name }
+init-upgrade-syncing-registry = Syncing registry
+init-upgrade-initializing-vault-git = Initialising vault/git
+init-upgrade-merging-config = Merging config fields
+init-upgrade-failed-read = Upgrade aborted: failed to read config.toml: { $error }
+init-upgrade-failed-parse = Upgrade aborted: failed to parse config.toml: { $error }
+init-upgrade-backup-saved-hint = Your original config was saved to backups/{ $name }
+init-upgrade-failed-parse-template = Upgrade aborted: failed to parse default config template: { $error }
+init-upgrade-failed-write = Upgrade aborted: failed to write config: { $error }
+init-upgrade-steps-complete = Upgrade steps complete
+label-backup = Backup
+label-new-fields = New fields
+
+auth-chatgpt-device-requested = Device authentication requested.
+auth-chatgpt-device-open-url = Open this URL in any browser:\n  { $url }\n
+auth-chatgpt-device-one-time-code = Enter this one-time code:\n  { $code }\n
+auth-chatgpt-device-do-not-share = Do not share this code.
+auth-chatgpt-device-waiting = Waiting for authorization...
+auth-chatgpt-switching-browser = \nSwitching to the standard browser login flow...\n
+auth-chatgpt-opening-browser = Opening browser for OpenAI authentication...
+auth-chatgpt-open-manually-hint = If the browser does not open, visit:\n  { $url }\n
+auth-chatgpt-open-browser-failed = Could not open browser automatically: { $error }
+auth-chatgpt-open-manually = Please open manually: { $url }
+auth-chatgpt-tokens-saved = \nChatGPT tokens saved to { $path }
+auth-chatgpt-detecting-model = Detecting best available model...
+auth-chatgpt-selected-model = Selected model: { $model }
+auth-chatgpt-config-updated = config.toml updated: provider = "chatgpt", model = "{ $model }"
+auth-chatgpt-starting-flow = Starting ChatGPT authentication flow...\n
+auth-chatgpt-complete = ChatGPT authentication complete.
+auth-chatgpt-failed = ChatGPT authentication failed: { $error }
+
+auth-pool-config-not-array = config.toml `credential_pools` exists but is not an array of tables
+auth-pool-daemon-error-fallback = Daemon returned HTTP { $status } — falling back to config.toml view
+auth-pool-daemon-connect-fallback = Failed to query daemon at { $url }: { $error } — falling back to config.toml view
+auth-pool-no-config-offline = No config at { $path } and daemon is not running.
+auth-pool-config-load-failed = Failed to load config: { $error }
+auth-pool-none-configured = No credential pools configured.
+auth-pool-invalid-env-name = `{ $env_var }` is not a valid env var name. Expected uppercase letters, digits, and underscores (e.g. OPENAI_API_KEY_2).
+auth-pool-env-empty = env var `{ $env_var }` is set but empty.
+auth-pool-env-empty-fix = Set it to your API key before adding the pool entry, e.g.\n  export { $env_var }=sk-…\nThen retry.
+auth-pool-env-not-set = env var `{ $env_var }` is not set in the current shell.
+auth-pool-env-not-set-fix = Export it before adding the pool entry, e.g.\n  export { $env_var }=sk-…\nThen retry. (The daemon will read it from its own environment at boot time — make sure it's exported there too.)
+auth-pool-keys-not-array = Pool for `{ $provider }` has a `keys` field that is not an array of tables.
+auth-pool-key-duplicate = Key with env_var `{ $env_var }` already exists in pool for provider `{ $provider }`.
+auth-pool-key-added = Added key `{ $label }` (env={ $env_var }, priority={ $priority }) to pool for `{ $provider }`. Restart the daemon or hot-reload config to apply.
+auth-pool-not-configured = No credential pool configured for provider `{ $provider }`.
+auth-pool-no-keys-field = Pool for `{ $provider }` has no keys array.
+auth-pool-key-not-found = No key with env_var `{ $env_var }` found in pool for `{ $provider }`.
+auth-pool-key-removed-pool-empty = Removed key `{ $env_var }` from pool for `{ $provider }`. Pool is now empty and has been removed entirely. Restart the daemon or hot-reload config to apply.
+auth-pool-key-removed = Removed key `{ $env_var }` from pool for `{ $provider }`. Restart the daemon or hot-reload config to apply.
+auth-pool-unknown-strategy = Unknown strategy `{ $strategy }`. Valid: fill_first, round_robin, random, least_used.
+auth-pool-strategy-set = Set pool strategy for `{ $provider }` to `{ $strategy }`. Restart the daemon or hot-reload config to apply.
+vault-empty = Vault is empty.
+vault-stored-count = Stored credentials ({ $count }):
+
+# --- Scanned & Extracted keys ---
+# init.rs
+init-upgrade-failed-create-backups-dir = Failed to create backups dir: { $error }
+init-upgrade-failed-backup-config = Failed to backup config: { $error }
+init-error-write-config-example = Could not write config.example.toml: { $error }
+
+# auth.rs
+auth-write-failed = Failed to write { $path }: { $error }
+auth-password-empty = Password cannot be empty.
+auth-passwords-mismatch = Passwords do not match.
+auth-password-hash-failed = Failed to hash password: { $error }
+vault-enter-value-prompt = Enter value for { $key }: 
+auth-enter-password-prompt = Enter password: 
+auth-confirm-password-prompt = Confirm password: 
+
+# agent.rs
+agent-spawn-choose-target-or-template = Choose either a positional target or `--template`, not both.
+agent-spawn-choose-target-or-template-fix = Use `librefang spawn coder` or `librefang spawn --template agents/custom/my-agent.toml`.
+agent-spawn-name-requires-template = `--name` requires a template name or manifest path.
+agent-spawn-name-requires-template-fix = Use `librefang spawn coder --name backend-coder` or `librefang spawn --template path/to/agent.toml --name backend-coder`.
+agent-spawn-dry-run-requires-template = Dry run needs a template name or manifest path.
+agent-spawn-dry-run-requires-template-fix = Use `librefang spawn coder --dry-run` or `librefang spawn --template path/to/agent.toml --dry-run`.
+agent-spawn-template-or-path-not-found = Template or manifest path not found: { $target }
+agent-spawn-template-or-path-not-found-fix = Run `librefang agent new` to browse templates, or pass a valid manifest path.
+agent-manifest-parse-failed = Failed to parse agent manifest from { $source }: { $error }
+agent-manifest-parse-failed-fix = Check the manifest TOML syntax and required fields.
+agent-manifest-serialize-failed = Failed to serialize updated manifest: { $error }
+agent-dry-run-title = Agent Dry Run
+agent-dry-run-success = Manifest parsed successfully. No agent was spawned.
+agent-delete-warning-text = WARNING: Deleting agent "{ $name }" will permanently remove its canonical UUID
+    and all associated memories and sessions.
+    This action cannot be undone.
+label-confirm-prompt = Confirm?
+label-aborted = Aborted.
+agent-delete-no-uuid = No canonical UUID recorded for agent name '{ $name }' — nothing to delete.
+agent-deleted-success = Agent "{ $name }" deleted (canonical UUID purged).
+agent-delete-failed-with-reason = Failed to delete agent: { $error }
+agent-reset-uuid-warning-text = WARNING: Resetting the canonical UUID for "{ $name }" will orphan all sessions
+    and memories tied to its current UUID. The next spawn under this
+    name will start with a fresh UUID. This action cannot be undone.
+agent-reset-uuid-success = Canonical UUID for "{ $name }" reset (was { $previous }).
+agent-reset-uuid-failed-with-reason = Failed to reset canonical UUID: { $error }
+agent-reset-uuid-not-found = No canonical UUID recorded for agent name '{ $name }'.
+agent-merge-history-not-implemented = merge-history is not yet implemented (refs #4614 follow-up).
+    Reassignment of sessions / memories from { $from } to the canonical UUID
+    for agent "{ $name }" requires cross-table SQL surgery in the memory
+    substrate that is being tracked separately.
+agent-set-model-success = Agent { $id } model set to { $value }.
+agent-set-model-failed-with-reason = Failed to set model: { $error }
+agent-set-no-daemon = No running daemon found. Start one with: librefang start
+agent-set-unknown-field = Unknown field: { $field }. Supported fields: model
+agent-new-no-templates = No agent templates found
+agent-new-no-templates-fix = Run `librefang init` to set up the agents directory
+agent-new-template-not-found = Template '{ $name }' not found
+agent-new-template-not-found-fix = Run `librefang agent new` to see available templates
+agent-new-choose-template-prompt =   Choose template [1]: 
+agent-sessions-none-active = No active sessions.
+agent-sessions-none-found = No sessions found.
+
+label-source = Source
+label-name = Name
+label-module = Module
+label-tools = Tools
+label-tags = Tags
+label-description = Description
+
+# daemon.rs
+daemon-first-run-setup = First run detected — running quick setup...
+daemon-config-not-found = Config file not found: { $path }
+daemon-config-not-found-fix = Run `librefang init` to create a default config at ~/.librefang/config.toml, or check the --config path.
+daemon-log-file-not-found = Log file not found
+daemon-log-file-not-found-fix = Expected at: { $path }
+daemon-log-not-found-showing-tui = Daemon log not found; showing TUI log at { $path }
+
+# hand.rs
+hand-install-error-no-toml = Error: No HAND.toml found in { $path }
+hand-install-error-read-toml = Error reading { $path }: { $error }
+hand-error-prefix = Error: { $error }
+hand-installed-success = Installed hand: { $name } ({ $id })
+hand-activate-hint = Use `librefang hand activate { $id }` to start it.
+hand-none-available = No hands available.
+hand-list-activate-hint =
+    Use `librefang hand activate <id>` to activate a hand.
+hand-none-active = No active hands.
+label-hand = Hand
+label-instance = Instance
+label-agent = Agent
+hand-status-title = Hand Status
+label-status-inactive = inactive
+hand-not-found = No active hand or installed hand found for '{ $id }'.
+hand-activated-success = Hand '{ $id }' activated (instance: { $instance }, agent: { $agent })
+hand-activate-failed = Failed to activate hand '{ $id }': { $error }
+hand-deactivated-success = Hand '{ $id }' deactivated.
+label-failed-reason = Failed: { $error }
+hand-no-active-instance = No active hand instance found for '{ $id }'.
+hand-info-not-found = Hand not found: { $error }
+hand-no-settings = Hand '{ $id }' has no configurable settings.
+hand-settings-title = Settings for '{ $id }'
+hand-set-setting-success = Set { $key }={ $value } for hand '{ $id }'.
+hand-reloaded-summary = Reloaded hands: { $added } added, { $updated } updated, { $total } total.
+hand-chat-welcome = Chat with { $name } (type /quit to exit)
+
+# mcp_cmds.rs
+mcp-catalog-unknown-entry = Unknown MCP catalog entry: '{ $name }'
+mcp-catalog-available-header =
+    Available MCP servers (catalog):
+mcp-failed-read-config = Failed to read { $path }: { $error }
+mcp-invalid-toml = { $path } is not valid TOML: { $error }
+mcp-already-configured = MCP server '{ $name }' is already configured. Run `librefang mcp remove { $name }` first if you want to re-install.
+mcp-failed-write-config = Failed to write config.toml: { $error }
+mcp-add-credentials-hint =
+    To add credentials:
+mcp-get-it-here =   Get it here: { $url }
+mcp-not-configured = MCP server '{ $name }' is not configured
+mcp-failed-update-config = Failed to update config.toml: { $error }
+mcp-removed-success = { $name } removed.
+mcp-catalog-no-matches = No MCP catalog entries matching '{ $query }'.
+mcp-catalog-none-available = No MCP catalog entries available.
+mcp-catalog-summary =   { $total } catalog entries ({ $installed } installed)
+mcp-catalog-install-hint =   Use `librefang mcp add <id>` to install an MCP server.
+mcp-none-configured = No MCP servers configured.
+mcp-list-catalog-hint =   Use `librefang mcp catalog` to list installable entries.
+
+# monitoring.rs
+monitoring-audit-reset-destructive = audit reset is destructive — re-run with `--confirm` to proceed
+monitoring-db-not-found = database not found at { $path }
+monitoring-db-open-failed = failed to open { $path }: { $error }
+monitoring-db-truncate-failed = failed to truncate audit_entries: { $error }
+monitoring-audit-reset-anchor-deleted = , deleted anchor at { $path }
+monitoring-audit-reset-anchor-none =  (no anchor file to remove)
+monitoring-audit-reset-success = Audit trail reset: removed { $count } row(s) from audit_entries{ $anchor_detail }.
+monitoring-audit-reset-would-header =   Would:
+monitoring-audit-reset-would-delete =     1. DELETE all rows from `audit_entries` in { $path }
+monitoring-audit-reset-would-remove-anchor =     2. Remove anchor file { $path }
+monitoring-audit-reset-would-restart =   The Merkle chain will restart from the next audit event.
+monitoring-daemon-running-error = daemon is running at { $url }; refusing to touch the audit database
+monitoring-daemon-running-error-fix = stop the daemon first: `librefang stop`
+monitoring-anchor-remove-failed = failed to remove anchor { $path }: { $error }
+monitoring-audit-reset-seed-fresh = The next daemon boot will seed a fresh Merkle chain from the current tip.
+monitoring-memory-no-entries = No memory entries for agent '{ $agent }'.
+monitoring-devices-none-paired = No paired devices.
+monitoring-webhooks-none-configured = No webhooks configured.
+
+# skill.rs
+skill-install-progress = Installing { $source }
+
+# system.rs
+migrate-error-home-dir = Error: Could not determine home directory
+migrate-start-msg = Migrating from { $source } ({ $path })...
+migrate-dry-run-hint =   (dry run — no changes will be made)
+migrate-progress-label = Running migration
+migrate-complete-msg = Migration complete
+migrate-warn-report-save-failed = Warning: Could not save migration report: { $error }
+migrate-report-saved =
+      Report saved to: { $path }
+migrate-failed-msg = Migration failed: { $error }
+
+# maintenance.rs
+maintenance-service-install-root-error = Running as root — the service will be installed for the root account, not your user. Run without sudo instead.
+maintenance-service-unsupported = Auto-start service is not supported on this platform.
+maintenance-failed-create-dir = Failed to create { $path }: { $error }
+maintenance-failed-write-file = Failed to write { $path }: { $error }
+maintenance-wrote-file = Wrote { $path }
+maintenance-systemctl-reload-failed = systemctl --user daemon-reload failed
+maintenance-service-enabled = Service enabled (will start on next login)
+maintenance-service-start-hint = Start now with: systemctl --user start librefang.service
+maintenance-service-linger-hint = For headless servers, also run: loginctl enable-linger
+maintenance-systemctl-enable-failed = systemctl --user enable librefang.service failed
+maintenance-launchagent-loaded = LaunchAgent loaded (will start on login and now)
+maintenance-launchctl-load-failed = launchctl load failed: { $error }
+maintenance-launchctl-run-failed = Failed to run launchctl: { $error }
+maintenance-windows-startup-added = Added to Windows startup (HKCU\Software\Microsoft\Windows\CurrentVersion\Run)
+maintenance-windows-registry-write-failed = Failed to write registry: { $error }
+maintenance-windows-reg-run-failed = Failed to run reg.exe: { $error }
+maintenance-systemd-removed = Removed systemd user service
+maintenance-systemd-remove-failed = Failed to remove service file: { $error }
+maintenance-systemd-not-found = No systemd user service found — nothing to remove.
+maintenance-launchagent-removed = Removed LaunchAgent
+maintenance-launchagent-remove-failed = Failed to remove plist: { $error }
+maintenance-launchagent-not-found = No LaunchAgent found — nothing to remove.
+maintenance-windows-startup-removed = Removed from Windows startup
+maintenance-windows-startup-not-found = No startup entry found — nothing to remove.
+maintenance-systemd-status-registered = Systemd user service is registered
+maintenance-status-label-enabled =   Enabled
+maintenance-status-label-active =   Active
+maintenance-systemd-status-not-registered = No systemd user service registered.
+maintenance-service-install-hint = Run `librefang service install` to set it up.
+maintenance-launchagent-status-registered = LaunchAgent is registered
+maintenance-status-label-loaded =   Loaded
+maintenance-launchagent-status-not-registered = No LaunchAgent registered.
+maintenance-windows-status-registered = Windows startup entry is registered
+maintenance-windows-status-not-registered = No startup entry registered.
+reset-confirm-message =   This will delete all data in { $path }
+      Including: config, database, agent manifests, credentials.
+reset-confirm-prompt =   Are you sure? Type 'yes' to confirm: 
+reset-not-needed = Nothing to reset — { $path } does not exist.
+maintenance-update-section = Update
+maintenance-update-error-exe-path = Cannot determine current executable path: { $error }
+maintenance-update-error-check-release = Failed to check latest release: { $error }
+maintenance-update-warn-resolve-release = Could not resolve the latest published release: { $error }
+maintenance-update-warn-resolve-release-fix = Retry later, or pass `--version <tag>` to target a specific release.
+maintenance-update-available = A newer published release is available: { $tag }
+maintenance-update-run-hint = Run `librefang update` to install it.
+maintenance-update-same-core = The published release { $tag } uses the same CLI version core as the current binary ({ $current }).
+maintenance-update-same-core-hint = Run `librefang update` if you want the latest published build for this version line.
+maintenance-update-ahead = Current binary version { $current } is ahead of the published release { $tag }.
+maintenance-update-compare-unknown = Could not compare the current binary with release tag { $tag }.
+maintenance-update-compare-unknown-hint = If you want that exact release, run `librefang update --version <tag>`.
+maintenance-update-unable-to-determine = Unable to determine whether an update is available.
+maintenance-update-unable-to-determine-hint = Retry later when GitHub Releases is reachable.
+maintenance-update-cannot-compare-safely = Could not safely compare the current binary against release tag { $tag }.
+maintenance-update-cannot-compare-safely-hint = Re-run with `librefang update --version { $tag }` to install it explicitly.
+maintenance-update-windows-daemon-running-error = Stop the running daemon before updating on Windows.
+maintenance-update-windows-daemon-running-error-fix = Run `librefang stop`, then `librefang update`, then `librefang start`.
+maintenance-update-cli-success = LibreFang CLI updated.
+maintenance-update-merging-config-defaults = Merging new config defaults...
+maintenance-update-restart-daemon-hint = If the daemon is running, restart it with `librefang restart`.
+maintenance-update-background-launched = Update launched in the background.
+maintenance-update-background-hint-terminal = Open a new terminal after it finishes and run `librefang --version`.
+maintenance-update-background-hint-restart = If the daemon is running, restart it after the update completes.
+maintenance-update-failed-error = Update failed: { $error }
+maintenance-update-cargo-blocked = This binary was installed with cargo. Running `cargo install` from inside the active executable is intentionally blocked.
+maintenance-update-unofficial-path = Automatic update only supports the official install path ({ $path }). This binary is running from a different location.
+maintenance-update-package-manager-hint = If this binary came from another package manager, update it with that package manager instead.
+
+# doctor_cmd.rs
+doctor-check-librefang-dir-ok = LibreFang directory: { $path }
+doctor-check-librefang-dir-fail = LibreFang directory not found.
+doctor-check-librefang-dir-created = Created LibreFang directory
+doctor-check-librefang-dir-create-fail = Failed to create directory
+doctor-check-librefang-dir-not-found-init = LibreFang directory not found. Run `librefang init` first.
+doctor-check-env-ok = .env file (permissions OK)
+doctor-check-env-fixed = .env file (permissions fixed to 0600)
+doctor-check-env-ok-generic = .env file
+doctor-check-env-loose-warn = .env file has loose permissions ({ $mode }), should be 0600
+doctor-check-env-not-found-warn = .env file not found (create with: librefang config set-key <provider>)
+doctor-check-config-ok = Config file: { $path }
+doctor-check-config-syntax-fail = Config file has syntax errors: { $error }
+doctor-check-config-not-found = Config file not found.
+doctor-check-config-created = Created default config.toml
+doctor-check-config-create-fail = Failed to create config.toml
+doctor-check-cli-version = CLI version: { $version } (channel: { $channel })
+doctor-check-update-available-warn = Update available: { $current } -> { $latest } (see https://github.com/librefang/librefang/releases)
+doctor-check-cli-up-to-date = CLI is up to date
+doctor-check-update-fail-warn = Could not check for updates (network unavailable)
+doctor-check-daemon-running = Daemon running at { $url }
+doctor-check-daemon-not-running-warn = Daemon not running (start with `librefang start`)
+doctor-check-port-available = Port { $address } is available
+doctor-check-port-in-use-warn = Port { $address } is in use by another process
+doctor-check-stale-daemon-json-removed = Removed stale daemon.json
+doctor-check-stale-daemon-json-warn = Stale daemon.json found (daemon not running). Run with --repair to clean up.
+doctor-check-db-ok = Database file (valid SQLite)
+doctor-check-db-invalid-fail = Database file exists but is not valid SQLite
+doctor-check-db-not-found-warn = No database file (will be created on first run)
+doctor-check-disk-space-low-warn = Low disk space: { $count }MB available
+doctor-check-disk-space-ok = Disk space: { $count }MB available
+doctor-check-manifests-ok = Agent manifests are valid
+doctor-check-manifest-invalid-fail = Invalid manifest { $file }: { $error }
+doctor-check-home-dir-fail = Could not determine home directory
+doctor-check-provider-key-rejected-warn = { $name } ({ $env_var }) - key rejected (401/403)
+doctor-check-endpoint-reachable = { $name } endpoint reachable ({ $endpoint })
+doctor-check-endpoint-unreachable-warn = { $name } endpoint unreachable ({ $endpoint })
+doctor-check-channel-token-format-warn = { $name } ({ $env_var }) - unexpected token format
+doctor-check-config-env-missing-warn = Config references { $env_var } but it is not set in env or .env
+doctor-check-config-deser-ok = Config deserializes into KernelConfig
+doctor-check-exec-policy = Exec policy: mode={ $mode }, safe_bins={ $count }
+doctor-check-include-file-ok = Include file: { $path }
+doctor-check-include-file-missing-warn = Include file missing: { $path }
+doctor-check-include-file-not-found-fail = Include file not found: { $path }
+doctor-check-mcp-servers-count = MCP servers configured: { $count }
+doctor-check-mcp-empty-command-warn = MCP server '{ $name }' has empty command
+doctor-check-mcp-empty-url-warn = MCP server '{ $name }' has empty URL
+doctor-check-mcp-empty-base-url-warn = MCP server '{ $name }' has empty base_url
+doctor-check-mcp-no-compat-tools-warn = MCP server '{ $name }' has no http_compat tools configured
+doctor-check-mcp-compat-header-empty-name-warn = MCP server '{ $name }' has an http_compat header with empty name
+doctor-check-mcp-compat-header-no-value-warn = MCP server '{ $name }' has an http_compat header without value/value_env
+doctor-check-mcp-compat-tool-empty-name-warn = MCP server '{ $name }' has an http_compat tool with empty name
+doctor-check-mcp-compat-tool-empty-path-warn = MCP server '{ $name }' has an http_compat tool with empty path
+doctor-check-config-deser-fail = Config fails KernelConfig deserialization: { $error }
+doctor-check-skills-loaded = Skills loaded: { $count }
+doctor-check-skills-load-fail-warn = Failed to load skills: { $error }
+doctor-check-skills-injection-ok = All skills pass prompt injection scan
+doctor-check-mcp-catalog-templates = MCP catalog templates: { $templates }
+doctor-check-mcp-configured-servers = Configured MCP servers: { $configured }
+doctor-check-running-agents = Running agents: { $count }
+doctor-check-daemon-uptime = Daemon uptime: { $hours }h { $mins }m
+doctor-check-db-connectivity-ok = Database connectivity: OK
+doctor-check-db-status-fail = Database status: { $status }
+doctor-check-health-detail-status-warn = Health detail returned { $status }
+doctor-check-health-detail-fail-warn = Failed to query daemon health: { $error }
+doctor-check-skills-loaded-daemon = Skills loaded in daemon: { $count }
+doctor-check-rust-version = Rust: { $version }
+doctor-check-rust-not-found-fail = Rust toolchain not found
+doctor-check-python-version = Python: { $version }
+doctor-check-python-not-found-warn = Python not found (needed for Python skill runtime)
+doctor-check-node-version = Node.js: { $version }
+doctor-check-node-not-found-warn = Node.js not found (needed for Node skill runtime)
+doctor-prompt-create-dir =     Create it now? [Y/n] 
+doctor-prompt-create-config =     Create default config? [Y/n] 
+doctor-section-providers =   LLM Providers:
+doctor-section-connectivity = 
+
+  Network Connectivity:
+doctor-section-channels = 
+
+  Channel Integrations:
+doctor-section-config-val = 
+
+  Config Validation:
+doctor-section-skills = 
+
+  Skills:
+doctor-check-skills-injection-critical-warn = Skill '{ $name }' has { $count } critical warning(s):
+doctor-check-skills-injection-warn = Prompt injection warning in skill: { $name }
+doctor-section-mcp-servers =
+  MCP servers:
+doctor-section-daemon-health =
+  Daemon Health:
+doctor-check-daemon-mcp-status = MCP servers: { $configured } configured, { $connected } connected
+doctor-check-daemon-mcp-health = MCP server health: { $healthy }/{ $total } healthy
+

--- a/crates/librefang-cli/locales/en/main.ftl
+++ b/crates/librefang-cli/locales/en/main.ftl
@@ -855,5 +855,38 @@ doctor-audit-config-ok = { $path } parses as TOML.
 doctor-audit-config-syntax-error = { $path } has TOML syntax errors: { $error }
 doctor-audit-config-syntax-error-hint = Edit { $path } or restore from a backup.
 
+# launcher menu items
+launcher-menu-get-started = Get started
+launcher-menu-get-started-hint = Providers, API keys, models, migration
+launcher-menu-settings = Settings
+launcher-menu-settings-hint = Providers, API keys, models, routing
+launcher-menu-chat = Chat with an agent
+launcher-menu-chat-hint = Quick chat in the terminal
+launcher-menu-dashboard = Open dashboard
+launcher-menu-dashboard-hint = Launch the web UI in your browser
+launcher-menu-desktop = Open desktop app
+launcher-menu-desktop-hint = Launch the native desktop app
+launcher-menu-tui = Launch terminal UI
+launcher-menu-tui-hint = Full interactive TUI dashboard
+launcher-menu-help = Show all commands
+launcher-menu-help-hint = Print full --help output
+
+# launcher screen strings
+launcher-welcome = Welcome! Let's get you set up.
+launcher-checking-daemon = Checking for daemon…
+launcher-daemon-running = Daemon running at { $url }
+launcher-daemon-no-running = No daemon running
+launcher-provider = Provider: { $provider }
+launcher-no-keys = No API keys detected
+launcher-hint-re-run =   Run 'Re-run setup' to configure a provider
+launcher-hint-get-started =   Select 'Get started' to configure
+launcher-migration-question = Coming from { $source }? 
+launcher-migration-hint = 'Get started' includes automatic migration.
+launcher-menu-hints = ↑↓/jk navigate  1-9 quick select  enter confirm  q quit
+launcher-help-title = All commands
+launcher-help-subtitle =   — q/Esc to go back
+launcher-help-hints = ↑↓/jk scroll  PgUp/PgDn  g/G top/bottom  q back
+
+
 
 

--- a/crates/librefang-cli/locales/uk/main.ftl
+++ b/crates/librefang-cli/locales/uk/main.ftl
@@ -803,3 +803,57 @@ doctor-section-daemon-health =
 doctor-check-daemon-mcp-status = MCP-сервери: { $configured } налаштовано, { $connected } підключено
 doctor-check-daemon-mcp-health = Здоров'я MCP-серверів: { $healthy }/{ $total } здорових
 
+doctor-suggest-groq = https://console.groq.com       (безкоштовно, швидко)
+doctor-suggest-gemini = https://aistudio.google.com    (безкоштовний тариф)
+doctor-suggest-deepseek = https://platform.deepseek.com  (дешево)
+
+desktop-install-launched = Десктопний додаток запущено.
+desktop-install-launch-fail = Не вдалося запустити { $path }: { $error }
+desktop-install-launch-fail-generic = Не вдалося запустити десктопний додаток: { $error }
+desktop-install-not-installed = LibreFang Desktop не встановлено.
+desktop-install-prompt =   Завантажити та встановити зараз? [Y/n] 
+desktop-install-skipped = Пропущено. Ви можете встановити його пізніше:
+desktop-install-skipped-brew =   brew install --cask librefang   (macOS)
+desktop-install-skipped-manual =   Або завантажте з https://github.com/librefang/librefang/releases
+desktop-install-fetching = Отримання інформації про останній реліз...
+desktop-install-unsupported = Непідтримувана платформа для автоматичного встановлення десктопної версії.
+desktop-install-download-manual = Завантажте вручну: https://github.com/librefang/librefang/releases
+desktop-install-github-fail = Не вдалося зв'язатися з GitHub: { $error }
+desktop-install-parse-fail = Не вдалося розібрати інформацію про реліз: { $error }
+desktop-install-kv-asset = Ресурс
+desktop-install-downloading = Завантаження...
+desktop-install-download-fail = Завантаження не вдалося: { $error }
+desktop-install-download-complete = Завантаження завершено.
+desktop-install-installing = Встановлення...
+desktop-install-success = LibreFang Desktop успішно встановлено.
+desktop-install-fail = Помилка встановлення: { $error }
+desktop-install-running-installer = Запуск інсталятора...
+
+doctor-audit-vault-key-unset = LIBREFANG_VAULT_KEY не встановлено — шифрування сховища вимкнено.
+doctor-audit-vault-key-invalid-base64 = LIBREFANG_VAULT_KEY не є коректним base64: { $error }
+doctor-audit-vault-key-invalid-base64-hint = Згенеруйте його за допомогою: openssl rand -base64 32
+doctor-audit-vault-key-wrong-length = LIBREFANG_VAULT_KEY розкодовується в { $count } байтів; має бути рівно 32. Зверніть увагу, що 32 ASCII символи НЕ дорівнюють 32 байтам після декодування base64.
+doctor-audit-vault-key-wrong-length-hint = Згенеруйте новий 32-байтний ключ: openssl rand -base64 32 (результат матиме 44 символи)
+doctor-audit-vault-key-ok = LIBREFANG_VAULT_KEY успішно розкодовується в 32 байти.
+
+doctor-audit-api-listen-no-config = config.toml не знайдено — пропуск перевірки api_listen.
+doctor-audit-api-listen-invalid-toml = config.toml не є коректним TOML: { $error }
+doctor-audit-api-listen-invalid-toml-hint = Відредагуйте ~/.librefang/config.toml або запустіть `librefang doctor --repair`.
+doctor-audit-api-listen-unset = api_listen не встановлено в конфігурації — ядро використовуватиме значення за замовчуванням.
+doctor-audit-api-listen-invalid-addr = api_listen `{ $address }` не є коректною сокет-адресою: { $error }
+doctor-audit-api-listen-invalid-addr-hint = Використовуйте форму `хост:порт`, наприклад `127.0.0.1:4545` або `[::1]:4545`.
+doctor-audit-api-listen-port-zero = api_listen `{ $address }` використовує порт 0 (тимчасовий, призначений ОС); клієнти не зможуть визначити URL-адресу демона після прив'язки.
+doctor-audit-api-listen-port-zero-hint = Оберіть явний порт (за замовчуванням 4545), наприклад `127.0.0.1:4545`.
+doctor-audit-api-listen-privileged = Порт api_listen { $port } є привілейованим (<1024); демон не зможе прив'язатися без прав root.
+doctor-audit-api-listen-privileged-hint = Використовуйте порт >= 1024 (за замовчуванням 4545), якщо вам не потрібні права root навмисно.
+doctor-audit-api-listen-ok = api_listen `{ $address }` успішно розібрано.
+
+doctor-audit-config-not-found = { $path } не існує.
+doctor-audit-config-not-found-hint = Запустіть `librefang init`, щоб створити конфігурацію за замовчуванням.
+doctor-audit-config-read-fail = Не вдалося прочитати { $path }: { $error }
+doctor-audit-config-ok = { $path } успішно розбирається як TOML.
+doctor-audit-config-syntax-error = { $path } містить синтаксичні помилки TOML: { $error }
+doctor-audit-config-syntax-error-hint = Відредагуйте { $path } або відновіть її з бекапу.
+
+
+

--- a/crates/librefang-cli/locales/uk/main.ftl
+++ b/crates/librefang-cli/locales/uk/main.ftl
@@ -855,5 +855,38 @@ doctor-audit-config-ok = { $path } успішно розбирається як 
 doctor-audit-config-syntax-error = { $path } містить синтаксичні помилки TOML: { $error }
 doctor-audit-config-syntax-error-hint = Відредагуйте { $path } або відновіть її з бекапу.
 
+# launcher menu items
+launcher-menu-get-started = Налаштувати та запустити
+launcher-menu-get-started-hint = Провайдери, API-ключі, моделі, міграція
+launcher-menu-settings = Налаштування
+launcher-menu-settings-hint = Провайдери, API-ключі, моделі, воркфлоу
+launcher-menu-chat = Чат з агентом
+launcher-menu-chat-hint = Швидкий чат у терміналі
+launcher-menu-dashboard = Відкрити панель приладів
+launcher-menu-dashboard-hint = Запустити веб-інтерфейс у браузері
+launcher-menu-desktop = Відкрити десктопний додаток
+launcher-menu-desktop-hint = Запустити нативний десктопний додаток
+launcher-menu-tui = Запустити термінальний UI
+launcher-menu-tui-hint = Інтерактивна консольна панель керування
+launcher-menu-help = Показати всі команди
+launcher-menu-help-hint = Вивести повну довідку --help
+
+# launcher screen strings
+launcher-welcome = Ласкаво просимо! Давайте налаштуємо систему.
+launcher-checking-daemon = Перевірка стану демона…
+launcher-daemon-running = Демон запущений за адресою { $url }
+launcher-daemon-no-running = Демон не запущений
+launcher-provider = Провайдер: { $provider }
+launcher-no-keys = API-ключі не виявлено
+launcher-hint-re-run =   Запустіть 'Налаштування' для вибору провайдера
+launcher-hint-get-started =   Оберіть 'Налаштувати та запустити' для конфігурації
+launcher-migration-question = Переходите з { $source }? 
+launcher-migration-hint = 'Налаштувати та запустити' включає автоматичну міграцію.
+launcher-menu-hints = ↑↓/jk навігація  1-9 швидкий вибір  enter підтвердити  q вихід
+launcher-help-title = Усі команди
+launcher-help-subtitle =   — q/Esc для повернення
+launcher-help-hints = ↑↓/jk прокрутка  PgUp/PgDn  g/G вгору/вниз  q назад
+
+
 
 

--- a/crates/librefang-cli/locales/uk/main.ftl
+++ b/crates/librefang-cli/locales/uk/main.ftl
@@ -1,0 +1,404 @@
+# --- Daemon lifecycle ---
+daemon-starting = Запуск демона...
+daemon-stopped = Демон LibreFang зупинений.
+kernel-booted = Ядро завантажено ({ $provider }/{ $model })
+models-available = Доступно моделей: { $count }
+agents-loaded = Завантажено агентів: { $count }
+daemon-started-bg = Демон запущений у фоновому режимі
+daemon-still-starting = Демон запущений у фоновому режимі та все ще запускається
+daemon-stopped-ok = Демон зупинений
+daemon-stopped-forced = Демон зупинений (примусово)
+daemon-error = Помилка демона: { $error }
+daemon-already-running = Демон уже запущений на { $url }
+daemon-already-running-fix = Використовуйте `librefang status` для перевірки або спочатку зупиніть його
+daemon-not-running = Демон не запущений.
+daemon-not-running-start = Демон не запущений. Запустіть його за допомогою: librefang start
+daemon-no-running-found = Запущеного демона не знайдено
+daemon-no-running-found-fix = Чи запущений він? Перевірте за допомогою: librefang status
+daemon-restarting = Перезапуск демона...
+daemon-no-running-starting = Запущеного демона не знайдено; запуск нового демона
+daemon-bg-exited = Фоновий демон завершив роботу до того, як став працездатним ({ $status })
+daemon-bg-exited-fix = Перевірте логи запуску: { $path }
+daemon-bg-wait-fail = Помилка під час очікування фонового демона
+daemon-bg-wait-fail-fix = { $error }. Перевірте логи запуску: { $path }
+daemon-launch-fail = Не вдалося запустити фоновий демон
+daemon-no-running-auto = Демон не запущений — запускаємо зараз...
+daemon-started = Демон запущений
+daemon-start-fail = Не вдалося запустити демона: { $error }
+daemon-start-fail-fix = Запустіть його вручну: librefang start
+shutdown-request-fail = Помилка запиту на вимкнення ({ $status })
+could-not-reach-daemon = Не вдалося зв'язатися з демоном: { $error }
+# Issue #4693 — after `curl install.sh | sh` upgrades the binary without
+# restarting the running daemon, `librefang restart` (new CLI) hits the old
+# daemon's `/api/shutdown` and is rejected with 401 because the new CLI's
+# Authorization header does not match the old daemon's expected key (typical
+# trigger: locked vault, rotated `[api] api_key`, or freshly enabled
+# dashboard credentials). Surface the cause + auto-fall-back to PID-based
+# shutdown so users can move forward without hand-editing config.
+shutdown-401-detected = Запит на вимкнення відхилено запущеним демоном (401 Unauthorized).
+shutdown-401-explainer = Новий CLI не може автентифікуватися в запущеному демоні. Зазвичай це відбувається після оновлення бінарного файлу за допомогою `curl install.sh | sh` без перезапуску демона — запущений демон було запущено з іншим api_key або не вдалося розблокувати сховище (vault), яке його містить.
+shutdown-401-fallback-attempt = Перехід до зупинки на основі PID (PID { $pid })...
+shutdown-401-fallback-success = Демон зупинено через PID { $pid }
+shutdown-401-fallback-fail = Зупинка на основі PID також не спрацювала.
+shutdown-401-fallback-fix = Зупиніть демон вручну, а потім запустіть його знову:
+    kill { $pid }    # або: kill -9 { $pid } якщо він не виходить
+    librefang start
+shutdown-401-no-pid-fix = Не вдалося прочитати PID демона з { $path }. Виконайте `ps -ef | grep librefang`, щоб знайти його, а потім `kill <pid>` та `librefang start`.
+
+# --- Labels ---
+label-api = API
+label-dashboard = Панель приладів
+label-provider = Провайдер
+label-model = Модель
+label-pid = PID
+label-log = Log
+label-status = Статус
+label-agents = Агенти
+label-data-dir = Директорія даних
+label-uptime = Час роботи
+label-version = Версія
+label-daemon = Демон
+label-id = ID
+label-active-agents = Активні агенти
+label-pairing-code = Код пейрингу
+label-expires = Закінчується
+
+# --- Hints ---
+hint-open-dashboard = Відкрийте панель приладів у браузері або виконайте `librefang chat`
+hint-stop-daemon = Використовуйте `librefang stop`, щоб зупинити демона
+hint-tail-stop = Ctrl+C зупиняє відстеження логів; демон продовжує працювати
+hint-check-status = Виконайте `librefang status`, щоб перевірити готовність
+hint-start-daemon = Запустіть його за допомогою: librefang start
+hint-start-daemon-cmd = Запуск демона: librefang start
+hint-or-chat = Або спробуйте `librefang chat`, що працює без демона
+hint-non-interactive = Виявлено неінтерактивний термінал — запуск у швидкому режимі
+hint-non-interactive-wizard = Для інтерактивного майстра виконайте: librefang init (у терміналі)
+hint-starting-chat = Запуск сесії чату...
+hint-no-api-keys = Не знайдено API ключів провайдерів LLM
+hint-groq-free = Groq пропонує безкоштовний тариф: https://console.groq.com
+hint-ollama-local = Або встановіть Ollama для локальних моделей: https://ollama.com
+hint-gemini-free = Gemini пропонує безкоштовний тариф: https://aistudio.google.com
+hint-deepseek-free = DeepSeek пропонує 5 млн безкоштовних токенів: https://platform.deepseek.com
+guide-title = Швидке налаштування
+guide-free-providers-title = Виберіть безкоштовного провайдера для початку (налаштування 2 хв):
+guide-get-free-key = Отримайте безкоштовний API ключ
+guide-paste-key-placeholder = вставте ваш API ключ сюди
+guide-setting-up = Налаштування
+guide-testing-key = Тестування ключа...
+guide-key-verified = ✓ Ключ підтверджено!
+guide-test-key-unverified = ⚠ Не вдалося підтвердити (може все одно працювати)
+guide-help-select = ↑↓ навігація  Enter вибір  s/Esc пропустити
+guide-help-paste = Вставити ключ + Enter  Esc назад
+guide-help-wait = Будь ласка, зачекайте...
+guide-paste-key-hint = Скопіюйте API ключ із браузера та вставте його нижче.
+hint-could-not-open-browser = Не вдалося автоматично відкрити браузер.
+hint-could-not-open-browser-visit = Не вдалося відкрити браузер. Відвідайте: { $url }
+hint-dashboard-url = Панель приладів: { $url }
+hint-try-dashboard = Спробуйте: librefang dashboard
+hint-install-desktop = Встановіть його за допомогою: cargo install librefang-desktop
+hint-fallback-web-dashboard = Перехід до веб-панелі приладів...
+hint-then-open-dashboard = Потім відкрийте: http://127.0.0.1:4545
+hint-chat-with-agent = Чат: librefang chat { $name }
+hint-agent-lost-on-exit = Примітка: Агент буде втрачений після завершення цього процесу
+hint-persistent-agents = Для постійних агентів спочатку запустіть `librefang start`
+hint-url-copied = URL скопійовано в буфер обміну
+hint-doctor-repair = Виконайте `librefang doctor --repair` для автоматичного виправлення
+hint-run-init = Виконайте `librefang init` для налаштування директорії агентів
+hint-run-start = Виконайте `librefang start` для запуску демона
+hint-config-edit = Виправте за допомогою: librefang config edit
+hint-set-key = Або виконайте: librefang config set-key groq
+hint-set-key-provider = Встановити пізніше: librefang config set-key email (або export EMAIL_PASSWORD=...)
+
+# --- Init ---
+init-quick-success = LibreFang ініціалізовано (швидкий режим)
+init-interactive-success = LibreFang ініціалізовано!
+init-cancelled = Налаштування скасовано.
+init-next-start = Запуск демона:  librefang start
+init-next-chat = Чат:              librefang chat
+
+# --- Error messages ---
+error-home-dir = Не вдалося визначити домашню директорію
+error-create-dir = Не вдалося створити { $path }
+error-create-dir-fix = Перевірте права доступу для { $path }
+error-write-config = Не вдалося записати конфігурацію
+error-config-created = Створено: { $path }
+error-config-exists = Конфігурація вже існує: { $path }
+
+# --- Daemon communication errors ---
+error-daemon-returned = Демон повернув помилку ({ $status })
+error-daemon-returned-fix = Перевірте логи демона за допомогою: librefang logs --follow
+error-request-timeout = Час очікування запиту минув
+error-request-timeout-fix = Агент може обробляти складний запит. Спробуйте ще раз або перевірте `librefang status`
+error-connect-refused = Не вдалося підключитися до демона
+error-connect-refused-fix = Чи запущений демон? Запустіть його за допомогою: librefang start
+error-daemon-comm = Помилка зв'язку з демоном: { $error }
+error-daemon-comm-fix = Перевірте `librefang status` або перезапустіть: librefang start
+
+# --- Boot errors ---
+error-boot-config = Не вдалося розібрати конфігурацію
+error-boot-config-fix = Перевірте синтаксис вашого config.toml: librefang config show
+error-boot-db = Помилка бази даних (файл може бути заблокований)
+error-boot-db-fix = Перевірте, чи запущений інший процес LibreFang: librefang status
+error-boot-auth = Помилка автентифікації провайдера LLM
+error-boot-auth-fix = Виконайте `librefang doctor`, щоб перевірити конфігурацію API-ключів
+error-boot-generic = Не вдалося завантажити ядро: { $error }
+error-boot-generic-fix = Виконайте `librefang doctor`, щоб діагностувати проблему
+
+# --- Require daemon ---
+error-require-daemon = `librefang { $command }` вимагає запущеного демона
+error-require-daemon-fix = Запустіть демона: librefang start
+
+# --- Provider detection ---
+detected-provider = Виявлено { $display } ({ $env_var })
+detected-gemini = Виявлено Gemini (GOOGLE_API_KEY)
+detected-ollama = Виявлено Ollama, що працює локально (API-ключ не потрібен)
+
+# --- Desktop app ---
+desktop-launching = Запуск LibreFang Desktop...
+desktop-started = Десктопний додаток запущений.
+desktop-launch-fail = Не вдалося запустити десктопний додаток: { $error }
+desktop-not-found = Десктопний додаток не знайдено.
+
+# --- Dashboard ---
+dashboard-opening = Відкриття панелі приладів на { $url }
+
+# --- Agent commands ---
+agent-spawned = Агент '{ $name }' запущений
+agent-spawned-inprocess = Агент '{ $name }' запущений (у процесі)
+agent-spawn-failed = Не вдалося запустити: { $error }
+agent-spawn-agent-failed = Не вдалося запустити агента: { $error }
+agent-template-not-found = Темплейт '{ $name }' не знайдено
+agent-template-not-found-fix = Виконайте `librefang agent new`, щоб переглянути доступні темплейти
+agent-no-templates = Темплейтів агентів не знайдено
+agent-no-templates-fix = Виконайте `librefang init`, щоб налаштувати директорії агентів
+agent-template-parse-fail = Не вдалося розібрати темплейт '{ $name }': { $error }
+agent-template-parse-fail-fix = Маніфест темплейту може бути пошкоджений
+agent-killed = Агент { $id } зупинений.
+agent-kill-failed = Не вдалося зупинити агента: { $error }
+agent-invalid-id = Некоректний ID агента: { $id }
+agent-model-set = Модель агента { $id } встановлено на { $value }.
+agent-set-model-failed = Не вдалося встановити модель: { $error }
+agent-no-daemon-for-set = Запущеного демона не знайдено. Запустіть його за допомогою: librefang start
+agent-unknown-field = Невідоме поле: { $field }. Підтримувані поля: model
+agent-no-agents = Немає запущених агентів.
+agent-spawn-success = Агента успішно запущено!
+agent-spawn-inprocess-mode = Агента запущено (внутрішньопроцесний режим).
+agent-note-lost = Примітка: Агент буде втрачений після завершення цього процесу.
+agent-note-persistent = Для постійних агентів спочатку запустіть `librefang start`.
+section-agent-templates = Доступні темплейти агентів
+
+# --- Manifest errors ---
+manifest-not-found = Файл маніфесту не знайдено: { $path }
+manifest-not-found-fix = Використовуйте `librefang agent new`, щоб запустити з темплейту
+error-reading-manifest = Помилка читання маніфесту: { $error }
+error-parsing-manifest = Помилка парсингу маніфесту: { $error }
+
+# --- Status ---
+section-daemon-status = Статус демона LibreFang
+section-status-inprocess = Статус LibreFang (внутрішньопроцесний)
+section-active-agents = Active Agents
+section-persisted-agents = Persisted Agents
+label-daemon-not-running = НЕ ЗАПУЩЕНИЙ
+label-home = Домашня директорія
+label-platform = Платформа
+label-sessions = Сесії
+label-memory = Пам'ять
+label-started = Запущено
+label-response = Відповідь
+label-checks = Перевірки
+section-status-locked = Обмежено (потрібен API-ключ)
+hint-status-locked = Встановіть `api_key` у ~/.librefang/config.toml, щоб бачити агентів / сесії / пам'ять.
+warn-public-bind = публічно прив'язано
+warn-key-missing = не встановлено
+section-recent-errors = Останні помилки (daemon.log)
+section-verbose = Деталі
+label-auth = Автентифікація
+label-mcp = MCP-сервери
+label-peers = OFP-піри
+label-channels = Канали
+label-skills = Скіли
+label-hands = Hands
+label-config-warnings = Попередження конфігурації
+auth-none = немає (анонімно)
+auth-api-key = API-ключ
+auth-dashboard-login = логін панелі приладів
+auth-user-keys = Ключів користувачів: { $count }
+
+# --- Doctor ---
+doctor-title = LibreFang Doctor
+doctor-all-passed = Усі перевірки пройдено! LibreFang готовий до роботи.
+doctor-repairs-applied = Виправлення застосовано. Запустіть `librefang doctor` знову для перевірки.
+doctor-some-failed = Деякі перевірки не пройдено.
+doctor-no-api-keys = Не знайдено API-ключів провайдерів LLM!
+section-getting-api-key = Отримання API-ключа (безкоштовні тарифи)
+
+# --- Security ---
+section-security-status = Стан безпеки
+label-audit-trail = Аудиторський слід
+label-taint-tracking = Відстеження міток
+label-wasm-sandbox = WASM-пісочниця
+label-wire-protocol = Мережевий протокол
+label-api-keys = API-ключі
+label-manifests = Маніфести
+value-audit-trail = Ланцюжок хешів Merkle (SHA-256)
+value-taint-tracking = Мітки потоку інформації
+value-wasm-sandbox = Подвійний облік (паливо + епоха)
+value-wire-protocol = Взаємна автентифікація OFP HMAC-SHA256
+value-api-keys = Zeroizing<String> (автоочищення при видаленні)
+value-manifests = Підписано Ed25519
+audit-verified = Цілісність аудиторського сліду підтверджено (ланцюжок Merkle валідний).
+audit-failed = Перевірка цілісності аудиторського сліду НЕ ВДАЛАСЯ.
+
+# --- Health ---
+health-ok = Демон здоровий
+health-not-running = Демон не запущений.
+
+# --- Channel setup ---
+section-channel-setup = Налаштування каналу
+channel-configured = Канал { $name } налаштовано
+channel-no-token = Токен не надано. Налаштування скасовано.
+channel-no-email = Email не надано. Налаштування скасовано.
+channel-token-saved = Токен збережено в ~/.librefang/.env
+channel-app-token-saved = Токен додатка збережено в ~/.librefang/.env
+channel-bot-token-saved = Токен бота збережено в ~/.librefang/.env
+channel-password-saved = Пароль збережено в ~/.librefang/.env
+channel-phone-saved = Телефон збережено в ~/.librefang/.env
+channel-key-saved = { $key } збережено в ~/.librefang/.env
+channel-unknown = Невідомий канал: { $name }
+channel-unknown-fix = Доступні: discord, slack, whatsapp, email, signal, matrix
+channel-test-ok = Тест каналу пройдено
+channel-test-fail = Тест каналу не пройдено
+section-setup-discord = Налаштування Discord
+section-setup-slack = Налаштування Slack
+section-setup-whatsapp = Налаштування WhatsApp
+section-setup-email = Налаштування Email
+section-setup-signal = Налаштування Signal
+section-setup-matrix = Налаштування Matrix
+
+# --- Vault ---
+vault-initialized = Зашифроване сховище ініціалізовано.
+vault-not-initialized = Сховище не ініціалізовано.
+vault-not-init-run = Сховище не ініціалізовано. Виконайте: librefang vault init
+vault-unlock-failed = Не вдалося розблокувати сховище: { $error }
+vault-empty-value = Порожнє значення — не збережено.
+vault-stored = Збережено '{ $key }' у сховіщі.
+vault-store-failed = Не вдалося зберегти: { $error }
+vault-removed = Видалено '{ $key }' зі сховища.
+vault-key-not-found = Ключ '{ $key }' не знайдено в сховищі.
+vault-remove-failed = Не вдалося видалити: { $error }
+vault-rotate-no-vault = Файл сховища не знайдено. Спочатку виконайте `librefang vault init`.
+vault-rotate-old-key-missing = LIBREFANG_VAULT_KEY_OLD не встановлено. Надайте поточний майстер-ключ (base64 від 32 байтів) перед ротацією.
+vault-rotate-new-key-missing = LIBREFANG_VAULT_KEY_NEW не встановлено. Надайте новий майстер-ключ (base64 від 32 байтів) або передайте --from-stdin, щоб зчитати його з stdin.
+vault-rotate-stdin-read-failed = Не вдалося зчитати новий ключ із stdin: { $error }
+vault-rotate-stdin-empty = Новий ключ, зчитаний із stdin, виявився порожнім.
+vault-rotate-same-key = LIBREFANG_VAULT_KEY_OLD та новий ключ ідентичні — відмова від ротації на той самий ключ.
+vault-rotate-old-key-invalid = LIBREFANG_VAULT_KEY_OLD не є валідним 32-байтовим ключем base64: { $error }
+vault-rotate-new-key-invalid = Новий ключ не є валідним 32-байтовим ключем base64: { $error }
+vault-rotate-unlock-failed = Не вдалося розблокувати сховище за допомогою СТАРОГО ключа: { $error }. Перевірте, чи відповідає LIBREFANG_VAULT_KEY_OLD ключу, яким сховище було спочатку зашифровано.
+vault-rotate-sentinel-failed = Перевірка сентингеля сховища не вдалася під СТАРИМ ключем: { $error }
+vault-rotate-rewrap-failed = Не вдалося перешифрувати сховище новим ключем: { $error }. Оригінальний файл сховища не змінено.
+vault-rotate-success = Сховище перешифровано під новим майстер-ключем (збережено користувацьких записів: { $count }).
+vault-rotate-next-step = Далі: встановіть LIBREFANG_VAULT_KEY у нове значення перед перезапуском демона.
+
+# --- Cron ---
+cron-created = Створено Cron-завдання: { $id }
+cron-create-failed = Не вдалося створити Cron-завдання: { $error }
+cron-deleted = Cron-завдання { $id } видалено.
+cron-delete-failed = Не вдалося видалити Cron-завдання: { $error }
+cron-toggled = Cron-завдання { $id } { $action }о.
+cron-toggle-failed = Не вдалося { $action } Cron-завдання: { $error }
+
+# --- Approvals ---
+approval-responded = Апрув { $id } { $action }о.
+approval-failed = Не вдалося { $action } апрув: { $error }
+
+# --- Memory ---
+memory-set = Встановлено { $key } для агента '{ $agent }'.
+memory-set-failed = Не вдалося встановити пам'ять: { $error }
+memory-deleted = Видалено ключ '{ $key }' для агента '{ $agent }'.
+memory-delete-failed = Не вдалося видалити пам'ять: { $error }
+
+# --- Devices ---
+section-device-pairing = Пейринг пристроїв
+device-scan-qr = Відскануйте цей QR-код за допомогою мобільного додатка LibreFang:
+device-removed = Пристрій { $id } видалено.
+device-remove-failed = Не вдалося видалити пристрій: { $error }
+
+# --- Webhooks ---
+webhook-created = Вебхук створено: { $id }
+webhook-create-failed = Не вдалося створити вебхук: { $error }
+webhook-deleted = Вебхук { $id } видалено.
+webhook-delete-failed = Не вдалося видалити вебхук: { $error }
+webhook-test-ok = Тестове корисне навантаження для вебхуку { $id } успішно надіслано.
+webhook-test-failed = Не вдалося протестувати вебхук: { $error }
+
+# --- Models ---
+model-set-success = Модель за замовчуванням встановлена на: { $model }
+model-set-failed = Не вдалося встановити model: { $error }
+model-no-catalog = У каталозі немає моделей.
+section-select-model = Виберіть модель
+model-out-of-range = Номер поза діапазоном (1-{ $max })
+
+# --- Config ---
+config-set-success = Значення конфігурації встановлено.
+config-unset-success = Ключ конфігурації видалено.
+config-no-file = Файл конфігурації не знайдено
+config-no-file-fix = Run `librefang init` first
+config-read-failed = Не вдалося прочитати конфігурацію: { $error }
+config-parse-error = Помилка парсингу конфігурації: { $error }
+config-parse-fix = Виправте синтаксис вашого config.toml або виконайте `librefang config edit`
+config-parse-fix-alt = Спочатку виправте синтаксис вашого config.toml
+config-key-not-found = Ключ не знайдено: { $key }
+config-key-path-not-found = Шлях до ключа не знайдено: { $key }
+config-empty-key = Порожній ключ
+config-section-not-scalar = '{ $key }' є розділом, а не скаляром
+config-section-not-scalar-fix = Використовуйте крапкову нотацію: { $key }.field_name
+config-parent-not-table = Батьківський елемент для '{ $key }' не є таблицею
+config-serialize-failed = Не вдалося серіалізувати конфігурацію: { $error }
+config-write-failed = Не вдалося записати конфігурацію: { $error }
+config-set-kv = Встановлено { $key } = { $value }
+config-removed-key = Видалено ключ: { $key }
+config-no-key = Ключ не надано. Скасовано.
+config-saved-key = Збережено { $env_var } у ~/.librefang/.env
+config-save-key-failed = Не вдалося зберегти ключ: { $error }
+config-removed-env = Видалено { $env_var } з ~/.librefang/.env
+config-remove-key-failed = Не вдалося видалити ключ: { $error }
+config-env-not-set = { $env_var } не встановлено
+config-set-key-hint = Встановіть його: librefang config set-key { $provider }
+config-update-key-hint = Оновіть ключ: librefang config set-key { $provider }
+
+# --- Hand commands ---
+hand-install-deps-success = Залежності для Hands '{ $id }' встановлено.
+hand-paused = Екземпляр Hands '{ $id }' призупинено.
+hand-resumed = Екземпляр Hands '{ $id }' відновлено.
+
+# --- Daemon notify ---
+daemon-restart-notify = Перезапустіть демона, щоб застосувати: librefang restart
+
+# --- System info ---
+section-system-info = Системна інформація LibreFang
+
+# --- Uninstall ---
+uninstall-goodbye = LibreFang було видалено. Бувайте!
+uninstall-cancelled = Скасовано.
+uninstall-stopping-daemon = Зупинка запущеного демона...
+uninstall-removed = Видалено { $path }
+uninstall-remove-failed = Не вдалося видалити { $path }: { $error }
+uninstall-removed-data-kept = Дані видалено (файли конфігурації збережено)
+uninstall-removed-autostart-win = Видалено запис автозапуску з реєстру Windows
+uninstall-removed-launch-agent = Видалено macOS launch agent
+uninstall-remove-launch-fail = Не вдалося видалити launch agent: { $error }
+uninstall-removed-autostart-linux = Видалено Linux autostart запис
+uninstall-remove-autostart-fail = Не вдалося видалити autostart запис: { $error }
+uninstall-removed-systemd = Видалено службу користувача systemd
+uninstall-remove-systemd-fail = Не вдалося видалити службу systemd: { $error }
+uninstall-cleaned-path = Очищено PATH від { $path }
+uninstall-cleaned-path-win = Очищено PATH в користувацькому оточенні Windows
+
+# --- Reset ---
+reset-success = Видалено { $path }
+reset-fail = Не вдалося видалити { $path }: { $error }
+
+# --- Logs ---
+log-following = --- Стеження за { $path } (Ctrl+C для зупинки) ---
+log-path-hint = Файл логу: { $path }

--- a/crates/librefang-cli/locales/uk/main.ftl
+++ b/crates/librefang-cli/locales/uk/main.ftl
@@ -62,6 +62,14 @@ label-id = ID
 label-active-agents = Активні агенти
 label-pairing-code = Код пейрингу
 label-expires = Закінчується
+label-yes = так
+label-not-loaded = не завантажено
+label-current = Поточна
+label-channel = Канал
+label-binary = Бінарний файл
+label-latest = Остання
+label-target = Цільова
+label-installed = Встановлено
 
 # --- Hints ---
 hint-open-dashboard = Відкрийте панель приладів у браузері або виконайте `librefang chat`
@@ -402,3 +410,396 @@ reset-fail = Не вдалося видалити { $path }: { $error }
 # --- Logs ---
 log-following = --- Стеження за { $path } (Ctrl+C для зупинки) ---
 log-path-hint = Файл логу: { $path }
+
+# --- Extracted from Rust sources ---
+init-upgrade-existing = Виявлено наявне встановлення — виконується оновлення для збереження ваших налаштувань.
+init-upgrade-fresh-hint = Щоб почати спочатку, видаліть ~/.librefang/config.toml та запустіть `librefang init` знову.
+init-upgrade-no-config = Немає чого оновлювати — config.toml не знайдено. Спочатку запустіть `librefang init`.
+init-upgrade-registry-synced = Реєстр синхронізовано
+init-upgrade-registry-failed = Помилка синхронізації реєстру (проблема з мережею?) — продовжуємо з кешованим вмістом
+init-upgrade-config-up-to-date = Конфігурація вже актуальна — нових полів не додано
+init-upgrade-sections-added = Додано { $count } нових розділів конфігурації:
+init-upgrade-legacy-openclaw = Виявлено застаріле встановлення ~/.openclaw.
+init-upgrade-legacy-openclaw-hint = Виконайте `librefang migrate --from openclaw`, щоб перенести ваші дані.
+init-upgrade-approval-warning = Ваш список require_approval містить лише "shell_exec". Файлові операції (file_write, file_delete) тепер вимагають схвалення за замовчуванням.
+init-upgrade-approval-hint = Щоб увімкнути: додайте "file_write" та "file_delete" до require_approval у config.toml
+init-upgrade-success-summary = Оновлення завершено!
+init-upgrade-title = Оновлення встановлення LibreFang
+init-upgrade-progress-label = Оновлення
+init-upgrade-backing-up = Резервне копіювання конфігурації
+init-upgrade-backup-success = Резервну копію конфігурації збережено у backups/{ $name }
+init-upgrade-syncing-registry = Синхронізація реєстру
+init-upgrade-initializing-vault-git = Ініціалізація сховища/git
+init-upgrade-merging-config = Об'єднання полів конфігурації
+init-upgrade-failed-read = Оновлення перервано: не вдалося прочитати config.toml: { $error }
+init-upgrade-failed-parse = Оновлення перервано: не вдалося розібрати config.toml: { $error }
+init-upgrade-backup-saved-hint = Вашу оригінальну конфігурацію було збережено у backups/{ $name }
+init-upgrade-failed-parse-template = Оновлення перервано: не вдалося розібрати шаблон конфігурації за замовчуванням: { $error }
+init-upgrade-failed-write = Оновлення перервано: не вдалося записати конфігурацію: { $error }
+init-upgrade-steps-complete = Кроки оновлення завершено
+label-backup = Бекап
+label-new-fields = Нові поля
+
+auth-chatgpt-device-requested = Запитано автентифікацію пристрою.
+auth-chatgpt-device-open-url = Відкрийте цю URL-адресу в будь-кому браузері:\n  { $url }\n
+auth-chatgpt-device-one-time-code = Введіть цей одноразовий код:\n  { $code }\n
+auth-chatgpt-device-do-not-share = Не діліться цим кодом.
+auth-chatgpt-device-waiting = Очікування авторизації...
+auth-chatgpt-switching-browser = \nПеремикання на стандартний процес входу через браузер...\n
+auth-chatgpt-opening-browser = Відкриття браузера для автентифікації OpenAI...
+auth-chatgpt-open-manually-hint = Якщо браузер не відкрився, відвідайте:\n  { $url }\n
+auth-chatgpt-open-browser-failed = Не вдалося автоматично відкрити браузер: { $error }
+auth-chatgpt-open-manually = Будь ласка, відкрийте вручну: { $url }
+auth-chatgpt-tokens-saved = \nТокени ChatGPT збережено в { $path }
+auth-chatgpt-detecting-model = Визначення найкращої доступної моделі...
+auth-chatgpt-selected-model = Вибрана модель: { $model }
+auth-chatgpt-config-updated = config.toml оновлено: provider = "chatgpt", model = "{ $model }"
+auth-chatgpt-starting-flow = Запуск процесу автентифікації ChatGPT...\n
+auth-chatgpt-complete = Автентифікацію ChatGPT завершено.
+auth-chatgpt-failed = Помилка автентифікації ChatGPT: { $error }
+
+auth-pool-config-not-array = config.toml `credential_pools` існує, але не є масивом таблиць
+auth-pool-daemon-error-fallback = Демон повернув HTTP { $status } — перехід до перегляду config.toml
+auth-pool-daemon-connect-fallback = Не вдалося зробити запит до демона на { $url }: { $error } — перехід до перегляду config.toml
+auth-pool-no-config-offline = Немає конфігурації в { $path } і демон не запущений.
+auth-pool-config-load-failed = Не вдалося завантажити конфігурацію: { $error }
+auth-pool-none-configured = Не налаштовано жодного пулу облікових даних.
+auth-pool-invalid-env-name = `{ $env_var }` не є коректним ім'ям змінної оточення. Очікуються великі літери, цифри та підкреслення (наприклад, OPENAI_API_KEY_2).
+auth-pool-env-empty = змінна оточення `{ $env_var }` встановлена, але порожня.
+auth-pool-env-empty-fix = Встановіть її у ваш API-ключ перед додаванням запису до пулу, наприклад:\n  export { $env_var }=sk-…\nПотім повторіть спробу.
+auth-pool-env-not-set = змінна оточення `{ $env_var }` не встановлена в поточному шеллі.
+auth-pool-env-not-set-fix = Експортуйте її перед додаванням запису до пулу, наприклад:\n  export { $env_var }=sk-…\nПотім повторіть спробу. (Демон зчитуватиме її зі свого власного оточення під час запуску — переконайтеся, що вона експортована і там.)
+auth-pool-keys-not-array = Пул для `{ $provider }` має поле `keys`, яке не є масивом таблиць.
+auth-pool-key-duplicate = Ключ зі змінною оточення `{ $env_var }` уже існує в пулі для провайдера `{ $provider }`.
+auth-pool-key-added = Додано ключ `{ $label }` (env={ $env_var }, priority={ $priority }) до пулу для `{ $provider }`. Перезапустіть демона або оновіть конфігурацію для застосування.
+auth-pool-not-configured = Не налаштовано жодного пулу облікових даних для провайдера `{ $provider }`.
+auth-pool-no-keys-field = Пул для `{ $provider }` не має масиву ключів.
+auth-pool-key-not-found = Не знайдено ключа зі змінною оточення `{ $env_var }` у пулі для `{ $provider }`.
+auth-pool-key-removed-pool-empty = Вилучено ключ `{ $env_var }` з пулу для `{ $provider }`. Тепер пул порожній і його було повністю видалено. Перезапустіть демона або оновіть конфігурацію для застосування.
+auth-pool-key-removed = Вилучено ключ `{ $env_var }` з пулу для `{ $provider }`. Перезапустіть демона або оновіть конфігурацію для застосування.
+auth-pool-unknown-strategy = Невідома стратегія `{ $strategy }`. Допустимі: fill_first, round_robin, random, least_used.
+auth-pool-strategy-set = Встановлено стратегію пулу для `{ $provider }` на `{ $strategy }`. Перезапустіть демона або оновіть конфігурацію для застосування.
+vault-empty = Сховище порожнє.
+vault-stored-count = Збережені облікові дані ({ $count }):
+
+# --- Scanned & Extracted keys ---
+# init.rs
+init-upgrade-failed-create-backups-dir = Не вдалося створити директорію бекапів: { $error }
+init-upgrade-failed-backup-config = Не вдалося створити бекап конфігурації: { $error }
+init-error-write-config-example = Не вдалося записати config.example.toml: { $error }
+
+# auth.rs
+auth-write-failed = Не вдалося записати { $path }: { $error }
+auth-password-empty = Пароль не може бути порожнім.
+auth-passwords-mismatch = Паролі не збігаються.
+auth-password-hash-failed = Не вдалося захешувати пароль: { $error }
+vault-enter-value-prompt = Введіть значення для { $key }: 
+auth-enter-password-prompt = Введіть пароль: 
+auth-confirm-password-prompt = Підтвердіть пароль: 
+
+# agent.rs
+agent-spawn-choose-target-or-template = Виберіть або позиційну ціль, або `--template`, але не обидва.
+agent-spawn-choose-target-or-template-fix = Використовуйте `librefang spawn coder` або `librefang spawn --template agents/custom/my-agent.toml`.
+agent-spawn-name-requires-template = `--name` вимагає імені темплейту або шляху до маніфесту.
+agent-spawn-name-requires-template-fix = Використовуйте `librefang spawn coder --name backend-coder` або `librefang spawn --template path/to/agent.toml --name backend-coder`.
+agent-spawn-dry-run-requires-template = Холостий запуск потребує імені темплейту або шляху до маніфесту.
+agent-spawn-dry-run-requires-template-fix = Використовуйте `librefang spawn coder --dry-run` or `librefang spawn --template path/to/agent.toml --dry-run`.
+agent-spawn-template-or-path-not-found = Темплейт або шлях до маніфесту не знайдено: { $target }
+agent-spawn-template-or-path-not-found-fix = Запустіть `librefang agent new`, щоб переглянути темплейти, або вкажіть правильний шлях до маніфесту.
+agent-manifest-parse-failed = Не вдалося розібрати маніфест агента з { $source }: { $error }
+agent-manifest-parse-failed-fix = Перевірте синтаксис TOML маніфесту та обов'язкові поля.
+agent-manifest-serialize-failed = Не вдалося серіалізувати оновлений маніфест: { $error }
+agent-dry-run-title = Холостий запуск агента
+agent-dry-run-success = Маніфест успішно розібрано. Жодного агента не було створено.
+agent-delete-warning-text = УВАГА: Видалення агента "{ $name }" назавжди вилучить його канонічний UUID
+    та всі пов'язані спогади й сесії.
+    Цю дію неможливо скасувати.
+label-confirm-prompt = Підтвердити?
+label-aborted = Скасовано.
+agent-delete-no-uuid = Не знайдено запису канонічного UUID для імені агента '{ $name }' — немає чого видаляти.
+agent-deleted-success = Агента "{ $name }" видалено (канонічний UUID очищено).
+agent-delete-failed-with-reason = Не вдалося видалити агента: { $error }
+agent-reset-uuid-warning-text = УВАГА: Скидання канонічного UUID для "{ $name }" призведе до втрати зв'язку з усіма сесіями
+    та спогадами, пов'язаними з поточним UUID. Наступний запуск під цим
+    іменем розпочнеться з новим UUID. Цю дію неможливо скасувати.
+agent-reset-uuid-success = Канонічний UUID для "{ $name }" скинуто (був { $previous }).
+agent-reset-uuid-failed-with-reason = Не вдалося скинути канонічний UUID: { $error }
+agent-reset-uuid-not-found = Не знайдено запису канонічного UUID для імені агента '{ $name }'.
+agent-merge-history-not-implemented = merge-history ще не реалізовано (слідкуючий тикет #4614).
+    Перепризначення сесій / спогадів з { $from } до канонічного UUID
+    для агента "{ $name }" вимагає крос-табличного SQL-втручання в субстрат
+    пам'яті, що відстежується окремо.
+agent-set-model-success = Для агента { $id } встановлено модель { $value }.
+agent-set-model-failed-with-reason = Не вдалося встановити модель: { $error }
+agent-set-no-daemon = Запущеного демона не знайдено. Запустіть його за допомогою: librefang start
+agent-set-unknown-field = Невідоме поле: { $field }. Підтримувані поля: model
+agent-new-no-templates = Не знайдено темплейтів агентів
+agent-new-no-templates-fix = Запустіть `librefang init`, щоб налаштувати директорію агентів
+agent-new-template-not-found = Темплейт '{ $name }' не знайдено
+agent-new-template-not-found-fix = Запустіть `librefang agent new`, щоб переглянути доступні темплейти
+agent-new-choose-template-prompt =   Оберіть темплейт [1]: 
+agent-sessions-none-active = Немає активних сесій.
+agent-sessions-none-found = Сесій не знайдено.
+
+label-source = Джерело
+label-name = Ім'я
+label-module = Модуль
+label-tools = Інструменти
+label-tags = Теги
+label-description = Опис
+
+# daemon.rs
+daemon-first-run-setup = Виявлено перший запуск — виконується швидке налаштування...
+daemon-config-not-found = Файл конфігурації не знайдено: { $path }
+daemon-config-not-found-fix = Запустіть `librefang init`, щоб створити конфігурацію за замовчуванням у ~/.librefang/config.toml, або перевірте шлях у --config.
+daemon-log-file-not-found = Файл логів не знайдено
+daemon-log-file-not-found-fix = Очікувався за шляхом: { $path }
+daemon-log-not-found-showing-tui = Лог демона не знайдено; показуємо лог TUI за шляхом { $path }
+
+# hand.rs
+hand-install-error-no-toml = Помилка: HAND.toml не знайдено в { $path }
+hand-install-error-read-toml = Помилка читання { $path }: { $error }
+hand-error-prefix = Помилка: { $error }
+hand-installed-success = Встановлено Hands: { $name } ({ $id })
+hand-activate-hint = Використовуйте `librefang hand activate { $id }`, щоб запустити його.
+hand-none-available = Немає доступних Hands.
+hand-list-activate-hint =
+    Використовуйте `librefang hand activate <id>`, щоб активувати Hands.
+hand-none-active = Немає активних Hands.
+label-hand = Hands
+label-instance = Інстанс
+label-agent = Агент
+hand-status-title = Статус Hands
+label-status-inactive = неактивний
+hand-not-found = Не знайдено активного або встановленого Hands для '{ $id }'.
+hand-activated-success = Hands '{ $id }' активовано (інстанс: { $instance }, агент: { $agent })
+hand-activate-failed = Не вдалося активувати Hands '{ $id }': { $error }
+hand-deactivated-success = Hands '{ $id }' деактивовано.
+label-failed-reason = Помилка: { $error }
+hand-no-active-instance = Не знайдено активного інстансу для Hands '{ $id }'.
+hand-info-not-found = Hands не знайдено: { $error }
+hand-no-settings = Hands '{ $id }' не має конфігурованих налаштувань.
+hand-settings-title = Налаштування для '{ $id }'
+hand-set-setting-success = Встановлено { $key }={ $value } для Hands '{ $id }'.
+hand-reloaded-summary = Перезавантажено Hands: { $added } додано, { $updated } оновлено, всього { $total }.
+hand-chat-welcome = Чат із { $name } (введіть /quit для виходу)
+
+# mcp_cmds.rs
+mcp-catalog-unknown-entry = Невідомий елемент каталогу MCP: '{ $name }'
+mcp-catalog-available-header =
+    Доступні сервери MCP (каталог):
+mcp-failed-read-config = Не вдалося прочитати { $path }: { $error }
+mcp-invalid-toml = { $path } не є коректним файлом TOML: { $error }
+mcp-already-configured = Сервер MCP '{ $name }' уже налаштований. Спочатку запустіть `librefang mcp remove { $name }`, якщо хочете перевстановити.
+mcp-failed-write-config = Не вдалося записати config.toml: { $error }
+mcp-add-credentials-hint =
+    Щоб додати облікові дані:
+mcp-get-it-here =   Отримайте тут: { $url }
+mcp-not-configured = Сервер MCP '{ $name }' не налаштований
+mcp-failed-update-config = Не вдалося оновити config.toml: { $error }
+mcp-removed-success = { $name } видалено.
+mcp-catalog-no-matches = Не знайдено елементів каталогу MCP, що відповідають '{ $query }'.
+mcp-catalog-none-available = Немає доступних елементів каталогу MCP.
+mcp-catalog-summary =   { $total } елементів каталогу ({ $installed } встановлено)
+mcp-catalog-install-hint =   Використовуйте `librefang mcp add <id>`, щоб встановити сервер MCP.
+mcp-none-configured = Немає налаштованих серверів MCP.
+mcp-list-catalog-hint =   Використовуйте `librefang mcp catalog`, щоб переглянути список доступних для встановлення серверів.
+
+# monitoring.rs
+monitoring-audit-reset-destructive = скидання аудиту є руйнівним — запустіть знову з `--confirm` для продовження
+monitoring-db-not-found = базу даних не знайдено за шляхом { $path }
+monitoring-db-open-failed = не вдалося відкрити { $path }: { $error }
+monitoring-db-truncate-failed = не вдалося очистити audit_entries: { $error }
+monitoring-audit-reset-anchor-deleted = , видалено якір за шляхом { $path }
+monitoring-audit-reset-anchor-none =  (немає якірного файлу для видалення)
+monitoring-audit-reset-success = Скинуто слід аудиту: вилучено { $count } рядків з audit_entries{ $anchor_detail }.
+monitoring-audit-reset-would-header =   Буде виконано:
+monitoring-audit-reset-would-delete =     1. ВИДАЛЕНО всі рядки з `audit_entries` у { $path }
+monitoring-audit-reset-would-remove-anchor =     2. Вилучено якірний файл { $path }
+monitoring-audit-reset-would-restart =   Ланцюг Меркла розпочнеться заново з наступної події аудиту.
+monitoring-daemon-running-error = демон запущений за адресою { $url }; відмовлено у зміні бази даних аудиту
+monitoring-daemon-running-error-fix = спочатку зупиніть демона: `librefang stop`
+monitoring-anchor-remove-failed = не вдалося вилучити якір { $path }: { $error }
+monitoring-audit-reset-seed-fresh = Наступний запуск демона створить свіжий ланцюг Меркла з поточного кінця.
+monitoring-memory-no-entries = Не знайдено записів пам'яті для агента '{ $agent }'.
+monitoring-devices-none-paired = Немає спарених пристроїв.
+monitoring-webhooks-none-configured = Вебхуки не налаштовані.
+
+# skill.rs
+skill-install-progress = Встановлення { $source }
+
+# system.rs
+migrate-error-home-dir = Помилка: не вдалося визначити домашню директорію
+migrate-start-msg = Міграція з { $source } ({ $path })...
+migrate-dry-run-hint =   (холостий запуск — жодних змін не буде внесено)
+migrate-progress-label = Виконання міграції
+migrate-complete-msg = Міграцію завершено
+migrate-warn-report-save-failed = Попередження: не вдалося зберегти звіт міграції: { $error }
+migrate-report-saved =
+      Звіт збережено за шляхом: { $path }
+migrate-failed-msg = Міграція завершилась невдачею: { $error }
+
+# maintenance.rs
+maintenance-service-install-root-error = Запущено від імені root — службу буде встановлено для облікового запису root, а не для вашого користувача. Запустіть без sudo.
+maintenance-service-unsupported = Автозапуск служби не підтримується на цій платформі.
+maintenance-failed-create-dir = Не вдалося створити { $path }: { $error }
+maintenance-failed-write-file = Не вдалося записати { $path }: { $error }
+maintenance-wrote-file = Записано { $path }
+maintenance-systemctl-reload-failed = помилка виконання systemctl --user daemon-reload
+maintenance-service-enabled = Службу увімкнено (запуститься при наступному вході в систему)
+maintenance-service-start-hint = Запустіть зараз за допомогою: systemctl --user start librefang.service
+maintenance-service-linger-hint = Для серверів без графічної оболонки також виконайте: loginctl enable-linger
+maintenance-systemctl-enable-failed = помилка виконання systemctl --user enable librefang.service
+maintenance-launchagent-loaded = LaunchAgent завантажено (запускатиметься при вході в систему та зараз)
+maintenance-launchctl-load-failed = помилка виконання launchctl load: { $error }
+maintenance-launchctl-run-failed = Не вдалося запустити launchctl: { $error }
+maintenance-windows-startup-added = Додано до автозавантаження Windows (HKCU\Software\Microsoft\Windows\CurrentVersion\Run)
+maintenance-windows-registry-write-failed = Не вдалося записати до реєстру Windows: { $error }
+maintenance-windows-reg-run-failed = Не вдалося запустити reg.exe: { $error }
+maintenance-systemd-removed = Вилучено користувацьку службу systemd
+maintenance-systemd-remove-failed = Не вдалося вилучити файл служби: { $error }
+maintenance-systemd-not-found = Користувацької служби systemd не знайдено — немає чого вилучати.
+maintenance-launchagent-removed = Вилучено LaunchAgent
+maintenance-launchagent-remove-failed = Не вдалося вилучити файл plist: { $error }
+maintenance-launchagent-not-found = LaunchAgent не знайдено — немає чого вилучати.
+maintenance-windows-startup-removed = Вилучено з автозавантаження Windows
+maintenance-windows-startup-not-found = Запису автозавантаження не знайдено — немає чого вилучати.
+maintenance-systemd-status-registered = Користувацьку службу systemd зареєстровано
+maintenance-status-label-enabled =   Увімкнено
+maintenance-status-label-active =   Активно
+maintenance-systemd-status-not-registered = Користувацьку службу systemd не зареєстровано.
+maintenance-service-install-hint = Запустіть `librefang service install`, щоб налаштувати її.
+maintenance-launchagent-status-registered = LaunchAgent зареєстровано
+maintenance-status-label-loaded =   Завантажено
+maintenance-launchagent-status-not-registered = LaunchAgent не зареєстровано.
+maintenance-windows-status-registered = Запис автозавантаження Windows зареєстровано
+maintenance-windows-status-not-registered = Запис автозавантаження не зареєстровано.
+reset-confirm-message =   Це видалить всі дані в { $path }
+      Включаючи: конфігурацію, базу даних, маніфести агентів, облікові дані.
+reset-confirm-prompt =   Ви впевнені? Введіть 'yes' для підтвердження: 
+reset-not-needed = Немає чого скидати — { $path } не існує.
+maintenance-update-section = Оновлення
+maintenance-update-error-exe-path = Не вдалося визначити шлях до поточного виконуваного файлу: { $error }
+maintenance-update-error-check-release = Не вдалося перевірити останній реліз: { $error }
+maintenance-update-warn-resolve-release = Не вдалося визначити останній опублікований реліз: { $error }
+maintenance-update-warn-resolve-release-fix = Спробуйте пізніше або передайте `--version <tag>`, щоб вказати конкретний реліз.
+maintenance-update-available = Доступний новіший опублікований реліз: { $tag }
+maintenance-update-run-hint = Запустіть `librefang update`, щоб встановити його.
+maintenance-update-same-core = Опублікований реліз { $tag } використовує ту саму версію ядра CLI, що й поточний виконуваний файл ({ $current }).
+maintenance-update-same-core-hint = Запустіть `librefang update`, якщо хочете отримати останню опубліковану збірку для цієї версії.
+maintenance-update-ahead = Поточна версія виконуваного файлу { $current } випереджає опублікований реліз { $tag }.
+maintenance-update-compare-unknown = Не вдалося порівняти поточну версію виконуваного файлу з тегом релізу { $tag }.
+maintenance-update-compare-unknown-hint = Якщо вам потрібен саме цей реліз, запустіть `librefang update --version <tag>`.
+maintenance-update-unable-to-determine = Не вдалося визначити наявність оновлення.
+maintenance-update-unable-to-determine-hint = Спробуйте пізніше, коли сервіс GitHub Releases буде доступним.
+maintenance-update-cannot-compare-safely = Не вдалося безпечно порівняти поточний виконуваний файл з тегом релізу { $tag }.
+maintenance-update-cannot-compare-safely-hint = Запустіть знову як `librefang update --version { $tag }`, щоб встановити його явно.
+maintenance-update-windows-daemon-running-error = Перед оновленням у Windows зупиніть працюючого демона.
+maintenance-update-windows-daemon-running-error-fix = Виконайте `librefang stop`, потім `librefang update`, а тоді `librefang start`.
+maintenance-update-cli-success = Локальний LibreFang CLI оновлено.
+maintenance-update-merging-config-defaults = Об'єднання нових налаштувань конфігурації за замовчуванням...
+maintenance-update-restart-daemon-hint = Якщо демон запущений, перезапустіть його за допомогою `librefang restart`.
+maintenance-update-background-launched = Оновлення запущено у фоновому режимі.
+maintenance-update-background-hint-terminal = Після завершення оновлення відкрийте новий термінал та запустіть `librefang --version`.
+maintenance-update-background-hint-restart = Якщо демон запущений, перезапустіть його після завершення оновлення.
+maintenance-update-failed-error = Помилка оновлення: { $error }
+maintenance-update-cargo-blocked = Цей виконуваний файл було встановлено через cargo. Запуск `cargo install` зсередини активного виконуваного файлу навмисно заблокований.
+maintenance-update-unofficial-path = Автоматичне оновлення підтримує лише офіційний шлях встановлення ({ $path }). Цей виконуваний файл запущено з іншого місця.
+maintenance-update-package-manager-hint = Якщо цей файл було встановлено через інший менеджер пакетів, оновіть його за допомогою цього менеджера.
+
+# doctor_cmd.rs
+doctor-check-librefang-dir-ok = Директорія LibreFang: { $path }
+doctor-check-librefang-dir-fail = Директорію LibreFang не знайдено.
+doctor-check-librefang-dir-created = Створено директорію LibreFang
+doctor-check-librefang-dir-create-fail = Не вдалося створити директорію
+doctor-check-librefang-dir-not-found-init = Директорію LibreFang не знайдено. Спочатку запустіть `librefang init`.
+doctor-check-env-ok = Файл .env (права доступу в нормі)
+doctor-check-env-fixed = Файл .env (права доступу виправлено на 0600)
+doctor-check-env-ok-generic = Файл .env
+doctor-check-env-loose-warn = Файл .env має занадто відкриті права доступу ({ $mode }), має бути 0600
+doctor-check-env-not-found-warn = Файл .env не знайдено (створіть за допомогою: librefang config set-key <provider>)
+doctor-check-config-ok = Файл конфігурації: { $path }
+doctor-check-config-syntax-fail = Файл конфігурації містить синтаксичні помилки: { $error }
+doctor-check-config-not-found = Файл конфігурації не знайдено.
+doctor-check-config-created = Створено config.toml за замовчуванням
+doctor-check-config-create-fail = Не вдалося створити config.toml
+doctor-check-cli-version = Версія CLI: { $version } (канал: { $channel })
+doctor-check-update-available-warn = Доступне оновлення: { $current } -> { $latest } (див. https://github.com/librefang/librefang/releases)
+doctor-check-cli-up-to-date = CLI оновлений до останньої версії
+doctor-check-update-fail-warn = Не вдалося перевірити наявність оновлень (мережа недоступна)
+doctor-check-daemon-running = Демон запущений за адресою { $url }
+doctor-check-daemon-not-running-warn = Демон не запущений (запустіть за допомогою `librefang start`)
+doctor-check-port-available = Порт { $address } вільний
+doctor-check-port-in-use-warn = Порт { $address } використовується іншим процесом
+doctor-check-stale-daemon-json-removed = Вилучено застарілий daemon.json
+doctor-check-stale-daemon-json-warn = Знайдено застарілий daemon.json (демон не запущений). Запустіть з --repair для очищення.
+doctor-check-db-ok = Файл бази даних (коректний SQLite)
+doctor-check-db-invalid-fail = Файл бази даних існує, але не є коректним SQLite
+doctor-check-db-not-found-warn = Файлу бази даних немає (буде створено при першому запуску)
+doctor-check-disk-space-low-warn = Мало вільного місця на диску: доступно { $count }МБ
+doctor-check-disk-space-ok = Вільне місце на диску: доступно { $count }МБ
+doctor-check-manifests-ok = Маніфести агентів коректні
+doctor-check-manifest-invalid-fail = Некоректний маніфест { $file }: { $error }
+doctor-check-home-dir-fail = Не вдалося визначити домашню директорію
+doctor-check-provider-key-rejected-warn = { $name } ({ $env_var }) - ключ відхилено (401/403)
+doctor-check-endpoint-reachable = Ендпоінт { $name } доступний ({ $endpoint })
+doctor-check-endpoint-unreachable-warn = Ендпоінт { $name } недоступний ({ $endpoint })
+doctor-check-channel-token-format-warn = { $name } ({ $env_var }) - неочікуваний формат токена
+doctor-check-config-env-missing-warn = Конфігурація посилається на { $env_var }, але його не встановлено в оточенні або у .env
+doctor-check-config-deser-ok = Конфігурація успішно десеріалізується в KernelConfig
+doctor-check-exec-policy = Політика виконання: mode={ $mode }, safe_bins={ $count }
+doctor-check-include-file-ok = Підключений файл: { $path }
+doctor-check-include-file-missing-warn = Підключений файл відсутній: { $path }
+doctor-check-include-file-not-found-fail = Підключений файл не знайдено: { $path }
+doctor-check-mcp-servers-count = Налаштовано серверів MCP: { $count }
+doctor-check-mcp-empty-command-warn = Сервер MCP '{ $name }' має порожню команду
+doctor-check-mcp-empty-url-warn = Сервер MCP '{ $name }' має порожню URL-адресу
+doctor-check-mcp-empty-base-url-warn = Сервер MCP '{ $name }' має порожній base_url
+doctor-check-mcp-no-compat-tools-warn = Сервер MCP '{ $name }' не має налаштованих інструментів http_compat
+doctor-check-mcp-compat-header-empty-name-warn = Сервер MCP '{ $name }' має заголовок http_compat з порожнім ім'ям
+doctor-check-mcp-compat-header-no-value-warn = Сервер MCP '{ $name }' має заголовок http_compat без value/value_env
+doctor-check-mcp-compat-tool-empty-name-warn = Сервер MCP '{ $name }' має інструмент http_compat з порожнім ім'ям
+doctor-check-mcp-compat-tool-empty-path-warn = Сервер MCP '{ $name }' має інструмент http_compat з порожнім шляхом
+doctor-check-config-deser-fail = Помилка десеріалізації конфігурації в KernelConfig: { $error }
+doctor-check-skills-loaded = Завантажено скілів: { $count }
+doctor-check-skills-load-fail-warn = Не вдалося завантажити скіли: { $error }
+doctor-check-skills-injection-ok = Усі скіли пройшли перевірку на ін'єкції промптів
+doctor-check-mcp-catalog-templates = Шаблони каталогу MCP: { $templates }
+doctor-check-mcp-configured-servers = Налаштовано серверів MCP: { $configured }
+doctor-check-running-agents = Запущено агентів: { $count }
+doctor-check-daemon-uptime = Час роботи демона: { $hours }год { $mins }хв
+doctor-check-db-connectivity-ok = Підключення до бази даних: OK
+doctor-check-db-status-fail = Стан бази даних: { $status }
+doctor-check-health-detail-status-warn = Ендпоінт стану повернув { $status }
+doctor-check-health-detail-fail-warn = Не вдалося запитати стан демона: { $error }
+doctor-check-skills-loaded-daemon = Завантажено скілів у демоні: { $count }
+doctor-check-rust-version = Rust: { $version }
+doctor-check-rust-not-found-fail = Інструментарій Rust не знайдено
+doctor-check-python-version = Python: { $version }
+doctor-check-python-not-found-warn = Python не знайдено (необхідний для скілів на Python)
+doctor-check-node-version = Node.js: { $version }
+doctor-check-node-not-found-warn = Node.js не знайдено (необхідний для скілів на Node.js)
+doctor-prompt-create-dir =     Створити зараз? [Y/n] 
+doctor-prompt-create-config =     Створити конфігурацію за замовчуванням? [Y/n] 
+doctor-section-providers =   LLM Провайдери:
+doctor-section-connectivity = 
+
+  Підключення до Мережі:
+doctor-section-channels = 
+
+  Інтеграція Каналів:
+doctor-section-config-val = 
+
+  Валідація Конфігурації:
+doctor-section-skills = 
+
+  Скіли:
+doctor-check-skills-injection-critical-warn = Скіл '{ $name }' має { $count } критичних попереджень:
+doctor-check-skills-injection-warn = Попередження про ін'єкцію промпту в скілі: { $name }
+doctor-section-mcp-servers =
+  MCP-сервери:
+doctor-section-daemon-health =
+  Здоров'я демона:
+doctor-check-daemon-mcp-status = MCP-сервери: { $configured } налаштовано, { $connected } підключено
+doctor-check-daemon-mcp-health = Здоров'я MCP-серверів: { $healthy }/{ $total } здорових
+

--- a/crates/librefang-cli/locales/uk/main.ftl
+++ b/crates/librefang-cli/locales/uk/main.ftl
@@ -887,6 +887,10 @@ launcher-help-title = Усі команди
 launcher-help-subtitle =   — q/Esc для повернення
 launcher-help-hints = ↑↓/jk прокрутка  PgUp/PgDn  g/G вгору/вниз  q назад
 
-
-
-
+# CLI shared UI strings
+ui-brand-tagline = Відкрита операційна система для агентів
+ui-label-hint = підказка:
+ui-label-next-steps = Наступні кроки
+ui-label-fix = виправити:
+ui-label-try = спробувати:
+ui-provider-not-set = { $env_var } не налаштовано

--- a/crates/librefang-cli/src/commands/agent.rs
+++ b/crates/librefang-cli/src/commands/agent.rs
@@ -162,7 +162,7 @@ pub(crate) fn prepared_agent_manifest_from_contents(
 
     let manifest_toml = if name_override.is_some() {
         toml::to_string_pretty(&manifest).unwrap_or_else(|e| {
-            ui::error(&format!("Failed to serialize updated manifest: {e}"));
+            ui::error(&i18n::t_args("agent-manifest-serialize-failed", &[("error", &e.to_string())]));
             std::process::exit(1);
         })
     } else {
@@ -177,30 +177,30 @@ pub(crate) fn prepared_agent_manifest_from_contents(
 }
 
 pub(crate) fn preview_agent_manifest(prepared: &PreparedAgentManifest) {
-    ui::section("Agent Dry Run");
-    ui::kv("Source", &prepared.source_label);
-    ui::kv("Name", &prepared.manifest.name);
-    ui::kv("Version", &prepared.manifest.version);
-    ui::kv("Module", &prepared.manifest.module);
+    ui::section(&i18n::t("agent-dry-run-title"));
+    ui::kv(&i18n::t("label-source"), &prepared.source_label);
+    ui::kv(&i18n::t("label-name"), &prepared.manifest.name);
+    ui::kv(&i18n::t("label-version"), &prepared.manifest.version);
+    ui::kv(&i18n::t("label-module"), &prepared.manifest.module);
     ui::kv(
-        "Model",
+        &i18n::t("label-model"),
         &format!(
             "{}/{}",
             prepared.manifest.model.provider, prepared.manifest.model.model
         ),
     );
     ui::kv(
-        "Tools",
+        &i18n::t("label-tools"),
         &prepared.manifest.capabilities.tools.len().to_string(),
     );
-    ui::kv("Skills", &prepared.manifest.skills.len().to_string());
+    ui::kv(&i18n::t("label-skills"), &prepared.manifest.skills.len().to_string());
     if !prepared.manifest.tags.is_empty() {
-        ui::kv("Tags", &prepared.manifest.tags.join(", "));
+        ui::kv(&i18n::t("label-tags"), &prepared.manifest.tags.join(", "));
     }
     if !prepared.manifest.description.is_empty() {
-        ui::kv("Description", &prepared.manifest.description);
+        ui::kv(&i18n::t("label-description"), &prepared.manifest.description);
     }
-    ui::success("Manifest parsed successfully. No agent was spawned.");
+    ui::success(&i18n::t("agent-dry-run-success"));
 }
 
 pub(crate) fn spawn_prepared_agent(config: Option<PathBuf>, prepared: PreparedAgentManifest) {

--- a/crates/librefang-cli/src/commands/agent.rs
+++ b/crates/librefang-cli/src/commands/agent.rs
@@ -162,7 +162,10 @@ pub(crate) fn prepared_agent_manifest_from_contents(
 
     let manifest_toml = if name_override.is_some() {
         toml::to_string_pretty(&manifest).unwrap_or_else(|e| {
-            ui::error(&i18n::t_args("agent-manifest-serialize-failed", &[("error", &e.to_string())]));
+            ui::error(&i18n::t_args(
+                "agent-manifest-serialize-failed",
+                &[("error", &e.to_string())],
+            ));
             std::process::exit(1);
         })
     } else {
@@ -193,12 +196,18 @@ pub(crate) fn preview_agent_manifest(prepared: &PreparedAgentManifest) {
         &i18n::t("label-tools"),
         &prepared.manifest.capabilities.tools.len().to_string(),
     );
-    ui::kv(&i18n::t("label-skills"), &prepared.manifest.skills.len().to_string());
+    ui::kv(
+        &i18n::t("label-skills"),
+        &prepared.manifest.skills.len().to_string(),
+    );
     if !prepared.manifest.tags.is_empty() {
         ui::kv(&i18n::t("label-tags"), &prepared.manifest.tags.join(", "));
     }
     if !prepared.manifest.description.is_empty() {
-        ui::kv(&i18n::t("label-description"), &prepared.manifest.description);
+        ui::kv(
+            &i18n::t("label-description"),
+            &prepared.manifest.description,
+        );
     }
     ui::success(&i18n::t("agent-dry-run-success"));
 }

--- a/crates/librefang-cli/src/commands/auth.rs
+++ b/crates/librefang-cli/src/commands/auth.rs
@@ -36,31 +36,31 @@ pub(crate) async fn authenticate_chatgpt(
     if device_auth {
         match resolve_device_auth_start(chatgpt_oauth::start_device_auth_flow().await)? {
             DeviceAuthNextStep::ContinueDevice(prompt) => {
-                println!("Device authentication requested.");
+                println!("{}", i18n::t("auth-chatgpt-device-requested"));
                 println!(
-                    "Open this URL in any browser:\n  {}\n",
-                    chatgpt_oauth::DEVICE_AUTH_URL
+                    "{}",
+                    i18n::t_args("auth-chatgpt-device-open-url", &[("url", chatgpt_oauth::DEVICE_AUTH_URL)])
                 );
-                println!("Enter this one-time code:\n  {}\n", prompt.user_code);
-                println!("Do not share this code.");
-                println!("Waiting for authorization...");
+                println!("{}", i18n::t_args("auth-chatgpt-device-one-time-code", &[("code", &prompt.user_code)]));
+                println!("{}", i18n::t("auth-chatgpt-device-do-not-share"));
+                println!("{}", i18n::t("auth-chatgpt-device-waiting"));
                 return chatgpt_oauth::poll_device_auth_flow(&prompt).await;
             }
             DeviceAuthNextStep::FallbackToBrowser(message) => {
                 println!("{message}");
-                println!("\nSwitching to the standard browser login flow...\n");
+                println!("{}", i18n::t("auth-chatgpt-switching-browser"));
             }
         }
     }
 
     let (auth_url, port, code_verifier, state) = chatgpt_oauth::start_oauth_flow().await?;
 
-    println!("Opening browser for OpenAI authentication...");
-    println!("If the browser does not open, visit:\n  {auth_url}\n");
+    println!("{}", i18n::t("auth-chatgpt-opening-browser"));
+    println!("{}", i18n::t_args("auth-chatgpt-open-manually-hint", &[("url", &auth_url)]));
 
     if let Err(e) = open::that(&auth_url) {
-        eprintln!("Could not open browser automatically: {e}");
-        eprintln!("Please open manually: {auth_url}");
+        eprintln!("{}", i18n::t_args("auth-chatgpt-open-browser-failed", &[("error", &e.to_string())]));
+        eprintln!("{}", i18n::t_args("auth-chatgpt-open-manually", &[("url", &auth_url)]));
     }
 
     let code = chatgpt_oauth::run_oauth_callback_server(port, &state).await?;
@@ -84,15 +84,15 @@ pub(crate) async fn persist_chatgpt_auth(
         refresh_token.as_ref().map(|rt| rt.as_str()),
     )?;
 
-    println!("\nChatGPT tokens saved to {}", secrets_path.display());
+    println!("{}", i18n::t_args("auth-chatgpt-tokens-saved", &[("path", &secrets_path.display().to_string())]));
 
-    println!("Detecting best available model...");
+    println!("{}", i18n::t("auth-chatgpt-detecting-model"));
     let best_model = chatgpt_oauth::fetch_best_codex_model(&access_token).await;
-    println!("Selected model: {best_model}");
+    println!("{}", i18n::t_args("auth-chatgpt-selected-model", &[("model", &best_model)]));
 
     update_chatgpt_config(&home, &best_model)?;
 
-    println!("config.toml updated: provider = \"chatgpt\", model = \"{best_model}\"");
+    println!("{}", i18n::t_args("auth-chatgpt-config-updated", &[("model", &best_model)]));
     Ok(())
 }
 
@@ -168,7 +168,7 @@ pub(crate) fn update_chatgpt_config(
 }
 
 pub(crate) fn cmd_auth_chatgpt(device_auth: bool) {
-    println!("Starting ChatGPT authentication flow...\n");
+    println!("{}", i18n::t("auth-chatgpt-starting-flow"));
 
     let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
 
@@ -178,9 +178,9 @@ pub(crate) fn cmd_auth_chatgpt(device_auth: bool) {
     });
 
     match result {
-        Ok(()) => ui::success("ChatGPT authentication complete."),
+        Ok(()) => ui::success(&i18n::t("auth-chatgpt-complete")),
         Err(e) => {
-            ui::error(&format!("ChatGPT authentication failed: {e}"));
+            ui::error(&i18n::t_args("auth-chatgpt-failed", &[("error", &e.to_string())]));
             std::process::exit(1);
         }
     }
@@ -227,7 +227,10 @@ pub(crate) fn pool_load_doc_or_exit(path: &std::path::Path) -> toml_edit::Docume
 
 pub(crate) fn pool_write_doc_or_exit(path: &std::path::Path, doc: &toml_edit::DocumentMut) {
     std::fs::write(path, doc.to_string()).unwrap_or_else(|e| {
-        ui::error(&format!("Failed to write {}: {e}", path.display()));
+        ui::error(&i18n::t_args(
+            "auth-write-failed",
+            &[("path", &path.display().to_string()), ("error", &e.to_string())],
+        ));
         std::process::exit(1);
     });
 }
@@ -262,7 +265,7 @@ pub(crate) fn pool_lookup_doc_mut<'d>(
     let arr = match item.as_array_of_tables_mut() {
         Some(a) => a,
         None => {
-            ui::error("config.toml `credential_pools` exists but is not an array of tables");
+            ui::error(&i18n::t("auth-pool-config-not-array"));
             std::process::exit(1);
         }
     };
@@ -296,15 +299,10 @@ pub(crate) fn cmd_auth_pool_list(config: Option<PathBuf>, json: bool) {
                 return;
             }
             Ok(r) => {
-                ui::check_warn(&format!(
-                    "Daemon returned HTTP {} — falling back to config.toml view",
-                    r.status()
-                ));
+                ui::check_warn(&i18n::t_args("auth-pool-daemon-error-fallback", &[("status", &r.status().to_string())]));
             }
             Err(e) => {
-                ui::check_warn(&format!(
-                    "Failed to query daemon at {url}: {e} — falling back to config.toml view"
-                ));
+                ui::check_warn(&i18n::t_args("auth-pool-daemon-connect-fallback", &[("url", &url), ("error", &e.to_string())]));
             }
         }
     }
@@ -315,15 +313,12 @@ pub(crate) fn cmd_auth_pool_list(config: Option<PathBuf>, json: bool) {
         if json {
             println!("[]");
         } else {
-            ui::check_warn(&format!(
-                "No config at {} and daemon is not running.",
-                path.display()
-            ));
+            ui::check_warn(&i18n::t_args("auth-pool-no-config-offline", &[("path", &path.display().to_string())]));
         }
         return;
     }
     let cfg = load_config(Some(&path)).unwrap_or_else(|e| {
-        ui::error(&format!("Failed to load config: {e}"));
+        ui::error(&i18n::t_args("auth-pool-config-load-failed", &[("error", &e.to_string())]));
         std::process::exit(1);
     });
     let mut pools: Vec<serde_json::Value> = cfg
@@ -380,7 +375,7 @@ pub(crate) fn print_pool_summary_human(body: &serde_json::Value) {
     let pools = match body.as_array() {
         Some(a) if !a.is_empty() => a,
         _ => {
-            println!("{}", "No credential pools configured.".to_string().dimmed());
+            println!("{}", i18n::t("auth-pool-none-configured").dimmed());
             println!();
             println!("Add one with:");
             println!(
@@ -469,9 +464,7 @@ pub(crate) fn cmd_auth_pool_add(
     priority: u32,
 ) {
     if !is_valid_env_var_name(env_var) {
-        ui::error(&format!(
-            "`{env_var}` is not a valid env var name. Expected uppercase letters, digits, and underscores (e.g. OPENAI_API_KEY_2)."
-        ));
+        ui::error(&i18n::t_args("auth-pool-invalid-env-name", &[("env_var", env_var)]));
         std::process::exit(1);
     }
     // Validate the env var is actually set at add time. Without this the
@@ -483,15 +476,15 @@ pub(crate) fn cmd_auth_pool_add(
         Ok(v) if !v.trim().is_empty() => {}
         Ok(_) => {
             ui::error_with_fix(
-                &format!("env var `{env_var}` is set but empty."),
-                &format!("Set it to your API key before adding the pool entry, e.g.\n  export {env_var}=sk-…\nThen retry."),
+                &i18n::t_args("auth-pool-env-empty", &[("env_var", env_var)]),
+                &i18n::t_args("auth-pool-env-empty-fix", &[("env_var", env_var)]),
             );
             std::process::exit(1);
         }
         Err(_) => {
             ui::error_with_fix(
-                &format!("env var `{env_var}` is not set in the current shell."),
-                &format!("Export it before adding the pool entry, e.g.\n  export {env_var}=sk-…\nThen retry. (The daemon will read it from its own environment at boot time — make sure it's exported there too.)"),
+                &i18n::t_args("auth-pool-env-not-set", &[("env_var", env_var)]),
+                &i18n::t_args("auth-pool-env-not-set-fix", &[("env_var", env_var)]),
             );
             std::process::exit(1);
         }
@@ -515,9 +508,7 @@ pub(crate) fn cmd_auth_pool_add(
                 let keys_arr = match keys_item.as_array_of_tables_mut() {
                     Some(a) => a,
                     None => {
-                        ui::error(&format!(
-                            "Pool for `{provider}` has a `keys` field that is not an array of tables."
-                        ));
+                        ui::error(&i18n::t_args("auth-pool-keys-not-array", &[("provider", provider)]));
                         std::process::exit(1);
                     }
                 };
@@ -529,9 +520,7 @@ pub(crate) fn cmd_auth_pool_add(
                         .unwrap_or(false)
                 });
                 if dup {
-                    ui::error(&format!(
-                        "Key with env_var `{env_var}` already exists in pool for provider `{provider}`."
-                    ));
+                    ui::error(&i18n::t_args("auth-pool-key-duplicate", &[("env_var", env_var), ("provider", provider)]));
                     std::process::exit(1);
                 }
                 let mut new_key_tbl = toml_edit::Table::new();
@@ -558,8 +547,14 @@ pub(crate) fn cmd_auth_pool_add(
     }
 
     pool_write_doc_or_exit(&path, &doc);
-    ui::success(&format!(
-        "Added key `{label}` (env={env_var}, priority={priority}) to pool for `{provider}`. Restart the daemon or hot-reload config to apply."
+    ui::success(&i18n::t_args(
+        "auth-pool-key-added",
+        &[
+            ("label", label),
+            ("env_var", env_var),
+            ("priority", &priority.to_string()),
+            ("provider", provider),
+        ],
     ));
 }
 
@@ -571,21 +566,17 @@ pub(crate) fn cmd_auth_pool_remove(config: Option<PathBuf>, provider: &str, env_
     {
         let (arr, idx) = pool_lookup_doc_mut(&mut doc, provider);
         let Some(i) = idx else {
-            ui::error(&format!(
-                "No credential pool configured for provider `{provider}`."
-            ));
+            ui::error(&i18n::t_args("auth-pool-not-configured", &[("provider", provider)]));
             std::process::exit(1);
         };
 
         let pool_tbl = arr.get_mut(i).expect("idx within bounds");
         let Some(keys_item) = pool_tbl.get_mut("keys") else {
-            ui::error(&format!("Pool for `{provider}` has no keys array."));
+            ui::error(&i18n::t_args("auth-pool-no-keys-field", &[("provider", provider)]));
             std::process::exit(1);
         };
         let Some(keys_arr) = keys_item.as_array_of_tables_mut() else {
-            ui::error(&format!(
-                "Pool for `{provider}` has a `keys` field that is not an array of tables."
-            ));
+            ui::error(&i18n::t_args("auth-pool-keys-not-array", &[("provider", provider)]));
             std::process::exit(1);
         };
         let before = keys_arr.len();
@@ -603,9 +594,7 @@ pub(crate) fn cmd_auth_pool_remove(config: Option<PathBuf>, provider: &str, env_
             }
         }
         if keys_arr.len() == before {
-            ui::error(&format!(
-                "No key with env_var `{env_var}` found in pool for `{provider}`."
-            ));
+            ui::error(&i18n::t_args("auth-pool-key-not-found", &[("env_var", env_var), ("provider", provider)]));
             std::process::exit(1);
         }
         if keys_arr.is_empty() {
@@ -616,20 +605,23 @@ pub(crate) fn cmd_auth_pool_remove(config: Option<PathBuf>, provider: &str, env_
 
     pool_write_doc_or_exit(&path, &doc);
     if empty_pool_removed {
-        ui::success(&format!(
-            "Removed key `{env_var}` from pool for `{provider}`. Pool is now empty and has been removed entirely. Restart the daemon or hot-reload config to apply."
+        ui::success(&i18n::t_args(
+            "auth-pool-key-removed-pool-empty",
+            &[("env_var", env_var), ("provider", provider)],
         ));
     } else {
-        ui::success(&format!(
-            "Removed key `{env_var}` from pool for `{provider}`. Restart the daemon or hot-reload config to apply."
+        ui::success(&i18n::t_args(
+            "auth-pool-key-removed",
+            &[("env_var", env_var), ("provider", provider)],
         ));
     }
 }
 
 pub(crate) fn cmd_auth_pool_strategy(config: Option<PathBuf>, provider: &str, strategy: &str) {
     let Some(canon) = pool_strategy_canon(strategy) else {
-        ui::error(&format!(
-            "Unknown strategy `{strategy}`. Valid: fill_first, round_robin, random, least_used."
+        ui::error(&i18n::t_args(
+            "auth-pool-unknown-strategy",
+            &[("strategy", strategy)],
         ));
         std::process::exit(1);
     };
@@ -640,9 +632,7 @@ pub(crate) fn cmd_auth_pool_strategy(config: Option<PathBuf>, provider: &str, st
     {
         let (arr, idx) = pool_lookup_doc_mut(&mut doc, provider);
         let Some(i) = idx else {
-            ui::error(&format!(
-                "No credential pool configured for provider `{provider}`."
-            ));
+            ui::error(&i18n::t_args("auth-pool-not-configured", &[("provider", provider)]));
             std::process::exit(1);
         };
         let pool_tbl = arr.get_mut(i).expect("idx within bounds");
@@ -650,8 +640,9 @@ pub(crate) fn cmd_auth_pool_strategy(config: Option<PathBuf>, provider: &str, st
     }
 
     pool_write_doc_or_exit(&path, &doc);
-    ui::success(&format!(
-        "Set pool strategy for `{provider}` to `{canon}`. Restart the daemon or hot-reload config to apply."
+    ui::success(&i18n::t_args(
+        "auth-pool-strategy-set",
+        &[("provider", provider), ("strategy", canon)],
     ));
 }
 
@@ -731,9 +722,9 @@ pub(crate) fn cmd_vault_list() {
 
     let keys = vault.list_keys();
     if keys.is_empty() {
-        println!("Vault is empty.");
+        println!("{}", i18n::t("vault-empty"));
     } else {
-        println!("Stored credentials ({}):", keys.len());
+        println!("{}", i18n::t_args("vault-stored-count", &[("count", &keys.len().to_string())]));
         for key in keys {
             println!("  {key}");
         }
@@ -922,14 +913,14 @@ pub(crate) fn cmd_hash_password(password: Option<String>) {
     let pass = match password {
         Some(p) => p,
         None => {
-            let p1 = prompt_input("Enter password: ");
+            let p1 = prompt_input(&i18n::t("auth-enter-password-prompt"));
             if p1.is_empty() {
-                ui::error("Password cannot be empty.");
+                ui::error(&i18n::t("auth-password-empty"));
                 std::process::exit(1);
             }
-            let p2 = prompt_input("Confirm password: ");
+            let p2 = prompt_input(&i18n::t("auth-confirm-password-prompt"));
             if p1 != p2 {
-                ui::error("Passwords do not match.");
+                ui::error(&i18n::t("auth-passwords-mismatch"));
                 std::process::exit(1);
             }
             p1
@@ -943,7 +934,7 @@ pub(crate) fn cmd_hash_password(password: Option<String>) {
             println!("  dashboard_pass_hash = \"{hash}\"");
         }
         Err(e) => {
-            ui::error(&format!("Failed to hash password: {e}"));
+            ui::error(&i18n::t_args("auth-password-hash-failed", &[("error", &e.to_string())]));
             std::process::exit(1);
         }
     }

--- a/crates/librefang-cli/src/commands/auth.rs
+++ b/crates/librefang-cli/src/commands/auth.rs
@@ -39,9 +39,18 @@ pub(crate) async fn authenticate_chatgpt(
                 println!("{}", i18n::t("auth-chatgpt-device-requested"));
                 println!(
                     "{}",
-                    i18n::t_args("auth-chatgpt-device-open-url", &[("url", chatgpt_oauth::DEVICE_AUTH_URL)])
+                    i18n::t_args(
+                        "auth-chatgpt-device-open-url",
+                        &[("url", chatgpt_oauth::DEVICE_AUTH_URL)]
+                    )
                 );
-                println!("{}", i18n::t_args("auth-chatgpt-device-one-time-code", &[("code", &prompt.user_code)]));
+                println!(
+                    "{}",
+                    i18n::t_args(
+                        "auth-chatgpt-device-one-time-code",
+                        &[("code", &prompt.user_code)]
+                    )
+                );
                 println!("{}", i18n::t("auth-chatgpt-device-do-not-share"));
                 println!("{}", i18n::t("auth-chatgpt-device-waiting"));
                 return chatgpt_oauth::poll_device_auth_flow(&prompt).await;
@@ -56,11 +65,23 @@ pub(crate) async fn authenticate_chatgpt(
     let (auth_url, port, code_verifier, state) = chatgpt_oauth::start_oauth_flow().await?;
 
     println!("{}", i18n::t("auth-chatgpt-opening-browser"));
-    println!("{}", i18n::t_args("auth-chatgpt-open-manually-hint", &[("url", &auth_url)]));
+    println!(
+        "{}",
+        i18n::t_args("auth-chatgpt-open-manually-hint", &[("url", &auth_url)])
+    );
 
     if let Err(e) = open::that(&auth_url) {
-        eprintln!("{}", i18n::t_args("auth-chatgpt-open-browser-failed", &[("error", &e.to_string())]));
-        eprintln!("{}", i18n::t_args("auth-chatgpt-open-manually", &[("url", &auth_url)]));
+        eprintln!(
+            "{}",
+            i18n::t_args(
+                "auth-chatgpt-open-browser-failed",
+                &[("error", &e.to_string())]
+            )
+        );
+        eprintln!(
+            "{}",
+            i18n::t_args("auth-chatgpt-open-manually", &[("url", &auth_url)])
+        );
     }
 
     let code = chatgpt_oauth::run_oauth_callback_server(port, &state).await?;
@@ -84,15 +105,27 @@ pub(crate) async fn persist_chatgpt_auth(
         refresh_token.as_ref().map(|rt| rt.as_str()),
     )?;
 
-    println!("{}", i18n::t_args("auth-chatgpt-tokens-saved", &[("path", &secrets_path.display().to_string())]));
+    println!(
+        "{}",
+        i18n::t_args(
+            "auth-chatgpt-tokens-saved",
+            &[("path", &secrets_path.display().to_string())]
+        )
+    );
 
     println!("{}", i18n::t("auth-chatgpt-detecting-model"));
     let best_model = chatgpt_oauth::fetch_best_codex_model(&access_token).await;
-    println!("{}", i18n::t_args("auth-chatgpt-selected-model", &[("model", &best_model)]));
+    println!(
+        "{}",
+        i18n::t_args("auth-chatgpt-selected-model", &[("model", &best_model)])
+    );
 
     update_chatgpt_config(&home, &best_model)?;
 
-    println!("{}", i18n::t_args("auth-chatgpt-config-updated", &[("model", &best_model)]));
+    println!(
+        "{}",
+        i18n::t_args("auth-chatgpt-config-updated", &[("model", &best_model)])
+    );
     Ok(())
 }
 
@@ -180,7 +213,10 @@ pub(crate) fn cmd_auth_chatgpt(device_auth: bool) {
     match result {
         Ok(()) => ui::success(&i18n::t("auth-chatgpt-complete")),
         Err(e) => {
-            ui::error(&i18n::t_args("auth-chatgpt-failed", &[("error", &e.to_string())]));
+            ui::error(&i18n::t_args(
+                "auth-chatgpt-failed",
+                &[("error", &e.to_string())],
+            ));
             std::process::exit(1);
         }
     }
@@ -229,7 +265,10 @@ pub(crate) fn pool_write_doc_or_exit(path: &std::path::Path, doc: &toml_edit::Do
     std::fs::write(path, doc.to_string()).unwrap_or_else(|e| {
         ui::error(&i18n::t_args(
             "auth-write-failed",
-            &[("path", &path.display().to_string()), ("error", &e.to_string())],
+            &[
+                ("path", &path.display().to_string()),
+                ("error", &e.to_string()),
+            ],
         ));
         std::process::exit(1);
     });
@@ -299,10 +338,16 @@ pub(crate) fn cmd_auth_pool_list(config: Option<PathBuf>, json: bool) {
                 return;
             }
             Ok(r) => {
-                ui::check_warn(&i18n::t_args("auth-pool-daemon-error-fallback", &[("status", &r.status().to_string())]));
+                ui::check_warn(&i18n::t_args(
+                    "auth-pool-daemon-error-fallback",
+                    &[("status", &r.status().to_string())],
+                ));
             }
             Err(e) => {
-                ui::check_warn(&i18n::t_args("auth-pool-daemon-connect-fallback", &[("url", &url), ("error", &e.to_string())]));
+                ui::check_warn(&i18n::t_args(
+                    "auth-pool-daemon-connect-fallback",
+                    &[("url", &url), ("error", &e.to_string())],
+                ));
             }
         }
     }
@@ -313,12 +358,18 @@ pub(crate) fn cmd_auth_pool_list(config: Option<PathBuf>, json: bool) {
         if json {
             println!("[]");
         } else {
-            ui::check_warn(&i18n::t_args("auth-pool-no-config-offline", &[("path", &path.display().to_string())]));
+            ui::check_warn(&i18n::t_args(
+                "auth-pool-no-config-offline",
+                &[("path", &path.display().to_string())],
+            ));
         }
         return;
     }
     let cfg = load_config(Some(&path)).unwrap_or_else(|e| {
-        ui::error(&i18n::t_args("auth-pool-config-load-failed", &[("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "auth-pool-config-load-failed",
+            &[("error", &e.to_string())],
+        ));
         std::process::exit(1);
     });
     let mut pools: Vec<serde_json::Value> = cfg
@@ -464,7 +515,10 @@ pub(crate) fn cmd_auth_pool_add(
     priority: u32,
 ) {
     if !is_valid_env_var_name(env_var) {
-        ui::error(&i18n::t_args("auth-pool-invalid-env-name", &[("env_var", env_var)]));
+        ui::error(&i18n::t_args(
+            "auth-pool-invalid-env-name",
+            &[("env_var", env_var)],
+        ));
         std::process::exit(1);
     }
     // Validate the env var is actually set at add time. Without this the
@@ -508,7 +562,10 @@ pub(crate) fn cmd_auth_pool_add(
                 let keys_arr = match keys_item.as_array_of_tables_mut() {
                     Some(a) => a,
                     None => {
-                        ui::error(&i18n::t_args("auth-pool-keys-not-array", &[("provider", provider)]));
+                        ui::error(&i18n::t_args(
+                            "auth-pool-keys-not-array",
+                            &[("provider", provider)],
+                        ));
                         std::process::exit(1);
                     }
                 };
@@ -520,7 +577,10 @@ pub(crate) fn cmd_auth_pool_add(
                         .unwrap_or(false)
                 });
                 if dup {
-                    ui::error(&i18n::t_args("auth-pool-key-duplicate", &[("env_var", env_var), ("provider", provider)]));
+                    ui::error(&i18n::t_args(
+                        "auth-pool-key-duplicate",
+                        &[("env_var", env_var), ("provider", provider)],
+                    ));
                     std::process::exit(1);
                 }
                 let mut new_key_tbl = toml_edit::Table::new();
@@ -566,17 +626,26 @@ pub(crate) fn cmd_auth_pool_remove(config: Option<PathBuf>, provider: &str, env_
     {
         let (arr, idx) = pool_lookup_doc_mut(&mut doc, provider);
         let Some(i) = idx else {
-            ui::error(&i18n::t_args("auth-pool-not-configured", &[("provider", provider)]));
+            ui::error(&i18n::t_args(
+                "auth-pool-not-configured",
+                &[("provider", provider)],
+            ));
             std::process::exit(1);
         };
 
         let pool_tbl = arr.get_mut(i).expect("idx within bounds");
         let Some(keys_item) = pool_tbl.get_mut("keys") else {
-            ui::error(&i18n::t_args("auth-pool-no-keys-field", &[("provider", provider)]));
+            ui::error(&i18n::t_args(
+                "auth-pool-no-keys-field",
+                &[("provider", provider)],
+            ));
             std::process::exit(1);
         };
         let Some(keys_arr) = keys_item.as_array_of_tables_mut() else {
-            ui::error(&i18n::t_args("auth-pool-keys-not-array", &[("provider", provider)]));
+            ui::error(&i18n::t_args(
+                "auth-pool-keys-not-array",
+                &[("provider", provider)],
+            ));
             std::process::exit(1);
         };
         let before = keys_arr.len();
@@ -594,7 +663,10 @@ pub(crate) fn cmd_auth_pool_remove(config: Option<PathBuf>, provider: &str, env_
             }
         }
         if keys_arr.len() == before {
-            ui::error(&i18n::t_args("auth-pool-key-not-found", &[("env_var", env_var), ("provider", provider)]));
+            ui::error(&i18n::t_args(
+                "auth-pool-key-not-found",
+                &[("env_var", env_var), ("provider", provider)],
+            ));
             std::process::exit(1);
         }
         if keys_arr.is_empty() {
@@ -632,7 +704,10 @@ pub(crate) fn cmd_auth_pool_strategy(config: Option<PathBuf>, provider: &str, st
     {
         let (arr, idx) = pool_lookup_doc_mut(&mut doc, provider);
         let Some(i) = idx else {
-            ui::error(&i18n::t_args("auth-pool-not-configured", &[("provider", provider)]));
+            ui::error(&i18n::t_args(
+                "auth-pool-not-configured",
+                &[("provider", provider)],
+            ));
             std::process::exit(1);
         };
         let pool_tbl = arr.get_mut(i).expect("idx within bounds");
@@ -724,7 +799,10 @@ pub(crate) fn cmd_vault_list() {
     if keys.is_empty() {
         println!("{}", i18n::t("vault-empty"));
     } else {
-        println!("{}", i18n::t_args("vault-stored-count", &[("count", &keys.len().to_string())]));
+        println!(
+            "{}",
+            i18n::t_args("vault-stored-count", &[("count", &keys.len().to_string())])
+        );
         for key in keys {
             println!("  {key}");
         }
@@ -934,7 +1012,10 @@ pub(crate) fn cmd_hash_password(password: Option<String>) {
             println!("  dashboard_pass_hash = \"{hash}\"");
         }
         Err(e) => {
-            ui::error(&i18n::t_args("auth-password-hash-failed", &[("error", &e.to_string())]));
+            ui::error(&i18n::t_args(
+                "auth-password-hash-failed",
+                &[("error", &e.to_string())],
+            ));
             std::process::exit(1);
         }
     }

--- a/crates/librefang-cli/src/commands/daemon.rs
+++ b/crates/librefang-cli/src/commands/daemon.rs
@@ -258,15 +258,15 @@ pub(crate) fn ensure_initialized(config: &Option<PathBuf>) {
         None => {
             let home = cli_librefang_home();
             if !home.join("config.toml").exists() {
-                ui::hint("First run detected — running quick setup...");
+                ui::hint(&i18n::t("daemon-first-run-setup"));
                 cmd_init(true);
             }
         }
         Some(path) => {
             if !path.exists() {
                 ui::error_with_fix(
-                    &format!("Config file not found: {}", path.display()),
-                    "Run `librefang init` to create a default config at ~/.librefang/config.toml, or check the --config path.",
+                    &i18n::t_args("daemon-config-not-found", &[("path", &path.display().to_string())]),
+                    &i18n::t("daemon-config-not-found-fix"),
                 );
                 std::process::exit(1);
             }
@@ -610,8 +610,8 @@ pub(crate) fn force_kill_pid(pid: u32) {
 pub(crate) fn show_log_file(log_path: &std::path::Path, lines: usize, follow: bool) {
     if !log_path.exists() {
         ui::error_with_fix(
-            "Log file not found",
-            &format!("Expected at: {}", log_path.display()),
+            &i18n::t("daemon-log-file-not-found"),
+            &i18n::t_args("daemon-log-file-not-found-fix", &[("path", &log_path.display().to_string())]),
         );
         std::process::exit(1);
     }
@@ -634,7 +634,7 @@ pub(crate) fn show_log_file(log_path: &std::path::Path, lines: usize, follow: bo
             for line in &all_lines[start..] {
                 println!("{line}");
             }
-            println!("--- Following {} (Ctrl+C to stop) ---", log_path.display());
+            println!("{}", i18n::t_args("log-following", &[("path", &log_path.display().to_string())]));
             let mut last_len = content.len();
             loop {
                 std::thread::sleep(std::time::Duration::from_millis(500));
@@ -669,9 +669,9 @@ pub(crate) fn cmd_logs(config: Option<PathBuf>, lines: usize, follow: bool) {
         None => daemon.home_dir.join("logs").join("tui.log"),
     };
     if tui_log.exists() {
-        ui::hint(&format!(
-            "Daemon log not found; showing TUI log at {}",
-            tui_log.display()
+        ui::hint(&i18n::t_args(
+            "daemon-log-not-found-showing-tui",
+            &[("path", &tui_log.display().to_string())],
         ));
         show_log_file(&tui_log, lines, follow);
         return;

--- a/crates/librefang-cli/src/commands/daemon.rs
+++ b/crates/librefang-cli/src/commands/daemon.rs
@@ -265,7 +265,10 @@ pub(crate) fn ensure_initialized(config: &Option<PathBuf>) {
         Some(path) => {
             if !path.exists() {
                 ui::error_with_fix(
-                    &i18n::t_args("daemon-config-not-found", &[("path", &path.display().to_string())]),
+                    &i18n::t_args(
+                        "daemon-config-not-found",
+                        &[("path", &path.display().to_string())],
+                    ),
                     &i18n::t("daemon-config-not-found-fix"),
                 );
                 std::process::exit(1);
@@ -611,7 +614,10 @@ pub(crate) fn show_log_file(log_path: &std::path::Path, lines: usize, follow: bo
     if !log_path.exists() {
         ui::error_with_fix(
             &i18n::t("daemon-log-file-not-found"),
-            &i18n::t_args("daemon-log-file-not-found-fix", &[("path", &log_path.display().to_string())]),
+            &i18n::t_args(
+                "daemon-log-file-not-found-fix",
+                &[("path", &log_path.display().to_string())],
+            ),
         );
         std::process::exit(1);
     }
@@ -634,7 +640,13 @@ pub(crate) fn show_log_file(log_path: &std::path::Path, lines: usize, follow: bo
             for line in &all_lines[start..] {
                 println!("{line}");
             }
-            println!("{}", i18n::t_args("log-following", &[("path", &log_path.display().to_string())]));
+            println!(
+                "{}",
+                i18n::t_args(
+                    "log-following",
+                    &[("path", &log_path.display().to_string())]
+                )
+            );
             let mut last_len = content.len();
             loop {
                 std::thread::sleep(std::time::Duration::from_millis(500));

--- a/crates/librefang-cli/src/commands/doctor_cmd.rs
+++ b/crates/librefang-cli/src/commands/doctor_cmd.rs
@@ -455,9 +455,9 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             ui::check_fail(&i18n::t("doctor-no-api-keys"));
             ui::blank();
             ui::section(&i18n::t("section-getting-api-key"));
-            ui::suggest_cmd("Groq:", "https://console.groq.com       (free, fast)");
-            ui::suggest_cmd("Gemini:", "https://aistudio.google.com    (free tier)");
-            ui::suggest_cmd("DeepSeek:", "https://platform.deepseek.com  (low cost)");
+            ui::suggest_cmd("Groq:", &i18n::t("doctor-suggest-groq"));
+            ui::suggest_cmd("Gemini:", &i18n::t("doctor-suggest-gemini"));
+            ui::suggest_cmd("DeepSeek:", &i18n::t("doctor-suggest-deepseek"));
             ui::blank();
             ui::hint(&i18n::t("hint-set-key"));
         }

--- a/crates/librefang-cli/src/commands/doctor_cmd.rs
+++ b/crates/librefang-cli/src/commands/doctor_cmd.rs
@@ -40,14 +40,14 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         // --- Check 1: LibreFang directory ---
         if librefang_dir.exists() {
             if !json {
-                ui::check_ok(&format!("LibreFang directory: {}", librefang_dir.display()));
+                ui::check_ok(&i18n::t_args("doctor-check-librefang-dir-ok", &[("path", &librefang_dir.display().to_string())]));
             }
             checks.push(serde_json::json!({"check": "librefang_dir", "status": "ok", "path": librefang_dir.display().to_string()}));
         } else if repair {
             if !json {
-                ui::check_fail("LibreFang directory not found.");
+                ui::check_fail(&i18n::t("doctor-check-librefang-dir-fail"));
             }
-            let answer = prompt_input("    Create it now? [Y/n] ");
+            let answer = prompt_input(&i18n::t("doctor-prompt-create-dir"));
             if answer.is_empty() || answer.starts_with('y') || answer.starts_with('Y') {
                 if std::fs::create_dir_all(&librefang_dir).is_ok() {
                     restrict_dir_permissions(&librefang_dir);
@@ -55,12 +55,12 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     let _ =
                         std::fs::create_dir_all(librefang_dir.join("workspaces").join("agents"));
                     if !json {
-                        ui::check_ok("Created LibreFang directory");
+                        ui::check_ok(&i18n::t("doctor-check-librefang-dir-created"));
                     }
                     repaired = true;
                 } else {
                     if !json {
-                        ui::check_fail("Failed to create directory");
+                        ui::check_fail(&i18n::t("doctor-check-librefang-dir-create-fail"));
                     }
                     all_ok = false;
                 }
@@ -70,7 +70,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             checks.push(serde_json::json!({"check": "librefang_dir", "status": if repaired { "repaired" } else { "fail" }}));
         } else {
             if !json {
-                ui::check_fail("LibreFang directory not found. Run `librefang init` first.");
+                ui::check_fail(&i18n::t("doctor-check-librefang-dir-not-found-init"));
             }
             checks.push(serde_json::json!({"check": "librefang_dir", "status": "fail"}));
             all_ok = false;
@@ -86,7 +86,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     let mode = meta.permissions().mode() & 0o777;
                     if mode == 0o600 {
                         if !json {
-                            ui::check_ok(".env file (permissions OK)");
+                            ui::check_ok(&i18n::t("doctor-check-env-ok"));
                         }
                     } else if repair {
                         let _ = std::fs::set_permissions(
@@ -94,31 +94,26 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                             std::fs::Permissions::from_mode(0o600),
                         );
                         if !json {
-                            ui::check_ok(".env file (permissions fixed to 0600)");
+                            ui::check_ok(&i18n::t("doctor-check-env-fixed"));
                         }
                         repaired = true;
                     } else if !json {
-                        ui::check_warn(&format!(
-                            ".env file has loose permissions ({:o}), should be 0600",
-                            mode
-                        ));
+                        ui::check_warn(&i18n::t_args("doctor-check-env-loose-warn", &[("mode", &format!("{:o}", mode))]));
                     }
                 } else if !json {
-                    ui::check_ok(".env file");
+                    ui::check_ok(&i18n::t("doctor-check-env-ok-generic"));
                 }
             }
             #[cfg(not(unix))]
             {
                 if !json {
-                    ui::check_ok(".env file");
+                    ui::check_ok(&i18n::t("doctor-check-env-ok-generic"));
                 }
             }
             checks.push(serde_json::json!({"check": "env_file", "status": "ok"}));
         } else {
             if !json {
-                ui::check_warn(
-                    ".env file not found (create with: librefang config set-key <provider>)",
-                );
+                ui::check_warn(&i18n::t("doctor-check-env-not-found-warn"));
             }
             checks.push(serde_json::json!({"check": "env_file", "status": "warn"}));
         }
@@ -130,13 +125,13 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             match toml::from_str::<toml::Value>(&config_content) {
                 Ok(_) => {
                     if !json {
-                        ui::check_ok(&format!("Config file: {}", config_path.display()));
+                        ui::check_ok(&i18n::t_args("doctor-check-config-ok", &[("path", &config_path.display().to_string())]));
                     }
                     checks.push(serde_json::json!({"check": "config_file", "status": "ok"}));
                 }
                 Err(e) => {
                     if !json {
-                        ui::check_fail(&format!("Config file has syntax errors: {e}"));
+                        ui::check_fail(&i18n::t_args("doctor-check-config-syntax-fail", &[("error", &e.to_string())]));
                         ui::hint(&i18n::t("hint-config-edit"));
                     }
                     checks.push(serde_json::json!({"check": "config_syntax", "status": "fail", "error": e.to_string()}));
@@ -145,9 +140,9 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             }
         } else if repair {
             if !json {
-                ui::check_fail("Config file not found.");
+                ui::check_fail(&i18n::t("doctor-check-config-not-found"));
             }
-            let answer = prompt_input("    Create default config? [Y/n] ");
+            let answer = prompt_input(&i18n::t("doctor-prompt-create-config"));
             if answer.is_empty() || answer.starts_with('y') || answer.starts_with('Y') {
                 let (provider, api_key_env, model) = detect_best_provider();
                 let default_config = render_init_default_config(&provider, &model, &api_key_env);
@@ -155,12 +150,12 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 if std::fs::write(&config_path, default_config).is_ok() {
                     restrict_file_permissions(&config_path);
                     if !json {
-                        ui::check_ok("Created default config.toml");
+                        ui::check_ok(&i18n::t("doctor-check-config-created"));
                     }
                     repaired = true;
                 } else {
                     if !json {
-                        ui::check_fail("Failed to create config.toml");
+                        ui::check_fail(&i18n::t("doctor-check-config-create-fail"));
                     }
                     all_ok = false;
                 }
@@ -170,7 +165,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             checks.push(serde_json::json!({"check": "config_file", "status": if repaired { "repaired" } else { "fail" }}));
         } else {
             if !json {
-                ui::check_fail("Config file not found.");
+                ui::check_fail(&i18n::t("doctor-check-config-not-found"));
             }
             checks.push(serde_json::json!({"check": "config_file", "status": "fail"}));
             all_ok = false;
@@ -181,9 +176,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             let current_version = env!("CARGO_PKG_VERSION");
             let update_channel = load_update_channel_from_config().unwrap_or_default();
             if !json {
-                ui::check_ok(&format!(
-                    "CLI version: {current_version} (channel: {update_channel})"
-                ));
+                ui::check_ok(&i18n::t_args("doctor-check-cli-version", &[("version", current_version), ("channel", &update_channel.to_string())]));
             }
             checks.push(serde_json::json!({"check": "cli_version", "status": "ok", "version": current_version, "channel": update_channel.to_string()}));
 
@@ -193,21 +186,22 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     let latest = tag.strip_prefix('v').unwrap_or(&tag);
                     if latest != current_version {
                         if !json {
-                            ui::check_warn(&format!(
-                                "Update available: {current_version} -> {latest} (see https://github.com/librefang/librefang/releases)"
+                            ui::check_warn(&i18n::t_args(
+                                "doctor-check-update-available-warn",
+                                &[("current", current_version), ("latest", latest)]
                             ));
                         }
                         checks.push(serde_json::json!({"check": "version_update", "status": "warn", "current": current_version, "latest": latest}));
                     } else {
                         if !json {
-                            ui::check_ok("CLI is up to date");
+                            ui::check_ok(&i18n::t("doctor-check-cli-up-to-date"));
                         }
                         checks.push(serde_json::json!({"check": "version_update", "status": "ok"}));
                     }
                 }
                 Err(_) => {
                     if !json {
-                        ui::check_warn("Could not check for updates (network unavailable)");
+                        ui::check_warn(&i18n::t("doctor-check-update-fail-warn"));
                     }
                     checks.push(serde_json::json!({"check": "version_update", "status": "warn", "reason": "network_error"}));
                 }
@@ -234,12 +228,12 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         let daemon_running = find_daemon();
         if let Some(ref base) = daemon_running {
             if !json {
-                ui::check_ok(&format!("Daemon running at {base}"));
+                ui::check_ok(&i18n::t_args("doctor-check-daemon-running", &[("url", base)]));
             }
             checks.push(serde_json::json!({"check": "daemon", "status": "ok", "url": base}));
         } else {
             if !json {
-                ui::check_warn("Daemon not running (start with `librefang start`)");
+                ui::check_warn(&i18n::t("doctor-check-daemon-not-running-warn"));
             }
             checks.push(serde_json::json!({"check": "daemon", "status": "warn"}));
 
@@ -252,7 +246,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             match std::net::TcpListener::bind(&bind_addr) {
                 Ok(_) => {
                     if !json {
-                        ui::check_ok(&format!("Port {api_listen} is available"));
+                        ui::check_ok(&i18n::t_args("doctor-check-port-available", &[("address", &api_listen)]));
                     }
                     checks.push(
                         serde_json::json!({"check": "port", "status": "ok", "address": api_listen}),
@@ -260,7 +254,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 }
                 Err(_) => {
                     if !json {
-                        ui::check_warn(&format!("Port {api_listen} is in use by another process"));
+                        ui::check_warn(&i18n::t_args("doctor-check-port-in-use-warn", &[("address", &api_listen)]));
                     }
                     checks.push(serde_json::json!({"check": "port", "status": "warn", "address": api_listen}));
                 }
@@ -273,13 +267,11 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             if repair {
                 let _ = std::fs::remove_file(&daemon_json_path);
                 if !json {
-                    ui::check_ok("Removed stale daemon.json");
+                    ui::check_ok(&i18n::t("doctor-check-stale-daemon-json-removed"));
                 }
                 repaired = true;
             } else if !json {
-                ui::check_warn(
-                    "Stale daemon.json found (daemon not running). Run with --repair to clean up.",
-                );
+                ui::check_warn(&i18n::t("doctor-check-stale-daemon-json-warn"));
             }
             checks.push(serde_json::json!({"check": "stale_daemon_json", "status": if repair { "repaired" } else { "warn" }}));
         }
@@ -291,12 +283,12 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             if let Ok(bytes) = std::fs::read(&db_path) {
                 if bytes.len() >= 16 && bytes.starts_with(b"SQLite format 3") {
                     if !json {
-                        ui::check_ok("Database file (valid SQLite)");
+                        ui::check_ok(&i18n::t("doctor-check-db-ok"));
                     }
                     checks.push(serde_json::json!({"check": "database", "status": "ok"}));
                 } else {
                     if !json {
-                        ui::check_fail("Database file exists but is not valid SQLite");
+                        ui::check_fail(&i18n::t("doctor-check-db-invalid-fail"));
                     }
                     checks.push(serde_json::json!({"check": "database", "status": "fail"}));
                     all_ok = false;
@@ -304,7 +296,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             }
         } else {
             if !json {
-                ui::check_warn("No database file (will be created on first run)");
+                ui::check_warn(&i18n::t("doctor-check-db-not-found-warn"));
             }
             checks.push(serde_json::json!({"check": "database", "status": "warn"}));
         }
@@ -324,16 +316,12 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         if let Ok(available_mb) = cols[3].parse::<u64>() {
                             if available_mb < 100 {
                                 if !json {
-                                    ui::check_warn(&format!(
-                                        "Low disk space: {available_mb}MB available"
-                                    ));
+                                    ui::check_warn(&i18n::t_args("doctor-check-disk-space-low-warn", &[("count", &available_mb.to_string())]));
                                 }
                                 checks.push(serde_json::json!({"check": "disk_space", "status": "warn", "available_mb": available_mb}));
                             } else {
                                 if !json {
-                                    ui::check_ok(&format!(
-                                        "Disk space: {available_mb}MB available"
-                                    ));
+                                    ui::check_ok(&i18n::t_args("doctor-check-disk-space-ok", &[("count", &available_mb.to_string())]));
                                 }
                                 checks.push(serde_json::json!({"check": "disk_space", "status": "ok", "available_mb": available_mb}));
                             }
@@ -367,13 +355,13 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             }
             if agent_errors.is_empty() {
                 if !json {
-                    ui::check_ok("Agent manifests are valid");
+                    ui::check_ok(&i18n::t("doctor-check-manifests-ok"));
                 }
                 checks.push(serde_json::json!({"check": "agent_manifests", "status": "ok"}));
             } else {
                 for (file, err) in &agent_errors {
                     if !json {
-                        ui::check_fail(&format!("Invalid manifest {file}: {err}"));
+                        ui::check_fail(&i18n::t_args("doctor-check-manifest-invalid-fail", &[("file", file), ("error", err)]));
                     }
                 }
                 checks.push(serde_json::json!({"check": "agent_manifests", "status": "fail", "errors": agent_errors.len()}));
@@ -382,7 +370,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         }
     } else {
         if !json {
-            ui::check_fail("Could not determine home directory");
+            ui::check_fail(&i18n::t("doctor-check-home-dir-fail"));
         }
         checks.push(serde_json::json!({"check": "home_dir", "status": "fail"}));
         all_ok = false;
@@ -390,7 +378,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
 
     // --- LLM providers ---
     if !json {
-        println!("\n  LLM Providers:");
+        println!("{}", i18n::t("doctor-section-providers"));
     }
     // Pretty display names for known provider IDs. Anything not listed
     // here falls back to a Title-Case derivation of the raw provider id
@@ -449,7 +437,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     ui::provider_status(name, env_var, true);
                 }
             } else if !json {
-                ui::check_warn(&format!("{name} ({env_var}) - key rejected (401/403)"));
+                ui::check_warn(&i18n::t_args("doctor-check-provider-key-rejected-warn", &[("name", name), ("env_var", env_var)]));
             }
             any_key_set = true;
             checks.push(serde_json::json!({"check": "provider", "name": name, "env_var": env_var, "status": if valid { "ok" } else { "warn" }, "live_test": !valid}));
@@ -506,7 +494,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
 
         if !configured.is_empty() {
             if !json {
-                println!("\n  Network Connectivity:");
+                println!("{}", i18n::t("doctor-section-connectivity"));
             }
             for (env_var, name, endpoint) in &configured {
                 use std::net::{TcpStream, ToSocketAddrs};
@@ -521,12 +509,12 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
 
                 if reachable {
                     if !json {
-                        ui::check_ok(&format!("{name} endpoint reachable ({endpoint})"));
+                        ui::check_ok(&i18n::t_args("doctor-check-endpoint-reachable", &[("name", name), ("endpoint", endpoint)]));
                     }
                     checks.push(serde_json::json!({"check": "network_connectivity", "provider": name, "endpoint": endpoint, "env_var": env_var, "status": "ok"}));
                 } else {
                     if !json {
-                        ui::check_warn(&format!("{name} endpoint unreachable ({endpoint})"));
+                        ui::check_warn(&i18n::t_args("doctor-check-endpoint-unreachable-warn", &[("name", name), ("endpoint", endpoint)]));
                     }
                     checks.push(serde_json::json!({"check": "network_connectivity", "provider": name, "endpoint": endpoint, "env_var": env_var, "status": "warn"}));
                 }
@@ -536,7 +524,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
 
     // --- Check 10: Channel token format validation ---
     if !json {
-        println!("\n  Channel Integrations:");
+        println!("{}", i18n::t("doctor-section-channels"));
     }
     let channel_keys = [
         ("TELEGRAM_BOT_TOKEN", "Telegram"),
@@ -561,7 +549,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     ui::provider_status(name, env_var, true);
                 }
             } else if !json {
-                ui::check_warn(&format!("{name} ({env_var}) - unexpected token format"));
+                ui::check_warn(&i18n::t_args("doctor-check-channel-token-format-warn", &[("name", name), ("env_var", env_var)]));
             }
             checks.push(serde_json::json!({"check": "channel", "name": name, "env_var": env_var, "status": if format_ok { "ok" } else { "warn" }}));
         } else {
@@ -586,9 +574,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         let val = val_part.trim().trim_matches('"');
                         if !val.is_empty() && std::env::var(val).is_err() {
                             if !json {
-                                ui::check_warn(&format!(
-                                    "Config references {val} but it is not set in env or .env"
-                                ));
+                                ui::check_warn(&i18n::t_args("doctor-check-config-env-missing-warn", &[("env_var", val)]));
                             }
                             checks.push(serde_json::json!({"check": "env_consistency", "status": "warn", "missing_var": val}));
                         }
@@ -604,13 +590,13 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         let config_path = librefang_dir.join("config.toml");
         if config_path.exists() {
             if !json {
-                println!("\n  Config Validation:");
+                println!("{}", i18n::t("doctor-section-config-val"));
             }
             let config_content = std::fs::read_to_string(&config_path).unwrap_or_default();
             match toml::from_str::<librefang_types::config::KernelConfig>(&config_content) {
                 Ok(cfg) => {
                     if !json {
-                        ui::check_ok("Config deserializes into KernelConfig");
+                        ui::check_ok(&i18n::t("doctor-check-config-deser-ok"));
                     }
                     checks.push(serde_json::json!({"check": "config_deser", "status": "ok"}));
 
@@ -618,9 +604,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     let mode = format!("{:?}", cfg.exec_policy.mode);
                     let safe_bins_count = cfg.exec_policy.safe_bins.len();
                     if !json {
-                        ui::check_ok(&format!(
-                            "Exec policy: mode={mode}, safe_bins={safe_bins_count}"
-                        ));
+                        ui::check_ok(&i18n::t_args("doctor-check-exec-policy", &[("mode", &mode), ("count", &safe_bins_count.to_string())]));
                     }
                     checks.push(serde_json::json!({"check": "exec_policy", "status": "ok", "mode": mode, "safe_bins": safe_bins_count}));
 
@@ -631,16 +615,16 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                             let inc_path = librefang_dir.join(inc);
                             if inc_path.exists() {
                                 if !json {
-                                    ui::check_ok(&format!("Include file: {inc}"));
+                                    ui::check_ok(&i18n::t_args("doctor-check-include-file-ok", &[("path", inc)]));
                                 }
                             } else if repair {
                                 if !json {
-                                    ui::check_warn(&format!("Include file missing: {inc}"));
+                                    ui::check_warn(&i18n::t_args("doctor-check-include-file-missing-warn", &[("path", inc)]));
                                 }
                                 include_ok = false;
                             } else {
                                 if !json {
-                                    ui::check_fail(&format!("Include file not found: {inc}"));
+                                    ui::check_fail(&i18n::t_args("doctor-check-include-file-not-found-fail", &[("path", inc)]));
                                 }
                                 include_ok = false;
                                 all_ok = false;
@@ -653,7 +637,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     if !cfg.mcp_servers.is_empty() {
                         let mcp_count = cfg.mcp_servers.len();
                         if !json {
-                            ui::check_ok(&format!("MCP servers configured: {mcp_count}"));
+                            ui::check_ok(&i18n::t_args("doctor-check-mcp-servers-count", &[("count", &mcp_count.to_string())]));
                         }
                         for server in &cfg.mcp_servers {
                             // Validate transport config
@@ -667,10 +651,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                                 } => {
                                     if command.is_empty() {
                                         if !json {
-                                            ui::check_warn(&format!(
-                                                "MCP server '{}' has empty command",
-                                                server.name
-                                            ));
+                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-empty-command-warn", &[("name", &server.name)]));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
@@ -679,10 +660,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                                 | librefang_types::config::McpTransportEntry::Http { url } => {
                                     if url.is_empty() {
                                         if !json {
-                                            ui::check_warn(&format!(
-                                                "MCP server '{}' has empty URL",
-                                                server.name
-                                            ));
+                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-empty-url-warn", &[("name", &server.name)]));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
@@ -694,28 +672,19 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                                 } => {
                                     if base_url.is_empty() {
                                         if !json {
-                                            ui::check_warn(&format!(
-                                                "MCP server '{}' has empty base_url",
-                                                server.name
-                                            ));
+                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-empty-base-url-warn", &[("name", &server.name)]));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
                                     if tools.is_empty() {
                                         if !json {
-                                            ui::check_warn(&format!(
-                                                "MCP server '{}' has no http_compat tools configured",
-                                                server.name
-                                            ));
+                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-no-compat-tools-warn", &[("name", &server.name)]));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
                                     if headers.iter().any(|h| h.name.trim().is_empty()) {
                                         if !json {
-                                            ui::check_warn(&format!(
-                                                "MCP server '{}' has an http_compat header with empty name",
-                                                server.name
-                                            ));
+                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-compat-header-empty-name-warn", &[("name", &server.name)]));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
@@ -726,28 +695,19 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                                                 .is_none_or(|value| value.trim().is_empty())
                                     }) {
                                         if !json {
-                                            ui::check_warn(&format!(
-                                                "MCP server '{}' has an http_compat header without value/value_env",
-                                                server.name
-                                            ));
+                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-compat-header-no-value-warn", &[("name", &server.name)]));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
                                     if tools.iter().any(|tool| tool.name.trim().is_empty()) {
                                         if !json {
-                                            ui::check_warn(&format!(
-                                                "MCP server '{}' has an http_compat tool with empty name",
-                                                server.name
-                                            ));
+                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-compat-tool-empty-name-warn", &[("name", &server.name)]));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
                                     if tools.iter().any(|tool| tool.path.trim().is_empty()) {
                                         if !json {
-                                            ui::check_warn(&format!(
-                                                "MCP server '{}' has an http_compat tool with empty path",
-                                                server.name
-                                            ));
+                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-compat-tool-empty-path-warn", &[("name", &server.name)]));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
@@ -759,7 +719,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 }
                 Err(e) => {
                     if !json {
-                        ui::check_fail(&format!("Config fails KernelConfig deserialization: {e}"));
+                        ui::check_fail(&i18n::t_args("doctor-check-config-deser-fail", &[("error", &e.to_string())]));
                     }
                     checks.push(serde_json::json!({"check": "config_deser", "status": "fail", "error": e.to_string()}));
                     all_ok = false;
@@ -771,20 +731,20 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
     // --- Check 13: Skill registry health ---
     {
         if !json {
-            println!("\n  Skills:");
+            println!("{}", i18n::t("doctor-section-skills"));
         }
         let skills_dir = cli_librefang_home().join("skills");
         let mut skill_reg = librefang_skills::registry::SkillRegistry::new(skills_dir.clone());
         match skill_reg.load_all() {
             Ok(count) => {
                 if !json {
-                    ui::check_ok(&format!("Skills loaded: {count}"));
+                    ui::check_ok(&i18n::t_args("doctor-check-skills-loaded", &[("count", &count.to_string())]));
                 }
                 checks.push(serde_json::json!({"check": "skills", "status": "ok", "count": count}));
             }
             Err(e) => {
                 if !json {
-                    ui::check_warn(&format!("Failed to load skills: {e}"));
+                    ui::check_warn(&i18n::t_args("doctor-check-skills-load-fail-warn", &[("error", &e.to_string())]));
                 }
                 checks.push(serde_json::json!({"check": "skills", "status": "warn", "error": e.to_string()}));
             }
@@ -806,9 +766,9 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 if has_critical {
                     injection_warnings += 1;
                     if !json {
-                        ui::check_warn(&format!(
-                            "Prompt injection warning in skill: {}",
-                            skill.manifest.skill.name
+                        ui::check_warn(&i18n::t_args(
+                            "doctor-check-skills-injection-warn",
+                            &[("name", &skill.manifest.skill.name)],
                         ));
                     }
                 }
@@ -818,7 +778,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             checks.push(serde_json::json!({"check": "skill_injection_scan", "status": "warn", "warnings": injection_warnings}));
         } else {
             if !json {
-                ui::check_ok("All skills pass prompt injection scan");
+                ui::check_ok(&i18n::t("doctor-check-skills-injection-ok"));
             }
             checks.push(serde_json::json!({"check": "skill_injection_scan", "status": "ok"}));
         }
@@ -827,7 +787,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
     // --- Check 14: MCP catalog + configured servers ---
     {
         if !json {
-            println!("\n  MCP servers:");
+            println!("\n{}", i18n::t("doctor-section-mcp-servers"));
         }
         let librefang_dir = cli_librefang_home();
         let mut catalog = librefang_extensions::catalog::McpCatalog::new(&librefang_dir);
@@ -851,8 +811,8 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             }
         };
         if !json {
-            ui::check_ok(&format!("MCP catalog templates: {template_count}"));
-            ui::check_ok(&format!("Configured MCP servers: {configured_count}"));
+            ui::check_ok(&i18n::t_args("doctor-check-mcp-catalog-templates", &[("templates", &template_count.to_string())]));
+            ui::check_ok(&i18n::t_args("doctor-check-mcp-configured-servers", &[("configured", &configured_count.to_string())]));
         }
         checks.push(
             serde_json::json!({"check": "mcp_catalog", "status": "ok", "count": template_count}),
@@ -863,7 +823,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
     // --- Check 15: Daemon health detail (if running) ---
     if let Some(ref base) = find_daemon() {
         if !json {
-            println!("\n  Daemon Health:");
+            println!("\n{}", i18n::t("doctor-section-daemon-health"));
         }
         let client = daemon_client();
         match client.get(format!("{base}/api/health/detail")).send() {
@@ -871,7 +831,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     if let Some(agents) = body.get("agent_count").and_then(|v| v.as_u64()) {
                         if !json {
-                            ui::check_ok(&format!("Running agents: {agents}"));
+                            ui::check_ok(&i18n::t_args("doctor-check-running-agents", &[("count", &agents.to_string())]));
                         }
                         checks.push(serde_json::json!({"check": "daemon_agents", "status": "ok", "count": agents}));
                     }
@@ -879,18 +839,18 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         let hours = uptime / 3600;
                         let mins = (uptime % 3600) / 60;
                         if !json {
-                            ui::check_ok(&format!("Daemon uptime: {hours}h {mins}m"));
+                            ui::check_ok(&i18n::t_args("doctor-check-daemon-uptime", &[("hours", &hours.to_string()), ("mins", &mins.to_string())]));
                         }
                         checks.push(serde_json::json!({"check": "daemon_uptime", "status": "ok", "secs": uptime}));
                     }
                     if let Some(db_status) = body.get("database").and_then(|v| v.as_str()) {
                         if db_status == "connected" || db_status == "ok" {
                             if !json {
-                                ui::check_ok("Database connectivity: OK");
+                                ui::check_ok(&i18n::t("doctor-check-db-connectivity-ok"));
                             }
                         } else {
                             if !json {
-                                ui::check_fail(&format!("Database status: {db_status}"));
+                                ui::check_fail(&i18n::t_args("doctor-check-db-status-fail", &[("status", db_status)]));
                             }
                             all_ok = false;
                         }
@@ -900,13 +860,13 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             }
             Ok(resp) => {
                 if !json {
-                    ui::check_warn(&format!("Health detail returned {}", resp.status()));
+                    ui::check_warn(&i18n::t_args("doctor-check-health-detail-status-warn", &[("status", &resp.status().to_string())]));
                 }
                 checks.push(serde_json::json!({"check": "daemon_health", "status": "warn"}));
             }
             Err(e) => {
                 if !json {
-                    ui::check_warn(&format!("Failed to query daemon health: {e}"));
+                    ui::check_warn(&i18n::t_args("doctor-check-health-detail-fail-warn", &[("error", &e.to_string())]));
                 }
                 checks.push(serde_json::json!({"check": "daemon_health", "status": "warn", "error": e.to_string()}));
             }
@@ -922,7 +882,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         .or_else(|| body.as_array())
                     {
                         if !json {
-                            ui::check_ok(&format!("Skills loaded in daemon: {}", arr.len()));
+                            ui::check_ok(&i18n::t_args("doctor-check-skills-loaded-daemon", &[("count", &arr.len().to_string())]));
                         }
                         checks.push(serde_json::json!({"check": "daemon_skills", "status": "ok", "count": arr.len()}));
                     }
@@ -949,10 +909,12 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                             })
                             .count();
                         if !json {
-                            ui::check_ok(&format!(
-                                "MCP servers: {} configured, {} connected",
-                                arr.len(),
-                                connected
+                            ui::check_ok(&i18n::t_args(
+                                "doctor-check-daemon-mcp-status",
+                                &[
+                                    ("configured", &arr.len().to_string()),
+                                    ("connected", &connected.to_string()),
+                                ],
                             ));
                         }
                         checks.push(serde_json::json!({"check": "daemon_mcp", "status": "ok", "configured": arr.len(), "connected": connected}));
@@ -980,13 +942,21 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         let total = arr.len();
                         if healthy == total {
                             if !json {
-                                ui::check_ok(&format!(
-                                    "MCP server health: {healthy}/{total} healthy"
+                                ui::check_ok(&i18n::t_args(
+                                    "doctor-check-daemon-mcp-health",
+                                    &[
+                                        ("healthy", &healthy.to_string()),
+                                        ("total", &total.to_string()),
+                                    ],
                                 ));
                             }
                         } else if !json {
-                            ui::check_warn(&format!(
-                                "MCP server health: {healthy}/{total} healthy"
+                            ui::check_warn(&i18n::t_args(
+                                "doctor-check-daemon-mcp-health",
+                                &[
+                                    ("healthy", &healthy.to_string()),
+                                    ("total", &total.to_string()),
+                                ],
                             ));
                         }
                         checks.push(serde_json::json!({"check": "mcp_health", "status": if healthy == total { "ok" } else { "warn" }, "healthy": healthy, "total": total}));
@@ -1007,13 +977,13 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         Ok(output) => {
             let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !json {
-                ui::check_ok(&format!("Rust: {version}"));
+                ui::check_ok(&i18n::t_args("doctor-check-rust-version", &[("version", &version)]));
             }
             checks.push(serde_json::json!({"check": "rust", "status": "ok", "version": version}));
         }
         Err(_) => {
             if !json {
-                ui::check_fail("Rust toolchain not found");
+                ui::check_fail(&i18n::t("doctor-check-rust-not-found-fail"));
             }
             checks.push(serde_json::json!({"check": "rust", "status": "fail"}));
             all_ok = false;
@@ -1028,7 +998,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !json {
-                ui::check_ok(&format!("Python: {version}"));
+                ui::check_ok(&i18n::t_args("doctor-check-python-version", &[("version", &version)]));
             }
             checks.push(serde_json::json!({"check": "python", "status": "ok", "version": version}));
         }
@@ -1041,7 +1011,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 Ok(output) if output.status.success() => {
                     let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
                     if !json {
-                        ui::check_ok(&format!("Python: {version}"));
+                        ui::check_ok(&i18n::t_args("doctor-check-python-version", &[("version", &version)]));
                     }
                     checks.push(
                         serde_json::json!({"check": "python", "status": "ok", "version": version}),
@@ -1049,7 +1019,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 }
                 _ => {
                     if !json {
-                        ui::check_warn("Python not found (needed for Python skill runtime)");
+                        ui::check_warn(&i18n::t("doctor-check-python-not-found-warn"));
                     }
                     checks.push(serde_json::json!({"check": "python", "status": "warn"}));
                 }
@@ -1062,13 +1032,13 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !json {
-                ui::check_ok(&format!("Node.js: {version}"));
+                ui::check_ok(&i18n::t_args("doctor-check-node-version", &[("version", &version)]));
             }
             checks.push(serde_json::json!({"check": "node", "status": "ok", "version": version}));
         }
         _ => {
             if !json {
-                ui::check_warn("Node.js not found (needed for Node skill runtime)");
+                ui::check_warn(&i18n::t("doctor-check-node-not-found-warn"));
             }
             checks.push(serde_json::json!({"check": "node", "status": "warn"}));
         }

--- a/crates/librefang-cli/src/commands/doctor_cmd.rs
+++ b/crates/librefang-cli/src/commands/doctor_cmd.rs
@@ -40,7 +40,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         // --- Check 1: LibreFang directory ---
         if librefang_dir.exists() {
             if !json {
-                ui::check_ok(&i18n::t_args("doctor-check-librefang-dir-ok", &[("path", &librefang_dir.display().to_string())]));
+                ui::check_ok(&i18n::t_args(
+                    "doctor-check-librefang-dir-ok",
+                    &[("path", &librefang_dir.display().to_string())],
+                ));
             }
             checks.push(serde_json::json!({"check": "librefang_dir", "status": "ok", "path": librefang_dir.display().to_string()}));
         } else if repair {
@@ -98,7 +101,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         }
                         repaired = true;
                     } else if !json {
-                        ui::check_warn(&i18n::t_args("doctor-check-env-loose-warn", &[("mode", &format!("{:o}", mode))]));
+                        ui::check_warn(&i18n::t_args(
+                            "doctor-check-env-loose-warn",
+                            &[("mode", &format!("{:o}", mode))],
+                        ));
                     }
                 } else if !json {
                     ui::check_ok(&i18n::t("doctor-check-env-ok-generic"));
@@ -125,13 +131,19 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             match toml::from_str::<toml::Value>(&config_content) {
                 Ok(_) => {
                     if !json {
-                        ui::check_ok(&i18n::t_args("doctor-check-config-ok", &[("path", &config_path.display().to_string())]));
+                        ui::check_ok(&i18n::t_args(
+                            "doctor-check-config-ok",
+                            &[("path", &config_path.display().to_string())],
+                        ));
                     }
                     checks.push(serde_json::json!({"check": "config_file", "status": "ok"}));
                 }
                 Err(e) => {
                     if !json {
-                        ui::check_fail(&i18n::t_args("doctor-check-config-syntax-fail", &[("error", &e.to_string())]));
+                        ui::check_fail(&i18n::t_args(
+                            "doctor-check-config-syntax-fail",
+                            &[("error", &e.to_string())],
+                        ));
                         ui::hint(&i18n::t("hint-config-edit"));
                     }
                     checks.push(serde_json::json!({"check": "config_syntax", "status": "fail", "error": e.to_string()}));
@@ -176,7 +188,13 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             let current_version = env!("CARGO_PKG_VERSION");
             let update_channel = load_update_channel_from_config().unwrap_or_default();
             if !json {
-                ui::check_ok(&i18n::t_args("doctor-check-cli-version", &[("version", current_version), ("channel", &update_channel.to_string())]));
+                ui::check_ok(&i18n::t_args(
+                    "doctor-check-cli-version",
+                    &[
+                        ("version", current_version),
+                        ("channel", &update_channel.to_string()),
+                    ],
+                ));
             }
             checks.push(serde_json::json!({"check": "cli_version", "status": "ok", "version": current_version, "channel": update_channel.to_string()}));
 
@@ -188,7 +206,7 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         if !json {
                             ui::check_warn(&i18n::t_args(
                                 "doctor-check-update-available-warn",
-                                &[("current", current_version), ("latest", latest)]
+                                &[("current", current_version), ("latest", latest)],
                             ));
                         }
                         checks.push(serde_json::json!({"check": "version_update", "status": "warn", "current": current_version, "latest": latest}));
@@ -228,7 +246,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         let daemon_running = find_daemon();
         if let Some(ref base) = daemon_running {
             if !json {
-                ui::check_ok(&i18n::t_args("doctor-check-daemon-running", &[("url", base)]));
+                ui::check_ok(&i18n::t_args(
+                    "doctor-check-daemon-running",
+                    &[("url", base)],
+                ));
             }
             checks.push(serde_json::json!({"check": "daemon", "status": "ok", "url": base}));
         } else {
@@ -246,7 +267,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             match std::net::TcpListener::bind(&bind_addr) {
                 Ok(_) => {
                     if !json {
-                        ui::check_ok(&i18n::t_args("doctor-check-port-available", &[("address", &api_listen)]));
+                        ui::check_ok(&i18n::t_args(
+                            "doctor-check-port-available",
+                            &[("address", &api_listen)],
+                        ));
                     }
                     checks.push(
                         serde_json::json!({"check": "port", "status": "ok", "address": api_listen}),
@@ -254,7 +278,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 }
                 Err(_) => {
                     if !json {
-                        ui::check_warn(&i18n::t_args("doctor-check-port-in-use-warn", &[("address", &api_listen)]));
+                        ui::check_warn(&i18n::t_args(
+                            "doctor-check-port-in-use-warn",
+                            &[("address", &api_listen)],
+                        ));
                     }
                     checks.push(serde_json::json!({"check": "port", "status": "warn", "address": api_listen}));
                 }
@@ -316,12 +343,18 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         if let Ok(available_mb) = cols[3].parse::<u64>() {
                             if available_mb < 100 {
                                 if !json {
-                                    ui::check_warn(&i18n::t_args("doctor-check-disk-space-low-warn", &[("count", &available_mb.to_string())]));
+                                    ui::check_warn(&i18n::t_args(
+                                        "doctor-check-disk-space-low-warn",
+                                        &[("count", &available_mb.to_string())],
+                                    ));
                                 }
                                 checks.push(serde_json::json!({"check": "disk_space", "status": "warn", "available_mb": available_mb}));
                             } else {
                                 if !json {
-                                    ui::check_ok(&i18n::t_args("doctor-check-disk-space-ok", &[("count", &available_mb.to_string())]));
+                                    ui::check_ok(&i18n::t_args(
+                                        "doctor-check-disk-space-ok",
+                                        &[("count", &available_mb.to_string())],
+                                    ));
                                 }
                                 checks.push(serde_json::json!({"check": "disk_space", "status": "ok", "available_mb": available_mb}));
                             }
@@ -361,7 +394,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             } else {
                 for (file, err) in &agent_errors {
                     if !json {
-                        ui::check_fail(&i18n::t_args("doctor-check-manifest-invalid-fail", &[("file", file), ("error", err)]));
+                        ui::check_fail(&i18n::t_args(
+                            "doctor-check-manifest-invalid-fail",
+                            &[("file", file), ("error", err)],
+                        ));
                     }
                 }
                 checks.push(serde_json::json!({"check": "agent_manifests", "status": "fail", "errors": agent_errors.len()}));
@@ -437,7 +473,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     ui::provider_status(name, env_var, true);
                 }
             } else if !json {
-                ui::check_warn(&i18n::t_args("doctor-check-provider-key-rejected-warn", &[("name", name), ("env_var", env_var)]));
+                ui::check_warn(&i18n::t_args(
+                    "doctor-check-provider-key-rejected-warn",
+                    &[("name", name), ("env_var", env_var)],
+                ));
             }
             any_key_set = true;
             checks.push(serde_json::json!({"check": "provider", "name": name, "env_var": env_var, "status": if valid { "ok" } else { "warn" }, "live_test": !valid}));
@@ -509,12 +548,18 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
 
                 if reachable {
                     if !json {
-                        ui::check_ok(&i18n::t_args("doctor-check-endpoint-reachable", &[("name", name), ("endpoint", endpoint)]));
+                        ui::check_ok(&i18n::t_args(
+                            "doctor-check-endpoint-reachable",
+                            &[("name", name), ("endpoint", endpoint)],
+                        ));
                     }
                     checks.push(serde_json::json!({"check": "network_connectivity", "provider": name, "endpoint": endpoint, "env_var": env_var, "status": "ok"}));
                 } else {
                     if !json {
-                        ui::check_warn(&i18n::t_args("doctor-check-endpoint-unreachable-warn", &[("name", name), ("endpoint", endpoint)]));
+                        ui::check_warn(&i18n::t_args(
+                            "doctor-check-endpoint-unreachable-warn",
+                            &[("name", name), ("endpoint", endpoint)],
+                        ));
                     }
                     checks.push(serde_json::json!({"check": "network_connectivity", "provider": name, "endpoint": endpoint, "env_var": env_var, "status": "warn"}));
                 }
@@ -549,7 +594,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     ui::provider_status(name, env_var, true);
                 }
             } else if !json {
-                ui::check_warn(&i18n::t_args("doctor-check-channel-token-format-warn", &[("name", name), ("env_var", env_var)]));
+                ui::check_warn(&i18n::t_args(
+                    "doctor-check-channel-token-format-warn",
+                    &[("name", name), ("env_var", env_var)],
+                ));
             }
             checks.push(serde_json::json!({"check": "channel", "name": name, "env_var": env_var, "status": if format_ok { "ok" } else { "warn" }}));
         } else {
@@ -574,7 +622,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         let val = val_part.trim().trim_matches('"');
                         if !val.is_empty() && std::env::var(val).is_err() {
                             if !json {
-                                ui::check_warn(&i18n::t_args("doctor-check-config-env-missing-warn", &[("env_var", val)]));
+                                ui::check_warn(&i18n::t_args(
+                                    "doctor-check-config-env-missing-warn",
+                                    &[("env_var", val)],
+                                ));
                             }
                             checks.push(serde_json::json!({"check": "env_consistency", "status": "warn", "missing_var": val}));
                         }
@@ -604,7 +655,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     let mode = format!("{:?}", cfg.exec_policy.mode);
                     let safe_bins_count = cfg.exec_policy.safe_bins.len();
                     if !json {
-                        ui::check_ok(&i18n::t_args("doctor-check-exec-policy", &[("mode", &mode), ("count", &safe_bins_count.to_string())]));
+                        ui::check_ok(&i18n::t_args(
+                            "doctor-check-exec-policy",
+                            &[("mode", &mode), ("count", &safe_bins_count.to_string())],
+                        ));
                     }
                     checks.push(serde_json::json!({"check": "exec_policy", "status": "ok", "mode": mode, "safe_bins": safe_bins_count}));
 
@@ -615,16 +669,25 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                             let inc_path = librefang_dir.join(inc);
                             if inc_path.exists() {
                                 if !json {
-                                    ui::check_ok(&i18n::t_args("doctor-check-include-file-ok", &[("path", inc)]));
+                                    ui::check_ok(&i18n::t_args(
+                                        "doctor-check-include-file-ok",
+                                        &[("path", inc)],
+                                    ));
                                 }
                             } else if repair {
                                 if !json {
-                                    ui::check_warn(&i18n::t_args("doctor-check-include-file-missing-warn", &[("path", inc)]));
+                                    ui::check_warn(&i18n::t_args(
+                                        "doctor-check-include-file-missing-warn",
+                                        &[("path", inc)],
+                                    ));
                                 }
                                 include_ok = false;
                             } else {
                                 if !json {
-                                    ui::check_fail(&i18n::t_args("doctor-check-include-file-not-found-fail", &[("path", inc)]));
+                                    ui::check_fail(&i18n::t_args(
+                                        "doctor-check-include-file-not-found-fail",
+                                        &[("path", inc)],
+                                    ));
                                 }
                                 include_ok = false;
                                 all_ok = false;
@@ -637,7 +700,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                     if !cfg.mcp_servers.is_empty() {
                         let mcp_count = cfg.mcp_servers.len();
                         if !json {
-                            ui::check_ok(&i18n::t_args("doctor-check-mcp-servers-count", &[("count", &mcp_count.to_string())]));
+                            ui::check_ok(&i18n::t_args(
+                                "doctor-check-mcp-servers-count",
+                                &[("count", &mcp_count.to_string())],
+                            ));
                         }
                         for server in &cfg.mcp_servers {
                             // Validate transport config
@@ -651,7 +717,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                                 } => {
                                     if command.is_empty() {
                                         if !json {
-                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-empty-command-warn", &[("name", &server.name)]));
+                                            ui::check_warn(&i18n::t_args(
+                                                "doctor-check-mcp-empty-command-warn",
+                                                &[("name", &server.name)],
+                                            ));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
@@ -660,7 +729,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                                 | librefang_types::config::McpTransportEntry::Http { url } => {
                                     if url.is_empty() {
                                         if !json {
-                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-empty-url-warn", &[("name", &server.name)]));
+                                            ui::check_warn(&i18n::t_args(
+                                                "doctor-check-mcp-empty-url-warn",
+                                                &[("name", &server.name)],
+                                            ));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
@@ -672,19 +744,28 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                                 } => {
                                     if base_url.is_empty() {
                                         if !json {
-                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-empty-base-url-warn", &[("name", &server.name)]));
+                                            ui::check_warn(&i18n::t_args(
+                                                "doctor-check-mcp-empty-base-url-warn",
+                                                &[("name", &server.name)],
+                                            ));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
                                     if tools.is_empty() {
                                         if !json {
-                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-no-compat-tools-warn", &[("name", &server.name)]));
+                                            ui::check_warn(&i18n::t_args(
+                                                "doctor-check-mcp-no-compat-tools-warn",
+                                                &[("name", &server.name)],
+                                            ));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
                                     if headers.iter().any(|h| h.name.trim().is_empty()) {
                                         if !json {
-                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-compat-header-empty-name-warn", &[("name", &server.name)]));
+                                            ui::check_warn(&i18n::t_args(
+                                                "doctor-check-mcp-compat-header-empty-name-warn",
+                                                &[("name", &server.name)],
+                                            ));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
@@ -695,19 +776,28 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                                                 .is_none_or(|value| value.trim().is_empty())
                                     }) {
                                         if !json {
-                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-compat-header-no-value-warn", &[("name", &server.name)]));
+                                            ui::check_warn(&i18n::t_args(
+                                                "doctor-check-mcp-compat-header-no-value-warn",
+                                                &[("name", &server.name)],
+                                            ));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
                                     if tools.iter().any(|tool| tool.name.trim().is_empty()) {
                                         if !json {
-                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-compat-tool-empty-name-warn", &[("name", &server.name)]));
+                                            ui::check_warn(&i18n::t_args(
+                                                "doctor-check-mcp-compat-tool-empty-name-warn",
+                                                &[("name", &server.name)],
+                                            ));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
                                     if tools.iter().any(|tool| tool.path.trim().is_empty()) {
                                         if !json {
-                                            ui::check_warn(&i18n::t_args("doctor-check-mcp-compat-tool-empty-path-warn", &[("name", &server.name)]));
+                                            ui::check_warn(&i18n::t_args(
+                                                "doctor-check-mcp-compat-tool-empty-path-warn",
+                                                &[("name", &server.name)],
+                                            ));
                                         }
                                         checks.push(serde_json::json!({"check": "mcp_server_config", "status": "warn", "name": server.name}));
                                     }
@@ -719,7 +809,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 }
                 Err(e) => {
                     if !json {
-                        ui::check_fail(&i18n::t_args("doctor-check-config-deser-fail", &[("error", &e.to_string())]));
+                        ui::check_fail(&i18n::t_args(
+                            "doctor-check-config-deser-fail",
+                            &[("error", &e.to_string())],
+                        ));
                     }
                     checks.push(serde_json::json!({"check": "config_deser", "status": "fail", "error": e.to_string()}));
                     all_ok = false;
@@ -738,13 +831,19 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         match skill_reg.load_all() {
             Ok(count) => {
                 if !json {
-                    ui::check_ok(&i18n::t_args("doctor-check-skills-loaded", &[("count", &count.to_string())]));
+                    ui::check_ok(&i18n::t_args(
+                        "doctor-check-skills-loaded",
+                        &[("count", &count.to_string())],
+                    ));
                 }
                 checks.push(serde_json::json!({"check": "skills", "status": "ok", "count": count}));
             }
             Err(e) => {
                 if !json {
-                    ui::check_warn(&i18n::t_args("doctor-check-skills-load-fail-warn", &[("error", &e.to_string())]));
+                    ui::check_warn(&i18n::t_args(
+                        "doctor-check-skills-load-fail-warn",
+                        &[("error", &e.to_string())],
+                    ));
                 }
                 checks.push(serde_json::json!({"check": "skills", "status": "warn", "error": e.to_string()}));
             }
@@ -811,8 +910,14 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             }
         };
         if !json {
-            ui::check_ok(&i18n::t_args("doctor-check-mcp-catalog-templates", &[("templates", &template_count.to_string())]));
-            ui::check_ok(&i18n::t_args("doctor-check-mcp-configured-servers", &[("configured", &configured_count.to_string())]));
+            ui::check_ok(&i18n::t_args(
+                "doctor-check-mcp-catalog-templates",
+                &[("templates", &template_count.to_string())],
+            ));
+            ui::check_ok(&i18n::t_args(
+                "doctor-check-mcp-configured-servers",
+                &[("configured", &configured_count.to_string())],
+            ));
         }
         checks.push(
             serde_json::json!({"check": "mcp_catalog", "status": "ok", "count": template_count}),
@@ -831,7 +936,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 if let Ok(body) = resp.json::<serde_json::Value>() {
                     if let Some(agents) = body.get("agent_count").and_then(|v| v.as_u64()) {
                         if !json {
-                            ui::check_ok(&i18n::t_args("doctor-check-running-agents", &[("count", &agents.to_string())]));
+                            ui::check_ok(&i18n::t_args(
+                                "doctor-check-running-agents",
+                                &[("count", &agents.to_string())],
+                            ));
                         }
                         checks.push(serde_json::json!({"check": "daemon_agents", "status": "ok", "count": agents}));
                     }
@@ -839,7 +947,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         let hours = uptime / 3600;
                         let mins = (uptime % 3600) / 60;
                         if !json {
-                            ui::check_ok(&i18n::t_args("doctor-check-daemon-uptime", &[("hours", &hours.to_string()), ("mins", &mins.to_string())]));
+                            ui::check_ok(&i18n::t_args(
+                                "doctor-check-daemon-uptime",
+                                &[("hours", &hours.to_string()), ("mins", &mins.to_string())],
+                            ));
                         }
                         checks.push(serde_json::json!({"check": "daemon_uptime", "status": "ok", "secs": uptime}));
                     }
@@ -850,7 +961,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                             }
                         } else {
                             if !json {
-                                ui::check_fail(&i18n::t_args("doctor-check-db-status-fail", &[("status", db_status)]));
+                                ui::check_fail(&i18n::t_args(
+                                    "doctor-check-db-status-fail",
+                                    &[("status", db_status)],
+                                ));
                             }
                             all_ok = false;
                         }
@@ -860,13 +974,19 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
             }
             Ok(resp) => {
                 if !json {
-                    ui::check_warn(&i18n::t_args("doctor-check-health-detail-status-warn", &[("status", &resp.status().to_string())]));
+                    ui::check_warn(&i18n::t_args(
+                        "doctor-check-health-detail-status-warn",
+                        &[("status", &resp.status().to_string())],
+                    ));
                 }
                 checks.push(serde_json::json!({"check": "daemon_health", "status": "warn"}));
             }
             Err(e) => {
                 if !json {
-                    ui::check_warn(&i18n::t_args("doctor-check-health-detail-fail-warn", &[("error", &e.to_string())]));
+                    ui::check_warn(&i18n::t_args(
+                        "doctor-check-health-detail-fail-warn",
+                        &[("error", &e.to_string())],
+                    ));
                 }
                 checks.push(serde_json::json!({"check": "daemon_health", "status": "warn", "error": e.to_string()}));
             }
@@ -882,7 +1002,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                         .or_else(|| body.as_array())
                     {
                         if !json {
-                            ui::check_ok(&i18n::t_args("doctor-check-skills-loaded-daemon", &[("count", &arr.len().to_string())]));
+                            ui::check_ok(&i18n::t_args(
+                                "doctor-check-skills-loaded-daemon",
+                                &[("count", &arr.len().to_string())],
+                            ));
                         }
                         checks.push(serde_json::json!({"check": "daemon_skills", "status": "ok", "count": arr.len()}));
                     }
@@ -977,7 +1100,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         Ok(output) => {
             let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !json {
-                ui::check_ok(&i18n::t_args("doctor-check-rust-version", &[("version", &version)]));
+                ui::check_ok(&i18n::t_args(
+                    "doctor-check-rust-version",
+                    &[("version", &version)],
+                ));
             }
             checks.push(serde_json::json!({"check": "rust", "status": "ok", "version": version}));
         }
@@ -998,7 +1124,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !json {
-                ui::check_ok(&i18n::t_args("doctor-check-python-version", &[("version", &version)]));
+                ui::check_ok(&i18n::t_args(
+                    "doctor-check-python-version",
+                    &[("version", &version)],
+                ));
             }
             checks.push(serde_json::json!({"check": "python", "status": "ok", "version": version}));
         }
@@ -1011,7 +1140,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
                 Ok(output) if output.status.success() => {
                     let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
                     if !json {
-                        ui::check_ok(&i18n::t_args("doctor-check-python-version", &[("version", &version)]));
+                        ui::check_ok(&i18n::t_args(
+                            "doctor-check-python-version",
+                            &[("version", &version)],
+                        ));
                     }
                     checks.push(
                         serde_json::json!({"check": "python", "status": "ok", "version": version}),
@@ -1032,7 +1164,10 @@ pub(crate) fn cmd_doctor(json: bool, repair: bool) {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !json {
-                ui::check_ok(&i18n::t_args("doctor-check-node-version", &[("version", &version)]));
+                ui::check_ok(&i18n::t_args(
+                    "doctor-check-node-version",
+                    &[("version", &version)],
+                ));
             }
             checks.push(serde_json::json!({"check": "node", "status": "ok", "version": version}));
         }

--- a/crates/librefang-cli/src/commands/hand.rs
+++ b/crates/librefang-cli/src/commands/hand.rs
@@ -147,30 +147,28 @@ pub(crate) fn cmd_hand_status(id: Option<&str>) {
         let instance_id = instance["instance_id"].as_str().unwrap_or("?");
         let agent_name = instance["agent_name"].as_str().unwrap_or("?");
 
-        ui::section("Hand Status");
-        ui::kv("Hand", hand_id);
-        ui::kv("Name", name);
-        ui::kv("Instance", instance_id);
-        ui::kv("Status", status);
-        ui::kv("Agent", agent_name);
+        ui::section(&i18n::t("hand-status-title"));
+        ui::kv(&i18n::t("label-hand"), hand_id);
+        ui::kv(&i18n::t("label-name"), name);
+        ui::kv(&i18n::t("label-instance"), instance_id);
+        ui::kv(&i18n::t("label-status"), status);
+        ui::kv(&i18n::t("label-agent"), agent_name);
         return;
     }
 
     let hand_body = daemon_json(client.get(format!("{base}/api/hands/{id}")).send());
     if hand_body.get("error").is_some() {
-        ui::error(&format!(
-            "No active hand or installed hand found for '{id}'."
-        ));
+        ui::error(&i18n::t_args("hand-not-found", &[("id", id)]));
         std::process::exit(1);
     }
 
-    ui::section("Hand Status");
-    ui::kv("Hand", hand_body["id"].as_str().unwrap_or(id));
-    ui::kv("Name", hand_body["name"].as_str().unwrap_or(id));
-    ui::kv("Status", "inactive");
+    ui::section(&i18n::t("hand-status-title"));
+    ui::kv(&i18n::t("label-hand"), hand_body["id"].as_str().unwrap_or(id));
+    ui::kv(&i18n::t("label-name"), hand_body["name"].as_str().unwrap_or(id));
+    ui::kv(&i18n::t("label-status"), &i18n::t("label-status-inactive"));
     if let Some(description) = hand_body["description"].as_str() {
         if !description.is_empty() {
-            ui::kv("Description", description);
+            ui::kv(&i18n::t("label-description"), description);
         }
     }
 }
@@ -375,15 +373,15 @@ pub(crate) fn cmd_hand_settings(id: &str) {
     }
     if let Some(config) = body.get("config").and_then(|c| c.as_object()) {
         if config.is_empty() {
-            ui::step(&format!("Hand '{id}' has no configurable settings."));
+            ui::step(&i18n::t_args("hand-no-settings", &[("id", id)]));
         } else {
-            ui::section(&format!("Settings for '{id}'"));
+            ui::section(&i18n::t_args("hand-settings-title", &[("id", id)]));
             for (k, v) in config {
                 println!("  {}: {}", k.bold(), v);
             }
         }
     } else {
-        ui::step(&format!("Hand '{id}' has no configurable settings."));
+        ui::step(&i18n::t_args("hand-no-settings", &[("id", id)]));
     }
 }
 
@@ -402,13 +400,16 @@ pub(crate) fn cmd_hand_set(id: &str, key: &str, value: &str) {
             .send(),
     );
     if body.get("error").is_some() {
-        ui::error(&format!(
-            "Failed: {}",
-            body["error"].as_str().unwrap_or("?")
+        ui::error(&i18n::t_args(
+            "label-failed-reason",
+            &[("error", body["error"].as_str().unwrap_or("?"))],
         ));
         std::process::exit(1);
     }
-    ui::success(&format!("Set {key}={value} for hand '{id}'."));
+    ui::success(&i18n::t_args(
+        "hand-set-setting-success",
+        &[("key", key), ("value", value), ("id", id)],
+    ));
 }
 
 pub(crate) fn cmd_hand_reload() {
@@ -416,17 +417,22 @@ pub(crate) fn cmd_hand_reload() {
     let client = daemon_client();
     let body = daemon_json(client.post(format!("{base}/api/hands/reload")).send());
     if body.get("error").is_some() {
-        ui::error(&format!(
-            "Failed: {}",
-            body["error"].as_str().unwrap_or("?")
+        ui::error(&i18n::t_args(
+            "label-failed-reason",
+            &[("error", body["error"].as_str().unwrap_or("?"))],
         ));
         std::process::exit(1);
     }
     let added = body["added"].as_u64().unwrap_or(0);
     let updated = body["updated"].as_u64().unwrap_or(0);
     let total = body["total"].as_u64().unwrap_or(0);
-    ui::success(&format!(
-        "Reloaded hands: {added} added, {updated} updated, {total} total."
+    ui::success(&i18n::t_args(
+        "hand-reloaded-summary",
+        &[
+            ("added", &added.to_string()),
+            ("updated", &updated.to_string()),
+            ("total", &total.to_string()),
+        ],
     ));
 }
 
@@ -437,8 +443,8 @@ pub(crate) fn cmd_hand_chat(id: &str) {
     let resolved = match resolve_hand_instance(&active, id) {
         Some(instance) => instance,
         None => {
-            ui::error(&format!("No active hand instance found for '{id}'."));
-            ui::hint("Activate it first: librefang hand activate");
+            ui::error(&i18n::t_args("hand-no-active-instance", &[( "id", id )]));
+            ui::hint(&i18n::t("hand-list-activate-hint"));
             std::process::exit(1);
         }
     };

--- a/crates/librefang-cli/src/commands/hand.rs
+++ b/crates/librefang-cli/src/commands/hand.rs
@@ -163,8 +163,14 @@ pub(crate) fn cmd_hand_status(id: Option<&str>) {
     }
 
     ui::section(&i18n::t("hand-status-title"));
-    ui::kv(&i18n::t("label-hand"), hand_body["id"].as_str().unwrap_or(id));
-    ui::kv(&i18n::t("label-name"), hand_body["name"].as_str().unwrap_or(id));
+    ui::kv(
+        &i18n::t("label-hand"),
+        hand_body["id"].as_str().unwrap_or(id),
+    );
+    ui::kv(
+        &i18n::t("label-name"),
+        hand_body["name"].as_str().unwrap_or(id),
+    );
     ui::kv(&i18n::t("label-status"), &i18n::t("label-status-inactive"));
     if let Some(description) = hand_body["description"].as_str() {
         if !description.is_empty() {
@@ -443,7 +449,7 @@ pub(crate) fn cmd_hand_chat(id: &str) {
     let resolved = match resolve_hand_instance(&active, id) {
         Some(instance) => instance,
         None => {
-            ui::error(&i18n::t_args("hand-no-active-instance", &[( "id", id )]));
+            ui::error(&i18n::t_args("hand-no-active-instance", &[("id", id)]));
             ui::hint(&i18n::t("hand-list-activate-hint"));
             std::process::exit(1);
         }

--- a/crates/librefang-cli/src/commands/init.rs
+++ b/crates/librefang-cli/src/commands/init.rs
@@ -114,19 +114,28 @@ pub(crate) fn cmd_init_upgrade() {
     p.set_message(&i18n::t("init-upgrade-backing-up"));
     let backups_dir = librefang_dir.join("backups");
     if let Err(e) = std::fs::create_dir_all(&backups_dir) {
-        p.finish_with_failure(&i18n::t_args("init-upgrade-failed-create-backups-dir", &[("error", &e.to_string())]));
+        p.finish_with_failure(&i18n::t_args(
+            "init-upgrade-failed-create-backups-dir",
+            &[("error", &e.to_string())],
+        ));
         std::process::exit(1);
     }
     let backup_name = format!("config-{}.toml", format_local_timestamp());
     let backup_path = backups_dir.join(&backup_name);
     if let Err(e) = std::fs::copy(&config_path, &backup_path) {
-        p.finish_with_failure(&i18n::t_args("init-upgrade-failed-backup-config", &[("error", &e.to_string())]));
+        p.finish_with_failure(&i18n::t_args(
+            "init-upgrade-failed-backup-config",
+            &[("error", &e.to_string())],
+        ));
         std::process::exit(1);
     }
     restrict_file_permissions(&backup_path);
     prune_old_config_backups(&backups_dir, 3);
     p.tick(1);
-    ui::success(&i18n::t_args("init-upgrade-backup-success", &[("name", &backup_name)]));
+    ui::success(&i18n::t_args(
+        "init-upgrade-backup-success",
+        &[("name", &backup_name)],
+    ));
 
     // 3. Sync registry (TTL=0 forces refresh regardless of last sync time)
     p.set_message(&i18n::t("init-upgrade-syncing-registry"));
@@ -163,7 +172,10 @@ pub(crate) fn cmd_init_upgrade() {
     let existing_raw = match std::fs::read_to_string(&config_path) {
         Ok(s) => s,
         Err(e) => {
-            p.finish_with_failure(&i18n::t_args("init-upgrade-failed-read", &[("error", &e.to_string())]));
+            p.finish_with_failure(&i18n::t_args(
+                "init-upgrade-failed-read",
+                &[("error", &e.to_string())],
+            ));
             std::process::exit(1);
         }
     };
@@ -171,8 +183,14 @@ pub(crate) fn cmd_init_upgrade() {
     let existing: toml::Value = match toml::from_str(&existing_raw) {
         Ok(v) => v,
         Err(e) => {
-            p.finish_with_failure(&i18n::t_args("init-upgrade-failed-parse", &[("error", &e.to_string())]));
-            ui::hint(&i18n::t_args("init-upgrade-backup-saved-hint", &[("name", &backup_name)]));
+            p.finish_with_failure(&i18n::t_args(
+                "init-upgrade-failed-parse",
+                &[("error", &e.to_string())],
+            ));
+            ui::hint(&i18n::t_args(
+                "init-upgrade-backup-saved-hint",
+                &[("name", &backup_name)],
+            ));
             std::process::exit(1);
         }
     };
@@ -182,7 +200,10 @@ pub(crate) fn cmd_init_upgrade() {
     let defaults: toml::Value = match toml::from_str(&default_config_str) {
         Ok(v) => v,
         Err(e) => {
-            p.finish_with_failure(&i18n::t_args("init-upgrade-failed-parse-template", &[("error", &e.to_string())]));
+            p.finish_with_failure(&i18n::t_args(
+                "init-upgrade-failed-parse-template",
+                &[("error", &e.to_string())],
+            ));
             std::process::exit(1);
         }
     };
@@ -243,12 +264,21 @@ pub(crate) fn cmd_init_upgrade() {
         }
 
         if let Err(e) = std::fs::write(&config_path, &content) {
-            p.finish_with_failure(&i18n::t_args("init-upgrade-failed-write", &[("error", &e.to_string())]));
-            ui::hint(&i18n::t_args("init-upgrade-backup-saved-hint", &[("name", &backup_name)]));
+            p.finish_with_failure(&i18n::t_args(
+                "init-upgrade-failed-write",
+                &[("error", &e.to_string())],
+            ));
+            ui::hint(&i18n::t_args(
+                "init-upgrade-backup-saved-hint",
+                &[("name", &backup_name)],
+            ));
             std::process::exit(1);
         }
         restrict_file_permissions(&config_path);
-        ui::success(&i18n::t_args("init-upgrade-sections-added", &[("count", &added.len().to_string())]));
+        ui::success(&i18n::t_args(
+            "init-upgrade-sections-added",
+            &[("count", &added.len().to_string())],
+        ));
         for key in &added {
             ui::kv("  +", key);
         }
@@ -620,7 +650,10 @@ pub(crate) fn write_config_if_missing(
     let example_path = librefang_dir.join("config.example.toml");
     if !example_path.exists() {
         if let Err(e) = std::fs::write(&example_path, INIT_DEFAULT_CONFIG_TEMPLATE) {
-            ui::hint(&i18n::t_args("init-error-write-config-example", &[("error", &e.to_string())]));
+            ui::hint(&i18n::t_args(
+                "init-error-write-config-example",
+                &[("error", &e.to_string())],
+            ));
         }
     }
 }

--- a/crates/librefang-cli/src/commands/init.rs
+++ b/crates/librefang-cli/src/commands/init.rs
@@ -25,8 +25,8 @@ pub(crate) fn cmd_init(quick: bool) {
     // The interactive wizard unconditionally overwrites config.toml, which
     // would silently delete channels and custom configuration (#1862).
     if !quick && librefang_dir.join("config.toml").exists() {
-        ui::hint("Existing installation detected — running upgrade to preserve your settings.");
-        ui::hint("To start fresh, remove ~/.librefang/config.toml and run `librefang init` again.");
+        ui::hint(&i18n::t("init-upgrade-existing"));
+        ui::hint(&i18n::t("init-upgrade-fresh-hint"));
         cmd_init_upgrade();
         return;
     }
@@ -99,47 +99,47 @@ pub(crate) fn cmd_init_upgrade() {
 
     // 1. Must have an existing installation
     if !config_path.exists() {
-        ui::error("Nothing to upgrade — no config.toml found. Run `librefang init` first.");
+        ui::error(&i18n::t("init-upgrade-no-config"));
         std::process::exit(1);
     }
 
     ui::banner();
     ui::blank();
-    ui::section("Upgrading LibreFang installation");
+    ui::section(&i18n::t("init-upgrade-title"));
 
     // Four upgrade steps: backup, registry sync, vault/git, config merge.
-    let mut p = progress::auto("Upgrading", Some(4));
+    let mut p = progress::auto(&i18n::t("init-upgrade-progress-label"), Some(4));
 
     // 2. Backup existing config under backups/ (keep last 3)
-    p.set_message("Backing up config");
+    p.set_message(&i18n::t("init-upgrade-backing-up"));
     let backups_dir = librefang_dir.join("backups");
     if let Err(e) = std::fs::create_dir_all(&backups_dir) {
-        p.finish_with_failure(&format!("Failed to create backups dir: {e}"));
+        p.finish_with_failure(&i18n::t_args("init-upgrade-failed-create-backups-dir", &[("error", &e.to_string())]));
         std::process::exit(1);
     }
     let backup_name = format!("config-{}.toml", format_local_timestamp());
     let backup_path = backups_dir.join(&backup_name);
     if let Err(e) = std::fs::copy(&config_path, &backup_path) {
-        p.finish_with_failure(&format!("Failed to backup config: {e}"));
+        p.finish_with_failure(&i18n::t_args("init-upgrade-failed-backup-config", &[("error", &e.to_string())]));
         std::process::exit(1);
     }
     restrict_file_permissions(&backup_path);
     prune_old_config_backups(&backups_dir, 3);
     p.tick(1);
-    ui::success(&format!("Backed up config to backups/{backup_name}"));
+    ui::success(&i18n::t_args("init-upgrade-backup-success", &[("name", &backup_name)]));
 
     // 3. Sync registry (TTL=0 forces refresh regardless of last sync time)
-    p.set_message("Syncing registry");
+    p.set_message(&i18n::t("init-upgrade-syncing-registry"));
     if librefang_runtime::registry_sync::sync_registry(&librefang_dir, 0, "", None) {
         p.tick(1);
-        ui::success("Registry synced");
+        ui::success(&i18n::t("init-upgrade-registry-synced"));
     } else {
         p.tick(1);
-        ui::hint("Registry sync failed (network issue?) — continuing with cached content");
+        ui::hint(&i18n::t("init-upgrade-registry-failed"));
     }
 
     // 4. Ensure data dir, vault, and git exist
-    p.set_message("Initialising vault/git");
+    p.set_message(&i18n::t("init-upgrade-initializing-vault-git"));
     let data_dir = librefang_dir.join("data");
     if !data_dir.exists() {
         let _ = std::fs::create_dir_all(&data_dir);
@@ -159,11 +159,11 @@ pub(crate) fn cmd_init_upgrade() {
     p.tick(1);
 
     // 5. Merge new default config fields
-    p.set_message("Merging config fields");
+    p.set_message(&i18n::t("init-upgrade-merging-config"));
     let existing_raw = match std::fs::read_to_string(&config_path) {
         Ok(s) => s,
         Err(e) => {
-            p.finish_with_failure(&format!("Upgrade aborted: failed to read config.toml: {e}"));
+            p.finish_with_failure(&i18n::t_args("init-upgrade-failed-read", &[("error", &e.to_string())]));
             std::process::exit(1);
         }
     };
@@ -171,12 +171,8 @@ pub(crate) fn cmd_init_upgrade() {
     let existing: toml::Value = match toml::from_str(&existing_raw) {
         Ok(v) => v,
         Err(e) => {
-            p.finish_with_failure(&format!(
-                "Upgrade aborted: failed to parse config.toml: {e}"
-            ));
-            ui::hint(&format!(
-                "Your original config was saved to backups/{backup_name}"
-            ));
+            p.finish_with_failure(&i18n::t_args("init-upgrade-failed-parse", &[("error", &e.to_string())]));
+            ui::hint(&i18n::t_args("init-upgrade-backup-saved-hint", &[("name", &backup_name)]));
             std::process::exit(1);
         }
     };
@@ -186,9 +182,7 @@ pub(crate) fn cmd_init_upgrade() {
     let defaults: toml::Value = match toml::from_str(&default_config_str) {
         Ok(v) => v,
         Err(e) => {
-            p.finish_with_failure(&format!(
-                "Upgrade aborted: failed to parse default config template: {e}"
-            ));
+            p.finish_with_failure(&i18n::t_args("init-upgrade-failed-parse-template", &[("error", &e.to_string())]));
             std::process::exit(1);
         }
     };
@@ -198,7 +192,7 @@ pub(crate) fn cmd_init_upgrade() {
     let added = find_missing_toplevel_keys(&existing, &defaults);
 
     if added.is_empty() {
-        ui::success("Config is already up to date — no new fields added");
+        ui::success(&i18n::t("init-upgrade-config-up-to-date"));
     } else {
         // Partition into scalars (must stay in TOML root scope) and tables.
         // Scalars appended after a [table] header would be absorbed into that
@@ -249,28 +243,26 @@ pub(crate) fn cmd_init_upgrade() {
         }
 
         if let Err(e) = std::fs::write(&config_path, &content) {
-            p.finish_with_failure(&format!("Upgrade aborted: failed to write config: {e}"));
-            ui::hint(&format!(
-                "Your original config was saved to backups/{backup_name}"
-            ));
+            p.finish_with_failure(&i18n::t_args("init-upgrade-failed-write", &[("error", &e.to_string())]));
+            ui::hint(&i18n::t_args("init-upgrade-backup-saved-hint", &[("name", &backup_name)]));
             std::process::exit(1);
         }
         restrict_file_permissions(&config_path);
-        ui::success(&format!("Added {} new config section(s):", added.len()));
+        ui::success(&i18n::t_args("init-upgrade-sections-added", &[("count", &added.len().to_string())]));
         for key in &added {
             ui::kv("  +", key);
         }
     }
     p.tick(1);
-    p.finish("Upgrade steps complete");
+    p.finish(&i18n::t("init-upgrade-steps-complete"));
 
     // 6. Check for legacy ~/.openclaw installation
     if let Some(home) = dirs::home_dir() {
         let openclaw_dir = home.join(".openclaw");
         if openclaw_dir.exists() {
             ui::blank();
-            ui::hint("Legacy ~/.openclaw installation detected.");
-            ui::hint("Run `librefang migrate --from openclaw` to migrate your data.");
+            ui::hint(&i18n::t("init-upgrade-legacy-openclaw"));
+            ui::hint(&i18n::t("init-upgrade-legacy-openclaw-hint"));
         }
     }
 
@@ -291,21 +283,16 @@ pub(crate) fn cmd_init_upgrade() {
         });
     if approval_needs_update {
         ui::blank();
-        ui::hint(
-            "Your require_approval list only contains \"shell_exec\". \
-             File operations (file_write, file_delete) now require approval by default.",
-        );
-        ui::hint(
-            "To enable: add \"file_write\" and \"file_delete\" to require_approval in config.toml",
-        );
+        ui::hint(&i18n::t("init-upgrade-approval-warning"));
+        ui::hint(&i18n::t("init-upgrade-approval-hint"));
     }
 
     // 8. Summary
     ui::blank();
-    ui::success("Upgrade complete!");
-    ui::kv("Backup", &format!("backups/{backup_name}"));
+    ui::success(&i18n::t("init-upgrade-success-summary"));
+    ui::kv(&i18n::t("label-backup"), &format!("backups/{backup_name}"));
     if !added.is_empty() {
-        ui::kv("New fields", &added.len().to_string());
+        ui::kv(&i18n::t("label-new-fields"), &added.len().to_string());
     }
     ui::blank();
 }
@@ -633,7 +620,7 @@ pub(crate) fn write_config_if_missing(
     let example_path = librefang_dir.join("config.example.toml");
     if !example_path.exists() {
         if let Err(e) = std::fs::write(&example_path, INIT_DEFAULT_CONFIG_TEMPLATE) {
-            ui::hint(&format!("Could not write config.example.toml: {e}"));
+            ui::hint(&i18n::t_args("init-error-write-config-example", &[("error", &e.to_string())]));
         }
     }
 }

--- a/crates/librefang-cli/src/commands/maintenance.rs
+++ b/crates/librefang-cli/src/commands/maintenance.rs
@@ -86,7 +86,13 @@ pub(crate) fn service_install_linux(binary: &std::path::Path, librefang_home: &s
     };
     let service_dir = home.join(".config/systemd/user");
     if let Err(e) = std::fs::create_dir_all(&service_dir) {
-        ui::error(&i18n::t_args("maintenance-failed-create-dir", &[("path", &service_dir.display().to_string()), ("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "maintenance-failed-create-dir",
+            &[
+                ("path", &service_dir.display().to_string()),
+                ("error", &e.to_string()),
+            ],
+        ));
         return;
     }
 
@@ -114,10 +120,19 @@ pub(crate) fn service_install_linux(binary: &std::path::Path, librefang_home: &s
 
     let service_path = service_dir.join("librefang.service");
     if let Err(e) = std::fs::write(&service_path, &unit) {
-        ui::error(&i18n::t_args("maintenance-failed-write-file", &[("path", &service_path.display().to_string()), ("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "maintenance-failed-write-file",
+            &[
+                ("path", &service_path.display().to_string()),
+                ("error", &e.to_string()),
+            ],
+        ));
         return;
     }
-    ui::success(&i18n::t_args("maintenance-wrote-file", &[("path", &service_path.display().to_string())]));
+    ui::success(&i18n::t_args(
+        "maintenance-wrote-file",
+        &[("path", &service_path.display().to_string())],
+    ));
 
     // Reload and enable
     let reload = std::process::Command::new("systemctl")
@@ -154,7 +169,13 @@ pub(crate) fn service_install_macos(binary: &std::path::Path, librefang_home: &s
     };
     let agents_dir = home.join("Library/LaunchAgents");
     if let Err(e) = std::fs::create_dir_all(&agents_dir) {
-        ui::error(&i18n::t_args("maintenance-failed-create-dir", &[("path", &agents_dir.display().to_string()), ("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "maintenance-failed-create-dir",
+            &[
+                ("path", &agents_dir.display().to_string()),
+                ("error", &e.to_string()),
+            ],
+        ));
         return;
     }
 
@@ -199,10 +220,19 @@ pub(crate) fn service_install_macos(binary: &std::path::Path, librefang_home: &s
     }
 
     if let Err(e) = std::fs::write(&plist_path, &plist) {
-        ui::error(&i18n::t_args("maintenance-failed-write-file", &[("path", &plist_path.display().to_string()), ("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "maintenance-failed-write-file",
+            &[
+                ("path", &plist_path.display().to_string()),
+                ("error", &e.to_string()),
+            ],
+        ));
         return;
     }
-    ui::success(&i18n::t_args("maintenance-wrote-file", &[("path", &plist_path.display().to_string())]));
+    ui::success(&i18n::t_args(
+        "maintenance-wrote-file",
+        &[("path", &plist_path.display().to_string())],
+    ));
 
     let load = std::process::Command::new("launchctl")
         .args(["load", &plist_path.to_string_lossy()])
@@ -213,9 +243,15 @@ pub(crate) fn service_install_macos(binary: &std::path::Path, librefang_home: &s
         }
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr);
-            ui::error(&i18n::t_args("maintenance-launchctl-load-failed", &[("error", &stderr.to_string())]));
+            ui::error(&i18n::t_args(
+                "maintenance-launchctl-load-failed",
+                &[("error", &stderr.to_string())],
+            ));
         }
-        Err(e) => ui::error(&i18n::t_args("maintenance-launchctl-run-failed", &[("error", &e.to_string())])),
+        Err(e) => ui::error(&i18n::t_args(
+            "maintenance-launchctl-run-failed",
+            &[("error", &e.to_string())],
+        )),
     }
 }
 
@@ -241,9 +277,15 @@ pub(crate) fn service_install_windows(binary: &std::path::Path) {
         }
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr);
-            ui::error(&i18n::t_args("maintenance-windows-registry-write-failed", &[("error", &stderr.to_string())]));
+            ui::error(&i18n::t_args(
+                "maintenance-windows-registry-write-failed",
+                &[("error", &stderr.to_string())],
+            ));
         }
-        Err(e) => ui::error(&i18n::t_args("maintenance-windows-reg-run-failed", &[("error", &e.to_string())])),
+        Err(e) => ui::error(&i18n::t_args(
+            "maintenance-windows-reg-run-failed",
+            &[("error", &e.to_string())],
+        )),
     }
 }
 
@@ -263,7 +305,10 @@ pub(crate) fn cmd_service_uninstall() {
                         .output();
                     ui::success(&i18n::t("maintenance-systemd-removed"));
                 }
-                Err(e) => ui::error(&i18n::t_args("maintenance-systemd-remove-failed", &[("error", &e.to_string())])),
+                Err(e) => ui::error(&i18n::t_args(
+                    "maintenance-systemd-remove-failed",
+                    &[("error", &e.to_string())],
+                )),
             }
         } else {
             ui::hint(&i18n::t("maintenance-systemd-not-found"));
@@ -279,7 +324,10 @@ pub(crate) fn cmd_service_uninstall() {
                 .output();
             match std::fs::remove_file(&plist_path) {
                 Ok(()) => ui::success(&i18n::t("maintenance-launchagent-removed")),
-                Err(e) => ui::error(&i18n::t_args("maintenance-launchagent-remove-failed", &[("error", &e.to_string())])),
+                Err(e) => ui::error(&i18n::t_args(
+                    "maintenance-launchagent-remove-failed",
+                    &[("error", &e.to_string())],
+                )),
             }
         } else {
             ui::hint(&i18n::t("maintenance-launchagent-not-found"));
@@ -350,7 +398,11 @@ pub(crate) fn cmd_service_status() {
                 let running = stdout.lines().any(|l| l.contains("ai.librefang.daemon"));
                 ui::kv(
                     &i18n::t("maintenance-status-label-loaded"),
-                    if running { &i18n::t("label-yes") } else { &i18n::t("label-not-loaded") }
+                    if running {
+                        &i18n::t("label-yes")
+                    } else {
+                        &i18n::t("label-not-loaded")
+                    },
                 );
             }
         } else {
@@ -428,7 +480,10 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
     use librefang_types::config::UpdateChannel;
 
     let current_exe = std::env::current_exe().unwrap_or_else(|e| {
-        ui::error(&i18n::t_args("maintenance-update-error-exe-path", &[("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "maintenance-update-error-exe-path",
+            &[("error", &e.to_string())],
+        ));
         std::process::exit(1);
     });
 
@@ -462,11 +517,17 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
             }
             Err(err) => {
                 if check {
-                    ui::error(&i18n::t_args("maintenance-update-error-check-release", &[("error", &err.to_string())]));
+                    ui::error(&i18n::t_args(
+                        "maintenance-update-error-check-release",
+                        &[("error", &err.to_string())],
+                    ));
                     std::process::exit(1);
                 }
                 ui::warn_with_fix(
-                    &i18n::t_args("maintenance-update-warn-resolve-release", &[("error", &err.to_string())]),
+                    &i18n::t_args(
+                        "maintenance-update-warn-resolve-release",
+                        &[("error", &err.to_string())],
+                    ),
                     &i18n::t("maintenance-update-warn-resolve-release-fix"),
                 );
                 None
@@ -583,7 +644,10 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
                 ui::hint(&i18n::t("maintenance-update-background-hint-restart"));
             }
             Err(err) => {
-                ui::error(&i18n::t_args("maintenance-update-failed-error", &[("error", &err.to_string())]));
+                ui::error(&i18n::t_args(
+                    "maintenance-update-failed-error",
+                    &[("error", &err.to_string())],
+                ));
                 std::process::exit(1);
             }
         }
@@ -592,16 +656,16 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
 
     if same_path(&current_exe, &cargo_install) {
         let cargo_cmd = cargo_update_command(target_version);
-        ui::warn_with_fix(
-            &i18n::t("maintenance-update-cargo-blocked"),
-            &cargo_cmd,
-        );
+        ui::warn_with_fix(&i18n::t("maintenance-update-cargo-blocked"), &cargo_cmd);
         return;
     }
 
     let official_path = default_install.display().to_string();
     ui::warn_with_fix(
-        &i18n::t_args("maintenance-update-unofficial-path", &[("path", &official_path)]),
+        &i18n::t_args(
+            "maintenance-update-unofficial-path",
+            &[("path", &official_path)],
+        ),
         &manual_installer_command(target_version),
     );
     ui::hint(&i18n::t("maintenance-update-package-manager-hint"));

--- a/crates/librefang-cli/src/commands/maintenance.rs
+++ b/crates/librefang-cli/src/commands/maintenance.rs
@@ -46,10 +46,7 @@ pub(crate) fn cmd_service_install() {
     {
         // SAFETY: geteuid() is always safe to call.
         if unsafe { libc::geteuid() } == 0 {
-            ui::error(
-                "Running as root — the service will be installed for the root account, \
-                 not your user. Run without sudo instead.",
-            );
+            ui::error(&i18n::t("maintenance-service-install-root-error"));
             std::process::exit(1);
         }
     }
@@ -74,7 +71,7 @@ pub(crate) fn cmd_service_install() {
     #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
     {
         let _ = &binary;
-        ui::error("Auto-start service is not supported on this platform.");
+        ui::error(&i18n::t("maintenance-service-unsupported"));
     }
 }
 
@@ -83,13 +80,13 @@ pub(crate) fn service_install_linux(binary: &std::path::Path, librefang_home: &s
     let home = match dirs::home_dir() {
         Some(h) => h,
         None => {
-            ui::error("Cannot determine home directory.");
+            ui::error(&i18n::t("migrate-error-home-dir"));
             return;
         }
     };
     let service_dir = home.join(".config/systemd/user");
     if let Err(e) = std::fs::create_dir_all(&service_dir) {
-        ui::error(&format!("Failed to create {}: {e}", service_dir.display()));
+        ui::error(&i18n::t_args("maintenance-failed-create-dir", &[("path", &service_dir.display().to_string()), ("error", &e.to_string())]));
         return;
     }
 
@@ -117,10 +114,10 @@ pub(crate) fn service_install_linux(binary: &std::path::Path, librefang_home: &s
 
     let service_path = service_dir.join("librefang.service");
     if let Err(e) = std::fs::write(&service_path, &unit) {
-        ui::error(&format!("Failed to write {}: {e}", service_path.display()));
+        ui::error(&i18n::t_args("maintenance-failed-write-file", &[("path", &service_path.display().to_string()), ("error", &e.to_string())]));
         return;
     }
-    ui::success(&format!("Wrote {}", service_path.display()));
+    ui::success(&i18n::t_args("maintenance-wrote-file", &[("path", &service_path.display().to_string())]));
 
     // Reload and enable
     let reload = std::process::Command::new("systemctl")
@@ -128,7 +125,7 @@ pub(crate) fn service_install_linux(binary: &std::path::Path, librefang_home: &s
         .output();
     if let Ok(o) = &reload {
         if !o.status.success() {
-            ui::error("systemctl --user daemon-reload failed");
+            ui::error(&i18n::t("maintenance-systemctl-reload-failed"));
             return;
         }
     }
@@ -137,12 +134,12 @@ pub(crate) fn service_install_linux(binary: &std::path::Path, librefang_home: &s
         .output();
     match enable {
         Ok(o) if o.status.success() => {
-            ui::success("Service enabled (will start on next login)");
-            ui::hint("Start now with: systemctl --user start librefang.service");
+            ui::success(&i18n::t("maintenance-service-enabled"));
+            ui::hint(&i18n::t("maintenance-service-start-hint"));
             // Enable lingering so the user service runs without an active login session
-            ui::hint("For headless servers, also run: loginctl enable-linger");
+            ui::hint(&i18n::t("maintenance-service-linger-hint"));
         }
-        _ => ui::error("systemctl --user enable librefang.service failed"),
+        _ => ui::error(&i18n::t("maintenance-systemctl-enable-failed")),
     }
 }
 
@@ -151,13 +148,13 @@ pub(crate) fn service_install_macos(binary: &std::path::Path, librefang_home: &s
     let home = match dirs::home_dir() {
         Some(h) => h,
         None => {
-            ui::error("Cannot determine home directory.");
+            ui::error(&i18n::t("migrate-error-home-dir"));
             return;
         }
     };
     let agents_dir = home.join("Library/LaunchAgents");
     if let Err(e) = std::fs::create_dir_all(&agents_dir) {
-        ui::error(&format!("Failed to create {}: {e}", agents_dir.display()));
+        ui::error(&i18n::t_args("maintenance-failed-create-dir", &[("path", &agents_dir.display().to_string()), ("error", &e.to_string())]));
         return;
     }
 
@@ -202,23 +199,23 @@ pub(crate) fn service_install_macos(binary: &std::path::Path, librefang_home: &s
     }
 
     if let Err(e) = std::fs::write(&plist_path, &plist) {
-        ui::error(&format!("Failed to write {}: {e}", plist_path.display()));
+        ui::error(&i18n::t_args("maintenance-failed-write-file", &[("path", &plist_path.display().to_string()), ("error", &e.to_string())]));
         return;
     }
-    ui::success(&format!("Wrote {}", plist_path.display()));
+    ui::success(&i18n::t_args("maintenance-wrote-file", &[("path", &plist_path.display().to_string())]));
 
     let load = std::process::Command::new("launchctl")
         .args(["load", &plist_path.to_string_lossy()])
         .output();
     match load {
         Ok(o) if o.status.success() => {
-            ui::success("LaunchAgent loaded (will start on login and now)");
+            ui::success(&i18n::t("maintenance-launchagent-loaded"));
         }
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr);
-            ui::error(&format!("launchctl load failed: {stderr}"));
+            ui::error(&i18n::t_args("maintenance-launchctl-load-failed", &[("error", &stderr.to_string())]));
         }
-        Err(e) => ui::error(&format!("Failed to run launchctl: {e}")),
+        Err(e) => ui::error(&i18n::t_args("maintenance-launchctl-run-failed", &[("error", &e.to_string())])),
     }
 }
 
@@ -240,13 +237,13 @@ pub(crate) fn service_install_windows(binary: &std::path::Path) {
         .output();
     match output {
         Ok(o) if o.status.success() => {
-            ui::success("Added to Windows startup (HKCU\\...\\Run)");
+            ui::success(&i18n::t("maintenance-windows-startup-added"));
         }
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr);
-            ui::error(&format!("Failed to write registry: {stderr}"));
+            ui::error(&i18n::t_args("maintenance-windows-registry-write-failed", &[("error", &stderr.to_string())]));
         }
-        Err(e) => ui::error(&format!("Failed to run reg.exe: {e}")),
+        Err(e) => ui::error(&i18n::t_args("maintenance-windows-reg-run-failed", &[("error", &e.to_string())])),
     }
 }
 
@@ -264,12 +261,12 @@ pub(crate) fn cmd_service_uninstall() {
                     let _ = std::process::Command::new("systemctl")
                         .args(["--user", "daemon-reload"])
                         .output();
-                    ui::success("Removed systemd user service");
+                    ui::success(&i18n::t("maintenance-systemd-removed"));
                 }
-                Err(e) => ui::error(&format!("Failed to remove service file: {e}")),
+                Err(e) => ui::error(&i18n::t_args("maintenance-systemd-remove-failed", &[("error", &e.to_string())])),
             }
         } else {
-            ui::hint("No systemd user service found — nothing to remove.");
+            ui::hint(&i18n::t("maintenance-systemd-not-found"));
         }
     }
     #[cfg(target_os = "macos")]
@@ -281,11 +278,11 @@ pub(crate) fn cmd_service_uninstall() {
                 .args(["unload", &plist_path.to_string_lossy()])
                 .output();
             match std::fs::remove_file(&plist_path) {
-                Ok(()) => ui::success("Removed LaunchAgent"),
-                Err(e) => ui::error(&format!("Failed to remove plist: {e}")),
+                Ok(()) => ui::success(&i18n::t("maintenance-launchagent-removed")),
+                Err(e) => ui::error(&i18n::t_args("maintenance-launchagent-remove-failed", &[("error", &e.to_string())])),
             }
         } else {
-            ui::hint("No LaunchAgent found — nothing to remove.");
+            ui::hint(&i18n::t("maintenance-launchagent-not-found"));
         }
     }
     #[cfg(windows)]
@@ -301,14 +298,14 @@ pub(crate) fn cmd_service_uninstall() {
             .output();
         match output {
             Ok(o) if o.status.success() => {
-                ui::success("Removed from Windows startup");
+                ui::success(&i18n::t("maintenance-windows-startup-removed"));
             }
-            _ => ui::hint("No startup entry found — nothing to remove."),
+            _ => ui::hint(&i18n::t("maintenance-windows-startup-not-found")),
         }
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
     {
-        ui::error("Auto-start service is not supported on this platform.");
+        ui::error(&i18n::t("maintenance-service-unsupported"));
     }
 }
 
@@ -318,25 +315,25 @@ pub(crate) fn cmd_service_status() {
         let home = dirs::home_dir().unwrap_or_default();
         let service_path = home.join(".config/systemd/user/librefang.service");
         if service_path.exists() {
-            ui::success("Systemd user service is registered");
+            ui::success(&i18n::t("maintenance-systemd-status-registered"));
             // Show enabled/active status
             if let Ok(output) = std::process::Command::new("systemctl")
                 .args(["--user", "is-enabled", "librefang.service"])
                 .output()
             {
                 let status = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                ui::kv("  Enabled", &status);
+                ui::kv(&i18n::t("maintenance-status-label-enabled"), &status);
             }
             if let Ok(output) = std::process::Command::new("systemctl")
                 .args(["--user", "is-active", "librefang.service"])
                 .output()
             {
                 let status = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                ui::kv("  Active", &status);
+                ui::kv(&i18n::t("maintenance-status-label-active"), &status);
             }
         } else {
-            ui::hint("No systemd user service registered.");
-            ui::hint("Run `librefang service install` to set it up.");
+            ui::hint(&i18n::t("maintenance-systemd-status-not-registered"));
+            ui::hint(&i18n::t("maintenance-service-install-hint"));
         }
     }
     #[cfg(target_os = "macos")]
@@ -344,18 +341,21 @@ pub(crate) fn cmd_service_status() {
         let home = dirs::home_dir().unwrap_or_default();
         let plist_path = home.join("Library/LaunchAgents/ai.librefang.daemon.plist");
         if plist_path.exists() {
-            ui::success("LaunchAgent is registered");
+            ui::success(&i18n::t("maintenance-launchagent-status-registered"));
             if let Ok(output) = std::process::Command::new("launchctl")
                 .args(["list"])
                 .output()
             {
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 let running = stdout.lines().any(|l| l.contains("ai.librefang.daemon"));
-                ui::kv("  Loaded", if running { "yes" } else { "not loaded" });
+                ui::kv(
+                    &i18n::t("maintenance-status-label-loaded"),
+                    if running { &i18n::t("label-yes") } else { &i18n::t("label-not-loaded") }
+                );
             }
         } else {
-            ui::hint("No LaunchAgent registered.");
-            ui::hint("Run `librefang service install` to set it up.");
+            ui::hint(&i18n::t("maintenance-launchagent-status-not-registered"));
+            ui::hint(&i18n::t("maintenance-service-install-hint"));
         }
     }
     #[cfg(windows)]
@@ -370,17 +370,17 @@ pub(crate) fn cmd_service_status() {
             .output();
         match output {
             Ok(o) if o.status.success() => {
-                ui::success("Windows startup entry is registered");
+                ui::success(&i18n::t("maintenance-windows-status-registered"));
             }
             _ => {
-                ui::hint("No startup entry registered.");
-                ui::hint("Run `librefang service install` to set it up.");
+                ui::hint(&i18n::t("maintenance-windows-status-not-registered"));
+                ui::hint(&i18n::t("maintenance-service-install-hint"));
             }
         }
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
     {
-        ui::error("Auto-start service is not supported on this platform.");
+        ui::error(&i18n::t("maintenance-service-unsupported"));
     }
 }
 
@@ -428,7 +428,7 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
     use librefang_types::config::UpdateChannel;
 
     let current_exe = std::env::current_exe().unwrap_or_else(|e| {
-        ui::error(&format!("Cannot determine current executable path: {e}"));
+        ui::error(&i18n::t_args("maintenance-update-error-exe-path", &[("error", &e.to_string())]));
         std::process::exit(1);
     });
 
@@ -449,32 +449,32 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
         load_update_channel_from_config().unwrap_or_default()
     };
 
-    ui::section("Update");
-    ui::kv("Current", current_version);
-    ui::kv("Channel", &channel.to_string());
-    ui::kv("Binary", &current_exe_display);
+    ui::section(&i18n::t("maintenance-update-section"));
+    ui::kv(&i18n::t("label-current"), current_version);
+    ui::kv(&i18n::t("label-channel"), &channel.to_string());
+    ui::kv(&i18n::t("label-binary"), &current_exe_display);
 
     let latest_tag = if requested_version.is_none() {
         match fetch_latest_release_tag(channel) {
             Ok(tag) => {
-                ui::kv("Latest", &tag);
+                ui::kv(&i18n::t("label-latest"), &tag);
                 Some(tag)
             }
             Err(err) => {
                 if check {
-                    ui::error(&format!("Failed to check latest release: {err}"));
+                    ui::error(&i18n::t_args("maintenance-update-error-check-release", &[("error", &err.to_string())]));
                     std::process::exit(1);
                 }
                 ui::warn_with_fix(
-                    &format!("Could not resolve the latest published release: {err}"),
-                    "Retry later, or pass `--version <tag>` to target a specific release.",
+                    &i18n::t_args("maintenance-update-warn-resolve-release", &[("error", &err.to_string())]),
+                    &i18n::t("maintenance-update-warn-resolve-release-fix"),
                 );
                 None
             }
         }
     } else {
         if let Some(target) = requested_version {
-            ui::kv("Target", target);
+            ui::kv(&i18n::t("label-target"), target);
         }
         None
     };
@@ -552,8 +552,8 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
     #[cfg(windows)]
     if same_path(&current_exe, &default_install) && find_daemon().is_some() {
         ui::error_with_fix(
-            "Stop the running daemon before updating on Windows.",
-            "Run `librefang stop`, then `librefang update`, then `librefang start`.",
+            &i18n::t("maintenance-update-windows-daemon-running-error"),
+            &i18n::t("maintenance-update-windows-daemon-running-error-fix"),
         );
         std::process::exit(1);
     }
@@ -562,28 +562,28 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
         match run_official_update(target_version) {
             #[cfg(not(windows))]
             Ok(UpdateLaunch::Completed) => {
-                ui::success("LibreFang CLI updated.");
+                ui::success(&i18n::t("maintenance-update-cli-success"));
                 if let Some(installed) = installed_binary_version(&default_install) {
-                    ui::kv("Installed", &installed);
+                    ui::kv(&i18n::t("label-installed"), &installed);
                 }
                 // Merge any new config defaults added in the updated binary.
                 // Spawn the new binary rather than calling cmd_init_upgrade() here,
                 // because the current process still holds the old binary's template.
                 ui::blank();
-                ui::hint("Merging new config defaults...");
+                ui::hint(&i18n::t("maintenance-update-merging-config-defaults"));
                 let _ = std::process::Command::new(&default_install)
                     .args(["init", "--upgrade"])
                     .status();
-                ui::hint("If the daemon is running, restart it with `librefang restart`.");
+                ui::hint(&i18n::t("maintenance-update-restart-daemon-hint"));
             }
             #[cfg(windows)]
             Ok(UpdateLaunch::Detached) => {
-                ui::success("Update launched in the background.");
-                ui::hint("Open a new terminal after it finishes and run `librefang --version`.");
-                ui::hint("If the daemon is running, restart it after the update completes.");
+                ui::success(&i18n::t("maintenance-update-background-launched"));
+                ui::hint(&i18n::t("maintenance-update-background-hint-terminal"));
+                ui::hint(&i18n::t("maintenance-update-background-hint-restart"));
             }
             Err(err) => {
-                ui::error(&format!("Update failed: {err}"));
+                ui::error(&i18n::t_args("maintenance-update-failed-error", &[("error", &err.to_string())]));
                 std::process::exit(1);
             }
         }
@@ -593,7 +593,7 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
     if same_path(&current_exe, &cargo_install) {
         let cargo_cmd = cargo_update_command(target_version);
         ui::warn_with_fix(
-            "This binary was installed with cargo. Running `cargo install` from inside the active executable is intentionally blocked.",
+            &i18n::t("maintenance-update-cargo-blocked"),
             &cargo_cmd,
         );
         return;
@@ -601,12 +601,10 @@ pub(crate) fn cmd_update(check: bool, version: Option<String>, channel_override:
 
     let official_path = default_install.display().to_string();
     ui::warn_with_fix(
-        &format!(
-            "Automatic update only supports the official install path ({official_path}). This binary is running from a different location."
-        ),
+        &i18n::t_args("maintenance-update-unofficial-path", &[("path", &official_path)]),
         &manual_installer_command(target_version),
     );
-    ui::hint("If this binary came from another package manager, update it with that package manager instead.");
+    ui::hint(&i18n::t("maintenance-update-package-manager-hint"));
 }
 
 pub(crate) fn fetch_latest_release_tag(

--- a/crates/librefang-cli/src/commands/mcp_cmds.rs
+++ b/crates/librefang-cli/src/commands/mcp_cmds.rs
@@ -18,8 +18,8 @@ pub(crate) fn cmd_mcp_add(name: &str, key: Option<&str>) {
     let template = match catalog.get(name) {
         Some(t) => t.clone(),
         None => {
-            ui::error(&format!("Unknown MCP catalog entry: '{name}'"));
-            println!("\nAvailable MCP servers (catalog):");
+            ui::error(&i18n::t_args("mcp-catalog-unknown-entry", &[("name", name)]));
+            println!("{}", i18n::t("mcp-catalog-available-header"));
             for t in catalog.list() {
                 println!("  {} {} — {}", t.icon, t.id, t.description);
             }
@@ -37,14 +37,14 @@ pub(crate) fn cmd_mcp_add(name: &str, key: Option<&str>) {
         let content = match std::fs::read_to_string(&config_path) {
             Ok(c) => c,
             Err(e) => {
-                ui::error(&format!("Failed to read {}: {e}", config_path.display()));
+                ui::error(&i18n::t_args("mcp-failed-read-config", &[("path", &config_path.display().to_string()), ("error", &e.to_string())]));
                 std::process::exit(1);
             }
         };
         let parsed: toml::value::Table = match toml::from_str(&content) {
             Ok(t) => t,
             Err(e) => {
-                ui::error(&format!("{} is not valid TOML: {e}", config_path.display()));
+                ui::error(&i18n::t_args("mcp-invalid-toml", &[("path", &config_path.display().to_string()), ("error", &e.to_string())]));
                 std::process::exit(1);
             }
         };
@@ -109,7 +109,7 @@ pub(crate) fn cmd_mcp_add(name: &str, key: Option<&str>) {
     // Persist the new [[mcp_servers]] entry directly into config.toml.
     let config_path = home.join("config.toml");
     if let Err(e) = upsert_mcp_server_local(&config_path, &result.server) {
-        ui::error(&format!("Failed to write config.toml: {e}"));
+        ui::error(&i18n::t_args("mcp-failed-write-config", &[("error", &e.to_string())]));
         std::process::exit(1);
     }
 
@@ -117,12 +117,12 @@ pub(crate) fn cmd_mcp_add(name: &str, key: Option<&str>) {
         librefang_types::mcp::McpStatus::Ready => ui::success(&result.message),
         librefang_types::mcp::McpStatus::Setup => {
             println!("{}", result.message.yellow());
-            println!("\nTo add credentials:");
+            println!("{}", i18n::t("mcp-add-credentials-hint"));
             for env in &template.required_env {
                 if env.is_secret {
                     println!("  librefang vault set {}  # {}", env.name, env.help);
                     if let Some(ref url) = env.get_url {
-                        println!("  Get it here: {url}");
+                        println!("{}", i18n::t_args("mcp-get-it-here", &[("url", url)]));
                     }
                 }
             }
@@ -166,17 +166,17 @@ pub(crate) fn cmd_mcp_remove(name: &str) {
     let target_name = match target_name {
         Some(n) => n,
         None => {
-            ui::error(&format!("MCP server '{name}' is not configured"));
+            ui::error(&i18n::t_args("mcp-not-configured", &[("name", name)]));
             std::process::exit(1);
         }
     };
 
     if let Err(e) = remove_mcp_server_local(&config_path, &target_name) {
-        ui::error(&format!("Failed to update config.toml: {e}"));
+        ui::error(&i18n::t_args("mcp-failed-update-config", &[("error", &e.to_string())]));
         std::process::exit(1);
     }
 
-    ui::success(&format!("{target_name} removed."));
+    ui::success(&i18n::t_args("mcp-removed-success", &[("name", &target_name)]));
 
     // Hot-reload daemon
     if let Some(base_url) = find_daemon() {

--- a/crates/librefang-cli/src/commands/mcp_cmds.rs
+++ b/crates/librefang-cli/src/commands/mcp_cmds.rs
@@ -18,7 +18,10 @@ pub(crate) fn cmd_mcp_add(name: &str, key: Option<&str>) {
     let template = match catalog.get(name) {
         Some(t) => t.clone(),
         None => {
-            ui::error(&i18n::t_args("mcp-catalog-unknown-entry", &[("name", name)]));
+            ui::error(&i18n::t_args(
+                "mcp-catalog-unknown-entry",
+                &[("name", name)],
+            ));
             println!("{}", i18n::t("mcp-catalog-available-header"));
             for t in catalog.list() {
                 println!("  {} {} — {}", t.icon, t.id, t.description);
@@ -37,14 +40,26 @@ pub(crate) fn cmd_mcp_add(name: &str, key: Option<&str>) {
         let content = match std::fs::read_to_string(&config_path) {
             Ok(c) => c,
             Err(e) => {
-                ui::error(&i18n::t_args("mcp-failed-read-config", &[("path", &config_path.display().to_string()), ("error", &e.to_string())]));
+                ui::error(&i18n::t_args(
+                    "mcp-failed-read-config",
+                    &[
+                        ("path", &config_path.display().to_string()),
+                        ("error", &e.to_string()),
+                    ],
+                ));
                 std::process::exit(1);
             }
         };
         let parsed: toml::value::Table = match toml::from_str(&content) {
             Ok(t) => t,
             Err(e) => {
-                ui::error(&i18n::t_args("mcp-invalid-toml", &[("path", &config_path.display().to_string()), ("error", &e.to_string())]));
+                ui::error(&i18n::t_args(
+                    "mcp-invalid-toml",
+                    &[
+                        ("path", &config_path.display().to_string()),
+                        ("error", &e.to_string()),
+                    ],
+                ));
                 std::process::exit(1);
             }
         };
@@ -109,7 +124,10 @@ pub(crate) fn cmd_mcp_add(name: &str, key: Option<&str>) {
     // Persist the new [[mcp_servers]] entry directly into config.toml.
     let config_path = home.join("config.toml");
     if let Err(e) = upsert_mcp_server_local(&config_path, &result.server) {
-        ui::error(&i18n::t_args("mcp-failed-write-config", &[("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "mcp-failed-write-config",
+            &[("error", &e.to_string())],
+        ));
         std::process::exit(1);
     }
 
@@ -172,11 +190,17 @@ pub(crate) fn cmd_mcp_remove(name: &str) {
     };
 
     if let Err(e) = remove_mcp_server_local(&config_path, &target_name) {
-        ui::error(&i18n::t_args("mcp-failed-update-config", &[("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "mcp-failed-update-config",
+            &[("error", &e.to_string())],
+        ));
         std::process::exit(1);
     }
 
-    ui::success(&i18n::t_args("mcp-removed-success", &[("name", &target_name)]));
+    ui::success(&i18n::t_args(
+        "mcp-removed-success",
+        &[("name", &target_name)],
+    ));
 
     // Hot-reload daemon
     if let Some(base_url) = find_daemon() {

--- a/crates/librefang-cli/src/commands/monitoring.rs
+++ b/crates/librefang-cli/src/commands/monitoring.rs
@@ -151,11 +151,17 @@ pub(crate) fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
         println!("{}", i18n::t("monitoring-audit-reset-would-header"));
         println!(
             "{}",
-            i18n::t_args("monitoring-audit-reset-would-delete", &[("path", &db_path.display().to_string())])
+            i18n::t_args(
+                "monitoring-audit-reset-would-delete",
+                &[("path", &db_path.display().to_string())]
+            )
         );
         println!(
             "{}",
-            i18n::t_args("monitoring-audit-reset-would-remove-anchor", &[("path", &anchor_path.display().to_string())])
+            i18n::t_args(
+                "monitoring-audit-reset-would-remove-anchor",
+                &[("path", &anchor_path.display().to_string())]
+            )
         );
         println!("{}", i18n::t("monitoring-audit-reset-would-restart"));
         std::process::exit(1);
@@ -171,14 +177,23 @@ pub(crate) fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
     }
 
     if !db_path.exists() {
-        ui::error(&i18n::t_args("monitoring-db-not-found", &[("path", &db_path.display().to_string())]));
+        ui::error(&i18n::t_args(
+            "monitoring-db-not-found",
+            &[("path", &db_path.display().to_string())],
+        ));
         std::process::exit(1);
     }
 
     let conn = match rusqlite::Connection::open(&db_path) {
         Ok(c) => c,
         Err(e) => {
-            ui::error(&i18n::t_args("monitoring-db-open-failed", &[("path", &db_path.display().to_string()), ("error", &e.to_string())]));
+            ui::error(&i18n::t_args(
+                "monitoring-db-open-failed",
+                &[
+                    ("path", &db_path.display().to_string()),
+                    ("error", &e.to_string()),
+                ],
+            ));
             std::process::exit(1);
         }
     };
@@ -199,7 +214,10 @@ pub(crate) fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
             Err(e) => {
                 ui::error(&i18n::t_args(
                     "monitoring-anchor-remove-failed",
-                    &[("path", &anchor_path.display().to_string()), ("error", &e.to_string())],
+                    &[
+                        ("path", &anchor_path.display().to_string()),
+                        ("error", &e.to_string()),
+                    ],
                 ));
                 std::process::exit(1);
             }
@@ -209,7 +227,10 @@ pub(crate) fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
     };
 
     if let Err(e) = conn.execute("DELETE FROM audit_entries", []) {
-        ui::error(&i18n::t_args("monitoring-db-truncate-failed", &[("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "monitoring-db-truncate-failed",
+            &[("error", &e.to_string())],
+        ));
         std::process::exit(1);
     }
     drop(conn);
@@ -218,7 +239,10 @@ pub(crate) fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
     // fiddling needed.
 
     let anchor_detail = if anchor_removed {
-        i18n::t_args("monitoring-audit-reset-anchor-deleted", &[("path", &anchor_path.display().to_string())])
+        i18n::t_args(
+            "monitoring-audit-reset-anchor-deleted",
+            &[("path", &anchor_path.display().to_string())],
+        )
     } else {
         i18n::t("monitoring-audit-reset-anchor-none")
     };

--- a/crates/librefang-cli/src/commands/monitoring.rs
+++ b/crates/librefang-cli/src/commands/monitoring.rs
@@ -146,36 +146,39 @@ pub(crate) fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
     };
 
     if !confirm {
-        ui::error("audit reset is destructive — re-run with `--confirm` to proceed");
+        ui::error(&i18n::t("monitoring-audit-reset-destructive"));
         ui::blank();
-        println!("  Would:");
+        println!("{}", i18n::t("monitoring-audit-reset-would-header"));
         println!(
-            "    1. DELETE all rows from `audit_entries` in {}",
-            db_path.display()
+            "{}",
+            i18n::t_args("monitoring-audit-reset-would-delete", &[("path", &db_path.display().to_string())])
         );
-        println!("    2. Remove anchor file {}", anchor_path.display());
-        println!("  The Merkle chain will restart from the next audit event.");
+        println!(
+            "{}",
+            i18n::t_args("monitoring-audit-reset-would-remove-anchor", &[("path", &anchor_path.display().to_string())])
+        );
+        println!("{}", i18n::t("monitoring-audit-reset-would-restart"));
         std::process::exit(1);
     }
 
     // Refuse if daemon is running — SQLite writer lock would block or corrupt.
     if let Some(base) = find_daemon_in_home(&daemon.home_dir) {
         ui::error_with_fix(
-            &format!("daemon is running at {base}; refusing to touch the audit database"),
-            "stop the daemon first: `librefang stop`",
+            &i18n::t_args("monitoring-daemon-running-error", &[("url", &base)]),
+            &i18n::t("monitoring-daemon-running-error-fix"),
         );
         std::process::exit(1);
     }
 
     if !db_path.exists() {
-        ui::error(&format!("database not found at {}", db_path.display()));
+        ui::error(&i18n::t_args("monitoring-db-not-found", &[("path", &db_path.display().to_string())]));
         std::process::exit(1);
     }
 
     let conn = match rusqlite::Connection::open(&db_path) {
         Ok(c) => c,
         Err(e) => {
-            ui::error(&format!("failed to open {}: {e}", db_path.display()));
+            ui::error(&i18n::t_args("monitoring-db-open-failed", &[("path", &db_path.display().to_string()), ("error", &e.to_string())]));
             std::process::exit(1);
         }
     };
@@ -194,9 +197,9 @@ pub(crate) fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
         match std::fs::remove_file(&anchor_path) {
             Ok(()) => true,
             Err(e) => {
-                ui::error(&format!(
-                    "failed to remove anchor {}: {e}",
-                    anchor_path.display()
+                ui::error(&i18n::t_args(
+                    "monitoring-anchor-remove-failed",
+                    &[("path", &anchor_path.display().to_string()), ("error", &e.to_string())],
                 ));
                 std::process::exit(1);
             }
@@ -206,7 +209,7 @@ pub(crate) fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
     };
 
     if let Err(e) = conn.execute("DELETE FROM audit_entries", []) {
-        ui::error(&format!("failed to truncate audit_entries: {e}"));
+        ui::error(&i18n::t_args("monitoring-db-truncate-failed", &[("error", &e.to_string())]));
         std::process::exit(1);
     }
     drop(conn);
@@ -214,15 +217,19 @@ pub(crate) fn cmd_audit_reset(config: Option<PathBuf>, confirm: bool) {
     // insert after an empty table naturally gets seq = 1. No sqlite_sequence
     // fiddling needed.
 
-    ui::success(&format!(
-        "Audit trail reset: removed {rows_before} row(s) from audit_entries{}.",
-        if anchor_removed {
-            format!(", deleted anchor at {}", anchor_path.display())
-        } else {
-            " (no anchor file to remove)".to_string()
-        }
+    let anchor_detail = if anchor_removed {
+        i18n::t_args("monitoring-audit-reset-anchor-deleted", &[("path", &anchor_path.display().to_string())])
+    } else {
+        i18n::t("monitoring-audit-reset-anchor-none")
+    };
+    ui::success(&i18n::t_args(
+        "monitoring-audit-reset-success",
+        &[
+            ("count", &rows_before.to_string()),
+            ("anchor_detail", &anchor_detail),
+        ],
     ));
-    ui::hint("The next daemon boot will seed a fresh Merkle chain from the current tip.");
+    ui::hint(&i18n::t("monitoring-audit-reset-seed-fresh"));
 }
 
 pub(crate) fn cmd_memory_list(agent: &str, json: bool) {

--- a/crates/librefang-cli/src/commands/skill.rs
+++ b/crates/librefang-cli/src/commands/skill.rs
@@ -125,7 +125,7 @@ pub(crate) fn cmd_skill_install(source: &str, hand: Option<&str>) {
         }
     } else {
         // Remote install from FangHub
-        let mut sp = progress::auto(&format!("Installing {source}"), None);
+        let mut sp = progress::auto(&i18n::t_args("skill-install-progress", &[("source", source)]), None);
         sp.tick(1);
         let rt = tokio::runtime::Runtime::new().unwrap();
         let client = librefang_skills::marketplace::MarketplaceClient::new(

--- a/crates/librefang-cli/src/commands/skill.rs
+++ b/crates/librefang-cli/src/commands/skill.rs
@@ -125,7 +125,10 @@ pub(crate) fn cmd_skill_install(source: &str, hand: Option<&str>) {
         }
     } else {
         // Remote install from FangHub
-        let mut sp = progress::auto(&i18n::t_args("skill-install-progress", &[("source", source)]), None);
+        let mut sp = progress::auto(
+            &i18n::t_args("skill-install-progress", &[("source", source)]),
+            None,
+        );
         sp.tick(1);
         let rt = tokio::runtime::Runtime::new().unwrap();
         let client = librefang_skills::marketplace::MarketplaceClient::new(

--- a/crates/librefang-cli/src/commands/system.rs
+++ b/crates/librefang-cli/src/commands/system.rs
@@ -67,7 +67,7 @@ pub(crate) fn cmd_migrate(args: MigrateArgs) {
 
     let source_dir = args.source_dir.unwrap_or_else(|| {
         let home = dirs::home_dir().unwrap_or_else(|| {
-            eprintln!("Error: Could not determine home directory");
+            eprintln!("{}", i18n::t("migrate-error-home-dir"));
             std::process::exit(1);
         });
         match source {
@@ -80,9 +80,9 @@ pub(crate) fn cmd_migrate(args: MigrateArgs) {
 
     let target_dir = cli_librefang_home();
 
-    println!("Migrating from {} ({})...", source, source_dir.display());
+    println!("{}", i18n::t_args("migrate-start-msg", &[("source", &source.to_string()), ("path", &source_dir.display().to_string())]));
     if args.dry_run {
-        println!("  (dry run — no changes will be made)\n");
+        println!("{}\n", i18n::t("migrate-dry-run-hint"));
     }
 
     let options = librefang_import::MigrateOptions {
@@ -92,24 +92,24 @@ pub(crate) fn cmd_migrate(args: MigrateArgs) {
         dry_run: args.dry_run,
     };
 
-    let mut sp = progress::auto("Running migration", None);
+    let mut sp = progress::auto(&i18n::t("migrate-progress-label"), None);
     match librefang_import::run_migration(&options) {
         Ok(report) => {
-            sp.finish("Migration complete");
+            sp.finish(&i18n::t("migrate-complete-msg"));
             report.print_summary();
 
             // Save migration report
             if !args.dry_run {
                 let report_path = options.target_dir.join("migration_report.md");
                 if let Err(e) = std::fs::write(&report_path, report.to_markdown()) {
-                    eprintln!("Warning: Could not save migration report: {e}");
+                    eprintln!("{}", i18n::t_args("migrate-warn-report-save-failed", &[("error", &e.to_string())]));
                 } else {
-                    println!("\n  Report saved to: {}", report_path.display());
+                    println!("{}", i18n::t_args("migrate-report-saved", &[("path", &report_path.display().to_string())]));
                 }
             }
         }
         Err(e) => {
-            sp.finish_with_failure(&format!("Migration failed: {e}"));
+            sp.finish_with_failure(&i18n::t_args("migrate-failed-msg", &[("error", &e.to_string())]));
             std::process::exit(1);
         }
     }

--- a/crates/librefang-cli/src/commands/system.rs
+++ b/crates/librefang-cli/src/commands/system.rs
@@ -80,7 +80,16 @@ pub(crate) fn cmd_migrate(args: MigrateArgs) {
 
     let target_dir = cli_librefang_home();
 
-    println!("{}", i18n::t_args("migrate-start-msg", &[("source", &source.to_string()), ("path", &source_dir.display().to_string())]));
+    println!(
+        "{}",
+        i18n::t_args(
+            "migrate-start-msg",
+            &[
+                ("source", &source.to_string()),
+                ("path", &source_dir.display().to_string())
+            ]
+        )
+    );
     if args.dry_run {
         println!("{}\n", i18n::t("migrate-dry-run-hint"));
     }
@@ -102,14 +111,29 @@ pub(crate) fn cmd_migrate(args: MigrateArgs) {
             if !args.dry_run {
                 let report_path = options.target_dir.join("migration_report.md");
                 if let Err(e) = std::fs::write(&report_path, report.to_markdown()) {
-                    eprintln!("{}", i18n::t_args("migrate-warn-report-save-failed", &[("error", &e.to_string())]));
+                    eprintln!(
+                        "{}",
+                        i18n::t_args(
+                            "migrate-warn-report-save-failed",
+                            &[("error", &e.to_string())]
+                        )
+                    );
                 } else {
-                    println!("{}", i18n::t_args("migrate-report-saved", &[("path", &report_path.display().to_string())]));
+                    println!(
+                        "{}",
+                        i18n::t_args(
+                            "migrate-report-saved",
+                            &[("path", &report_path.display().to_string())]
+                        )
+                    );
                 }
             }
         }
         Err(e) => {
-            sp.finish_with_failure(&i18n::t_args("migrate-failed-msg", &[("error", &e.to_string())]));
+            sp.finish_with_failure(&i18n::t_args(
+                "migrate-failed-msg",
+                &[("error", &e.to_string())],
+            ));
             std::process::exit(1);
         }
     }

--- a/crates/librefang-cli/src/desktop_install.rs
+++ b/crates/librefang-cli/src/desktop_install.rs
@@ -6,6 +6,7 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::i18n;
 use crate::ui;
 
 /// GitHub repository for release assets.
@@ -53,11 +54,17 @@ pub fn launch(path: &Path) {
                 .spawn()
             {
                 Ok(_) => {
-                    ui::success("Desktop app launched.");
+                    ui::success(&i18n::t("desktop-install-launched"));
                     return;
                 }
                 Err(e) => {
-                    ui::error(&format!("Failed to launch {}: {e}", app_bundle.display()));
+                    ui::error(&i18n::t_args(
+                        "desktop-install-launch-fail",
+                        &[
+                            ("path", &app_bundle.to_string_lossy()),
+                            ("error", &e.to_string()),
+                        ],
+                    ));
                 }
             }
             return;
@@ -70,24 +77,24 @@ pub fn launch(path: &Path) {
         .stderr(std::process::Stdio::null())
         .spawn()
     {
-        Ok(_) => ui::success("Desktop app launched."),
-        Err(e) => ui::error(&format!("Failed to launch desktop app: {e}")),
+        Ok(_) => ui::success(&i18n::t("desktop-install-launched")),
+        Err(e) => ui::error(&i18n::t_args("desktop-install-launch-fail-generic", &[("error", &e.to_string())])),
     }
 }
 
 /// Prompt user to download and install the desktop app.
 /// Returns the installed binary path on success, `None` if cancelled or failed.
 pub fn prompt_and_install() -> Option<PathBuf> {
-    ui::hint("LibreFang Desktop is not installed.");
+    ui::hint(&i18n::t("desktop-install-not-installed"));
 
-    let answer = crate::prompt_input("  Download and install it now? [Y/n] ");
+    let answer = crate::prompt_input(&i18n::t("desktop-install-prompt"));
     if !answer.is_empty()
         && !answer.eq_ignore_ascii_case("y")
         && !answer.eq_ignore_ascii_case("yes")
     {
-        ui::hint("Skipped. You can install it later:");
-        ui::hint("  brew install --cask librefang   (macOS)");
-        ui::hint("  Or download from https://github.com/librefang/librefang/releases");
+        ui::hint(&i18n::t("desktop-install-skipped"));
+        ui::hint(&i18n::t("desktop-install-skipped-brew"));
+        ui::hint(&i18n::t("desktop-install-skipped-manual"));
         return None;
     }
 
@@ -97,13 +104,13 @@ pub fn prompt_and_install() -> Option<PathBuf> {
 // ── Download & Install ───────────────────────────────────────────────────────
 
 fn download_and_install() -> Option<PathBuf> {
-    ui::step("Fetching latest release info...");
+    ui::step(&i18n::t("desktop-install-fetching"));
 
     let asset_suffix = match platform_asset_suffix() {
         Some(s) => s,
         None => {
-            ui::error("Unsupported platform for automatic desktop install.");
-            ui::hint("Download manually: https://github.com/librefang/librefang/releases");
+            ui::error(&i18n::t("desktop-install-unsupported"));
+            ui::hint(&i18n::t("desktop-install-download-manual"));
             return None;
         }
     };
@@ -119,7 +126,7 @@ fn download_and_install() -> Option<PathBuf> {
     {
         Ok(r) => r,
         Err(e) => {
-            ui::error(&format!("Failed to reach GitHub: {e}"));
+            ui::error(&i18n::t_args("desktop-install-github-fail", &[("error", &e.to_string())]));
             return None;
         }
     };
@@ -127,7 +134,7 @@ fn download_and_install() -> Option<PathBuf> {
     let body: serde_json::Value = match resp.json() {
         Ok(v) => v,
         Err(e) => {
-            ui::error(&format!("Failed to parse release info: {e}"));
+            ui::error(&i18n::t_args("desktop-install-parse-fail", &[("error", &e.to_string())]));
             return None;
         }
     };
@@ -150,21 +157,21 @@ fn download_and_install() -> Option<PathBuf> {
         String::new()
     };
 
-    ui::kv("Asset", &format!("{file_name}{size_display}"));
-    ui::step("Downloading...");
+    ui::kv(&i18n::t("desktop-install-kv-asset"), &format!("{file_name}{size_display}"));
+    ui::step(&i18n::t("desktop-install-downloading"));
 
     let tmp_dir = std::env::temp_dir().join("librefang-desktop-install");
     let _ = std::fs::create_dir_all(&tmp_dir);
     let tmp_file = tmp_dir.join(file_name);
 
     if let Err(e) = download_file(download_url, &tmp_file) {
-        ui::error(&format!("Download failed: {e}"));
+        ui::error(&i18n::t_args("desktop-install-download-fail", &[("error", &e.to_string())]));
         let _ = std::fs::remove_dir_all(&tmp_dir);
         return None;
     }
 
-    ui::success("Download complete.");
-    ui::step("Installing...");
+    ui::success(&i18n::t("desktop-install-download-complete"));
+    ui::step(&i18n::t("desktop-install-installing"));
 
     let result = install_platform(&tmp_file);
 
@@ -173,11 +180,11 @@ fn download_and_install() -> Option<PathBuf> {
 
     match result {
         Ok(installed_path) => {
-            ui::success("LibreFang Desktop installed successfully.");
+            ui::success(&i18n::t("desktop-install-success"));
             Some(installed_path)
         }
         Err(e) => {
-            ui::error(&format!("Installation failed: {e}"));
+            ui::error(&i18n::t_args("desktop-install-fail", &[("error", &e.to_string())]));
             None
         }
     }
@@ -376,7 +383,7 @@ fn install_macos_dmg(dmg_path: &Path) -> Result<PathBuf, String> {
 fn install_windows(installer_path: &Path) -> Result<PathBuf, String> {
     use std::process::Command;
 
-    ui::hint("Running installer...");
+    ui::hint(&i18n::t("desktop-install-running-installer"));
 
     // NSIS installer: run with /S for silent install
     let status = Command::new(installer_path)

--- a/crates/librefang-cli/src/desktop_install.rs
+++ b/crates/librefang-cli/src/desktop_install.rs
@@ -78,7 +78,10 @@ pub fn launch(path: &Path) {
         .spawn()
     {
         Ok(_) => ui::success(&i18n::t("desktop-install-launched")),
-        Err(e) => ui::error(&i18n::t_args("desktop-install-launch-fail-generic", &[("error", &e.to_string())])),
+        Err(e) => ui::error(&i18n::t_args(
+            "desktop-install-launch-fail-generic",
+            &[("error", &e.to_string())],
+        )),
     }
 }
 
@@ -126,7 +129,10 @@ fn download_and_install() -> Option<PathBuf> {
     {
         Ok(r) => r,
         Err(e) => {
-            ui::error(&i18n::t_args("desktop-install-github-fail", &[("error", &e.to_string())]));
+            ui::error(&i18n::t_args(
+                "desktop-install-github-fail",
+                &[("error", &e.to_string())],
+            ));
             return None;
         }
     };
@@ -134,7 +140,10 @@ fn download_and_install() -> Option<PathBuf> {
     let body: serde_json::Value = match resp.json() {
         Ok(v) => v,
         Err(e) => {
-            ui::error(&i18n::t_args("desktop-install-parse-fail", &[("error", &e.to_string())]));
+            ui::error(&i18n::t_args(
+                "desktop-install-parse-fail",
+                &[("error", &e.to_string())],
+            ));
             return None;
         }
     };
@@ -157,7 +166,10 @@ fn download_and_install() -> Option<PathBuf> {
         String::new()
     };
 
-    ui::kv(&i18n::t("desktop-install-kv-asset"), &format!("{file_name}{size_display}"));
+    ui::kv(
+        &i18n::t("desktop-install-kv-asset"),
+        &format!("{file_name}{size_display}"),
+    );
     ui::step(&i18n::t("desktop-install-downloading"));
 
     let tmp_dir = std::env::temp_dir().join("librefang-desktop-install");
@@ -165,7 +177,10 @@ fn download_and_install() -> Option<PathBuf> {
     let tmp_file = tmp_dir.join(file_name);
 
     if let Err(e) = download_file(download_url, &tmp_file) {
-        ui::error(&i18n::t_args("desktop-install-download-fail", &[("error", &e.to_string())]));
+        ui::error(&i18n::t_args(
+            "desktop-install-download-fail",
+            &[("error", &e.to_string())],
+        ));
         let _ = std::fs::remove_dir_all(&tmp_dir);
         return None;
     }
@@ -184,7 +199,10 @@ fn download_and_install() -> Option<PathBuf> {
             Some(installed_path)
         }
         Err(e) => {
-            ui::error(&i18n::t_args("desktop-install-fail", &[("error", &e.to_string())]));
+            ui::error(&i18n::t_args(
+                "desktop-install-fail",
+                &[("error", &e.to_string())],
+            ));
             None
         }
     }

--- a/crates/librefang-cli/src/doctor.rs
+++ b/crates/librefang-cli/src/doctor.rs
@@ -22,6 +22,7 @@
 
 use base64::Engine;
 use std::path::PathBuf;
+use crate::i18n;
 
 /// Severity of a single audit finding.
 ///
@@ -149,7 +150,7 @@ impl AuditCheck for VaultKeyCheck {
             Err(_) => {
                 return AuditResult::info(
                     NAME,
-                    "LIBREFANG_VAULT_KEY not set — vault encryption disabled.",
+                    i18n::t("doctor-audit-vault-key-unset"),
                 );
             }
         };
@@ -160,21 +161,17 @@ impl AuditCheck for VaultKeyCheck {
         match base64::engine::general_purpose::STANDARD.decode(raw.as_bytes()) {
             Err(e) => AuditResult::error(
                 NAME,
-                format!("LIBREFANG_VAULT_KEY is not valid base64: {e}"),
-                Some("Generate one with: openssl rand -base64 32".into()),
+                i18n::t_args("doctor-audit-vault-key-invalid-base64", &[("error", &e.to_string())]),
+                Some(i18n::t("doctor-audit-vault-key-invalid-base64-hint")),
             ),
             Ok(bytes) if bytes.len() != 32 => AuditResult::error(
                 NAME,
-                format!(
-                    "LIBREFANG_VAULT_KEY decodes to {} bytes; must be exactly 32. \
-                     Note that 32 ASCII characters is NOT 32 bytes after base64 decode.",
-                    bytes.len()
-                ),
+                i18n::t_args("doctor-audit-vault-key-wrong-length", &[("count", &bytes.len().to_string())]),
                 Some(
-                    "Generate a fresh 32-byte key: openssl rand -base64 32 (44-char output)".into(),
+                    i18n::t("doctor-audit-vault-key-wrong-length-hint"),
                 ),
             ),
-            Ok(_) => AuditResult::pass(NAME, "LIBREFANG_VAULT_KEY decodes to 32 bytes."),
+            Ok(_) => AuditResult::pass(NAME, i18n::t("doctor-audit-vault-key-ok")),
         }
     }
 }
@@ -196,7 +193,7 @@ impl AuditCheck for ApiListenAddrCheck {
             Err(_) => {
                 return AuditResult::info(
                     NAME,
-                    "config.toml not found — skipping api_listen check.",
+                    i18n::t("doctor-audit-api-listen-no-config"),
                 );
             }
         };
@@ -208,9 +205,9 @@ impl AuditCheck for ApiListenAddrCheck {
             Err(e) => {
                 return AuditResult::error(
                     NAME,
-                    format!("config.toml is not valid TOML: {e}"),
+                    i18n::t_args("doctor-audit-api-listen-invalid-toml", &[("error", &e.to_string())]),
                     Some(
-                        "Edit ~/.librefang/config.toml or run `librefang doctor --repair`.".into(),
+                        i18n::t("doctor-audit-api-listen-invalid-toml-hint"),
                     ),
                 );
             }
@@ -220,42 +217,33 @@ impl AuditCheck for ApiListenAddrCheck {
             None => {
                 return AuditResult::info(
                     NAME,
-                    "api_listen not set in config — kernel will use the default.",
+                    i18n::t("doctor-audit-api-listen-unset"),
                 );
             }
         };
         match listen.parse::<std::net::SocketAddr>() {
             Err(e) => AuditResult::error(
                 NAME,
-                format!("api_listen `{listen}` is not a valid socket address: {e}"),
+                i18n::t_args("doctor-audit-api-listen-invalid-addr", &[("address", listen), ("error", &e.to_string())]),
                 Some(
-                    "Use `host:port` form, e.g. `127.0.0.1:4545` or `[::1]:4545`."
-                        .into(),
+                    i18n::t("doctor-audit-api-listen-invalid-addr-hint"),
                 ),
             ),
             Ok(addr) if addr.port() == 0 => AuditResult::warn(
                 NAME,
-                format!(
-                    "api_listen `{addr}` uses port 0 (OS-assigned ephemeral); clients can't \
-                     discover the daemon URL after bind."
-                ),
+                i18n::t_args("doctor-audit-api-listen-port-zero", &[("address", &addr.to_string())]),
                 Some(
-                    "Pick an explicit port (default 4545), e.g. `127.0.0.1:4545`."
-                        .into(),
+                    i18n::t("doctor-audit-api-listen-port-zero-hint"),
                 ),
             ),
             Ok(addr) if addr.port() < 1024 => AuditResult::warn(
                 NAME,
-                format!(
-                    "api_listen port {} is privileged (<1024); daemon will fail to bind without root.",
-                    addr.port()
-                ),
+                i18n::t_args("doctor-audit-api-listen-privileged", &[("port", &addr.port().to_string())]),
                 Some(
-                    "Use a port >= 1024 (default 4545) unless you intentionally need root."
-                        .into(),
+                    i18n::t("doctor-audit-api-listen-privileged-hint"),
                 ),
             ),
-            Ok(addr) => AuditResult::pass(NAME, format!("api_listen `{addr}` parses cleanly.")),
+            Ok(addr) => AuditResult::pass(NAME, i18n::t_args("doctor-audit-api-listen-ok", &[("address", &addr.to_string())])),
         }
     }
 }
@@ -276,8 +264,8 @@ impl AuditCheck for ConfigTomlSchemaCheck {
         if !path.exists() {
             return AuditResult::warn(
                 NAME,
-                format!("{} does not exist.", path.display()),
-                Some("Run `librefang init` to create a default config.".into()),
+                i18n::t_args("doctor-audit-config-not-found", &[("path", &path.display().to_string())]),
+                Some(i18n::t("doctor-audit-config-not-found-hint")),
             );
         }
         let raw = match std::fs::read_to_string(&path) {
@@ -285,17 +273,17 @@ impl AuditCheck for ConfigTomlSchemaCheck {
             Err(e) => {
                 return AuditResult::error(
                     NAME,
-                    format!("Failed to read {}: {e}", path.display()),
+                    i18n::t_args("doctor-audit-config-read-fail", &[("path", &path.display().to_string()), ("error", &e.to_string())]),
                     None,
                 );
             }
         };
         match toml::from_str::<toml::Value>(&raw) {
-            Ok(_) => AuditResult::pass(NAME, format!("{} parses as TOML.", path.display())),
+            Ok(_) => AuditResult::pass(NAME, i18n::t_args("doctor-audit-config-ok", &[("path", &path.display().to_string())])),
             Err(e) => AuditResult::error(
                 NAME,
-                format!("{} has TOML syntax errors: {e}", path.display()),
-                Some(format!("Edit {} or restore from a backup.", path.display())),
+                i18n::t_args("doctor-audit-config-syntax-error", &[("path", &path.display().to_string()), ("error", &e.to_string())]),
+                Some(i18n::t_args("doctor-audit-config-syntax-error-hint", &[("path", &path.display().to_string())])),
             ),
         }
     }

--- a/crates/librefang-cli/src/doctor.rs
+++ b/crates/librefang-cli/src/doctor.rs
@@ -20,9 +20,9 @@
 //! Each check should be a leaf operation that doesn't bleed into others —
 //! tests for one check shouldn't have to set up state for another.
 
+use crate::i18n;
 use base64::Engine;
 use std::path::PathBuf;
-use crate::i18n;
 
 /// Severity of a single audit finding.
 ///
@@ -148,10 +148,7 @@ impl AuditCheck for VaultKeyCheck {
         let raw = match std::env::var("LIBREFANG_VAULT_KEY") {
             Ok(v) => v,
             Err(_) => {
-                return AuditResult::info(
-                    NAME,
-                    i18n::t("doctor-audit-vault-key-unset"),
-                );
+                return AuditResult::info(NAME, i18n::t("doctor-audit-vault-key-unset"));
             }
         };
         // Match production: `decode_master_key` in librefang-extensions/src/vault.rs
@@ -161,15 +158,19 @@ impl AuditCheck for VaultKeyCheck {
         match base64::engine::general_purpose::STANDARD.decode(raw.as_bytes()) {
             Err(e) => AuditResult::error(
                 NAME,
-                i18n::t_args("doctor-audit-vault-key-invalid-base64", &[("error", &e.to_string())]),
+                i18n::t_args(
+                    "doctor-audit-vault-key-invalid-base64",
+                    &[("error", &e.to_string())],
+                ),
                 Some(i18n::t("doctor-audit-vault-key-invalid-base64-hint")),
             ),
             Ok(bytes) if bytes.len() != 32 => AuditResult::error(
                 NAME,
-                i18n::t_args("doctor-audit-vault-key-wrong-length", &[("count", &bytes.len().to_string())]),
-                Some(
-                    i18n::t("doctor-audit-vault-key-wrong-length-hint"),
+                i18n::t_args(
+                    "doctor-audit-vault-key-wrong-length",
+                    &[("count", &bytes.len().to_string())],
                 ),
+                Some(i18n::t("doctor-audit-vault-key-wrong-length-hint")),
             ),
             Ok(_) => AuditResult::pass(NAME, i18n::t("doctor-audit-vault-key-ok")),
         }
@@ -191,10 +192,7 @@ impl AuditCheck for ApiListenAddrCheck {
         let raw = match std::fs::read_to_string(&config_path) {
             Ok(s) => s,
             Err(_) => {
-                return AuditResult::info(
-                    NAME,
-                    i18n::t("doctor-audit-api-listen-no-config"),
-                );
+                return AuditResult::info(NAME, i18n::t("doctor-audit-api-listen-no-config"));
             }
         };
         // Accept any TOML and just look at api_listen if present. Don't
@@ -205,45 +203,52 @@ impl AuditCheck for ApiListenAddrCheck {
             Err(e) => {
                 return AuditResult::error(
                     NAME,
-                    i18n::t_args("doctor-audit-api-listen-invalid-toml", &[("error", &e.to_string())]),
-                    Some(
-                        i18n::t("doctor-audit-api-listen-invalid-toml-hint"),
+                    i18n::t_args(
+                        "doctor-audit-api-listen-invalid-toml",
+                        &[("error", &e.to_string())],
                     ),
+                    Some(i18n::t("doctor-audit-api-listen-invalid-toml-hint")),
                 );
             }
         };
         let listen = match value.get("api_listen").and_then(|v| v.as_str()) {
             Some(s) => s,
             None => {
-                return AuditResult::info(
-                    NAME,
-                    i18n::t("doctor-audit-api-listen-unset"),
-                );
+                return AuditResult::info(NAME, i18n::t("doctor-audit-api-listen-unset"));
             }
         };
         match listen.parse::<std::net::SocketAddr>() {
             Err(e) => AuditResult::error(
                 NAME,
-                i18n::t_args("doctor-audit-api-listen-invalid-addr", &[("address", listen), ("error", &e.to_string())]),
-                Some(
-                    i18n::t("doctor-audit-api-listen-invalid-addr-hint"),
+                i18n::t_args(
+                    "doctor-audit-api-listen-invalid-addr",
+                    &[("address", listen), ("error", &e.to_string())],
                 ),
+                Some(i18n::t("doctor-audit-api-listen-invalid-addr-hint")),
             ),
             Ok(addr) if addr.port() == 0 => AuditResult::warn(
                 NAME,
-                i18n::t_args("doctor-audit-api-listen-port-zero", &[("address", &addr.to_string())]),
-                Some(
-                    i18n::t("doctor-audit-api-listen-port-zero-hint"),
+                i18n::t_args(
+                    "doctor-audit-api-listen-port-zero",
+                    &[("address", &addr.to_string())],
                 ),
+                Some(i18n::t("doctor-audit-api-listen-port-zero-hint")),
             ),
             Ok(addr) if addr.port() < 1024 => AuditResult::warn(
                 NAME,
-                i18n::t_args("doctor-audit-api-listen-privileged", &[("port", &addr.port().to_string())]),
-                Some(
-                    i18n::t("doctor-audit-api-listen-privileged-hint"),
+                i18n::t_args(
+                    "doctor-audit-api-listen-privileged",
+                    &[("port", &addr.port().to_string())],
+                ),
+                Some(i18n::t("doctor-audit-api-listen-privileged-hint")),
+            ),
+            Ok(addr) => AuditResult::pass(
+                NAME,
+                i18n::t_args(
+                    "doctor-audit-api-listen-ok",
+                    &[("address", &addr.to_string())],
                 ),
             ),
-            Ok(addr) => AuditResult::pass(NAME, i18n::t_args("doctor-audit-api-listen-ok", &[("address", &addr.to_string())])),
         }
     }
 }
@@ -264,7 +269,10 @@ impl AuditCheck for ConfigTomlSchemaCheck {
         if !path.exists() {
             return AuditResult::warn(
                 NAME,
-                i18n::t_args("doctor-audit-config-not-found", &[("path", &path.display().to_string())]),
+                i18n::t_args(
+                    "doctor-audit-config-not-found",
+                    &[("path", &path.display().to_string())],
+                ),
                 Some(i18n::t("doctor-audit-config-not-found-hint")),
             );
         }
@@ -273,17 +281,38 @@ impl AuditCheck for ConfigTomlSchemaCheck {
             Err(e) => {
                 return AuditResult::error(
                     NAME,
-                    i18n::t_args("doctor-audit-config-read-fail", &[("path", &path.display().to_string()), ("error", &e.to_string())]),
+                    i18n::t_args(
+                        "doctor-audit-config-read-fail",
+                        &[
+                            ("path", &path.display().to_string()),
+                            ("error", &e.to_string()),
+                        ],
+                    ),
                     None,
                 );
             }
         };
         match toml::from_str::<toml::Value>(&raw) {
-            Ok(_) => AuditResult::pass(NAME, i18n::t_args("doctor-audit-config-ok", &[("path", &path.display().to_string())])),
+            Ok(_) => AuditResult::pass(
+                NAME,
+                i18n::t_args(
+                    "doctor-audit-config-ok",
+                    &[("path", &path.display().to_string())],
+                ),
+            ),
             Err(e) => AuditResult::error(
                 NAME,
-                i18n::t_args("doctor-audit-config-syntax-error", &[("path", &path.display().to_string()), ("error", &e.to_string())]),
-                Some(i18n::t_args("doctor-audit-config-syntax-error-hint", &[("path", &path.display().to_string())])),
+                i18n::t_args(
+                    "doctor-audit-config-syntax-error",
+                    &[
+                        ("path", &path.display().to_string()),
+                        ("error", &e.to_string()),
+                    ],
+                ),
+                Some(i18n::t_args(
+                    "doctor-audit-config-syntax-error-hint",
+                    &[("path", &path.display().to_string())],
+                )),
             ),
         }
     }

--- a/crates/librefang-cli/src/i18n.rs
+++ b/crates/librefang-cli/src/i18n.rs
@@ -73,24 +73,32 @@ pub fn init(language: &str) {
 
 pub fn t(key: &str) -> String {
     I18N.with(|cell| {
-        cell.borrow()
-            .as_ref()
-            .map(|i18n| i18n.get(key, None))
-            .unwrap_or_else(|| format!("[{key}]"))
+        let mut borrow = cell.borrow_mut();
+        if borrow.is_none() {
+            let i18n = I18n::new(DEFAULT_LANGUAGE).unwrap_or_else(|error| {
+                panic!("failed to initialize default i18n fallback: {error}");
+            });
+            *borrow = Some(i18n);
+        }
+        borrow.as_ref().unwrap().get(key, None)
     })
 }
 
 pub fn t_args(key: &str, args: &[(&str, &str)]) -> String {
     I18N.with(|cell| {
-        if let Some(i18n) = cell.borrow().as_ref() {
-            let mut fluent_args = FluentArgs::new();
-            for (name, value) in args {
-                fluent_args.set(*name, FluentValue::from(*value));
-            }
-            i18n.get(key, Some(&fluent_args))
-        } else {
-            format!("[{key}]")
+        let mut borrow = cell.borrow_mut();
+        if borrow.is_none() {
+            let i18n = I18n::new(DEFAULT_LANGUAGE).unwrap_or_else(|error| {
+                panic!("failed to initialize default i18n fallback: {error}");
+            });
+            *borrow = Some(i18n);
         }
+        let i18n = borrow.as_ref().unwrap();
+        let mut fluent_args = FluentArgs::new();
+        for (name, value) in args {
+            fluent_args.set(*name, FluentValue::from(*value));
+        }
+        i18n.get(key, Some(&fluent_args))
     })
 }
 

--- a/crates/librefang-cli/src/i18n.rs
+++ b/crates/librefang-cli/src/i18n.rs
@@ -6,8 +6,9 @@ use unic_langid::LanguageIdentifier;
 
 const EN_FTL: &str = include_str!("../locales/en/main.ftl");
 const ZH_CN_FTL: &str = include_str!("../locales/zh-CN/main.ftl");
+const UK_FTL: &str = include_str!("../locales/uk/main.ftl");
 
-pub const SUPPORTED_LANGUAGES: &[&str] = &["en", "zh-CN"];
+pub const SUPPORTED_LANGUAGES: &[&str] = &["en", "zh-CN", "uk"];
 pub use librefang_types::i18n::DEFAULT_LANGUAGE;
 
 thread_local! {
@@ -32,6 +33,7 @@ impl I18n {
         bundle.set_use_isolating(false);
         let source = match selected {
             "zh-CN" => ZH_CN_FTL,
+            "uk" => UK_FTL,
             _ => EN_FTL,
         };
         let resource = FluentResource::try_new(source.to_string())
@@ -106,6 +108,12 @@ mod tests {
     fn renders_chinese_translation() {
         init("zh-CN");
         assert_eq!(t("label-dashboard"), "控制台");
+    }
+
+    #[test]
+    fn renders_ukrainian_translation() {
+        init("uk");
+        assert_eq!(t("label-dashboard"), "Панель приладів");
     }
 
     #[test]

--- a/crates/librefang-cli/src/i18n.rs
+++ b/crates/librefang-cli/src/i18n.rs
@@ -71,6 +71,43 @@ pub fn init(language: &str) {
     });
 }
 
+pub fn detect_system_language() -> String {
+    let vars = ["LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"];
+    for var in vars {
+        if let Ok(val) = std::env::var(var) {
+            let parts = val.split([':', ';']);
+            for part in parts {
+                let part = part.trim();
+                if part.is_empty() {
+                    continue;
+                }
+                let base = part.split(['.', '@']).next().unwrap_or(part);
+                let normalized = base.replace('_', "-");
+
+                // Try exact match
+                for lang in SUPPORTED_LANGUAGES {
+                    if lang.eq_ignore_ascii_case(&normalized) {
+                        return lang.to_string();
+                    }
+                }
+
+                // Try match by prefix before '-'
+                let prefix = normalized.split('-').next().unwrap_or(&normalized);
+                for lang in SUPPORTED_LANGUAGES {
+                    if lang.eq_ignore_ascii_case(prefix) {
+                        return lang.to_string();
+                    }
+                    let lang_prefix = lang.split('-').next().unwrap_or(lang);
+                    if lang_prefix.eq_ignore_ascii_case(prefix) {
+                        return lang.to_string();
+                    }
+                }
+            }
+        }
+    }
+    DEFAULT_LANGUAGE.to_string()
+}
+
 pub fn t(key: &str) -> String {
     I18N.with(|cell| {
         let mut borrow = cell.borrow_mut();
@@ -139,5 +176,36 @@ mod tests {
             *cell.borrow_mut() = None;
         });
         assert_eq!(t("daemon-starting"), "Starting daemon...");
+    }
+
+    #[test]
+    fn test_detect_system_language() {
+        let backup_language = std::env::var("LANGUAGE").ok();
+        let backup_lang = std::env::var("LANG").ok();
+
+        // Test matching "uk" from "uk:en_US"
+        std::env::set_var("LANGUAGE", "uk:en_US");
+        assert_eq!(detect_system_language(), "uk");
+
+        // Test matching "zh-CN" from "zh_CN.UTF-8"
+        std::env::remove_var("LANGUAGE");
+        std::env::set_var("LANG", "zh_CN.UTF-8");
+        assert_eq!(detect_system_language(), "zh-CN");
+
+        // Test fallback to default
+        std::env::set_var("LANG", "fr_FR.UTF-8");
+        assert_eq!(detect_system_language(), "en");
+
+        // Restore env vars
+        if let Some(val) = backup_language {
+            std::env::set_var("LANGUAGE", val);
+        } else {
+            std::env::remove_var("LANGUAGE");
+        }
+        if let Some(val) = backup_lang {
+            std::env::set_var("LANG", val);
+        } else {
+            std::env::remove_var("LANG");
+        }
     }
 }

--- a/crates/librefang-cli/src/i18n.rs
+++ b/crates/librefang-cli/src/i18n.rs
@@ -132,4 +132,12 @@ mod tests {
             "12 models available"
         );
     }
+
+    #[test]
+    fn auto_initializes_when_not_initialized() {
+        I18N.with(|cell| {
+            *cell.borrow_mut() = None;
+        });
+        assert_eq!(t("daemon-starting"), "Starting daemon...");
+    }
 }

--- a/crates/librefang-cli/src/i18n.rs
+++ b/crates/librefang-cli/src/i18n.rs
@@ -71,7 +71,33 @@ pub fn init(language: &str) {
     });
 }
 
+fn is_utf8_locale() -> bool {
+    let vars = ["LC_ALL", "LC_MESSAGES", "LANG"];
+    for var in vars {
+        if let Ok(val) = std::env::var(var) {
+            let val_lower = val.to_lowercase();
+            if val_lower.contains("utf8") || val_lower.contains("utf-8") {
+                return true;
+            }
+            if val_lower == "c" || val_lower == "posix" {
+                return false;
+            }
+            if let Some(dot_idx) = val.find('.') {
+                let encoding = &val_lower[dot_idx + 1..];
+                if encoding.contains("utf8") || encoding.contains("utf-8") {
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+    true
+}
+
 pub fn detect_system_language() -> String {
+    if !is_utf8_locale() {
+        return DEFAULT_LANGUAGE.to_string();
+    }
     let vars = ["LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"];
     for var in vars {
         if let Ok(val) = std::env::var(var) {
@@ -186,6 +212,14 @@ mod tests {
         // Test matching "uk" from "uk:en_US"
         std::env::set_var("LANGUAGE", "uk:en_US");
         assert_eq!(detect_system_language(), "uk");
+
+        // Test non-UTF-8 fallback to English even if LANGUAGE=uk:en_US is set
+        std::env::set_var("LANG", "uk_UA.KOI8-U");
+        assert_eq!(detect_system_language(), "en");
+
+        // Test C locale fallback
+        std::env::set_var("LANG", "C");
+        assert_eq!(detect_system_language(), "en");
 
         // Test matching "zh-CN" from "zh_CN.UTF-8"
         std::env::remove_var("LANGUAGE");

--- a/crates/librefang-cli/src/launcher.rs
+++ b/crates/librefang-cli/src/launcher.rs
@@ -592,7 +592,10 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
         } else {
             lines.push(Line::from(vec![
                 Span::styled("\u{25cb} ", Style::default().fg(theme::YELLOW)),
-                Span::styled(i18n::t("launcher-no-keys"), Style::default().fg(theme::YELLOW)),
+                Span::styled(
+                    i18n::t("launcher-no-keys"),
+                    Style::default().fg(theme::YELLOW),
+                ),
             ]));
             if !state.first_run {
                 lines.push(Line::from(vec![Span::styled(
@@ -631,16 +634,37 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
             let (label, hint) = match item.choice {
                 LauncherChoice::GetStarted => {
                     if state.first_run {
-                        (i18n::t("launcher-menu-get-started"), i18n::t("launcher-menu-get-started-hint"))
+                        (
+                            i18n::t("launcher-menu-get-started"),
+                            i18n::t("launcher-menu-get-started-hint"),
+                        )
                     } else {
-                        (i18n::t("launcher-menu-settings"), i18n::t("launcher-menu-settings-hint"))
+                        (
+                            i18n::t("launcher-menu-settings"),
+                            i18n::t("launcher-menu-settings-hint"),
+                        )
                     }
                 }
-                LauncherChoice::Chat => (i18n::t("launcher-menu-chat"), i18n::t("launcher-menu-chat-hint")),
-                LauncherChoice::Dashboard => (i18n::t("launcher-menu-dashboard"), i18n::t("launcher-menu-dashboard-hint")),
-                LauncherChoice::DesktopApp => (i18n::t("launcher-menu-desktop"), i18n::t("launcher-menu-desktop-hint")),
-                LauncherChoice::TerminalUI => (i18n::t("launcher-menu-tui"), i18n::t("launcher-menu-tui-hint")),
-                LauncherChoice::ShowHelp => (i18n::t("launcher-menu-help"), i18n::t("launcher-menu-help-hint")),
+                LauncherChoice::Chat => (
+                    i18n::t("launcher-menu-chat"),
+                    i18n::t("launcher-menu-chat-hint"),
+                ),
+                LauncherChoice::Dashboard => (
+                    i18n::t("launcher-menu-dashboard"),
+                    i18n::t("launcher-menu-dashboard-hint"),
+                ),
+                LauncherChoice::DesktopApp => (
+                    i18n::t("launcher-menu-desktop"),
+                    i18n::t("launcher-menu-desktop-hint"),
+                ),
+                LauncherChoice::TerminalUI => (
+                    i18n::t("launcher-menu-tui"),
+                    i18n::t("launcher-menu-tui-hint"),
+                ),
+                LauncherChoice::ShowHelp => (
+                    i18n::t("launcher-menu-help"),
+                    i18n::t("launcher-menu-help-hint"),
+                ),
                 LauncherChoice::Quit => (String::new(), String::new()),
             };
 
@@ -678,10 +702,7 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
                     i18n::t_args("launcher-migration-question", &[("source", source)]),
                     Style::default().fg(theme::BLUE),
                 ),
-                Span::styled(
-                    i18n::t("launcher-migration-hint"),
-                    theme::hint_style(),
-                ),
+                Span::styled(i18n::t("launcher-migration-hint"), theme::hint_style()),
             ]),
         ];
         frame.render_widget(Paragraph::new(hint_lines), chunks[6]);

--- a/crates/librefang-cli/src/launcher.rs
+++ b/crates/librefang-cli/src/launcher.rs
@@ -14,6 +14,7 @@ use ratatui::widgets::{
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::i18n;
 use crate::tui::theme;
 
 // ── Provider detection ──────────────────────────────────────────────────────
@@ -78,6 +79,7 @@ pub enum LauncherChoice {
     Quit,
 }
 
+#[allow(dead_code)]
 struct MenuItem {
     label: &'static str,
     hint: &'static str,
@@ -506,7 +508,7 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
             ]),
             Line::from(""),
             Line::from(vec![Span::styled(
-                "Welcome! Let's get you set up.",
+                i18n::t("launcher-welcome"),
                 Style::default().fg(theme::TEXT_PRIMARY),
             )]),
         ];
@@ -535,7 +537,7 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
         let spinner = theme::SPINNER_FRAMES[state.tick % theme::SPINNER_FRAMES.len()];
         let line = Line::from(vec![
             Span::styled(format!("{spinner} "), Style::default().fg(theme::YELLOW)),
-            Span::styled("Checking for daemon\u{2026}", theme::dim_style()),
+            Span::styled(i18n::t("launcher-checking-daemon"), theme::dim_style()),
         ]);
         frame.render_widget(Paragraph::new(line), chunks[3]);
     } else {
@@ -560,7 +562,7 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
                         .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
-                    format!("Daemon running at {url}"),
+                    i18n::t_args("launcher-daemon-running", &[("url", url)]),
                     Style::default().fg(theme::TEXT_PRIMARY),
                 ),
                 Span::styled(agent_suffix, Style::default().fg(theme::GREEN)),
@@ -568,7 +570,7 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
         } else {
             lines.push(Line::from(vec![
                 Span::styled("\u{25cb} ", theme::dim_style()),
-                Span::styled("No daemon running", theme::dim_style()),
+                Span::styled(i18n::t("launcher-daemon-no-running"), theme::dim_style()),
             ]));
         }
 
@@ -582,7 +584,7 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
                         .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
-                    format!("Provider: {provider}"),
+                    i18n::t_args("launcher-provider", &[("provider", provider)]),
                     Style::default().fg(theme::TEXT_PRIMARY),
                 ),
                 Span::styled(format!(" ({env_var})"), theme::dim_style()),
@@ -590,16 +592,16 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
         } else {
             lines.push(Line::from(vec![
                 Span::styled("\u{25cb} ", Style::default().fg(theme::YELLOW)),
-                Span::styled("No API keys detected", Style::default().fg(theme::YELLOW)),
+                Span::styled(i18n::t("launcher-no-keys"), Style::default().fg(theme::YELLOW)),
             ]));
             if !state.first_run {
                 lines.push(Line::from(vec![Span::styled(
-                    "  Run 'Re-run setup' to configure a provider",
+                    i18n::t("launcher-hint-re-run"),
                     theme::hint_style(),
                 )]));
             } else {
                 lines.push(Line::from(vec![Span::styled(
-                    "  Select 'Get started' to configure",
+                    i18n::t("launcher-hint-get-started"),
                     theme::hint_style(),
                 )]));
             }
@@ -626,9 +628,25 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
                 Style::default().fg(theme::TEXT_PRIMARY)
             };
 
+            let (label, hint) = match item.choice {
+                LauncherChoice::GetStarted => {
+                    if state.first_run {
+                        (i18n::t("launcher-menu-get-started"), i18n::t("launcher-menu-get-started-hint"))
+                    } else {
+                        (i18n::t("launcher-menu-settings"), i18n::t("launcher-menu-settings-hint"))
+                    }
+                }
+                LauncherChoice::Chat => (i18n::t("launcher-menu-chat"), i18n::t("launcher-menu-chat-hint")),
+                LauncherChoice::Dashboard => (i18n::t("launcher-menu-dashboard"), i18n::t("launcher-menu-dashboard-hint")),
+                LauncherChoice::DesktopApp => (i18n::t("launcher-menu-desktop"), i18n::t("launcher-menu-desktop-hint")),
+                LauncherChoice::TerminalUI => (i18n::t("launcher-menu-tui"), i18n::t("launcher-menu-tui-hint")),
+                LauncherChoice::ShowHelp => (i18n::t("launcher-menu-help"), i18n::t("launcher-menu-help-hint")),
+                LauncherChoice::Quit => (String::new(), String::new()),
+            };
+
             ListItem::new(Line::from(vec![
-                Span::styled(format!("{:<26}", item.label), label_style),
-                Span::styled(item.hint, theme::dim_style()),
+                Span::styled(format!("{:<26}", label), label_style),
+                Span::styled(hint, theme::dim_style()),
             ]))
         })
         .collect();
@@ -657,11 +675,11 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
             Line::from(vec![
                 Span::styled("\u{2192} ", Style::default().fg(theme::BLUE)),
                 Span::styled(
-                    format!("Coming from {source}? "),
+                    i18n::t_args("launcher-migration-question", &[("source", source)]),
                     Style::default().fg(theme::BLUE),
                 ),
                 Span::styled(
-                    "'Get started' includes automatic migration.",
+                    i18n::t("launcher-migration-hint"),
                     theme::hint_style(),
                 ),
             ]),
@@ -671,7 +689,7 @@ fn draw_menu(frame: &mut ratatui::Frame, state: &mut LauncherState) {
 
     // ── Keybind hints ───────────────────────────────────────────────────────
     let hints = Line::from(vec![Span::styled(
-        "\u{2191}\u{2193}/jk navigate  1-9 quick select  enter confirm  q quit",
+        i18n::t("launcher-menu-hints"),
         theme::hint_style(),
     )]);
     frame.render_widget(Paragraph::new(hints), chunks[7]);
@@ -729,12 +747,12 @@ fn draw_help(frame: &mut ratatui::Frame, lines: &[String], scroll: usize) -> usi
     frame.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled(
-                "All commands",
+                i18n::t("launcher-help-title"),
                 Style::default()
                     .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled("  — q/Esc to go back", theme::dim_style()),
+            Span::styled(i18n::t("launcher-help-subtitle"), theme::dim_style()),
         ])),
         title_area,
     );
@@ -768,7 +786,7 @@ fn draw_help(frame: &mut ratatui::Frame, lines: &[String], scroll: usize) -> usi
 
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "\u{2191}\u{2193}/jk scroll  PgUp/PgDn  g/G top/bottom  q back",
+            i18n::t("launcher-help-hints"),
             theme::hint_style(),
         ))),
         hint_area,

--- a/crates/librefang-cli/src/main.rs
+++ b/crates/librefang-cli/src/main.rs
@@ -331,7 +331,7 @@ fn main() {
     // Load ~/.librefang/.env into process environment (system env takes priority).
     dotenv::load_dotenv();
 
-    let language = load_language_from_config().unwrap_or_else(|| "en".to_string());
+    let language = load_language_from_config().unwrap_or_else(i18n::detect_system_language);
     i18n::init(&language);
 
     let cli = Cli::parse();

--- a/crates/librefang-cli/src/ui.rs
+++ b/crates/librefang-cli/src/ui.rs
@@ -3,6 +3,7 @@
 //! Uses `colored` for terminal output. The interactive TUI uses ratatui instead.
 
 use colored::Colorize;
+use crate::i18n;
 
 // ---------------------------------------------------------------------------
 // Existing helpers
@@ -49,7 +50,7 @@ pub fn banner() {
         ">>".bright_cyan().bold(),
         "LibreFang Agent OS".bold()
     );
-    println!("     {}", "The open-source agent operating system".dimmed());
+    println!("     {}", i18n::t("ui-brand-tagline").dimmed());
 }
 
 /// Section header: ">> Title" in cyan.
@@ -74,12 +75,12 @@ pub fn kv_warn(label: &str, value: &str) {
 
 /// Hint line: "  hint: message" in dimmed text.
 pub fn hint(msg: &str) {
-    println!("  {} {}", "hint:".dimmed(), msg.dimmed());
+    println!("  {} {}", i18n::t("ui-label-hint").dimmed(), msg.dimmed());
 }
 
 /// Numbered "Next steps:" list.
 pub fn next_steps(steps: &[&str]) {
-    println!("  {}:", "Next steps".bold());
+    println!("  {}:", i18n::t("ui-label-next-steps").bold());
     for (i, step) in steps.iter().enumerate() {
         println!("    {}. {step}", i + 1);
     }
@@ -93,13 +94,13 @@ pub fn suggest_cmd(label: &str, cmd: &str) {
 /// Red error + yellow "fix:" suggestion.
 pub fn error_with_fix(msg: &str, fix: &str) {
     println!("  {} {}", "\u{2718}".bright_red(), msg.bright_red());
-    println!("    {} {}", "fix:".bright_yellow(), fix);
+    println!("    {} {}", i18n::t("ui-label-fix").bright_yellow(), fix);
 }
 
 /// Yellow warning + "try:" suggestion.
 pub fn warn_with_fix(msg: &str, fix: &str) {
     println!("  {} {}", "-".bright_yellow(), msg.yellow());
-    println!("    {} {}", "try:".bright_yellow(), fix);
+    println!("    {} {}", i18n::t("ui-label-try").bright_yellow(), fix);
 }
 
 /// Provider status line: checkmark/circle + name + env var.
@@ -107,11 +108,12 @@ pub fn provider_status(name: &str, env_var: &str, configured: bool) {
     if configured {
         println!("  {} {:<14} ({})", "\u{2714}".bright_green(), name, env_var);
     } else {
+        let not_set_msg = i18n::t_args("ui-provider-not-set", &[("env_var", env_var)]);
         println!(
-            "  {} {:<14} ({} not set)",
+            "  {} {:<14} ({})",
             "\u{25cb}".dimmed(),
             name.dimmed(),
-            env_var.dimmed()
+            not_set_msg.dimmed()
         );
     }
 }

--- a/crates/librefang-cli/src/ui.rs
+++ b/crates/librefang-cli/src/ui.rs
@@ -2,8 +2,8 @@
 //!
 //! Uses `colored` for terminal output. The interactive TUI uses ratatui instead.
 
-use colored::Colorize;
 use crate::i18n;
+use colored::Colorize;
 
 // ---------------------------------------------------------------------------
 // Existing helpers


### PR DESCRIPTION
## Type

- [x] Feature (Rust)
- [x] Documentation / Translation
- [ ] Other

## Summary

This PR completes the localization of the LibreFang CLI console output and the interactive TUI launcher screen to Ukrainian, and implements automatic system locale detection (with a fallback to English for non-UTF-8 locales to prevent corrupted terminal outputs).

## Changes

* **Auto System Locale Detection:**
  * Implemented `i18n::detect_system_language()` checking environment variables (`LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, `LANG` in order of priority).
  * Added `is_utf8_locale()` check to ensure legacy non-UTF-8 encodings (like `KOI8-U`, `CP1251`, `C`) fallback safely to English (`en`) instead of displaying garbled characters.
  * Updated the CLI entry point (`main.rs`) to default to the detected system language if not explicitly configured in `config.toml`.
  * Added comprehensive unit test `test_detect_system_language` to verify all detection scenarios (UTF-8, non-UTF-8, and fallback).
* **CLI/TUI Launcher Screen Localization (`launcher.rs`):**
  * Localized all menu items, action labels, spinner messages, status summaries, keybind hints, and command help screens.
* **Shared Console UI Formatting Helper Localization (`ui.rs`):**
  * Moved brand banner taglines, `"hint:"`, `"Next steps"`, `"fix:"`, `"try:"`, and provider status `"not set"` messages to Fluent translations.
* **CLI Command Inline Text Translation (`doctor_cmd.rs`, `desktop_install.rs`, `doctor.rs`):**
  * Localized all inline checks in the `doctor` command (skills check, prompt injection warning, daemon/metrics connectivity, and toolchain checks).
  * Localized installer console outputs, download bars, and platform-specific execution logs for the desktop installer.
  * Localized the audit framework summaries and hint messages.
* **Translation Resources:**
  * Added English and Ukrainian Fluent translation resources in `crates/librefang-cli/locales/en/main.ftl` and `crates/librefang-cli/locales/uk/main.ftl`.

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (run locally: `cargo test -p librefang-cli` 231 tests pass)
- [x] Live integration tested (tested manually with various `LANG` settings)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries