### PR TITLE
fix(nix): include openrouter-models.snapshot.json in the flake source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,10 @@
           fileset = pkgs.lib.fileset.unions [
             (craneLib.fileset.commonCargoSources ./.)
             ./crates/librefang-types/locales
+            # librefang-runtime embeds this at compile time via include_str!
+            # (crates/librefang-runtime/src/model_catalog.rs) as the offline
+            # fallback catalog; without it the Nix build fails to read the file.
+            ./crates/librefang-runtime/openrouter-models.snapshot.json
             ./crates/librefang-api/static
             ./crates/librefang-api/src/login_page.html
             ./crates/librefang-cli/templates


### PR DESCRIPTION
## Summary

The `Nix Build` lane has been **red on main since 2026-07-16** (last green `9d3beeb1`, 2026-07-15) — six days, across many commits, unrelated to any recent PR.

Root cause: `librefang-runtime/src/model_catalog.rs` embeds `crates/librefang-runtime/openrouter-models.snapshot.json` via `include_str!` (the offline model-catalog fallback added in #6384), but `flake.nix` builds from a **filtered source** (`lib.fileset.toSource` with a hand-listed `fileset.unions`) that keeps Rust sources plus an explicit set of non-`.rs` assets. The snapshot was never added to that list, so the sandboxed Nix build can't read the file and `librefang-runtime` fails to compile — taking down both the `librefang-cli` and `librefang-desktop` derivations.

The regular `CI` lane is green because it builds against the full working tree; only Nix's filtered source dropped the asset.

## Fix

Add `./crates/librefang-runtime/openrouter-models.snapshot.json` to the flake `fileset`, mirroring the existing `tauri.conf.json` / `login_page.html` / `static` entries that exist for the same "non-.rs asset needed at compile time" reason.

## Verification

`nix` is not available on the dev box, so this relies on the PR's own `Nix Build` lane to confirm green. The change is a one-line addition to an existing asset list; the file is git-tracked and present at the referenced path.
