### PR TITLE
feat(runtime): code_search workspace regex search tool (#6295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,11 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Added
 
+- **feat(runtime): `code_search` tool — workspace-wide regex code search for coding agents** (@houko) — proposed by @pavver (#6295).
+  Coding agents previously had to locate code by looping `file_list` + `file_read`, spending tool calls and context rediscovering structure.
+  `code_search` regex-searches every text file under a workspace-relative path in one call and returns `relpath:line: content` rows, skipping `.git` / `target` / `node_modules`, hidden, binary, and oversized (> 2 MB) files; results are sorted by path then line for deterministic output (#3298), and `max_results` (default 100, hard cap 1000) bounds the response.
+  It is a read-only, always-native tool — no approval gate, like `file_list` — and pulls in no new dependency (hand-rolled `tokio::fs` walk, existing `regex` crate).
+  This is the first, lexical-only slice of the #6295 workspace code-intelligence layer; structural symbol indexing, repo maps, and LSP / vector backends are out of scope here and tracked as later stages.
 - **feat(workflows): per-step errors and re-run with same parameters** (#6292) (@houko).
   `StepResult` gains an `error: Option<String>` field, exposed in `GET /api/workflows/runs/{run_id}` and the synchronous `POST /api/workflows/{id}/run` response.
   Operator-node steps that fail without an LLM call (gate / transform / branch) already recorded a synthetic `StepResult` with the cause stuffed into `output`; that cause is now also carried in the dedicated `error` field, so a client can distinguish a failed step from a successful one without parsing `output`.

--- a/crates/librefang-kernel/src/auth.rs
+++ b/crates/librefang-kernel/src/auth.rs
@@ -1054,6 +1054,7 @@ fn guest_gate(tool_name: &str) -> UserToolGate {
     const READ_ONLY_TOOLS: &[&str] = &[
         "file_read",
         "file_list",
+        "code_search",
         "glob",
         "grep",
         "web_search",

--- a/crates/librefang-runtime/src/prompt_builder.rs
+++ b/crates/librefang-runtime/src/prompt_builder.rs
@@ -1169,7 +1169,7 @@ const OPERATIONAL_GUIDELINES: &str = "\
 pub fn tool_category(name: &str) -> &'static str {
     match name {
         "file_read" | "file_write" | "file_list" | "file_delete" | "file_move" | "file_copy"
-        | "file_search" => "Files",
+        | "file_search" | "code_search" => "Files",
 
         "web_search" | "web_fetch" | "web_fetch_to_file" => "Web",
 
@@ -1212,6 +1212,7 @@ pub fn tool_hint(name: &str) -> &'static str {
         "file_move" => "move or rename a file",
         "file_copy" => "copy a file",
         "file_search" => "search files by name pattern",
+        "code_search" => "regex-search file contents across the workspace",
 
         // Web
         "web_search" => "search the web for information",

--- a/crates/librefang-runtime/src/tool_runner/definitions.rs
+++ b/crates/librefang-runtime/src/tool_runner/definitions.rs
@@ -18,6 +18,7 @@ mod tool_name {
     pub const FILE_WRITE: &str = "file_write";
     pub const FILE_LIST: &str = "file_list";
     pub const APPLY_PATCH: &str = "apply_patch";
+    pub const CODE_SEARCH: &str = "code_search";
     pub const WEB_FETCH: &str = "web_fetch";
     pub const WEB_FETCH_TO_FILE: &str = "web_fetch_to_file";
     pub const WEB_SEARCH: &str = "web_search";
@@ -132,6 +133,7 @@ pub const ALWAYS_NATIVE_TOOLS: &[&str] = &[
     tool_name::FILE_READ,
     tool_name::FILE_WRITE,
     tool_name::FILE_LIST,
+    tool_name::CODE_SEARCH,
     tool_name::AGENT_SEND,
     tool_name::AGENT_LIST,
     tool_name::CHANNEL_SEND,
@@ -206,6 +208,20 @@ pub fn builtin_tool_definitions() -> Vec<ToolDefinition> {
                         "path": { "type": "string", "description": "The directory path to list" }
                     },
                     "required": ["path"]
+                }),
+            },
+            ToolDefinition {
+                name: tool_name::CODE_SEARCH.to_string(),
+                description: "Regex-search the text of every file under a workspace path and return matching `relpath:line: content` rows. Prefer this over repeated file_list + file_read to locate a symbol, string, or pattern across the workspace in one call. Skips .git/target/node_modules, hidden, binary, and oversized files.".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "query": { "type": "string", "description": "Regular expression to search for (Rust regex syntax)" },
+                        "path": { "type": "string", "description": "Workspace-relative directory to search under (default: the workspace root)" },
+                        "case_sensitive": { "type": "boolean", "description": "Match case-sensitively (default: false)" },
+                        "max_results": { "type": "integer", "description": "Maximum matching lines to return (default: 100, max: 1000)" }
+                    },
+                    "required": ["query"]
                 }),
             },
             ToolDefinition {

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -405,8 +405,7 @@ pub async fn execute_tool_raw(
             tool_file_list(input, *workspace_root, &extra_refs).await
         }
         "code_search" => {
-            // Read-only, like file_list: allow searching named workspaces and
-            // the bridge download dir in addition to the agent's own workspace.
+            // Same read access as file_list: named workspaces and bridge download dir.
             let mut extra = named_ws_prefixes(*kernel, *caller_agent_id);
             if let Some(dl) = kernel.and_then(|k| k.channel_file_download_dir()) {
                 extra.push(dl);

--- a/crates/librefang-runtime/src/tool_runner/dispatch.rs
+++ b/crates/librefang-runtime/src/tool_runner/dispatch.rs
@@ -404,6 +404,16 @@ pub async fn execute_tool_raw(
             let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
             tool_file_list(input, *workspace_root, &extra_refs).await
         }
+        "code_search" => {
+            // Read-only, like file_list: allow searching named workspaces and
+            // the bridge download dir in addition to the agent's own workspace.
+            let mut extra = named_ws_prefixes(*kernel, *caller_agent_id);
+            if let Some(dl) = kernel.and_then(|k| k.channel_file_download_dir()) {
+                extra.push(dl);
+            }
+            let extra_refs: Vec<&Path> = extra.iter().map(|p| p.as_path()).collect();
+            tool_code_search(input, *workspace_root, &extra_refs).await
+        }
         "apply_patch" => {
             // SECURITY #3662: Enforce named workspace read-only restrictions
             // before applying the patch.  Mirrors the upfront check in the

--- a/crates/librefang-runtime/src/tool_runner/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/mod.rs
@@ -30,6 +30,7 @@ mod process;
 #[cfg(feature = "docker-sandbox")]
 mod sandbox;
 mod schedule;
+mod search;
 mod shell;
 mod shell_safety;
 mod skill;
@@ -83,6 +84,7 @@ use self::sandbox::tool_docker_exec;
 use self::schedule::{
     tool_schedule_create, tool_schedule_delete, tool_schedule_list, tool_schedule_resume,
 };
+use self::search::tool_code_search;
 use self::shell::tool_shell_exec;
 use self::shell_safety::{classify_shell_exec_ro_safety, RoSafety};
 use self::skill::{

--- a/crates/librefang-runtime/src/tool_runner/search.rs
+++ b/crates/librefang-runtime/src/tool_runner/search.rs
@@ -1,0 +1,257 @@
+//! `code_search` — workspace-wide lexical / regex code search.
+//!
+//! First slice of the workspace code-intelligence layer (#6295): give a coding
+//! agent one `grep`-style tool so it can locate a symbol or string across the
+//! whole workspace in a single call, instead of looping `file_list` +
+//! `file_read` and burning context rediscovering structure.
+//!
+//! Scope is deliberately lexical-only. Structural symbol indexing, repo maps,
+//! reference graphs, and LSP / vector backends are out of scope for this slice
+//! and tracked as later stages of #6295. No new dependency is pulled in: the
+//! walk is a hand-rolled iterative DFS over `tokio::fs::read_dir` and matching
+//! uses the already-vendored `regex` crate.
+
+use super::error::{ToolError, ToolResult};
+use super::fs::resolve_file_path_ext;
+use regex::RegexBuilder;
+use std::path::{Path, PathBuf};
+
+/// Directories never worth searching — VCS metadata, build output, vendored deps.
+const SKIP_DIRS: &[&str] = &[".git", ".hg", ".svn", "target", "node_modules"];
+/// Files larger than this are skipped (generated / vendored / binary blobs).
+const MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
+/// Default cap on returned match lines.
+const DEFAULT_MAX_RESULTS: usize = 100;
+/// Hard ceiling on `max_results` so a caller can't ask for an unbounded dump.
+const HARD_MAX_RESULTS: usize = 1000;
+/// Stop after scanning this many files so a pathological tree can't hang a turn.
+const MAX_FILES_SCANNED: usize = 20_000;
+/// Per-line character cap in output so one minified line can't blow the budget.
+const MAX_LINE_CHARS: usize = 400;
+
+/// `code_search` handler: regex-search every text file under `path` (relative
+/// to the agent workspace), returning `relpath:line: content` rows sorted by
+/// path then line for deterministic output (#3298).
+pub(super) async fn tool_code_search(
+    input: &serde_json::Value,
+    workspace_root: Option<&Path>,
+    additional_roots: &[&Path],
+) -> ToolResult {
+    let query = input["query"]
+        .as_str()
+        .ok_or(ToolError::MissingParameter("query"))?;
+    if query.is_empty() {
+        return Err(ToolError::InvalidParameter {
+            name: "query",
+            reason: "query must not be empty".to_string(),
+        });
+    }
+    let raw_path = input["path"].as_str().unwrap_or(".");
+    let root = resolve_file_path_ext(raw_path, workspace_root, additional_roots).map_err(
+        |reason| ToolError::InvalidParameter {
+            name: "path",
+            reason,
+        },
+    )?;
+    let case_sensitive = input["case_sensitive"].as_bool().unwrap_or(false);
+    let max_results = (input["max_results"]
+        .as_u64()
+        .map(|n| n as usize)
+        .unwrap_or(DEFAULT_MAX_RESULTS))
+    .clamp(1, HARD_MAX_RESULTS);
+
+    let re = RegexBuilder::new(query)
+        .case_insensitive(!case_sensitive)
+        .build()
+        .map_err(|e| ToolError::InvalidParameter {
+            name: "query",
+            reason: format!("invalid regex: {e}"),
+        })?;
+
+    // Iterative DFS — no recursion, no `walkdir` dependency. Each directory's
+    // entries are sorted before being visited so traversal order (and thus the
+    // truncation boundary) is deterministic regardless of `read_dir` order.
+    let mut matches: Vec<(String, usize, String)> = Vec::new();
+    let mut files_scanned: usize = 0;
+    let mut truncated = false;
+    let mut stack: Vec<PathBuf> = vec![root.clone()];
+
+    'walk: while let Some(dir) = stack.pop() {
+        let mut rd = match tokio::fs::read_dir(&dir).await {
+            Ok(rd) => rd,
+            // Unreadable directory: skip it rather than failing the whole search.
+            Err(_) => continue,
+        };
+        let mut entries: Vec<PathBuf> = Vec::new();
+        while let Ok(Some(e)) = rd.next_entry().await {
+            entries.push(e.path());
+        }
+        entries.sort();
+
+        let mut subdirs: Vec<PathBuf> = Vec::new();
+        for path in entries {
+            // symlink_metadata so we never follow a symlink out of the tree.
+            let meta = match tokio::fs::symlink_metadata(&path).await {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if meta.file_type().is_symlink() {
+                continue;
+            }
+            if meta.is_dir() {
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if name.starts_with('.') || SKIP_DIRS.contains(&name) {
+                    continue;
+                }
+                subdirs.push(path);
+                continue;
+            }
+            if !meta.is_file() || meta.len() > MAX_FILE_BYTES {
+                continue;
+            }
+
+            files_scanned += 1;
+            if files_scanned > MAX_FILES_SCANNED {
+                truncated = true;
+                break 'walk;
+            }
+
+            let bytes = match tokio::fs::read(&path).await {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            if bytes.contains(&0u8) {
+                continue; // binary
+            }
+            let text = String::from_utf8_lossy(&bytes);
+            let rel = path
+                .strip_prefix(&root)
+                .unwrap_or(path.as_path())
+                .display()
+                .to_string();
+            for (idx, line) in text.lines().enumerate() {
+                if re.is_match(line) {
+                    matches.push((rel.clone(), idx + 1, clip_line(line)));
+                    if matches.len() >= max_results {
+                        truncated = true;
+                        break 'walk;
+                    }
+                }
+            }
+        }
+        // Push in reverse so the next pops visit subdirs in sorted order.
+        for d in subdirs.into_iter().rev() {
+            stack.push(d);
+        }
+    }
+
+    if matches.is_empty() {
+        return Ok(format!("No matches for /{query}/ under '{raw_path}'."));
+    }
+    matches.sort();
+    let mut out = String::with_capacity(matches.len() * 48);
+    for (rel, line, content) in &matches {
+        out.push_str(&format!("{rel}:{line}: {content}\n"));
+    }
+    if truncated {
+        out.push_str(&format!(
+            "--- truncated at {} matches; narrow `path` or refine the query ---\n",
+            matches.len()
+        ));
+    }
+    Ok(out)
+}
+
+/// Trim a matched line and cap it at [`MAX_LINE_CHARS`] characters, counting by
+/// `char` so the cut never lands inside a multi-byte UTF-8 sequence (which a
+/// byte-wise `String::truncate` would panic on).
+fn clip_line(line: &str) -> String {
+    let t = line.trim();
+    if t.chars().count() > MAX_LINE_CHARS {
+        let mut s: String = t.chars().take(MAX_LINE_CHARS).collect();
+        s.push('…');
+        s
+    } else {
+        t.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn missing_query_is_missing_parameter() {
+        let r = tool_code_search(&json!({}), None, &[]).await;
+        assert!(matches!(r, Err(ToolError::MissingParameter("query"))), "{r:?}");
+    }
+
+    #[tokio::test]
+    async fn invalid_regex_is_invalid_parameter() {
+        let tmp = TempDir::new().unwrap();
+        let r = tool_code_search(&json!({"query": "(unclosed"}), Some(tmp.path()), &[]).await;
+        assert!(
+            matches!(r, Err(ToolError::InvalidParameter { name: "query", .. })),
+            "{r:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn finds_matches_with_line_numbers() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("a.rs"), "fn alpha() {}\nfn beta() {}\n").unwrap();
+        std::fs::write(tmp.path().join("b.rs"), "let x = alpha();\n").unwrap();
+        let out = tool_code_search(&json!({"query": "alpha"}), Some(tmp.path()), &[])
+            .await
+            .unwrap();
+        assert!(out.contains("a.rs:1: fn alpha() {}"), "got: {out}");
+        assert!(out.contains("b.rs:1: let x = alpha();"), "got: {out}");
+        // beta line must not appear.
+        assert!(!out.contains("beta"), "got: {out}");
+    }
+
+    #[tokio::test]
+    async fn is_case_insensitive_by_default_and_respects_flag() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "Needle\n").unwrap();
+        let ci = tool_code_search(&json!({"query": "needle"}), Some(tmp.path()), &[])
+            .await
+            .unwrap();
+        assert!(ci.contains("a.txt:1:"), "default should be case-insensitive: {ci}");
+        let cs = tool_code_search(
+            &json!({"query": "needle", "case_sensitive": true}),
+            Some(tmp.path()),
+            &[],
+        )
+        .await
+        .unwrap();
+        assert!(cs.contains("No matches"), "case_sensitive should miss: {cs}");
+    }
+
+    #[tokio::test]
+    async fn skips_git_dir_and_binary_files() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".git")).unwrap();
+        std::fs::write(tmp.path().join(".git").join("config"), "needle in git\n").unwrap();
+        std::fs::write(tmp.path().join("bin.dat"), [b'n', b'e', 0u8, b'e', b'd']).unwrap();
+        std::fs::write(tmp.path().join("ok.txt"), "needle here\n").unwrap();
+        let out = tool_code_search(&json!({"query": "needle"}), Some(tmp.path()), &[])
+            .await
+            .unwrap();
+        assert!(out.contains("ok.txt:1:"), "got: {out}");
+        assert!(!out.contains(".git"), "must skip .git: {out}");
+        assert!(!out.contains("bin.dat"), "must skip binary: {out}");
+    }
+
+    #[tokio::test]
+    async fn no_matches_returns_friendly_message() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "hello\n").unwrap();
+        let out = tool_code_search(&json!({"query": "zzz_absent"}), Some(tmp.path()), &[])
+            .await
+            .unwrap();
+        assert!(out.contains("No matches"), "got: {out}");
+    }
+}

--- a/crates/librefang-runtime/src/tool_runner/search.rs
+++ b/crates/librefang-runtime/src/tool_runner/search.rs
@@ -34,12 +34,13 @@ pub(super) async fn tool_code_search(
         });
     }
     let raw_path = input["path"].as_str().unwrap_or(".");
-    let root = resolve_file_path_ext(raw_path, workspace_root, additional_roots).map_err(
-        |reason| ToolError::InvalidParameter {
-            name: "path",
-            reason,
-        },
-    )?;
+    let root =
+        resolve_file_path_ext(raw_path, workspace_root, additional_roots).map_err(|reason| {
+            ToolError::InvalidParameter {
+                name: "path",
+                reason,
+            }
+        })?;
     let case_sensitive = input["case_sensitive"].as_bool().unwrap_or(false);
     let max_results = (input["max_results"]
         .as_u64()
@@ -170,7 +171,10 @@ mod tests {
     #[tokio::test]
     async fn missing_query_is_missing_parameter() {
         let r = tool_code_search(&json!({}), None, &[]).await;
-        assert!(matches!(r, Err(ToolError::MissingParameter("query"))), "{r:?}");
+        assert!(
+            matches!(r, Err(ToolError::MissingParameter("query"))),
+            "{r:?}"
+        );
     }
 
     #[tokio::test]
@@ -204,7 +208,10 @@ mod tests {
         let ci = tool_code_search(&json!({"query": "needle"}), Some(tmp.path()), &[])
             .await
             .unwrap();
-        assert!(ci.contains("a.txt:1:"), "default should be case-insensitive: {ci}");
+        assert!(
+            ci.contains("a.txt:1:"),
+            "default should be case-insensitive: {ci}"
+        );
         let cs = tool_code_search(
             &json!({"query": "needle", "case_sensitive": true}),
             Some(tmp.path()),
@@ -212,7 +219,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(cs.contains("No matches"), "case_sensitive should miss: {cs}");
+        assert!(
+            cs.contains("No matches"),
+            "case_sensitive should miss: {cs}"
+        );
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/tool_runner/search.rs
+++ b/crates/librefang-runtime/src/tool_runner/search.rs
@@ -1,15 +1,4 @@
-//! `code_search` — workspace-wide lexical / regex code search.
-//!
-//! First slice of the workspace code-intelligence layer (#6295): give a coding
-//! agent one `grep`-style tool so it can locate a symbol or string across the
-//! whole workspace in a single call, instead of looping `file_list` +
-//! `file_read` and burning context rediscovering structure.
-//!
-//! Scope is deliberately lexical-only. Structural symbol indexing, repo maps,
-//! reference graphs, and LSP / vector backends are out of scope for this slice
-//! and tracked as later stages of #6295. No new dependency is pulled in: the
-//! walk is a hand-rolled iterative DFS over `tokio::fs::read_dir` and matching
-//! uses the already-vendored `regex` crate.
+//! Workspace-wide regex code search tool.
 
 use super::error::{ToolError, ToolResult};
 use super::fs::resolve_file_path_ext;
@@ -29,9 +18,7 @@ const MAX_FILES_SCANNED: usize = 20_000;
 /// Per-line character cap in output so one minified line can't blow the budget.
 const MAX_LINE_CHARS: usize = 400;
 
-/// `code_search` handler: regex-search every text file under `path` (relative
-/// to the agent workspace), returning `relpath:line: content` rows sorted by
-/// path then line for deterministic output (#3298).
+/// Returns `relpath:line: content` rows sorted by path then line (#3298).
 pub(super) async fn tool_code_search(
     input: &serde_json::Value,
     workspace_root: Option<&Path>,
@@ -68,9 +55,7 @@ pub(super) async fn tool_code_search(
             reason: format!("invalid regex: {e}"),
         })?;
 
-    // Iterative DFS — no recursion, no `walkdir` dependency. Each directory's
-    // entries are sorted before being visited so traversal order (and thus the
-    // truncation boundary) is deterministic regardless of `read_dir` order.
+    // Sort entries per directory so the truncation boundary is deterministic (#3298).
     let mut matches: Vec<(String, usize, String)> = Vec::new();
     let mut files_scanned: usize = 0;
     let mut truncated = false;


### PR DESCRIPTION
## What

First slice of the #6295 workspace code-intelligence layer: a `code_search` agent tool that regex-searches the workspace in one call.

Coding agents currently locate code by looping `file_list` + `file_read` — there is no `grep`-equivalent built-in. `code_search` closes that gap: one call returns `relpath:line: content` rows for every match under a workspace-relative path.

## Scope (deliberately minimal)

Lexical / regex search only. Structural symbol indexing, repo maps, reference graphs, and LSP / vector backends from @pavver's proposal are **out of scope for this slice** and tracked as later stages of #6295. Starting with lexical search follows the discussion's "FTS / repo maps before LSP and vectors" ordering and keeps the first slice small and reviewable.

## Behaviour

- Input: `query` (regex, required), `path` (workspace-relative, default root), `case_sensitive` (default false), `max_results` (default 100, hard cap 1000).
- Skips `.git` / `.hg` / `.svn` / `target` / `node_modules`, hidden dirs, symlinks (not followed), binary files (NUL-byte sniff), and files larger than 2 MB. Caps total files scanned at 20k.
- Output sorted by path then line (deterministic, #3298); per-line output clipped to 400 chars on a `char` boundary; truncation is flagged in the output.

## Design decisions

- **No new dependency**: hand-rolled iterative `tokio::fs::read_dir` DFS + the already-vendored `regex` crate. No `walkdir`, no `tree-sitter`.
- **Lives in** `librefang-runtime/src/tool_runner/search.rs`, wired like any other built-in tool — no new crate (the crate-boundary question from #6295 is left for the structural-index stage).
- **Read-only, always-native**: added to `ALWAYS_NATIVE_TOOLS` (eager, no lazy-load round-trip) and to the guest read-only allowlist in `kernel/auth.rs`, so it needs no approval gate — same treatment as `file_list`. Path access goes through the existing `resolve_file_path_ext` sandbox.

## Wiring

- `tool_runner/search.rs` — handler `tool_code_search` + 5 unit tests.
- `tool_runner/definitions.rs` — `tool_name::CODE_SEARCH`, `ToolDefinition` (JSON schema), `ALWAYS_NATIVE_TOOLS`.
- `tool_runner/dispatch.rs` — `"code_search"` match arm (named-workspace + download-dir read allowlist, like `file_list`).
- `tool_runner/mod.rs` — `mod search;` + handler import.
- `kernel/auth.rs` — guest `READ_ONLY_TOOLS` allowlist.
- `prompt_builder.rs` — `tool_category` (Files) + `tool_hint`.

## Tests (in `search.rs`)

- `missing_query_is_missing_parameter`
- `invalid_regex_is_invalid_parameter`
- `finds_matches_with_line_numbers`
- `is_case_insensitive_by_default_and_respects_flag`
- `skips_git_dir_and_binary_files`
- `no_matches_returns_friendly_message`

## Verification

This box has no native Rust toolchain and Docker was unavailable in this session, so `cargo check` / `cargo fmt` could not be run locally (the pre-commit fmt hook took its documented no-rustfmt soft-skip). **CI is the authoritative check** — the runtime unit lane compiles + runs the new tests, and the fmt lane validates formatting. Types were cross-checked against the `file_list` handler template (`ToolError` / `ToolResult` / `resolve_file_path_ext` signatures) and the existing drift tests (`no_duplicate_tool_names`, `tools.len() at least 40`) cover the new registration.

refs #6295
