### PR TITLE
chore(deps): remove 5 orphaned email dependencies after sidecar migra…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -800,6 +800,8 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ### Changed
 
+- **chore(deps): remove 5 orphaned email dependencies (lettre, imap, rustls-connector, mailparse, rustls-pemfile)** (@mrchn)
+
 - **refactor(error-contracts): migrate `web_search.rs` tool functions from `Result<String, String>` to `Result<String, ToolError>`** (#3576) (@houko) — one slice of the ongoing structured-error-contracts migration.
 The multi-provider search engine (`WebSearchEngine::search` and its `search_brave` / `search_tavily` / `search_perplexity` / `search_jina` / `search_duckduckgo` / `search_searxng` / `search_auto` / `list_searxng_categories` helpers) now returns the typed `ToolError` instead of an opaque `String`: missing API keys and unconfigured SearXNG URLs map to `Unavailable`, invalid `pageno` / `category` to `InvalidParameter`, `reqwest` send/JSON failures to `Upstream` via `ToolError::upstream` (preserving the `reqwest::Error` source chain per #3745), and "no results" / "all providers failed" to `Upstream` via `upstream_msg`.
 The dispatch boundary still narrows to a `String` via `Display`, so the LLM-visible error text now reflects the structured variant form (e.g. `"SearXNG URL unavailable"`, `"Invalid parameter 'pageno': must be >= 1 (pages are 1-indexed)"`) — the intended outcome of the migration.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,8 +123,6 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "str
 rustls = "0.23"
 webpki-roots = "1"
 rustls-native-certs = "0.8"
-# PEM parsing for user-supplied IMAP root CA certs (#4877). Tiny dep, no I/O.
-rustls-pemfile = "2"
 
 # Async trait
 async-trait = "0.1"
@@ -259,14 +257,6 @@ socket2 = "0.6.4"
 
 # Zip archive extraction
 zip = { version = "8", default-features = false, features = ["deflate"] }
-
-# Email (SMTP + IMAP)
-lettre = { version = "0.11", default-features = false, features = ["builder", "hostname", "smtp-transport", "tokio1", "tokio1-rustls-tls"] }
-imap = { version = "2", default-features = false }
-# `native-certs` is no longer a default feature in 0.23, but the
-# channels crate relies on the system trust store for IMAP/SMTP.
-rustls-connector = { version = "0.23", features = ["native-certs"] }
-mailparse = "0.16"
 
 # Internationalization (i18n)
 fluent = "0.17"


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

Removes lettre, imap, rustls-connector, mailparse, and rustls-pemfile from the 
root Cargo.toml. These were left over from a pre-sidecar email implementation. 
Verified zero consumers across all crates/ with source search before removal.

Fixes #5 (ponytail audit finding)

## Changes

- Removed 5 orphaned workspace dependencies from root Cargo.toml
- Cleaned up resulting blank lines
- Updated CHANGELOG.md under [Unreleased]

## Notes

cargo test --workspace and cargo clippy --workspace fail on the current codebase 
due to a pre-existing MSRV mismatch (sysinfo@0.39.3 requires rustc 1.95, toolchain 
is 1.94.1). This failure exists on unmodified main and is unrelated to this change.