### PR TITLE
test(runtime): token-estimation accuracy benchmark with multi-tokenizer baselines

### DIFF
--- a/crates/librefang-llm-drivers/examples/capture_token_truth.rs
+++ b/crates/librefang-llm-drivers/examples/capture_token_truth.rs
@@ -1,0 +1,257 @@
+//! Capture real provider `input_tokens` for the token-estimation corpus.
+//!
+//! This is the live, human-run half of the token-estimation accuracy benchmark
+//! (the offline half is `librefang-runtime/tests/token_estimation_accuracy.rs`).
+//! It reads the committed corpus, sends each sample once with `max_tokens = 1`
+//! and prompt caching disabled, and records the provider-reported
+//! `usage.input_tokens` as ground truth.
+//!
+//! Run once and commit the output; CI never invokes this.
+//!
+//! ```bash
+//! OPENAI_API_KEY=<key> cargo run -p librefang-llm-drivers \
+//!   --example capture_token_truth -- \
+//!   --provider openai --model gpt-4o-mini \
+//!   --out crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.json
+//! ```
+
+use librefang_llm_drivers::drivers::anthropic::AnthropicDriver;
+use librefang_llm_drivers::drivers::openai::OpenAIDriver;
+use librefang_llm_drivers::llm_driver::{CompletionRequest, LlmDriver};
+use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+use serde::Deserialize;
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// Max attempts per sample before giving up.
+const MAX_RETRIES: u32 = 6;
+/// Base backoff (seconds), multiplied by attempt number. Free-tier limits
+/// typically reset within a minute, so the first retry alone clears most.
+const RETRY_BACKOFF_SECS: u64 = 25;
+/// Pause between successful requests to stay under per-minute rate caps.
+const INTER_REQUEST_SECS: u64 = 5;
+
+#[derive(Debug, Deserialize)]
+struct Corpus {
+    samples: Vec<Sample>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Sample {
+    id: String,
+    #[serde(default)]
+    system: Option<String>,
+    turns: Vec<Turn>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "role", rename_all = "snake_case")]
+enum Turn {
+    User {
+        text: String,
+    },
+    Assistant {
+        text: String,
+    },
+    ToolUse {
+        tool_id: String,
+        tool_name: String,
+        tool_input: serde_json::Value,
+    },
+    ToolResult {
+        tool_id: String,
+        tool_name: String,
+        content: String,
+    },
+}
+
+/// Mirror of the benchmark's builder so the bytes sent for ground truth match
+/// the bytes the estimator scores.
+fn build_messages(sample: &Sample) -> (Vec<Message>, Option<String>) {
+    let mut messages = Vec::with_capacity(sample.turns.len());
+    for turn in &sample.turns {
+        match turn {
+            Turn::User { text } => messages.push(Message::user(text.clone())),
+            Turn::Assistant { text } => messages.push(Message::assistant(text.clone())),
+            Turn::ToolUse {
+                tool_id,
+                tool_name,
+                tool_input,
+            } => messages.push(Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+                    id: tool_id.clone(),
+                    name: tool_name.clone(),
+                    input: tool_input.clone(),
+                    provider_metadata: None,
+                }]),
+                pinned: false,
+                timestamp: None,
+            }),
+            Turn::ToolResult {
+                tool_id,
+                tool_name,
+                content,
+            } => messages.push(Message::user_with_blocks(vec![ContentBlock::ToolResult {
+                tool_use_id: tool_id.clone(),
+                tool_name: tool_name.clone(),
+                content: content.clone(),
+                is_error: false,
+                status: Default::default(),
+                approval_request_id: None,
+            }])),
+        }
+    }
+    (messages, sample.system.clone())
+}
+
+struct Args {
+    provider: String,
+    /// Provenance label written into the truth file. Defaults to `provider`,
+    /// but lets an OpenAI-compatible backend (Zhipu/GLM, Groq, Moonshot, …)
+    /// record its real identity even though it is driven via `--provider openai`.
+    label: String,
+    model: String,
+    base_url: Option<String>,
+    corpus: String,
+    out: String,
+}
+
+fn parse_args() -> Args {
+    let mut provider = None;
+    let mut label = None;
+    let mut model = None;
+    let mut base_url = None;
+    let mut corpus =
+        "crates/librefang-runtime/tests/fixtures/token_estimation/corpus.json".to_string();
+    let mut out =
+        "crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.json".to_string();
+
+    let mut it = std::env::args().skip(1);
+    while let Some(flag) = it.next() {
+        let mut next = || {
+            it.next()
+                .unwrap_or_else(|| panic!("missing value for {flag}"))
+        };
+        match flag.as_str() {
+            "--provider" => provider = Some(next()),
+            "--label" => label = Some(next()),
+            "--model" => model = Some(next()),
+            "--base-url" => base_url = Some(next()),
+            "--corpus" => corpus = next(),
+            "--out" => out = next(),
+            other => panic!("unknown flag: {other}"),
+        }
+    }
+    let provider = provider.expect("--provider is required (openai|anthropic)");
+    Args {
+        label: label.unwrap_or_else(|| provider.clone()),
+        provider,
+        model: model.expect("--model is required"),
+        base_url,
+        corpus,
+        out,
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let args = parse_args();
+
+    let (driver, default_base): (Box<dyn LlmDriver>, &str) = match args.provider.as_str() {
+        "openai" => {
+            let key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
+            let base = args
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://api.openai.com/v1".into());
+            (
+                Box::new(OpenAIDriver::new(key, base.clone())),
+                "https://api.openai.com/v1",
+            )
+        }
+        "anthropic" => {
+            let key = std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
+            let base = args
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://api.anthropic.com".into());
+            (
+                Box::new(AnthropicDriver::new(key, base.clone())),
+                "https://api.anthropic.com",
+            )
+        }
+        other => panic!("unsupported --provider {other} (expected openai|anthropic)"),
+    };
+    let base_url = args
+        .base_url
+        .clone()
+        .unwrap_or_else(|| default_base.to_string());
+
+    let raw = std::fs::read_to_string(&args.corpus)
+        .unwrap_or_else(|e| panic!("read corpus {}: {e}", args.corpus));
+    let corpus: Corpus = serde_json::from_str(&raw).expect("parse corpus.json");
+
+    let mut samples: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    for sample in &corpus.samples {
+        let (messages, system) = build_messages(sample);
+        let make_request = || CompletionRequest {
+            model: args.model.clone(),
+            messages: Arc::new(messages.clone()),
+            tools: Arc::new(vec![]),
+            max_tokens: 1,
+            temperature: 0.0,
+            system: system.clone(),
+            prompt_caching: false,
+            ..Default::default()
+        };
+
+        // Free tiers (OpenRouter, …) rate-limit aggressively. Retry on any
+        // error with backoff rather than aborting the whole run, and pace
+        // requests so we stay under per-minute caps.
+        let mut input = None;
+        for attempt in 0..MAX_RETRIES {
+            match driver.complete(make_request()).await {
+                Ok(resp) => {
+                    input = Some(resp.usage.input_tokens);
+                    break;
+                }
+                Err(e) if attempt + 1 < MAX_RETRIES => {
+                    let backoff = RETRY_BACKOFF_SECS * (attempt + 1) as u64;
+                    eprintln!(
+                        "  {:<18} attempt {} failed ({e}); retrying in {backoff}s",
+                        sample.id,
+                        attempt + 1
+                    );
+                    tokio::time::sleep(std::time::Duration::from_secs(backoff)).await;
+                }
+                Err(e) => panic!(
+                    "sample {} failed after {MAX_RETRIES} attempts: {e}",
+                    sample.id
+                ),
+            }
+        }
+        let input = input.expect("retry loop guarantees a value or panics");
+        eprintln!("  {:<18} input_tokens = {input}", sample.id);
+        samples.insert(
+            sample.id.clone(),
+            json!({ "provider": args.label, "model": args.model, "input_tokens": input }),
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(INTER_REQUEST_SECS)).await;
+    }
+
+    let doc = json!({
+        "captured_with": {
+            "provider": args.label,
+            "driver": args.provider,
+            "model": args.model,
+            "base_url": base_url,
+            "prompt_caching": false,
+        },
+        "samples": samples,
+    });
+    let pretty = serde_json::to_string_pretty(&doc).expect("serialize truth");
+    std::fs::write(&args.out, pretty + "\n").unwrap_or_else(|e| panic!("write {}: {e}", args.out));
+    eprintln!("\nWrote {} samples to {}", samples.len(), args.out);
+}

--- a/crates/librefang-runtime/tests/fixtures/token_estimation/README.md
+++ b/crates/librefang-runtime/tests/fixtures/token_estimation/README.md
@@ -1,0 +1,114 @@
+# Token-estimation accuracy fixtures
+
+These fixtures back the offline benchmark in
+`crates/librefang-runtime/tests/token_estimation_accuracy.rs`, which measures
+`compactor::estimate_token_count` against real provider `input_tokens`.
+
+## Files
+
+- `corpus.json` — message samples bucketed by content shape
+  (`english_prose`, `cjk`, `mixed_cjk_latin`, `tool_json`).
+  Committed; safe to extend.
+- `tokens_truth.example.json` — the shape of the ground-truth file, with
+  placeholder `input_tokens: 0` values.
+- `tokens_truth*.json` — real captured ground truth, one file per
+  provider/tokenizer. The harness reports each separately. Committed baselines:
+  `tokens_truth.json` (Zhipu GLM `glm-4-flash`) and `tokens_truth_gptoss.json`
+  (`openai/gpt-oss-120b`, o200k tokenizer family). Counts are per-tokenizer, so
+  add a new file (e.g. `tokens_truth_anthropic.json`) rather than overwriting
+  when measuring another provider.
+
+The corpus stores plain content, not serialized `Message` objects, so it stays
+readable and decoupled from message-struct serde changes. The benchmark and the
+capture tool build identical `Message`s from it, so the bytes the estimator
+sees match the bytes sent to the provider.
+
+## Regenerating ground truth (live providers — run once, by a human)
+
+Capturing real `input_tokens` requires live API calls and is therefore a
+human-run step, not something CI or an assistant performs. Each sample is sent
+once with `max_tokens = 1` and prompt caching disabled, so `input_tokens` is the
+full, uncached prompt count; only one token is generated, keeping cost
+negligible.
+
+```bash
+# OpenAI-compatible (OpenAI / Groq / Moonshot / …):
+OPENAI_API_KEY=<key> cargo run -p librefang-llm-drivers \
+  --example capture_token_truth -- \
+  --provider openai --model gpt-4o-mini \
+  --base-url https://api.openai.com/v1 \
+  --out crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.json
+
+# Any other OpenAI-compatible backend (e.g. Zhipu / GLM): drive it via
+# `--provider openai`, point `--base-url` at its endpoint, and pass `--label`
+# so the recorded provenance is the real provider, not "openai". The API key
+# still goes in OPENAI_API_KEY.
+OPENAI_API_KEY=<zhipu-key> cargo run -p librefang-llm-drivers \
+  --example capture_token_truth -- \
+  --provider openai --label zhipu --model glm-4-flash \
+  --base-url https://open.bigmodel.cn/api/paas/v4 \
+  --out crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.json
+
+# Anthropic:
+ANTHROPIC_API_KEY=<key> cargo run -p librefang-llm-drivers \
+  --example capture_token_truth -- \
+  --provider anthropic --model claude-haiku-4-5-20251001 \
+  --out crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.json
+```
+
+Then run the benchmark and read the per-bucket error table:
+
+```bash
+cargo test -p librefang-runtime --test token_estimation_accuracy -- --nocapture
+```
+
+Once a baseline is committed, gate regressions by setting a ceiling:
+
+```bash
+LIBREFANG_TOKEN_EST_MAX_MAE_PCT=20 \
+  cargo test -p librefang-runtime --test token_estimation_accuracy
+```
+
+## Baseline findings (16 samples, 4 per bucket)
+
+Two committed baselines with different tokenizers — `tokens_truth.json` (Zhipu
+GLM `glm-4-flash`) and `tokens_truth_gptoss.json` (`openai/gpt-oss-120b` via
+OpenRouter, which uses the o200k tokenizer family and is a close stand-in for
+GPT-4o-class OpenAI models). Mean signed error of `estimate_token_count` vs real
+`input_tokens` (positive = overestimate):
+
+| bucket | GLM (efficient CJK) | gpt-oss (OpenAI o200k) |
+| --- | --- | --- |
+| cjk | +126% | +18% |
+| mixed_cjk_latin | +76% | -4% |
+| english_prose | +29% | -15% |
+| tool_json | **-14%** | **-46%** |
+| **ALL (signed)** | +54% | -12% |
+
+Reading the two columns together is the point — it separates tokenizer-specific
+error from cross-provider error:
+
+- The CJK error is **strongly tokenizer-specific**: +126% on GLM but only +18%
+  on the OpenAI-style tokenizer. GLM has a large Chinese vocabulary and
+  tokenizes Han text very efficiently (often well under one token per
+  character), so the heuristic's 1.5-tokens-per-CJK-char weight overshoots badly
+  *for GLM* while being roughly reasonable for o200k. Do **not** change the CJK
+  weight on the strength of this — it would help GLM and hurt OpenAI.
+- The `tool_json` *under*-estimate is the **cross-provider signal**: both
+  tokenizers undercount JSON-heavy tool steps (-14% GLM, -46% o200k), and o200k
+  is worse. JSON structure and escaping in tool calls are currently weighted at
+  the flat 0.25/char, which undercounts. Because the sign agrees across
+  tokenizers, this is the safe, language-independent candidate for a later
+  tuning change.
+
+## Methodology notes
+
+- Per-request fixed overhead (role framing, BOS markers, and for tool steps the
+  provider's own JSON serialization of tool calls) is real and provider-specific.
+  Keep samples non-trivial so this overhead does not dominate relative error,
+  and read absolute `MAE tokens` alongside `MAE%`.
+- Ground truth is per-provider: different tokenizers give different counts for
+  the same bytes. Record `provider` and `model` in each entry and do not mix
+  providers within one `tokens_truth.json` without noting it.
+- Capture with caching disabled so `input_tokens` reflects the whole prompt; a
+  cached run would report a smaller new-input count.

--- a/crates/librefang-runtime/tests/fixtures/token_estimation/corpus.json
+++ b/crates/librefang-runtime/tests/fixtures/token_estimation/corpus.json
@@ -1,0 +1,209 @@
+{
+  "_about": "Ground-truth corpus for the token-estimation accuracy benchmark. Each sample is bucketed by content shape so per-bucket estimator error can be measured against real provider usage. Keep samples non-trivial in size: per-request fixed overhead (role framing, BOS) dominates tiny inputs and inflates relative error. See README.md for how to regenerate tokens_truth.json.",
+  "samples": [
+    {
+      "id": "english_prose_01",
+      "bucket": "english_prose",
+      "system": "You are a concise, helpful software engineering assistant.",
+      "turns": [
+        { "role": "user", "text": "Explain the difference between a process and a thread, then describe when you would prefer multiprocessing over multithreading in a CPU-bound Python workload. Keep it to two short paragraphs and avoid bullet points." },
+        { "role": "assistant", "text": "A process owns an isolated address space while threads share one; that isolation is exactly why CPython's global interpreter lock makes multiprocessing the better fit for CPU-bound work. Each process gets its own interpreter and GIL, so several can saturate several cores in true parallel. Threads in CPython interleave on a single core for CPU-bound code because the GIL serializes bytecode execution, so they help only when the work is I/O-bound and releases the lock. Prefer multiprocessing when the bottleneck is computation and the per-task data is large enough to amortize the cost of pickling and inter-process communication." }
+      ]
+    },
+    {
+      "id": "english_prose_02",
+      "bucket": "english_prose",
+      "system": null,
+      "turns": [
+        { "role": "user", "text": "Summarize the tradeoffs of optimistic versus pessimistic locking in a high-write database, including how each behaves under contention and what failure mode the application code must handle." }
+      ]
+    },
+    {
+      "id": "english_prose_03",
+      "bucket": "english_prose",
+      "system": "You are a careful technical writer. Prefer precise language over hand-waving.",
+      "turns": [
+        { "role": "user", "text": "Walk me through how a TCP three-way handshake establishes a connection, and then explain what actually happens to in-flight data when one side sends a RST instead of a graceful FIN." },
+        { "role": "assistant", "text": "The handshake begins when the client sends a SYN carrying its initial sequence number; the server replies with a SYN-ACK that acknowledges the client's sequence number and supplies its own; the client then returns an ACK, and at that point both sides have agreed on starting sequence numbers and the connection is established. A graceful teardown uses FIN segments so that each direction is closed independently and any data already queued is delivered before the socket reaches the closed state. A RST is different in kind: it is an abrupt abort that tells the peer the connection no longer exists, so the kernel discards any unacknowledged in-flight data on both the send and receive queues, delivers an error such as connection reset to the application, and skips the TIME_WAIT bookkeeping that a normal close would observe." }
+      ]
+    },
+    {
+      "id": "english_prose_04",
+      "bucket": "english_prose",
+      "system": null,
+      "turns": [
+        { "role": "user", "text": "I keep seeing advice to make idempotent API endpoints. Explain what idempotency actually means for HTTP methods, why retries make it matter, and how an idempotency key on a POST is supposed to work end to end." },
+        { "role": "assistant", "text": "Idempotency means that performing the same operation more than once leaves the server in the same state as performing it once, so GET, PUT, and DELETE are idempotent by definition while a naive POST that creates a row is not. It matters because networks drop responses: a client that does not hear back cannot tell whether its request succeeded, so it retries, and without protection that retry can create a second charge or a duplicate order. An idempotency key fixes this by having the client generate a unique token, attach it to the POST, and resend the same token on every retry; the server records the token together with the result of the first successful execution, and when it sees the token again it returns the stored result instead of executing the side effect a second time." }
+      ]
+    },
+    {
+      "id": "cjk_01",
+      "bucket": "cjk",
+      "system": "你是一个严谨的中文技术写作助手。",
+      "turns": [
+        { "role": "user", "text": "请解释什么是数据库的乐观锁和悲观锁，并说明在高并发写入场景下二者各自的优劣，以及应用层需要分别处理哪些异常情况。请用两段话回答，不要使用列表。" },
+        { "role": "assistant", "text": "乐观锁假设冲突很少发生，因此读取时不加锁，只在提交时通过版本号或时间戳检查数据是否被他人修改；一旦检测到冲突就回滚并由应用层重试。它在读多写少、冲突概率低的场景下吞吐更高，但在高并发写入下会频繁触发重试，应用代码必须正确处理重试与幂等。悲观锁则在读取阶段就对记录加锁，阻止其他事务修改，避免了重试风暴，但锁的持有会显著降低并发度，并带来死锁与锁等待超时的风险，应用层需要为此设计超时与死锁恢复逻辑。" }
+      ]
+    },
+    {
+      "id": "cjk_02",
+      "bucket": "cjk",
+      "system": null,
+      "turns": [
+        { "role": "user", "text": "我们的服务最近在高峰期偶尔出现请求超时，但数据库和应用的 CPU 都不高。请从连接池、线程模型、慢查询、以及下游依赖四个角度，分析可能的原因，并给出排查的先后顺序。" }
+      ]
+    },
+    {
+      "id": "cjk_03",
+      "bucket": "cjk",
+      "system": "你是一位资深的分布式系统工程师，回答要兼顾原理与工程实践。",
+      "turns": [
+        { "role": "user", "text": "请通俗地解释 CAP 定理，并说明为什么在网络分区发生时只能在一致性和可用性之间二选一。再结合一个电商下单扣库存的例子，说明分别选择 CP 和 AP 会带来什么样的用户可见行为。" },
+        { "role": "assistant", "text": "CAP 定理说的是在一个会发生网络分区的分布式系统里，一致性、可用性和分区容忍性三者无法同时完全满足。由于现实网络一定会出现分区，分区容忍性几乎是必选项，于是真正的取舍发生在一致性和可用性之间：当节点之间无法通信时，系统要么拒绝服务以保证数据一致，要么继续响应但可能返回过期数据。以电商下单扣库存为例，选择 CP 时，分区期间无法确认库存的下单请求会直接失败或阻塞，用户看到的是下单暂时不可用，但绝不会超卖；选择 AP 时，系统在分区期间仍然接受下单，用户体验流畅，但两侧可能同时扣减同一批库存，分区恢复后需要对账和补偿，极端情况下会出现超卖需要取消订单。" }
+      ]
+    },
+    {
+      "id": "cjk_04",
+      "bucket": "cjk",
+      "system": null,
+      "turns": [
+        { "role": "user", "text": "请帮我审阅一段提交说明的措辞：本次改动修复了在会话压缩时聚合开发者循环导致出现连续用户消息的问题。我希望它更清晰地说明根因和影响范围，但不要太长。" }
+      ]
+    },
+    {
+      "id": "mixed_01",
+      "bucket": "mixed_cjk_latin",
+      "system": null,
+      "turns": [
+        { "role": "user", "text": "在 Rust 里，String 和 &str 的区别是什么？什么时候应该在函数签名里用 impl Into<String>，什么时候用 &str？请结合 ownership 和 borrow checker 简要说明，并给出一个 fn greet 的例子。" }
+      ]
+    },
+    {
+      "id": "mixed_02",
+      "bucket": "mixed_cjk_latin",
+      "system": "你是一个中英混合的代码评审助手，术语保留英文。",
+      "turns": [
+        { "role": "user", "text": "我们在用 tokio 写一个 async 服务，遇到一个 deadlock：一个 task 持有 Mutex 的 guard 时又 .await 了另一个会去抢同一把锁的 future。请解释为什么持锁 await 在 async 场景下特别危险，以及用 tokio::sync::Mutex 还是把临界区缩小到 drop(guard) 之后再 await 更合适。" },
+        { "role": "assistant", "text": "问题的根源在于 async 任务的 .await 是一个让出点，标准库的 std::sync::Mutex 的 guard 在跨越 .await 时仍然被持有，于是这把锁会在整个挂起期间一直被占用；如果被唤醒所依赖的 future 又需要同一把锁，就会形成自锁或与其他任务相互等待的 deadlock。更糟的是 std::sync::MutexGuard 不是 Send，跨 .await 持有它在多线程 runtime 上根本无法编译，逼你要么换锁要么改结构。通常更干净的做法是缩小临界区：在 .await 之前显式 drop(guard)，只在真正访问共享状态的那几行持锁；只有当你确实需要跨 await 持有锁时，才换成 tokio::sync::Mutex，它的 guard 是 Send 且为异步等待设计，但代价是更高的开销和仍然存在的逻辑 deadlock 风险。" }
+      ]
+    },
+    {
+      "id": "mixed_03",
+      "bucket": "mixed_cjk_latin",
+      "system": null,
+      "turns": [
+        { "role": "user", "text": "帮我理解一下 prompt caching：Anthropic 的 cache_control breakpoint 是怎么工作的？为什么 system prompt 和 tool definitions 适合放进 cached prefix，而每轮变化的 user message 不适合？如果 message 顺序里混入了一个 HashMap 迭代产生的非确定性 ordering，会对 cache hit 有什么影响？" }
+      ]
+    },
+    {
+      "id": "mixed_04",
+      "bucket": "mixed_cjk_latin",
+      "system": "你是一个 DevOps 助手。",
+      "turns": [
+        { "role": "user", "text": "我的 Dockerfile 用 multi-stage build，builder 阶段 cargo build --release 每次都全量重编，没有命中 layer cache。请说明 Cargo 的 dependency caching 在 Docker 里失效的常见原因，以及用 cargo-chef 或手动先 COPY Cargo.toml 再 build 一个 dummy main 的两种方案各自的取舍。" }
+      ]
+    },
+    {
+      "id": "tool_json_01",
+      "bucket": "tool_json",
+      "system": "You are an agent that edits files via tools.",
+      "turns": [
+        { "role": "user", "text": "Create a minimal Cargo.toml for a binary crate named widget." },
+        {
+          "role": "tool_use",
+          "tool_id": "call_a1",
+          "tool_name": "file_write",
+          "tool_input": {
+            "path": "Cargo.toml",
+            "content": "[package]\nname = \"widget\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\n",
+            "create_dirs": true,
+            "mode": "overwrite"
+          }
+        },
+        {
+          "role": "tool_result",
+          "tool_id": "call_a1",
+          "tool_name": "file_write",
+          "content": "Wrote 7 lines (98 bytes) to Cargo.toml. File did not previously exist."
+        }
+      ]
+    },
+    {
+      "id": "tool_json_02",
+      "bucket": "tool_json",
+      "system": null,
+      "turns": [
+        { "role": "user", "text": "List the open TCP ports." },
+        {
+          "role": "tool_use",
+          "tool_id": "call_b2",
+          "tool_name": "shell_exec",
+          "tool_input": {
+            "command": "ss -tlnp",
+            "timeout_secs": 10,
+            "env": { "LANG": "C" }
+          }
+        },
+        {
+          "role": "tool_result",
+          "tool_id": "call_b2",
+          "tool_name": "shell_exec",
+          "content": "State  Recv-Q Send-Q Local Address:Port Peer Address:Port\nLISTEN 0      128    0.0.0.0:22        0.0.0.0:*\nLISTEN 0      128    127.0.0.1:4545    0.0.0.0:*\nLISTEN 0      511    0.0.0.0:80        0.0.0.0:*"
+        }
+      ]
+    },
+    {
+      "id": "tool_json_03",
+      "bucket": "tool_json",
+      "system": "You are a coding agent with grep, read_file, and apply_patch tools.",
+      "turns": [
+        { "role": "user", "text": "Find where the retry budget is configured and show me the struct." },
+        {
+          "role": "tool_use",
+          "tool_id": "call_c3",
+          "tool_name": "grep",
+          "tool_input": {
+            "pattern": "struct\\s+RetryBudget",
+            "path": "crates",
+            "glob": "*.rs",
+            "output_mode": "content",
+            "case_insensitive": false,
+            "max_results": 20
+          }
+        },
+        {
+          "role": "tool_result",
+          "tool_id": "call_c3",
+          "tool_name": "grep",
+          "content": "crates/librefang-rl-export/src/retry.rs:41:pub struct RetryBudget {\ncrates/librefang-rl-export/src/retry.rs:43:    pub max_attempts: u32,\ncrates/librefang-rl-export/src/retry.rs:45:    pub base_delay_ms: u64,\ncrates/librefang-rl-export/src/retry.rs:47:    pub max_delay_ms: u64,\ncrates/librefang-rl-export/src/retry.rs:49:    pub jitter: bool,\n}"
+        }
+      ]
+    },
+    {
+      "id": "tool_json_04",
+      "bucket": "tool_json",
+      "system": null,
+      "turns": [
+        { "role": "user", "text": "Fetch the current weather for Shanghai and Beijing." },
+        {
+          "role": "tool_use",
+          "tool_id": "call_d4",
+          "tool_name": "http_request",
+          "tool_input": {
+            "method": "GET",
+            "url": "https://api.example.com/v1/weather",
+            "query": { "cities": ["Shanghai", "Beijing"], "units": "metric" },
+            "headers": { "Accept": "application/json", "Authorization": "Bearer REDACTED" },
+            "timeout_ms": 5000
+          }
+        },
+        {
+          "role": "tool_result",
+          "tool_id": "call_d4",
+          "tool_name": "http_request",
+          "content": "{\"results\":[{\"city\":\"Shanghai\",\"temp_c\":24.6,\"humidity\":0.71,\"conditions\":\"partly cloudy\"},{\"city\":\"Beijing\",\"temp_c\":19.2,\"humidity\":0.38,\"conditions\":\"clear\"}],\"fetched_at\":\"2026-06-22T03:14:00Z\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.example.json
+++ b/crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.example.json
@@ -1,0 +1,15 @@
+{
+  "_about": "Example shape of tokens_truth.json. The real file is produced by the capture tool (see README.md) against live providers and committed alongside corpus.json. The benchmark keys ground truth by `<sample_id>` and reads `input_tokens` as the authoritative prompt-token count. Numbers below are illustrative placeholders, not measured values.",
+  "captured_with": {
+    "note": "Free-form provenance recorded by the capture tool: provider, model, base_url, date, prompt_caching disabled.",
+    "prompt_caching": false
+  },
+  "samples": {
+    "english_prose_01": { "provider": "openai", "model": "gpt-4o-mini", "input_tokens": 0 },
+    "english_prose_02": { "provider": "openai", "model": "gpt-4o-mini", "input_tokens": 0 },
+    "cjk_01": { "provider": "openai", "model": "gpt-4o-mini", "input_tokens": 0 },
+    "mixed_01": { "provider": "openai", "model": "gpt-4o-mini", "input_tokens": 0 },
+    "tool_json_01": { "provider": "openai", "model": "gpt-4o-mini", "input_tokens": 0 },
+    "tool_json_02": { "provider": "openai", "model": "gpt-4o-mini", "input_tokens": 0 }
+  }
+}

--- a/crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.json
+++ b/crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.json
@@ -1,0 +1,91 @@
+{
+  "captured_with": {
+    "base_url": "https://open.bigmodel.cn/api/paas/v4",
+    "driver": "openai",
+    "model": "glm-4-flash",
+    "prompt_caching": false,
+    "provider": "zhipu"
+  },
+  "samples": {
+    "cjk_01": {
+      "input_tokens": 192,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "cjk_02": {
+      "input_tokens": 53,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "cjk_03": {
+      "input_tokens": 226,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "cjk_04": {
+      "input_tokens": 50,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "english_prose_01": {
+      "input_tokens": 179,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "english_prose_02": {
+      "input_tokens": 39,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "english_prose_03": {
+      "input_tokens": 216,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "english_prose_04": {
+      "input_tokens": 213,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "mixed_01": {
+      "input_tokens": 53,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "mixed_02": {
+      "input_tokens": 284,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "mixed_03": {
+      "input_tokens": 66,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "mixed_04": {
+      "input_tokens": 84,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "tool_json_01": {
+      "input_tokens": 107,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "tool_json_02": {
+      "input_tokens": 142,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "tool_json_03": {
+      "input_tokens": 190,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    },
+    "tool_json_04": {
+      "input_tokens": 138,
+      "model": "glm-4-flash",
+      "provider": "zhipu"
+    }
+  }
+}

--- a/crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth_gptoss.json
+++ b/crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth_gptoss.json
@@ -1,0 +1,91 @@
+{
+  "captured_with": {
+    "base_url": "https://openrouter.ai/api/v1",
+    "driver": "openai",
+    "model": "openai/gpt-oss-120b:free",
+    "prompt_caching": false,
+    "provider": "gptoss"
+  },
+  "samples": {
+    "cjk_01": {
+      "input_tokens": 305,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "cjk_02": {
+      "input_tokens": 126,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "cjk_03": {
+      "input_tokens": 361,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "cjk_04": {
+      "input_tokens": 122,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "english_prose_01": {
+      "input_tokens": 249,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "english_prose_02": {
+      "input_tokens": 101,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "english_prose_03": {
+      "input_tokens": 283,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "english_prose_04": {
+      "input_tokens": 276,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "mixed_01": {
+      "input_tokens": 117,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "mixed_02": {
+      "input_tokens": 405,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "mixed_03": {
+      "input_tokens": 137,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "mixed_04": {
+      "input_tokens": 154,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "tool_json_01": {
+      "input_tokens": 190,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "tool_json_02": {
+      "input_tokens": 222,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "tool_json_03": {
+      "input_tokens": 275,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    },
+    "tool_json_04": {
+      "input_tokens": 221,
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "gptoss"
+    }
+  }
+}

--- a/crates/librefang-runtime/tests/token_estimation_accuracy.rs
+++ b/crates/librefang-runtime/tests/token_estimation_accuracy.rs
@@ -1,0 +1,312 @@
+//! Token-estimation accuracy benchmark (offline harness).
+//!
+//! `compactor::estimate_token_count` drives compaction triggers, the
+//! context-usage report, and cost estimation, yet it is a character-weighted
+//! heuristic (CJK ~1.5 tokens, other chars/4) with no ground truth behind it.
+//! This harness measures that estimator against real provider `input_tokens`
+//! so the error is a number instead of a guess, and so a later tuning PR can
+//! prove an improvement rather than assert one.
+//!
+//! Two halves, deliberately split so CI stays offline and deterministic:
+//!   - Corpus (`fixtures/token_estimation/corpus.json`) — message samples
+//!     bucketed by content shape (English prose, CJK, mixed, JSON-heavy tool
+//!     steps). Committed.
+//!   - Ground truth (`fixtures/token_estimation/tokens_truth*.json`) — real
+//!     `input_tokens` per sample, captured against live providers by the
+//!     `capture_token_truth` example (see the fixtures README). Each file is a
+//!     separate provider/tokenizer baseline and is reported on its own; the
+//!     committed baselines are Zhipu GLM (`glm-4-flash`) and `openai/gpt-oss`
+//!     (o200k tokenizer family).
+//!
+//! The estimator runs fully offline here. When ground-truth files are present
+//! the harness additionally reports per-bucket error for each; when none exist
+//! it prints how to generate one and still exercises the offline invariants.
+
+use librefang_runtime::compactor::estimate_token_count;
+use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+// --- Corpus schema ---------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct Corpus {
+    samples: Vec<Sample>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Sample {
+    id: String,
+    bucket: String,
+    #[serde(default)]
+    system: Option<String>,
+    turns: Vec<Turn>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "role", rename_all = "snake_case")]
+enum Turn {
+    User {
+        text: String,
+    },
+    Assistant {
+        text: String,
+    },
+    ToolUse {
+        tool_id: String,
+        tool_name: String,
+        tool_input: serde_json::Value,
+    },
+    ToolResult {
+        tool_id: String,
+        tool_name: String,
+        content: String,
+    },
+}
+
+/// Build the `(messages, system)` pair a sample represents. Kept intentionally
+/// simple and mirrored by the `capture_token_truth` example so the bytes the
+/// estimator sees match the bytes sent to the provider for ground truth.
+fn build_messages(sample: &Sample) -> (Vec<Message>, Option<String>) {
+    let mut messages = Vec::with_capacity(sample.turns.len());
+    for turn in &sample.turns {
+        match turn {
+            Turn::User { text } => messages.push(Message::user(text.clone())),
+            Turn::Assistant { text } => messages.push(Message::assistant(text.clone())),
+            Turn::ToolUse {
+                tool_id,
+                tool_name,
+                tool_input,
+            } => messages.push(Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+                    id: tool_id.clone(),
+                    name: tool_name.clone(),
+                    input: tool_input.clone(),
+                    provider_metadata: None,
+                }]),
+                pinned: false,
+                timestamp: None,
+            }),
+            Turn::ToolResult {
+                tool_id,
+                tool_name,
+                content,
+            } => messages.push(Message::user_with_blocks(vec![ContentBlock::ToolResult {
+                tool_use_id: tool_id.clone(),
+                tool_name: tool_name.clone(),
+                content: content.clone(),
+                is_error: false,
+                status: Default::default(),
+                approval_request_id: None,
+            }])),
+        }
+    }
+    (messages, sample.system.clone())
+}
+
+// --- Ground truth schema ---------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct GroundTruth {
+    samples: BTreeMap<String, TruthEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TruthEntry {
+    #[allow(dead_code)]
+    provider: String,
+    #[allow(dead_code)]
+    model: String,
+    input_tokens: u64,
+}
+
+// --- Fixture loading -------------------------------------------------------
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/token_estimation")
+}
+
+fn load_corpus() -> Corpus {
+    let path = fixtures_dir().join("corpus.json");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read corpus {}: {e}", path.display()));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse corpus {}: {e}", path.display()))
+}
+
+/// Discover every captured ground-truth file (`tokens_truth*.json`, excluding
+/// the `.example.json` placeholder), sorted by name for deterministic output.
+/// Each file is a separate provider/tokenizer baseline, reported on its own.
+fn load_ground_truth_files() -> Vec<(String, GroundTruth)> {
+    let dir = fixtures_dir();
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return out;
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            name.starts_with("tokens_truth")
+                && name.ends_with(".json")
+                && !name.contains(".example.")
+        })
+        .collect();
+    paths.sort();
+    for path in paths {
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        let truth: GroundTruth =
+            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+        let name = path
+            .file_stem()
+            .and_then(|n| n.to_str())
+            .unwrap_or("?")
+            .to_string();
+        out.push((name, truth));
+    }
+    out
+}
+
+// --- Per-bucket error accounting -------------------------------------------
+
+#[derive(Default)]
+struct BucketStats {
+    n: usize,
+    sum_signed_pct: f64,
+    sum_abs_pct: f64,
+    sum_abs_tokens: u64,
+}
+
+impl BucketStats {
+    fn record(&mut self, estimate: usize, truth: u64) {
+        let truth_f = truth.max(1) as f64;
+        let signed = (estimate as f64 - truth as f64) / truth_f * 100.0;
+        self.n += 1;
+        self.sum_signed_pct += signed;
+        self.sum_abs_pct += signed.abs();
+        self.sum_abs_tokens += (estimate as i64 - truth as i64).unsigned_abs();
+    }
+    fn mean_signed_pct(&self) -> f64 {
+        self.sum_signed_pct / self.n.max(1) as f64
+    }
+    fn mae_pct(&self) -> f64 {
+        self.sum_abs_pct / self.n.max(1) as f64
+    }
+    fn mae_tokens(&self) -> f64 {
+        self.sum_abs_tokens as f64 / self.n.max(1) as f64
+    }
+}
+
+// --- Tests -----------------------------------------------------------------
+
+/// Offline invariants that hold without any provider call: every sample
+/// estimates to a positive token count and the estimator is deterministic
+/// (the prompt-cache correctness rule, #3298, depends on stable estimates).
+#[test]
+fn estimator_is_positive_and_deterministic_over_corpus() {
+    let corpus = load_corpus();
+    assert!(!corpus.samples.is_empty(), "corpus must not be empty");
+    for sample in &corpus.samples {
+        let (messages, system) = build_messages(sample);
+        let a = estimate_token_count(&messages, system.as_deref(), None);
+        let b = estimate_token_count(&messages, system.as_deref(), None);
+        assert!(a > 0, "sample {} estimated 0 tokens", sample.id);
+        assert_eq!(a, b, "sample {} estimate not deterministic", sample.id);
+    }
+}
+
+/// Report estimator error against every captured ground-truth baseline,
+/// bucketed by content shape. Each `tokens_truth*.json` file is a distinct
+/// provider/tokenizer; the per-bucket signs across files are what reveal which
+/// errors are tokenizer-specific (e.g. CJK) versus cross-provider (e.g. the
+/// JSON-heavy `tool_json` undercount). Prints a table per baseline (visible
+/// with `--nocapture`).
+#[test]
+fn report_estimator_error_against_ground_truth() {
+    let corpus = load_corpus();
+    let baselines = load_ground_truth_files();
+    if baselines.is_empty() {
+        eprintln!(
+            "\n[token-estimation] no tokens_truth*.json yet — offline-only run.\n\
+             Generate one against a real provider:\n  \
+             cargo run -p librefang-llm-drivers --example capture_token_truth -- \\\n    \
+             --provider openai --model gpt-4o-mini --out \
+             crates/librefang-runtime/tests/fixtures/token_estimation/tokens_truth.json\n\
+             See crates/librefang-runtime/tests/fixtures/token_estimation/README.md.\n"
+        );
+        return;
+    }
+
+    let ceiling = std::env::var("LIBREFANG_TOKEN_EST_MAX_MAE_PCT")
+        .ok()
+        .map(|v| {
+            v.parse::<f64>()
+                .expect("LIBREFANG_TOKEN_EST_MAX_MAE_PCT must be a number")
+        });
+
+    for (name, truth) in &baselines {
+        let mut per_bucket: BTreeMap<String, BucketStats> = BTreeMap::new();
+        let mut overall = BucketStats::default();
+        let mut missing = Vec::new();
+
+        for sample in &corpus.samples {
+            let Some(entry) = truth.samples.get(&sample.id) else {
+                missing.push(sample.id.clone());
+                continue;
+            };
+            let (messages, system) = build_messages(sample);
+            let estimate = estimate_token_count(&messages, system.as_deref(), None);
+            per_bucket
+                .entry(sample.bucket.clone())
+                .or_default()
+                .record(estimate, entry.input_tokens);
+            overall.record(estimate, entry.input_tokens);
+        }
+
+        eprintln!("\n[token-estimation] {name}: estimator error vs provider input_tokens");
+        eprintln!(
+            "  {:<18} {:>5} {:>12} {:>10} {:>11}",
+            "bucket", "n", "mean signed%", "MAE%", "MAE tokens"
+        );
+        for (bucket, s) in &per_bucket {
+            eprintln!(
+                "  {:<18} {:>5} {:>11.1}% {:>9.1}% {:>11.1}",
+                bucket,
+                s.n,
+                s.mean_signed_pct(),
+                s.mae_pct(),
+                s.mae_tokens()
+            );
+        }
+        eprintln!(
+            "  {:<18} {:>5} {:>11.1}% {:>9.1}% {:>11.1}",
+            "ALL",
+            overall.n,
+            overall.mean_signed_pct(),
+            overall.mae_pct(),
+            overall.mae_tokens()
+        );
+        if !missing.is_empty() {
+            eprintln!("  (no ground truth for: {})", missing.join(", "));
+        }
+
+        assert!(
+            overall.n > 0,
+            "{name}: ground truth present but no sample ids matched the corpus"
+        );
+
+        // Regression ceiling: opt-in via env, applied per baseline. Off by
+        // default because the error is provider-specific and no cross-provider
+        // ceiling has been agreed yet.
+        if let Some(ceiling) = ceiling {
+            assert!(
+                overall.mae_pct() <= ceiling,
+                "{name}: overall MAE {:.1}% exceeds ceiling {:.1}%",
+                overall.mae_pct(),
+                ceiling
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`compactor::estimate_token_count` drives compaction triggers, the context-usage report, and cost estimation, but it is a character-weighted heuristic (CJK ~1.5 tokens, other chars/4) with no ground truth behind it.
There is no way to know how far off it is, so any tuning would be a guess and any regression would be silent.

## Change

Adds a token-estimation accuracy benchmark — an offline harness, a live capture tool, and two measured baselines with **different tokenizers** — **without changing the estimator or adding a dependency**.

- `corpus.json` — 16 message samples, 4 per content bucket (`english_prose`, `cjk`, `mixed_cjk_latin`, `tool_json`).
  Stored as plain content, not serialized `Message` objects, so it stays readable and decoupled from message-struct serde changes.
- `token_estimation_accuracy.rs` — offline harness.
  Builds `Message`s from the corpus, asserts the estimator is positive and deterministic over every sample, and reports per-bucket signed error, MAE%, and MAE tokens against each captured baseline.
  It auto-discovers every `tokens_truth*.json` file and reports them separately, so multiple provider/tokenizer baselines are first-class.
  A regression ceiling is opt-in via `LIBREFANG_TOKEN_EST_MAX_MAE_PCT` (applied per baseline), so the benchmark is green offline and CI stays deterministic.
- `examples/capture_token_truth.rs` — the live, human-run half.
  Sends each sample once with `max_tokens=1` and prompt caching disabled, records `usage.input_tokens`.
  Mirrors the harness's message builder so the bytes scored match the bytes sent.
  Retries with backoff and paces requests so free-tier rate limits do not abort a run.
  `--label` records the real provider when an OpenAI-compatible backend (Zhipu/GLM, OpenRouter, Groq, Moonshot) is driven via `--provider openai`.
  CI never invokes it.
- `tokens_truth.json` — Zhipu GLM `glm-4-flash` (efficient-CJK tokenizer).
- `tokens_truth_gptoss.json` — `openai/gpt-oss-120b` via OpenRouter (o200k tokenizer family, a close stand-in for GPT-4o-class OpenAI models).

## Baseline findings (16 samples, 4 per bucket)

Mean signed error of `estimate_token_count` vs real `input_tokens` (positive = overestimate):

| bucket | GLM (efficient CJK) | gpt-oss (OpenAI o200k) |
| --- | --- | --- |
| cjk | +126% | +18% |
| mixed_cjk_latin | +76% | -4% |
| english_prose | +29% | -15% |
| tool_json | **-14%** | **-46%** |
| **ALL (signed)** | +54% | -12% |

Reading the two tokenizers together is the point — it separates tokenizer-specific error from cross-provider error:

- The CJK error is **strongly tokenizer-specific**: +126% on GLM but only +18% on the OpenAI-style tokenizer.
  GLM tokenizes Han text very efficiently (large Chinese vocabulary), so the 1.5-tokens-per-CJK-char weight overshoots for GLM while being roughly reasonable for o200k.
  This PR therefore does **not** change the CJK weight — doing so on single-provider evidence would help GLM and hurt OpenAI.
- The `tool_json` under-estimate is the **cross-provider signal**: both tokenizers undercount JSON-heavy tool steps (-14% GLM, -46% o200k).
  JSON structure and escaping in tool calls are weighted at the flat 0.25/char and undercount.
  Because the sign agrees across tokenizers, that JSON/escaping path is the safe, language-independent candidate for a later tuning change.

## Scope

Infrastructure plus a measured finding.
It deliberately does not touch `estimate_token_count`; a tuning PR can use this harness to prove an improvement rather than assert one.

## Verification

- `cargo test -p librefang-runtime --test token_estimation_accuracy` (2 passed)
- `cargo check -p librefang-llm-drivers --example capture_token_truth` (clean)
- `cargo clippy -p librefang-runtime --test token_estimation_accuracy -- -D warnings` (clean)
- `cargo clippy -p librefang-llm-drivers --example capture_token_truth -- -D warnings` (clean)

## Out-of-scope follow-ups

- Add OpenAI / Anthropic ground-truth files (the harness already picks up any `tokens_truth*.json`).
- Tune the `tool_json` (JSON/escaping) estimation path, gated by a committed per-baseline MAE ceiling.
