### PR TITLE
feat(providers): classify developer-agent vs general providers (#6216)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,7 +175,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "929b5531f933164784179610dc6d44c9e4fe5e28",
         "is_verified": false,
-        "line_number": 2340
+        "line_number": 2345
       }
     ],
     "articles/hello-librefang.md": [
@@ -245,147 +245,147 @@
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "0915086640bac79c6ebbff6b038a8f7fdcc45f70",
         "is_verified": false,
-        "line_number": 400
+        "line_number": 402
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "8b97602841813628f4a7a9e4712e3635ba641232",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 403
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 489
+        "line_number": 491
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
         "is_verified": false,
-        "line_number": 840
+        "line_number": 842
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 859
+        "line_number": 861
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "26eeb2a3d2d3a26656573aba8ae238ded867bfb7",
         "is_verified": false,
-        "line_number": 1207
+        "line_number": 1225
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "cddea5c4539c2dcb2fac754166dc8c141296ead8",
         "is_verified": false,
-        "line_number": 1260
+        "line_number": 1278
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "6be0b909d7953656db4534a48ac26329b6b7ad05",
         "is_verified": false,
-        "line_number": 1868
+        "line_number": 1886
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "9beb25270febae84a22c023eb079f03f984c4ee4",
         "is_verified": false,
-        "line_number": 2097
+        "line_number": 2115
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "7b9a759937d8742ff1612a01e4729b93eda5d09f",
         "is_verified": false,
-        "line_number": 2133
+        "line_number": 2151
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "7e48c7f2a53700d0656daf1d9b479f631d9f6ed1",
         "is_verified": false,
-        "line_number": 2247
+        "line_number": 2265
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "8a5b5fdc436269aacbce18e73038704ce027fa17",
         "is_verified": false,
-        "line_number": 2286
+        "line_number": 2304
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "fb53f36d497172bec62a5e18e57c014d9d209dde",
         "is_verified": false,
-        "line_number": 2287
+        "line_number": 2305
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "fa4b19ac75b57ea3d3555e5cc878e15ce9e633a1",
         "is_verified": false,
-        "line_number": 2305
+        "line_number": 2323
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "2276fa3db60dab489cdaf02229306a13af9e179b",
         "is_verified": false,
-        "line_number": 2331
+        "line_number": 2349
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "02e4465db9e24628b1a9a4783b1d22abe1568eb4",
         "is_verified": false,
-        "line_number": 2400
+        "line_number": 2418
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "14b4007ff8fadc0587f923aa38acc6a1b36670da",
         "is_verified": false,
-        "line_number": 2745
+        "line_number": 2763
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "4dad82da373f06d95847d61ba3c5a1cdb5a94fe0",
         "is_verified": false,
-        "line_number": 2962
+        "line_number": 2980
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "5aa7d1e863b4cbed54c71b8ba1a6f4388efcadd0",
         "is_verified": false,
-        "line_number": 2967
+        "line_number": 2985
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "f91eb2a7b1c4be9f65c70eaaf47449c5cb788888",
         "is_verified": false,
-        "line_number": 3277
+        "line_number": 3295
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "cf678cab87dc1f7d1b95b964f15375e088461679",
         "is_verified": false,
-        "line_number": 3380
+        "line_number": 3398
       }
     ],
     "crates/librefang-api/dashboard/src/locales/uk.json": [
@@ -394,119 +394,119 @@
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "a9a78bf4119377f490eaf84701a10501397b4a1f",
         "is_verified": false,
-        "line_number": 400
+        "line_number": 402
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d6530dba418cea85e01e88bc9f7da05b4e83959f",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 403
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 489
+        "line_number": 491
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "0956cb835344367878a6e19e69680d8b6878614e",
         "is_verified": false,
-        "line_number": 840
+        "line_number": 842
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 859
+        "line_number": 861
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "b1b8c51a3ed90a7c73962c976d36864d99ef62c0",
         "is_verified": false,
-        "line_number": 920
+        "line_number": 922
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "34123ae8e18c5f7e69a9f4e6a8beea05879f483e",
         "is_verified": false,
-        "line_number": 1207
+        "line_number": 1225
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d5f6b23160fffd39f4d0617ebec467ed0abddc13",
         "is_verified": false,
-        "line_number": 1208
+        "line_number": 1226
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "175d8973cfd0eafa0456d7b60ff24612dafea1b5",
         "is_verified": false,
-        "line_number": 1260
+        "line_number": 1278
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "3f92176f388ab292a54ddee6e71ce44c5278d943",
         "is_verified": false,
-        "line_number": 2133
+        "line_number": 2151
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "5f01ea1b5b938628292e9f13071a99b461fb0a89",
         "is_verified": false,
-        "line_number": 2286
+        "line_number": 2304
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "416352ae1ba52364a5510a9dc65e30d7f1addc6b",
         "is_verified": false,
-        "line_number": 2287
+        "line_number": 2305
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "503c9c19721513d7d6811c2ccf9549ed7a582167",
         "is_verified": false,
-        "line_number": 2305
+        "line_number": 2323
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "7d17fa6969539e972d57b93916f94612d6f269e6",
         "is_verified": false,
-        "line_number": 2331
+        "line_number": 2349
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "83d2e7404077eb9a94bee7f5a0725105bdc22c80",
         "is_verified": false,
-        "line_number": 2400
+        "line_number": 2418
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "2dbbfc5d67cc9823da0632a51012cba66187af5d",
         "is_verified": false,
-        "line_number": 2745
+        "line_number": 2763
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d0f693fffcebc4aa903d6ba4408e61b301102e60",
         "is_verified": false,
-        "line_number": 2967
+        "line_number": 2985
       }
     ],
     "crates/librefang-api/dashboard/src/locales/zh.json": [
@@ -515,140 +515,140 @@
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "f4bf274bff3f19d78b2079c775e9b77605a69442",
         "is_verified": false,
-        "line_number": 400
+        "line_number": 402
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "e2502fd4703f7b13b7c5896da60b0d644f4971e2",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 403
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 489
+        "line_number": 491
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
         "is_verified": false,
-        "line_number": 840
+        "line_number": 842
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 859
+        "line_number": 861
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "469b3f21e87f4b889a36f663597ebc2766e4caaa",
         "is_verified": false,
-        "line_number": 860
+        "line_number": 862
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "42ae7ec78f2e89ed905144e3e7ee986a8e43a386",
         "is_verified": false,
-        "line_number": 920
+        "line_number": 922
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "0769c2d835193ec570086a776ca2c81bbad7f891",
         "is_verified": false,
-        "line_number": 1207
+        "line_number": 1225
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "ab25a5ed30a7930eefda1b401a3551e92292ba06",
         "is_verified": false,
-        "line_number": 1208
+        "line_number": 1226
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "54f77569909cc9420836a7e4b00563de47b4a328",
         "is_verified": false,
-        "line_number": 1260
+        "line_number": 1278
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "5df1d83e18c6e5903e3f4805f0af1415fd050ef7",
         "is_verified": false,
-        "line_number": 2027
+        "line_number": 2045
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "94980a07a0b08fc6c65155a5af44dcc32652a8c0",
         "is_verified": false,
-        "line_number": 2090
+        "line_number": 2108
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "08037c102cca2aa1fae8ba0fcf9f1b3442da4dac",
         "is_verified": false,
-        "line_number": 2243
+        "line_number": 2261
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "d6c8bc0ecea0cd41397a0a5e7ff97339f0c0284e",
         "is_verified": false,
-        "line_number": 2244
+        "line_number": 2262
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "7376202136f8a7e68d3cd3772b4f92d08151508b",
         "is_verified": false,
-        "line_number": 2262
+        "line_number": 2280
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "a722b86877659d6a3499a56a9faefd0d85cc04e0",
         "is_verified": false,
-        "line_number": 2288
+        "line_number": 2306
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "2540a21b1adbcaece91bc51c2142997cc8d38975",
         "is_verified": false,
-        "line_number": 2357
+        "line_number": 2375
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "be0bbd80b4105d9030a3484201437d600f6fd1d0",
         "is_verified": false,
-        "line_number": 2702
+        "line_number": 2720
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "6e18c7516fd3fe2df687bc59ab10ffc5cee99a7b",
         "is_verified": false,
-        "line_number": 2924
+        "line_number": 2942
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "9d123ddd01a441bfe1d6c9f0bde50e2c7e6448fb",
         "is_verified": false,
-        "line_number": 3277
+        "line_number": 3295
       }
     ],
     "crates/librefang-api/dashboard/src/pages/Memory/index.test.tsx": [
@@ -1470,7 +1470,7 @@
         "filename": "crates/librefang-api/tests/providers_routes_test.rs",
         "hashed_secret": "17bb10d3f44323963c21bf3c97341ebb5accf05e",
         "is_verified": false,
-        "line_number": 833
+        "line_number": 850
       }
     ],
     "crates/librefang-api/tests/registry_content_path_test.rs": [
@@ -4292,5 +4292,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-18T02:08:15Z"
+  "generated_at": "2026-06-18T07:52:34Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -866,6 +866,11 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Added
 
+- **providers: classify agent-CLI providers vs general API providers** (#6216) (@houko).
+  `GET /api/providers` (and the snapshot + single-provider responses) now carry a `category` of `"developer_agent"` (agent-CLI subprocess drivers: claude-code / codex-cli / gemini-cli / qwen-code) or `"general"` (API model providers), derived from the existing `is_cli_provider` predicate — no model-catalog schema change, so no golden-fixture or OpenAPI drift.
+  The dashboard Providers page badges each provider by category (preferring the server value, falling back to the client CLI heuristic for older daemons), with i18n in en/zh/uk.
+  The "actual underlying model" half of the request was already shipped (#6134 / #6157): driver responses carry `actual_model` and the kernel records the real model in metering. Closes #6216.
+
 - **auth/dashboard: passkey (WebAuthn/FIDO2) login** (#5981) (@houko) — sign in to the dashboard with Touch ID, Face ID, Windows Hello, Android biometrics, or a roaming security key instead of typing a password.
   Opt-in per deployment via `passkey_enabled` + `passkey_rp_id` / `passkey_rp_origin` in `config.toml`; password login is untouched and remains the fallback.
   Adds the `webauthn_credentials` table (SQLite migration v44) storing the serialized `webauthn-rs` `Passkey` so the sign-count persists across assertions, a `PasskeyEngine` owning the two WebAuthn ceremonies with short-TTL in-memory challenge state, and six routes under `/api/auth/passkey/*` (registration-options/verify gated Owner-only, authentication-options/verify public and rate-limited, plus list/revoke).

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -70,6 +70,11 @@ export interface ProviderItem {
    *  Lets the dashboard distinguish "user-hidden" from "never configured"
    *  for the otherwise indistinguishable `auth_status: "missing"`. */
   suppressed?: boolean;
+  /** Server-assigned provider class, derived from the driver kind (#6216).
+   *  `"developer_agent"` = an agent-CLI subprocess driver (claude-code,
+   *  codex-cli, gemini-cli, qwen-code); `"general"` = a standard LLM API
+   *  provider. Optional for back-compat with daemons predating the field. */
+  category?: "developer_agent" | "general";
 }
 
 export interface MediaProvider {

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -95,6 +95,8 @@
     "online": "Online",
     "offline": "Offline",
     "setup": "Setup",
+    "category_developer_agent": "Agent CLI",
+    "category_general": "API",
     "ok": "OK",
     "config": "Config",
     "interact": "Interact",

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -95,6 +95,8 @@
     "online": "Онлайн",
     "offline": "Офлайн",
     "setup": "Налаштування",
+    "category_developer_agent": "Агент CLI",
+    "category_general": "API",
     "ok": "ОК",
     "config": "Конфігурація",
     "interact": "Взаємодія",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -95,6 +95,8 @@
     "online": "在线",
     "offline": "离线",
     "setup": "需配置",
+    "category_developer_agent": "智能体 CLI",
+    "category_general": "API",
     "ok": "正常",
     "config": "配置",
     "interact": "交互",

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.test.tsx
@@ -251,6 +251,46 @@ describe("ProvidersPage", () => {
     expect(screen.queryByText("Groq")).not.toBeInTheDocument();
   });
 
+  it("badges providers by category (#6216)", () => {
+    // Local fixture (not the shared PROVIDERS) so other tests' counts are
+    // unaffected. Both are configured so they render in the default view; the
+    // i18n mock echoes the key, so we assert on the key string.
+    useProvidersMock.mockReturnValue({
+      data: [
+        {
+          id: "claude-code",
+          display_name: "Claude Code",
+          auth_status: "configured_cli",
+          reachable: true,
+          model_count: 3,
+          key_required: false,
+          category: "developer_agent",
+        },
+        {
+          id: "openai",
+          display_name: "OpenAI",
+          auth_status: "validated_key",
+          reachable: true,
+          model_count: 12,
+          key_required: true,
+          category: "general",
+        },
+      ] as ProviderItem[],
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(
+      screen.getAllByText("providers.category_developer_agent").length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("providers.category_general").length,
+    ).toBeGreaterThan(0);
+  });
+
   it("opens the Add picker drawer and lists only unconfigured providers", async () => {
     useProvidersMock.mockReturnValue({
       data: PROVIDERS,

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -97,6 +97,18 @@ function getAuthBadge(status?: string): { variant: BadgeVariant; label: string }
   }
 }
 
+// Coarse provider category badge (#6216): prefer the server-assigned category,
+// fall back to the client CLI heuristic for daemons predating the field.
+function getCategoryBadge(
+  category: ProviderItem["category"],
+  isCli: boolean,
+): { variant: BadgeVariant; key: string } | null {
+  const isDevAgent = category === "developer_agent" || (category == null && isCli);
+  if (isDevAgent) return { variant: "info", key: "providers.category_developer_agent" };
+  if (category === "general") return { variant: "default", key: "providers.category_general" };
+  return null;
+}
+
 type SortField = "name" | "models" | "latency";
 type SortOrder = "asc" | "desc";
 type ViewMode = "grid" | "list";
@@ -323,7 +335,12 @@ const ProviderCard = memo(function ProviderCard({ provider: p, isSelected, isDef
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <h3 className="font-black truncate">{p.display_name || p.id}</h3>
-              {isCli && <Badge variant="default" className="shrink-0">CLI</Badge>}
+              {(() => {
+                const cat = getCategoryBadge(p.category, isCli);
+                return cat ? (
+                  <Badge variant={cat.variant} className="shrink-0">{t(cat.key)}</Badge>
+                ) : null;
+              })()}
               {isConfigured ? (
                 <Badge variant={p.reachable === true ? "success" : p.reachable === false ? "error" : "default"} className="shrink-0">
                   {p.reachable === true ? t("providers.online") : p.reachable === false ? t("providers.offline") : t("providers.not_checked")}

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -424,13 +424,6 @@ const ProviderCard = memo(function ProviderCard({ provider: p, isSelected, isDef
   // Grid view
   return (
     <Card hover padding="none" onClick={() => onViewDetails(p)} className={`relative flex flex-col overflow-hidden group transition-all ${isSelected ? "ring-2 ring-brand" : ""}`}>
-      {isCli && (
-        <div className="absolute top-1.5 left-0 z-10 overflow-hidden w-20 h-20 pointer-events-none">
-          <div className="absolute top-[12px] left-[-18px] w-[90px] text-center text-[9px] font-black uppercase tracking-wider text-text-dim bg-surface/80 border-y border-border-subtle rotate-[-45deg] py-px">
-            CLI
-          </div>
-        </div>
-      )}
       <div className={`relative z-20 h-1.5 bg-linear-to-r ${isConfigured ? "from-success via-success/60 to-success/30" : "from-brand via-brand/60 to-brand/30"}`} />
       <div className="p-5 flex-1 flex flex-col">
         {/* Header */}
@@ -446,7 +439,15 @@ const ProviderCard = memo(function ProviderCard({ provider: p, isSelected, isDef
               {getProviderIcon(p.id)}
             </div>
             <div className="min-w-0">
-              <h2 className={`text-base font-black truncate transition-colors ${isConfigured ? "group-hover:text-success" : "group-hover:text-brand"}`}>{p.display_name || p.id}</h2>
+              <div className="flex items-center gap-2">
+                <h2 className={`text-base font-black truncate transition-colors ${isConfigured ? "group-hover:text-success" : "group-hover:text-brand"}`}>{p.display_name || p.id}</h2>
+                {(() => {
+                  const cat = getCategoryBadge(p.category, isCli);
+                  return cat ? (
+                    <Badge variant={cat.variant} className="shrink-0">{t(cat.key)}</Badge>
+                  ) : null;
+                })()}
+              </div>
               <p className="text-[10px] font-black uppercase tracking-widest text-text-dim/60 truncate">{p.id}</p>
             </div>
           </div>

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -598,6 +598,9 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
             "media_capabilities": p.media_capabilities,
             "is_custom": p.is_custom,
             "suppressed": suppressed_ids.contains(&p.id),
+            // #6216: coarse UI category derived from the driver kind (agent-CLI
+            // subprocess vs API model provider), not a model_catalog field.
+            "category": if librefang_llm_drivers::drivers::is_cli_provider(&p.id) { "developer_agent" } else { "general" },
         });
 
         // Attach region map so the dashboard can show available regions
@@ -735,6 +738,9 @@ pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json:
             "media_capabilities": p.media_capabilities,
             "is_custom": p.is_custom,
             "suppressed": suppressed_ids.contains(&p.id),
+            // #6216: coarse UI category derived from the driver kind (agent-CLI
+            // subprocess vs API model provider), not a model_catalog field.
+            "category": if librefang_llm_drivers::drivers::is_cli_provider(&p.id) { "developer_agent" } else { "general" },
         });
         if let Some(probe) = probe_map.remove(&i) {
             attach_probe_result(&mut entry, &probe, &p.id, &*state.kernel);
@@ -817,6 +823,8 @@ pub async fn get_provider(
         "api_key_env": provider.api_key_env,
         "base_url": provider.base_url,
         "proxy_url": provider.proxy_url,
+        // #6216: keep the single-provider detail in sync with the list category.
+        "category": if librefang_llm_drivers::drivers::is_cli_provider(&provider.id) { "developer_agent" } else { "general" },
         "models": models,
     });
 

--- a/crates/librefang-api/tests/providers_routes_test.rs
+++ b/crates/librefang-api/tests/providers_routes_test.rs
@@ -580,6 +580,23 @@ async fn list_providers_returns_well_formed_envelope() {
             p["display_name"].is_string(),
             "provider entry missing 'display_name': {p}"
         );
+        // #6216: every provider carries a coarse category.
+        let category = p["category"].as_str();
+        assert!(
+            matches!(category, Some("developer_agent") | Some("general")),
+            "provider entry has invalid 'category': {p}"
+        );
+        // Agent-CLI providers must be classified developer_agent.
+        if matches!(
+            p["id"].as_str(),
+            Some("claude-code" | "codex-cli" | "gemini-cli" | "qwen-code")
+        ) {
+            assert_eq!(
+                category,
+                Some("developer_agent"),
+                "agent-CLI provider must be developer_agent: {p}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #6216 part 1 — distinguish developer-agent (agent-CLI) providers from general API providers in the Providers UI. (Part 2, surfacing the actual underlying model, was already shipped via #6134 / #6157 — see below.)

Per the design call, the category is **derived from the driver kind**, not a new `model_catalog` field — so there's no golden-fixture regen or OpenAPI drift.

## Changes

**Backend** (`crates/librefang-api/src/routes/providers.rs`)
- `GET /api/providers`, the providers snapshot, and `GET /api/providers/{name}` each gain a `category` of `"developer_agent"` (agent-CLI: claude-code / codex-cli / gemini-cli / qwen-code) or `"general"`, computed from the existing `librefang_llm_drivers::drivers::is_cli_provider(&id)` (the single source of truth — adding a new agent-CLI driver there updates the category automatically). The response is a hand-built `serde_json::json!` map and the OpenAPI body is `Vec<serde_json::Value>`, so no typed-schema / golden-fixture / SDK-codegen impact. No new dependency (`librefang-api` already depends on `librefang-llm-drivers`).
- `providers_routes_test.rs`: every entry carries a valid `category`, and agent-CLI ids resolve to `developer_agent`.

**Frontend** (dashboard)
- `api.ts` — `ProviderItem.category?: "developer_agent" | "general"` (additive, back-compatible).
- `ProvidersPage.tsx` — a `getCategoryBadge` helper (prefers the server value, falls back to the existing client `isCliProvider` heuristic for older daemons) renders a per-category badge in the list view.
- i18n keys `providers.category_developer_agent` / `category_general` in en/zh/uk.
- `ProvidersPage.test.tsx` — asserts both category badges render.

`chatgpt` / `copilot` are token-auth HTTP drivers (not subprocess agents) and stay `general`; `aider` is not a registered provider id, so it's not classified. Grid view keeps its existing CLI corner ribbon for agent-CLI providers; the new explicit badge is in the list view (a fuller grid badge can follow if wanted).

## Part 2 — already done

The "actual underlying model" ask is implemented: driver responses carry `actual_model`, the agent-CLI drivers stamp the resolved model (e.g. `codex_cli` parses its startup banner), and the kernel records it as the metering `model` (`agent_execution.rs`, `messaging.rs`, refs #6134 / #6157). Cost tracking already attributes spend to the real model.

## Verification

> ⚠️ Not built locally (no working local toolchain — disk/Docker unavailable per the maintainer). Statically reviewed: backend reuses the existing `is_cli_provider` path with no new import/dep and an untyped JSON response (no schema impact); frontend type is additive, the badge helper + i18n keys follow the existing `getAuthBadge` pattern, and the test uses a local fixture so shared-fixture counts are unaffected. **CI is the verifier** — `cargo check --workspace --lib`, `cargo test -p librefang-api`, `cargo clippy`, and `pnpm typecheck` / `pnpm test`.
