### PR TITLE
feat(kernel): gate auto-routing on AutoRouteStrategy, not the "assistant" name (#6139)

### DIFF
--- a/crates/librefang-kernel/src/kernel/assistant_routing.rs
+++ b/crates/librefang-kernel/src/kernel/assistant_routing.rs
@@ -187,17 +187,7 @@ impl LibreFangKernel {
         let entry = self.agents.registry.get(agent_id).ok_or_else(|| {
             KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
         })?;
-        // Auto-routing eligibility (#6139). Engage intent classification when
-        // either:
-        //   - the agent is the legacy "assistant" dispatcher — this also covers
-        //     the `/message/stream` classify-and-route path, which carries no
-        //     channel `sender_context` (see `send_message_streaming_with_routing`),
-        //   - or the channel explicitly opted into routing via `auto_route != Off`.
-        // Previously this gated solely on the literal name "assistant", so an
-        // operator who set e.g. `auto_route = "sticky_ttl"` on a channel whose
-        // default agent was named anything else got silently no routing — the
-        // `AutoRouteStrategy` gate below was unreachable. Keying on the strategy
-        // makes routing a config capability rather than a magic agent name.
+        // Route on AutoRouteStrategy, not just the literal "assistant" name — the legacy name check silently bypassed opt-in strategies on other agents.
         let is_assistant_dispatcher = entry.name == "assistant";
         drop(entry);
 
@@ -388,14 +378,6 @@ impl LibreFangKernel {
         Ok(agent_id)
     }
 
-    /// Whether auto-routing should be skipped entirely for this invocation,
-    /// short-circuiting straight to the requested agent (#6139).
-    ///
-    /// Routing engages for the legacy `"assistant"` dispatcher (which also
-    /// covers the no-`sender_context` `/message/stream` classify path) or
-    /// whenever a channel explicitly opted in via `auto_route != Off`. Any
-    /// other agent on an `Off` channel — the default for every channel — is
-    /// answered directly, preserving pre-#6139 behaviour.
     fn auto_route_bypasses(is_assistant_dispatcher: bool, auto_route: &AutoRouteStrategy) -> bool {
         !is_assistant_dispatcher && *auto_route == AutoRouteStrategy::Off
     }
@@ -507,15 +489,8 @@ impl LibreFangKernel {
 mod tests {
     use super::*;
 
-    // #6139: routing eligibility is keyed on `AutoRouteStrategy`, not on the
-    // literal agent name. The legacy "assistant" dispatcher always stays
-    // eligible (it carries the no-`sender_context` `/message/stream` path);
-    // any other agent becomes eligible only once its channel opts in.
-
     #[test]
     fn assistant_dispatcher_is_never_bypassed() {
-        // The "assistant" agent classifies regardless of strategy — including
-        // `Off`, which is what the no-`sender_context` stream path resolves to.
         for strategy in [
             AutoRouteStrategy::Off,
             AutoRouteStrategy::ExplicitOnly,
@@ -531,8 +506,6 @@ mod tests {
 
     #[test]
     fn non_assistant_bypasses_only_when_off() {
-        // The regression this fixes: a non-"assistant" front-door agent on a
-        // channel with `auto_route != Off` must now route, not bypass.
         assert!(
             LibreFangKernel::auto_route_bypasses(false, &AutoRouteStrategy::Off),
             "non-assistant + Off → bypass (legacy default, no routing)",

--- a/crates/librefang-kernel/src/kernel/assistant_routing.rs
+++ b/crates/librefang-kernel/src/kernel/assistant_routing.rs
@@ -187,10 +187,25 @@ impl LibreFangKernel {
         let entry = self.agents.registry.get(agent_id).ok_or_else(|| {
             KernelError::LibreFang(LibreFangError::AgentNotFound(agent_id.to_string()))
         })?;
-        if entry.name != "assistant" {
+        // Auto-routing eligibility (#6139). Engage intent classification when
+        // either:
+        //   - the agent is the legacy "assistant" dispatcher — this also covers
+        //     the `/message/stream` classify-and-route path, which carries no
+        //     channel `sender_context` (see `send_message_streaming_with_routing`),
+        //   - or the channel explicitly opted into routing via `auto_route != Off`.
+        // Previously this gated solely on the literal name "assistant", so an
+        // operator who set e.g. `auto_route = "sticky_ttl"` on a channel whose
+        // default agent was named anything else got silently no routing — the
+        // `AutoRouteStrategy` gate below was unreachable. Keying on the strategy
+        // makes routing a config capability rather than a magic agent name.
+        let is_assistant_dispatcher = entry.name == "assistant";
+        drop(entry);
+
+        let off = AutoRouteStrategy::Off;
+        let strategy = sender_context.map(|ctx| &ctx.auto_route).unwrap_or(&off);
+        if Self::auto_route_bypasses(is_assistant_dispatcher, strategy) {
             return Ok(agent_id);
         }
-        drop(entry);
 
         // Per-channel auto-routing strategy gate.
         //
@@ -373,6 +388,18 @@ impl LibreFangKernel {
         Ok(agent_id)
     }
 
+    /// Whether auto-routing should be skipped entirely for this invocation,
+    /// short-circuiting straight to the requested agent (#6139).
+    ///
+    /// Routing engages for the legacy `"assistant"` dispatcher (which also
+    /// covers the no-`sender_context` `/message/stream` classify path) or
+    /// whenever a channel explicitly opted in via `auto_route != Off`. Any
+    /// other agent on an `Off` channel — the default for every channel — is
+    /// answered directly, preserving pre-#6139 behaviour.
+    fn auto_route_bypasses(is_assistant_dispatcher: bool, auto_route: &AutoRouteStrategy) -> bool {
+        !is_assistant_dispatcher && *auto_route == AutoRouteStrategy::Off
+    }
+
     fn route_assistant_by_metadata(&self, message: &str) -> Option<AssistantRouteTarget> {
         let hand_selection = router::auto_select_hand(message, None);
         let template_selection = router::auto_select_template(
@@ -473,5 +500,52 @@ impl LibreFangKernel {
     pub(crate) fn should_skip_intent_classification(message: &str) -> bool {
         let trimmed = message.trim();
         trimmed.len() < 15 && !trimmed.contains("http")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // #6139: routing eligibility is keyed on `AutoRouteStrategy`, not on the
+    // literal agent name. The legacy "assistant" dispatcher always stays
+    // eligible (it carries the no-`sender_context` `/message/stream` path);
+    // any other agent becomes eligible only once its channel opts in.
+
+    #[test]
+    fn assistant_dispatcher_is_never_bypassed() {
+        // The "assistant" agent classifies regardless of strategy — including
+        // `Off`, which is what the no-`sender_context` stream path resolves to.
+        for strategy in [
+            AutoRouteStrategy::Off,
+            AutoRouteStrategy::ExplicitOnly,
+            AutoRouteStrategy::StickyTtl,
+            AutoRouteStrategy::StickyHeuristic,
+        ] {
+            assert!(
+                !LibreFangKernel::auto_route_bypasses(true, &strategy),
+                "assistant dispatcher must stay eligible under {strategy:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn non_assistant_bypasses_only_when_off() {
+        // The regression this fixes: a non-"assistant" front-door agent on a
+        // channel with `auto_route != Off` must now route, not bypass.
+        assert!(
+            LibreFangKernel::auto_route_bypasses(false, &AutoRouteStrategy::Off),
+            "non-assistant + Off → bypass (legacy default, no routing)",
+        );
+        for strategy in [
+            AutoRouteStrategy::ExplicitOnly,
+            AutoRouteStrategy::StickyTtl,
+            AutoRouteStrategy::StickyHeuristic,
+        ] {
+            assert!(
+                !LibreFangKernel::auto_route_bypasses(false, &strategy),
+                "non-assistant + {strategy:?} → route (the #6139 fix)",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #6139. `resolve_assistant_target` only engaged auto-routing when the channel's resolved agent was *literally named* `"assistant"`. That name check ran **before** the per-channel `AutoRouteStrategy` gate, so any other front-door agent silently bypassed intent classification — even when an operator had explicitly opted in via `auto_route` (#2150). Setting `auto_route = "sticky_ttl"` on a channel whose default agent was named anything else did nothing, with no warning or log.

## Change

Key routing eligibility on the strategy rather than the magic name. Auto-routing now engages when **either**:

- the agent is the legacy `"assistant"` dispatcher — which also covers the `/message/stream` classify-and-route path that carries no channel `sender_context` (`send_message_streaming_with_routing`), **or**
- the channel explicitly opted in via `auto_route != Off`.

```diff
-        if entry.name != "assistant" {
-            return Ok(agent_id);
-        }
-        drop(entry);
+        let is_assistant_dispatcher = entry.name == "assistant";
+        drop(entry);
+
+        let off = AutoRouteStrategy::Off;
+        let strategy = sender_context.map(|ctx| &ctx.auto_route).unwrap_or(&off);
+        if Self::auto_route_bypasses(is_assistant_dispatcher, strategy) {
+            return Ok(agent_id);
+        }
```

The decision is extracted into `auto_route_bypasses(is_assistant_dispatcher, auto_route)` so it can be unit-tested without standing up a kernel.

## Backwards compatibility

`AutoRouteStrategy::Off` is the default for every channel, so a non-`"assistant"` agent on a default channel still answers directly — unchanged. The `"assistant"` dispatcher stays eligible under every strategy (including the no-`sender_context` stream path), so the existing dashboard/`/message/stream` classify behaviour is preserved. The only new behaviour is the intended one: an agent named something other than `"assistant"` can finally opt into routing.

The sentinel-in-*output* uses of `"assistant"` (the classifier returning `"assistant"` to mean "handle it yourself" at `llm_classify_intent`, and the metadata path skipping `template == "assistant"`) are unchanged — those are distinct from the entry gate and remain correct.

## Verification

- `cargo test -p librefang-kernel --lib` — new tests `assistant_dispatcher_is_never_bypassed` and `non_assistant_bypasses_only_when_off` pass; full kernel lib suite green.
- `cargo clippy -p librefang-kernel --lib` — zero warnings.
- `cargo fmt` clean.

(Run via the repo's native toolchain; full workspace build/test runs in CI.)
