### PR TITLE
fix(channels): describe inbound images on the debounced channel path (#6321)

### DIFF
--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1082,6 +1082,13 @@ fn flush_debounced(
                 );
             }
 
+            // Parity with the immediate (`dispatch_message`) path: describe
+            // each inbound image so text-only models receive a description next
+            // to the `ImageFile` block. Coalesced (debounced) images used to
+            // skip this step entirely — the #6321 bug — because only the
+            // immediate path called it. Self-gates on `[media] image_description`.
+            let blocks = prepend_image_descriptions(&channel_handle, blocks).await;
+
             let ct_str = channel_type_str(&merged_msg.channel);
 
             // --- Input sanitization (prompt injection detection) ---
@@ -3935,33 +3942,15 @@ async fn dispatch_message(
                 ContentBlock::Image { .. } | ContentBlock::ImageFile { .. }
             )
         }) {
-            // We have actual image data.
-            //
-            // Optionally run `describe_inbound_image` so that text-only
-            // models receive a natural-language description next to the
-            // `ImageFile` block.  Vision-capable models ignore the text
-            // block and use the raw image bytes directly.
-            //
-            // Extract the (path, media_type) from the first `ImageFile`
-            // block so `maybe_describe_inbound_image` can pass it to the
-            // kernel's `MediaEngine`.  Inline `Image` blocks (base64
-            // fallback when the save failed) have no on-disk path, so
-            // skip description for those.
-            let saved_image: Option<(std::path::PathBuf, String)> = blocks.iter().find_map(|b| {
-                if let ContentBlock::ImageFile { path, media_type } = b {
-                    Some((std::path::PathBuf::from(path), media_type.clone()))
-                } else {
-                    None
-                }
-            });
-            let mut final_blocks = blocks;
-            if let Some(ref saved) = saved_image {
-                if let Some(desc_block) = maybe_describe_inbound_image(handle, Some(saved)).await {
-                    // Prepend the description so the model reads context
-                    // before the raw image bytes.
-                    final_blocks.insert(0, desc_block);
-                }
-            }
+            // We have actual image data. Optionally run `describe_inbound_image`
+            // for each inbound image so that text-only models receive a
+            // natural-language description next to the `ImageFile` block;
+            // vision-capable models ignore the text block and use the raw image
+            // bytes directly. Inline `Image` blocks (base64 fallback when the
+            // save failed) have no on-disk path and are left untouched. This is
+            // the same helper the debounced path uses, so the two cannot drift
+            // out of parity (refs #6321).
+            let final_blocks = prepend_image_descriptions(handle, blocks).await;
             // Send as structured blocks for vision
             dispatch_with_blocks(
                 final_blocks,
@@ -5514,6 +5503,42 @@ async fn maybe_describe_inbound_image_with_timeout(
             })
         }
     }
+}
+
+/// Prepend a vision-description text block immediately before every inbound
+/// `ImageFile` block in `blocks` (refs #6321).
+///
+/// Text-only models (`supports_vision = false`) cannot read raw image bytes,
+/// so without a description they only ever see the `[image omitted: …]`
+/// placeholder from the #6010 vision gate and behave as if the photo never
+/// arrived. Vision-capable models ignore the text block and read the image
+/// directly.
+///
+/// The per-image work self-gates on `[media] image_description` (the flag is
+/// checked inside `describe_inbound_image`), so this is a cheap no-op when the
+/// operator has not opted in; a failed or timed-out description degrades to an
+/// opaque `[Image description unavailable]` note rather than dropping the image.
+///
+/// Both inbound paths funnel through this one helper so they cannot drift apart
+/// again: the original bug was that only the immediate (`dispatch_message`)
+/// path described images while the debounced (`flush_debounced`) path did not.
+/// Because the debounced path coalesces several messages it can carry multiple
+/// `ImageFile` blocks, so every image is described — not just the first.
+async fn prepend_image_descriptions(
+    handle: &Arc<dyn ChannelBridgeHandle>,
+    blocks: Vec<ContentBlock>,
+) -> Vec<ContentBlock> {
+    let mut out: Vec<ContentBlock> = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        if let ContentBlock::ImageFile { path, media_type } = &block {
+            let saved = (std::path::PathBuf::from(path), media_type.clone());
+            if let Some(desc) = maybe_describe_inbound_image(handle, Some(&saved)).await {
+                out.push(desc);
+            }
+        }
+        out.push(block);
+    }
+    out
 }
 
 /// Hard deadline for the vision round-trip during channel image dispatch.
@@ -10419,6 +10444,90 @@ mod tests {
             let s = saved("/tmp/photo.jpg", "image/jpeg");
             let block = maybe_describe_inbound_image(&h, s.as_ref()).await;
             assert!(block.is_none(), "empty description must be dropped");
+        }
+
+        #[tokio::test]
+        async fn prepend_describes_every_imagefile_before_its_block() {
+            // The debounced path coalesces several messages into one block list
+            // that can hold multiple `ImageFile`s. Every image must get its own
+            // description, inserted immediately before it — not just the first.
+            // Regression guard for #6321: the debounced path previously skipped
+            // description entirely, and the immediate path described only the
+            // first image.
+            let (h, rec) = handle_with(Ok(Some("a photo".into())));
+            let input = vec![
+                ContentBlock::Text {
+                    text: "caption".into(),
+                    provider_metadata: None,
+                },
+                ContentBlock::ImageFile {
+                    path: "/tmp/a.jpg".into(),
+                    media_type: "image/jpeg".into(),
+                },
+                ContentBlock::ImageFile {
+                    path: "/tmp/b.png".into(),
+                    media_type: "image/png".into(),
+                },
+            ];
+            let out = prepend_image_descriptions(&h, input).await;
+            // Expected: [Text(caption), desc, ImageFile(a), desc, ImageFile(b)]
+            assert_eq!(out.len(), 5, "two descriptions inserted, got {out:?}");
+            assert!(
+                matches!(&out[0], ContentBlock::Text { text, .. } if text == "caption"),
+                "original caption preserved at front"
+            );
+            assert!(
+                matches!(&out[1], ContentBlock::Text { text, .. } if text == "[Image description: a photo]"),
+                "description precedes first image"
+            );
+            assert!(
+                matches!(&out[2], ContentBlock::ImageFile { path, .. } if path == "/tmp/a.jpg"),
+            );
+            assert!(
+                matches!(&out[3], ContentBlock::Text { text, .. } if text == "[Image description: a photo]"),
+                "description precedes second image"
+            );
+            assert!(
+                matches!(&out[4], ContentBlock::ImageFile { path, .. } if path == "/tmp/b.png"),
+            );
+            assert_eq!(
+                rec.calls.lock().unwrap().len(),
+                2,
+                "both images sent to the vision path"
+            );
+        }
+
+        #[tokio::test]
+        async fn prepend_is_noop_when_description_disabled() {
+            // `[media] image_description = false` → kernel returns `Ok(None)`;
+            // the image block passes through unchanged with no sibling text.
+            let (h, _rec) = handle_with(Ok(None));
+            let input = vec![ContentBlock::ImageFile {
+                path: "/tmp/a.jpg".into(),
+                media_type: "image/jpeg".into(),
+            }];
+            let out = prepend_image_descriptions(&h, input).await;
+            assert_eq!(out.len(), 1, "disabled config must not add blocks");
+            assert!(
+                matches!(&out[0], ContentBlock::ImageFile { path, .. } if path == "/tmp/a.jpg")
+            );
+        }
+
+        #[tokio::test]
+        async fn prepend_leaves_non_image_blocks_untouched() {
+            // No `ImageFile` present → no vision call, identical block list.
+            let (h, rec) = handle_with(Ok(Some("unused".into())));
+            let input = vec![ContentBlock::Text {
+                text: "hello".into(),
+                provider_metadata: None,
+            }];
+            let out = prepend_image_descriptions(&h, input).await;
+            assert_eq!(out.len(), 1);
+            assert!(matches!(&out[0], ContentBlock::Text { text, .. } if text == "hello"));
+            assert!(
+                rec.calls.lock().unwrap().is_empty(),
+                "no image means no vision round-trip"
+            );
         }
 
         #[tokio::test]

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -1082,11 +1082,9 @@ fn flush_debounced(
                 );
             }
 
-            // Parity with the immediate (`dispatch_message`) path: describe
-            // each inbound image so text-only models receive a description next
-            // to the `ImageFile` block. Coalesced (debounced) images used to
-            // skip this step entirely — the #6321 bug — because only the
-            // immediate path called it. Self-gates on `[media] image_description`.
+            // Parity with the immediate (`dispatch_message`) path: describe each inbound image so text-only models receive a description next to the `ImageFile` block.
+            // Coalesced (debounced) images used to skip this step entirely — the #6321 bug — because only the immediate path called it.
+            // Self-gates on `[media] image_description`.
             let blocks = prepend_image_descriptions(&channel_handle, blocks).await;
 
             let ct_str = channel_type_str(&merged_msg.channel);
@@ -3942,14 +3940,10 @@ async fn dispatch_message(
                 ContentBlock::Image { .. } | ContentBlock::ImageFile { .. }
             )
         }) {
-            // We have actual image data. Optionally run `describe_inbound_image`
-            // for each inbound image so that text-only models receive a
-            // natural-language description next to the `ImageFile` block;
-            // vision-capable models ignore the text block and use the raw image
-            // bytes directly. Inline `Image` blocks (base64 fallback when the
-            // save failed) have no on-disk path and are left untouched. This is
-            // the same helper the debounced path uses, so the two cannot drift
-            // out of parity (refs #6321).
+            // We have actual image data.
+            // Optionally run `describe_inbound_image` for each inbound image so that text-only models receive a natural-language description next to the `ImageFile` block; vision-capable models ignore the text block and use the raw image bytes directly.
+            // Inline `Image` blocks (base64 fallback when the save failed) have no on-disk path and are left untouched.
+            // This is the same helper the debounced path uses, so the two cannot drift out of parity (refs #6321).
             let final_blocks = prepend_image_descriptions(handle, blocks).await;
             // Send as structured blocks for vision
             dispatch_with_blocks(
@@ -5505,25 +5499,15 @@ async fn maybe_describe_inbound_image_with_timeout(
     }
 }
 
-/// Prepend a vision-description text block immediately before every inbound
-/// `ImageFile` block in `blocks` (refs #6321).
+/// Prepend a vision-description text block immediately before every inbound `ImageFile` block in `blocks` (refs #6321).
 ///
-/// Text-only models (`supports_vision = false`) cannot read raw image bytes,
-/// so without a description they only ever see the `[image omitted: …]`
-/// placeholder from the #6010 vision gate and behave as if the photo never
-/// arrived. Vision-capable models ignore the text block and read the image
-/// directly.
+/// Text-only models (`supports_vision = false`) cannot read raw image bytes, so without a description they only ever see the `[image omitted: …]` placeholder from the #6010 vision gate and behave as if the photo never arrived.
+/// Vision-capable models ignore the text block and read the image directly.
 ///
-/// The per-image work self-gates on `[media] image_description` (the flag is
-/// checked inside `describe_inbound_image`), so this is a cheap no-op when the
-/// operator has not opted in; a failed or timed-out description degrades to an
-/// opaque `[Image description unavailable]` note rather than dropping the image.
+/// The per-image work self-gates on `[media] image_description` (the flag is checked inside `describe_inbound_image`), so this is a cheap no-op when the operator has not opted in; a failed or timed-out description degrades to an opaque `[Image description unavailable]` note rather than dropping the image.
 ///
-/// Both inbound paths funnel through this one helper so they cannot drift apart
-/// again: the original bug was that only the immediate (`dispatch_message`)
-/// path described images while the debounced (`flush_debounced`) path did not.
-/// Because the debounced path coalesces several messages it can carry multiple
-/// `ImageFile` blocks, so every image is described — not just the first.
+/// Both inbound paths funnel through this one helper so they cannot drift apart again: the original bug was that only the immediate (`dispatch_message`) path described images while the debounced (`flush_debounced`) path did not.
+/// Because the debounced path coalesces several messages it can carry multiple `ImageFile` blocks, so every image is described — not just the first.
 async fn prepend_image_descriptions(
     handle: &Arc<dyn ChannelBridgeHandle>,
     blocks: Vec<ContentBlock>,


### PR DESCRIPTION
## Summary

Fixes #6321. Inbound channel images were only described on the immediate dispatch path; the debounced (message-coalesce) path never ran the description step, so text-only models lost vision on coalesced bots.

The kernel's image-description step (`maybe_describe_inbound_image`, gated by `[media] image_description`) was reachable only from `dispatch_message` (the `message_coalesce_window_ms == 0` fast path). The debounced path (`message_coalesce_window_ms > 0`) assembles its image blocks in `flush_debounced` and calls the shared `dispatch_with_blocks` tail directly, which contains no description call. So `[media] image_description` was only ever consulted when coalescing was off.

On a text-only model the un-described `ImageFile` block is then redacted to the `[image omitted: …]` placeholder by the #6010 vision gate, so the failure is silent — no HTTP 400, no crash, the agent simply replies that it cannot see the image. Vision-capable models were unaffected (they read the raw bytes either way), which is why this only surfaced on text-only + coalesce setups.

## Change

- Extract the per-image describe-and-prepend logic into one shared helper, `prepend_image_descriptions(handle, blocks)`, placed next to `maybe_describe_inbound_image`.
- Call it from **both** `dispatch_message` (immediate) and `flush_debounced` (debounced) right before `dispatch_with_blocks`, so the description step lives in one place and the two paths cannot drift out of parity again — the root cause was exactly that divergence.
- The helper describes **every** `ImageFile` block, not just the first, inserting each description immediately before its image. This matters because `MessageDebouncer::drain` coalesces the image blocks of several buffered messages into one list (`all_blocks.extend(...)`), so a debounced batch can legitimately carry multiple images.

The step self-gates inside `describe_inbound_image` (`[media] image_description`), so it remains a cheap no-op when the operator has not opted in, and a failed/timed-out description still degrades to the existing opaque `[Image description unavailable]` note rather than dropping the image.

### Behavior note (intentional)

On the immediate path the description used to be prepended at index 0 (before the caption); it is now inserted immediately before the image block (after the caption), matching the debounced path. The description is still adjacent to and precedes the image, so model behavior is unchanged; the ordering is now consistent across both paths. No test asserted the old absolute-front position.

## Verification

- `cargo check -p librefang-channels --lib` — clean
- `cargo clippy -p librefang-channels --all-targets -- -D warnings` — zero warnings
- `cargo test -p librefang-channels --lib` — **510 passed, 0 failed**
- `cargo fmt -p librefang-channels -- --check` — clean

New regression tests in `bridge::tests::inbound_image_description` (reuse the existing `DescribeHandle` fake):

- `prepend_describes_every_imagefile_before_its_block` — multi-image list gets a description before each image; both images hit the vision path.
- `prepend_is_noop_when_description_disabled` — `Ok(None)` (feature off) leaves blocks unchanged.
- `prepend_leaves_non_image_blocks_untouched` — a text-only list triggers no vision call.

The existing `maybe_describe_inbound_image` cases (success / disabled / provider-failure-doesn't-leak / timeout / non-image-mime) continue to pass.

## Out of scope

Live LLM round-trip verification (real Groq vision call against a coalesced bot) requires a running daemon and is left for a maintainer per the repo's human-only integration-testing policy.
