### PR TITLE
fix(test): gate use std::sync::Arc behind cfg(unix) to complete the Windows-red fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Fixed
 
+- **fix(test): also gate the now-Unix-only `use std::sync::Arc` in the scriptable-hook tests so Windows compiles** (@houko).
+  Follow-up to #6306: gating `make_transform_engine` left `use std::sync::Arc` referenced only by Unix-gated code, so Windows failed `-D warnings` with an `unused_imports` error (the rest of the test module uses the fully-qualified `std::sync::Arc`).
+  The import is now `#[cfg(unix)]` as well, completing the #6304 Windows-red fix.
 - **fix(test): gate the scriptable `transform_tool_result` hook tests behind `#[cfg(unix)]` so Windows CI stops failing** (@houko).
   The #6291 transform-hook tests run a real `#!/bin/sh` script through the native script runtime; Windows has no `/bin/sh`, so the spawn failed and `transform_tool_result_script_rewrites_content` / `transform_tool_result_missing_content_is_noop` broke the metrics assertions on both Windows shards — turning `main` red (#6304) and making every open PR inherit the failure on its next run.
   The four shell-script tests and their `make_transform_script` / `make_transform_engine` helpers (plus the now-test-only `MemorySubstrate` / `ToolExecutionStatus` imports) are now `#[cfg(unix)]`; the transform-hook feature itself is unchanged and still covered on Linux and macOS.

--- a/crates/librefang-runtime/src/context_engine/scriptable/engine.rs
+++ b/crates/librefang-runtime/src/context_engine/scriptable/engine.rs
@@ -1251,8 +1251,7 @@ mod request_llm_summary_tests {
     use librefang_types::message::{ContentBlock, StopReason, TokenUsage};
     #[cfg(unix)]
     use librefang_types::tool::ToolExecutionStatus;
-    // Only the Unix-gated make_transform_engine uses the short `Arc` name; the
-    // rest of the module (StubDriver) uses the fully-qualified `std::sync::Arc`.
+    // Short `Arc` only used by Unix-gated make_transform_engine; rest of module uses std::sync::Arc fully-qualified.
     #[cfg(unix)]
     use std::sync::Arc;
 

--- a/crates/librefang-runtime/src/context_engine/scriptable/engine.rs
+++ b/crates/librefang-runtime/src/context_engine/scriptable/engine.rs
@@ -1251,6 +1251,9 @@ mod request_llm_summary_tests {
     use librefang_types::message::{ContentBlock, StopReason, TokenUsage};
     #[cfg(unix)]
     use librefang_types::tool::ToolExecutionStatus;
+    // Only the Unix-gated make_transform_engine uses the short `Arc` name; the
+    // rest of the module (StubDriver) uses the fully-qualified `std::sync::Arc`.
+    #[cfg(unix)]
     use std::sync::Arc;
 
     // Windows has no /bin/sh — only this shell-script test harness is gated, not the feature.


### PR DESCRIPTION
## Problem

`main` is still red after #6306. That PR gated the scriptable `transform_tool_result` hook tests behind `#[cfg(unix)]` (including `make_transform_engine`), but missed one import: `use std::sync::Arc` in the same test module is now referenced **only** by the Unix-gated `make_transform_engine` (`Arc::new(MemorySubstrate::open_in_memory(..))`). The rest of the module uses the fully-qualified `std::sync::Arc` (e.g. `StubDriver`'s `driver()`), so on Windows the short import is unused and the build fails:

```
error: unused import: `std::sync::Arc`
  --> crates/librefang-runtime/src/context_engine/scriptable/engine.rs:1254
  = note: `-D unused-imports` implied by `-D warnings`
```

Both Windows shards fail at the `cargo test --no-run` compile step, so `main`'s post-merge CI stayed red and every PR keeps inheriting it.

## Fix

Gate `use std::sync::Arc` behind `#[cfg(unix)]`, matching the already-gated `make_transform_engine` / `MemorySubstrate` / `ToolExecutionStatus`. Verified `Arc` (short name) is used only at the single gated site; everything else in the module uses `std::sync::Arc` fully-qualified.

## Verification

Linux / macOS are unaffected — `cfg(unix)` is true there, so `Arc` stays imported and used. Windows is the platform that was failing and can't be reproduced locally (no native Rust toolchain / Docker this session), so the **Windows lane on `main` after merge is the authoritative check** (PR CI skips Windows by design). The fix is the exact, minimal counterpart of the compile error CI reported.

Completes #6304. Follow-up to #6306.
