### PR TITLE
feat(mcp): confidential OAuth clients via client_secret_env (revives #5060)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -753,7 +753,7 @@
         "filename": "crates/librefang-api/src/routes/mcp_auth.rs",
         "hashed_secret": "b87f8466a65efc7c714b07e2b840a7fc08e3d696",
         "is_verified": false,
-        "line_number": 1666
+        "line_number": 1804
       }
     ],
     "crates/librefang-api/src/routes/registry.rs": [
@@ -1974,14 +1974,14 @@
         "filename": "crates/librefang-kernel/src/mcp_oauth_provider.rs",
         "hashed_secret": "b87f8466a65efc7c714b07e2b840a7fc08e3d696",
         "is_verified": false,
-        "line_number": 1162
+        "line_number": 1170
       },
       {
         "type": "Secret Keyword",
         "filename": "crates/librefang-kernel/src/mcp_oauth_provider.rs",
         "hashed_secret": "60086327f69887c5cd4585477bf89eee7db89624",
         "is_verified": false,
-        "line_number": 1325
+        "line_number": 1333
       }
     ],
     "crates/librefang-kernel/src/rl_export/mod.rs": [
@@ -2583,7 +2583,7 @@
         "filename": "crates/librefang-runtime-mcp/src/mcp_oauth.rs",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 1580
+        "line_number": 1581
       }
     ],
     "crates/librefang-runtime/src/checkpoint_manager.rs": [
@@ -2982,6 +2982,13 @@
         "hashed_secret": "fd385d38140af325c5a7d4ba662a2d0747acce43",
         "is_verified": false,
         "line_number": 5286
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "crates/librefang-types/src/config/types.rs",
+        "hashed_secret": "13003c4504e22a34e98b827793880e9e4ed9cd72",
+        "is_verified": false,
+        "line_number": 6146
       }
     ],
     "crates/librefang-types/src/config/version.rs": [
@@ -4294,5 +4301,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-21T00:34:10Z"
+  "generated_at": "2026-06-21T00:51:07Z"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4591,6 +4591,7 @@ dependencies = [
  "webauthn-rs",
  "which",
  "windows-sys 0.61.2",
+ "zeroize",
  "zip 8.6.0",
 ]
 

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -64,6 +64,7 @@ sha2 = { workspace = true }
 argon2 = "0.5"
 hex = { workspace = true }
 rand = { workspace = true }
+zeroize = { workspace = true }
 tracing-subscriber = { workspace = true }
 utoipa = { version = "5", features = ["axum_extras"] }
 include_dir = "0.7"

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -355,6 +355,137 @@ pub async fn auth_start(
         provider.vault_get_or_warn(&KernelOAuthProvider::vault_key(&server_url, "client_id"))
     });
 
+    // ── client_secret_env resolution (PR #5060) ──────────────────────
+    //
+    // Resolve the optional OAuth client secret from the environment and
+    // reconcile it with the vault so both `auth_callback` (initial token
+    // exchange) and `try_refresh` (later refresh requests) see the same
+    // value the operator has currently exported. Confidential clients
+    // (e.g. Google Workspace MCP servers) reject refresh requests without
+    // `client_secret`; public PKCE clients leave `client_secret_env`
+    // unset and the vault entry is removed.
+    let vault_key_secret = KernelOAuthProvider::vault_key(&server_url, "client_secret");
+    let resolved_secret: Option<zeroize::Zeroizing<String>> = oauth_config
+        .client_secret_env
+        .as_deref()
+        .and_then(|env_var| match std::env::var(env_var) {
+            Ok(secret) if !secret.is_empty() => Some(zeroize::Zeroizing::new(secret)),
+            Ok(_) => {
+                tracing::warn!(
+                    target: "audit",
+                    op = "client_secret_env_resolve",
+                    env_var,
+                    server = %name,
+                    "client_secret_env resolved to an empty value — treating as unset \
+                     and clearing any stale vault entry"
+                );
+                None
+            }
+            Err(_) => {
+                tracing::warn!(
+                    target: "audit",
+                    op = "client_secret_env_resolve",
+                    env_var,
+                    server = %name,
+                    "client_secret_env points at an undefined environment variable — \
+                     treating as unset and clearing any stale vault entry"
+                );
+                None
+            }
+        });
+
+    // Bug-D ordering (PR #5060 review): check DCR incompatibility BEFORE
+    // persisting the secret to the vault. If the operator declared
+    // `client_secret_env` but has no `client_id`, DCR would register a
+    // public client that receives a `client_secret` it does not recognise.
+    // Fail-fast here so no stale vault entry is left behind.
+    if client_id.is_none()
+        && metadata.registration_endpoint.is_some()
+        && oauth_config.client_secret_env.is_some()
+    {
+        tracing::warn!(
+            target: "audit",
+            op = "auth_start_misconfig",
+            server = %name,
+            "client_secret_env is set but no client_id is available; \
+             refusing to run Dynamic Client Registration as a public \
+             client for a confidential configuration"
+        );
+        let mut auth_states = state.kernel.mcp_auth_states_ref().lock().await;
+        auth_states.insert(
+            name.clone(),
+            McpAuthState::Error {
+                message: "Confidential OAuth client (client_secret_env set) requires \
+                     a pre-registered client_id. Dynamic Client Registration only \
+                     produces public clients. Set `oauth.client_id` in config.toml \
+                     or remove `client_secret_env` to use public PKCE."
+                    .to_string(),
+            },
+        );
+        return ApiErrorResponse::bad_request(
+            "Confidential OAuth (client_secret_env) requires `oauth.client_id` \
+             in config.toml; Dynamic Client Registration cannot register a \
+             confidential client.",
+        )
+        .into_json_tuple();
+    }
+
+    // Now safe to persist the resolved secret (or clear stale entry).
+    match resolved_secret {
+        Some(secret) => {
+            if let Err(e) = provider.vault_set(&vault_key_secret, secret.as_str()) {
+                tracing::error!(
+                    target: "audit",
+                    op = "vault_set",
+                    key = %vault_key_secret,
+                    error = %e,
+                    "vault op failed persisting MCP client_secret — aborting auth_start"
+                );
+                let mut auth_states = state.kernel.mcp_auth_states_ref().lock().await;
+                auth_states.insert(
+                    name.clone(),
+                    McpAuthState::Error {
+                        message: "Failed to persist OAuth client secret to vault — \
+                             check LIBREFANG_VAULT_KEY and ~/.librefang permissions."
+                            .to_string(),
+                    },
+                );
+                return ApiErrorResponse::internal(format!(
+                    "Failed to persist OAuth client secret to vault: {e}. \
+                     Ensure LIBREFANG_VAULT_KEY is set and ~/.librefang is writable."
+                ))
+                .into_json_tuple();
+            }
+        }
+        None => {
+            // No env-derived secret: keep the vault aligned with env.
+            // `vault_remove` is best-effort — the entry may simply not
+            // exist (fresh install / pure public client).
+            match provider.vault_remove(&vault_key_secret) {
+                Ok(true) => {
+                    tracing::info!(
+                        target: "audit",
+                        op = "vault_remove",
+                        key = %vault_key_secret,
+                        server = %name,
+                        "Cleared stale client_secret from vault (env no longer set)"
+                    );
+                }
+                Ok(false) => {} // nothing to clear
+                Err(e) => {
+                    tracing::warn!(
+                        target: "audit",
+                        op = "vault_remove",
+                        key = %vault_key_secret,
+                        error = %e,
+                        server = %name,
+                        "Failed to clear stale client_secret from vault (non-fatal)"
+                    );
+                }
+            }
+        }
+    }
+
     if client_id.is_none() {
         if let Some(ref reg_endpoint) = metadata.registration_endpoint {
             tracing::info!(
@@ -816,6 +947,13 @@ pub async fn auth_callback(
     ];
     if let Some(ref cid) = client_id {
         form_params.push(("client_id", cid.clone()));
+    }
+    // Persisted at auth_start when McpOAuthConfig::client_secret_env was set.
+    if let Some(secret) = provider.vault_get_or_warn(&KernelOAuthProvider::vault_key(
+        &server_url,
+        "client_secret",
+    )) {
+        form_params.push(("client_secret", secret));
     }
 
     // #3730: user-visible errors must NOT leak the token endpoint URL or the

--- a/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
+++ b/crates/librefang-api/tests/fixtures/kernel_config_schema.golden.json
@@ -106,6 +106,11 @@
           "description": "Auto-approve in autonomous mode. Default: `false`.",
           "type": "boolean"
         },
+        "cache_approvals_per_session": {
+          "default": true,
+          "description": "Cache approvals within a chat session (#5600).\n\nWhen `true` (the default), the first time a user approves a tool inside a session, subsequent calls of the same tool name in that session auto-approve without re-prompting. This matches typical IDE / MCP-client behaviour (one approval per (session, tool) is enough). Set to `false` to require per-call approval — useful for compliance environments that need an explicit human decision on every tool execution.\n\nScope: in-memory only. Daemon restart clears the cache. The cache keys on `(session_id, tool_name)`; different sessions still each see one prompt per distinct tool.",
+          "type": "boolean"
+        },
         "channel_rules": {
           "default": [],
           "description": "Per-channel tool authorization rules.\n\nEach rule specifies allowed and/or denied tools for a specific channel. Rules are evaluated in order; the first matching rule wins.  If no rule matches the request's channel, the default `require_approval` list applies.",
@@ -820,7 +825,7 @@
       "type": "object"
     },
     "ChannelsConfig": {
-      "description": "Channel bridge configuration.\n\nEach field uses `OneOrMany<T>` to support both single-instance (`[channels.slack]`) and multi-instance (`[[channels.slack]]`) TOML syntax for multi-bot routing.",
+      "description": "Channel bridge configuration.\n\nEvery channel runs as a sidecar (`[[sidecar_channels]]` — see [`SidecarChannelConfig`]); the per-vendor in-process fields that used to live here (`telegram`, `slack`, `whatsapp`, …, each typed `OneOrMany<*Config>`) are gone. What remains are the shared file-transfer caps + download dir that every channel honours.",
       "properties": {
         "file_download_dir": {
           "default": null,
@@ -2390,7 +2395,7 @@
       "type": "object"
     },
     "McpOAuthConfig": {
-      "description": "Optional OAuth configuration for an MCP server.\n\nUsed as fallback when the server doesn't support `.well-known` discovery, or to override specific values from discovery. All fields are optional — discovery results fill gaps, config values take precedence.\n\n# Example (config.toml)\n\n```toml [[mcp_servers]] name = \"custom-server\" transport = { type = \"http\", url = \"https://my-server.com/mcp\" }\n\n[mcp_servers.oauth] auth_url = \"https://my-server.com/oauth/authorize\" token_url = \"https://my-server.com/oauth/token\" client_id = \"my-client-id\" scopes = [\"read\", \"write\"] ```",
+      "description": "Optional OAuth configuration for an MCP server.\n\nUsed as fallback when the server doesn't support `.well-known` discovery, or to override specific values from discovery. All fields are optional — discovery results fill gaps, config values take precedence.\n\n# Example (config.toml)\n\n```toml [[mcp_servers]] name = \"custom-server\" transport = { type = \"http\", url = \"https://my-server.com/mcp\" }\n\n[mcp_servers.oauth] auth_url = \"https://my-server.com/oauth/authorize\" token_url = \"https://my-server.com/oauth/token\" client_id = \"my-client-id\" client_secret_env = \"MY_SERVER_CLIENT_SECRET\" scopes = [\"read\", \"write\"] ```",
       "properties": {
         "auth_url": {
           "default": null,
@@ -2401,6 +2406,14 @@
         },
         "client_id": {
           "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "client_secret_env": {
+          "default": null,
+          "description": "Name of the environment variable holding the OAuth client secret. The secret itself is never stored in `config.toml`. Required when the upstream provider treats the client as confidential (e.g. Google Workspace MCP servers reject the refresh request without `client_secret`, even for Desktop/Installed OAuth client types). Leave unset for purely public PKCE clients (Notion, ChatGPT, etc.) — the OAuth flow is unchanged.\n\nResolved once at `auth_start`; the resolved value is persisted in the credential vault under the `client_secret` field alongside `refresh_token`, so it survives daemon restarts and is reused on every refresh.",
           "type": [
             "string",
             "null"
@@ -5810,6 +5823,7 @@
         "audit_retention_days": 90,
         "auto_approve": false,
         "auto_approve_autonomous": false,
+        "cache_approvals_per_session": true,
         "channel_rules": [],
         "require_approval": [
           "shell_exec",
@@ -6301,6 +6315,11 @@
       },
       "description": "External authentication provider configuration (OAuth2/OIDC)."
     },
+    "external_auth_proxy": {
+      "default": false,
+      "description": "Acknowledges that the daemon is fronted by an external auth proxy (e.g. nginx `auth_request`, Cloudflare Access, a corporate IAM SSO sidecar) so the dashboard-reads allowlist can legitimately be left open.\n\nThis flag exists because the `require_auth_for_reads = Some(false)` escape hatch is otherwise indistinguishable from a config typo: an operator who flipped it without an external proxy in front exposed `/api/agents`, `/api/sessions`, `/api/providers` to any unauthenticated reader on non-loopback binds. Per audit `require-auth-for-reads-false-leak`, the resolver now refuses to honour `Some(false)` UNLESS this flag is also set — defence in depth against a single-line config mistake.\n\nBoot also emits a warning when `bind` is non-loopback and this flag is `false`, regardless of `require_auth_for_reads`, so an operator running open-on-LAN sees the posture mismatch even if they meant to. Defaults to `false` (no external proxy assumed); set to `true` only when the proxy in front is known-good.",
+      "type": "boolean"
+    },
     "fallback_providers": {
       "description": "Fallback providers tried in order if the primary fails. Configure in config.toml as `[[fallback_providers]]`.",
       "items": {
@@ -6444,7 +6463,7 @@
       "type": "integer"
     },
     "max_history_messages": {
-      "description": "Operator override for the agent message-history trim cap. When set, any agent without its own `max_history_messages` uses this value instead of the compiled-in default (`agent_loop::DEFAULT_MAX_HISTORY_MESSAGES`). Lower it to bound per-turn token cost; raise it for long-context models. `None` means \"use the compiled-in default\". Values below 4 are silently clamped at runtime with a warning log.",
+      "description": "Operator override for the agent message-history trim cap. When set, any agent without its own `max_history_messages` uses this value instead of the compiled-in default (`agent_loop::history::DEFAULT_MAX_HISTORY_MESSAGES`). Lower it to bound per-turn token cost; raise it for long-context models. `None` means \"use the compiled-in default\". Runtime clamps values below 4 up to the safe-trim floor and values above 500 down to the hard ceiling, emitting a `warn!` log with `agent`, `requested`, and `applied`.",
       "format": "uint",
       "minimum": 0.0,
       "type": [

--- a/crates/librefang-extensions/src/installer.rs
+++ b/crates/librefang-extensions/src/installer.rs
@@ -176,6 +176,7 @@ fn oauth_template_to_config(t: &OAuthTemplate) -> McpOAuthConfig {
         auth_url: Some(t.auth_url.clone()),
         token_url: Some(t.token_url.clone()),
         client_id: None,
+        client_secret_env: None,
         scopes: t.scopes.clone(),
         user_scopes: Vec::new(),
     }

--- a/crates/librefang-kernel/src/mcp_oauth_provider.rs
+++ b/crates/librefang-kernel/src/mcp_oauth_provider.rs
@@ -235,6 +235,7 @@ const ALL_VAULT_FIELDS: &[&str] = &[
     "expires_at",
     "token_endpoint",
     "client_id",
+    "client_secret",
     "pkce_verifier",
     "pkce_state",
     "redirect_uri",
@@ -365,6 +366,9 @@ impl KernelOAuthProvider {
         }
 
         let client_id = self.vault_get_or_warn(&Self::vault_key(server_url, "client_id"));
+        // Confidential clients (Google Workspace MCP) require client_secret
+        // on refresh; persisted at auth_start when client_secret_env was set.
+        let client_secret = self.vault_get_or_warn(&Self::vault_key(server_url, "client_secret"));
 
         let client = librefang_extensions::http_client::new_client();
         let mut params = vec![
@@ -373,6 +377,9 @@ impl KernelOAuthProvider {
         ];
         if let Some(cid) = &client_id {
             params.push(("client_id", cid.clone()));
+        }
+        if let Some(ref secret) = client_secret {
+            params.push(("client_secret", secret.clone()));
         }
 
         let resp = match client.post(&token_endpoint).form(&params).send().await {
@@ -1135,6 +1142,7 @@ mod tests {
             "expires_at",
             "token_endpoint",
             "client_id",
+            "client_secret",
             "pkce_verifier",
             "pkce_state",
             "redirect_uri",
@@ -1147,7 +1155,7 @@ mod tests {
         }
         assert_eq!(
             fields.len(),
-            8,
+            9,
             "Unexpected field count in ALL_VAULT_FIELDS — update this assertion if new fields are intentionally added"
         );
     }
@@ -1543,6 +1551,54 @@ mod tests {
         assert_eq!(
             token, None,
             "expired token with no refresh token must yield Ok(None), not the stale token"
+        );
+    }
+
+    /// Integration test for the `client_secret_env` → vault → `try_refresh`
+    /// form-params wire (PR #5060). Validates the full round-trip:
+    ///   1. `vault_set` persists `client_secret` under the expected vault key
+    ///   2. `vault_get` reads it back through a fresh provider instance
+    ///   3. The vault key namespace matches what `try_refresh` reads
+    ///
+    /// This does NOT exercise the HTTP POST (that requires a real token
+    /// endpoint); it pins the storage contract so a future rename /
+    /// re-keying of the vault field breaks a test, not production.
+    #[test]
+    #[serial_test::serial(librefang_vault_key)]
+    fn client_secret_env_vault_round_trip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().to_path_buf();
+        let _vault_key = VaultKeyEnvGuard::set(TEST_VAULT_KEY);
+
+        let provider = KernelOAuthProvider::new(home.clone());
+        let server_url = "https://accounts.google.com/mcp";
+        let vault_key = KernelOAuthProvider::vault_key(server_url, "client_secret");
+
+        // Initially absent.
+        assert_eq!(
+            provider.vault_get_or_warn(&vault_key),
+            None,
+            "client_secret must be absent before auth_start persists it"
+        );
+
+        // Simulate what auth_start does: resolve env → vault_set.
+        provider
+            .vault_set(&vault_key, "GOCSPX-test-secret-value")
+            .expect("vault_set client_secret");
+
+        // Read through a fresh provider (simulates daemon restart).
+        let reader = KernelOAuthProvider::new(home);
+        assert_eq!(
+            reader.vault_get(&vault_key).expect("vault_get"),
+            Some("GOCSPX-test-secret-value".to_string()),
+            "client_secret must survive a provider reinstantiation (vault round-trip)"
+        );
+
+        // Verify the key namespace matches what try_refresh reads.
+        assert_eq!(
+            vault_key,
+            format!("mcp_oauth:{server_url}:client_secret"),
+            "vault key must be in the mcp_oauth:<url>:client_secret namespace"
         );
     }
 }

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -1143,6 +1143,7 @@ mod tests {
             client_id: Some("override-client".to_string()),
             scopes: vec!["admin".to_string()],
             user_scopes: Vec::new(),
+            client_secret_env: None,
         };
         let merged = merge_metadata_with_config(discovered, &config);
         assert_eq!(merged.authorization_endpoint, "https://override.com/auth");

--- a/crates/librefang-runtime/tests/mcp_oauth_integration.rs
+++ b/crates/librefang-runtime/tests/mcp_oauth_integration.rs
@@ -13,6 +13,7 @@ async fn test_discover_fallback_to_config() {
         client_id: Some("test-id".into()),
         scopes: vec!["read".into()],
         user_scopes: Vec::new(),
+        client_secret_env: None,
     };
     let result =
         discover_oauth_metadata("https://nonexistent.example.com/mcp", None, Some(&config)).await;

--- a/crates/librefang-types/src/config/types.rs
+++ b/crates/librefang-types/src/config/types.rs
@@ -6143,6 +6143,7 @@ pub enum McpTransportEntry {
 /// auth_url = "https://my-server.com/oauth/authorize"
 /// token_url = "https://my-server.com/oauth/token"
 /// client_id = "my-client-id"
+/// client_secret_env = "MY_SERVER_CLIENT_SECRET"
 /// scopes = ["read", "write"]
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
@@ -6153,6 +6154,20 @@ pub struct McpOAuthConfig {
     pub token_url: Option<String>,
     #[serde(default)]
     pub client_id: Option<String>,
+    /// Name of the environment variable holding the OAuth client secret.
+    /// The secret itself is never stored in `config.toml`. Required when the
+    /// upstream provider treats the client as confidential (e.g. Google
+    /// Workspace MCP servers reject the refresh request without
+    /// `client_secret`, even for Desktop/Installed OAuth client types).
+    /// Leave unset for purely public PKCE clients (Notion, ChatGPT, etc.)
+    /// — the OAuth flow is unchanged.
+    ///
+    /// Resolved once at `auth_start`; the resolved value is persisted in the
+    /// credential vault under the `client_secret` field alongside
+    /// `refresh_token`, so it survives daemon restarts and is reused on
+    /// every refresh.
+    #[serde(default)]
+    pub client_secret_env: Option<String>,
     #[serde(default)]
     pub scopes: Vec<String>,
     /// Slack-style user scopes, appended to the authorization URL as


### PR DESCRIPTION
## Summary

Revives the confidential-OAuth-client feature from #5060 (originally by @f-liva), rebased onto current `main`.
#5060 was closed as stale — explicitly **not** a rejection ("This is not a rejection of the underlying idea... please rebase onto current main... and open a fresh PR").
This is that fresh PR.

Adds `client_secret_env` to `McpOAuthConfig` so MCP servers that require a `client_secret` in the token-refresh body (e.g. Google Workspace MCP previews: `gmailmcp` / `calendarmcp` / `drivemcp` / `chatmcp`) work with confidential OAuth clients while still using PKCE.
The secret value never lands in `config.toml` — only the env-var *name* is persisted; the value is read from the environment, wrapped in `zeroize::Zeroizing`, stored in the existing credential vault, and reused on initial exchange and refresh.

## Commits

- `feat(mcp-oauth): add client_secret_env for confidential OAuth clients` — original feature, authorship preserved (@f-liva).
- `fix(mcp): set client_secret_env in test McpOAuthConfig + refresh secrets baseline` — original follow-up.
- `fix(mcp): add client_secret_env to mcp_oauth_integration test McpOAuthConfig` — new here.

## What changed vs the original #5060

- Rebased the two original commits onto current `main` (the original merge-base was ~81 commits back). The feature commit cherry-picked clean; only `.secrets.baseline` conflicted and was resolved by regenerating it (one new entry: a doc-example string in `types.rs`, a false positive now baselined).
- Fixed the recurring `E0063: missing field client_secret_env in initializer of McpOAuthConfig` that blocked #5060 each time `main` moved. `McpOAuthConfig` derives `Default` but the struct literal in `crates/librefang-runtime/tests/mcp_oauth_integration.rs` does not use `..Default::default()`, so the new field is mandatory there — added `client_secret_env: None`.
- Statically verified every `McpOAuthConfig { .. }` literal in the tree (`installer.rs`, `mcp_oauth.rs`, `mcp_oauth_integration.rs`) now sets the field.

## Verification

- Cherry-picks applied cleanly; baseline regenerated with `detect-secrets scan --baseline .secrets.baseline` (no unbaselined secrets).
- Static check of all `McpOAuthConfig` struct literals (the E0063 class) — done, all set the field.
- **Not** locally compiled: this host has no native cargo and the Docker dev image is unavailable right now, so `cargo check` / `cargo test` / the schema-golden regen could not be run locally. CI must confirm compile + `kernel_config_schema` golden + the runtime/api test lanes across platforms. Draft until green.

## For reviewers

The original design was already reviewed favourably on #5060 (PKCE preserved, env→vault→zeroize secret handling, fail-fast when DCR is attempted with `client_secret_env` set).
Please re-check the reconciliation with the OAuth redaction system (`redact_token_endpoint_response`) that landed on `main` after the original merge-base — the original branch carried a narrower body-scrub; this rebase keeps `main`'s version.

Refs #5060.
