### PR TITLE
fix(runtime): request /json/new with PUT so HTTP CDP discovery works on current Chrome

### DIFF
--- a/changelog.d/fixed/6619-json-new-put-verb.md
+++ b/changelog.d/fixed/6619-json-new-put-verb.md
@@ -1,0 +1,4 @@
+Request `/json/new` with `PUT` when discovering a target over HTTP, so `cdp_endpoint` works against Chrome 111 and newer.
+Chrome moved the endpoint to `PUT` as CSRF hardening; librefang still sent `GET` and got back a `405` page whose HTML then failed to parse, so the operator saw `Invalid JSON from /json/new: expected value at line 1 column 1` — a parser error that says nothing about the verb that caused it.
+The request now tries `PUT` first and falls back to `GET` on `405`, which keeps older builds and proxies that only route `GET` working, and the response status is checked before the body is parsed so a non-2xx reply is reported as itself rather than as malformed JSON.
+The two verb-negotiation tests pin the call counts rather than only the returned target, since a GET-first implementation reaches the same result and would otherwise pass both (#6619) (@nevgenov)

--- a/crates/librefang-runtime/src/browser.rs
+++ b/crates/librefang-runtime/src/browser.rs
@@ -243,6 +243,51 @@ impl Drop for CdpConnection {
     }
 }
 
+// ── HTTP target discovery ──────────────────────────────────────────────────
+
+/// Ask a Chrome-style HTTP discovery endpoint for a fresh tab.
+///
+/// Returns the tab's WebSocket URL and its target ID, when the endpoint reports one.
+///
+/// `/json/new` is requested with PUT.
+/// Chrome has required that verb since 111 and answers a GET with `405 Method Not Allowed` and the body "Using unsafe HTTP verb GET to invoke /json/new. This action supports only PUT verb.", which this code used to walk straight into.
+/// Older Chromium builds and third-party CDP proxies may route only GET, so a 405 falls back to it rather than failing the session.
+async fn http_discover_target(cdp_endpoint: &str) -> Result<(String, Option<String>), String> {
+    let base = cdp_endpoint.trim_end_matches('/');
+    let new_url = format!("{base}/json/new");
+    let client = crate::http_client::new_client();
+
+    let send = |req: reqwest::RequestBuilder| async {
+        tokio::time::timeout(Duration::from_secs(CDP_CONNECT_TIMEOUT_SECS), req.send())
+            .await
+            .map_err(|_| format!("Timed out connecting to CDP endpoint: {cdp_endpoint}"))?
+            .map_err(|e| format!("Failed to reach CDP endpoint {cdp_endpoint}: {e}"))
+    };
+
+    let mut resp = send(client.put(&new_url)).await?;
+    if resp.status() == reqwest::StatusCode::METHOD_NOT_ALLOWED {
+        debug!("PUT /json/new rejected with 405; retrying with GET");
+        resp = send(client.get(&new_url)).await?;
+    }
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("/json/new returned {status}"));
+    }
+
+    let target: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Invalid JSON from /json/new: {e}"))?;
+
+    let page_ws = target["webSocketDebuggerUrl"]
+        .as_str()
+        .ok_or("Missing webSocketDebuggerUrl in /json/new response")?
+        .to_string();
+    let target_id = target["id"].as_str().map(|s| s.to_string());
+    Ok((page_ws, target_id))
+}
+
 // ── Browser session ────────────────────────────────────────────────────────
 
 /// A live browser session: one CDP connection per agent.
@@ -363,9 +408,8 @@ impl BrowserSession {
     /// Attach to a remote CDP endpoint instead of spawning a local Chromium.
     ///
     /// Accepted formats for `cdp_endpoint`:
-    /// - `http[s]://host:port` — HTTP discovery; `GET /json/new` creates a fresh
-    ///   tab and returns its WebSocket URL. The created target ID is stored for
-    ///   cleanup when the session ends.
+    /// - `http[s]://host:port` — HTTP discovery; `/json/new` creates a fresh tab (PUT, falling back to GET on a 405) and returns its WebSocket URL.
+    ///   The created target ID is stored for cleanup when the session ends.
     /// - `ws[s]://…` — Direct WebSocket attach (assumes page-level endpoint).
     ///
     /// `auth_token` is sent as `Authorization: Bearer <token>` on the WS upgrade,
@@ -376,27 +420,9 @@ impl BrowserSession {
 
         let lower = cdp_endpoint.to_lowercase();
         if lower.starts_with("http://") || lower.starts_with("https://") {
-            // Normalise: strip trailing slash
-            let base = cdp_endpoint.trim_end_matches('/');
-            let new_url = format!("{base}/json/new");
-            let resp = tokio::time::timeout(
-                Duration::from_secs(CDP_CONNECT_TIMEOUT_SECS),
-                crate::http_client::new_client().get(&new_url).send(),
-            )
-            .await
-            .map_err(|_| format!("Timed out connecting to CDP endpoint: {cdp_endpoint}"))?
-            .map_err(|e| format!("Failed to reach CDP endpoint {cdp_endpoint}: {e}"))?;
-
-            let target: serde_json::Value = resp
-                .json()
-                .await
-                .map_err(|e| format!("Invalid JSON from /json/new: {e}"))?;
-
-            page_ws = target["webSocketDebuggerUrl"]
-                .as_str()
-                .ok_or("Missing webSocketDebuggerUrl in /json/new response")?
-                .to_string();
-            target_id = target["id"].as_str().map(|s| s.to_string());
+            let (ws, id) = http_discover_target(cdp_endpoint).await?;
+            page_ws = ws;
+            target_id = id;
             debug!(ws = %page_ws, "Attached via HTTP discovery (/json/new)");
         } else if lower.starts_with("ws://") || lower.starts_with("wss://") {
             page_ws = cdp_endpoint.to_string();
@@ -1295,6 +1321,80 @@ mod tests {
         let err = BrowserResponse::err("bad");
         assert!(!err.success);
         assert_eq!(err.error.unwrap(), "bad");
+    }
+
+    /// Chrome 111+ serves `/json/new` on PUT only, answering GET with 405.
+    #[tokio::test]
+    async fn test_http_discovery_uses_put() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // The counts are the assertion: a PUT-second implementation reaches the same result by trying GET first, so only the call counts tell the two orders apart.
+        Mock::given(method("GET"))
+            .and(path("/json/new"))
+            .respond_with(ResponseTemplate::new(405))
+            .expect(0)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/json/new"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "TAB-1",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/page/TAB-1",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (ws, id) = http_discover_target(&server.uri()).await.unwrap();
+        assert_eq!(ws, "ws://127.0.0.1:9222/devtools/page/TAB-1");
+        assert_eq!(id.as_deref(), Some("TAB-1"));
+    }
+
+    /// Endpoints that route only GET still work: a 405 on PUT falls back.
+    #[tokio::test]
+    async fn test_http_discovery_falls_back_to_get_on_405() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // Both verbs must be exercised: a GET-first implementation would answer from the GET mock alone and never prove that PUT was attempted at all.
+        Mock::given(method("PUT"))
+            .and(path("/json/new"))
+            .respond_with(ResponseTemplate::new(405))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/json/new"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "TAB-2",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/page/TAB-2",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (ws, id) = http_discover_target(&server.uri()).await.unwrap();
+        assert_eq!(ws, "ws://127.0.0.1:9222/devtools/page/TAB-2");
+        assert_eq!(id.as_deref(), Some("TAB-2"));
+    }
+
+    /// A non-2xx that is not 405 surfaces as an error instead of a JSON parse failure further down.
+    #[tokio::test]
+    async fn test_http_discovery_reports_non_success_status() {
+        use wiremock::matchers::path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(path("/json/new"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let err = http_discover_target(&server.uri()).await.unwrap_err();
+        assert!(err.contains("404"), "unexpected error: {err}");
     }
 }
 


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

Attaching to an `http://` `cdp_endpoint` fails against any current Chrome. `attach()` requests `/json/new` with **GET**, but Chrome has required **PUT** on that route since 111 and rejects a GET outright:

```
$ curl -s -o /dev/null -w '%{http_code}' 'http://127.0.0.1:9222/json/new?url=https://example.com'
405

$ curl -s 'http://127.0.0.1:9222/json/new?url=https://example.com'
Using unsafe HTTP verb GET to invoke /json/new. This action supports only PUT verb.
```

Reproduced against Chrome for Testing 148.0.7778.96. Every browser session on such an endpoint dies before its first command.

The error the operator actually sees points nowhere near the cause:

```
Failed to attach: Invalid JSON from /json/new: expected value at line 1 column 1
```

That is because the 405 body is plain text and the response status was never checked at all — the code went straight to `resp.json()`.

## Changes

- `/json/new` is requested with PUT.
- A 405 on PUT falls back to GET rather than failing the session. Older Chromium builds and third-party CDP proxies may route only the older verb, and there is no version handshake to branch on, so trying the modern verb first and degrading on the one status that specifically means "wrong verb" seemed better than picking a side.
- The response status is checked. A non-2xx that is not a 405 is now reported as the status it was, instead of resurfacing as a JSON parse error further down.
- Discovery moved out of `attach()` into `http_discover_target()`, so the verb negotiation is testable without a live browser.

`ws://` endpoints are untouched.

## Attribution

- [x] This PR preserves author attribution for any adapted prior work

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p librefang-runtime` and `cargo test -p librefang-types` pass (scoped per CLAUDE.md; 2147 and 891 tests)
- [x] Live integration tested (if applicable)

Three new `wiremock` tests cover the branches: PUT is used when the server serves it, a 405 on PUT falls back to GET, and a non-405 error status surfaces as an error rather than a parse failure.

Live check against Chrome for Testing 148.0.7778.96:

| verb | status |
|---|---|
| `GET /json/new` (what this code sent) | `405` |
| `PUT /json/new` (what it sends now) | `200` |

Two caveats worth stating rather than hiding:

- I could not verify the fallback against a pre-111 Chromium. The only older build available to me (Chromium 131) would not start in this environment, and 131 is already past the cutoff anyway. The fallback is therefore defensive rather than empirically confirmed on a server that needs it — if maintainers would rather drop it and go PUT-only, that is a one-line change and I am happy to make it.
- 
## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries


