### PR TITLE
docs(readme): wrap homebrew-core note at sentence boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
-> 🎉 **LibreFang is now in [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Accepted into the official Homebrew tap on 2026-07-08 — install the CLI with zero setup, no tap required.
+> 🎉 **LibreFang is now in [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!**
+> Accepted into the official Homebrew tap on 2026-07-08 — install the CLI with zero setup, no tap required.
 
 ```bash
 brew install librefang              # CLI (stable) — official homebrew-core

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -63,7 +63,8 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
-> 🎉 **LibreFang ist jetzt in [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Am 2026-07-08 in den offiziellen Homebrew-Tap aufgenommen — die CLI lässt sich ohne Einrichtung und ohne Tap installieren.
+> 🎉 **LibreFang ist jetzt in [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!**
+> Am 2026-07-08 in den offiziellen Homebrew-Tap aufgenommen — die CLI lässt sich ohne Einrichtung und ohne Tap installieren.
 
 ```bash
 brew install librefang              # CLI (stable) — offizielles homebrew-core

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -63,7 +63,8 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
-> 🎉 **¡LibreFang ya está en [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Aceptado en el tap oficial de Homebrew el 2026-07-08: instala la CLI sin configuración y sin necesidad de tap.
+> 🎉 **¡LibreFang ya está en [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!**
+> Aceptado en el tap oficial de Homebrew el 2026-07-08: instala la CLI sin configuración y sin necesidad de tap.
 
 ```bash
 brew install librefang              # CLI (stable) — homebrew-core oficial

--- a/i18n/README.fr.md
+++ b/i18n/README.fr.md
@@ -65,7 +65,8 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
-> 🎉 **LibreFang est désormais dans [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413) !** Accepté dans le tap officiel Homebrew le 2026-07-08 — installez la CLI sans configuration, sans tap.
+> 🎉 **LibreFang est désormais dans [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413) !**
+> Accepté dans le tap officiel Homebrew le 2026-07-08 — installez la CLI sans configuration, sans tap.
 
 ```bash
 brew install librefang              # CLI (stable) — homebrew-core officiel

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -63,7 +63,8 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
-> 🎉 **LibreFang が [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413) に登録されました！** 2026-07-08 に公式 Homebrew に採用されました — tap 不要、追加設定なしで CLI をインストールできます。
+> 🎉 **LibreFang が [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413) に登録されました！**
+> 2026-07-08 に公式 Homebrew に採用されました — tap 不要、追加設定なしで CLI をインストールできます。
 
 ```bash
 brew install librefang              # CLI (stable) — 公式 homebrew-core

--- a/i18n/README.ko.md
+++ b/i18n/README.ko.md
@@ -63,7 +63,8 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
-> 🎉 **LibreFang이 [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)에 등록되었습니다!** 2026-07-08 공식 Homebrew tap에 채택되었습니다 — tap 없이, 별도 설정 없이 CLI를 설치할 수 있습니다.
+> 🎉 **LibreFang이 [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)에 등록되었습니다!**
+> 2026-07-08 공식 Homebrew tap에 채택되었습니다 — tap 없이, 별도 설정 없이 CLI를 설치할 수 있습니다.
 
 ```bash
 brew install librefang              # CLI (stable) — 공식 homebrew-core

--- a/i18n/README.pl.md
+++ b/i18n/README.pl.md
@@ -63,7 +63,8 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
-> 🎉 **LibreFang jest już w [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Przyjęty do oficjalnego tap Homebrew 2026-07-08 — zainstaluj CLI bez konfiguracji i bez tap.
+> 🎉 **LibreFang jest już w [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!**
+> Przyjęty do oficjalnego tap Homebrew 2026-07-08 — zainstaluj CLI bez konfiguracji i bez tap.
 
 ```bash
 brew install librefang              # CLI (stable) — oficjalne homebrew-core

--- a/i18n/README.uk.md
+++ b/i18n/README.uk.md
@@ -63,7 +63,8 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
-> 🎉 **LibreFang тепер у [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!** Прийнято до офіційного tap Homebrew 2026-07-08 — встановлюйте CLI без налаштувань і без tap.
+> 🎉 **LibreFang тепер у [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)!**
+> Прийнято до офіційного tap Homebrew 2026-07-08 — встановлюйте CLI без налаштувань і без tap.
 
 ```bash
 brew install librefang              # CLI (стабільна версія) — офіційний homebrew-core

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -63,7 +63,8 @@ librefang start
 <details>
 <summary><strong>Homebrew</strong></summary>
 
-> 🎉 **LibreFang 已进入 [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)！** 2026-07-08 正式合入官方 Homebrew 仓库——安装 CLI 无需额外配置，也无需再 tap。
+> 🎉 **LibreFang 已进入 [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/290413)！**
+> 2026-07-08 正式合入官方 Homebrew 仓库——安装 CLI 无需额外配置，也无需再 tap。
 
 ```bash
 brew install librefang              # CLI (stable) — 官方 homebrew-core


### PR DESCRIPTION
## What

Follow-up to #6414, which merged while this fix was in flight — the fix commit landed on the now-closed `docs/readme-homebrew-core` branch but never reached `main`.

CLAUDE.md's prose-wrapping rule requires one sentence per line so a single-word edit doesn't reflow the whole paragraph. The blockquote note added by #6414 packed two sentences onto one line, across all nine READMEs.

## Changes

- Split the 🎉 homebrew-core blockquote note into two lines at the sentence boundary (after the first `!`/`！` bold-text sentence) in `README.md` and all eight `i18n/README.*.md` translations.
- No wording, links, or rendered content changed — purely a line-break split within the existing blockquote.

## Verification

- Docs-only change; no code touched.
- Diff-reviewed each of the nine files to confirm the split lands exactly at the sentence boundary and both lines still start with `>` (blockquote continues correctly).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqL6CZRnhv4rpXHZc7ivxo)_