### PR TITLE
feat(sidecar-telegram): env opt-out (TELEGRAM_STREAMING) for the streaming path

### DIFF
--- a/docs/src/app/architecture/rust-telegram-sidecar/page.mdx
+++ b/docs/src/app/architecture/rust-telegram-sidecar/page.mdx
@@ -42,6 +42,7 @@ The dashboard's configure form is populated from the schema the binary serves vi
 | `TELEGRAM_BOT_TOKEN` | secret | yes | BotFather token. Dashboard masks it on display; redacted from every error path. |
 | `ALLOWED_USERS` | list, advanced | no | CSV of numeric user IDs or `@usernames` (case-insensitive). Empty ⇒ open. |
 | `TELEGRAM_CLEAR_DONE_REACTION` | bool, advanced | no | When `true`, the ✅ "done" reaction clears prior reactions instead of stacking. |
+| `TELEGRAM_STREAMING` | bool, advanced | no | Defaults to `true`. Set `0` / `false` / `no` / `off` (case-insensitive) to drop the `streaming` capability, so responses arrive as a single final message instead of a live-edited placeholder — avoids the placeholder flash on fast, short turns. |
 
 ## Capabilities
 

--- a/docs/src/app/zh/architecture/rust-telegram-sidecar/page.mdx
+++ b/docs/src/app/zh/architecture/rust-telegram-sidecar/page.mdx
@@ -42,6 +42,7 @@ Dashboard 的配置表单由二进制 `--describe` 返回的 schema 渲染，运
 | `TELEGRAM_BOT_TOKEN` | secret | 是 | BotFather 给的 token。Dashboard 显示时会打码；所有错误路径都做了脱敏。 |
 | `ALLOWED_USERS` | list, advanced | 否 | 数字 user ID 或 `@username` 的 CSV（大小写不敏感）。空 ⇒ 开放。 |
 | `TELEGRAM_CLEAR_DONE_REACTION` | bool, advanced | 否 | 为 `true` 时，✅ "done" 反应会清空已有反应而非叠加。 |
+| `TELEGRAM_STREAMING` | bool, advanced | 否 | 默认 `true`。设为 `0` / `false` / `no` / `off`（大小写不敏感）会去掉 `streaming` 能力，回复以单条最终消息一次性送达，而不是实时编辑占位消息——避免快速、简短回合时占位消息的闪现。 |
 
 ## 能力声明
 

--- a/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
@@ -42,9 +42,12 @@ macro_rules! tg_trace {
     ($($arg:tt)*) => { trace(format_args!($($arg)*)) };
 }
 
-/// Whether the streaming send path is advertised as a capability. Reads `TELEGRAM_STREAMING` live on each `capabilities()` call and defaults to enabled. `"0"` / `"false"` / `"no"` / `"off"` (case-insensitive, trimmed) disable it; everything else — including an unset variable — leaves it enabled.
+/// Whether the streaming send path is advertised as a capability.
+/// Reads `TELEGRAM_STREAMING` live on each `capabilities()` call and defaults to enabled.
+/// `"0"` / `"false"` / `"no"` / `"off"` (case-insensitive, trimmed) disable it; everything else — including an unset variable — leaves it enabled.
 ///
-/// When disabled the `"streaming"` capability is dropped, so the daemon routes every send through the plain (non-streaming) path. That trades incremental updates for a single final message, avoiding the visible placeholder flash on fast / short LLM turns.
+/// When disabled the `"streaming"` capability is dropped, so the daemon routes every send through the plain (non-streaming) path.
+/// That trades incremental updates for a single final message, avoiding the visible placeholder flash on fast / short LLM turns.
 fn streaming_enabled() -> bool {
     match std::env::var("TELEGRAM_STREAMING") {
         Ok(v) => !matches!(
@@ -211,8 +214,7 @@ impl SidecarAdapter for TelegramAdapter {
             "interactive".into(),
             "thread".into(),
         ];
-        // `"streaming"` is opt-out via `TELEGRAM_STREAMING`; appended last so the
-        // base capability order stays deterministic.
+        // `"streaming"` is opt-out via `TELEGRAM_STREAMING`; appended last so the base capability order stays deterministic.
         if streaming_enabled() {
             caps.push("streaming".into());
         }
@@ -469,8 +471,7 @@ impl SidecarAdapter for TelegramAdapter {
 mod tests {
     use super::*;
 
-    /// Restores `TELEGRAM_STREAMING` to its pre-test value on drop, so the
-    /// mutation stays contained even if an assertion panics mid-test.
+    /// Restores `TELEGRAM_STREAMING` to its pre-test value on drop, so the mutation stays contained even if an assertion panics mid-test.
     struct EnvGuard(Option<String>);
     impl Drop for EnvGuard {
         fn drop(&mut self) {
@@ -497,9 +498,8 @@ mod tests {
         }
     }
 
-    // `TELEGRAM_STREAMING` is process-global state; this is the only test in the
-    // crate that touches it and every case runs sequentially in one function, so
-    // nothing races with a parallel test. The guard restores the original value.
+    // `TELEGRAM_STREAMING` is process-global state; this is the only test in the crate that touches it and every case runs sequentially in one function, so nothing races with a parallel test.
+    // The guard restores the original value.
     #[test]
     fn streaming_enabled_parsing_and_capability_gate() {
         let _guard = EnvGuard(std::env::var("TELEGRAM_STREAMING").ok());

--- a/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/adapter.rs
@@ -42,6 +42,19 @@ macro_rules! tg_trace {
     ($($arg:tt)*) => { trace(format_args!($($arg)*)) };
 }
 
+/// Whether the streaming send path is advertised as a capability. Reads `TELEGRAM_STREAMING` live on each `capabilities()` call and defaults to enabled. `"0"` / `"false"` / `"no"` / `"off"` (case-insensitive, trimmed) disable it; everything else — including an unset variable — leaves it enabled.
+///
+/// When disabled the `"streaming"` capability is dropped, so the daemon routes every send through the plain (non-streaming) path. That trades incremental updates for a single final message, avoiding the visible placeholder flash on fast / short LLM turns.
+fn streaming_enabled() -> bool {
+    match std::env::var("TELEGRAM_STREAMING") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        Err(_) => true,
+    }
+}
+
 pub struct TelegramAdapter {
     client: Arc<BotClient>,
     allowlist: AllowList,
@@ -192,13 +205,18 @@ impl TelegramAdapter {
 #[async_trait]
 impl SidecarAdapter for TelegramAdapter {
     fn capabilities(&self) -> Vec<String> {
-        vec![
+        let mut caps: Vec<String> = vec![
             "typing".into(),
             "reaction".into(),
             "interactive".into(),
             "thread".into(),
-            "streaming".into(),
-        ]
+        ];
+        // `"streaming"` is opt-out via `TELEGRAM_STREAMING`; appended last so the
+        // base capability order stays deterministic.
+        if streaming_enabled() {
+            caps.push("streaming".into());
+        }
+        caps
     }
 
     fn header_rules(&self) -> Vec<Value> {
@@ -444,5 +462,89 @@ impl SidecarAdapter for TelegramAdapter {
             // Tiny breather to let other tasks make progress between poll iterations.
             tokio::task::yield_now().await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Restores `TELEGRAM_STREAMING` to its pre-test value on drop, so the
+    /// mutation stays contained even if an assertion panics mid-test.
+    struct EnvGuard(Option<String>);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(v) => std::env::set_var("TELEGRAM_STREAMING", v),
+                None => std::env::remove_var("TELEGRAM_STREAMING"),
+            }
+        }
+    }
+
+    fn set_streaming(v: Option<&str>) {
+        match v {
+            Some(v) => std::env::set_var("TELEGRAM_STREAMING", v),
+            None => std::env::remove_var("TELEGRAM_STREAMING"),
+        }
+    }
+
+    fn test_adapter() -> TelegramAdapter {
+        TelegramAdapter {
+            client: Arc::new(BotClient::new("123456:test-token").expect("dummy client")),
+            allowlist: AllowList::from_env_value(None),
+            clear_done_reaction: false,
+            streams: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    // `TELEGRAM_STREAMING` is process-global state; this is the only test in the
+    // crate that touches it and every case runs sequentially in one function, so
+    // nothing races with a parallel test. The guard restores the original value.
+    #[test]
+    fn streaming_enabled_parsing_and_capability_gate() {
+        let _guard = EnvGuard(std::env::var("TELEGRAM_STREAMING").ok());
+
+        // Unset defaults to enabled.
+        set_streaming(None);
+        assert!(streaming_enabled(), "unset should default to enabled");
+
+        // Explicit truthy values stay enabled.
+        set_streaming(Some("true"));
+        assert!(streaming_enabled());
+        set_streaming(Some("1"));
+        assert!(streaming_enabled());
+
+        // Disable tokens, case-insensitive and trimmed.
+        for v in ["0", "false", "no", "off", " OFF ", "False", "Off"] {
+            set_streaming(Some(v));
+            assert!(!streaming_enabled(), "{v:?} should disable streaming");
+        }
+
+        // Unknown values fall back to enabled.
+        set_streaming(Some("maybe"));
+        assert!(streaming_enabled(), "unknown value should stay enabled");
+
+        let adapter = test_adapter();
+
+        // Disabled -> "streaming" dropped, the four base capabilities intact.
+        set_streaming(Some("0"));
+        let caps = adapter.capabilities();
+        assert!(
+            !caps.iter().any(|c| c == "streaming"),
+            "streaming must be dropped when disabled"
+        );
+        for base in ["typing", "reaction", "interactive", "thread"] {
+            assert!(
+                caps.iter().any(|c| c == base),
+                "missing base capability {base}"
+            );
+        }
+
+        // Enabled -> "streaming" present again.
+        set_streaming(Some("true"));
+        assert!(
+            adapter.capabilities().iter().any(|c| c == "streaming"),
+            "streaming must be advertised when enabled"
+        );
     }
 }

--- a/sdk/rust/librefang-sidecar-telegram/src/schema.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/schema.rs
@@ -29,12 +29,14 @@ pub fn telegram_schema() -> Schema {
 mod tests {
     use super::*;
 
-    // Guards the docs <-> schema drift the `--describe` form depends on: the
-    // dashboard configure form renders exactly the fields this function emits,
-    // so a var documented as a `--describe` field (see
-    // docs/src/app/architecture/rust-telegram-sidecar/page.mdx) must appear
-    // here or the toggle silently never shows. Lives inline because this is a
-    // binary-only crate and `telegram_schema` is not exported to a lib target.
+    // Pins that `telegram_schema()` declares the fields the dashboard
+    // `--describe` configure form renders — including TELEGRAM_STREAMING, which
+    // the docs advertise as a configurable field (see
+    // docs/src/app/architecture/rust-telegram-sidecar/page.mdx); if it were
+    // dropped here the toggle would silently never show. This is a schema-side
+    // presence check, not a docs parser, so the two must be kept in sync by
+    // hand. Lives inline because this is a binary-only crate and
+    // `telegram_schema` is not exported to a lib target.
     #[test]
     fn schema_declares_expected_fields() {
         let schema = telegram_schema();

--- a/sdk/rust/librefang-sidecar-telegram/src/schema.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/schema.rs
@@ -20,6 +20,40 @@ pub fn telegram_schema() -> Schema {
                 FieldType::Bool,
             )
             .advanced(),
+            Field::new("TELEGRAM_STREAMING", "Streaming", FieldType::Bool).advanced(),
         ],
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guards the docs <-> schema drift the `--describe` form depends on: the
+    // dashboard configure form renders exactly the fields this function emits,
+    // so a var documented as a `--describe` field (see
+    // docs/src/app/architecture/rust-telegram-sidecar/page.mdx) must appear
+    // here or the toggle silently never shows. Lives inline because this is a
+    // binary-only crate and `telegram_schema` is not exported to a lib target.
+    #[test]
+    fn schema_declares_expected_fields() {
+        let schema = telegram_schema();
+        assert_eq!(schema.name, "telegram");
+
+        let bot_token = schema
+            .fields
+            .iter()
+            .find(|f| f.key == "TELEGRAM_BOT_TOKEN")
+            .expect("schema must declare TELEGRAM_BOT_TOKEN");
+        assert_eq!(bot_token.field_type, FieldType::Secret);
+        assert!(bot_token.required);
+
+        let streaming = schema
+            .fields
+            .iter()
+            .find(|f| f.key == "TELEGRAM_STREAMING")
+            .expect("schema must declare TELEGRAM_STREAMING");
+        assert_eq!(streaming.field_type, FieldType::Bool);
+        assert!(streaming.advanced);
+    }
 }


### PR DESCRIPTION
Closes #6469.

## Problem

`TelegramAdapter::capabilities()` unconditionally included `"streaming"`, so the daemon routed every send through the streaming path (`bridge` gates on `adapter.supports_streaming()` -> `has_cap("streaming")`).
For fast / short LLM turns this surfaces a visible `…` placeholder that flashes before the real answer, then gets replaced.

## Changes

- Add `streaming_enabled()` in `sdk/rust/librefang-sidecar-telegram/src/adapter.rs`: reads `TELEGRAM_STREAMING` live on each `capabilities()` call, defaulting to enabled. `"0"` / `"false"` / `"no"` / `"off"` (case-insensitive, trimmed) disable it; everything else — including an unset variable — leaves it enabled.
- `capabilities()` now builds the base vec `["typing","reaction","interactive","thread"]` and appends `"streaming"` only when `streaming_enabled()` is true. The base order is fixed and `"streaming"` is appended last, so the advertised capability list stays deterministic.
- Docs: add a `TELEGRAM_STREAMING` row (default `true`) to the sidecar env-var tables in `docs/src/app/architecture/rust-telegram-sidecar/page.mdx` and its zh translation.

`StreamEnd` / `finalize_as_new_message` behaviour is deliberately untouched — per the issue, the defensive edit-in-place change is a separate tradeoff and out of scope here.

## Tests

- `streaming_enabled_parsing_and_capability_gate` (unit test in `adapter.rs`): covers `streaming_enabled()` parsing for unset / `true` / `1` / `0` / `false` / `no` / `off` / ` OFF ` / `False` / `Off` / unknown, and asserts `capabilities()` drops `"streaming"` (while keeping the four base caps) when disabled and re-advertises it when enabled.
  Env-var mutation is process-global; this is the only test in the crate touching `TELEGRAM_STREAMING`, all cases run sequentially in one function, and an `EnvGuard` restores the original value on drop (even on panic).

## Verification

Cargo was not run locally: six sibling agents share this machine's `target/` and local compilation would thrash it (per the worktree workflow), so CI is the verification gate.
Reasoning checks performed by reading source: `BotClient::new` accepts any non-empty token (no network), `AllowList::from_env_value(Option<&str>)` matches the `None` call, the test module is a child of `adapter.rs` so it can construct `TelegramAdapter` with its private fields, and no other test asserts an exact telegram capabilities vector.
