### PR TITLE
fix(kernel): route post-approval reply through account-qualified outbound (#6492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ### Fixed
 
+- Route the post-approval agent reply through the account-qualified outbound path so multi-account installs deliver to the correct bot/chat: `wake_agent_after_approval` previously looked the channel adapter up by the bare channel key (`channel_adapters.get(channel)`), ignoring `deferred.account_id`, but adapters are registered under both the bare key and the account-qualified key (`"<channel>:<account_id>"`), so a resumed reply for a non-first account was delivered to the wrong account's adapter or missed entirely; it now reuses `ChannelSender::send_channel_message`, which builds the same account-qualified lookup key the canonical outbound path uses (#6492) (@houko)
 - Pin `crates/librefang-api/src/login_page.html` to LF in `.gitattributes`: the file is embedded verbatim via `include_str!` and its inline `<script>` is authorised by an exact SHA-256 baked into the CSP (`middleware.rs`), so a Windows checkout with `core.autocrlf=true` rewrote it to CRLF, shifted the computed hash, and failed `dashboard_login_page_script_is_allowed_by_csp_hash` on the Windows shard only — turning `main` red on every merge since #6486 touched the page (#6481) (@houko)
 
 ### Added

--- a/crates/librefang-kernel/src/kernel/mod.rs
+++ b/crates/librefang-kernel/src/kernel/mod.rs
@@ -1741,8 +1741,8 @@ impl LibreFangKernel {
         // Skipping this step is what made "tap [Approve] → silence"
         // surface in production: the agent loop ran and produced a
         // perfect natural-language follow-up that nobody ever showed
-        // the user. Route it now via the channel registry, looking up
-        // the adapter the original tool call's `channel` field names.
+        // the user. Route it now through the canonical outbound path,
+        // keyed by the original tool call's `channel` and `account_id`.
         if loop_result.silent || loop_result.response.is_empty() {
             debug!(
                 agent_id = %agent_id,
@@ -1751,25 +1751,29 @@ impl LibreFangKernel {
             );
             return;
         }
-        let Some(adapter) = self.mesh.channel_adapters.get(channel) else {
-            warn!(
-                agent_id = %agent_id,
-                tool_use_id = %deferred.tool_use_id,
-                channel = channel,
-                "No active adapter for the originating channel — agent reply produced but cannot be delivered; session has the reply persisted so the next user turn surfaces it"
-            );
-            return;
-        };
-        let recipient = librefang_channels::types::ChannelUser {
-            platform_id: routing_chat_id.to_string(),
-            display_name: String::new(),
-            librefang_user: None,
-        };
-        if let Err(e) = adapter
-            .value()
-            .send(
-                &recipient,
-                librefang_channels::types::ChannelContent::Text(loop_result.response.clone()),
+        // Route the reply through the canonical account-qualified outbound
+        // path (#6492 Bug 2). `send_channel_message` builds the adapter
+        // lookup key as `"<channel>:<account_id>"` when an account is present
+        // and falls back to the bare `<channel>` otherwise — matching how the
+        // channel bridge registers adapters under BOTH keys for multi-account
+        // installs. The previous bare `channel_adapters.get(channel)` ignored
+        // `deferred.account_id`, so on a multi-account daemon a post-approval
+        // reply for a non-first account was delivered to the wrong account's
+        // adapter (wrong bot/chat) or missed entirely. Reusing the canonical
+        // path also picks up the adapter's `output_format` override for free,
+        // exactly as a normal inbound reply would. `thread_id: None` — the wake
+        // path carries no thread context (mirrors the pre-fix `adapter.send()`,
+        // which never threaded). On an adapter-miss OR a send failure the call
+        // returns `Err`; we log WARN (it does not log itself) with the same
+        // information as before — the reply is still persisted in session
+        // history, so the next user turn surfaces it.
+        if let Err(e) = self
+            .send_channel_message(
+                channel,
+                routing_chat_id,
+                &loop_result.response,
+                None,
+                deferred.account_id.as_deref(),
             )
             .await
         {
@@ -1777,9 +1781,10 @@ impl LibreFangKernel {
                 agent_id = %agent_id,
                 tool_use_id = %deferred.tool_use_id,
                 channel = channel,
-                recipient = %recipient.platform_id,
+                account_id = ?deferred.account_id,
+                recipient = routing_chat_id,
                 error = %e,
-                "Failed to deliver post-approval agent reply to channel — reply is still persisted in session history"
+                "No active adapter for the originating channel/account, or delivery failed — post-approval agent reply produced but not delivered; reply is still persisted in session history so the next user turn surfaces it"
             );
         }
     }

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -325,6 +325,133 @@ async fn test_send_channel_message_honours_adapter_output_format_override_6445()
     kernel.shutdown();
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_post_approval_reply_routes_to_account_qualified_adapter_6492() {
+    // #6492 Bug 2: the post-approval wake path (`wake_agent_after_approval`)
+    // used to deliver the resumed agent reply with a BARE adapter lookup
+    // (`channel_adapters.get(channel)`) that ignored `deferred.account_id`.
+    // On a multi-account install the channel bridge registers each adapter
+    // under BOTH the bare key (`"whatsapp"`) and the account-qualified key
+    // (`"whatsapp:<account_id>"`), so a reply for a non-first account landed
+    // on the wrong account's bot/chat (or missed entirely). The fix routes the
+    // reply through the canonical `send_channel_message`, which keys by
+    // `"<channel>:<account_id>"` first and falls back to the bare channel.
+    //
+    // This test asserts that account-qualified delivery contract the wake path
+    // now delegates to — driving `send_channel_message` with the exact
+    // `(routing_chat_id, account_id)` that `wake_agent_after_approval` extracts
+    // from the `DeferredToolExecution`. (The full `send_message_full` LLM
+    // round-trip inside the wake path is out of unit-test scope, matching the
+    // module note on the notification tests.)
+    use librefang_types::tool::DeferredToolExecution;
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().to_path_buf();
+    std::fs::create_dir_all(home_dir.join("data")).unwrap();
+    let config = KernelConfig {
+        home_dir: home_dir.clone(),
+        data_dir: home_dir.join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(config).expect("Kernel should boot");
+
+    // Two adapters for the same channel type, registered under the bare and the
+    // account-qualified keys — exactly what the bridge does for a multi-account
+    // WhatsApp deployment.
+    let bare_adapter = Arc::new(RecordingChannelAdapter::new("whatsapp"));
+    let bare_sent = bare_adapter.sent.clone();
+    let acct_adapter = Arc::new(RecordingChannelAdapter::new("whatsapp"));
+    let acct_sent = acct_adapter.sent.clone();
+    kernel
+        .mesh
+        .channel_adapters
+        .insert("whatsapp".to_string(), bare_adapter);
+    kernel
+        .mesh
+        .channel_adapters
+        .insert("whatsapp:acct1".to_string(), acct_adapter);
+
+    // Case 1: a deferred exec that arrived on account "acct1" in a group chat.
+    // The reply MUST land on the "whatsapp:acct1" adapter and NOT the bare one.
+    let deferred_acct = DeferredToolExecution {
+        agent_id: "agent-1".to_string(),
+        tool_use_id: "tu-acct".to_string(),
+        tool_name: "file_write".to_string(),
+        input: serde_json::json!({}),
+        allowed_tools: None,
+        allowed_env_vars: None,
+        exec_policy: None,
+        sender_id: Some("user-7".to_string()),
+        channel: Some("whatsapp".to_string()),
+        chat_id: Some("group-99".to_string()),
+        account_id: Some("acct1".to_string()),
+        workspace_root: None,
+        force_human: false,
+        session_id: None,
+    };
+    // Recipient + account resolution mirror `wake_agent_after_approval`: prefer
+    // chat_id over sender_id, and forward account_id verbatim.
+    let routing_chat_id = deferred_acct
+        .chat_id
+        .as_deref()
+        .filter(|c| !c.is_empty())
+        .unwrap_or_else(|| deferred_acct.sender_id.as_deref().unwrap());
+    kernel
+        .send_channel_message(
+            deferred_acct.channel.as_deref().unwrap(),
+            routing_chat_id,
+            "approved — done",
+            None,
+            deferred_acct.account_id.as_deref(),
+        )
+        .await
+        .expect("send should succeed to the account-qualified adapter");
+    assert_eq!(
+        acct_sent.lock().unwrap().clone(),
+        vec!["group-99:approved — done".to_string()],
+        "post-approval reply for account 'acct1' must be delivered via the 'whatsapp:acct1' adapter"
+    );
+    assert!(
+        bare_sent.lock().unwrap().is_empty(),
+        "post-approval reply for account 'acct1' must NOT leak to the bare 'whatsapp' adapter (the misdelivery bug)"
+    );
+
+    // Case 2: a deferred exec with no account (single-tenant / bare source)
+    // routes to the bare "whatsapp" adapter, not the account-qualified one.
+    let deferred_bare = DeferredToolExecution {
+        account_id: None,
+        chat_id: Some("dm-1".to_string()),
+        tool_use_id: "tu-bare".to_string(),
+        ..deferred_acct.clone()
+    };
+    let routing_chat_id_bare = deferred_bare
+        .chat_id
+        .as_deref()
+        .filter(|c| !c.is_empty())
+        .unwrap_or_else(|| deferred_bare.sender_id.as_deref().unwrap());
+    kernel
+        .send_channel_message(
+            deferred_bare.channel.as_deref().unwrap(),
+            routing_chat_id_bare,
+            "approved — bare",
+            None,
+            deferred_bare.account_id.as_deref(),
+        )
+        .await
+        .expect("send should succeed to the bare adapter");
+    assert_eq!(
+        bare_sent.lock().unwrap().clone(),
+        vec!["dm-1:approved — bare".to_string()],
+        "post-approval reply with no account must be delivered via the bare 'whatsapp' adapter"
+    );
+    assert_eq!(
+        acct_sent.lock().unwrap().len(),
+        1,
+        "bare-account reply must NOT reach the account-qualified adapter (still only the case-1 send)"
+    );
+
+    kernel.shutdown();
+}
+
 #[test]
 fn test_manifest_to_capabilities() {
     let mut manifest = AgentManifest {


### PR DESCRIPTION
Fixes the deliverable case of #6492 Bug 2 — the multi-account misdelivery / wrong-adapter bug in the post-approval wake path.

## The bug

`wake_agent_after_approval` (`crates/librefang-kernel/src/kernel/mod.rs`) generates the resumed agent reply and then delivered it with a BARE adapter lookup: `self.mesh.channel_adapters.get(channel)` followed by a manual `ChannelUser` + `adapter.send(...)`.
That lookup ignored `deferred.account_id`.

But the channel bridge registers each adapter under TWO keys (`crates/librefang-api/src/channel_bridge.rs`): the bare channel key (`"whatsapp"`) and the account-qualified key (`"whatsapp:<account_id>"`).
So on a multi-account install, a post-approval reply for a non-first account was delivered to the wrong account's adapter (wrong bot/chat) — or missed entirely.
The canonical outbound path (`ChannelSender::send_channel_message` in `crates/librefang-kernel/src/kernel/handles/channel_sender.rs`) does not have this bug: it builds `lookup_key = account_id.map(|aid| format!("{channel}:{aid}")).unwrap_or(channel)`.

## The fix

Replace the bare `channel_adapters.get(channel)` + manual `adapter.send()` block in the wake path with a single call to the existing account-qualified, format-aware outbound contract:

```rust
self.send_channel_message(
    channel,
    routing_chat_id,
    &loop_result.response,
    None,                          // no thread context on the wake path
    deferred.account_id.as_deref(),
)
```

This keys the adapter lookup by `"<channel>:<account_id>"` first (falling back to the bare channel) — the same key the bridge registers and the same contract every other outbound path already uses — so multi-account installs deliver the post-approval reply to the correct bot/chat.
It also picks up the adapter's `output_format` override for free, matching a normal inbound reply.

Preserved unchanged:

- The empty / silent-reply guard above the delivery block (an empty or silent reply is still not delivered).
- The `chat_id`-over-`sender_id` routing recipient preference already computed above.
- The early return when there is no channel / sender context (non-channel sources like the dashboard have nowhere to deliver).
- On an adapter-miss OR a send failure, a WARN is still logged (the reply stays persisted in session history so the next user turn surfaces it) — `send_channel_message` returns `Err` on both and does not log itself, so the wake path logs it with the same information as before plus the `account_id`.

The diff is localized to the wake path's outbound block; no refactor.

## Verification

- New unit test `test_post_approval_reply_routes_to_account_qualified_adapter_6492` in `crates/librefang-kernel/src/kernel/tests.rs`: registers two adapters under `"whatsapp"` and `"whatsapp:acct1"`, then asserts a deferred exec with `account_id = Some("acct1")` delivers to the `"whatsapp:acct1"` adapter and does NOT leak to the bare `"whatsapp"` adapter (the core of the bug), and that a deferred exec with `account_id = None` delivers to the bare `"whatsapp"` adapter.
  It drives `send_channel_message` with the exact `(routing_chat_id, account_id)` the wake path extracts from the `DeferredToolExecution`; the full `send_message_full` LLM round-trip inside the wake path is out of unit-test scope (matching the existing module note on the notification tests).
- `cargo check --workspace --all-targets` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings.
- `cargo test -p librefang-kernel --lib test_post_approval_reply_routes_to_account_qualified_adapter_6492` — passes.

(Run in the repo's `Dockerfile.rust-dev` dev image against a per-worktree, host-isolated target volume.)

## Out of scope — the un-deliverable case

This PR fixes only the deliverable case: a reply that has a real channel adapter to route to.
It does NOT address the other half of #6492 Bug 2 — a pure external `POST /api/agents/{id}/message` integration with no sidecar adapter and no callback URL.
That request has no outbound channel to deliver an async post-approval reply to at all, so it is a separate delivery-contract decision, not an adapter-lookup bug.
The sanctioned answer today is to run the `webhook` sidecar with `WEBHOOK_CALLBACK_URL` configured.
If raw-endpoint async delivery (delivering a post-approval reply back to a caller that hit the raw HTTP endpoint) is wanted, it should be specced separately — modeled on `CronDeliveryTarget::Webhook` + `validate_webhook_url_resolved` — rather than bolted onto this fix.
