### PR TITLE
feat(runtime-media): emit a failure metric for media-understanding (vision/STT) (#6538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
   When a server advertises the `resources` capability (read live from the rmcp handshake `peer_info`, or captured from the SSE `initialize` response) the client registers two synthetic tools — `list_resources` and `read_resource` — that flow through the normal tool-call loop and are intercepted before the transport `tools/call`, so a real server tool literally named `read_resource` is unaffected.
   A `resource_link` in a tool result is now surfaced as a first-class `[resource_link] name — uri (mime)` line instead of being flattened into an opaque JSON string, and an embedded resource contributes its text (binary blobs are elided, never inlined into the prompt); resource lists are sorted by URI for prompt-cache stability.
   No `resources` client capability is declared because the MCP `resources` capability is server-side and rmcp's `ClientCapabilities` has no such field (#6501) (@houko)
+- Emit a `librefang_media_understanding_failures_total{kind,provider,model}` counter (with a matching structured `warn!`) whenever vision description or audio transcription fails, so a hosted model that a provider silently retires — e.g. Groq removing the hardcoded default `meta-llama/llama-4-scout-17b-16e-instruct` — surfaces as an actionable metric instead of a days-later user report.
+  The counter is incremented at the point of failure inside `librefang-runtime-media` (both the image and audio provider-dispatch paths, plus the empty-result case), so it is captured regardless of caller, and its description is registered in `librefang-telemetry` for the Prometheus exporter.
+  The hardcoded default models are intentionally left unchanged (choosing replacements is an operator call); a comment on `default_vision_model` now documents that these ids rot and points at the new metric (#6538) (@houko)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5021,6 +5021,8 @@ dependencies = [
  "hex",
  "librefang-http",
  "librefang-types",
+ "metrics",
+ "metrics-util",
  "reqwest",
  "serde_json",
  "serial_test",

--- a/crates/librefang-runtime-media/Cargo.toml
+++ b/crates/librefang-runtime-media/Cargo.toml
@@ -17,12 +17,16 @@ dashmap = { workspace = true }
 tracing = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
+metrics = { workspace = true }
 
 [dev-dependencies]
 # Serialises the env-mutating ElevenLabs voice_id validator tests so
 # they cannot race with one another over `ELEVENLABS_API_KEY`. Same
 # version pin as the rest of the workspace (`librefang-runtime`).
 serial_test = "3"
+# Thread-local recorder for asserting `metrics::counter!` output in unit
+# tests, same version pin as `librefang-runtime`.
+metrics-util = { version = "0.20", features = ["debugging"] }
 
 [lints]
 workspace = true

--- a/crates/librefang-runtime-media/src/media_understanding.rs
+++ b/crates/librefang-runtime-media/src/media_understanding.rs
@@ -15,6 +15,40 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::Semaphore;
 use tracing::info;
 
+/// Record a media-understanding failure so operators can alert on a provider /
+/// model that has silently stopped working — e.g. a hosted model retired by the
+/// provider (`model_decommissioned`), which previously degraded to a raw
+/// image/audio passthrough with only a `warn!` in the channel bridge and no
+/// metric to diff against the hardcoded default (#6538).
+///
+/// Emits the `librefang_media_understanding_failures_total` counter and a
+/// structured `warn!` carrying the same fields, at the point of failure inside
+/// the media engine so it is captured regardless of the caller (channel bridge,
+/// tool path, …), not only in `bridge.rs`.
+///
+/// Cardinality: `kind` is one of {image, audio}; `provider` and `model` are
+/// drawn from the operator-configured or built-in default set (bounded) —
+/// matching the bounded-label discipline of the other LibreFang counters
+/// (`librefang_mcp_reconnect_total`, `librefang_tool_call_total`, …).
+fn record_media_understanding_failure(kind: &str, provider: &str, model: &str, error: &str) {
+    metrics::counter!(
+        "librefang_media_understanding_failures_total",
+        "kind" => kind.to_string(),
+        "provider" => provider.to_string(),
+        "model" => model.to_string(),
+    )
+    .increment(1);
+    tracing::warn!(
+        kind,
+        provider,
+        model,
+        error,
+        "Media understanding failed — the selected provider/model returned an \
+         error; a hosted model may have been retired, check the provider's \
+         current model list against the configured/default model"
+    );
+}
+
 /// Media understanding engine.
 pub struct MediaEngine {
     config: MediaConfig,
@@ -110,19 +144,34 @@ impl MediaEngine {
             "Sending image for description"
         );
 
-        let description = match provider {
-            "anthropic" => anthropic_describe_image(model, &image_bytes, mime_type).await?,
-            "openai" | "groq" => {
-                let (api_url, api_key) = openai_vision_provider_config(provider)?;
-                openai_describe_image(&api_url, &api_key, model, &image_bytes, mime_type).await?
+        // Capture the provider dispatch as a `Result` (rather than `?`-ing each
+        // arm) so any failure is counted with its provider/model before it
+        // propagates — this is the "hosted model silently retired" signal (#6538).
+        let dispatch_result: Result<String, String> = async {
+            match provider {
+                "anthropic" => anthropic_describe_image(model, &image_bytes, mime_type).await,
+                "openai" | "groq" => {
+                    let (api_url, api_key) = openai_vision_provider_config(provider)?;
+                    openai_describe_image(&api_url, &api_key, model, &image_bytes, mime_type).await
+                }
+                "gemini" => gemini_describe_image(model, &image_bytes, mime_type).await,
+                other => Err(format!("Unsupported image description provider: {}", other)),
             }
-            "gemini" => gemini_describe_image(model, &image_bytes, mime_type).await?,
-            other => return Err(format!("Unsupported image description provider: {}", other)),
+        }
+        .await;
+        let description = match dispatch_result {
+            Ok(d) => d,
+            Err(e) => {
+                record_media_understanding_failure("image", provider, model, &e);
+                return Err(e);
+            }
         };
 
         let description = description.trim().to_string();
         if description.is_empty() {
-            return Err("Image description returned empty text".into());
+            let e = "Image description returned empty text".to_string();
+            record_media_understanding_failure("image", provider, model, &e);
+            return Err(e);
         }
 
         info!(
@@ -254,26 +303,43 @@ impl MediaEngine {
 
         info!(provider, model, filename = %filename, size = audio_bytes.len(), "Sending audio for transcription");
 
-        let transcription = match provider {
-            // Whisper-compatible providers (OpenAI multipart protocol)
-            "groq" | "openai" | "minimax" | "fireworks" | "together" | "siliconflow" => {
-                let (api_url, api_key) = whisper_provider_config(provider)?;
-                whisper_transcribe(&api_url, &api_key, model, audio_bytes, &filename, &mime).await?
+        // Capture the provider dispatch as a `Result` so any failure is counted
+        // with its provider/model before propagating — the STT analogue of the
+        // vision "hosted model silently retired" signal (#6538).
+        let dispatch_result: Result<String, String> = async {
+            match provider {
+                // Whisper-compatible providers (OpenAI multipart protocol)
+                "groq" | "openai" | "minimax" | "fireworks" | "together" | "siliconflow" => {
+                    let (api_url, api_key) = whisper_provider_config(provider)?;
+                    whisper_transcribe(&api_url, &api_key, model, audio_bytes, &filename, &mime)
+                        .await
+                }
+                // Gemini — multimodal content generation with audio input
+                "gemini" => gemini_transcribe(model, audio_bytes, &mime).await,
+                // ElevenLabs — Speech-to-Text API
+                "elevenlabs" => elevenlabs_transcribe(model, audio_bytes, &mime).await,
+                // Custom / self-hosted OpenAI-compatible Whisper endpoint
+                _other => {
+                    let (api_url, api_key) = custom_stt_config(provider, &self.config.custom_stt)?;
+                    whisper_transcribe(&api_url, &api_key, model, audio_bytes, &filename, &mime)
+                        .await
+                }
             }
-            // Gemini — multimodal content generation with audio input
-            "gemini" => gemini_transcribe(model, audio_bytes, &mime).await?,
-            // ElevenLabs — Speech-to-Text API
-            "elevenlabs" => elevenlabs_transcribe(model, audio_bytes, &mime).await?,
-            // Custom / self-hosted OpenAI-compatible Whisper endpoint
-            _other => {
-                let (api_url, api_key) = custom_stt_config(provider, &self.config.custom_stt)?;
-                whisper_transcribe(&api_url, &api_key, model, audio_bytes, &filename, &mime).await?
+        }
+        .await;
+        let transcription = match dispatch_result {
+            Ok(t) => t,
+            Err(e) => {
+                record_media_understanding_failure("audio", provider, model, &e);
+                return Err(e);
             }
         };
 
         let transcription = transcription.trim().to_string();
         if transcription.is_empty() {
-            return Err("Transcription returned empty text".into());
+            let e = "Transcription returned empty text".to_string();
+            record_media_understanding_failure("audio", provider, model, &e);
+            return Err(e);
         }
 
         info!(
@@ -1007,6 +1073,15 @@ fn detect_audio_provider() -> Option<&'static str> {
 }
 
 /// Get the default vision model for a provider.
+///
+/// These hardcoded ids rot: a provider can retire a hosted model at any time
+/// (e.g. Groq removed `meta-llama/llama-4-scout-17b-16e-instruct`), after which
+/// every non-explicitly-configured setup silently degrades. There is no safe
+/// way to keep this list evergreen in-tree; the mitigation is observability —
+/// `record_media_understanding_failure` emits
+/// `librefang_media_understanding_failures_total{kind,provider,model}` so the
+/// rot surfaces as an actionable signal instead of a days-later user report
+/// (#6538). Prefer setting `[media] image_model` explicitly in production.
 fn default_vision_model(provider: &str) -> &str {
     match provider {
         "anthropic" => "claude-sonnet-4-20250514",
@@ -1065,6 +1140,46 @@ mod tests {
         let config = MediaConfig::default();
         let engine = MediaEngine::new(config);
         assert_eq!(engine.config.max_concurrency, 2);
+    }
+
+    // #6538: a media-understanding failure must be observable via the
+    // `librefang_media_understanding_failures_total` counter, labeled by
+    // kind/provider/model, so operators can alert on a retired hosted model
+    // instead of finding out days later. Mirrors the `DebuggingRecorder` +
+    // `with_local_recorder` pattern in `librefang-runtime::command_lane`.
+    #[test]
+    fn media_understanding_failure_increments_counter_with_labels() {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            record_media_understanding_failure(
+                "image",
+                "groq",
+                "meta-llama/llama-4-scout-17b-16e-instruct",
+                "Vision API error (404): model_decommissioned",
+            );
+        });
+
+        let snap = snapshotter.snapshot().into_vec();
+        let hit = snap.iter().find(|(ckey, _, _, _)| {
+            ckey.key().name() == "librefang_media_understanding_failures_total"
+                && ckey
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "kind" && l.value() == "image")
+                && ckey
+                    .key()
+                    .labels()
+                    .any(|l| l.key() == "provider" && l.value() == "groq")
+                && ckey.key().labels().any(|l| {
+                    l.key() == "model" && l.value() == "meta-llama/llama-4-scout-17b-16e-instruct"
+                })
+        });
+        let (_, _, _, val) = hit.expect("media-understanding failure counter must be recorded");
+        assert_eq!(*val, DebugValue::Counter(1), "counter must increment by 1");
     }
 
     #[test]

--- a/crates/librefang-telemetry/src/metrics.rs
+++ b/crates/librefang-telemetry/src/metrics.rs
@@ -169,6 +169,14 @@ pub fn describe_observability_metrics() {
          schedule-fallback misses, labeled by agent. Alert on any increase: \
          the job has silently stopped firing until re-enabled."
     );
+    metrics::describe_counter!(
+        "librefang_media_understanding_failures_total",
+        "Media understanding (vision describe / STT transcribe) failures, \
+         labeled by kind (image|audio), provider, and model. A rising rate for \
+         a given provider/model flags a hosted model that has been retired or \
+         is otherwise failing — the agent degrades to a raw-media passthrough, \
+         so without this counter the rot is only visible days later (#6538)."
+    );
 }
 
 /// Render an HTTP metrics summary.


### PR DESCRIPTION
## Summary

Closes #6538. When media understanding fails — e.g. Groq retires the hardcoded default vision model and every non-explicitly-configured `image_provider = "groq"` setup silently stops describing photos — the agent degrades gracefully (raw media passthrough) but the only signal was a `warn!` in the channel bridge. Nothing reached metrics/health, so a rotted hardcoded default was found days later by manually diffing the provider's model list (second time this pattern bit; the first was Groq Whisper STT).

## Change

Add a counter **`librefang_media_understanding_failures_total`**, labeled `kind` (image|audio), `provider`, `model`, incremented **at the point of failure inside `librefang-runtime-media`** (`describe_image` and `transcribe_audio` — both the provider-dispatch failure and empty-result paths), so it's captured regardless of caller (channel bridge, tool path). A new `record_media_understanding_failure` helper emits the counter plus a structured `warn!` with the same fields; the counter is `describe_counter!`-registered for the Prometheus exporter in `librefang-telemetry`. Mirrors the repo's existing `metrics::counter!(...).increment(1)` pattern (`mcp_setup.rs` / `command_lane.rs`) — no new metrics stack.

Hardcoded default models are **left unchanged** (picking new defaults is a separate maintainer call); a comment on `default_vision_model` documents that these ids rot and points at the metric. No health-surface change — no existing aggregation pattern to extend, and the metric + structured warn is sufficient.

## ⚠️ Dependency note (maintainer review)

Adds a **dev-dependency** `metrics-util` (`features = ["debugging"]`, same version as `librefang-runtime`) used **only** to assert the counter emission in a unit test (`DebuggingRecorder` + `with_local_recorder`, mirroring the existing `command_lane` test). Flagged per the repo's no-unapproved-deps rule — it's test-only and precedented, but say the word if you'd rather drop the assertion test and the dep with it. The non-dev `metrics` dep is already a workspace dependency.

## Verification

Run with external `TMPDIR` (dev system disk was full):
- `cargo test -p librefang-runtime-media` — 84 passed, incl. new `media_understanding_failure_increments_counter_with_labels`.
- `cargo clippy -p librefang-runtime-media -p librefang-telemetry --all-targets -- -D warnings` clean; `cargo check -p librefang-telemetry` clean.
