### PR TITLE
fix(dashboard/hands): refetch hand settings after save so inputs persist (#6145)

### DIFF
--- a/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
@@ -194,7 +194,7 @@ describe("useUpdateHandSettings", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.detail("h1"),
     });
-    // #6145: the settings query backs the editor's displayed values, so it
+    // The settings query backs the editor's displayed values, so it
     // must be invalidated for saved inputs to reappear after save.
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.settings("h1"),

--- a/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
+++ b/crates/librefang-api/dashboard/src/lib/mutations/hands.test.tsx
@@ -173,7 +173,7 @@ describe("useSetHandSecret", () => {
 });
 
 describe("useUpdateHandSettings", () => {
-  it("invalidates handKeys.lists() and handKeys.detail(handId)", async () => {
+  it("invalidates handKeys.lists(), handKeys.detail(handId), and handKeys.settings(handId)", async () => {
     const args: UpdateHandSettingsInput = { handId: "h1", config: { foo: 1 } };
     vi.mocked(http.updateHandSettings).mockResolvedValue({
       status: "ok",
@@ -193,6 +193,11 @@ describe("useUpdateHandSettings", () => {
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: handKeys.detail("h1"),
+    });
+    // #6145: the settings query backs the editor's displayed values, so it
+    // must be invalidated for saved inputs to reappear after save.
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: handKeys.settings("h1"),
     });
   });
 });

--- a/crates/librefang-api/dashboard/src/lib/mutations/hands.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/hands.ts
@@ -134,9 +134,9 @@ export function useUpdateHandSettings() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: handKeys.lists() });
       qc.invalidateQueries({ queryKey: handKeys.detail(variables.handId) });
-      // The settings editor reads the saved values back from this query's
+      // The settings editor reads saved values back from this query's
       // `current_values`; without invalidating it the freshly saved inputs
-      // never reappear after the local draft is cleared (#6145).
+      // never reappear once the local draft is cleared.
       qc.invalidateQueries({ queryKey: handKeys.settings(variables.handId) });
     },
   });

--- a/crates/librefang-api/dashboard/src/lib/mutations/hands.ts
+++ b/crates/librefang-api/dashboard/src/lib/mutations/hands.ts
@@ -134,6 +134,10 @@ export function useUpdateHandSettings() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: handKeys.lists() });
       qc.invalidateQueries({ queryKey: handKeys.detail(variables.handId) });
+      // The settings editor reads the saved values back from this query's
+      // `current_values`; without invalidating it the freshly saved inputs
+      // never reappear after the local draft is cleared (#6145).
+      qc.invalidateQueries({ queryKey: handKeys.settings(variables.handId) });
     },
   });
 }


### PR DESCRIPTION
## Summary

Fixes #6145. On the Hands "开发团队" (dev team) settings editor, typing values into the input fields and clicking **Save** left the UI showing the old/empty values instead of what was just saved — the data appeared not to persist.

## Root cause

`HandSettingsEditor` (`crates/librefang-api/dashboard/src/pages/HandsPage.tsx`) keeps edits in a local `draft`. On a successful save it clears the draft (`setDraft({})`), after which each input falls back to `settings.current_values[key]` — sourced from the `useHandSettings` query (key `handKeys.settings(handId)`).

But `useUpdateHandSettings` only invalidated `handKeys.lists()` and `handKeys.detail(handId)`:

```ts
onSuccess: (_data, variables) => {
  qc.invalidateQueries({ queryKey: handKeys.lists() });
  qc.invalidateQueries({ queryKey: handKeys.detail(variables.handId) });
  // settings query never invalidated → current_values stays stale
},
```

The backend `PUT /api/hands/{id}/settings` persists the config (the editor only allows saving while the hand is active, so there is always a live instance to write to), but the cached settings query was never refetched. So once the local draft was cleared, the inputs reverted to the pre-save `current_values`.

## Fix

Invalidate the settings query in `onSuccess` so the editor refetches and displays the saved values:

```diff
 onSuccess: (_data, variables) => {
   qc.invalidateQueries({ queryKey: handKeys.lists() });
   qc.invalidateQueries({ queryKey: handKeys.detail(variables.handId) });
+  qc.invalidateQueries({ queryKey: handKeys.settings(variables.handId) });
 },
```

## Verification

- Extended the existing `useUpdateHandSettings` test to assert the `handKeys.settings(handId)` invalidation. Confirmed it **fails** before the fix and **passes** after.
- `pnpm test --run` — 785 passed (80 files)
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (pre-existing baseline warnings only)
- `pnpm build` — ok
