### PR TITLE
fix(release): count debug-symbols siblings separately in the SHA256SUMS guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1146,6 +1146,14 @@ jobs:
             exit 1
           fi
 
+          # The list holds two kinds of sibling, and only one of them is
+          # one-per-matrix-target. Count them separately, or the debug-symbols
+          # assets #6677 added inflate the platform total and fail the release
+          # — which is exactly what happened on v2026.7.31 (expected 12, got
+          # 16), the first release cut after that PR landed.
+          grep -v -- '-debug-symbols\.tar\.gz\.sha256$' asset-list.txt > platform-list.txt || true
+          grep -- '-debug-symbols\.tar\.gz\.sha256$' asset-list.txt > symbol-list.txt || true
+
           # Exact-match sanity check: must equal the total number of matrix
           # targets across the cli_* jobs in `needs:` above (NOT the number of
           # jobs — most cli_* are matrix jobs that emit one .sha256 per target).
@@ -1165,11 +1173,29 @@ jobs:
           # decrementing it blocks all releases until corrected (the desired
           # loud failure). Update both together.
           EXPECTED_PLATFORMS=12
-          ACTUAL=$(wc -l < asset-list.txt | tr -d ' ')
+          ACTUAL=$(wc -l < platform-list.txt | tr -d ' ')
           if [ "$ACTUAL" -ne "$EXPECTED_PLATFORMS" ]; then
-            echo "::error::expected exactly $EXPECTED_PLATFORMS .sha256 siblings (one per matrix target across cli_* jobs), got $ACTUAL"
-            cat asset-list.txt
+            echo "::error::expected exactly $EXPECTED_PLATFORMS platform .sha256 siblings (one per matrix target across cli_* jobs), got $ACTUAL"
+            cat platform-list.txt
             exit 1
+          fi
+
+          # Debug symbols (#6677) are a diagnostic aid, not a platform target,
+          # so they get a range rather than an equality. `cli_mac` fails when
+          # its .dSYM is missing, so both macOS targets are guaranteed; the
+          # `cli_linux` targets are cross-compiled and only warn when the .dwp
+          # is absent, so 2 of the 4 are best-effort. A count outside 2..4 means
+          # the macOS hard-failure path did not hold, which is worth stopping
+          # for; a count of 2 or 3 only means Linux split-debuginfo did not
+          # materialize, which must not take a release down over a diagnostic.
+          SYMBOLS=$(wc -l < symbol-list.txt | tr -d ' ')
+          if [ "$SYMBOLS" -lt 2 ] || [ "$SYMBOLS" -gt 4 ]; then
+            echo "::error::expected 2-4 debug-symbols .sha256 siblings (2 macOS guaranteed + up to 2 best-effort Linux), got $SYMBOLS"
+            cat symbol-list.txt
+            exit 1
+          fi
+          if [ "$SYMBOLS" -lt 4 ]; then
+            echo "::warning::only $SYMBOLS/4 debug-symbols assets present — a Linux target's split debuginfo did not materialize"
           fi
 
           while IFS= read -r name; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1146,11 +1146,8 @@ jobs:
             exit 1
           fi
 
-          # The list holds two kinds of sibling, and only one of them is
-          # one-per-matrix-target. Count them separately, or the debug-symbols
-          # assets #6677 added inflate the platform total and fail the release
-          # — which is exactly what happened on v2026.7.31 (expected 12, got
-          # 16), the first release cut after that PR landed.
+          # The list holds two kinds of sibling, and only one of them is one-per-matrix-target.
+          # Count them separately, or the debug-symbols assets #6677 added inflate the platform total and fail the release — which is exactly what happened on v2026.7.31 (expected 12, got 16), the first release cut after that PR landed.
           grep -v -- '-debug-symbols\.tar\.gz\.sha256$' asset-list.txt > platform-list.txt || true
           grep -- '-debug-symbols\.tar\.gz\.sha256$' asset-list.txt > symbol-list.txt || true
 
@@ -1180,14 +1177,9 @@ jobs:
             exit 1
           fi
 
-          # Debug symbols (#6677) are a diagnostic aid, not a platform target,
-          # so they get a range rather than an equality. `cli_mac` fails when
-          # its .dSYM is missing, so both macOS targets are guaranteed; the
-          # `cli_linux` targets are cross-compiled and only warn when the .dwp
-          # is absent, so 2 of the 4 are best-effort. A count outside 2..4 means
-          # the macOS hard-failure path did not hold, which is worth stopping
-          # for; a count of 2 or 3 only means Linux split-debuginfo did not
-          # materialize, which must not take a release down over a diagnostic.
+          # Debug symbols (#6677) are a diagnostic aid, not a platform target, so they get a range rather than an equality.
+          # `cli_mac` fails when its .dSYM is missing, so both macOS targets are guaranteed; the `cli_linux` targets are cross-compiled and only warn when the .dwp is absent, so 2 of the 4 are best-effort.
+          # A count outside 2..4 means the macOS hard-failure path did not hold, which is worth stopping for; a count of 2 or 3 only means Linux split-debuginfo did not materialize, which must not take a release down over a diagnostic.
           SYMBOLS=$(wc -l < symbol-list.txt | tr -d ' ')
           if [ "$SYMBOLS" -lt 2 ] || [ "$SYMBOLS" -gt 4 ]; then
             echo "::error::expected 2-4 debug-symbols .sha256 siblings (2 macOS guaranteed + up to 2 best-effort Linux), got $SYMBOLS"

--- a/changelog.d/fixed/6691-sha256sums-debug-symbols-count.md
+++ b/changelog.d/fixed/6691-sha256sums-debug-symbols-count.md
@@ -1,0 +1,7 @@
+Fix `Sign Release Artifacts` failing every release since #6677, which shipped debug symbols as their own assets without updating the sibling-count guard that assumed one `.sha256` per platform target.
+The guard exists to catch matrix drift in either direction and is deliberately an equality, so the four new `librefang-<target>-debug-symbols.tar.gz.sha256` files read as four extra platforms: v2026.7.31, the first release cut after #6677 landed, failed with `expected exactly 12 .sha256 siblings, got 16` after every artifact had already been built and published.
+The two kinds of sibling are now counted separately, because only one of them is one-per-matrix-target.
+Platform binaries keep the strict `= 12` equality that makes a dropped or added target stop the release loudly.
+Debug symbols get a `2..4` range instead, matching how they are produced: `cli_mac` fails outright when its `.dSYM` is missing, so both macOS targets are guaranteed, while the cross-compiled `cli_linux` targets only warn when the `.dwp` is absent — a count below 2 means the macOS hard-failure path did not hold and is worth stopping for, and a count of 2 or 3 emits a warning rather than taking a release down over a diagnostic aid.
+The manifest itself is unchanged: the download loop and `ls *.sha256` still read the full asset list, so every hash including the debug-symbols ones stays in `SHA256SUMS` and under the cosign signature.
+(#6691) (@houko)


### PR DESCRIPTION
`Sign Release Artifacts` failed on v2026.7.31 with `expected exactly 12 .sha256 siblings (one per matrix target across cli_* jobs), got 16` — after every artifact had already been built and published. It will fail the same way on every subsequent release until this lands.

## Cause

#6677 ships debug symbols as their own release assets, adding four `librefang-<target>-debug-symbols.tar.gz.sha256` files. The sibling-count guard in `sign_release_artifacts` assumes one `.sha256` per platform target and is deliberately an equality — its comment says drift in either direction is a bug, and blocking releases is the intended loud failure. So the four new files read as four extra platforms.

v2026.7.31 is the first release cut since #6677 landed, so this is a first exposure rather than a regression. The guard behaved exactly as designed; the constant simply was not updated alongside the new assets, and the two kinds of sibling are not the same kind of thing.

## Fix

Split the list before counting.

- **Platform binaries** keep the strict `= 12`. A dropped or added matrix target still stops the release loudly, which is the whole point of the guard.
- **Debug symbols** get `2..4`, matching how they are actually produced: `cli_mac` fails outright when its `.dSYM` is missing (so both macOS targets are guaranteed), while the cross-compiled `cli_linux` targets only warn when the `.dwp` is absent — that asymmetry is deliberate per #6677, so a hard `= 4` would take a release down over a diagnostic aid. Below 2 means the macOS hard-failure path did not hold, which is worth stopping for; 2 or 3 emits a warning.

The manifest itself is unchanged. The download loop and `ls *.sha256` still read the full asset list, so every hash including the debug-symbols ones stays in `SHA256SUMS` and under the cosign signature — this touches only the count check.

## Verification

The step was extracted from the workflow and run against the **real v2026.7.31 asset list** plus three boundary cases:

| Scenario | Assets | Result |
| --- | --- | --- |
| Real v2026.7.31 | 16 | PASS (platform=12, symbols=4) |
| Linux symbols absent | 14 | PASS + warning (symbols=2) |
| All symbols absent | 12 | FAIL (macOS guarantee broken) |
| One platform target dropped | 15 | FAIL (platform=11) |

YAML parses.

## Note on scope

Found while verifying the v2026.7.31 release pipeline (#6688 / #6689 / #6690). Unrelated to those changes in cause, but it blocks every future release, so it is fixed here rather than deferred.

The other failing job on that release, `Mobile / iOS (ipa)`, also failed on v2026.7.27 and is `continue-on-error: true` by design — left alone, as it needs Apple signing credentials rather than a code change.
