### PR TITLE
fix(dashboard/sessions): show the correct Hand agent name in the sessions view (#6156)

### DIFF
--- a/crates/librefang-api/dashboard/src/pages/SessionsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SessionsPage.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SessionsPage } from "./SessionsPage";
+import { useAgents } from "../lib/queries/agents";
+import { useSessions } from "../lib/queries/sessions";
+import { useDeleteAgentSession } from "../lib/mutations/agents";
+import { useSetSessionLabel } from "../lib/mutations/sessions";
+
+vi.mock("../lib/queries/agents", () => ({
+  useAgents: vi.fn(),
+}));
+
+vi.mock("../lib/queries/sessions", () => ({
+  useSessions: vi.fn(),
+}));
+
+vi.mock("../lib/mutations/agents", () => ({
+  useDeleteAgentSession: vi.fn(),
+}));
+
+vi.mock("../lib/mutations/sessions", () => ({
+  useSetSessionLabel: vi.fn(),
+}));
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>(
+    "react-i18next",
+  );
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) =>
+        (opts?.defaultValue as string | undefined) ?? key,
+      i18n: { language: "en" },
+    }),
+  };
+});
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("../lib/store", () => ({
+  useUIStore: (
+    selector: (state: { addToast: (m: string, t?: string) => void }) => unknown,
+  ) => selector({ addToast: vi.fn() }),
+}));
+
+const useAgentsMock = useAgents as unknown as ReturnType<typeof vi.fn>;
+const useSessionsMock = useSessions as unknown as ReturnType<typeof vi.fn>;
+const useDeleteAgentSessionMock =
+  useDeleteAgentSession as unknown as ReturnType<typeof vi.fn>;
+const useSetSessionLabelMock =
+  useSetSessionLabel as unknown as ReturnType<typeof vi.fn>;
+
+const HAND_AGENT_ID = "11111111-1111-1111-1111-111111111111";
+const HAND_SESSION_ID = "22222222-2222-2222-2222-222222222222";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <SessionsPage />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDeleteAgentSessionMock.mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  });
+  useSetSessionLabelMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  useSessionsMock.mockReturnValue({
+    data: [
+      {
+        session_id: HAND_SESSION_ID,
+        agent_id: HAND_AGENT_ID,
+        created_at: "2026-06-17T00:00:00Z",
+        active: false,
+      },
+    ],
+    isLoading: false,
+    isError: false,
+    isFetching: false,
+    refetch: vi.fn(),
+    truncated: false,
+  });
+});
+
+describe("SessionsPage hand agent name (#6156)", () => {
+  it("requests the agent list with hand agents included", () => {
+    useAgentsMock.mockReturnValue({ data: [], isLoading: false, isError: false });
+    renderPage();
+    // The bare `/api/agents` list excludes hand agents; the sessions view
+    // must opt in so a hand-owned session can resolve its agent name.
+    expect(useAgentsMock).toHaveBeenCalledWith({ includeHands: true });
+  });
+
+  it("renders the hand agent's real name for a hand-owned session", () => {
+    useAgentsMock.mockReturnValue({
+      data: [{ id: HAND_AGENT_ID, name: "My Hand Agent", is_hand: true }],
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+    expect(screen.getByText("My Hand Agent")).toBeInTheDocument();
+    expect(screen.queryByText("sessions.unknown_agent")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the unknown-agent label when the agent is missing", () => {
+    // Regression guard: if the hand agent were filtered out (the pre-fix
+    // behaviour), the lookup misses and the unknown label is shown.
+    useAgentsMock.mockReturnValue({ data: [], isLoading: false, isError: false });
+    renderPage();
+    expect(screen.getByText("sessions.unknown_agent")).toBeInTheDocument();
+  });
+});

--- a/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
@@ -29,7 +29,11 @@ export function SessionsPage() {
   const addToast = useUIStore((s) => s.addToast);
 
   const sessionsQuery = useSessions();
-  const agentsQuery = useAgents();
+  // Include hand-spawned agents so a session owned by a Hand agent resolves to
+  // its real name instead of falling back to "unknown agent" (#6156). The
+  // bare `/api/agents` list excludes hand agents by default, but session rows
+  // carry the hand agent's `agent_id`, so the name lookup must see them too.
+  const agentsQuery = useAgents({ includeHands: true });
 
   const deleteMutation = useDeleteAgentSession();
   const navigate = useNavigate();

--- a/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SessionsPage.tsx
@@ -30,7 +30,7 @@ export function SessionsPage() {
 
   const sessionsQuery = useSessions();
   // Include hand-spawned agents so a session owned by a Hand agent resolves to
-  // its real name instead of falling back to "unknown agent" (#6156). The
+  // its real name instead of falling back to "unknown agent". The
   // bare `/api/agents` list excludes hand agents by default, but session rows
   // carry the hand agent's `agent_id`, so the name lookup must see them too.
   const agentsQuery = useAgents({ includeHands: true });


### PR DESCRIPTION
## Root cause

The sessions view rendered each row's agent name by looking up the session's `agent_id` in the result of `useAgents()`.

`useAgents()` calls `GET /api/agents`, and that endpoint **excludes hand-spawned agents by default** — see `crates/librefang-api/src/routes/agents/lifecycle.rs:617-619` (`if !params.include_hands.unwrap_or(false) { agents.retain(|e| !e.is_hand); }`).

A session owned by a Hand agent carries that hand agent's `agent_id` on its row (the list handler at `crates/librefang-api/src/routes/tools_sessions.rs:391` returns it verbatim), but because the hand agent was filtered out of the agent map, the lookup at `crates/librefang-api/dashboard/src/pages/SessionsPage.tsx` missed and the row fell back to the `sessions.unknown_agent` label instead of showing the Hand agent's real name.

The wrong layer was the frontend lookup: the backend already returns the hand agent (with its correct `name`) when asked via `?include_hands=true`, and it already emits the correct `agent_id` on each session row, so the authoritative fix is to make the sessions view request hand agents.

## The fix

Pass `{ includeHands: true }` to `useAgents()` in `SessionsPage.tsx` (the hook already supports this option and `listAgents()` already maps it to `include_hands=true`).
The agent map then includes hand agents and the `agent_id -> name` lookup resolves correctly.
No backend route or payload change, so no Rust integration test is needed; no new user-visible strings, so no locale changes.

## Verification

- New `crates/librefang-api/dashboard/src/pages/SessionsPage.test.tsx` (3 cases):
  - `requests the agent list with hand agents included` — asserts `useAgents` is called with `{ includeHands: true }`.
  - `renders the hand agent's real name for a hand-owned session` — a hand-owned session row shows the Hand agent name, not the unknown fallback.
  - `falls back to the unknown-agent label when the agent is missing` — regression guard for the pre-fix behaviour.
- `pnpm typecheck` — clean.
- `pnpm lint` — 0 errors (the one warning at `SessionsPage.tsx:42` is the pre-existing `const agents = agentsQuery.data ?? []` `react-hooks/exhaustive-deps` pattern shared by SkillsPage/WorkflowsPage; not introduced here).
- `pnpm build` — succeeds.
- `pnpm test` — 81 files, 797 tests pass (includes the new SessionsPage tests and the existing `sessions-hands.test.tsx`).
- `pnpm test:i18n-parity` — all locales in parity.

Closes #6156
