### PR TITLE
refactor(uploads): normalize on-disk upload naming to <uuid>.<ext> (#6530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
   A `resource_link` in a tool result is now surfaced as a first-class `[resource_link] name — uri (mime)` line instead of being flattened into an opaque JSON string, and an embedded resource contributes its text (binary blobs are elided, never inlined into the prompt); resource lists are sorted by URI for prompt-cache stability.
   No `resources` client capability is declared because the MCP `resources` capability is server-side and rmcp's `ClientCapabilities` has no such field (#6501) (@houko)
 
+### Changed
+
+- Normalize on-disk upload naming so every producer that writes into the shared upload directory names the file `<uuid>.<ext>` instead of today's three divergent schemes (bare `<uuid>`, `image_<uuid>.png`, `<uuid>.<ext>`), keeping the file's type at rest for extension-sniffing tools and for any flow that persists or re-dispatches the bytes.
+  A single deterministic `librefang_types::media::on_disk_name(file_id, content_type, filename)` helper (extension from `ext_for_content_type`, then a safe filename extension, else a bare UUID) is now the one naming authority: the API upload / media / session-image / generated-image / browser-screenshot producers all route through it, and the client-facing `file_id` stays a bare UUID so the path-traversal and #3361 owner guards still `uuid::Uuid::parse_str` it.
+  `serve_upload` and `resolve_attachments` reconstruct the name through a shared resolver that also tolerates legacy bare-`<uuid>` files and probes `<uuid>.*` for generated images not in the upload registry, so existing uploads keep serving (#6530) (@houko)
+
 ### Documentation
 
 - Document how `[approval].trusted_senders` composes with `[[users]]` RBAC on the approvals security page (EN + zh mirror): the two are separate trust surfaces and the per-user RBAC gate is evaluated first, so an ID listed in `trusted_senders` that is not also a registered `[[users]]` on the `api` channel still has its low-risk tools (e.g. `memory_*`) gated by the `guest_gate`, because the forced-approval verdict short-circuits before the `trusted_senders` bypass is consulted; the new subsection gives the concrete fix (register the operator as a `[[users]]` bound to the `api` channel with a `tool_policy` covering the tools it drives) and notes that with no `[[users]]` configured `trusted_senders` works standalone (#6492) (@houko)

--- a/crates/librefang-api/src/routes/agents/attachments.rs
+++ b/crates/librefang-api/src/routes/agents/attachments.rs
@@ -147,7 +147,15 @@ pub fn resolve_attachments(
             continue;
         }
 
-        let file_path = upload_dir.join(&att.file_id);
+        // Reconstruct the `<uuid>.<ext>` on-disk name written by the producer
+        // (#6530), tolerating legacy bare-`<uuid>` files and the `<uuid>.*`
+        // probe for generated images. Skip the attachment if nothing is on disk.
+        let Some(file_path) =
+            resolve_existing_upload_path(&upload_dir, &att.file_id, &raw_content_type, &filename)
+        else {
+            tracing::debug!(file_id = %att.file_id, "attachment not found on disk; skipping");
+            continue;
+        };
 
         if content_type.starts_with("image/") {
             match std::fs::read(&file_path) {

--- a/crates/librefang-api/src/routes/agents/sessions.rs
+++ b/crates/librefang-api/src/routes/agents/sessions.rs
@@ -136,8 +136,14 @@ pub async fn get_agent_session(
                                     if let Ok(bytes) =
                                         base64::engine::general_purpose::STANDARD.decode(data)
                                     {
+                                        // Persist as `<uuid>.<ext>` (#6530); the
+                                        // registry stores content_type so the
+                                        // history-load serve reconstructs it.
+                                        let on_disk = librefang_types::media::on_disk_name(
+                                            &file_id, media_type, "",
+                                        );
                                         if let Err(e) =
-                                            std::fs::write(upload_dir.join(&file_id), &bytes)
+                                            std::fs::write(upload_dir.join(&on_disk), &bytes)
                                         {
                                             tracing::warn!("Failed to write upload file: {e}");
                                         }

--- a/crates/librefang-api/src/routes/agents/uploads.rs
+++ b/crates/librefang-api/src/routes/agents/uploads.rs
@@ -141,7 +141,12 @@ pub async fn upload_file(
         );
     }
 
-    let file_path = upload_dir.join(&file_id);
+    // Persist under `<uuid>.<ext>` so the type survives at rest (#6530), while
+    // the registry key / client-facing `file_id` stays a bare UUID for the
+    // traversal + owner guards. Readers reconstruct the same name via
+    // `on_disk_name` from the registry's stored content_type/filename.
+    let on_disk = librefang_types::media::on_disk_name(&file_id, &content_type, &filename);
+    let file_path = upload_dir.join(&on_disk);
     if let Err(e) = tokio::fs::write(&file_path, &body).await {
         tracing::warn!("Failed to write upload: {e}");
         return (
@@ -197,6 +202,42 @@ pub async fn upload_file(
     )
 }
 
+/// Resolve the on-disk path of a persisted upload, tolerating both the
+/// `<uuid>.<ext>` scheme (#6530) and the historical bare-`<uuid>` scheme.
+///
+/// Tries, in order: the deterministic `<uuid>.<ext>` name (from the known
+/// content type / filename), the bare `<uuid>` (files written before #6530 and
+/// registry misses), then a `<uuid>.*` directory probe (generated images whose
+/// content type the reader may not know). Returns the first existing path.
+/// `file_id` is a validated UUID, so the probe's prefix match cannot escape
+/// `dir`.
+pub(crate) fn resolve_existing_upload_path(
+    dir: &std::path::Path,
+    file_id: &str,
+    content_type: &str,
+    filename: &str,
+) -> Option<std::path::PathBuf> {
+    let named = dir.join(librefang_types::media::on_disk_name(
+        file_id,
+        content_type,
+        filename,
+    ));
+    if named.exists() {
+        return Some(named);
+    }
+    let bare = dir.join(file_id);
+    if bare.exists() {
+        return Some(bare);
+    }
+    let prefix = format!("{file_id}.");
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        if entry.file_name().to_string_lossy().starts_with(&prefix) {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
 /// GET /api/uploads/{file_id} — Serve an uploaded file.
 #[utoipa::path(
     get,
@@ -224,31 +265,33 @@ pub async fn serve_upload(
         );
     }
 
-    let file_path = state
+    let upload_dir = state
         .kernel
         .config_ref()
         .channels
-        .effective_file_download_dir()
-        .join(&file_id);
+        .effective_file_download_dir();
 
-    // Look up metadata from registry; fall back to disk probe for generated images
-    // (image_generate saves files without registering in UPLOAD_REGISTRY).
-    let (content_type, owner) = match UPLOAD_REGISTRY.get(&file_id) {
-        Some(m) => (m.content_type.clone(), m.uploaded_by),
-        None => {
-            // Infer content type from file magic bytes
-            if !file_path.exists() {
-                return (
-                    StatusCode::NOT_FOUND,
-                    [(
-                        axum::http::header::CONTENT_TYPE,
-                        "application/json".to_string(),
-                    )],
-                    b"{\"error\":\"File not found\"}".to_vec(),
-                );
-            }
-            ("image/png".to_string(), None)
-        }
+    // The registry carries the content_type/filename needed to reconstruct the
+    // `<uuid>.<ext>` on-disk name (#6530) and the owner for the access check. A
+    // miss means a generated image / pre-registry file — the resolver's
+    // `<uuid>.*` probe still finds it, and the content type defaults to PNG (the
+    // only un-registered producer today is image_generate).
+    let (content_type, filename, owner) = match UPLOAD_REGISTRY.get(&file_id) {
+        Some(m) => (m.content_type.clone(), m.filename.clone(), m.uploaded_by),
+        None => ("image/png".to_string(), String::new(), None),
+    };
+
+    let Some(file_path) =
+        resolve_existing_upload_path(&upload_dir, &file_id, &content_type, &filename)
+    else {
+        return (
+            StatusCode::NOT_FOUND,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/json".to_string(),
+            )],
+            b"{\"error\":\"File not found\"}".to_vec(),
+        );
     };
 
     // SECURITY (#3361): Bind uploads to their uploader. A bare UUID is not
@@ -293,5 +336,48 @@ pub async fn serve_upload(
             )],
             b"{\"error\":\"File not found on disk\"}".to_vec(),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_existing_upload_path;
+
+    #[test]
+    fn resolver_finds_named_bare_and_generated_image_schemes() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path();
+
+        // 1. Registry hit: producer wrote `<uuid>.png`, reader knows the type.
+        let named_id = "11111111-1111-1111-1111-111111111111";
+        std::fs::write(p.join(format!("{named_id}.png")), b"png").unwrap();
+        assert_eq!(
+            resolve_existing_upload_path(p, named_id, "image/png", "shot.png"),
+            Some(p.join(format!("{named_id}.png")))
+        );
+
+        // 2. Legacy file written bare `<uuid>` before #6530: still served, even
+        //    though the reader now computes a `.png` name that does not exist.
+        let bare_id = "22222222-2222-2222-2222-222222222222";
+        std::fs::write(p.join(bare_id), b"legacy").unwrap();
+        assert_eq!(
+            resolve_existing_upload_path(p, bare_id, "image/png", "old.png"),
+            Some(p.join(bare_id))
+        );
+
+        // 3. Generated image not in the registry: the reader defaults the type,
+        //    but the `<uuid>.*` probe finds the real extension.
+        let gen_id = "33333333-3333-3333-3333-333333333333";
+        std::fs::write(p.join(format!("{gen_id}.jpg")), b"jpg").unwrap();
+        assert_eq!(
+            resolve_existing_upload_path(p, gen_id, "application/octet-stream", ""),
+            Some(p.join(format!("{gen_id}.jpg")))
+        );
+
+        // 4. Nothing on disk → None.
+        assert_eq!(
+            resolve_existing_upload_path(p, "44444444-4444-4444-4444-444444444444", "", ""),
+            None
+        );
     }
 }

--- a/crates/librefang-api/src/routes/media.rs
+++ b/crates/librefang-api/src/routes/media.rs
@@ -92,7 +92,10 @@ fn save_upload(
         .effective_file_download_dir();
     std::fs::create_dir_all(&upload_dir)
         .map_err(|e| format!("Failed to create upload directory: {e}"))?;
-    std::fs::write(upload_dir.join(&file_id), data)
+    // Persist as `<uuid>.<ext>` (#6530); the registry entry below stores the
+    // content type so serve_upload reconstructs the same name.
+    let on_disk = librefang_types::media::on_disk_name(&file_id, content_type, filename);
+    std::fs::write(upload_dir.join(&on_disk), data)
         .map_err(|e| format!("Failed to write upload file: {e}"))?;
 
     // Register metadata so serve_upload returns the correct content type.
@@ -424,7 +427,13 @@ pub async fn transcribe_audio(
         return ApiErrorResponse::internal_scrub(e).into_response();
     }
     let file_id = uuid::Uuid::new_v4().to_string();
-    let file_path = upload_dir.join(&file_id);
+    // Transient file read straight back by the media engine via `file_path`;
+    // still named `<uuid>.<ext>` so all producers share one scheme (#6530).
+    let file_path = upload_dir.join(librefang_types::media::on_disk_name(
+        &file_id,
+        &content_type,
+        "",
+    ));
     if let Err(e) = tokio::fs::write(&file_path, &body).await {
         return ApiErrorResponse::internal_scrub(e).into_response();
     }

--- a/crates/librefang-api/tests/api_integration_test.rs
+++ b/crates/librefang-api/tests/api_integration_test.rs
@@ -4720,6 +4720,100 @@ async fn test_upload_over_limit_returns_413() {
     );
 }
 
+/// #6530 round-trip: a file uploaded via `POST /upload` is persisted on disk as
+/// `<uuid>.<ext>`, but the client-facing `file_id` stays a bare UUID. Serving
+/// it back by that bare `file_id` must still find the file — this proves the
+/// write-side `on_disk_name` matches the read-side reconstruction in
+/// `serve_upload`. Covers a typed content type (PNG → `.png`) and the generic
+/// `application/octet-stream` (no extension → bare `<uuid>`) so both arms of
+/// `on_disk_name` are exercised end to end.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_upload_roundtrip_serves_by_bare_file_id() {
+    let harness = start_full_router("").await;
+
+    async fn upload_then_serve(
+        harness: &FullRouterHarness,
+        content_type: &str,
+        filename: &str,
+        body: Vec<u8>,
+    ) {
+        // The upload route validates the agent-id *format* (parses as a UUID);
+        // it does not require the agent to exist, so a fresh UUID is enough.
+        let agent_id = uuid::Uuid::new_v4();
+        let mut up = Request::builder()
+            .method("POST")
+            .uri(format!("/api/agents/{agent_id}/upload"))
+            .header("content-type", content_type)
+            .header("x-filename", filename)
+            .header("content-length", body.len().to_string())
+            .body(Body::from(body.clone()))
+            .unwrap();
+        up.extensions_mut()
+            .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                [127, 0, 0, 1],
+                0,
+            ))));
+        let up_resp = harness.app.clone().oneshot(up).await.unwrap();
+        let up_status = up_resp.status();
+        let bytes = axum::body::to_bytes(up_resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(
+            up_status,
+            StatusCode::CREATED,
+            "upload of {content_type} must succeed, got {up_status}: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let file_id = json["file_id"].as_str().expect("file_id in response");
+        // The client-facing id is a bare UUID (the traversal/owner guards parse it).
+        assert!(
+            uuid::Uuid::parse_str(file_id).is_ok(),
+            "file_id must stay a bare UUID, got {file_id}"
+        );
+
+        let mut serve = Request::builder()
+            .method("GET")
+            .uri(format!("/api/uploads/{file_id}"))
+            .body(Body::empty())
+            .unwrap();
+        serve
+            .extensions_mut()
+            .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                [127, 0, 0, 1],
+                0,
+            ))));
+        let serve_resp = harness.app.clone().oneshot(serve).await.unwrap();
+        assert_eq!(
+            serve_resp.status(),
+            StatusCode::OK,
+            "serve_upload must find the {content_type} file by its bare id"
+        );
+        let served = axum::body::to_bytes(serve_resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(
+            served.as_ref(),
+            body.as_slice(),
+            "served bytes must match the uploaded bytes"
+        );
+    }
+
+    // PNG → persisted as `<uuid>.png`, served by bare id. The bare-uuid arm of
+    // on_disk_name (generic content type) is covered by the media.rs unit tests;
+    // application/octet-stream is not an allowed upload content type so it can't
+    // exercise that arm through this route.
+    upload_then_serve(
+        &harness,
+        "image/png",
+        "shot.png",
+        b"\x89PNG\r\n\x1a\nHELLO-6530".to_vec(),
+    )
+    .await;
+    // text/plain → persisted as `<uuid>.txt`; also round-trips by bare id.
+    upload_then_serve(&harness, "text/plain", "note.txt", b"hello-6530".to_vec()).await;
+}
+
 // ---------------------------------------------------------------------------
 // Per-user LLM provider credentials (#6460 Follow-up B)
 //

--- a/crates/librefang-runtime/src/browser_tools.rs
+++ b/crates/librefang-runtime/src/browser_tools.rs
@@ -147,7 +147,13 @@ pub async fn tool_browser_screenshot(
         let _ = std::fs::create_dir_all(upload_dir);
         let file_id = uuid::Uuid::new_v4().to_string();
         if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(b64) {
-            let path = upload_dir.join(&file_id);
+            // Screenshots are PNG; persist as `<uuid>.png` (#6530). The URL
+            // keeps the bare file_id and serve_upload's resolver finds the file.
+            let path = upload_dir.join(librefang_types::media::on_disk_name(
+                &file_id,
+                "image/png",
+                "",
+            ));
             if std::fs::write(&path, &decoded).is_ok() {
                 image_urls.push(format!("/api/uploads/{file_id}"));
             }

--- a/crates/librefang-runtime/src/tool_runner/media.rs
+++ b/crates/librefang-runtime/src/tool_runner/media.rs
@@ -321,7 +321,13 @@ pub(super) async fn tool_image_generate(
                 .map_err(|e| {
                     ToolError::upstream_msg(format!("Failed to decode image data: {e}"))
                 })?;
-            let path = upload_dir.join(&file_id);
+            // Persist as `<uuid>.png` (#6530); the URL keeps the bare file_id
+            // and serve_upload's resolver reconstructs the `.png` name.
+            let path = upload_dir.join(librefang_types::media::on_disk_name(
+                &file_id,
+                "image/png",
+                "",
+            ));
             tokio::fs::write(&path, &decoded).await.map_err(|e| {
                 ToolError::upstream_msg(format!("Failed to write upload file: {e}"))
             })?;
@@ -362,7 +368,8 @@ async fn save_media_images_to_workspace(
             .decode(&img.data_base64)
             .map_err(|e| ToolError::upstream_msg(format!("Failed to decode image: {e}")))?;
         let file_id = uuid::Uuid::new_v4();
-        let filename = format!("image_{file_id}.png");
+        // Converge on the shared `<uuid>.<ext>` naming (#6530); these are PNGs.
+        let filename = librefang_types::media::on_disk_name(&file_id.to_string(), "image/png", "");
         let path = output_dir.join(&filename);
         tokio::fs::write(&path, &decoded)
             .await
@@ -396,7 +403,14 @@ async fn save_media_images_to_uploads(
         if decoded.is_empty() {
             continue;
         }
-        let path = upload_dir.join(&file_id);
+        // Persist as `<uuid>.png` (#6530); the returned URL keeps the bare
+        // `file_id`, and serve_upload's resolver reconstructs the `.png` name
+        // (these generated images are not in UPLOAD_REGISTRY).
+        let path = upload_dir.join(librefang_types::media::on_disk_name(
+            &file_id,
+            "image/png",
+            "",
+        ));
         tokio::fs::write(&path, &decoded)
             .await
             .map_err(|e| ToolError::upstream_msg(format!("Failed to write upload file: {e}")))?;

--- a/crates/librefang-types/src/media.rs
+++ b/crates/librefang-types/src/media.rs
@@ -216,6 +216,91 @@ pub fn mime_base(mime: &str) -> String {
         .to_ascii_lowercase()
 }
 
+/// Map a content type to the bare file extension (no leading dot) a persisted
+/// upload should carry, or `None` when the type is generic/unknown.
+///
+/// The MIME is normalized with [`mime_base`] first, so parameterized values
+/// (`text/plain; charset=utf-8`, `audio/ogg; codecs=opus`) still match. Returns
+/// `None` for `application/octet-stream` and anything unmapped so callers fall
+/// back to the filename extension or a bare UUID rather than inventing a
+/// misleading extension. Used by [`on_disk_name`].
+pub fn ext_for_content_type(content_type: &str) -> Option<&'static str> {
+    match mime_base(content_type).as_str() {
+        "image/png" => Some("png"),
+        "image/jpeg" | "image/jpg" => Some("jpg"),
+        "image/gif" => Some("gif"),
+        "image/webp" => Some("webp"),
+        "image/svg+xml" => Some("svg"),
+        "image/bmp" => Some("bmp"),
+        "image/tiff" => Some("tiff"),
+        "application/pdf" => Some("pdf"),
+        "text/plain" => Some("txt"),
+        "text/markdown" => Some("md"),
+        "text/csv" => Some("csv"),
+        "text/html" => Some("html"),
+        "application/json" => Some("json"),
+        "application/xml" | "text/xml" => Some("xml"),
+        "audio/ogg" => Some("oga"),
+        "audio/mpeg" => Some("mp3"),
+        "audio/wav" | "audio/x-wav" => Some("wav"),
+        "audio/mp4" | "audio/m4a" | "audio/x-m4a" => Some("m4a"),
+        "audio/webm" => Some("weba"),
+        "audio/flac" => Some("flac"),
+        "video/mp4" => Some("mp4"),
+        "video/quicktime" => Some("mov"),
+        "video/webm" => Some("webm"),
+        _ => None,
+    }
+}
+
+/// Extract a safe lowercase extension from a filename, or `None`.
+///
+/// Guards against a filename doubling as a path-injection vector: the
+/// extension must be short, purely ASCII-alphanumeric, and free of any path
+/// separator. This is the fallback arm of [`on_disk_name`] for content types
+/// [`ext_for_content_type`] does not map.
+fn safe_ext_from_filename(filename: &str) -> Option<String> {
+    let ext = std::path::Path::new(filename).extension()?.to_str()?;
+    let lower = ext.to_ascii_lowercase();
+    if !lower.is_empty() && lower.len() <= 8 && lower.chars().all(|c| c.is_ascii_alphanumeric()) {
+        Some(lower)
+    } else {
+        None
+    }
+}
+
+/// Compute the on-disk basename for a persisted upload: `"<file_id>.<ext>"`,
+/// or a bare `"<file_id>"` when no extension can be determined.
+///
+/// This is the single naming authority shared by every producer that writes
+/// into, and every consumer that reads back from, the shared upload directory
+/// (`channels::effective_file_download_dir()`). The client-facing `file_id`
+/// stays a bare UUID — the path-traversal and owner-access guards parse it with
+/// `uuid::Uuid::parse_str` — while the on-disk name additionally carries the
+/// type so extension-sniffing tools and persisted copies keep their type at
+/// rest (#6530).
+///
+/// The extension is chosen deterministically: the mapped
+/// [`ext_for_content_type`] first, then a safe extension parsed from
+/// `filename`, then none.
+///
+/// INVARIANT — this function is pure: identical `(file_id, content_type,
+/// filename)` inputs always yield the same name. Writers and readers call it
+/// independently and never coordinate, so a read site MUST pass the same
+/// `content_type` / `filename` the write site used (the `UPLOAD_REGISTRY`
+/// stores both for API uploads; cross-crate producers key on a fixed
+/// content type both sides know). A reader that lacks those inputs must fall
+/// back to a `"<file_id>.*"` directory probe instead of guessing here.
+pub fn on_disk_name(file_id: &str, content_type: &str, filename: &str) -> String {
+    let ext = ext_for_content_type(content_type)
+        .map(str::to_string)
+        .or_else(|| safe_ext_from_filename(filename));
+    match ext {
+        Some(ext) => format!("{file_id}.{ext}"),
+        None => file_id.to_string(),
+    }
+}
+
 impl MediaAttachment {
     /// Validate the attachment against security constraints.
     pub fn validate(&self) -> Result<(), String> {
@@ -772,6 +857,59 @@ pub struct MediaMusicResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ext_for_content_type_maps_known_and_rejects_generic() {
+        assert_eq!(ext_for_content_type("image/png"), Some("png"));
+        assert_eq!(ext_for_content_type("image/jpeg"), Some("jpg"));
+        assert_eq!(ext_for_content_type("application/pdf"), Some("pdf"));
+        assert_eq!(ext_for_content_type("audio/ogg"), Some("oga"));
+        // Parameters and case are normalized via mime_base.
+        assert_eq!(
+            ext_for_content_type("text/plain; charset=utf-8"),
+            Some("txt")
+        );
+        assert_eq!(ext_for_content_type("IMAGE/PNG"), Some("png"));
+        // Generic / unknown → None (caller falls back to filename or bare uuid).
+        assert_eq!(ext_for_content_type("application/octet-stream"), None);
+        assert_eq!(ext_for_content_type("application/x-not-real"), None);
+        assert_eq!(ext_for_content_type(""), None);
+    }
+
+    #[test]
+    fn on_disk_name_prefers_content_type_then_filename_then_bare() {
+        let id = "11111111-1111-1111-1111-111111111111";
+        // Content type wins even when the filename disagrees.
+        assert_eq!(
+            on_disk_name(id, "image/png", "photo.jpeg"),
+            format!("{id}.png")
+        );
+        // Unknown content type falls back to the filename extension.
+        assert_eq!(
+            on_disk_name(id, "application/octet-stream", "notes.md"),
+            format!("{id}.md")
+        );
+        // Neither known → bare uuid (no dot), so the traversal guard still parses it.
+        assert_eq!(on_disk_name(id, "application/octet-stream", "noext"), id);
+        // A filename with an unsafe/oversized "extension" is ignored, not joined.
+        assert_eq!(
+            on_disk_name(id, "application/octet-stream", "x.evil/../y"),
+            id
+        );
+        assert_eq!(
+            on_disk_name(id, "application/octet-stream", "x.verylongext"),
+            id
+        );
+    }
+
+    #[test]
+    fn on_disk_name_is_deterministic() {
+        let id = "22222222-2222-2222-2222-222222222222";
+        assert_eq!(
+            on_disk_name(id, "audio/ogg; codecs=opus", "voice.oga"),
+            on_disk_name(id, "audio/ogg; codecs=opus", "voice.oga"),
+        );
+    }
 
     #[test]
     fn test_media_type_display() {


### PR DESCRIPTION
## Summary

Closes #6530 (follow-up to the upload-path work in #6529 / #6531). The shared upload directory (`channels::effective_file_download_dir()`) was written by several producers under **three divergent naming schemes** — bare `<uuid>`, `image_<uuid>.png`, and `<uuid>.<ext>` — so a consumer that reconstructs a path from the bare `file_id` only found the bare-`<uuid>` producers, and a persisted upload lost its type at rest (extension-sniffing tools like `media_transcribe`, and any persist / re-dispatch flow, then mis-handled or type-erased the bytes).

## Approach

One deterministic naming authority in `librefang-types::media` (the shared crate all producers/consumers already depend on):

- `ext_for_content_type(content_type) -> Option<&'static str>` — MIME → extension after `mime_base`, `None` for `application/octet-stream` / unmapped.
- `on_disk_name(file_id, content_type, filename) -> String` — `<uuid>.<ext>`, picking the extension from `ext_for_content_type` first, then a safe filename extension, else a bare UUID. Pure/deterministic — documented as the invariant writers and readers both rely on.

Every producer routes through it: the API upload, media routes, session base64-image, generated images, and browser screenshot. **`file_id` stays a bare UUID**, so the path-traversal guard and the #3361 owner-access check still `uuid::Uuid::parse_str` it — only the on-disk basename diverges.

Consumers (`serve_upload`, `resolve_attachments`) reconstruct through a shared `resolve_existing_upload_path` that tries, in order: `<uuid>.<ext>`, the historical bare `<uuid>` (files written before this change, and registry misses after a daemon restart since `UPLOAD_REGISTRY` is in-memory), then a `<uuid>.*` directory probe (generated images whose content type the reader may not know). **Existing uploads keep serving** — backward compatible.

## Deliberately out of scope

Sites with **no** reconstruct-by-`file_id` mismatch, so nothing to converge:

- The image/audio/video/music generators that write to the agent **workspace** `output_dir` and return **full paths** (self-consistent; never rebuilt from `file_id`).
- The channel bridge, which already emits `<uuid>.<ext>` and delivers full paths — it is the reference scheme.
- `dispatch.rs` media reads (`image_analyze`, `media_transcribe`, …): these **allowlist the download dir** and the agent passes the complete `<uuid>.<ext>` path the kernel delivered — no `file_id` reconstruction happens.

## Verification (scoped)

- `librefang-types`: unit tests for `ext_for_content_type` and `on_disk_name` (content-type ext, filename fallback, bare-uuid for unknown, determinism).
- `librefang-api`: `resolver_finds_named_bare_and_generated_image_schemes` (all three resolution tiers incl. legacy bare + generated-image glob) and a `TestServer` round-trip — upload a PNG (`.png`) and a `text/plain` (`.txt`), `serve_upload` by the returned bare `file_id`, bytes match.
- `cargo check` / `cargo clippy --all-targets -- -D warnings` across `librefang-{types,api,runtime,channels}` — clean.
- `cargo test -p librefang-types` / `-p librefang-api` (upload + resolver) — pass.
