### PR TITLE
feat(dashboard/agents): allow a custom model id when editing an agent (#6318)

### DIFF
--- a/crates/librefang-api/dashboard/src/locales/en.json
+++ b/crates/librefang-api/dashboard/src/locales/en.json
@@ -828,8 +828,7 @@
     "tools_declared_desc": "Tools this agent can use. Leave empty for unrestricted access to all tools.",
     "providers_error_loading": "Error loading",
     "no_providers": "No providers",
-    "select_provider_first": "Select provider first",
-    "no_models": "No models"
+    "select_provider_first": "Select provider first"
   },
   "providers": {
     "title": "Providers",

--- a/crates/librefang-api/dashboard/src/locales/uk.json
+++ b/crates/librefang-api/dashboard/src/locales/uk.json
@@ -828,8 +828,7 @@
     "tools_declared_title": "Оголошені інструменти",
     "providers_error_loading": "Помилка завантаження",
     "no_providers": "Немає провайдерів",
-    "select_provider_first": "Спочатку оберіть провайдера",
-    "no_models": "Немає моделей"
+    "select_provider_first": "Спочатку оберіть провайдера"
   },
   "providers": {
     "title": "Провайдери",

--- a/crates/librefang-api/dashboard/src/locales/zh.json
+++ b/crates/librefang-api/dashboard/src/locales/zh.json
@@ -828,8 +828,7 @@
     "tools_declared_desc": "此智能体可使用的工具。留空则可不受限制地访问所有工具。",
     "providers_error_loading": "加载错误",
     "no_providers": "没有供应商",
-    "select_provider_first": "请先选择供应商",
-    "no_models": "没有模型"
+    "select_provider_first": "请先选择供应商"
   },
   "providers": {
     "title": "供应商",

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -2435,22 +2435,36 @@ export function AgentsPage() {
                           </select>
                         </DetailRow>
                         <DetailRow label={t("agents.model")}>
-                          <select
+                          {/* Combobox, not a plain <select>: the <datalist>
+                              suggests catalog models for the provider, but the
+                              field still accepts a typed-in id. Agent-type
+                              providers (codex-cli / claude-code / gemini-cli)
+                              carry no catalog models, and one pointed at a
+                              third-party base may run a model the catalog never
+                              lists — both must remain settable from the UI when
+                              editing an existing agent, matching the create
+                              form's free-text fallback (#6318). */}
+                          <input
+                            list="agent-detail-model-options"
                             value={modelDraft.model}
                             onChange={e => setModelDraft(d => ({ ...d, model: e.target.value }))}
                             className="w-44 px-2 py-1 rounded-md border border-border-subtle bg-surface text-sm font-mono outline-none focus:border-brand text-right"
                             disabled={modelsQuery.isLoading || !modelDraft.provider.trim()}
-                          >
-                            {!modelDraft.provider.trim() && <option value="">{t("agents.select_provider_first", { defaultValue: "Select provider first" })}</option>}
-                            {modelDraft.provider.trim() && modelsQuery.isLoading && <option value="">{t("common.loading", { defaultValue: "Loading..." })}</option>}
-                            {modelDraft.provider.trim() && !modelsQuery.isLoading && visibleModels.length === 0 && <option value="">{t("agents.no_models", { defaultValue: "No models" })}</option>}
-                            {modelDraft.model && !visibleModels.some(m => m.id === modelDraft.model) && (
-                              <option value={modelDraft.model}>{modelDraft.model}</option>
-                            )}
+                            autoComplete="off"
+                            spellCheck={false}
+                            placeholder={
+                              !modelDraft.provider.trim()
+                                ? t("agents.select_provider_first", { defaultValue: "Select provider first" })
+                                : modelsQuery.isLoading
+                                  ? t("common.loading", { defaultValue: "Loading..." })
+                                  : t("agents.form.model_id_placeholder", { defaultValue: "e.g. gpt-4o" })
+                            }
+                          />
+                          <datalist id="agent-detail-model-options">
                             {visibleModels.map(m => (
                               <option key={m.id} value={m.id}>{m.display_name || m.id}</option>
                             ))}
-                          </select>
+                          </datalist>
                         </DetailRow>
                         <DetailRow label={t("agents.max_tokens")}>
                           <input


### PR DESCRIPTION
## Summary

Addresses #6318 (the "manually manage the base model" half). Lets you set a model id that isn't in the catalog when editing an existing agent, so an agent-type provider (codex-cli / claude-code / gemini-cli) pointed at a third-party base can be configured from the dashboard.

## Background

- The driver layer already passes any model through: each agent driver's `model_flag` (`crates/librefang-llm-drivers/src/drivers/{codex_cli,claude_code,gemini_cli}.rs`) falls through `_ => Some(stripped.to_string())`, so an unknown model id reaches the CLI verbatim. There is no hard rejection — this is not a backend bug.
- The third-party base itself is selected via the CLI's own env (`OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, …), which LibreFang doesn't manage.
- The create form (`AgentManifestForm`) already drops to a free-text `<input>` when the provider has no catalog models, so custom ids were enterable there.
- The **gap** was the agent detail drawer's model editor: a plain `<select>` populated only from catalog models, showing a disabled "No models" option for agent-type providers (whose catalog is empty) — so you could not change an existing agent to a custom / third-party model from the UI.

## Change

`crates/librefang-api/dashboard/src/pages/AgentsPage.tsx` — the detail-drawer model field becomes an `<input list=…>` + `<datalist>` combobox. It still suggests the provider's catalog models, but now accepts a typed-in id. Provider-not-selected / loading states move to the input's `placeholder`; the disabled "No models" dead-end is gone. The existing auto-select-single-model effect (#5917) and the per-id save flow are unchanged.

Removed the now-unused `agents.no_models` i18n key from `en/zh/uk` (locale parity preserved; the dead-key coverage test enforces this).

## Out of scope

The other half of #6318 — **auto-detecting** the model an agent CLI actually ran — is a separate enhancement. codex-cli already does this via `parse_model_from_banner`; claude-code's JSON output carries a `model` field that isn't parsed yet. Left for a follow-up so this UI fix can land independently.

## Verification

In `crates/librefang-api/dashboard/`:

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (warnings are pre-existing baseline)
- `pnpm test --run` — **838 passed (85 files)**, including the locale dead-key + parity gates
- `pnpm build` — succeeds

No render-test was added for the model editor: `AgentsPage.test.tsx` documents that the page has no render harness (~20 hooks) and tests the extracted `SystemPromptSection` directly. The change is a `<select>`→`<input list>` swap with identical `value`/`onChange`/`disabled` wiring, covered by typecheck + build.
