### PR TITLE
feat(llm-drivers,kernel): report the model codex actually used (#6134)

### DIFF
--- a/crates/librefang-cli/src/tui/event.rs
+++ b/crates/librefang-cli/src/tui/event.rs
@@ -524,6 +524,7 @@ pub fn spawn_daemon_stream(
             // the daemon side has already billed against the right
             // provider; no value to forward here.
             actual_provider: None,
+            actual_model: None,
         })));
     });
     token
@@ -576,6 +577,7 @@ fn daemon_fallback(
             // daemon side has already billed against the right
             // provider; no value to forward here.
             actual_provider: None,
+            actual_model: None,
         })
     } else {
         Err(body["error"]

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -150,6 +150,7 @@ impl LibreFangKernel {
             skill_evolution_suggested: false,
             owner_notice: None,
             actual_provider: None,
+            actual_model: None,
         })
     }
 
@@ -226,6 +227,7 @@ impl LibreFangKernel {
             skill_evolution_suggested: false,
             owner_notice: None,
             actual_provider: None,
+            actual_model: None,
         })
     }
 

--- a/crates/librefang-kernel/src/kernel/agent_execution.rs
+++ b/crates/librefang-kernel/src/kernel/agent_execution.rs
@@ -1305,7 +1305,10 @@ impl LibreFangKernel {
         let usage_record = librefang_memory::usage::UsageRecord {
             agent_id,
             provider: billed_provider,
-            model: model.clone(),
+            // #6134: honour `actual_model` so a driver that resolved its own
+            // model (e.g. codex-cli) records the model it actually ran. Mirrors
+            // the streaming path's UsageRecord construction.
+            model: result.actual_model.clone().unwrap_or_else(|| model.clone()),
             input_tokens: result.total_usage.input_tokens,
             output_tokens: result.total_usage.output_tokens,
             cost_usd: cost,

--- a/crates/librefang-kernel/src/kernel/messaging.rs
+++ b/crates/librefang-kernel/src/kernel/messaging.rs
@@ -708,7 +708,9 @@ impl LibreFangKernel {
         let usage_record = librefang_memory::usage::UsageRecord {
             agent_id,
             provider: billed_provider,
-            model: model.clone(),
+            // #6134: honour `actual_model` so a driver that resolved its own
+            // model (e.g. codex-cli) records the model it actually ran.
+            model: result.actual_model.clone().unwrap_or_else(|| model.clone()),
             input_tokens: result.total_usage.input_tokens,
             output_tokens: result.total_usage.output_tokens,
             cost_usd: cost,
@@ -2983,7 +2985,9 @@ impl LibreFangKernel {
                     let usage_record = librefang_memory::usage::UsageRecord {
                         agent_id,
                         provider: billed_provider,
-                        model: model.clone(),
+                        // #6134: honour `actual_model` so a driver that resolved its own
+                        // model (e.g. codex-cli) records the model it actually ran.
+                        model: result.actual_model.clone().unwrap_or_else(|| model.clone()),
                         input_tokens: result.total_usage.input_tokens,
                         output_tokens: result.total_usage.output_tokens,
                         cost_usd: cost,

--- a/crates/librefang-kernel/src/kernel/session_ops.rs
+++ b/crates/librefang-kernel/src/kernel/session_ops.rs
@@ -1796,6 +1796,7 @@ mod session_summary_tests {
                     cache_read_input_tokens: 0,
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
 

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -9039,6 +9039,7 @@ mod try_summarize_trim_tests {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }

--- a/crates/librefang-kernel/src/kernel/tools_and_skills.rs
+++ b/crates/librefang-kernel/src/kernel/tools_and_skills.rs
@@ -848,7 +848,11 @@ impl LibreFangKernel {
             let usage_record = librefang_memory::usage::UsageRecord {
                 agent_id: triggering_agent_id,
                 provider: billed_provider,
-                model: default_model.model.clone(),
+                // #6134: honour `actual_model` from the aux response.
+                model: response
+                    .actual_model
+                    .clone()
+                    .unwrap_or_else(|| default_model.model.clone()),
                 input_tokens: response.usage.input_tokens,
                 output_tokens: response.usage.output_tokens,
                 cost_usd: cost,

--- a/crates/librefang-kernel/src/skill_workshop/llm_review.rs
+++ b/crates/librefang-kernel/src/skill_workshop/llm_review.rs
@@ -296,6 +296,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -351,6 +352,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }

--- a/crates/librefang-kernel/tests/cron_compaction_test.rs
+++ b/crates/librefang-kernel/tests/cron_compaction_test.rs
@@ -64,6 +64,7 @@ impl LlmDriver for FakeDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 }

--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -416,6 +416,18 @@ pub struct CompletionResponse {
     /// on inner leaf drivers; populated by the outermost chain
     /// wrapper. See librefang/librefang#4807 review nit 10.
     pub actual_provider: Option<String>,
+    /// The model the provider actually used, when it differs from the
+    /// requested model id.
+    ///
+    /// Most drivers honour the requested model verbatim and leave this
+    /// `None`, so billing records the nominated model. Some drivers delegate
+    /// model selection to an external process that resolves its own model —
+    /// e.g. the `codex-cli` driver, where the CLI may run a different model
+    /// than the one requested (librefang/librefang#6134). Those drivers set
+    /// this to the model the call actually ran, and the kernel's
+    /// `UsageRecord` construction honours it so metering reflects reality
+    /// rather than the nominated id. `None` means "use the requested model".
+    pub actual_model: Option<String>,
 }
 
 impl CompletionResponse {
@@ -868,6 +880,7 @@ mod tests {
             tool_calls: vec![],
             usage: TokenUsage::default(),
             actual_provider: None,
+            actual_model: None,
         };
         assert_eq!(response.text(), "Hello world!");
     }
@@ -1010,6 +1023,7 @@ mod tests {
                         ..Default::default()
                     },
                     actual_provider: None,
+                    actual_model: None,
                 })
             }
         }
@@ -1078,6 +1092,7 @@ mod tests {
                     tool_calls: vec![],
                     usage: TokenUsage::default(),
                     actual_provider: None,
+                    actual_model: None,
                 })
             }
         }

--- a/crates/librefang-llm-drivers/src/drivers/aider.rs
+++ b/crates/librefang-llm-drivers/src/drivers/aider.rs
@@ -169,6 +169,7 @@ impl LlmDriver for AiderDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/anthropic.rs
+++ b/crates/librefang-llm-drivers/src/drivers/anthropic.rs
@@ -1049,6 +1049,7 @@ impl LlmDriver for AnthropicDriver {
                 tool_calls,
                 usage,
                 actual_provider: None,
+                actual_model: None,
             });
         }
 
@@ -1433,6 +1434,7 @@ fn convert_response(api: ApiResponse) -> CompletionResponse {
             cache_read_input_tokens: api.usage.cache_read_input_tokens,
         },
         actual_provider: None,
+        actual_model: None,
     }
 }
 

--- a/crates/librefang-llm-drivers/src/drivers/bedrock.rs
+++ b/crates/librefang-llm-drivers/src/drivers/bedrock.rs
@@ -740,6 +740,7 @@ fn convert_response(resp: ConverseResponse) -> Result<CompletionResponse, LlmErr
             cache_read_input_tokens: resp.usage.cache_read_input_tokens,
         },
         actual_provider: None,
+        actual_model: None,
     })
 }
 

--- a/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
+++ b/crates/librefang-llm-drivers/src/drivers/chatgpt.rs
@@ -897,6 +897,7 @@ impl ChatGptDriver {
             tool_calls,
             usage,
             actual_provider: None,
+            actual_model: None,
         })
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -1132,6 +1132,7 @@ impl LlmDriver for ClaudeCodeDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             });
         }
 
@@ -1157,6 +1158,7 @@ impl LlmDriver for ClaudeCodeDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 
@@ -1603,6 +1605,7 @@ impl LlmDriver for ClaudeCodeDriver {
             tool_calls: Vec::new(),
             usage: final_usage,
             actual_provider: None,
+            actual_model: None,
         })
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
@@ -175,6 +175,83 @@ impl CodexCliDriver {
         }
     }
 
+    /// Strip ANSI CSI escape sequences (e.g. `\x1b[1m` … `\x1b[0m`) from a
+    /// line. codex styles its banner keys with bold when it thinks the stream
+    /// is a terminal; we read it from a pipe where that detection is usually
+    /// off, but strip defensively so a `--color always` or future detection
+    /// change can't break model extraction.
+    fn strip_ansi(line: &str) -> String {
+        let bytes = line.as_bytes();
+        let mut out = String::with_capacity(line.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == 0x1b {
+                // ESC: skip an optional '[' then everything up to and including
+                // the final byte in 0x40..=0x7e (the CSI terminator, e.g. 'm').
+                i += 1;
+                if i < bytes.len() && bytes[i] == b'[' {
+                    i += 1;
+                    while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
+                        i += 1;
+                    }
+                    if i < bytes.len() {
+                        i += 1; // consume the terminator byte
+                    }
+                }
+                continue;
+            }
+            // `line` is valid UTF-8 and ANSI bytes are ASCII; copy this byte's
+            // full char to preserve multi-byte content (e.g. workdir paths).
+            let ch_len = line[i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+            out.push_str(&line[i..i + ch_len]);
+            i += ch_len;
+        }
+        out
+    }
+
+    /// Extract the model codex actually resolved, from its stderr startup
+    /// banner.
+    ///
+    /// `codex exec` prints a human-readable preamble to **stderr** (even when
+    /// piped to a non-TTY), with a `model:` line, e.g.:
+    ///
+    /// ```text
+    /// OpenAI Codex v0.114.0 (research preview)
+    /// --------
+    /// workdir: /path/to/repo
+    /// model: gpt-5.3-codex
+    /// provider: openai
+    /// --------
+    /// ```
+    ///
+    /// The `--json` event stream carries no model field (confirmed against
+    /// codex-rs `exec_events.rs`; the request to add one was closed
+    /// unimplemented), so the banner is the only authoritative source for the
+    /// model the CLI actually used (librefang/librefang#6134). The summary is
+    /// emitted by codex's `print_config_summary` via `eprintln!`, so it always
+    /// lands on stderr regardless of `--json`.
+    ///
+    /// Tolerant by design: strips ANSI styling, scans for the first line whose
+    /// key is `model` (case-insensitive), returns the trimmed value, and
+    /// yields `None` on any banner shape we don't recognise so the caller can
+    /// fall back to the requested model id. Never panics, never assumes a fixed
+    /// line position.
+    fn parse_model_from_banner(stderr: &str) -> Option<String> {
+        for line in stderr.lines() {
+            let clean = Self::strip_ansi(line);
+            let trimmed = clean.trim();
+            if let Some((key, value)) = trimmed.split_once(':') {
+                if key.trim().eq_ignore_ascii_case("model") {
+                    let model = value.trim();
+                    if !model.is_empty() {
+                        return Some(model.to_string());
+                    }
+                }
+            }
+        }
+        None
+    }
+
     /// Apply security env filtering to a command.
     fn apply_env_filter(cmd: &mut tokio::process::Command) {
         for key in SENSITIVE_ENV_EXACT {
@@ -257,6 +334,22 @@ impl LlmDriver for CodexCliDriver {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let text = stdout.trim().to_string();
 
+        // Recover the model codex actually resolved from its stderr startup
+        // banner (#6134). codex's `--json` events carry no model field, but the
+        // banner's `model:` line does — and stderr was already piped above.
+        // Stamp it into `actual_model` so kernel-side metering records the real
+        // model rather than the requested id. Degrade safely: fall back to the
+        // requested model id when the banner can't be parsed so attribution is
+        // never empty and the call never breaks.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let resolved_model = match Self::parse_model_from_banner(&stderr) {
+            Some(banner_model) => {
+                debug!(requested = %request.model, actual = %banner_model, "Codex CLI resolved model");
+                banner_model
+            }
+            None => Self::model_flag(&request.model).unwrap_or_else(|| request.model.clone()),
+        };
+
         Ok(CompletionResponse {
             content: vec![ContentBlock::Text {
                 text,
@@ -270,6 +363,7 @@ impl LlmDriver for CodexCliDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: Some(resolved_model),
         })
     }
 
@@ -372,6 +466,52 @@ mod tests {
             CodexCliDriver::model_flag("custom-model"),
             Some("custom-model".to_string())
         );
+    }
+
+    #[test]
+    fn test_parse_model_from_banner_extracts_model() {
+        // Verbatim shape of codex exec's stderr startup banner. The `model:`
+        // line sits mid-banner, so extraction must not depend on line position.
+        let banner = "OpenAI Codex v0.114.0 (research preview)\n\
+--------\n\
+workdir: /Users/codex-user/Documents/repo\n\
+model: gpt-5.3-codex\n\
+provider: openai\n\
+approval: never\n\
+sandbox: read-only\n\
+--------\n";
+        assert_eq!(
+            CodexCliDriver::parse_model_from_banner(banner),
+            Some("gpt-5.3-codex".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_model_from_banner_strips_ansi() {
+        // codex bolds the banner keys with ANSI when it thinks the stream is a
+        // terminal; the parser must see through `\x1b[1mmodel:\x1b[0m`.
+        let banner = "\u{1b}[1mworkdir:\u{1b}[0m /repo\n\
+\u{1b}[1mmodel:\u{1b}[0m o4-mini\n\
+\u{1b}[1mprovider:\u{1b}[0m openai\n";
+        assert_eq!(
+            CodexCliDriver::parse_model_from_banner(banner),
+            Some("o4-mini".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_model_from_banner_absent_returns_none() {
+        // No `model:` line → None, so the caller falls back to the requested
+        // model id rather than fabricating one.
+        let no_model = "OpenAI Codex v0.114.0\n\
+--------\n\
+workdir: /repo\n\
+provider: openai\n\
+--------\n";
+        assert_eq!(CodexCliDriver::parse_model_from_banner(no_model), None);
+        assert_eq!(CodexCliDriver::parse_model_from_banner(""), None);
+        // A `model:` key with an empty value is also rejected.
+        assert_eq!(CodexCliDriver::parse_model_from_banner("model: \n"), None);
     }
 
     #[test]

--- a/crates/librefang-llm-drivers/src/drivers/fallback.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback.rs
@@ -468,6 +468,7 @@ mod tests {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -711,6 +712,7 @@ mod tests {
                             ..Default::default()
                         },
                         actual_provider: None,
+                        actual_model: None,
                     })
                 }
             }

--- a/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
+++ b/crates/librefang-llm-drivers/src/drivers/fallback_chain.rs
@@ -598,6 +598,7 @@ mod tests {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         }
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/gemini.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini.rs
@@ -614,6 +614,7 @@ fn convert_response(resp: GeminiResponse) -> Result<CompletionResponse, LlmError
         tool_calls,
         usage,
         actual_provider: None,
+        actual_model: None,
     })
 }
 
@@ -883,6 +884,7 @@ pub(crate) async fn stream_gemini_sse(
         tool_calls,
         usage,
         actual_provider: None,
+        actual_model: None,
     })
 }
 
@@ -1422,6 +1424,7 @@ impl LlmDriver for GeminiDriver {
                 tool_calls,
                 usage,
                 actual_provider: None,
+                actual_model: None,
             });
         }
 

--- a/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
@@ -266,6 +266,7 @@ impl LlmDriver for GeminiCliDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/ollama.rs
+++ b/crates/librefang-llm-drivers/src/drivers/ollama.rs
@@ -741,6 +741,7 @@ impl LlmDriver for OllamaDriver {
             tool_calls,
             usage,
             actual_provider: None,
+            actual_model: None,
         })
     }
 
@@ -989,6 +990,7 @@ impl LlmDriver for OllamaDriver {
             tool_calls,
             usage,
             actual_provider: None,
+            actual_model: None,
         })
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/openai.rs
+++ b/crates/librefang-llm-drivers/src/drivers/openai.rs
@@ -1550,6 +1550,7 @@ impl LlmDriver for OpenAIDriver {
                 tool_calls,
                 usage,
                 actual_provider: None,
+                actual_model: None,
             });
         }
 
@@ -2247,6 +2248,7 @@ impl LlmDriver for OpenAIDriver {
                 tool_calls,
                 usage,
                 actual_provider: None,
+                actual_model: None,
             });
         }
 
@@ -2448,6 +2450,7 @@ fn parse_groq_failed_tool_call(body: &str) -> Option<CompletionResponse> {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             });
         }
         return None;
@@ -2463,6 +2466,7 @@ fn parse_groq_failed_tool_call(body: &str) -> Option<CompletionResponse> {
             ..Default::default()
         },
         actual_provider: None,
+        actual_model: None,
     })
 }
 

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -758,6 +758,7 @@ impl QwenCodeDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             });
         }
 
@@ -775,6 +776,7 @@ impl QwenCodeDriver {
             tool_calls: Vec::new(),
             usage,
             actual_provider: None,
+            actual_model: None,
         })
     }
 
@@ -991,6 +993,7 @@ impl QwenCodeDriver {
             tool_calls: Vec::new(),
             usage: final_usage,
             actual_provider: None,
+            actual_model: None,
         })
     }
 }

--- a/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
+++ b/crates/librefang-llm-drivers/src/drivers/token_rotation.rs
@@ -395,6 +395,7 @@ mod tests {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         }
     }
 

--- a/crates/librefang-runtime/src/agent_loop/end_turn.rs
+++ b/crates/librefang-runtime/src/agent_loop/end_turn.rs
@@ -54,6 +54,9 @@ pub(super) struct FinalizeEndTurnResultData {
     /// Provider slot that actually served the LLM request (#4807 nit
     /// 10). Carried through to [`AgentLoopResult::actual_provider`].
     pub(super) actual_provider: Option<String>,
+    /// Model the last LLM call actually ran (#6134). Carried through to
+    /// [`AgentLoopResult::actual_model`].
+    pub(super) actual_model: Option<String>,
 }
 
 pub(super) struct EndTurnRetryContext<'a> {
@@ -115,6 +118,7 @@ pub(super) fn build_silent_agent_loop_result(
         skill_evolution_suggested: false,
         owner_notice: None,
         actual_provider: None,
+        actual_model: None,
     }
 }
 
@@ -381,6 +385,7 @@ pub(super) async fn finalize_successful_end_turn(
         skill_evolution_suggested: tool_call_count >= 5,
         owner_notice: end_turn.owner_notice.clone(),
         actual_provider: end_turn.actual_provider,
+        actual_model: end_turn.actual_model,
     })
 }
 

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -685,6 +685,9 @@ pub async fn run_agent_loop(
     // and stamps the matching `UsageRecord.provider` so billing rolls
     // up against the slot that did the work.
     let mut last_actual_provider: Option<String> = None;
+    // Model the last LLM call actually ran (#6134) — threaded into
+    // `AgentLoopResult.actual_model` so the kernel records the real model.
+    let mut last_actual_model: Option<String> = None;
     // Accumulate text content from intermediate tool_use iterations. A turn
     // that yields a tool_use response may also carry user-facing text (e.g.
     // "Looking that up for you..." before a memory_store call). Without this
@@ -1141,6 +1144,12 @@ pub async fn run_agent_loop(
         if let Some(ref p) = response.actual_provider {
             last_actual_provider = Some(p.clone());
         }
+        // Track the model the call actually ran (#6134) — e.g. a CLI driver
+        // that resolves its own model. Stays None for drivers that honour the
+        // requested model, so billing falls back to the nominated model.
+        if let Some(ref m) = response.actual_model {
+            last_actual_model = Some(m.clone());
+        }
 
         // Snapshot prompt tokens for the next iteration's should_compress check.
         // This is the per-turn input cost, NOT a running sum — we deliberately
@@ -1406,6 +1415,7 @@ pub async fn run_agent_loop(
                         new_messages_start,
                         owner_notice: pending_owner_notice.take(),
                         actual_provider: last_actual_provider.clone(),
+                        actual_model: last_actual_model.clone(),
                     },
                 )
                 .await;
@@ -1870,6 +1880,7 @@ pub async fn run_agent_loop(
                         new_messages_start,
                         owner_notice: std::mem::take(&mut pending_owner_notice),
                         actual_provider: last_actual_provider.clone(),
+                        actual_model: last_actual_model.clone(),
                     });
                 }
                 // Model hit token limit — add partial response and continue

--- a/crates/librefang-runtime/src/agent_loop/retry.rs
+++ b/crates/librefang-runtime/src/agent_loop/retry.rs
@@ -281,6 +281,7 @@ pub(super) async fn stream_with_retry(
                     tool_calls: vec![],
                     usage: TokenUsage::default(),
                     actual_provider: None,
+                    actual_model: None,
                 },
                 cascade_leak_aborted: true,
             });

--- a/crates/librefang-runtime/src/agent_loop/run_streaming.rs
+++ b/crates/librefang-runtime/src/agent_loop/run_streaming.rs
@@ -337,6 +337,8 @@ pub async fn run_agent_loop_streaming(
     // Track the slot that actually served the most recent LLM call (#4807
     // review nit 10). See run_agent_loop for rationale.
     let mut last_actual_provider: Option<String> = None;
+    // Model the last LLM call actually ran (#6134) — see run_agent_loop.
+    let mut last_actual_model: Option<String> = None;
     // Accumulated text from intermediate tool_use iterations — see the
     // matching declaration in run_agent_loop for full rationale.
     let mut accumulated_text = String::new();
@@ -860,6 +862,10 @@ pub async fn run_agent_loop_streaming(
         if let Some(ref p) = response.actual_provider {
             last_actual_provider = Some(p.clone());
         }
+        // Track the model the call actually ran (#6134).
+        if let Some(ref m) = response.actual_model {
+            last_actual_model = Some(m.clone());
+        }
 
         // Snapshot prompt tokens for the next iteration's should_compress check.
         // Some drivers (gemini_cli, codex_cli) return input_tokens = 0.  Fall
@@ -1114,6 +1120,7 @@ pub async fn run_agent_loop_streaming(
                         new_messages_start,
                         owner_notice: pending_owner_notice.take(),
                         actual_provider: last_actual_provider.clone(),
+                        actual_model: last_actual_model.clone(),
                     },
                 )
                 .await;
@@ -1587,6 +1594,7 @@ pub async fn run_agent_loop_streaming(
                         new_messages_start,
                         owner_notice: std::mem::take(&mut pending_owner_notice),
                         actual_provider: last_actual_provider.clone(),
+                        actual_model: last_actual_model.clone(),
                     });
                 }
                 let text = response.text();

--- a/crates/librefang-runtime/src/agent_loop/tests/integration.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/integration.rs
@@ -53,6 +53,7 @@ impl LlmDriver for EmptyAfterToolUseDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         } else {
             // Second call: LLM returns EndTurn with EMPTY text (the bug)
@@ -66,6 +67,7 @@ impl LlmDriver for EmptyAfterToolUseDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -109,6 +111,7 @@ impl LlmDriver for FailThenTextDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         } else {
             Ok(CompletionResponse {
@@ -124,6 +127,7 @@ impl LlmDriver for FailThenTextDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -155,6 +159,7 @@ impl LlmDriver for AlwaysFailingToolDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 }
@@ -176,6 +181,7 @@ impl LlmDriver for EmptyMaxTokensDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 }
@@ -199,6 +205,7 @@ impl LlmDriver for NormalDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 }
@@ -224,6 +231,7 @@ impl LlmDriver for DirectiveDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 }
@@ -272,6 +280,7 @@ impl LlmDriver for NotifyOwnerThenMaxTokensDriver {
                     ..Default::default()
                 },
                 actual_provider: Some("fallback-a".to_string()),
+                actual_model: None,
             }),
             _ if self.final_tool_calls => Ok(CompletionResponse {
                 content: vec![
@@ -304,6 +313,7 @@ impl LlmDriver for NotifyOwnerThenMaxTokensDriver {
                     ..Default::default()
                 },
                 actual_provider: Some("fallback-b".to_string()),
+                actual_model: Some("actual-model-x".to_string()),
             }),
             _ => Ok(CompletionResponse {
                 content: vec![ContentBlock::Text {
@@ -318,6 +328,7 @@ impl LlmDriver for NotifyOwnerThenMaxTokensDriver {
                     ..Default::default()
                 },
                 actual_provider: Some("fallback-b".to_string()),
+                actual_model: Some("actual-model-x".to_string()),
             }),
         }
     }
@@ -832,6 +843,8 @@ async fn test_max_tokens_owner_notice_and_actual_provider_survive_non_streaming(
         Some("[NOTIFY] handoff_needed: Fallback provider needs owner visibility.")
     );
     assert_eq!(result.actual_provider.as_deref(), Some("fallback-b"));
+    // #6134: the model the call actually ran threads through to AgentLoopResult.
+    assert_eq!(result.actual_model.as_deref(), Some("actual-model-x"));
 }
 
 #[tokio::test]
@@ -964,6 +977,7 @@ impl LlmDriver for MultiToolCycleDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         } else {
             Ok(CompletionResponse {
@@ -979,6 +993,7 @@ impl LlmDriver for MultiToolCycleDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -1004,6 +1019,7 @@ impl LlmDriver for FoldSummaryDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 }
@@ -1418,6 +1434,8 @@ async fn test_streaming_max_tokens_owner_notice_and_actual_provider_survive_resu
         Some("[NOTIFY] handoff_needed: Fallback provider needs owner visibility.")
     );
     assert_eq!(result.actual_provider.as_deref(), Some("fallback-b"));
+    // #6134: the model the call actually ran threads through to AgentLoopResult.
+    assert_eq!(result.actual_model.as_deref(), Some("actual-model-x"));
     let mut events = Vec::new();
     while let Ok(event) = rx.try_recv() {
         events.push(event);
@@ -1898,6 +1916,7 @@ impl LlmDriver for EmptyThenNormalDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         } else {
             // Second call (retry): normal response
@@ -1914,6 +1933,7 @@ impl LlmDriver for EmptyThenNormalDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -1936,6 +1956,7 @@ impl LlmDriver for AlwaysEmptyDriver {
                 ..Default::default()
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 }
@@ -2268,6 +2289,7 @@ impl LlmDriver for BatchFileReadDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         } else {
             Ok(CompletionResponse {
@@ -2283,6 +2305,7 @@ impl LlmDriver for BatchFileReadDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }

--- a/crates/librefang-runtime/src/agent_loop/tests/recovery.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/recovery.rs
@@ -654,6 +654,7 @@ impl LlmDriver for TextToolCallDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         } else {
             // After tool result, return normal response
@@ -670,6 +671,7 @@ impl LlmDriver for TextToolCallDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }

--- a/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
@@ -1051,6 +1051,7 @@ fn agent_loop_result_actual_provider_can_be_set() {
     // when this is None, and bills the named provider when set.
     let r = AgentLoopResult {
         actual_provider: Some("anthropic-backup".into()),
+        actual_model: None,
         ..AgentLoopResult::default()
     };
     assert_eq!(r.actual_provider.as_deref(), Some("anthropic-backup"));

--- a/crates/librefang-runtime/src/agent_loop/types.rs
+++ b/crates/librefang-runtime/src/agent_loop/types.rs
@@ -240,6 +240,13 @@ pub struct AgentLoopResult {
     /// (the call hit the originally nominated provider or no slot at
     /// all is identifiable — e.g. CLI drivers).
     pub actual_provider: Option<String>,
+    /// The model the last LLM call actually ran, when it differs from the
+    /// requested model id (#6134). Carried up from
+    /// [`librefang_llm_driver::CompletionResponse::actual_model`]; the kernel's
+    /// `UsageRecord` construction honours it so metering reflects the model the
+    /// provider really used (e.g. a `codex-cli` CLI that resolves its own
+    /// model). `None` means "use the requested model".
+    pub actual_model: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/librefang-runtime/src/agent_loop/web_augment.rs
+++ b/crates/librefang-runtime/src/agent_loop/web_augment.rs
@@ -297,6 +297,7 @@ mod tests {
                 stop_reason: StopReason::EndTurn,
                 usage: TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -313,6 +314,7 @@ mod tests {
                 stop_reason: StopReason::EndTurn,
                 usage: TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }

--- a/crates/librefang-runtime/src/aux_client.rs
+++ b/crates/librefang-runtime/src/aux_client.rs
@@ -358,6 +358,7 @@ mod tests {
                 tool_calls: vec![],
                 usage: TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
 

--- a/crates/librefang-runtime/src/compactor.rs
+++ b/crates/librefang-runtime/src/compactor.rs
@@ -1124,6 +1124,7 @@ mod tests {
                         ..Default::default()
                     },
                     actual_provider: None,
+                    actual_model: None,
                 })
             }
         }
@@ -1199,6 +1200,7 @@ mod tests {
                         ..Default::default()
                     },
                     actual_provider: None,
+                    actual_model: None,
                 })
             }
         }
@@ -1311,6 +1313,7 @@ mod tests {
                         ..Default::default()
                     },
                     actual_provider: None,
+                    actual_model: None,
                 })
             }
         }
@@ -1531,6 +1534,7 @@ mod tests {
                         ..Default::default()
                     },
                     actual_provider: None,
+                    actual_model: None,
                 })
             }
         }

--- a/crates/librefang-runtime/src/context_compressor.rs
+++ b/crates/librefang-runtime/src/context_compressor.rs
@@ -553,6 +553,7 @@ mod tests {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }

--- a/crates/librefang-runtime/src/context_engine/tests.rs
+++ b/crates/librefang-runtime/src/context_engine/tests.rs
@@ -461,6 +461,7 @@ async fn test_summary_engine_compact_called_once_on_threshold_cross() {
                     ..Default::default()
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }

--- a/crates/librefang-runtime/src/history_fold.rs
+++ b/crates/librefang-runtime/src/history_fold.rs
@@ -865,6 +865,7 @@ mod tests {
                 stop_reason: librefang_types::message::StopReason::EndTurn,
                 usage: librefang_types::message::TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -885,6 +886,7 @@ mod tests {
                 stop_reason: librefang_types::message::StopReason::EndTurn,
                 usage: librefang_types::message::TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -920,6 +922,7 @@ mod tests {
                 stop_reason: librefang_types::message::StopReason::EndTurn,
                 usage: librefang_types::message::TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -979,6 +982,7 @@ mod tests {
                 stop_reason: librefang_types::message::StopReason::EndTurn,
                 usage: librefang_types::message::TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }
@@ -2342,6 +2346,7 @@ mod tests {
                 stop_reason: librefang_types::message::StopReason::EndTurn,
                 usage: librefang_types::message::TokenUsage::default(),
                 actual_provider: None,
+                actual_model: None,
             })
         }
     }

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -1070,6 +1070,7 @@ mod tests {
                     cache_read_input_tokens: 0,
                 },
                 actual_provider: None,
+                actual_model: None,
             })
         }
         fn is_configured(&self) -> bool {

--- a/crates/librefang-runtime/tests/proactive_memory_extraction_model_override.rs
+++ b/crates/librefang-runtime/tests/proactive_memory_extraction_model_override.rs
@@ -293,6 +293,7 @@ impl librefang_runtime::llm_driver::LlmDriver for SharedRecordingDriver {
                 cache_read_input_tokens: 0,
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
     fn is_configured(&self) -> bool {

--- a/crates/librefang-testing/src/mock_driver.rs
+++ b/crates/librefang-testing/src/mock_driver.rs
@@ -148,6 +148,7 @@ impl LlmDriver for MockLlmDriver {
                 cache_read_input_tokens: 0,
             },
             actual_provider: None,
+            actual_model: None,
         })
     }
 


### PR DESCRIPTION
The codex-cli driver echoed the requested model id; the model the CLI actually resolved (which can differ from the predefined one) was never surfaced, so metering and the dashboard showed the nominated model rather than reality.

The fix threads the real model through a dedicated channel rather than reusing `actual_provider` — that field is the billing *provider* slot (`UsageRecord.provider`), so putting a model there would corrupt provider attribution.

- New `CompletionResponse.actual_model: Option<String>` — "the model the provider actually ran, when it differs from the requested id; None means use the requested model". Added `actual_model: None` at every existing construction site across the workspace (drivers, runtime, kernel, tests).
- Threaded `actual_model` through the agent loop exactly like `actual_provider`: captured per-LLM-call into `last_actual_model`, carried via `EndTurn` into `AgentLoopResult.actual_model`, in both the streaming and non-streaming paths.
- The kernel's `UsageRecord` construction now records `actual_model` when present (the two `messaging.rs` agent-turn sites and the `tools_and_skills.rs` aux-review site), falling back to the nominated model otherwise — mirroring how `actual_provider` is already honoured next to it. Cost basis is unchanged (codex usage is 0/0, so the model-name override never alters billed cost).
- codex-cli driver: parse the model from codex `exec`'s stderr startup banner. Verified against codex's own source — `print_config_summary` writes `model: <value>` to stderr via `eprintln!`, unconditionally, in human-output mode (the driver's mode; it does not pass `--json`, and the `--json` event stream carries no model field per `exec_events.rs`). The parser strips ANSI styling (codex bolds banner keys), is case-insensitive and position-independent, and degrades safely to the requested model id when the banner can't be parsed so the call never breaks.

Verification:
- cargo check --workspace --all-targets — clean (all construction sites updated).
- cargo clippy --workspace --all-targets — zero warnings.
- cargo test -p librefang-llm-drivers --lib — 562 pass, incl. 3 new codex banner-parser tests (plain banner, ANSI-styled banner, absent/empty → None fallback).
- cargo test -p librefang-kernel --lib — 1238 pass.
- Runtime threading: extended the existing actual_provider survival tests (non-streaming + streaming) to also assert actual_model threads from CompletionResponse to AgentLoopResult.
