### PR TITLE
fix(cli): make i18n locale-detection test deterministic on macOS (refs #6240)

### DIFF
--- a/crates/librefang-cli/src/i18n.rs
+++ b/crates/librefang-cli/src/i18n.rs
@@ -210,13 +210,7 @@ mod tests {
         let backup_lang = std::env::var("LANG").ok();
         let backup_lc_all = std::env::var("LC_ALL").ok();
         let backup_lc_messages = std::env::var("LC_MESSAGES").ok();
-        // `detect_system_language` / `is_utf8_locale` read LANGUAGE, LC_ALL,
-        // LC_MESSAGES and LANG, with LC_ALL/LC_MESSAGES taking precedence over
-        // LANG. CI runners (notably the macOS lane) export LC_ALL/LC_MESSAGES
-        // to a UTF-8 locale, which would make `is_utf8_locale()` return true
-        // off LC_ALL and defeat the non-UTF-8 LANG case below (it returned
-        // "uk" instead of "en"). Clear every locale var up front so the test
-        // fully controls the inputs; each case then sets exactly what it needs.
+        // macOS CI exports LC_ALL/LC_MESSAGES at UTF-8, which takes precedence over LANG and defeats the non-UTF-8 cases below.
         std::env::remove_var("LC_ALL");
         std::env::remove_var("LC_MESSAGES");
         std::env::remove_var("LANG");

--- a/crates/librefang-cli/src/i18n.rs
+++ b/crates/librefang-cli/src/i18n.rs
@@ -208,6 +208,18 @@ mod tests {
     fn test_detect_system_language() {
         let backup_language = std::env::var("LANGUAGE").ok();
         let backup_lang = std::env::var("LANG").ok();
+        let backup_lc_all = std::env::var("LC_ALL").ok();
+        let backup_lc_messages = std::env::var("LC_MESSAGES").ok();
+        // `detect_system_language` / `is_utf8_locale` read LANGUAGE, LC_ALL,
+        // LC_MESSAGES and LANG, with LC_ALL/LC_MESSAGES taking precedence over
+        // LANG. CI runners (notably the macOS lane) export LC_ALL/LC_MESSAGES
+        // to a UTF-8 locale, which would make `is_utf8_locale()` return true
+        // off LC_ALL and defeat the non-UTF-8 LANG case below (it returned
+        // "uk" instead of "en"). Clear every locale var up front so the test
+        // fully controls the inputs; each case then sets exactly what it needs.
+        std::env::remove_var("LC_ALL");
+        std::env::remove_var("LC_MESSAGES");
+        std::env::remove_var("LANG");
 
         // Test matching "uk" from "uk:en_US"
         std::env::set_var("LANGUAGE", "uk:en_US");
@@ -240,6 +252,14 @@ mod tests {
             std::env::set_var("LANG", val);
         } else {
             std::env::remove_var("LANG");
+        }
+        match backup_lc_all {
+            Some(val) => std::env::set_var("LC_ALL", val),
+            None => std::env::remove_var("LC_ALL"),
+        }
+        match backup_lc_messages {
+            Some(val) => std::env::set_var("LC_MESSAGES", val),
+            None => std::env::remove_var("LC_MESSAGES"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Part of the `main`-red macOS failures tracked in #6240. macOS tests are SKIPPED on PRs and only run on `main` after merge, so these were never caught pre-merge.

`crates/librefang-cli/src/i18n.rs::tests::test_detect_system_language` failed **deterministically** on macOS: it sets `LANGUAGE` / `LANG` and asserts on `detect_system_language()`, but both `detect_system_language` and `is_utf8_locale` also read **`LC_ALL`** and **`LC_MESSAGES`**, with higher precedence than `LANG`. The macOS CI runner exports those to a UTF-8 locale, so `is_utf8_locale()` returned `true` off `LC_ALL`, the non-UTF-8 `LANG=uk_UA.KOI8-U` case fell through to `LANGUAGE`, and it returned `"uk"` instead of `"en"` (panic at `i18n.rs:218`). Linux passes because those vars are unset there.

## Change

The test backs up + clears `LC_ALL`, `LC_MESSAGES`, and `LANG` up front so it controls every input the detection logic reads, then restores all three at the end. No production code changes.

## Scope note — the other half of #6240 is NOT fixed here

The remaining macOS failures are `librefang-hands::registry::tests::*` (25 tests), which fail with:

```
fatal: unable to access 'https://github.com/librefang/librefang-registry.git/': Could not resolve host: github.com
... expected at least 15 hands, got 0
```

i.e. **the macOS CI runner has no github.com egress**, so `resolve_home_dir_for_tests()` → `sync_registry()` (a `git clone` / HTTP download of the registry) fails and the registry is empty. Those tests are correct; the runner lacks network. That is a CI-infra / test-design decision (give the macOS runner egress, filter the network-dependent `registry::tests` on the macOS lane, or make those tests offline-tolerant) — intentionally left out of this PR rather than blind-editing 25 tests. Flagging for a maintainer call.

## Verification

The failing platform (macOS) cannot be run locally, so this is verified by inspection: after the change the test sets exactly the locale vars each case needs and clears the rest, so the result no longer depends on the runner's ambient `LC_*`. The existing assertions are unchanged and continue to hold on the Linux/Windows lanes.

Refs #6240.
