### PR TITLE
fix(runtime): spill oversized shell_exec output instead of truncating (#6242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -836,9 +836,6 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ### Added
 
-- **fix(runtime): spill oversized `shell_exec` output to the artifact store instead of lossily truncating it** (#6242) (@houko).
-  `shell_exec` capped each of stdout/stderr at `max_output_bytes` (default 100 KB) with `safe_truncate_str` and an `[truncated, N total bytes]` note, so the dropped middle of a long run (e.g. a 25k-line test log) was unrecoverable — the universal artifact spill never saw those bytes because the tool truncated them first.
-  Oversized streams now route through `artifact_store::maybe_spill`, yielding a compact stub the agent can page back in full via `read_artifact`, closing the only place the artifact store leaked information.
 - **feat(dashboard): provider max-token limit on the Providers page** (#6209) (@houko).
   Each provider card now shows the representative model's max-output-token limit (the `max_tokens` override when set, else the catalog `max_output_tokens`), and the config drawer lets you edit it; clearing the field reverts to the catalog default.
   Persisted through the existing per-model override endpoint, so no new persistence path is introduced.
@@ -866,6 +863,9 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ### Changed
 
+- **fix(runtime): spill oversized `shell_exec` output to the artifact store instead of lossily truncating it** (#6242) (@houko).
+  `shell_exec` capped each of stdout/stderr at `max_output_bytes` (default 100 KB) with `safe_truncate_str` and an `[truncated, N total bytes]` note, so the dropped middle of a long run (e.g. a 25k-line test log) was unrecoverable — the universal artifact spill never saw those bytes because the tool truncated them first.
+  Oversized streams now route through `artifact_store::maybe_spill`, yielding a compact stub the agent can page back in full via `read_artifact`, closing the only place the artifact store leaked information.
 - **dashboard(agents): drop the arbitrary 200000 cap on the model `max_tokens` input** (#6209) (@houko).
   The agent model-config `max_tokens` field hard-capped its input at `max={200000}`, silently preventing operators from setting a higher output budget; the provider validates the real per-model ceiling anyway, so the UI no longer imposes its own arbitrary limit (`min={1}` is kept).
   Closes #6209.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -836,6 +836,9 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ### Added
 
+- **fix(runtime): spill oversized `shell_exec` output to the artifact store instead of lossily truncating it** (#6242) (@houko).
+  `shell_exec` capped each of stdout/stderr at `max_output_bytes` (default 100 KB) with `safe_truncate_str` and an `[truncated, N total bytes]` note, so the dropped middle of a long run (e.g. a 25k-line test log) was unrecoverable — the universal artifact spill never saw those bytes because the tool truncated them first.
+  Oversized streams now route through `artifact_store::maybe_spill`, yielding a compact stub the agent can page back in full via `read_artifact`, closing the only place the artifact store leaked information.
 - **feat(dashboard): provider max-token limit on the Providers page** (#6209) (@houko).
   Each provider card now shows the representative model's max-output-token limit (the `max_tokens` override when set, else the catalog `max_output_tokens`), and the config drawer lets you edit it; clearing the field reverts to the catalog default.
   Persisted through the existing per-model override endpoint, so no new persistence path is introduced.

--- a/crates/librefang-runtime/src/tool_runner/shell.rs
+++ b/crates/librefang-runtime/src/tool_runner/shell.rs
@@ -196,24 +196,25 @@ pub(super) async fn tool_shell_exec(
                 reg.mark_finished(pid, exit_code);
             }
 
-            let stdout_str = if stdout.len() > max_output {
-                format!(
-                    "{}...\n[truncated, {} total bytes]",
-                    crate::str_utils::safe_truncate_str(&stdout, max_output),
-                    stdout.len()
-                )
-            } else {
-                stdout.to_string()
-            };
-            let stderr_str = if stderr.len() > max_output {
-                format!(
-                    "{}...\n[truncated, {} total bytes]",
-                    crate::str_utils::safe_truncate_str(&stderr, max_output),
-                    stderr.len()
-                )
-            } else {
-                stderr.to_string()
-            };
+            // #6242: route oversized streams through the artifact store so the
+            // full bytes stay recoverable via `read_artifact`, instead of the
+            // old lossy `safe_truncate_str` that dropped the middle of a long
+            // run (e.g. a 25k-line test log) with no way to page it back in.
+            // Streams at or below `max_output` pass through inline; the
+            // universal post-tool spill (#3347) still applies to the assembled
+            // result, so small streams are unaffected.
+            let stdout_str = super::spill::spill_or_passthrough(
+                "shell_exec",
+                stdout.to_string(),
+                max_output as u64,
+                crate::artifact_store::DEFAULT_MAX_ARTIFACT_BYTES,
+            );
+            let stderr_str = super::spill::spill_or_passthrough(
+                "shell_exec",
+                stderr.to_string(),
+                max_output as u64,
+                crate::artifact_store::DEFAULT_MAX_ARTIFACT_BYTES,
+            );
 
             Ok(format!(
                 "Exit code: {exit_code}\n\nSTDOUT:\n{stdout_str}\nSTDERR:\n{stderr_str}"

--- a/crates/librefang-runtime/src/tool_runner/shell.rs
+++ b/crates/librefang-runtime/src/tool_runner/shell.rs
@@ -196,13 +196,6 @@ pub(super) async fn tool_shell_exec(
                 reg.mark_finished(pid, exit_code);
             }
 
-            // #6242: route oversized streams through the artifact store so the
-            // full bytes stay recoverable via `read_artifact`, instead of the
-            // old lossy `safe_truncate_str` that dropped the middle of a long
-            // run (e.g. a 25k-line test log) with no way to page it back in.
-            // Streams at or below `max_output` pass through inline; the
-            // universal post-tool spill (#3347) still applies to the assembled
-            // result, so small streams are unaffected.
             let stdout_str = super::spill::spill_or_passthrough(
                 "shell_exec",
                 stdout.to_string(),

--- a/crates/librefang-runtime/src/tool_runner/spill.rs
+++ b/crates/librefang-runtime/src/tool_runner/spill.rs
@@ -78,14 +78,23 @@ mod tests {
 
         // The oversized stream is replaced by a compact stub — not returned
         // verbatim, and not the old lossy `[truncated, N total bytes]` form.
-        assert!(out.len() < 8192, "oversized body must be replaced by a compact stub");
+        assert!(
+            out.len() < 8192,
+            "oversized body must be replaced by a compact stub"
+        );
         assert!(!out.contains("[truncated"), "must not lossily truncate");
         // The full bytes were written to the artifact store, so the agent can
         // page them back via read_artifact — the loss the issue (#6242) flags.
         let artifacts = tmp.path().join("data").join("artifacts");
         let wrote_artifact = std::fs::read_dir(&artifacts)
-            .map(|d| d.flatten().any(|e| e.path().extension().is_some_and(|x| x == "bin")))
+            .map(|d| {
+                d.flatten()
+                    .any(|e| e.path().extension().is_some_and(|x| x == "bin"))
+            })
             .unwrap_or(false);
-        assert!(wrote_artifact, "a recoverable artifact file must be written");
+        assert!(
+            wrote_artifact,
+            "a recoverable artifact file must be written"
+        );
     }
 }

--- a/crates/librefang-runtime/src/tool_runner/spill.rs
+++ b/crates/librefang-runtime/src/tool_runner/spill.rs
@@ -51,3 +51,41 @@ pub(super) fn spill_or_passthrough(
         body
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_small_body_through_unchanged() {
+        let body = "short shell output".to_string();
+        let out = spill_or_passthrough("shell_exec", body.clone(), 1024, 1 << 20);
+        assert_eq!(out, body);
+    }
+
+    #[test]
+    fn spills_oversized_body_to_a_recoverable_artifact() {
+        // Point the artifact store at an isolated temp home so the test does
+        // not write to the real `~/.librefang`. nextest runs each test in its
+        // own process, so this env mutation does not race other tests.
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("LIBREFANG_HOME", tmp.path());
+
+        let body = "x".repeat(8192);
+        let out = spill_or_passthrough("shell_exec", body, 1024, 1 << 20);
+
+        std::env::remove_var("LIBREFANG_HOME");
+
+        // The oversized stream is replaced by a compact stub — not returned
+        // verbatim, and not the old lossy `[truncated, N total bytes]` form.
+        assert!(out.len() < 8192, "oversized body must be replaced by a compact stub");
+        assert!(!out.contains("[truncated"), "must not lossily truncate");
+        // The full bytes were written to the artifact store, so the agent can
+        // page them back via read_artifact — the loss the issue (#6242) flags.
+        let artifacts = tmp.path().join("data").join("artifacts");
+        let wrote_artifact = std::fs::read_dir(&artifacts)
+            .map(|d| d.flatten().any(|e| e.path().extension().is_some_and(|x| x == "bin")))
+            .unwrap_or(false);
+        assert!(wrote_artifact, "a recoverable artifact file must be written");
+    }
+}


### PR DESCRIPTION
## Summary

Refs #6242 — implements the core information-loss fix from @pavver's proposal (the gap in Option 1).

The artifact store (#3347) already spills oversized tool results to disk and hands the agent a `read_artifact` stub. But `shell_exec` truncated its stdout/stderr **lossily** (`safe_truncate_str` at `max_output_bytes`, default 100 KB) **before** the universal spill ever saw the bytes — so a long run's dropped middle was gone, not recoverable. That is the one place the store leaked information, and it's exactly the issue's motivating example (a 25k-line `cargo test` losing its middle).

## Change

`shell_exec` now routes oversized stdout/stderr through `artifact_store::maybe_spill` (via the existing `spill::spill_or_passthrough` helper) instead of `safe_truncate_str`. Streams ≤ `max_output` pass through inline; over it, the agent gets a compact stub recoverable via `read_artifact`. Reuses the existing store — GC, dedup, atomic writes, the `read_artifact` retrieval tool — so there's no new subsystem; the change is confined to `shell.rs` plus a unit test in `spill.rs`.

## Verification

Adds `spill.rs` unit tests: below-threshold passthrough returns the body unchanged, and above-threshold spill writes a recoverable artifact (isolated via `LIBREFANG_HOME` + a tempdir, so the real home is untouched). The underlying spill machinery (`maybe_spill` / `write` / `build_spill_stub`) is already covered by `artifact_store.rs` tests.

## Follow-ups (not in this PR)

Options 2/3 (exit-code-aware line filtering) and Option 4 (a prompt quiet-flag bullet) from the proposal are optional enhancements that should build *on* this spill — filter the context view, never the stored bytes. Please close #6242 if this core fix is sufficient, or keep it open to track those.
