### PR TITLE
ci(nix-build): raise job timeout to 120 minutes for cold builds

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -31,7 +31,9 @@ jobs:
   nix-build:
     name: nix build (${{ matrix.package }})
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Cold builds are the norm here: the Rust CI lanes churn through the repo's 10 GB Actions cache quota daily, so the /nix/store cache below is usually evicted before the next run and each leg rebuilds the full crane deps + workspace closure from scratch.
+    # A cold librefang-cli leg takes ~80-95 minutes (it was still compiling workspace crates when a 60-minute limit cancelled it), so 120 covers a cold build with margin while still catching a genuinely hung one.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 - Stop CLI providers (`codex-cli`, `gemini-cli`, `claude-code`, `qwen-code`) from forcing a placeholder `--model <provider-id>` onto their CLI for a bare provider id, so each CLI defers to its own configured default model (#6365) (@houko)
 - Clear `cargo-deny` advisory failures on `main` by bumping `anyhow` to 1.0.103 (RUSTSEC-2026-0190) and ignoring the unmaintained `ttf-parser` advisory (RUSTSEC-2026-0192 — transitive via `pdf-extract` → `lopdf`, no safe upgrade available) (#6366) (@houko)
 - Clear the `quick-xml` advisories RUSTSEC-2026-0194 / RUSTSEC-2026-0195 by bumping `plist` to 1.10.0 (pulls the patched `quick-xml` 0.41.0) and `tauri-winrt-notification` to 0.7.3 (drops its `quick-xml` dependency), removing both vulnerable versions from the lockfile (#6387) (@houko)
+- Raise the Nix Build job timeout to 120 minutes so the now-routine cold builds — the Rust CI lanes churn the repo's 10 GB Actions cache quota daily, evicting the `/nix/store` cache between runs — complete instead of being cancelled at 60 minutes, unbreaking the workflow that had been red on `main` since June 11 (#6389) (@houko)
 
 ### Documentation
 


### PR DESCRIPTION
## Problem

The Nix Build workflow has not gone green on `main` since June 11 (last success: run 27324913045).
Every push-to-main run since then either failed with `Nix daemon disconnected unexpectedly` (late June) or was cancelled at exactly 1h00m by the 60-minute job timeout (run 28433400325, run 28709165648 — both matrix legs).

## Diagnosis

- The `/nix/store` cache saved by `cache-nix-action` almost never survives to the next run: the Rust CI lanes create ~8 caches of 0.9–1.9 GiB each per day (≈9.6 GiB on July 4 alone), which churns through the repo's 10 GB Actions cache quota and LRU-evicts the `nix-*` entries. Every Nix Build run is therefore a cold build of the full crane deps + workspace closure.
- The eviction was already biting on June 11: the `librefang-desktop` leg finished in 82 s (full cache hit) while the `librefang-cli` leg took 56 min (its cache had been evicted) — right at the edge of the 60-minute limit.
- In the July 4 cancelled run the cli leg was still compiling workspace crates (`librefang-acp`, with `librefang-api` and the final link still ahead) at the 60-minute mark, putting a cold leg at roughly 80–95 minutes.
- The `Nix daemon disconnected` failures from late June were the disk-exhaustion mode tracked in #6081/#6082. That mode is gone: runners now report a 145 GB disk with ~89 GB free *before* the free-space step (July 4 run logs). The free-space step is kept as cheap defense.

## Change

- Raise `timeout-minutes` from 60 to 120 in `.github/workflows/nix-build.yml`, with a comment recording why (cold builds are the norm while the cache quota is contended; 120 covers an observed ~80–95 min cold leg with margin while still catching a hung build).
- CHANGELOG entry under `[Unreleased]`.

## Verification

- `workflow_dispatch` run of Nix Build on this branch (both legs must complete within the new limit): https://github.com/librefang/librefang/actions/runs/28730744137 — a cold run takes ~80–95 min; check the result there rather than waiting on this thread.

## Out of scope, surfaced for a maintainer decision

The durable fix for the cache eviction is an external binary cache (Cachix / FlakeHub cache), which needs an account + repo secret and is deliberately not part of this PR.
Without it, Nix Build stays a cold ~80–95 min job on every Cargo.lock-touching push to main.
