### PR TITLE
feat(channels): Slack multi-step progress display via AgentPhase-driven Block Kit updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ## [Unreleased]
 
+### Added
+
+- Slack sidecar multi-step task-progress display: the generic AgentPhase lifecycle (Thinking → ToolUse{name} → Done/Error) now reaches the Slack adapter as `reaction` commands — Slack declares the existing `reaction` capability rather than a new one, since that is the capability `ChannelAdapter::send_reaction` already dispatches the phase lifecycle through — and is rendered as an updated-in-place Block Kit step list via `chat.update` for multi-step turns, while single-step turns keep the prior eyes → white_check_mark receipt reactions (both honour `SLACK_REACTIONS`); the `reaction` command gained optional `phase` / `tool_name` fields (backward-compatible, omitted when empty) carrying the lifecycle detail the emoji alone drops, and the bridge now also emits `ToolUse` phases on the non-streaming dispatch path so a non-streaming adapter that declares `reaction` sees the full `Thinking → ToolUse… → Done/Error` sequence (#6451) (@houko)
+
 ### Changed
 
 - Thread `CanvasConfig.max_html_bytes` / `allowed_tags` into the canvas tool: the `CANVAS_MAX_BYTES` task-local was never `.scope()`d and `allowed_tags` was read nowhere, so both operator knobs were dead config and the tool always used the hardcoded 512 KiB cap + built-in tag allowlist; the agent loop now scopes both task-locals from the resolved config (kernel-populated `LoopOptions.canvas_config`), and an empty `allowed_tags` still falls back to the built-in list (#6446) (@houko)

--- a/crates/librefang-channels/src/bridge.rs
+++ b/crates/librefang-channels/src/bridge.rs
@@ -4945,6 +4945,24 @@ async fn dispatch_message(
     {
         let mut accumulated = String::new();
         while let Some(delta) = delta_rx.recv().await {
+            // Surface tool invocations as live ToolUse lifecycle phases —
+            // the streaming path (above) already does this from the same
+            // `\n\n🔧 toolname\n\n` markers; mirroring it here lets a
+            // non-streaming adapter that consumes lifecycle reactions
+            // (e.g. the Slack sidecar's multi-step task display, #6451)
+            // build a per-tool step list instead of only Thinking→Done.
+            // Adapters that don't declare the `reaction` capability treat
+            // each of these as a no-op, so this is inert for everyone else.
+            if let Some(name) = extract_tool_marker_name(&delta) {
+                send_lifecycle_reaction(
+                    adapter,
+                    &message.sender,
+                    msg_id,
+                    &AgentPhase::tool_use(&name),
+                    false,
+                )
+                .await;
+            }
             accumulated.push_str(&delta);
         }
         // Status is sent after the text channel fully drains, so awaiting

--- a/crates/librefang-channels/src/sidecar.rs
+++ b/crates/librefang-channels/src/sidecar.rs
@@ -5,8 +5,8 @@
 //! newline-delimited JSON (one JSON object per line) over stdin/stdout.
 
 use crate::types::{
-    ChannelAdapter, ChannelContent, ChannelMessage, ChannelStatus, ChannelType, ChannelUser,
-    GroupMember, InteractiveMessage, LifecycleReaction, ParticipantRef, TypingEvent,
+    AgentPhase, ChannelAdapter, ChannelContent, ChannelMessage, ChannelStatus, ChannelType,
+    ChannelUser, GroupMember, InteractiveMessage, LifecycleReaction, ParticipantRef, TypingEvent,
 };
 use async_trait::async_trait;
 use chrono::Utc;
@@ -296,11 +296,27 @@ pub struct SidecarTypingCmdParams {
 }
 
 /// `reaction` command params (P0 skeleton — wired in P2).
+///
+/// `reaction` carries the phase-appropriate emoji; `phase` and
+/// `tool_name` (added for the Slack multi-step task display, #6451)
+/// carry the structured lifecycle detail an emoji-only frame drops.
+/// Both are skipped from the wire when empty so a plain phase reaction
+/// serializes to exactly the legacy `{channel_id, message_id, reaction}`
+/// frame — adapters that predate the fields ignore them, adapters that
+/// want a step list read them.
 #[derive(Debug, Serialize)]
 pub struct SidecarReactionParams {
     pub channel_id: String,
     pub message_id: String,
     pub reaction: String,
+    /// Lifecycle phase tag: one of `queued`, `thinking`, `tool_use`,
+    /// `streaming`, `done`, `error` (matches `AgentPhase`'s snake_case
+    /// serde tags). Empty only when a caller constructs a bare reaction.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub phase: String,
+    /// The tool being executed, present for the `tool_use` phase only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
 }
 
 /// `interactive` command params — full button shape.
@@ -1885,11 +1901,24 @@ impl ChannelAdapter for SidecarAdapter {
         if !self.has_cap("reaction") {
             return Ok(());
         }
+        // Project the structured phase onto the wire tag + optional tool
+        // name so a reaction consumer can render a live step list, not
+        // just an emoji (the `⚙️` tool_use emoji alone drops which tool).
+        let (phase, tool_name) = match &reaction.phase {
+            AgentPhase::Queued => ("queued", None),
+            AgentPhase::Thinking => ("thinking", None),
+            AgentPhase::ToolUse { tool_name } => ("tool_use", Some(tool_name.clone())),
+            AgentPhase::Streaming => ("streaming", None),
+            AgentPhase::Done => ("done", None),
+            AgentPhase::Error => ("error", None),
+        };
         self.send_command(&SidecarCommand::Reaction {
             params: SidecarReactionParams {
                 channel_id: user.platform_id.clone(),
                 message_id: message_id.to_string(),
                 reaction: reaction.emoji.clone(),
+                phase: phase.to_string(),
+                tool_name,
             },
         })
         .await
@@ -2694,6 +2723,8 @@ mod tests {
                     channel_id: "c".to_string(),
                     message_id: "m".to_string(),
                     reaction: "👍".to_string(),
+                    phase: String::new(),
+                    tool_name: None,
                 },
             },
             SidecarCommand::Interactive {

--- a/crates/librefang-channels/tests/bridge_integration_test.rs
+++ b/crates/librefang-channels/tests/bridge_integration_test.rs
@@ -12,7 +12,8 @@ use futures::Stream;
 use librefang_channels::bridge::{BridgeManager, ChannelBridgeHandle};
 use librefang_channels::router::AgentRouter;
 use librefang_channels::types::{
-    ChannelAdapter, ChannelContent, ChannelMessage, ChannelType, ChannelUser,
+    AgentPhase, ChannelAdapter, ChannelContent, ChannelMessage, ChannelType, ChannelUser,
+    LifecycleReaction,
 };
 use librefang_types::agent::AgentId;
 use librefang_types::config::ChannelOverrides;
@@ -1153,6 +1154,225 @@ async fn test_bridge_non_streaming_adapter_sees_progress_markers() {
         "Expected post-tool prose in reply, got: {:?}",
         sent[0].1
     );
+
+    manager.stop().await;
+}
+
+// ---------------------------------------------------------------------------
+// ToolUse lifecycle reaction on the non-streaming-adapter path (#6451)
+// ---------------------------------------------------------------------------
+//
+// The non-streaming-adapter branch of `dispatch_message` mirrors the streaming
+// path: each `\n\n🔧 <tool>\n\n` marker in the accumulated delta stream is
+// surfaced as an `AgentPhase::ToolUse` reaction via `send_reaction`, so a
+// non-streaming adapter that consumes reactions (the Slack sidecar's
+// multi-step task display) can build a per-tool step list.
+// `test_bridge_non_streaming_adapter_sees_progress_markers` above only asserts
+// the marker text lands in the consolidated reply — it never exercises the
+// reaction call. This test records reactions through a non-streaming adapter
+// and asserts the ToolUse phase (carrying the tool name) reaches
+// `send_reaction`.
+
+/// Non-streaming adapter that records every lifecycle reaction it receives.
+/// Mirrors `MockAdapter` (also non-streaming) but captures the reactions the
+/// default no-op `send_reaction` would otherwise drop.
+struct ReactionRecordingAdapter {
+    name: String,
+    channel_type: ChannelType,
+    rx: Mutex<Option<mpsc::Receiver<ChannelMessage>>>,
+    reactions: Arc<Mutex<Vec<LifecycleReaction>>>,
+    shutdown_tx: watch::Sender<bool>,
+}
+
+impl ReactionRecordingAdapter {
+    fn new(name: &str, channel_type: ChannelType) -> (Arc<Self>, mpsc::Sender<ChannelMessage>) {
+        let (tx, rx) = mpsc::channel(256);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let a = Arc::new(Self {
+            name: name.to_string(),
+            channel_type,
+            rx: Mutex::new(Some(rx)),
+            reactions: Arc::new(Mutex::new(Vec::new())),
+            shutdown_tx,
+        });
+        (a, tx)
+    }
+
+    fn get_reactions(&self) -> Vec<LifecycleReaction> {
+        self.reactions.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ChannelAdapter for ReactionRecordingAdapter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn channel_type(&self) -> ChannelType {
+        self.channel_type.clone()
+    }
+    async fn start(
+        &self,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = ChannelMessage> + Send>>,
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
+        let rx = self
+            .rx
+            .lock()
+            .unwrap()
+            .take()
+            .expect("start() called more than once");
+        Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
+    }
+    async fn send(
+        &self,
+        _user: &ChannelUser,
+        _content: ChannelContent,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
+    async fn send_reaction(
+        &self,
+        _user: &ChannelUser,
+        _message_id: &str,
+        reaction: &LifecycleReaction,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.reactions.lock().unwrap().push(reaction.clone());
+        Ok(())
+    }
+    async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let _ = self.shutdown_tx.send(true);
+        Ok(())
+    }
+}
+
+/// Handle whose streaming API emits a tool marker delta in the exact shape
+/// `extract_tool_marker_name` recognizes — a standalone `tx.send` of
+/// `\n\n🔧 <tool>\n\n`, matching the real producer
+/// (`channel_bridge.rs`: `format!("\n\n🔧 {pretty}\n\n")`). `MockProgressHandle`
+/// above deliberately emits a differently-shaped marker (single trailing
+/// newline, backticks) that does NOT match, so it can drive the text-in-reply
+/// assertion but not the reaction assertion.
+struct MockToolReactionHandle {
+    agents: Mutex<Vec<(AgentId, String)>>,
+}
+
+impl MockToolReactionHandle {
+    fn new(agents: Vec<(AgentId, String)>) -> Self {
+        Self {
+            agents: Mutex::new(agents),
+        }
+    }
+}
+
+#[async_trait]
+impl ChannelBridgeHandle for MockToolReactionHandle {
+    async fn send_message(&self, _agent_id: AgentId, message: &str) -> Result<String, String> {
+        Ok(format!("Echo: {message}"))
+    }
+
+    async fn find_agent_by_name(&self, name: &str) -> Result<Option<AgentId>, String> {
+        let agents = self.agents.lock().unwrap();
+        Ok(agents.iter().find(|(_, n)| n == name).map(|(id, _)| *id))
+    }
+
+    async fn list_agents(&self) -> Result<Vec<(AgentId, String)>, String> {
+        Ok(self.agents.lock().unwrap().clone())
+    }
+
+    async fn spawn_agent_by_name(&self, _manifest_name: &str) -> Result<AgentId, String> {
+        Err("mock: spawn not implemented".to_string())
+    }
+
+    async fn send_message_streaming_with_sender_status(
+        &self,
+        _agent_id: AgentId,
+        _message: &str,
+        _sender: &librefang_channels::types::SenderContext,
+    ) -> Result<
+        (
+            mpsc::Receiver<String>,
+            tokio::sync::oneshot::Receiver<Result<(), String>>,
+        ),
+        String,
+    > {
+        let (tx, rx) = mpsc::channel(16);
+        let (status_tx, status_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            // Standalone marker delta in the exact shape the api bridge injects
+            // on `ToolUseStart` — must be its own `tx.send` with blank lines on
+            // both sides for `extract_tool_marker_name` to recognize it.
+            let _ = tx.send("\n\n🔧 web_search\n\n".to_string()).await;
+            let _ = tx.send("Found 3 results.".to_string()).await;
+            drop(tx);
+            let _ = status_tx.send(Ok(()));
+        });
+        Ok((rx, status_rx))
+    }
+    fn record_consumer_lag(&self, _n: u64, _ctx: &'static str) {}
+}
+
+/// A non-streaming adapter must receive the per-tool `AgentPhase::ToolUse`
+/// reaction (carrying the tool name) followed by the terminal `Done` reaction.
+/// This locks the non-streaming-adapter lifecycle emission that #6451 added so
+/// the Slack sidecar's step list keeps getting per-tool signals.
+#[tokio::test]
+async fn test_non_streaming_adapter_receives_tool_use_reaction() {
+    let agent_id = AgentId::new();
+    let handle: Arc<dyn ChannelBridgeHandle> = Arc::new(MockToolReactionHandle::new(vec![(
+        agent_id,
+        "tool-user".to_string(),
+    )]));
+    let router = Arc::new(AgentRouter::new());
+    router.set_user_default("user1".to_string(), agent_id);
+
+    let (adapter, tx) = ReactionRecordingAdapter::new("slack-mock", ChannelType::Slack);
+    let adapter_ref = adapter.clone();
+
+    let mut manager = BridgeManager::new(handle.clone(), router);
+    manager.start_adapter(adapter.clone()).await.unwrap();
+
+    tx.send(make_text_msg(
+        ChannelType::Slack,
+        "user1",
+        "search for rust async",
+    ))
+    .await
+    .unwrap();
+
+    // Wait until the ToolUse reaction lands.
+    wait_until("tool_use reaction", || {
+        adapter_ref
+            .get_reactions()
+            .iter()
+            .any(|r| matches!(&r.phase, AgentPhase::ToolUse { .. }))
+    })
+    .await;
+
+    let reactions = adapter_ref.get_reactions();
+    let tool_use = reactions
+        .iter()
+        .find(|r| matches!(&r.phase, AgentPhase::ToolUse { .. }))
+        .expect("a ToolUse reaction should have reached send_reaction");
+    match &tool_use.phase {
+        AgentPhase::ToolUse { tool_name } => {
+            assert_eq!(
+                tool_name, "web_search",
+                "ToolUse reaction must carry the tool name extracted from the marker"
+            );
+        }
+        other => panic!("expected ToolUse phase, got {other:?}"),
+    }
+
+    // The turn still terminates with a Done reaction after the tool phase.
+    wait_until("done reaction", || {
+        adapter_ref
+            .get_reactions()
+            .iter()
+            .any(|r| matches!(&r.phase, AgentPhase::Done))
+    })
+    .await;
 
     manager.stop().await;
 }

--- a/crates/librefang-channels/tests/sidecar_protocol_conformance.rs
+++ b/crates/librefang-channels/tests/sidecar_protocol_conformance.rs
@@ -174,6 +174,11 @@ fn commands_serialize_to_corpus() {
                     channel_id: "c1".into(),
                     message_id: "55".into(),
                     reaction: "👍".into(),
+                    // Empty `phase` / `None` `tool_name` are skipped on the
+                    // wire, so the enriched struct still serializes to the
+                    // legacy emoji-only corpus frame (#6451).
+                    phase: String::new(),
+                    tool_name: None,
                 },
             },
         ),
@@ -256,4 +261,49 @@ fn commands_serialize_to_corpus() {
         let want = read_corpus(&format!("commands/{name}"));
         assert_eq!(got, want, "commands/{name}: serialize != corpus");
     }
+}
+
+/// #6451: a `tool_use` reaction serializes the enriched `phase` +
+/// `tool_name` fields (so a reaction consumer can render a live step
+/// list), while an empty `phase` / absent `tool_name` are dropped from
+/// the wire (backward-compatible with the emoji-only frame).
+#[test]
+fn reaction_serializes_phase_and_tool_name_when_present() {
+    let cmd = SidecarCommand::Reaction {
+        params: SidecarReactionParams {
+            channel_id: "c1".into(),
+            message_id: "55".into(),
+            reaction: "\u{2699}\u{FE0F}".into(),
+            phase: "tool_use".into(),
+            tool_name: Some("web_fetch".into()),
+        },
+    };
+    let got = serde_json::to_value(&cmd).unwrap();
+    assert_eq!(
+        got,
+        serde_json::json!({
+            "method": "reaction",
+            "params": {
+                "channel_id": "c1",
+                "message_id": "55",
+                "reaction": "\u{2699}\u{FE0F}",
+                "phase": "tool_use",
+                "tool_name": "web_fetch",
+            }
+        })
+    );
+
+    // A non-tool phase drops `tool_name` but keeps `phase`.
+    let thinking = SidecarCommand::Reaction {
+        params: SidecarReactionParams {
+            channel_id: "c1".into(),
+            message_id: "55".into(),
+            reaction: "\u{1F914}".into(),
+            phase: "thinking".into(),
+            tool_name: None,
+        },
+    };
+    let got = serde_json::to_value(&thinking).unwrap();
+    assert_eq!(got["params"].get("tool_name"), None);
+    assert_eq!(got["params"]["phase"], "thinking");
 }

--- a/docs/architecture/sidecar-channels.md
+++ b/docs/architecture/sidecar-channels.md
@@ -89,6 +89,16 @@ Commands (daemon → subprocess, stdin): `send`, `ready_ack`, `typing`,
 direction) are tolerated, not fatal — that is what lets a new daemon
 send `ready_ack` to an older adapter and vice versa.
 
+The `reaction` command carries the phase-appropriate emoji plus two
+optional structured fields — `phase` (the lifecycle tag: `queued` /
+`thinking` / `tool_use` / `streaming` / `done` / `error`) and
+`tool_name` (set for `tool_use` only). Both are omitted from the frame
+when empty, so a plain reaction is byte-for-byte the legacy
+`{channel_id, message_id, reaction}` shape and an adapter that predates
+the fields ignores them. They let an adapter render a live multi-step
+progress display from the lifecycle instead of only mapping the emoji
+(the `⚙️` tool-use emoji alone drops *which* tool ran). See #6451.
+
 stdout carries only protocol frames. All adapter logging goes to
 stderr (the SDK enforces this).
 
@@ -102,6 +112,41 @@ pre-sidecar behaviour (plain text). `create_webhook_routes` stays
 `None` for sidecars — an `axum::Router` can't cross stdio; an adapter
 that needs inbound HTTP runs its own listener and POSTs events back
 through stdout.
+
+### The AgentPhase lifecycle rides on `reaction`
+
+The generic agent lifecycle — `Queued → Thinking → ToolUse{tool_name}
+→ Streaming → Done/Error` (`AgentPhase` in
+`crates/librefang-channels/src/types.rs`) — is dispatched to adapters
+through `ChannelAdapter::send_reaction` (`bridge.rs`), which the
+sidecar trampoline gates on the **`reaction`** capability. So an
+adapter receives the lifecycle if and only if it declares `reaction`;
+`interactive` gates `send_interactive` only and never carries phase
+events. An adapter wanting a task/step progress display therefore
+reuses the existing `reaction` capability — no new `task_update`
+capability is required, and none was added. The enriched `phase` /
+`tool_name` fields on the `reaction` command (see Protocol above) give
+the adapter the structured detail an emoji alone drops.
+
+Two dispatch details matter for a multi-step display:
+
+- **Non-streaming adapters** (those that do *not* declare `streaming`,
+  e.g. Slack) previously received only `Queued`/`Thinking` up front and
+  `Done`/`Error` at the end; the per-tool `ToolUse{name}` phases were
+  emitted on the streaming path only. The bridge now also extracts the
+  `🔧 tool_name` markers on the non-streaming accumulation path and
+  emits `ToolUse` lifecycle reactions there, so a non-streaming adapter
+  that declares `reaction` sees the full `Thinking → ToolUse… →
+  Done/Error` sequence. Adapters that do not declare `reaction` treat
+  every one of these as a no-op, so the change is inert for them.
+- The **Slack** sidecar (`sdk/python/librefang/sidecar/adapters/slack.py`)
+  is the first consumer: it declares `reaction` and folds the phase
+  stream into an updated-in-place Block Kit card (`chat.update`) that
+  shows the live step list for multi-step turns. Single-step turns (no
+  tool ran) post no card and keep the pre-existing `eyes → check`
+  receipt reactions, which are driven independently by the receive/send
+  hooks — the phase stream never emits emoji reactions on Slack. The
+  card honours the same `SLACK_REACTIONS` opt-out as the receipts.
 
 ## Supervision
 

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -38,6 +38,13 @@ Behaviour parity with the Rust adapter:
   (matches the Rust ``SLACK_MSG_LIMIT``).
 * **Reactions**: ``eyes`` on receive, ``white_check_mark`` on
   completion (opt-out via ``SLACK_REACTIONS=false``).
+* **Task progress** (#6451): the generic AgentPhase lifecycle
+  (Thinking → ToolUse{name} → Done/Error) reaches the adapter as
+  ``reaction`` commands through the declared ``reaction`` capability
+  and is rendered as an updated-in-place Block Kit step list
+  (``chat.update``) for multi-step turns. Single-step turns post no
+  card and keep just the receipt reactions. Same ``SLACK_REACTIONS``
+  opt-out.
 
 Stdlib-only: HTTPS via ``urllib.request``, WebSocket via a
 hand-rolled RFC 6455 client over ``socket`` + ``ssl`` (same pattern
@@ -380,8 +387,24 @@ class SlackAdapter(SidecarAdapter):
     # The in-process adapter declared no capability strings either —
     # routing rich content (interactive, etc.) is determined per-API
     # call. We declare ``interactive`` so the kernel routes button
-    # interactions back to ``on_command``/``on_send``.
-    capabilities: list = ["interactive", "thread"]
+    # interactions back to ``on_command``/``on_send``, ``thread`` for
+    # threaded replies, and ``reaction`` so the generic AgentPhase
+    # lifecycle (Queued → Thinking → ToolUse{name} → Streaming →
+    # Done/Error) reaches ``on_command`` as ``reaction`` commands. We
+    # repurpose that phase stream into an updated-in-place Block Kit
+    # task-progress card for multi-step turns (#6451) — the eyes/
+    # white_check_mark receipt reactions stay driven by the receive/send
+    # hooks, independent of the lifecycle stream.
+    #
+    # Why ``reaction`` and not a new ``task_update`` capability: the
+    # generic phase lifecycle is dispatched to adapters through
+    # ``ChannelAdapter::send_reaction`` (bridge.rs), which the sidecar
+    # trampoline gates on exactly this capability. ``interactive`` gates
+    # ``send_interactive`` only and never carries phase events, so
+    # reusing it would not deliver the lifecycle. ``reaction`` is already
+    # in the negotiation table and already carries every phase, so no new
+    # capability is required (see docs/architecture/sidecar-channels.md).
+    capabilities: list = ["interactive", "thread", "reaction"]
 
     SCHEMA = Schema(
         name="slack",
@@ -410,7 +433,8 @@ class SlackAdapter(SidecarAdapter):
                   placeholder="false",
                   advanced=True),
             Field("SLACK_REACTIONS",
-                  "Add eyes/check reactions to indicate processing state",
+                  "Show processing-state indicators (eyes/check receipt "
+                  "reactions and the multi-step task-progress card)",
                   "bool",
                   placeholder="true",
                   advanced=True),
@@ -464,12 +488,23 @@ class SlackAdapter(SidecarAdapter):
         # without sends can't grow this without bound.
         self._pending_reactions: dict[tuple[str, str], str] = {}
         self._pending_lock = threading.Lock()
+        # Live task-progress cards keyed by (channel_id, triggering ts).
+        # Populated from the AgentPhase lifecycle `reaction` commands and
+        # rendered as an updated-in-place Block Kit message for
+        # multi-step turns (#6451). Touched only from the serialized
+        # `on_command` reader path, so no lock is required.
+        self._task_progress: dict[tuple[str, str], "_TaskProgress"] = {}
 
     # Capacity cap on the pending-reaction map. The in-process Rust
     # adapter used an unbounded ``RwLock<HashMap>``; we cap to 2k
     # entries here so a flood of inbound messages followed by a hang
     # in the agent loop doesn't grow the map without bound.
     MAX_PENDING_REACTIONS = 2_000
+
+    # Capacity cap on the task-progress map (same rationale as
+    # MAX_PENDING_REACTIONS): a turn that never reaches a terminal phase
+    # must not grow the map without bound.
+    MAX_TASK_PROGRESS = 1_000
 
     # ---- HTTP helpers ------------------------------------------------
 
@@ -618,6 +653,75 @@ class SlackAdapter(SidecarAdapter):
                 err = resp.get("error") or "unknown"
                 # Match Rust fail-open behaviour: log, continue chunking.
                 log.warn("slack chat.postMessage rejected", error=err)
+
+    def _post_blocks(
+        self,
+        channel_id: str,
+        text: str,
+        blocks: list,
+        *,
+        thread_ts: Optional[str] = None,
+    ) -> Optional[str]:
+        """POST a single Block Kit message (no chunking) and return its
+        ``ts`` so the caller can later ``chat.update`` it in place.
+        Returns ``None`` on any transport/API failure — the task-progress
+        card is best-effort UX and must never break the reply path."""
+        payload: dict[str, Any] = {
+            "channel": channel_id,
+            "text": text,
+            "blocks": blocks,
+        }
+        if thread_ts:
+            payload["thread_ts"] = thread_ts
+        if self.unfurl_links is not None:
+            payload["unfurl_links"] = self.unfurl_links
+        body = json.dumps(payload).encode("utf-8")
+        status, resp, raw = self._http(
+            f"{self.api_base}/chat.postMessage",
+            method="POST",
+            body=body,
+            headers=self._auth_headers(content_type=True),
+        )
+        if status >= 300:
+            snippet = raw[:200].decode("utf-8", "replace") if raw else ""
+            log.warn("slack task-progress post transport error",
+                     status=status, body=snippet)
+            return None
+        if isinstance(resp, dict):
+            if resp.get("ok") is not True:
+                log.warn("slack task-progress post rejected",
+                         error=resp.get("error") or "unknown")
+                return None
+            ts = resp.get("ts")
+            return ts if isinstance(ts, str) and ts else None
+        return None
+
+    def _update_blocks(
+        self, channel_id: str, ts: str, text: str, blocks: list,
+    ) -> None:
+        """``chat.update`` an existing Block Kit message in place.
+        Best-effort: a failure just leaves the card at its prior state."""
+        payload = {
+            "channel": channel_id,
+            "ts": ts,
+            "text": text,
+            "blocks": blocks,
+        }
+        body = json.dumps(payload).encode("utf-8")
+        status, resp, raw = self._http(
+            f"{self.api_base}/chat.update",
+            method="POST",
+            body=body,
+            headers=self._auth_headers(content_type=True),
+        )
+        if status >= 300:
+            snippet = raw[:200].decode("utf-8", "replace") if raw else ""
+            log.warn("slack task-progress update transport error",
+                     status=status, body=snippet)
+            return
+        if isinstance(resp, dict) and resp.get("ok") is not True:
+            log.warn("slack task-progress update rejected",
+                     error=resp.get("error") or "unknown")
 
     def _add_reaction(self, channel: str, ts: str, name: str) -> None:
         if not self.reactions_enabled:
@@ -922,6 +1026,162 @@ class SlackAdapter(SidecarAdapter):
                     channel_id, inbound_thread_id,
                 ),
             )
+
+    async def on_command(self, cmd) -> None:
+        """Route lifecycle ``reaction`` commands to the task-progress
+        display; defer everything else (``send`` → ``on_send``) to the
+        base dispatcher."""
+        if isinstance(cmd, protocol.Reaction):
+            await self._on_phase(cmd)
+            return
+        await super().on_command(cmd)
+
+    async def _on_phase(self, cmd) -> None:
+        """Fold one AgentPhase lifecycle ``reaction`` into a live Block
+        Kit task-progress card.
+
+        The card is materialized lazily — only once a turn actually runs
+        a tool (a genuinely multi-step turn). Single-step turns
+        (Queued → Thinking → Done with no ToolUse) post nothing here and
+        keep the pre-#6451 UX: the eyes → white_check_mark receipt
+        reaction driven by the receive/send hooks. Called only from the
+        serialized ``on_command`` reader path, so the state map needs no
+        lock; the Slack Web API calls are offloaded to the executor.
+        """
+        # The progress card is a processing-state indicator, so it honours
+        # the same operator toggle (`SLACK_REACTIONS`) as the eyes/check
+        # receipt reactions — disabling it silences all processing chatter.
+        if not self.reactions_enabled:
+            return
+        phase = (getattr(cmd, "phase", "") or "").strip()
+        if not phase:
+            # Legacy emoji-only reaction (pre-#6451 daemon): no structured
+            # phase to render, and single-step UX is already covered by
+            # the receipt reactions. Ignore.
+            return
+        channel_id = cmd.channel_id
+        message_id = cmd.message_id
+        if not channel_id or not message_id:
+            return
+        key = (channel_id, message_id)
+        terminal = phase in ("done", "error")
+
+        prog = self._task_progress.get(key)
+        if prog is None:
+            if terminal:
+                # Terminal phase with no tracked task = a single-step turn
+                # (no tool ran, so no card was ever posted). Nothing to
+                # finalize.
+                return
+            prog = _TaskProgress()
+            # Bounded insert: evict the oldest entry (insertion-ordered
+            # dict) so a turn that never terminates can't grow the map.
+            if len(self._task_progress) >= self.MAX_TASK_PROGRESS:
+                try:
+                    del self._task_progress[next(iter(self._task_progress))]
+                except StopIteration:
+                    pass
+            self._task_progress[key] = prog
+
+        # Record the step. `queued` is transient and never shown.
+        if phase == "tool_use":
+            prog.steps.append(("tool_use", getattr(cmd, "tool_name", None)))
+        elif phase in ("thinking", "streaming"):
+            # Collapse consecutive duplicates so repeated thinking /
+            # streaming phases don't spam the list.
+            if not prog.steps or prog.steps[-1][0] != phase:
+                prog.steps.append((phase, None))
+
+        # Materialize the card only for multi-step turns (a tool ran), or
+        # keep updating one already posted.
+        has_tool = any(s[0] == "tool_use" for s in prog.steps)
+        if not has_tool and prog.card_ts is None:
+            if terminal:
+                self._task_progress.pop(key, None)
+            return
+
+        text, blocks = _build_task_progress_blocks(prog.steps, phase)
+        loop = asyncio.get_event_loop()
+        if prog.card_ts is None:
+            thread_ts = None if self.force_flat_replies else message_id
+            ts = await loop.run_in_executor(
+                None,
+                lambda: self._post_blocks(
+                    channel_id, text, blocks, thread_ts=thread_ts,
+                ),
+            )
+            prog.card_ts = ts
+        else:
+            card_ts = prog.card_ts
+            await loop.run_in_executor(
+                None,
+                lambda: self._update_blocks(channel_id, card_ts, text, blocks),
+            )
+
+        if terminal:
+            self._task_progress.pop(key, None)
+
+
+class _TaskProgress:
+    """In-flight task-progress state for one agent turn."""
+
+    __slots__ = ("steps", "card_ts")
+
+    def __init__(self) -> None:
+        # Ordered list of (phase, tool_name) steps. `tool_name` is set
+        # only for `tool_use` steps.
+        self.steps: list[tuple[str, Optional[str]]] = []
+        # Slack `ts` of the posted progress card; None until first post.
+        self.card_ts: Optional[str] = None
+
+
+# Per-phase step icon for the live (in-progress) step in the card.
+_PHASE_STEP_ICON = {
+    "thinking": "\U0001f914",   # 🤔
+    "tool_use": "⚙️",  # ⚙️
+    "streaming": "✍️",  # ✍️
+}
+
+
+def _phase_step_label(phase: str, tool_name: Optional[str]) -> str:
+    if phase == "tool_use":
+        return f"`{tool_name}`" if tool_name else "Running a tool"
+    if phase == "thinking":
+        return "Thinking"
+    if phase == "streaming":
+        return "Writing response"
+    return phase
+
+
+def _build_task_progress_blocks(
+    steps: list, current_phase: str,
+) -> tuple[str, list]:
+    """Render the ordered step list into a single-section Block Kit card.
+
+    Returns ``(text, blocks)`` — ``text`` is the mrkdwn fallback Slack
+    shows in notifications, ``blocks`` the rich rendering. Completed
+    steps carry a ``✓``; the active (last, non-terminal) step carries its
+    phase icon so the user sees which step is running right now.
+    """
+    if current_phase == "error":
+        header = "*❌ Task failed*"        # ❌
+    elif current_phase == "done":
+        header = "*✅ Task complete*"      # ✅
+    else:
+        header = "*⏳ Working…*"       # ⏳ Working…
+    terminal = current_phase in ("done", "error")
+    lines = [header]
+    n = len(steps)
+    for i, (phase, tool_name) in enumerate(steps):
+        active = (not terminal) and (i == n - 1)
+        icon = _PHASE_STEP_ICON.get(phase, "•") if active else "✓"  # ✓
+        lines.append(f"{icon} {_phase_step_label(phase, tool_name)}")
+    text = "\n".join(lines)
+    blocks = [{
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": text},
+    }]
+    return text, blocks
 
 
 # Matches one code span — fenced ```...``` or inline `...`.

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -1177,6 +1177,26 @@ def _build_task_progress_blocks(
         icon = _PHASE_STEP_ICON.get(phase, "•") if active else "✓"  # ✓
         lines.append(f"{icon} {_phase_step_label(phase, tool_name)}")
     text = "\n".join(lines)
+    # Slack rejects a section whose text exceeds SLACK_MSG_LIMIT (3000) chars,
+    # which would freeze the progress card on a long or looping turn. Keep the
+    # header plus the most recent steps under the limit, collapsing older steps
+    # into a single summary line (#6451 review).
+    if len(text) > SLACK_MSG_LIMIT:
+        header_line = lines[0]
+        step_lines = lines[1:]
+        budget = SLACK_MSG_LIMIT - len(header_line) - 40
+        kept: list[str] = []
+        for line in reversed(step_lines):
+            if sum(len(x) + 1 for x in kept) + len(line) + 1 > budget:
+                break
+            kept.append(line)
+        kept.reverse()
+        dropped = len(step_lines) - len(kept)
+        summary = [header_line]
+        if dropped > 0:
+            summary.append(f"… {dropped} earlier step{'s' if dropped != 1 else ''}")
+        summary.extend(kept)
+        text = "\n".join(summary)
     blocks = [{
         "type": "section",
         "text": {"type": "mrkdwn", "text": text},

--- a/sdk/python/librefang/sidecar/protocol.py
+++ b/sdk/python/librefang/sidecar/protocol.py
@@ -347,6 +347,13 @@ class Reaction:
     channel_id: str
     message_id: str
     reaction: str
+    #: Lifecycle phase tag: ``queued`` / ``thinking`` / ``tool_use`` /
+    #: ``streaming`` / ``done`` / ``error``. Empty on the legacy
+    #: emoji-only frame; carried so an adapter can render a live step
+    #: list from the phase lifecycle (#6451).
+    phase: str = ""
+    #: Tool being executed, present for the ``tool_use`` phase only.
+    tool_name: Optional[str] = None
 
 
 @dataclass
@@ -420,7 +427,8 @@ def parse_command(line: str) -> Command:
         return TypingCmd(p.get("channel_id", ""))
     if method == "reaction":
         return Reaction(p.get("channel_id", ""), p.get("message_id", ""),
-                        p.get("reaction", ""))
+                        p.get("reaction", ""), p.get("phase", ""),
+                        p.get("tool_name"))
     if method == "interactive":
         return Interactive(p.get("channel_id", ""), p.get("message", {}))
     if method == "stream_start":

--- a/sdk/python/tests/test_sidecar_protocol.py
+++ b/sdk/python/tests/test_sidecar_protocol.py
@@ -147,6 +147,8 @@ def test_parse_command_all_kinds():
         "params": {"channel_id": "c", "message_id": "m", "reaction": "👍"},
     }))
     assert isinstance(r, Reaction) and r.reaction == "👍"
+    # Legacy emoji-only frame → the #6451 fields default cleanly.
+    assert r.phase == "" and r.tool_name is None
 
     i = parse_command(json.dumps({
         "method": "interactive",
@@ -182,6 +184,22 @@ def test_parse_command_non_object_json_raises_decode_error():
     for bad in ("123", '"a string"', "[1,2,3]", "true", "null"):
         with pytest.raises(json.JSONDecodeError):
             parse_command(bad)
+
+
+def test_parse_command_reaction_carries_phase_and_tool_name():
+    # #6451: the enriched reaction frame carries the lifecycle phase tag
+    # and (for tool_use) the tool name so an adapter can render a step
+    # list, not just an emoji.
+    r = parse_command(json.dumps({
+        "method": "reaction",
+        "params": {
+            "channel_id": "c", "message_id": "m", "reaction": "⚙️",
+            "phase": "tool_use", "tool_name": "web_fetch",
+        },
+    }))
+    assert isinstance(r, Reaction)
+    assert r.phase == "tool_use"
+    assert r.tool_name == "web_fetch"
 
 
 def test_parse_command_stream_start_carries_thread_id():

--- a/sdk/python/tests/test_slack_adapter.py
+++ b/sdk/python/tests/test_slack_adapter.py
@@ -1218,6 +1218,22 @@ def test_build_task_progress_blocks_active_and_done():
     assert "Task failed" in etext.split("\n")[0]
 
 
+def test_build_task_progress_blocks_bounds_long_step_list():
+    # Enough steps that a naive join blows past Slack's 3000-char section limit;
+    # the card must stay under the limit by collapsing older steps into a
+    # summary line while keeping the most recent ones (#6451 review).
+    steps = [("tool_use", f"very_long_tool_name_number_{i:04d}") for i in range(200)]
+    text, blocks = sa._build_task_progress_blocks(steps, "tool_use")
+    assert len(text) <= sa.SLACK_MSG_LIMIT, (
+        f"the progress card must stay under the Slack section limit; got {len(text)}"
+    )
+    # The rendered block carries exactly the bounded text.
+    assert blocks[0]["text"]["text"] == text
+    # Older steps are collapsed into a summary line; the newest step survives.
+    assert "earlier step" in text
+    assert "very_long_tool_name_number_0199" in text
+
+
 @pytest.mark.asyncio
 async def test_phase_single_step_posts_no_card(monkeypatch):
     # A turn that never runs a tool (queued → thinking → done) posts no

--- a/sdk/python/tests/test_slack_adapter.py
+++ b/sdk/python/tests/test_slack_adapter.py
@@ -1174,3 +1174,149 @@ async def test_on_send_converts_markdown_to_mrkdwn(monkeypatch):
     await a.on_send(_Cmd())
     body = json.loads(fake.calls[0]["body_raw"])
     assert body["text"] == "*Title*\n*bold* <https://e.example|x>"
+
+
+# ---- multi-step task progress (#6451) ------------------------------
+
+
+def _reaction(phase, tool_name=None, channel_id="C01", message_id="T1",
+              emoji="x"):
+    """Build an AgentPhase lifecycle `reaction` command the way the
+    bridge serializes it (channel_id, message_id, emoji, phase,
+    tool_name)."""
+    return sa.protocol.Reaction(channel_id, message_id, emoji, phase,
+                                tool_name)
+
+
+def test_capabilities_include_reaction():
+    # `reaction` is what carries the AgentPhase lifecycle to the adapter;
+    # the existing interactive/thread caps stay declared.
+    assert "reaction" in sa.SlackAdapter.capabilities
+    assert "interactive" in sa.SlackAdapter.capabilities
+    assert "thread" in sa.SlackAdapter.capabilities
+
+
+def test_build_task_progress_blocks_active_and_done():
+    steps = [("thinking", None), ("tool_use", "web_fetch")]
+    text, blocks = sa._build_task_progress_blocks(steps, "tool_use")
+    assert blocks[0]["type"] == "section"
+    assert blocks[0]["text"]["type"] == "mrkdwn"
+    lines = text.split("\n")
+    assert "Working" in lines[0]
+    # Completed thinking step gets a checkmark; the active tool step
+    # keeps its own (non-check) phase icon and shows the tool name.
+    assert lines[1].startswith("✓")
+    assert "Thinking" in lines[1]
+    assert not lines[2].startswith("✓")
+    assert "`web_fetch`" in lines[2]
+    # Terminal render flips the header and marks every step done.
+    dtext, _ = sa._build_task_progress_blocks(steps, "done")
+    assert "Task complete" in dtext.split("\n")[0]
+    for ln in dtext.split("\n")[1:]:
+        assert ln.startswith("✓")
+    etext, _ = sa._build_task_progress_blocks(steps, "error")
+    assert "Task failed" in etext.split("\n")[0]
+
+
+@pytest.mark.asyncio
+async def test_phase_single_step_posts_no_card(monkeypatch):
+    # A turn that never runs a tool (queued → thinking → done) posts no
+    # card — single-step UX stays exactly as before (#6451).
+    fake = _FakeUrlopen([])  # no HTTP expected
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    await a.on_command(_reaction("queued"))
+    await a.on_command(_reaction("thinking"))
+    await a.on_command(_reaction("done"))
+    assert fake.calls == []
+    # State is cleaned up on the terminal phase.
+    assert a._task_progress == {}
+
+
+@pytest.mark.asyncio
+async def test_phase_multi_step_posts_then_updates_card(monkeypatch):
+    fake = _FakeUrlopen([
+        (200, {"ok": True, "ts": "CARD1"}),  # first tool_use → post
+        (200, {"ok": True}),                 # second tool_use → update
+        (200, {"ok": True}),                 # done → finalize update
+    ])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    await a.on_command(_reaction("thinking"))
+    await a.on_command(_reaction("tool_use", tool_name="web_fetch"))
+    await a.on_command(_reaction("tool_use", tool_name="read_file"))
+    await a.on_command(_reaction("done"))
+    assert len(fake.calls) == 3
+    assert fake.calls[0]["url"].endswith("/chat.postMessage")
+    assert fake.calls[1]["url"].endswith("/chat.update")
+    assert fake.calls[2]["url"].endswith("/chat.update")
+    # The card threads under the triggering message ts by default.
+    post_body = json.loads(fake.calls[0]["body_raw"])
+    assert post_body["thread_ts"] == "T1"
+    assert any(b["type"] == "section" for b in post_body["blocks"])
+    # Updates target the posted card's ts (returned from the first post).
+    assert json.loads(fake.calls[1]["body_raw"])["ts"] == "CARD1"
+    assert json.loads(fake.calls[2]["body_raw"])["ts"] == "CARD1"
+    # Both tool names survive into the finalized card.
+    final = json.loads(fake.calls[2]["body_raw"])
+    final_text = final["blocks"][0]["text"]["text"]
+    assert "web_fetch" in final_text and "read_file" in final_text
+    assert "Task complete" in final_text
+    # State cleaned up after the terminal phase.
+    assert a._task_progress == {}
+
+
+@pytest.mark.asyncio
+async def test_phase_card_force_flat_omits_thread_ts(monkeypatch):
+    fake = _FakeUrlopen([
+        (200, {"ok": True, "ts": "CARD1"}),  # tool_use → post
+        (200, {"ok": True}),                 # error → finalize
+    ])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter(SLACK_FORCE_FLAT_REPLIES="true")
+    await a.on_command(_reaction("thinking"))
+    await a.on_command(_reaction("tool_use", tool_name="web_fetch"))
+    await a.on_command(_reaction("error"))
+    post_body = json.loads(fake.calls[0]["body_raw"])
+    assert "thread_ts" not in post_body
+    final = json.loads(fake.calls[1]["body_raw"])
+    assert "Task failed" in final["blocks"][0]["text"]["text"]
+
+
+@pytest.mark.asyncio
+async def test_phase_card_suppressed_when_reactions_disabled(monkeypatch):
+    # SLACK_REACTIONS=false silences all processing-state chatter,
+    # including the task-progress card.
+    fake = _FakeUrlopen([])  # no HTTP expected
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter(SLACK_REACTIONS="false")
+    await a.on_command(_reaction("thinking"))
+    await a.on_command(_reaction("tool_use", tool_name="web_fetch"))
+    await a.on_command(_reaction("done"))
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_phase_legacy_emoji_only_reaction_ignored(monkeypatch):
+    # A pre-#6451 reaction command with no `phase` carries nothing we
+    # can render — it must not post a card.
+    fake = _FakeUrlopen([])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    await a.on_command(_reaction("", emoji="👀"))
+    assert fake.calls == []
+    assert a._task_progress == {}
+
+
+@pytest.mark.asyncio
+async def test_on_command_send_still_routes_to_on_send(monkeypatch):
+    # The on_command override must not break the default Send → on_send
+    # dispatch.
+    fake = _FakeUrlopen([(200, {"ok": True})])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    a.reactions_enabled = False
+    cmd = sa.protocol.Send("C01", "hi", {"Text": "hi"}, None, {})
+    await a.on_command(cmd)
+    body = json.loads(fake.calls[0]["body_raw"])
+    assert body["channel"] == "C01" and body["text"] == "hi"

--- a/sdk/rust/librefang-sidecar/src/protocol.rs
+++ b/sdk/rust/librefang-sidecar/src/protocol.rs
@@ -522,6 +522,15 @@ pub struct Reaction {
     pub channel_id: String,
     pub message_id: String,
     pub reaction: String,
+    /// Lifecycle phase tag (`queued` / `thinking` / `tool_use` /
+    /// `streaming` / `done` / `error`) carried alongside the emoji so a
+    /// reaction consumer can render a live step list (#6451). Absent on
+    /// the legacy emoji-only frame — defaults to empty.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub phase: String,
+    /// Tool being executed, present for the `tool_use` phase only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]


### PR DESCRIPTION
Closes #6451.

## What

Wire the generic `AgentPhase` lifecycle (Queued → Thinking → ToolUse{name} → Done/Error) into the Slack sidecar and render it as an updated-in-place Block Kit task-progress card for multi-step turns.

Before this change the lifecycle never reached Slack: it is dispatched to adapters through `ChannelAdapter::send_reaction` (`bridge.rs`), which the sidecar trampoline gates on the `reaction` capability, and Slack declared only `["interactive", "thread"]`. Slack's hand-rolled eyes/white_check_mark reactions were its only progress signal.

## Capability decision — reuse `reaction`, no new capability

The phase lifecycle rides on `send_reaction`, so an adapter receives it iff it declares `reaction`. `interactive` gates `send_interactive` only and never carries phase events, so reusing the already-declared `interactive` capability would not deliver the lifecycle. `reaction` is already in the negotiation table and already carries every phase, so the correct minimal choice is to add `reaction` to Slack's declared capabilities — no new `task_update` capability, no negotiation-table change. This is documented in `docs/architecture/sidecar-channels.md`.

The Slack adapter repurposes the phase stream purely as a progress signal for the Block Kit card; it does not emit Slack emoji reactions from it. The existing eyes → white_check_mark receipt reactions stay driven independently by the receive/send hooks, so single-step behavior is unchanged.

## Detail-passing (Rust type + all call sites + sidecar serialization)

The `reaction` command previously carried only the emoji, which drops *which* tool ran (`⚙️` is the same for every tool). Added optional `phase` and `tool_name` fields to the reaction command, skipped on the wire when empty so a plain reaction is byte-for-byte the legacy `{channel_id, message_id, reaction}` frame:

- `SidecarReactionParams` (`crates/librefang-channels/src/sidecar.rs`) + `send_reaction` projects `AgentPhase` → `(phase tag, tool_name)`.
- The Python SDK `Reaction` dataclass + `parse_command` (`sdk/python/.../protocol.py`).
- The Rust SDK `Reaction` struct (`sdk/rust/librefang-sidecar/src/protocol.rs`), kept in protocol-sync (`#[serde(default)]`, additive).
- Every `SidecarReactionParams` construction site updated (send path + two conformance/test literals).

## Non-streaming ToolUse dispatch (bridge)

The per-tool `ToolUse{name}` phases were emitted on the streaming path only; the non-streaming accumulation path (used by Slack/Discord/Matrix) surfaced tool lines in the *text* but never as lifecycle phases. `dispatch_message` now extracts the same `\n\n🔧 tool\n\n` markers on the non-streaming path and emits `ToolUse` reactions, so a non-streaming adapter that declares `reaction` sees the full step sequence. Adapters without the `reaction` capability treat each as a no-op, so this is inert for them.

## Slack adapter (`slack.py`)

- Declares `reaction`; new `on_command` override routes `reaction` → `_on_phase`, defers `send` to the base dispatcher.
- `_on_phase` folds phases into a per-turn step list keyed by `(channel_id, triggering ts)`, bounded by `MAX_TASK_PROGRESS`, cleaned up on the terminal phase.
- The card is materialized lazily — only once a turn actually runs a tool (genuinely multi-step). Single-step turns (no tool) post nothing and keep the receipt reactions. Card posts threaded under the triggering message (respecting `force_flat_replies`) and updates in place via `chat.update`.
- Honours the same `SLACK_REACTIONS` opt-out as the receipt reactions.
- New `_post_blocks` (returns `ts`) / `_update_blocks` (`chat.update`) helpers; `_build_task_progress_blocks` renders the step list (completed steps `✓`, active step its phase icon, terminal header).

## Tests

Rust:
- `reaction_serializes_phase_and_tool_name_when_present` (`crates/librefang-channels/tests/sidecar_protocol_conformance.rs`) — enriched serialization + empty-field skip.
- Updated the existing `reaction.json` conformance literal and the `sidecar.rs` command-tag test literal for the new fields (empty → still serializes to the unchanged corpus frame).

Python (`sdk/python/tests`):
- `test_slack_adapter.py`: `test_capabilities_include_reaction`, `test_build_task_progress_blocks_active_and_done`, `test_phase_single_step_posts_no_card`, `test_phase_multi_step_posts_then_updates_card`, `test_phase_card_force_flat_omits_thread_ts`, `test_phase_card_suppressed_when_reactions_disabled`, `test_phase_legacy_emoji_only_reaction_ignored`, `test_on_command_send_still_routes_to_on_send`.
- `test_sidecar_protocol.py`: `test_parse_command_reaction_carries_phase_and_tool_name` + extended the existing reaction assertion for the default-empty legacy shape.

## Verification

- Python: full SDK suite run locally — `python3 -m pytest` in `sdk/python`, **1911 passed** (includes the new Slack/protocol/conformance tests).
- Rust: **not compiled locally** — six sibling agents run in parallel and local `cargo` contends on the shared `target/`, so per the worktree policy the Rust build/test is left to CI. `rustfmt --check` was run on all changed Rust files (clean). The change was written against the verbatim source of every touched type and call site; correctness of the enriched serialization is unit-tested and the non-streaming bridge change mirrors the already-tested streaming drain.
