### PR TITLE
fix(ci): pin login_page.html to LF so the CSP-hash test passes on Windows (#6481)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,9 +5,7 @@
 # explicit `eol=lf` here is a safety rail for tests that byte-compare.)
 crates/librefang-api/tests/fixtures/*.json text eol=lf
 
-# login_page.html is embedded verbatim via include_str! and its inline
-# <script> is pinned by an exact SHA-256 in the CSP (middleware.rs). A
-# Windows checkout with core.autocrlf=true rewrites it to CRLF, which
-# shifts the hash and fails dashboard_login_page_script_is_allowed_by_csp_hash
-# on Windows only. Pin it to LF so the embedded bytes match CI on every OS.
+# login_page.html is embedded verbatim via include_str! and its inline <script> is pinned by an exact SHA-256 in the CSP (middleware.rs).
+# A Windows checkout with core.autocrlf=true rewrites it to CRLF, which shifts the hash and fails dashboard_login_page_script_is_allowed_by_csp_hash on Windows only.
+# Pin it to LF so the embedded bytes match CI on every OS.
 crates/librefang-api/src/login_page.html text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,10 @@
 # tests would fail cross-platform. (Rust source + JSON are fine as-is; the
 # explicit `eol=lf` here is a safety rail for tests that byte-compare.)
 crates/librefang-api/tests/fixtures/*.json text eol=lf
+
+# login_page.html is embedded verbatim via include_str! and its inline
+# <script> is pinned by an exact SHA-256 in the CSP (middleware.rs). A
+# Windows checkout with core.autocrlf=true rewrites it to CRLF, which
+# shifts the hash and fails dashboard_login_page_script_is_allowed_by_csp_hash
+# on Windows only. Pin it to LF so the embedded bytes match CI on every OS.
+crates/librefang-api/src/login_page.html text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin `crates/librefang-api/src/login_page.html` to LF in `.gitattributes`: the file is embedded verbatim via `include_str!` and its inline `<script>` is authorised by an exact SHA-256 baked into the CSP (`middleware.rs`), so a Windows checkout with `core.autocrlf=true` rewrote it to CRLF, shifted the computed hash, and failed `dashboard_login_page_script_is_allowed_by_csp_hash` on the Windows shard only — turning `main` red on every merge since #6486 touched the page (#6481) (@houko)
+
 ### Added
 
 - Edit `HAND.toml` online from the Hands panel: the read-only manifest viewer now has an Edit / Save / Cancel affordance backed by a new authenticated `PUT /api/hands/{id}/manifest` that validates the submitted TOML by parsing it into a `HandDefinition` (rejecting invalid TOML or a changed `id` with a 400 and leaving the on-disk file untouched), runs the same supply-chain audit as the install path, persists the file to whichever on-disk copy the hand loads from, and hot-reloads the in-memory definitions — an already-active hand instance keeps its old manifest until it is deactivated and reactivated, and edits to a built-in (registry) hand are overwritten on the next registry sync (#6478) (@houko)


### PR DESCRIPTION
## Problem

`main` has been red on the **Windows shard only** since #6486 last touched the login page. The failing test is:

```
FAIL middleware::tests::dashboard_login_page_script_is_allowed_by_csp_hash
thread panicked at crates/librefang-api/src/middleware.rs:3759
```

(Confirmed from run 29559606139 `--log-failed`; macOS and Ubuntu shards are green.)

### Root cause

`login_page.html` is embedded verbatim via `include_str!` (`middleware.rs:1730`), and its inline `<script>` is authorised by an exact SHA-256 hardcoded in the CSP (`middleware.rs:1731`, `sha256-TDA4xC…`). The file had **no `.gitattributes` rule**, so a Windows runner checkout with `core.autocrlf=true` materialises it with CRLF line endings. The `\r` bytes flow into the embedded string, the runtime `Sha256::digest(script)` no longer matches the hardcoded hash, and the assertion at `middleware.rs:3759` fails. The failure is invisible on macOS/Linux because they check the file out as LF.

Every open PR inherited this failure on its next CI run — the bot filed #6481 and re-attributed it across #6482 / #6485 / #6486 as they merged.

## Fix

One `.gitattributes` rule pinning the file to LF, mirroring the existing golden-fixtures rule right above it:

```
crates/librefang-api/src/login_page.html text eol=lf
```

The blob is already LF in the index (`git ls-files --eol` → `i/lf`), so `--renormalize` produced no content change — this only stops Windows checkouts from drifting to CRLF.

## Scope note

`login_page.html` is the **only** `include_str!`-embedded, byte-compared HTML in the tree (verified: the sole such reference is `middleware.rs:1730`), so no sibling files need the same treatment.

## Verification

- `git check-attr text eol -- crates/librefang-api/src/login_page.html` → `text: set`, `eol: lf`.
- No Rust code changed, so no behavioural test applies; the fix is a checkout-normalisation rule whose effect only manifests on a Windows runner. CI's Windows shard on this PR is the real verification — if it goes green, `main` is unblocked.

Refs #6481
