### PR TITLE
fix(dashboard/providers): keep Save actionable after a passing Test (#6144)

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.test.tsx
@@ -359,4 +359,49 @@ describe("ProvidersPage", () => {
     expect(testMutateAsync).toHaveBeenCalledTimes(1);
     expect(typeof testMutateAsync.mock.calls[0][0]).toBe("string");
   });
+
+  it("keeps Save actionable after a passing Test in the configure drawer (#6144)", async () => {
+    useProvidersMock.mockReturnValue({
+      data: PROVIDERS,
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage();
+
+    // Add → pick an unconfigured provider (Groq) to open the configure
+    // drawer, mirroring a user adding a fresh provider.
+    fireEvent.click(screen.getByRole("button", { name: /providers\.add/ }));
+    const picker = await screen.findByTestId("drawer-slot");
+    fireEvent.click(within(picker).getByText("Groq"));
+
+    // Configure drawer now owns the slot. Enter an API key — Save is
+    // enabled at this point because the key input is dirty.
+    let drawer = await screen.findByTestId("drawer-slot");
+    fireEvent.change(
+      within(drawer).getByPlaceholderText("providers.key_placeholder"),
+      { target: { value: "sk-test-key" } },
+    );
+    expect(
+      within(drawer).getByRole("button", { name: /common\.save/ }),
+    ).not.toBeDisabled();
+
+    // Click Test. `testKey` persists the key (which clears `keyInput`) then
+    // runs the test mutation, which resolves ok.
+    fireEvent.click(
+      within(drawer).getByRole("button", { name: /providers\.test/ }),
+    );
+    // Wait for the success banner so the test result has landed in state.
+    drawer = await screen.findByTestId("drawer-slot");
+    await within(drawer).findByText("providers.reachable");
+
+    // Regression (#6144): the passing Test cleared `keyInput`, so the form
+    // looks "unchanged" — but the credential is already saved. Save must
+    // stay actionable; otherwise the greyed-out button reads as "the
+    // provider can't be added".
+    expect(
+      within(drawer).getByRole("button", { name: /common\.save/ }),
+    ).not.toBeDisabled();
+  });
 });

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.test.tsx
@@ -370,14 +370,13 @@ describe("ProvidersPage", () => {
 
     renderPage();
 
-    // Add → pick an unconfigured provider (Groq) to open the configure
-    // drawer, mirroring a user adding a fresh provider.
+    // Add → pick an unconfigured provider (Groq) to open the configure drawer, mirroring a user adding a fresh provider.
     fireEvent.click(screen.getByRole("button", { name: /providers\.add/ }));
     const picker = await screen.findByTestId("drawer-slot");
     fireEvent.click(within(picker).getByText("Groq"));
 
-    // Configure drawer now owns the slot. Enter an API key — Save is
-    // enabled at this point because the key input is dirty.
+    // Configure drawer now owns the slot.
+    // Enter an API key — Save is enabled at this point because the key input is dirty.
     let drawer = await screen.findByTestId("drawer-slot");
     fireEvent.change(
       within(drawer).getByPlaceholderText("providers.key_placeholder"),
@@ -387,8 +386,7 @@ describe("ProvidersPage", () => {
       within(drawer).getByRole("button", { name: /common\.save/ }),
     ).not.toBeDisabled();
 
-    // Click Test. `testKey` persists the key (which clears `keyInput`) then
-    // runs the test mutation, which resolves ok.
+    // Click Test. `testKey` persists the key (which clears `keyInput`) then runs the test mutation, which resolves ok.
     fireEvent.click(
       within(drawer).getByRole("button", { name: /providers\.test/ }),
     );
@@ -396,10 +394,8 @@ describe("ProvidersPage", () => {
     drawer = await screen.findByTestId("drawer-slot");
     await within(drawer).findByText("providers.reachable");
 
-    // Regression (#6144): the passing Test cleared `keyInput`, so the form
-    // looks "unchanged" — but the credential is already saved. Save must
-    // stay actionable; otherwise the greyed-out button reads as "the
-    // provider can't be added".
+    // The passing Test clears `keyInput`, making the form look "unchanged" — but the credential is already saved.
+    // Save must stay actionable; otherwise the greyed-out button reads as "provider can't be added".
     expect(
       within(drawer).getByRole("button", { name: /common\.save/ }),
     ).not.toBeDisabled();

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1402,7 +1402,14 @@ export function ProvidersPage() {
     && !config.keyInput.trim()
     && config.urlInput === (config.provider.base_url || "")
     && config.proxyInput === (config.provider.proxy_url || "");
-  const saveDisabled = !config.provider || config.saving || config.testing || isUnchanged;
+  // A successful Test (#6144) already persists the key — `testKey` calls
+  // `set_provider_key` and then clears `keyInput`, which makes `isUnchanged`
+  // true even though the user just configured the provider. Keep Save
+  // actionable after a passing test so the user has a clear confirm-and-close
+  // affordance; otherwise the greyed-out button reads as "provider can't be
+  // added" even though the credential is already saved.
+  const testedOk = config.testResult?.ok === true;
+  const saveDisabled = !config.provider || config.saving || config.testing || (isUnchanged && !testedOk);
   // Local providers (Ollama / vLLM / LM Studio) declare `key_required: false`
   // — for them, the Test button must NOT require a key, otherwise users have
   // no way to verify their custom base_url. Issue #3138.

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1402,12 +1402,7 @@ export function ProvidersPage() {
     && !config.keyInput.trim()
     && config.urlInput === (config.provider.base_url || "")
     && config.proxyInput === (config.provider.proxy_url || "");
-  // A successful Test (#6144) already persists the key — `testKey` calls
-  // `set_provider_key` and then clears `keyInput`, which makes `isUnchanged`
-  // true even though the user just configured the provider. Keep Save
-  // actionable after a passing test so the user has a clear confirm-and-close
-  // affordance; otherwise the greyed-out button reads as "provider can't be
-  // added" even though the credential is already saved.
+  // testKey() clears keyInput after saving, making isUnchanged true — keep Save enabled when the last test passed.
   const testedOk = config.testResult?.ok === true;
   const saveDisabled = !config.provider || config.saving || config.testing || (isUnchanged && !testedOk);
   // Local providers (Ollama / vLLM / LM Studio) declare `key_required: false`


### PR DESCRIPTION
## Summary

Fixes #6144. Adding an LLM provider (the reporter used "claude") and clicking **Test** left the **Save** button greyed out, so the provider appeared impossible to add even though the connection test passed.

## Root cause

The configure drawer's `testKey` (in `useProviderConfig`) does two things on a Test click:

1. Persists the entered key via `set_provider_key` (the backend test endpoint validates the *stored* credential, so it has to be saved first), then sets `keyInput: ""` so the password field shows its "existing key" placeholder.
2. Runs the test mutation and records `testResult`.

Step 1's clearing of `keyInput` makes `isUnchanged` evaluate to true (empty key input, unchanged base/proxy URL), and `isUnchanged` fed directly into `saveDisabled`. So after a passing Test the Save button greyed out — even though the credential was already persisted by the Test itself. To the user that reads as "this provider can't be added".

## Fix

Keep Save enabled when the form is otherwise unchanged but a Test has just passed (`testResult.ok`). The credential is already saved at that point, so clicking Save runs the no-op save path and dismisses the drawer with the usual success toast — a clear confirm-and-close affordance instead of a dead-looking button.

```diff
-  const saveDisabled = !config.provider || config.saving || config.testing || isUnchanged;
+  const testedOk = config.testResult?.ok === true;
+  const saveDisabled = !config.provider || config.saving || config.testing || (isUnchanged && !testedOk);
```

## Verification

- Added a regression test in `ProvidersPage.test.tsx`: open the Add picker, pick an unconfigured provider, enter a key, click Test, and assert Save stays enabled. Confirmed it **fails** on the pre-fix `saveDisabled` condition and **passes** after the fix.
- `pnpm test --run` — 786 passed (80 files)
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (pre-existing baseline warnings only, none in the touched files)
- `pnpm build` — ok
