### PR TITLE
chore(deps): update yanked spin 0.9.8 to 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9160,9 +9160,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"


### PR DESCRIPTION
## Summary

`spin 0.9.8` was yanked on crates.io, so the `cargo-deny (advisories)` check now fails on every PR whose lockfile is based on current main — including the open dependabot bump PRs #6452 and #6453 (`error[yanked]: detected yanked crate (try cargo update -p spin)`).

- `cargo update -p spin`: `spin 0.9.8 -> 0.9.9` (Cargo.lock only, no manifest changes; `spin` is a transitive dependency).

## Verification

- Local `cargo deny check advisories` on this branch: `advisories ok`.
- Lockfile-only change; no code compiled locally per repo policy — full workspace build/test runs in CI.

## Follow-up

After this merges, `@dependabot rebase` on #6452 and #6453 picks up the fixed lockfile; the `Test / Ubuntu (shard 3/4)` failure on #6453 is an unrelated runner flake (`collect2: fatal error: ld terminated with signal 7 [Bus error]`) and the rebase re-runs it.
