### PR TITLE
feat(arch-repo): publish aarch64 packages alongside x86_64 (#6334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ _33 PRs from 5 contributors since v2026.6.22-beta.22._
 ### Added
 
 - Publish an official project-maintained pacman repository for Arch Linux — GPG-signed packages on Cloudflare R2, installable via `pacman -Syu`, sidestepping the closed AUR registration that blocks #6341 (#6334) (@houko)
+- Add aarch64 (Arch Linux ARM) packages to the pacman repository for `librefang-bin` and `librefang-docker`, published under `arch/aarch64/` and selected automatically by pacman's `$arch`; `librefang-desktop-bin` stays x86_64-only since upstream ships no ARM Linux desktop bundle (#6334) (@houko)
 
 ### Fixed
 

--- a/packaging/arch-repo/README.md
+++ b/packaging/arch-repo/README.md
@@ -28,24 +28,27 @@ sudo pacman -Syu
 sudo pacman -S librefang-bin librefang-desktop-bin
 ```
 
-`$arch` is pacman's own variable — leave it literal in `pacman.conf`; pacman expands it to `x86_64`.
+`$arch` is pacman's own variable — leave it literal in `pacman.conf`; pacman expands it to `x86_64` (or `aarch64` on Arch Linux ARM).
 Both the database and every package are GPG-signed, so the default `SigLevel` (inherited from `[options]`) verifies them once the key above is locally signed.
 Do **not** set `SigLevel = Never` — that disables the verification this repository exists to provide.
 
 Available packages:
 
-- `librefang-bin` — CLI, daemon, HTTP API, and dashboard on port 4545.
-- `librefang-desktop-bin` — native desktop launcher.
-- `librefang-docker` — Docker-backed systemd service pinned to the release tag.
+- `librefang-bin` — CLI, daemon, HTTP API, and dashboard on port 4545. x86_64 and aarch64.
+- `librefang-desktop-bin` — native desktop launcher. x86_64 only (upstream ships no ARM Linux desktop bundle).
+- `librefang-docker` — Docker-backed systemd service pinned to the release tag (`any`). x86_64 and aarch64.
+
+aarch64 serves Arch Linux ARM — the repo path is `arch/aarch64/`, selected automatically by pacman's `$arch`.
+On aarch64 only `librefang-bin` and `librefang-docker` are available (no ARM desktop bundle upstream); `pacman -S librefang-desktop-bin` there will report a target not found.
 
 ## How it works (CI)
 
 `release.yml`'s `publish_arch_repo` job runs `publish-arch-repo.sh` inside an `archlinux:base-devel` container on every `v*` tag (and on a `channel=current` re-publish).
-The script:
+It publishes one repo per architecture under `arch/<arch>/` (`x86_64` and `aarch64`). The script:
 
 1. Reuses the committed PKGBUILDs under `packaging/aur/<package>/` as the source of truth, deriving only the per-release values — `pkgver` (encoding the tag's first `-` as `_`), `pkgrel=1`, the desktop bundle version (read off the actual `LibreFang_<ver>_amd64.deb` asset name), the pinned `ghcr.io/librefang/librefang:<version>` tag — then regenerates `sha256sums` with `updpkgsums`.
-2. Builds and GPG-signs each package with `makepkg --sign` (no Rust compile — these repackage the prebuilt release artifacts).
-3. Folds every package into one shared, signed pacman database with `repo-add --sign`, pulling the existing database from R2 first so the update is incremental.
+2. Builds and GPG-signs each package with `makepkg --sign` (no Rust compile — these repackage the prebuilt release artifacts). aarch64 packages are repackaged on the x86_64 runner by repointing the source tarball to the `aarch64-unknown-linux-gnu` asset and setting `CARCH` (the arch field is metadata only); the host strip cannot process foreign binaries, so aarch64 sets `!strip` (the release tarball is already stripped upstream).
+3. Folds each arch's packages into that arch's shared, signed pacman database with `repo-add --sign`, pulling the existing database from R2 first so the update is incremental.
 4. Uploads the packages, signatures, database, and the public key to R2.
 5. Prunes old package files beyond the newest `RETAIN` (default 5) per package — best-effort, kept only for manual `pacman -U <url>` downgrades; the database always points at the latest build.
 

--- a/packaging/arch-repo/README.md
+++ b/packaging/arch-repo/README.md
@@ -44,7 +44,8 @@ On aarch64 only `librefang-bin` and `librefang-docker` are available (no ARM des
 ## How it works (CI)
 
 `release.yml`'s `publish_arch_repo` job runs `publish-arch-repo.sh` inside an `archlinux:base-devel` container on every `v*` tag (and on a `channel=current` re-publish).
-It publishes one repo per architecture under `arch/<arch>/` (`x86_64` and `aarch64`). The script:
+It publishes one repo per architecture under `arch/<arch>/` (`x86_64` and `aarch64`).
+The script:
 
 1. Reuses the committed PKGBUILDs under `packaging/aur/<package>/` as the source of truth, deriving only the per-release values — `pkgver` (encoding the tag's first `-` as `_`), `pkgrel=1`, the desktop bundle version (read off the actual `LibreFang_<ver>_amd64.deb` asset name), the pinned `ghcr.io/librefang/librefang:<version>` tag — then regenerates `sha256sums` with `updpkgsums`.
 2. Builds and GPG-signs each package with `makepkg --sign` (no Rust compile — these repackage the prebuilt release artifacts). aarch64 packages are repackaged on the x86_64 runner by repointing the source tarball to the `aarch64-unknown-linux-gnu` asset and setting `CARCH` (the arch field is metadata only); the host strip cannot process foreign binaries, so aarch64 sets `!strip` (the release tarball is already stripped upstream).

--- a/packaging/arch-repo/publish-arch-repo.sh
+++ b/packaging/arch-repo/publish-arch-repo.sh
@@ -13,8 +13,17 @@
 # (pkgver, sha256sums, the desktop bundle version, the pinned Docker image
 # tag) are derived here, exactly like the AUR publisher. The difference is
 # the tail: instead of pushing each PKGBUILD to its own AUR git repository,
-# this builds the .pkg.tar.zst, GPG-signs it, folds it into a single shared
+# this builds the .pkg.tar.zst, GPG-signs it, folds it into a per-arch shared
 # pacman database (repo-add), and syncs the result to Cloudflare R2.
+#
+# Multi-arch: publishes one repo per architecture under arch/<arch>/.
+#   x86_64  : librefang-bin, librefang-desktop-bin, librefang-docker
+#   aarch64 : librefang-bin, librefang-docker   (no ARM Linux desktop bundle
+#             exists upstream, so librefang-desktop-bin is x86_64-only)
+# The packages just repackage prebuilt release artifacts (no compilation), so
+# the aarch64 packages are built on the x86_64 runner by repointing the source
+# tarball and setting CARCH — makepkg's arch field is metadata only. The host
+# strip cannot process foreign binaries, so aarch64 builds disable !strip.
 #
 # Designed to run inside `archlinux:base-devel`. It self-bootstraps: when
 # invoked as root it installs the packaging + upload tooling, creates an
@@ -31,26 +40,32 @@
 #   R2_BUCKET            R2 bucket name (e.g. librefang-packages)
 # Optional:
 #   REPO_NAME            pacman db name (default "librefang")
-#   REPO_ARCH            target architecture (default "x86_64")
-#   REPO_PREFIX          object prefix inside the bucket (default "arch/$REPO_ARCH")
+#   ARCHES               space-separated arches to publish (default "x86_64 aarch64")
+#   REPO_PREFIX_BASE     object prefix base inside the bucket (default "arch"; the
+#                        per-arch repo lands at "$REPO_PREFIX_BASE/<arch>")
 #   RETAIN               old package versions to keep per pkgname (default 5)
 #   GITHUB_REPOSITORY    owner/repo for the release API (default librefang/librefang)
 #   GH_API_TOKEN         raises the unauthenticated GitHub API rate limit
 #
-# Usage: publish-arch-repo.sh   (builds all packages; takes no arguments)
+# Usage: publish-arch-repo.sh   (builds every package for every arch; no args)
 set -euo pipefail
 
 : "${RELEASE_TAG:?RELEASE_TAG is required}"
 REPO="${GITHUB_REPOSITORY:-librefang/librefang}"
 REPO_NAME="${REPO_NAME:-librefang}"
-REPO_ARCH="${REPO_ARCH:-x86_64}"
-REPO_PREFIX="${REPO_PREFIX:-arch/$REPO_ARCH}"
+ARCHES="${ARCHES:-x86_64 aarch64}"
+REPO_PREFIX_BASE="${REPO_PREFIX_BASE:-arch}"
 RETAIN="${RETAIN:-5}"
 
-# Packages folded into the repository. x86_64-only baseline (matches the
-# committed PKGBUILDs and the fact the desktop bundle ships amd64 only);
-# librefang-docker is arch=any but lands in the same x86_64 repo path.
-PACKAGES=(librefang-bin librefang-desktop-bin librefang-docker)
+# Which packages belong in a given arch's repo. librefang-docker is arch=any
+# and lands in every arch path; librefang-desktop-bin is x86_64-only because
+# upstream ships no ARM Linux desktop bundle.
+packages_for_arch() {
+  case "$1" in
+    x86_64) echo "librefang-bin librefang-desktop-bin librefang-docker" ;;
+    *)      echo "librefang-bin librefang-docker" ;;
+  esac
+}
 
 # ── Root phase: install tools, drop privileges, re-exec as builder ─────────
 if [[ "$(id -u)" -eq 0 ]]; then
@@ -77,19 +92,19 @@ if [[ "$(id -u)" -eq 0 ]]; then
         R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required}" \
         R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required}" \
         R2_BUCKET="${R2_BUCKET:?R2_BUCKET is required}" \
-        REPO_NAME="$REPO_NAME" REPO_ARCH="$REPO_ARCH" \
-        REPO_PREFIX="$REPO_PREFIX" RETAIN="$RETAIN" \
+        REPO_NAME="$REPO_NAME" ARCHES="$ARCHES" \
+        REPO_PREFIX_BASE="$REPO_PREFIX_BASE" RETAIN="$RETAIN" \
         bash "$0"
 fi
 
 # ── Builder phase ──────────────────────────────────────────────────────────
 VER_RAW="${RELEASE_TAG#v}"   # 2026.6.26-beta.24  (matches the git tag minus the v)
 VER_PKG="${VER_RAW/-/_}"     # 2026.6.26_beta.24  (Arch pkgver cannot contain '-')
-echo "Publishing pacman repo '$REPO_NAME' ($REPO_ARCH) for release $RELEASE_TAG (pkgver=$VER_PKG)"
+echo "Publishing pacman repo '$REPO_NAME' for release $RELEASE_TAG (pkgver=$VER_PKG); arches: $ARCHES"
 
-STAGING="$(mktemp -d)/repo"
+STAGING_BASE="$(mktemp -d)/repo"
 BUILDROOT="$(mktemp -d)/build"
-mkdir -p "$STAGING" "$BUILDROOT"
+mkdir -p "$STAGING_BASE" "$BUILDROOT"
 
 # ── GPG: import the signing key, mark it trusted for makepkg + repo-add ────
 gpg --batch --quiet --import "$GPG_KEY_FILE"
@@ -108,7 +123,6 @@ export RCLONE_CONFIG_R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.
 export RCLONE_CONFIG_R2_ACL=private
 # R2's S3 API rejects the trailing-checksum header rclone adds by default.
 export RCLONE_S3_NO_CHECK_BUCKET=true
-R2_DEST="r2:${R2_BUCKET}/${REPO_PREFIX}"
 
 api_release_json() {
   local hdr=(-H "Accept: application/vnd.github+json")
@@ -133,15 +147,17 @@ wait_for_asset() {
   return 1
 }
 
-# Build + sign one package from its committed PKGBUILD. Echoes nothing; on
-# success the signed .pkg.tar.zst (+ .sig) land in $STAGING. Returns non-zero
-# on failure so the caller can skip just that package without sinking the rest.
+# Build + sign one package from its committed PKGBUILD for arch $2. On success
+# the signed .pkg.tar.zst (+ .sig) land in $STAGING (the per-arch dir, set by
+# the caller). Returns non-zero on failure so the caller can skip just that
+# package without sinking the rest. CARCH is set per-arch in ~/.makepkg.conf
+# by the caller before this runs.
 build_pkg() {
-  local pkg="$1"
+  local pkg="$1" arch="$2"
   local src="/repo/packaging/aur/$pkg"
   [[ -f "$src/PKGBUILD" ]] || { echo "::warning::no PKGBUILD at $src — skipping $pkg"; return 1; }
 
-  local work="$BUILDROOT/$pkg"
+  local work="$BUILDROOT/$arch/$pkg"
   mkdir -p "$work"
   # Plain -R (not -a): the source tree is bind-mounted with a foreign owner,
   # and preserving ownership as the unprivileged builder fails under set -e.
@@ -154,7 +170,16 @@ build_pkg() {
 
   case "$pkg" in
     librefang-bin)
-      wait_for_asset "librefang-${REPO_ARCH}-unknown-linux-gnu.tar.gz" >/dev/null
+      # Repoint the source tarball + arch field to the target arch. These are
+      # prebuilt binaries, so the only per-arch change is which tarball to pull
+      # and the metadata arch. The host strip can't process foreign binaries —
+      # disable it (the release tarball is already stripped upstream anyway).
+      if [[ "$arch" != x86_64 ]]; then
+        sed -i "s/x86_64-unknown-linux-gnu/${arch}-unknown-linux-gnu/g" PKGBUILD
+        sed -i "s/^arch=.*/arch=('$arch')/" PKGBUILD
+        sed -i "s/^options=.*/options=('!debug' '!strip')/" PKGBUILD
+      fi
+      wait_for_asset "librefang-${arch}-unknown-linux-gnu.tar.gz" >/dev/null
       ;;
     librefang-desktop-bin)
       # The Tauri bundle version differs from the release tag; read it off the
@@ -169,6 +194,7 @@ build_pkg() {
     librefang-docker)
       # No release asset to download — re-pin the embedded image tag in the
       # helper + env (their sha256sums then change and are regenerated below).
+      # arch=any; the same package lands in every arch's repo.
       sed -i -E "s#(ghcr\.io/librefang/librefang:)[A-Za-z0-9._-]+#\1$VER_RAW#g" \
         librefang-docker librefang-docker.env
       ;;
@@ -186,68 +212,15 @@ build_pkg() {
   cp ./*.pkg.tar.zst ./*.pkg.tar.zst.sig "$STAGING"/
 }
 
-# ── Build every package; collect which ones succeeded ──────────────────────
-built=()
-for pkg in "${PACKAGES[@]}"; do
-  if build_pkg "$pkg"; then
-    built+=("$pkg")
-  else
-    echo "::warning::build failed for $pkg — it will not be published this run"
-  fi
-done
-[[ ${#built[@]} -gt 0 ]] || { echo "::error::no packages built — nothing to publish"; exit 1; }
-echo "Built: ${built[*]}"
-
-cd "$STAGING"
-
-# ── Fold into the shared pacman db (pull the existing db first; cold start ──
-#    on first run simply finds none and creates a fresh one). ───────────────
-rclone copy "$R2_DEST" "$STAGING" \
-  --include "${REPO_NAME}.db*" --include "${REPO_NAME}.files*" 2>/dev/null || true
-
-# repo-add replaces any same-pkgname entry with the new version, so the db
-# always points at the latest build; older package files become orphaned in
-# R2 and are pruned below by RETAIN.
-repo-add --sign --key "$GPG_KEY_ID" "$STAGING/${REPO_NAME}.db.tar.gz" "$STAGING"/*.pkg.tar.zst
-
-# R2 (object storage) has no symlinks. repo-add --sign writes FOUR symlinks —
-# `librefang.db`, `librefang.db.sig`, `librefang.files`, `librefang.files.sig`
-# — each pointing at its .tar.gz / .tar.gz.sig target. Materialise every one as
-# a real object so `Server = …/$arch` + `pacman -Sy` can fetch the db AND its
-# detached signature by plain name; rclone silently skips symlinks, and a
-# missing `.db.sig` breaks signed-db verification (SigLevel) on the client.
-for link in "${REPO_NAME}.db" "${REPO_NAME}.db.sig" "${REPO_NAME}.files" "${REPO_NAME}.files.sig"; do
-  f="$STAGING/$link"
-  [[ -L "$f" ]] && cp --remove-destination "$(readlink -f "$f")" "$f"
-done
-
-# Publish the signing public key alongside the repo so the install docs can
-# point users at a stable URL (idempotent — overwrites the same object).
-gpg --batch --armor --export "$GPG_KEY_ID" > "$STAGING/${REPO_NAME}.gpg"
-
-# ── Upload: packages + signatures + db + files + public key ────────────────
-rclone copy "$STAGING" "$R2_DEST" \
-  --include "*.pkg.tar.zst" --include "*.pkg.tar.zst.sig" \
-  --include "${REPO_NAME}.db*" --include "${REPO_NAME}.files*"
-rclone copyto "$STAGING/${REPO_NAME}.gpg" "r2:${R2_BUCKET}/${REPO_NAME}.gpg"
-echo "Uploaded repo for $VER_RAW to $R2_DEST"
-
-# ── Retention: keep the newest $RETAIN package files per pkgname; prune the ─
-#    rest from R2 (best-effort — a prune failure must not fail the release, ──
-#    the new packages are already published).
-#
-# repo-add already replaced each pkgname's db entry with this run's version,
-# so the db points only at the latest build and the older files are orphans
-# the db never references. Pruning them is therefore a pure R2 cleanup — it
-# must NOT call repo-remove, which addresses by pkgname and would drop the
-# current (latest) entry, not an old version. The files are kept (not deleted
-# immediately) only to allow manual `pacman -U <url>` downgrades.
+# Keep the newest $RETAIN package files per pkgname in $R2_DEST; prune the rest
+# (best-effort — a prune failure must not fail the release, the new packages
+# are already published). repo-add already replaced each pkgname's db entry
+# with this run's version, so older files are orphans the db never references;
+# pruning is a pure R2 cleanup and must NOT call repo-remove (which addresses
+# by pkgname and would drop the current entry). Files are kept (not deleted at
+# once) only to allow manual `pacman -U <url>` downgrades.
 prune_old() {
   local listing pkgname
-  # "<mtime>;<path>" — sorted newest-first; group by pkgname, drop all but the
-  # newest RETAIN. pkgname is everything before the trailing
-  # -<pkgver>-<pkgrel>-<arch>.pkg.tar.zst (none of those three fields contain a
-  # hyphen: pkgver encodes '-' as '_', pkgrel is numeric, arch is x86_64/any).
   listing="$(rclone lsf "$R2_DEST" --files-only --include '*.pkg.tar.zst' \
     --format 'tp' --separator ';' 2>/dev/null | sort -r)" || return 0
   declare -A seen=()
@@ -262,4 +235,66 @@ prune_old() {
     fi
   done <<< "$listing"
 }
-prune_old || echo "::warning::retention prune hit an error — packages published, cleanup skipped"
+
+# ── Per-arch: build → fold into that arch's db → upload arch/<arch>/ ────────
+published=0
+for arch in $ARCHES; do
+  echo "═══ arch: $arch ═══"
+  # makepkg reads CARCH from makepkg.conf (not the environment); override it
+  # per-arch in the builder's own config so package names + the arch check use
+  # the target arch. Everything else is inherited from /etc/makepkg.conf.
+  printf 'CARCH="%s"\n' "$arch" > "$HOME/.makepkg.conf"
+
+  STAGING="$STAGING_BASE/$arch"
+  mkdir -p "$STAGING"
+  R2_DEST="r2:${R2_BUCKET}/${REPO_PREFIX_BASE}/${arch}"
+
+  built=()
+  for pkg in $(packages_for_arch "$arch"); do
+    if build_pkg "$pkg" "$arch"; then
+      built+=("$pkg")
+    else
+      echo "::warning::build failed for $pkg ($arch) — not published this run"
+    fi
+  done
+  if [[ ${#built[@]} -eq 0 ]]; then
+    echo "::warning::no packages built for $arch — skipping"
+    continue
+  fi
+  echo "Built ($arch): ${built[*]}"
+
+  cd "$STAGING"
+
+  # Pull the existing db first so the update is incremental (cold start on the
+  # first run simply finds none and creates a fresh one).
+  rclone copy "$R2_DEST" "$STAGING" \
+    --include "${REPO_NAME}.db*" --include "${REPO_NAME}.files*" 2>/dev/null || true
+
+  repo-add --sign --key "$GPG_KEY_ID" "$STAGING/${REPO_NAME}.db.tar.gz" "$STAGING"/*.pkg.tar.zst
+
+  # Object storage has no symlinks. repo-add --sign writes four — db, db.sig,
+  # files, files.sig — each pointing at its .tar.gz / .tar.gz.sig target.
+  # Materialise every one as a real object so pacman can fetch the db AND its
+  # detached signature by plain name; rclone skips symlinks, and a missing
+  # .db.sig breaks signed-db verification (SigLevel) on the client.
+  for link in "${REPO_NAME}.db" "${REPO_NAME}.db.sig" "${REPO_NAME}.files" "${REPO_NAME}.files.sig"; do
+    f="$STAGING/$link"
+    [[ -L "$f" ]] && cp --remove-destination "$(readlink -f "$f")" "$f"
+  done
+
+  rclone copy "$STAGING" "$R2_DEST" \
+    --include "*.pkg.tar.zst" --include "*.pkg.tar.zst.sig" \
+    --include "${REPO_NAME}.db*" --include "${REPO_NAME}.files*"
+  echo "Uploaded $arch repo for $VER_RAW to $R2_DEST"
+
+  prune_old || echo "::warning::retention prune hit an error for $arch — packages published, cleanup skipped"
+  published=$(( published + 1 ))
+done
+
+[[ $published -gt 0 ]] || { echo "::error::no arch published — nothing uploaded"; exit 1; }
+
+# ── Publish the signing public key once (arch-independent, bucket root) so the
+#    install docs can point users at a stable URL (idempotent). ──────────────
+gpg --batch --armor --export "$GPG_KEY_ID" > "$STAGING_BASE/${REPO_NAME}.gpg"
+rclone copyto "$STAGING_BASE/${REPO_NAME}.gpg" "r2:${R2_BUCKET}/${REPO_NAME}.gpg"
+echo "Published signing public key to r2:${R2_BUCKET}/${REPO_NAME}.gpg"


### PR DESCRIPTION
## What

Extends the project-maintained pacman repository (#6352) to **aarch64** (Arch Linux ARM).

It was x86_64-only. Now `librefang-bin` and `librefang-docker` are also published for aarch64 under `arch/aarch64/`. `librefang-desktop-bin` stays x86_64-only because upstream ships no ARM Linux desktop bundle (the arm64 release assets are Windows/macOS only).

## How

`publish-arch-repo.sh` loops over `ARCHES` (default `x86_64 aarch64`), publishing one signed pacman repo per arch under `arch/<arch>/`. Clients pick the right one automatically through pacman's `$arch` in the existing `Server = …/arch/$arch` line — **no install-doc change**.

These packages repackage prebuilt release binaries (no compile), so aarch64 builds on the x86_64 runner:

- `librefang-bin`: repoint the source tarball to the `aarch64-unknown-linux-gnu` asset, set `arch=('aarch64')` + `CARCH` (via `~/.makepkg.conf`), and `!strip` — the host strip can't process foreign binaries, and the release tarball is already stripped upstream.
- `librefang-docker`: `arch=any`, lands in every arch path.

No change to `action.yml` / `release.yml` / secrets — the multi-arch loop is entirely inside the script.

## Verification

Local amd64 container (`file` is the decisive evidence that we shipped a real ARM package, not a mislabeled x86_64 one):

- `updpkgsums` pulls `librefang-aarch64-unknown-linux-gnu.tar.gz`, sha passes
- produces `librefang-bin-…-aarch64.pkg.tar.zst`; `pacman -Qip` → `Architecture: aarch64`
- `file` on the bundled `/usr/bin/librefang` → `ELF 64-bit LSB pie executable, ARM aarch64 … stripped`
- `bash -n` clean on the rewritten script

The x86_64 path is unchanged from the merged #6352 (already verified end-to-end: real `pacman -S librefang-bin` install + signature check on a live Arch container). The first CI release confirms the aarch64 path on the native amd64 runner.

Refs #6334
