### PR TITLE
fix(ci): repair the kubernetes workflow YAML, which never parsed, and guard the whole class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,13 +263,9 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             patchelf
-      # A workflow file that fails to parse cannot report that it failed to
-      # parse: GitHub records a run with no jobs, it never appears in a PR's
-      # check rollup, and nothing goes red. `kubernetes.yml` shipped that way —
-      # a backslash continuation inside a `run: |` block put the next line at
-      # column 0, ending the block scalar — and was merged to main having never
-      # executed a single step. Parsing every workflow from a job that does run
-      # is the only thing that catches this class.
+      # A workflow file that fails to parse cannot report that it failed to parse: GitHub records a run with no jobs, it never appears in a PR's check rollup, and nothing goes red.
+      # `kubernetes.yml` shipped that way — a backslash continuation inside a `run: |` block put the next line at column 0, ending the block scalar — and was merged to main having never executed a single step.
+      # Parsing every workflow from a job that does run is the only thing that catches this class.
       - name: Validate workflow YAML parses
         run: |
           python3 - <<'PY'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,36 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             patchelf
+      # A workflow file that fails to parse cannot report that it failed to
+      # parse: GitHub records a run with no jobs, it never appears in a PR's
+      # check rollup, and nothing goes red. `kubernetes.yml` shipped that way —
+      # a backslash continuation inside a `run: |` block put the next line at
+      # column 0, ending the block scalar — and was merged to main having never
+      # executed a single step. Parsing every workflow from a job that does run
+      # is the only thing that catches this class.
+      - name: Validate workflow YAML parses
+        run: |
+          python3 - <<'PY'
+          import glob, sys, yaml
+          bad = []
+          for path in sorted(glob.glob('.github/workflows/*.yml')):
+              try:
+                  doc = yaml.safe_load(open(path))
+              except Exception as exc:
+                  bad.append(f'{path}: {type(exc).__name__}: {exc}')
+                  continue
+              # `on` is truthy-keyed by YAML 1.1, so it can land under `True`.
+              if not (doc.get('on') or doc.get(True)):
+                  bad.append(f'{path}: parsed but declares no triggers')
+              if not doc.get('jobs'):
+                  bad.append(f'{path}: parsed but declares no jobs')
+          if bad:
+              print('::error::invalid workflow definitions:')
+              for line in bad:
+                  print(f'  {line}')
+              sys.exit(1)
+          print(f'{len(glob.glob(".github/workflows/*.yml"))} workflow files parse and declare triggers + jobs')
+          PY
       - name: Check formatting
         run: cargo xtask fmt
       - name: Check API error response shape (issue #3505)

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -266,9 +266,8 @@ jobs:
           [ "$sentinel" = "persisted" ] || {
             echo "::error::/data did not survive pod replacement (read '$sentinel')"; exit 1; }
           after="$(kubectl -n "$NS" exec statefulset/librefang -- stat -c '%i' /data/config.toml | tr -d '\r')"
-          # One line on purpose. A backslash continuation here put the next
-          # line at column 0, which ends the `run: |` block scalar and made the
-          # whole workflow file fail to parse — no job ever started.
+          # One line on purpose.
+          # A backslash continuation here put the next line at column 0, which ends the `run: |` block scalar and made the whole workflow file fail to parse — no job ever started.
           [ "$before" = "$after" ] || {
             echo "::error::config.toml was recreated ($before -> $after) — the pod came up on a fresh volume instead of reattaching the PVC"; exit 1; }
           echo "✓ /data survived pod replacement (config.toml inode $after unchanged)"

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -266,9 +266,11 @@ jobs:
           [ "$sentinel" = "persisted" ] || {
             echo "::error::/data did not survive pod replacement (read '$sentinel')"; exit 1; }
           after="$(kubectl -n "$NS" exec statefulset/librefang -- stat -c '%i' /data/config.toml | tr -d '\r')"
+          # One line on purpose. A backslash continuation here put the next
+          # line at column 0, which ends the `run: |` block scalar and made the
+          # whole workflow file fail to parse — no job ever started.
           [ "$before" = "$after" ] || {
-            echo "::error::config.toml was recreated ($before -> $after) — the pod \
-came up on a fresh volume instead of reattaching the PVC"; exit 1; }
+            echo "::error::config.toml was recreated ($before -> $after) — the pod came up on a fresh volume instead of reattaching the PVC"; exit 1; }
           echo "✓ /data survived pod replacement (config.toml inode $after unchanged)"
 
       - name: Diagnostics (always)


### PR DESCRIPTION
Follow-up to #6638. The Kubernetes workflow it added has **never executed a single step**, and I only found out because `workflow_dispatch` was rejected as not being one of its triggers.

## What was wrong

```yaml
[ "$before" = "$after" ] || {
  echo "::error::config.toml was recreated ($before -> $after) — the pod \
came up on a fresh volume instead of reattaching the PVC"; exit 1; }
```

A backslash continuation inside a `run: |` block put the next line at **column 0**. Indentation is what delimits a block scalar, so column 0 ends it, and the file failed to parse.

## Why nothing caught it

An unparseable workflow produces no jobs, and therefore no checks. GitHub records a run, marks it failed with "This run likely failed because of a workflow file issue", and that run **never appears in the pull request's check rollup**. #6638 showed 29 pass / 4 skipping and `mergeStateStatus: CLEAN` while this file was inert the whole time.

Five such runs exist: two on `feat/k8s-deployment-baseline`, two on `main` after #6638 merged, one on an unrelated branch.

So the `render` and `kind` jobs described in #6638 were never validation — they were text. That is on me: I wrote the file and never parsed it locally.

## Changes

**Fix**: the message is one line. A continuation inside a block scalar is only safe when the next line stays at or beyond the block's indentation, and a hand-wrapped error string is not worth that trap. A comment at the site records why.

**Guard** (the part that matters longer-term): a workflow that fails to parse cannot report that it failed to parse, so `Quality` now parses every `.github/workflows/*.yml`. It also asserts each file declares triggers and jobs — a file that parses into something without them is equally inert, which the failure mode here would otherwise still allow.

The guard lives in `Quality` rather than its own workflow because it needs to run from a job that is itself known to work; a self-checking workflow has the same blind spot.

## Verification

- All 48 workflow files parse.
- `kubernetes.yml` now resolves to triggers `[pull_request, push, workflow_dispatch]` and jobs `[render, kind]` — previously it resolved to nothing.
- **Mutation-tested**: reintroducing the column-0 continuation makes the guard fail with a `ScannerError`, so it is not vacuous.

## Still unverified after this merges

The `kind` job is `if: github.event_name != 'pull_request'`, so this PR exercises only `render`. Its first real execution is on merge to main, and it will be the first time the manifests are actually booted in a cluster by CI (~40 min: Rust release build, then kind). If it fails there, that is a bug in the job rather than in the merged deployment code — the manifests themselves were verified locally (`kubectl kustomize`, server-side dry-run under enforced `restricted` PSS, the validator plus its ten mutation tests) and the entrypoint's rootless path was container-tested on a real Linux volume.

I would rather it run and fail visibly on main than keep looking green while doing nothing.
