### PR TITLE
fix(test): gate scriptable transform-hook tests behind cfg(unix) to unbreak Windows CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Fixed
 
+- **fix(test): gate the scriptable `transform_tool_result` hook tests behind `#[cfg(unix)]` so Windows CI stops failing** (@houko).
+  The #6291 transform-hook tests run a real `#!/bin/sh` script through the native script runtime; Windows has no `/bin/sh`, so the spawn failed and `transform_tool_result_script_rewrites_content` / `transform_tool_result_missing_content_is_noop` broke the metrics assertions on both Windows shards — turning `main` red (#6304) and making every open PR inherit the failure on its next run.
+  The four shell-script tests and their `make_transform_script` / `make_transform_engine` helpers (plus the now-test-only `MemorySubstrate` / `ToolExecutionStatus` imports) are now `#[cfg(unix)]`; the transform-hook feature itself is unchanged and still covered on Linux and macOS.
 - **fix(api): scope `GET /api/workflows/{id}/runs` to the workflow named in the path** (@houko).
   The handler ignored its `{id}` path parameter and called `list_runs(None)`, so it returned every workflow's runs instead of the requested one.
   Each run carries its initial `input`, so the unscoped list also exposed unrelated workflows' run inputs to any caller of one workflow's runs endpoint.

--- a/crates/librefang-runtime/src/context_engine/scriptable/engine.rs
+++ b/crates/librefang-runtime/src/context_engine/scriptable/engine.rs
@@ -1246,11 +1246,20 @@ mod request_llm_summary_tests {
     use super::*;
     use crate::llm_driver::{CompletionRequest, CompletionResponse, LlmError};
     use async_trait::async_trait;
+    // Only used by the Unix-gated transform-hook tests below (see make_transform_script).
+    #[cfg(unix)]
     use librefang_memory::MemorySubstrate;
     use librefang_types::message::{ContentBlock, StopReason, TokenUsage};
+    #[cfg(unix)]
     use librefang_types::tool::ToolExecutionStatus;
     use std::sync::Arc;
 
+    // Unix-only: these tests run a real `#!/bin/sh` hook through the native
+    // script runtime. Windows has no `/bin/sh`, so the spawn fails and the
+    // metrics assertions (`successes`, rewritten content) don't hold —
+    // regression #6304, from the #6291 transform-hook tests. The transform-hook
+    // feature itself is not Unix-gated; only this shell-script test harness is.
+    #[cfg(unix)]
     fn make_transform_script(body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
         let tmp = tempfile::tempdir().unwrap();
         let script = tmp.path().join("rewrite.sh");
@@ -1265,6 +1274,7 @@ mod request_llm_summary_tests {
         (tmp, script)
     }
 
+    #[cfg(unix)]
     fn make_transform_engine(
         hooks: librefang_types::config::ContextEngineHooks,
     ) -> ScriptableContextEngine {
@@ -1347,6 +1357,7 @@ mod request_llm_summary_tests {
         assert!(try_host_summary(&output, &driver("x"), "m").await.is_none());
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn transform_tool_result_script_rewrites_content() {
         let (_tmp, script) = make_transform_script(
@@ -1377,6 +1388,7 @@ mod request_llm_summary_tests {
         assert_eq!(engine.metrics().transform_tool_result.successes, 1);
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn transform_tool_result_missing_content_is_noop() {
         let (_tmp, script) =
@@ -1406,6 +1418,7 @@ mod request_llm_summary_tests {
         assert_eq!(engine.metrics().transform_tool_result.successes, 1);
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn transform_tool_result_script_failure_is_noop_with_warn_policy() {
         let (_tmp, script) = make_transform_script("#!/bin/sh\nexit 42\n");
@@ -1434,6 +1447,7 @@ mod request_llm_summary_tests {
         assert_eq!(engine.metrics().transform_tool_result.failures, 1);
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn transform_tool_result_agent_filter_skips_hook() {
         let (_tmp, script) = make_transform_script(

--- a/crates/librefang-runtime/src/context_engine/scriptable/engine.rs
+++ b/crates/librefang-runtime/src/context_engine/scriptable/engine.rs
@@ -1246,7 +1246,6 @@ mod request_llm_summary_tests {
     use super::*;
     use crate::llm_driver::{CompletionRequest, CompletionResponse, LlmError};
     use async_trait::async_trait;
-    // Only used by the Unix-gated transform-hook tests below (see make_transform_script).
     #[cfg(unix)]
     use librefang_memory::MemorySubstrate;
     use librefang_types::message::{ContentBlock, StopReason, TokenUsage};
@@ -1254,11 +1253,7 @@ mod request_llm_summary_tests {
     use librefang_types::tool::ToolExecutionStatus;
     use std::sync::Arc;
 
-    // Unix-only: these tests run a real `#!/bin/sh` hook through the native
-    // script runtime. Windows has no `/bin/sh`, so the spawn fails and the
-    // metrics assertions (`successes`, rewritten content) don't hold —
-    // regression #6304, from the #6291 transform-hook tests. The transform-hook
-    // feature itself is not Unix-gated; only this shell-script test harness is.
+    // Windows has no /bin/sh — only this shell-script test harness is gated, not the feature.
     #[cfg(unix)]
     fn make_transform_script(body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
         let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Problem

`main` is red (#6304). The `Test / Windows` lane fails on both shards, and because Windows/macOS lanes only run on `main`'s post-merge push CI (not on PR CI, where they are `skipping`), every PR inherits the failure on its next run.

Root cause is **not** #6299 / #6305 (they only inherited the red). The failing test is from #6291:

```
context_engine::scriptable::engine::request_llm_summary_tests::transform_tool_result_missing_content_is_noop
crates/librefang-runtime/src/context_engine/scriptable/engine.rs  assertion `left == right` failed (successes)
```

The four `transform_tool_result_*` tests build a `#!/bin/sh` script via `make_transform_script` and run it through the native script runtime as a hook. Windows has no `/bin/sh`, so the spawn fails: the script-success path (`rewrites_content`, `missing_content_is_noop`) breaks its metrics assertions on Windows, one per shard. Linux/macOS pass (4691 passed, 1 failed).

## Fix

Gate the shell-script test harness behind `#[cfg(unix)]`:

- the 4 `transform_tool_result_*` tests
- `make_transform_script` (already had an inner `#[cfg(unix)]` for the chmod) and `make_transform_engine`
- the now-test-only `use MemorySubstrate` / `use ToolExecutionStatus` imports — gated too, so Windows doesn't trip `unused_imports` / `dead_code` under `-D warnings`

The `transform_tool_result` **feature** is unchanged; only this Unix-shell test harness is gated. Coverage stays on Linux and macOS.

## Verification

- The change is `#[cfg(unix)]`-only. On Linux `cfg(unix)` is always true, so the compiled output is identical to the current code — no behavior change on the lanes that were already green.
- Windows is the platform that matters here and can't be reproduced locally (Linux-only dev container; Docker was unavailable in this session, so `cargo fmt --check` ran via the hook's documented soft-skip). The **Windows CI lane on this PR is the authoritative check** — it must go from red to green.
- Every import/helper that becomes Windows-only was gated to avoid a follow-on `-D warnings` failure.

refs #6304
