### PR TITLE
feat(runtime): the cron-management tool disables jobs instead of deleting them (#6159)

### DIFF
--- a/crates/librefang-kernel-handle/src/cron_control.rs
+++ b/crates/librefang-kernel-handle/src/cron_control.rs
@@ -32,11 +32,8 @@ pub trait CronControl: Send + Sync {
 
     /// Enable or disable a cron job by ID, preserving its configuration.
     ///
-    /// This is the agent-facing alternative to `cron_cancel`: disabling a job
-    /// pauses it without losing the schedule / action / delivery config, so an
-    /// operator can recover what was set up and re-enable it later. Agent tools
-    /// route their "stop this job" action here rather than to `cron_cancel`;
-    /// hard deletion stays a human-only dashboard operation (#6159).
+    /// This is the agent-facing alternative to `cron_cancel`: disabling a job pauses it without losing the schedule / action / delivery config, so an operator can recover what was set up and re-enable it later.
+    /// Agent tools route their "stop this job" action here rather than to `cron_cancel`; hard deletion stays a human-only dashboard operation (#6159).
     async fn cron_set_enabled(&self, job_id: &str, enabled: bool) -> Result<(), KernelOpError> {
         let _ = (job_id, enabled);
         Err(KernelOpError::unavailable("Cron scheduler"))

--- a/crates/librefang-kernel-handle/src/cron_control.rs
+++ b/crates/librefang-kernel-handle/src/cron_control.rs
@@ -29,4 +29,16 @@ pub trait CronControl: Send + Sync {
         let _ = job_id;
         Err(KernelOpError::unavailable("Cron scheduler"))
     }
+
+    /// Enable or disable a cron job by ID, preserving its configuration.
+    ///
+    /// This is the agent-facing alternative to `cron_cancel`: disabling a job
+    /// pauses it without losing the schedule / action / delivery config, so an
+    /// operator can recover what was set up and re-enable it later. Agent tools
+    /// route their "stop this job" action here rather than to `cron_cancel`;
+    /// hard deletion stays a human-only dashboard operation (#6159).
+    async fn cron_set_enabled(&self, job_id: &str, enabled: bool) -> Result<(), KernelOpError> {
+        let _ = (job_id, enabled);
+        Err(KernelOpError::unavailable("Cron scheduler"))
+    }
 }

--- a/crates/librefang-kernel-handle/tests/defaults_returns.rs
+++ b/crates/librefang-kernel-handle/tests/defaults_returns.rs
@@ -218,6 +218,12 @@ async fn test_cron_defaults_return_errors() {
         Err(KernelOpError::Unavailable(c)) if c == "Cron scheduler" => {}
         other => panic!("cron_cancel: expected Unavailable, got {other:?}"),
     }
+
+    let result = handle.cron_set_enabled("job1", false).await;
+    match result {
+        Err(KernelOpError::Unavailable(c)) if c == "Cron scheduler" => {}
+        other => panic!("cron_set_enabled: expected Unavailable, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/librefang-kernel/src/kernel/handles/cron_control.rs
+++ b/crates/librefang-kernel/src/kernel/handles/cron_control.rs
@@ -138,4 +138,29 @@ impl kernel_handle::CronControl for LibreFangKernel {
 
         Ok(())
     }
+
+    async fn cron_set_enabled(
+        &self,
+        job_id: &str,
+        enabled: bool,
+    ) -> Result<(), kernel_handle::KernelOpError> {
+        use kernel_handle::KernelOpError;
+        let id = librefang_types::scheduler::CronJobId(
+            uuid::Uuid::parse_str(job_id)
+                .map_err(|e| KernelOpError::InvalidInput(format!("job_id: {e}")))?,
+        );
+        self.workflows
+            .cron_scheduler
+            .set_enabled(id, enabled)
+            .map_err(|e| KernelOpError::Internal(e.to_string()))?;
+
+        // Persist after the toggle, mirroring `toggle_cron_job` in the HTTP
+        // route (#3515): an in-memory enable/disable that never reaches disk
+        // would silently revert on daemon restart.
+        if let Err(e) = self.workflows.cron_scheduler.persist() {
+            tracing::warn!("Failed to persist cron jobs: {e}");
+        }
+
+        Ok(())
+    }
 }

--- a/crates/librefang-kernel/src/kernel/handles/cron_control.rs
+++ b/crates/librefang-kernel/src/kernel/handles/cron_control.rs
@@ -154,9 +154,7 @@ impl kernel_handle::CronControl for LibreFangKernel {
             .set_enabled(id, enabled)
             .map_err(|e| KernelOpError::Internal(e.to_string()))?;
 
-        // Persist after the toggle, mirroring `toggle_cron_job` in the HTTP
-        // route (#3515): an in-memory enable/disable that never reaches disk
-        // would silently revert on daemon restart.
+        // Persist after the toggle, mirroring `toggle_cron_job` in the HTTP route (#3515): an in-memory enable/disable that never reaches disk would silently revert on daemon restart.
         if let Err(e) = self.workflows.cron_scheduler.persist() {
             tracing::warn!("Failed to persist cron jobs: {e}");
         }

--- a/crates/librefang-runtime/src/tool_policy.rs
+++ b/crates/librefang-runtime/src/tool_policy.rs
@@ -190,8 +190,10 @@ fn glob_match(pattern: &str, text: &str) -> bool {
 const SUBAGENT_DENY_ALWAYS: &[&str] = &[
     "cron_create",
     "cron_cancel",
+    "cron_enable",
     "schedule_create",
     "schedule_delete",
+    "schedule_resume",
     "hand_activate",
     "hand_deactivate",
     "process_start",

--- a/crates/librefang-runtime/src/tool_runner/cron.rs
+++ b/crates/librefang-runtime/src/tool_runner/cron.rs
@@ -54,11 +54,56 @@ pub(super) async fn tool_cron_list(
     Ok(serde_json::to_string_pretty(&jobs)?)
 }
 
+/// Disable a cron job by ID — the agent-facing "stop this job" action.
+///
+/// Despite the historical `cron_cancel` tool name, this pauses the job via
+/// `cron_set_enabled(false)` rather than hard-deleting it: the schedule /
+/// action / delivery config is preserved so the operator can recover what was
+/// set up and the agent (or a human) can re-enable it later. Hard deletion is
+/// a human-only dashboard operation (#6159). Re-enable via `tool_cron_enable`.
 pub(super) async fn tool_cron_cancel(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
 ) -> ToolResult {
+    let job_id = require_owned_job_id(input, kernel, caller_agent_id, "cron_cancel").await?;
+    let kh = require_kernel_typed(kernel)?;
+    kh.cron_set_enabled(&job_id, false)
+        .await
+        .map_err(ToolError::upstream)?;
+    Ok(format!(
+        "Cron job '{job_id}' disabled (paused). Its configuration is preserved — re-enable it with cron_enable."
+    ))
+}
+
+/// Enable (resume) a previously disabled cron job by ID.
+pub(super) async fn tool_cron_enable(
+    input: &serde_json::Value,
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
+) -> ToolResult {
+    let job_id = require_owned_job_id(input, kernel, caller_agent_id, "cron_enable").await?;
+    let kh = require_kernel_typed(kernel)?;
+    kh.cron_set_enabled(&job_id, true)
+        .await
+        .map_err(ToolError::upstream)?;
+    Ok(format!("Cron job '{job_id}' enabled (resumed)."))
+}
+
+/// Validate the `job_id` parameter and confirm the caller owns the job.
+///
+/// `KernelHandle::cron_set_enabled` toggles by UUID with no ownership check
+/// (see `kernel/handles/cron_control.rs`), so the ownership guard must live at
+/// the tool layer — otherwise any agent could pause/resume another agent's job
+/// by learning its UUID. Returns the validated, owned `job_id` as an owned
+/// `String` (the borrow on `kh.cron_list(...)` ends before the caller's own
+/// kernel call).
+async fn require_owned_job_id(
+    input: &serde_json::Value,
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
+    tool: &'static str,
+) -> Result<String, ToolError> {
     let job_id = input["job_id"]
         .as_str()
         .ok_or(ToolError::MissingParameter("job_id"))?;
@@ -69,7 +114,7 @@ pub(super) async fn tool_cron_cancel(
         });
     }
     let kh = require_kernel_typed(kernel)?;
-    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("cron_cancel"))?;
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing(tool))?;
     let owned = kh.cron_list(agent_id).await.map_err(ToolError::upstream)?;
     let owned_ids: HashSet<&str> = owned
         .iter()
@@ -81,8 +126,7 @@ pub(super) async fn tool_cron_cancel(
             id: job_id.to_string(),
         });
     }
-    kh.cron_cancel(job_id).await.map_err(ToolError::upstream)?;
-    Ok(format!("Cron job '{job_id}' cancelled."))
+    Ok(job_id.to_string())
 }
 
 #[cfg(test)]
@@ -122,6 +166,27 @@ mod tests {
     #[tokio::test]
     async fn cron_cancel_empty_job_id_rejected() {
         let r = tool_cron_cancel(&json!({"job_id": ""}), None, Some("agent-a")).await;
+        match r {
+            Err(ToolError::InvalidParameter { name, reason }) => {
+                assert_eq!(name, "job_id");
+                assert!(
+                    reason.contains("empty"),
+                    "reason should mention empty: {reason}"
+                );
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cron_enable_without_kernel_returns_unavailable() {
+        let r = tool_cron_enable(&json!({"job_id": "x"}), None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn cron_enable_empty_job_id_rejected() {
+        let r = tool_cron_enable(&json!({"job_id": ""}), None, Some("agent-a")).await;
         match r {
             Err(ToolError::InvalidParameter { name, reason }) => {
                 assert_eq!(name, "job_id");

--- a/crates/librefang-runtime/src/tool_runner/cron.rs
+++ b/crates/librefang-runtime/src/tool_runner/cron.rs
@@ -56,11 +56,9 @@ pub(super) async fn tool_cron_list(
 
 /// Disable a cron job by ID — the agent-facing "stop this job" action.
 ///
-/// Despite the historical `cron_cancel` tool name, this pauses the job via
-/// `cron_set_enabled(false)` rather than hard-deleting it: the schedule /
-/// action / delivery config is preserved so the operator can recover what was
-/// set up and the agent (or a human) can re-enable it later. Hard deletion is
-/// a human-only dashboard operation (#6159). Re-enable via `tool_cron_enable`.
+/// Despite the historical `cron_cancel` tool name, this pauses the job via `cron_set_enabled(false)` rather than hard-deleting it: the schedule / action / delivery config is preserved so the operator can recover what was set up and the agent (or a human) can re-enable it later.
+/// Hard deletion is a human-only dashboard operation (#6159).
+/// Re-enable via `tool_cron_enable`.
 pub(super) async fn tool_cron_cancel(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
@@ -92,12 +90,8 @@ pub(super) async fn tool_cron_enable(
 
 /// Validate the `job_id` parameter and confirm the caller owns the job.
 ///
-/// `KernelHandle::cron_set_enabled` toggles by UUID with no ownership check
-/// (see `kernel/handles/cron_control.rs`), so the ownership guard must live at
-/// the tool layer — otherwise any agent could pause/resume another agent's job
-/// by learning its UUID. Returns the validated, owned `job_id` as an owned
-/// `String` (the borrow on `kh.cron_list(...)` ends before the caller's own
-/// kernel call).
+/// `KernelHandle::cron_set_enabled` toggles by UUID with no ownership check (see `kernel/handles/cron_control.rs`), so the ownership guard must live at the tool layer — otherwise any agent could pause/resume another agent's job by learning its UUID.
+/// Returns the validated, owned `job_id` as an owned `String` (the borrow on `kh.cron_list(...)` ends before the caller's own kernel call).
 async fn require_owned_job_id(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,

--- a/crates/librefang-runtime/src/tool_runner/definitions.rs
+++ b/crates/librefang-runtime/src/tool_runner/definitions.rs
@@ -44,6 +44,7 @@ mod tool_name {
     pub const SCHEDULE_CREATE: &str = "schedule_create";
     pub const SCHEDULE_LIST: &str = "schedule_list";
     pub const SCHEDULE_DELETE: &str = "schedule_delete";
+    pub const SCHEDULE_RESUME: &str = "schedule_resume";
     pub const KNOWLEDGE_ADD_ENTITY: &str = "knowledge_add_entity";
     pub const KNOWLEDGE_ADD_RELATION: &str = "knowledge_add_relation";
     pub const KNOWLEDGE_QUERY: &str = "knowledge_query";
@@ -68,6 +69,7 @@ mod tool_name {
     pub const CRON_CREATE: &str = "cron_create";
     pub const CRON_LIST: &str = "cron_list";
     pub const CRON_CANCEL: &str = "cron_cancel";
+    pub const CRON_ENABLE: &str = "cron_enable";
     pub const CHANNEL_SEND: &str = "channel_send";
     pub const HAND_LIST: &str = "hand_list";
     pub const HAND_ACTIVATE: &str = "hand_activate";
@@ -564,11 +566,22 @@ use instead of web_fetch + file_write (which round-trips the entire body through
             },
             ToolDefinition {
                 name: tool_name::SCHEDULE_DELETE.to_string(),
-                description: "Remove a scheduled task by its ID.".to_string(),
+                description: "Pause (disable) a scheduled task by its ID. The task stops running but its configuration is preserved, so it can be resumed later with schedule_resume. This does NOT permanently delete the task — only a human operator can hard-delete a schedule via the dashboard.".to_string(),
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "id": { "type": "string", "description": "The schedule ID to remove" }
+                        "id": { "type": "string", "description": "The schedule ID to pause" }
+                    },
+                    "required": ["id"]
+                }),
+            },
+            ToolDefinition {
+                name: tool_name::SCHEDULE_RESUME.to_string(),
+                description: "Resume (re-enable) a scheduled task that was previously paused with schedule_delete. The task starts running on its original schedule again.".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string", "description": "The schedule ID to resume" }
                     },
                     "required": ["id"]
                 }),
@@ -861,11 +874,22 @@ use instead of web_fetch + file_write (which round-trips the entire body through
             },
             ToolDefinition {
                 name: tool_name::CRON_CANCEL.to_string(),
-                description: "Cancel a scheduled/cron job by its ID.".to_string(),
+                description: "Pause (disable) a scheduled/cron job by its ID. The job stops firing but its configuration is preserved, so it can be re-enabled later with cron_enable. This does NOT permanently delete the job — only a human operator can hard-delete a cron job via the dashboard.".to_string(),
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "job_id": { "type": "string", "description": "The UUID of the cron job to cancel" }
+                        "job_id": { "type": "string", "description": "The UUID of the cron job to pause" }
+                    },
+                    "required": ["job_id"]
+                }),
+            },
+            ToolDefinition {
+                name: tool_name::CRON_ENABLE.to_string(),
+                description: "Re-enable (resume) a scheduled/cron job that was previously paused with cron_cancel. The job starts firing on its original schedule again.".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "job_id": { "type": "string", "description": "The UUID of the cron job to re-enable" }
                     },
                     "required": ["job_id"]
                 }),

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -968,6 +968,7 @@ pub async fn execute_tool_raw(
         }
         "schedule_list" => tool_schedule_list(*kernel, *caller_agent_id).await,
         "schedule_delete" => tool_schedule_delete(input, *kernel, *caller_agent_id).await,
+        "schedule_resume" => tool_schedule_resume(input, *kernel, *caller_agent_id).await,
 
         // Knowledge graph tools.
         "knowledge_add_entity" => tool_knowledge_add_entity(input, *kernel).await,
@@ -1082,6 +1083,7 @@ pub async fn execute_tool_raw(
         "cron_create" => tool_cron_create(input, *kernel, *caller_agent_id, *sender_id).await,
         "cron_list" => tool_cron_list(*kernel, *caller_agent_id).await,
         "cron_cancel" => tool_cron_cancel(input, *kernel, *caller_agent_id).await,
+        "cron_enable" => tool_cron_enable(input, *kernel, *caller_agent_id).await,
 
         // Channel send tool (proactive outbound messaging)
         "channel_send" => {

--- a/crates/librefang-runtime/src/tool_runner/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/mod.rs
@@ -50,7 +50,7 @@ use self::artifact::tool_read_artifact;
 pub use self::canvas::sanitize_canvas_html;
 use self::canvas::tool_canvas_present;
 use self::channel::tool_channel_send;
-use self::cron::{tool_cron_cancel, tool_cron_create, tool_cron_list};
+use self::cron::{tool_cron_cancel, tool_cron_create, tool_cron_enable, tool_cron_list};
 pub use self::definitions::{builtin_tool_definitions, select_native_tools, ALWAYS_NATIVE_TOOLS};
 pub use self::dispatch::{current_agent_depth, execute_tool, execute_tool_raw, ToolExecContext};
 #[allow(unused_imports)] // Re-exported for incremental migration of submodules (#3576).
@@ -80,7 +80,9 @@ use self::process::{
 };
 #[cfg(feature = "docker-sandbox")]
 use self::sandbox::tool_docker_exec;
-use self::schedule::{tool_schedule_create, tool_schedule_delete, tool_schedule_list};
+use self::schedule::{
+    tool_schedule_create, tool_schedule_delete, tool_schedule_list, tool_schedule_resume,
+};
 use self::shell::tool_shell_exec;
 use self::shell_safety::{classify_shell_exec_ro_safety, RoSafety};
 use self::skill::{

--- a/crates/librefang-runtime/src/tool_runner/schedule.rs
+++ b/crates/librefang-runtime/src/tool_runner/schedule.rs
@@ -342,24 +342,65 @@ pub(super) async fn tool_schedule_list(
     Ok(output)
 }
 
+/// Disable (pause) a scheduled task — the agent-facing "stop this schedule"
+/// action.
+///
+/// Despite the historical `schedule_delete` tool name, this pauses the job via
+/// `cron_set_enabled(false)` rather than hard-deleting it, so the schedule and
+/// its action survive and the operator can recover what was set up. Hard
+/// deletion is a human-only dashboard operation (#6159); the agent re-enables
+/// a paused schedule with `schedule_resume`.
 pub(super) async fn tool_schedule_delete(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
     caller_agent_id: Option<&str>,
 ) -> ToolResult {
+    let id = require_owned_schedule_id(input, kernel, caller_agent_id, "schedule_delete").await?;
+    let kh = require_kernel_typed(kernel)?;
+    kh.cron_set_enabled(&id, false)
+        .await
+        .map_err(ToolError::upstream)?;
+    Ok(format!(
+        "Schedule '{id}' disabled (paused). Its configuration is preserved — resume it with schedule_resume."
+    ))
+}
+
+/// Re-enable (resume) a previously paused scheduled task.
+pub(super) async fn tool_schedule_resume(
+    input: &serde_json::Value,
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
+) -> ToolResult {
+    let id = require_owned_schedule_id(input, kernel, caller_agent_id, "schedule_resume").await?;
+    let kh = require_kernel_typed(kernel)?;
+    kh.cron_set_enabled(&id, true)
+        .await
+        .map_err(ToolError::upstream)?;
+    Ok(format!("Schedule '{id}' resumed (re-enabled)."))
+}
+
+/// Resolve the schedule id (accepting `id` or `job_id`) and confirm the caller
+/// owns it.
+///
+/// `KernelHandle::cron_set_enabled` toggles by UUID with no ownership check
+/// (see `kernel/handles/cron_control.rs`), so the ownership guard lives at the
+/// tool layer — otherwise any agent with this tool could pause/resume another
+/// agent's job by learning its UUID. Returns the validated, owned id as an
+/// owned `String` so the borrow on `kh.cron_list(...)` ends before the
+/// caller's own kernel mutation.
+async fn require_owned_schedule_id(
+    input: &serde_json::Value,
+    kernel: Option<&Arc<dyn KernelHandle>>,
+    caller_agent_id: Option<&str>,
+    tool: &'static str,
+) -> Result<String, ToolError> {
     let kh = require_kernel_typed(kernel)?;
     // Accept either "id" or "job_id" for backward compatibility
     let id = input["id"]
         .as_str()
         .or_else(|| input["job_id"].as_str())
         .ok_or(ToolError::MissingParameter("id"))?;
-    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing("schedule_delete"))?;
-    // Authorize: the caller may only delete jobs that belong to them.
-    // `KernelHandle::cron_cancel` removes by UUID with no ownership check
-    // (see `kernel/handles/cron_control.rs`), and the sibling `cron_cancel`
-    // tool already enforces this guard at the tool layer — `schedule_delete`
-    // must too, or it is a trivial bypass: any agent with this tool could
-    // cancel another agent's job by learning its UUID.
+    let agent_id = caller_agent_id.ok_or_else(|| caller_agent_id_missing(tool))?;
     let owned = kh.cron_list(agent_id).await.map_err(ToolError::upstream)?;
     let owns_job = owned.iter().any(|job| {
         job.get("id")
@@ -375,8 +416,7 @@ pub(super) async fn tool_schedule_delete(
             id: id.to_string(),
         });
     }
-    kh.cron_cancel(id).await.map_err(ToolError::upstream)?;
-    Ok(format!("Schedule '{id}' deleted."))
+    Ok(id.to_string())
 }
 
 #[cfg(test)]
@@ -405,6 +445,12 @@ mod tests {
     #[tokio::test]
     async fn schedule_delete_without_kernel_returns_unavailable() {
         let r = tool_schedule_delete(&json!({"id": "x"}), None, Some("agent-a")).await;
+        assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
+    }
+
+    #[tokio::test]
+    async fn schedule_resume_without_kernel_returns_unavailable() {
+        let r = tool_schedule_resume(&json!({"id": "x"}), None, Some("agent-a")).await;
         assert!(matches!(r, Err(ToolError::Unavailable("Kernel handle"))));
     }
 

--- a/crates/librefang-runtime/src/tool_runner/schedule.rs
+++ b/crates/librefang-runtime/src/tool_runner/schedule.rs
@@ -342,14 +342,10 @@ pub(super) async fn tool_schedule_list(
     Ok(output)
 }
 
-/// Disable (pause) a scheduled task — the agent-facing "stop this schedule"
-/// action.
+/// Disable (pause) a scheduled task — the agent-facing "stop this schedule" action.
 ///
-/// Despite the historical `schedule_delete` tool name, this pauses the job via
-/// `cron_set_enabled(false)` rather than hard-deleting it, so the schedule and
-/// its action survive and the operator can recover what was set up. Hard
-/// deletion is a human-only dashboard operation (#6159); the agent re-enables
-/// a paused schedule with `schedule_resume`.
+/// Despite the historical `schedule_delete` tool name, this pauses the job via `cron_set_enabled(false)` rather than hard-deleting it, so the schedule and its action survive and the operator can recover what was set up.
+/// Hard deletion is a human-only dashboard operation (#6159); the agent re-enables a paused schedule with `schedule_resume`.
 pub(super) async fn tool_schedule_delete(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,
@@ -379,15 +375,10 @@ pub(super) async fn tool_schedule_resume(
     Ok(format!("Schedule '{id}' resumed (re-enabled)."))
 }
 
-/// Resolve the schedule id (accepting `id` or `job_id`) and confirm the caller
-/// owns it.
+/// Resolve the schedule id (accepting `id` or `job_id`) and confirm the caller owns it.
 ///
-/// `KernelHandle::cron_set_enabled` toggles by UUID with no ownership check
-/// (see `kernel/handles/cron_control.rs`), so the ownership guard lives at the
-/// tool layer — otherwise any agent with this tool could pause/resume another
-/// agent's job by learning its UUID. Returns the validated, owned id as an
-/// owned `String` so the borrow on `kh.cron_list(...)` ends before the
-/// caller's own kernel mutation.
+/// `KernelHandle::cron_set_enabled` toggles by UUID with no ownership check (see `kernel/handles/cron_control.rs`), so the ownership guard lives at the tool layer — otherwise any agent with this tool could pause/resume another agent's job by learning its UUID.
+/// Returns the validated, owned id as an owned `String` so the borrow on `kh.cron_list(...)` ends before the caller's own kernel mutation.
 async fn require_owned_schedule_id(
     input: &serde_json::Value,
     kernel: Option<&Arc<dyn KernelHandle>>,

--- a/crates/librefang-runtime/src/tool_runner/tests/workspace.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/workspace.rs
@@ -142,6 +142,7 @@ fn test_builtin_tool_definitions() {
     assert!(names.contains(&"schedule_create"));
     assert!(names.contains(&"schedule_list"));
     assert!(names.contains(&"schedule_delete"));
+    assert!(names.contains(&"schedule_resume"));
     assert!(names.contains(&"image_analyze"));
     assert!(names.contains(&"location_get"));
     assert!(names.contains(&"system_time"));
@@ -164,10 +165,11 @@ fn test_builtin_tool_definitions() {
     assert!(names.contains(&"video_generate"));
     assert!(names.contains(&"video_status"));
     assert!(names.contains(&"music_generate"));
-    // 3 cron tools
+    // 4 cron tools
     assert!(names.contains(&"cron_create"));
     assert!(names.contains(&"cron_list"));
     assert!(names.contains(&"cron_cancel"));
+    assert!(names.contains(&"cron_enable"));
     // 1 channel send tool
     assert!(names.contains(&"channel_send"));
     // 4 hand tools

--- a/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
+++ b/crates/librefang-runtime/tests/tool_runner_forwarding_task_cron.rs
@@ -8,6 +8,7 @@ type TaskPostCalls = Arc<Mutex<Vec<Option<String>>>>;
 type CronCreateCalls = Arc<Mutex<Vec<(String, serde_json::Value)>>>;
 type CronListCalls = Arc<Mutex<Vec<String>>>;
 type CronCancelCalls = Arc<Mutex<Vec<String>>>;
+type CronSetEnabledCalls = Arc<Mutex<Vec<(String, bool)>>>;
 type TaskGetCalls = Arc<Mutex<Vec<String>>>;
 
 struct CapturedCalls {
@@ -15,6 +16,7 @@ struct CapturedCalls {
     cron_create: CronCreateCalls,
     cron_list: CronListCalls,
     cron_cancel: CronCancelCalls,
+    cron_set_enabled: CronSetEnabledCalls,
     task_get: TaskGetCalls,
 }
 
@@ -23,6 +25,7 @@ struct CapturingKernel {
     cron_create_calls: CronCreateCalls,
     cron_list_calls: CronListCalls,
     cron_cancel_calls: CronCancelCalls,
+    cron_set_enabled_calls: CronSetEnabledCalls,
     task_get_calls: TaskGetCalls,
     // When set, task_get returns Some(this) regardless of id; otherwise None.
     task_get_response: Mutex<Option<serde_json::Value>>,
@@ -37,12 +40,14 @@ impl CapturingKernel {
         let cron_create = Arc::new(Mutex::new(Vec::new()));
         let cron_list = Arc::new(Mutex::new(Vec::new()));
         let cron_cancel = Arc::new(Mutex::new(Vec::new()));
+        let cron_set_enabled = Arc::new(Mutex::new(Vec::new()));
         let task_get = Arc::new(Mutex::new(Vec::new()));
         let kernel = Self {
             task_post_calls: Arc::clone(&task_post),
             cron_create_calls: Arc::clone(&cron_create),
             cron_list_calls: Arc::clone(&cron_list),
             cron_cancel_calls: Arc::clone(&cron_cancel),
+            cron_set_enabled_calls: Arc::clone(&cron_set_enabled),
             task_get_calls: Arc::clone(&task_get),
             task_get_response: Mutex::new(None),
             cron_list_response: Mutex::new(Vec::new()),
@@ -54,6 +59,7 @@ impl CapturingKernel {
                 cron_create,
                 cron_list,
                 cron_cancel,
+                cron_set_enabled,
                 task_get,
             },
         )
@@ -251,6 +257,18 @@ impl CronControl for CapturingKernel {
             .lock()
             .unwrap()
             .push(job_id.to_string());
+        Ok(())
+    }
+
+    async fn cron_set_enabled(
+        &self,
+        job_id: &str,
+        enabled: bool,
+    ) -> Result<(), librefang_kernel_handle::KernelOpError> {
+        self.cron_set_enabled_calls
+            .lock()
+            .unwrap()
+            .push((job_id.to_string(), enabled));
         Ok(())
     }
 }
@@ -549,7 +567,12 @@ async fn test_cron_list_returns_serialized_jobs() {
 }
 
 #[tokio::test]
-async fn test_cron_cancel_succeeds_when_caller_owns_the_job() {
+async fn test_cron_cancel_disables_and_does_not_hard_delete() {
+    // #6159: the agent-facing "cron_cancel" tool must pause the job via
+    // `cron_set_enabled(false)`, NOT hard-delete it via `cron_cancel`. The job
+    // therefore still exists (with enabled=false) after the agent invokes it,
+    // and `KernelHandle::cron_cancel` (the destructive deletion path) is never
+    // reached.
     let (kernel, calls) = CapturingKernel::new();
     kernel.set_cron_list_response(vec![json!({"id": "cron-99"})]);
     let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
@@ -562,9 +585,66 @@ async fn test_cron_cancel_succeeds_when_caller_owns_the_job() {
         "cron_cancel should succeed when caller owns the job: {}",
         result.content
     );
-    let cancel_calls = calls.cron_cancel.lock().unwrap();
-    assert_eq!(cancel_calls.len(), 1);
-    assert_eq!(cancel_calls[0], "cron-99");
+    // Disables, not deletes.
+    let set_enabled_calls = calls.cron_set_enabled.lock().unwrap();
+    assert_eq!(set_enabled_calls.len(), 1);
+    assert_eq!(set_enabled_calls[0], ("cron-99".to_string(), false));
+    // The destructive deletion path is never touched.
+    assert!(
+        calls.cron_cancel.lock().unwrap().is_empty(),
+        "cron_cancel tool must NOT hard-delete via KernelHandle::cron_cancel"
+    );
+    assert!(
+        result.content.contains("disabled") || result.content.contains("paused"),
+        "user-facing message should say the job was paused/disabled, got: {}",
+        result.content
+    );
+}
+
+#[tokio::test]
+async fn test_cron_enable_resumes_owned_job() {
+    // The agent can re-enable a paused job, so the pause is reversible.
+    let (kernel, calls) = CapturingKernel::new();
+    kernel.set_cron_list_response(vec![json!({"id": "cron-99"})]);
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, Some("agent-1"));
+    let result = execute_tool_raw("ce1", "cron_enable", &json!({"job_id": "cron-99"}), &ctx).await;
+
+    assert!(
+        !result.is_error,
+        "cron_enable should succeed when caller owns the job: {}",
+        result.content
+    );
+    let set_enabled_calls = calls.cron_set_enabled.lock().unwrap();
+    assert_eq!(set_enabled_calls.len(), 1);
+    assert_eq!(set_enabled_calls[0], ("cron-99".to_string(), true));
+}
+
+#[tokio::test]
+async fn test_cron_enable_unowned_job_renders_as_not_found() {
+    let (kernel, calls) = CapturingKernel::new();
+    kernel.set_cron_list_response(vec![json!({"id": "cron-mine"})]);
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, Some("agent-1"));
+    let result =
+        execute_tool_raw("ce2", "cron_enable", &json!({"job_id": "cron-other"}), &ctx).await;
+
+    assert!(
+        result.is_error,
+        "cron_enable on unowned job must error: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("Cron job 'cron-other' not found"),
+        "expected NotFound display, got: {}",
+        result.content
+    );
+    assert!(
+        calls.cron_set_enabled.lock().unwrap().is_empty(),
+        "cron_enable must NOT reach the kernel when the caller doesn't own the job"
+    );
 }
 
 #[tokio::test]
@@ -602,6 +682,10 @@ async fn test_cron_cancel_unowned_job_renders_as_not_found() {
         cancel_was_never_called(&calls),
         "cron_cancel must NOT reach the kernel when the caller doesn't own the job"
     );
+    assert!(
+        calls.cron_set_enabled.lock().unwrap().is_empty(),
+        "cron_cancel must NOT toggle a job the caller doesn't own"
+    );
 }
 
 #[tokio::test]
@@ -633,14 +717,19 @@ fn cancel_was_never_called(calls: &CapturedCalls) -> bool {
     calls.cron_cancel.lock().unwrap().is_empty()
 }
 
-// schedule_delete ownership coverage (#3576 second-slice migration). The
-// natural-language `schedule_delete` shares `KernelHandle::cron_cancel` with
-// `cron_cancel`, which cancels by UUID with no ownership filtering. These pin
-// that `schedule_delete` enforces the same tool-layer ownership guard as
-// `cron_cancel` — previously it did not, so it was a bypass.
+// schedule_delete ownership coverage (#3576 second-slice migration, extended
+// by #6159). The natural-language `schedule_delete` enforces the same
+// tool-layer ownership guard as `cron_cancel`. Since #6159 it pauses via
+// `cron_set_enabled(false)` instead of hard-deleting, so the config survives
+// and a human can recover it; these pin both the ownership guard and the
+// disable-not-delete behaviour.
 
 #[tokio::test]
-async fn test_schedule_delete_succeeds_when_caller_owns_the_job() {
+async fn test_schedule_delete_disables_and_does_not_hard_delete() {
+    // #6159: the agent-facing "schedule_delete" tool pauses the job via
+    // `cron_set_enabled(false)`, NOT hard-delete via `cron_cancel`. The job
+    // still exists (enabled=false) afterwards, and the destructive deletion
+    // path is never reached.
     let (kernel, calls) = CapturingKernel::new();
     kernel.set_cron_list_response(vec![json!({"id": "sched-99"})]);
     let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
@@ -653,9 +742,37 @@ async fn test_schedule_delete_succeeds_when_caller_owns_the_job() {
         "schedule_delete should succeed when caller owns the job: {}",
         result.content
     );
-    let cancel_calls = calls.cron_cancel.lock().unwrap();
-    assert_eq!(cancel_calls.len(), 1);
-    assert_eq!(cancel_calls[0], "sched-99");
+    let set_enabled_calls = calls.cron_set_enabled.lock().unwrap();
+    assert_eq!(set_enabled_calls.len(), 1);
+    assert_eq!(set_enabled_calls[0], ("sched-99".to_string(), false));
+    assert!(
+        calls.cron_cancel.lock().unwrap().is_empty(),
+        "schedule_delete tool must NOT hard-delete via KernelHandle::cron_cancel"
+    );
+    assert!(
+        result.content.contains("disabled") || result.content.contains("paused"),
+        "user-facing message should say the schedule was paused/disabled, got: {}",
+        result.content
+    );
+}
+
+#[tokio::test]
+async fn test_schedule_resume_resumes_owned_job() {
+    let (kernel, calls) = CapturingKernel::new();
+    kernel.set_cron_list_response(vec![json!({"id": "sched-99"})]);
+    let kernel: Arc<dyn KernelHandle> = Arc::new(kernel);
+
+    let ctx = make_ctx(&kernel, None, Some("agent-1"));
+    let result = execute_tool_raw("sr1", "schedule_resume", &json!({"id": "sched-99"}), &ctx).await;
+
+    assert!(
+        !result.is_error,
+        "schedule_resume should succeed when caller owns the job: {}",
+        result.content
+    );
+    let set_enabled_calls = calls.cron_set_enabled.lock().unwrap();
+    assert_eq!(set_enabled_calls.len(), 1);
+    assert_eq!(set_enabled_calls[0], ("sched-99".to_string(), true));
 }
 
 #[tokio::test]
@@ -692,6 +809,10 @@ async fn test_schedule_delete_unowned_job_renders_as_not_found() {
     assert!(
         cancel_was_never_called(&calls),
         "schedule_delete must NOT reach the kernel when the caller doesn't own the job"
+    );
+    assert!(
+        calls.cron_set_enabled.lock().unwrap().is_empty(),
+        "schedule_delete must NOT toggle a job the caller doesn't own"
     );
 }
 

--- a/crates/librefang-types/src/tool_compat.rs
+++ b/crates/librefang-types/src/tool_compat.rs
@@ -77,6 +77,7 @@ pub fn is_known_librefang_tool(name: &str) -> bool {
             | "schedule_create"
             | "schedule_list"
             | "schedule_delete"
+            | "schedule_resume"
             | "image_analyze"
             | "location_get"
     )
@@ -204,6 +205,7 @@ mod tests {
             "schedule_create",
             "schedule_list",
             "schedule_delete",
+            "schedule_resume",
             "image_analyze",
             "location_get",
         ];

--- a/docs/src/app/agent/tools/page.mdx
+++ b/docs/src/app/agent/tools/page.mdx
@@ -155,18 +155,20 @@ Subprocesses inherit the agent's workspace as `cwd` by default, the agent's envi
 
 ## Runtime Scheduling
 
-Manifest `[[cron]]` entries are the static way to schedule turns. These tools let an agent **dynamically** create / list / cancel scheduled work from the loop itself.
+Manifest `[[cron]]` entries are the static way to schedule turns. These tools let an agent **dynamically** create / list / pause / resume scheduled work from the loop itself.
 
 | Tool | Purpose |
 |---|---|
 | `schedule_create(when, prompt, channel?)` | Schedule a single future turn at a one-shot timestamp. |
 | `schedule_list()` | List the agent's scheduled turns. |
-| `schedule_delete(schedule_id)` | Cancel a scheduled turn. |
+| `schedule_delete(schedule_id)` | Pause (disable) a scheduled turn — its config is preserved, not deleted. |
+| `schedule_resume(schedule_id)` | Resume a paused scheduled turn. |
 | `cron_create(expression, prompt, channel?)` | Schedule a recurring turn (5-field cron). |
 | `cron_list()` | List the agent's runtime-created cron jobs. |
-| `cron_cancel(cron_id)` | Cancel a runtime cron job. |
+| `cron_cancel(cron_id)` | Pause (disable) a runtime cron job — its config is preserved, not deleted. |
+| `cron_enable(cron_id)` | Re-enable a paused runtime cron job. |
 
-Runtime jobs created with these tools are persisted in the same store as manifest crons — they survive daemon restarts. Their `cron_id` / `schedule_id` is opaque; round-trip through `cron_list()` to discover it.
+Agents cannot hard-delete a scheduled job: `schedule_delete` / `cron_cancel` only pause it, so a misbehaving or over-eager agent can never silently lose a configured schedule. Permanent deletion is a human-only operation via the dashboard (#6159). Runtime jobs created with these tools are persisted in the same store as manifest crons — they survive daemon restarts. Their `cron_id` / `schedule_id` is opaque; round-trip through `cron_list()` to discover it.
 
 ---
 

--- a/docs/src/app/agent/tools/page.mdx
+++ b/docs/src/app/agent/tools/page.mdx
@@ -168,7 +168,10 @@ Manifest `[[cron]]` entries are the static way to schedule turns. These tools le
 | `cron_cancel(cron_id)` | Pause (disable) a runtime cron job — its config is preserved, not deleted. |
 | `cron_enable(cron_id)` | Re-enable a paused runtime cron job. |
 
-Agents cannot hard-delete a scheduled job: `schedule_delete` / `cron_cancel` only pause it, so a misbehaving or over-eager agent can never silently lose a configured schedule. Permanent deletion is a human-only operation via the dashboard (#6159). Runtime jobs created with these tools are persisted in the same store as manifest crons — they survive daemon restarts. Their `cron_id` / `schedule_id` is opaque; round-trip through `cron_list()` to discover it.
+Agents cannot hard-delete a scheduled job: `schedule_delete` / `cron_cancel` only pause it, so a misbehaving or over-eager agent can never silently lose a configured schedule.
+Permanent deletion is a human-only operation via the dashboard (#6159).
+Runtime jobs created with these tools are persisted in the same store as manifest crons — they survive daemon restarts.
+Their `cron_id` / `schedule_id` is opaque; round-trip through `cron_list()` to discover it.
 
 ---
 

--- a/docs/src/app/architecture/page.mdx
+++ b/docs/src/app/architecture/page.mdx
@@ -830,7 +830,7 @@ All skills pass through a security pipeline before activation:
 | **Process Management (5)** | process_start, process_poll, process_write, process_kill, process_list |
 | **Media & AI (6)** | image_analyze, media_describe, media_transcribe, image_generate, text_to_speech, speech_to_text |
 | **Hands Control (4)** | hand_list, hand_activate, hand_status, hand_deactivate |
-| **Scheduling & Comms (7)** | cron_create, cron_list, cron_cancel, channel_send, schedule_create, schedule_list, schedule_delete |
+| **Scheduling & Comms (9)** | cron_create, cron_list, cron_cancel, cron_enable, channel_send, schedule_create, schedule_list, schedule_delete, schedule_resume |
 | **A2A & Canvas (3)** | a2a_discover, a2a_send, canvas_present |
 
 ### Ecosystem Bridges

--- a/docs/src/app/zh/agent/tools/page.mdx
+++ b/docs/src/app/zh/agent/tools/page.mdx
@@ -155,18 +155,20 @@ Agent 打开的页面绑在该 agent 的 tab 池里(默认 4)。池满时 `brows
 
 ## 运行时调度
 
-manifest `[[cron]]` 是静态的安排方式。这些工具让 agent **从循环里动态**创建/列出/取消调度。
+manifest `[[cron]]` 是静态的安排方式。这些工具让 agent **从循环里动态**创建/列出/暂停/恢复调度。
 
 | 工具 | 用途 |
 |---|---|
 | `schedule_create(when, prompt, channel?)` | 在某未来时间戳调度一次性轮次。 |
 | `schedule_list()` | 列出 agent 已调度的轮次。 |
-| `schedule_delete(schedule_id)` | 取消已调度的轮次。 |
+| `schedule_delete(schedule_id)` | 暂停（禁用）已调度的轮次 —— 保留配置而非删除。 |
+| `schedule_resume(schedule_id)` | 恢复被暂停的已调度轮次。 |
 | `cron_create(expression, prompt, channel?)` | 5 字段 cron 调度循环轮次。 |
 | `cron_list()` | 列出 agent 运行时创建的 cron 任务。 |
-| `cron_cancel(cron_id)` | 取消运行时 cron 任务。 |
+| `cron_cancel(cron_id)` | 暂停（禁用）运行时 cron 任务 —— 保留配置而非删除。 |
+| `cron_enable(cron_id)` | 重新启用被暂停的运行时 cron 任务。 |
 
-这些工具创建的运行时任务和 manifest cron 共用持久化存储 —— 跨 daemon 重启依然存在。`cron_id` / `schedule_id` 是不透明的;通过 `cron_list()` 往返获取。
+agent 不能硬删除已调度的任务:`schedule_delete` / `cron_cancel` 只会暂停它,因此即使是行为异常或过于激进的 agent 也无法静默丢失一个已配置好的调度。永久删除是仅限人类的操作,通过 dashboard 完成(#6159)。这些工具创建的运行时任务和 manifest cron 共用持久化存储 —— 跨 daemon 重启依然存在。`cron_id` / `schedule_id` 是不透明的;通过 `cron_list()` 往返获取。
 
 ---
 

--- a/docs/src/app/zh/agent/tools/page.mdx
+++ b/docs/src/app/zh/agent/tools/page.mdx
@@ -168,7 +168,10 @@ manifest `[[cron]]` 是静态的安排方式。这些工具让 agent **从循环
 | `cron_cancel(cron_id)` | 暂停（禁用）运行时 cron 任务 —— 保留配置而非删除。 |
 | `cron_enable(cron_id)` | 重新启用被暂停的运行时 cron 任务。 |
 
-agent 不能硬删除已调度的任务:`schedule_delete` / `cron_cancel` 只会暂停它,因此即使是行为异常或过于激进的 agent 也无法静默丢失一个已配置好的调度。永久删除是仅限人类的操作,通过 dashboard 完成(#6159)。这些工具创建的运行时任务和 manifest cron 共用持久化存储 —— 跨 daemon 重启依然存在。`cron_id` / `schedule_id` 是不透明的;通过 `cron_list()` 往返获取。
+agent 不能硬删除已调度的任务:`schedule_delete` / `cron_cancel` 只会暂停它,因此即使是行为异常或过于激进的 agent 也无法静默丢失一个已配置好的调度。
+永久删除是仅限人类的操作,通过 dashboard 完成(#6159)。
+这些工具创建的运行时任务和 manifest cron 共用持久化存储 —— 跨 daemon 重启依然存在。
+`cron_id` / `schedule_id` 是不透明的;通过 `cron_list()` 往返获取。
 
 ---
 

--- a/docs/src/app/zh/architecture/page.mdx
+++ b/docs/src/app/zh/architecture/page.mdx
@@ -830,7 +830,7 @@ Wire 协议认证在握手双方使用 `hmac_sign(secret, nonce + node_id)`。No
 | **进程管理 (5)** | process_start、process_poll、process_write、process_kill、process_list |
 | **媒体与 AI (6)** | image_analyze、media_describe、media_transcribe、image_generate、text_to_speech、speech_to_text |
 | **Hands 控制 (4)** | hand_list、hand_activate、hand_status、hand_deactivate |
-| **调度与通信 (7)** | cron_create、cron_list、cron_cancel、channel_send、schedule_create、schedule_list、schedule_delete |
+| **调度与通信 (9)** | cron_create、cron_list、cron_cancel、cron_enable、channel_send、schedule_create、schedule_list、schedule_delete、schedule_resume |
 | **A2A 与 Canvas (3)** | a2a_discover、a2a_send、canvas_present |
 
 ### 生态桥接


### PR DESCRIPTION
## Design decision

The agent (bot) must not be able to silently throw away a configured scheduled job.
Before this change, the agent-facing cron tools `cron_cancel` and `schedule_delete` both called `KernelHandle::cron_cancel`, which hard-deletes the job from the scheduler and discards its schedule / action / delivery configuration.
A bot that "cancelled" a job left the operator with no record of what was set up and no way to recover it.

I repointed the two destructive tools to **pause (disable)** the job instead of deleting it, and added matching **resume (enable)** tools so the pause is reversible from the agent loop.
I chose to repoint rather than rename the existing tools: the names `cron_cancel` / `schedule_delete` are already in agent allow-lists, the `tool_compat` native-tool whitelist, the subagent deny-list, and persisted manifests, so renaming would be a wide backward-incompatible churn for no behavioural gain.
The tool descriptions now state honestly that they pause (not delete) and that permanent deletion is a human-only dashboard operation.

Hard deletion stays human-only: the dashboard `DELETE /api/cron/jobs/{id}` route is unchanged.
The agent has no tool that reaches `KernelHandle::cron_cancel` anymore.

## What changed

New kernel-handle capability:

- `crates/librefang-kernel-handle/src/cron_control.rs` — added `CronControl::cron_set_enabled(job_id, enabled)` (default impl returns `Unavailable`, matching the other methods).
- `crates/librefang-kernel/src/kernel/handles/cron_control.rs` — implemented it against the existing `CronScheduler::set_enabled` (which clears error counters and recomputes `next_run` on re-enable) followed by `persist()`, mirroring the HTTP `toggle_cron_job` route's persist-after-toggle (#3515).

Agent tools repointed and added:

- `crates/librefang-runtime/src/tool_runner/cron.rs` — `tool_cron_cancel` now calls `cron_set_enabled(false)`; added `tool_cron_enable` (calls `cron_set_enabled(true)`).
  The shared `require_owned_job_id` helper keeps the existing per-agent ownership guard for both.
- `crates/librefang-runtime/src/tool_runner/schedule.rs` — `tool_schedule_delete` now calls `cron_set_enabled(false)`; added `tool_schedule_resume`.
  Shared `require_owned_schedule_id` helper preserves the ownership guard (#3576 second slice) for both.
- `crates/librefang-runtime/src/tool_runner/dispatch.rs` — routed `cron_enable` and `schedule_resume`.
- `crates/librefang-runtime/src/tool_runner/mod.rs` — imports for the new tool fns.
- `crates/librefang-runtime/src/tool_runner/definitions.rs` — added `cron_enable` / `schedule_resume` `ToolDefinition`s; rewrote the `cron_cancel` / `schedule_delete` descriptions to say "Pause (disable) … config preserved … only a human can hard-delete via the dashboard".
  Definitions are appended in source order, so deterministic prompt ordering (#3298) is unaffected.

Supporting surfaces:

- `crates/librefang-runtime/src/tool_policy.rs` — `cron_enable` / `schedule_resume` added to `SUBAGENT_DENY_ALWAYS` (consistent with the existing scheduling tools being top-level-only).
- `crates/librefang-types/src/tool_compat.rs` — `schedule_resume` added to the native-tool whitelist (the `schedule_*` family is listed there; the low-level `cron_*` family is not, so `cron_enable` is not added — matching `cron_cancel`).
- `docs/src/app/agent/tools/page.mdx`, `docs/src/app/zh/agent/tools/page.mdx`, `docs/src/app/architecture/page.mdx`, `docs/src/app/zh/architecture/page.mdx` — documented the pause/resume semantics and updated the tool tables/counts.

## Verification

Run in the repo's sanctioned Docker dev image (`Dockerfile.rust-dev`) with a per-worktree target volume, per CLAUDE.md "Verifying without a native toolchain".

- `cargo fmt --all` — clean (no diff beyond the intended change).
- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-kernel-handle -p librefang-types -p librefang-runtime --all-targets -- -D warnings` — clean.
- `cargo clippy -p librefang-kernel --all-targets -- -D warnings` — clean.

Tests (all green):

- `cargo test -p librefang-runtime --test tool_runner_forwarding_task_cron` — 18 tests, including new behaviour tests:
  - `test_cron_cancel_disables_and_does_not_hard_delete` — asserts the tool calls `cron_set_enabled(job, false)` and **never** reaches `KernelHandle::cron_cancel`; user message says "paused/disabled".
  - `test_schedule_delete_disables_and_does_not_hard_delete` — same for the natural-language tool.
  - `test_cron_enable_resumes_owned_job` / `test_schedule_resume_resumes_owned_job` — assert `cron_set_enabled(job, true)`.
  - `test_cron_enable_unowned_job_renders_as_not_found` — ownership guard on the new enable tool.
  - Updated unowned-job tests now also assert `cron_set_enabled` is never called for an unowned job.
- `cargo test -p librefang-runtime --lib -- tool_runner::cron::tests tool_runner::schedule::tests tool_policy::tests filter_tools_by_depth tool_runner::tests::workspace` — 57 tests (new `cron_enable_*` / `schedule_resume_without_kernel_*` unit tests; `test_builtin_tool_definitions` updated for the two new tools).
- `cargo test -p librefang-kernel-handle --test defaults_returns` — 7 tests (new `cron_set_enabled` default-Unavailable assertion in `test_cron_defaults_return_errors`).
- `cargo test -p librefang-types --lib tool_compat` — 3 tests (whitelist update covered).
- `cargo test -p librefang-kernel --lib cron::` — 79 tests; `cron::tests::test_set_enabled` already proves the scheduler keeps the job (config preserved) after disable and resets on re-enable.

The Docker image runs Linux only; this change is platform-independent (no OS-specific paths), so the Linux run is sufficient.

## Maintainer notes — delete-vs-disable design choice

I repointed `cron_cancel` / `schedule_delete` to disable rather than renaming them, to avoid a backward-incompatible churn across agent allow-lists, `tool_compat`, the subagent deny-list, and persisted manifests.
The trade-off is that the tool *names* still read "cancel" / "delete" while the behaviour is "pause"; I made the tool descriptions explicit about this and added the resume counterparts, so the LLM-visible contract is honest.
If you would prefer fully renamed tools (e.g. `cron_pause` / `cron_resume`) with deprecation aliases instead, I can follow up — but that touches a wider surface than this issue's scope, so I kept it to the behavioural fix.

Closes #6159
