### PR TITLE
release: v2026.6.17-beta.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to LibreFang will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
+## [2026.6.17] - 2026-06-17
+
+_22 PRs from 3 contributors since v2026.6.16-beta.19._
+
+### Added
+
+- Per-conversation agent routing for multi-agent groups (#5323) (#6127) (@houko)
+- Passkey (WebAuthn/FIDO2) dashboard login (#5981) (#6129) (@houko)
+- Deterministic inbound dispatch — channel-instance binding lookup (#5671 Model A) (#6131) (@houko)
+- GitHub/Codeberg registry source selector (#6142) (@houko)
+- Gate auto-routing on AutoRouteStrategy, not the "assistant" name (#6139) (#6148) (@houko)
+- Propagate W3C traceparent on outbound MCP tool calls (#6128) (#6153) (@houko)
+- Report the model codex actually used (#6134) (#6157) (@houko)
+- Dock the agent panel as a resizable sidebar with a larger prompt editor (#6154 #6155) (#6164) (@houko)
+- The cron-management tool disables jobs instead of deleting them (#6159) (#6165) (@houko)
+- Enlarge TOML view, edit agent system prompt and tools with reset-to-default (#6150 #6151 #6152) (#6166) (@houko)
+- Central prompt repository page with versions and agent binding (#6160) (#6167) (@houko)
+
+### Fixed
+
+- Enforce cross-chat dispatch guard through the /mcp bridge (#6117) (#6125) (@houko)
+- Take over a stale conversation-ownership claim from a channel-ineligible holder (#5323) (#6132) (@houko)
+- Respect `LIBREFANG_HOME` when resolving plugin directory (#6136) (@HuaGu-Dragon)
+- Close channel media RBAC bypass and audit findings (#6141) (@houko)
+- Keep Save actionable after a passing Test (#6144) (#6146) (@houko)
+- Refetch hand settings after save so inputs persist (#6145) (#6147) (@houko)
+- Show the correct Hand agent name in the sessions view (#6156) (#6162) (@houko)
+- Build vendored OpenSSL on Windows so webauthn-rs links (#6161) (#6163) (@houko)
+- Pin vendored OpenSSL to Strawberry Perl on the Windows test lane (#6171) (@houko)
+
+### Changed
+
+- Lift tool dispatch table to typed ToolError (#3576 slice 5) (#6124) (@houko)
+
+<details>
+<summary>Documentation, maintenance, and other internal changes</summary>
+
+### Maintenance
+
+- Bump the actions-minor-patch group with 2 updates (#6140) (@app/dependabot)
+
+</details>
+
+
 ## [2026.6.16] - 2026-06-16
 
 _18 PRs from 3 contributors since v2026.6.11-beta.18._

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-acp"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-tokio",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "async-trait",
  "axum",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "axum",
  "clap",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "librefang-types",
  "reqwest",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-import"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "librefang-llm-driver",
  "librefang-memory",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4947,7 +4947,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory-wiki"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "chrono",
  "librefang-kernel-handle",
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-rl-export"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5072,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-audit"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "chrono",
  "hex",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-media"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-sandbox-docker"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-subprocess"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "metrics",
  "serde_json",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5219,7 +5219,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -12803,7 +12803,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.6.32179",
+  "version": "26.6.32190",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
     },
-    "version": "2026.6.16-beta.19"
+    "version": "2026.6.17-beta.20"
   },
   "paths": {
     "/.well-known/agent.json": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.6.16-beta.19",
+  "version": "2026.6.17-beta.20",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.6.16-beta.19",
+  "version": "2026.6.17-beta.20",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.6.16b19",
+    version="2026.6.17b20",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.6.16-beta.19"
+version = "2026.6.17-beta.20"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-08aa65f521766eb06f979d7eafe95d37ba2fa314e0ac885d2d5bc5bdd47ffd2b  openapi.json
+35a591ded3b5614f561bd862828ab7c05df40ce06c9d4b54afb4a2e3fa7d8e4a  openapi.json


### PR DESCRIPTION
<!-- release-tag:v2026.6.17-beta.20 -->
## Release v2026.6.17-beta.20

_22 PRs from 3 contributors since v2026.6.16-beta.19._

### Added

- Per-conversation agent routing for multi-agent groups (#5323) (#6127) (@houko)
- Passkey (WebAuthn/FIDO2) dashboard login (#5981) (#6129) (@houko)
- Deterministic inbound dispatch — channel-instance binding lookup (#5671 Model A) (#6131) (@houko)
- GitHub/Codeberg registry source selector (#6142) (@houko)
- Gate auto-routing on AutoRouteStrategy, not the "assistant" name (#6139) (#6148) (@houko)
- Propagate W3C traceparent on outbound MCP tool calls (#6128) (#6153) (@houko)
- Report the model codex actually used (#6134) (#6157) (@houko)
- Dock the agent panel as a resizable sidebar with a larger prompt editor (#6154 #6155) (#6164) (@houko)
- The cron-management tool disables jobs instead of deleting them (#6159) (#6165) (@houko)
- Enlarge TOML view, edit agent system prompt and tools with reset-to-default (#6150 #6151 #6152) (#6166) (@houko)
- Central prompt repository page with versions and agent binding (#6160) (#6167) (@houko)

### Fixed

- Enforce cross-chat dispatch guard through the /mcp bridge (#6117) (#6125) (@houko)
- Take over a stale conversation-ownership claim from a channel-ineligible holder (#5323) (#6132) (@houko)
- Respect `LIBREFANG_HOME` when resolving plugin directory (#6136) (@HuaGu-Dragon)
- Close channel media RBAC bypass and audit findings (#6141) (@houko)
- Keep Save actionable after a passing Test (#6144) (#6146) (@houko)
- Refetch hand settings after save so inputs persist (#6145) (#6147) (@houko)
- Show the correct Hand agent name in the sessions view (#6156) (#6162) (@houko)
- Build vendored OpenSSL on Windows so webauthn-rs links (#6161) (#6163) (@houko)
- Pin vendored OpenSSL to Strawberry Perl on the Windows test lane (#6171) (@houko)

### Changed

- Lift tool dispatch table to typed ToolError (#3576 slice 5) (#6124) (@houko)

<details>
<summary>Documentation, maintenance, and other internal changes</summary>

### Maintenance

- Bump the actions-minor-patch group with 2 updates (#6140) (@app/dependabot)

</details>

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.6.16-beta.19...v2026.6.17-beta.20