### PR TITLE
release: v2026.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,15 +42,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ## [2026.7.10] - 2026-07-10
 
-_39 PRs from 4 contributors since v2026.6.29._
-
-### Highlights
-
-- **Codex CLI model visibility** — the dashboard now surfaces which model your Codex CLI is configured to use
-- **Slack formatting** — messages are converted from Markdown to Slack's native mrkdwn format in the Slack sidecar
-- **OpenAI-compat extended thinking** — reasoning effort is now correctly forwarded to the OpenAI-compatible driver, enabling extended thinking on supported models
-- **Artifact read deduplication** — read_artifact results are no longer re-spilled at the post-tool chokepoint, preventing redundant output
-- **Dashboard & website translations** — completed and proofread translations across the dashboard and website
+_40 PRs from 4 contributors since v2026.6.29._
 
 ### Added
 
@@ -70,6 +62,7 @@ _39 PRs from 4 contributors since v2026.6.29._
 - Correlate chat turns with their WS terminal frames (#6419) (@houko)
 - Single-source the invisible-char set; skip reply-precheck on captionless media (#6426) (@houko)
 - Drop redundant refs in TUI format! args (Rust 1.97 clippy) (#6428) (@houko)
+- Reliable CLI→PyPI publishing — stable-only gate + stop desktop deleting CLI assets (#6433) (@houko)
 
 <details>
 <summary>Documentation, maintenance, and other internal changes</summary>


### PR DESCRIPTION
<!-- release-tag:v2026.7.10 -->
## Release v2026.7.10

_40 PRs from 4 contributors since v2026.6.29._

### Added

- Surface the model the Codex CLI is configured to run (#6365) (@houko)
- Complete and proofread dashboard and website translations (#6376) (@houko)

### Fixed

- Clear cargo-deny advisory failures on main (#6366) (@houko)
- Keep [Unreleased] at the top; prune stale buried entries (#6367) (@houko)
- Clear quick-xml RUSTSEC-2026-0194/0195 advisories (#6387) (@houko)
- Convert Markdown to Slack mrkdwn in the Slack sidecar (#6397) (@neo-wanderer)
- Clear crossbeam-epoch RUSTSEC-2026-0204 advisory (#6400) (@houko)
- Never re-spill read_artifact results at the post-tool chokepoint (#6406) (@houko)
- Request extended thinking via reasoning_effort in the OpenAI-compat driver (#6407) (@houko)
- Add LIBREFANG_REGISTRY_OFFLINE to skip registry network refresh in tests (#6408) (@houko)
- Correlate chat turns with their WS terminal frames (#6419) (@houko)
- Single-source the invisible-char set; skip reply-precheck on captionless media (#6426) (@houko)
- Drop redundant refs in TUI format! args (Rust 1.97 clippy) (#6428) (@houko)
- Reliable CLI→PyPI publishing — stable-only gate + stop desktop deleting CLI assets (#6433) (@houko)

<details>
<summary>Documentation, maintenance, and other internal changes</summary>

### Documentation

- Add Arch Linux pacman installation instructions (#6386) (@pavver)
- Only the WhatsApp sidecar reads DM/group policy env vars (#6405) (@houko)
- Install CLI from official homebrew-core (#6414) (@houko)
- Wrap homebrew-core note at sentence boundaries (#6415) (@houko)

### Maintenance

- Bump rmcp from 1.7.0 to 2.0.0 (#6364) (@app/dependabot)
- Adopt tera 2.0 (#6368) (@houko)
- Adopt aes-gcm 0.11 and the cargo-minor-patch bumps (#6369) (@houko)
- Gitignore the AUR CI deploy key pair (#6370) (@houko)
- Bump the actions-minor-patch group with 2 updates (#6373) (@app/dependabot)
- Bump tauri-apps/tauri-action from 0.6.2 to 1.0.0 (#6374) (@app/dependabot)
- Bump the web-minor-patch group in /web with 10 updates (#6377) (@app/dependabot)
- Bump the dashboard-minor-patch group in /crates/librefang-api/dashboard with 15 updates (#6378) (@app/dependabot)
- Bump the docs-minor-patch group in /docs with 10 updates (#6380) (@app/dependabot)
- Bump @types/node from 25.9.3 to 26.1.0 in /docs (#6381) (@app/dependabot)
- Raise job timeout to 120 minutes for cold builds (#6389) (@houko)
- Bump the cargo-minor-patch group with 5 updates (#6394) (@app/dependabot)
- Bump the actions-minor-patch group with 5 updates (#6401) (@app/dependabot)
- Make webhook-agent happy-path test hermetic (#6402) (@houko)
- Export LIBREFANG_REGISTRY_OFFLINE in the workspace test lanes (#6410) (@houko)
- Bump the web-minor-patch group in /web with 3 updates (#6411) (@app/dependabot)
- Bump typescript from 6.0.3 to 7.0.2 in /web (#6412) (@app/dependabot)
- Bump the dashboard-minor-patch group in /crates/librefang-api/dashboard with 6 updates (#6413) (@app/dependabot)
- Move stable CLI to homebrew-core and fix tap sync bugs (#6416) (@houko)
- Match Homebrew class_s casing for versioned tap formula (#6418) (@houko)
- Seed registry content from a pinned in-repo fixture instead of the network (#6421) (@houko)
- Bump the docs-minor-patch group in /docs with 4 updates (#6424) (@app/dependabot)

</details>

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.6.29...v2026.7.10