### PR TITLE
test(llm-drivers): pin claude_code resolved-model parsing (#6318)

### DIFF
--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -2096,6 +2096,42 @@ mod tests {
     }
 
     #[test]
+    fn stream_json_init_event_carries_resolved_model() {
+        // The #6318 auto-detect path for the streaming agent loop: `claude -p
+        // --output-format stream-json` emits a `system`/`init` event up front
+        // whose `model` field is the model the CLI actually resolved for the run.
+        // `stream` captures it into `CompletionResponse.actual_model` so kernel
+        // metering attributes the real model rather than the requested id.
+        // This locks the deserialization contract — dropping the `#[serde] model`
+        // field (or renaming it) breaks this test rather than silently turning
+        // resolved-model detection back into a no-op.
+        let init_line = r#"{"type":"system","subtype":"init","cwd":"/repo","session_id":"s-1","tools":["Bash"],"model":"claude-sonnet-4-5-20250929","permissionMode":"bypassPermissions"}"#;
+        let event: ClaudeStreamEvent =
+            serde_json::from_str(init_line).expect("init event deserializes");
+        assert_eq!(event.r#type, "system");
+        assert_eq!(event.model.as_deref(), Some("claude-sonnet-4-5-20250929"));
+    }
+
+    #[test]
+    fn json_output_surfaces_model_when_present_else_none() {
+        // `complete` reads the resolved model from the result JSON's `model`
+        // field. Today `claude -p --output-format json` does not emit it, so the
+        // field stays `None` and the kernel falls back to the requested id; when
+        // a future CLI version adds it, `complete` surfaces it with no code
+        // change. Both shapes are pinned here so neither regresses silently.
+        let without_model = r#"{"type":"result","subtype":"success","is_error":false,"result":"hi","usage":{"input_tokens":10,"output_tokens":5}}"#;
+        let parsed: ClaudeJsonOutput =
+            serde_json::from_str(without_model).expect("result json deserializes");
+        assert_eq!(parsed.model, None);
+        assert_eq!(parsed.result.as_deref(), Some("hi"));
+
+        let with_model = r#"{"type":"result","is_error":false,"result":"hi","model":"claude-opus-4-1-20250805"}"#;
+        let parsed: ClaudeJsonOutput =
+            serde_json::from_str(with_model).expect("result json deserializes");
+        assert_eq!(parsed.model.as_deref(), Some("claude-opus-4-1-20250805"));
+    }
+
+    #[test]
     fn test_new_defaults_to_claude() {
         let driver = ClaudeCodeDriver::new(None, true);
         assert_eq!(driver.cli_path, "claude");

--- a/crates/librefang-llm-drivers/src/drivers/claude_code.rs
+++ b/crates/librefang-llm-drivers/src/drivers/claude_code.rs
@@ -2097,14 +2097,7 @@ mod tests {
 
     #[test]
     fn stream_json_init_event_carries_resolved_model() {
-        // The #6318 auto-detect path for the streaming agent loop: `claude -p
-        // --output-format stream-json` emits a `system`/`init` event up front
-        // whose `model` field is the model the CLI actually resolved for the run.
-        // `stream` captures it into `CompletionResponse.actual_model` so kernel
-        // metering attributes the real model rather than the requested id.
-        // This locks the deserialization contract — dropping the `#[serde] model`
-        // field (or renaming it) breaks this test rather than silently turning
-        // resolved-model detection back into a no-op.
+        // Locks the serde contract: stream-json init event carries a `model` field — dropping or renaming it silently disables the #6318 resolved-model detection path.
         let init_line = r#"{"type":"system","subtype":"init","cwd":"/repo","session_id":"s-1","tools":["Bash"],"model":"claude-sonnet-4-5-20250929","permissionMode":"bypassPermissions"}"#;
         let event: ClaudeStreamEvent =
             serde_json::from_str(init_line).expect("init event deserializes");
@@ -2114,11 +2107,7 @@ mod tests {
 
     #[test]
     fn json_output_surfaces_model_when_present_else_none() {
-        // `complete` reads the resolved model from the result JSON's `model`
-        // field. Today `claude -p --output-format json` does not emit it, so the
-        // field stays `None` and the kernel falls back to the requested id; when
-        // a future CLI version adds it, `complete` surfaces it with no code
-        // change. Both shapes are pinned here so neither regresses silently.
+        // Pins both ClaudeJsonOutput shapes: absent `model` (today's --output-format json) → None; present → surfaced (forward-compat for future CLI versions).
         let without_model = r#"{"type":"result","subtype":"success","is_error":false,"result":"hi","usage":{"input_tokens":10,"output_tokens":5}}"#;
         let parsed: ClaudeJsonOutput =
             serde_json::from_str(without_model).expect("result json deserializes");


### PR DESCRIPTION
## Summary

Follow-up to #6318 (the "auto-detect the model an agent CLI actually ran" half). The detection itself already exists across the agent-CLI drivers; this PR closes the one remaining gap — it was untested for `claude_code`.

State of the auto-detect mechanism (verified):

- **codex_cli** — `parse_model_from_banner` reads the `model:` line from codex's stderr startup banner and stamps it into `CompletionResponse.actual_model` (landed in #6134). Already covered by `test_parse_model_from_banner_*`.
- **claude_code** — `stream()` captures the resolved model from the stream-json `system`/`init` event; `complete()` reads it from the result JSON's `model` field (forward-compat — `claude -p --output-format json` does not emit it yet, so that path stays `None` and the kernel falls back to the requested id). **Both paths were wired but had no test.**
- Kernel metering honours it uniformly: `model: result.actual_model.clone().unwrap_or_else(|| model.clone())` (`messaging.rs`, `agent_execution.rs`, `tools_and_skills.rs`), so a driver that resolves its own model attributes the real one.

## Change

Test-only. Two regression tests in `crates/librefang-llm-drivers/src/drivers/claude_code.rs`:

- `stream_json_init_event_carries_resolved_model` — deserializes a representative stream-json `system`/`init` line and asserts `ClaudeStreamEvent.model` is parsed (the streaming agent path's detection source).
- `json_output_surfaces_model_when_present_else_none` — pins both shapes of the result JSON: absent `model` → `None` (today's `--output-format json` behaviour, kernel falls back to requested id), present `model` → surfaced (forward-compat for a future CLI version).

These lock the deserialization contract so a refactor that drops or renames the serde `model` field fails loudly instead of silently turning resolved-model detection back into a no-op.

## Not changed (and why)

- **gemini_cli** stamps `actual_model: None`. Gemini CLI emits no model banner/JSON field and runs exactly the `--model` it is given (no divergence), so there is nothing to detect; `None` correctly falls back to the requested id. Its CLI calls report zero tokens (billing is on the user's Google account), so the recorded model string is display-only and not a cost-attribution input — stamping the prefix-stripped id would only drop the `gemini-cli/` provenance for no benefit.

## Verification

In the worktree:

- `cargo test -p librefang-llm-drivers --lib model` — 24 passed, 0 failed (includes the two new tests)
- `cargo clippy -p librefang-llm-drivers --all-targets -- -D warnings` — clean
- `cargo fmt -p librefang-llm-drivers -- --check` — clean

Refs #6318. The manual-management half landed in #6327.
