### PR TITLE
fix(plugin): respect `LIBREFANG_HOME` when resolving plugin directory

### DIFF
--- a/crates/librefang-runtime/src/context_engine/scriptable/mod.rs
+++ b/crates/librefang-runtime/src/context_engine/scriptable/mod.rs
@@ -1765,10 +1765,7 @@ impl ScriptableContextEngine {
 
 /// Default plugin directory: `~/.librefang/plugins/`.
 pub fn plugins_dir() -> std::path::PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(".librefang")
-        .join("plugins")
+    crate::plugin_manager::librefang_home().join("plugins")
 }
 
 /// Load a plugin manifest from `~/.librefang/plugins/<name>/plugin.toml`.

--- a/crates/librefang-runtime/src/plugin_manager.rs
+++ b/crates/librefang-runtime/src/plugin_manager.rs
@@ -79,23 +79,18 @@ pub fn validate_plugin_name(name: &str) -> Result<(), String> {
     Ok(())
 }
 
+pub fn librefang_home() -> PathBuf {
+    if let Ok(home) = std::env::var("LIBREFANG_HOME") {
+        return PathBuf::from(home);
+    }
+    dirs::home_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join(".librefang")
+}
+
 /// Default plugin directory: `~/.librefang/plugins/`.
 pub fn plugins_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| {
-            warn!("HOME directory not set; using temporary directory for plugins");
-            #[cfg(unix)]
-            let fallback = PathBuf::from("/tmp/librefang");
-            #[cfg(windows)]
-            let fallback =
-                PathBuf::from(std::env::var("TEMP").unwrap_or_else(|_| r"C:\Temp".to_string()))
-                    .join("librefang");
-            #[cfg(not(any(unix, windows)))]
-            let fallback = PathBuf::from(".librefang");
-            fallback
-        })
-        .join(".librefang")
-        .join("plugins")
+    librefang_home().join("plugins")
 }
 
 /// Ensure the plugins directory exists.

--- a/crates/librefang-runtime/src/plugin_manager/tests.rs
+++ b/crates/librefang-runtime/src/plugin_manager/tests.rs
@@ -13,6 +13,14 @@ fn test_plugins_dir() {
 }
 
 #[test]
+fn test_plugins_dir_with_env() {
+    std::env::set_var("LIBREFANG_HOME", ".test");
+    let dir = plugins_dir();
+    assert!(dir.ends_with("plugins"));
+    assert!(dir.to_string_lossy().contains(".test"));
+}
+
+#[test]
 fn test_list_plugins_no_panic() {
     // Should not panic even if plugins dir doesn't exist
     let _ = list_plugins();

--- a/crates/librefang-runtime/src/plugin_manager/tests.rs
+++ b/crates/librefang-runtime/src/plugin_manager/tests.rs
@@ -5,8 +5,13 @@ use super::registry::{
 };
 use super::*;
 
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[test]
 fn test_plugins_dir() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    std::env::remove_var("LIBREFANG_HOME");
     let dir = plugins_dir();
     assert!(dir.ends_with("plugins"));
     assert!(dir.to_string_lossy().contains(".librefang"));
@@ -14,8 +19,12 @@ fn test_plugins_dir() {
 
 #[test]
 fn test_plugins_dir_with_env() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
     std::env::set_var("LIBREFANG_HOME", ".test");
     let dir = plugins_dir();
+
+    std::env::remove_var("LIBREFANG_HOME");
     assert!(dir.ends_with("plugins"));
     assert!(dir.to_string_lossy().contains(".test"));
 }


### PR DESCRIPTION
<!-- PR title must follow conventional commit format: type[scope]: description -->
<!-- Examples: feat: add X, fix(kernel): resolve Y, docs: update Z -->
<!-- Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

## Type

<!-- Check one: -->

- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [x] Bug fix
- [ ] Feature (Rust)
- [ ] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [ ] Other

## Summary

respect `LIBREFANG_HOME` when resolving plugin directory

like

https://github.com/librefang/librefang/blob/dceae897a7a14d6b092999e07d25bd6aa9ab392a/crates/librefang-kernel/src/config.rs#L504-L512

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] Live integration tested (if applicable)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
