### PR TITLE
fix(release): cap the PR and release bodies, and stop the desktop build blanking release notes

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -183,11 +183,8 @@ jobs:
             esac
           done
 
-      # tauri-action's `tagName` path runs getOrCreateRelease, which PATCHes
-      # an existing published release with whatever `releaseBody` holds — and
-      # this workflow passes none, so it would blank the notes of the release
-      # being rebuilt. Its `releaseId` path only uploads assets, so resolve
-      # the id here and address the release by it.
+      # tauri-action's `tagName` path runs getOrCreateRelease, which PATCHes an existing published release with whatever `releaseBody` holds — and this workflow passes none, so it would blank the notes of the release being rebuilt.
+      # Its `releaseId` path only uploads assets, so resolve the id here and address the release by it.
       - name: Resolve release id
         id: release_id
         shell: bash

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -183,6 +183,26 @@ jobs:
             esac
           done
 
+      # tauri-action's `tagName` path runs getOrCreateRelease, which PATCHes
+      # an existing published release with whatever `releaseBody` holds — and
+      # this workflow passes none, so it would blank the notes of the release
+      # being rebuilt. Its `releaseId` path only uploads assets, so resolve
+      # the id here and address the release by it.
+      - name: Resolve release id
+        id: release_id
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          ID=$(gh release view "$TAG" --json databaseId --jq '.databaseId')
+          if [ -z "$ID" ] || [ "$ID" = "null" ]; then
+            echo "::error::could not resolve release id for $TAG"
+            exit 1
+          fi
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "Release $TAG has id $ID"
+
       - name: Build and bundle Tauri desktop app
         if: runner.os != 'macOS' || env.APPLE_SIGNING_IDENTITY == ''
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
@@ -191,10 +211,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ inputs.tag }}
-          releaseName: "${{ inputs.tag }}"
-          releaseDraft: false
-          prerelease: false
+          # id, not tag — see the `release_id` step above.
+          releaseId: ${{ steps.release_id.outputs.id }}
           uploadUpdaterJson: true
           projectPath: crates/librefang-desktop
           args: ${{ matrix.platform.args }}
@@ -211,10 +229,8 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.MAC_NOTARIZE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.MAC_NOTARIZE_TEAM_ID }}
         with:
-          tagName: ${{ inputs.tag }}
-          releaseName: "${{ inputs.tag }}"
-          releaseDraft: false
-          prerelease: false
+          # id, not tag — see the `release_id` step above.
+          releaseId: ${{ steps.release_id.outputs.id }}
           uploadUpdaterJson: true
           projectPath: crates/librefang-desktop
           args: ${{ matrix.platform.args }}

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -188,15 +188,9 @@ jobs:
             CHANGES="See [CHANGELOG](https://github.com/librefang/librefang/blob/main/CHANGELOG.md) for details."
           fi
 
-          # `head -20` bounds the line count but not the length: a changelog
-          # bullet in this repo routinely runs past 1,800 characters, so 20 of
-          # them clear Discord's 2,000-character `content` cap on their own and
-          # the webhook answers 400 `Must be 2000 or fewer in length`
-          # (v2026.7.31's first 20 lines are 2,755 characters). The header,
-          # the five build-status lines, and the footer below cost a fixed
-          # ~466, leaving ~1,534; 1400 keeps a margin for a longer tag or an
-          # extra status line. Cut on a character boundary, since these
-          # entries are full of em dashes and arrows.
+          # `head -20` bounds the line count but not the length: a changelog bullet in this repo routinely runs past 1,800 characters, so 20 of them clear Discord's 2,000-character `content` cap on their own and the webhook answers 400 `Must be 2000 or fewer in length` (v2026.7.31's first 20 lines are 2,755 characters).
+          # The header, the five build-status lines, and the footer below cost a fixed ~466, leaving ~1,534; 1400 keeps a margin for a longer tag or an extra status line.
+          # Cut on a character boundary, since these entries are full of em dashes and arrows.
           CHANGES=$(CHANGES="$CHANGES" python3 -c "
           import os
           t = os.environ['CHANGES']

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -188,6 +188,24 @@ jobs:
             CHANGES="See [CHANGELOG](https://github.com/librefang/librefang/blob/main/CHANGELOG.md) for details."
           fi
 
+          # `head -20` bounds the line count but not the length: a changelog
+          # bullet in this repo routinely runs past 1,800 characters, so 20 of
+          # them clear Discord's 2,000-character `content` cap on their own and
+          # the webhook answers 400 `Must be 2000 or fewer in length`
+          # (v2026.7.31's first 20 lines are 2,755 characters). The header,
+          # the five build-status lines, and the footer below cost a fixed
+          # ~466, leaving ~1,534; 1400 keeps a margin for a longer tag or an
+          # extra status line. Cut on a character boundary, since these
+          # entries are full of em dashes and arrows.
+          CHANGES=$(CHANGES="$CHANGES" python3 -c "
+          import os
+          t = os.environ['CHANGES']
+          if len(t) > 1400:
+              t = t[:1400]
+              t = t[: t.rfind('\n')] + '\n\n_…truncated — see the [CHANGELOG](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)._'
+          print(t, end='')
+          ")
+
           # Count successes (deploy tracked separately from image build)
           TOTAL=5
           SUCCESS=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,18 +335,11 @@ jobs:
           # Write to file for multiline output
           echo "$CHANGES" > /tmp/changelog.md
 
-          # The release API rejects a body over 125,000 characters with
-          # HTTP 422 "body is too long", which would fail this job after the
-          # tag is already pushed — the worst point in the pipeline to stop.
-          # A release that folds ~60 PRs of prose (v2026.7.31's section was
-          # 208 KB) clears that ceiling on its own, before the install block
-          # below adds its share. Cut to a line boundary with room to spare,
-          # and close a fence the kept prefix left open so the install
-          # section does not render inside a code block.
+          # The release API rejects a body over 125,000 characters with HTTP 422 "body is too long", which would fail this job after the tag is already pushed — the worst point in the pipeline to stop.
+          # A release that folds ~60 PRs of prose (v2026.7.31's section was 208 KB) clears that ceiling on its own, before the install block below adds its share.
+          # Cut to a line boundary with room to spare, and close a fence the kept prefix left open so the install section does not render inside a code block.
           #
-          # Done in python rather than `head -c` because the cut has to land
-          # on a character boundary: these entries are full of em dashes and
-          # arrows, and slicing one in half yields invalid UTF-8.
+          # Done in python rather than `head -c` because the cut has to land on a character boundary: these entries are full of em dashes and arrows, and slicing one in half yields invalid UTF-8.
           python3 - <<'TRUNC'
           import pathlib
           MAX = 100_000
@@ -438,12 +431,9 @@ jobs:
           fi
 
       # Published so the desktop matrix can address the release by id.
-      # tauri-action's `tagName` path calls getOrCreateRelease, which PATCHes
-      # an already-published release with whatever `releaseBody` holds — and
-      # we pass none, so it overwrites the notes above with an empty string.
-      # That is why v2026.7.21 and v2026.7.27 shipped with a blank body. Its
-      # `releaseId` path skips getOrCreateRelease entirely and only uploads
-      # assets, so handing it the id keeps the notes intact.
+      # tauri-action's `tagName` path calls getOrCreateRelease, which PATCHes an already-published release with whatever `releaseBody` holds — and we pass none, so it overwrites the notes above with an empty string.
+      # That is why v2026.7.21 and v2026.7.27 shipped with a blank body.
+      # Its `releaseId` path skips getOrCreateRelease entirely and only uploads assets, so handing it the id keeps the notes intact.
       - name: Publish release id
         id: release_id
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,6 +290,8 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
       || (github.event_name == 'workflow_dispatch' && inputs.channel == 'current' && startsWith(inputs.tag, 'v'))
     runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.release_id.outputs.id }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -332,6 +334,36 @@ jobs:
 
           # Write to file for multiline output
           echo "$CHANGES" > /tmp/changelog.md
+
+          # The release API rejects a body over 125,000 characters with
+          # HTTP 422 "body is too long", which would fail this job after the
+          # tag is already pushed — the worst point in the pipeline to stop.
+          # A release that folds ~60 PRs of prose (v2026.7.31's section was
+          # 208 KB) clears that ceiling on its own, before the install block
+          # below adds its share. Cut to a line boundary with room to spare,
+          # and close a fence the kept prefix left open so the install
+          # section does not render inside a code block.
+          #
+          # Done in python rather than `head -c` because the cut has to land
+          # on a character boundary: these entries are full of em dashes and
+          # arrows, and slicing one in half yields invalid UTF-8.
+          python3 - <<'TRUNC'
+          import pathlib
+          MAX = 100_000
+          NOTICE = (
+              "\n\n_Changelog truncated — the release body is capped at 125,000 characters._\n"
+              "_Read the full section in [CHANGELOG.md](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)._\n"
+          )
+          p = pathlib.Path("/tmp/changelog.md")
+          text = p.read_text(encoding="utf-8")
+          if len(text) > MAX:
+              print(f"::warning::changelog section is {len(text)} chars — truncating for the release body")
+              kept = text[: MAX - len(NOTICE)]
+              kept = kept[: kept.rfind("\n")]
+              if sum(1 for line in kept.splitlines() if line.lstrip().startswith("```")) % 2:
+                  kept += "\n```"
+              p.write_text(kept + NOTICE, encoding="utf-8")
+          TRUNC
 
       # Use HOMEBREW_TAP_TOKEN (PAT) instead of GITHUB_TOKEN so that the
       # `release: published` event fires downstream workflows. Releases
@@ -404,6 +436,26 @@ jobs:
               --title "$TAG" \
               --notes-file /tmp/release-body.md
           fi
+
+      # Published so the desktop matrix can address the release by id.
+      # tauri-action's `tagName` path calls getOrCreateRelease, which PATCHes
+      # an already-published release with whatever `releaseBody` holds — and
+      # we pass none, so it overwrites the notes above with an empty string.
+      # That is why v2026.7.21 and v2026.7.27 shipped with a blank body. Its
+      # `releaseId` path skips getOrCreateRelease entirely and only uploads
+      # assets, so handing it the id keeps the notes intact.
+      - name: Publish release id
+        id: release_id
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          ID=$(gh release view "$RELEASE_TAG" --json databaseId --jq '.databaseId')
+          if [ -z "$ID" ] || [ "$ID" = "null" ]; then
+            echo "::error::could not resolve release id for $RELEASE_TAG"
+            exit 1
+          fi
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "Release $RELEASE_TAG has id $ID"
 
   # ═════════════════════════════════════════════════════════════════════════
   # LTS branch (from release-lts.yml)
@@ -1726,10 +1778,10 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ env.RELEASE_TAG }}
-          releaseName: "${{ env.RELEASE_TAG }}"
-          releaseDraft: false
-          prerelease: false
+          # Address the release by id, not tag: the tagName path re-runs
+          # getOrCreateRelease and PATCHes the notes to an empty body. See
+          # the `release_id` step in create_release.
+          releaseId: ${{ needs.create_release.outputs.release_id }}
           uploadUpdaterJson: true
           projectPath: crates/librefang-desktop
           args: ${{ matrix.platform.args }}
@@ -1746,10 +1798,8 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.MAC_NOTARIZE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.MAC_NOTARIZE_TEAM_ID }}
         with:
-          tagName: ${{ env.RELEASE_TAG }}
-          releaseName: "${{ env.RELEASE_TAG }}"
-          releaseDraft: false
-          prerelease: false
+          # See the note on the unsigned step above — id, not tag.
+          releaseId: ${{ needs.create_release.outputs.release_id }}
           uploadUpdaterJson: true
           projectPath: crates/librefang-desktop
           args: ${{ matrix.platform.args }}

--- a/changelog.d/fixed/6689-release-body-limits.md
+++ b/changelog.d/fixed/6689-release-body-limits.md
@@ -1,0 +1,9 @@
+Fix three ways the release pipeline mishandled a large changelog, all of which fired on v2026.7.31 and left the release stuck.
+`cargo xtask release` passed the whole changelog section as the PR body, which GitHub rejects over 65,536 characters with `GraphQL: Body is too long` — the version bump committed and pushed, but no PR opened, so `tag_on_merge` never got the `<!-- release-tag: -->` marker it tags from and the release simply stopped.
+The body is now capped with a prefix-preserving truncation (the marker sits at position 0 and the Highlights lead, so a tail cut drops only the least-important bullets), cut on a character boundary, closing a code fence the kept prefix left open, and handed to `gh` via `--body-file` rather than an argv entry.
+`release.yml` fed the same section to `gh release create --notes-file`, where the API's own 125,000-character ceiling would have failed the job *after* the tag was already pushed; it now truncates the same way.
+Separately, `tauri-action` was invoked with `tagName`, whose `getOrCreateRelease` path PATCHes an already-published release with whatever `releaseBody` holds — and the desktop matrix passes none, so every desktop build overwrote the release notes with an empty string.
+That is why v2026.7.21 and v2026.7.27 both shipped with a blank body despite `create_release` writing one correctly.
+Both `release.yml` and `release-desktop.yml` now address the release by `releaseId`, which only uploads assets and leaves the notes alone.
+The release commit also stages `xtask/baselines/` now: the run regenerates the schema baselines just before committing, so staging `openapi.json` without them left a drifted `openapi.sha256` in the working tree that would fail `schema-check check` on every subsequent PR.
+(#6689) (@houko)

--- a/changelog.d/fixed/6689-release-body-limits.md
+++ b/changelog.d/fixed/6689-release-body-limits.md
@@ -1,9 +1,10 @@
-Fix three ways the release pipeline mishandled a large changelog, all of which fired on v2026.7.31 and left the release stuck.
+Fix four ways the release pipeline mishandled a large changelog, all of which fired on v2026.7.31 and left the release stuck.
 `cargo xtask release` passed the whole changelog section as the PR body, which GitHub rejects over 65,536 characters with `GraphQL: Body is too long` — the version bump committed and pushed, but no PR opened, so `tag_on_merge` never got the `<!-- release-tag: -->` marker it tags from and the release simply stopped.
 The body is now capped with a prefix-preserving truncation (the marker sits at position 0 and the Highlights lead, so a tail cut drops only the least-important bullets), cut on a character boundary, closing a code fence the kept prefix left open, and handed to `gh` via `--body-file` rather than an argv entry.
 `release.yml` fed the same section to `gh release create --notes-file`, where the API's own 125,000-character ceiling would have failed the job *after* the tag was already pushed; it now truncates the same way.
 Separately, `tauri-action` was invoked with `tagName`, whose `getOrCreateRelease` path PATCHes an already-published release with whatever `releaseBody` holds — and the desktop matrix passes none, so every desktop build overwrote the release notes with an empty string.
 That is why v2026.7.21 and v2026.7.27 both shipped with a blank body despite `create_release` writing one correctly.
 Both `release.yml` and `release-desktop.yml` now address the release by `releaseId`, which only uploads assets and leaves the notes alone.
+`release-notify.yml` bounded its Discord announcement by line count (`head -20`) but not by length, and a single bullet here runs past 1,800 characters, so the webhook would answer 400 `Must be 2000 or fewer in length`; it now truncates to a character budget that leaves room for the build-status block.
 The release commit also stages `xtask/baselines/` now: the run regenerates the schema baselines just before committing, so staging `openapi.json` without them left a drifted `openapi.sha256` in the working tree that would fail `schema-check check` on every subsequent PR.
 (#6689) (@houko)

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -121,6 +121,12 @@ const RELEASE_STAGED_PATHS: &[&str] = &[
     "sdk/go/librefang.go",
     "packages/whatsapp-gateway/package.json",
     "crates/librefang-desktop/tauri.conf.json",
+    // The release run calls `cargo xtask schema-check gen` just before
+    // committing, so any schema surface the version bump touched leaves a
+    // rewritten baseline behind. Staging `openapi.json` without its baseline
+    // is what left v2026.7.31's `xtask/baselines/openapi.sha256` uncommitted
+    // in the working tree — the exact drift the regen step exists to prevent.
+    "xtask/baselines",
     changelog::FRAGMENT_DIR,
 ];
 
@@ -273,6 +279,80 @@ fn extract_changelog_section(content: &str, heading: &str) -> String {
         }
         None => String::new(),
     }
+}
+
+/// GitHub rejects a pull-request body longer than 65,536 characters with
+/// `GraphQL: Body is too long`. We cut well under it so the truncation
+/// notice, the trailing full-diff link, and any future prefix all fit
+/// without recomputing the margin.
+const MAX_PR_BODY_CHARS: usize = 60_000;
+
+/// Clamp a PR body to what GitHub will accept, truncating the *tail*.
+///
+/// Everything load-bearing lives in the prefix: `tag_on_merge` in
+/// `release.yml` reads the `<!-- release-tag:vX.Y.Z -->` marker, which
+/// `build_release_pr_body` writes at position 0, and the changelog's
+/// Highlights section leads the body. So a prefix-preserving cut keeps the
+/// release machinery working and drops only the least-important bullets.
+///
+/// The cut lands on a line boundary, and a fence that was opened but not
+/// closed by the kept prefix gets one appended — otherwise the truncation
+/// notice and the full-diff link would render inside a code block.
+fn truncate_pr_body(body: &str, max_chars: usize) -> String {
+    if body.chars().count() <= max_chars {
+        return body.to_string();
+    }
+
+    const NOTICE: &str = "\n\n_Changelog truncated — GitHub caps a PR body at 65,536 characters. \
+                          The full section is in [CHANGELOG.md](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)._";
+
+    // Reserve room for the notice, then cut on a char boundary (byte
+    // slicing would panic mid-codepoint on the non-ASCII em dashes these
+    // changelog entries are full of).
+    let budget = max_chars.saturating_sub(NOTICE.chars().count());
+    let mut kept: String = body.chars().take(budget).collect();
+
+    // Back up to the last complete line so we never publish half a bullet.
+    if let Some(nl) = kept.rfind('\n') {
+        kept.truncate(nl);
+    }
+
+    // An odd number of fence lines means the kept prefix opened a block it
+    // never closed.
+    let fences = kept
+        .lines()
+        .filter(|l| l.trim_start().starts_with("```"))
+        .count();
+    if fences % 2 == 1 {
+        kept.push_str("\n```");
+    }
+
+    kept.push_str(NOTICE);
+    kept
+}
+
+/// Assemble the release PR body: the `release-tag` marker the auto-tag
+/// workflow greps for, this version's changelog section, and a compare
+/// link against the previous tag.
+fn build_release_pr_body(
+    tag: &str,
+    changelog_section: &str,
+    prev_tag: Option<&str>,
+    max_chars: usize,
+) -> String {
+    let mut body = format!("<!-- release-tag:{} -->\n## Release {}", tag, tag);
+    if !changelog_section.is_empty() {
+        body.push_str("\n\n");
+        body.push_str(changelog_section);
+    }
+    let mut body = truncate_pr_body(&body, max_chars);
+    if let Some(pt) = prev_tag {
+        body.push_str(&format!(
+            "\n\n---\n**Full diff:** https://github.com/librefang/librefang/compare/{}...{}",
+            pt, tag
+        ));
+    }
+    body
 }
 
 /// Dispatch the existing release run for the latest tag with
@@ -1001,23 +1081,23 @@ pip install librefang-sdk
 
             // Build PR body with changelog content
             // <!-- release-tag:vX.Y.Z --> marker is used by the auto-tag workflow
-            let mut pr_body = format!("<!-- release-tag:{} -->\n## Release {}", tag, tag);
             let changelog_path = root.join("CHANGELOG.md");
-            if changelog_path.exists() {
+            let section = if changelog_path.exists() {
                 let cl_content = fs::read_to_string(&changelog_path).unwrap_or_default();
                 let heading = format!("## [{}]", changelog_version);
-                let section = extract_changelog_section(&cl_content, &heading);
-                if !section.is_empty() {
-                    pr_body.push_str("\n\n");
-                    pr_body.push_str(&section);
-                }
-            }
-            if let Some(ref pt) = prev_tag {
-                pr_body.push_str(&format!(
-                    "\n\n---\n**Full diff:** https://github.com/librefang/librefang/compare/{}...{}",
-                    pt, tag
-                ));
-            }
+                extract_changelog_section(&cl_content, &heading)
+            } else {
+                String::new()
+            };
+            let pr_body =
+                build_release_pr_body(&tag, &section, prev_tag.as_deref(), MAX_PR_BODY_CHARS);
+
+            // Pass the body through a file rather than an argv entry: a
+            // release body runs to tens of kilobytes, which is a large
+            // fraction of the platform `ARG_MAX`, and markdown in argv has
+            // to survive whatever quoting the shell layer applies.
+            let body_file = std::env::temp_dir().join(format!("librefang-release-pr-{}.md", tag));
+            fs::write(&body_file, &pr_body)?;
 
             let pr_output = Command::new("gh")
                 .args([
@@ -1027,8 +1107,8 @@ pip install librefang-sdk
                     "librefang/librefang",
                     "--title",
                     &format!("release: {}", tag),
-                    "--body",
-                    &pr_body,
+                    "--body-file",
+                    &body_file.display().to_string(),
                     "--base",
                     "main",
                     "--head",
@@ -1036,6 +1116,7 @@ pip install librefang-sdk
                 ])
                 .current_dir(&root)
                 .output()?;
+            let _ = fs::remove_file(&body_file);
 
             if pr_output.status.success() {
                 let pr_url = String::from_utf8_lossy(&pr_output.stdout)
@@ -1294,6 +1375,86 @@ mod tests {
             !staged.contains("changelog.d/fixed/.gitkeep"),
             ".gitkeep must be untouched, or the section directory stops being tracked:\n{staged}"
         );
+    }
+
+    /// `schema-check gen` runs during the release, so a version bump that
+    /// moves a schema surface rewrites its baseline. Staging the surface
+    /// without the baseline is what left v2026.7.31's `openapi.sha256`
+    /// uncommitted, which would fail `schema-check check` on every PR that
+    /// followed it onto main.
+    #[test]
+    fn release_staging_includes_the_schema_baselines() {
+        assert!(
+            RELEASE_STAGED_PATHS.contains(&"xtask/baselines"),
+            "the schema baselines must ship in the release commit alongside openapi.json"
+        );
+    }
+
+    fn body_of(len: usize) -> String {
+        (0..len).map(|i| format!("- bullet {i}\n")).collect()
+    }
+
+    #[test]
+    fn short_pr_body_is_returned_unchanged() {
+        let body = "<!-- release-tag:v1.0.0 -->\n## Release v1.0.0\n\n- one bullet";
+        assert_eq!(truncate_pr_body(body, MAX_PR_BODY_CHARS), body);
+    }
+
+    /// The `release-tag` marker sits at position 0 and `tag_on_merge` in
+    /// `release.yml` greps for it, so truncation has to keep the prefix —
+    /// a tail-preserving cut would silently stop tagging releases.
+    #[test]
+    fn truncated_pr_body_fits_and_keeps_the_release_tag_marker() {
+        let section = body_of(20_000);
+        let body = build_release_pr_body("v1.0.0", &section, Some("v0.9.0"), MAX_PR_BODY_CHARS);
+
+        assert!(body.chars().count() < 65_536, "still over GitHub's cap");
+        assert!(body.starts_with("<!-- release-tag:v1.0.0 -->"));
+        assert!(body.contains("_Changelog truncated"));
+        assert!(
+            body.ends_with("compare/v0.9.0...v1.0.0"),
+            "the compare link is appended after truncation, so it always survives"
+        );
+    }
+
+    /// An unbalanced fence would swallow the truncation notice and the
+    /// compare link into a code block.
+    #[test]
+    fn truncation_closes_a_fence_the_kept_prefix_left_open() {
+        let mut section = String::from("- intro\n\n```toml\n");
+        section.push_str(&body_of(20_000));
+        let body = build_release_pr_body("v1.0.0", &section, None, MAX_PR_BODY_CHARS);
+
+        let fences = body
+            .lines()
+            .filter(|l| l.trim_start().starts_with("```"))
+            .count();
+        assert_eq!(fences % 2, 0, "unbalanced code fence");
+    }
+
+    /// The notice is written as a continued string literal; a stray
+    /// indent there would render as a markdown code block.
+    #[test]
+    fn truncation_notice_is_a_single_unindented_line() {
+        let body = build_release_pr_body("v1.0.0", &body_of(20_000), None, MAX_PR_BODY_CHARS);
+        let notice = body
+            .lines()
+            .find(|l| l.contains("_Changelog truncated"))
+            .expect("truncated body must carry the notice");
+        assert!(!notice.starts_with(' '), "indented notice: {notice:?}");
+        assert!(notice.contains("characters. The full section is in"));
+    }
+
+    /// Changelog entries are full of em dashes, so a byte-wise cut would
+    /// panic on a char boundary or emit invalid UTF-8.
+    #[test]
+    fn truncation_cuts_on_char_boundaries() {
+        let section: String = (0..20_000)
+            .map(|i| format!("- entry {i} — note\n"))
+            .collect();
+        let body = build_release_pr_body("v1.0.0", &section, None, MAX_PR_BODY_CHARS);
+        assert!(body.chars().count() <= MAX_PR_BODY_CHARS);
+        assert!(body.contains('—'), "the em dashes should still be intact");
     }
 
     /// Reproduces the closure in `run()` so the generator's output format

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -121,11 +121,8 @@ const RELEASE_STAGED_PATHS: &[&str] = &[
     "sdk/go/librefang.go",
     "packages/whatsapp-gateway/package.json",
     "crates/librefang-desktop/tauri.conf.json",
-    // The release run calls `cargo xtask schema-check gen` just before
-    // committing, so any schema surface the version bump touched leaves a
-    // rewritten baseline behind. Staging `openapi.json` without its baseline
-    // is what left v2026.7.31's `xtask/baselines/openapi.sha256` uncommitted
-    // in the working tree — the exact drift the regen step exists to prevent.
+    // The release run calls `cargo xtask schema-check gen` just before committing, so any schema surface the version bump touched leaves a rewritten baseline behind.
+    // Staging `openapi.json` without its baseline is what left v2026.7.31's `xtask/baselines/openapi.sha256` uncommitted in the working tree — the exact drift the regen step exists to prevent.
     "xtask/baselines",
     changelog::FRAGMENT_DIR,
 ];
@@ -281,23 +278,16 @@ fn extract_changelog_section(content: &str, heading: &str) -> String {
     }
 }
 
-/// GitHub rejects a pull-request body longer than 65,536 characters with
-/// `GraphQL: Body is too long`. We cut well under it so the truncation
-/// notice, the trailing full-diff link, and any future prefix all fit
-/// without recomputing the margin.
+/// GitHub rejects a pull-request body longer than 65,536 characters with `GraphQL: Body is too long`.
+/// We cut well under it so the truncation notice, the trailing full-diff link, and any future prefix all fit without recomputing the margin.
 const MAX_PR_BODY_CHARS: usize = 60_000;
 
 /// Clamp a PR body to what GitHub will accept, truncating the *tail*.
 ///
-/// Everything load-bearing lives in the prefix: `tag_on_merge` in
-/// `release.yml` reads the `<!-- release-tag:vX.Y.Z -->` marker, which
-/// `build_release_pr_body` writes at position 0, and the changelog's
-/// Highlights section leads the body. So a prefix-preserving cut keeps the
-/// release machinery working and drops only the least-important bullets.
+/// Everything load-bearing lives in the prefix: `tag_on_merge` in `release.yml` reads the `<!-- release-tag:vX.Y.Z -->` marker, which `build_release_pr_body` writes at position 0, and the changelog's Highlights section leads the body.
+/// So a prefix-preserving cut keeps the release machinery working and drops only the least-important bullets.
 ///
-/// The cut lands on a line boundary, and a fence that was opened but not
-/// closed by the kept prefix gets one appended — otherwise the truncation
-/// notice and the full-diff link would render inside a code block.
+/// The cut lands on a line boundary, and a fence that was opened but not closed by the kept prefix gets one appended — otherwise the truncation notice and the full-diff link would render inside a code block.
 fn truncate_pr_body(body: &str, max_chars: usize) -> String {
     if body.chars().count() <= max_chars {
         return body.to_string();
@@ -306,9 +296,7 @@ fn truncate_pr_body(body: &str, max_chars: usize) -> String {
     const NOTICE: &str = "\n\n_Changelog truncated — GitHub caps a PR body at 65,536 characters. \
                           The full section is in [CHANGELOG.md](https://github.com/librefang/librefang/blob/main/CHANGELOG.md)._";
 
-    // Reserve room for the notice, then cut on a char boundary (byte
-    // slicing would panic mid-codepoint on the non-ASCII em dashes these
-    // changelog entries are full of).
+    // Reserve room for the notice, then cut on a char boundary (byte slicing would panic mid-codepoint on the non-ASCII em dashes these changelog entries are full of).
     let budget = max_chars.saturating_sub(NOTICE.chars().count());
     let mut kept: String = body.chars().take(budget).collect();
 
@@ -317,8 +305,7 @@ fn truncate_pr_body(body: &str, max_chars: usize) -> String {
         kept.truncate(nl);
     }
 
-    // An odd number of fence lines means the kept prefix opened a block it
-    // never closed.
+    // An odd number of fence lines means the kept prefix opened a block it never closed.
     let fences = kept
         .lines()
         .filter(|l| l.trim_start().starts_with("```"))
@@ -331,9 +318,7 @@ fn truncate_pr_body(body: &str, max_chars: usize) -> String {
     kept
 }
 
-/// Assemble the release PR body: the `release-tag` marker the auto-tag
-/// workflow greps for, this version's changelog section, and a compare
-/// link against the previous tag.
+/// Assemble the release PR body: the `release-tag` marker the auto-tag workflow greps for, this version's changelog section, and a compare link against the previous tag.
 fn build_release_pr_body(
     tag: &str,
     changelog_section: &str,
@@ -1092,10 +1077,7 @@ pip install librefang-sdk
             let pr_body =
                 build_release_pr_body(&tag, &section, prev_tag.as_deref(), MAX_PR_BODY_CHARS);
 
-            // Pass the body through a file rather than an argv entry: a
-            // release body runs to tens of kilobytes, which is a large
-            // fraction of the platform `ARG_MAX`, and markdown in argv has
-            // to survive whatever quoting the shell layer applies.
+            // Pass the body through a file rather than an argv entry: a release body runs to tens of kilobytes, which is a large fraction of the platform `ARG_MAX`, and markdown in argv has to survive whatever quoting the shell layer applies.
             let body_file = std::env::temp_dir().join(format!("librefang-release-pr-{}.md", tag));
             fs::write(&body_file, &pr_body)?;
 
@@ -1377,11 +1359,8 @@ mod tests {
         );
     }
 
-    /// `schema-check gen` runs during the release, so a version bump that
-    /// moves a schema surface rewrites its baseline. Staging the surface
-    /// without the baseline is what left v2026.7.31's `openapi.sha256`
-    /// uncommitted, which would fail `schema-check check` on every PR that
-    /// followed it onto main.
+    /// `schema-check gen` runs during the release, so a version bump that moves a schema surface rewrites its baseline.
+    /// Staging the surface without the baseline is what left v2026.7.31's `openapi.sha256` uncommitted, which would fail `schema-check check` on every PR that followed it onto main.
     #[test]
     fn release_staging_includes_the_schema_baselines() {
         assert!(
@@ -1400,9 +1379,7 @@ mod tests {
         assert_eq!(truncate_pr_body(body, MAX_PR_BODY_CHARS), body);
     }
 
-    /// The `release-tag` marker sits at position 0 and `tag_on_merge` in
-    /// `release.yml` greps for it, so truncation has to keep the prefix —
-    /// a tail-preserving cut would silently stop tagging releases.
+    /// The `release-tag` marker sits at position 0 and `tag_on_merge` in `release.yml` greps for it, so truncation has to keep the prefix — a tail-preserving cut would silently stop tagging releases.
     #[test]
     fn truncated_pr_body_fits_and_keeps_the_release_tag_marker() {
         let section = body_of(20_000);
@@ -1417,8 +1394,7 @@ mod tests {
         );
     }
 
-    /// An unbalanced fence would swallow the truncation notice and the
-    /// compare link into a code block.
+    /// An unbalanced fence would swallow the truncation notice and the compare link into a code block.
     #[test]
     fn truncation_closes_a_fence_the_kept_prefix_left_open() {
         let mut section = String::from("- intro\n\n```toml\n");
@@ -1432,8 +1408,7 @@ mod tests {
         assert_eq!(fences % 2, 0, "unbalanced code fence");
     }
 
-    /// The notice is written as a continued string literal; a stray
-    /// indent there would render as a markdown code block.
+    /// The notice is written as a continued string literal; a stray indent there would render as a markdown code block.
     #[test]
     fn truncation_notice_is_a_single_unindented_line() {
         let body = build_release_pr_body("v1.0.0", &body_of(20_000), None, MAX_PR_BODY_CHARS);
@@ -1445,8 +1420,7 @@ mod tests {
         assert!(notice.contains("characters. The full section is in"));
     }
 
-    /// Changelog entries are full of em dashes, so a byte-wise cut would
-    /// panic on a char boundary or emit invalid UTF-8.
+    /// Changelog entries are full of em dashes, so a byte-wise cut would panic on a char boundary or emit invalid UTF-8.
     #[test]
     fn truncation_cuts_on_char_boundaries() {
         let section: String = (0..20_000)


### PR DESCRIPTION
Four failures on the release pipeline, all triggered by v2026.7.31's 208 KB changelog section, plus one uncommitted-artifact bug found in the same run.

## What broke

**PR body over GitHub's limit — the release stopped dead.** `cargo xtask release` passed the whole changelog section as the PR body. GitHub rejects a body over 65,536 characters with `GraphQL: Body is too long`, so the version bump committed and pushed but no PR opened. `tag_on_merge` in `release.yml` tags from the `<!-- release-tag:vX.Y.Z -->` marker inside that PR body, so with no PR there was nothing to merge and no tag — the release simply halted after the push.

**Release body over the API limit — would have failed after the tag was pushed.** `release.yml` feeds the same section to `gh release create --notes-file`. The release API caps `body` at 125,000 characters (HTTP 422 `body is too long`), which this section clears on its own before the install block adds its share. Unblocking the PR alone would have moved the failure downstream to the worst possible point: after the tag exists.

**Desktop builds blanked the release notes.** `tauri-action` was invoked with `tagName`, whose `getOrCreateRelease` PATCHes an already-published release with whatever `releaseBody` holds — and the desktop matrix passes none, so every desktop build overwrote the notes with an empty string. This is why v2026.7.21 and v2026.7.27 both published with an empty body despite `create_release` writing one correctly; `gh api repos/librefang/librefang/releases` shows `body` length 0 for both, and non-zero for every release before the current desktop wiring.

**The Discord announcement exceeded its own cap.** `release-notify.yml` bounded `CHANGES` by line count (`head -20`) but not by length. A single bullet in this repo routinely runs past 1,800 characters, so twenty of them clear Discord's 2,000-character `content` cap on their own — v2026.7.31's first twenty lines are 2,755 — and the webhook answers 400 `Must be 2000 or fewer in length`.

**The release commit dropped the schema baselines.** The run calls `cargo xtask schema-check gen` just before committing, but `RELEASE_STAGED_PATHS` listed `openapi.json` without `xtask/baselines/`. v2026.7.31 left a drifted `openapi.sha256` in the working tree — precisely the drift `schema-check check` exists to catch, and it would have failed on every PR that followed onto main.

## Changes

- `xtask/src/release.rs`: new `truncate_pr_body` / `build_release_pr_body`. Truncation is prefix-preserving because everything load-bearing is at the front (the `release-tag` marker at position 0, Highlights leading the section), cuts on a character boundary rather than a byte one (these entries are full of em dashes), backs up to a line boundary so no half-bullet ships, and closes a code fence the kept prefix left open so the notice and compare link don't render inside a block. The compare link is appended after truncation, so it always survives. Body now goes to `gh` via `--body-file` rather than an argv entry.
- `xtask/src/release.rs`: `xtask/baselines` added to `RELEASE_STAGED_PATHS`.
- `.github/workflows/release.yml`: truncates `/tmp/changelog.md` to 100,000 characters with the same line-boundary and fence handling, in python rather than `head -c` so the cut lands on a character boundary. `create_release` now publishes a `release_id` output, and both `tauri-action` steps take `releaseId` instead of `tagName`.
- `.github/workflows/release-desktop.yml`: same `releaseId` switch, with the id resolved in a new step next to the existing asset-cleanup.
- `.github/workflows/release-notify.yml`: truncates `CHANGES` to 1,400 characters, leaving the ~466 that the header, the five build-status lines, and the footer cost. The Bluesky path already truncates to 300 graphemes and is untouched.

## Verification

- `cargo test -p xtask` — 112 passed, 6 new: marker survival under truncation, fence balancing, char-boundary cutting, the notice rendering unindented, short bodies passing through unchanged, and the baselines being in the staged set.
- `cargo clippy -p xtask --all-targets -- -D warnings` — clean.
- All three workflows parse as YAML; the `desktop` job's `with:` block was dumped and confirmed to resolve `releaseId` from `needs.create_release.outputs.release_id`.
- `gh release view v2026.7.27 --json databaseId` returns a real id, so the new resolve step cannot fail the way a wrong field name would (that step gates the whole desktop matrix through `needs`).
- The `release.yml` truncation was extracted from the workflow and run against the real v2026.7.31 section: 208,129 characters in, 99,177 out, cut on a complete bullet, fences balanced, notice appended.
- The `release-notify.yml` truncation was extracted and run against the real CHANGELOG for three versions: 2026.7.31 → 1,304 (+466 = 1,770), 2026.7.27 → 1,325 (+466 = 1,791, untruncated), 2026.7.21 → 1,424 (+466 = 1,890). All under 2,000.
- `tauri-action`'s behaviour was read at the pinned SHA (`1deb371b`) rather than inferred: `src/create-release.ts` calls `updateRelease` with `body: bodyFileContent || body` for any existing non-draft release, and `src/index.ts` only enters that path when `tagName && !releaseId`.

The immediate v2026.7.31 release was unblocked separately by opening #6688 by hand with a truncated body; the marker there was verified to match the workflow's `grep -oP` pattern. Auto-merge was deliberately not enabled on it.
