### PR TITLE
ci(release): publish project-maintained pacman repo to R2 (#6334)

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -136,6 +136,49 @@ token only as a break-glass option.
 
 ---
 
+## Arch pacman repository (release.yml `publish_arch_repo`)
+
+Build, GPG-sign, and publish the project-maintained pacman repository to Cloudflare R2 (`packages.librefang.ai`) on every tag.
+This is the official binary repo installable with `pacman -Syu`, distinct from the AUR packages under `packaging/aur/`.
+When the GPG key or any R2 credential is absent the job no-ops with a notice — nothing downstream depends on it, so forks and unconfigured repos are unaffected.
+
+pacman verifies packages with **GPG/PGP only** — it cannot consume the cosign keyless signatures the rest of the release uses, so this is the project's first long-lived signing key.
+Treat it accordingly: keep the **primary key offline**, register only a **passphrase-less signing subkey** in CI, and revoke the subkey (not the identity) if a runner is compromised.
+
+| Secret | Purpose | Format | Rotation |
+|---|---|---|---|
+| `ARCH_REPO_GPG_PRIVATE_KEY` | Ascii-armored, passphrase-less signing **subkey**. `makepkg --sign` and `repo-add --sign` produce the `.sig` files and sign the db with it. Its public half is what users import via `pacman-key`. | `gpg --armor --export-secret-subkeys <subkey-id>!` (incl. BEGIN/END) | Rotate the subkey on personnel change or runner compromise; the offline primary key and its fingerprint stay stable so users never re-import |
+| `ARCH_REPO_GPG_KEY_ID` | The signing subkey id (or its fingerprint) passed to `makepkg --sign --key` / `repo-add -k`. | hex key id / fingerprint | Matches the subkey above |
+| `R2_ACCESS_KEY_ID` | R2 S3 access key id for the bucket behind `packages.librefang.ai`. Scope it to that one bucket. | plain string | When personnel changes or the key is compromised |
+| `R2_SECRET_ACCESS_KEY` | R2 S3 secret access key paired with the id above. | plain string | With the id above |
+
+`CLOUDFLARE_ACCOUNT_ID` is reused from the Workers deploys (it forms the R2 S3 endpoint host); no new account secret is needed.
+The bucket name defaults to `librefang-packages` (the `r2-bucket` action input) — override it there if your bucket differs.
+
+**Generation reference**
+
+```sh
+# 1. Create the signing key once, OFFLINE. Use a primary key for identity and
+#    a separate signing subkey for CI so the subkey can be revoked alone:
+gpg --quick-generate-key "LibreFang Packaging <packaging@librefang.ai>" ed25519 sign never
+gpg --quick-add-key <PRIMARY_FPR> ed25519 sign 2y          # the CI subkey
+
+# 2. Export ONLY the subkey's secret half (note the trailing '!'), no passphrase:
+gpg --armor --export-secret-subkeys <SUBKEY_ID>! > arch_repo_signing.asc   # → ARCH_REPO_GPG_PRIVATE_KEY
+echo <SUBKEY_ID>                                                            # → ARCH_REPO_GPG_KEY_ID
+
+# 3. Create an R2 bucket + S3 access key in the Cloudflare dashboard,
+#    bind it to packages.librefang.ai, paste the two values into the R2_* secrets.
+
+# 4. Back up the OFFLINE primary key + its revocation certificate somewhere
+#    the CI runner can never reach. Losing it means users must re-import a new key.
+```
+
+The public key is published to `https://packages.librefang.ai/<repo>.gpg` by the job itself on each run; the install docs (`packaging/arch-repo/README.md`) point users there.
+Validate end-to-end with `workflow_dispatch` on `release.yml` (`channel=current`, `tag=<existing release>`) before the next real release.
+
+---
+
 ## Internal infrastructure
 
 | Secret | Purpose |

--- a/.github/actions/publish-arch-repo/action.yml
+++ b/.github/actions/publish-arch-repo/action.yml
@@ -1,0 +1,90 @@
+name: Publish pacman repository
+description: >
+  Build, GPG-sign, and publish the project-maintained LibreFang pacman
+  repository to Cloudflare R2. No-ops (with a notice) when the GPG signing
+  key or the R2 credentials are not configured, so forks and unconfigured
+  repositories do not fail.
+
+inputs:
+  release-tag:
+    description: Release tag to pin (e.g. v2026.6.26-beta.24).
+    required: true
+  gpg-private-key:
+    description: >
+      Ascii-armored, passphrase-less GPG signing key. When empty the publish
+      is skipped.
+    required: true
+  gpg-key-id:
+    description: Signing key / subkey id used by makepkg --sign and repo-add.
+    required: false
+    default: ""
+  r2-account-id:
+    description: Cloudflare account id (R2 S3 endpoint host).
+    required: false
+    default: ""
+  r2-access-key-id:
+    description: R2 S3 access key id.
+    required: false
+    default: ""
+  r2-secret-access-key:
+    description: R2 S3 secret access key.
+    required: false
+    default: ""
+  r2-bucket:
+    description: R2 bucket name that backs packages.librefang.ai.
+    required: false
+    default: librefang-packages
+  retain:
+    description: Old package versions to keep per pkgname before pruning.
+    required: false
+    default: "5"
+
+runs:
+  using: composite
+  steps:
+    - name: Publish pacman repository to R2
+      shell: bash
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg-private-key }}
+        GPG_KEY_ID: ${{ inputs.gpg-key-id }}
+        R2_ACCOUNT_ID: ${{ inputs.r2-account-id }}
+        R2_ACCESS_KEY_ID: ${{ inputs.r2-access-key-id }}
+        R2_SECRET_ACCESS_KEY: ${{ inputs.r2-secret-access-key }}
+        R2_BUCKET: ${{ inputs.r2-bucket }}
+        RETAIN: ${{ inputs.retain }}
+        RELEASE_TAG: ${{ inputs.release-tag }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GH_API_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        # Degrade to a no-op unless every secret needed to sign AND upload is
+        # present. A half-configured repo (key but no R2, or vice versa) would
+        # build packages it cannot publish — treat that as "not configured".
+        missing=""
+        [[ -z "${GPG_PRIVATE_KEY//[[:space:]]/}" ]] && missing="$missing GPG_PRIVATE_KEY"
+        [[ -z "${GPG_KEY_ID//[[:space:]]/}" ]] && missing="$missing GPG_KEY_ID"
+        [[ -z "${R2_ACCOUNT_ID//[[:space:]]/}" ]] && missing="$missing R2_ACCOUNT_ID"
+        [[ -z "${R2_ACCESS_KEY_ID//[[:space:]]/}" ]] && missing="$missing R2_ACCESS_KEY_ID"
+        [[ -z "${R2_SECRET_ACCESS_KEY//[[:space:]]/}" ]] && missing="$missing R2_SECRET_ACCESS_KEY"
+        if [[ -n "$missing" ]]; then
+          echo "::notice::pacman repo publish skipped — unset secret(s):$missing"
+          exit 0
+        fi
+
+        # Materialise the signing key to a temp dir wiped on step exit
+        # (success or failure) per the SECRETS.md operational rule.
+        WORKDIR="$(mktemp -d)"
+        trap 'rm -rf "$WORKDIR"' EXIT
+        KEY="$WORKDIR/signing.asc"
+        ( umask 077; printf '%s\n' "$GPG_PRIVATE_KEY" > "$KEY" )
+
+        docker run --rm \
+          -v "$GITHUB_WORKSPACE":/repo \
+          -v "$KEY":/keys/signing.asc:ro \
+          -e RELEASE_TAG -e GITHUB_REPOSITORY -e GH_API_TOKEN \
+          -e GPG_KEY_ID -e RETAIN \
+          -e R2_ACCOUNT_ID -e R2_ACCESS_KEY_ID -e R2_SECRET_ACCESS_KEY -e R2_BUCKET \
+          -e GPG_KEY_FILE=/keys/signing.asc \
+          archlinux:base-devel \
+          bash /repo/packaging/arch-repo/publish-arch-repo.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2692,6 +2692,40 @@ jobs:
             $TAGS \
             $(printf "$IMAGE@sha256:%s " *)
 
+  # ═════════════════════════════════════════════════════════════════════════
+  # Arch pacman repository — the project-maintained binary repo published to
+  # Cloudflare R2 (packages.librefang.ai), distinct from the AUR packages
+  # under packaging/aur/. Exists because AUR account registration is closed
+  # (see #6334), so this ships the same release-pinned packages directly via
+  # `pacman -Syu`. Single job (not three): all packages fold into one shared
+  # pacman db, so they must be repo-add'd together. A fixed concurrency group
+  # serialises the read-modify-write on that db across releases. Degrades to a
+  # no-op when the GPG key / R2 secrets are absent (forks / unconfigured).
+  # ═════════════════════════════════════════════════════════════════════════
+
+  publish_arch_repo:
+    name: Publish pacman repo (Arch)
+    if: >
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
+    runs-on: ubuntu-latest
+    needs: [cli_linux, desktop, docker-manifest]
+    concurrency:
+      group: arch-pacman-repo
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.RELEASE_REF }}
+      - uses: ./.github/actions/publish-arch-repo
+        with:
+          release-tag: ${{ env.RELEASE_TAG }}
+          gpg-private-key: ${{ secrets.ARCH_REPO_GPG_PRIVATE_KEY }}
+          gpg-key-id: ${{ secrets.ARCH_REPO_GPG_KEY_ID }}
+          r2-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
   deploy_fly:
     name: Deploy to Fly.io
     if: >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ _33 PRs from 5 contributors since v2026.6.22-beta.22._
 
 ## [Unreleased]
 
+### Added
+
+- Publish an official project-maintained pacman repository for Arch Linux — GPG-signed packages on Cloudflare R2, installable via `pacman -Syu`, sidestepping the closed AUR registration that blocks #6341 (#6334) (@houko)
+
 ### Fixed
 
 - Allow the Codex CLI provider to run from desktop and daemon processes outside a Git repository, and replace its deprecated `--full-auto` flag (@pavver)

--- a/packaging/arch-repo/README.md
+++ b/packaging/arch-repo/README.md
@@ -1,0 +1,64 @@
+# Arch pacman repository
+
+The project-maintained binary repository for Arch Linux, published to Cloudflare R2 behind `packages.librefang.ai`.
+Install LibreFang with `pacman -Syu` and track every release through normal system updates.
+
+This is distinct from the AUR packages under `packaging/aur/`.
+It exists because AUR account registration was closed with no reopening date (see #6334), which blocks the AUR automation in #6341.
+This repository ships the same release-pinned binary packages directly, with no AUR account required.
+The two are complementary: when AUR registration reopens, #6341 publishes the AUR `-bin` packages for `yay` users, while this repository keeps serving `pacman` users.
+
+## Installing (users)
+
+```sh
+# 1. Import the LibreFang packaging public key and locally sign it so pacman
+#    will trust packages signed by it.
+curl -fsSL https://packages.librefang.ai/librefang.gpg -o /tmp/librefang.gpg
+sudo pacman-key --add /tmp/librefang.gpg
+sudo pacman-key --finger packaging@librefang.ai      # confirm the fingerprint, then:
+sudo pacman-key --lsign-key <FINGERPRINT-printed-above>
+
+# 2. Add the repository to /etc/pacman.conf (append at the end):
+#
+#      [librefang]
+#      Server = https://packages.librefang.ai/arch/$arch
+#
+# 3. Sync and install. The CLI/daemon and the desktop app:
+sudo pacman -Syu
+sudo pacman -S librefang-bin librefang-desktop-bin
+```
+
+`$arch` is pacman's own variable — leave it literal in `pacman.conf`; pacman expands it to `x86_64`.
+Both the database and every package are GPG-signed, so the default `SigLevel` (inherited from `[options]`) verifies them once the key above is locally signed.
+Do **not** set `SigLevel = Never` — that disables the verification this repository exists to provide.
+
+Available packages:
+
+- `librefang-bin` — CLI, daemon, HTTP API, and dashboard on port 4545.
+- `librefang-desktop-bin` — native desktop launcher.
+- `librefang-docker` — Docker-backed systemd service pinned to the release tag.
+
+## How it works (CI)
+
+`release.yml`'s `publish_arch_repo` job runs `publish-arch-repo.sh` inside an `archlinux:base-devel` container on every `v*` tag (and on a `channel=current` re-publish).
+The script:
+
+1. Reuses the committed PKGBUILDs under `packaging/aur/<package>/` as the source of truth, deriving only the per-release values — `pkgver` (encoding the tag's first `-` as `_`), `pkgrel=1`, the desktop bundle version (read off the actual `LibreFang_<ver>_amd64.deb` asset name), the pinned `ghcr.io/librefang/librefang:<version>` tag — then regenerates `sha256sums` with `updpkgsums`.
+2. Builds and GPG-signs each package with `makepkg --sign` (no Rust compile — these repackage the prebuilt release artifacts).
+3. Folds every package into one shared, signed pacman database with `repo-add --sign`, pulling the existing database from R2 first so the update is incremental.
+4. Uploads the packages, signatures, database, and the public key to R2.
+5. Prunes old package files beyond the newest `RETAIN` (default 5) per package — best-effort, kept only for manual `pacman -U <url>` downgrades; the database always points at the latest build.
+
+The job degrades to a no-op with a notice until the maintainer configures the signing key and R2 credentials, so it is safe to merge before the secrets exist.
+
+Object storage has no symlinks, so `librefang.db` / `librefang.files` (which `repo-add` writes as symlinks to their `.tar.gz`) are materialised as real objects before upload.
+
+## One-time maintainer bootstrap
+
+1. Create the signing key **offline** — a primary key for identity plus a passphrase-less signing subkey for CI — and an R2 bucket bound to `packages.librefang.ai`.
+   Exact commands, formats, and rotation policy are in `.github/SECRETS.md` (`Arch pacman repository` section).
+2. Add the secrets: `ARCH_REPO_GPG_PRIVATE_KEY`, `ARCH_REPO_GPG_KEY_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (`CLOUDFLARE_ACCOUNT_ID` is reused from the Workers deploys).
+3. Validate end-to-end with `workflow_dispatch` on `release.yml` (`channel=current`, `tag=<an existing release tag>`) before the next real release.
+   The first run cold-starts the database; subsequent runs update it incrementally.
+
+The committed `pkgver` / `sha256sums` under `packaging/aur/` are a working baseline for local `makepkg`; the release-correct values are derived into R2 on each tag and are never committed.

--- a/packaging/arch-repo/publish-arch-repo.sh
+++ b/packaging/arch-repo/publish-arch-repo.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Build, GPG-sign, and publish the official LibreFang pacman repository.
+#
+# This is the project-maintained Arch binary repository — distinct from the
+# AUR packages under packaging/aur/. It exists because AUR account
+# registration was closed with no reopening date (see #6334), so the AUR
+# automation in #6341 cannot publish yet. This repository ships the same
+# release-pinned binary packages directly, installable with `pacman -Syu`
+# once a user adds the `[librefang]` section to /etc/pacman.conf.
+#
+# It reuses the committed PKGBUILDs under packaging/aur/<package>/ as the
+# single source of truth for each package — only the per-release values
+# (pkgver, sha256sums, the desktop bundle version, the pinned Docker image
+# tag) are derived here, exactly like the AUR publisher. The difference is
+# the tail: instead of pushing each PKGBUILD to its own AUR git repository,
+# this builds the .pkg.tar.zst, GPG-signs it, folds it into a single shared
+# pacman database (repo-add), and syncs the result to Cloudflare R2.
+#
+# Designed to run inside `archlinux:base-devel`. It self-bootstraps: when
+# invoked as root it installs the packaging + upload tooling, creates an
+# unprivileged `builder` user (makepkg refuses to run as root), and re-execs
+# itself as that user.
+#
+# Required environment:
+#   RELEASE_TAG          e.g. v2026.6.26-beta.24
+#   GPG_KEY_FILE         path to the ascii-armored signing key (passphrase-less)
+#   GPG_KEY_ID           signing key / subkey id used by makepkg --sign + repo-add
+#   R2_ACCOUNT_ID        Cloudflare account id (R2 S3 endpoint host)
+#   R2_ACCESS_KEY_ID     R2 S3 access key id
+#   R2_SECRET_ACCESS_KEY R2 S3 secret access key
+#   R2_BUCKET            R2 bucket name (e.g. librefang-packages)
+# Optional:
+#   REPO_NAME            pacman db name (default "librefang")
+#   REPO_ARCH            target architecture (default "x86_64")
+#   REPO_PREFIX          object prefix inside the bucket (default "arch/$REPO_ARCH")
+#   RETAIN               old package versions to keep per pkgname (default 5)
+#   GITHUB_REPOSITORY    owner/repo for the release API (default librefang/librefang)
+#   GH_API_TOKEN         raises the unauthenticated GitHub API rate limit
+#
+# Usage: publish-arch-repo.sh   (builds all packages; takes no arguments)
+set -euo pipefail
+
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+REPO="${GITHUB_REPOSITORY:-librefang/librefang}"
+REPO_NAME="${REPO_NAME:-librefang}"
+REPO_ARCH="${REPO_ARCH:-x86_64}"
+REPO_PREFIX="${REPO_PREFIX:-arch/$REPO_ARCH}"
+RETAIN="${RETAIN:-5}"
+
+# Packages folded into the repository. x86_64-only baseline (matches the
+# committed PKGBUILDs and the fact the desktop bundle ships amd64 only);
+# librefang-docker is arch=any but lands in the same x86_64 repo path.
+PACKAGES=(librefang-bin librefang-desktop-bin librefang-docker)
+
+# ── Root phase: install tools, drop privileges, re-exec as builder ─────────
+if [[ "$(id -u)" -eq 0 ]]; then
+  # Refresh archlinux-keyring in the same transaction so a slightly stale
+  # base image can still verify freshly-signed packages.
+  pacman -Syu --noconfirm --needed \
+    archlinux-keyring base-devel pacman-contrib jq rclone >/dev/null
+
+  useradd --create-home --shell /bin/bash builder 2>/dev/null || true
+
+  # Hand the signing key to the builder with tight perms.
+  install -d -o builder -g builder -m 700 /home/builder/keys
+  install -o builder -g builder -m 600 \
+    "${GPG_KEY_FILE:?GPG_KEY_FILE is required}" /home/builder/keys/signing.asc
+
+  exec sudo -u builder \
+    env HOME=/home/builder \
+        RELEASE_TAG="$RELEASE_TAG" \
+        GITHUB_REPOSITORY="$REPO" \
+        GH_API_TOKEN="${GH_API_TOKEN:-}" \
+        GPG_KEY_FILE=/home/builder/keys/signing.asc \
+        GPG_KEY_ID="${GPG_KEY_ID:?GPG_KEY_ID is required}" \
+        R2_ACCOUNT_ID="${R2_ACCOUNT_ID:?R2_ACCOUNT_ID is required}" \
+        R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required}" \
+        R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required}" \
+        R2_BUCKET="${R2_BUCKET:?R2_BUCKET is required}" \
+        REPO_NAME="$REPO_NAME" REPO_ARCH="$REPO_ARCH" \
+        REPO_PREFIX="$REPO_PREFIX" RETAIN="$RETAIN" \
+        bash "$0"
+fi
+
+# ── Builder phase ──────────────────────────────────────────────────────────
+VER_RAW="${RELEASE_TAG#v}"   # 2026.6.26-beta.24  (matches the git tag minus the v)
+VER_PKG="${VER_RAW/-/_}"     # 2026.6.26_beta.24  (Arch pkgver cannot contain '-')
+echo "Publishing pacman repo '$REPO_NAME' ($REPO_ARCH) for release $RELEASE_TAG (pkgver=$VER_PKG)"
+
+STAGING="$(mktemp -d)/repo"
+BUILDROOT="$(mktemp -d)/build"
+mkdir -p "$STAGING" "$BUILDROOT"
+
+# ── GPG: import the signing key, mark it trusted for makepkg + repo-add ────
+gpg --batch --quiet --import "$GPG_KEY_FILE"
+# Ownertrust must address the primary key fingerprint, not the subkey id.
+FPR="$(gpg --batch --with-colons --fingerprint "$GPG_KEY_ID" \
+        | awk -F: '/^fpr:/ {print $10; exit}')"
+[[ -n "$FPR" ]] || { echo "::error::could not resolve fingerprint for $GPG_KEY_ID"; exit 1; }
+printf '%s:6:\n' "$FPR" | gpg --batch --import-ownertrust
+
+# ── Cloudflare R2 over rclone's S3 backend (config via env, no config file) ─
+export RCLONE_CONFIG_R2_TYPE=s3
+export RCLONE_CONFIG_R2_PROVIDER=Cloudflare
+export RCLONE_CONFIG_R2_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export RCLONE_CONFIG_R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+export RCLONE_CONFIG_R2_ACL=private
+# R2's S3 API rejects the trailing-checksum header rclone adds by default.
+export RCLONE_S3_NO_CHECK_BUCKET=true
+R2_DEST="r2:${R2_BUCKET}/${REPO_PREFIX}"
+
+api_release_json() {
+  local hdr=(-H "Accept: application/vnd.github+json")
+  [[ -n "${GH_API_TOKEN:-}" ]] && hdr+=(-H "Authorization: Bearer $GH_API_TOKEN")
+  curl -fsSL --retry 3 "${hdr[@]}" \
+    "https://api.github.com/repos/$REPO/releases/tags/$RELEASE_TAG"
+}
+
+# Wait until a release asset whose name ends with $1 is visible; echo its name.
+# `needs:` already orders us after the build jobs, but asset visibility can
+# lag a job's completion by a few seconds.
+wait_for_asset() {
+  local suffix="$1" name
+  for attempt in $(seq 1 18); do
+    name="$(api_release_json | jq -r --arg s "$suffix" \
+      '[.assets[].name | select(endswith($s))][0] // empty')"
+    if [[ -n "$name" ]]; then echo "$name"; return 0; fi
+    echo "Waiting for asset *$suffix on $RELEASE_TAG ($attempt/18)..." >&2
+    sleep 10
+  done
+  echo "::error::asset *$suffix not found on $RELEASE_TAG after 180s" >&2
+  return 1
+}
+
+# Build + sign one package from its committed PKGBUILD. Echoes nothing; on
+# success the signed .pkg.tar.zst (+ .sig) land in $STAGING. Returns non-zero
+# on failure so the caller can skip just that package without sinking the rest.
+build_pkg() {
+  local pkg="$1"
+  local src="/repo/packaging/aur/$pkg"
+  [[ -f "$src/PKGBUILD" ]] || { echo "::warning::no PKGBUILD at $src — skipping $pkg"; return 1; }
+
+  local work="$BUILDROOT/$pkg"
+  mkdir -p "$work"
+  # Plain -R (not -a): the source tree is bind-mounted with a foreign owner,
+  # and preserving ownership as the unprivileged builder fails under set -e.
+  # Modes are irrelevant — the PKGBUILD installs each file with explicit -m.
+  cp -R "$src"/. "$work"/
+  cd "$work"
+
+  sed -i "s/^pkgver=.*/pkgver=$VER_PKG/" PKGBUILD
+  sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+  case "$pkg" in
+    librefang-bin)
+      wait_for_asset "librefang-${REPO_ARCH}-unknown-linux-gnu.tar.gz" >/dev/null
+      ;;
+    librefang-desktop-bin)
+      # The Tauri bundle version differs from the release tag; read it off the
+      # actual .deb asset name (LibreFang_<bundle-ver>_amd64.deb).
+      local deb dv
+      deb="$(wait_for_asset "_amd64.deb")"
+      dv="${deb#LibreFang_}"; dv="${dv%_amd64.deb}"
+      [[ -n "$dv" ]] || { echo "::error::could not parse bundle version from '$deb'"; return 1; }
+      sed -i "s/^_desktop_ver=.*/_desktop_ver=$dv/" PKGBUILD
+      echo "Desktop bundle version: $dv"
+      ;;
+    librefang-docker)
+      # No release asset to download — re-pin the embedded image tag in the
+      # helper + env (their sha256sums then change and are regenerated below).
+      sed -i -E "s#(ghcr\.io/librefang/librefang:)[A-Za-z0-9._-]+#\1$VER_RAW#g" \
+        librefang-docker librefang-docker.env
+      ;;
+    *)
+      echo "::error::unknown package '$pkg'"; return 1 ;;
+  esac
+
+  updpkgsums
+  grep -qx "pkgver=$VER_PKG" PKGBUILD || { echo "::error::pkgver patch did not stick for $pkg"; return 1; }
+
+  # --nodeps: these repackage prebuilt release artifacts, so runtime depends
+  # need not be installed in the build container. --sign with the imported key.
+  makepkg --force --nodeps --nocheck --sign --key "$GPG_KEY_ID" --noconfirm
+
+  cp ./*.pkg.tar.zst ./*.pkg.tar.zst.sig "$STAGING"/
+}
+
+# ── Build every package; collect which ones succeeded ──────────────────────
+built=()
+for pkg in "${PACKAGES[@]}"; do
+  if build_pkg "$pkg"; then
+    built+=("$pkg")
+  else
+    echo "::warning::build failed for $pkg — it will not be published this run"
+  fi
+done
+[[ ${#built[@]} -gt 0 ]] || { echo "::error::no packages built — nothing to publish"; exit 1; }
+echo "Built: ${built[*]}"
+
+cd "$STAGING"
+
+# ── Fold into the shared pacman db (pull the existing db first; cold start ──
+#    on first run simply finds none and creates a fresh one). ───────────────
+rclone copy "$R2_DEST" "$STAGING" \
+  --include "${REPO_NAME}.db*" --include "${REPO_NAME}.files*" 2>/dev/null || true
+
+# repo-add replaces any same-pkgname entry with the new version, so the db
+# always points at the latest build; older package files become orphaned in
+# R2 and are pruned below by RETAIN.
+repo-add --sign --key "$GPG_KEY_ID" "$STAGING/${REPO_NAME}.db.tar.gz" "$STAGING"/*.pkg.tar.zst
+
+# R2 (object storage) has no symlinks. repo-add writes `librefang.db` and
+# `librefang.files` as symlinks to their .tar.gz; materialise them as real
+# objects so `Server = …/$arch` + `pacman -Sy` can fetch them by plain name.
+for ext in db files; do
+  if [[ -L "$STAGING/${REPO_NAME}.${ext}" ]]; then
+    cp --remove-destination "$STAGING/${REPO_NAME}.${ext}.tar.gz" "$STAGING/${REPO_NAME}.${ext}"
+  fi
+done
+
+# Publish the signing public key alongside the repo so the install docs can
+# point users at a stable URL (idempotent — overwrites the same object).
+gpg --batch --armor --export "$GPG_KEY_ID" > "$STAGING/${REPO_NAME}.gpg"
+
+# ── Upload: packages + signatures + db + files + public key ────────────────
+rclone copy "$STAGING" "$R2_DEST" \
+  --include "*.pkg.tar.zst" --include "*.pkg.tar.zst.sig" \
+  --include "${REPO_NAME}.db*" --include "${REPO_NAME}.files*"
+rclone copyto "$STAGING/${REPO_NAME}.gpg" "r2:${R2_BUCKET}/${REPO_NAME}.gpg"
+echo "Uploaded repo for $VER_RAW to $R2_DEST"
+
+# ── Retention: keep the newest $RETAIN package files per pkgname; prune the ─
+#    rest from R2 (best-effort — a prune failure must not fail the release, ──
+#    the new packages are already published).
+#
+# repo-add already replaced each pkgname's db entry with this run's version,
+# so the db points only at the latest build and the older files are orphans
+# the db never references. Pruning them is therefore a pure R2 cleanup — it
+# must NOT call repo-remove, which addresses by pkgname and would drop the
+# current (latest) entry, not an old version. The files are kept (not deleted
+# immediately) only to allow manual `pacman -U <url>` downgrades.
+prune_old() {
+  local listing pkgname
+  # "<mtime>;<path>" — sorted newest-first; group by pkgname, drop all but the
+  # newest RETAIN. pkgname is everything before the trailing
+  # -<pkgver>-<pkgrel>-<arch>.pkg.tar.zst (none of those three fields contain a
+  # hyphen: pkgver encodes '-' as '_', pkgrel is numeric, arch is x86_64/any).
+  listing="$(rclone lsf "$R2_DEST" --files-only --include '*.pkg.tar.zst' \
+    --format 'tp' --separator ';' 2>/dev/null | sort -r)" || return 0
+  declare -A seen=()
+  while IFS=';' read -r _mtime path; do
+    [[ -n "$path" ]] || continue
+    pkgname="$(printf '%s' "${path%.pkg.tar.zst}" | rev | cut -d- -f4- | rev)"
+    seen["$pkgname"]=$(( ${seen["$pkgname"]:-0} + 1 ))
+    if (( seen["$pkgname"] > RETAIN )); then
+      echo "Pruning old package: $path (keeping newest $RETAIN of $pkgname)"
+      rclone deletefile "$R2_DEST/$path" 2>/dev/null || true
+      rclone deletefile "$R2_DEST/$path.sig" 2>/dev/null || true
+    fi
+  done <<< "$listing"
+}
+prune_old || echo "::warning::retention prune hit an error — packages published, cleanup skipped"

--- a/packaging/arch-repo/publish-arch-repo.sh
+++ b/packaging/arch-repo/publish-arch-repo.sh
@@ -210,13 +210,15 @@ rclone copy "$R2_DEST" "$STAGING" \
 # R2 and are pruned below by RETAIN.
 repo-add --sign --key "$GPG_KEY_ID" "$STAGING/${REPO_NAME}.db.tar.gz" "$STAGING"/*.pkg.tar.zst
 
-# R2 (object storage) has no symlinks. repo-add writes `librefang.db` and
-# `librefang.files` as symlinks to their .tar.gz; materialise them as real
-# objects so `Server = …/$arch` + `pacman -Sy` can fetch them by plain name.
-for ext in db files; do
-  if [[ -L "$STAGING/${REPO_NAME}.${ext}" ]]; then
-    cp --remove-destination "$STAGING/${REPO_NAME}.${ext}.tar.gz" "$STAGING/${REPO_NAME}.${ext}"
-  fi
+# R2 (object storage) has no symlinks. repo-add --sign writes FOUR symlinks —
+# `librefang.db`, `librefang.db.sig`, `librefang.files`, `librefang.files.sig`
+# — each pointing at its .tar.gz / .tar.gz.sig target. Materialise every one as
+# a real object so `Server = …/$arch` + `pacman -Sy` can fetch the db AND its
+# detached signature by plain name; rclone silently skips symlinks, and a
+# missing `.db.sig` breaks signed-db verification (SigLevel) on the client.
+for link in "${REPO_NAME}.db" "${REPO_NAME}.db.sig" "${REPO_NAME}.files" "${REPO_NAME}.files.sig"; do
+  f="$STAGING/$link"
+  [[ -L "$f" ]] && cp --remove-destination "$(readlink -f "$f")" "$f"
 done
 
 # Publish the signing public key alongside the repo so the install docs can


### PR DESCRIPTION
## What

Implements the project-maintained pacman repository proposed in #6334 — the path that can actually ship today.
AUR account registration is closed with no reopening date, which blocks the AUR automation in #6341 (those jobs no-op forever without an AUR account).
This publishes the **same** release-pinned binary packages directly, so Arch users install with `pacman -Syu` and track every release through normal system updates.

The two are complementary, not competing: when AUR registration reopens, #6341 serves `yay` users; this serves `pacman` users. Nothing here changes or depends on #6341.

## How

A new `publish_arch_repo` job in `release.yml` runs on every `v*` tag (and on a `channel=current` re-publish), modeled on the existing `sync_homebrew*` jobs. It runs a composite action that executes `packaging/arch-repo/publish-arch-repo.sh` inside `archlinux:base-devel`, which:

- Reuses the committed PKGBUILDs under `packaging/aur/<package>/` as the **single source of truth**, deriving only the per-release values (`pkgver`, `sha256sums`, the desktop bundle version off the actual `.deb` asset name, the pinned `ghcr.io/...` tag) — the same derivation the AUR publisher in #6341 does.
- Builds and **GPG-signs** each package with `makepkg --sign` (no Rust compile — these repackage the prebuilt release artifacts).
- Folds `librefang-bin` / `librefang-desktop-bin` / `librefang-docker` into **one shared, signed** pacman database with `repo-add --sign`, pulling the existing db from R2 first so the update is incremental.
- Syncs packages, signatures, db, and the public key to **Cloudflare R2** (`packages.librefang.ai`).
- Prunes old package files beyond the newest 5 per package (best-effort; the db always points at the latest build).

**Single job, not three** (unlike #6341): all packages share one pacman db, so they must be `repo-add`'d together. A fixed `concurrency: { group: arch-pacman-repo }` serialises the read-modify-write on that db across releases. A failed build of one package is skipped with a `::warning::` and the others still publish.

## Design decisions I made (please confirm)

These were the open questions from the issue thread; I picked defaults and want a maintainer's sign-off:

- **Cloudflare R2, not GitHub Pages** (pavver's original suggestion). The project already runs on Cloudflare (`deploy-worker.yml`, `CLOUDFLARE_ACCOUNT_ID`); R2 has no GH-Pages 1GB/100GB soft caps, free egress, and `librefang.ai` DNS is presumably already there. `CLOUDFLARE_ACCOUNT_ID` is reused; only the R2 S3 keys are new.
- **First long-lived GPG key.** pacman verifies GPG/PGP only — it cannot use the cosign keyless signatures `sign_release_artifacts` produces. So this is the project's **first long-lived signing key**. Documented as an **offline primary key + passphrase-less CI subkey** so a runner compromise revokes the subkey without rotating the identity users imported.
- **Retain 5 versions / x86_64 only / publish every tag** (matches the committed PKGBUILDs' `arch=('x86_64')`, the desktop amd64-only bundle, and the Homebrew sync cadence). aarch64 and a separate `[librefang-beta]` channel are natural later extensions.

## Maintainer setup required (the job no-ops until then)

Safe to merge first — the job degrades to a `::notice::` no-op while any secret is unset, so forks and the unconfigured repo are unaffected. To activate (full commands + rotation policy in `.github/SECRETS.md`):

1. Create the signing key offline + an R2 bucket bound to `packages.librefang.ai`.
2. Add secrets: `ARCH_REPO_GPG_PRIVATE_KEY`, `ARCH_REPO_GPG_KEY_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`.
3. Validate via `workflow_dispatch` on `release.yml` (`channel=current`, `tag=<existing release>`) — the first run cold-starts the db.

## Verification

- `bash -n` passes on `publish-arch-repo.sh`.
- `yaml.safe_load` parses `action.yml` and `release.yml`.
- The composite action's `run:` block contains no `${{ }}` interpolation (no shell-injection surface); all values pass through `env:`.
- `needs:` targets (`cli_linux`, `desktop`, `docker-manifest`) all exist; the new job id is unique (32 jobs total).
- Walked the version round-trip, the desktop `.deb` version parse, the Docker image-tag re-pin, the symlink-materialisation for object storage, and the per-pkgname retention grouping against the real PKGBUILDs and pacman file-naming.

Live end-to-end (real GPG sign + R2 push + a real Arch container against real release assets) can only run the first time a maintainer dispatches a release with the secrets configured — it cannot run in CI without the key, exactly like the mobile/desktop signing jobs.

## Out-of-scope follow-up

- Docs-site (`docs/src/app/...integrations/cli`) integration of the install steps is deferred because it touches the Next.js site + its `zh` i18n mirror — a different domain than this CI/packaging change. The full install instructions live in `packaging/arch-repo/README.md` in the meantime; happy to do the site page in a follow-up if wanted.

Refs #6334
