### PR TITLE
ci(mobile): symlink legacy NDK binutils so vendored OpenSSL cross-compiles for Android

### DIFF
--- a/.github/workflows/mobile-smoke.yml
+++ b/.github/workflows/mobile-smoke.yml
@@ -57,6 +57,19 @@ jobs:
       - name: Export NDK_HOME
         run: echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/$NDK_VERSION" >> "$GITHUB_ENV"
 
+      # NDK r23+ ships only the llvm-prefixed binutils (llvm-ar, llvm-ranlib);
+      # the legacy `<target>-ranlib` wrappers were removed. openssl-src builds
+      # vendored OpenSSL with CROSS_COMPILE=aarch64-linux-android- and shells out
+      # to `aarch64-linux-android-ranlib`, so `make install_dev` dies with
+      # "ranlib: not found" (exit 127). Expose the legacy names as symlinks to
+      # the llvm equivalents so the vendored build links.
+      - name: Symlink legacy NDK binutils for openssl-src cross-compile
+        run: |
+          NDK_BIN="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          for tool in ar ranlib nm strip; do
+            ln -sf "$NDK_BIN/llvm-$tool" "$NDK_BIN/aarch64-linux-android-$tool"
+          done
+
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: aarch64-linux-android

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1730,6 +1730,20 @@ jobs:
         run: |
           echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/$NDK_VERSION" >> "$GITHUB_ENV"
 
+      # NDK r23+ ships only the llvm-prefixed binutils (llvm-ar, llvm-ranlib);
+      # the legacy `<target>-ranlib` wrappers were removed. openssl-src builds
+      # vendored OpenSSL with CROSS_COMPILE=<target>- and shells out to
+      # `<target>-ranlib`, so `make install_dev` dies with "ranlib: not found"
+      # (exit 127). Expose the legacy names (both Android ABIs this job builds)
+      # as symlinks to the llvm equivalents so the vendored build links.
+      - name: Symlink legacy NDK binutils for openssl-src cross-compile
+        run: |
+          NDK_BIN="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          for tool in ar ranlib nm strip; do
+            ln -sf "$NDK_BIN/llvm-$tool" "$NDK_BIN/aarch64-linux-android-$tool"
+            ln -sf "$NDK_BIN/llvm-$tool" "$NDK_BIN/arm-linux-androideabi-$tool"
+          done
+
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi


### PR DESCRIPTION
## Problem

The Android Tauri legs have been red on `main` for days, independent of any feature work:

- `Mobile Build Smoke / Android (debug, unsigned)` (push-to-main canary)
- `Release / Mobile / Android (aab + apk)` (`continue-on-error: true`, so it does not block a release but ships no Android artifact)

Both fail at the same spot while building **vendored** OpenSSL for `aarch64-linux-android`:

```
/bin/sh: 1: aarch64-linux-android-ranlib: not found
make: *** [Makefile:2802: install_dev] Error 127
Error installing OpenSSL: 'make' reported failure with exit status: 2
cargo build --package librefang-desktop --target aarch64-linux-android ... exited with code 101
```

This is pre-existing — the `v2026.6.24-beta.23` release run shows the same `Mobile / Android: failure`, and `mobile-smoke` has failed on every relevant main push since 2026-06-23.

## Root cause

`#6279` vendored OpenSSL unconditionally so cross-compiled targets link. `openssl-src` then builds OpenSSL from source for Android and runs `make install_dev`, which archives via `${CROSS_COMPILE}ranlib` = `aarch64-linux-android-ranlib`.

NDK r23+ removed the legacy GNU-style `<target>-ar` / `-ranlib` wrappers in favour of `llvm-ar` / `llvm-ranlib`. This repo pins NDK **r27** (`27.0.12077973`), so `aarch64-linux-android-ranlib` does not exist and the archive-indexing step exits 127.

The same-target `CLI / aarch64-linux-android` job passes — only the Tauri desktop/mobile build pulls the vendored `openssl-sys`, which is why this surfaced solely on the mobile legs.

## Fix

After `NDK_HOME` is exported, symlink the legacy-named `ar` / `ranlib` / `nm` / `strip` to their `llvm-*` equivalents in the NDK toolchain bin, in both Android jobs:

- `.github/workflows/mobile-smoke.yml` — `aarch64-linux-android-*`
- `.github/workflows/release.yml` — `aarch64-linux-android-*` and `arm-linux-androideabi-*` (this job also builds `armv7-linux-androideabi`)

Minimal and additive: it only provides names the modern NDK dropped; nothing else in the toolchain changes.

## Verification

- Both workflow files parse as valid YAML.
- Verified end-to-end by dispatching `Mobile Build Smoke` against this branch — see the run linked in a comment below. (`mobile-smoke.yml` does not run on PRs by design — ~25 min cold NDK build — but it supports `workflow_dispatch`, which reads the workflow + checks out the code from this branch, so the dispatched run exercises exactly this fix.)

Cannot be reproduced on the macOS dev host (no Linux Android NDK cross-compile); the CI Android job is the authoritative check.
