### PR TITLE
ci(release): publish AUR packages on release (#6334)

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -147,10 +147,8 @@ token only as a break-glass option.
 
 ## AUR publishing (release.yml `sync_aur_bin` / `sync_aur_desktop` / `sync_aur_docker`)
 
-Push the release-pinned packages under `packaging/aur/` to the Arch User
-Repository on every tag. When `AUR_SSH_PRIVATE_KEY` is absent the three
-jobs no-op with a notice — nothing downstream depends on them, so forks and
-unconfigured repos are unaffected.
+Push the release-pinned packages under `packaging/aur/` to the Arch User Repository on every tag.
+When `AUR_SSH_PRIVATE_KEY` is absent the three jobs no-op with a notice — nothing downstream depends on them, so forks and unconfigured repos are unaffected.
 
 | Secret | Purpose | Format | Rotation |
 |---|---|---|---|
@@ -174,9 +172,8 @@ ssh-keygen -t ed25519 -C "librefang-aur-ci" -f aur_ci -N ""
 ssh-keyscan aur.archlinux.org   # paste into AUR_KNOWN_HOSTS
 ```
 
-The AUR repositories (`ssh://aur@aur.archlinux.org/librefang-bin.git`, etc.)
-must exist and be owned by that account before the first push. See
-`packaging/aur/README.md` for the one-time bootstrap.
+The AUR repositories (`ssh://aur@aur.archlinux.org/librefang-bin.git`, etc.) must exist and be owned by that account before the first push.
+See `packaging/aur/README.md` for the one-time bootstrap.
 
 ---
 

--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -145,6 +145,41 @@ token only as a break-glass option.
 
 ---
 
+## AUR publishing (release.yml `sync_aur_bin` / `sync_aur_desktop` / `sync_aur_docker`)
+
+Push the release-pinned packages under `packaging/aur/` to the Arch User
+Repository on every tag. When `AUR_SSH_PRIVATE_KEY` is absent the three
+jobs no-op with a notice — nothing downstream depends on them, so forks and
+unconfigured repos are unaffected.
+
+| Secret | Purpose | Format | Rotation |
+|---|---|---|---|
+| `AUR_SSH_PRIVATE_KEY` | SSH private key whose public half is registered on the AUR account that owns `librefang-bin`, `librefang-desktop-bin`, `librefang-docker`. Authenticates `git push ssh://aur@aur.archlinux.org/…`. | OpenSSH private key incl. BEGIN/END lines (multi-line; no base64) | When personnel changes or the key is compromised |
+| `AUR_KNOWN_HOSTS` | Optional. `known_hosts` line(s) pinning `aur.archlinux.org`. When absent the workflow fetches them with `ssh-keyscan` at runtime (trust-on-first-use). Set it to remove the TOFU window. | `ssh-keyscan aur.archlinux.org` output | When AUR rotates its host key |
+| `AUR_GIT_NAME` | Optional. Commit author name for AUR pushes. Defaults to `LibreFang Release Bot`. | plain string | n/a |
+| `AUR_GIT_EMAIL` | Optional. Commit author email for AUR pushes. Defaults to `release-bot@librefang.ai`. | email | n/a |
+
+**Generation reference**
+
+```sh
+# 1. Dedicated keypair for CI (no passphrase — Actions cannot answer a prompt):
+ssh-keygen -t ed25519 -C "librefang-aur-ci" -f aur_ci -N ""
+
+# 2. Register the PUBLIC key on the AUR account that owns the packages:
+#    https://aur.archlinux.org/account → "SSH Public Key" (append aur_ci.pub).
+
+# 3. Paste the PRIVATE key (aur_ci, incl. BEGIN/END) into AUR_SSH_PRIVATE_KEY.
+
+# 4. (Optional) pin the host key instead of relying on ssh-keyscan:
+ssh-keyscan aur.archlinux.org   # paste into AUR_KNOWN_HOSTS
+```
+
+The AUR repositories (`ssh://aur@aur.archlinux.org/librefang-bin.git`, etc.)
+must exist and be owned by that account before the first push. See
+`packaging/aur/README.md` for the one-time bootstrap.
+
+---
+
 ## Operational rules
 
 - **Never echo a secret.** GitHub Actions masks known secret values, but

--- a/.github/actions/publish-aur/action.yml
+++ b/.github/actions/publish-aur/action.yml
@@ -1,0 +1,79 @@
+name: Publish AUR package
+description: >
+  Publish one release-pinned LibreFang package to the Arch User Repository.
+  No-ops (with a notice) when the AUR SSH key is not configured, so forks and
+  unconfigured repositories do not fail.
+
+inputs:
+  package:
+    description: Package directory under packaging/aur/ (e.g. librefang-bin).
+    required: true
+  release-tag:
+    description: Release tag to pin (e.g. v2026.6.26-beta.24).
+    required: true
+  ssh-private-key:
+    description: AUR SSH private key. When empty the publish is skipped.
+    required: true
+  known-hosts:
+    description: >
+      known_hosts entries for aur.archlinux.org. When empty they are fetched
+      with ssh-keyscan at runtime (trust-on-first-use).
+    required: false
+    default: ""
+  git-name:
+    description: Commit author name for the AUR push.
+    required: false
+    default: ""
+  git-email:
+    description: Commit author email for the AUR push.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Publish ${{ inputs.package }} to AUR
+      shell: bash
+      env:
+        AUR_SSH_PRIVATE_KEY: ${{ inputs.ssh-private-key }}
+        AUR_KNOWN_HOSTS: ${{ inputs.known-hosts }}
+        AUR_GIT_NAME: ${{ inputs.git-name }}
+        AUR_GIT_EMAIL: ${{ inputs.git-email }}
+        RELEASE_TAG: ${{ inputs.release-tag }}
+        PACKAGE: ${{ inputs.package }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GH_API_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${AUR_SSH_PRIVATE_KEY//[[:space:]]/}" ]]; then
+          echo "::notice::AUR_SSH_PRIVATE_KEY not configured — skipping AUR publish for $PACKAGE."
+          exit 0
+        fi
+
+        # Materialise the SSH credentials to a temp dir wiped on step exit
+        # (success or failure) per the SECRETS.md operational rule.
+        WORKDIR="$(mktemp -d)"
+        trap 'rm -rf "$WORKDIR"' EXIT
+        KEY="$WORKDIR/aur_key"
+        KNOWN="$WORKDIR/known_hosts"
+
+        ( umask 077; printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$KEY" )
+
+        if [[ -n "${AUR_KNOWN_HOSTS//[[:space:]]/}" ]]; then
+          printf '%s\n' "$AUR_KNOWN_HOSTS" > "$KNOWN"
+        else
+          ssh-keyscan -t rsa,ecdsa,ed25519 aur.archlinux.org > "$KNOWN" 2>/dev/null
+        fi
+        [[ -s "$KNOWN" ]] || { echo "::error::empty known_hosts for aur.archlinux.org"; exit 1; }
+
+        docker run --rm \
+          -v "$GITHUB_WORKSPACE":/repo \
+          -v "$KEY":/keys/aur_key:ro \
+          -v "$KNOWN":/keys/known_hosts:ro \
+          -e RELEASE_TAG -e GITHUB_REPOSITORY -e GH_API_TOKEN \
+          -e AUR_GIT_NAME -e AUR_GIT_EMAIL \
+          -e AUR_KEY_FILE=/keys/aur_key \
+          -e AUR_KNOWN_HOSTS_FILE=/keys/known_hosts \
+          archlinux:base-devel \
+          bash /repo/packaging/aur/publish-to-aur.sh "$PACKAGE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2586,6 +2586,79 @@ jobs:
           git push
 
   # ═════════════════════════════════════════════════════════════════════════
+  # AUR (Arch User Repository) — publish the release-pinned packages from
+  # packaging/aur/. Each job mirrors the Homebrew sync above: it runs only on
+  # a real tag (or a channel=current re-publish), waits on the build job that
+  # produced its asset, and degrades to a no-op when AUR_SSH_PRIVATE_KEY is
+  # absent (forks / unconfigured repos). The composite action regenerates
+  # pkgver / sha256sums / .SRCINFO and pushes to ssh://aur@aur.archlinux.org.
+  # Split into three independent jobs (not a matrix) so a desktop build
+  # failure cannot block the librefang-bin publish, and vice versa.
+  # ═════════════════════════════════════════════════════════════════════════
+
+  sync_aur_bin:
+    name: Publish AUR / librefang-bin
+    if: >
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
+    runs-on: ubuntu-latest
+    needs: [cli_linux]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.RELEASE_REF }}
+      - uses: ./.github/actions/publish-aur
+        with:
+          package: librefang-bin
+          release-tag: ${{ env.RELEASE_TAG }}
+          ssh-private-key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          known-hosts: ${{ secrets.AUR_KNOWN_HOSTS }}
+          git-name: ${{ secrets.AUR_GIT_NAME }}
+          git-email: ${{ secrets.AUR_GIT_EMAIL }}
+
+  sync_aur_desktop:
+    name: Publish AUR / librefang-desktop-bin
+    if: >
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
+    runs-on: ubuntu-latest
+    needs: [desktop]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.RELEASE_REF }}
+      - uses: ./.github/actions/publish-aur
+        with:
+          package: librefang-desktop-bin
+          release-tag: ${{ env.RELEASE_TAG }}
+          ssh-private-key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          known-hosts: ${{ secrets.AUR_KNOWN_HOSTS }}
+          git-name: ${{ secrets.AUR_GIT_NAME }}
+          git-email: ${{ secrets.AUR_GIT_EMAIL }}
+
+  sync_aur_docker:
+    name: Publish AUR / librefang-docker
+    if: >
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
+    runs-on: ubuntu-latest
+    # Pin only after the multi-arch image + tag exist, so `librefang-docker
+    # pull` works the moment the package lands.
+    needs: [docker-manifest]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.RELEASE_REF }}
+      - uses: ./.github/actions/publish-aur
+        with:
+          package: librefang-docker
+          release-tag: ${{ env.RELEASE_TAG }}
+          ssh-private-key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          known-hosts: ${{ secrets.AUR_KNOWN_HOSTS }}
+          git-name: ${{ secrets.AUR_GIT_NAME }}
+          git-email: ${{ secrets.AUR_GIT_EMAIL }}
+
+  # ═════════════════════════════════════════════════════════════════════════
   # Docker — from release-docker.yml
   # ═════════════════════════════════════════════════════════════════════════
 

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -61,8 +61,7 @@ Do not commit downloaded sources, `src/`, `pkg/`, or `*.pkg.tar.*` outputs.
 
 ## Automated publishing on release
 
-`release.yml` publishes these packages to AUR on every tag via three jobs
-(`sync_aur_bin`, `sync_aur_desktop`, `sync_aur_docker`).
+`release.yml` publishes these packages to AUR on every tag via three jobs (`sync_aur_bin`, `sync_aur_desktop`, `sync_aur_docker`).
 Each job runs `publish-to-aur.sh` inside an `archlinux:base-devel` container, which takes the committed files here as the source of truth and derives only the per-release values: it bumps `pkgver` (encoding the tag's first `-` as `_`), resets `pkgrel` to `1`, sets `_desktop_ver` from the actual `LibreFang_<bundle-ver>_amd64.deb` asset name for the desktop package, re-pins the `ghcr.io/librefang/librefang:<version>` tag inside the Docker helper and env, then regenerates `sha256sums` (`updpkgsums`) and `.SRCINFO` (`makepkg --printsrcinfo`) before pushing to `ssh://aur@aur.archlinux.org/<package>.git`.
 
 The committed `pkgver` / `sha256sums` / `.SRCINFO` here are not bumped per release; they are a working baseline for local `makepkg` runs.

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -58,3 +58,27 @@ sed -n '1,120p' pkg/librefang-desktop-bin/usr/share/applications/LibreFang.deskt
 
 Only commit the AUR source files.
 Do not commit downloaded sources, `src/`, `pkg/`, or `*.pkg.tar.*` outputs.
+
+## Automated publishing on release
+
+`release.yml` publishes these packages to AUR on every tag via three jobs
+(`sync_aur_bin`, `sync_aur_desktop`, `sync_aur_docker`).
+Each job runs `publish-to-aur.sh` inside an `archlinux:base-devel` container, which takes the committed files here as the source of truth and derives only the per-release values: it bumps `pkgver` (encoding the tag's first `-` as `_`), resets `pkgrel` to `1`, sets `_desktop_ver` from the actual `LibreFang_<bundle-ver>_amd64.deb` asset name for the desktop package, re-pins the `ghcr.io/librefang/librefang:<version>` tag inside the Docker helper and env, then regenerates `sha256sums` (`updpkgsums`) and `.SRCINFO` (`makepkg --printsrcinfo`) before pushing to `ssh://aur@aur.archlinux.org/<package>.git`.
+
+The committed `pkgver` / `sha256sums` / `.SRCINFO` here are not bumped per release; they are a working baseline for local `makepkg` runs.
+The release-correct values live in the AUR repositories, regenerated on each tag.
+
+The automation is inert until a maintainer configures the secrets — when `AUR_SSH_PRIVATE_KEY` is absent the jobs no-op with a notice.
+
+### One-time maintainer bootstrap
+
+1. Create the three AUR repositories under the AUR account that will own them — push an initial commit (or let the first release populate them):
+
+   - `ssh://aur@aur.archlinux.org/librefang-bin.git`
+   - `ssh://aur@aur.archlinux.org/librefang-desktop-bin.git`
+   - `ssh://aur@aur.archlinux.org/librefang-docker.git`
+
+2. Generate a dedicated CI keypair, register the public half on that AUR account, and add the secrets (`AUR_SSH_PRIVATE_KEY` and the optional `AUR_KNOWN_HOSTS` / `AUR_GIT_NAME` / `AUR_GIT_EMAIL`).
+   See `.github/SECRETS.md` for the exact commands and rotation policy.
+
+3. Validate end-to-end with `workflow_dispatch` on `release.yml` (`channel=current`, `tag=<an existing release tag>`) before the next real release.

--- a/packaging/aur/publish-to-aur.sh
+++ b/packaging/aur/publish-to-aur.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Publish one release-pinned AUR package from packaging/aur/<package>/.
+#
+# Designed to run inside `archlinux:base-devel`. It self-bootstraps: when
+# invoked as root it installs the Arch packaging tools, creates an
+# unprivileged `builder` user (makepkg refuses to run as root), and
+# re-execs itself as that user. The builder phase patches the committed
+# PKGBUILD to the current release, regenerates the checksums and
+# `.SRCINFO`, then pushes the result to the matching AUR git repository.
+#
+# The committed files under packaging/aur/<package>/ are the source of
+# truth for everything except the per-release values (pkgver, sha256sums,
+# the desktop bundle version, the pinned Docker image tag) which are
+# derived here so a release never has to hand-edit the package.
+#
+# Required environment:
+#   RELEASE_TAG           e.g. v2026.6.26-beta.24
+#   AUR_KEY_FILE          path to the AUR SSH private key (root phase reads it)
+#   AUR_KNOWN_HOSTS_FILE  path to a known_hosts file pinning aur.archlinux.org
+# Optional:
+#   GITHUB_REPOSITORY     owner/repo for the release API (default librefang/librefang)
+#   GH_API_TOKEN          raises the unauthenticated GitHub API rate limit
+#   AUR_GIT_NAME          commit author name  (default "LibreFang Release Bot")
+#   AUR_GIT_EMAIL         commit author email (default "release-bot@librefang.ai")
+#
+# Usage: publish-to-aur.sh <librefang-bin|librefang-desktop-bin|librefang-docker>
+set -euo pipefail
+
+PKG="${1:?usage: publish-to-aur.sh <package>}"
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+REPO="${GITHUB_REPOSITORY:-librefang/librefang}"
+
+# ── Root phase: install tools, drop privileges, re-exec as builder ─────────
+if [[ "$(id -u)" -eq 0 ]]; then
+  # Refresh archlinux-keyring in the same transaction so a slightly stale
+  # base image can still verify freshly-signed packages.
+  pacman -Syu --noconfirm --needed archlinux-keyring git openssh jq pacman-contrib >/dev/null
+
+  useradd --create-home --shell /bin/bash builder 2>/dev/null || true
+
+  install -d -o builder -g builder -m 700 /home/builder/.ssh
+  install -o builder -g builder -m 600 "${AUR_KEY_FILE:?AUR_KEY_FILE is required}" /home/builder/.ssh/aur
+  install -o builder -g builder -m 644 "${AUR_KNOWN_HOSTS_FILE:?AUR_KNOWN_HOSTS_FILE is required}" /home/builder/.ssh/known_hosts
+
+  exec sudo -u builder \
+    env HOME=/home/builder \
+        RELEASE_TAG="$RELEASE_TAG" \
+        GITHUB_REPOSITORY="$REPO" \
+        GH_API_TOKEN="${GH_API_TOKEN:-}" \
+        AUR_GIT_NAME="${AUR_GIT_NAME:-}" \
+        AUR_GIT_EMAIL="${AUR_GIT_EMAIL:-}" \
+        bash "$0" "$PKG"
+fi
+
+# ── Builder phase ──────────────────────────────────────────────────────────
+VER_RAW="${RELEASE_TAG#v}"   # 2026.6.26-beta.24  (matches the git tag minus the v)
+VER_PKG="${VER_RAW/-/_}"     # 2026.6.26_beta.24  (Arch pkgver cannot contain '-')
+echo "Publishing AUR package '$PKG' for release $RELEASE_TAG (pkgver=$VER_PKG)"
+
+SRC="/repo/packaging/aur/$PKG"
+[[ -f "$SRC/PKGBUILD" ]] || { echo "::error::no PKGBUILD at $SRC"; exit 1; }
+
+WORK="$(mktemp -d)/$PKG"
+mkdir -p "$WORK"
+# Plain -R (not -a): the source tree is bind-mounted with a foreign owner, and
+# preserving ownership as the unprivileged builder would fail under `set -e`.
+# File modes are irrelevant — the PKGBUILD installs each file with an explicit
+# `install -m`, so the source-side bits never reach the package.
+cp -R "$SRC"/. "$WORK"/
+cd "$WORK"
+
+# Capture the committed file set BEFORE updpkgsums downloads sources, so the
+# generated LICENSE / tarball / .deb never get pushed to AUR.
+shopt -s dotglob nullglob
+SRC_FILES=( * )
+shopt -u dotglob nullglob
+
+api_release_json() {
+  local hdr=(-H "Accept: application/vnd.github+json")
+  [[ -n "${GH_API_TOKEN:-}" ]] && hdr+=(-H "Authorization: Bearer $GH_API_TOKEN")
+  curl -fsSL --retry 3 "${hdr[@]}" \
+    "https://api.github.com/repos/$REPO/releases/tags/$RELEASE_TAG"
+}
+
+# Wait until a release asset whose name ends with $1 is visible; echo its name.
+# `needs:` in the workflow already orders us after the build job, but asset
+# visibility can lag the job's completion by a few seconds.
+wait_for_asset() {
+  local suffix="$1" name
+  for attempt in $(seq 1 18); do
+    name="$(api_release_json | jq -r --arg s "$suffix" \
+      '[.assets[].name | select(endswith($s))][0] // empty')"
+    if [[ -n "$name" ]]; then
+      echo "$name"
+      return 0
+    fi
+    echo "Waiting for asset *$suffix on $RELEASE_TAG ($attempt/18)..." >&2
+    sleep 10
+  done
+  echo "::error::asset *$suffix not found on $RELEASE_TAG after 180s" >&2
+  return 1
+}
+
+sed -i "s/^pkgver=.*/pkgver=$VER_PKG/" PKGBUILD
+sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+case "$PKG" in
+  librefang-bin)
+    wait_for_asset "librefang-x86_64-unknown-linux-gnu.tar.gz" >/dev/null
+    ;;
+  librefang-desktop-bin)
+    # The Tauri bundle version differs from the release tag; read it off the
+    # actual .deb asset name (LibreFang_<bundle-ver>_amd64.deb).
+    DEB="$(wait_for_asset "_amd64.deb")"
+    DV="${DEB#LibreFang_}"; DV="${DV%_amd64.deb}"
+    [[ -n "$DV" ]] || { echo "::error::could not parse bundle version from '$DEB'"; exit 1; }
+    sed -i "s/^_desktop_ver=.*/_desktop_ver=$DV/" PKGBUILD
+    echo "Desktop bundle version: $DV"
+    ;;
+  librefang-docker)
+    # No release asset to download — re-pin the embedded image tag in the
+    # helper + env (their sha256sums then change and are regenerated below).
+    sed -i -E "s#(ghcr\.io/librefang/librefang:)[A-Za-z0-9._-]+#\1$VER_RAW#g" \
+      librefang-docker librefang-docker.env
+    ;;
+  *)
+    echo "::error::unknown package '$PKG'"; exit 1 ;;
+esac
+
+# Regenerate checksums + .SRCINFO from the patched PKGBUILD. AUR rejects any
+# push whose .SRCINFO does not match `makepkg --printsrcinfo`, so always
+# produce it the same way.
+updpkgsums
+makepkg --printsrcinfo > .SRCINFO
+
+grep -qx "pkgver=$VER_PKG" PKGBUILD || { echo "::error::pkgver patch did not stick"; exit 1; }
+
+# ── Push to AUR ─────────────────────────────────────────────────────────────
+export GIT_SSH_COMMAND="ssh -i $HOME/.ssh/aur -o IdentitiesOnly=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
+git config --global user.name "${AUR_GIT_NAME:-LibreFang Release Bot}"
+git config --global user.email "${AUR_GIT_EMAIL:-release-bot@librefang.ai}"
+git config --global init.defaultBranch master
+
+CLONE="$(mktemp -d)/aur"
+git clone --quiet "ssh://aur@aur.archlinux.org/$PKG.git" "$CLONE"
+
+# Copy only the committed source files (never downloaded artifacts).
+for f in "${SRC_FILES[@]}"; do
+  cp "$WORK/$f" "$CLONE/$f"
+done
+
+cd "$CLONE"
+git add -A
+if git diff --cached --quiet; then
+  echo "AUR/$PKG already up to date at $VER_RAW — nothing to push."
+  exit 0
+fi
+git commit --quiet -m "Update to $VER_RAW"
+git push origin HEAD:master
+echo "Pushed AUR/$PKG $VER_RAW."


### PR DESCRIPTION
## What

Implements **Option 2** of #6334: automated AUR publishing on release.

PR #6314 added the AUR package sources under `packaging/aur/` but nothing pushes them to the Arch User Repository.
This adds the automation so `yay -S librefang-bin` / `librefang-desktop-bin` / `librefang-docker` track each LibreFang release, pinned to the exact version (never `latest`).

## How

Three new `release.yml` jobs — `sync_aur_bin`, `sync_aur_desktop`, `sync_aur_docker` — modeled directly on the existing `sync_homebrew` / `sync_homebrew_cask` jobs.
They share the same tag/dispatch `if:` guard and each waits (`needs:`) on the build job that produced its asset (`cli_linux` / `desktop` / `docker-manifest`).
Split into three independent jobs (not a matrix) so a desktop build failure cannot block the `librefang-bin` publish, and vice versa.

A shared composite action (`.github/actions/publish-aur`) runs `packaging/aur/publish-to-aur.sh` inside `archlinux:base-devel` (via `docker run` on the ubuntu host, so `actions/checkout` keeps using the host's Node/git).
The script self-bootstraps: as root it installs the Arch tooling and drops to an unprivileged `builder` (makepkg refuses to run as root), then per package it:

- bumps `pkgver` (encoding the tag's first `-` as `_`, e.g. `v2026.6.26-beta.24` → `2026.6.26_beta.24`) and resets `pkgrel` to `1`;
- for `librefang-desktop-bin`, reads the Tauri bundle version off the actual `LibreFang_<ver>_amd64.deb` asset name (it differs from the tag, exactly like the cask sync);
- for `librefang-docker`, re-pins the `ghcr.io/librefang/librefang:<version>` tag inside the helper script and env file;
- regenerates `sha256sums` (`updpkgsums`) and `.SRCINFO` (`makepkg --printsrcinfo`);
- clones `ssh://aur@aur.archlinux.org/<package>.git`, copies only the committed source files (never downloaded artifacts), and pushes if anything changed.

The committed `packaging/aur/` files remain a working baseline for local `makepkg`; the release-correct `pkgver` / `sha256sums` / `.SRCINFO` are generated into the AUR repositories on each tag.

## Maintainer setup required (the issue's Option-2 prerequisites)

The jobs degrade to a **no-op with a notice** until `AUR_SSH_PRIVATE_KEY` is configured, so this PR is safe to merge first.
To activate:

1. Create the three AUR repositories under the owning AUR account.
2. Add `AUR_SSH_PRIVATE_KEY` (and optionally `AUR_KNOWN_HOSTS`, `AUR_GIT_NAME`, `AUR_GIT_EMAIL`) as repo secrets — full commands in `.github/SECRETS.md`.
3. Validate via `workflow_dispatch` on `release.yml` (`channel=current`, `tag=<existing release>`).

## Notes

- Publishes for **every `v*` tag** including betas, matching the Homebrew sync and the project's current beta-only cadence; the version is always pinned (no floating `latest`), per the issue's requirement.
- `known_hosts` is fetched with `ssh-keyscan` at runtime (TOFU) unless `AUR_KNOWN_HOSTS` is set; the SSH key file is wiped on step exit via a `trap`.
- `archlinux-keyring` is refreshed in the same pacman transaction to avoid the stale-keyring signature-verification flake.

## Verification

- `python3 -c "yaml.safe_load(...)"` parses `release.yml` and `action.yml`.
- `bash -n` passes on `publish-to-aur.sh` and the composite action's run block; the run block contains no `${{ }}` interpolation (no shell-injection surface).
- All three `needs:` targets (`cli_linux`, `desktop`, `docker-manifest`) exist; the three new job IDs are unique across the file.
- Simulated the version round-trip (beta/stable/rc/lts), the `pkgver`/`pkgrel` edits, the desktop `.deb` version parse, and the Docker image-tag `sed` against the real PKGBUILDs — the image-tag regex replaces only the version and preserves the surrounding `${...:-...}` brace.

Live AUR push is exercised the first time the maintainer dispatches a release with the secret configured (it cannot run in CI without the key).

Refs #6334
