### PR TITLE
fix(runtime): block separator-less secret env names from WASM guests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ _33 PRs from 5 contributors since v2026.6.22-beta.22._
 ### Security
 
 - Pin `redirect::Policy::none()` on all MCP OAuth outbound HTTP clients (metadata discovery, token exchange, dynamic client registration, refresh) so a malicious or compromised authorization server cannot use a 3xx redirect to replay `client_secret` / `code_verifier` / `refresh_token` to an attacker-controlled host or pivot the daemon at internal / cloud-metadata endpoints — the per-URL SSRF guard only validated the initial URL, never redirect hops (#6315) (@houko).
+- Close a WASM env-var secret-blocklist bypass: `host_env_read` suppressed names like `API_KEY` / `MY_TOKEN` via a both-sides word-boundary match, but a separator-less name such as `APIKEY`, `MYTOKEN`, `DBPASSWORD` or `ALGOLIA_APIKEY` glued the credential word to the end with no boundary and slipped through, leaking the real value to any plugin holding `EnvRead("*")`; a suffix rule now treats any name ending in a blocked secret word as a secret (@houko)
 
 ### Changed
 

--- a/crates/librefang-runtime/src/host_functions.rs
+++ b/crates/librefang-runtime/src/host_functions.rs
@@ -797,9 +797,20 @@ fn is_blocked_env_var(name: &str) -> bool {
     // non-alphanumeric boundary on at least one side of the match
     // (start/end of string counts), so e.g. `AWS_API_KEY` and
     // `MY_PASSWORD_HASH` still match while `MONKEYHOUSE` does not.
+    //
+    // Plus a suffix rule: a separator-less secret name like `APIKEY`,
+    // `MYTOKEN`, `DBPASSWORD` or `ALGOLIA_APIKEY` glues the credential word
+    // to the end with no boundary, so the both-sides check above misses it
+    // and the real value would leak to a wildcard-`EnvRead` guest.  Treat
+    // any name *ending* in a blocked word as a secret.  This errs toward
+    // over-blocking (a benign `TURKEY` / `MONKEY` ending in `KEY` is also
+    // suppressed), which is the safe direction here — the guest receives
+    // `null`, never a credential.  A `starts_with` rule is deliberately NOT
+    // added: it would re-break `TOKENIZER_OPTS` / `PRIVATELABEL_NAME` /
+    // `PASSWORDLIST_FILE`, which legitimately begin with a blocked word.
     BLOCKED_ENV_SUBSTRINGS
         .iter()
-        .any(|sub| has_word_boundary_substring(&upper, sub))
+        .any(|sub| upper.ends_with(sub) || has_word_boundary_substring(&upper, sub))
 }
 
 /// `true` iff `needle` appears in `haystack` as its own word —
@@ -1127,6 +1138,25 @@ mod tests {
         // Boundary punctuation other than `_` is also a boundary.
         assert!(is_blocked_env_var("MY-API-KEY"));
         assert!(is_blocked_env_var("KEY.PRIVATE"));
+
+        // Separator-less secret names: the credential word is glued to the
+        // end with no boundary, so the both-sides rule above misses them.
+        // The suffix rule must suppress these (regression for the
+        // `APIKEY` / `MYTOKEN` / `DBPASSWORD` leak to wildcard-`EnvRead`
+        // guests).
+        for name in &[
+            "APIKEY",
+            "MYTOKEN",
+            "DBPASSWORD",
+            "GHTOKEN",
+            "STRIPEKEY",
+            "ALGOLIA_APIKEY",
+        ] {
+            assert!(
+                is_blocked_env_var(name),
+                "{name} must be blocked (separator-less secret suffix)"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`host_env_read` (the WASM host function backing `EnvRead`) suppresses secret-looking environment variables before handing them to a guest, so that a plugin granted `EnvRead("*")` cannot read `ANTHROPIC_API_KEY`, `MY_TOKEN`, etc.
The match is a both-sides word-boundary check, deliberately tightened (over a plain `contains`) so benign config like `MONKEYHOUSE`, `KEYBOARD_LAYOUT`, `TOKENIZER_OPTS` stays readable.

The gap: a **separator-less** secret name glues the credential word to the end with no boundary — `APIKEY`, `MYTOKEN`, `DBPASSWORD`, `GHTOKEN`, `STRIPEKEY`, `ALGOLIA_APIKEY`.
For `APIKEY`, `KEY` starts at index 3 with the preceding byte `I` (alphanumeric), so the both-sides rule rejects the match and the variable is **not** blocked — `host_env_read` then returns the real secret to the guest.
This is a defense-in-depth bypass for any plugin holding a wildcard `EnvRead` capability.

## Changes

- `crates/librefang-runtime/src/host_functions.rs` — `is_blocked_env_var` now matches `upper.ends_with(sub) || has_word_boundary_substring(&upper, sub)`.
  The suffix arm catches the separator-less names; the existing both-sides arm is unchanged.
- A `starts_with` arm is intentionally omitted: it would re-flag `TOKENIZER_OPTS` / `PRIVATELABEL_NAME` / `PASSWORDLIST_FILE`, the exact benign-config false positives the both-sides rule was written to allow.
- Trade-off documented in code: the suffix rule over-blocks a benign name ending in a secret word (`TURKEY`, `MONKEY`), which is the safe direction — the guest gets `null`, never a credential.

## Verification

- `cargo clippy -p librefang-runtime --lib -- -D warnings` — passed, zero warnings.
- `cargo test -p librefang-runtime --lib is_blocked_env_var` — 2 passed, 0 failed. The extended `test_is_blocked_env_var_word_boundary` now asserts `APIKEY` / `MYTOKEN` / `DBPASSWORD` / `GHTOKEN` / `STRIPEKEY` / `ALGOLIA_APIKEY` are blocked, while the existing benign negatives (`MONKEYHOUSE`, `KEYBOARD_LAYOUT`, `TOKENIZER_OPTS`, `PRIVATELABEL_NAME`, `PASSWORDLIST_FILE`, `MASTERKEYBOARD`) still pass.
- `cargo fmt -p librefang-runtime --check` — clean.

(Run in the repo's `Dockerfile.rust-dev` image against an isolated target volume, per the project's no-local-cargo rule.)

## Context

Surfaced by a repo-wide security audit. Filed as its own PR (one of several from that pass); it is self-contained in the WASM-sandbox host-function layer and unrelated to the other findings.
