### PR TITLE
fix(ci): vendor OpenSSL unconditionally so cross-compiled release targets link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,17 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Network resilience for crate downloads. A release that fails one
+  # CLI build job ships without that platform's asset and becomes a
+  # "stuck" release (see #6272). The dominant cause is a flaky
+  # `cargo fetch`: crates.io over HTTP/2 intermittently returns
+  # "[16] Error in the HTTP2 framing layer", which aborted the
+  # x86_64-apple-darwin job after 17s in v2026.6.22-beta.22. Bump
+  # cargo's network retry count and disable HTTP/2 multiplexing
+  # (the canonical workaround for that framing error) so a transient
+  # registry hiccup retries instead of dropping an asset.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
   # Effective ref for source-using checkouts.
   # - tag push (normal release): use the pushed tag's frozen commit
   # - workflow_dispatch channel=current: use main HEAD so a hotfix

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -9,6 +9,13 @@ readme = "README.md"
 [dependencies]
 librefang-types = { path = "../librefang-types" }
 schemars = { version = "0.8", features = ["chrono", "uuid1"] }
+# webauthn-rs (via webauthn-rs-core) links against OpenSSL through openssl-sys, which is a non-optional transitive dependency present for every target.
+# Pull `openssl` in directly with the `vendored` feature so cargo feature-unification builds openssl-sys from source on ALL targets instead of probing for a system library.
+# This must be unconditional, not target-gated: Windows MSVC runners have no discoverable system OpenSSL, and the cross-compiled release targets (aarch64-linux-gnu, *-apple-darwin, aarch64-linux-android, *-musl) have no usable cross OpenSSL either — openssl-sys otherwise finds the build host's library (e.g. 1.0.2g) and aborts on the version mismatch.
+# Vendoring everywhere also makes the released binaries self-contained (statically linked OpenSSL) rather than depending on the user's system OpenSSL at runtime.
+# The vendored builder (openssl-src) auto-detects nasm and falls back to a no-asm build when it is absent, so a host Perl + C compiler are the only prerequisites (all release runners and cross images ship them).
+# Refs #6161 (Windows-only fix this supersedes).
+openssl = { version = "0.10", features = ["vendored"] }
 librefang-kernel = { path = "../librefang-kernel" }
 librefang-acp = { path = "../librefang-acp", features = ["kernel-adapter"] }
 agent-client-protocol = { workspace = true }
@@ -119,12 +126,6 @@ windows-sys = { version = "0.61", features = [
     "Win32_Security",
     "Win32_Security_Authorization",
 ] }
-# webauthn-rs (via webauthn-rs-core) links against system OpenSSL through openssl-sys.
-# The Windows MSVC CI runners have no discoverable system OpenSSL (openssl-sys fails its probe with "Could not find directory of OpenSSL installation").
-# Enable the vendored feature here so cargo feature-unification builds openssl-sys from source on Windows only; Unix keeps using the system library already present on those runners.
-# The vendored builder (openssl-src) auto-detects nasm and falls back to a no-asm build when it is absent, so the runners' bundled Perl is the only host prerequisite (both Windows images ship it).
-# Refs #6161.
-openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
 # `build.rs` uses `chrono::Utc::now()` to stamp `BUILD_DATE` instead of

--- a/crates/librefang-api/Cargo.toml
+++ b/crates/librefang-api/Cargo.toml
@@ -9,12 +9,7 @@ readme = "README.md"
 [dependencies]
 librefang-types = { path = "../librefang-types" }
 schemars = { version = "0.8", features = ["chrono", "uuid1"] }
-# webauthn-rs (via webauthn-rs-core) links against OpenSSL through openssl-sys, which is a non-optional transitive dependency present for every target.
-# Pull `openssl` in directly with the `vendored` feature so cargo feature-unification builds openssl-sys from source on ALL targets instead of probing for a system library.
-# This must be unconditional, not target-gated: Windows MSVC runners have no discoverable system OpenSSL, and the cross-compiled release targets (aarch64-linux-gnu, *-apple-darwin, aarch64-linux-android, *-musl) have no usable cross OpenSSL either — openssl-sys otherwise finds the build host's library (e.g. 1.0.2g) and aborts on the version mismatch.
-# Vendoring everywhere also makes the released binaries self-contained (statically linked OpenSSL) rather than depending on the user's system OpenSSL at runtime.
-# The vendored builder (openssl-src) auto-detects nasm and falls back to a no-asm build when it is absent, so a host Perl + C compiler are the only prerequisites (all release runners and cross images ship them).
-# Refs #6161 (Windows-only fix this supersedes).
+# webauthn-rs pulls in openssl-sys on every target; vendor unconditionally so cross-compiled release targets don't probe the host's incompatible system library (replaces the Windows-only gate from #6161).
 openssl = { version = "0.10", features = ["vendored"] }
 librefang-kernel = { path = "../librefang-kernel" }
 librefang-acp = { path = "../librefang-acp", features = ["kernel-adapter"] }


### PR DESCRIPTION
## Problem

The Release workflow has failed on every tag since beta.21 (also beta.22, #6273). The `CLI / *` build jobs for every cross-compiled target die in ~4 min during **Build CLI**:

- `aarch64-unknown-linux-gnu`, `*-apple-darwin`, `aarch64-linux-android`, `*-musl (static)` → `error: failed to run custom build command for openssl-sys v0.9.117`
- Android: `Could not find directory of OpenSSL installation`
- Linux/macOS cross: `This crate is only compatible with OpenSSL (1.1.0, 1.1.1, 3.x, 4.x) … but a different version of OpenSSL was found` (it picked up the build host's 1.0.2g, `version_number=1000207f`)

The native `x86_64-unknown-linux-gnu` and Windows jobs pass, which is why it looked intermittent.

## Root cause

`webauthn-rs` (via `webauthn-rs-core`) pulls in `openssl-sys` as a **non-optional transitive dependency for every target**, so every release build must resolve an OpenSSL library. #6161 added `openssl = { version = "0.10", features = ["vendored"] }` to fix the Windows MSVC runners — but placed it under `[target.'cfg(windows)'.dependencies]`, so the `vendored` feature only unified on Windows.

Every cross-compiled target therefore still built `openssl-sys` in non-vendored mode and probed the build host for OpenSSL — which has no usable cross library. Native x86_64-linux happened to have system OpenSSL 3.x and Windows had vendored, so only those two passed.

## Fix

Move the `openssl` dependency from the Windows-only section to the unconditional `[dependencies]` section. Feature-unification now builds `openssl-sys` from source (`openssl-src`) on **all** targets instead of probing for a system library.

This is the standard, supported approach for `cross` builds, and as a bonus makes the released native binaries self-contained (statically linked OpenSSL) rather than depending on the user's system OpenSSL at runtime. `ubuntu-22.04`, `macos-latest`, and the `cross` images all ship the Perl + C-compiler prerequisites `openssl-src` needs; `nasm` is auto-detected with a no-asm fallback.

Supersedes the Windows-only #6161.

## Verification

- One-line dependency-section relocation; the `vendored` feature itself is already proven (it is how the Windows release jobs succeed today).
- Could not compile locally (no native toolchain; Docker dev image's daemon was offline this session) — the real verification is the Release workflow re-running green on the next tag across every CLI target. The build matrix is unchanged otherwise.
