### PR TITLE
fix(channels): deliver streaming final answer as a fresh notifying message (#6248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -834,6 +834,12 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix(channels): the streaming final answer now fires a push notification** (#6248) (@houko) — reported and diagnosed by @neo-wanderer.
+  On streaming channels (Telegram, Matrix) the agent's final answer was delivered as an *edit* of the `"…"` streaming placeholder, and edits do not generate a client push notification — so the push fired on the empty placeholder and the actual answer landed silently (unless it overflowed the per-message length limit, whose tail chunk is a fresh, notifying message).
+  Both adapters now finalize the answer as a *fresh* message — Telegram sends the answer and deletes the placeholder; Matrix sends a new `m.room.message` and redacts the placeholder — so the notification fires on the answer regardless of length. The overflow path already sent a notifying tail, so finalize-as-new is skipped there to avoid a duplicate ping.
+
 ### Added
 
 - **feat(runtime): add the `agent` dimension to `librefang_tool_execution_seconds`** (#6244) (@houko).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -838,7 +838,8 @@ _308 PRs from 7 contributors since v2026.5.17-beta.12._
 
 - **fix(channels): the streaming final answer now fires a push notification** (#6248) (@houko) — reported and diagnosed by @neo-wanderer.
   On streaming channels (Telegram, Matrix) the agent's final answer was delivered as an *edit* of the `"…"` streaming placeholder, and edits do not generate a client push notification — so the push fired on the empty placeholder and the actual answer landed silently (unless it overflowed the per-message length limit, whose tail chunk is a fresh, notifying message).
-  Both adapters now finalize the answer as a *fresh* message — Telegram sends the answer and deletes the placeholder; Matrix sends a new `m.room.message` and redacts the placeholder — so the notification fires on the answer regardless of length. The overflow path already sent a notifying tail, so finalize-as-new is skipped there to avoid a duplicate ping.
+  Both adapters now finalize the answer as a *fresh* message — Telegram sends the answer and deletes the placeholder; Matrix sends a new `m.room.message` and redacts the placeholder — so the notification fires on the answer regardless of length.
+  The overflow path already sent a notifying tail, so finalize-as-new is skipped there to avoid a duplicate ping.
 
 ### Added
 

--- a/sdk/python/librefang/sidecar/adapters/matrix.py
+++ b/sdk/python/librefang/sidecar/adapters/matrix.py
@@ -1772,6 +1772,7 @@ class MatrixAdapter(SidecarAdapter):
             "last_flushed_len": 0,
             "flushed_initial": False,
             "thread_extra": thread_extra,
+            "overflowed": False,
         })
 
     async def _on_stream_delta(self, cmd) -> None:
@@ -1800,11 +1801,13 @@ class MatrixAdapter(SidecarAdapter):
         state = self._stream_state_get(cmd.stream_id)
         if state is None:
             return
-        # Drain remaining buffer with overflow splits.
+        # Drain any overflow chunks first; `_stream_flush` already sends those
+        # tails as fresh, notifying events.
         while len(state["buffer"]) > MAX_MESSAGE_LEN:
             await self._stream_flush(state)
-        if state["buffer"]:
-            await self._stream_flush(state)
+        # #6248: finalize the answer as a fresh (notifying) message instead of a
+        # final m.replace edit, which never fires a push notification.
+        await self._finalize_as_new_message(state)
         self._stream_state_set(cmd.stream_id, None)
 
     async def _stream_flush(self, state: dict) -> None:
@@ -1851,6 +1854,48 @@ class MatrixAdapter(SidecarAdapter):
         state["buffer"] = tail
         state["last_flushed_len"] = len(tail)
         state["last_flush_t"] = time.monotonic()
+        # #6248: an overflow tail was sent as a fresh (notifying) event, so the
+        # final frame already notifies — don't re-send it at stream end.
+        state["overflowed"] = True
+
+    async def _finalize_as_new_message(self, state: dict) -> None:
+        """#6248: deliver the final streaming answer as a fresh
+        ``m.room.message`` rather than a final ``m.replace`` edit, which does
+        not trigger a push notification, then redact the ``"…"`` placeholder.
+
+        Only fires when the whole answer was delivered via edits to the
+        placeholder (the common short-answer case). When the answer overflowed
+        ``MAX_MESSAGE_LEN``, ``_stream_flush`` already sent the tail as a fresh
+        notifying event, so we keep the final edit in place to avoid a duplicate
+        notification.
+        """
+        final_text = state["buffer"]
+        if not final_text:
+            return
+        if state.get("overflowed"):
+            # Overflow already notified via a fresh tail event; just apply the
+            # remaining edit as before.
+            await self._stream_flush(state)
+            return
+        room_id = state["room_id"]
+        placeholder_id = state["placeholder_id"]
+        thread_extra = state.get("thread_extra")
+        loop = asyncio.get_event_loop()
+
+        def _do() -> None:
+            body = text_body_with_html(final_text, thread_extra)
+            self._put_event(room_id, "m.room.message", body)
+            # Drop the "…" placeholder (and its edit chain) now the real answer
+            # has landed as a notifying message. Best-effort; ``_redact`` logs
+            # and skips on failure.
+            self._redact(room_id, placeholder_id, "#6248 finalize as new message")
+
+        try:
+            await loop.run_in_executor(None, _do)
+        except Exception as e:  # noqa: BLE001
+            log.warn("matrix stream finalize failed", error=str(e))
+            # Fall back to the old edit-in-place so the answer is still visible.
+            await self._stream_flush(state)
 
     # ---- public sidecar surface -------------------------------------
 

--- a/sdk/python/librefang/sidecar/adapters/matrix.py
+++ b/sdk/python/librefang/sidecar/adapters/matrix.py
@@ -1805,7 +1805,7 @@ class MatrixAdapter(SidecarAdapter):
         # tails as fresh, notifying events.
         while len(state["buffer"]) > MAX_MESSAGE_LEN:
             await self._stream_flush(state)
-        # #6248: finalize the answer as a fresh (notifying) message instead of a
+        # Finalize the answer as a fresh (notifying) message instead of a
         # final m.replace edit, which never fires a push notification.
         await self._finalize_as_new_message(state)
         self._stream_state_set(cmd.stream_id, None)
@@ -1854,12 +1854,12 @@ class MatrixAdapter(SidecarAdapter):
         state["buffer"] = tail
         state["last_flushed_len"] = len(tail)
         state["last_flush_t"] = time.monotonic()
-        # #6248: an overflow tail was sent as a fresh (notifying) event, so the
+        # An overflow tail was sent as a fresh (notifying) event, so the
         # final frame already notifies — don't re-send it at stream end.
         state["overflowed"] = True
 
     async def _finalize_as_new_message(self, state: dict) -> None:
-        """#6248: deliver the final streaming answer as a fresh
+        """Deliver the final streaming answer as a fresh
         ``m.room.message`` rather than a final ``m.replace`` edit, which does
         not trigger a push notification, then redact the ``"…"`` placeholder.
 

--- a/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
@@ -54,7 +54,7 @@ pub struct TelegramAdapter {
 struct StreamState {
     chat_id: i64,
     message_id: i64,
-    // #6248: the topic/thread the placeholder was posted in, so the final
+    // The topic/thread the placeholder was posted in, so the final
     // answer can be delivered as a fresh (notifying) message in the same thread.
     thread_id: Option<i64>,
     buf: String,
@@ -132,7 +132,7 @@ impl TelegramAdapter {
         }
     }
 
-    /// #6248: deliver the final streaming answer as a *fresh* message instead
+    /// Deliver the final streaming answer as a *fresh* message instead
     /// of an edit of the `"…"` placeholder. Telegram edits never fire a push
     /// notification, so a user who backgrounded the client after the placeholder
     /// ping received nothing when the answer landed. A new message notifies

--- a/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
@@ -54,6 +54,9 @@ pub struct TelegramAdapter {
 struct StreamState {
     chat_id: i64,
     message_id: i64,
+    // #6248: the topic/thread the placeholder was posted in, so the final
+    // answer can be delivered as a fresh (notifying) message in the same thread.
+    thread_id: Option<i64>,
     buf: String,
     last_edit: Instant,
 }
@@ -126,6 +129,62 @@ impl TelegramAdapter {
             Err(e) => {
                 eprintln!("[telegram] stream edit failed: {e}");
             }
+        }
+    }
+
+    /// #6248: deliver the final streaming answer as a *fresh* message instead
+    /// of an edit of the `"…"` placeholder. Telegram edits never fire a push
+    /// notification, so a user who backgrounded the client after the placeholder
+    /// ping received nothing when the answer landed. A new message notifies
+    /// reliably; the placeholder is then deleted. Mirrors `edit_with_fallback`'s
+    /// HTML→plain fallback, and if the fresh send fails outright it falls back to
+    /// editing the placeholder in place (answer still visible, just no push).
+    async fn finalize_as_new_message(
+        client: &BotClient,
+        chat_id: i64,
+        placeholder_id: i64,
+        thread_id: Option<i64>,
+        html_body: &str,
+    ) {
+        if html_body.trim().is_empty() {
+            // No answer to deliver — leave the placeholder as-is (matches the
+            // empty-body early return in `edit_with_fallback`).
+            return;
+        }
+        let sent = match client
+            .send_message(chat_id, html_body, Some("HTML"), thread_id, None)
+            .await
+        {
+            Ok(_) => true,
+            Err(e) if is_parse_entities_error(&e) => {
+                let plain = crate::dispatcher::html_to_plain(html_body);
+                match client
+                    .send_message(chat_id, &plain, None, thread_id, None)
+                    .await
+                {
+                    Ok(_) => true,
+                    Err(e2) => {
+                        eprintln!("[telegram] stream finalize (plain fallback) failed: {e2}");
+                        false
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("[telegram] stream finalize failed: {e}");
+                false
+            }
+        };
+        if sent {
+            // Drop the "…" placeholder now the real answer has landed. Deletion
+            // can fail (message too old / no rights) — harmless, the new message
+            // already notified; the placeholder just lingers.
+            if let Err(e) = client.delete_message(chat_id, placeholder_id).await {
+                eprintln!("[telegram] stream placeholder delete failed: {e}");
+            }
+        } else {
+            // Fresh send failed outright — fall back to the old edit-in-place so
+            // the answer is still visible (no notification, but not lost).
+            Self::edit_with_fallback(client, chat_id, placeholder_id, html_body).await;
         }
     }
 }
@@ -247,6 +306,7 @@ impl SidecarAdapter for TelegramAdapter {
                     StreamState {
                         chat_id,
                         message_id: res.message_id,
+                        thread_id,
                         buf: String::new(),
                         // `Instant::now() - 2s` panics if the system has been up less than 2 s (cold-boot container, embedded sidecar). saturating_sub returns `Instant::now()` in that case — the first delta will be throttled instead of firing immediately, which is fine.
                         last_edit: Instant::now()
@@ -289,8 +349,10 @@ impl SidecarAdapter for TelegramAdapter {
                 let body = crate::format::format_and_sanitize(&state.buf);
                 let chat_id = state.chat_id;
                 let message_id = state.message_id;
+                let thread_id = state.thread_id;
                 drop(map);
-                Self::edit_with_fallback(&self.client, chat_id, message_id, &body).await;
+                Self::finalize_as_new_message(&self.client, chat_id, message_id, thread_id, &body)
+                    .await;
                 Ok(())
             }
             // Unknown / forward-compat commands are silently tolerated.


### PR DESCRIPTION
## Summary

Closes #6248. Implements @neo-wanderer's **Option A** from a thorough bug report + diagnosis — full credit to them.

On streaming channels that deliver output via in-place edits (Telegram, Matrix), the agent's **final answer was an edit of the `"…"` streaming placeholder**. On both platforms an *edit* does not generate a client push notification — only the initial *new* message (the empty `"…"` placeholder) does. Net effect: the push fired on the placeholder and the actual answer landed **silently**, unless the answer overflowed the per-message length limit (whose tail chunk is a fresh, notifying message — which is why the bug felt intermittent).

## Fix — Option A: finalize as a fresh message

**Telegram** (`sdk/rust/librefang-sidecar-telegram/src/adapter.rs`)
- `StreamState` gains `thread_id`, so the final message lands in the same topic/thread as the placeholder.
- `StreamEnd` now calls `finalize_as_new_message`: `sendMessage` the answer (HTML, reusing the existing HTML→plain fallback), then `deleteMessage` the placeholder. If the delete fails (message too old / no rights) it's harmless — the new message already notified. If the fresh send fails entirely, it falls back to the prior edit-in-place so the answer is still visible.
- Mid-turn `StreamDelta` edits are unchanged — the live-typing UX is preserved; only the final frame moves to a send.

**Matrix** (`sdk/python/librefang/sidecar/adapters/matrix.py`)
- `_on_stream_end` calls `_finalize_as_new_message`: send the answer as a new `m.room.message` (carrying the thread relation, not `m.replace`), then `_redact` the placeholder (best-effort — `_redact` logs-and-skips on failure).
- The overflow path in `_stream_flush` already sends the tail as a fresh, notifying event, so it sets an `overflowed` flag and finalize-as-new is **skipped** in that case to avoid a duplicate notification.
- Falls back to the prior edit on send failure.

## Verification

The Telegram sidecar (standalone crate) and the Python sidecar are both built/linted in CI; `matrix.py` parses clean locally. There are no existing unit tests for these streaming handlers (they'd need a mocked bot / homeserver client), and I can't drive live Telegram/Matrix from here — so this wants a smoke test on a real channel before release:
- short answer → one notification, on the answer;
- overflow answer → notifies once, not twice;
- placeholder is removed once the answer lands.

Flagging that explicitly rather than implying it's been run against a live server.

Closes #6248.
