### PR TITLE
chore(deps): bump vulnerable/yanked lockfile deps to clear global CI failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,9 +1700,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -3657,9 +3657,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "ctutils",
  "subtle",
@@ -7518,9 +7518,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -10832,9 +10832,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"


### PR DESCRIPTION
## Problem

CI is red on **every branch** since ~23:00 UTC 2026-06-22 — this PR, the open dependabot PRs (cron #6278, wasmtime, cargo-minor-patch), and main's next scheduled run. It was green on main at the beta.22 push (10:57). Two independent upstream events, neither caused by any PR's content, wedged two separate required checks:

### 1. `cargo-deny (advisories)` — yanked crate
`crypto-bigint` **0.7.0 through 0.7.4 were all yanked** from crates.io. The lock pinned the yanked **0.7.3**, and `deny.toml` sets `yanked = "deny"`:
```
error[yanked]: detected yanked crate (try `cargo update -p crypto-bigint`)
```

### 2. `Security` (`cargo xtask deps --audit`) — new high-severity advisory
**RUSTSEC-2026-0185** (published 2026-06-22, **7.5 high**) against **quinn-proto < 0.11.15** — "Remote memory exhaustion from unbounded out-of-order stream reassembly". The lock pinned the vulnerable **0.11.14**:
```
error: 1 vulnerability found!
```

## Fix

Lock-only bumps to the fixed releases, plus the minimal compatible cascade each requires (all resolver-chosen, within existing semver ranges):

- `crypto-bigint` 0.7.3 → 0.7.5 — pulls `hybrid-array` 0.4.10 → 0.4.12 and `typenum` 1.19.0 → 1.20.1
- `quinn-proto` 0.11.14 → 0.11.15

No source, manifest, or feature changes. Merging this unblocks both `cargo-deny` and `Security` across all open branches once they rebase.

## Verification

- `git diff origin/main --stat`: only `Cargo.lock`, 8 lines each side (the four crate version+checksum pairs above).
- Resolver-chosen patch/minor bumps; full build/test covered by CI.
