### PR TITLE
fix(channels): rank explicit per-peer bindings above the sidecar instance default

### DIFF
--- a/crates/librefang-api/src/channel_bridge.rs
+++ b/crates/librefang-api/src/channel_bridge.rs
@@ -2419,6 +2419,28 @@ fn apply_channel_proxy<A>(
 // EmailCredentials + resolve_email_credentials removed alongside the
 // in-process adapter. See SIDECAR_CATALOG in routes/channels.rs.
 
+/// Seed the router's name->id cache used for binding resolution.
+///
+/// `identities` should enumerate *every defined* agent (the canonical identity
+/// registry), so a binding to an agent that has not been spawned yet still
+/// resolves; `spawned` overlays the live runtime set (which additionally
+/// carries hand-derived `<hand>:<role>` agents that are absent from the
+/// identity registry). Later inserts win, so passing `spawned` last lets the
+/// live id override the canonical one in the (refs #4614: identical) event they
+/// ever diverge.
+fn seed_router_agent_names(
+    router: &AgentRouter,
+    identities: impl IntoIterator<Item = (String, AgentId)>,
+    spawned: impl IntoIterator<Item = (String, AgentId)>,
+) {
+    for (name, id) in identities {
+        router.register_agent(name, id);
+    }
+    for (name, id) in spawned {
+        router.register_agent(name, id);
+    }
+}
+
 /// Start the channel bridge for all configured channels based on kernel config.
 ///
 /// Returns `Some(BridgeManager)` if any channels were configured and started,
@@ -2723,10 +2745,37 @@ pub async fn start_channel_bridge_with_config(
     let bindings = kernel.list_bindings();
     if !bindings.is_empty() {
         // Register all known agents in the router's name cache for binding
-        // resolution. Read-only iteration; cheap Arc clones (#3569).
-        for entry in kernel.agent_registry().list_arcs() {
-            router.register_agent(entry.name.clone(), entry.id);
-        }
+        // resolution. A binding references its target agent by *name*, so the
+        // router must be able to map every bindable name -> AgentId.
+        //
+        // The runtime `agent_registry()` only holds agents that have been
+        // *spawned* (`registry.register()` is called from the spawn path).
+        // Standalone agents that spawn lazily (e.g. first cron fire) — or any
+        // agent reconciled to Suspended after an unclean shutdown — are absent
+        // from it at bridge-startup, so seeding from `list_arcs()` alone leaves
+        // their channel bindings unresolvable: `resolve_binding` matches the
+        // peer_id but the name->id lookup misses, and inbound traffic silently
+        // falls through to the system default agent.
+        //
+        // The canonical identity registry maps *every defined* agent name to
+        // its canonical UUID (== the runtime id once spawned, refs #4614),
+        // independent of spawn state, so seed from it first. Then overlay the
+        // live spawned set, which also covers hand-derived agents (their
+        // namespaced `<hand>:<role>` names are not in the identity registry but
+        // are present once their hand is activated at boot).
+        seed_router_agent_names(
+            &router,
+            kernel
+                .agent_identities()
+                .list()
+                .into_iter()
+                .map(|(name, record)| (name, record.canonical_uuid)),
+            kernel
+                .agent_registry()
+                .list_arcs()
+                .into_iter()
+                .map(|entry| (entry.name.clone(), entry.id)),
+        );
         router.load_bindings(&bindings);
         info!(count = bindings.len(), "Loaded agent bindings into router");
     }
@@ -2972,6 +3021,96 @@ pub async fn reload_channels_from_disk(
 mod tests {
     use super::*;
     use librefang_kernel::event_bus::EventBus;
+
+    // ── seed_router_agent_names: defined-but-unspawned agents ─────
+    //
+    // Regression for inbound channel bindings silently falling through
+    // to the system default agent. A binding references its target by
+    // *name*; the router can only honour it if that name is in its cache.
+    // Standalone agents spawn lazily (first cron fire) or reconcile to
+    // Suspended after an unclean shutdown, so at channel-bridge startup
+    // they are absent from the runtime `agent_registry` (`list_arcs`) —
+    // seeding from spawned agents alone leaves their bindings dead and
+    // inbound traffic lands on the default agent (which lacks all context).
+    // Seeding from the canonical identity registry (every *defined* agent)
+    // fixes it.
+    #[test]
+    fn seed_router_includes_defined_but_unspawned_agents() {
+        use librefang_channels::types::ChannelType;
+        use librefang_types::config::{AgentBinding, BindingMatchRule};
+
+        let unspawned = AgentId::new();
+        let default_agent = AgentId::new();
+        let room = "!room:example.org";
+        let binding = AgentBinding {
+            agent: "lifeos-health".to_string(),
+            match_rule: BindingMatchRule {
+                channel: Some("matrix".to_string()),
+                peer_id: Some(room.to_string()),
+                ..Default::default()
+            },
+        };
+
+        // Old behaviour: seed from the spawned set only. The lazily-spawned
+        // agent is absent, so the binding matches peer_id but the name->id
+        // lookup misses and resolution falls to the system default.
+        let mut buggy = AgentRouter::new();
+        buggy.set_default(default_agent);
+        seed_router_agent_names(&buggy, std::iter::empty(), std::iter::empty());
+        buggy.load_bindings(std::slice::from_ref(&binding));
+        assert_eq!(
+            buggy.resolve(&ChannelType::Matrix, room, None),
+            Some(default_agent),
+            "pre-fix: unspawned bound agent should fall through to default"
+        );
+
+        // Fixed behaviour: seed from the identity registry (every defined
+        // agent), even though nothing is spawned. The binding now resolves
+        // to the intended agent.
+        let mut fixed = AgentRouter::new();
+        fixed.set_default(default_agent);
+        seed_router_agent_names(
+            &fixed,
+            std::iter::once(("lifeos-health".to_string(), unspawned)),
+            std::iter::empty(),
+        );
+        fixed.load_bindings(std::slice::from_ref(&binding));
+        assert_eq!(
+            fixed.resolve(&ChannelType::Matrix, room, None),
+            Some(unspawned),
+            "post-fix: defined-but-unspawned bound agent resolves from identity registry"
+        );
+    }
+
+    // ── seed_router_agent_names: spawned overlays identity ────────
+    #[test]
+    fn seed_router_spawned_overlays_identity() {
+        use librefang_channels::types::ChannelType;
+        use librefang_types::config::{AgentBinding, BindingMatchRule};
+
+        let canonical = AgentId::new();
+        let live = AgentId::new();
+        let mut router = AgentRouter::new();
+        router.set_default(AgentId::new());
+        // Same name in both sets; spawned is applied last and must win.
+        seed_router_agent_names(
+            &router,
+            std::iter::once(("agent-x".to_string(), canonical)),
+            std::iter::once(("agent-x".to_string(), live)),
+        );
+        router.load_bindings(&[AgentBinding {
+            agent: "agent-x".to_string(),
+            match_rule: BindingMatchRule {
+                channel: Some("matrix".to_string()),
+                ..Default::default()
+            },
+        }]);
+        assert_eq!(
+            router.resolve(&ChannelType::Matrix, "anyone", None),
+            Some(live),
+            "spawned (live) id must override the canonical id for the same name"
+        );
+    }
 
     // ── resolve_no_pending_message ───────────────────────────────
     //

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -3213,6 +3213,30 @@ async fn resolve_addressed_agent(
         .await
 }
 
+/// Build the [`BindingContext`](crate::router::BindingContext) for an inbound
+/// message: channel + `account_id`/`guild_id` metadata + the sender's
+/// `platform_id` as the peer (for a group this is the chat/room id; see the
+/// `binding_keys` note in [`resolve_or_fallback`]). Shared by the per-peer
+/// binding check and the legacy router-chain resolution so the two evaluate the
+/// exact same context.
+fn binding_context(message: &ChannelMessage) -> crate::router::BindingContext<'_> {
+    crate::router::BindingContext {
+        channel: std::borrow::Cow::Borrowed(crate::router::channel_type_to_str(&message.channel)),
+        account_id: message
+            .metadata
+            .get("account_id")
+            .and_then(|v| v.as_str())
+            .map(std::borrow::Cow::Borrowed),
+        peer_id: std::borrow::Cow::Borrowed(&message.sender.platform_id),
+        guild_id: message
+            .metadata
+            .get("guild_id")
+            .and_then(|v| v.as_str())
+            .map(std::borrow::Cow::Borrowed),
+        roles: smallvec::SmallVec::new(),
+    }
+}
+
 /// Resolve the target agent for an incoming message.
 ///
 /// Routing precedence (highest first):
@@ -3220,8 +3244,9 @@ async fn resolve_addressed_agent(
 ///   2. Explicit group addressing (#5323) — an `@`-mention or a non-default agent's alias. The strongest user signal; overrides every binding so a user can address agentB even while agentA is otherwise routed.
 ///   3. Explicit per-conversation `/agent` override (#5671 Model A, upper binding level) — a deliberate user command; outranks the sticky holder so a fresh `/agent` can re-point a conversation that already has a claim.
 ///   4. Sticky conversation-ownership holder (#5323) — keeps an already-claimed group conversation on its holder without a fresh mention.
-///   5. Instance-default binding (#5671 Model A, lower binding level) — seeded from `[[sidecar_channels]] agent`; the operator's standing default for otherwise-unaddressed traffic.
-///   6. Legacy fallback (transitional) — the `AgentRouter` binding chain, the attention scorer, the `"assistant"` agent, then the non-deterministic `list_agents().first()`. Reached only when nothing above resolves; it emits a deprecation WARN at the non-deterministic tail so operators can see they should set `agent` on the instance.
+///   5. Explicit per-peer binding — a config `[[bindings]]` whose `match_rule` pins a `peer_id` matching this conversation. The operator's deliberate per-room/per-DM route; strictly more specific than the channel-wide instance default, so it outranks it.
+///   6. Instance-default binding (#5671 Model A, lower binding level) — seeded from `[[sidecar_channels]] agent`; the operator's standing default for otherwise-unaddressed traffic.
+///   7. Legacy fallback (transitional) — the `AgentRouter` binding chain (channel-only bindings, channel/system defaults), the attention scorer, the `"assistant"` agent, then the non-deterministic `list_agents().first()`. Reached only when nothing above resolves; it emits a deprecation WARN at the non-deterministic tail so operators can see they should set `agent` on the instance.
 ///
 /// Returns a [`RouteResolution`] whose `agent_id` is `None` only when no eligible agent exists at all.
 ///
@@ -3320,6 +3345,25 @@ async fn resolve_or_fallback(
         }
     }
 
+    // Explicit per-peer binding: a config `[[bindings]]` whose `match_rule`
+    // pins a `peer_id` matching THIS conversation is the operator's deliberate
+    // per-room/per-DM route, and is strictly more specific than the
+    // channel-wide instance default below — so it must outrank it. Without this
+    // a sidecar `default_agent` (seeded as the instance default) shadows every
+    // per-room binding: the channel-wide default resolves first and the
+    // peer-specific `[[bindings]]` entry never gets a turn, collapsing all
+    // inbound traffic onto the default agent. Channel-only bindings (no
+    // `peer_id`) intentionally stay in the lower-precedence router chain below,
+    // under the instance default, preserving the #5671 ordering.
+    if thread_route_agent_id.is_none() {
+        let ctx = binding_context(message);
+        if let Some(id) = router.resolve_specific_binding(&ctx) {
+            if agent_allows_channel(handle, id, ct).await {
+                return RouteResolution::plain(id);
+            }
+        }
+    }
+
     // Instance default (#5671, lower binding level) seeded from
     // `[[sidecar_channels]] agent`. The operator's standing default for
     // otherwise-unaddressed traffic; wins over the router/assistant/
@@ -3334,23 +3378,7 @@ async fn resolve_or_fallback(
     let agent_id = if let Some(id) = thread_route_agent_id {
         Some(id)
     } else {
-        let ctx = crate::router::BindingContext {
-            channel: std::borrow::Cow::Borrowed(crate::router::channel_type_to_str(
-                &message.channel,
-            )),
-            account_id: message
-                .metadata
-                .get("account_id")
-                .and_then(|v| v.as_str())
-                .map(std::borrow::Cow::Borrowed),
-            peer_id: std::borrow::Cow::Borrowed(&message.sender.platform_id),
-            guild_id: message
-                .metadata
-                .get("guild_id")
-                .and_then(|v| v.as_str())
-                .map(std::borrow::Cow::Borrowed),
-            roles: smallvec::SmallVec::new(),
-        };
+        let ctx = binding_context(message);
         router.resolve_with_context(
             &message.channel,
             &message.sender.platform_id,
@@ -7551,6 +7579,47 @@ mod tests {
             resolved.agent_id,
             Some(sticky),
             "the sticky holder must outrank the instance default"
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_binding_outranks_instance_default() {
+        // A config `[[bindings]]` pinned to a specific peer/room is strictly more
+        // specific than the channel-wide instance default, so it must win.
+        // Regression: a sidecar `default_agent` (seeded as the instance default)
+        // used to shadow every per-room binding, collapsing all inbound traffic
+        // onto the default agent (the real-world symptom that motivated this).
+        let bound = AgentId::new();
+        let default_agent = AgentId::new();
+        let handle: Arc<dyn ChannelBridgeHandle> = Arc::new(BindingMockHandle {
+            agents: vec![
+                (bound, "room-agent".into()),
+                (default_agent, "operator".into()),
+            ],
+            conversation_override: None,
+            instance_default: Some(("tg-bot".into(), default_agent)),
+        });
+        let router = Arc::new(AgentRouter::new());
+        // The bound agent need not be spawned — only present in the name cache
+        // (see `seed_router_agent_names`); register it directly here.
+        router.register_agent("room-agent".into(), bound);
+        router.load_bindings(&[librefang_types::config::AgentBinding {
+            agent: "room-agent".into(),
+            match_rule: librefang_types::config::BindingMatchRule {
+                channel: Some("telegram".into()),
+                peer_id: Some("group-chat-9".into()),
+                ..Default::default()
+            },
+        }]);
+        let thread_ownership = Arc::new(crate::thread_ownership::ThreadOwnershipRegistry::new());
+        // No sticky claim seeded: a fresh conversation, first message after boot.
+        let msg = inbound_message("group-chat-9", "tg-bot", true);
+
+        let resolved = resolve_or_fallback(&msg, &handle, &router, &thread_ownership).await;
+        assert_eq!(
+            resolved.agent_id,
+            Some(bound),
+            "an explicit per-peer binding must outrank the channel-wide instance default"
         );
     }
 

--- a/crates/librefang-channels/src/router.rs
+++ b/crates/librefang-channels/src/router.rs
@@ -468,6 +468,39 @@ impl AgentRouter {
         None
     }
 
+    /// Evaluate only *specific* bindings — those whose `match_rule` pins a
+    /// `peer_id` (a per-conversation route, e.g. a Matrix room or a DM peer).
+    ///
+    /// The inbound dispatcher uses this to rank an operator's explicit
+    /// per-conversation binding **above** the channel-wide instance default
+    /// (`[[sidecar_channels]] agent`). Without that ranking a sidecar
+    /// `default_agent` shadows every per-room binding: the channel-wide default
+    /// is consulted first and the more-specific `[[bindings]]` entry never gets
+    /// a turn, collapsing all inbound traffic onto the default agent.
+    ///
+    /// Channel-only bindings (no `peer_id`) are intentionally excluded here —
+    /// they stay in the lower-precedence [`resolve`] / [`resolve_with_context`]
+    /// chain, below the instance default, preserving the #5671 precedence.
+    /// Returns `None` when no peer-specific binding matches.
+    pub fn resolve_specific_binding(&self, ctx: &BindingContext<'_>) -> Option<AgentId> {
+        let bindings = self.bindings.lock().unwrap_or_else(|e| e.into_inner());
+        for (binding, _agent_name) in bindings.iter() {
+            if binding.match_rule.peer_id.is_none() {
+                continue;
+            }
+            if self.binding_matches(binding, ctx) {
+                if let Some(id) = self.agent_name_cache.get(&binding.agent) {
+                    return Some(*id);
+                }
+                warn!(
+                    agent = %binding.agent,
+                    "Specific binding matched but agent not found in cache"
+                );
+            }
+        }
+        None
+    }
+
     /// Check if a single binding's match_rule matches the context.
     ///
     /// Delegates to [`BindingMatchRule::matches`] in `librefang-types` — the
@@ -582,6 +615,64 @@ mod tests {
         assert_eq!(
             router.resolve(&ChannelType::Telegram, "u1", None),
             Some(new_id)
+        );
+    }
+
+    #[test]
+    fn resolve_specific_binding_only_matches_peer_id_rules() {
+        let router = AgentRouter::new();
+        let room_agent = AgentId::new();
+        let channel_agent = AgentId::new();
+        router.register_agent("room-agent".to_string(), room_agent);
+        router.register_agent("channel-agent".to_string(), channel_agent);
+        router.load_bindings(&[
+            // Peer-specific binding (a room) — this is what should win over a
+            // channel-wide instance default.
+            AgentBinding {
+                agent: "room-agent".to_string(),
+                match_rule: librefang_types::config::BindingMatchRule {
+                    channel: Some("matrix".to_string()),
+                    peer_id: Some("!room:example.org".to_string()),
+                    ..Default::default()
+                },
+            },
+            // Channel-only binding — must be IGNORED by resolve_specific_binding
+            // (it stays in the lower-precedence chain, under the instance default).
+            AgentBinding {
+                agent: "channel-agent".to_string(),
+                match_rule: librefang_types::config::BindingMatchRule {
+                    channel: Some("matrix".to_string()),
+                    ..Default::default()
+                },
+            },
+        ]);
+
+        let room_ctx = BindingContext {
+            channel: std::borrow::Cow::Borrowed("matrix"),
+            account_id: None,
+            peer_id: std::borrow::Cow::Borrowed("!room:example.org"),
+            guild_id: None,
+            roles: SmallVec::new(),
+        };
+        assert_eq!(
+            router.resolve_specific_binding(&room_ctx),
+            Some(room_agent),
+            "peer-specific binding must resolve"
+        );
+
+        // A different room: no peer-specific binding matches, and the
+        // channel-only binding must NOT be returned here.
+        let other_ctx = BindingContext {
+            channel: std::borrow::Cow::Borrowed("matrix"),
+            account_id: None,
+            peer_id: std::borrow::Cow::Borrowed("!other:example.org"),
+            guild_id: None,
+            roles: SmallVec::new(),
+        };
+        assert_eq!(
+            router.resolve_specific_binding(&other_ctx),
+            None,
+            "channel-only binding must be excluded from specific resolution"
         );
     }
 


### PR DESCRIPTION
Fixes #6257.

## Problem

A sidecar channel configured with `default_agent` seeds a channel-wide **instance default**. An explicit per-conversation `[[bindings]]` pinned to a `peer_id` (a specific room / DM) was then never honored for inbound traffic — every inbound message routed to the instance default, regardless of the room. The per-room binding matched the peer but was never consulted.

Cause: in `resolve_or_fallback` (`crates/librefang-channels/src/bridge.rs`) the instance default (branch 5) is consulted before the `[[bindings]]` router chain (branch 6). A binding pinning a specific `peer_id` is more specific than a channel-wide default and must outrank it.

Secondary latent bug (surfaces once precedence is fixed): the router's name→id cache is seeded at channel-bridge startup from `agent_registry().list_arcs()` (spawned agents only). A defined-but-unspawned agent — one that spawns lazily on its first cron fire, or was reconciled to Suspended after an unclean shutdown — is absent, so even when its binding is reached the name lookup misses and routing falls to the default.

## Changes

- **`AgentRouter::resolve_specific_binding`** (`router.rs`): evaluates only bindings whose `match_rule` pins a `peer_id`. Consulted in `resolve_or_fallback` between the sticky-holder check and the instance default. Channel-only bindings stay in the lower-precedence `resolve_with_context` chain, under the instance default — preserving the existing #5671 ordering.
- **`binding_context`** (`bridge.rs`): extracted so the per-peer check and the legacy chain evaluate the identical context.
- **Router name-cache seeding** (`channel_bridge.rs`): seed from the canonical agent-identity registry (`agent_identities().list()` — every defined agent, spawn-independent, refs #4614) in addition to the live spawned set; the spawned set is applied last so the live id wins for hand-derived `<hand>:<role>` agents not in the identity registry. Extracted as `seed_router_agent_names`.
- Updated the `resolve_or_fallback` precedence doc-comment (now 7 tiers).

## Verification

- `cargo check -p librefang-channels -p librefang-api --lib` — clean.
- `cargo clippy -p librefang-channels -p librefang-api --lib --all-targets -- -D warnings` — clean.
- New unit tests, all green:
  - `router::tests::resolve_specific_binding_only_matches_peer_id_rules` — only peer-pinned rules resolve; channel-only excluded.
  - `bridge::tests::peer_binding_outranks_instance_default` — end-to-end precedence.
  - `channel_bridge::tests::seed_router_includes_defined_but_unspawned_agents` — defined-but-unspawned bound agent resolves instead of falling to default.
  - `channel_bridge::tests::seed_router_spawned_overlays_identity` — spawned id overrides canonical for a shared name.
  - Existing `sticky_holder_outranks_instance_default` / `conversation_override_outranks_sticky_holder` unchanged.
