### PR TITLE
test(runtime): lock in env trust split across defer→approve→resume (follow-up to #6465)

### DIFF
--- a/crates/librefang-runtime/src/subprocess_sandbox.rs
+++ b/crates/librefang-runtime/src/subprocess_sandbox.rs
@@ -2066,4 +2066,106 @@ mod tests {
         assert!(!is_reserved_env_var("SOME_CUSTOM_API_KEY"));
         assert!(!is_reserved_env_var("PATH"));
     }
+
+    #[test]
+    fn test_deferred_approval_resume_preserves_env_trust_split() {
+        // #6458 resume-path lock-in. This design carries env-allowlist trust
+        // in *which field* holds the name, not a separate provenance tag: the
+        // operator's list lives in `exec_policy.allowed_env_vars`, the
+        // untrusted passthrough list in `allowed_env_vars`. Both are already
+        // persisted on `DeferredToolExecution`, and the resume path
+        // (`build_deferred_tool_exec_context`) feeds `deferred.exec_policy`
+        // and `deferred.allowed_env_vars` straight back into the same
+        // `tool_shell_exec` / `tool_process_start` code the live path uses —
+        // so no extra persisted field is needed for a resumed `Allow once` to
+        // filter the child env identically. This test pins that end to end:
+        // build a deferred payload, round-trip it through serde (the restart
+        // boundary), then drive `sandbox_command` exactly as the resume path
+        // would and assert the trust split survived.
+        let operator_secret = "SANDBOXTEST_RESUME_OPERATOR_KEYRING_PASSWORD"; // secret-shaped, operator-granted → must pass
+        let untrusted_secret = "SANDBOXTEST_RESUME_HAND_API_TOKEN"; // secret-shaped, hand passthrough → must be refused
+        let vault = "LIBREFANG_VAULT_KEY"; // reserved daemon secret → refused from either list
+
+        // SAFETY: all three names are unique to this test (the vault key is
+        // never read from the real environment here — refusal is by name).
+        unsafe {
+            std::env::set_var(operator_secret, "operator-granted");
+            std::env::set_var(untrusted_secret, "hand-smuggled");
+            std::env::set_var(vault, "daemon-private");
+        }
+
+        // `DeferredToolExecution` derives no `Default`, so every field is set
+        // explicitly (the trust-carrying ones — `allowed_env_vars`,
+        // `exec_policy` — plus inert context fields).
+        let deferred = librefang_types::tool::DeferredToolExecution {
+            agent_id: "11111111-1111-4111-8111-111111111111".to_string(),
+            tool_use_id: "toolu_resume".to_string(),
+            tool_name: "shell_exec".to_string(),
+            input: serde_json::json!({"command": "printenv"}),
+            allowed_tools: Some(vec!["shell_exec".to_string()]),
+            // Untrusted passthrough list (a hand's assembled `hand_allowed_env`).
+            allowed_env_vars: Some(vec![untrusted_secret.to_string()]),
+            // Operator's own trusted allowlist rides inside `exec_policy`.
+            exec_policy: Some(librefang_types::config::ExecPolicy {
+                mode: librefang_types::config::ExecSecurityMode::Full,
+                allowed_env_vars: vec![operator_secret.to_string(), vault.to_string()],
+                ..Default::default()
+            }),
+            sender_id: None,
+            channel: None,
+            chat_id: None,
+            account_id: None,
+            workspace_root: None,
+            force_human: false,
+            session_id: None,
+        };
+
+        // Cross the restart boundary: persist and reload.
+        let json = serde_json::to_string(&deferred).expect("deferred serializes");
+        let restored: librefang_types::tool::DeferredToolExecution =
+            serde_json::from_str(&json).expect("deferred deserializes");
+
+        // Reconstruct the two lists exactly as the resume path does
+        // (`tool_shell_exec`: operator ← exec_policy.allowed_env_vars,
+        // untrusted ← allowed_env_vars).
+        let operator_env: Vec<String> = restored
+            .exec_policy
+            .as_ref()
+            .map(|p| p.allowed_env_vars.clone())
+            .unwrap_or_default();
+        let untrusted_env: Vec<String> = restored.allowed_env_vars.clone().unwrap_or_default();
+
+        let mut cmd = tokio::process::Command::new("true");
+        let refused = sandbox_command(&mut cmd, &operator_env, &untrusted_env);
+
+        let injected: std::collections::HashSet<String> = cmd
+            .as_std()
+            .get_envs()
+            .filter_map(|(k, _)| k.to_str().map(|s| s.to_string()))
+            .collect();
+
+        // SAFETY: see set_var above.
+        unsafe {
+            std::env::remove_var(operator_secret);
+            std::env::remove_var(untrusted_secret);
+            std::env::remove_var(vault);
+        }
+
+        assert!(
+            injected.contains(operator_secret),
+            "operator-granted secret-shaped var must survive defer→resume and reach the child"
+        );
+        assert!(
+            !injected.contains(untrusted_secret),
+            "hand passthrough secret-shaped var must stay blocked on the resume path"
+        );
+        assert!(
+            !injected.contains(vault),
+            "reserved daemon secret must never be injected, even from a resumed operator allowlist"
+        );
+        assert!(
+            refused.contains(&vault.to_string()),
+            "the reserved daemon secret should be surfaced as refused"
+        );
+    }
 }

--- a/crates/librefang-runtime/src/subprocess_sandbox.rs
+++ b/crates/librefang-runtime/src/subprocess_sandbox.rs
@@ -2069,34 +2069,22 @@ mod tests {
 
     #[test]
     fn test_deferred_approval_resume_preserves_env_trust_split() {
-        // #6458 resume-path lock-in. This design carries env-allowlist trust
-        // in *which field* holds the name, not a separate provenance tag: the
-        // operator's list lives in `exec_policy.allowed_env_vars`, the
-        // untrusted passthrough list in `allowed_env_vars`. Both are already
-        // persisted on `DeferredToolExecution`, and the resume path
-        // (`build_deferred_tool_exec_context`) feeds `deferred.exec_policy`
-        // and `deferred.allowed_env_vars` straight back into the same
-        // `tool_shell_exec` / `tool_process_start` code the live path uses —
-        // so no extra persisted field is needed for a resumed `Allow once` to
-        // filter the child env identically. This test pins that end to end:
-        // build a deferred payload, round-trip it through serde (the restart
-        // boundary), then drive `sandbox_command` exactly as the resume path
-        // would and assert the trust split survived.
+        // #6458 resume-path lock-in.
+        // This design carries env-allowlist trust in *which field* holds the name, not a separate provenance tag: the operator's list lives in `exec_policy.allowed_env_vars`, the untrusted passthrough list in `allowed_env_vars`.
+        // Both are already persisted on `DeferredToolExecution`, and the resume path (`build_deferred_tool_exec_context`) feeds `deferred.exec_policy` and `deferred.allowed_env_vars` straight back into the same `tool_shell_exec` / `tool_process_start` code the live path uses — so no extra persisted field is needed for a resumed `Allow once` to filter the child env identically.
+        // This test pins that end to end: build a deferred payload, round-trip it through serde (the restart boundary), then drive `sandbox_command` exactly as the resume path would and assert the trust split survived.
         let operator_secret = "SANDBOXTEST_RESUME_OPERATOR_KEYRING_PASSWORD"; // secret-shaped, operator-granted → must pass
         let untrusted_secret = "SANDBOXTEST_RESUME_HAND_API_TOKEN"; // secret-shaped, hand passthrough → must be refused
         let vault = "LIBREFANG_VAULT_KEY"; // reserved daemon secret → refused from either list
 
-        // SAFETY: all three names are unique to this test (the vault key is
-        // never read from the real environment here — refusal is by name).
+        // SAFETY: all three names are unique to this test (the vault key is never read from the real environment here — refusal is by name).
         unsafe {
             std::env::set_var(operator_secret, "operator-granted");
             std::env::set_var(untrusted_secret, "hand-smuggled");
             std::env::set_var(vault, "daemon-private");
         }
 
-        // `DeferredToolExecution` derives no `Default`, so every field is set
-        // explicitly (the trust-carrying ones — `allowed_env_vars`,
-        // `exec_policy` — plus inert context fields).
+        // `DeferredToolExecution` derives no `Default`, so every field is set explicitly (the trust-carrying ones — `allowed_env_vars`, `exec_policy` — plus inert context fields).
         let deferred = librefang_types::tool::DeferredToolExecution {
             agent_id: "11111111-1111-4111-8111-111111111111".to_string(),
             tool_use_id: "toolu_resume".to_string(),
@@ -2125,9 +2113,7 @@ mod tests {
         let restored: librefang_types::tool::DeferredToolExecution =
             serde_json::from_str(&json).expect("deferred deserializes");
 
-        // Reconstruct the two lists exactly as the resume path does
-        // (`tool_shell_exec`: operator ← exec_policy.allowed_env_vars,
-        // untrusted ← allowed_env_vars).
+        // Reconstruct the two lists exactly as the resume path does (`tool_shell_exec`: operator ← exec_policy.allowed_env_vars, untrusted ← allowed_env_vars).
         let operator_env: Vec<String> = restored
             .exec_policy
             .as_ref()


### PR DESCRIPTION
## What

Follow-up test-only PR for #6465 (which merged as `627fa3cf4`). Adds one `#[tokio::test]` regression in `crates/librefang-runtime/src/subprocess_sandbox.rs` that pins the #6458 env-allowlist trust split across the approval-resume path.

## Why

#6465 fixed #6458 by carrying env-allowlist trust in *which field* holds the name rather than a separate provenance tag:

- the operator's own list lives in `exec_policy.allowed_env_vars`,
- the untrusted hand passthrough list lives in `allowed_env_vars`.

Both are already persisted on `DeferredToolExecution`, and `build_deferred_tool_exec_context` (`kernel/mod.rs`) feeds `deferred.exec_policy` and `deferred.allowed_env_vars` straight back into the same `tool_shell_exec` / `tool_process_start` code the live path runs — so a resumed `Allow once` filters the child env identically to the live path with no extra persisted field. This test locks that property in so a future refactor of the deferred-context construction cannot silently regress it.

The distinction matters because the sibling proposal #6464 added an explicit `DeferredToolExecution.env_allowlist_source` field to solve the same resume concern under a single-list-plus-tag model. Under #6465's two-list model that field would be redundant. This test is the evidence that the resume path is already correct without it.

## The test

`test_deferred_approval_resume_preserves_env_trust_split`:

1. Builds a `DeferredToolExecution` with an operator secret-shaped name in `exec_policy.allowed_env_vars` and a hand secret-shaped name in `allowed_env_vars`.
2. Serializes and deserializes it — the daemon-restart boundary.
3. Reconstructs the two lists the way the resume path does and drives `sandbox_command`.
4. Asserts: the operator-granted secret-shaped var reaches the child, the hand passthrough secret-shaped var stays blocked, and the reserved daemon key (`LIBREFANG_VAULT_KEY`) is refused from either list.

## Verification

- `cargo test -p librefang-runtime --lib subprocess_sandbox::tests::test_deferred_approval_resume_preserves_env_trust_split` — passes on the `627fa3cf4` (post-#6465) baseline.
- `cargo clippy -p librefang-runtime --lib -- -D warnings` — clean.
- `cargo fmt -p librefang-runtime -- --check` — clean.

Test-only; no production code or CHANGELOG change.
