### PR TITLE
feat(runtime): make agent_send non-blocking by default when a caller is known

### DIFF
--- a/changelog.d/changed/6740-agent-send-async-default.md
+++ b/changelog.d/changed/6740-agent-send-async-default.md
@@ -2,4 +2,4 @@
   The previous blocking default required the model to predict in advance that a delegation would be slow and opt in to `"async": true`; a wrong guess spent the entire turn waiting for `tool_timeout_secs`.
   An unnecessary `task_id` costs one extra turn to collect, whereas an unnecessary block can lose the turn outright.
   Pass `"async": false` for a quick sub-question whose answer is needed within the same turn.
-  Callerless system-initiated sends keep dispatching synchronously, because the async tracker has no session to route a completion back to. (#6740) (@houko)
+  Callerless system-initiated sends keep dispatching synchronously, because the async tracker requires a known caller agent to route a completion back to. (#6740) (@houko)

--- a/changelog.d/changed/6740-agent-send-async-default.md
+++ b/changelog.d/changed/6740-agent-send-async-default.md
@@ -1,0 +1,5 @@
+`agent_send` now delegates non-blockingly by default when the calling agent is known, returning a `task_id` whose reply is delivered to the caller's session on completion.
+  The previous blocking default required the model to predict in advance that a delegation would be slow and opt in to `"async": true`; a wrong guess spent the entire turn waiting for `tool_timeout_secs`.
+  An unnecessary `task_id` costs one extra turn to collect, whereas an unnecessary block can lose the turn outright.
+  Pass `"async": false` for a quick sub-question whose answer is needed within the same turn.
+  Callerless system-initiated sends keep dispatching synchronously, because the async tracker has no session to route a completion back to. (#6740) (@houko)

--- a/crates/librefang-runtime/src/tool_runner/agent.rs
+++ b/crates/librefang-runtime/src/tool_runner/agent.rs
@@ -58,7 +58,7 @@ pub(super) async fn tool_agent_send(
     // blocking this agent's loop until the callee replies (which otherwise
     // trips `tool_timeout_secs` for any long delegation).
     //
-    // Non-blocking is the DEFAULT when a caller agent is known, because the blocking default made every unannotated delegation a timeout risk: the model had to predict that the callee would be slow and opt out in advance, and a wrong guess burned the turn on `tool_timeout_secs`.
+    // Non-blocking is the DEFAULT when a caller agent is known, because the blocking default made every unannotated delegation a timeout risk: the model had to predict that the callee would be slow and opt in to async in advance, and a wrong guess burned the turn on `tool_timeout_secs`.
     //
     // The default is deliberately conditional on `caller_agent_id` rather than an unconditional `true`.
     // The async path below requires a known caller so the tracker can route the completion back, and rejects the call outright without one; the blocking path has explicit `(None, _)` arms for system-initiated sends.

--- a/crates/librefang-runtime/src/tool_runner/agent.rs
+++ b/crates/librefang-runtime/src/tool_runner/agent.rs
@@ -57,7 +57,24 @@ pub(super) async fn tool_agent_send(
     // kernel async-task tracker and return a task id immediately instead of
     // blocking this agent's loop until the callee replies (which otherwise
     // trips `tool_timeout_secs` for any long delegation).
-    let async_mode = input["async"].as_bool().unwrap_or(false);
+    //
+    // Non-blocking is the DEFAULT when a caller agent is known, because the
+    // blocking default made every unannotated delegation a timeout risk: the
+    // model had to predict that the callee would be slow and opt out in
+    // advance, and a wrong guess burned the turn on `tool_timeout_secs`.
+    //
+    // The default is deliberately conditional on `caller_agent_id` rather than
+    // an unconditional `true`. The async path below requires a known caller so
+    // the tracker can route the completion back, and rejects the call outright
+    // without one; the blocking path has explicit `(None, _)` arms for
+    // system-initiated sends. An unconditional default would therefore turn
+    // every callerless send — the kernel's own system-initiated dispatches —
+    // into an `InvalidParameter` error. An explicit `"async": true` still
+    // errors without a caller, which is the pre-existing contract and is left
+    // untouched.
+    let async_mode = input["async"]
+        .as_bool()
+        .unwrap_or_else(|| caller_agent_id.is_some());
 
     if let Some(caller) = caller_agent_id {
         if caller == agent_id {

--- a/crates/librefang-runtime/src/tool_runner/agent.rs
+++ b/crates/librefang-runtime/src/tool_runner/agent.rs
@@ -58,20 +58,12 @@ pub(super) async fn tool_agent_send(
     // blocking this agent's loop until the callee replies (which otherwise
     // trips `tool_timeout_secs` for any long delegation).
     //
-    // Non-blocking is the DEFAULT when a caller agent is known, because the
-    // blocking default made every unannotated delegation a timeout risk: the
-    // model had to predict that the callee would be slow and opt out in
-    // advance, and a wrong guess burned the turn on `tool_timeout_secs`.
+    // Non-blocking is the DEFAULT when a caller agent is known, because the blocking default made every unannotated delegation a timeout risk: the model had to predict that the callee would be slow and opt out in advance, and a wrong guess burned the turn on `tool_timeout_secs`.
     //
-    // The default is deliberately conditional on `caller_agent_id` rather than
-    // an unconditional `true`. The async path below requires a known caller so
-    // the tracker can route the completion back, and rejects the call outright
-    // without one; the blocking path has explicit `(None, _)` arms for
-    // system-initiated sends. An unconditional default would therefore turn
-    // every callerless send — the kernel's own system-initiated dispatches —
-    // into an `InvalidParameter` error. An explicit `"async": true` still
-    // errors without a caller, which is the pre-existing contract and is left
-    // untouched.
+    // The default is deliberately conditional on `caller_agent_id` rather than an unconditional `true`.
+    // The async path below requires a known caller so the tracker can route the completion back, and rejects the call outright without one; the blocking path has explicit `(None, _)` arms for system-initiated sends.
+    // An unconditional default would therefore turn every callerless send — the kernel's own system-initiated dispatches — into an `InvalidParameter` error.
+    // An explicit `"async": true` still errors without a caller, which is the pre-existing contract and is left untouched.
     let async_mode = input["async"]
         .as_bool()
         .unwrap_or_else(|| caller_agent_id.is_some());

--- a/crates/librefang-runtime/src/tool_runner/definitions.rs
+++ b/crates/librefang-runtime/src/tool_runner/definitions.rs
@@ -320,7 +320,7 @@ use instead of web_fetch + file_write (which round-trips the entire body through
             },
             ToolDefinition {
                 name: tool_name::AGENT_SEND.to_string(),
-                description: "Send a message to another agent. By default this BLOCKS until the agent replies and returns their response — only use the blocking mode for quick sub-questions whose answer you need within this turn. For any delegation that may take a while (research, multi-step work), set \"async\": true so you are not blocked and don't hit the tool timeout. Accepts UUID or agent name. Use agent_find first to discover agents.".to_string(),
+                description: "Send a message to another agent. By default this is NON-BLOCKING: you get back a task_id immediately and the target's reply is delivered to your session when it finishes, so a long delegation cannot burn your turn on the tool timeout. Set \"async\": false for a quick sub-question whose answer you need within this same turn — that blocks until the agent replies and returns their response directly. Accepts UUID or agent name. Use agent_find first to discover agents.".to_string(),
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -332,7 +332,7 @@ use instead of web_fetch + file_write (which round-trips the entire body through
                         },
                         "async": {
                             "type": "boolean",
-                            "description": "When true, requests non-blocking delegation. On success you get back a task_id and the target agent's response is delivered to your session automatically when it finishes, so you can continue or end your turn. Async tracking needs a live caller session: on surfaces that have none (the MCP HTTP bridge, the REST tool endpoint) the delegation runs inline and you get the target's reply itself rather than a task_id — read what you receive rather than assuming a task is pending. Use this for any delegation that might take longer than a few seconds (it avoids the tool-execution timeout). Defaults to false (blocking)."
+                            "description": "Controls blocking. Omit it to get the default non-blocking delegation: you receive a task_id and the target agent's response is delivered to your session automatically when it finishes, so you can continue or end your turn. Set it to false to block until the target replies and get their response directly — appropriate only for a quick sub-question you need answered inside this turn. Async tracking needs a live caller session: on surfaces that have none (the MCP HTTP bridge, the REST tool endpoint) the delegation runs inline and you get the target's reply itself rather than a task_id — read what you receive rather than assuming a task is pending."
                         }
                     },
                     "required": ["agent_id", "message"]

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -1161,10 +1161,8 @@ async fn agent_send_no_key_no_caller_routes_to_send_to_agent() {
 async fn agent_send_no_key_with_caller_routes_to_send_to_agent_as() {
     let cap = Arc::new(DispatchCapture::default());
     let kernel: Arc<dyn KernelHandle> = cap.clone();
-    // `"async": false` is explicit because non-blocking is now the default when
-    // a caller is known. This test covers the blocking path's caller-aware
-    // routing, which still exists and is still reachable — see
-    // `agent_send_defaults_to_async_when_caller_is_known` for the new default.
+    // `"async": false` is explicit because non-blocking is now the default when a caller is known.
+    // This test covers the blocking path's caller-aware routing, which still exists and is still reachable — see `agent_send_defaults_to_async_when_caller_is_known` for the new default.
     let input = serde_json::json!({ "agent_id": "target", "message": "hi", "async": false });
 
     let result =
@@ -1183,8 +1181,7 @@ async fn agent_send_no_key_with_caller_routes_to_send_to_agent_as() {
 async fn agent_send_same_key_routes_to_as_with_key_both_calls() {
     let cap = Arc::new(DispatchCapture::default());
     let kernel: Arc<dyn KernelHandle> = cap.clone();
-    // `"async": false` throughout: this test pins the keyed BLOCKING dispatch,
-    // which non-blocking delegation does not go through.
+    // `"async": false` throughout: this test pins the keyed BLOCKING dispatch, which non-blocking delegation does not go through.
     let input = serde_json::json!({
         "agent_id": "target",
         "message": "turn one",
@@ -1224,8 +1221,7 @@ async fn agent_send_distinct_keys_produce_isolated_dispatch() {
     let call = |key: &'static str| {
         let kernel = kernel.clone();
         async move {
-            // `"async": false`: distinct-key isolation is a property of the
-            // blocking keyed dispatch.
+            // `"async": false`: distinct-key isolation is a property of the blocking keyed dispatch.
             let input = serde_json::json!({
                 "agent_id": "target",
                 "message": "msg",
@@ -1330,7 +1326,8 @@ async fn agent_send_defaults_to_async_when_caller_is_known() {
 /// Omitting `async` WITHOUT a caller agent still dispatches blocking, because the async path cannot serve a callerless send at all.
 ///
 /// `tool_agent_send` rejects `async` with `InvalidParameter` when `caller_agent_id` is `None` — the tracker has nowhere to route the completion — while the blocking path has explicit `(None, Some(key))` and `(None, None)` arms for system-initiated sends.
-/// So an unconditional non-blocking default would convert every kernel-initiated `agent_send` into an error. This test is the guard against "simplifying" the conditional default into `unwrap_or(true)`.
+/// So an unconditional non-blocking default would convert every kernel-initiated `agent_send` into an error.
+/// This test is the guard against "simplifying" the conditional default into `unwrap_or(true)`.
 #[tokio::test]
 async fn agent_send_without_caller_still_defaults_to_blocking() {
     let cap = Arc::new(DispatchCapture::default());

--- a/crates/librefang-runtime/src/tool_runner/tests/mod.rs
+++ b/crates/librefang-runtime/src/tool_runner/tests/mod.rs
@@ -1161,7 +1161,11 @@ async fn agent_send_no_key_no_caller_routes_to_send_to_agent() {
 async fn agent_send_no_key_with_caller_routes_to_send_to_agent_as() {
     let cap = Arc::new(DispatchCapture::default());
     let kernel: Arc<dyn KernelHandle> = cap.clone();
-    let input = serde_json::json!({ "agent_id": "target", "message": "hi" });
+    // `"async": false` is explicit because non-blocking is now the default when
+    // a caller is known. This test covers the blocking path's caller-aware
+    // routing, which still exists and is still reachable — see
+    // `agent_send_defaults_to_async_when_caller_is_known` for the new default.
+    let input = serde_json::json!({ "agent_id": "target", "message": "hi", "async": false });
 
     let result =
         super::agent::tool_agent_send(&input, Some(&kernel), Some("parent-agent"), None, None)
@@ -1179,10 +1183,13 @@ async fn agent_send_no_key_with_caller_routes_to_send_to_agent_as() {
 async fn agent_send_same_key_routes_to_as_with_key_both_calls() {
     let cap = Arc::new(DispatchCapture::default());
     let kernel: Arc<dyn KernelHandle> = cap.clone();
+    // `"async": false` throughout: this test pins the keyed BLOCKING dispatch,
+    // which non-blocking delegation does not go through.
     let input = serde_json::json!({
         "agent_id": "target",
         "message": "turn one",
         "conversation_key": "thread-abc",
+        "async": false,
     });
 
     super::agent::tool_agent_send(&input, Some(&kernel), Some("parent-agent"), None, None)
@@ -1193,6 +1200,7 @@ async fn agent_send_same_key_routes_to_as_with_key_both_calls() {
         "agent_id": "target",
         "message": "turn two",
         "conversation_key": "thread-abc",
+        "async": false,
     });
     super::agent::tool_agent_send(&input2, Some(&kernel), Some("parent-agent"), None, None)
         .await
@@ -1216,10 +1224,13 @@ async fn agent_send_distinct_keys_produce_isolated_dispatch() {
     let call = |key: &'static str| {
         let kernel = kernel.clone();
         async move {
+            // `"async": false`: distinct-key isolation is a property of the
+            // blocking keyed dispatch.
             let input = serde_json::json!({
                 "agent_id": "target",
                 "message": "msg",
                 "conversation_key": key,
+                "async": false,
             });
             super::agent::tool_agent_send(&input, Some(&kernel), Some("parent-agent"), None, None)
                 .await
@@ -1275,6 +1286,68 @@ async fn agent_send_async_routes_to_tracked_path_and_returns_task_id() {
         &[format!("async_tracked:session={}", session.0)],
         "async=true must hit the tracker path and forward the caller session, \
          not the blocking send_to_agent_as"
+    );
+}
+
+/// Omitting `async` delegates non-blockingly when a caller agent is known.
+///
+/// The blocking default made every unannotated delegation a timeout risk: the model had to predict in advance that the callee would be slow and opt in to `async`, and a wrong guess spent the turn waiting until `tool_timeout_secs` fired.
+/// Non-blocking is the safe default because an unnecessary `task_id` costs one extra turn to collect, while an unnecessary block can lose the turn entirely.
+#[tokio::test]
+async fn agent_send_defaults_to_async_when_caller_is_known() {
+    use librefang_types::agent::SessionId;
+
+    let cap = Arc::new(DispatchCapture::default());
+    let kernel: Arc<dyn KernelHandle> = cap.clone();
+    // No "async" key at all — this is what a model emits when it does not think
+    // about blocking, which is the common case.
+    let input = serde_json::json!({ "agent_id": "target", "message": "research this" });
+    let session = SessionId(uuid::Uuid::new_v4());
+
+    let out = super::agent::tool_agent_send(
+        &input,
+        Some(&kernel),
+        Some("parent-agent"),
+        Some(session),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["status"], "delegated");
+    assert_eq!(v["task_id"], "task-fake-1234");
+
+    let calls = cap.calls.lock().unwrap();
+    assert_eq!(
+        &*calls,
+        &[format!("async_tracked:session={}", session.0)],
+        "an omitted async flag with a known caller must take the tracker path, \
+         not the blocking send_to_agent_as"
+    );
+}
+
+/// Omitting `async` WITHOUT a caller agent still dispatches blocking, because the async path cannot serve a callerless send at all.
+///
+/// `tool_agent_send` rejects `async` with `InvalidParameter` when `caller_agent_id` is `None` — the tracker has nowhere to route the completion — while the blocking path has explicit `(None, Some(key))` and `(None, None)` arms for system-initiated sends.
+/// So an unconditional non-blocking default would convert every kernel-initiated `agent_send` into an error. This test is the guard against "simplifying" the conditional default into `unwrap_or(true)`.
+#[tokio::test]
+async fn agent_send_without_caller_still_defaults_to_blocking() {
+    let cap = Arc::new(DispatchCapture::default());
+    let kernel: Arc<dyn KernelHandle> = cap.clone();
+    let input = serde_json::json!({ "agent_id": "target", "message": "system notice" });
+
+    // caller_agent_id = None: a system-initiated send.
+    let out = super::agent::tool_agent_send(&input, Some(&kernel), None, None, None)
+        .await
+        .expect("a callerless send must not be rejected as an invalid async request");
+
+    assert_eq!(out, "no-key-no-parent");
+    let calls = cap.calls.lock().unwrap();
+    assert_eq!(
+        &*calls,
+        &["send_to_agent"],
+        "without a caller the tool must stay on the blocking path"
     );
 }
 

--- a/docs/src/app/agent/tools/page.mdx
+++ b/docs/src/app/agent/tools/page.mdx
@@ -36,7 +36,7 @@ For talking to other agents **inside the same LibreFang daemon** (no A2A protoco
 
 | Tool | Arguments | Purpose |
 |---|---|---|
-| `agent_send` | `agent_id`, `message` | Send a message to another agent in this daemon and wait for the reply. Uses the in-process kernel router; respects the agent_call depth limit. |
+| `agent_send` | `agent_id`, `message`, optional `async` | Send a message to another agent in this daemon. Non-blocking by default: returns a `task_id` and the reply is delivered to the caller's session on completion. Pass `async: false` to block and get the reply directly. Uses the in-process kernel router; respects the agent_call depth limit. |
 | `agent_spawn` | `template`, optional `name`, `goal` | Spawn a child agent from a template. Returns the new `agent_id`. Sub-agents are denied `agent_spawn` and `agent_kill` by default to prevent fork bombs. |
 | `agent_list` | — | List accessible agents (id, name, status). |
 | `agent_find` | `query` | Search agents by name, ID, or tag. |

--- a/docs/src/app/zh/agent/tools/page.mdx
+++ b/docs/src/app/zh/agent/tools/page.mdx
@@ -36,7 +36,7 @@ Lazy loading 在 manifest 用 `lazy_tools = true` 按 agent 开启。关掉则�
 
 | 工具 | 参数 | 用途 |
 |---|---|---|
-| `agent_send` | `agent_id`、`message` | 给本 daemon 内别的 agent 发消息并等回复。走进程内 kernel 路由器;受 agent_call 深度上限约束。 |
+| `agent_send` | `agent_id`、`message`、可选 `async` | 给本 daemon 内别的 agent 发消息。默认非阻塞:立即返回 `task_id`,对方回复完成后投递到调用方 session。传 `async: false` 则阻塞并直接拿到回复。走进程内 kernel 路由器;受 agent_call 深度上限约束。 |
 | `agent_spawn` | `template`、可选 `name`、`goal` | 从模板 spawn 子 agent。返回新的 `agent_id`。子 agent 默认禁 `agent_spawn` 和 `agent_kill` 防止 fork 炸弹。 |
 | `agent_list` | — | 列出可访问 agent(id、name、status)。 |
 | `agent_find` | `query` | 按名字、ID 或 tag 搜 agent。 |


### PR DESCRIPTION
## Why

`agent_send` defaulted to blocking, which made every unannotated delegation a timeout risk. The model had to predict *in advance* that the callee would be slow and opt in to `"async": true`, and a wrong guess spent the whole turn waiting until `tool_timeout_secs` fired. The asymmetry runs one way: an unnecessary `task_id` costs one extra turn to collect, while an unnecessary block can lose the turn entirely.

This was requested as its own PR on 2026-07-19. It is also the shared root of the red `Test / Unit (lib+bin)` lane on both #6504 and #6505 — both carry the same one-line flip against four untouched test expectations. Landing it here lets both rebase and drop it, taking #6504 from four red checks to two.

## The flip is conditional, deliberately

The obvious change is `unwrap_or(false)` → `unwrap_or(true)` at `crates/librefang-runtime/src/tool_runner/agent.rs:60`. That is wrong, and it is what both contributor branches do.

The async path requires a known caller — `caller_agent_id.ok_or(ToolError::InvalidParameter { name: "async", … })` at `agent.rs:110-113` — because the tracker has nowhere to route the completion without one. The blocking path, by contrast, has explicit arms for callerless sends: `(None, Some(key))` and `(None, None)` at `agent.rs:154-160`, with a comment stating that system-initiated calls fall back to the legacy path.

So an unconditional `true` converts **every callerless `agent_send` into an `InvalidParameter` error** — including the kernel's own system-initiated dispatches. The existing test `agent_send_async_without_caller_is_invalid_parameter` already pins that error for the explicit case, which is direct evidence the unconditional form breaks the callerless one.

The default is therefore `unwrap_or_else(|| caller_agent_id.is_some())`:

| `"async"` | caller | behaviour | changed? |
| --- | --- | --- | --- |
| omitted | known | non-blocking, returns `task_id` | **yes — this is the fix** |
| omitted | none | blocking | no |
| `false` | any | blocking | no |
| `true` | known | non-blocking | no |
| `true` | none | `InvalidParameter` | no (pre-existing contract) |

## Changes

**`crates/librefang-runtime/src/tool_runner/agent.rs`** — the conditional default, with a comment recording why it is not unconditional so the next reader does not "simplify" it.

**`crates/librefang-runtime/src/tool_runner/definitions.rs`** — the tool description said "By default this BLOCKS" and the `async` property said "Defaults to false (blocking)". Both now describe the non-blocking default and tell the model to pass `"async": false` for a quick sub-question it needs answered inside the turn. This is what the LLM actually reads, so leaving it stale would be the whole bug in a different place.

**`crates/librefang-runtime/src/tool_runner/tests/mod.rs`**

Three tests that cover caller-aware and keyed *blocking* routing now pass `"async": false` explicitly, rather than having their expectations bumped to the tracker path:

- `agent_send_no_key_with_caller_routes_to_send_to_agent_as`
- `agent_send_same_key_routes_to_as_with_key_both_calls`
- `agent_send_distinct_keys_produce_isolated_dispatch`

Bumping them instead would have deleted the only coverage of `send_to_agent_as` / `send_to_agent_as_with_key` — dispatch arms that still exist and are still reachable via `"async": false`. Moving a test's expectation to the new behaviour is not the same as keeping the old behaviour tested.

`agent_send_no_key_no_caller_routes_to_send_to_agent` is untouched: with no caller the default is still blocking, so its expectation is correct as written.

Two new tests:

- `agent_send_defaults_to_async_when_caller_is_known` — no `"async"` key at all (what a model emits when it does not think about blocking) with a caller and session must reach `async_tracked` and return a `task_id`.
- `agent_send_without_caller_still_defaults_to_blocking` — the guard against collapsing the conditional into `unwrap_or(true)`. A callerless send must stay on `send_to_agent` and must not be rejected.

**`docs/src/app/agent/tools/page.mdx`** and its `zh/` mirror — the tools table said `agent_send` "and wait for the reply" / 「并等回复」, which is no longer true. Both now state the non-blocking default and the `async: false` opt-out.

## Verification

Run natively on macOS aarch64 in the worktree, based on `origin/main` at c403439a.

- **`cargo test -p librefang-runtime --lib tool_runner::tests::agent_send`** — 10 passed, 0 failed. Includes both new tests and the three modified ones, plus the pre-existing `agent_send_async_without_caller_is_invalid_parameter` and `agent_send_async_without_session_returns_the_reply_not_a_fake_task_id_6650`, which still pass unchanged.
- **`cargo check --workspace --lib`** — clean, `Finished` in 8m 34s.
- **`cargo clippy --workspace --all-targets -- -D warnings`** — exit code **0**, captured explicitly rather than inferred from the `Finished` line.
- **`cargo test -p librefang-runtime --lib`** (full crate) — 2175 passed, 0 failed, 2 ignored. See the flake note below.
- **Breadth scan** for other dependencies on the blocking default: `grep` for `tool_agent_send` across `crates/` finds only the definition, the `dispatch.rs:964` call site (which threads `caller_agent_id` through unchanged) and comment references in `librefang-kernel`. No copy of the old `"Defaults to false (blocking)"` string survives anywhere in the tree. No JSON schema fixture or SDK snapshot carries the `agent_send` tool description.

### Unrelated flake observed, not fixed here

Across four full-crate runs, one test failed twice:

```
---- plugin_runtime::tests::overflow_kills_child_without_waiting_for_timeout stdout ----
panicked at crates/librefang-runtime/src/plugin_runtime/tests.rs:412:5:
kill took 5.670414042s, expected <5s (timeout was 30s) — child likely deadlocked
```

It is a wall-clock assertion with a hard 5s threshold, and it failed on the runs that followed a full `clippy --all-targets` compile — i.e. under machine load, not because the child deadlocked. Runs 1 and 2 of a back-to-back set of three passed; run 3 failed. It is in `plugin_runtime`, touches nothing in this diff, and is a pre-existing condition on `main`.

Not fixed here because it is a different module from the one this PR changes and it deserves its own change (condition polling instead of a load-sensitive deadline) rather than riding along inside a semantics change. Flagging it rather than staying quiet: it will randomly red other PRs.

### Behaviour change reviewers should weigh

Every agent that calls `agent_send` without specifying `async` now gets a `task_id` instead of the callee's reply, and must collect the reply from its session on a later turn instead of using it inside the same turn. Prompts or skills that assume the reply arrives inline will need `"async": false`. The tool description now says so, so a model reading the current schema will adapt; anything hardcoding the old assumption will not.

Refs #6504 #6505
