### PR TITLE
feat(runtime): emit agent-loop exit-reason metric (#6227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -834,6 +834,14 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ## [Unreleased]
 
+### Added
+
+- **feat(runtime): emit `librefang_agent_loop_exits_total{agent,reason}`** so operators can alert on non-success agent-loop terminations (#6227) (@houko).
+  The agent loop previously recorded no metric when it aborted on repeated tool failures, max iterations, a loop-guard circuit break, or a provider content-filter — the only signal was reading transcripts, and a cron/trigger fire that aborted still recorded `librefang_cron_fires_total{outcome="ok"}` because the loop returned.
+  Reasons: `completed`, `max_iterations`, `repeated_tool_failures`, `circuit_break`, `content_filtered`, `error`.
+  The counter increments exactly once per termination from a thin wrapper around the streaming and non-streaming loops, so no branch fall-through can double-count.
+  Alert with `rate(librefang_agent_loop_exits_total{reason!="completed"}) > 0` per agent.
+
 ### Breaking Changes
 
 - **Subprocess plugin sandbox is now secure-by-default** (#2) (@houko).

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -139,45 +139,12 @@ const MAX_CONSECUTIVE_ALL_FAILED: u32 = 3;
 /// Used by channel_bridge to detect this case without fragile string matching.
 pub const TIMEOUT_PARTIAL_OUTPUT_MARKER: &str = "[partial_output_delivered]";
 
-/// Sanitize an agent name into a bounded, low-cardinality metric label.
-///
-/// Mirrors `sanitize_tool_label` in `tool_call.rs` and the bounded-cardinality
-/// contract documented on `record_cron_fire_metric` in the kernel's `cron.rs`:
-/// strip control chars and cap the length so a pathological agent name can't
-/// blow up the metric registry. The agent roster is bounded in steady state.
+/// Strips control chars and caps length to bound metric cardinality.
 fn sanitize_agent_label(name: &str) -> String {
     name.chars().filter(|c| !c.is_control()).take(64).collect()
 }
 
-/// Classify the final result of an agent-loop run into a stable metric
-/// `reason` label for `librefang_agent_loop_exits_total`.
-///
-/// One reason per real termination branch in `run_agent_loop` /
-/// `run_agent_loop_streaming`:
-/// - `completed` — any `Ok(_)` return: a finalized EndTurn reply, a silent
-///   completion (NO_REPLY / cascade-leak / progress-leak / mid-stream
-///   cascade-leak abort), a MaxTokens partial return, an interrupt-cancel
-///   early return, or the provider-not-configured early return. These all
-///   represent the loop handing control back without an error.
-/// - `max_iterations` — `Err(MaxIterationsExceeded)`: the `for` loop ran out.
-/// - `repeated_tool_failures` — `Err(RepeatedToolFailures)`:
-///   `consecutive_all_failed >= MAX_CONSECUTIVE_ALL_FAILED`.
-/// - `circuit_break` — the loop-guard global circuit breaker tripped. It
-///   surfaces as `Err(Internal(msg))` propagated up through the `?` on
-///   `execute_single_tool_call`; matched via the shared
-///   `loop_guard::CIRCUIT_BREAKER_MSG_PREFIX` constant.
-/// - `content_filtered` — `Err(ContentFiltered)`: provider safety / content
-///   filter blocked the response.
-/// - `error` — any other propagated `Err` (LLM call failure, memory error,
-///   etc.).
-///
-/// NOTE on the issue's suggested set: there is no distinct `empty_response`
-/// *termination* branch. An empty LLM response is a one-shot in-loop retry
-/// (`EndTurnRetry::EmptyResponse` → `continue`); the turn then either retries
-/// to a real reply or finalizes via `finalize_end_turn_text`, both of which
-/// land on `completed`. `content_filtered` is added because it is a real
-/// distinct terminal branch operators will want to separate from generic
-/// `error`.
+/// Maps the loop result to a stable metric `reason` label; no `empty_response` branch (empty replies retry in-loop and land on `completed`).
 fn classify_exit_reason(result: &LibreFangResult<AgentLoopResult>) -> &'static str {
     match result {
         Ok(_) => "completed",
@@ -193,16 +160,7 @@ fn classify_exit_reason(result: &LibreFangResult<AgentLoopResult>) -> &'static s
     }
 }
 
-/// Emit the agent-loop exit counter exactly once per loop termination.
-///
-/// Single-increment is guaranteed structurally: the public entry points
-/// (`run_agent_loop`, `run_agent_loop_streaming`) are thin wrappers that call
-/// their respective `*_inner` body once and feed the single returned `Result`
-/// here. No terminal site inside the loop touches this metric, so there is no
-/// path that can double-count even when one branch falls through to another.
-///
-/// Operators alert on
-/// `rate(librefang_agent_loop_exits_total{reason!="completed"}) > 0` per agent.
+/// Increments the exit counter exactly once — called only by the instrumented wrappers, never from within the loop.
 fn record_agent_loop_exit(agent: &str, result: &LibreFangResult<AgentLoopResult>) {
     metrics::counter!(
         "librefang_agent_loop_exits_total",
@@ -443,11 +401,6 @@ pub async fn run_agent_loop(
     pending_messages: Option<&tokio::sync::Mutex<mpsc::Receiver<AgentLoopSignal>>>,
     opts: &LoopOptions,
 ) -> LibreFangResult<AgentLoopResult> {
-    // Thin instrumented wrapper around `run_agent_loop_inner`. The single
-    // returned `Result` is classified into the `librefang_agent_loop_exits_total`
-    // metric exactly once here (see `record_agent_loop_exit`), so every
-    // termination branch — `Ok`, propagated `?` error, or explicit `Err` — is
-    // counted once and only once, with no per-site increments to double-count.
     let agent_label = manifest.name.clone();
     let result = run_agent_loop_inner(
         manifest,

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -139,6 +139,79 @@ const MAX_CONSECUTIVE_ALL_FAILED: u32 = 3;
 /// Used by channel_bridge to detect this case without fragile string matching.
 pub const TIMEOUT_PARTIAL_OUTPUT_MARKER: &str = "[partial_output_delivered]";
 
+/// Sanitize an agent name into a bounded, low-cardinality metric label.
+///
+/// Mirrors `sanitize_tool_label` in `tool_call.rs` and the bounded-cardinality
+/// contract documented on `record_cron_fire_metric` in the kernel's `cron.rs`:
+/// strip control chars and cap the length so a pathological agent name can't
+/// blow up the metric registry. The agent roster is bounded in steady state.
+fn sanitize_agent_label(name: &str) -> String {
+    name.chars().filter(|c| !c.is_control()).take(64).collect()
+}
+
+/// Classify the final result of an agent-loop run into a stable metric
+/// `reason` label for `librefang_agent_loop_exits_total`.
+///
+/// One reason per real termination branch in `run_agent_loop` /
+/// `run_agent_loop_streaming`:
+/// - `completed` — any `Ok(_)` return: a finalized EndTurn reply, a silent
+///   completion (NO_REPLY / cascade-leak / progress-leak / mid-stream
+///   cascade-leak abort), a MaxTokens partial return, an interrupt-cancel
+///   early return, or the provider-not-configured early return. These all
+///   represent the loop handing control back without an error.
+/// - `max_iterations` — `Err(MaxIterationsExceeded)`: the `for` loop ran out.
+/// - `repeated_tool_failures` — `Err(RepeatedToolFailures)`:
+///   `consecutive_all_failed >= MAX_CONSECUTIVE_ALL_FAILED`.
+/// - `circuit_break` — the loop-guard global circuit breaker tripped. It
+///   surfaces as `Err(Internal(msg))` propagated up through the `?` on
+///   `execute_single_tool_call`; matched via the shared
+///   `loop_guard::CIRCUIT_BREAKER_MSG_PREFIX` constant.
+/// - `content_filtered` — `Err(ContentFiltered)`: provider safety / content
+///   filter blocked the response.
+/// - `error` — any other propagated `Err` (LLM call failure, memory error,
+///   etc.).
+///
+/// NOTE on the issue's suggested set: there is no distinct `empty_response`
+/// *termination* branch. An empty LLM response is a one-shot in-loop retry
+/// (`EndTurnRetry::EmptyResponse` → `continue`); the turn then either retries
+/// to a real reply or finalizes via `finalize_end_turn_text`, both of which
+/// land on `completed`. `content_filtered` is added because it is a real
+/// distinct terminal branch operators will want to separate from generic
+/// `error`.
+fn classify_exit_reason(result: &LibreFangResult<AgentLoopResult>) -> &'static str {
+    match result {
+        Ok(_) => "completed",
+        Err(LibreFangError::MaxIterationsExceeded(_)) => "max_iterations",
+        Err(LibreFangError::RepeatedToolFailures { .. }) => "repeated_tool_failures",
+        Err(LibreFangError::ContentFiltered { .. }) => "content_filtered",
+        Err(LibreFangError::Internal(msg))
+            if msg.starts_with(crate::loop_guard::CIRCUIT_BREAKER_MSG_PREFIX) =>
+        {
+            "circuit_break"
+        }
+        Err(_) => "error",
+    }
+}
+
+/// Emit the agent-loop exit counter exactly once per loop termination.
+///
+/// Single-increment is guaranteed structurally: the public entry points
+/// (`run_agent_loop`, `run_agent_loop_streaming`) are thin wrappers that call
+/// their respective `*_inner` body once and feed the single returned `Result`
+/// here. No terminal site inside the loop touches this metric, so there is no
+/// path that can double-count even when one branch falls through to another.
+///
+/// Operators alert on
+/// `rate(librefang_agent_loop_exits_total{reason!="completed"}) > 0` per agent.
+fn record_agent_loop_exit(agent: &str, result: &LibreFangResult<AgentLoopResult>) {
+    metrics::counter!(
+        "librefang_agent_loop_exits_total",
+        "agent" => sanitize_agent_label(agent),
+        "reason" => classify_exit_reason(result),
+    )
+    .increment(1);
+}
+
 /// Notify the stream consumer that the LLM has finished producing text for
 /// this turn so the UI can unblock input before the agent loop's remaining
 /// post-processing (session persistence, proactive memory extraction) lands
@@ -341,6 +414,78 @@ pub(super) fn redact_images_for_text_only(mut messages: Vec<Message>, model: &st
 // The span itself does not emit a log line; the level only gates creation.
 #[instrument(level = "warn", skip_all, fields(agent.name = %manifest.name, agent.id = %session.agent_id, session.id = %session.id))]
 pub async fn run_agent_loop(
+    manifest: &AgentManifest,
+    user_message: &str,
+    session: &mut Session,
+    memory: &MemorySubstrate,
+    driver: Arc<dyn LlmDriver>,
+    available_tools: &[ToolDefinition],
+    kernel: Option<Arc<dyn KernelHandle>>,
+    skill_registry: Option<&SkillRegistry>,
+    mcp_connections: Option<&tokio::sync::Mutex<Vec<McpConnection>>>,
+    web_ctx: Option<&WebToolsContext>,
+    browser_ctx: Option<&crate::browser::BrowserManager>,
+    embedding_driver: Option<&(dyn EmbeddingDriver + Send + Sync)>,
+    workspace_root: Option<&Path>,
+    on_phase: Option<&PhaseCallback>,
+    media_engine: Option<&crate::media_understanding::MediaEngine>,
+    media_drivers: Option<&crate::media::MediaDriverCache>,
+    tts_engine: Option<&crate::tts::TtsEngine>,
+    docker_config: Option<&librefang_types::config::DockerSandboxConfig>,
+    hooks: Option<&crate::hooks::HookRegistry>,
+    context_window_tokens: Option<usize>,
+    process_manager: Option<&crate::process_manager::ProcessManager>,
+    checkpoint_manager: Option<Arc<CheckpointManager>>,
+    process_registry: Option<&crate::process_registry::ProcessRegistry>,
+    user_content_blocks: Option<Vec<ContentBlock>>,
+    proactive_memory: Option<Arc<librefang_memory::ProactiveMemoryStore>>,
+    context_engine: Option<&dyn ContextEngine>,
+    pending_messages: Option<&tokio::sync::Mutex<mpsc::Receiver<AgentLoopSignal>>>,
+    opts: &LoopOptions,
+) -> LibreFangResult<AgentLoopResult> {
+    // Thin instrumented wrapper around `run_agent_loop_inner`. The single
+    // returned `Result` is classified into the `librefang_agent_loop_exits_total`
+    // metric exactly once here (see `record_agent_loop_exit`), so every
+    // termination branch — `Ok`, propagated `?` error, or explicit `Err` — is
+    // counted once and only once, with no per-site increments to double-count.
+    let agent_label = manifest.name.clone();
+    let result = run_agent_loop_inner(
+        manifest,
+        user_message,
+        session,
+        memory,
+        driver,
+        available_tools,
+        kernel,
+        skill_registry,
+        mcp_connections,
+        web_ctx,
+        browser_ctx,
+        embedding_driver,
+        workspace_root,
+        on_phase,
+        media_engine,
+        media_drivers,
+        tts_engine,
+        docker_config,
+        hooks,
+        context_window_tokens,
+        process_manager,
+        checkpoint_manager,
+        process_registry,
+        user_content_blocks,
+        proactive_memory,
+        context_engine,
+        pending_messages,
+        opts,
+    )
+    .await;
+    record_agent_loop_exit(&agent_label, &result);
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_agent_loop_inner(
     manifest: &AgentManifest,
     user_message: &str,
     session: &mut Session,

--- a/crates/librefang-runtime/src/agent_loop/run_streaming.rs
+++ b/crates/librefang-runtime/src/agent_loop/run_streaming.rs
@@ -49,6 +49,79 @@ pub async fn run_agent_loop_streaming(
     pending_messages: Option<&tokio::sync::Mutex<mpsc::Receiver<AgentLoopSignal>>>,
     opts: &LoopOptions,
 ) -> LibreFangResult<AgentLoopResult> {
+    // Thin instrumented wrapper around `run_agent_loop_streaming_inner` — see
+    // `run_agent_loop` for the single-increment rationale. The streaming and
+    // non-streaming loops share the same `librefang_agent_loop_exits_total`
+    // metric and `record_agent_loop_exit` classifier.
+    let agent_label = manifest.name.clone();
+    let result = run_agent_loop_streaming_inner(
+        manifest,
+        user_message,
+        session,
+        memory,
+        driver,
+        available_tools,
+        kernel,
+        stream_tx,
+        skill_registry,
+        mcp_connections,
+        web_ctx,
+        browser_ctx,
+        embedding_driver,
+        workspace_root,
+        on_phase,
+        media_engine,
+        media_drivers,
+        tts_engine,
+        docker_config,
+        hooks,
+        context_window_tokens,
+        process_manager,
+        checkpoint_manager,
+        process_registry,
+        user_content_blocks,
+        proactive_memory,
+        context_engine,
+        pending_messages,
+        opts,
+    )
+    .await;
+    super::record_agent_loop_exit(&agent_label, &result);
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_agent_loop_streaming_inner(
+    manifest: &AgentManifest,
+    user_message: &str,
+    session: &mut Session,
+    memory: &MemorySubstrate,
+    driver: Arc<dyn LlmDriver>,
+    available_tools: &[ToolDefinition],
+    kernel: Option<Arc<dyn KernelHandle>>,
+    stream_tx: mpsc::Sender<StreamEvent>,
+    skill_registry: Option<&SkillRegistry>,
+    mcp_connections: Option<&tokio::sync::Mutex<Vec<McpConnection>>>,
+    web_ctx: Option<&WebToolsContext>,
+    browser_ctx: Option<&crate::browser::BrowserManager>,
+    embedding_driver: Option<&(dyn EmbeddingDriver + Send + Sync)>,
+    workspace_root: Option<&Path>,
+    on_phase: Option<&PhaseCallback>,
+    media_engine: Option<&crate::media_understanding::MediaEngine>,
+    media_drivers: Option<&crate::media::MediaDriverCache>,
+    tts_engine: Option<&crate::tts::TtsEngine>,
+    docker_config: Option<&librefang_types::config::DockerSandboxConfig>,
+    hooks: Option<&crate::hooks::HookRegistry>,
+    context_window_tokens: Option<usize>,
+    process_manager: Option<&crate::process_manager::ProcessManager>,
+    checkpoint_manager: Option<Arc<CheckpointManager>>,
+    process_registry: Option<&crate::process_registry::ProcessRegistry>,
+    user_content_blocks: Option<Vec<ContentBlock>>,
+    proactive_memory: Option<Arc<librefang_memory::ProactiveMemoryStore>>,
+    context_engine: Option<&dyn ContextEngine>,
+    pending_messages: Option<&tokio::sync::Mutex<mpsc::Receiver<AgentLoopSignal>>>,
+    opts: &LoopOptions,
+) -> LibreFangResult<AgentLoopResult> {
     info!(agent = %manifest.name, "Starting streaming agent loop");
 
     // Start index of new messages added during this turn. See the matching

--- a/crates/librefang-runtime/src/agent_loop/run_streaming.rs
+++ b/crates/librefang-runtime/src/agent_loop/run_streaming.rs
@@ -49,10 +49,6 @@ pub async fn run_agent_loop_streaming(
     pending_messages: Option<&tokio::sync::Mutex<mpsc::Receiver<AgentLoopSignal>>>,
     opts: &LoopOptions,
 ) -> LibreFangResult<AgentLoopResult> {
-    // Thin instrumented wrapper around `run_agent_loop_streaming_inner` — see
-    // `run_agent_loop` for the single-increment rationale. The streaming and
-    // non-streaming loops share the same `librefang_agent_loop_exits_total`
-    // metric and `record_agent_loop_exit` classifier.
     let agent_label = manifest.name.clone();
     let result = run_agent_loop_streaming_inner(
         manifest,

--- a/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
@@ -1293,6 +1293,129 @@ fn test_record_tool_call_metric_success_outcome() {
     );
 }
 
+// ── Agent-loop exit metric (refs #6227) ────────────────────────────────
+//
+// `librefang_agent_loop_exits_total{agent,reason}` must increment exactly
+// once per loop termination, with the `reason` label matching the real
+// termination branch. The wrapper (`run_agent_loop` /
+// `run_agent_loop_streaming`) classifies the single returned `Result` via
+// `classify_exit_reason` and emits through `record_agent_loop_exit`. These
+// tests pin the classifier mapping for every branch and prove the single
+// `record_agent_loop_exit` call increments exactly once with the right
+// labels — the injection site of the metric.
+
+/// `classify_exit_reason` maps each real termination `Result` to its stable
+/// `reason` label. Pins the exact reason set so a future error-variant or
+/// branch change can't silently re-bucket a termination.
+#[test]
+fn test_classify_exit_reason_covers_every_branch() {
+    // completed — any Ok return (finalized reply, silent completion,
+    // MaxTokens partial, interrupt cancel, provider-not-configured).
+    assert_eq!(
+        classify_exit_reason(&Ok(AgentLoopResult::default())),
+        "completed"
+    );
+    // max_iterations — the for-loop ran out.
+    assert_eq!(
+        classify_exit_reason(&Err(LibreFangError::MaxIterationsExceeded(40))),
+        "max_iterations"
+    );
+    // repeated_tool_failures — consecutive_all_failed cap reached.
+    assert_eq!(
+        classify_exit_reason(&Err(LibreFangError::RepeatedToolFailures {
+            iterations: 3,
+            error_count: 3,
+        })),
+        "repeated_tool_failures"
+    );
+    // content_filtered — provider safety / content filter blocked the reply.
+    assert_eq!(
+        classify_exit_reason(&Err(LibreFangError::ContentFiltered {
+            message: "blocked".to_string(),
+        })),
+        "content_filtered"
+    );
+    // circuit_break — loop-guard global breaker surfaces as Internal(msg)
+    // whose text begins with the shared CIRCUIT_BREAKER_MSG_PREFIX const.
+    let cb_msg = format!(
+        "{} exceeded 30 total tool calls in this loop. The agent appears to be stuck.",
+        crate::loop_guard::CIRCUIT_BREAKER_MSG_PREFIX
+    );
+    assert_eq!(
+        classify_exit_reason(&Err(LibreFangError::Internal(cb_msg))),
+        "circuit_break"
+    );
+    // error — any other propagated Err (e.g. an unrelated Internal error).
+    assert_eq!(
+        classify_exit_reason(&Err(LibreFangError::Internal(
+            "some unrelated failure".to_string()
+        ))),
+        "error"
+    );
+}
+
+/// `record_agent_loop_exit` increments the counter exactly once per call,
+/// labeled with the sanitized agent and the classified reason. Mirrors the
+/// `record_tool_call_metric` DebuggingRecorder pattern above.
+#[test]
+fn test_record_agent_loop_exit_increments_once_with_labels() {
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+    // One representative per reason: an Ok (completed) and a structured Err
+    // (max_iterations). Both must produce a single increment with the right
+    // reason label and the agent label.
+    let cases: &[(LibreFangResult<AgentLoopResult>, &str)] = &[
+        (Ok(AgentLoopResult::default()), "completed"),
+        (
+            Err(LibreFangError::MaxIterationsExceeded(40)),
+            "max_iterations",
+        ),
+    ];
+
+    for (result, expected_reason) in cases {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            record_agent_loop_exit("my-agent", result);
+        });
+
+        let snap = snapshotter.snapshot().into_vec();
+        let exit_counter = snap.iter().find(|(ckey, _, _, val)| {
+            ckey.key().name() == "librefang_agent_loop_exits_total"
+                && ckey
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "agent" && l.value() == "my-agent")
+                && ckey
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "reason" && l.value() == *expected_reason)
+                && matches!(val, DebugValue::Counter(_))
+        });
+        assert!(
+            exit_counter.is_some(),
+            "agent-loop exit counter must be recorded with reason={expected_reason}"
+        );
+        if let Some((_, _, _, DebugValue::Counter(count))) = exit_counter {
+            assert_eq!(
+                *count, 1,
+                "exit counter for reason={expected_reason} must increment exactly once"
+            );
+        }
+    }
+}
+
+/// The agent label is sanitized (control chars stripped, length capped)
+/// like the tool / cron agent labels, so a pathological agent name cannot
+/// blow up metric cardinality.
+#[test]
+fn test_sanitize_agent_label_strips_control_and_caps_length() {
+    assert_eq!(sanitize_agent_label("agent\u{0007}\n-1"), "agent-1");
+    let long: String = "a".repeat(200);
+    assert_eq!(sanitize_agent_label(&long).chars().count(), 64);
+}
+
 // ── Incognito persistence guards (refs #4073) ──────────────────────────
 //
 // These two tests prove the `LoopOptions::incognito` guard at the

--- a/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
@@ -1293,20 +1293,9 @@ fn test_record_tool_call_metric_success_outcome() {
     );
 }
 
-// ── Agent-loop exit metric (refs #6227) ────────────────────────────────
-//
-// `librefang_agent_loop_exits_total{agent,reason}` must increment exactly
-// once per loop termination, with the `reason` label matching the real
-// termination branch. The wrapper (`run_agent_loop` /
-// `run_agent_loop_streaming`) classifies the single returned `Result` via
-// `classify_exit_reason` and emits through `record_agent_loop_exit`. These
-// tests pin the classifier mapping for every branch and prove the single
-// `record_agent_loop_exit` call increments exactly once with the right
-// labels — the injection site of the metric.
+// ── Agent-loop exit metric ──────────────────────────────────────────────
 
-/// `classify_exit_reason` maps each real termination `Result` to its stable
-/// `reason` label. Pins the exact reason set so a future error-variant or
-/// branch change can't silently re-bucket a termination.
+/// Pins every `classify_exit_reason` mapping so future variant changes can't silently re-bucket an exit.
 #[test]
 fn test_classify_exit_reason_covers_every_branch() {
     // completed — any Ok return (finalized reply, silent completion,
@@ -1354,9 +1343,7 @@ fn test_classify_exit_reason_covers_every_branch() {
     );
 }
 
-/// `record_agent_loop_exit` increments the counter exactly once per call,
-/// labeled with the sanitized agent and the classified reason. Mirrors the
-/// `record_tool_call_metric` DebuggingRecorder pattern above.
+/// Counter increments exactly once per call with the right agent and reason labels.
 #[test]
 fn test_record_agent_loop_exit_increments_once_with_labels() {
     use metrics_util::debugging::{DebugValue, DebuggingRecorder};
@@ -1406,9 +1393,7 @@ fn test_record_agent_loop_exit_increments_once_with_labels() {
     }
 }
 
-/// The agent label is sanitized (control chars stripped, length capped)
-/// like the tool / cron agent labels, so a pathological agent name cannot
-/// blow up metric cardinality.
+/// A pathological agent name cannot blow up metric cardinality.
 #[test]
 fn test_sanitize_agent_label_strips_control_and_caps_length() {
     assert_eq!(sanitize_agent_label("agent\u{0007}\n-1"), "agent-1");

--- a/crates/librefang-runtime/src/loop_guard.rs
+++ b/crates/librefang-runtime/src/loop_guard.rs
@@ -55,15 +55,7 @@ const POLL_KEYWORDS: &[&str] = &[
 /// Maximum recent call history size for ping-pong detection.
 const HISTORY_SIZE: usize = 30;
 
-/// Stable prefix of the [`LoopGuardVerdict::CircuitBreak`] message.
-///
-/// Single source of truth shared between the producer (the `check` global
-/// circuit-breaker branch below) and the agent-loop exit classifier
-/// (`agent_loop::classify_exit_reason`), which maps the propagated
-/// `LibreFangError::Internal(msg)` back to the `circuit_break` exit reason
-/// for the `librefang_agent_loop_exits_total` metric. Referencing the same
-/// `const` from both sides keeps the match compiler-anchored rather than a
-/// loose string literal duplicated across modules.
+/// Shared prefix anchoring the circuit-break classifier in `agent_loop` to the producer here.
 pub(crate) const CIRCUIT_BREAKER_MSG_PREFIX: &str = "Circuit breaker:";
 
 /// Backoff schedule in milliseconds for polling tools.

--- a/crates/librefang-runtime/src/loop_guard.rs
+++ b/crates/librefang-runtime/src/loop_guard.rs
@@ -55,6 +55,17 @@ const POLL_KEYWORDS: &[&str] = &[
 /// Maximum recent call history size for ping-pong detection.
 const HISTORY_SIZE: usize = 30;
 
+/// Stable prefix of the [`LoopGuardVerdict::CircuitBreak`] message.
+///
+/// Single source of truth shared between the producer (the `check` global
+/// circuit-breaker branch below) and the agent-loop exit classifier
+/// (`agent_loop::classify_exit_reason`), which maps the propagated
+/// `LibreFangError::Internal(msg)` back to the `circuit_break` exit reason
+/// for the `librefang_agent_loop_exits_total` metric. Referencing the same
+/// `const` from both sides keeps the match compiler-anchored rather than a
+/// loose string literal duplicated across modules.
+pub(crate) const CIRCUIT_BREAKER_MSG_PREFIX: &str = "Circuit breaker:";
+
 /// Backoff schedule in milliseconds for polling tools.
 const BACKOFF_SCHEDULE_MS: &[u64] = &[5000, 10000, 30000, 60000];
 
@@ -176,7 +187,7 @@ impl LoopGuard {
         if self.total_calls > self.config.global_circuit_breaker {
             self.blocked_calls += 1;
             return LoopGuardVerdict::CircuitBreak(format!(
-                "Circuit breaker: exceeded {} total tool calls in this loop. \
+                "{CIRCUIT_BREAKER_MSG_PREFIX} exceeded {} total tool calls in this loop. \
                  The agent appears to be stuck.",
                 self.config.global_circuit_breaker
             ));


### PR DESCRIPTION
## Summary

Emits a counter at every agent-loop termination so operators can finally alert on non-success exits.
Before this, the agent loop recorded no metric when it aborted on repeated tool failures, max iterations, a loop-guard circuit break, or a provider content-filter — the only signal was reading transcripts.
A cron / trigger fire that aborted on repeated tool failures still recorded `librefang_cron_fires_total{outcome="ok"}` because the loop returned (did not throw).

New metric:

```
librefang_agent_loop_exits_total{agent, reason}
```

Acceptance alert (per #6227): `rate(librefang_agent_loop_exits_total{reason!="completed"}) > 0` per agent.

## Reason set

Matched to the real termination branches in `run_streaming.rs`, `mod.rs`, and `loop_guard.rs`:

- `completed` — any `Ok(_)` return: a finalized EndTurn reply, a silent completion (NO_REPLY / cascade-leak / progress-leak / mid-stream cascade-leak abort), a MaxTokens partial return, an interrupt-cancel early return, or the provider-not-configured early return.
- `max_iterations` — `Err(MaxIterationsExceeded)`: the `for` loop ran out.
- `repeated_tool_failures` — `Err(RepeatedToolFailures)`: `consecutive_all_failed >= MAX_CONSECUTIVE_ALL_FAILED`.
- `circuit_break` — loop-guard global circuit breaker tripped.
- `content_filtered` — `Err(ContentFiltered)`: provider safety / content filter blocked the reply.
- `error` — any other propagated `Err` (LLM call failure, memory error, etc.).

### Deviations from the issue's suggested set (documented per the task)

- **No `empty_response` reason.** The issue listed it, but there is no distinct empty-response *termination* branch: an empty LLM response is a one-shot in-loop retry (`EndTurnRetry::EmptyResponse` → `continue`); the turn then either retries to a real reply or finalizes via `finalize_end_turn_text`, both of which land on `completed`.
- **Added `content_filtered`.** `ContentFiltered` is a real, distinct terminal `Err` branch operators will want to separate from generic `error`.

## How exactly-one increment is guaranteed

Structural, not by discipline at each site:

- `run_agent_loop` and `run_agent_loop_streaming` become thin instrumented wrappers (the `#[instrument]` span name and fields are unchanged, so the `instrument_span_fields` / CLI span-name tests stay green).
- Each wrapper calls its `*_inner` body once and feeds the single returned `Result` to `record_agent_loop_exit(agent, &result)`.
- `classify_exit_reason` maps that one `Result` to one reason; the counter is incremented once.
- No terminal site inside the loop touches the metric, so there is no path where one branch falls through into another and double-counts. `?`-propagated exits (circuit-break, LLM/memory errors) are caught at the wrapper too — they would have been missed by per-`return`-site increments.

Circuit-break surfaces as `Err(Internal(msg))` propagated up through the `?` on `execute_single_tool_call`. It is classified by matching the shared `loop_guard::CIRCUIT_BREAKER_MSG_PREFIX` constant — a single source of truth now referenced by both the producer (`LoopGuard::check`) and the classifier, so the match is compiler-anchored rather than a loose duplicated string literal.

## Label cardinality

The `agent` label is sanitized (control chars stripped, length capped at 64) by `sanitize_agent_label`, mirroring `sanitize_tool_label` in `tool_call.rs` and the bounded-cardinality contract on `record_cron_fire_metric` in the kernel's `cron.rs`.

## Changes

- `crates/librefang-runtime/src/agent_loop/mod.rs` — `sanitize_agent_label`, `classify_exit_reason`, `record_agent_loop_exit`; `run_agent_loop` split into instrumented wrapper + `run_agent_loop_inner`.
- `crates/librefang-runtime/src/agent_loop/run_streaming.rs` — `run_agent_loop_streaming` split into instrumented wrapper + `run_agent_loop_streaming_inner`, calling `super::record_agent_loop_exit`.
- `crates/librefang-runtime/src/loop_guard.rs` — extract `CIRCUIT_BREAKER_MSG_PREFIX` const; use it in the circuit-break message.
- `crates/librefang-runtime/src/agent_loop/tests/utilities.rs` — three injection-site tests (below).
- `CHANGELOG.md` — `[Unreleased] / Added` entry.

## Tests

Added at the injection site (`agent_loop::tests::utilities`):

- `test_classify_exit_reason_covers_every_branch` — pins each reason mapping (`completed`, `max_iterations`, `repeated_tool_failures`, `content_filtered`, `circuit_break`, `error`) so a future error-variant or branch change can't silently re-bucket a termination.
- `test_record_agent_loop_exit_increments_once_with_labels` — `DebuggingRecorder` (same pattern as the existing `record_tool_call_metric` tests) asserts the counter increments **exactly once** with the right `agent` and `reason` labels.
- `test_sanitize_agent_label_strips_control_and_caps_length` — cardinality guard.

## Verification

All run in the sanctioned `librefang-rust-dev` Docker image (no native cargo on this host), scoped to `librefang-runtime`:

- `cargo check -p librefang-runtime --lib` — Finished, clean.
- `cargo clippy -p librefang-runtime --all-targets -- -D warnings` — Finished, zero warnings.
- `mold -run cargo test -p librefang-runtime --lib -- test_classify_exit_reason test_record_agent_loop_exit test_sanitize_agent_label` — `3 passed; 0 failed`.
- `mold -run cargo test -p librefang-runtime --lib agent_loop::tests::utilities` — `70 passed; 0 failed`.
- `cargo fmt -p librefang-runtime` applied.

Live LLM verification is not required: this change does not alter any LLM call path or prompt/metering wiring; it only adds an observability counter classified from the loop's existing return value, fully covered by the unit tests above.

Closes #6227