### PR TITLE
chore(deps): adopt tera 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,16 +856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,30 +3313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.13.0",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3888,22 +3854,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]
@@ -10118,18 +10068,11 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.20.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+checksum = "38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c"
 dependencies = [
- "globwalk",
- "lazy_static",
- "pest",
- "pest_derive",
- "regex",
  "serde",
- "serde_json",
- "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ psl = "2"
 # trees that we would have to babysit for security. Pin a single major
 # so a future bump is a deliberate review, not a transient dependabot
 # ping.
-tera = { version = "1", default-features = false }
+tera = { version = "2", default-features = false }
 
 # WASM sandbox
 wasmtime = "46"

--- a/crates/librefang-api/tests/workflow_operator_nodes_test.rs
+++ b/crates/librefang-api/tests/workflow_operator_nodes_test.rs
@@ -560,13 +560,19 @@ async fn transform_step_missing_variable_halts_workflow_with_recorded_reason() {
 async fn transform_step_oversize_output_halts_workflow_with_recorded_reason() {
     let test = boot();
     let engine = test.state.kernel.workflow_engine();
-    // Tera's `range()` builtin is enabled by default; this template
-    // renders roughly 2 * MAX_TRANSFORM_OUTPUT_BYTES bytes — guaranteed
-    // to trip the cap.
-    let code = format!(
-        "{{% for i in range(end={}) %}}xx{{% endfor %}}",
-        MAX_TRANSFORM_OUTPUT_BYTES
+    // Render roughly 2 * MAX_TRANSFORM_OUTPUT_BYTES bytes to trip our own
+    // output cap. Tera 2.0 caps the `range()` builtin at 100_000 elements, so
+    // we can no longer loop MAX_TRANSFORM_OUTPUT_BYTES (1 MiB) times; emit a
+    // wide chunk per iteration and keep the loop count well under tera's range
+    // cap instead.
+    const CHUNK_BYTES: usize = 64;
+    let iters = (2 * MAX_TRANSFORM_OUTPUT_BYTES).div_ceil(CHUNK_BYTES);
+    assert!(
+        iters < 100_000,
+        "loop count {iters} must stay under tera 2.0's range() limit"
     );
+    let chunk = "x".repeat(CHUNK_BYTES);
+    let code = format!("{{% for i in range(end={iters}) %}}{chunk}{{% endfor %}}");
     let workflow = workflow_with_op_step("transform-huge", StepMode::Transform { code });
     let wf_id = workflow.id;
     engine.register(workflow).await;

--- a/crates/librefang-api/tests/workflow_operator_nodes_test.rs
+++ b/crates/librefang-api/tests/workflow_operator_nodes_test.rs
@@ -560,11 +560,7 @@ async fn transform_step_missing_variable_halts_workflow_with_recorded_reason() {
 async fn transform_step_oversize_output_halts_workflow_with_recorded_reason() {
     let test = boot();
     let engine = test.state.kernel.workflow_engine();
-    // Render roughly 2 * MAX_TRANSFORM_OUTPUT_BYTES bytes to trip our own
-    // output cap. Tera 2.0 caps the `range()` builtin at 100_000 elements, so
-    // we can no longer loop MAX_TRANSFORM_OUTPUT_BYTES (1 MiB) times; emit a
-    // wide chunk per iteration and keep the loop count well under tera's range
-    // cap instead.
+    // Trip the output cap; tera 2.0 limits range() to 100k iterations, so emit a wide chunk per loop.
     const CHUNK_BYTES: usize = 64;
     let iters = (2 * MAX_TRANSFORM_OUTPUT_BYTES).div_ceil(CHUNK_BYTES);
     assert!(


### PR DESCRIPTION
## What

Adopt `tera` 2.0 (1.20 → 2.0). Supersedes #6363 (dependabot), which could not merge: it was based on stale `main` (failing the now-fixed `cargo-deny` advisory from #6366) and failed one test under tera 2.0.

## The tera 2.0 break

tera 2.0 added a hard cap of 100_000 elements to the `range()` builtin. The test `transform_step_oversize_output_halts_workflow_with_recorded_reason` built `{% for i in range(end=1048576) %}xx{% endfor %}` to render ~2 MiB and trip our own `MAX_TRANSFORM_OUTPUT_BYTES` (1 MiB) cap. Under tera 2.0 the render now fails inside tera's range check *before* our cap fires, so the halt reason no longer names the cap and the assertion fails.

## Fix

The test now emits a wide 64-byte chunk per iteration and keeps the loop count (`2 * MAX_TRANSFORM_OUTPUT_BYTES / 64` = 32768) well under tera's range limit, with an assert guarding that bound. It still renders > `MAX_TRANSFORM_OUTPUT_BYTES` and exercises the same cap-halt path, so the test's intent is unchanged.

`render_transform_template` / `validate_transform_template` in `librefang-kernel` compile unchanged against tera 2.0. The bump also drops the unused glob template-loader transitive deps (bstr, globset, globwalk, ignore).

## Verification (local, scoped)

- `cargo check -p librefang-kernel` — clean (workflow.rs compiles against tera 2.0).
- `cargo test -p librefang-api --test workflow_operator_nodes_test` — 20 passed (incl. the previously-failing oversize test).
- `cargo test -p librefang-kernel workflow` — passed.
- `cargo clippy -p librefang-kernel -- -D warnings` — zero warnings.
- `cargo fmt -p librefang-api -- --check` — clean.
