### PR TITLE
chore: gitignore the AUR CI deploy key pair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ config.toml
 *.cert
 *.p12
 *.pfx
+# AUR CI deploy key pair (OpenSSH key has no extension, so *.pem / *.key miss it).
+# Lives at the repo root for local AUR publishing; never commit it.
+/aur_ci
+/aur_ci.pub
 
 # Runtime artifacts
 collector_hand_state.json


### PR DESCRIPTION
## What

Ignore the AUR CI deploy key pair (`aur_ci` private key + `aur_ci.pub`) that lives untracked at the repo root for local AUR publishing.

## Why

The existing `*.pem` / `*.key` rules in the "Certificates & keys" block don't match these: an OpenSSH private key has no extension, and the public half ends in `.pub`. Without an explicit rule a stray `git add -A` (or an editor's "stage all") could commit the private key. The entries are anchored to the repo root (`/aur_ci`, `/aur_ci.pub`) so they only ignore these specific files, not any `aur_ci` deeper in the tree.

No tracked files are affected — both are currently untracked.
