### PR TITLE
ci: unblock the Windows test lane and gate main-red auto-close on lanes that ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -997,31 +997,17 @@ jobs:
           # reshuffle the others; deleting tests doesn't either. Stable
           # buckets are critical for cache hit rates across runs.
           #
-          # `--exclude librefang-desktop`: its test binary builds and links on
-          # Windows but cannot be *loaded* — the process aborts at start with
-          # 0xc0000139 (STATUS_ENTRYPOINT_NOT_FOUND, "the specified procedure
-          # could not be found"), so nextest cannot even run `--list` against
-          # it and the whole lane aborts before a single test executes (#6729).
-          # A nextest filter expression (`-E 'not binary_id(…)'`) would not
-          # help: nextest still executes the binary during the list phase.
-          # Cargo's package-level `--exclude` is what keeps it out of the
-          # selected set entirely, and since nothing in the workspace depends
-          # on librefang-desktop (it is a leaf) it is then never built here.
-          # Its 11 tests are platform-independent URL/scheme logic and still
-          # run on the Ubuntu shards, the unit-fast lane and macOS; the
-          # separate link-only step below keeps the Windows compile+link
-          # coverage. Remove both once the missing DLL export is identified.
+          # `--exclude librefang-desktop`: its test binary builds and links on Windows but cannot be *loaded* — the process aborts at start with 0xc0000139 (STATUS_ENTRYPOINT_NOT_FOUND, "the specified procedure could not be found"), so nextest cannot even run `--list` against it and the whole lane aborts before a single test executes (#6729).
+          # A nextest filter expression (`-E 'not binary_id(…)'`) would not help: nextest still executes the binary during the list phase.
+          # Cargo's package-level `--exclude` is what keeps it out of the selected set entirely, and since nothing in the workspace depends on librefang-desktop (it is a leaf) it is then never built here.
+          # Its 11 tests are platform-independent URL/scheme logic and still run on the Ubuntu shards, the unit-fast lane and macOS; the separate link-only step below keeps the Windows compile+link coverage.
+          # Remove both once the missing DLL export is identified.
           cargo nextest run --workspace --exclude librefang-desktop --no-fail-fast \
             --partition hash:${{ matrix.shard }}/2
       # Restores the Windows compile+link coverage that `--exclude` above drops.
-      # This is the only Windows build of librefang-desktop in CI
-      # (release-desktop.yml is workflow_dispatch-only, mobile-smoke.yml is
-      # ubuntu/macOS), so without this a Windows-only break in the crate would
-      # reach a release tag unseen. `--no-run` rather than `cargo check` because
-      # only the former exercises the link step, which is where such a
-      # regression shows up. Its own step — not a trailing line in `Run tests` —
-      # so a failure elsewhere in the workspace does not skip it (`shell: bash`
-      # runs with `-e`), and so the alert workflow can name it as the failing step.
+      # This is the only Windows build of librefang-desktop in CI (release-desktop.yml is workflow_dispatch-only, mobile-smoke.yml is ubuntu/macOS), so without this a Windows-only break in the crate would reach a release tag unseen.
+      # `--no-run` rather than `cargo check` because only the former exercises the link step, which is where such a regression shows up.
+      # Its own step — not a trailing line in `Run tests` — so a failure elsewhere in the workspace does not skip it (`shell: bash` runs with `-e`), and so the alert workflow can name it as the failing step.
       - name: Build librefang-desktop test targets (link-only)
         if: ${{ !cancelled() }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,9 +321,9 @@ jobs:
             PFLAGS=""
             for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
             echo "Selective build for:  $CRATES"
-            # No --lib: binary-only crates (librefang-cli, librefang-desktop)
-            # error with "no library targets found" otherwise. Default targets
-            # (lib + bins) are what we want anyway.
+            # No --lib: binary-only crates (librefang-cli) error with "no
+            # library targets found" otherwise. Default targets (lib + bins)
+            # are what we want anyway.
             cargo build $PFLAGS
             echo "Selective clippy for: $CRATES"
             cargo clippy $PFLAGS --all-targets --all-features -- -D warnings
@@ -782,7 +782,7 @@ jobs:
   #
   # Filter via nextest's expression language (`-E`) instead of `--lib --bins`:
   # the latter errors with "no library targets found" when a `-p <crate>`
-  # selector targets a binary-only crate (librefang-cli, librefang-desktop).
+  # selector targets a binary-only crate (librefang-cli).
   # The `-E 'kind(lib) | kind(bin)'` form matches whichever target kinds the
   # selected crates actually contain — silently skipping the missing kind for
   # bin-only crates — so the selective lane no longer breaks when a PR (or a
@@ -940,8 +940,8 @@ jobs:
             PFLAGS=""
             for c in $CRATES; do PFLAGS="$PFLAGS -p $c"; done
             # `--no-tests=pass` keeps PRs that only touch a crate without
-            # tests (e.g. librefang-desktop) from failing the selective lane
-            # — nextest defaults to exit-4 when -p X resolves to zero tests.
+            # tests from failing the selective lane — nextest defaults to
+            # exit-4 when -p X resolves to zero tests.
             cargo nextest run $PFLAGS --no-fail-fast --no-tests=pass
           fi
 
@@ -996,8 +996,38 @@ jobs:
           # one of M shards by the hash of its name. Adding tests doesn't
           # reshuffle the others; deleting tests doesn't either. Stable
           # buckets are critical for cache hit rates across runs.
-          cargo nextest run --workspace --no-fail-fast \
+          #
+          # `--exclude librefang-desktop`: its test binary builds and links on
+          # Windows but cannot be *loaded* — the process aborts at start with
+          # 0xc0000139 (STATUS_ENTRYPOINT_NOT_FOUND, "the specified procedure
+          # could not be found"), so nextest cannot even run `--list` against
+          # it and the whole lane aborts before a single test executes (#6729).
+          # A nextest filter expression (`-E 'not binary_id(…)'`) would not
+          # help: nextest still executes the binary during the list phase.
+          # Cargo's package-level `--exclude` is what keeps it out of the
+          # selected set entirely, and since nothing in the workspace depends
+          # on librefang-desktop (it is a leaf) it is then never built here.
+          # Its 11 tests are platform-independent URL/scheme logic and still
+          # run on the Ubuntu shards, the unit-fast lane and macOS; the
+          # separate link-only step below keeps the Windows compile+link
+          # coverage. Remove both once the missing DLL export is identified.
+          cargo nextest run --workspace --exclude librefang-desktop --no-fail-fast \
             --partition hash:${{ matrix.shard }}/2
+      # Restores the Windows compile+link coverage that `--exclude` above drops.
+      # This is the only Windows build of librefang-desktop in CI
+      # (release-desktop.yml is workflow_dispatch-only, mobile-smoke.yml is
+      # ubuntu/macOS), so without this a Windows-only break in the crate would
+      # reach a release tag unseen. `--no-run` rather than `cargo check` because
+      # only the former exercises the link step, which is where such a
+      # regression shows up. Its own step — not a trailing line in `Run tests` —
+      # so a failure elsewhere in the workspace does not skip it (`shell: bash`
+      # runs with `-e`), and so the alert workflow can name it as the failing step.
+      - name: Build librefang-desktop test targets (link-only)
+        if: ${{ !cancelled() }}
+        shell: bash
+        env:
+          OPENSSL_SRC_PERL: C:/Strawberry/perl/bin/perl.exe
+        run: cargo test -p librefang-desktop --all-targets --no-run
 
   # ── macOS tests: main-push only ────────────────────────────────────────────────
   # See test-windows above — macOS does not run on PRs (the PR test lane is

--- a/.github/workflows/main-build-alert.yml
+++ b/.github/workflows/main-build-alert.yml
@@ -8,6 +8,16 @@ name: Main Build Alert
 # `PR + current main`, so two PRs that are individually green can produce
 # a red main when merged in sequence (incident: #4179). Without a signal
 # at merge time, the breakage stays invisible until the next PR opens.
+#
+# Green does not automatically mean recovered. The CI workflow's `changes`
+# gate skips every Rust lane on a docs- or dependency-only push, and the run
+# still concludes `success`, so auto-closing on conclusion alone erases a real
+# breakage as soon as an unrelated Dependabot PR lands. That is not
+# hypothetical: the Windows lane died on 2026-08-04 and the same failure was
+# filed and falsely auto-closed three times (#6716, #6721, #6729) before
+# anyone noticed main had been red for days. The success branch below
+# therefore requires that at least one Rust test lane actually ran and passed
+# on the commit before it closes anything.
 
 on:
   workflow_run:
@@ -37,7 +47,14 @@ jobs:
             const runUrl = process.env.RUN_URL;
             const headSha = process.env.HEAD_SHA;
             const shortSha = headSha.slice(0, 7);
+            const runId = context.payload.workflow_run.id;
             const label = 'main-red';
+
+            // Job names of the lanes that actually compile and run Rust. The
+            // `changes` gate skips all of them on a docs- or dependency-only
+            // push, so a `success` conclusion from such a run proves nothing
+            // about the state of the Rust build.
+            const RUST_TEST_LANE = /^Test \/ (Windows|macOS|Ubuntu|Unit)/;
 
             // Ensure the label exists; ignore "already_exists" 422.
             try {
@@ -61,6 +78,40 @@ jobs:
             });
 
             if (conclusion === 'success') {
+              if (open.length === 0) return;
+
+              // A green run only clears an open `main-red` issue if at least
+              // one Rust test lane actually ran on this commit. Docs- and
+              // dependency-only pushes skip every Rust lane and still report
+              // `success`, which is how the Windows breakage from #6711 was
+              // filed and falsely auto-closed three times (#6716, #6721,
+              // #6729) while main stayed red. Errors here mean we do not know,
+              // so we leave the issue open — a false close hides a real
+              // breakage, a false open costs one glance.
+              let rustLaneRan = false;
+              try {
+                const jobs = await github.paginate(
+                  github.rest.actions.listJobsForWorkflowRun,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: runId,
+                    per_page: 100,
+                  }
+                );
+                rustLaneRan = jobs.some(
+                  job => RUST_TEST_LANE.test(job.name) && job.conclusion === 'success'
+                );
+              } catch (e) {
+                core.warning(`Could not enumerate jobs for ${shortSha}: ${e.message} — not auto-closing.`);
+                return;
+              }
+
+              if (!rustLaneRan) {
+                core.info(`Main CI succeeded on ${shortSha} (${runUrl}) but no Rust test lane ran on that commit — leaving open.`);
+                return;
+              }
+
               // Auto-close any open red-main issue when CI goes green again.
               for (const issue of open) {
                 await github.rest.issues.createComment({
@@ -83,14 +134,18 @@ jobs:
               return; // skipped/neutral/etc — nothing to do
             }
 
-            // ── Resolve the PR that introduced the breakage ──────────────
-            // The merge commit subject conventionally ends in `(#NNNN)`.
-            // Falling back to the listPullRequestsAssociatedWithCommit API
-            // covers squash-merges that ship without the PR suffix in the
-            // subject. Best-effort — title/body still readable if both fail.
-            let prNumber = null;
+            // ── Identify the head commit the run fired on ────────────────
+            // Identification only, deliberately NOT attribution: the run
+            // reports the state of `main` at this commit, which is not
+            // evidence that this commit caused the failure. A lane can be red
+            // from an earlier merge whose own run skipped it, from an
+            // infrastructure change, or from a flaky runner. Three consecutive
+            // filings (#6715, #6720, #6727) named unrelated openrouter
+            // snapshot PRs for a Windows breakage introduced days earlier by
+            // db81fe79, and the alert's "revert PR #N" line is what made that
+            // read as a verdict, so the PR number and commit author are no
+            // longer surfaced at all.
             let commitSubject = '';
-            let commitAuthor = '';
             try {
               const { data: commit } = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
@@ -98,18 +153,6 @@ jobs:
                 ref: headSha,
               });
               commitSubject = (commit.commit.message || '').split('\n')[0];
-              commitAuthor = commit.author?.login || commit.commit.author?.name || '';
-              const m = commitSubject.match(/\(#(\d+)\)\s*$/);
-              if (m) {
-                prNumber = parseInt(m[1], 10);
-              } else {
-                const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  commit_sha: headSha,
-                });
-                if (prs.length > 0) prNumber = prs[0].number;
-              }
             } catch (e) {
               core.warning(`Could not resolve commit metadata for ${shortSha}: ${e.message}`);
             }
@@ -122,7 +165,7 @@ jobs:
                 {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  run_id: context.payload.workflow_run.id,
+                  run_id: runId,
                   per_page: 100,
                 }
               );
@@ -142,17 +185,15 @@ jobs:
             }
 
             // ── Build the issue body ─────────────────────────────────────
+            // Strip the merge subject's trailing `(#NNNN)`: leaving it in
+            // renders as a cross-reference that back-links the issue onto that
+            // PR's timeline, which is the same false accusation in a quieter
+            // form. `shortSha` still auto-links to the commit, and the commit
+            // page names its PR, so nothing navigable is lost.
             const cleanSubject = commitSubject.replace(/\s*\(#\d+\)\s*$/, '');
+            const subj = cleanSubject ? ` — ${cleanSubject}` : '';
             const lines = [];
-            if (prNumber) {
-              const subj = cleanSubject ? ` — ${cleanSubject}` : '';
-              const by = commitAuthor ? ` by @${commitAuthor}` : '';
-              lines.push(`Main CI **${conclusion}** on PR #${prNumber}${subj}${by} (commit ${shortSha}).`);
-            } else {
-              const subj = cleanSubject ? ` — ${cleanSubject}` : '';
-              const by = commitAuthor ? ` by @${commitAuthor}` : '';
-              lines.push(`Main CI **${conclusion}** on commit ${shortSha}${subj}${by}.`);
-            }
+            lines.push(`Main CI **${conclusion}** on \`main\` at commit ${shortSha}${subj}.`);
             lines.push('');
             lines.push(`Run: ${runUrl}`);
             lines.push('');
@@ -166,16 +207,11 @@ jobs:
               lines.push('');
             }
 
-            lines.push(`Every open PR will inherit this failure on its next CI run.`);
-            if (prNumber) {
-              lines.push(`Either land a fix (preferred) or revert PR #${prNumber}.`);
-            } else {
-              lines.push(`Either land a fix (preferred) or revert the offending merge.`);
-            }
+            lines.push(`This is the state of \`main\` at that commit, not a claim that the commit introduced the failure — read the failing job's log before attributing it.`);
+            lines.push(`Every open PR will inherit this failure on its next CI run, so land a fix on \`main\` or revert the merge the log actually implicates.`);
 
             const body = lines.join('\n');
-            const titleSuffix = prNumber ? `PR #${prNumber}` : `${shortSha}`;
-            const title = `[main red] CI ${conclusion} on ${titleSuffix}`;
+            const title = `[main red] CI ${conclusion} on ${shortSha}`;
 
             if (open.length > 0) {
               await github.rest.issues.createComment({

--- a/.github/workflows/main-build-alert.yml
+++ b/.github/workflows/main-build-alert.yml
@@ -9,15 +9,10 @@ name: Main Build Alert
 # a red main when merged in sequence (incident: #4179). Without a signal
 # at merge time, the breakage stays invisible until the next PR opens.
 #
-# Green does not automatically mean recovered. The CI workflow's `changes`
-# gate skips every Rust lane on a docs- or dependency-only push, and the run
-# still concludes `success`, so auto-closing on conclusion alone erases a real
-# breakage as soon as an unrelated Dependabot PR lands. That is not
-# hypothetical: the Windows lane died on 2026-08-04 and the same failure was
-# filed and falsely auto-closed three times (#6716, #6721, #6729) before
-# anyone noticed main had been red for days. The success branch below
-# therefore requires that at least one Rust test lane actually ran and passed
-# on the commit before it closes anything.
+# Green does not automatically mean recovered.
+# The CI workflow's `changes` gate skips every Rust lane on a docs- or dependency-only push, and the run still concludes `success`, so auto-closing on conclusion alone erases a real breakage as soon as an unrelated Dependabot PR lands.
+# That is not hypothetical: the Windows lane died on 2026-08-04 and the same failure was filed and falsely auto-closed three times (#6716, #6721, #6729) before anyone noticed main had been red for days.
+# The success branch below therefore requires that at least one Rust test lane actually ran and passed on the commit before it closes anything.
 
 on:
   workflow_run:
@@ -50,10 +45,8 @@ jobs:
             const runId = context.payload.workflow_run.id;
             const label = 'main-red';
 
-            // Job names of the lanes that actually compile and run Rust. The
-            // `changes` gate skips all of them on a docs- or dependency-only
-            // push, so a `success` conclusion from such a run proves nothing
-            // about the state of the Rust build.
+            // Job names of the lanes that actually compile and run Rust.
+            // The `changes` gate skips all of them on a docs- or dependency-only push, so a `success` conclusion from such a run proves nothing about the state of the Rust build.
             const RUST_TEST_LANE = /^Test \/ (Windows|macOS|Ubuntu|Unit)/;
 
             // Ensure the label exists; ignore "already_exists" 422.
@@ -80,14 +73,9 @@ jobs:
             if (conclusion === 'success') {
               if (open.length === 0) return;
 
-              // A green run only clears an open `main-red` issue if at least
-              // one Rust test lane actually ran on this commit. Docs- and
-              // dependency-only pushes skip every Rust lane and still report
-              // `success`, which is how the Windows breakage from #6711 was
-              // filed and falsely auto-closed three times (#6716, #6721,
-              // #6729) while main stayed red. Errors here mean we do not know,
-              // so we leave the issue open — a false close hides a real
-              // breakage, a false open costs one glance.
+              // A green run only clears an open `main-red` issue if at least one Rust test lane actually ran on this commit.
+              // Docs- and dependency-only pushes skip every Rust lane and still report `success`, which is how the Windows breakage from #6711 was filed and falsely auto-closed three times (#6716, #6721, #6729) while main stayed red.
+              // Errors here mean we do not know, so we leave the issue open — a false close hides a real breakage, a false open costs one glance.
               let rustLaneRan = false;
               try {
                 const jobs = await github.paginate(
@@ -135,16 +123,9 @@ jobs:
             }
 
             // ── Identify the head commit the run fired on ────────────────
-            // Identification only, deliberately NOT attribution: the run
-            // reports the state of `main` at this commit, which is not
-            // evidence that this commit caused the failure. A lane can be red
-            // from an earlier merge whose own run skipped it, from an
-            // infrastructure change, or from a flaky runner. Three consecutive
-            // filings (#6715, #6720, #6727) named unrelated openrouter
-            // snapshot PRs for a Windows breakage introduced days earlier by
-            // db81fe79, and the alert's "revert PR #N" line is what made that
-            // read as a verdict, so the PR number and commit author are no
-            // longer surfaced at all.
+            // Identification only, deliberately NOT attribution: the run reports the state of `main` at this commit, which is not evidence that this commit caused the failure.
+            // A lane can be red from an earlier merge whose own run skipped it, from an infrastructure change, or from a flaky runner.
+            // Three consecutive filings (#6715, #6720, #6727) named unrelated openrouter snapshot PRs for a Windows breakage introduced days earlier by db81fe79, and the alert's "revert PR #N" line is what made that read as a verdict, so the PR number and commit author are no longer surfaced at all.
             let commitSubject = '';
             try {
               const { data: commit } = await github.rest.repos.getCommit({
@@ -185,11 +166,8 @@ jobs:
             }
 
             // ── Build the issue body ─────────────────────────────────────
-            // Strip the merge subject's trailing `(#NNNN)`: leaving it in
-            // renders as a cross-reference that back-links the issue onto that
-            // PR's timeline, which is the same false accusation in a quieter
-            // form. `shortSha` still auto-links to the commit, and the commit
-            // page names its PR, so nothing navigable is lost.
+            // Strip the merge subject's trailing `(#NNNN)`: leaving it in renders as a cross-reference that back-links the issue onto that PR's timeline, which is the same false accusation in a quieter form.
+            // `shortSha` still auto-links to the commit, and the commit page names its PR, so nothing navigable is lost.
             const cleanSubject = commitSubject.replace(/\s*\(#\d+\)\s*$/, '');
             const subj = cleanSubject ? ` — ${cleanSubject}` : '';
             const lines = [];

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,15 +104,15 @@ CI splits tests into two separate jobs so a unit failure surfaces quickly:
 - **Unit-fast** (`Test / Unit (lib+bin)`, ~2 min): `cargo nextest run --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast`
   — lib and binary unit tests only; no integration test binaries. Run this locally for quick iteration.
 - **Integration** (`Test / Ubuntu (shard N/4)`, ~10-20 min): sharded across 4 Ubuntu runners via
-  `--partition hash:N/4`; also single jobs on macOS and Windows. Runs all `--tests` targets.
+  `--partition hash:N/4`; plus a single macOS job and a 2-way-sharded Windows job, both main-push only. Runs all `--tests` targets.
 
-The unit-fast lane uses nextest's `-E 'kind(lib) | kind(bin)'` filter rather
-than `--lib --bins` because the latter errors with "no library targets found"
-when a `-p <crate>` selector targets a binary-only crate
-(`librefang-cli`, `librefang-desktop`). The expression form matches whichever
-kinds the selected crates actually have, so the selective CI lane stays green
-when a PR touches only `librefang-cli/main.rs` (or when a stale-base diff
-drags it in).
+The unit-fast lane uses nextest's `-E 'kind(lib) | kind(bin)'` filter rather than `--lib --bins` because the latter errors with "no library targets found" when a `-p <crate>` selector targets a binary-only crate (`librefang-cli`).
+The expression form matches whichever kinds the selected crates actually have, so the selective CI lane stays green when a PR touches only `librefang-cli/main.rs` (or when a stale-base diff drags it in).
+`librefang-desktop` is not binary-only — it has a lib target carrying 11 tests, so `-p librefang-desktop` resolves fine.
+
+The Windows lane passes `--exclude librefang-desktop` (#6729): the crate's test binary links on Windows but aborts at load with 0xc0000139 (STATUS_ENTRYPOINT_NOT_FOUND), which kills nextest's list phase and takes the whole lane — and therefore CI Gate — down.
+A dedicated `cargo test -p librefang-desktop --all-targets --no-run` step keeps the Windows compile+link coverage; the tests themselves are platform-independent and still run on Ubuntu, macOS and the unit-fast lane.
+Drop both once the missing DLL export is identified.
 
 Local equivalents:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,8 @@ CI splits tests into two separate jobs so a unit failure surfaces quickly:
 
 - **Unit-fast** (`Test / Unit (lib+bin)`, ~2 min): `cargo nextest run --workspace -E 'kind(lib) | kind(bin)' --no-fail-fast`
   — lib and binary unit tests only; no integration test binaries. Run this locally for quick iteration.
-- **Integration** (`Test / Ubuntu (shard N/4)`, ~10-20 min): sharded across 4 Ubuntu runners via
-  `--partition hash:N/4`; plus a single macOS job and a 2-way-sharded Windows job, both main-push only. Runs all `--tests` targets.
+- **Integration** (`Test / Ubuntu (shard N/4)`, ~10-20 min): sharded across 4 Ubuntu runners via `--partition hash:N/4`; plus a single macOS job and a 2-way-sharded Windows job, both main-push only.
+  Runs all `--tests` targets.
 
 The unit-fast lane uses nextest's `-E 'kind(lib) | kind(bin)'` filter rather than `--lib --bins` because the latter errors with "no library targets found" when a `-p <crate>` selector targets a binary-only crate (`librefang-cli`).
 The expression form matches whichever kinds the selected crates actually have, so the selective CI lane stays green when a PR touches only `librefang-cli/main.rs` (or when a stale-base diff drags it in).

--- a/changelog.d/fixed/6735-windows-desktop-test-lane.md
+++ b/changelog.d/fixed/6735-windows-desktop-test-lane.md
@@ -1,0 +1,8 @@
+Restore the Windows test lane, which had aborted on every push to `main` since #6711 and taken `CI Gate` down with it, so for three days no PR merged with a Windows signal behind it.
+`librefang-desktop`'s test binary links on Windows but cannot be loaded — the process dies at start with `0xc0000139` (`STATUS_ENTRYPOINT_NOT_FOUND`) — and nextest executes every test binary with `--list` to enumerate its tests, so the lane died before running a single one.
+The crate is now excluded from that lane's nextest invocation and built there link-only instead, which keeps the Windows compile+link coverage that nothing else in CI provides while its 11 platform-independent URL/scheme tests continue to run on Ubuntu, macOS and the unit-fast lane.
+The missing DLL export behind the abort is still unidentified, so this is a workaround carrying a note to remove it once the real cause is found.
+A green `main` run also no longer closes an open `main-red` issue unless a Rust test lane actually ran on that commit.
+The `changes` gate skips every Rust lane on a docs- or dependency-only push while the run still concludes `success`, which is how this one breakage came to be filed and auto-closed three times (#6716, #6721, #6729) before anyone noticed `main` had been red for days — nine of the last sixteen green `main` runs would have closed it.
+The failure notice now names the head commit and the run URL without asserting that the commit caused the failure, because three consecutive filings told readers to revert an unrelated openrouter model-snapshot PR for a breakage introduced days earlier.
+(#6735) (@houko)


### PR DESCRIPTION
## Why

Two defects, one root symptom: `main` has been red since 2026-08-04 and nobody knew, because the alert that was supposed to tell us kept closing its own issue.

**1. The Windows test lane is dead.** `librefang-desktop`'s test binary builds and links on Windows but cannot be *loaded* — the process aborts at start with `0xc0000139` (`STATUS_ENTRYPOINT_NOT_FOUND`). nextest runs each test binary with `--list --format terse` to enumerate tests, so the lane dies in the list phase before a single test executes, and `test-windows` is in `CI Gate`'s `needs:` list, so CI Gate goes red with it. From run 31096230292:

```
for `librefang-desktop`, command `...\librefang_desktop-dedc14a49eb100f7.exe --list --format terse`
aborted with code 0xc0000139: The specified procedure could not be found. (os error 127)
```

Introduced by db81fe79 (#6711), which added the `#[cfg(desktop)] mod new_window_requests` tests — the first tests in this crate to link `tauri::Wry`. **Not** reverting #6711: it is the fix for #6706, and reverting re-breaks that.

**2. `main-build-alert.yml` auto-closes on any `success` conclusion.** The CI workflow's `changes` gate skips every Rust lane on a docs- or dependency-only push, and the run still concludes `success`. So the very next Dependabot merge erased the tracking issue. That is why one breakage was filed and falsely closed three times — #6716 (closed by run 30998442165), #6721, #6729 (closed by run 31149565632, `chore(deps): bump the docs-minor-patch group`, where every `Test /` job is `skipped` and only `CI Gate` succeeded).

## Changes

**`.github/workflows/ci.yml`**

- Windows lane runs `cargo nextest run --workspace --exclude librefang-desktop …`. Cargo's package-level `--exclude` is used deliberately instead of a nextest filter expression (`-E 'not binary_id(…)'`): an excluded package is never selected, built, linked or executed, whereas a filter expression still leaves nextest executing the binary during the list phase — which is exactly where the abort happens. There is no pre-merge Windows signal available to catch a wrong guess here.
- New `Build librefang-desktop test targets (link-only)` step runs `cargo test -p librefang-desktop --all-targets --no-run`, restoring the compile+link coverage that `--exclude` removes. This is the only Windows build of the crate anywhere in CI (`release-desktop.yml` is `workflow_dispatch`-only, `mobile-smoke.yml` is ubuntu/macOS), so without it a Windows-only break in the crate would reach a release tag unseen. `--no-run` rather than `cargo check` because only the former exercises the link step. It is a **separate step**, not a trailing line inside `Run tests`: `shell: bash` runs with `-e`, so appended after the nextest call it would be skipped on exactly the red days it exists for. `if: ${{ !cancelled() }}` and its own `OPENSSL_SRC_PERL` (the crate pulls `librefang-api`, which is what triggers the Windows vendored-OpenSSL build).
- Three comments that asserted the opposite of the code are corrected: `librefang-desktop` is not a binary-only crate and is not a crate without tests. It has a lib target with 11 tests in `crates/librefang-desktop/src/lib.rs` — 7 `validate_server_url` cases including the `userinfo_loopback_bypass_rejected` security case, plus 4 in `#[cfg(desktop)] mod new_window_requests`.

**`.github/workflows/main-build-alert.yml`**

- The `success` branch now enumerates the run's jobs and only auto-closes when at least one `Test / (Windows|macOS|Ubuntu|Unit)` job actually concluded `success`. Otherwise it logs via `core.info` and leaves the issue open. If the jobs API call throws, it also leaves the issue open — a false close hides a real breakage, a false open costs one glance.
- No comment is posted in the skipped-lane case. A comment would fire on every docs/deps push (two of them landed nine seconds apart in the run list above), which the repo's own "at most two follow-up comments without human input" rule rules out. Not closing *is* the fix; the log line is for whoever reads the workflow run.
- The `failure` branch stops asserting that the head commit caused the failure. `prNumber`, `commitAuthor` and the `listPullRequestsAssociatedWithCommit` fallback are removed — they existed only to feed `Either land a fix or revert PR #N`, which three times told readers to revert an unrelated openrouter-snapshot PR (#6715, #6720, #6727) for a breakage introduced days earlier by db81fe79. The issue now names the commit and the run URL, says explicitly that this is the state of `main` at that commit rather than a claim about its cause, and points at the failing job's log. The subject's trailing `(#NNNN)` is stripped so the issue no longer back-links itself onto an innocent PR's timeline.
- `context.payload.workflow_run.id` is hoisted to a `runId` const shared by both branches.

**`CLAUDE.md`** — the CI test lanes section repeated the same two wrong facts (`librefang-desktop` listed as binary-only; Windows described as a single job when it is 2-way sharded) and now documents the `--exclude` workaround so the next agent does not "fix" it back.

## Verification

Run in this worktree on macOS (aarch64). Real output, summarised:

- **`actionlint .github/workflows/ci.yml .github/workflows/main-build-alert.yml`** — 10 shellcheck `info` findings, all `SC2086`/`SC2016` on untouched `run:` blocks. Diffed against `actionlint` on the same two files at `origin/main`: **identical, no new findings**. (actionlint is not run by any CI job in this repo; those 10 are the pre-existing baseline.)
- **`node --check` on the extracted `github-script` body** — OK (186 lines).
- **Behavioural replay of the new alert logic against real GitHub job lists.** The script body was extracted and executed with stubbed `github`/`context`/`core` against `gh api .../jobs` output from actual runs:
  - run 31149565632 (docs-only, the one that closed #6729), one open `main-red` issue → `core.info(... no Rust test lane ran ... leaving open)`, **no close** (previously: comment + close).
  - run 30891430890 (Rust lanes green), one open issue → comment + `close`, unchanged.
  - docs-only + no open issue → no API calls at all.
  - run 31096230292 (the real red run) → files `[main red] CI failure on 41def18` with the 3 failed jobs and their failing steps, no PR number and no author anywhere in title or body.
  - Surveyed the last 16 green `main` CI runs: **9 had zero successful Rust test lanes** and would no longer auto-close; 7 had 8 successful lanes and still would. The bug fires on more than half of green main runs.
- **`cargo nextest run --help`** (nextest 0.9.143) — `--exclude <EXCLUDE>  Exclude packages from the test`. Flag exists on `nextest run`.
- **`--exclude` reaches cargo's package resolver**, proven by a typo probe with an isolated `CARGO_TARGET_DIR`: `--exclude librefang-desktop-typo` emits `warning: excluded package(s) 'librefang-desktop-typo' not found in workspace`, while `--exclude librefang-desktop` emits no such warning — i.e. the real name resolves to a workspace member and is excluded, rather than being swallowed by nextest.
- **`librefang-desktop` is a leaf**: `grep -n librefang-desktop crates/*/Cargo.toml Cargo.toml` matches only the workspace member list and one unrelated comment in `librefang-api/Cargo.toml`. Nothing depends on it, so excluding it from the selected set means it is never built as a dependency either. This step is **argued from the dependency graph, not executed** — running `cargo nextest list --workspace --exclude librefang-desktop` to observe it directly is a full workspace test-binary build, which is the unscoped workspace form this repo forbids.
- **`grep -ln tauri crates/*/Cargo.toml`** → `crates/librefang-desktop/Cargo.toml` only. No second Tauri-linked test binary can abort the same way, so excluding this one package is a complete unblock rather than the first of several.
- **`cargo test -p librefang-desktop --all-targets --no-run`** (the new CI step's exact command) — **passes**, exit 0, `Finished \`test\` profile [unoptimized + debuginfo] target(s) in 24m 36s`, producing `Executable unittests src/lib.rs` and `Executable unittests src/main.rs`. macOS, so this proves the command is well-formed and selects the two intended targets; it does not prove MSVC linking (see below).
- **`cargo check --workspace --lib`** — clean, `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 15m 09s`.
- **`cargo clippy --workspace --all-targets -- -D warnings`** — clean, `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 25m 27s`. With `-D warnings` a `Finished` line *is* the zero-warning result: **0 warnings**.
- **No scoped `cargo test -p <crate>` run.** This PR contains no `.rs` changes at all — the diff is two workflow files, `CLAUDE.md` and a changelog fragment — so no crate's behaviour changed and there is nothing for a scoped test run to distinguish from `origin/main`. The check and clippy runs above are included as a guard against having accidentally touched Rust, not as evidence about behaviour.

### What could NOT be verified

**The Windows lane itself gets no pre-merge signal.** `ci.yml` triggers on `push: [main]`, `pull_request: [main]` and `merge_group`; `gh run list --workflow ci.yml --event merge_group` returns `[]`, so the merge queue is unused and `test-windows` is gated on `github.event_name == 'push' || 'merge_group'`. This PR's own CI run will therefore not execute the lane it fixes. There is no Windows host or Windows-capable container available here, and the repo's Docker dev image is Linux-only. The real signal is this PR's merge commit on `main` — which will fire the lane, since the `changes` gate sets `ci=true` for any `.github/workflows/**` diff.

**The macOS link check does not prove the Windows link check.** `cargo test -p librefang-desktop --all-targets --no-run` passing here proves the command is well-formed and selects the intended targets; it says nothing about MSVC linking. The Windows log already shows the crate compiling and linking successfully there (`librefang-desktop (lib test) generated 1 warning`, then the abort at *load*), so the new step is expected to pass — but that is inference from the failing run's log, not an executed Windows build.

**Root cause is not fixed.** The missing DLL export behind `0xc0000139` is still unidentified. This restores the lane's signal for the other 23 crates; it does not restore Windows *execution* of `librefang-desktop`'s tests. Those 11 tests are platform-independent URL/scheme logic and still run on the Ubuntu shards, the unit-fast lane and macOS, so the security case (`userinfo_loopback_bypass_rejected`) keeps coverage. The `ci.yml` comment and the `CLAUDE.md` section both say to drop the exclusion once the export is identified.

Closes #6734
Closes #6729
Refs #6716 #6721 #6711

#6734 is the fourth and currently **open** filing of this one defect — the alert opened it at 05:41Z blaming #6718, then commented on it twice more blaming #6725 and #6717, all three of them unrelated. It is the issue a reader would actually find, so it is closed here alongside the #6729 the fix was scoped against.

#6716, #6721 and #6729 are already closed — falsely, by the auto-close bug this PR fixes — and are deliberately left alone rather than reopened. They are duplicate filings of one breakage, not separate work; reopening three issues to close them again is noise.

Nice property of the fix: if #6734 is still open when this merges, the first green `main` run *with Rust lanes* will close it through the very logic added here, and a docs-only green run will not.
