### PR TITLE
fix(ci): install libdbus-1-dev in the release Bump Version job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,15 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
+      - name: Install build deps
+        # `cargo xtask release` runs `cargo xtask codegen --openapi`, which
+        # compiles the workspace to regenerate openapi.json. libdbus-1-dev is
+        # required by libdbus-sys, pulled in transitively on glibc Linux (keyring
+        # secret-service / notify-rust). Every other Linux release job already
+        # installs it; this job was missing it, so the bump step panicked in
+        # libdbus-sys build.rs ("system library dbus-1 not found").
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libdbus-1-dev
+
       - name: Run xtask release
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,12 +265,9 @@ jobs:
           git config user.email "actions@github.com"
 
       - name: Install build deps
-        # `cargo xtask release` runs `cargo xtask codegen --openapi`, which
-        # compiles the workspace to regenerate openapi.json. libdbus-1-dev is
-        # required by libdbus-sys, pulled in transitively on glibc Linux (keyring
-        # secret-service / notify-rust). Every other Linux release job already
-        # installs it; this job was missing it, so the bump step panicked in
-        # libdbus-sys build.rs ("system library dbus-1 not found").
+        # `cargo xtask release` runs `cargo xtask codegen --openapi`, which compiles the workspace to regenerate openapi.json.
+        # libdbus-1-dev is required by libdbus-sys, pulled in transitively on glibc Linux (keyring secret-service / notify-rust).
+        # Every other Linux release job already installs it; this job was missing it, so the bump step panicked in libdbus-sys build.rs ("system library dbus-1 not found").
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libdbus-1-dev
 
       - name: Run xtask release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Fixed
 
+- **fix(ci): install `libdbus-1-dev` in the release `Bump Version` job so dispatching a beta/stable release no longer panics** (@houko).
+  `cargo xtask release` (run for `channel != current`) compiles the workspace via `cargo xtask codegen --openapi` to regenerate `openapi.json`; that pulls in `libdbus-sys` transitively (keyring / notify-rust) and panicked with `system library 'dbus-1' not found` because — unlike every other Linux release job — the `Bump Version` job never installed `libdbus-1-dev`.
+  So `release.yml` dispatched with `channel=beta` failed at the bump step before it could open the version PR; the job now installs the dep, matching the other release jobs.
 - **fix(test): also gate the now-Unix-only `use std::sync::Arc` in the scriptable-hook tests so Windows compiles** (@houko).
   Follow-up to #6306: gating `make_transform_engine` left `use std::sync::Arc` referenced only by Unix-gated code, so Windows failed `-D warnings` with an `unused_imports` error (the rest of the test module uses the fully-qualified `std::sync::Arc`).
   The import is now `#[cfg(unix)]` as well, completing the #6304 Windows-red fix.


### PR DESCRIPTION
## Problem

Dispatching a beta release (`release.yml`, `channel=beta`) failed at the `Bump Version` job before it could open the version PR:

```
error: failed to run custom build command for `libdbus-sys v0.2.7`
  The system library `dbus-1` required by crate `libdbus-sys` was not found.
Error: cargo xtask codegen --openapi failed
```

`cargo xtask release` (for `channel != current`) runs `cargo xtask codegen --openapi`, which compiles the workspace to regenerate `openapi.json`. That transitively pulls in `libdbus-sys` (keyring secret-service / notify-rust on glibc Linux), whose `build.rs` panics when `dbus-1` is absent.

Every other Linux job in `release.yml` (the CLI matrix at ~L590, ~L719, the desktop job at ~L1526) already installs `libdbus-1-dev` for exactly this reason — the `Bump Version` job is the only one that didn't, so any beta/stable/rc/lts dispatch died at the bump step.

## Fix

Add the same `Install build deps` step (`pkg-config libssl-dev libdbus-1-dev`) to the `Bump Version` job, before `Run xtask release`. One-line parity with the other release jobs.

## Verification

Can't run the release workflow from a branch (it only triggers on `workflow_dispatch` against `main` / tag push). After merge I'll re-dispatch `channel=beta` and confirm the bump step gets past codegen and opens the version PR. This unblocks #6289 (verifying the #6279 cross-compile fix restored the `aarch64-unknown-linux-musl` / `aarch64-linux-android` tarballs), which was the reason for cutting a fresh beta.
