### PR TITLE
fix(channels,kernel): kill sidecar child on shutdown + forward async delegation result to channel

### DIFF
--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -1614,9 +1614,21 @@ impl ChannelAdapter for SidecarAdapter {
                         }
                         let exit = handle.await.unwrap_or(ReaderExit::ChildClosed);
                         match exit {
-                            ReaderExit::Shutdown | ReaderExit::ReceiverGone => break,
+                            ReaderExit::Shutdown | ReaderExit::ReceiverGone => {
+                                // ponytail: kill orphaned child on shutdown, else it survives daemon restart
+                                let mut g = ctx.child.lock().await;
+                                if let Some(mut c) = g.take() {
+                                    let _ = c.kill().await;
+                                }
+                                break;
+                            }
                             ReaderExit::ChildClosed => {
                                 if *shutdown_rx.borrow() || ctx.tx.is_closed() || !ctx.sup.restart {
+                                    // ponytail: same kill on child-closed + shutdown
+                                    let mut g = ctx.child.lock().await;
+                                    if let Some(mut c) = g.take() {
+                                        let _ = c.kill().await;
+                                    }
                                     break;
                                 }
                                 // Stable uptime resets backoff so a

--- a/crates/librefang-kernel/src/kernel/task_registry.rs
+++ b/crates/librefang-kernel/src/kernel/task_registry.rs
@@ -334,6 +334,44 @@ impl LibreFangKernel {
                 session_id = %entry.session_id,
                 "Async task completion injected (mid-turn path)"
             );
+            // Belt-and-suspenders: also forward the completion text
+            // directly to the agent's home channel so the operator
+            // sees the delegation result immediately, rather than
+            // waiting for the agent's next turn to surface it. The
+            // mid-turn signal injects into the loop so the agent can
+            // read and continue, but the NL response may not reach
+            // the channel until the turn ends — this forward fires
+            // instantly.
+            if let Some(ref chat_id) = entry.chat_id {
+                if !chat_id.is_empty() {
+                    let kernel_arc = match self.self_handle.get().and_then(|w| w.upgrade()) {
+                        Some(arc) => arc,
+                        None => return Ok(true),
+                    };
+                    let body = format_task_completion_text(&event);
+                    if let Some(ctx) = kernel_arc.resolve_agent_home_channel(entry.agent_id) {
+                        use librefang_runtime::kernel_handle::ChannelSender;
+                        let _ = kernel_arc
+                            .send_channel_message(
+                                &ctx.channel,
+                                chat_id,
+                                &body,
+                                None,
+                                ctx.account_id.as_deref(),
+                            )
+                            .await
+                            .map_err(|e| {
+                                tracing::warn!(
+                                    task_id = %task_id,
+                                    channel = %ctx.channel,
+                                    chat_id = %chat_id,
+                                    error = %e,
+                                    "Async task: failed to forward completion to home channel (mid-turn path)"
+                                );
+                            });
+                    }
+                }
+            }
             return Ok(true);
         }
 


### PR DESCRIPTION
Two fixes found and verified during live testing on proteo.

## 1. Sidecar zombie (channels: sidecar.rs)

The sidecar supervisor never killed the child process on shutdown — it just broke out of the spawn loop. This left orphaned Python processes that survived daemon restart, held the Telegram long-poll connection, and blocked the new sidecar from sending/receiving messages.

**Fix**: Before breaking the supervisor loop on shutdown/child-closed signals, lock the child guard and call  — same pattern already used in the timeout path.

## 2. Async delegation result not forwarded to channel (kernel: task_registry.rs)

Async delegation callbacks arrived mid-turn via  signal injection, but the delegation result was only surfaced inside the agent session. The wake-idle path already forwarded via , but the mid-turn injection path skipped this — the operator never saw the result on the channel unless the agent explicitly echoed it.

**Fix**: After mid-turn injection, also forward the completion text directly via  to the agent's home channel. This fires immediately without waiting for the agent to process the signal.

## Verification

- Tested live on proteo with deannatroi → coder async delegation
- Basic HTTP → Telegram delivery: works
- Async delegation callback appears on Telegram: confirmed
- Sidecar zombie after daemon restart: eliminated