### PR TITLE
feat(runtime): add agent dimension to librefang_tool_execution_seconds (#6244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -836,6 +836,9 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ### Added
 
+- **feat(runtime): add the `agent` dimension to `librefang_tool_execution_seconds`** (#6244) (@houko).
+  The per-tool latency histogram carried only a `tool` label, so per-tool p95 was an unweighted blend across every calling agent — a slow agent and a fast agent sharing a tool were indistinguishable, even though the sibling `librefang_tool_call_total` counter already carried `agent` (#6226).
+  The histogram now emits `{agent,tool}`, with `agent` sourced from the `agent_id` already in scope and sanitized + length-capped like `tool`, so tool latency is attributable per agent while cardinality stays bounded.
 - **feat(dashboard): provider max-token limit on the Providers page** (#6209) (@houko).
   Each provider card now shows the representative model's max-output-token limit (the `max_tokens` override when set, else the catalog `max_output_tokens`), and the config drawer lets you edit it; clearing the field reverts to the catalog default.
   Persisted through the existing per-model override endpoint, so no new persistence path is introduced.

--- a/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
@@ -1416,6 +1416,10 @@ fn test_record_tool_call_metric_emits_latency_histogram() {
                 .key()
                 .labels()
                 .any(|l| l.key() == "tool" && l.value() == "histtool")
+            && ckey
+                .key()
+                .labels()
+                .any(|l| l.key() == "agent" && l.value() == "agent")
             && matches!(val, DebugValue::Histogram(_))
     });
     let hist = hist.expect("librefang_tool_execution_seconds{tool=histtool} must be recorded");

--- a/crates/librefang-runtime/src/agent_loop/tool_call.rs
+++ b/crates/librefang-runtime/src/agent_loop/tool_call.rs
@@ -99,11 +99,11 @@ pub(super) fn record_tool_call_metric(
     )
     .increment(1);
 
-    // Per-tool latency histogram (#6228; agent dimension #6244). The duration
-    // was already captured for the decision trace; export it here so
-    // dashboards get a `librefang_tool_execution_seconds{agent,tool}`
-    // distribution attributable per agent. Both labels are sanitized + capped,
-    // so cardinality stays bounded.
+    // Per-tool latency histogram (#6228). The duration was already
+    // captured for the decision trace; export it here so dashboards get a
+    // `librefang_tool_execution_seconds{agent,tool}` distribution
+    // attributable per agent. Both labels are sanitized + capped, so
+    // cardinality stays bounded.
     if let Some(ms) = execution_ms {
         metrics::histogram!(
             "librefang_tool_execution_seconds",

--- a/crates/librefang-runtime/src/agent_loop/tool_call.rs
+++ b/crates/librefang-runtime/src/agent_loop/tool_call.rs
@@ -73,7 +73,7 @@ pub(super) fn failure_type_label(
 ///   `outcome` is `"success"` / `"failure"`; `failure_type` breaks the
 ///   failure down into a fixed low-cardinality enum (see
 ///   [`failure_type_label`]). We never push raw error text into labels.
-/// - `librefang_tool_execution_seconds{tool}` histogram — per-tool wall
+/// - `librefang_tool_execution_seconds{agent,tool}` histogram — per-tool wall
 ///   time of the dispatch, recorded only when a duration is available
 ///   (`execution_ms` from the decision trace). Emitted in seconds.
 ///
@@ -99,14 +99,15 @@ pub(super) fn record_tool_call_metric(
     )
     .increment(1);
 
-    // Per-tool latency histogram (#6228). The duration was already
-    // captured for the decision trace; export it here so dashboards get a
-    // `librefang_tool_execution_seconds{tool}` distribution. `tool` is the
-    // only label, and it is already sanitized + capped, so cardinality
-    // stays bounded.
+    // Per-tool latency histogram (#6228; agent dimension #6244). The duration
+    // was already captured for the decision trace; export it here so
+    // dashboards get a `librefang_tool_execution_seconds{agent,tool}`
+    // distribution attributable per agent. Both labels are sanitized + capped,
+    // so cardinality stays bounded.
     if let Some(ms) = execution_ms {
         metrics::histogram!(
             "librefang_tool_execution_seconds",
+            "agent" => sanitize_tool_label(agent_id),
             "tool" => tool,
         )
         .record(ms as f64 / 1000.0);


### PR DESCRIPTION
## Summary

Closes #6244. `librefang_tool_execution_seconds` (the per-tool latency histogram added in #6228 / #6233) carried only a `tool` label, while the sibling `librefang_tool_call_total` counter emitted from the **same function** already carries `agent` (#6226). So tool *failures* were attributable per agent but tool *latency* was not — on a host running many agents that share tools, the per-tool p95 was an unweighted blend across callers (a slow agent and a fast agent on the same tool were indistinguishable).

## Change

`record_tool_call_metric` (`crates/librefang-runtime/src/agent_loop/tool_call.rs`) now emits the histogram with `{agent, tool}`. `agent` is sourced from the `agent_id` already in scope and sanitized + length-capped via the same `sanitize_tool_label` used for the counter, so cardinality stays bounded — agent×tool is lower than the counter's existing agent×tool×outcome×failure_type. Doc comment and the inline comment updated to match.

## Verification

Updated `test_record_tool_call_metric_emits_latency_histogram` (`tests/utilities.rs`) to assert the histogram carries the `agent` label (`agent=agent`) alongside `tool=histtool`. `cargo test -p librefang-runtime` runs in CI.

Closes #6244.
