### PR TITLE
release: v2026.7.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,69 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 - Document installation from the signed project-maintained Arch Linux pacman repository while AUR account registration is unavailable (#6386) (@pavver)
 
+## [2026.7.27] - 2026-07-27
+
+_33 PRs from 2 contributors since v2026.7.21._
+
+### Highlights
+
+- **EveryAPI integration** — connect EveryAPI as a model provider via `librefang models connect everyapi` from the CLI or the new Providers page connect action, with a built-in wiring doctor check
+- **macOS boot-time service** — `service install --system` installs a LaunchDaemon so LibreFang starts automatically at login without a running user session
+- **NixOS & additional Linux distros** — first-class NixOS deployment support with deepin/Debian distro awareness out of the box
+- **Audit log integrity** — audit entries are now preserved (WORM-protected) when an agent is purged, preventing accidental evidence loss
+- **Tool result and context fidelity fixes** — stops lossily truncating tool results in the spill dead band, and correctly honors `context_window` from `agent.toml` on all turn-execution paths
+
+### Added
+
+- Emit a failure metric for media-understanding (vision/STT) (#6538) (#6551) (@houko)
+- First-class NixOS deployment and deepin/Debian distro awareness (#6582) (@houko)
+- Add `librefang models connect everyapi` and an EveryAPI wiring doctor check (#6583) (@houko)
+- Add `service install --system` for a boot-time LaunchDaemon on macOS (#6584) (@houko)
+- Add an EveryAPI connect action to the Providers page (#6586) (@houko)
+
+### Fixed
+
+- Override sharp to >=0.35.0 to clear the libvips high advisory (#6546) (@houko)
+- Include openrouter-models.snapshot.json in the flake source (#6547) (@houko)
+- Anchor credential-prefix secret patterns to stop false positives (#6541) (#6548) (@houko)
+- Make skills/reload honest in frozen Stable mode (#6540) (#6549) (@houko)
+- Stop lossily truncating tool results in the spill dead band (#6545) (#6550) (@houko)
+- Bump next to 16.2.11 to clear the App Router security advisories (#6557) (@houko)
+- Don't delete audit_entries when purging an agent (WORM integrity) (#6553) (#6558) (@houko)
+- Apply busy_timeout to every pooled connection in modify() test helper (#6561) (@houko)
+- Treat blank parent_id / agent_id as absent instead of 404 (#6577) (@houko)
+- Collect new_name on clone, reflect mcp_servers grants in Tools tab (#6578) (@houko)
+- Resolve callback message_id from either metadata shape or the native id (#6579) (@houko)
+- Honour agent.toml context_window on the paths that run a turn (#6580) (@houko)
+- Install and search from the synced registry checkout (#6581) (@houko)
+- Give the TUI a process-lifetime runtime (startup panic + silent session-summary loss) (#6585) (@houko)
+
+<details>
+<summary>Documentation, maintenance, and other internal changes</summary>
+
+### Documentation
+
+- Move the misplaced `### Fixed` block out of the `### Added` list (#6587) (@houko)
+
+### Maintenance
+
+- Update model snapshot (#6539) (@houko)
+- Bump the actions-minor-patch group across 1 directory with 4 updates (#6542) (@app/dependabot)
+- Bump actions/labeler from 6.2.0 to 7.0.0 (#6543) (@app/dependabot)
+- Bump actions/setup-python from 6 to 7 (#6544) (@app/dependabot)
+- Update model snapshot (#6552) (@houko)
+- Bump the web-minor-patch group in /web with 10 updates (#6554) (@app/dependabot)
+- Bump the dashboard-minor-patch group across 1 directory with 12 updates (#6555) (@app/dependabot)
+- Bump @testing-library/jest-dom from 6.9.1 to 7.0.0 in /crates/librefang-api/dashboard (#6556) (@app/dependabot)
+- Update model snapshot (#6563) (@houko)
+- Bump the docs-minor-patch group in /docs with 6 updates (#6567) (@app/dependabot)
+- Update model snapshot (#6571) (@houko)
+- Update model snapshot (#6574) (@houko)
+- Update model snapshot (#6576) (@houko)
+
+</details>
+
+
 ## [2026.7.21] - 2026-07-21
 
 _61 PRs from 4 contributors since v2026.7.11._

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-acp"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-api"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-channels"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "async-trait",
  "axum",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-cli"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "arc-swap",
  "base64 0.22.1",
@@ -4571,7 +4571,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-desktop"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "axum",
  "clap",
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-extensions"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "aes-gcm",
  "argon2 0.5.3",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-hands"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-http"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "librefang-types",
  "reqwest",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-import"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-handle"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-metering"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "librefang-llm-driver",
  "librefang-memory",
@@ -4776,7 +4776,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-kernel-router"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "dirs 6.0.0",
  "librefang-hands",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-driver"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-llm-drivers"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4840,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-memory-wiki"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "chrono",
  "librefang-kernel-handle",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-rl-export"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4898,7 +4898,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-audit"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "chrono",
  "hex",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-mcp"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-media"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5032,7 +5032,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-runtime-sandbox-docker"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-skills"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-subprocess"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "metrics",
  "serde_json",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-telemetry"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "librefang-types",
  "metrics",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-testing"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-types"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "librefang-wire"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -12618,7 +12618,7 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xtask"
-version = "2026.7.21"
+version = "2026.7.27"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2026.7.21"
+version = "2026.7.27"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/librefang/librefang"

--- a/articles/release-2026.7.27.md
+++ b/articles/release-2026.7.27.md
@@ -1,26 +1,38 @@
 # LibreFang 2026.7.27 Released
 
-We're shipping **v2026.7.27** with 33 improvements spanning provider integrations, operational polish, and critical fidelity fixes. Here's what matters for your Agent OS deployments.
+We're shipping **v2026.7.27** with 33 improvements spanning provider integrations, operational polish, and critical fidelity fixes.
+Here's what matters for your Agent OS deployments.
 
 ## New: Provider Integrations & Deployment
 
-**EveryAPI is now a first-class model provider.** Connect it via `librefang models connect everyapi` in the CLI or the new Providers page UI. The CLI includes a built-in wiring doctor to catch misconfiguration—no more debugging silent auth failures.
+**EveryAPI is now a first-class model provider.**
+Connect it via `librefang models connect everyapi` in the CLI or the new Providers page UI.
+The CLI includes a built-in wiring doctor to catch misconfiguration—no more debugging silent auth failures.
 
-**macOS users: LibreFang now runs at boot.** The new `service install --system` command installs a LaunchDaemon so your daemon starts automatically at login, even without a user session. Forget about manual restarts after reboot.
+**macOS users: LibreFang now runs at boot.**
+The new `service install --system` command installs a LaunchDaemon so your daemon starts automatically at login, even without a user session.
+Forget about manual restarts after reboot.
 
-**NixOS and additional Linux distros are now officially supported.** We've added first-class deployment support for NixOS with deepin and Debian distro awareness baked in, making it trivial to package and deploy across diverse Linux environments.
+**NixOS and additional Linux distros are now officially supported.**
+We've added first-class deployment support for NixOS with deepin and Debian distro awareness baked in, making it trivial to package and deploy across diverse Linux environments.
 
 ## Fixes: Correctness & Data Integrity
 
 Three correctness fixes ship with this release:
 
-- **Audit logs are now WORM-protected.** Audit entries persist even when an agent is purged, preventing accidental evidence loss in compliance-sensitive deployments.
-- **Tool results are no longer lossy.** We fixed a spill dead band that was truncating tool outputs. Results now round-trip without silent truncation.
-- **Context windows from `agent.toml` are now honored everywhere.** Previously some turn-execution paths ignored the configured `context_window`, leading to inconsistent behavior. This is fixed across all paths.
+- **Audit logs are now WORM-protected.**
+  Audit entries persist even when an agent is purged, preventing accidental evidence loss in compliance-sensitive deployments.
+- **Tool results are no longer lossy.**
+  We fixed a spill dead band that was truncating tool outputs.
+  Results now round-trip without silent truncation.
+- **Context windows from `agent.toml` are now honored everywhere.**
+  Previously some turn-execution paths ignored the configured `context_window`, leading to inconsistent behavior.
+  This is fixed across all paths.
 
 ## Under the Hood
 
-Security dependency bumps clear high-severity advisories in libvips (via sharp >=0.35.0) and Next.js App Router. We've also hardened credential-pattern detection to reduce false positives, improved test reliability with connection pool timeouts, and fixed callback message ID resolution for MCP OAuth flows.
+Security dependency bumps clear high-severity advisories in libvips (via sharp >=0.35.0) and Next.js App Router.
+We've also hardened credential-pattern detection to reduce false positives, improved test reliability with connection pool timeouts, and fixed callback message ID resolution for MCP OAuth flows.
 
 The TUI now runs on a process-lifetime runtime, preventing startup panics and silent session-summary loss during shutdown.
 

--- a/articles/release-2026.7.27.md
+++ b/articles/release-2026.7.27.md
@@ -1,0 +1,51 @@
+# LibreFang 2026.7.27 Released
+
+We're shipping **v2026.7.27** with 33 improvements spanning provider integrations, operational polish, and critical fidelity fixes. Here's what matters for your Agent OS deployments.
+
+## New: Provider Integrations & Deployment
+
+**EveryAPI is now a first-class model provider.** Connect it via `librefang models connect everyapi` in the CLI or the new Providers page UI. The CLI includes a built-in wiring doctor to catch misconfiguration—no more debugging silent auth failures.
+
+**macOS users: LibreFang now runs at boot.** The new `service install --system` command installs a LaunchDaemon so your daemon starts automatically at login, even without a user session. Forget about manual restarts after reboot.
+
+**NixOS and additional Linux distros are now officially supported.** We've added first-class deployment support for NixOS with deepin and Debian distro awareness baked in, making it trivial to package and deploy across diverse Linux environments.
+
+## Fixes: Correctness & Data Integrity
+
+Three correctness fixes ship with this release:
+
+- **Audit logs are now WORM-protected.** Audit entries persist even when an agent is purged, preventing accidental evidence loss in compliance-sensitive deployments.
+- **Tool results are no longer lossy.** We fixed a spill dead band that was truncating tool outputs. Results now round-trip without silent truncation.
+- **Context windows from `agent.toml` are now honored everywhere.** Previously some turn-execution paths ignored the configured `context_window`, leading to inconsistent behavior. This is fixed across all paths.
+
+## Under the Hood
+
+Security dependency bumps clear high-severity advisories in libvips (via sharp >=0.35.0) and Next.js App Router. We've also hardened credential-pattern detection to reduce false positives, improved test reliability with connection pool timeouts, and fixed callback message ID resolution for MCP OAuth flows.
+
+The TUI now runs on a process-lifetime runtime, preventing startup panics and silent session-summary loss during shutdown.
+
+_33 PRs from 2 contributors since v2026.7.21._
+
+## Install / Upgrade
+
+```bash
+# Binary
+curl -fsSL https://get.librefang.ai | sh
+
+# Rust SDK
+cargo add librefang
+
+# JavaScript SDK
+npm install @librefang/sdk
+
+# Python SDK
+pip install librefang-sdk
+```
+
+## Links
+
+- [Full Changelog](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)
+- [GitHub Release](https://github.com/librefang/librefang/releases/tag/v2026.7.27)
+- [GitHub](https://github.com/librefang/librefang)
+- [Discord](https://discord.gg/DzTYqAZZmc)
+- [Contributing Guide](https://github.com/librefang/librefang/blob/main/docs/CONTRIBUTING.md)

--- a/crates/librefang-desktop/tauri.conf.json
+++ b/crates/librefang-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LibreFang",
-  "version": "26.7.32219",
+  "version": "26.7.32279",
   "identifier": "ai.librefang.desktop",
   "build": {},
   "app": {

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
     },
-    "version": "2026.7.21"
+    "version": "2026.7.27"
   },
   "paths": {
     "/.well-known/agent.json": {

--- a/packages/whatsapp-gateway/package.json
+++ b/packages/whatsapp-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/whatsapp-gateway",
-  "version": "2026.7.21",
+  "version": "2026.7.27",
   "description": "WhatsApp Web gateway for LibreFang — QR code login, bidirectional messaging via Baileys",
   "bin": {
     "librefang-whatsapp-gateway": "./index.js"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librefang/sdk",
-  "version": "2026.7.21",
+  "version": "2026.7.27",
   "description": "Official JavaScript/TypeScript client for the LibreFang Agent OS REST API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="librefang",
-    version="2026.7.21",
+    version="2026.7.27",
     description="Official Python client for the LibreFang Agent OS REST API",
     py_modules=["librefang_sdk", "librefang_client"],
     python_requires=">=3.8",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "librefang"
-version = "2026.7.21"
+version = "2026.7.27"
 edition = "2021"
 description = "Official Rust client for LibreFang Agent OS"
 license = "MIT"

--- a/xtask/baselines/openapi.sha256
+++ b/xtask/baselines/openapi.sha256
@@ -1,1 +1,1 @@
-cb77d454cfc3976a0079e04625786f6ffc0cde002a615ddb2d2cc16c1dcd313f  openapi.json
+0e66d676e2abb6af386c59a70abce564983b2bb5ad38f83ca82791d8c7e470d7  openapi.json


### PR DESCRIPTION
<!-- release-tag:v2026.7.27 -->
## Release v2026.7.27

_33 PRs from 2 contributors since v2026.7.21._

### Highlights

- **EveryAPI integration** — connect EveryAPI as a model provider via `librefang models connect everyapi` from the CLI or the new Providers page connect action, with a built-in wiring doctor check
- **macOS boot-time service** — `service install --system` installs a LaunchDaemon so LibreFang starts automatically at login without a running user session
- **NixOS & additional Linux distros** — first-class NixOS deployment support with deepin/Debian distro awareness out of the box
- **Audit log integrity** — audit entries are now preserved (WORM-protected) when an agent is purged, preventing accidental evidence loss
- **Tool result and context fidelity fixes** — stops lossily truncating tool results in the spill dead band, and correctly honors `context_window` from `agent.toml` on all turn-execution paths

### Added

- Emit a failure metric for media-understanding (vision/STT) (#6538) (#6551) (@houko)
- First-class NixOS deployment and deepin/Debian distro awareness (#6582) (@houko)
- Add `librefang models connect everyapi` and an EveryAPI wiring doctor check (#6583) (@houko)
- Add `service install --system` for a boot-time LaunchDaemon on macOS (#6584) (@houko)
- Add an EveryAPI connect action to the Providers page (#6586) (@houko)

### Fixed

- Override sharp to >=0.35.0 to clear the libvips high advisory (#6546) (@houko)
- Include openrouter-models.snapshot.json in the flake source (#6547) (@houko)
- Anchor credential-prefix secret patterns to stop false positives (#6541) (#6548) (@houko)
- Make skills/reload honest in frozen Stable mode (#6540) (#6549) (@houko)
- Stop lossily truncating tool results in the spill dead band (#6545) (#6550) (@houko)
- Bump next to 16.2.11 to clear the App Router security advisories (#6557) (@houko)
- Don't delete audit_entries when purging an agent (WORM integrity) (#6553) (#6558) (@houko)
- Apply busy_timeout to every pooled connection in modify() test helper (#6561) (@houko)
- Treat blank parent_id / agent_id as absent instead of 404 (#6577) (@houko)
- Collect new_name on clone, reflect mcp_servers grants in Tools tab (#6578) (@houko)
- Resolve callback message_id from either metadata shape or the native id (#6579) (@houko)
- Honour agent.toml context_window on the paths that run a turn (#6580) (@houko)
- Install and search from the synced registry checkout (#6581) (@houko)
- Give the TUI a process-lifetime runtime (startup panic + silent session-summary loss) (#6585) (@houko)

<details>
<summary>Documentation, maintenance, and other internal changes</summary>

### Documentation

- Move the misplaced `### Fixed` block out of the `### Added` list (#6587) (@houko)

### Maintenance

- Update model snapshot (#6539) (@houko)
- Bump the actions-minor-patch group across 1 directory with 4 updates (#6542) (@app/dependabot)
- Bump actions/labeler from 6.2.0 to 7.0.0 (#6543) (@app/dependabot)
- Bump actions/setup-python from 6 to 7 (#6544) (@app/dependabot)
- Update model snapshot (#6552) (@houko)
- Bump the web-minor-patch group in /web with 10 updates (#6554) (@app/dependabot)
- Bump the dashboard-minor-patch group across 1 directory with 12 updates (#6555) (@app/dependabot)
- Bump @testing-library/jest-dom from 6.9.1 to 7.0.0 in /crates/librefang-api/dashboard (#6556) (@app/dependabot)
- Update model snapshot (#6563) (@houko)
- Bump the docs-minor-patch group in /docs with 6 updates (#6567) (@app/dependabot)
- Update model snapshot (#6571) (@houko)
- Update model snapshot (#6574) (@houko)
- Update model snapshot (#6576) (@houko)

</details>

---
**Full diff:** https://github.com/librefang/librefang/compare/v2026.7.21...v2026.7.27