### PR TITLE
fix(deps): clear cargo-deny advisory failures on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/deny.toml
+++ b/deny.toml
@@ -61,6 +61,7 @@ ignore = [
     { id = "RUSTSEC-2025-0081", reason = "unic-* unmaintained (kuchikiki/selectors chain). https://rustsec.org/advisories/RUSTSEC-2025-0081" },
     { id = "RUSTSEC-2025-0098", reason = "unic-* unmaintained (kuchikiki/selectors chain). https://rustsec.org/advisories/RUSTSEC-2025-0098" },
     { id = "RUSTSEC-2025-0100", reason = "unic-* unmaintained (kuchikiki/selectors chain). https://rustsec.org/advisories/RUSTSEC-2025-0100" },
+    { id = "RUSTSEC-2026-0192", reason = "ttf-parser unmaintained; transitive via pdf-extract -> lopdf, no safe upgrade available. https://rustsec.org/advisories/RUSTSEC-2026-0192" },
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Restore a green `cargo-deny (advisories)` job on `main`. Two RustSec advisories began failing the audit once they were published to the live advisory DB — `main` went red with no source change of ours.

## Advisories

- **RUSTSEC-2026-0190** — `anyhow` 1.0.102 has an unsoundness in `Error::downcast_mut()` (UB when downcasting after `Error::context`). Fixed upstream in 1.0.103. Remediated by bumping the lockfile only (`cargo update -p anyhow`), so it applies to every dependency path, not just the `agent-client-protocol` chain that surfaced it.
- **RUSTSEC-2026-0192** — `ttf-parser` 0.25.1 is unmaintained (author has stated no further fixes). No safe upgrade is available, and it is transitive via `pdf-extract -> lopdf -> ttf-parser`. Added a scoped `ignore` entry to `deny.toml` next to the other unmaintained transitive crates, matching the existing policy and the precedent set by #6339 (the lopdf RUSTSEC fix).

## Changes

- `Cargo.lock`: `anyhow` 1.0.102 -> 1.0.103.
- `deny.toml`: ignore `RUSTSEC-2026-0192` with a linked, scoped reason.

## Verification

- `cargo deny check advisories` -> `advisories ok`.
- `cargo deny check` (all: advisories, bans, licenses, sources) -> `advisories ok, bans ok, licenses ok, sources ok`. Pre-existing wildcard `warn`s on workspace-internal path deps are unchanged.

## Out-of-scope findings (surfaced, not fixed here)

- **`Nix Build` failure on `main`** — `error: Nix daemon disconnected unexpectedly` during `librefang-acp` compilation. Infra/OOM flake, not a code issue; its failed job has been re-run on `main`.
- **Misplaced `## [Unreleased]` in `CHANGELOG.md`** — the single `## [Unreleased]` heading is buried between `[2026.6.24]` and `[2026.6.22]` (≈ line 136) instead of at the top above `[2026.6.29]`, and the section is ~480 lines with duplicated `### Fixed` / `### Added` subsections — pending entries accumulated across cycles without reorganization. Entries are not dropped today (there is only one `[Unreleased]`), but the next release will emit a release block in the wrong position and the section is disorganized. Reorganizing it needs a maintainer call on what was already shipped (e.g. #6334 appears both here and in `[2026.6.29]`), so it is intentionally left out of this CI-fix PR — and no CHANGELOG entry was added here, since adding one at the correct top position would create a second `[Unreleased]` and trip the duplicate guard.
