### PR TITLE
fix(api): scope GET /api/workflows/{id}/runs to the path workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@ In-crate only; no cross-crate error-shape changes.
   It is now backed by a process-global `PROVIDER_COOLDOWN` (shared across all agent loops, mirroring the existing `LLM_CONCURRENCY` static) and passed into both call sites.
   Separately, `check()` never recorded the probe it granted (`last_probe` was only ever set by `record_probe_result`, which no production path calls), so during an open cooldown every request was let through as a probe and the breaker never actually rejected anything; `check()` now marks the probe attempt, so requests are throttled to one probe per `probe_interval_secs` (default 30s) until a probe succeeds and closes the circuit.
   Behavior change: a genuinely failing / out-of-credit provider now fails fast with a "Provider in cooldown" error (except the periodic probe) instead of doing the full retry-then-defer dance on every call; a healthy provider is never affected (the circuit only opens after a real failure, and the first post-failure call is a probe that closes it on success).
+- **fix(api): scope `GET /api/workflows/{id}/runs` to the workflow named in the path** (@houko).
+  The handler ignored its `{id}` path parameter and called `list_runs(None)`, so it returned every workflow's runs instead of the requested one.
+  Each run carries its initial `input`, so the unscoped list also exposed unrelated workflows' run inputs to any caller of one workflow's runs endpoint.
+  An invalid id now returns `400` instead of being silently treated as a request for all runs.
 - **fix(kernel): forward web-UI-initiated delegation results to the agent's home channel** (#6266) (@houko) — reported by @DaBlitzStein.
   A delegation kicked off from a web-UI turn carries no inbound `chat_id`, so the mid-turn completion forward added in #6267 was skipped and the result surfaced only in the web-UI session, never on the agent's channel.
   The forward now falls back to the home channel's configured `default_conversation` (new optional `[[sidecar_channels]].default_conversation`); with no default configured it stays a no-op rather than guessing a recipient.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Fixed
 
+- **fix(api): scope `GET /api/workflows/{id}/runs` to the workflow named in the path** (@houko).
+  The handler ignored its `{id}` path parameter and called `list_runs(None)`, so it returned every workflow's runs instead of the requested one.
+  Each run carries its initial `input`, so the unscoped list also exposed unrelated workflows' run inputs to any caller of one workflow's runs endpoint.
+  An invalid id now returns `400` instead of being silently treated as a request for all runs.
 - **fix(runtime): close a workspace-sandbox escape via an intermediate-ancestor symlink when writing into a not-yet-existing directory** (@houko).
   `resolve_sandbox_path_ext` — the single resolver behind `file_write`, `apply_patch`, and the network-reachable `web_fetch_to_file` — took a string-rebase shortcut when the target's parent directory did not exist: it stripped the workspace prefix and rejoined the suffix onto the canonical root, so the returned path still contained any *existing* intermediate-ancestor symlink while passing the `starts_with` check at the string level.
   The leaf-symlink guard (#5141) only inspects the final path component, so a path like `link/newdir/file.txt` — where `link` is a symlink to a directory outside the workspace and `newdir` does not exist yet — resolved to `<workspace>/link/newdir/file.txt`, passed the check, and then had the caller's `create_dir_all` + write follow `link` straight out of the jail (overwriting e.g. `~/.ssh/authorized_keys` or `~/.librefang/config.toml`); `web_fetch_to_file` made this reachable from a network-driven turn with no shell access.
@@ -104,10 +108,6 @@ In-crate only; no cross-crate error-shape changes.
   It is now backed by a process-global `PROVIDER_COOLDOWN` (shared across all agent loops, mirroring the existing `LLM_CONCURRENCY` static) and passed into both call sites.
   Separately, `check()` never recorded the probe it granted (`last_probe` was only ever set by `record_probe_result`, which no production path calls), so during an open cooldown every request was let through as a probe and the breaker never actually rejected anything; `check()` now marks the probe attempt, so requests are throttled to one probe per `probe_interval_secs` (default 30s) until a probe succeeds and closes the circuit.
   Behavior change: a genuinely failing / out-of-credit provider now fails fast with a "Provider in cooldown" error (except the periodic probe) instead of doing the full retry-then-defer dance on every call; a healthy provider is never affected (the circuit only opens after a real failure, and the first post-failure call is a probe that closes it on success).
-- **fix(api): scope `GET /api/workflows/{id}/runs` to the workflow named in the path** (@houko).
-  The handler ignored its `{id}` path parameter and called `list_runs(None)`, so it returned every workflow's runs instead of the requested one.
-  Each run carries its initial `input`, so the unscoped list also exposed unrelated workflows' run inputs to any caller of one workflow's runs endpoint.
-  An invalid id now returns `400` instead of being silently treated as a request for all runs.
 - **fix(kernel): forward web-UI-initiated delegation results to the agent's home channel** (#6266) (@houko) — reported by @DaBlitzStein.
   A delegation kicked off from a web-UI turn carries no inbound `chat_id`, so the mid-turn completion forward added in #6267 was skipped and the result surfaced only in the web-UI session, never on the agent's channel.
   The forward now falls back to the home channel's configured `default_conversation` (new optional `[[sidecar_channels]].default_conversation`); with no default configured it stays a no-op rather than guessing a recipient.

--- a/crates/librefang-api/src/routes/workflows/workflow.rs
+++ b/crates/librefang-api/src/routes/workflows/workflow.rs
@@ -1456,15 +1456,28 @@ pub async fn list_pending_operator_workflow_runs(
     Json(body)
 }
 
-/// GET /api/workflows/:id/runs — List runs for a workflow.
-#[utoipa::path(get, path = "/api/workflows/{id}/runs", tag = "workflows", params(("id" = String, Path, description = "Workflow ID")), responses((status = 200, description = "List workflow runs", body = Vec<serde_json::Value>)))]
+/// GET /api/workflows/:id/runs — List runs for the workflow named in the path.
+#[utoipa::path(get, path = "/api/workflows/{id}/runs", tag = "workflows", params(("id" = String, Path, description = "Workflow ID")), responses((status = 200, description = "List workflow runs", body = Vec<serde_json::Value>), (status = 400, description = "Invalid workflow ID")))]
 pub async fn list_workflow_runs(
     State(state): State<Arc<AppState>>,
-    Path(_id): Path<String>,
+    Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let runs = state.kernel.workflow_engine().list_runs(None).await;
-    let list: Vec<serde_json::Value> = runs
+    let workflow_id = WorkflowId(match id.parse() {
+        Ok(u) => u,
+        Err(_) => {
+            return ApiErrorResponse::bad_request("Invalid workflow ID").into_json_tuple();
+        }
+    });
+    // Scope to the workflow named in the path. `list_runs(None)` returns every
+    // workflow's runs, so without this filter `GET /api/workflows/A/runs` would
+    // leak the runs (and their inputs) of unrelated workflows B, C, ….
+    let list: Vec<serde_json::Value> = state
+        .kernel
+        .workflow_engine()
+        .list_runs(None)
+        .await
         .iter()
+        .filter(|r| r.workflow_id == workflow_id)
         .map(|r| {
             serde_json::json!({
                 "id": r.id.to_string(),
@@ -1476,7 +1489,7 @@ pub async fn list_workflow_runs(
             })
         })
         .collect();
-    Json(list)
+    (StatusCode::OK, Json(serde_json::Value::Array(list)))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/src/routes/workflows/workflow.rs
+++ b/crates/librefang-api/src/routes/workflows/workflow.rs
@@ -1468,9 +1468,7 @@ pub async fn list_workflow_runs(
             return ApiErrorResponse::bad_request("Invalid workflow ID").into_json_tuple();
         }
     });
-    // Scope to the workflow named in the path. `list_runs(None)` returns every
-    // workflow's runs, so without this filter `GET /api/workflows/A/runs` would
-    // leak the runs (and their inputs) of unrelated workflows B, C, ….
+    // `list_runs(None)` returns all workflows' runs; filter to this workflow to prevent cross-workflow data leak.
     let list: Vec<serde_json::Value> = state
         .kernel
         .workflow_engine()

--- a/crates/librefang-api/tests/workflow_lifecycle_test.rs
+++ b/crates/librefang-api/tests/workflow_lifecycle_test.rs
@@ -803,8 +803,7 @@ async fn run_detail_exposes_per_step_error_for_failed_step() {
 // GET /api/workflows/{id}/runs scoping (regression)
 // ---------------------------------------------------------------------------
 
-/// `GET /api/workflows/{id}/runs` must return only the runs of the workflow named in the path, not every workflow's runs.
-/// Regression: the handler previously ignored the path id and returned `list_runs(None)` wholesale, leaking other workflows' runs (and their `input`) into the response.
+/// Regression: `GET /api/workflows/{id}/runs` must scope to the path workflow — previously `list_runs(None)` returned all workflows' runs.
 #[tokio::test(flavor = "multi_thread")]
 async fn list_workflow_runs_is_scoped_to_path_workflow() {
     use librefang_kernel::workflow::WorkflowId;

--- a/crates/librefang-api/tests/workflow_lifecycle_test.rs
+++ b/crates/librefang-api/tests/workflow_lifecycle_test.rs
@@ -798,3 +798,59 @@ async fn run_detail_exposes_per_step_error_for_failed_step() {
         "failed step must expose a non-empty error in the API payload: {failed:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// GET /api/workflows/{id}/runs scoping (regression)
+// ---------------------------------------------------------------------------
+
+/// `GET /api/workflows/{id}/runs` must return only the runs of the workflow named in the path, not every workflow's runs.
+/// Regression: the handler previously ignored the path id and returned `list_runs(None)` wholesale, leaking other workflows' runs (and their `input`) into the response.
+#[tokio::test(flavor = "multi_thread")]
+async fn list_workflow_runs_is_scoped_to_path_workflow() {
+    use librefang_kernel::workflow::WorkflowId;
+
+    let h = boot().await;
+    let wf_a = create_workflow(&h).await;
+    let wf_b = create_workflow(&h).await;
+    assert_ne!(wf_a, wf_b, "two distinct workflows expected");
+    let id_a = WorkflowId(wf_a.parse().unwrap());
+    let id_b = WorkflowId(wf_b.parse().unwrap());
+
+    let engine = h.state.kernel.workflow_engine();
+    let run_a = engine
+        .create_run(id_a, "input-a".to_string())
+        .await
+        .expect("create run a");
+    engine
+        .create_run(id_b, "input-b1".to_string())
+        .await
+        .expect("create run b1");
+    engine
+        .create_run(id_b, "input-b2".to_string())
+        .await
+        .expect("create run b2");
+
+    // A's endpoint must return exactly A's single run.
+    let (status, body) = get(&h, &format!("/api/workflows/{wf_a}/runs")).await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    let arr = body.as_array().expect("array body");
+    assert_eq!(arr.len(), 1, "expected only workflow A's run: {body:?}");
+    assert_eq!(
+        arr[0]["id"].as_str(),
+        Some(run_a.to_string().as_str()),
+        "wrong run returned for A: {body:?}"
+    );
+
+    // B's endpoint must return exactly B's two runs.
+    let (status, body) = get(&h, &format!("/api/workflows/{wf_b}/runs")).await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert_eq!(
+        body.as_array().expect("array body").len(),
+        2,
+        "expected workflow B's two runs: {body:?}"
+    );
+
+    // Invalid id must be rejected with 400, not silently treated as "all runs".
+    let (status, _body) = get(&h, "/api/workflows/not-a-uuid/runs").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}

--- a/openapi.json
+++ b/openapi.json
@@ -12958,7 +12958,7 @@
         "tags": [
           "workflows"
         ],
-        "summary": "GET /api/workflows/:id/runs — List runs for a workflow.",
+        "summary": "GET /api/workflows/:id/runs — List runs for the workflow named in the path.",
         "operationId": "list_workflow_runs",
         "parameters": [
           {
@@ -12982,6 +12982,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid workflow ID"
           }
         }
       }

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-8bd1beffce4e41e544e4bbbecb89fee1bdf5934fd58b51d0d11577457a5fa70a  openapi.json
+86cf44cffa3e21d639f50ca295091069b8770672350294a9d6cf2652affe937c  openapi.json


### PR DESCRIPTION
## What

`GET /api/workflows/{id}/runs` ignored its `{id}` path parameter: the handler bound it as `Path(_id)` and called `list_runs(None)`, which returns **every** workflow's runs. So `GET /api/workflows/A/runs` returned the runs of all workflows, not just A's.

Since each `WorkflowRun` carries its initial `input` string, the unscoped list also leaked the inputs of unrelated workflows to any caller of a single workflow's runs endpoint.

## Changes

- `crates/librefang-api/src/routes/workflows/workflow.rs` — parse the path id into a `WorkflowId` (400 on an unparseable id, matching `get_workflow` / `run_workflow` and the other endpoints), then `filter(|r| r.workflow_id == workflow_id)` over `list_runs(None)`. Both return paths now produce `(StatusCode, Json<Value>)`.
- `crates/librefang-api/tests/workflow_lifecycle_test.rs` — regression test `list_workflow_runs_is_scoped_to_path_workflow`: creates two workflows, seeds one run on A and two on B via `engine.create_run`, then asserts `GET /api/workflows/{A}/runs` returns only A's run, `{B}/runs` returns B's two, and an invalid id returns 400.

## Verification

- `cargo test -p librefang-api --test workflow_lifecycle_test` — 13 passed, incl. the new test.
- `cargo fmt -p librefang-api` clean; pre-commit hooks (CHANGELOG `[Unreleased]` attribution, gitleaks) pass.

## Notes

- This is a pre-existing bug, independent of #6293. But #6293 (open) adds `input`/`error` to this same endpoint's payload, which is what escalates the unscoped list into an input-data leak. The two PRs touch the same handler, so whichever lands second needs a trivial conflict resolution — flagged on #6293.
- Scope is deliberately limited to the read endpoint; the `list_runs` signature is unchanged (its other callers pass `None`/state filters and are unaffected).
