### PR TITLE
fix(llm): allow Codex CLI outside Git repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ _33 PRs from 5 contributors since v2026.6.22-beta.22._
 
 ### Fixed
 
+- Allow the Codex CLI provider to run from desktop and daemon processes outside a Git repository, and replace its deprecated `--full-auto` flag (@pavver)
 - Accept the empty-recipient handshake HMAC binding so `bootstrap_peers` connections succeed instead of failing with `403 HMAC authentication failed` (regression from #3920) (#6330) (@houko)
 - Bump `pdf-extract` 0.10→0.12 to pull the patched `lopdf` 0.42, fixing RUSTSEC-2026-0187 — a stack overflow on deeply nested PDF objects reachable via attacker-supplied PDF attachments (the existing `catch_unwind` guards do not mitigate it, since a stack overflow aborts rather than unwinds) (@houko)
 

--- a/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
+++ b/crates/librefang-llm-drivers/src/drivers/codex_cli.rs
@@ -53,12 +53,12 @@ impl CodexCliDriver {
     /// Create a new Codex CLI driver.
     ///
     /// `cli_path` overrides the CLI binary path; defaults to `"codex"` on PATH.
-    /// `skip_permissions` adds `--full-auto` to the spawned command so that the CLI
-    /// runs non-interactively (required for daemon mode).
+    /// `skip_permissions` adds `--sandbox workspace-write` to the spawned command
+    /// so that the CLI runs non-interactively (required for daemon mode).
     pub fn new(cli_path: Option<String>, skip_permissions: bool) -> Self {
         if skip_permissions {
             warn!(
-                "Codex CLI driver: --full-auto enabled. \
+                "Codex CLI driver: workspace-write sandbox enabled. \
                  The CLI will not prompt for tool approvals. \
                  LibreFang's own capability/RBAC system enforces access control."
             );
@@ -124,10 +124,14 @@ impl CodexCliDriver {
 
     /// Build the CLI arguments for a given request.
     pub fn build_args(&self, prompt: &str, model: &str) -> Vec<String> {
-        let mut args = vec!["exec".to_string()];
+        // LibreFang can run as a desktop app or daemon whose current directory
+        // is not a Git repository. Codex otherwise rejects non-interactive
+        // execution before processing the prompt.
+        let mut args = vec!["exec".to_string(), "--skip-git-repo-check".to_string()];
 
         if self.skip_permissions {
-            args.push("--full-auto".to_string());
+            args.push("--sandbox".to_string());
+            args.push("workspace-write".to_string());
         }
 
         let model_flag = Self::model_flag(model);
@@ -438,23 +442,37 @@ mod tests {
     }
 
     #[test]
-    fn test_build_args_with_full_auto() {
+    fn test_build_args_with_workspace_write_sandbox() {
         let driver = CodexCliDriver::new(None, true);
         let args = driver.build_args("test prompt", "codex-cli/o4-mini");
-        assert_eq!(args.first().map(String::as_str), Some("exec"));
-        assert!(args.contains(&"test prompt".to_string()));
-        assert!(args.contains(&"--full-auto".to_string()));
-        assert!(args.contains(&"--model".to_string()));
-        assert!(args.contains(&"o4-mini".to_string()));
+        assert_eq!(
+            args,
+            [
+                "exec",
+                "--skip-git-repo-check",
+                "--sandbox",
+                "workspace-write",
+                "--model",
+                "o4-mini",
+                "test prompt",
+            ]
+        );
     }
 
     #[test]
-    fn test_build_args_without_full_auto() {
+    fn test_build_args_without_workspace_write_sandbox() {
         let driver = CodexCliDriver::new(None, false);
         let args = driver.build_args("test prompt", "codex-cli/o3");
-        assert!(!args.contains(&"--full-auto".to_string()));
-        assert_eq!(args.first().map(String::as_str), Some("exec"));
-        assert!(!args.contains(&"-q".to_string()));
+        assert_eq!(
+            args,
+            [
+                "exec",
+                "--skip-git-repo-check",
+                "--model",
+                "o3",
+                "test prompt",
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Codex CLI provider failed when LibreFang was started as a desktop application or daemon outside a Git repository.

The provider check still reported Codex as available because it only verified that the executable and credentials existed. The first real completion then failed with:

```text
Not inside a trusted directory and --skip-git-repo-check was not specified.
```

The driver also passed the deprecated `--full-auto` option, producing a warning on every request.

## Root cause

LibreFang launched `codex exec` in the process working directory.

Desktop and daemon processes are not guaranteed to start inside a Git repository, while non-interactive Codex execution rejects such directories unless `--skip-git-repo-check` is explicitly supplied.

## Changes

- Always pass `--skip-git-repo-check` to `codex exec`.
- Replace deprecated `--full-auto` with `--sandbox workspace-write`.
- Update the driver warning and documentation to describe the current sandbox option.
- Add regression tests that verify the complete argument list in both permission modes.
- Add an entry to the unreleased changelog.

## Verification

- `cargo fmt --check`
- `cargo test -p librefang-llm-drivers --lib codex_cli`
  - 14 Codex CLI driver tests passed.
- `cargo clippy -p librefang-llm-drivers --lib -- -D warnings`
- Built a local `librefang-desktop` release package.
- Verified that the packaged executable contains `--skip-git-repo-check` and no longer contains `--full-auto`.
- Installed the package and completed real Codex CLI-backed agent requests from the desktop application.

## Out of scope

The desktop dashboard currently retries an agent WebSocket connection with an Origin based on its random frontend port, while the API validates it against the separate API listen port. This produces repeated `403 Origin validation failed` warnings. HTTP message fallback still works, and this separate desktop/WebSocket issue is not included in this PR.
