### PR TITLE
chore(deps): drop five orphaned email workspace dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -847,7 +847,8 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 - **chore(deps): drop five orphaned email `[workspace.dependencies]` left after the channel sidecar migration** (#6176) (@houko).
   `lettre` / `imap` / `rustls-connector` / `mailparse` / `rustls-pemfile` were declared in the root `Cargo.toml` but had no member consumer (no `.workspace = true`, no `use`) and were already absent from `Cargo.lock`, so they were never compiled or audited — the issue's "adds compile time / binary size / supply-chain surface" framing was inaccurate; the real defect was dead declaration cruft.
   The now-unmatchable `deny.toml` ignore for `RUSTSEC-2025-0134` (`rustls-pemfile`) is dropped in the same change, since that crate no longer appears in the resolved graph.
-  Declaration-only removal; `Cargo.lock` is unchanged. Closes #6176.
+  Declaration-only removal; `Cargo.lock` is unchanged.
+  Closes #6176.
 
 - **refactor(error-contracts): migrate `web_search.rs` tool functions from `Result<String, String>` to `Result<String, ToolError>`** (#3576) (@houko) — one slice of the ongoing structured-error-contracts migration.
 The multi-provider search engine (`WebSearchEngine::search` and its `search_brave` / `search_tavily` / `search_perplexity` / `search_jina` / `search_duckduckgo` / `search_searxng` / `search_auto` / `list_searxng_categories` helpers) now returns the typed `ToolError` instead of an opaque `String`: missing API keys and unconfigured SearXNG URLs map to `Unavailable`, invalid `pageno` / `category` to `InvalidParameter`, `reqwest` send/JSON failures to `Upstream` via `ToolError::upstream` (preserving the `reqwest::Error` source chain per #3745), and "no results" / "all providers failed" to `Upstream` via `upstream_msg`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -844,6 +844,11 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ### Changed
 
+- **chore(deps): drop five orphaned email `[workspace.dependencies]` left after the channel sidecar migration** (#6176) (@houko).
+  `lettre` / `imap` / `rustls-connector` / `mailparse` / `rustls-pemfile` were declared in the root `Cargo.toml` but had no member consumer (no `.workspace = true`, no `use`) and were already absent from `Cargo.lock`, so they were never compiled or audited — the issue's "adds compile time / binary size / supply-chain surface" framing was inaccurate; the real defect was dead declaration cruft.
+  The now-unmatchable `deny.toml` ignore for `RUSTSEC-2025-0134` (`rustls-pemfile`) is dropped in the same change, since that crate no longer appears in the resolved graph.
+  Declaration-only removal; `Cargo.lock` is unchanged. Closes #6176.
+
 - **refactor(error-contracts): migrate `web_search.rs` tool functions from `Result<String, String>` to `Result<String, ToolError>`** (#3576) (@houko) — one slice of the ongoing structured-error-contracts migration.
 The multi-provider search engine (`WebSearchEngine::search` and its `search_brave` / `search_tavily` / `search_perplexity` / `search_jina` / `search_duckduckgo` / `search_searxng` / `search_auto` / `list_searxng_categories` helpers) now returns the typed `ToolError` instead of an opaque `String`: missing API keys and unconfigured SearXNG URLs map to `Unavailable`, invalid `pageno` / `category` to `InvalidParameter`, `reqwest` send/JSON failures to `Upstream` via `ToolError::upstream` (preserving the `reqwest::Error` source chain per #3745), and "no results" / "all providers failed" to `Upstream` via `upstream_msg`.
 The dispatch boundary still narrows to a `String` via `Display`, so the LLM-visible error text now reflects the structured variant form (e.g. `"SearXNG URL unavailable"`, `"Invalid parameter 'pageno': must be >= 1 (pages are 1-indexed)"`) — the intended outcome of the migration.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,8 +123,6 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "str
 rustls = "0.23"
 webpki-roots = "1"
 rustls-native-certs = "0.8"
-# PEM parsing for user-supplied IMAP root CA certs (#4877). Tiny dep, no I/O.
-rustls-pemfile = "2"
 
 # Async trait
 async-trait = "0.1"
@@ -259,14 +257,6 @@ socket2 = "0.6.4"
 
 # Zip archive extraction
 zip = { version = "8", default-features = false, features = ["deflate"] }
-
-# Email (SMTP + IMAP)
-lettre = { version = "0.11", default-features = false, features = ["builder", "hostname", "smtp-transport", "tokio1", "tokio1-rustls-tls"] }
-imap = { version = "2", default-features = false }
-# `native-certs` is no longer a default feature in 0.23, but the
-# channels crate relies on the system trust store for IMAP/SMTP.
-rustls-connector = { version = "0.23", features = ["native-certs"] }
-mailparse = "0.16"
 
 # Internationalization (i18n)
 fluent = "0.17"

--- a/deny.toml
+++ b/deny.toml
@@ -61,7 +61,6 @@ ignore = [
     { id = "RUSTSEC-2025-0081", reason = "unic-* unmaintained (kuchikiki/selectors chain). https://rustsec.org/advisories/RUSTSEC-2025-0081" },
     { id = "RUSTSEC-2025-0098", reason = "unic-* unmaintained (kuchikiki/selectors chain). https://rustsec.org/advisories/RUSTSEC-2025-0098" },
     { id = "RUSTSEC-2025-0100", reason = "unic-* unmaintained (kuchikiki/selectors chain). https://rustsec.org/advisories/RUSTSEC-2025-0100" },
-    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained; transitive. https://rustsec.org/advisories/RUSTSEC-2025-0134" },
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #6176. Five email dependencies left over from the channel sidecar migration are declared in the root `Cargo.toml` `[workspace.dependencies]` but have **no member consumer** and are **already absent from `Cargo.lock`**.

A correction to the issue's framing: an unused `[workspace.dependencies]` entry is never pulled into the build graph by Cargo, so these were **not** compiled, audited, or adding to binary size. The real defect is dead declaration cruft, which is still worth removing.

## Verification of orphan status

```
$ for c in lettre imap rustls-connector mailparse rustls-pemfile; do
    echo "$c lock-count=$(grep -c "^name = \"$c\"" Cargo.lock)"; done
lettre lock-count=0
imap lock-count=0
rustls-connector lock-count=0
mailparse lock-count=0
rustls-pemfile lock-count=0
```

No member declares any via `.workspace = true`; no `.rs` file imports them. The documenting comments in `crates/librefang-channels/Cargo.toml` and `crates/librefang-cli/Cargo.toml` already note these were dropped alongside their adapters (the sidecars use Python stdlib).

## Changes

- `Cargo.toml` — remove the 5 orphaned `[workspace.dependencies]` (`lettre`, `imap`, `rustls-connector`, `mailparse`, `rustls-pemfile`) and their section comments.
- `deny.toml` — remove the now-unmatchable `RUSTSEC-2025-0134` (`rustls-pemfile`) advisory ignore, since that crate no longer appears in the resolved graph.
- `CHANGELOG.md` — entry under `[Unreleased] → Changed`.

`Cargo.lock` is unchanged (the crates were never in it).

## Verification

```
$ cargo check --workspace --lib
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 10s
```

Passes — no member opted in, so removing the declarations cannot change the compiled output.
