### PR TITLE
feat(runtime-mcp): propagate W3C traceparent on outbound MCP tool calls (#6128)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5017,6 +5017,9 @@ dependencies = [
  "http",
  "librefang-http",
  "librefang-types",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
  "psl",
  "rand 0.10.1",
  "reqwest",
@@ -5027,6 +5030,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "url",
  "wiremock",
 ]

--- a/crates/librefang-runtime-mcp/Cargo.toml
+++ b/crates/librefang-runtime-mcp/Cargo.toml
@@ -14,6 +14,8 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry-http = { workspace = true }
 http = "1"
 async-trait = { workspace = true }
 thiserror = { workspace = true }
@@ -27,6 +29,9 @@ arc-swap = { workspace = true }
 [dev-dependencies]
 wiremock = "0.6"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+opentelemetry_sdk = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -2379,12 +2379,7 @@ impl McpConnection {
                     }
                 }
 
-                // Stitch the agent's trace into the server's tool span (#6128).
-                // rmcp 1.7 sets `custom_headers` once at connect time and
-                // exposes no per-request header hook, so the W3C trace context
-                // rides in `_meta` under `io.librefang/trace`, alongside (never
-                // replacing) the caller entry. Empty when telemetry is off / no
-                // active span — then nothing is added and the call is unchanged.
+                // Ride in `_meta` because rmcp 1.7 exposes no per-request header hook (#6128).
                 let trace_pairs = crate::trace_context::current_w3c_trace_meta();
                 if !trace_pairs.is_empty() {
                     let trace_obj: serde_json::Map<String, serde_json::Value> = trace_pairs
@@ -2463,12 +2458,7 @@ impl McpConnection {
                     }
                 }
 
-                // Stitch the agent's trace into the server's tool span (#6128).
-                // `sse_send_request` is shared by every SSE JSON-RPC call and
-                // takes no per-request header argument, so the W3C trace context
-                // rides in the params `_meta`, merged with (never overwriting)
-                // any caller `_meta` set just above. Empty when telemetry is off
-                // / no active span.
+                // Ride in `_meta` because `sse_send_request` takes no per-request header argument (#6128).
                 let trace_pairs = crate::trace_context::current_w3c_trace_meta();
                 if !trace_pairs.is_empty() {
                     let trace_obj: serde_json::Map<String, serde_json::Value> = trace_pairs
@@ -2690,10 +2680,7 @@ impl McpConnection {
             }
         }
 
-        // Stitch the agent's trace into the backend's span (#6128): HttpCompat
-        // builds the reqwest request per call, so the W3C trace context goes on
-        // as real per-request headers next to the caller header. No headers are
-        // added when telemetry is off / there is no active span.
+        // HttpCompat builds the reqwest request per call, so real per-request headers are available (#6128).
         for (name, value) in crate::trace_context::current_w3c_trace_headers().iter() {
             request = request.header(name.clone(), value.clone());
         }

--- a/crates/librefang-runtime-mcp/src/lib.rs
+++ b/crates/librefang-runtime-mcp/src/lib.rs
@@ -7,6 +7,7 @@
 //! All MCP tools are namespaced with `mcp_{server}_{tool}` to prevent collisions.
 
 pub mod mcp_oauth;
+mod trace_context;
 
 use arc_swap::ArcSwap;
 use http::{HeaderName, HeaderValue};
@@ -2378,6 +2379,25 @@ impl McpConnection {
                     }
                 }
 
+                // Stitch the agent's trace into the server's tool span (#6128).
+                // rmcp 1.7 sets `custom_headers` once at connect time and
+                // exposes no per-request header hook, so the W3C trace context
+                // rides in `_meta` under `io.librefang/trace`, alongside (never
+                // replacing) the caller entry. Empty when telemetry is off / no
+                // active span — then nothing is added and the call is unchanged.
+                let trace_pairs = crate::trace_context::current_w3c_trace_meta();
+                if !trace_pairs.is_empty() {
+                    let trace_obj: serde_json::Map<String, serde_json::Value> = trace_pairs
+                        .into_iter()
+                        .map(|(k, v)| (k, serde_json::Value::String(v)))
+                        .collect();
+                    let meta = params.meta.get_or_insert_with(rmcp::model::Meta::new);
+                    meta.insert(
+                        crate::trace_context::TRACE_CONTEXT_META_KEY.to_string(),
+                        serde_json::Value::Object(trace_obj),
+                    );
+                }
+
                 let timeout = std::time::Duration::from_secs(self.config.timeout_secs);
                 let result: rmcp::model::CallToolResult =
                     tokio::time::timeout(timeout, client.call_tool(params))
@@ -2440,6 +2460,31 @@ impl McpConnection {
                         params["_meta"] = serde_json::json!({
                             (CALLER_CONTEXT_META_KEY): v,
                         });
+                    }
+                }
+
+                // Stitch the agent's trace into the server's tool span (#6128).
+                // `sse_send_request` is shared by every SSE JSON-RPC call and
+                // takes no per-request header argument, so the W3C trace context
+                // rides in the params `_meta`, merged with (never overwriting)
+                // any caller `_meta` set just above. Empty when telemetry is off
+                // / no active span.
+                let trace_pairs = crate::trace_context::current_w3c_trace_meta();
+                if !trace_pairs.is_empty() {
+                    let trace_obj: serde_json::Map<String, serde_json::Value> = trace_pairs
+                        .into_iter()
+                        .map(|(k, v)| (k, serde_json::Value::String(v)))
+                        .collect();
+                    let meta = params
+                        .as_object_mut()
+                        .expect("params is a json object literal")
+                        .entry("_meta")
+                        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+                    if let Some(meta_obj) = meta.as_object_mut() {
+                        meta_obj.insert(
+                            crate::trace_context::TRACE_CONTEXT_META_KEY.to_string(),
+                            serde_json::Value::Object(trace_obj),
+                        );
                     }
                 }
 
@@ -2643,6 +2688,14 @@ impl McpConnection {
                     );
                 }
             }
+        }
+
+        // Stitch the agent's trace into the backend's span (#6128): HttpCompat
+        // builds the reqwest request per call, so the W3C trace context goes on
+        // as real per-request headers next to the caller header. No headers are
+        // added when telemetry is off / there is no active span.
+        for (name, value) in crate::trace_context::current_w3c_trace_headers().iter() {
+            request = request.header(name.clone(), value.clone());
         }
 
         match tool.request_mode {

--- a/crates/librefang-runtime-mcp/src/trace_context.rs
+++ b/crates/librefang-runtime-mcp/src/trace_context.rs
@@ -1,0 +1,215 @@
+//! Outbound W3C Trace Context propagation for MCP tool calls (#6128).
+//!
+//! Mirrors `librefang-llm-drivers`' `drivers::trace_headers::inject_w3c_trace_context`:
+//! it sources the active trace from [`opentelemetry::Context::current()`] (NOT
+//! `tracing::Span::current().context()`, which silently yields an invalid
+//! context behind LibreFang's `tracing_subscriber::reload::Layer` — see the
+//! root-cause analysis in `trace_headers.rs`) and injects via the
+//! globally-registered text-map propagator.
+//!
+//! Two transports can set per-request headers (HttpCompat builds the reqwest
+//! request per call), so they take the [`http::HeaderMap`] view. The
+//! streamable-HTTP / Rmcp transport sets its `custom_headers` once at connect
+//! time and rmcp 1.7 exposes no per-request header hook; the SSE transport
+//! sends through a shared `sse_send_request` helper that takes no per-request
+//! header argument. Both therefore carry the context in the request `_meta`
+//! under [`TRACE_CONTEXT_META_KEY`] via the `Vec<(String, String)>` view,
+//! alongside (never replacing) the existing `io.librefang/caller` entry.
+//!
+//! **Unconditional and self-disabling.** Like the LLM-driver helper this is not
+//! gated on any config flag — W3C Trace Context is a standard interop
+//! primitive. When telemetry is disabled the global propagator is the default
+//! `NoopTextMapPropagator` (writes nothing); when a real propagator is
+//! registered but there is no recording span the context's `SpanContext` is
+//! invalid and `TraceContextPropagator::inject_context` writes nothing. In both
+//! cases the returned carrier is empty and the tool call proceeds unchanged.
+
+use opentelemetry::global;
+use opentelemetry::Context;
+use opentelemetry_http::HeaderInjector;
+
+/// `_meta` key under which the outbound W3C trace context is shipped on the
+/// Rmcp (streamable-HTTP) and SSE transports. Reverse-DNS namespaced per the
+/// MCP `_meta` convention, matching the sibling caller key `io.librefang/caller`.
+/// The value is a JSON object whose keys are the lowercase W3C field names
+/// (`traceparent`, and `tracestate` when non-empty), so an OTel-instrumented
+/// server can read them back the same way a `HeaderExtractor` would.
+pub(crate) const TRACE_CONTEXT_META_KEY: &str = "io.librefang/trace";
+
+/// Inject the current W3C trace context into a fresh [`http::HeaderMap`] and
+/// return it. Empty when telemetry is disabled or there is no active recording
+/// span (see module docs). Used by the HttpCompat per-request path, which can
+/// attach real per-request headers.
+pub(crate) fn current_w3c_trace_headers() -> http::HeaderMap {
+    let mut map = http::HeaderMap::new();
+    let cx = Context::current();
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&cx, &mut HeaderInjector(&mut map));
+    });
+    map
+}
+
+/// Same context as [`current_w3c_trace_headers`], rendered as a list of
+/// `(name, value)` pairs (e.g. `("traceparent", "00-…")`) for embedding in the
+/// MCP request `_meta`. Header names are already lowercase ASCII as emitted by
+/// the W3C propagator; values are guaranteed valid ASCII (a `traceparent` is
+/// hex + dashes, a `tracestate` is restricted to ASCII per the spec). Empty
+/// when telemetry is disabled or there is no active recording span — callers
+/// must then add nothing to `_meta`.
+pub(crate) fn current_w3c_trace_meta() -> Vec<(String, String)> {
+    current_w3c_trace_headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|v| (name.as_str().to_string(), v.to_string()))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{TraceContextExt, TracerProvider as _};
+    use opentelemetry::Context as OtelContext;
+    use opentelemetry_sdk::propagation::TraceContextPropagator;
+    use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+    use tracing::Subscriber;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{reload, Registry};
+
+    type BoxedReloadLayer = Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync + 'static>;
+
+    /// Reproduce the production wiring: the `OpenTelemetryLayer` installed
+    /// *behind a `tracing_subscriber::reload::Layer`*, exactly as
+    /// `librefang_api::telemetry` does at runtime. This is the load-bearing
+    /// difference — behind the reload slot the `OpenTelemetrySpanExt::context()`
+    /// downcast can never succeed, so a test that installed the OTel layer
+    /// directly would mask the real bug `current_w3c_trace_*` is built to
+    /// avoid (see `trace_headers.rs`).
+    fn otel_subscriber_behind_reload() -> (impl Subscriber + Send + Sync, SdkTracerProvider) {
+        let provider = SdkTracerProvider::builder()
+            .with_sampler(Sampler::AlwaysOn)
+            .build();
+        let tracer = provider.tracer("mcp-trace-context-test");
+
+        let (reload_layer, handle) = reload::Layer::<Option<BoxedReloadLayer>, Registry>::new(None);
+        let subscriber = tracing_subscriber::registry().with(reload_layer);
+        let otel_layer: BoxedReloadLayer =
+            Box::new(tracing_opentelemetry::layer().with_tracer(tracer));
+        handle
+            .modify(|slot| *slot = Some(otel_layer))
+            .expect("reload handle must accept the OTel layer");
+        (subscriber, provider)
+    }
+
+    /// Under a recording span (production reload-layer wiring) the helper must
+    /// surface a `traceparent` whose trace id matches the active span — both in
+    /// the `_meta` view and the header view.
+    #[test]
+    fn recording_span_yields_non_all_zero_traceparent() {
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+        let (subscriber, _provider) = otel_subscriber_behind_reload();
+        let (meta, header_map, expected_trace_id) =
+            tracing::subscriber::with_default(subscriber, || {
+                let span = tracing::info_span!("mcp.tool.call");
+                let _enter = span.enter();
+
+                let expected_trace_id = OtelContext::current()
+                    .span()
+                    .span_context()
+                    .trace_id()
+                    .to_string();
+
+                (
+                    current_w3c_trace_meta(),
+                    current_w3c_trace_headers(),
+                    expected_trace_id,
+                )
+            });
+
+        let traceparent = meta
+            .iter()
+            .find(|(k, _)| k == "traceparent")
+            .map(|(_, v)| v.clone())
+            .expect("traceparent must be present under a recording span");
+
+        // W3C format: "00-<32 hex trace id>-<16 hex span id>-<2 hex flags>".
+        let parts: Vec<&str> = traceparent.split('-').collect();
+        assert_eq!(
+            parts.len(),
+            4,
+            "traceparent must have 4 parts: {traceparent}"
+        );
+        assert_eq!(parts[0], "00", "version must be 00");
+        assert_eq!(parts[1].len(), 32, "trace id must be 32 hex chars");
+        assert_ne!(parts[1], "0".repeat(32), "trace id must not be all-zero");
+        assert_eq!(
+            parts[1], expected_trace_id,
+            "trace id must match active span"
+        );
+        assert_eq!(parts[3], "01", "sampled flag must be set");
+
+        // The header view carries the same context.
+        assert_eq!(
+            header_map
+                .get("traceparent")
+                .and_then(|v| v.to_str().ok())
+                .expect("header view must also carry traceparent"),
+            traceparent,
+        );
+    }
+
+    /// With no active recording span the context is invalid, so the propagator
+    /// writes nothing — proving the no-op-when-disabled guarantee. Runs without
+    /// entering any span; `Context::current()` is thread-local, so this is
+    /// robust even when the recording-span test runs concurrently.
+    #[test]
+    fn no_active_span_yields_empty() {
+        assert!(
+            current_w3c_trace_meta().is_empty(),
+            "no active span → no _meta trace pairs",
+        );
+        assert!(
+            !current_w3c_trace_headers().contains_key("traceparent"),
+            "no active span → no traceparent header",
+        );
+    }
+
+    /// The `_meta` view and the header view are derived from one injection, so
+    /// they must carry exactly the same key/value pairs — a server reading
+    /// either surface sees the same context. (We faithfully pass through
+    /// whatever the global propagator emits, e.g. a possibly-empty `tracestate`,
+    /// matching the `trace_headers.rs` LLM-egress precedent rather than
+    /// second-guessing the propagator.)
+    #[test]
+    fn meta_and_header_views_are_consistent() {
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+        let (subscriber, _provider) = otel_subscriber_behind_reload();
+        let (meta, header_map) = tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("mcp.tool.call");
+            let _enter = span.enter();
+            (current_w3c_trace_meta(), current_w3c_trace_headers())
+        });
+
+        assert!(
+            meta.iter().any(|(k, _)| k == "traceparent"),
+            "traceparent present in the _meta view",
+        );
+
+        let mut meta_sorted = meta.clone();
+        meta_sorted.sort();
+        let mut header_sorted: Vec<(String, String)> = header_map
+            .iter()
+            .map(|(n, v)| (n.as_str().to_string(), v.to_str().unwrap().to_string()))
+            .collect();
+        header_sorted.sort();
+        assert_eq!(
+            meta_sorted, header_sorted,
+            "_meta and header views must carry identical pairs",
+        );
+    }
+}

--- a/crates/librefang-runtime-mcp/src/trace_context.rs
+++ b/crates/librefang-runtime-mcp/src/trace_context.rs
@@ -1,45 +1,13 @@
-//! Outbound W3C Trace Context propagation for MCP tool calls (#6128).
-//!
-//! Mirrors `librefang-llm-drivers`' `drivers::trace_headers::inject_w3c_trace_context`:
-//! it sources the active trace from [`opentelemetry::Context::current()`] (NOT
-//! `tracing::Span::current().context()`, which silently yields an invalid
-//! context behind LibreFang's `tracing_subscriber::reload::Layer` — see the
-//! root-cause analysis in `trace_headers.rs`) and injects via the
-//! globally-registered text-map propagator.
-//!
-//! Two transports can set per-request headers (HttpCompat builds the reqwest
-//! request per call), so they take the [`http::HeaderMap`] view. The
-//! streamable-HTTP / Rmcp transport sets its `custom_headers` once at connect
-//! time and rmcp 1.7 exposes no per-request header hook; the SSE transport
-//! sends through a shared `sse_send_request` helper that takes no per-request
-//! header argument. Both therefore carry the context in the request `_meta`
-//! under [`TRACE_CONTEXT_META_KEY`] via the `Vec<(String, String)>` view,
-//! alongside (never replacing) the existing `io.librefang/caller` entry.
-//!
-//! **Unconditional and self-disabling.** Like the LLM-driver helper this is not
-//! gated on any config flag — W3C Trace Context is a standard interop
-//! primitive. When telemetry is disabled the global propagator is the default
-//! `NoopTextMapPropagator` (writes nothing); when a real propagator is
-//! registered but there is no recording span the context's `SpanContext` is
-//! invalid and `TraceContextPropagator::inject_context` writes nothing. In both
-//! cases the returned carrier is empty and the tool call proceeds unchanged.
+//! Outbound W3C traceparent propagation for MCP tool calls; uses `opentelemetry::Context::current()` (not `tracing::Span`) to survive the `reload::Layer` downcast limitation (#6128).
 
 use opentelemetry::global;
 use opentelemetry::Context;
 use opentelemetry_http::HeaderInjector;
 
-/// `_meta` key under which the outbound W3C trace context is shipped on the
-/// Rmcp (streamable-HTTP) and SSE transports. Reverse-DNS namespaced per the
-/// MCP `_meta` convention, matching the sibling caller key `io.librefang/caller`.
-/// The value is a JSON object whose keys are the lowercase W3C field names
-/// (`traceparent`, and `tracestate` when non-empty), so an OTel-instrumented
-/// server can read them back the same way a `HeaderExtractor` would.
+/// MCP `_meta` key for the W3C trace context; value is `{"traceparent": "…"}` so OTel-instrumented servers can extract it the same way they would an HTTP header.
 pub(crate) const TRACE_CONTEXT_META_KEY: &str = "io.librefang/trace";
 
-/// Inject the current W3C trace context into a fresh [`http::HeaderMap`] and
-/// return it. Empty when telemetry is disabled or there is no active recording
-/// span (see module docs). Used by the HttpCompat per-request path, which can
-/// attach real per-request headers.
+/// Returns the active W3C trace context as an HTTP header map; empty when no recording span is active.
 pub(crate) fn current_w3c_trace_headers() -> http::HeaderMap {
     let mut map = http::HeaderMap::new();
     let cx = Context::current();
@@ -49,13 +17,7 @@ pub(crate) fn current_w3c_trace_headers() -> http::HeaderMap {
     map
 }
 
-/// Same context as [`current_w3c_trace_headers`], rendered as a list of
-/// `(name, value)` pairs (e.g. `("traceparent", "00-…")`) for embedding in the
-/// MCP request `_meta`. Header names are already lowercase ASCII as emitted by
-/// the W3C propagator; values are guaranteed valid ASCII (a `traceparent` is
-/// hex + dashes, a `tracestate` is restricted to ASCII per the spec). Empty
-/// when telemetry is disabled or there is no active recording span — callers
-/// must then add nothing to `_meta`.
+/// Same as `current_w3c_trace_headers` but as `(name, value)` pairs for embedding in MCP `_meta`; empty when no recording span is active.
 pub(crate) fn current_w3c_trace_meta() -> Vec<(String, String)> {
     current_w3c_trace_headers()
         .iter()
@@ -81,13 +43,7 @@ mod tests {
 
     type BoxedReloadLayer = Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync + 'static>;
 
-    /// Reproduce the production wiring: the `OpenTelemetryLayer` installed
-    /// *behind a `tracing_subscriber::reload::Layer`*, exactly as
-    /// `librefang_api::telemetry` does at runtime. This is the load-bearing
-    /// difference — behind the reload slot the `OpenTelemetrySpanExt::context()`
-    /// downcast can never succeed, so a test that installed the OTel layer
-    /// directly would mask the real bug `current_w3c_trace_*` is built to
-    /// avoid (see `trace_headers.rs`).
+    /// Wires OTel behind a `reload::Layer` (production topology) so the `OpenTelemetrySpanExt::context()` downcast failure is exercised rather than masked.
     fn otel_subscriber_behind_reload() -> (impl Subscriber + Send + Sync, SdkTracerProvider) {
         let provider = SdkTracerProvider::builder()
             .with_sampler(Sampler::AlwaysOn)
@@ -104,9 +60,6 @@ mod tests {
         (subscriber, provider)
     }
 
-    /// Under a recording span (production reload-layer wiring) the helper must
-    /// surface a `traceparent` whose trace id matches the active span — both in
-    /// the `_meta` view and the header view.
     #[test]
     fn recording_span_yields_non_all_zero_traceparent() {
         opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
@@ -162,10 +115,6 @@ mod tests {
         );
     }
 
-    /// With no active recording span the context is invalid, so the propagator
-    /// writes nothing — proving the no-op-when-disabled guarantee. Runs without
-    /// entering any span; `Context::current()` is thread-local, so this is
-    /// robust even when the recording-span test runs concurrently.
     #[test]
     fn no_active_span_yields_empty() {
         assert!(
@@ -178,12 +127,6 @@ mod tests {
         );
     }
 
-    /// The `_meta` view and the header view are derived from one injection, so
-    /// they must carry exactly the same key/value pairs — a server reading
-    /// either surface sees the same context. (We faithfully pass through
-    /// whatever the global propagator emits, e.g. a possibly-empty `tracestate`,
-    /// matching the `trace_headers.rs` LLM-egress precedent rather than
-    /// second-guessing the propagator.)
     #[test]
     fn meta_and_header_views_are_consistent() {
         opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());


### PR DESCRIPTION
The MCP client did not propagate W3C trace context to the servers it calls, so spans from an OTel-instrumented MCP server started their own disconnected trace instead of joining the LibreFang agent turn that triggered the tool call. LibreFang already does this on LLM HTTP egress (`librefang-llm-drivers::drivers::trace_headers::inject_w3c_trace_context`); this mirrors it on the MCP transport.

New `trace_context` module reads the active trace from `opentelemetry::Context::current()` (not `tracing::Span::current().context()`, which is silently invalid behind the reload layer — see the trace_headers.rs root-cause notes) and injects via the globally-registered text-map propagator, exposing one context as two views: an `http::HeaderMap` for the per-request HttpCompat path, and a `(name, value)` list for the MCP `_meta` path.

Wired into all three transports of `call_tool_with_caller`, alongside (never replacing) the existing `io.librefang/caller` entry:
- HttpCompat builds the reqwest request per call, so the context goes on as real per-request `traceparent`/`tracestate` headers that standard `opentelemetry-http` middleware extracts directly.
- Rmcp/streamable-HTTP sets `custom_headers` once at connect time and rmcp 1.7 exposes no per-request header hook, so the context rides in the request `_meta` under `io.librefang/trace`.
- SSE goes through a shared `sse_send_request` helper that takes no per-request header argument, so it uses the same `_meta` carrier (merged with any caller `_meta`).

Unconditional and self-disabling, matching the LLM-egress precedent: when telemetry is off the global propagator is the Noop propagator (writes nothing); when no recording span is active the context is invalid and the propagator writes nothing. Either way the carrier is empty and the call is unchanged.

Known limitation: for the Rmcp and SSE transports the context is in `_meta`, not wire headers, so a server that only auto-extracts `traceparent` from HTTP headers will not stitch on those transports until rmcp exposes a per-request header hook (the upstream gap noted in the issue). HttpCompat is unaffected. Acceptance criterion #1 (outbound call carries a traceparent matching the active span) holds on all three.

Adds `opentelemetry` + `opentelemetry-http` deps (already in the workspace via telemetry) and otel/tracing dev-deps for the test.

Verification:
- cargo test -p librefang-runtime-mcp — 169 lib + 3 integration tests pass, including 3 new trace_context tests (recording span yields a non-all-zero traceparent matching the active span; no active span yields nothing; _meta and header views are consistent), reusing the reload-layer test harness from trace_headers.rs.
- cargo clippy -p librefang-runtime-mcp --all-targets — zero warnings.
- cargo fmt clean.
