### PR TITLE
fix(mcp-oauth): disable redirect following on OAuth HTTP clients (SSRF + credential leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ _33 PRs from 5 contributors since v2026.6.22-beta.22._
 
 ### Security
 
-- Pin `redirect::Policy::none()` on all MCP OAuth outbound HTTP clients (metadata discovery, token exchange, dynamic client registration, refresh) so a malicious or compromised authorization server cannot use a 3xx redirect to replay `client_secret` / `code_verifier` / `refresh_token` to an attacker-controlled host or pivot the daemon at internal / cloud-metadata endpoints — the per-URL SSRF guard only validated the initial URL, never redirect hops (#6315) (@houko)
+- Pin `redirect::Policy::none()` on all MCP OAuth outbound HTTP clients (metadata discovery, token exchange, dynamic client registration, refresh) so a malicious or compromised authorization server cannot use a 3xx redirect to replay `client_secret` / `code_verifier` / `refresh_token` to an attacker-controlled host or pivot the daemon at internal / cloud-metadata endpoints — the per-URL SSRF guard only validated the initial URL, never redirect hops (#6315) (@houko).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ _33 PRs from 5 contributors since v2026.6.22-beta.22._
 
 ### Security
 
-- Pin `redirect::Policy::none()` on all MCP OAuth outbound HTTP clients (metadata discovery, token exchange, dynamic client registration, refresh) so a malicious or compromised authorization server cannot use a 3xx redirect to replay `client_secret` / `code_verifier` / `refresh_token` to an attacker-controlled host or pivot the daemon at internal / cloud-metadata endpoints — the per-URL SSRF guard only validated the initial URL, never redirect hops (@houko)
+- Pin `redirect::Policy::none()` on all MCP OAuth outbound HTTP clients (metadata discovery, token exchange, dynamic client registration, refresh) so a malicious or compromised authorization server cannot use a 3xx redirect to replay `client_secret` / `code_verifier` / `refresh_token` to an attacker-controlled host or pivot the daemon at internal / cloud-metadata endpoints — the per-URL SSRF guard only validated the initial URL, never redirect hops (#6315) (@houko)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ _33 PRs from 5 contributors since v2026.6.22-beta.22._
 
 ## [Unreleased]
 
+### Security
+
+- Pin `redirect::Policy::none()` on all MCP OAuth outbound HTTP clients (metadata discovery, token exchange, dynamic client registration, refresh) so a malicious or compromised authorization server cannot use a 3xx redirect to replay `client_secret` / `code_verifier` / `refresh_token` to an attacker-controlled host or pivot the daemon at internal / cloud-metadata endpoints — the per-URL SSRF guard only validated the initial URL, never redirect hops (@houko)
+
 ### Changed
 
 - **chore(secrets): replace the detect-secrets baseline with gitleaks** (#6262) (@houko).

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -936,10 +936,8 @@ pub async fn auth_callback(
     };
 
     // Exchange authorization code for tokens.
-    // Use the proxy-aware OAuth client so token endpoint requests respect proxy
-    // config and inherit default connect/read timeouts (prevents hung token
-    // exchanges). Redirects are disabled: a 307/308 here would replay the PKCE
-    // code_verifier and any client_secret to an attacker-controlled target.
+    // Use the proxy-aware OAuth client so token endpoint requests respect proxy config and inherit default connect/read timeouts (prevents hung token exchanges).
+    // Redirects are disabled: a 307/308 here would replay the PKCE code_verifier and any client_secret to an attacker-controlled target.
     let http_client = librefang_kernel::http_client::oauth_client();
     let mut form_params = vec![
         ("grant_type", "authorization_code".to_string()),

--- a/crates/librefang-api/src/routes/mcp_auth.rs
+++ b/crates/librefang-api/src/routes/mcp_auth.rs
@@ -936,9 +936,11 @@ pub async fn auth_callback(
     };
 
     // Exchange authorization code for tokens.
-    // Use the proxy-aware client so token endpoint requests respect proxy config
-    // and inherit default connect/read timeouts (prevents hung token exchanges).
-    let http_client = librefang_kernel::http_client::proxied_client();
+    // Use the proxy-aware OAuth client so token endpoint requests respect proxy
+    // config and inherit default connect/read timeouts (prevents hung token
+    // exchanges). Redirects are disabled: a 307/308 here would replay the PKCE
+    // code_verifier and any client_secret to an attacker-controlled target.
+    let http_client = librefang_kernel::http_client::oauth_client();
     let mut form_params = vec![
         ("grant_type", "authorization_code".to_string()),
         ("code", code),

--- a/crates/librefang-http/src/lib.rs
+++ b/crates/librefang-http/src/lib.rs
@@ -172,6 +172,25 @@ pub fn proxied_client() -> reqwest::Client {
         .expect("HTTP client with proxy/TLS config should always build")
 }
 
+/// Proxy-aware [`reqwest::ClientBuilder`] that NEVER follows HTTP redirects, for OAuth machine-to-machine endpoints (metadata discovery, token exchange, dynamic client registration, token refresh).
+///
+/// OAuth endpoints return JSON directly and have no legitimate reason to emit a 3xx mid-flow.
+/// Following a redirect on these calls is a security hole the per-URL SSRF guard cannot catch, because that guard validates only the initial URL — never the redirect `Location`.
+/// A `307`/`308` on a credential-bearing POST replays the request body (`client_secret`, `code_verifier`, `refresh_token`) to an attacker-controlled redirect target; a `302` on discovery becomes a blind SSRF / cloud-metadata pivot.
+///
+/// This mirrors `librefang_runtime::web_fetch`'s pinned client, which disables reqwest's automatic redirect following for the same reason.
+/// Use this for every outbound OAuth request; do not reach for [`proxied_client_builder`] there, whose default policy follows up to 10 hops.
+pub fn oauth_client_builder() -> reqwest::ClientBuilder {
+    proxied_client_builder().redirect(reqwest::redirect::Policy::none())
+}
+
+/// Convenience: ready-to-use proxy-aware OAuth [`reqwest::Client`] with redirect following disabled. See [`oauth_client_builder`].
+pub fn oauth_client() -> reqwest::Client {
+    oauth_client_builder()
+        .build()
+        .expect("OAuth HTTP client with proxy/TLS config should always build")
+}
+
 /// Build a fallback [`reqwest::Client`] used when a per-provider proxy override
 /// is invalid. Identical to [`proxied_client`] but also enforces a total
 /// per-request timeout so a stuck upstream cannot wedge the agent loop

--- a/crates/librefang-kernel/src/mcp_oauth_provider.rs
+++ b/crates/librefang-kernel/src/mcp_oauth_provider.rs
@@ -370,11 +370,8 @@ impl KernelOAuthProvider {
         // on refresh; persisted at auth_start when client_secret_env was set.
         let client_secret = self.vault_get_or_warn(&Self::vault_key(server_url, "client_secret"));
 
-        // Proxy-aware OAuth client with redirects disabled: a 307/308 on the
-        // refresh POST would replay refresh_token / client_secret to the
-        // redirect target, and the SSRF guard above validates only the initial
-        // token_endpoint, not redirect hops. `oauth_client` also routes through
-        // [proxy] config (#3577), which the previous bundled-CA client skipped.
+        // Proxy-aware OAuth client with redirects disabled: a 307/308 on the refresh POST would replay refresh_token / client_secret to the redirect target, and the SSRF guard above validates only the initial token_endpoint, not redirect hops.
+        // `oauth_client` also routes through [proxy] config (#3577), which the previous bundled-CA client skipped.
         let client = librefang_runtime::http_client::oauth_client();
         let mut params = vec![
             ("grant_type", "refresh_token".to_string()),
@@ -549,10 +546,7 @@ impl KernelOAuthProvider {
         {
             return Err(format!("SSRF: registration_endpoint rejected: {reason}"));
         }
-        // Proxy-aware OAuth client with redirects disabled — same rationale as
-        // try_refresh / token exchange: an OAuth endpoint emitting a 3xx is
-        // never legitimate, and following it would pivot the registration POST
-        // (and the client_secret the AS echoes back) to an attacker target.
+        // Proxy-aware OAuth client with redirects disabled — same rationale as try_refresh / token exchange: an OAuth endpoint emitting a 3xx is never legitimate, and following it would pivot the registration POST (and the client_secret the AS echoes back) to an attacker target.
         let client = librefang_runtime::http_client::oauth_client();
 
         let body = serde_json::json!({

--- a/crates/librefang-kernel/src/mcp_oauth_provider.rs
+++ b/crates/librefang-kernel/src/mcp_oauth_provider.rs
@@ -370,7 +370,12 @@ impl KernelOAuthProvider {
         // on refresh; persisted at auth_start when client_secret_env was set.
         let client_secret = self.vault_get_or_warn(&Self::vault_key(server_url, "client_secret"));
 
-        let client = librefang_extensions::http_client::new_client();
+        // Proxy-aware OAuth client with redirects disabled: a 307/308 on the
+        // refresh POST would replay refresh_token / client_secret to the
+        // redirect target, and the SSRF guard above validates only the initial
+        // token_endpoint, not redirect hops. `oauth_client` also routes through
+        // [proxy] config (#3577), which the previous bundled-CA client skipped.
+        let client = librefang_runtime::http_client::oauth_client();
         let mut params = vec![
             ("grant_type", "refresh_token".to_string()),
             ("refresh_token", refresh_token.to_string()),
@@ -544,7 +549,11 @@ impl KernelOAuthProvider {
         {
             return Err(format!("SSRF: registration_endpoint rejected: {reason}"));
         }
-        let client = librefang_extensions::http_client::new_client();
+        // Proxy-aware OAuth client with redirects disabled — same rationale as
+        // try_refresh / token exchange: an OAuth endpoint emitting a 3xx is
+        // never legitimate, and following it would pivot the registration POST
+        // (and the client_secret the AS echoes back) to an attacker target.
+        let client = librefang_runtime::http_client::oauth_client();
 
         let body = serde_json::json!({
             "client_name": "LibreFang",

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -780,7 +780,10 @@ pub async fn discover_oauth_metadata(
 ) -> Result<OAuthMetadata, String> {
     // OAuth metadata discovery must respect [proxy] config (#3577) — corporate
     // networks routinely require a proxy and OAuth was a primary failure case.
-    let client = librefang_http::proxied_client_builder()
+    // Redirects are disabled: a malicious/compromised MCP server returning a
+    // 302 would otherwise drive a blind SSRF / cloud-metadata pivot, since the
+    // SSRF guard validates only the initial URL, not redirect hops.
+    let client = librefang_http::oauth_client_builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()
         .map_err(|e| format!("Failed to build HTTP client: {e}"))?;

--- a/crates/librefang-runtime-mcp/src/mcp_oauth.rs
+++ b/crates/librefang-runtime-mcp/src/mcp_oauth.rs
@@ -780,9 +780,7 @@ pub async fn discover_oauth_metadata(
 ) -> Result<OAuthMetadata, String> {
     // OAuth metadata discovery must respect [proxy] config (#3577) — corporate
     // networks routinely require a proxy and OAuth was a primary failure case.
-    // Redirects are disabled: a malicious/compromised MCP server returning a
-    // 302 would otherwise drive a blind SSRF / cloud-metadata pivot, since the
-    // SSRF guard validates only the initial URL, not redirect hops.
+    // Redirects are disabled: a malicious/compromised MCP server returning a 302 would otherwise drive a blind SSRF / cloud-metadata pivot, since the SSRF guard validates only the initial URL, not redirect hops.
     let client = librefang_http::oauth_client_builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()

--- a/crates/librefang-runtime/tests/mcp_oauth_integration.rs
+++ b/crates/librefang-runtime/tests/mcp_oauth_integration.rs
@@ -363,3 +363,84 @@ fn test_needs_auth_serializes_differently_from_pending_auth() {
         "NeedsAuth and PendingAuth must serialize to different state values"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Regression: OAuth HTTP clients must NOT follow redirects.
+//
+// A 307/308 on a credential-bearing OAuth POST (token exchange, refresh, DCR)
+// would replay client_secret / code_verifier / refresh_token to the redirect
+// target, and a 302 on metadata discovery is a blind SSRF / cloud-metadata
+// pivot. The per-URL SSRF guard validates only the initial URL, so the client
+// built by `oauth_client()` must itself refuse to follow any redirect.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn test_oauth_client_does_not_follow_redirects() {
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    // Mock OAuth endpoint: 302 to /followed on the first request, 200 on any
+    // request to /followed. The client only reaches /followed if it followed
+    // the redirect — which `Policy::none()` must prevent.
+    let server = tokio::spawn(async move {
+        let mut followed = false;
+        // reqwest may reuse the keep-alive connection or open a new one to
+        // follow, so accept up to two connections.
+        for _ in 0..2 {
+            let Ok(Ok((mut stream, _))) =
+                tokio::time::timeout(Duration::from_millis(500), listener.accept()).await
+            else {
+                break;
+            };
+            loop {
+                let mut buf = [0u8; 1024];
+                let n =
+                    match tokio::time::timeout(Duration::from_millis(300), stream.read(&mut buf))
+                        .await
+                    {
+                        Ok(Ok(n)) if n > 0 => n,
+                        _ => break,
+                    };
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let path = req.split_whitespace().nth(1).unwrap_or("");
+                if path == "/followed" {
+                    followed = true;
+                    let _ = stream
+                        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nFOLLOWED")
+                        .await;
+                } else {
+                    let _ = stream
+                        .write_all(
+                            b"HTTP/1.1 302 Found\r\nLocation: /followed\r\nContent-Length: 0\r\n\r\n",
+                        )
+                        .await;
+                }
+            }
+        }
+        followed
+    });
+
+    let client = librefang_runtime::http_client::oauth_client();
+    let resp = client
+        .get(format!("http://127.0.0.1:{port}/token"))
+        .send()
+        .await
+        .expect("request to mock OAuth endpoint should succeed");
+
+    // Policy::none() returns the 302 verbatim instead of transparently
+    // following it to /followed and surfacing the 200.
+    assert_eq!(
+        resp.status().as_u16(),
+        302,
+        "OAuth client followed a redirect — credential-replay / SSRF guard bypass"
+    );
+
+    let followed = server.await.unwrap_or(false);
+    assert!(
+        !followed,
+        "OAuth client requested the redirect target — Policy::none() not applied"
+    );
+}


### PR DESCRIPTION
## Summary

The four MCP OAuth outbound HTTP call sites built their reqwest clients with redirect following enabled — reqwest's default policy follows up to 10 hops, and the kernel/extensions bundled-CA client used `redirect::Policy::limited(5)`.
The per-URL SSRF guard (`is_ssrf_blocked_url`) validates only the *initial* request URL; it never re-checks the redirect `Location`.
A malicious or compromised MCP authorization server could therefore:

- return a `307`/`308` on a credential-bearing POST (authorization-code exchange, token refresh, dynamic client registration) to replay the request body — `client_secret`, the PKCE `code_verifier`, the `refresh_token` — to an attacker-controlled redirect target; or
- return a `302` on metadata discovery to drive a blind SSRF / cloud-metadata (IMDS) pivot from the long-running daemon.

This brings the OAuth call paths in line with `librefang_runtime::web_fetch`'s pinned client, which already disables reqwest's automatic redirect following for exactly this reason.

## Changes

- `librefang-http`: add `oauth_client_builder()` / `oauth_client()` — proxy-aware client builders that pin `redirect::Policy::none()`. The shared `build_http_client` default is left untouched (LLM-streaming callers legitimately need redirects).
- `discover_oauth_metadata` (`librefang-runtime-mcp`): build the discovery client via `oauth_client_builder()`.
- Token exchange (`librefang-api`, `routes/mcp_auth.rs`): build via `librefang_kernel::http_client::oauth_client()`.
- `try_refresh` and `register_client` / DCR (`librefang-kernel`, `mcp_oauth_provider.rs`): switch from `librefang_extensions::http_client::new_client()` (bundled-CA, `Policy::limited(5)`, proxy-unaware) to `librefang_runtime::http_client::oauth_client()`. This disables redirects and also gives refresh/DCR the same proxy support discovery and token exchange already had (#3577); with no proxy configured the behavior is unchanged.

Otherwise the per-site handling is unchanged: each call site already treats a non-`is_success()` response as a failure (discovery falls through to the next tier / config fallback; token/refresh/DCR log a redacted digest and surface a generic error).
With redirects disabled the credential body is never re-sent to a redirect target.

## Verification

- `cargo check -p librefang-http -p librefang-runtime-mcp -p librefang-api -p librefang-kernel -p librefang-runtime --lib` — passed, clean.
- `cargo clippy -p librefang-http -p librefang-runtime-mcp -p librefang-api -p librefang-kernel -p librefang-runtime --all-targets -- -D warnings` — passed, zero warnings.
- `cargo test -p librefang-runtime --test mcp_oauth_integration` — 10 passed, 0 failed. The new `test_oauth_client_does_not_follow_redirects` stands up a loopback mock that answers every non-`/followed` request with a `302 Location: /followed`; it asserts `oauth_client()` returns the `302` verbatim (status `302`) and never requests the redirect target. Existing OAuth discovery/lifecycle tests still pass.

(Run in the repo's `Dockerfile.rust-dev` image against an isolated target volume, per the project's no-local-cargo rule.)

## Out of scope (intentionally separate PRs)

- DNS-resolution SSRF: `is_ssrf_blocked_url` matches host strings literally, so a hostname whose A-record points at `169.254.169.254` / `127.0.0.1` still passes the initial-URL guard. Closing it requires resolving DNS before the IP-tier check (and pinning the connecting client's resolution, as `web_fetch` does); `librefang-channels` currently documents DNS-resolution SSRF as out of scope by design, so this is a deliberate, larger follow-up rather than something to bolt on here.
- Other audit findings surfaced alongside this one (paired-device approval privilege escalation, the deterministic non-expiring dashboard session token, the WASM env-var blocklist suffix bypass, the MCP tool-definition prompt-injection scan gap, two kernel concurrency TOCTOU races, the proactive-memory off→on hot-reload no-op) each belong to a different crate/threat class and will be filed as their own PRs.
