### PR TITLE
fix(kernel): guard gc_sweep running_tasks removal with task_id (TOCTOU)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,8 @@ In-crate only; no cross-crate error-shape changes.
 ### Fixed
 
 - **fix(kernel): stop the GC sweep from aborting a successor turn (TOCTOU on `running_tasks`)** (@houko).
-  The 5-minute sweep collected dead/finished `(agent, session)` keys and then did a bare `running_tasks.remove(&key)`; a faster successor turn that swapped a fresh, live `RunningTask` into the same key between the collect and the remove was dropped and had its in-flight `AbortHandle` fired, killing a live turn. The sweep now snapshots the observed `task_id` and removes via `remove_if(... v.task_id == observed)` — the same `#3445` guard the streaming-cleanup path uses — so a swapped-in successor is never touched.
+  The 5-minute sweep collected dead/finished `(agent, session)` keys and then did a bare `running_tasks.remove(&key)`; a faster successor turn that swapped a fresh, live `RunningTask` into the same key between the collect and the remove was dropped and had its in-flight `AbortHandle` fired, killing a live turn.
+  The sweep now snapshots the observed `task_id` and removes via `remove_if(... v.task_id == observed)` — the same `#3445` guard the streaming-cleanup path uses — so a swapped-in successor is never touched.
 
 - **fix(ci): install `libdbus-1-dev` in the release `Bump Version` job so dispatching a beta/stable release no longer panics** (@houko).
   `cargo xtask release` (run for `channel != current`) compiles the workspace via `cargo xtask codegen --openapi` to regenerate `openapi.json`; that pulls in `libdbus-sys` transitively (keyring / notify-rust) and panicked with `system library 'dbus-1' not found` because — unlike every other Linux release job — the `Bump Version` job never installed `libdbus-1-dev`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,9 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Fixed
 
+- **fix(kernel): stop the GC sweep from aborting a successor turn (TOCTOU on `running_tasks`)** (@houko).
+  The 5-minute sweep collected dead/finished `(agent, session)` keys and then did a bare `running_tasks.remove(&key)`; a faster successor turn that swapped a fresh, live `RunningTask` into the same key between the collect and the remove was dropped and had its in-flight `AbortHandle` fired, killing a live turn. The sweep now snapshots the observed `task_id` and removes via `remove_if(... v.task_id == observed)` — the same `#3445` guard the streaming-cleanup path uses — so a swapped-in successor is never touched.
+
 - **fix(ci): install `libdbus-1-dev` in the release `Bump Version` job so dispatching a beta/stable release no longer panics** (@houko).
   `cargo xtask release` (run for `channel != current`) compiles the workspace via `cargo xtask codegen --openapi` to regenerate `openapi.json`; that pulls in `libdbus-sys` transitively (keyring / notify-rust) and panicked with `system library 'dbus-1' not found` because — unlike every other Linux release job — the `Bump Version` job never installed `libdbus-1-dev`.
   So `release.yml` dispatched with `channel=beta` failed at the bump step before it could open the version PR; the job now installs the dep, matching the other release jobs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,7 @@ In-crate only; no cross-crate error-shape changes.
 
 ### Fixed
 
-- **fix(kernel): stop the GC sweep from aborting a successor turn (TOCTOU on `running_tasks`)** (@houko).
+- **fix(kernel): stop the GC sweep from aborting a successor turn (TOCTOU on `running_tasks`)** (#6317) (@houko).
   The 5-minute sweep collected dead/finished `(agent, session)` keys and then did a bare `running_tasks.remove(&key)`; a faster successor turn that swapped a fresh, live `RunningTask` into the same key between the collect and the remove was dropped and had its in-flight `AbortHandle` fired, killing a live turn.
   The sweep now snapshots the observed `task_id` and removes via `remove_if(... v.task_id == observed)` — the same `#3445` guard the streaming-cleanup path uses — so a swapped-in successor is never touched.
 

--- a/crates/librefang-kernel/src/kernel/accessors.rs
+++ b/crates/librefang-kernel/src/kernel/accessors.rs
@@ -1067,14 +1067,8 @@ impl LibreFangKernel {
         //    fans out across all sessions for each dead/finished agent.
         {
             // Snapshot each dead/finished entry's `task_id` alongside its key.
-            // Between this snapshot and the `remove` below a successor turn on
-            // the same `(agent, session)` can swap in a fresh, live
-            // `RunningTask` — the insert is not serialized against this sweep —
-            // so a bare `remove(&key)` would drop that successor and `abort()`
-            // its in-flight turn. Remove only when the entry is still the same
-            // task we observed, via the `#3445` task_id guard the streaming
-            // cleanup path already uses (messaging.rs `remove_if(... v.task_id
-            // == turn_task_id)`).
+            // Between this snapshot and the `remove` below a successor turn on the same `(agent, session)` can swap in a fresh, live `RunningTask` — the insert is not serialized against this sweep — so a bare `remove(&key)` would drop that successor and `abort()` its in-flight turn.
+            // Remove only when the entry is still the same task we observed, via the `#3445` task_id guard the streaming cleanup path already uses (messaging.rs `remove_if(... v.task_id == turn_task_id)`).
             let finished: Vec<(AgentId, SessionId, uuid::Uuid)> = self
                 .agents
                 .running_tasks
@@ -1092,10 +1086,8 @@ impl LibreFangKernel {
                 // `AbortHandle` without cancelling the task, so the killed
                 // agent's request keeps burning tokens until the provider
                 // returns. `abort()` on an already-finished task is a no-op,
-                // so the live-but-finished branch is unaffected. The task_id
-                // guard means a successor that swapped in after the snapshot is
-                // left untouched (a dead agent's successor self-ejects via its
-                // own post-insert recheck, so nothing leaks).
+                // so the live-but-finished branch is unaffected.
+                // The task_id guard means a successor that swapped in after the snapshot is left untouched (a dead agent's successor self-ejects via its own post-insert recheck, so nothing leaks).
                 if let Some((_, task)) = self
                     .agents
                     .running_tasks

--- a/crates/librefang-kernel/src/kernel/accessors.rs
+++ b/crates/librefang-kernel/src/kernel/accessors.rs
@@ -1066,24 +1066,43 @@ impl LibreFangKernel {
         //    Map is keyed by `(agent, session)` post-#3172, so the sweep
         //    fans out across all sessions for each dead/finished agent.
         {
-            let finished: Vec<(AgentId, SessionId)> = self
+            // Snapshot each dead/finished entry's `task_id` alongside its key.
+            // Between this snapshot and the `remove` below a successor turn on
+            // the same `(agent, session)` can swap in a fresh, live
+            // `RunningTask` — the insert is not serialized against this sweep —
+            // so a bare `remove(&key)` would drop that successor and `abort()`
+            // its in-flight turn. Remove only when the entry is still the same
+            // task we observed, via the `#3445` task_id guard the streaming
+            // cleanup path already uses (messaging.rs `remove_if(... v.task_id
+            // == turn_task_id)`).
+            let finished: Vec<(AgentId, SessionId, uuid::Uuid)> = self
                 .agents
                 .running_tasks
                 .iter()
                 .filter(|e| !live_agents.contains(&e.key().0) || e.value().abort.is_finished())
-                .map(|e| *e.key())
+                .map(|e| {
+                    let (agent, session) = *e.key();
+                    (agent, session, e.value().task_id)
+                })
                 .collect();
-            total_removed += finished.len();
-            for key in finished {
+            for (agent, session, task_id) in finished {
                 // Fire the abort handle before dropping the map entry (#5142).
                 // For a dead agent the loop may still be parked at an `.await`
                 // inside an LLM stream; merely removing the entry drops the
                 // `AbortHandle` without cancelling the task, so the killed
                 // agent's request keeps burning tokens until the provider
                 // returns. `abort()` on an already-finished task is a no-op,
-                // so the live-but-finished branch is unaffected.
-                if let Some((_, task)) = self.agents.running_tasks.remove(&key) {
+                // so the live-but-finished branch is unaffected. The task_id
+                // guard means a successor that swapped in after the snapshot is
+                // left untouched (a dead agent's successor self-ejects via its
+                // own post-insert recheck, so nothing leaks).
+                if let Some((_, task)) = self
+                    .agents
+                    .running_tasks
+                    .remove_if(&(agent, session), |_, v| v.task_id == task_id)
+                {
                     task.abort.abort();
+                    total_removed += 1;
                 }
             }
         }

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4426,6 +4426,110 @@ async fn gc_sweep_aborts_orphaned_running_task_5142() {
     kernel.shutdown();
 }
 
+/// TOCTOU regression: the periodic GC sweep must NOT abort a *successor* turn
+/// that swapped into `running_tasks` after the sweep snapshotted a finished
+/// predecessor under the same `(agent, session)` key. Pre-fix the sweep
+/// collected the keys, then did a bare `running_tasks.remove(&key)`; a faster
+/// successor inserted between the collect and the remove was dropped and its
+/// in-flight `AbortHandle` fired, killing a live turn. The fix snapshots the
+/// observed `task_id` and removes via `remove_if(... v.task_id == observed)`,
+/// so a swapped-in successor (different task_id) is never touched.
+///
+/// The race is internal to one `gc_sweep` call, so this is a stress test: it
+/// is deterministically green with the fix (the sweep can never remove the
+/// live successor's entry) and turns red probabilistically without it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gc_sweep_does_not_abort_live_successor_turn() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home_dir = tmp.path().join("librefang-kernel-gc-successor-toctou");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let kernel = Arc::new(
+        LibreFangKernel::boot_with_config(KernelConfig {
+            home_dir: home_dir.clone(),
+            data_dir: home_dir.join("data"),
+            ..KernelConfig::default()
+        })
+        .expect("kernel should boot"),
+    );
+
+    // A LIVE agent: its running_tasks entries are collected by the sweep only
+    // when the task itself is finished (not via the dead-agent branch), which
+    // is exactly the path the successor race lives on.
+    let manifest = AgentManifest {
+        name: "gc-successor-victim".to_string(),
+        description: "agent for gc successor TOCTOU".to_string(),
+        author: "test".to_string(),
+        module: "builtin:chat".to_string(),
+        ..Default::default()
+    };
+    let agent_id = kernel.spawn_agent(manifest).expect("spawn should succeed");
+    let session = SessionId::new();
+
+    let aborted_live = Arc::new(AtomicUsize::new(0));
+    let mut live_tasks = Vec::new();
+
+    for _ in 0..200 {
+        // (1) A finished predecessor — the entry the sweep will collect.
+        let pre = tokio::spawn(async {});
+        let pre_abort = pre.abort_handle();
+        let _ = pre.await;
+        let predecessor_task_id = uuid::Uuid::new_v4();
+        kernel.agents.running_tasks.insert(
+            (agent_id, session),
+            RunningTask {
+                abort: pre_abort,
+                started_at: chrono::Utc::now(),
+                task_id: predecessor_task_id,
+            },
+        );
+
+        // (2) Fire the sweep concurrently so it can snapshot the finished
+        //     predecessor.
+        let sweeper_kernel = Arc::clone(&kernel);
+        let sweeper = tokio::spawn(async move { sweeper_kernel.gc_sweep() });
+
+        // (3) Swap in a live successor under the same key, racing the sweep's
+        //     collect -> remove window.
+        tokio::task::yield_now().await;
+        let live =
+            tokio::spawn(async { tokio::time::sleep(std::time::Duration::from_secs(60)).await });
+        let live_abort = live.abort_handle();
+        live_tasks.push(live);
+        kernel.agents.running_tasks.insert(
+            (agent_id, session),
+            RunningTask {
+                abort: live_abort.clone(),
+                started_at: chrono::Utc::now(),
+                task_id: uuid::Uuid::new_v4(),
+            },
+        );
+
+        let _ = sweeper.await;
+
+        // The live successor must survive: a live agent's not-yet-finished
+        // task is never a legitimate sweep target, so an abort here means the
+        // sweep removed an entry whose task_id no longer matched what it saw.
+        if live_abort.is_finished() {
+            aborted_live.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    for t in live_tasks {
+        t.abort();
+    }
+
+    assert_eq!(
+        aborted_live.load(Ordering::Relaxed),
+        0,
+        "gc_sweep aborted a live successor turn — TOCTOU on running_tasks \
+         (bare remove instead of task_id-guarded remove_if)"
+    );
+
+    kernel.shutdown();
+}
+
 /// The GC sweep must NOT reclaim a dead agent's `agent_msg_locks` entry while
 /// an in-flight turn still holds the Arc (`Arc::strong_count > 1`). Pre-fix the
 /// sweep filtered on dead-agent membership alone and dropped the slot out from

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -4426,18 +4426,11 @@ async fn gc_sweep_aborts_orphaned_running_task_5142() {
     kernel.shutdown();
 }
 
-/// TOCTOU regression: the periodic GC sweep must NOT abort a *successor* turn
-/// that swapped into `running_tasks` after the sweep snapshotted a finished
-/// predecessor under the same `(agent, session)` key. Pre-fix the sweep
-/// collected the keys, then did a bare `running_tasks.remove(&key)`; a faster
-/// successor inserted between the collect and the remove was dropped and its
-/// in-flight `AbortHandle` fired, killing a live turn. The fix snapshots the
-/// observed `task_id` and removes via `remove_if(... v.task_id == observed)`,
-/// so a swapped-in successor (different task_id) is never touched.
+/// TOCTOU regression: the periodic GC sweep must NOT abort a *successor* turn that swapped into `running_tasks` after the sweep snapshotted a finished predecessor under the same `(agent, session)` key.
+/// Pre-fix the sweep collected the keys, then did a bare `running_tasks.remove(&key)`; a faster successor inserted between the collect and the remove was dropped and its in-flight `AbortHandle` fired, killing a live turn.
+/// The fix snapshots the observed `task_id` and removes via `remove_if(... v.task_id == observed)`, so a swapped-in successor (different task_id) is never touched.
 ///
-/// The race is internal to one `gc_sweep` call, so this is a stress test: it
-/// is deterministically green with the fix (the sweep can never remove the
-/// live successor's entry) and turns red probabilistically without it.
+/// The race is internal to one `gc_sweep` call, so this is a stress test: it is deterministically green with the fix (the sweep can never remove the live successor's entry) and turns red probabilistically without it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_sweep_does_not_abort_live_successor_turn() {
     use std::sync::atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
## Summary

The kernel's periodic GC sweep (`gc_sweep`, runs every 5 minutes) reaps `running_tasks` entries for dead agents and finished turns.
It collected the matching `(agent, session)` keys into a `Vec`, then looped doing a bare `running_tasks.remove(&key)`.

Between the collect and the remove, a faster **successor** turn on the same `(agent, session)` can swap a fresh, live `RunningTask` into that key — the per-turn insert is not serialized against the sweep.
The bare `remove(&key)` then dropped that successor's entry and fired its in-flight `AbortHandle`, so the GC could **abort a user's live turn**.

The streaming-cleanup path already protects against exactly this (the `#3445` stale-entry guard: `running_tasks.remove_if(&key, |_, v| v.task_id == turn_task_id)`); `gc_sweep` was the one removal site that did not.

## Changes

- `crates/librefang-kernel/src/kernel/accessors.rs` — `gc_sweep` snapshots each candidate's `task_id` alongside its key and removes via `remove_if(&(agent, session), |_, v| v.task_id == observed)`.
  An entry whose `task_id` changed (a successor swapped in) is left untouched; a dead agent's successor self-ejects via its own post-insert recheck, so nothing leaks.
  `total_removed` now counts actual removals instead of collected candidates.

## Verification

- `cargo clippy -p librefang-kernel --lib -- -D warnings` — clean.
- `cargo test -p librefang-kernel --lib gc_sweep` — the existing `gc_sweep_aborts_orphaned_running_task_5142` (#5142 abort-on-reap) and `gc_sweep_preserves_agent_msg_lock_with_inflight_holder` still pass, plus the new `gc_sweep_does_not_abort_live_successor_turn`.
- `cargo test -p librefang-kernel --lib kill_agent_dispatch_insert_race` — the concurrent kill/dispatch race test still passes (no regression to the dead-agent reap path).
- `cargo fmt -p librefang-kernel --check` — clean.

The new test is a stress test (the race is internal to one `gc_sweep` call, so it cannot be hit deterministically from a single test thread): it is deterministically green with the fix — the sweep can never remove the live successor's entry — and turns red probabilistically without it.

(Run in the repo's `Dockerfile.rust-dev` image against an isolated target volume, per the project's no-local-cargo rule.)

## Related, observed but deliberately not in this PR

In the same race family, the streaming-cleanup path (`messaging.rs`, the `!is_fork` blocks around the Ok/Err arms) removes `session_interrupts` **unconditionally** while guarding the adjacent `running_tasks` removal with the `task_id` check.
A faster successor's interrupt registration can therefore be wiped by its predecessor's cleanup, degrading a later `stop_session_run` from cooperative `cancel()` to a hard abort.
The fix there is an inline-closure reorder (remove `running_tasks` first, gate the `session_interrupts.remove` on it returning `Some`).
That call site is inside a spawned closure and cannot be exercised by a deterministic unit test, so it warrants its own change with a race/loom-style test rather than being bundled into this one — flagged here so it is not lost.
