### PR TITLE
fix(memory): apply busy_timeout to every pooled connection in modify() test helper

### DIFF
--- a/crates/librefang-memory/src/structured.rs
+++ b/crates/librefang-memory/src/structured.rs
@@ -787,15 +787,8 @@ mod tests {
     /// `:memory:` DB with `max_size(1)` cannot exercise the race the
     /// transactional `modify` fixes.
     ///
-    /// `busy_timeout` must be set via `with_init`, not on a single
-    /// connection pulled from the pool after `build()`: r2d2 defaults
-    /// `min_idle` to `max_size`, so it eagerly opens up to 8 connections in
-    /// the background, and every subsequent checkout can hand out a fresh
-    /// one on demand too. Configuring only the one connection grabbed here
-    /// left the other pooled connections with SQLite's default 0ms busy
-    /// timeout, so concurrent `modify()` calls under contention failed
-    /// immediately with "database is locked" instead of waiting — flaky,
-    /// mostly on Windows CI where lock contention is more likely to line up.
+    /// `busy_timeout` must be set via `with_init`, not on a single connection pulled from the pool after `build()`: r2d2 defaults `min_idle` to `max_size`, so it eagerly opens up to 8 connections in the background, and every subsequent checkout can hand out a fresh one on demand too.
+    /// Configuring only the one connection grabbed here left the other pooled connections with SQLite's default 0ms busy timeout, so concurrent `modify()` calls under contention failed immediately with "database is locked" instead of waiting — flaky, mostly on Windows CI where lock contention is more likely to line up.
     fn setup_file_backed(path: &std::path::Path) -> StructuredStore {
         let pool = Pool::builder()
             .max_size(8)

--- a/crates/librefang-memory/src/structured.rs
+++ b/crates/librefang-memory/src/structured.rs
@@ -786,17 +786,25 @@ mod tests {
     /// genuinely contend for the SQLite write lock. An in-memory
     /// `:memory:` DB with `max_size(1)` cannot exercise the race the
     /// transactional `modify` fixes.
+    ///
+    /// `busy_timeout` must be set via `with_init`, not on a single
+    /// connection pulled from the pool after `build()`: r2d2 defaults
+    /// `min_idle` to `max_size`, so it eagerly opens up to 8 connections in
+    /// the background, and every subsequent checkout can hand out a fresh
+    /// one on demand too. Configuring only the one connection grabbed here
+    /// left the other pooled connections with SQLite's default 0ms busy
+    /// timeout, so concurrent `modify()` calls under contention failed
+    /// immediately with "database is locked" instead of waiting — flaky,
+    /// mostly on Windows CI where lock contention is more likely to line up.
     fn setup_file_backed(path: &std::path::Path) -> StructuredStore {
         let pool = Pool::builder()
             .max_size(8)
-            .build(SqliteConnectionManager::file(path))
+            .build(
+                SqliteConnectionManager::file(path)
+                    .with_init(|c| c.busy_timeout(std::time::Duration::from_secs(10))),
+            )
             .unwrap();
-        {
-            let conn = pool.get().unwrap();
-            conn.busy_timeout(std::time::Duration::from_secs(10))
-                .unwrap();
-            run_migrations(&conn).unwrap();
-        }
+        run_migrations(&pool.get().unwrap()).unwrap();
         StructuredStore::new(pool)
     }
 


### PR DESCRIPTION
## Summary

`main`'s tip commit (d1c91366d) has a red `CI Gate` / `Test / Windows (shard 2/2)` check.
The failure is `structured::tests::modify_concurrent_appends_lose_no_writes_5138` in `crates/librefang-memory/src/structured.rs`, panicking with `Memory { message: "database is locked", source: Some(SqliteFailure(Error { code: DatabaseBusy, ... }, ...)) }`.
Run: https://github.com/librefang/librefang/actions/runs/29983234553/job/89129494230

## Root cause

The test's `setup_file_backed` helper builds an 8-connection file-backed r2d2 pool and then calls `busy_timeout(10s)` on only the single connection returned by one `pool.get()` call.

r2d2 defaults `min_idle` to `max_size`, so it eagerly opens the remaining connections in the background without ever running that pragma, and later checkouts can also hand back a freshly-created, unconfigured connection.

`modify_concurrent_appends_lose_no_writes_5138` spawns 24 threads that all call `store.modify()`, each doing a `BEGIN IMMEDIATE` transaction against the same key. Any thread that lands on a connection without `busy_timeout` set fails immediately with SQLite's default 0 ms timeout instead of waiting for the lock, producing the "database is locked" panic. This is not deterministic - it depends on which connections the pool happens to hand out - so it's more likely to reproduce under Windows' file-locking behavior/CI contention than locally.

## Fix

Set the pragma through `SqliteConnectionManager::with_init`, so it applies to every connection the pool creates, matching the pattern the production pool already uses in `substrate.rs` (`open_with_pool_size`).

## Verification

Ran locally with the host's native `cargo`/`rustc` 1.96.0 (Docker's `librefang-rust-dev` image could not be pulled/built in this sandbox - registry access was blocked - so this substitutes for the Dockerized workflow described in `CLAUDE.md`):

- `cargo check -p librefang-memory --lib` - clean
- `cargo clippy -p librefang-memory --all-targets -- -D warnings` - clean
- `cargo test -p librefang-memory --lib` - 333 passed, 0 failed
- `modify_concurrent_appends_lose_no_writes_5138` run 5x in isolation after the fix - all green
- `cargo fmt -p librefang-memory --check` - clean

Note on confidence: the pre-fix baseline also passed on macOS across 3 runs in this sandbox, so this doesn't reproduce the Windows-specific contention locally; the fix is a direct match to the already-correct production pooling pattern, and CI on this PR (including the Windows shard) is the real confirmation.

## Out-of-scope observation

`crates/librefang-kernel/src/workflow.rs` (`pending_run_survives_crash_before_first_persist`) builds a similar file-backed pool without `busy_timeout` at all. I left it alone: that test's two `make_store()` calls run strictly sequentially (create -> drop -> reopen), not concurrently, so it isn't exposed to this race, and fixing it means touching a different crate/domain than this PR. Flagging in case it's worth a follow-up if that test ever grows concurrent access.
