### PR TITLE
feat(llm-drivers,api,dashboard): coding-agent class, actual_model reporting, CodeWhale driver, provider grouping

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -280,112 +280,112 @@
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "26eeb2a3d2d3a26656573aba8ae238ded867bfb7",
         "is_verified": false,
-        "line_number": 1207
+        "line_number": 1223
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "cddea5c4539c2dcb2fac754166dc8c141296ead8",
         "is_verified": false,
-        "line_number": 1260
+        "line_number": 1276
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "6be0b909d7953656db4534a48ac26329b6b7ad05",
         "is_verified": false,
-        "line_number": 1868
+        "line_number": 1884
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "9beb25270febae84a22c023eb079f03f984c4ee4",
         "is_verified": false,
-        "line_number": 2097
+        "line_number": 2113
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "7b9a759937d8742ff1612a01e4729b93eda5d09f",
         "is_verified": false,
-        "line_number": 2133
+        "line_number": 2149
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "7e48c7f2a53700d0656daf1d9b479f631d9f6ed1",
         "is_verified": false,
-        "line_number": 2247
+        "line_number": 2263
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "8a5b5fdc436269aacbce18e73038704ce027fa17",
         "is_verified": false,
-        "line_number": 2286
+        "line_number": 2302
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "fb53f36d497172bec62a5e18e57c014d9d209dde",
         "is_verified": false,
-        "line_number": 2287
+        "line_number": 2303
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "fa4b19ac75b57ea3d3555e5cc878e15ce9e633a1",
         "is_verified": false,
-        "line_number": 2305
+        "line_number": 2321
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "2276fa3db60dab489cdaf02229306a13af9e179b",
         "is_verified": false,
-        "line_number": 2331
+        "line_number": 2347
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "02e4465db9e24628b1a9a4783b1d22abe1568eb4",
         "is_verified": false,
-        "line_number": 2400
+        "line_number": 2416
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "14b4007ff8fadc0587f923aa38acc6a1b36670da",
         "is_verified": false,
-        "line_number": 2745
+        "line_number": 2761
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "4dad82da373f06d95847d61ba3c5a1cdb5a94fe0",
         "is_verified": false,
-        "line_number": 2962
+        "line_number": 2978
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "5aa7d1e863b4cbed54c71b8ba1a6f4388efcadd0",
         "is_verified": false,
-        "line_number": 2967
+        "line_number": 2983
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "f91eb2a7b1c4be9f65c70eaaf47449c5cb788888",
         "is_verified": false,
-        "line_number": 3277
+        "line_number": 3293
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "cf678cab87dc1f7d1b95b964f15375e088461679",
         "is_verified": false,
-        "line_number": 3380
+        "line_number": 3396
       }
     ],
     "crates/librefang-api/dashboard/src/locales/uk.json": [
@@ -436,77 +436,77 @@
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "34123ae8e18c5f7e69a9f4e6a8beea05879f483e",
         "is_verified": false,
-        "line_number": 1207
+        "line_number": 1223
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d5f6b23160fffd39f4d0617ebec467ed0abddc13",
         "is_verified": false,
-        "line_number": 1208
+        "line_number": 1224
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "175d8973cfd0eafa0456d7b60ff24612dafea1b5",
         "is_verified": false,
-        "line_number": 1260
+        "line_number": 1276
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "3f92176f388ab292a54ddee6e71ce44c5278d943",
         "is_verified": false,
-        "line_number": 2133
+        "line_number": 2149
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "5f01ea1b5b938628292e9f13071a99b461fb0a89",
         "is_verified": false,
-        "line_number": 2286
+        "line_number": 2302
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "416352ae1ba52364a5510a9dc65e30d7f1addc6b",
         "is_verified": false,
-        "line_number": 2287
+        "line_number": 2303
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "503c9c19721513d7d6811c2ccf9549ed7a582167",
         "is_verified": false,
-        "line_number": 2305
+        "line_number": 2321
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "7d17fa6969539e972d57b93916f94612d6f269e6",
         "is_verified": false,
-        "line_number": 2331
+        "line_number": 2347
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "83d2e7404077eb9a94bee7f5a0725105bdc22c80",
         "is_verified": false,
-        "line_number": 2400
+        "line_number": 2416
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "2dbbfc5d67cc9823da0632a51012cba66187af5d",
         "is_verified": false,
-        "line_number": 2745
+        "line_number": 2761
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d0f693fffcebc4aa903d6ba4408e61b301102e60",
         "is_verified": false,
-        "line_number": 2967
+        "line_number": 2983
       }
     ],
     "crates/librefang-api/dashboard/src/locales/zh.json": [
@@ -564,91 +564,91 @@
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "0769c2d835193ec570086a776ca2c81bbad7f891",
         "is_verified": false,
-        "line_number": 1207
+        "line_number": 1223
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "ab25a5ed30a7930eefda1b401a3551e92292ba06",
         "is_verified": false,
-        "line_number": 1208
+        "line_number": 1224
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "54f77569909cc9420836a7e4b00563de47b4a328",
         "is_verified": false,
-        "line_number": 1260
+        "line_number": 1276
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "5df1d83e18c6e5903e3f4805f0af1415fd050ef7",
         "is_verified": false,
-        "line_number": 2027
+        "line_number": 2043
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "94980a07a0b08fc6c65155a5af44dcc32652a8c0",
         "is_verified": false,
-        "line_number": 2090
+        "line_number": 2106
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "08037c102cca2aa1fae8ba0fcf9f1b3442da4dac",
         "is_verified": false,
-        "line_number": 2243
+        "line_number": 2259
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "d6c8bc0ecea0cd41397a0a5e7ff97339f0c0284e",
         "is_verified": false,
-        "line_number": 2244
+        "line_number": 2260
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "7376202136f8a7e68d3cd3772b4f92d08151508b",
         "is_verified": false,
-        "line_number": 2262
+        "line_number": 2278
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "a722b86877659d6a3499a56a9faefd0d85cc04e0",
         "is_verified": false,
-        "line_number": 2288
+        "line_number": 2304
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "2540a21b1adbcaece91bc51c2142997cc8d38975",
         "is_verified": false,
-        "line_number": 2357
+        "line_number": 2373
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "be0bbd80b4105d9030a3484201437d600f6fd1d0",
         "is_verified": false,
-        "line_number": 2702
+        "line_number": 2718
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "6e18c7516fd3fe2df687bc59ab10ffc5cee99a7b",
         "is_verified": false,
-        "line_number": 2924
+        "line_number": 2940
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "9d123ddd01a441bfe1d6c9f0bde50e2c7e6448fb",
         "is_verified": false,
-        "line_number": 3277
+        "line_number": 3293
       }
     ],
     "crates/librefang-api/dashboard/src/pages/Memory/index.test.tsx": [
@@ -2101,7 +2101,7 @@
         "filename": "crates/librefang-llm-driver/src/lib.rs",
         "hashed_secret": "db3b0f09c3b4063e773a698bcf5d7f7a2ba1c0e2",
         "is_verified": false,
-        "line_number": 1140
+        "line_number": 1180
       }
     ],
     "crates/librefang-llm-drivers/src/drivers/mod.rs": [
@@ -4292,5 +4292,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-18T02:08:15Z"
+  "generated_at": "2026-06-18T08:20:45Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -266,126 +266,126 @@
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
         "is_verified": false,
-        "line_number": 840
+        "line_number": 842
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 859
+        "line_number": 861
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "26eeb2a3d2d3a26656573aba8ae238ded867bfb7",
         "is_verified": false,
-        "line_number": 1223
+        "line_number": 1225
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "cddea5c4539c2dcb2fac754166dc8c141296ead8",
         "is_verified": false,
-        "line_number": 1276
+        "line_number": 1278
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "6be0b909d7953656db4534a48ac26329b6b7ad05",
         "is_verified": false,
-        "line_number": 1884
+        "line_number": 1886
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "9beb25270febae84a22c023eb079f03f984c4ee4",
         "is_verified": false,
-        "line_number": 2113
+        "line_number": 2115
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "7b9a759937d8742ff1612a01e4729b93eda5d09f",
         "is_verified": false,
-        "line_number": 2149
+        "line_number": 2151
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "7e48c7f2a53700d0656daf1d9b479f631d9f6ed1",
         "is_verified": false,
-        "line_number": 2263
+        "line_number": 2265
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "8a5b5fdc436269aacbce18e73038704ce027fa17",
         "is_verified": false,
-        "line_number": 2302
+        "line_number": 2304
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "fb53f36d497172bec62a5e18e57c014d9d209dde",
         "is_verified": false,
-        "line_number": 2303
+        "line_number": 2305
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "fa4b19ac75b57ea3d3555e5cc878e15ce9e633a1",
         "is_verified": false,
-        "line_number": 2321
+        "line_number": 2323
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "2276fa3db60dab489cdaf02229306a13af9e179b",
         "is_verified": false,
-        "line_number": 2347
+        "line_number": 2349
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "02e4465db9e24628b1a9a4783b1d22abe1568eb4",
         "is_verified": false,
-        "line_number": 2416
+        "line_number": 2418
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "14b4007ff8fadc0587f923aa38acc6a1b36670da",
         "is_verified": false,
-        "line_number": 2761
+        "line_number": 2763
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "4dad82da373f06d95847d61ba3c5a1cdb5a94fe0",
         "is_verified": false,
-        "line_number": 2978
+        "line_number": 2980
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "5aa7d1e863b4cbed54c71b8ba1a6f4388efcadd0",
         "is_verified": false,
-        "line_number": 2983
+        "line_number": 2985
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "f91eb2a7b1c4be9f65c70eaaf47449c5cb788888",
         "is_verified": false,
-        "line_number": 3293
+        "line_number": 3295
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "cf678cab87dc1f7d1b95b964f15375e088461679",
         "is_verified": false,
-        "line_number": 3396
+        "line_number": 3398
       }
     ],
     "crates/librefang-api/dashboard/src/locales/uk.json": [
@@ -415,98 +415,98 @@
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "0956cb835344367878a6e19e69680d8b6878614e",
         "is_verified": false,
-        "line_number": 840
+        "line_number": 842
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 859
+        "line_number": 861
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "b1b8c51a3ed90a7c73962c976d36864d99ef62c0",
         "is_verified": false,
-        "line_number": 920
+        "line_number": 922
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "34123ae8e18c5f7e69a9f4e6a8beea05879f483e",
         "is_verified": false,
-        "line_number": 1223
+        "line_number": 1225
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d5f6b23160fffd39f4d0617ebec467ed0abddc13",
         "is_verified": false,
-        "line_number": 1224
+        "line_number": 1226
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "175d8973cfd0eafa0456d7b60ff24612dafea1b5",
         "is_verified": false,
-        "line_number": 1276
+        "line_number": 1278
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "3f92176f388ab292a54ddee6e71ce44c5278d943",
         "is_verified": false,
-        "line_number": 2149
+        "line_number": 2151
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "5f01ea1b5b938628292e9f13071a99b461fb0a89",
         "is_verified": false,
-        "line_number": 2302
+        "line_number": 2304
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "416352ae1ba52364a5510a9dc65e30d7f1addc6b",
         "is_verified": false,
-        "line_number": 2303
+        "line_number": 2305
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "503c9c19721513d7d6811c2ccf9549ed7a582167",
         "is_verified": false,
-        "line_number": 2321
+        "line_number": 2323
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "7d17fa6969539e972d57b93916f94612d6f269e6",
         "is_verified": false,
-        "line_number": 2347
+        "line_number": 2349
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "83d2e7404077eb9a94bee7f5a0725105bdc22c80",
         "is_verified": false,
-        "line_number": 2416
+        "line_number": 2418
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "2dbbfc5d67cc9823da0632a51012cba66187af5d",
         "is_verified": false,
-        "line_number": 2761
+        "line_number": 2763
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d0f693fffcebc4aa903d6ba4408e61b301102e60",
         "is_verified": false,
-        "line_number": 2983
+        "line_number": 2985
       }
     ],
     "crates/librefang-api/dashboard/src/locales/zh.json": [
@@ -536,119 +536,119 @@
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
         "is_verified": false,
-        "line_number": 840
+        "line_number": 842
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 859
+        "line_number": 861
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "469b3f21e87f4b889a36f663597ebc2766e4caaa",
         "is_verified": false,
-        "line_number": 860
+        "line_number": 862
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "42ae7ec78f2e89ed905144e3e7ee986a8e43a386",
         "is_verified": false,
-        "line_number": 920
+        "line_number": 922
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "0769c2d835193ec570086a776ca2c81bbad7f891",
         "is_verified": false,
-        "line_number": 1223
+        "line_number": 1225
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "ab25a5ed30a7930eefda1b401a3551e92292ba06",
         "is_verified": false,
-        "line_number": 1224
+        "line_number": 1226
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "54f77569909cc9420836a7e4b00563de47b4a328",
         "is_verified": false,
-        "line_number": 1276
+        "line_number": 1278
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "5df1d83e18c6e5903e3f4805f0af1415fd050ef7",
         "is_verified": false,
-        "line_number": 2043
+        "line_number": 2045
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "94980a07a0b08fc6c65155a5af44dcc32652a8c0",
         "is_verified": false,
-        "line_number": 2106
+        "line_number": 2108
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "08037c102cca2aa1fae8ba0fcf9f1b3442da4dac",
         "is_verified": false,
-        "line_number": 2259
+        "line_number": 2261
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "d6c8bc0ecea0cd41397a0a5e7ff97339f0c0284e",
         "is_verified": false,
-        "line_number": 2260
+        "line_number": 2262
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "7376202136f8a7e68d3cd3772b4f92d08151508b",
         "is_verified": false,
-        "line_number": 2278
+        "line_number": 2280
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "a722b86877659d6a3499a56a9faefd0d85cc04e0",
         "is_verified": false,
-        "line_number": 2304
+        "line_number": 2306
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "2540a21b1adbcaece91bc51c2142997cc8d38975",
         "is_verified": false,
-        "line_number": 2373
+        "line_number": 2375
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "be0bbd80b4105d9030a3484201437d600f6fd1d0",
         "is_verified": false,
-        "line_number": 2718
+        "line_number": 2720
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "6e18c7516fd3fe2df687bc59ab10ffc5cee99a7b",
         "is_verified": false,
-        "line_number": 2940
+        "line_number": 2942
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "9d123ddd01a441bfe1d6c9f0bde50e2c7e6448fb",
         "is_verified": false,
-        "line_number": 3293
+        "line_number": 3295
       }
     ],
     "crates/librefang-api/dashboard/src/pages/Memory/index.test.tsx": [
@@ -2110,301 +2110,301 @@
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 184
+        "line_number": 187
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "8c54c83815c506733132fb233da840b45905bf1e",
         "is_verified": false,
-        "line_number": 194
+        "line_number": 197
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "3e10d010e7dfb478858d30459fa03f3824340d47",
         "is_verified": false,
-        "line_number": 204
+        "line_number": 207
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 214
+        "line_number": 217
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "1a37d41260f96724ee881be5e261b4d043f0626b",
         "is_verified": false,
-        "line_number": 224
+        "line_number": 227
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "96133e4265d7a277409c8094e5eff6a41934cf07",
         "is_verified": false,
-        "line_number": 234
+        "line_number": 237
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "4835254aab9494e03d8b72e816719a4914612587",
         "is_verified": false,
-        "line_number": 244
+        "line_number": 247
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "4e5111dafe7d9739f9228906d90cf421d5ec5371",
         "is_verified": false,
-        "line_number": 254
+        "line_number": 257
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "c8f16a194efc59559549c7bd69f7bea038742e79",
         "is_verified": false,
-        "line_number": 264
+        "line_number": 267
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "fbc8cff8359639c2cc4b0c135565e801ab38358f",
         "is_verified": false,
-        "line_number": 274
+        "line_number": 277
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "877ae368395eca61a0d7667c45101f061ed399cd",
         "is_verified": false,
-        "line_number": 284
+        "line_number": 287
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "17bb10d3f44323963c21bf3c97341ebb5accf05e",
         "is_verified": false,
-        "line_number": 302
+        "line_number": 305
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
         "is_verified": false,
-        "line_number": 312
+        "line_number": 315
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "66e0e2b808ba68e8d1169e0bcbeaec099b2a9466",
         "is_verified": false,
-        "line_number": 322
+        "line_number": 325
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "c38d9d35eb7e936d9bde96db5c177189ce41d7d9",
         "is_verified": false,
-        "line_number": 332
+        "line_number": 335
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "05e4bcd7b031cd6255f628df4f8a976559d44f06",
         "is_verified": false,
-        "line_number": 342
+        "line_number": 345
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "824403a55b39792bcab40973349a9b54f42a1620",
         "is_verified": false,
-        "line_number": 352
+        "line_number": 355
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "38701bc7d344d76dfd8de72f608e4a2868cf13c4",
         "is_verified": false,
-        "line_number": 362
+        "line_number": 365
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "e4ee3f5fcc26c286e96d3eb9d736b4df95085685",
         "is_verified": false,
-        "line_number": 372
+        "line_number": 375
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "1742b1fd73638d34a3058c15ff657f8b7f5c691d",
         "is_verified": false,
-        "line_number": 382
+        "line_number": 385
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "97ebd8cdea0b54bbcd8734279a78a419bb4eeb48",
         "is_verified": false,
-        "line_number": 392
+        "line_number": 395
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "ed22c446f75d6d553f791fb763db5d0616debb67",
         "is_verified": false,
-        "line_number": 402
+        "line_number": 405
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "c267b646441a206d44803d8cb20896c4a166cac2",
         "is_verified": false,
-        "line_number": 412
+        "line_number": 415
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "7ed5377fddc625775754888af04df4571ef4bb29",
         "is_verified": false,
-        "line_number": 422
+        "line_number": 425
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "319608a684d2f387e6d2469c45de78fafec48fd4",
         "is_verified": false,
-        "line_number": 472
+        "line_number": 485
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "0bb40964ad52813c1979f7b24ffdfda36d440b27",
         "is_verified": false,
-        "line_number": 482
+        "line_number": 495
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "ba4d38e2a7e8c718913887136d2526351d05cd69",
         "is_verified": false,
-        "line_number": 492
+        "line_number": 505
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
         "is_verified": false,
-        "line_number": 502
+        "line_number": 515
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "5310a428a374b7be3574e6db76ee6dbaa8c79aca",
         "is_verified": false,
-        "line_number": 512
+        "line_number": 525
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "04bcd5dc8989ab03ac2448f39069acf8fa6df2a7",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 535
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "5264067a1346e7acfebddbe220bd0369dfe8f3b7",
         "is_verified": false,
-        "line_number": 532
+        "line_number": 545
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "1cca928446678dd27af2195d6c42f88b546c21fe",
         "is_verified": false,
-        "line_number": 542
+        "line_number": 555
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "658dd3210bd7109ef1c646cc0a3cc1a5671f6b66",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 565
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "65fd0c618dff1186325e71796f36b31221efa689",
         "is_verified": false,
-        "line_number": 562
+        "line_number": 575
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "b3c0256fbb0ef80557ac65d4c17a59214bf2f8f6",
         "is_verified": false,
-        "line_number": 572
+        "line_number": 585
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "420f28ff212061beeb02f96f58bba7c19be94852",
         "is_verified": false,
-        "line_number": 582
+        "line_number": 595
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "b08953471d41cf0a413629eb0e194b7bcf2f66b7",
         "is_verified": false,
-        "line_number": 592
+        "line_number": 605
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "e134efd3af10678ddb9a7c15e13a5725c0c4f8b4",
         "is_verified": false,
-        "line_number": 602
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "04827ce753ca41ba673b446b1c94b47a905a59b6",
         "is_verified": false,
-        "line_number": 612
+        "line_number": 625
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "aa4cef86416f362b892f15c1889c53f14b014a2d",
         "is_verified": false,
-        "line_number": 622
+        "line_number": 635
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "920025a944b7037f2c0ab7f2bb7746de0993a803",
         "is_verified": false,
-        "line_number": 632
+        "line_number": 645
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "c00540932fdecc92365ceaecddc11b657f164351",
         "is_verified": false,
-        "line_number": 642
+        "line_number": 655
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-llm-drivers/src/drivers/mod.rs",
         "hashed_secret": "3908d8c8e0ea4502218b700b7bf7decd7f00630f",
         "is_verified": false,
-        "line_number": 653
+        "line_number": 666
       }
     ],
     "crates/librefang-llm-drivers/tests/gemini_retry.rs": [
@@ -4292,5 +4292,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-18T08:20:45Z"
+  "generated_at": "2026-06-18T08:42:20Z"
 }

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -70,6 +70,11 @@ export interface ProviderItem {
    *  Lets the dashboard distinguish "user-hidden" from "never configured"
    *  for the otherwise indistinguishable `auth_status: "missing"`. */
   suppressed?: boolean;
+  /** True when this provider is a coding-agent CLI (claude-code, codex-cli,
+   *  gemini-cli, qwen-code, codewhale) rather than a raw provider API.
+   *  Sourced from the backend (`is_coding_agent_provider`) so the dashboard
+   *  can group coding agents apart from providers. */
+  is_coding_agent?: boolean;
 }
 
 export interface MediaProvider {

--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -809,6 +809,8 @@
     "offline": "Offline",
     "require_config": "Requires Setup",
     "no_configured": "No configured providers",
+    "section_coding_agents": "Coding Agents",
+    "section_providers": "Providers",
     "no_unconfigured": "No unconfigured providers",
     "no_results": "No matching providers",
     "name": "Name",

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -809,6 +809,8 @@
     "offline": "Офлайн",
     "require_config": "Потребує налаштування",
     "no_configured": "Немає налаштованих провайдерів",
+    "section_coding_agents": "Агенти кодування",
+    "section_providers": "Провайдери",
     "no_unconfigured": "Немає неналаштованих провайдерів",
     "no_results": "Немає відповідних провайдерів",
     "name": "Назва",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -809,6 +809,8 @@
     "offline": "离线",
     "require_config": "需配置",
     "no_configured": "暂无已配置的供应商",
+    "section_coding_agents": "开发 Agent",
+    "section_providers": "模型服务商",
     "no_unconfigured": "暂无未配置的供应商",
     "no_results": "没有匹配的供应商",
     "name": "名称",

--- a/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ProvidersPage.tsx
@@ -1243,7 +1243,7 @@ export function ProvidersPage() {
     t,
   );
 
-  const providers = providersQuery.data ?? [];
+  const providers = useMemo(() => providersQuery.data ?? [], [providersQuery.data]);
   const currentDefaultProvider = statusQuery.data?.default_provider ?? "";
   const configuredCount = useMemo(() => providers.filter(p => isProviderAvailable(p.auth_status)).length, [providers]);
 
@@ -1280,6 +1280,22 @@ export function ProvidersPage() {
       }),
     [providers, search, filterStatus, sortField, sortOrder],
   );
+
+  // Split the configured list into coding-agent CLIs (claude-code, codex-cli,
+  // gemini-cli, qwen-code, codewhale) vs raw provider APIs, using the backend
+  // `is_coding_agent` flag, so the page shows them under separate headers.
+  // Order within each group is preserved from `filteredProviders`.
+  const codingAgentProviders = useMemo(
+    () => filteredProviders.filter(p => p.is_coding_agent),
+    [filteredProviders],
+  );
+  const apiProviders = useMemo(
+    () => filteredProviders.filter(p => !p.is_coding_agent),
+    [filteredProviders],
+  );
+  // Only show the group headers when both groups are non-empty — a single
+  // group renders flat, without a lone header.
+  const showGroupHeaders = codingAgentProviders.length > 0 && apiProviders.length > 0;
 
   // Catalog of unconfigured providers, surfaced in the Add picker.
   const pickerProviders = useMemo(
@@ -1551,23 +1567,54 @@ export function ProvidersPage() {
             )}
           </div>
 
-          <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
-            {filteredProviders.map((p) => (
-              <ProviderCard
-                key={p.id} provider={p}
-                isSelected={selectedIds.has(p.id)}
-                isDefault={p.id === currentDefaultProvider}
-                pendingId={testingIds.has(p.id) ? p.id : pendingId}
-                viewMode={viewMode}
-                onSelect={handleSelect}
-                onTest={handleTest}
-                onSetDefault={handleSetDefault}
-                onViewDetails={setDetailsProvider}
-                onConfigure={config.open}
-                onDelete={setDeleteConfirmProvider}
-              />
-            ))}
-          </div>
+          {codingAgentProviders.length > 0 && (
+            <>
+              {showGroupHeaders && (
+                <h3 className="text-xs font-black uppercase tracking-wider text-text-dim">{t("providers.section_coding_agents")}</h3>
+              )}
+              <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
+                {codingAgentProviders.map((p) => (
+                  <ProviderCard
+                    key={p.id} provider={p}
+                    isSelected={selectedIds.has(p.id)}
+                    isDefault={p.id === currentDefaultProvider}
+                    pendingId={testingIds.has(p.id) ? p.id : pendingId}
+                    viewMode={viewMode}
+                    onSelect={handleSelect}
+                    onTest={handleTest}
+                    onSetDefault={handleSetDefault}
+                    onViewDetails={setDetailsProvider}
+                    onConfigure={config.open}
+                    onDelete={setDeleteConfirmProvider}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+          {apiProviders.length > 0 && (
+            <>
+              {showGroupHeaders && (
+                <h3 className="text-xs font-black uppercase tracking-wider text-text-dim">{t("providers.section_providers")}</h3>
+              )}
+              <div className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 4xl:grid-cols-6" : "flex flex-col gap-2"}>
+                {apiProviders.map((p) => (
+                  <ProviderCard
+                    key={p.id} provider={p}
+                    isSelected={selectedIds.has(p.id)}
+                    isDefault={p.id === currentDefaultProvider}
+                    pendingId={testingIds.has(p.id) ? p.id : pendingId}
+                    viewMode={viewMode}
+                    onSelect={handleSelect}
+                    onTest={handleTest}
+                    onSetDefault={handleSetDefault}
+                    onViewDetails={setDetailsProvider}
+                    onConfigure={config.open}
+                    onDelete={setDeleteConfirmProvider}
+                  />
+                ))}
+              </div>
+            </>
+          )}
         </>
       )}
       </div>

--- a/crates/librefang-api/src/routes/providers.rs
+++ b/crates/librefang-api/src/routes/providers.rs
@@ -598,6 +598,7 @@ pub async fn list_providers(State(state): State<Arc<AppState>>) -> impl IntoResp
             "media_capabilities": p.media_capabilities,
             "is_custom": p.is_custom,
             "suppressed": suppressed_ids.contains(&p.id),
+            "is_coding_agent": librefang_kernel::drivers::is_coding_agent_provider(&p.id),
         });
 
         // Attach region map so the dashboard can show available regions
@@ -735,6 +736,7 @@ pub(crate) async fn providers_snapshot(state: &Arc<AppState>) -> Vec<serde_json:
             "media_capabilities": p.media_capabilities,
             "is_custom": p.is_custom,
             "suppressed": suppressed_ids.contains(&p.id),
+            "is_coding_agent": librefang_kernel::drivers::is_coding_agent_provider(&p.id),
         });
         if let Some(probe) = probe_map.remove(&i) {
             attach_probe_result(&mut entry, &probe, &p.id, &*state.kernel);

--- a/crates/librefang-llm-driver/src/lib.rs
+++ b/crates/librefang-llm-driver/src/lib.rs
@@ -583,6 +583,28 @@ pub trait LlmDriver: Send + Sync {
     fn family(&self) -> LlmFamily {
         LlmFamily::Other
     }
+
+    /// Whether this driver delegates to an external *coding-agent* CLI that
+    /// resolves and runs its own model — Claude Code, Codex, Gemini CLI, Qwen
+    /// Code, CodeWhale, … — rather than calling a raw provider API with a
+    /// caller-nominated model.
+    ///
+    /// This axis is orthogonal to [`LlmFamily`] (which groups by wire format):
+    /// the `claude-code` CLI and the Anthropic HTTP API are both
+    /// [`LlmFamily::Anthropic`], yet only the former is a coding agent.
+    /// Likewise `codex-cli` and the OpenAI API are both [`LlmFamily::OpenAi`].
+    ///
+    /// Coding agents own model selection — the spawned CLI may resolve a model
+    /// that differs from the requested id (codex picks from its own config,
+    /// CodeWhale's `/model auto` re-picks per turn) — so they are the drivers
+    /// that can meaningfully populate [`CompletionResponse::actual_model`]. Raw
+    /// providers honour the requested model verbatim and leave it `None`.
+    ///
+    /// Defaults to `false` so every existing HTTP provider and out-of-tree
+    /// driver keeps compiling unchanged; the in-tree CLI drivers override it.
+    fn is_coding_agent(&self) -> bool {
+        false
+    }
 }
 
 /// Configuration for creating an LLM driver.
@@ -996,6 +1018,24 @@ mod tests {
         }
 
         assert_eq!(BareDriver.family(), LlmFamily::Other);
+    }
+
+    #[test]
+    fn test_llm_driver_is_coding_agent_default_is_false() {
+        struct BareDriver;
+
+        #[async_trait]
+        impl LlmDriver for BareDriver {
+            async fn complete(
+                &self,
+                _request: CompletionRequest,
+            ) -> Result<CompletionResponse, LlmError> {
+                unreachable!("test does not call complete")
+            }
+        }
+
+        // Raw providers / out-of-tree drivers are not coding agents by default.
+        assert!(!BareDriver.is_coding_agent());
     }
 
     #[tokio::test]

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -1612,6 +1612,10 @@ impl LlmDriver for ClaudeCodeDriver {
     fn family(&self) -> crate::llm_driver::LlmFamily {
         crate::llm_driver::LlmFamily::Anthropic
     }
+
+    fn is_coding_agent(&self) -> bool {
+        true
+    }
 }
 
 /// Check if the Claude Code CLI is available.
@@ -1667,6 +1671,11 @@ fn home_dir() -> Option<std::path::PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_coding_agent_is_true() {
+        assert!(ClaudeCodeDriver::new(None, false).is_coding_agent());
+    }
 
     /// Spawn a tiny cross-platform child process for the
     /// `diagnose_stdin_write_failure` tests. POSIX runners can rely on

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -804,6 +804,11 @@ struct ClaudeJsonOutput {
     /// The CLI sets this when the result is an error (auth failure, etc.).
     #[serde(default)]
     is_error: bool,
+    /// The model the CLI reports running. `claude -p --output-format json` does
+    /// not currently emit it (so this stays `None`); captured for forward-compat
+    /// if a future CLI version adds it.
+    #[serde(default)]
+    model: Option<String>,
 }
 
 /// Usage stats from Claude CLI JSON output.
@@ -829,6 +834,10 @@ struct ClaudeStreamEvent {
     /// The CLI sets this when the result is an error (auth failure, etc.).
     #[serde(default)]
     is_error: bool,
+    /// Present on the `system`/`init` event in stream-json mode: the model the
+    /// CLI resolved for this run.
+    #[serde(default)]
+    model: Option<String>,
 }
 
 /// Check if CLI response text looks like an auth or rate-limit error that
@@ -1132,7 +1141,7 @@ impl LlmDriver for ClaudeCodeDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
-                actual_model: None,
+                actual_model: parsed.model,
             });
         }
 
@@ -1289,6 +1298,9 @@ impl LlmDriver for ClaudeCodeDriver {
             output_tokens: 0,
             ..Default::default()
         };
+        // The model the CLI resolved, recovered from the stream-json `init`
+        // event (stream-json mode emits it up front). Surfaced as actual_model.
+        let mut actual_model: Option<String> = None;
 
         // Track last known activity for timeout diagnostics
         let mut last_activity = "starting".to_string();
@@ -1379,6 +1391,16 @@ impl LlmDriver for ClaudeCodeDriver {
 
                     match serde_json::from_str::<ClaudeStreamEvent>(&line) {
                         Ok(event) => {
+                            // Recover the resolved model from whichever event
+                            // carries it (the `system`/`init` event in
+                            // stream-json mode emits it up front).
+                            if actual_model.is_none() {
+                                if let Some(ref m) = event.model {
+                                    if !m.is_empty() {
+                                        actual_model = Some(m.clone());
+                                    }
+                                }
+                            }
                             // Track last activity for timeout diagnostics
                             let etype = event.r#type.as_str();
                             if etype.contains("tool") {
@@ -1605,7 +1627,7 @@ impl LlmDriver for ClaudeCodeDriver {
             tool_calls: Vec::new(),
             usage: final_usage,
             actual_provider: None,
-            actual_model: None,
+            actual_model,
         })
     }
 

--- a/crates/librefang-llm-drivers/src/drivers/codewhale.rs
+++ b/crates/librefang-llm-drivers/src/drivers/codewhale.rs
@@ -1,0 +1,450 @@
+//! CodeWhale CLI backend driver.
+//!
+//! Spawns the `codewhale` CLI (an open-source Rust terminal coding agent,
+//! DeepSeek-V4-first and OpenAI-compatible) via its non-interactive
+//! `exec --json` one-shot mode, which handles its own authentication and
+//! provider/model resolution.
+//!
+//! Like the `codex-cli` driver, CodeWhale resolves its own model — its
+//! `/model auto` route re-picks a model per turn — so the model the CLI
+//! actually ran can differ from the requested id. The one-shot `--json`
+//! summary reports that resolved model in its `model` field, which we surface
+//! through [`CompletionResponse::actual_model`] so kernel-side metering
+//! records reality rather than the nominated id.
+//!
+//! We use the **one-shot** path (`exec --json`, not `--auto`) so CodeWhale
+//! performs a single model call rather than running its own tool-using agent
+//! loop on top of LibreFang's — LibreFang already owns the agent loop and tool
+//! surface; here CodeWhale is just the LLM backend.
+
+use crate::llm_driver::{CompletionRequest, CompletionResponse, LlmDriver, LlmError};
+use async_trait::async_trait;
+use librefang_types::message::{ContentBlock, Role, StopReason, TokenUsage};
+use serde::Deserialize;
+use tracing::{debug, warn};
+
+/// LLM driver that delegates to the CodeWhale CLI.
+pub struct CodeWhaleDriver {
+    cli_path: String,
+    skip_permissions: bool,
+    /// When `true` (the default), set `LIBREFANG_AGENT_ID`,
+    /// `LIBREFANG_SESSION_ID`, and `LIBREFANG_STEP_ID` env vars on the spawned
+    /// subprocess so operators can correlate process-tree entries with
+    /// LibreFang agent sessions.
+    emit_caller_trace_headers: bool,
+}
+
+/// One-shot summary emitted by `codewhale exec --json`.
+///
+/// Shape: `{"mode":"one-shot","model":"<id>","success":true,"output":"<text>"}`.
+/// `output` carries the assistant text; `model` is the model CodeWhale
+/// actually resolved (it may differ from the requested id under `/model auto`).
+/// Older / alternate builds may name the text field `result`/`content`/`text`,
+/// so we try each. All fields are optional so a partial or future-shaped
+/// summary still deserializes and degrades gracefully.
+#[derive(Debug, Deserialize, Default)]
+struct CodeWhaleExecSummary {
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    output: Option<String>,
+    #[serde(default)]
+    result: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    /// `false` marks a failed run even when the process exits 0.
+    #[serde(default = "default_true")]
+    success: bool,
+    /// Populated on failure.
+    #[serde(default)]
+    error: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl CodeWhaleDriver {
+    /// Create a new CodeWhale CLI driver.
+    ///
+    /// `cli_path` overrides the CLI binary path; defaults to `"codewhale"` on
+    /// PATH. `skip_permissions` runs the CLI non-interactively (required for
+    /// daemon mode) — CodeWhale's one-shot `exec` does not prompt, so this is
+    /// informational parity with the other CLI drivers.
+    pub fn new(cli_path: Option<String>, skip_permissions: bool) -> Self {
+        Self {
+            cli_path: cli_path
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "codewhale".to_string()),
+            skip_permissions,
+            emit_caller_trace_headers: true,
+        }
+    }
+
+    /// Control whether caller-trace env vars are injected into the spawned
+    /// subprocess.
+    pub fn with_emit_caller_trace_headers(mut self, emit: bool) -> Self {
+        self.emit_caller_trace_headers = emit;
+        self
+    }
+
+    /// Inject caller-trace env vars into a subprocess command when the flag is
+    /// on. Empty / `None` values are skipped.
+    fn apply_caller_trace_envs(cmd: &mut tokio::process::Command, request: &CompletionRequest) {
+        if let Some(ref id) = request.agent_id {
+            if !id.is_empty() {
+                cmd.env("LIBREFANG_AGENT_ID", id);
+            }
+        }
+        if let Some(ref sid) = request.session_id {
+            if !sid.is_empty() {
+                cmd.env("LIBREFANG_SESSION_ID", sid);
+            }
+        }
+        if let Some(ref step) = request.step_id {
+            if !step.is_empty() {
+                cmd.env("LIBREFANG_STEP_ID", step);
+            }
+        }
+    }
+
+    /// Detect if the CodeWhale CLI is available on PATH.
+    pub fn detect() -> Option<String> {
+        let output = std::process::Command::new("codewhale")
+            .arg("--version")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?;
+
+        if output.status.success() {
+            Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Build the CLI arguments for a request.
+    ///
+    /// One-shot JSON mode: `exec --json [--model <m>] <prompt>`. The prompt is
+    /// the trailing positional; CodeWhale's `exec` declares it with
+    /// `allow_hyphen_values`, so a prompt that starts with `-` is not parsed as
+    /// a flag.
+    pub fn build_args(&self, prompt: &str, model: &str) -> Vec<String> {
+        let mut args = vec!["exec".to_string(), "--json".to_string()];
+
+        if let Some(m) = Self::model_flag(model) {
+            args.push("--model".to_string());
+            args.push(m);
+        }
+
+        args.push(prompt.to_string());
+        args
+    }
+
+    /// Map a model id like `codewhale/deepseek-v4-pro` to the `--model` value.
+    ///
+    /// Returns `None` for the bare provider id (`codewhale`) or an empty
+    /// string, so CodeWhale falls back to its configured default model rather
+    /// than being handed a non-model token.
+    fn model_flag(model: &str) -> Option<String> {
+        let stripped = model.strip_prefix("codewhale/").unwrap_or(model);
+        let stripped = stripped.trim();
+        if stripped.is_empty() || stripped == "codewhale" {
+            None
+        } else {
+            Some(stripped.to_string())
+        }
+    }
+
+    /// Build a text prompt from the completion request messages.
+    fn build_prompt(request: &CompletionRequest) -> String {
+        let mut parts = Vec::new();
+
+        if let Some(ref sys) = request.system {
+            parts.push(format!("[System]\n{sys}"));
+        }
+
+        for msg in request.messages.iter() {
+            let role_label = match msg.role {
+                Role::User => "User",
+                Role::Assistant => "Assistant",
+                Role::System => "System",
+            };
+            let text = msg.content.text_content();
+            if !text.is_empty() {
+                parts.push(format!("[{role_label}]\n{text}"));
+            }
+        }
+
+        parts.join("\n\n")
+    }
+
+    /// Extract assistant text from a parsed summary, trying the documented
+    /// `output` field first then alternate field names.
+    fn summary_text(summary: &CodeWhaleExecSummary) -> String {
+        summary
+            .output
+            .clone()
+            .or_else(|| summary.result.clone())
+            .or_else(|| summary.content.clone())
+            .or_else(|| summary.text.clone())
+            .unwrap_or_default()
+    }
+}
+
+#[async_trait]
+impl LlmDriver for CodeWhaleDriver {
+    #[tracing::instrument(
+        name = "llm.complete",
+        skip_all,
+        fields(provider = "codewhale", model = %request.model)
+    )]
+    async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        let prompt = Self::build_prompt(&request);
+        let args = self.build_args(&prompt, &request.model);
+
+        let mut cmd = tokio::process::Command::new(&self.cli_path);
+        for arg in &args {
+            cmd.arg(arg);
+        }
+
+        // CodeWhale is multi-provider (DeepSeek, OpenAI, OpenRouter, NVIDIA, …)
+        // and reads whichever provider key is configured, so — like the aider
+        // driver — we do not strip provider keys from the environment.
+        if self.emit_caller_trace_headers {
+            Self::apply_caller_trace_envs(&mut cmd, &request);
+        }
+
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        debug!(cli = %self.cli_path, skip_permissions = self.skip_permissions, "Spawning CodeWhale CLI");
+
+        let output = cmd.output().await.map_err(|e| {
+            LlmError::Http(format!(
+                "CodeWhale CLI not found or failed to start ({e}). \
+                 Install: npm install -g codewhale"
+            ))
+        })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        if !output.status.success() {
+            let detail = if !stderr.trim().is_empty() {
+                stderr.trim()
+            } else {
+                stdout.trim()
+            };
+            let code = output.status.code().unwrap_or(1);
+
+            let message = if detail.contains("not authenticated")
+                || detail.contains("auth")
+                || detail.contains("login")
+                || detail.contains("credentials")
+                || detail.contains("api key")
+                || detail.contains("API key")
+            {
+                format!(
+                    "CodeWhale CLI is not authenticated. Run: codewhale auth set --provider deepseek\nDetail: {detail}"
+                )
+            } else {
+                format!("CodeWhale CLI exited with code {code}: {detail}")
+            };
+
+            return Err(LlmError::Api {
+                status: code as u16,
+                message,
+                code: None,
+            });
+        }
+
+        // Parse the one-shot `--json` summary. Recover the resolved model from
+        // its `model` field (#6134-style actual-model reporting); fall back to
+        // the requested id when the summary lacks one so attribution is never
+        // empty.
+        let trimmed = stdout.trim();
+        if let Ok(summary) = serde_json::from_str::<CodeWhaleExecSummary>(trimmed) {
+            let text = Self::summary_text(&summary);
+
+            if !summary.success {
+                let detail = summary.error.unwrap_or_else(|| {
+                    if text.is_empty() {
+                        "CodeWhale reported failure".to_string()
+                    } else {
+                        text.clone()
+                    }
+                });
+                return Err(LlmError::Api {
+                    status: 1,
+                    message: format!("CodeWhale run failed: {detail}"),
+                    code: None,
+                });
+            }
+
+            let resolved_model = match summary.model {
+                Some(m) if !m.trim().is_empty() => {
+                    debug!(requested = %request.model, actual = %m, "CodeWhale resolved model");
+                    m
+                }
+                _ => Self::model_flag(&request.model).unwrap_or_else(|| request.model.clone()),
+            };
+
+            return Ok(CompletionResponse {
+                content: vec![ContentBlock::Text {
+                    text,
+                    provider_metadata: None,
+                }],
+                stop_reason: StopReason::EndTurn,
+                tool_calls: Vec::new(),
+                usage: TokenUsage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    ..Default::default()
+                },
+                actual_provider: None,
+                actual_model: Some(resolved_model),
+            });
+        }
+
+        // Fallback: stdout was not the expected JSON summary. Treat it as plain
+        // text and fall back to the requested model id for attribution.
+        warn!("CodeWhale CLI output was not a JSON summary; treating stdout as plain text");
+        let resolved_model =
+            Self::model_flag(&request.model).unwrap_or_else(|| request.model.clone());
+        Ok(CompletionResponse {
+            content: vec![ContentBlock::Text {
+                text: trimmed.to_string(),
+                provider_metadata: None,
+            }],
+            stop_reason: StopReason::EndTurn,
+            tool_calls: Vec::new(),
+            usage: TokenUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+                ..Default::default()
+            },
+            actual_provider: None,
+            actual_model: Some(resolved_model),
+        })
+    }
+
+    fn family(&self) -> crate::llm_driver::LlmFamily {
+        // CodeWhale is DeepSeek-first and OpenAI-wire-compatible.
+        crate::llm_driver::LlmFamily::OpenAi
+    }
+
+    fn is_coding_agent(&self) -> bool {
+        true
+    }
+}
+
+/// Check if the CodeWhale CLI is available (binary on PATH or credentials
+/// exist).
+pub fn codewhale_available() -> bool {
+    CodeWhaleDriver::detect().is_some() || codewhale_credentials_exist()
+}
+
+/// Check if CodeWhale credentials/config exist.
+fn codewhale_credentials_exist() -> bool {
+    if let Some(home) = home_dir() {
+        let dir = home.join(".codewhale");
+        dir.join("config.toml").exists() || dir.join("auth.json").exists()
+    } else {
+        false
+    }
+}
+
+/// Cross-platform home directory.
+fn home_dir() -> Option<std::path::PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var("USERPROFILE")
+            .ok()
+            .map(std::path::PathBuf::from)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::env::var("HOME").ok().map(std::path::PathBuf::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_coding_agent_is_true() {
+        assert!(CodeWhaleDriver::new(None, false).is_coding_agent());
+    }
+
+    #[test]
+    fn test_new_defaults() {
+        let driver = CodeWhaleDriver::new(None, false);
+        assert_eq!(driver.cli_path, "codewhale");
+        assert!(!driver.skip_permissions);
+    }
+
+    #[test]
+    fn test_new_with_empty_path() {
+        let driver = CodeWhaleDriver::new(Some(String::new()), false);
+        assert_eq!(driver.cli_path, "codewhale");
+    }
+
+    #[test]
+    fn test_build_args_one_shot_json() {
+        let driver = CodeWhaleDriver::new(None, true);
+        let args = driver.build_args("hello prompt", "codewhale/deepseek-v4-pro");
+        assert_eq!(args.first().map(String::as_str), Some("exec"));
+        assert!(args.contains(&"--json".to_string()));
+        assert!(args.contains(&"--model".to_string()));
+        assert!(args.contains(&"deepseek-v4-pro".to_string()));
+        assert_eq!(args.last().map(String::as_str), Some("hello prompt"));
+    }
+
+    #[test]
+    fn test_model_flag_strips_prefix_and_defaults() {
+        assert_eq!(
+            CodeWhaleDriver::model_flag("codewhale/deepseek-v4-pro"),
+            Some("deepseek-v4-pro".to_string())
+        );
+        assert_eq!(
+            CodeWhaleDriver::model_flag("mimo-v2.5-pro"),
+            Some("mimo-v2.5-pro".to_string())
+        );
+        // Bare provider id / empty → None so CodeWhale uses its own default.
+        assert_eq!(CodeWhaleDriver::model_flag("codewhale"), None);
+        assert_eq!(CodeWhaleDriver::model_flag(""), None);
+    }
+
+    #[test]
+    fn test_parse_summary_extracts_model_and_output() {
+        let json =
+            r#"{"mode":"one-shot","model":"deepseek-v4-pro","success":true,"output":"hi there"}"#;
+        let summary: CodeWhaleExecSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(summary.model.as_deref(), Some("deepseek-v4-pro"));
+        assert!(summary.success);
+        assert_eq!(CodeWhaleDriver::summary_text(&summary), "hi there");
+    }
+
+    #[test]
+    fn test_parse_summary_failure_flag() {
+        let json = r#"{"mode":"one-shot","success":false,"error":"boom"}"#;
+        let summary: CodeWhaleExecSummary = serde_json::from_str(json).unwrap();
+        assert!(!summary.success);
+        assert_eq!(summary.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn test_summary_text_field_fallbacks() {
+        // Alternate builds may use `result`/`content`/`text` instead of `output`.
+        let s = CodeWhaleExecSummary {
+            result: Some("from result".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(CodeWhaleDriver::summary_text(&s), "from result");
+    }
+}

--- a/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
@@ -370,6 +370,10 @@ impl LlmDriver for CodexCliDriver {
     fn family(&self) -> crate::llm_driver::LlmFamily {
         crate::llm_driver::LlmFamily::OpenAi
     }
+
+    fn is_coding_agent(&self) -> bool {
+        true
+    }
 }
 
 /// Check if the Codex CLI is available.
@@ -407,6 +411,11 @@ fn home_dir() -> Option<std::path::PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_coding_agent_is_true() {
+        assert!(CodexCliDriver::new(None, false).is_coding_agent());
+    }
 
     #[test]
     fn test_new_defaults() {

--- a/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/gemini_cli.rs
@@ -273,6 +273,10 @@ impl LlmDriver for GeminiCliDriver {
     fn family(&self) -> crate::llm_driver::LlmFamily {
         crate::llm_driver::LlmFamily::Google
     }
+
+    fn is_coding_agent(&self) -> bool {
+        true
+    }
 }
 
 /// Check if the Gemini CLI is available.
@@ -330,6 +334,11 @@ fn home_dir() -> Option<std::path::PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_coding_agent_is_true() {
+        assert!(GeminiCliDriver::new(None, false).is_coding_agent());
+    }
 
     #[test]
     fn test_new_defaults() {

--- a/crates/librefang-llm-drivers/src/drivers/mod.rs
+++ b/crates/librefang-llm-drivers/src/drivers/mod.rs
@@ -8,6 +8,7 @@ pub mod anthropic;
 pub mod bedrock;
 pub mod chatgpt;
 pub mod claude_code;
+pub mod codewhale;
 pub mod codex_cli;
 pub mod copilot;
 pub mod fallback;
@@ -135,6 +136,8 @@ pub enum ApiFormat {
     GeminiCli,
     /// Codex CLI subprocess.
     CodexCli,
+    /// CodeWhale CLI subprocess.
+    CodeWhale,
     /// ChatGPT with session token authentication.
     ChatGpt,
     /// GitHub Copilot with automatic token exchange.
@@ -466,6 +469,16 @@ static PROVIDER_REGISTRY: &[ProviderEntry] = &[
         hidden: false,
     },
     ProviderEntry {
+        name: "codewhale",
+        aliases: &[],
+        base_url: "",
+        api_key_env: "",
+        key_required: false,
+        api_format: ApiFormat::CodeWhale,
+        alt_api_key_env: None,
+        hidden: false,
+    },
+    ProviderEntry {
         name: "moonshot",
         aliases: &["kimi", "kimi2"],
         base_url: "https://api.moonshot.ai/v1",
@@ -779,6 +792,10 @@ fn create_driver_from_entry(
             codex_cli::CodexCliDriver::new(config.base_url.clone(), config.skip_permissions)
                 .with_emit_caller_trace_headers(config.emit_caller_trace_headers),
         )),
+        ApiFormat::CodeWhale => Ok(Arc::new(
+            codewhale::CodeWhaleDriver::new(config.base_url.clone(), config.skip_permissions)
+                .with_emit_caller_trace_headers(config.emit_caller_trace_headers),
+        )),
         ApiFormat::ChatGpt => Ok(Arc::new(
             chatgpt::ChatGptDriver::with_proxy(api_key, base_url, proxy_url)
                 .with_emit_caller_trace_headers(config.emit_caller_trace_headers),
@@ -910,7 +927,7 @@ pub fn create_driver(config: &DriverConfig) -> Result<Arc<dyn LlmDriver>, LlmErr
             "Unknown provider '{}'. Supported: anthropic, chatgpt, gemini, openai, groq, openrouter, \
              deepseek, deepinfra, together, mistral, fireworks, ollama, vllm, lmstudio, perplexity, \
              cohere, cerebras, sambanova, huggingface, xai, replicate, github-copilot, \
-             azure-openai, vertex-ai, nvidia-nim, novita, bedrock, claude-code, qwen-code, gemini-cli, codex-cli, \
+             azure-openai, vertex-ai, nvidia-nim, novita, bedrock, claude-code, qwen-code, gemini-cli, codex-cli, codewhale, \
              qwen, minimax, zhipu, zhipu_coding, zai, moonshot, kimi_coding, \
              qianfan, volcengine, byteplus, alibaba-coding-plan. \
              Or set base_url for a custom OpenAI-compatible endpoint.",
@@ -991,7 +1008,13 @@ pub fn detect_available_provider() -> Option<(&'static str, &'static str, &'stat
     //
     // Order matches typical install prevalence — claude-code first, then
     // codex-cli, then Google's Gemini CLI, then Qwen's fork.
-    const CLI_PRIORITY: &[&str] = &["claude-code", "codex-cli", "gemini-cli", "qwen-code"];
+    const CLI_PRIORITY: &[&str] = &[
+        "claude-code",
+        "codex-cli",
+        "codewhale",
+        "gemini-cli",
+        "qwen-code",
+    ];
     for &name in CLI_PRIORITY {
         if cli_provider_available(name) {
             return Some((name, "", ""));
@@ -1025,6 +1048,27 @@ pub fn provider_api_format(name: &str) -> Option<ApiFormat> {
         .iter()
         .find(|p| p.name == name || p.aliases.contains(&name))
         .map(|p| p.api_format)
+}
+
+/// Whether a provider id (or alias) maps to a coding-agent CLI driver —
+/// `claude-code`, `codex-cli`, `gemini-cli`, `qwen-code`, `codewhale`.
+///
+/// Registry-level mirror of [`crate::llm_driver::LlmDriver::is_coding_agent`]
+/// for the in-tree drivers: lets surfaces that only have a provider name (the
+/// dashboard provider list, metering labels) group coding agents apart from
+/// raw provider APIs without instantiating a driver. Returns `false` for
+/// unknown providers.
+pub fn is_coding_agent_provider(name: &str) -> bool {
+    matches!(
+        provider_api_format(name),
+        Some(
+            ApiFormat::ClaudeCode
+                | ApiFormat::QwenCode
+                | ApiFormat::GeminiCli
+                | ApiFormat::CodexCli
+                | ApiFormat::CodeWhale
+        )
+    )
 }
 
 /// `(env_var, provider_id)` pairs for every cloud provider in the registry
@@ -1062,6 +1106,7 @@ pub fn cli_provider_available(name: &str) -> bool {
         "qwen-code" => qwen_code::qwen_code_available(),
         "gemini-cli" => gemini_cli::gemini_cli_available(),
         "codex-cli" => codex_cli::codex_cli_available(),
+        "codewhale" => codewhale::codewhale_available(),
         _ => false,
     }
 }
@@ -1094,7 +1139,7 @@ pub fn is_proxied_via_env(env_vars: &[&str], official_hosts: &[&str]) -> bool {
 pub fn is_cli_provider(name: &str) -> bool {
     matches!(
         name,
-        "claude-code" | "qwen-code" | "gemini-cli" | "codex-cli"
+        "claude-code" | "qwen-code" | "gemini-cli" | "codex-cli" | "codewhale"
     )
 }
 
@@ -1321,13 +1366,37 @@ mod tests {
         assert!(providers.contains(&"qwen-code"));
         assert!(providers.contains(&"gemini-cli"));
         assert!(providers.contains(&"codex-cli"));
+        assert!(providers.contains(&"codewhale"));
         assert!(providers.contains(&"azure-openai"));
         assert!(providers.contains(&"vertex-ai"));
         assert!(providers.contains(&"nvidia-nim"));
         assert!(providers.contains(&"novita"));
         assert!(providers.contains(&"bedrock"));
         assert!(providers.contains(&"microsoft"));
-        assert_eq!(providers.len(), 43);
+        assert_eq!(providers.len(), 44);
+    }
+
+    #[test]
+    fn is_coding_agent_provider_classifies_cli_drivers() {
+        for p in [
+            "claude-code",
+            "codex-cli",
+            "gemini-cli",
+            "qwen-code",
+            "codewhale",
+        ] {
+            assert!(
+                super::is_coding_agent_provider(p),
+                "{p} should be a coding agent"
+            );
+        }
+        for p in ["openai", "anthropic", "gemini", "ollama", "deepseek"] {
+            assert!(
+                !super::is_coding_agent_provider(p),
+                "{p} should NOT be a coding agent"
+            );
+        }
+        assert!(!super::is_coding_agent_provider("nonexistent-xyz"));
     }
 
     /// `microsoft` (GitHub Models / Azure AI Inference) must declare its own

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -1030,6 +1030,10 @@ impl LlmDriver for QwenCodeDriver {
     fn family(&self) -> crate::llm_driver::LlmFamily {
         crate::llm_driver::LlmFamily::OpenAi
     }
+
+    fn is_coding_agent(&self) -> bool {
+        true
+    }
 }
 
 /// Check if the Qwen Code CLI is available.
@@ -1074,6 +1078,11 @@ fn home_dir() -> Option<std::path::PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_coding_agent_is_true() {
+        assert!(QwenCodeDriver::new(None, false).is_coding_agent());
+    }
 
     #[test]
     fn extract_text_single_object() {

--- a/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/qwen_code.rs
@@ -545,6 +545,9 @@ struct QwenJsonOutput {
     #[serde(default)]
     #[allow(dead_code)]
     cost_usd: Option<f64>,
+    /// The model the CLI reports running, when present.
+    #[serde(default)]
+    model: Option<String>,
 }
 
 /// Usage stats from Qwen CLI JSON output.
@@ -567,6 +570,9 @@ struct QwenStreamEvent {
     result: Option<String>,
     #[serde(default)]
     usage: Option<QwenUsage>,
+    /// Model the CLI reports, when present (e.g. on an init/system event).
+    #[serde(default)]
+    model: Option<String>,
 }
 
 /// Extract assistant text and token usage from Qwen CLI stdout when the
@@ -758,7 +764,7 @@ impl QwenCodeDriver {
                     ..Default::default()
                 },
                 actual_provider: None,
-                actual_model: None,
+                actual_model: parsed.model,
             });
         }
 
@@ -856,6 +862,9 @@ impl QwenCodeDriver {
             output_tokens: 0,
             ..Default::default()
         };
+        // Model the CLI resolved, recovered from whichever stream event carries
+        // it. Surfaced as actual_model (best-effort: None if the CLI omits it).
+        let mut actual_model: Option<String> = None;
         // Set when a `tx.send(...)` fails — kill the child and stop reading
         // stdout so the CLI doesn't keep producing tokens for nobody (#3769).
         let mut receiver_dropped = false;
@@ -889,6 +898,13 @@ impl QwenCodeDriver {
             };
 
             for event in events {
+                if actual_model.is_none() {
+                    if let Some(ref m) = event.model {
+                        if !m.is_empty() {
+                            actual_model = Some(m.clone());
+                        }
+                    }
+                }
                 match event.r#type.as_str() {
                     "content" | "text" | "assistant" | "content_block_delta" => {
                         if let Some(ref content) = event.content {
@@ -993,7 +1009,7 @@ impl QwenCodeDriver {
             tool_calls: Vec::new(),
             usage: final_usage,
             actual_provider: None,
-            actual_model: None,
+            actual_model,
         })
     }
 }


### PR DESCRIPTION
## Summary

Treats coding-agent CLIs as a first-class category distinct from raw provider APIs, generalizes "report the model the CLI actually used" (#6157, codex-cli) across that category, adds a new **CodeWhale** coding-agent driver, and surfaces the distinction in the dashboard. Delivered as one feature across three commits.

## 1. `is_coding_agent()` driver classification

New `LlmDriver::is_coding_agent()` trait method (default `false`), overridden `true` by the coding-agent CLI drivers (claude-code, codex-cli, gemini-cli, qwen-code, codewhale). Orthogonal to the existing `LlmFamily` (wire format): claude-code and the Anthropic HTTP API are both `LlmFamily::Anthropic`, yet only the former is a coding agent. Coding agents own model selection, so they are the drivers that can populate `CompletionResponse::actual_model`. `aider.rs` is unwired dead code and left untouched.

## 2. `actual_model` reporting across coding agents

- **codex-cli** — already done in #6157 (stderr banner).
- **claude-code** — captures the resolved model from the stream-json `init` event. The non-stream `--output-format json` result carries no model field, so that path stays `None` (field captured for forward-compat).
- **qwen-code** — best-effort capture from the JSON / stream events where the CLI reports a model.
- **codewhale** — see below.

## 3. New CodeWhale driver

CodeWhale (Hmbown/CodeWhale) is an open-source Rust terminal coding agent, DeepSeek-V4-first and OpenAI-compatible, whose `/model auto` re-picks a model per turn. The driver spawns `codewhale exec --json` (one-shot, so CodeWhale does a single model call rather than running its own agent loop on top of LibreFang's) and parses the summary's `model` field into `actual_model`. Registered in the provider factory (`ApiFormat::CodeWhale`, provider id `codewhale`), CLI-availability detection, `is_cli_provider`, and the CLI fallback priority list.

## 4. Dashboard grouping

`GET /api/providers` now includes `is_coding_agent` per provider (via the new registry helper `is_coding_agent_provider`, `ApiFormat`-based — no driver instantiation). The endpoint returns untyped JSON, so **no openapi/SDK regen is needed**. The Providers page splits the configured list into a "Coding Agents" section and a "Providers" section (headers shown only when both groups are present). i18n keys added to en/zh/uk.

## Verification

Run in the repo's `Dockerfile.rust-dev` image (no native toolchain on the dev box; isolated named target volume) and via pnpm:

- `cargo fmt --check` — clean
- `cargo clippy -p librefang-llm-driver -p librefang-llm-drivers --all-targets -- -D warnings` — zero warnings
- `cargo test -p librefang-llm-drivers --lib` — 575 passed (incl. 8 CodeWhale tests, `is_coding_agent` classification per driver, `is_coding_agent_provider`, known-providers count)
- `cargo test -p librefang-llm-driver --lib` — 62 passed
- `cargo check -p librefang-api --lib` — clean
- dashboard: `pnpm typecheck` clean, `eslint` clean on `ProvidersPage.tsx`, locale-parity vitest passes, `ProvidersPage.test.tsx` 10 passed

## Notes / out of scope

- No CHANGELOG entry: `CHANGELOG.md` already has a **pre-existing duplicate `## [Unreleased]`** (line ~841, the historical `#2` block) on `main`, which trips the pre-commit duplicate guard for any new `[Unreleased]` addition. That stale section should be folded into a release separately; flagging rather than touching historical content here.
- `actual_model` for claude-code's non-stream path and qwen-code is best-effort: those CLIs don't always emit the model in machine-readable output. The field is captured wherever they do.
