### PR TITLE
fix(api): deliver manually run schedule outputs

### DIFF
--- a/changelog.d/fixed/6708-manual-schedule-delivery.md
+++ b/changelog.d/fixed/6708-manual-schedule-delivery.md
@@ -1,0 +1,1 @@
+Manual schedule runs now deliver successful agent and workflow output through configured primary and fan-out targets, matching timed cron fires instead of returning output only to the API caller (#6708) (@Kvitral)

--- a/crates/librefang-api/src/routes/workflows/schedules.rs
+++ b/crates/librefang-api/src/routes/workflows/schedules.rs
@@ -529,16 +529,30 @@ pub async fn run_schedule(
                 .clone()
                 .unwrap_or_else(|| format!("[Scheduled workflow '{}' triggered]", name));
             match state.kernel.run_workflow_typed(wid, wf_input).await {
-                Ok((run_id, output)) => (
-                    StatusCode::OK,
-                    Json(serde_json::json!({
-                        "status": "completed",
-                        "schedule_id": id,
-                        "workflow_id": workflow_id,
-                        "run_id": run_id.to_string(),
-                        "output": output,
-                    })),
-                ),
+                Ok((run_id, output)) => {
+                    state
+                        .kernel
+                        .clone()
+                        .deliver_cron_output(
+                            agent_id,
+                            &name,
+                            &output,
+                            false,
+                            &job.delivery,
+                            &job.delivery_targets,
+                        )
+                        .await;
+                    (
+                        StatusCode::OK,
+                        Json(serde_json::json!({
+                            "status": "completed",
+                            "schedule_id": id,
+                            "workflow_id": workflow_id,
+                            "run_id": run_id.to_string(),
+                            "output": output,
+                        })),
+                    )
+                }
                 Err(e) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(serde_json::json!({
@@ -556,15 +570,29 @@ pub async fn run_schedule(
                 .send_message_with_handle(agent_id, message, Some(kernel_handle))
                 .await
             {
-                Ok(result) => (
-                    StatusCode::OK,
-                    Json(serde_json::json!({
-                        "status": "completed",
-                        "schedule_id": id,
-                        "agent_id": agent_id.to_string(),
-                        "response": result.response,
-                    })),
-                ),
+                Ok(result) => {
+                    state
+                        .kernel
+                        .clone()
+                        .deliver_cron_output(
+                            agent_id,
+                            &name,
+                            &result.response,
+                            result.silent,
+                            &job.delivery,
+                            &job.delivery_targets,
+                        )
+                        .await;
+                    (
+                        StatusCode::OK,
+                        Json(serde_json::json!({
+                            "status": "completed",
+                            "schedule_id": id,
+                            "agent_id": agent_id.to_string(),
+                            "response": result.response,
+                        })),
+                    )
+                }
                 Err(e) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(serde_json::json!({

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -13,9 +13,10 @@
 //! without spinning up an agent or hitting an external service.
 //!
 //! Out of scope (skipped intentionally):
-//! - `POST /api/workflows/{id}/run` and `POST /api/schedules/{id}/run` —
-//!   actually invoke an LLM-backed agent loop, which our test kernel has no
-//!   credentials for.
+//! - LLM-backed `POST /api/workflows/{id}/run` and agent-turn
+//!   `POST /api/schedules/{id}/run` coverage — our test kernel has no model
+//!   credentials. Manual schedule delivery is covered with a deterministic
+//!   zero-step workflow.
 //! - `POST /api/workflows/{id}/dry-run` agent-execution coverage — the
 //!   step-context path walks into agent-registry lookups for agents we
 //!   haven't registered, so `agent_found` is always false here. The
@@ -29,13 +30,62 @@
 //!   cap → 400 path live in `trigger_workflow_test.rs` (which seeds a real
 //!   agent via `spawn_agent`).
 
+use async_trait::async_trait;
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 use axum::Router;
+use futures::Stream;
 use librefang_api::routes::{self, AppState};
+use librefang_channels::types::{
+    ChannelAdapter, ChannelContent, ChannelMessage, ChannelType, ChannelUser,
+};
 use librefang_testing::{MockKernelBuilder, TestAppState};
+use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::Mutex;
 use tower::ServiceExt;
+
+struct RecordingChannelAdapter {
+    sent: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl ChannelAdapter for RecordingChannelAdapter {
+    fn name(&self) -> &str {
+        "telegram"
+    }
+
+    fn channel_type(&self) -> ChannelType {
+        ChannelType::Telegram
+    }
+
+    async fn start(
+        &self,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = ChannelMessage> + Send>>,
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
+        Ok(Box::pin(futures::stream::empty()))
+    }
+
+    async fn send(
+        &self,
+        user: &ChannelUser,
+        content: ChannelContent,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if let ChannelContent::Text(text) = content {
+            self.sent
+                .lock()
+                .expect("recording adapter lock")
+                .push(format!("{}:{text}", user.platform_id));
+        }
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
+}
 
 struct Harness {
     app: Router,
@@ -884,6 +934,80 @@ async fn workflow_template_instantiate_unknown_returns_404() {
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn schedule_manual_run_delivers_workflow_output_to_channel_targets() {
+    use chrono::Utc;
+    use librefang_types::agent::AgentId;
+    use librefang_types::scheduler::{
+        CronAction, CronDelivery, CronDeliveryTarget, CronJob, CronJobId, CronSchedule,
+    };
+
+    let h = boot().await;
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    h._state.kernel.channel_adapters_ref().insert(
+        "telegram".to_string(),
+        Arc::new(RecordingChannelAdapter { sent: sent.clone() }),
+    );
+
+    // An empty workflow is deterministic: its output is its input, so the
+    // route can be exercised without an LLM provider or live Telegram bot.
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/workflows",
+        Some(serde_json::json!({"name": "manual-delivery", "steps": []})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body:?}");
+    let workflow_id = body["workflow_id"].as_str().expect("workflow id");
+
+    let job = CronJob {
+        id: CronJobId::new(),
+        agent_id: AgentId::new(),
+        name: "manual telegram delivery".to_string(),
+        enabled: true,
+        schedule: CronSchedule::Every { every_secs: 3600 },
+        action: CronAction::Workflow {
+            workflow_id: workflow_id.to_string(),
+            input: Some("scheduled hello".to_string()),
+            timeout_secs: Some(30),
+        },
+        delivery: CronDelivery::None,
+        delivery_targets: vec![CronDeliveryTarget::Channel {
+            channel_type: "telegram".to_string(),
+            recipient: "115186674".to_string(),
+            thread_id: None,
+            account_id: None,
+        }],
+        peer_id: None,
+        session_mode: None,
+        created_at: Utc::now(),
+        last_run: None,
+        next_run: None,
+    };
+    let job_id = h
+        ._state
+        .kernel
+        .cron()
+        .add_job(job, false)
+        .expect("add schedule");
+
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        &format!("/api/schedules/{job_id}/run"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body:?}");
+    assert_eq!(body["output"], "scheduled hello");
+    assert_eq!(
+        sent.lock().expect("recording adapter lock").as_slice(),
+        ["115186674:scheduled hello"],
+        "manual schedule run must use the same delivery_targets fan-out as a timed fire"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -13,10 +13,8 @@
 //! without spinning up an agent or hitting an external service.
 //!
 //! Out of scope (skipped intentionally):
-//! - LLM-backed `POST /api/workflows/{id}/run` and agent-turn
-//!   `POST /api/schedules/{id}/run` coverage — our test kernel has no model
-//!   credentials. Manual schedule delivery is covered with a deterministic
-//!   zero-step workflow.
+//! - LLM-backed `POST /api/workflows/{id}/run` and agent-turn `POST /api/schedules/{id}/run` coverage — our test kernel has no model credentials.
+//!   Manual schedule delivery is covered with a deterministic zero-step workflow.
 //! - `POST /api/workflows/{id}/dry-run` agent-execution coverage — the
 //!   step-context path walks into agent-registry lookups for agents we
 //!   haven't registered, so `agent_found` is always false here. The
@@ -951,8 +949,7 @@ async fn schedule_manual_run_delivers_workflow_output_to_channel_targets() {
         Arc::new(RecordingChannelAdapter { sent: sent.clone() }),
     );
 
-    // An empty workflow is deterministic: its output is its input, so the
-    // route can be exercised without an LLM provider or live Telegram bot.
+    // An empty workflow is deterministic: its output is its input, so the route can be exercised without an LLM provider or live Telegram bot.
     let (status, body) = json_request(
         &h,
         Method::POST,
@@ -977,7 +974,7 @@ async fn schedule_manual_run_delivers_workflow_output_to_channel_targets() {
         delivery: CronDelivery::None,
         delivery_targets: vec![CronDeliveryTarget::Channel {
             channel_type: "telegram".to_string(),
-            recipient: "115186674".to_string(),
+            recipient: "test-chat-id".to_string(),
             thread_id: None,
             account_id: None,
         }],
@@ -1005,7 +1002,7 @@ async fn schedule_manual_run_delivers_workflow_output_to_channel_targets() {
     assert_eq!(body["output"], "scheduled hello");
     assert_eq!(
         sent.lock().expect("recording adapter lock").as_slice(),
-        ["115186674:scheduled hello"],
+        ["test-chat-id:scheduled hello"],
         "manual schedule run must use the same delivery_targets fan-out as a timed fire"
     );
 }

--- a/crates/librefang-kernel/src/kernel/cron_bridge.rs
+++ b/crates/librefang-kernel/src/kernel/cron_bridge.rs
@@ -14,13 +14,10 @@ use librefang_types::agent::AgentId;
 use super::{KernelCronBridge, LibreFangKernel};
 
 impl LibreFangKernel {
-    /// Deliver the output produced by a cron action through both the legacy
-    /// single-destination setting and the newer multi-target fan-out list.
+    /// Deliver the output produced by a cron action through both the legacy single-destination setting and the newer multi-target fan-out list.
     ///
-    /// Keeping this operation on the kernel gives scheduled fires and manual
-    /// `POST /api/schedules/{id}/run` calls one delivery path. Delivery is
-    /// intentionally best-effort: adapter failures are logged by the helpers
-    /// and do not turn a successfully completed action into a failed action.
+    /// Keeping this operation on the kernel gives scheduled fires and manual `POST /api/schedules/{id}/run` calls one delivery path.
+    /// Delivery is intentionally best-effort: adapter failures are logged by the helpers and do not turn a successfully completed action into a failed action.
     pub async fn deliver_cron_output(
         self: &Arc<Self>,
         agent_id: AgentId,

--- a/crates/librefang-kernel/src/kernel/cron_bridge.rs
+++ b/crates/librefang-kernel/src/kernel/cron_bridge.rs
@@ -13,6 +13,34 @@ use librefang_types::agent::AgentId;
 
 use super::{KernelCronBridge, LibreFangKernel};
 
+impl LibreFangKernel {
+    /// Deliver the output produced by a cron action through both the legacy
+    /// single-destination setting and the newer multi-target fan-out list.
+    ///
+    /// Keeping this operation on the kernel gives scheduled fires and manual
+    /// `POST /api/schedules/{id}/run` calls one delivery path. Delivery is
+    /// intentionally best-effort: adapter failures are logged by the helpers
+    /// and do not turn a successfully completed action into a failed action.
+    pub async fn deliver_cron_output(
+        self: &Arc<Self>,
+        agent_id: AgentId,
+        job_name: &str,
+        output: &str,
+        silent: bool,
+        delivery: &librefang_types::scheduler::CronDelivery,
+        delivery_targets: &[librefang_types::scheduler::CronDeliveryTarget],
+    ) {
+        if silent {
+            return;
+        }
+
+        cron_deliver_response(self, agent_id, output, delivery).await;
+        if !delivery_targets.is_empty() {
+            cron_fan_out_targets(self, job_name, output, delivery_targets).await;
+        }
+    }
+}
+
 /// Webhook HTTP timeout used for the fan-out client. Mirrors
 /// `crate::cron_delivery::WEBHOOK_TIMEOUT_SECS` (kept private there); the
 /// duplication is acceptable because this builder lives outside the engine

--- a/crates/librefang-kernel/src/kernel/cron_tick.rs
+++ b/crates/librefang-kernel/src/kernel/cron_tick.rs
@@ -17,7 +17,6 @@ use librefang_types::event::{Event, EventPayload, EventTarget};
 
 use tracing::{debug, warn};
 
-use super::cron_bridge::{cron_deliver_response, cron_fan_out_targets};
 use super::cron_compaction::{
     apply_cron_prune, cron_clamp_keep_recent, cron_compute_keep_count,
     cron_resolve_compaction_mode, try_summarize_trim,
@@ -363,31 +362,16 @@ pub(super) async fn run_cron_scheduler_loop(kernel: Arc<LibreFangKernel>) {
                                 if let Err(e) = kernel_job.workflows.cron_scheduler.persist() {
                                     tracing::warn!(job = %job_name, "Cron post-run persist failed: {e}");
                                 }
-                                // Deliver response to configured channel (skip NO_REPLY/silent)
-                                if !result.silent {
-                                    cron_deliver_response(
-                                        &kernel_job,
+                                kernel_job
+                                    .deliver_cron_output(
                                         agent_id,
+                                        &job_name,
                                         &result.response,
+                                        result.silent,
                                         &delivery,
+                                        &delivery_targets,
                                     )
                                     .await;
-                                    // Fan out to multi-destination
-                                    // delivery_targets (best-effort,
-                                    // failure-isolated). Skip the whole
-                                    // call when there are no targets so
-                                    // we never construct a fan-out engine
-                                    // for the common no-webhook job (#5127).
-                                    if !delivery_targets.is_empty() {
-                                        cron_fan_out_targets(
-                                            &kernel_job,
-                                            &job_name,
-                                            &result.response,
-                                            &delivery_targets,
-                                        )
-                                        .await;
-                                    }
-                                }
                             }
                             Ok(Err(e)) => {
                                 let err_msg = format!("{e}");
@@ -477,26 +461,16 @@ pub(super) async fn run_cron_scheduler_loop(kernel: Arc<LibreFangKernel>) {
                                         {
                                             tracing::warn!(job = %job_name, "Cron post-run persist failed: {e}");
                                         }
-                                        cron_deliver_response(
-                                            &kernel_job,
-                                            agent_id,
-                                            &output,
-                                            &delivery,
-                                        )
-                                        .await;
-                                        // Skip the fan-out call when no
-                                        // targets are configured so we
-                                        // don't construct an engine for
-                                        // the common no-webhook job (#5127).
-                                        if !delivery_targets.is_empty() {
-                                            cron_fan_out_targets(
-                                                &kernel_job,
+                                        kernel_job
+                                            .deliver_cron_output(
+                                                agent_id,
                                                 &job_name,
                                                 &output,
+                                                false,
+                                                &delivery,
                                                 &delivery_targets,
                                             )
                                             .await;
-                                        }
                                     }
                                     Ok(Err(e)) => {
                                         let err_msg = format!("{e}");

--- a/crates/librefang-kernel/src/kernel_api.rs
+++ b/crates/librefang-kernel/src/kernel_api.rs
@@ -683,6 +683,15 @@ pub trait KernelApi: KernelHandle + Send + Sync {
     fn channel_adapters_ref(
         &self,
     ) -> &dashmap::DashMap<String, Arc<dyn librefang_channels::types::ChannelAdapter>>;
+    async fn deliver_cron_output(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        job_name: &str,
+        output: &str,
+        silent: bool,
+        delivery: &librefang_types::scheduler::CronDelivery,
+        delivery_targets: &[librefang_types::scheduler::CronDeliveryTarget],
+    );
     fn trigger_engine(&self) -> &crate::triggers::TriggerEngine;
     fn broadcast_ref(&self) -> &librefang_types::config::BroadcastConfig;
     fn auto_reply(&self) -> &crate::auto_reply::AutoReplyEngine;
@@ -1583,6 +1592,26 @@ impl KernelApi for LibreFangKernel {
         &self,
     ) -> &dashmap::DashMap<String, Arc<dyn librefang_channels::types::ChannelAdapter>> {
         <Self as crate::MeshSubsystemApi>::channel_adapters_ref(self)
+    }
+    async fn deliver_cron_output(
+        self: Arc<Self>,
+        agent_id: AgentId,
+        job_name: &str,
+        output: &str,
+        silent: bool,
+        delivery: &librefang_types::scheduler::CronDelivery,
+        delivery_targets: &[librefang_types::scheduler::CronDeliveryTarget],
+    ) {
+        LibreFangKernel::deliver_cron_output(
+            &self,
+            agent_id,
+            job_name,
+            output,
+            silent,
+            delivery,
+            delivery_targets,
+        )
+        .await;
     }
     fn trigger_engine(&self) -> &crate::triggers::TriggerEngine {
         <Self as crate::WorkflowSubsystemApi>::triggers_ref(self)


### PR DESCRIPTION
## Type

- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [x] Bug fix
- [ ] Feature (Rust)
- [ ] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [ ] Other

## Summary

Fixes #6707.

Manual schedule runs completed their agent turn or workflow but did not deliver
the resulting output through the schedule's `delivery` or `delivery_targets`.

The manual API route now uses the same output-delivery operation as timed cron
fires.

## Changes

- Add a shared kernel operation for primary and fan-out cron output delivery.
- Use the shared operation from timed agent and workflow cron execution.
- Deliver successful manual agent and workflow output to configured targets.
- Preserve silent-response behavior for agent turns.
- Add an integration test using a recording Telegram adapter without external services.

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

No prior work was adapted.

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

Additional verification:

- `cargo test -p librefang-api --test workflows_routes_integration -- --test-threads=1`
  - 67 passed
- `cargo test -p librefang-kernel cron_bridge::tests -- --test-threads=1`
  - 2 passed
- `cargo check --workspace --lib`
- `cargo fmt --all -- --check`
- Reproduced through the dashboard using a local Ollama agent and Telegram target.

The workspace-wide test command was not run. Scoped tests were used to avoid
target-directory contention and excessive file-descriptor usage.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries