### PR TITLE
fix(ci): clear .secrets.baseline drift from #6190 and hard-error pre-commit when detect-secrets missing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,7 +175,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "929b5531f933164784179610dc6d44c9e4fe5e28",
         "is_verified": false,
-        "line_number": 2356
+        "line_number": 2470
       }
     ],
     "articles/hello-librefang.md": [
@@ -245,147 +245,147 @@
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "0915086640bac79c6ebbff6b038a8f7fdcc45f70",
         "is_verified": false,
-        "line_number": 400
+        "line_number": 408
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "8b97602841813628f4a7a9e4712e3635ba641232",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 409
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 489
+        "line_number": 497
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
         "is_verified": false,
-        "line_number": 842
+        "line_number": 857
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 861
+        "line_number": 876
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "26eeb2a3d2d3a26656573aba8ae238ded867bfb7",
         "is_verified": false,
-        "line_number": 1228
+        "line_number": 1243
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "cddea5c4539c2dcb2fac754166dc8c141296ead8",
         "is_verified": false,
-        "line_number": 1284
+        "line_number": 1299
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "6be0b909d7953656db4534a48ac26329b6b7ad05",
         "is_verified": false,
-        "line_number": 1892
+        "line_number": 1907
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "9beb25270febae84a22c023eb079f03f984c4ee4",
         "is_verified": false,
-        "line_number": 2121
+        "line_number": 2136
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "7b9a759937d8742ff1612a01e4729b93eda5d09f",
         "is_verified": false,
-        "line_number": 2157
+        "line_number": 2172
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "7e48c7f2a53700d0656daf1d9b479f631d9f6ed1",
         "is_verified": false,
-        "line_number": 2271
+        "line_number": 2286
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "8a5b5fdc436269aacbce18e73038704ce027fa17",
         "is_verified": false,
-        "line_number": 2310
+        "line_number": 2325
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "fb53f36d497172bec62a5e18e57c014d9d209dde",
         "is_verified": false,
-        "line_number": 2311
+        "line_number": 2326
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "fa4b19ac75b57ea3d3555e5cc878e15ce9e633a1",
         "is_verified": false,
-        "line_number": 2329
+        "line_number": 2344
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "2276fa3db60dab489cdaf02229306a13af9e179b",
         "is_verified": false,
-        "line_number": 2355
+        "line_number": 2370
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "02e4465db9e24628b1a9a4783b1d22abe1568eb4",
         "is_verified": false,
-        "line_number": 2424
+        "line_number": 2439
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "14b4007ff8fadc0587f923aa38acc6a1b36670da",
         "is_verified": false,
-        "line_number": 2769
+        "line_number": 2789
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "4dad82da373f06d95847d61ba3c5a1cdb5a94fe0",
         "is_verified": false,
-        "line_number": 2986
+        "line_number": 3006
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "5aa7d1e863b4cbed54c71b8ba1a6f4388efcadd0",
         "is_verified": false,
-        "line_number": 2991
+        "line_number": 3011
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "f91eb2a7b1c4be9f65c70eaaf47449c5cb788888",
         "is_verified": false,
-        "line_number": 3301
+        "line_number": 3321
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/en.json",
         "hashed_secret": "cf678cab87dc1f7d1b95b964f15375e088461679",
         "is_verified": false,
-        "line_number": 3404
+        "line_number": 3424
       }
     ],
     "crates/librefang-api/dashboard/src/locales/uk.json": [
@@ -394,119 +394,119 @@
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "a9a78bf4119377f490eaf84701a10501397b4a1f",
         "is_verified": false,
-        "line_number": 400
+        "line_number": 408
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d6530dba418cea85e01e88bc9f7da05b4e83959f",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 409
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 489
+        "line_number": 497
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "0956cb835344367878a6e19e69680d8b6878614e",
         "is_verified": false,
-        "line_number": 842
+        "line_number": 857
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 861
+        "line_number": 876
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "b1b8c51a3ed90a7c73962c976d36864d99ef62c0",
         "is_verified": false,
-        "line_number": 925
+        "line_number": 940
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "34123ae8e18c5f7e69a9f4e6a8beea05879f483e",
         "is_verified": false,
-        "line_number": 1228
+        "line_number": 1243
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d5f6b23160fffd39f4d0617ebec467ed0abddc13",
         "is_verified": false,
-        "line_number": 1229
+        "line_number": 1244
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "175d8973cfd0eafa0456d7b60ff24612dafea1b5",
         "is_verified": false,
-        "line_number": 1284
+        "line_number": 1299
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "3f92176f388ab292a54ddee6e71ce44c5278d943",
         "is_verified": false,
-        "line_number": 2157
+        "line_number": 2172
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "5f01ea1b5b938628292e9f13071a99b461fb0a89",
         "is_verified": false,
-        "line_number": 2310
+        "line_number": 2325
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "416352ae1ba52364a5510a9dc65e30d7f1addc6b",
         "is_verified": false,
-        "line_number": 2311
+        "line_number": 2326
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "503c9c19721513d7d6811c2ccf9549ed7a582167",
         "is_verified": false,
-        "line_number": 2329
+        "line_number": 2344
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "7d17fa6969539e972d57b93916f94612d6f269e6",
         "is_verified": false,
-        "line_number": 2355
+        "line_number": 2370
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "83d2e7404077eb9a94bee7f5a0725105bdc22c80",
         "is_verified": false,
-        "line_number": 2424
+        "line_number": 2439
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "2dbbfc5d67cc9823da0632a51012cba66187af5d",
         "is_verified": false,
-        "line_number": 2769
+        "line_number": 2789
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/uk.json",
         "hashed_secret": "d0f693fffcebc4aa903d6ba4408e61b301102e60",
         "is_verified": false,
-        "line_number": 2991
+        "line_number": 3011
       }
     ],
     "crates/librefang-api/dashboard/src/locales/zh.json": [
@@ -515,140 +515,140 @@
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "f4bf274bff3f19d78b2079c775e9b77605a69442",
         "is_verified": false,
-        "line_number": 400
+        "line_number": 408
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "e2502fd4703f7b13b7c5896da60b0d644f4971e2",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 409
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 489
+        "line_number": 497
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "47acd2028cf81b5da88ddeedb2aea4eca4b71fbd",
         "is_verified": false,
-        "line_number": 842
+        "line_number": 857
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 861
+        "line_number": 876
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "469b3f21e87f4b889a36f663597ebc2766e4caaa",
         "is_verified": false,
-        "line_number": 862
+        "line_number": 877
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "42ae7ec78f2e89ed905144e3e7ee986a8e43a386",
         "is_verified": false,
-        "line_number": 925
+        "line_number": 940
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "0769c2d835193ec570086a776ca2c81bbad7f891",
         "is_verified": false,
-        "line_number": 1228
+        "line_number": 1243
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "ab25a5ed30a7930eefda1b401a3551e92292ba06",
         "is_verified": false,
-        "line_number": 1229
+        "line_number": 1244
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "54f77569909cc9420836a7e4b00563de47b4a328",
         "is_verified": false,
-        "line_number": 1284
+        "line_number": 1299
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "5df1d83e18c6e5903e3f4805f0af1415fd050ef7",
         "is_verified": false,
-        "line_number": 2051
+        "line_number": 2066
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "94980a07a0b08fc6c65155a5af44dcc32652a8c0",
         "is_verified": false,
-        "line_number": 2114
+        "line_number": 2129
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "08037c102cca2aa1fae8ba0fcf9f1b3442da4dac",
         "is_verified": false,
-        "line_number": 2267
+        "line_number": 2282
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "d6c8bc0ecea0cd41397a0a5e7ff97339f0c0284e",
         "is_verified": false,
-        "line_number": 2268
+        "line_number": 2283
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "7376202136f8a7e68d3cd3772b4f92d08151508b",
         "is_verified": false,
-        "line_number": 2286
+        "line_number": 2301
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "a722b86877659d6a3499a56a9faefd0d85cc04e0",
         "is_verified": false,
-        "line_number": 2312
+        "line_number": 2327
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "2540a21b1adbcaece91bc51c2142997cc8d38975",
         "is_verified": false,
-        "line_number": 2381
+        "line_number": 2396
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "be0bbd80b4105d9030a3484201437d600f6fd1d0",
         "is_verified": false,
-        "line_number": 2726
+        "line_number": 2746
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "6e18c7516fd3fe2df687bc59ab10ffc5cee99a7b",
         "is_verified": false,
-        "line_number": 2948
+        "line_number": 2968
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/dashboard/src/locales/zh.json",
         "hashed_secret": "9d123ddd01a441bfe1d6c9f0bde50e2c7e6448fb",
         "is_verified": false,
-        "line_number": 3301
+        "line_number": 3321
       }
     ],
     "crates/librefang-api/dashboard/src/pages/Memory/index.test.tsx": [
@@ -721,14 +721,14 @@
         "filename": "crates/librefang-api/src/routes/agents/mod.rs",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 1344
+        "line_number": 1348
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-api/src/routes/agents/mod.rs",
         "hashed_secret": "4835254aab9494e03d8b72e816719a4914612587",
         "is_verified": false,
-        "line_number": 1353
+        "line_number": 1357
       }
     ],
     "crates/librefang-api/src/routes/config/mod.rs": [
@@ -1479,7 +1479,7 @@
         "filename": "crates/librefang-api/tests/providers_routes_test.rs",
         "hashed_secret": "17bb10d3f44323963c21bf3c97341ebb5accf05e",
         "is_verified": false,
-        "line_number": 833
+        "line_number": 912
       }
     ],
     "crates/librefang-api/tests/registry_content_path_test.rs": [
@@ -1660,7 +1660,7 @@
         "filename": "crates/librefang-channels/src/sidecar.rs",
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_verified": false,
-        "line_number": 2932
+        "line_number": 2970
       }
     ],
     "crates/librefang-cli/src/commands/monitoring.rs": [
@@ -2475,7 +2475,7 @@
         "filename": "crates/librefang-memory/src/migration.rs",
         "hashed_secret": "d5662d7353c6257f68cab2a3b0f758cc79b1ac5e",
         "is_verified": false,
-        "line_number": 2317
+        "line_number": 2350
       }
     ],
     "crates/librefang-rl-export/src/redact.rs": [
@@ -2646,13 +2646,6 @@
         "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
         "is_verified": false,
         "line_number": 1097
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "crates/librefang-runtime/src/embedding.rs",
-        "hashed_secret": "40ce4379f5763c05b71c88f9a371809fdbce6a21",
-        "is_verified": false,
-        "line_number": 1281
       }
     ],
     "crates/librefang-runtime/src/host_functions.rs": [
@@ -2661,7 +2654,7 @@
         "filename": "crates/librefang-runtime/src/host_functions.rs",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 1861
+        "line_number": 2022
       }
     ],
     "crates/librefang-runtime/src/model_catalog.rs": [
@@ -2960,35 +2953,35 @@
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 2990
+        "line_number": 3011
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "e84fc93286dec77fb75fbe036dff86318eb3503e",
         "is_verified": false,
-        "line_number": 3933
+        "line_number": 3954
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "c6c914a1fb807d140dfafbe0139614358330e43f",
         "is_verified": false,
-        "line_number": 3948
+        "line_number": 3969
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "6baf51b50e44bb41da5fb5dc6dbbb801217ffd32",
         "is_verified": false,
-        "line_number": 4610
+        "line_number": 4631
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-types/src/config/types.rs",
         "hashed_secret": "fd385d38140af325c5a7d4ba662a2d0747acce43",
         "is_verified": false,
-        "line_number": 5265
+        "line_number": 5286
       }
     ],
     "crates/librefang-types/src/config/version.rs": [
@@ -4206,14 +4199,14 @@
         "filename": "librefang.toml.example",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 332
+        "line_number": 343
       },
       {
         "type": "Secret Keyword",
         "filename": "librefang.toml.example",
         "hashed_secret": "7839e0c4e4a5981ccf3f5981c9360378095881e8",
         "is_verified": false,
-        "line_number": 680
+        "line_number": 691
       }
     ],
     "packages/whatsapp-gateway/index.js": [
@@ -4301,5 +4294,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-19T05:10:18Z"
+  "generated_at": "2026-06-21T00:34:10Z"
 }

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -10,7 +10,8 @@
 # Checks performed:
 #   1. cargo fmt --check on staged *.rs files only (no full-workspace scan)
 #   2. CHANGELOG guard: reject duplicate `## [Unreleased]` headings (#3395)
-#   3. detect-secrets scan against .secrets.baseline (if installed)
+#   3. detect-secrets scan against .secrets.baseline (hard error if the
+#      tool is missing; set LIBREFANG_SKIP_SECRETS_SCAN=1 to opt out)
 #   4. openapi.sha256 baseline auto-sync when openapi.json is staged (#4690)
 
 set -eu
@@ -90,10 +91,20 @@ if git diff --cached --name-only | grep -qx "CHANGELOG.md"; then
     fi
 fi
 
-# 3. Secret detection. Soft-fail if detect-secrets is not installed —
-# the .pre-commit-config.yaml entry pins the canonical version, and CI
-# is the authoritative gate. We don't want to wedge contributors who
-# haven't installed it yet, but we do warn.
+# 3. Secret detection. Hard error if detect-secrets is not installed.
+#
+# This used to soft-skip when the tool was missing, on the theory that
+# CI is the authoritative gate. In practice that let baseline drift sail
+# straight to main: a commit changes a fixture so a previously-flagged
+# line no longer matches (e.g. #6190 swapping a plain-string api_key for
+# Zeroizing::new("bogus")), the committer's hook skips because they never
+# installed detect-secrets, and the `secrets` CI job goes red on every
+# subsequent push until someone regenerates .secrets.baseline. Erroring
+# locally moves that failure to the one place that can fix it cheaply.
+#
+# Escape hatch for the genuinely tool-less host (e.g. the Docker-only dev
+# box in CLAUDE.md > Build & Verify, mirroring the rustfmt soft-skip and
+# pre-push's LIBREFANG_PREPUSH_SKIP): set LIBREFANG_SKIP_SECRETS_SCAN=1.
 if [ -f .secrets.baseline ]; then
     if command -v detect-secrets >/dev/null 2>&1; then
         STAGED=$(git diff --cached --name-only --diff-filter=ACMR || true)
@@ -107,9 +118,15 @@ if [ -f .secrets.baseline ]; then
                 exit 1
             fi
         fi
+    elif [ "${LIBREFANG_SKIP_SECRETS_SCAN:-0}" = "1" ]; then
+        echo "warning: detect-secrets not installed; secret scan skipped via LIBREFANG_SKIP_SECRETS_SCAN=1." >&2
     else
-        echo "warning: detect-secrets not installed; skipping secret scan." >&2
-        echo "  install with: pipx install detect-secrets" >&2
+        echo "Error: detect-secrets is not installed; cannot scan staged files for credentials." >&2
+        echo "  Install it:    pipx install detect-secrets   (or: pip install 'detect-secrets>=1.5.0,<2.0.0')" >&2
+        echo "  After install, re-stage and commit again." >&2
+        echo "  Tool-less host (e.g. Docker-only dev box)? Bypass once with:" >&2
+        echo "    LIBREFANG_SKIP_SECRETS_SCAN=1 git commit ..." >&2
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
## Why

The `secrets` CI job has been red on every push to `main` since #6190 merged (first failing run: commit `3f2a1626`, 2026-06-20).

Root cause: #6190 (`fix(sec): zeroize EmbeddingConfig.api_key on drop`) changed a test fixture in `crates/librefang-runtime/src/embedding.rs` from a plain-string `api_key` to `Zeroizing::new("bogus".to_string())`, so detect-secrets no longer flags that line.
The committed `.secrets.baseline` was not regenerated, leaving a stale `Secret Keyword` entry (`40ce4379…`) that a fresh scan no longer reproduces.
The `secrets` job enforces a byte-for-byte match between a fresh scan and the committed baseline (ignoring `generated_at` / `version` / `line_number`), so the mismatch failed every run.

## Changes

1. **Regenerate `.secrets.baseline`** — drops the phantom `embedding.rs` entry. The substantive diff is exactly that one removal; the rest is `line_number` churn the CI comparison already strips.
2. **Harden `scripts/hooks/pre-commit`** — the detect-secrets step used to soft-skip when the tool was not installed, which is precisely how this drift sailed past local hooks straight to CI.
   It now hard-errors and refuses the commit when detect-secrets is absent.
   A genuinely tool-less host (the Docker-only dev box in `CLAUDE.md > Build & Verify`) can opt out with `LIBREFANG_SKIP_SECRETS_SCAN=1`, mirroring the rustfmt soft-skip above it and pre-push's `LIBREFANG_PREPUSH_SKIP`.

## Verification

- CI-equivalent jq comparison (`del(.generated_at, .version, .results[][].line_number)`) of old vs regenerated baseline shows only the single `40ce4379…` removal — matches the failing run's diff exactly.
- `sh -n scripts/hooks/pre-commit` passes.
- Hook exercised both paths: missing tool + no flag → error, exit 1; `LIBREFANG_SKIP_SECRETS_SCAN=1` → warn, exit 0. The second commit in this PR was itself made through the escape hatch.
