### PR TITLE
fix(attachments): surface on-disk upload path to agents for every file type

### DIFF
--- a/crates/librefang-api/src/routes/agents/attachments.rs
+++ b/crates/librefang-api/src/routes/agents/attachments.rs
@@ -78,6 +78,33 @@ fn is_text_like_attachment(content_type: &str, filename: &str) -> bool {
     )
 }
 
+/// Build the `[File: <name>] saved to <path>` marker block that tells the
+/// agent where the raw upload bytes live on disk.
+///
+/// Emitted for EVERY resolved attachment type (image / PDF / text / other),
+/// so the on-disk path is available to the agent regardless of whether the
+/// content was also inlined. This mirrors the channel bridge's path block
+/// (`librefang-channels` `bridge.rs`, `FILE_SAVED_BLOCK_PREFIX`, #4448) so
+/// web/dashboard uploads reach the LLM with the same path affordance channel
+/// (Telegram/Matrix) uploads already have — previously the dashboard path
+/// omitted it, forcing agents to guess the file by listing the upload dir and
+/// size-matching.
+///
+/// Kept as its OWN `Text` block — never folded into the `Image` block — so it
+/// survives the two image-redaction passes (`redact_images_for_text_only` for
+/// no-vision models and `strip_images` for history trimming), both of which
+/// replace only `Image`/`ImageFile` blocks and leave `Text` untouched. That is
+/// what lets a non-vision model still learn where an uploaded image lives.
+fn file_saved_block(
+    filename: &str,
+    path: &std::path::Path,
+) -> librefang_types::message::ContentBlock {
+    librefang_types::message::ContentBlock::Text {
+        text: format!("[File: {}] saved to {}", filename, path.display()),
+        provider_metadata: None,
+    }
+}
+
 /// Resolve uploaded file attachments into content blocks.
 ///
 /// Reads each file from the upload directory and produces blocks the
@@ -91,7 +118,13 @@ fn is_text_like_attachment(content_type: &str, filename: &str) -> bool {
 ///     plus common code/data extensions) → `ContentBlock::Text` with a
 ///     `[Attached file: <filename>]` header. Read as UTF-8 lossy and
 ///     truncated at 200K chars.
-///   - everything else → skipped with a warn log.
+///   - everything else → a bare note that the file exists but its type is not
+///     inlined (the path block below still points the agent at the bytes).
+///
+/// In ALL cases a `[File: <name>] saved to <path>` block (see
+/// [`file_saved_block`]) is appended so the agent always knows the on-disk
+/// path of the raw upload — this is the parity fix that lets the agent attach
+/// the file to a vault / transcribe it / read it, for every file type.
 pub fn resolve_attachments(
     state: &AppState,
     attachments: &[AttachmentRef],
@@ -144,6 +177,10 @@ pub fn resolve_attachments(
                         media_type: content_type,
                         data: b64,
                     });
+                    // Sibling path block: survives no-vision redaction /
+                    // history image-stripping so the agent can still locate
+                    // and act on the raw image file.
+                    blocks.push(file_saved_block(&filename, &file_path));
                 }
                 Err(e) => {
                     tracing::warn!(file_id = %att.file_id, error = %e, "Failed to read image upload");
@@ -176,6 +213,7 @@ pub fn resolve_attachments(
                         text: format!("{header}\n\n{body}"),
                         provider_metadata: None,
                     });
+                    blocks.push(file_saved_block(&filename, &file_path));
                 }
                 Err(e) => {
                     tracing::warn!(file_id = %att.file_id, error = %e, "Failed to read PDF upload");
@@ -213,18 +251,40 @@ pub fn resolve_attachments(
                         text: format!("{header}\n\n{body}"),
                         provider_metadata: None,
                     });
+                    blocks.push(file_saved_block(&filename, &file_path));
                 }
                 Err(e) => {
                     tracing::warn!(file_id = %att.file_id, error = %e, "Failed to read text upload");
                 }
             }
         } else {
-            tracing::warn!(
-                file_id = %att.file_id,
-                content_type = %content_type,
-                filename = %filename,
-                "Attachment type not yet wired into the agent loop; skipping"
-            );
+            // Unsupported/binary type: we can't inline its content, but the
+            // file IS on disk and the agent may still want to act on it (attach
+            // to a vault, hand to a file-reader tool). Surface a note + the
+            // path block instead of silently dropping the attachment. Guarded
+            // on existence so we never advertise a path to a missing file.
+            if file_path.exists() {
+                tracing::info!(
+                    file_id = %att.file_id,
+                    content_type = %content_type,
+                    filename = %filename,
+                    "Attachment type not inlined; surfacing on-disk path only"
+                );
+                blocks.push(librefang_types::message::ContentBlock::Text {
+                    text: format!(
+                        "[Attached file: {filename} ({content_type})] — content not inlined for this type; the raw file is available on disk."
+                    ),
+                    provider_metadata: None,
+                });
+                blocks.push(file_saved_block(&filename, &file_path));
+            } else {
+                tracing::warn!(
+                    file_id = %att.file_id,
+                    content_type = %content_type,
+                    filename = %filename,
+                    "Attachment type not wired into the agent loop and file missing on disk; skipping"
+                );
+            }
         }
     }
 
@@ -423,6 +483,29 @@ mod tests {
     /// Regression: the streaming attachment fetch must bound peak memory by
     /// refusing a chunk that would exceed the cap (previously `resp.bytes()`
     /// buffered the whole body first, enabling remote OOM).
+    /// The `[File: <name>] saved to <path>` marker is the contract downstream
+    /// agents parse to locate an uploaded file on disk (and it must match the
+    /// channel bridge's `FILE_SAVED_BLOCK_PREFIX` format). Pin the exact shape.
+    #[test]
+    fn file_saved_block_has_expected_format() {
+        let block = file_saved_block(
+            "H1 report.pdf",
+            std::path::Path::new("/tmp/librefang_uploads/9ff3f16a"),
+        );
+        match block {
+            librefang_types::message::ContentBlock::Text { text, .. } => {
+                assert_eq!(
+                    text,
+                    "[File: H1 report.pdf] saved to /tmp/librefang_uploads/9ff3f16a"
+                );
+                // Prefix parity with librefang-channels bridge.rs.
+                assert!(text.starts_with("[File: "));
+                assert!(text.contains("] saved to "));
+            }
+            other => panic!("expected Text block, got {other:?}"),
+        }
+    }
+
     #[test]
     fn push_within_cap_rejects_over_cap_chunk() {
         let mut buf = Vec::new();

--- a/crates/librefang-api/src/routes/agents/attachments.rs
+++ b/crates/librefang-api/src/routes/agents/attachments.rs
@@ -78,23 +78,13 @@ fn is_text_like_attachment(content_type: &str, filename: &str) -> bool {
     )
 }
 
-/// Build the `[File: <name>] saved to <path>` marker block that tells the
-/// agent where the raw upload bytes live on disk.
+/// Build the `[File: <name>] saved to <path>` marker block that tells the agent where the raw upload bytes live on disk.
 ///
-/// Emitted for EVERY resolved attachment type (image / PDF / text / other),
-/// so the on-disk path is available to the agent regardless of whether the
-/// content was also inlined. This mirrors the channel bridge's path block
-/// (`librefang-channels` `bridge.rs`, `FILE_SAVED_BLOCK_PREFIX`, #4448) so
-/// web/dashboard uploads reach the LLM with the same path affordance channel
-/// (Telegram/Matrix) uploads already have — previously the dashboard path
-/// omitted it, forcing agents to guess the file by listing the upload dir and
-/// size-matching.
+/// Emitted for EVERY resolved attachment type (image / PDF / text / other), so the on-disk path is available to the agent regardless of whether the content was also inlined.
+/// This mirrors the channel bridge's path block (`librefang-channels` `bridge.rs`, `FILE_SAVED_BLOCK_PREFIX`, #4448) so web/dashboard uploads reach the LLM with the same path affordance channel (Telegram/Matrix) uploads already have — previously the dashboard path omitted it, forcing agents to guess the file by listing the upload dir and size-matching.
 ///
-/// Kept as its OWN `Text` block — never folded into the `Image` block — so it
-/// survives the two image-redaction passes (`redact_images_for_text_only` for
-/// no-vision models and `strip_images` for history trimming), both of which
-/// replace only `Image`/`ImageFile` blocks and leave `Text` untouched. That is
-/// what lets a non-vision model still learn where an uploaded image lives.
+/// Kept as its OWN `Text` block — never folded into the `Image` block — so it survives the two image-redaction passes (`redact_images_for_text_only` for no-vision models and `strip_images` for history trimming), both of which replace only `Image`/`ImageFile` blocks and leave `Text` untouched.
+/// That is what lets a non-vision model still learn where an uploaded image lives.
 fn file_saved_block(
     filename: &str,
     path: &std::path::Path,
@@ -121,10 +111,7 @@ fn file_saved_block(
 ///   - everything else → a bare note that the file exists but its type is not
 ///     inlined (the path block below still points the agent at the bytes).
 ///
-/// In ALL cases a `[File: <name>] saved to <path>` block (see
-/// [`file_saved_block`]) is appended so the agent always knows the on-disk
-/// path of the raw upload — this is the parity fix that lets the agent attach
-/// the file to a vault / transcribe it / read it, for every file type.
+/// In ALL cases a `[File: <name>] saved to <path>` block (see [`file_saved_block`]) is appended so the agent always knows the on-disk path of the raw upload — this is the parity fix that lets the agent attach the file to a vault / transcribe it / read it, for every file type.
 pub fn resolve_attachments(
     state: &AppState,
     attachments: &[AttachmentRef],
@@ -177,9 +164,7 @@ pub fn resolve_attachments(
                         media_type: content_type,
                         data: b64,
                     });
-                    // Sibling path block: survives no-vision redaction /
-                    // history image-stripping so the agent can still locate
-                    // and act on the raw image file.
+                    // Sibling path block: survives no-vision redaction / history image-stripping so the agent can still locate and act on the raw image file.
                     blocks.push(file_saved_block(&filename, &file_path));
                 }
                 Err(e) => {
@@ -258,11 +243,9 @@ pub fn resolve_attachments(
                 }
             }
         } else {
-            // Unsupported/binary type: we can't inline its content, but the
-            // file IS on disk and the agent may still want to act on it (attach
-            // to a vault, hand to a file-reader tool). Surface a note + the
-            // path block instead of silently dropping the attachment. Guarded
-            // on existence so we never advertise a path to a missing file.
+            // Unsupported/binary type: we can't inline its content, but the file IS on disk and the agent may still want to act on it (attach to a vault, hand to a file-reader tool).
+            // Surface a note + the path block instead of silently dropping the attachment.
+            // Guarded on existence so we never advertise a path to a missing file.
             if file_path.exists() {
                 tracing::info!(
                     file_id = %att.file_id,
@@ -480,12 +463,8 @@ fn mime_from_url(url: &str) -> Option<String> {
 mod tests {
     use super::*;
 
-    /// Regression: the streaming attachment fetch must bound peak memory by
-    /// refusing a chunk that would exceed the cap (previously `resp.bytes()`
-    /// buffered the whole body first, enabling remote OOM).
-    /// The `[File: <name>] saved to <path>` marker is the contract downstream
-    /// agents parse to locate an uploaded file on disk (and it must match the
-    /// channel bridge's `FILE_SAVED_BLOCK_PREFIX` format). Pin the exact shape.
+    /// The `[File: <name>] saved to <path>` marker is the contract downstream agents parse to locate an uploaded file on disk.
+    /// It must match the channel bridge's `FILE_SAVED_BLOCK_PREFIX` format, so pin the exact shape.
     #[test]
     fn file_saved_block_has_expected_format() {
         let block = file_saved_block(
@@ -506,6 +485,8 @@ mod tests {
         }
     }
 
+    /// Regression: the streaming attachment fetch must bound peak memory by refusing a chunk that would exceed the cap.
+    /// Previously `resp.bytes()` buffered the whole body first, enabling remote OOM.
     #[test]
     fn push_within_cap_rejects_over_cap_chunk() {
         let mut buf = Vec::new();

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -348,19 +348,30 @@ fn build_sender_prefix(manifest: &AgentManifest, sender_user_id: Option<&str>) -
 /// user sent a photo. Redacting upstream of the driver covers *every* entry
 /// path (WebUI, channels, sidecars, triggers), not just the OpenAI driver.
 ///
+/// For `ImageFile` blocks (which reference the image by on-disk path) the
+/// placeholder keeps that path, so a text-only agent can still read or attach
+/// the raw file even though it can't see the pixels. The inline base64
+/// `Image` variant has no path to keep.
+///
 /// Pure function: the caller passes a clone, so the live session history is
 /// never mutated and the vision path stays byte-identical to before.
 pub(super) fn redact_images_for_text_only(mut messages: Vec<Message>, model: &str) -> Vec<Message> {
-    let placeholder = format!("[image omitted: model `{model}` has no vision support]");
     for msg in &mut messages {
         if let MessageContent::Blocks(blocks) = &mut msg.content {
             for block in blocks.iter_mut() {
-                if matches!(
-                    block,
-                    ContentBlock::Image { .. } | ContentBlock::ImageFile { .. }
-                ) {
+                let replacement = match block {
+                    ContentBlock::ImageFile { path, .. } => Some(format!(
+                        "[image omitted: model `{model}` has no vision support. \
+                         The image file is on disk at {path} — read or attach it directly if you need its contents.]"
+                    )),
+                    ContentBlock::Image { .. } => {
+                        Some(format!("[image omitted: model `{model}` has no vision support]"))
+                    }
+                    _ => None,
+                };
+                if let Some(text) = replacement {
                     *block = ContentBlock::Text {
-                        text: placeholder.clone(),
+                        text,
                         provider_metadata: None,
                     };
                 }

--- a/crates/librefang-runtime/src/agent_loop/mod.rs
+++ b/crates/librefang-runtime/src/agent_loop/mod.rs
@@ -348,10 +348,8 @@ fn build_sender_prefix(manifest: &AgentManifest, sender_user_id: Option<&str>) -
 /// user sent a photo. Redacting upstream of the driver covers *every* entry
 /// path (WebUI, channels, sidecars, triggers), not just the OpenAI driver.
 ///
-/// For `ImageFile` blocks (which reference the image by on-disk path) the
-/// placeholder keeps that path, so a text-only agent can still read or attach
-/// the raw file even though it can't see the pixels. The inline base64
-/// `Image` variant has no path to keep.
+/// For `ImageFile` blocks (which reference the image by on-disk path) the placeholder keeps that path, so a text-only agent can still read or attach the raw file even though it can't see the pixels.
+/// The inline base64 `Image` variant has no path to keep.
 ///
 /// Pure function: the caller passes a clone, so the live session history is
 /// never mutated and the vision path stays byte-identical to before.

--- a/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
@@ -2161,8 +2161,7 @@ fn redact_images_for_text_only_preserves_imagefile_path() {
     let messages = vec![Message {
         role: Role::User,
         content: MessageContent::Blocks(vec![
-            // On-disk image: path must survive into the placeholder so a
-            // text-only agent can still read/attach the raw file.
+            // On-disk image: path must survive into the placeholder so a text-only agent can still read/attach the raw file.
             ContentBlock::ImageFile {
                 media_type: "image/png".to_string(),
                 path: "/tmp/librefang_uploads/0dc8dfe0.png".to_string(),

--- a/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
@@ -2154,6 +2154,63 @@ fn redact_images_for_text_only_replaces_image_and_imagefile_blocks() {
 }
 
 #[test]
+fn redact_images_for_text_only_preserves_imagefile_path() {
+    use super::super::redact_images_for_text_only;
+    use librefang_types::message::{ContentBlock, Message, MessageContent, Role};
+
+    let messages = vec![Message {
+        role: Role::User,
+        content: MessageContent::Blocks(vec![
+            // On-disk image: path must survive into the placeholder so a
+            // text-only agent can still read/attach the raw file.
+            ContentBlock::ImageFile {
+                media_type: "image/png".to_string(),
+                path: "/tmp/librefang_uploads/0dc8dfe0.png".to_string(),
+            },
+            // Inline base64 image: no path exists, so none may be fabricated.
+            ContentBlock::Image {
+                media_type: "image/jpeg".to_string(),
+                data: "aGVsbG8=".to_string(),
+            },
+        ]),
+        pinned: false,
+        timestamp: None,
+    }];
+
+    let out = redact_images_for_text_only(messages, "deepseek-v4");
+    let blocks = match &out[0].content {
+        MessageContent::Blocks(b) => b,
+        other => panic!("expected Blocks, got {other:?}"),
+    };
+
+    // ImageFile placeholder keeps the on-disk path.
+    match &blocks[0] {
+        ContentBlock::Text { text, .. } => {
+            assert!(
+                text.contains("image omitted") && text.contains("no vision support"),
+                "got {text:?}"
+            );
+            assert!(
+                text.contains("/tmp/librefang_uploads/0dc8dfe0.png"),
+                "ImageFile placeholder must keep the on-disk path, got {text:?}"
+            );
+        }
+        other => panic!("expected Text, got {other:?}"),
+    }
+    // Base64 Image placeholder must not claim a path it does not have.
+    match &blocks[1] {
+        ContentBlock::Text { text, .. } => {
+            assert!(text.contains("image omitted"), "got {text:?}");
+            assert!(
+                !text.contains("on disk at"),
+                "base64 Image has no path and must not claim one, got {text:?}"
+            );
+        }
+        other => panic!("expected Text, got {other:?}"),
+    }
+}
+
+#[test]
 fn redact_images_for_text_only_is_noop_without_images() {
     use super::super::redact_images_for_text_only;
     use librefang_types::message::{ContentBlock, Message, MessageContent, Role};

--- a/crates/librefang-types/src/message.rs
+++ b/crates/librefang-types/src/message.rs
@@ -252,12 +252,18 @@ impl MessageContent {
             MessageContent::Blocks(blocks) => {
                 let mut stripped = false;
                 for block in blocks.iter_mut() {
+                    // Capture the media type and, for on-disk `ImageFile`
+                    // blocks, the path — so the placeholder can point a later
+                    // turn at the raw bytes even after the pixels are dropped.
+                    // The inline base64 `Image` variant carries no path.
                     let media = match block {
-                        ContentBlock::Image { media_type, .. }
-                        | ContentBlock::ImageFile { media_type, .. } => Some(media_type.clone()),
+                        ContentBlock::Image { media_type, .. } => Some((media_type.clone(), None)),
+                        ContentBlock::ImageFile { media_type, path } => {
+                            Some((media_type.clone(), Some(path.clone())))
+                        }
                         _ => None,
                     };
-                    if let Some(mt) = media {
+                    if let Some((mt, path)) = media {
                         // Phrase the placeholder so an LLM, on re-reading the
                         // session, infers "I already received and analyzed this
                         // image earlier in this thread" rather than the literal
@@ -265,10 +271,21 @@ impl MessageContent {
                         // mistake for "no image was delivered". The model
                         // saying "I did not receive any image" is the symptom
                         // we are guarding against here.
+                        //
+                        // When the source was an `ImageFile`, keep its on-disk
+                        // path in the placeholder: a follow-up turn may want to
+                        // attach or re-read the raw file even though the pixels
+                        // are gone from history.
+                        let path_hint = match path {
+                            Some(p) => format!(
+                                " The raw file remains on disk at {p} if you need to act on it directly."
+                            ),
+                            None => String::new(),
+                        };
                         let placeholder = format!(
                             "[Image ({mt}) — already received and analyzed by you (the assistant) earlier in this conversation; \
                              the raw bytes were removed from history to save context tokens. Your earlier turn in this thread \
-                             contains your analysis of this image — refer to it rather than claiming the image is missing.]"
+                             contains your analysis of this image — refer to it rather than claiming the image is missing.]{path_hint}"
                         );
                         *block = ContentBlock::Text {
                             text: placeholder,
@@ -719,6 +736,29 @@ mod tests {
         assert!(!content.has_images());
         let text = content.text_content();
         assert!(text.contains("[Image (image/jpeg) — already received and analyzed"));
+        // The on-disk path of an ImageFile survives stripping so a later turn
+        // can still act on the raw file.
+        assert!(
+            text.contains("/tmp/x.jpg"),
+            "stripped ImageFile placeholder must keep the on-disk path: {text}"
+        );
+    }
+
+    #[test]
+    fn test_strip_images_base64_has_no_path_hint() {
+        // The inline base64 `Image` variant carries no path, so its stripped
+        // placeholder must NOT fabricate a "remains on disk at" hint.
+        let mut content = MessageContent::Blocks(vec![ContentBlock::Image {
+            media_type: "image/png".to_string(),
+            data: "abc123".to_string(),
+        }]);
+        assert!(content.strip_images());
+        let text = content.text_content();
+        assert!(text.contains("[Image (image/png) — already received and analyzed"));
+        assert!(
+            !text.contains("remains on disk"),
+            "base64 Image has no path and must not claim one: {text}"
+        );
     }
 
     #[test]

--- a/crates/librefang-types/src/message.rs
+++ b/crates/librefang-types/src/message.rs
@@ -252,9 +252,7 @@ impl MessageContent {
             MessageContent::Blocks(blocks) => {
                 let mut stripped = false;
                 for block in blocks.iter_mut() {
-                    // Capture the media type and, for on-disk `ImageFile`
-                    // blocks, the path — so the placeholder can point a later
-                    // turn at the raw bytes even after the pixels are dropped.
+                    // Capture the media type and, for on-disk `ImageFile` blocks, the path — so the placeholder can point a later turn at the raw bytes even after the pixels are dropped.
                     // The inline base64 `Image` variant carries no path.
                     let media = match block {
                         ContentBlock::Image { media_type, .. } => Some((media_type.clone(), None)),
@@ -272,10 +270,7 @@ impl MessageContent {
                         // saying "I did not receive any image" is the symptom
                         // we are guarding against here.
                         //
-                        // When the source was an `ImageFile`, keep its on-disk
-                        // path in the placeholder: a follow-up turn may want to
-                        // attach or re-read the raw file even though the pixels
-                        // are gone from history.
+                        // When the source was an `ImageFile`, keep its on-disk path in the placeholder: a follow-up turn may want to attach or re-read the raw file even though the pixels are gone from history.
                         let path_hint = match path {
                             Some(p) => format!(
                                 " The raw file remains on disk at {p} if you need to act on it directly."


### PR DESCRIPTION
Fixes #6529.

## Problem

Dashboard/API uploads (`POST /api/agents/{id}/upload`) reached the LLM **without the on-disk path** of the saved file, while channel (Telegram/Matrix) uploads surface it via a `[File: <name>] saved to <path>` block. An agent asked to act on a dashboard-uploaded file had to list the upload dir and guess by size. For an **image on a non-vision model** the redaction placeholder dropped both pixels and path, leaving no reference at all.

## Changes

- **`resolve_attachments`** (`librefang-api/.../attachments.rs`): append a standalone `[File: <name>] saved to <path>` text block for **every** resolved attachment type — image, PDF, text, and previously-skipped binary/unknown types (now surfaced with a note + path instead of being dropped). Mirrors the channel bridge's `FILE_SAVED_BLOCK_PREFIX`. New private helper `file_saved_block`. Kept as its own `Text` block so it survives image redaction.
- **`redact_images_for_text_only`** (`librefang-runtime/.../agent_loop/mod.rs`, no-vision path): keep the on-disk path in the placeholder when the block is an `ImageFile`. Base64 `Image` (no path) unchanged.
- **`MessageContent::strip_images`** (`librefang-types/.../message.rs`, history trimming): same path preservation for `ImageFile`.

## Breaking change

Agents now receive an additional `[File: ...] saved to ...` content block for every uploaded attachment. Downstream code asserting on exact attachment message content will observe the new block.

## Tests

- `attachments::tests::file_saved_block_has_expected_format` — pins the `[File: … saved to …]` format / prefix parity.
- `message::tests::test_image_file_strip_images` (extended) + `test_strip_images_base64_has_no_path_hint` — ImageFile keeps path; base64 Image fabricates none.
- `agent_loop::tests::utilities::redact_images_for_text_only_preserves_imagefile_path` — ImageFile keeps path under no-vision redaction; base64 Image does not.

## Verification

- `cargo check --workspace --lib` — clean.
- `cargo clippy -p librefang-types -p librefang-api -p librefang-runtime --all-targets -- -D warnings` — clean.
- `cargo test -p librefang-types strip_images` (6 passed), `cargo test -p librefang-runtime redact_images_for_text_only` (3 passed), `cargo test -p librefang-api file_saved_block` (1 passed).

## Out of scope

On-disk upload naming is inconsistent across producers (`<uuid>.<ext>` vs bare `<uuid>` vs `image_<uuid>.png`). Normalizing that shared temp namespace is a cross-cutting change tracked separately in #6530.
