### PR TITLE
fix(api): login page unreadable in light theme (CSS cascade source-order bug)

### DIFF
--- a/crates/librefang-api/src/login_page.html
+++ b/crates/librefang-api/src/login_page.html
@@ -15,12 +15,6 @@
     color: #e6e8ee;
     display: grid; place-items: center;
   }
-  @media (prefers-color-scheme: light) {
-    body { background: #f6f7fb; color: #1a1c22; }
-    .card { background: #fff; box-shadow: 0 10px 30px rgba(20,20,40,.08); }
-    input { background: #fff; color: #1a1c22; border-color: #d7d9e1; }
-    .sub { color: #5a6070; }
-  }
   .card {
     width: min(92vw, 380px);
     padding: 28px 24px;
@@ -51,6 +45,17 @@
     margin-top: 10px; min-height: 1.2em; font-size: 12px; color: #ff7a7a;
   }
   .foot { margin-top: 16px; font-size: 11px; color: #6b7182; text-align: center; }
+  /* Light-theme overrides. Declared AFTER every base rule so they win the
+     cascade at equal specificity in light mode; if placed earlier the later
+     dark base rules override .card/input/.foot and the card text becomes
+     unreadable on a light page (#6477). */
+  @media (prefers-color-scheme: light) {
+    body { background: #f6f7fb; color: #1a1c22; }
+    .card { background: #fff; border-color: #d7d9e1; box-shadow: 0 10px 30px rgba(20,20,40,.08); }
+    input { background: #fff; color: #1a1c22; border-color: #d7d9e1; }
+    .sub { color: #5a6070; }
+    .foot { color: #5a6070; }
+  }
 </style>
 </head>
 <body>

--- a/crates/librefang-api/src/login_page.html
+++ b/crates/librefang-api/src/login_page.html
@@ -55,6 +55,7 @@
     input { background: #fff; color: #1a1c22; border-color: #d7d9e1; }
     .sub { color: #5a6070; }
     .foot { color: #5a6070; }
+    .err { color: #b91c1c; }
   }
 </style>
 </head>

--- a/crates/librefang-api/src/middleware.rs
+++ b/crates/librefang-api/src/middleware.rs
@@ -3672,6 +3672,39 @@ mod tests {
         );
     }
 
+    /// Regression for #6477: the `@media (prefers-color-scheme: light)` block
+    /// must be declared AFTER the base `.card` rule. CSS resolves equal-
+    /// specificity conflicts by source order, so a light override placed
+    /// before the dark base rule loses in light mode — the page background
+    /// turns light while `.card`/`input` keep their dark base values, leaving
+    /// dark heading/label text invisible on a dark card. Assert the ordering
+    /// in the source so the block can never drift back above the base rules.
+    #[test]
+    fn login_page_light_theme_block_follows_base_card_rule() {
+        let html = super::LOGIN_PAGE_HTML;
+        let base_card = html
+            .find(".card {")
+            .expect("login page must define a base `.card` rule");
+        let light_media = html
+            .find("@media (prefers-color-scheme: light)")
+            .expect("login page must define a light-theme media block");
+        assert!(
+            light_media > base_card,
+            "the light-theme media block must come AFTER the base `.card` rule so \
+             its overrides win the cascade in light mode (#6477); found media block \
+             at byte {light_media}, base .card at byte {base_card}"
+        );
+        // The light block must actually re-style the surfaces that carry dark
+        // base values, or light mode leaves unreadable text on a dark card.
+        let light_block = &html[light_media..];
+        for needed in [".card {", "input {", ".sub {", ".foot {"] {
+            assert!(
+                light_block.contains(needed),
+                "light-theme media block must override `{needed}` (#6477)"
+            );
+        }
+    }
+
     /// The `/dashboard` login page depends on its inline submit handler.
     /// The CSP must allow its exact hash without permitting arbitrary inline JavaScript.
     #[tokio::test]


### PR DESCRIPTION
Closes #6477.

## Problem

On a light OS/browser theme the login page was unusable: the page background turned light but the card stayed dark, so the `LibreFang` heading and the `Username` / `Password` labels rendered as dark text on a dark card — invisible.

Root cause is a CSS cascade source-order bug in `crates/librefang-api/src/login_page.html`.
The `@media (prefers-color-scheme: light)` block was declared **before** the base `.card`, `input`, and `.foot` rules.
CSS resolves equal-specificity conflicts by source order, so in light mode the later base rules won:

- `body` picked up the light override (its base rule preceded the media block) → page background went light;
- `.card` (base `background:#12151c`) and `input` (base `background:#0b0d12`) kept their **dark** base values because those rules came after the media block;
- `h1` and `label` have no explicit color and inherit `body` color (dark in light mode) → dark text on the still-dark card.

## Fix

- Move the entire `@media (prefers-color-scheme: light)` block to just before `</style>`, after every base rule, so its overrides win the cascade in light mode.
- Add the two overrides the old block was missing: a visible `.card` light border (`border-color:#d7d9e1` — the base `1px solid rgba(255,255,255,.06)` is invisible on white) and a `.foot` color override.
- Dark mode (the default) is untouched: base rules are byte-identical and the media block does not match, so it renders exactly as before.
- Page remains fully self-contained inline CSS with no external assets, preserving the CSP contract. The `<script>` block is unchanged, so the CSP script-hash test is unaffected.

## Tests

- Added `login_page_light_theme_block_follows_base_card_rule` in `crates/librefang-api/src/middleware.rs` (reuses the existing `super::LOGIN_PAGE_HTML` `include_str!` harness). It asserts via byte-offset ordering that the `@media (prefers-color-scheme: light)` block appears **after** the base `.card` rule, and that the light block re-styles `.card`, `input`, `.sub`, and `.foot`. This fails on the pre-fix source order, guarding the regression.

## Verification

`cargo build` / scoped `cargo test` and the dashboard build were **not** run locally — parallel worktrees share `target/` and local compilation thrashes the machine, so CI is the verification gate for this change.
The fix is a pure CSS source-order move plus a string-ordering unit test; correctness was verified by reading the full `<style>` cascade.
