### PR TITLE
docs: fix typo in prompts.rs comment

### DIFF
--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -174,7 +174,7 @@ async fn create_prompt_version(
     // Audit: `docs/issues/prompt-version-system-prompt-no-cap.md`.
     // Reject oversize `system_prompt` BEFORE any write. Once a version is
     // activated, its `system_prompt` rides every LLM call — an uncapped
-    // field is a direct token-cost amplification vector. Cheked against
+    // field is a direct token-cost amplification vector. Checked against
     // both a byte cap (memory) and a character cap (token / billing).
     if let Err(e) = crate::validation::check_system_prompt_size(&version.system_prompt) {
         return e.into_response();

--- a/crates/librefang-api/src/routes/prompts.rs
+++ b/crates/librefang-api/src/routes/prompts.rs
@@ -172,10 +172,9 @@ async fn create_prompt_version(
         }
     };
     // Audit: `docs/issues/prompt-version-system-prompt-no-cap.md`.
-    // Reject oversize `system_prompt` BEFORE any write. Once a version is
-    // activated, its `system_prompt` rides every LLM call — an uncapped
-    // field is a direct token-cost amplification vector. Checked against
-    // both a byte cap (memory) and a character cap (token / billing).
+    // Reject oversize `system_prompt` BEFORE any write.
+    // Once a version is activated, its `system_prompt` rides every LLM call — an uncapped field is a direct token-cost amplification vector.
+    // Checked against both a byte cap (memory) and a character cap (token / billing).
     if let Err(e) = crate::validation::check_system_prompt_size(&version.system_prompt) {
         return e.into_response();
     }


### PR DESCRIPTION
## Summary
Fixes a one-character typo in a comment in `crates/librefang-api/src/routes/prompts.rs`: "Cheked against" → "Checked against".

## Testing
- `cargo build -p librefang-api` — clean
- `cargo clippy -p librefang-api --all-targets` — zero warnings
