### PR TITLE
ci(contributors): enable auto-merge instead of forcing --admin

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -41,13 +41,24 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
+          # Create the PR with a PAT, not the default GITHUB_TOKEN. Branch
+          # pushes made by GITHUB_TOKEN do not trigger `on: pull_request`
+          # workflows (GitHub's recursion guard), so CI — and the required
+          # "CI Gate" status check — would never run on this PR, leaving it
+          # permanently unmergeable.
+          token: ${{ secrets.WEBSITE_REPO_TOKEN }}
           branch: chore/update-contributors-star-history
           commit-message: "docs: update contributors and star history"
           title: "docs: update contributors and star history"
           delete-branch: true
 
-      - name: Auto-merge PR
+      - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true' && steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.WEBSITE_REPO_TOKEN }}
-        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --delete-branch --admin
+        # The `main` ruleset requires the "CI Gate" check and has an empty
+        # bypass_actors list, so `--admin` cannot force the merge — it fails
+        # with "Required status check 'CI Gate' is expected" while CI is still
+        # pending. Enable auto-merge instead; GitHub squash-merges the PR on
+        # its own once CI Gate passes (0 approvals are required).
+        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --delete-branch --auto


### PR DESCRIPTION
## Problem

The daily `Update Contributors & Star History` workflow's `Auto-merge PR` step fails every run (e.g. [run 28233594935](https://github.com/librefang/librefang/actions/runs/28233594935/job/83642999323)):

```
GraphQL: Repository rule violations found
Required status check "CI Gate" is expected.
 (mergePullRequest)
```

Two independent root causes, both confirmed against the live repo config:

1. `--admin` cannot bypass the `main` ruleset. The ruleset requires the `CI Gate` status check and its `bypass_actors` list is **empty**, so no actor — not even an admin token — can force the merge while `CI Gate` is still in the `expected` (unreported) state.

2. `CI Gate` never runs on the PR on its own. The PR was created with the default `GITHUB_TOKEN`, and branch pushes made by `GITHUB_TOKEN` do not trigger `on: pull_request` workflows (GitHub's recursion guard). So `CI Gate` stays `expected` forever, and a maintainer had to manually re-trigger CI and merge by hand each day (PR #6337 was merged manually by a human at 11:43, ~48 min after the bot's failed attempt).

## Fix

- Create the PR with the `WEBSITE_REPO_TOKEN` PAT instead of the default `GITHUB_TOKEN`, so the push triggers `on: pull_request` CI and `CI Gate` actually runs.
- Replace `gh pr merge --admin` with `gh pr merge --auto`. GitHub squash-merges the PR automatically once `CI Gate` passes (the ruleset requires 0 approvals and allows the squash method), respecting the ruleset instead of fighting it.

Net effect: the daily contributors/star-history update merges itself with no manual intervention.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- Ruleset confirmed via `gh api repos/librefang/librefang/rulesets/13809063`: single required check `CI Gate`, `bypass_actors: []`, `required_approving_review_count: 0`, `allowed_merge_methods` includes `squash`.
- Repo settings confirmed: `allow_auto_merge: true`, `allow_squash_merge: true`, `delete_branch_on_merge: true`.
- `WEBSITE_REPO_TOKEN` confirmed present in repo secrets.
- This is a workflow-only change; full validation is the next scheduled (or `workflow_dispatch`) run of the job.
