### PR TITLE
fix(deps): clear crossbeam-epoch RUSTSEC-2026-0204 advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
+- Clear the `cargo-deny` / security-audit advisory RUSTSEC-2026-0204 failing CI on every branch by bumping the transitive `crossbeam-epoch` to 0.9.20 (invalid pointer dereference in the `fmt::Pointer` / `fmt::Display` impls for null `Atomic` / `Shared` pointers; pulled in via `rayon-core` → `crossbeam-deque`, lockfile-only change) (#6400) (@houko)
 - Surface the model each CLI passthrough provider (`codex-cli`, `claude-code`, `gemini-cli`, `qwen-code`) is configured to run, read live from the tool's own config, so a custom model — DeepSeek via `~/.codex/config.toml`, a Kimi/Moonshot id via Claude Code's `ANTHROPIC_MODEL` / `~/.claude/settings.json`, a Gemini preview via `GEMINI_MODEL` / `~/.gemini/settings.json`, or an OpenAI-compatible id via `~/.qwen/settings.json` — is recognised on the Providers page and in the agent model picker instead of only the catalog's default models (#6365) (@houko)
 - Stop CLI providers (`codex-cli`, `gemini-cli`, `claude-code`, `qwen-code`) from forcing a placeholder `--model <provider-id>` onto their CLI for a bare provider id, so each CLI defers to its own configured default model (#6365) (@houko)
 - Clear `cargo-deny` advisory failures on `main` by bumping `anyhow` to 1.0.103 (RUSTSEC-2026-0190) and ignoring the unmaintained `ttf-parser` advisory (RUSTSEC-2026-0192 — transitive via `pdf-extract` → `lopdf`, no safe upgrade available) (#6366) (@houko)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

RUSTSEC-2026-0204 was published against `crossbeam-epoch` 0.9.18 (invalid pointer dereference in the `fmt::Pointer` / `fmt::Display` impls for null `Atomic` / `Shared` pointers, fixed in 0.9.20).
Since 2026-07-07 it fails `cargo-deny (advisories)`, the `Security` audit job, and therefore `CI Gate` on `main` and every open PR — including unrelated ones such as #6394.

## Changes

- `cargo update -p crossbeam-epoch` — bumps the transitive `crossbeam-epoch` 0.9.18 → 0.9.20 in `Cargo.lock`.
  It is pulled in via `rayon-core` → `crossbeam-deque`; no direct dependency, no source change.
- CHANGELOG entry under `[Unreleased]`.

## Verification

- `Cargo.lock` diff is the single-package bump (`Locking 1 package to latest compatible version`).
- The advisory's listed solution is exactly this upgrade (`>= 0.9.20`).
- CI on this PR runs the same `cargo-deny` / `Security` lanes that were red; they gate the merge.

Same pattern as the previous advisory clears #6366 (`anyhow`) and #6387 (`quick-xml`).
