### PR TITLE
ci: raise Windows test-lane timeout to 90min for vendored OpenSSL cold build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -879,15 +879,16 @@ jobs:
   # minutes cost 2× Linux). The per-shard budget is still tight, though: a cold
   # cache (any Cargo.lock change busts `test-windows-${hashFiles(Cargo.lock)}`)
   # pays a ~22min full compile on top of ~22min of test execution per shard, so
-  # a warm run lands at ~45min and a cold one overran the old 45min cap. Match
-  # macOS at 60min — the headroom absorbs a cold compile without inflating the
-  # green-run cost (the job ends when nextest finishes, not at the ceiling).
+  # a warm run lands at ~45min and a cold one overran the old 45min cap.
+  # #6163 then added a Windows-only vendored OpenSSL build (compiled from source, to link webauthn-rs), which made the cold compile heavier still: the first cold run after it saw a shard pass its tests but get cancelled at the 60min ceiling during the cache-save post-step.
+  # Windows therefore gets 90min, decoupled from macOS, which keeps 60min on its lighter system-OpenSSL build.
+  # The ceiling never inflates a green run — the job ends when nextest and the cache save finish, not at the cap, so a warm shard still lands in ~15min.
   test-windows:
     name: Test / Windows (shard ${{ matrix.shard }}/2)
     needs: changes
     if: (github.event_name == 'push' || github.event_name == 'merge_group') && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true')
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,7 +175,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "929b5531f933164784179610dc6d44c9e4fe5e28",
         "is_verified": false,
-        "line_number": 2285
+        "line_number": 2290
       }
     ],
     "articles/hello-librefang.md": [
@@ -4292,5 +4292,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T14:53:56Z"
+  "generated_at": "2026-06-17T16:33:31Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -890,6 +890,11 @@ In-crate only; no cross-crate error-shape changes.
   `openssl-src` shells out to whichever `perl` is first on `PATH`; the `OPENSSL_SRC_PERL` env var (its documented override, ahead of `PERL` and the bare `perl` fallback) now pins the job at the runner's Windows-native `C:/Strawberry/perl/bin/perl.exe`.
   The release Windows jobs are unaffected — their `cargo build` step runs under the default `pwsh`, where the system `PATH` resolves `perl` to Strawberry directly.
 
+- **ci: raise the Windows test-lane timeout to 90min so the heavier vendored-OpenSSL cold build fits** (#6161) (@houko).
+  Follow-up to #6171: with the Perl fix in place both Windows shards' tests passed, but the first cold run after #6163 had no warm cache, so the from-source OpenSSL build pushed one shard to the 60min ceiling — it passed its tests and was then cancelled mid cache-save, leaving `main` red on a non-test failure.
+  The vendored build recurs cold on every `Cargo.lock` change that busts the `test-windows` cache, so the ceiling is raised from 60min to 90min (macOS keeps 60min — its system-OpenSSL build is lighter).
+  The cap never inflates a green run: the job ends when nextest and the cache save finish, not at the ceiling, so a warm shard still lands in ~15min.
+
 - **channels: a conversation-ownership claim held by an agent that can no longer serve the channel is now taken over instead of silently dropping follow-ups** (#5323) (@houko).
   Follow-up to #6127: if agent A claimed a thread and A's `manifest.channels` allowlist was then narrowed to exclude that channel, the still-live claim suppressed every non-addressed follow-up (routed to an eligible agent B) until the TTL expired — a silent message drop.
   `conversation_ownership_allows` now checks the current holder's channel eligibility and, when the holder can no longer serve the channel, treats the dispatch as a takeover so the eligible candidate re-claims immediately.


### PR DESCRIPTION
## Context

Follow-up to #6171 (Perl fix) and #6163 (vendored OpenSSL on Windows).

After #6171 landed, I watched the `Test / Windows` lane on the resulting run ([27700302019](https://github.com/librefang/librefang/actions/runs/27700302019)). The Perl fix is confirmed working — **both shards' `Run tests` step passed**, so vendored `openssl-sys` builds and the sharded tests run green on Windows.

But the run was still red:

| shard | result | duration |
|-------|--------|----------|
| 1/2 | success | 53m12s |
| 2/2 | `Run tests` passed, then **cancelled** during `Post Run` cache-save | 1h0m07s |

Shard 2 hit the job's `timeout-minutes: 60` ceiling *after* its tests passed, while `Swatinem/rust-cache` was saving the cache.

## Why it timed out

This was the first cold run after #6163: the prior run failed at the OpenSSL build and never saved a `test-windows` cache, so both shards did a fully cold compile. #6163's vendored OpenSSL is built from source on Windows (to link `webauthn-rs`), which makes that cold compile heavier than the ~45min the 60min ceiling was sized for. Shard 1 squeaked in at 53m; shard 2 tipped past 60m during cache upload.

The `test-windows` cache key is busted by every `Cargo.lock` change (`hashFiles(Cargo.lock)`), so a cold Windows build recurs regularly (dependency bumps, dependabot, the auto-update cron) — this is a durable hazard, not a one-off.

## Change

Raise the Windows job ceiling `60 → 90` minutes and update the explanatory comment. macOS keeps 60min (its system-OpenSSL build is lighter and unaffected).

The ceiling never inflates a green run — the job ends when nextest and the cache save finish, not at the cap — so warm shards still land in ~15min; only a cold build uses the extra headroom.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML.
- Independent of this PR, I re-ran the cancelled shard 2 of run 27700302019: with shard 1's warm cache it restores the compiled OpenSSL + deps and finishes well under the ceiling.
- This PR's own `Test / Windows` lane (push/merge_group only) will run with that warm cache and pass comfortably.

Refs #6161.
