### PR TITLE
docs: explain trusted_senders vs [[users]] RBAC composition (#6492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ## [Unreleased]
 
+### Documentation
+
+- Document how `[approval].trusted_senders` composes with `[[users]]` RBAC on the approvals security page (EN + zh mirror): the two are separate trust surfaces and the per-user RBAC gate is evaluated first, so an ID listed in `trusted_senders` that is not also a registered `[[users]]` on the `api` channel still has its low-risk tools (e.g. `memory_*`) gated by the `guest_gate`, because the forced-approval verdict short-circuits before the `trusted_senders` bypass is consulted; the new subsection gives the concrete fix (register the operator as a `[[users]]` bound to the `api` channel with a `tool_policy` covering the tools it drives) and notes that with no `[[users]]` configured `trusted_senders` works standalone (#6492) (@houko)
+
 ### Fixed
 
 - Pin `crates/librefang-api/src/login_page.html` to LF in `.gitattributes`: the file is embedded verbatim via `include_str!` and its inline `<script>` is authorised by an exact SHA-256 baked into the CSP (`middleware.rs`), so a Windows checkout with `core.autocrlf=true` rewrote it to CRLF, shifted the computed hash, and failed `dashboard_login_page_script_is_allowed_by_csp_hash` on the Windows shard only — turning `main` red on every merge since #6486 touched the page (#6481) (@houko)

--- a/docs/src/app/security/approvals/page.mdx
+++ b/docs/src/app/security/approvals/page.mdx
@@ -58,6 +58,39 @@ When an approval times out, the action falls through to `timeout_fallback`:
 - `allow` — action proceeds. Only safe in fully-trusted autonomous setups.
 - `retry` — re-requests approval once more.
 
+### How `trusted_senders` composes with `[[users]]` RBAC
+
+`trusted_senders` and `[[users]]` RBAC are two separate trust surfaces, and being listed in one does not exempt a sender from the other.
+`trusted_senders` governs only the approval layer — it waives the approval prompt for a trusted sender's low-risk tools (high-risk tools stay gated, per the [Hardening Checklist](#hardening-checklist)).
+`[[users]]` RBAC governs the per-user tool gate, which is evaluated **first** and independently.
+
+Because RBAC runs first, a "needs approval" verdict from it wins before the `trusted_senders` bypass is ever consulted.
+So when `[[users]]` is configured and a sender is **not** a registered user on the `api` channel — the channel REST `POST /api/agents/{id}/message` requests arrive on — that sender falls to the built-in guest gate (`guest_gate`).
+The guest gate allows only a small read-only set (file reads, search, `web_fetch`, …) and returns "needs approval" for everything else — including `memory_store` / `memory_recall`, which are otherwise low-risk.
+The surprising consequence: an ID listed in `trusted_senders` that is not *also* a registered `[[users]]` on the `api` channel still has its `memory_*` calls gated, because the guest gate forced approval before `trusted_senders` could waive it.
+
+**Fix — register the operator as a user bound to the `api` channel**, with a tool policy covering the tools it drives:
+
+```toml
+[[users]]
+name = "ops-bot"
+role = "user"
+
+# Bind the REST sender_id (the `sender_id` field on the /message request)
+# to this user on the "api" channel.
+[users.channel_bindings]
+api = "ops-bot-sender-id"
+
+# Grant the low-risk tools this operator uses; the RBAC gate now returns
+# Allow for these instead of routing them through the guest gate.
+[users.tool_policy]
+allowed_tools = ["memory_*"]
+```
+
+With this in place the RBAC gate returns `Allow` for `memory_*`, so approval is no longer forced and the `trusted_senders` bypass applies on top exactly as designed.
+
+If no `[[users]]` are configured at all, RBAC is inactive — the per-user gate returns `Allow` for every sender — and `trusted_senders` works standalone with no extra setup.
+
 ---
 
 ## Enabling TOTP

--- a/docs/src/app/zh/security/approvals/page.mdx
+++ b/docs/src/app/zh/security/approvals/page.mdx
@@ -60,7 +60,7 @@ totp_tools = []                        # 留空表示审批列表内所有工具
 ### `trusted_senders` 与 `[[users]]` RBAC 如何叠加
 
 `trusted_senders` 和 `[[users]]` RBAC 是两个相互独立的信任面，被其中一个信任并不意味着可以豁免另一个。
-`trusted_senders` 只作用于审批层——它为受信任发送者的低风险工具免除审批提示（高风险工具仍被拦截，见[加固清单](#hardening-checklist)）。
+`trusted_senders` 只作用于审批层——它为受信任发送者的低风险工具免除审批提示（高风险工具仍被拦截，见[加固清单](#加固清单)）。
 `[[users]]` RBAC 作用于按用户的工具门禁，而该门禁**先于**审批层、且独立地被求值。
 
 由于 RBAC 先运行，它给出的「需要审批」结论会在 `trusted_senders` 免审批被查阅之前就先生效。

--- a/docs/src/app/zh/security/approvals/page.mdx
+++ b/docs/src/app/zh/security/approvals/page.mdx
@@ -57,6 +57,39 @@ totp_tools = []                        # 留空表示审批列表内所有工具
 - `allow`——放行。仅适用于完全受信任的自主场景。
 - `retry`——再请求一次审批。
 
+### `trusted_senders` 与 `[[users]]` RBAC 如何叠加
+
+`trusted_senders` 和 `[[users]]` RBAC 是两个相互独立的信任面，被其中一个信任并不意味着可以豁免另一个。
+`trusted_senders` 只作用于审批层——它为受信任发送者的低风险工具免除审批提示（高风险工具仍被拦截，见[加固清单](#hardening-checklist)）。
+`[[users]]` RBAC 作用于按用户的工具门禁，而该门禁**先于**审批层、且独立地被求值。
+
+由于 RBAC 先运行，它给出的「需要审批」结论会在 `trusted_senders` 免审批被查阅之前就先生效。
+因此，当配置了 `[[users]]` 而某个发送者**不是** `api` 通道上已注册的用户时（REST `POST /api/agents/{id}/message` 请求正是走 `api` 通道），该发送者会落入内置的 guest gate（`guest_gate`）。
+guest gate 只放行一小组只读工具（文件读取、搜索、`web_fetch` 等），对其余一切都返回「需要审批」——包括本属低风险的 `memory_store` / `memory_recall`。
+由此得出一个反直觉的结果：一个列入 `trusted_senders`、但**未**同时注册为 `api` 通道上 `[[users]]` 的 ID，其 `memory_*` 调用仍会被拦截，因为 guest gate 在 `trusted_senders` 免审批生效之前就已强制审批。
+
+**解决办法——把该操作者注册为绑定到 `api` 通道的用户**，并授予覆盖其所用工具的策略：
+
+```toml
+[[users]]
+name = "ops-bot"
+role = "user"
+
+# 把 REST 的 sender_id（/message 请求上的 `sender_id` 字段）
+# 绑定到该用户在 "api" 通道上的身份。
+[users.channel_bindings]
+api = "ops-bot-sender-id"
+
+# 授予该操作者所用的低风险工具；RBAC 门禁此时对这些工具返回
+# Allow，而不再把它们路由进 guest gate。
+[users.tool_policy]
+allowed_tools = ["memory_*"]
+```
+
+如此配置后，RBAC 门禁对 `memory_*` 返回 `Allow`，于是不再强制审批，`trusted_senders` 免审批便如设计般在其之上叠加生效。
+
+如果完全没有配置 `[[users]]`，RBAC 处于未启用状态——按用户门禁对每个发送者都返回 `Allow`——此时 `trusted_senders` 无需额外设置即可独立工作。
+
 ---
 
 ## 启用 TOTP


### PR DESCRIPTION
## Summary

Documentation-only change fulfilling the docs pass @houko committed to in #6492 "regardless" of the other bug decisions.

The security docs mentioned `[approval].trusted_senders` but never explained how it composes with `[[users]]` RBAC and the guest-gate. Users were confused because a `trusted_senders` entry does **not** bypass the RBAC guest-gate.

Adds a new subsection — "How `trusted_senders` composes with `[[users]]` RBAC" — to the approvals security page and its Simplified-Chinese mirror.

## What the subsection says

- `[approval].trusted_senders` and `[[users]]` RBAC are two separate trust surfaces. `trusted_senders` governs only the approval layer (waives approval for low-risk tools; high-risk tools stay gated). `[[users]]` RBAC governs the per-user tool gate.
- The RBAC gate is evaluated **first** and independently. When `[[users]]` is configured and the REST `sender_id` does not resolve to a registered user on the `api` channel, the sender falls to `guest_gate`, whose read-only allowlist does not include `memory_store` / `memory_recall` — so it returns "needs approval". That forced-approval verdict short-circuits (`force_approval || requires_approval_with_context(...)`) before the `trusted_senders` bypass is ever consulted.
- Consequence: an ID in `trusted_senders` that is not also a registered `[[users]]` on the `api` channel still has its low-risk `memory_*` calls gated.
- Concrete fix (with a minimal TOML snippet): register the operator as `[[users]]` bound to the `api` channel with a `tool_policy` allowing the tools it needs; the RBAC gate then returns `Allow` and the `trusted_senders` bypass applies on top as designed.
- With no `[[users]]` configured, RBAC is inactive and `trusted_senders` works standalone.

## Files changed

- `docs/src/app/security/approvals/page.mdx` — new subsection under Approval Policy.
- `docs/src/app/zh/security/approvals/page.mdx` — equivalent Simplified-Chinese subsection.
- `CHANGELOG.md` — `### Documentation` bullet under `[Unreleased]`.

## Verification

- Every behavioural claim verified against current source (`crates/librefang-kernel/src/auth.rs` `resolve_user_tool_decision` / `guest_gate`, `crates/librefang-runtime/src/tool_runner/dispatch.rs` `force_approval` short-circuit, `crates/librefang-kernel/src/approval.rs` `requires_approval_with_context` / `classify_risk`, `crates/librefang-api/src/routes/agents/mod.rs` `api` channel + `sender_id`). The cited paths had not drifted.
- TOML snippet validated with `tomllib`; MDX code-fences balanced in both files; internal `#hardening-checklist` anchor present in both.

## Scope

This is the committed docs pass on `trusted_senders` vs RBAC composition only. It does **not** resolve Bug 1 (needs the reporter's config to reproduce) or Bug 2 (needs a design decision) tracked in #6492.

Closes the docs commitment in #6492.
