### PR TITLE
docs(readme): install CLI from official homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,18 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
+> 🎉 **LibreFang is now in [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Accepted into the official Homebrew tap on 2026-07-08 — install the CLI with zero setup, no tap required.
+
+```bash
+brew install librefang              # CLI (stable) — official homebrew-core
+```
+
+The desktop app and pre-release channels are published through the LibreFang tap:
+
 ```bash
 brew tap librefang/tap
-brew install librefang              # CLI (stable)
 brew install --cask librefang       # Desktop (stable)
-# Beta/RC channels also available:
+# Beta/RC channels:
 # brew install librefang-beta       # or librefang-rc
 # brew install --cask librefang-rc  # or librefang-beta
 ```

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -63,13 +63,20 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
+> 🎉 **LibreFang ist jetzt in [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Am 2026-07-08 in den offiziellen Homebrew-Tap aufgenommen — die CLI lässt sich ohne Einrichtung und ohne Tap installieren.
+
+```bash
+brew install librefang              # CLI (stable) — offizielles homebrew-core
+```
+
+Die Desktop-App und die Vorabversions-Kanäle werden weiterhin über den LibreFang-Tap veröffentlicht:
+
 ```bash
 brew tap librefang/tap
-brew install librefang              # CLI (stable)
 brew install --cask librefang       # Desktop (stable)
-# Beta/RC channels also available:
-# brew install librefang-beta       # or librefang-rc
-# brew install --cask librefang-rc  # or librefang-beta
+# Beta/RC-Kanäle:
+# brew install librefang-beta       # oder librefang-rc
+# brew install --cask librefang-rc  # oder librefang-beta
 ```
 
 </details>

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -63,13 +63,20 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
+> 🎉 **¡LibreFang ya está en [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Aceptado en el tap oficial de Homebrew el 2026-07-08: instala la CLI sin configuración y sin necesidad de tap.
+
+```bash
+brew install librefang              # CLI (stable) — homebrew-core oficial
+```
+
+La app de escritorio y los canales de prelanzamiento se siguen publicando a través del tap de LibreFang:
+
 ```bash
 brew tap librefang/tap
-brew install librefang              # CLI (stable)
 brew install --cask librefang       # Desktop (stable)
-# Beta/RC channels also available:
-# brew install librefang-beta       # or librefang-rc
-# brew install --cask librefang-rc  # or librefang-beta
+# Canales Beta/RC:
+# brew install librefang-beta       # o librefang-rc
+# brew install --cask librefang-rc  # o librefang-beta
 ```
 
 </details>

--- a/i18n/README.fr.md
+++ b/i18n/README.fr.md
@@ -65,13 +65,20 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
+> 🎉 **LibreFang est désormais dans [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413) !** Accepté dans le tap officiel Homebrew le 2026-07-08 — installez la CLI sans configuration, sans tap.
+
+```bash
+brew install librefang              # CLI (stable) — homebrew-core officiel
+```
+
+L'application de bureau et les canaux de préversion restent publiés via le tap LibreFang :
+
 ```bash
 brew tap librefang/tap
-brew install librefang              # CLI (stable)
 brew install --cask librefang       # Desktop (stable)
-# Beta/RC channels also available:
-# brew install librefang-beta       # or librefang-rc
-# brew install --cask librefang-rc  # or librefang-beta
+# Canaux Beta/RC :
+# brew install librefang-beta       # ou librefang-rc
+# brew install --cask librefang-rc  # ou librefang-beta
 ```
 
 </details>

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -63,13 +63,20 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
+> 🎉 **LibreFang が [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413) に登録されました！** 2026-07-08 に公式 Homebrew に採用されました — tap 不要、追加設定なしで CLI をインストールできます。
+
+```bash
+brew install librefang              # CLI (stable) — 公式 homebrew-core
+```
+
+デスクトップ版とプレリリースチャンネルは引き続き LibreFang tap から配布されます：
+
 ```bash
 brew tap librefang/tap
-brew install librefang              # CLI (stable)
 brew install --cask librefang       # Desktop (stable)
-# Beta/RC channels also available:
-# brew install librefang-beta       # or librefang-rc
-# brew install --cask librefang-rc  # or librefang-beta
+# Beta/RC チャンネル：
+# brew install librefang-beta       # または librefang-rc
+# brew install --cask librefang-rc  # または librefang-beta
 ```
 
 </details>

--- a/i18n/README.ko.md
+++ b/i18n/README.ko.md
@@ -63,13 +63,20 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
+> 🎉 **LibreFang이 [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)에 등록되었습니다!** 2026-07-08 공식 Homebrew tap에 채택되었습니다 — tap 없이, 별도 설정 없이 CLI를 설치할 수 있습니다.
+
+```bash
+brew install librefang              # CLI (stable) — 공식 homebrew-core
+```
+
+데스크톱 앱과 프리릴리스 채널은 계속 LibreFang tap을 통해 배포됩니다:
+
 ```bash
 brew tap librefang/tap
-brew install librefang              # CLI (stable)
 brew install --cask librefang       # Desktop (stable)
-# Beta/RC channels also available:
-# brew install librefang-beta       # or librefang-rc
-# brew install --cask librefang-rc  # or librefang-beta
+# Beta/RC 채널:
+# brew install librefang-beta       # 또는 librefang-rc
+# brew install --cask librefang-rc  # 또는 librefang-beta
 ```
 
 </details>

--- a/i18n/README.pl.md
+++ b/i18n/README.pl.md
@@ -63,13 +63,20 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
+> 🎉 **LibreFang jest już w [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Przyjęty do oficjalnego tap Homebrew 2026-07-08 — zainstaluj CLI bez konfiguracji i bez tap.
+
+```bash
+brew install librefang              # CLI (stable) — oficjalne homebrew-core
+```
+
+Aplikacja desktopowa i kanały przedpremierowe są nadal publikowane przez tap LibreFang:
+
 ```bash
 brew tap librefang/tap
-brew install librefang              # CLI (stable)
 brew install --cask librefang       # Desktop (stable)
-# Beta/RC channels also available:
-# brew install librefang-beta       # or librefang-rc
-# brew install --cask librefang-rc  # or librefang-beta
+# Kanały Beta/RC:
+# brew install librefang-beta       # lub librefang-rc
+# brew install --cask librefang-rc  # lub librefang-beta
 ```
 
 </details>

--- a/i18n/README.uk.md
+++ b/i18n/README.uk.md
@@ -63,11 +63,18 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
+> 🎉 **LibreFang тепер у [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Прийнято до офіційного tap Homebrew 2026-07-08 — встановлюйте CLI без налаштувань і без tap.
+
+```bash
+brew install librefang              # CLI (стабільна версія) — офіційний homebrew-core
+```
+
+Десктопний застосунок і канали передрелізів, як і раніше, публікуються через tap LibreFang:
+
 ```bash
 brew tap librefang/tap
-brew install librefang              # CLI (стабільна версія)
 brew install --cask librefang       # Desktop (стабільна версія)
-# Також доступні бета та RC канали:
+# Канали бета та RC:
 # brew install librefang-beta       # або librefang-rc
 # brew install --cask librefang-rc  # або librefang-beta
 ```

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -63,13 +63,20 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
+> 🎉 **LibreFang 已进入 [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)！** 2026-07-08 正式合入官方 Homebrew 仓库——安装 CLI 无需额外配置，也无需再 tap。
+
+```bash
+brew install librefang              # CLI (stable) — 官方 homebrew-core
+```
+
+桌面版和预发布渠道仍通过 LibreFang tap 发布：
+
 ```bash
 brew tap librefang/tap
-brew install librefang              # CLI (stable)
 brew install --cask librefang       # Desktop (stable)
-# Beta/RC channels also available:
-# brew install librefang-beta       # or librefang-rc
-# brew install --cask librefang-rc  # or librefang-beta
+# Beta/RC 渠道：
+# brew install librefang-beta       # 或 librefang-rc
+# brew install --cask librefang-rc  # 或 librefang-beta
 ```
 
 </details>


### PR DESCRIPTION
## What

LibreFang's CLI formula was accepted into **homebrew-core** on 2026-07-08 (Homebrew/homebrew-core#290413).
`brew install librefang` now installs the CLI directly from the official tap — no `brew tap` required.

This updates the Homebrew install section to lead with the official one-liner and adds a short celebration note linking the PR and the acceptance date.

## Changes

- Homebrew section now installs the CLI via `brew install librefang` (official homebrew-core).
- Added a 🎉 note with the acceptance date (2026-07-08) and a link to Homebrew/homebrew-core#290413.
- The desktop cask (`brew install --cask librefang`) and the beta/rc channels still ship through `librefang/tap`, so those lines are kept under a follow-up block.
- Applied consistently across all nine READMEs: English + `de` / `es` / `fr` / `ja` / `ko` / `pl` / `uk` / `zh`.

## Verification

- Docs-only change; no code touched.
- Rendered the updated `<details>` block locally to confirm the Markdown (blockquote + two code fences) renders correctly and `</details>` still closes the section.
