### PR TITLE
fix(ci): build vendored OpenSSL on Windows so webauthn-rs links (#6161)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,7 +175,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "929b5531f933164784179610dc6d44c9e4fe5e28",
         "is_verified": false,
-        "line_number": 2273
+        "line_number": 2279
       }
     ],
     "articles/hello-librefang.md": [
@@ -4292,5 +4292,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T08:33:00Z"
+  "generated_at": "2026-06-17T11:40:27Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -878,6 +878,12 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Fixed
 
+- **ci: the Windows test lane is green again — `librefang-api` now builds vendored OpenSSL on Windows so `webauthn-rs` links** (#6161) (@houko).
+  The passkey/WebAuthn work (#5981) added `webauthn-rs`, which pulls in `webauthn-rs-core` → native `openssl-sys`; the Windows MSVC runners have no discoverable system OpenSSL, so `cargo test --no-run --workspace` failed there with "Could not find directory of OpenSSL installation".
+  A Windows-gated `openssl = { features = ["vendored"] }` dependency in `crates/librefang-api/Cargo.toml` makes cargo feature-unification build `openssl-sys` from source on Windows only; Unix keeps using the system library and is unaffected.
+  No NASM setup step is needed — the vendored builder auto-detects `nasm` and falls back to a no-asm build when it is absent, and both Windows runner images already ship the Perl the build requires.
+  Closes #6161.
+
 - **channels: a conversation-ownership claim held by an agent that can no longer serve the channel is now taken over instead of silently dropping follow-ups** (#5323) (@houko).
   Follow-up to #6127: if agent A claimed a thread and A's `manifest.channels` allowlist was then narrowed to exclude that channel, the still-live claim suppressed every non-addressed follow-up (routed to an eligible agent B) until the TTL expired — a silent message drop.
   `conversation_ownership_allows` now checks the current holder's channel eligibility and, when the holder can no longer serve the channel, treats the dispatch as a takeover so the eligible candidate re-claims immediately.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4554,6 +4554,7 @@ dependencies = [
  "librefang-wire",
  "metrics",
  "metrics-exporter-prometheus",
+ "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -6248,6 +6249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6255,6 +6265,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -117,6 +117,16 @@ windows-sys = { version = "0.61", features = [
     "Win32_Security",
     "Win32_Security_Authorization",
 ] }
+# webauthn-rs (via webauthn-rs-core) links against system OpenSSL through
+# openssl-sys. The Windows MSVC CI runners have no discoverable system OpenSSL
+# (openssl-sys fails its probe with "Could not find directory of OpenSSL
+# installation"). Enable the vendored feature here so cargo feature-unification
+# builds openssl-sys from source on Windows only; Unix keeps using the system
+# library already present on those runners. The vendored builder (openssl-src)
+# auto-detects nasm and falls back to a no-asm build when it is absent, so the
+# runners' bundled Perl is the only host prerequisite (both Windows images ship
+# it). Refs #6161.
+openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
 # `build.rs` uses `chrono::Utc::now()` to stamp `BUILD_DATE` instead of

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -117,15 +117,11 @@ windows-sys = { version = "0.61", features = [
     "Win32_Security",
     "Win32_Security_Authorization",
 ] }
-# webauthn-rs (via webauthn-rs-core) links against system OpenSSL through
-# openssl-sys. The Windows MSVC CI runners have no discoverable system OpenSSL
-# (openssl-sys fails its probe with "Could not find directory of OpenSSL
-# installation"). Enable the vendored feature here so cargo feature-unification
-# builds openssl-sys from source on Windows only; Unix keeps using the system
-# library already present on those runners. The vendored builder (openssl-src)
-# auto-detects nasm and falls back to a no-asm build when it is absent, so the
-# runners' bundled Perl is the only host prerequisite (both Windows images ship
-# it). Refs #6161.
+# webauthn-rs (via webauthn-rs-core) links against system OpenSSL through openssl-sys.
+# The Windows MSVC CI runners have no discoverable system OpenSSL (openssl-sys fails its probe with "Could not find directory of OpenSSL installation").
+# Enable the vendored feature here so cargo feature-unification builds openssl-sys from source on Windows only; Unix keeps using the system library already present on those runners.
+# The vendored builder (openssl-src) auto-detects nasm and falls back to a no-asm build when it is absent, so the runners' bundled Perl is the only host prerequisite (both Windows images ship it).
+# Refs #6161.
 openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]


### PR DESCRIPTION
## Problem

`main` is red on the Windows test lane.
PR #6129 / #5981 (passkey, WebAuthn) added `webauthn-rs`, which pulls in `webauthn-rs-core` and through it the native `openssl-sys` crate.
On the Windows MSVC CI runners there is no discoverable system OpenSSL and the vendored build was not enabled, so the workspace test build fails with:

> Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed.

Linux and macOS runners ship a probed system OpenSSL, so they are unaffected — the failure is Windows-only.
Failing run: https://github.com/librefang/librefang/actions/runs/27675199468

## Fix

Add a `cfg(windows)`-gated dependency to `crates/librefang-api/Cargo.toml` that enables the vendored OpenSSL build:

```toml
[target.'cfg(windows)'.dependencies]
openssl = { version = "0.10", features = ["vendored"] }
```

Cargo feature-unification then makes `openssl-sys` build from vendored source on **Windows only**.
Unix targets keep using the fast system library already present in CI — the `cfg(windows)` gate means nothing changes for Linux/macOS.
The dependency is added to the **existing** `[target.'cfg(windows)'.dependencies]` table (which already carries `windows-sys`), not a duplicate table.
`version = "0.10"` matches the `openssl 0.10.81` already resolved in `Cargo.lock`.

### Why no NASM / Perl setup step

The vendored builder is `openssl-src`. It auto-detects whether `nasm.exe` is on PATH: if present it enables the assembly routines, if absent it configures `no-asm` and builds without them rather than failing (`OPENSSL_RUST_USE_NASM` left unset → auto-detect).
So the absence of NASM on the GitHub Windows runner images is not a build blocker.
Both `windows-2022` and `windows-2025` runner images ship Perl (5.32.1 / 5.42.0), which is the only host prerequisite the vendored build actually needs.
This keeps the change to a single line — no new CI install step. (I verified the `test-windows` job in `.github/workflows/ci.yml` has no existing `nasm`/`perl` setup step and confirmed against the `actions/runner-images` readmes that Perl is preinstalled and NASM is not.)

## Changes

- `crates/librefang-api/Cargo.toml`: add `cfg(windows)`-gated `openssl = { version = "0.10", features = ["vendored"] }` with an explanatory comment.
- `Cargo.lock`: regenerated — adds `openssl-src 300.6.1+3.6.3` as a dependency of `openssl-sys`, and `openssl` as a direct dep of `librefang-api`. The lockfile is target-agnostic, so the `cfg(windows)` dep resolves and locks even on a Linux host.
- `CHANGELOG.md`: one `### Fixed` bullet under `[Unreleased]`.
- `.secrets.baseline`: line-number refresh emitted by the `detect-secrets` pre-commit hook (an existing already-baselined CHANGELOG entry shifted down 6 lines); no new secret.

## Verification

This host has no native cargo, so verification ran through the repo's sanctioned `librefang-rust-dev` Docker image (Linux), using a per-worktree target volume + the shared download volume, exactly as `CLAUDE.md` (“Verifying without a native toolchain”) prescribes:

```bash
docker build -t librefang-rust-dev:latest -f Dockerfile.rust-dev .

WORKTREE="$(git rev-parse --show-toplevel)"
TARGET_VOL="librefang-target-$(basename "$WORKTREE")"
docker run --rm \
  -v "$WORKTREE":/work \
  -v librefang-cargo:/cargo -v "$TARGET_VOL":/target \
  -e CARGO_HOME=/cargo -e CARGO_TARGET_DIR=/target -w /work \
  librefang-rust-dev:latest \
  sh -c 'export PATH=/usr/local/cargo/bin:$PATH; cargo check -p librefang-api'
# → Finished `dev` profile in 1m 12s (updated Cargo.lock with openssl-src)
```

Results:

- `cargo check -p librefang-api` — clean (`Finished` in ~1m12s); this regenerated `Cargo.lock`.
- `cargo check -p librefang-api --locked` — clean, no further lockfile changes (`Finished` in 0.26s), confirming `Cargo.lock` is `--locked`-clean.
- `cargo check --workspace --lib --locked` — clean (`Finished` in ~1m05s).

No `.rs` files were touched, so `cargo fmt` was not required.

The container is Linux-only and cannot compile the `cfg(windows)` branch, so it does not itself exercise the vendored OpenSSL build — but the lockfile resolution above proves the dependency graph is correct, and the fix is the standard MSVC remedy for an `openssl-sys` link failure.

## CI nuance

The Windows test lane (`test-windows` in `.github/workflows/ci.yml`) runs **only** on push to `main` and in the merge queue (`github.event_name == 'push' || 'merge_group'`) — it does **not** run on pull requests, and there is no `workflow_dispatch` or label to trigger it on a PR.
So this PR's own CI will not exercise Windows.
If the repo merges through a merge queue, the `merge_group` event will run the Windows job before this lands on `main`; otherwise the first Windows validation happens on the post-merge `main` push.
Either way the fix is the canonical vendored-OpenSSL remedy and has been validated by dependency-graph resolution + the Docker Linux checks above.

Closes #6161.
