### PR TITLE
fix(deps): clear quick-xml RUSTSEC-2026-0194/0195 advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 - Surface the model each CLI passthrough provider (`codex-cli`, `claude-code`, `gemini-cli`, `qwen-code`) is configured to run, read live from the tool's own config, so a custom model — DeepSeek via `~/.codex/config.toml`, a Kimi/Moonshot id via Claude Code's `ANTHROPIC_MODEL` / `~/.claude/settings.json`, a Gemini preview via `GEMINI_MODEL` / `~/.gemini/settings.json`, or an OpenAI-compatible id via `~/.qwen/settings.json` — is recognised on the Providers page and in the agent model picker instead of only the catalog's default models (#6365) (@houko)
 - Stop CLI providers (`codex-cli`, `gemini-cli`, `claude-code`, `qwen-code`) from forcing a placeholder `--model <provider-id>` onto their CLI for a bare provider id, so each CLI defers to its own configured default model (#6365) (@houko)
 - Clear `cargo-deny` advisory failures on `main` by bumping `anyhow` to 1.0.103 (RUSTSEC-2026-0190) and ignoring the unmaintained `ttf-parser` advisory (RUSTSEC-2026-0192 — transitive via `pdf-extract` → `lopdf`, no safe upgrade available) (#6366) (@houko)
+- Clear the `quick-xml` advisories RUSTSEC-2026-0194 / RUSTSEC-2026-0195 by bumping `plist` to 1.10.0 (pulls the patched `quick-xml` 0.41.0) and `tauri-winrt-notification` to 0.7.3 (drops its `quick-xml` dependency), removing both vulnerable versions from the lockfile (#6387) (@houko)
 
 ### Documentation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,7 +3055,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -6909,13 +6909,13 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -7347,18 +7347,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -9954,11 +9945,10 @@ dependencies = [
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "quick-xml 0.37.5",
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-version",


### PR DESCRIPTION
## Summary

Two quick-xml advisories published today fail `cargo-deny (advisories)` and the `Security` audit job on every branch that runs them, main included (first surfaced on #6384, whose changes are unrelated):

- RUSTSEC-2026-0194 — quadratic runtime when checking a start tag for duplicate attribute names.
- RUSTSEC-2026-0195 — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS).

Both are patched only in quick-xml >= 0.41.0.
The lockfile carried two vulnerable copies: 0.38.4 via `plist` (tauri chain) and 0.37.5 via `tauri-winrt-notification` (notify-rust chain).

## Changes

- `cargo update -p plist -p tauri-winrt-notification` — Cargo.lock only, no code changes:
  - `plist` 1.8.0 → 1.10.0, which depends on the patched `quick-xml` ^0.41.0.
  - `tauri-winrt-notification` 0.7.2 → 0.7.3, which drops its `quick-xml` dependency entirely (its `windows-link` reference moves to 0.2.1, already present in the lockfile).
  - Both vulnerable `quick-xml` versions (0.37.5, 0.38.4) leave the lockfile; 0.41.0 is the only remaining copy.
- CHANGELOG entry under `[Unreleased]` / `### Fixed`.

## Verification

- Lock diff audited by hand: only `plist`, `quick-xml`, `tauri-winrt-notification`, and the `windows-link` reference inside `tauri-winrt-notification` change.
- Upstream semver constraints allow both bumps in place: tauri / tauri-utils require `plist ^1`, notify-rust requires `tauri-winrt-notification ^0.7`, so no direct-dependency changes are needed.
- Lock-only change; the full build/test matrix on CI validates the upgraded tauri chain.

Unblocks #6384 — its `cargo-deny (advisories)` / `Security` failures are these advisories, not that PR's own changes.
