### PR TITLE
fix(sidecar): drive the Slack receipt reaction off the turn lifecycle and stop the formatting overflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       crates: ${{ steps.diff.outputs.crates }}
       skill_sdk: ${{ steps.diff.outputs.skill_sdk }}
       sidecar_rust: ${{ steps.diff.outputs.sidecar_rust }}
+      sdk_python: ${{ steps.diff.outputs.sdk_python }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -79,6 +80,7 @@ jobs:
               echo "rust=true"; echo "docs=true"; echo "ci=true"; echo "install=true"
               echo "full_run=true"; echo "full_test=true"
               echo "skill_sdk=true"; echo "sidecar_rust=true"
+              echo "sdk_python=true"
               echo "crates="
             } >> "$GITHUB_OUTPUT"
             echo "merge_group: forcing full run on all platforms"
@@ -126,6 +128,12 @@ jobs:
           # pipeline relies on, catching cross / sibling-path-dep breakage at
           # PR time. See #5936.
           SIDECAR_RUST=false; has '^(sdk/rust/librefang-sidecar/|sdk/rust/librefang-sidecar-telegram/|\.github/workflows/release(-cli)?\.yml$)' && SIDECAR_RUST=true
+          # The Python SDK carries the sidecar channel adapters (slack, discord,
+          # telegram, …) and ~1900 pytest cases that no lane ran before #6738.
+          # `sdk/` is folded into RUST above only as an openapi/codegen drift
+          # guard — that lane runs cargo, never pytest — so a Python-only
+          # regression shipped green. Route `sdk/python/**` to its own job.
+          SDK_PYTHON=false; has '^sdk/python/' && SDK_PYTHON=true
           # Workspace-level Cargo manifest ≠ xtask source. A workspace
           # `Cargo.toml` change can shift dep versions, profile flags,
           # workspace lints, or membership — anything in the tree may
@@ -185,6 +193,7 @@ jobs:
             echo "full_test=$FULL_TEST"
             echo "skill_sdk=$SKILL_SDK"
             echo "sidecar_rust=$SIDECAR_RUST"
+            echo "sdk_python=$SDK_PYTHON"
           } >> "$GITHUB_OUTPUT"
           echo "Route: full_run=$FULL ($REASON), full_test=$FULL_TEST ($TREASON)"
 
@@ -406,6 +415,41 @@ jobs:
         # Mirrors the release pipeline's cross step. Proves `cross` can mount
         # and resolve the out-of-workspace `../librefang-sidecar` path dep.
         run: cross build --release --target aarch64-unknown-linux-musl --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml
+
+  # ── Python SDK + sidecar adapter test suite ────────────────────────────────────
+  # `sdk/python/tests/` holds ~1900 pytest cases covering the HTTP client and every
+  # stdlib-only sidecar channel adapter (slack, discord, telegram, mastodon, …), and
+  # until #6738 no workflow ran a single one of them — `grep -rn pytest .github/workflows/`
+  # came back empty. The adapters are the production code path for every sidecar
+  # channel, so a regression there reached users with CI fully green.
+  # The suite is hermetic (urllib and the WebSocket client are monkeypatched, no
+  # network) and finishes in well under a minute, so it runs on any `sdk/python/**`
+  # change with no path-filter subtlety beyond that one prefix.
+  sdk-python:
+    name: Python SDK Tests
+    needs: changes
+    if: needs.changes.outputs.sdk_python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+      # `pyproject.toml` declares `dependencies = []` with pytest / pytest-asyncio
+      # under `[project.optional-dependencies] dev`, so the editable install with
+      # the `dev` extra is the whole environment. Installing (rather than setting
+      # PYTHONPATH) is what makes `import librefang` resolve — running pytest from
+      # the repo root against an uninstalled tree fails with
+      # `ModuleNotFoundError: No module named 'librefang'`.
+      - name: Install the SDK with dev extras
+        run: python -m pip install -e './sdk/python[dev]'
+      # `working-directory` puts pytest's rootdir on `sdk/python`, so
+      # `[tool.pytest.ini_options]` — and with it `asyncio_mode = "auto"`, which the
+      # async adapter tests need — is picked up without relying on rootdir discovery
+      # walking up from an argument path.
+      - name: pytest
+        working-directory: sdk/python
+        run: python -m pytest tests -q
 
   # ── git-side hook corpus tests ─────────────────────────────────────────────────
   # `scripts/hooks/*` run inside git, so nothing in the Rust or dashboard test suites covers them, and their corpus tests under `scripts/tests/` existed without ever being wired into CI — the same gap #3400 closed for the changelog validator's own unit tests, one directory over.
@@ -1119,6 +1163,7 @@ jobs:
       - quality
       - skills-wasm-sdk
       - rust-telegram-sidecar
+      - sdk-python
       - githook-tests
       - image-vuln-gate
       - changelog-attribution

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,18 +428,11 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
-      # `pyproject.toml` declares `dependencies = []` with pytest / pytest-asyncio
-      # under `[project.optional-dependencies] dev`, so the editable install with
-      # the `dev` extra is the whole environment. Installing (rather than setting
-      # PYTHONPATH) is what makes `import librefang` resolve — running pytest from
-      # the repo root against an uninstalled tree fails with
-      # `ModuleNotFoundError: No module named 'librefang'`.
+      # `pyproject.toml` declares `dependencies = []` with pytest / pytest-asyncio under `[project.optional-dependencies] dev`, so the editable install with the `dev` extra is the whole environment.
+      # Installing (rather than setting PYTHONPATH) is what makes `import librefang` resolve — running pytest from the repo root against an uninstalled tree fails with `ModuleNotFoundError: No module named 'librefang'`.
       - name: Install the SDK with dev extras
         run: python -m pip install -e './sdk/python[dev]'
-      # `working-directory` puts pytest's rootdir on `sdk/python`, so
-      # `[tool.pytest.ini_options]` — and with it `asyncio_mode = "auto"`, which the
-      # async adapter tests need — is picked up without relying on rootdir discovery
-      # walking up from an argument path.
+      # `working-directory` puts pytest's rootdir on `sdk/python`, so `[tool.pytest.ini_options]` — and with it `asyncio_mode = "auto"`, which the async adapter tests need — is picked up without relying on rootdir discovery walking up from an argument path.
       - name: pytest
         working-directory: sdk/python
         run: python -m pytest tests -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,9 @@ jobs:
           # pipeline relies on, catching cross / sibling-path-dep breakage at
           # PR time. See #5936.
           SIDECAR_RUST=false; has '^(sdk/rust/librefang-sidecar/|sdk/rust/librefang-sidecar-telegram/|\.github/workflows/release(-cli)?\.yml$)' && SIDECAR_RUST=true
-          # The Python SDK carries the sidecar channel adapters (slack, discord,
-          # telegram, …) and ~1900 pytest cases that no lane ran before #6741.
-          # `sdk/` is folded into RUST above only as an openapi/codegen drift
-          # guard — that lane runs cargo, never pytest — so a Python-only
-          # regression shipped green. Route `sdk/python/**` to its own job.
+          # The Python SDK carries the sidecar channel adapters (slack, discord, telegram, …) and ~1900 pytest cases that no lane ran before #6741.
+          # `sdk/` is folded into RUST above only as an openapi/codegen drift guard — that lane runs cargo, never pytest — so a Python-only regression shipped green.
+          # Route `sdk/python/**` to its own job.
           SDK_PYTHON=false; has '^sdk/python/' && SDK_PYTHON=true
           # Workspace-level Cargo manifest ≠ xtask source. A workspace
           # `Cargo.toml` change can shift dep versions, profile flags,
@@ -417,14 +415,9 @@ jobs:
         run: cross build --release --target aarch64-unknown-linux-musl --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml
 
   # ── Python SDK + sidecar adapter test suite ────────────────────────────────────
-  # `sdk/python/tests/` holds ~1900 pytest cases covering the HTTP client and every
-  # stdlib-only sidecar channel adapter (slack, discord, telegram, mastodon, …), and
-  # until #6741 no workflow ran a single one of them — `grep -rn pytest .github/workflows/`
-  # came back empty. The adapters are the production code path for every sidecar
-  # channel, so a regression there reached users with CI fully green.
-  # The suite is hermetic (urllib and the WebSocket client are monkeypatched, no
-  # network) and finishes in well under a minute, so it runs on any `sdk/python/**`
-  # change with no path-filter subtlety beyond that one prefix.
+  # `sdk/python/tests/` holds ~1900 pytest cases covering the HTTP client and every stdlib-only sidecar channel adapter (slack, discord, telegram, mastodon, …), and until #6741 no workflow ran a single one of them — `grep -rn pytest .github/workflows/` came back empty.
+  # The adapters are the production code path for every sidecar channel, so a regression there reached users with CI fully green.
+  # The suite is hermetic (urllib and the WebSocket client are monkeypatched, no network) and finishes in well under a minute, so it runs on any `sdk/python/**` change with no path-filter subtlety beyond that one prefix.
   sdk-python:
     name: Python SDK Tests
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           # PR time. See #5936.
           SIDECAR_RUST=false; has '^(sdk/rust/librefang-sidecar/|sdk/rust/librefang-sidecar-telegram/|\.github/workflows/release(-cli)?\.yml$)' && SIDECAR_RUST=true
           # The Python SDK carries the sidecar channel adapters (slack, discord,
-          # telegram, …) and ~1900 pytest cases that no lane ran before #6738.
+          # telegram, …) and ~1900 pytest cases that no lane ran before #6741.
           # `sdk/` is folded into RUST above only as an openapi/codegen drift
           # guard — that lane runs cargo, never pytest — so a Python-only
           # regression shipped green. Route `sdk/python/**` to its own job.
@@ -419,7 +419,7 @@ jobs:
   # ── Python SDK + sidecar adapter test suite ────────────────────────────────────
   # `sdk/python/tests/` holds ~1900 pytest cases covering the HTTP client and every
   # stdlib-only sidecar channel adapter (slack, discord, telegram, mastodon, …), and
-  # until #6738 no workflow ran a single one of them — `grep -rn pytest .github/workflows/`
+  # until #6741 no workflow ran a single one of them — `grep -rn pytest .github/workflows/`
   # came back empty. The adapters are the production code path for every sidecar
   # channel, so a regression there reached users with CI fully green.
   # The suite is hermetic (urllib and the WebSocket client are monkeypatched, no

--- a/changelog.d/added/6741-python-sdk-ci-lane.md
+++ b/changelog.d/added/6741-python-sdk-ci-lane.md
@@ -1,0 +1,4 @@
+Run the Python SDK test suite in CI.
+`sdk/python/tests/` held roughly 1900 pytest cases covering the HTTP client and every stdlib-only sidecar channel adapter — slack, discord, telegram, mastodon and the rest — and no workflow ran a single one of them, so the production code path for every sidecar channel shipped with CI fully green regardless of what broke.
+The `sdk/` prefix was already routed to the Rust lane, but only as an openapi codegen drift guard, which runs cargo and never pytest.
+The new lane installs the package with its `dev` extra and runs the suite on any `sdk/python/**` change, in under a minute (#6741) (@houko)

--- a/changelog.d/changed/6741-slack-progress-card-toggle.md
+++ b/changelog.d/changed/6741-slack-progress-card-toggle.md
@@ -1,0 +1,3 @@
+Split the Slack multi-step task-progress card from the processing-state reactions with a new `SLACK_PROGRESS_CARD` switch.
+The card was gated on `SLACK_REACTIONS`, so the only way to stop the emoji noise was to also lose the step list — the more useful of the two indicators on a long tool-using turn.
+The new switch defaults to whatever `SLACK_REACTIONS` resolves to, so an operator who set `SLACK_REACTIONS=false` for silence keeps exactly that, while `SLACK_REACTIONS=false` with `SLACK_PROGRESS_CARD=true` now gives the card without the reactions and the reverse gives the reactions without the card (#6741) (@houko)

--- a/changelog.d/fixed/6741-slack-message-formatting.md
+++ b/changelog.d/fixed/6741-slack-message-formatting.md
@@ -1,0 +1,5 @@
+Stop two Slack formatting defects that made long replies unreadable or invisible.
+Runs of blank lines now collapse to the single blank line Slack uses as a paragraph separator; the Markdown converter mapped lines one-for-one, so a model that padded its answer turned a short reply into a wall of whitespace.
+The collapse runs while fenced code is masked as a single token, so code interiors keep their own blank lines.
+An interactive Block Kit reply longer than Slack's 3000-character per-section limit is now split across as many sections as it needs instead of being rejected wholesale and dropped with nothing but a log line, and the section count is budgeted against the 50-blocks-per-message cap so the buttons — the functional payload — are never the thing that gets dropped.
+The plain-text path was never affected: its chunker already emitted pieces under the limit (#6741) (@houko)

--- a/changelog.d/fixed/6741-slack-receipt-reaction-leak.md
+++ b/changelog.d/fixed/6741-slack-receipt-reaction-leak.md
@@ -1,0 +1,5 @@
+Stop the Slack adapter leaving a permanent 👀 on messages the daemon never answers.
+The reaction was added the moment the adapter received a message, but `dispatch_message` has roughly two dozen `return` paths above the first adapter-visible lifecycle signal — mention-only group gating, per-user and per-channel rate limits, RBAC, command policy, slash commands the bridge handles itself — and none of them was visible to the adapter, so the mark stayed on a message no agent ever read.
+Both halves of the receipt now ride the turn lifecycle instead: 👀 on the `queued` phase, ✅ on `done`, ❌ on `error`.
+That closes every one of those paths structurally rather than one at a time, gives a failed turn a terminal state it previously never got, and honours the daemon's `clear_done_reaction` knob on Slack for the first time.
+Keying strictly on the triggering message's own id also deletes a "pick the first pending message in this channel" fallback that fired on every in-thread reply — the send hook looked up the thread root while the 👀 was tracked under the message's own timestamp, so the ✅ landed on an unrelated sibling, sometimes one of the leaked marks (#6741) (@houko)

--- a/crates/librefang-channels/tests/bridge_integration_test.rs
+++ b/crates/librefang-channels/tests/bridge_integration_test.rs
@@ -1180,7 +1180,10 @@ struct ReactionRecordingAdapter {
     name: String,
     channel_type: ChannelType,
     rx: Mutex<Option<mpsc::Receiver<ChannelMessage>>>,
-    reactions: Arc<Mutex<Vec<LifecycleReaction>>>,
+    /// Every reaction, paired with the `message_id` it targeted. The id is
+    /// what the Slack sidecar keys its receipt on (#6731), so a test that
+    /// asserts "this message got no reaction" needs it recorded.
+    reactions: Arc<Mutex<Vec<(String, LifecycleReaction)>>>,
     shutdown_tx: watch::Sender<bool>,
 }
 
@@ -1199,7 +1202,23 @@ impl ReactionRecordingAdapter {
     }
 
     fn get_reactions(&self) -> Vec<LifecycleReaction> {
-        self.reactions.lock().unwrap().clone()
+        self.reactions
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(_, r)| r.clone())
+            .collect()
+    }
+
+    /// Phases recorded for one `message_id`, in arrival order.
+    fn phases_for(&self, message_id: &str) -> Vec<AgentPhase> {
+        self.reactions
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(id, _)| id == message_id)
+            .map(|(_, r)| r.phase.clone())
+            .collect()
     }
 }
 
@@ -1235,10 +1254,13 @@ impl ChannelAdapter for ReactionRecordingAdapter {
     async fn send_reaction(
         &self,
         _user: &ChannelUser,
-        _message_id: &str,
+        message_id: &str,
         reaction: &LifecycleReaction,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.reactions.lock().unwrap().push(reaction.clone());
+        self.reactions
+            .lock()
+            .unwrap()
+            .push((message_id.to_string(), reaction.clone()));
         Ok(())
     }
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -1373,6 +1395,206 @@ async fn test_non_streaming_adapter_receives_tool_use_reaction() {
             .any(|r| matches!(&r.phase, AgentPhase::Done))
     })
     .await;
+
+    manager.stop().await;
+}
+
+// ---------------------------------------------------------------------------
+// Group gating emits NO lifecycle reaction (#6731)
+// ---------------------------------------------------------------------------
+//
+// The Slack sidecar's eyes/check receipt keys off the `Queued` lifecycle phase
+// rather than off receiving a message, which is only correct if a message the
+// bridge declines to answer produces no lifecycle signal at all. Mention-only
+// group gating is the path #6731 was reported on: `dispatch_message` returns at
+// the `!should_process_group_message` arm, well before the first
+// `send_lifecycle_reaction(Queued)` call. This test pins that contract so a
+// future refactor that moved the reaction above the gate would resurrect the
+// permanently-stuck eyes on the Slack side.
+
+/// Handle that reports `group_policy = mention_only` as a per-agent override,
+/// the way an `agent.toml` `[channel_overrides]` block does. The trait default
+/// returns `None`, so without this the bridge sees no policy and processes
+/// every group message.
+struct MockMentionOnlyHandle {
+    agents: Mutex<Vec<(AgentId, String)>>,
+}
+
+impl MockMentionOnlyHandle {
+    fn new(agents: Vec<(AgentId, String)>) -> Self {
+        Self {
+            agents: Mutex::new(agents),
+        }
+    }
+}
+
+#[async_trait]
+impl ChannelBridgeHandle for MockMentionOnlyHandle {
+    async fn send_message(&self, _agent_id: AgentId, message: &str) -> Result<String, String> {
+        Ok(format!("Echo: {message}"))
+    }
+
+    async fn find_agent_by_name(&self, name: &str) -> Result<Option<AgentId>, String> {
+        let agents = self.agents.lock().unwrap();
+        Ok(agents.iter().find(|(_, n)| n == name).map(|(id, _)| *id))
+    }
+
+    async fn list_agents(&self) -> Result<Vec<(AgentId, String)>, String> {
+        Ok(self.agents.lock().unwrap().clone())
+    }
+
+    async fn spawn_agent_by_name(&self, _manifest_name: &str) -> Result<AgentId, String> {
+        Err("mock: spawn not implemented".to_string())
+    }
+
+    async fn agent_channel_overrides(&self, _agent_id: AgentId) -> Option<ChannelOverrides> {
+        Some(ChannelOverrides {
+            group_policy: Some(librefang_types::config::GroupPolicy::MentionOnly),
+            ..Default::default()
+        })
+    }
+
+    fn record_consumer_lag(&self, _n: u64, _ctx: &'static str) {}
+}
+
+/// Build a group message with an explicit platform message id, so a test can
+/// tell one message's reactions from another's.
+fn make_group_msg(
+    channel: ChannelType,
+    group_id: &str,
+    message_id: &str,
+    text: &str,
+    was_mentioned: bool,
+) -> ChannelMessage {
+    let mut metadata = HashMap::new();
+    if was_mentioned {
+        metadata.insert("was_mentioned".to_string(), serde_json::json!(true));
+    }
+    ChannelMessage {
+        channel,
+        platform_message_id: message_id.to_string(),
+        sender: ChannelUser {
+            platform_id: group_id.to_string(),
+            display_name: "GroupUser".to_string(),
+            librefang_user: None,
+        },
+        content: ChannelContent::Text(text.to_string()),
+        target_agent: None,
+        timestamp: chrono::Utc::now(),
+        is_group: true,
+        thread_id: None,
+        metadata,
+    }
+}
+
+#[tokio::test]
+async fn test_group_gating_skip_emits_no_lifecycle_reaction_6731() {
+    let agent_id = AgentId::new();
+    let handle: Arc<dyn ChannelBridgeHandle> = Arc::new(MockMentionOnlyHandle::new(vec![(
+        agent_id,
+        "gated".to_string(),
+    )]));
+    let router = Arc::new(AgentRouter::new());
+    // Group messages resolve on `sender.platform_id`, which for a group is the
+    // chat id (see `resolve_or_fallback`'s binding-keys comment).
+    router.set_user_default("G01".to_string(), agent_id);
+
+    let (adapter, tx) = ReactionRecordingAdapter::new("slack-mock", ChannelType::Slack);
+    let adapter_ref = adapter.clone();
+
+    let mut manager = BridgeManager::new(handle.clone(), router);
+    manager.start_adapter(adapter.clone()).await.unwrap();
+
+    // Unaddressed first, then an addressed one. Both are dispatched on the same
+    // serialized adapter stream, so once the addressed message has reached its
+    // terminal phase the unaddressed one has had its full turn to produce a
+    // reaction — no sleeps needed to prove the absence.
+    tx.send(make_group_msg(
+        ChannelType::Slack,
+        "G01",
+        "skip-1",
+        "just chatting among ourselves",
+        false,
+    ))
+    .await
+    .unwrap();
+    tx.send(make_group_msg(
+        ChannelType::Slack,
+        "G01",
+        "pass-1",
+        "hey bot, do the thing",
+        true,
+    ))
+    .await
+    .unwrap();
+
+    // Positive control: the addressed message really did run a turn, so the
+    // harness and the override are both wired correctly.
+    wait_until("done reaction for the addressed message", || {
+        adapter_ref
+            .phases_for("pass-1")
+            .iter()
+            .any(|p| matches!(p, AgentPhase::Done))
+    })
+    .await;
+
+    // The gated-out message never got a lifecycle signal, so the Slack sidecar
+    // never adds an eyes it would have no way to clear.
+    assert!(
+        adapter_ref.phases_for("skip-1").is_empty(),
+        "a mention-only-gated group message must produce no lifecycle reaction, got {:?}",
+        adapter_ref.phases_for("skip-1")
+    );
+
+    manager.stop().await;
+}
+
+#[tokio::test]
+async fn test_group_gating_pass_emits_queued_then_done_6731() {
+    let agent_id = AgentId::new();
+    let handle: Arc<dyn ChannelBridgeHandle> = Arc::new(MockMentionOnlyHandle::new(vec![(
+        agent_id,
+        "gated".to_string(),
+    )]));
+    let router = Arc::new(AgentRouter::new());
+    router.set_user_default("G01".to_string(), agent_id);
+
+    let (adapter, tx) = ReactionRecordingAdapter::new("slack-mock", ChannelType::Slack);
+    let adapter_ref = adapter.clone();
+
+    let mut manager = BridgeManager::new(handle.clone(), router);
+    manager.start_adapter(adapter.clone()).await.unwrap();
+
+    tx.send(make_group_msg(
+        ChannelType::Slack,
+        "G01",
+        "pass-1",
+        "hey bot, do the thing",
+        true,
+    ))
+    .await
+    .unwrap();
+
+    wait_until("done reaction", || {
+        adapter_ref
+            .phases_for("pass-1")
+            .iter()
+            .any(|p| matches!(p, AgentPhase::Done))
+    })
+    .await;
+
+    // Queued must arrive, and arrive first: it is what the Slack sidecar hangs
+    // the eyes on, and a Done without a preceding Queued would leave a turn
+    // with a check and no in-progress marker.
+    let phases = adapter_ref.phases_for("pass-1");
+    assert!(
+        matches!(phases.first(), Some(AgentPhase::Queued)),
+        "the first lifecycle phase of a dispatched turn must be Queued, got {phases:?}"
+    );
+    assert!(
+        matches!(phases.last(), Some(AgentPhase::Done)),
+        "a successful turn must end on Done, got {phases:?}"
+    );
 
     manager.stop().await;
 }

--- a/crates/librefang-channels/tests/bridge_integration_test.rs
+++ b/crates/librefang-channels/tests/bridge_integration_test.rs
@@ -1180,9 +1180,8 @@ struct ReactionRecordingAdapter {
     name: String,
     channel_type: ChannelType,
     rx: Mutex<Option<mpsc::Receiver<ChannelMessage>>>,
-    /// Every reaction, paired with the `message_id` it targeted. The id is
-    /// what the Slack sidecar keys its receipt on (#6731), so a test that
-    /// asserts "this message got no reaction" needs it recorded.
+    /// Every reaction, paired with the `message_id` it targeted.
+    /// The id is what the Slack sidecar keys its receipt on (#6731), so a test that asserts "this message got no reaction" needs it recorded.
     reactions: Arc<Mutex<Vec<(String, LifecycleReaction)>>>,
     shutdown_tx: watch::Sender<bool>,
 }
@@ -1403,19 +1402,12 @@ async fn test_non_streaming_adapter_receives_tool_use_reaction() {
 // Group gating emits NO lifecycle reaction (#6731)
 // ---------------------------------------------------------------------------
 //
-// The Slack sidecar's eyes/check receipt keys off the `Queued` lifecycle phase
-// rather than off receiving a message, which is only correct if a message the
-// bridge declines to answer produces no lifecycle signal at all. Mention-only
-// group gating is the path #6731 was reported on: `dispatch_message` returns at
-// the `!should_process_group_message` arm, well before the first
-// `send_lifecycle_reaction(Queued)` call. This test pins that contract so a
-// future refactor that moved the reaction above the gate would resurrect the
-// permanently-stuck eyes on the Slack side.
+// The Slack sidecar's eyes/check receipt keys off the `Queued` lifecycle phase rather than off receiving a message, which is only correct if a message the bridge declines to answer produces no lifecycle signal at all.
+// Mention-only group gating is the path #6731 was reported on: `dispatch_message` returns at the `!should_process_group_message` arm, well before the first `send_lifecycle_reaction(Queued)` call.
+// This test pins that contract so a future refactor that moved the reaction above the gate would resurrect the permanently-stuck eyes on the Slack side.
 
-/// Handle that reports `group_policy = mention_only` as a per-agent override,
-/// the way an `agent.toml` `[channel_overrides]` block does. The trait default
-/// returns `None`, so without this the bridge sees no policy and processes
-/// every group message.
+/// Handle that reports `group_policy = mention_only` as a per-agent override, the way an `agent.toml` `[channel_overrides]` block does.
+/// The trait default returns `None`, so without this the bridge sees no policy and processes every group message.
 struct MockMentionOnlyHandle {
     agents: Mutex<Vec<(AgentId, String)>>,
 }
@@ -1457,8 +1449,7 @@ impl ChannelBridgeHandle for MockMentionOnlyHandle {
     fn record_consumer_lag(&self, _n: u64, _ctx: &'static str) {}
 }
 
-/// Build a group message with an explicit platform message id, so a test can
-/// tell one message's reactions from another's.
+/// Build a group message with an explicit platform message id, so a test can tell one message's reactions from another's.
 fn make_group_msg(
     channel: ChannelType,
     group_id: &str,
@@ -1505,10 +1496,8 @@ async fn test_group_gating_skip_emits_no_lifecycle_reaction_6731() {
     let mut manager = BridgeManager::new(handle.clone(), router);
     manager.start_adapter(adapter.clone()).await.unwrap();
 
-    // Unaddressed first, then an addressed one. Both are dispatched on the same
-    // serialized adapter stream, so once the addressed message has reached its
-    // terminal phase the unaddressed one has had its full turn to produce a
-    // reaction — no sleeps needed to prove the absence.
+    // Unaddressed first, then an addressed one.
+    // Both are dispatched on the same serialized adapter stream, so once the addressed message has reached its terminal phase the unaddressed one has had its full turn to produce a reaction — no sleeps needed to prove the absence.
     tx.send(make_group_msg(
         ChannelType::Slack,
         "G01",
@@ -1528,8 +1517,7 @@ async fn test_group_gating_skip_emits_no_lifecycle_reaction_6731() {
     .await
     .unwrap();
 
-    // Positive control: the addressed message really did run a turn, so the
-    // harness and the override are both wired correctly.
+    // Positive control: the addressed message really did run a turn, so the harness and the override are both wired correctly.
     wait_until("done reaction for the addressed message", || {
         adapter_ref
             .phases_for("pass-1")
@@ -1538,8 +1526,7 @@ async fn test_group_gating_skip_emits_no_lifecycle_reaction_6731() {
     })
     .await;
 
-    // The gated-out message never got a lifecycle signal, so the Slack sidecar
-    // never adds an eyes it would have no way to clear.
+    // The gated-out message never got a lifecycle signal, so the Slack sidecar never adds an eyes it would have no way to clear.
     assert!(
         adapter_ref.phases_for("skip-1").is_empty(),
         "a mention-only-gated group message must produce no lifecycle reaction, got {:?}",
@@ -1583,9 +1570,7 @@ async fn test_group_gating_pass_emits_queued_then_done_6731() {
     })
     .await;
 
-    // Queued must arrive, and arrive first: it is what the Slack sidecar hangs
-    // the eyes on, and a Done without a preceding Queued would leave a turn
-    // with a check and no in-progress marker.
+    // Queued must arrive, and arrive first: it is what the Slack sidecar hangs the eyes on, and a Done without a preceding Queued would leave a turn with a check and no in-progress marker.
     let phases = adapter_ref.phases_for("pass-1");
     assert!(
         matches!(phases.first(), Some(AgentPhase::Queued)),

--- a/crates/librefang-channels/tests/bridge_integration_test.rs
+++ b/crates/librefang-channels/tests/bridge_integration_test.rs
@@ -1486,8 +1486,7 @@ async fn test_group_gating_skip_emits_no_lifecycle_reaction_6731() {
         "gated".to_string(),
     )]));
     let router = Arc::new(AgentRouter::new());
-    // Group messages resolve on `sender.platform_id`, which for a group is the
-    // chat id (see `resolve_or_fallback`'s binding-keys comment).
+    // Group messages resolve on `sender.platform_id`, which for a group is the chat id (see `resolve_or_fallback`'s binding-keys comment).
     router.set_user_default("G01".to_string(), agent_id);
 
     let (adapter, tx) = ReactionRecordingAdapter::new("slack-mock", ChannelType::Slack);

--- a/docs/architecture/sidecar-channels.md
+++ b/docs/architecture/sidecar-channels.md
@@ -140,13 +140,43 @@ Two dispatch details matter for a multi-step display:
   Done/Error` sequence. Adapters that do not declare `reaction` treat
   every one of these as a no-op, so the change is inert for them.
 - The **Slack** sidecar (`sdk/python/librefang/sidecar/adapters/slack.py`)
-  is the first consumer: it declares `reaction` and folds the phase
-  stream into an updated-in-place Block Kit card (`chat.update`) that
-  shows the live step list for multi-step turns. Single-step turns (no
-  tool ran) post no card and keep the pre-existing `eyes → check`
-  receipt reactions, which are driven independently by the receive/send
-  hooks — the phase stream never emits emoji reactions on Slack. The
-  card honours the same `SLACK_REACTIONS` opt-out as the receipts.
+  is the first consumer: it declares `reaction` and drives *both* of its
+  processing indicators off the one phase stream.
+  The `eyes → check` receipt is added on `Queued` and flipped on
+  `Done` / `Error` (to `white_check_mark` / `x`); the multi-step
+  Block Kit card is posted lazily on the first `ToolUse` and updated in
+  place (`chat.update`) until the turn terminates. Single-step turns
+  (no tool ran) post no card and keep just the receipt.
+
+  The receipt used to be driven by the receive/send hooks instead, and
+  #6731 moved it onto the lifecycle because "we received a message" and
+  "we are answering it" are different facts. `dispatch_message` has
+  roughly two dozen `return` paths above the first
+  `send_lifecycle_reaction(Queued)` call — mention-only group gating,
+  per-user and per-channel rate limits, the reply-intent precheck,
+  command policy, thread ownership, RBAC — and none of them was visible
+  to the adapter, so a receive-time reaction on a declined message was
+  never cleared. Keying off `Queued` closes all of them structurally
+  rather than one at a time, and `Error` gives a failed turn a terminal
+  state it previously never got. Two integration tests in
+  `crates/librefang-channels/tests/bridge_integration_test.rs`
+  (`test_group_gating_skip_emits_no_lifecycle_reaction_6731`,
+  `test_group_gating_pass_emits_queued_then_done_6731`) pin the contract
+  the adapter now depends on: a gated-out group message emits no
+  lifecycle reaction, and a dispatched one starts on `Queued`.
+
+  An adapter consuming the phase stream must therefore key its state
+  strictly on the frame's `message_id`. Slack learned that the hard way:
+  the old send-hook finalization keyed on the reply's thread id, which
+  for an in-thread reply is the thread *root*, so the exact key missed
+  and a "first pending entry in this channel" fallback flipped an
+  unrelated sibling message's reaction.
+
+  The two indicators have independent switches: `SLACK_REACTIONS` for
+  the receipt and `SLACK_PROGRESS_CARD` for the card (#6730). The card's
+  default follows `SLACK_REACTIONS`, so an operator who set
+  `SLACK_REACTIONS=false` for silence keeps it, but either can now be
+  turned off without the other.
 
 ## Supervision
 

--- a/docs/architecture/sidecar-channels.md
+++ b/docs/architecture/sidecar-channels.md
@@ -139,44 +139,20 @@ Two dispatch details matter for a multi-step display:
   that declares `reaction` sees the full `Thinking → ToolUse… →
   Done/Error` sequence. Adapters that do not declare `reaction` treat
   every one of these as a no-op, so the change is inert for them.
-- The **Slack** sidecar (`sdk/python/librefang/sidecar/adapters/slack.py`)
-  is the first consumer: it declares `reaction` and drives *both* of its
-  processing indicators off the one phase stream.
-  The `eyes → check` receipt is added on `Queued` and flipped on
-  `Done` / `Error` (to `white_check_mark` / `x`); the multi-step
-  Block Kit card is posted lazily on the first `ToolUse` and updated in
-  place (`chat.update`) until the turn terminates. Single-step turns
-  (no tool ran) post no card and keep just the receipt.
+- The **Slack** sidecar (`sdk/python/librefang/sidecar/adapters/slack.py`) is the first consumer: it declares `reaction` and drives *both* of its processing indicators off the one phase stream.
+  The `eyes → check` receipt is added on `Queued` and flipped on `Done` / `Error` (to `white_check_mark` / `x`); the multi-step Block Kit card is posted lazily on the first `ToolUse` and updated in place (`chat.update`) until the turn terminates.
+  Single-step turns (no tool ran) post no card and keep just the receipt.
 
-  The receipt used to be driven by the receive/send hooks instead, and
-  #6731 moved it onto the lifecycle because "we received a message" and
-  "we are answering it" are different facts. `dispatch_message` has
-  roughly two dozen `return` paths above the first
-  `send_lifecycle_reaction(Queued)` call — mention-only group gating,
-  per-user and per-channel rate limits, the reply-intent precheck,
-  command policy, thread ownership, RBAC — and none of them was visible
-  to the adapter, so a receive-time reaction on a declined message was
-  never cleared. Keying off `Queued` closes all of them structurally
-  rather than one at a time, and `Error` gives a failed turn a terminal
-  state it previously never got. Two integration tests in
-  `crates/librefang-channels/tests/bridge_integration_test.rs`
-  (`test_group_gating_skip_emits_no_lifecycle_reaction_6731`,
-  `test_group_gating_pass_emits_queued_then_done_6731`) pin the contract
-  the adapter now depends on: a gated-out group message emits no
-  lifecycle reaction, and a dispatched one starts on `Queued`.
+  The receipt used to be driven by the receive/send hooks instead, and #6731 moved it onto the lifecycle because "we received a message" and "we are answering it" are different facts.
+  `dispatch_message` has roughly two dozen `return` paths above the first `send_lifecycle_reaction(Queued)` call — mention-only group gating, per-user and per-channel rate limits, the reply-intent precheck, command policy, thread ownership, RBAC — and none of them was visible to the adapter, so a receive-time reaction on a declined message was never cleared.
+  Keying off `Queued` closes all of them structurally rather than one at a time, and `Error` gives a failed turn a terminal state it previously never got.
+  Two integration tests in `crates/librefang-channels/tests/bridge_integration_test.rs` (`test_group_gating_skip_emits_no_lifecycle_reaction_6731`, `test_group_gating_pass_emits_queued_then_done_6731`) pin the contract the adapter now depends on: a gated-out group message emits no lifecycle reaction, and a dispatched one starts on `Queued`.
 
-  An adapter consuming the phase stream must therefore key its state
-  strictly on the frame's `message_id`. Slack learned that the hard way:
-  the old send-hook finalization keyed on the reply's thread id, which
-  for an in-thread reply is the thread *root*, so the exact key missed
-  and a "first pending entry in this channel" fallback flipped an
-  unrelated sibling message's reaction.
+  An adapter consuming the phase stream must therefore key its state strictly on the frame's `message_id`.
+  Slack learned that the hard way: the old send-hook finalization keyed on the reply's thread id, which for an in-thread reply is the thread *root*, so the exact key missed and a "first pending entry in this channel" fallback flipped an unrelated sibling message's reaction.
 
-  The two indicators have independent switches: `SLACK_REACTIONS` for
-  the receipt and `SLACK_PROGRESS_CARD` for the card (#6730). The card's
-  default follows `SLACK_REACTIONS`, so an operator who set
-  `SLACK_REACTIONS=false` for silence keeps it, but either can now be
-  turned off without the other.
+  The two indicators have independent switches: `SLACK_REACTIONS` for the receipt and `SLACK_PROGRESS_CARD` for the card (#6730).
+  The card's default follows `SLACK_REACTIONS`, so an operator who set `SLACK_REACTIONS=false` for silence keeps it, but either can now be turned off without the other.
 
 ## Supervision
 

--- a/docs/src/app/configuration/channels/page.mdx
+++ b/docs/src/app/configuration/channels/page.mdx
@@ -116,6 +116,7 @@ SLACK_BOT_TOKEN = "xoxb-..."
 # SLACK_UNFURL_LINKS = "false"
 # SLACK_FORCE_FLAT_REPLIES = "false"
 # SLACK_REACTIONS = "true"
+# SLACK_PROGRESS_CARD = "true"
 # SLACK_ACCOUNT_ID = "workspace-prod"
 ```
 

--- a/docs/src/app/configuration/page.mdx
+++ b/docs/src/app/configuration/page.mdx
@@ -895,6 +895,7 @@ SLACK_BOT_TOKEN = "xoxb-..."
 # SLACK_UNFURL_LINKS = "false"
 # SLACK_FORCE_FLAT_REPLIES = "false"
 # SLACK_REACTIONS = "true"
+# SLACK_PROGRESS_CARD = "true"
 # SLACK_ACCOUNT_ID = "workspace-prod"
 ```
 

--- a/docs/src/app/integrations/channels/core/page.mdx
+++ b/docs/src/app/integrations/channels/core/page.mdx
@@ -187,7 +187,9 @@ The Slack adapter uses Socket Mode, which establishes a WebSocket connection to 
 
 The Slack adapter shows live "I'm working on it" feedback by adding 👀 to the message that triggered a turn, then replacing it with ✅ when the turn succeeds or ❌ when it fails.
 The receipt is driven by the daemon's turn lifecycle, not by receiving the message, so a message the daemon declines to answer — one that misses mention-only group gating, a rate-limited sender, a slash command the bridge handles itself — gets no reaction at all rather than a 👀 that is never cleared.
-Toggle with the `SLACK_REACTIONS` environment variable (default `true` — set to `false` to disable). `already_reacted` and `no_reaction` errors are silently ignored, so reaction failures never block message processing. See [Reactions and Processing State](/integrations/channels#reactions-and-processing-state) on the channels overview.
+Toggle with the `SLACK_REACTIONS` environment variable (default `true` — set to `false` to disable).
+`already_reacted` and `no_reaction` errors are silently ignored, so reaction failures never block message processing.
+See [Reactions and Processing State](/integrations/channels#reactions-and-processing-state) on the channels overview.
 
 The multi-step task-progress card (the Block Kit step list a tool-using turn updates in place) is a separate indicator with its own switch, `SLACK_PROGRESS_CARD`.
 It defaults to whatever `SLACK_REACTIONS` is set to, so `SLACK_REACTIONS=false` still means total silence — but the two can now be set independently: `SLACK_REACTIONS=false` with `SLACK_PROGRESS_CARD=true` gives the card without the emoji, and the reverse gives the receipt without the card.

--- a/docs/src/app/integrations/channels/core/page.mdx
+++ b/docs/src/app/integrations/channels/core/page.mdx
@@ -173,6 +173,8 @@ channel_type = "slack"
 SLACK_APP_TOKEN = "xapp-..."
 SLACK_BOT_TOKEN = "xoxb-..."
 # SLACK_FORCE_FLAT_REPLIES = "false"   # set "true" to post replies as top-level messages
+# SLACK_REACTIONS = "true"             # set "false" to drop the 👀 / ✅ receipt
+# SLACK_PROGRESS_CARD = "true"         # set "false" to drop the task-progress card
 ```
 
 8. Restart the daemon.
@@ -183,7 +185,12 @@ The Slack adapter uses Socket Mode, which establishes a WebSocket connection to 
 
 ### Processing-State Reactions
 
-The Slack adapter shows live "I'm working on it" feedback by adding 👀 to the user's message on receive and replacing it with ✅ when the reply is sent. Toggle with the `SLACK_REACTIONS` environment variable (default `true` — set to `false` to disable). `already_reacted` and `no_reaction` errors are silently ignored, so reaction failures never block message processing. See [Reactions and Processing State](/integrations/channels#reactions-and-processing-state) on the channels overview.
+The Slack adapter shows live "I'm working on it" feedback by adding 👀 to the message that triggered a turn, then replacing it with ✅ when the turn succeeds or ❌ when it fails.
+The receipt is driven by the daemon's turn lifecycle, not by receiving the message, so a message the daemon declines to answer — one that misses mention-only group gating, a rate-limited sender, a slash command the bridge handles itself — gets no reaction at all rather than a 👀 that is never cleared.
+Toggle with the `SLACK_REACTIONS` environment variable (default `true` — set to `false` to disable). `already_reacted` and `no_reaction` errors are silently ignored, so reaction failures never block message processing. See [Reactions and Processing State](/integrations/channels#reactions-and-processing-state) on the channels overview.
+
+The multi-step task-progress card (the Block Kit step list a tool-using turn updates in place) is a separate indicator with its own switch, `SLACK_PROGRESS_CARD`.
+It defaults to whatever `SLACK_REACTIONS` is set to, so `SLACK_REACTIONS=false` still means total silence — but the two can now be set independently: `SLACK_REACTIONS=false` with `SLACK_PROGRESS_CARD=true` gives the card without the emoji, and the reverse gives the receipt without the card.
 
 ---
 

--- a/docs/src/app/integrations/channels/page.mdx
+++ b/docs/src/app/integrations/channels/page.mdx
@@ -246,7 +246,10 @@ Other channels keep their previous formatter defaults — only Signal flipped.
 
 Several adapters can show "I'm working on it" feedback by attaching a reaction to the user's message and removing it once the reply is sent. This is per-channel:
 
-- **Slack** — `reactions_enabled` toggle (env var `SLACK_REACTIONS`, default `true`). Adds 👀 when a turn starts, replaces it with ✅ when the turn succeeds and ❌ when it fails. Driven by the daemon's turn lifecycle rather than by receiving the message, so a message the daemon declines to answer (mention-only group gating, a rate limit, a slash command handled in-bridge) gets nothing rather than a 👀 nobody ever clears. The multi-step task-progress card is a separate indicator with its own `SLACK_PROGRESS_CARD` switch, defaulting to whatever `SLACK_REACTIONS` is. `already_reacted` / `no_reaction` errors are silently ignored (fail-open).
+- **Slack** — `reactions_enabled` toggle (env var `SLACK_REACTIONS`, default `true`). Adds 👀 when a turn starts, replaces it with ✅ when the turn succeeds and ❌ when it fails.
+  Driven by the daemon's turn lifecycle rather than by receiving the message, so a message the daemon declines to answer (mention-only group gating, a rate limit, a slash command handled in-bridge) gets nothing rather than a 👀 nobody ever clears.
+  The multi-step task-progress card is a separate indicator with its own `SLACK_PROGRESS_CARD` switch, defaulting to whatever `SLACK_REACTIONS` is.
+  `already_reacted` / `no_reaction` errors are silently ignored (fail-open).
 - **Feishu** — adds a `Typing` reaction on receive, removes it on reply send. Both calls are fire-and-forget; API failures `warn!` but never block message processing.
 
 Add the same on a custom adapter by spawning the reaction call as a `tokio::spawn` task and storing `(reaction_id, message_id)` in a per-chat map keyed off the chat id.

--- a/docs/src/app/integrations/channels/page.mdx
+++ b/docs/src/app/integrations/channels/page.mdx
@@ -246,7 +246,7 @@ Other channels keep their previous formatter defaults — only Signal flipped.
 
 Several adapters can show "I'm working on it" feedback by attaching a reaction to the user's message and removing it once the reply is sent. This is per-channel:
 
-- **Slack** — `reactions_enabled` toggle (env var `SLACK_REACTIONS`, default `true`). Adds 👀 on receive, replaces with ✅ on reply. `already_reacted` / `no_reaction` errors are silently ignored (fail-open).
+- **Slack** — `reactions_enabled` toggle (env var `SLACK_REACTIONS`, default `true`). Adds 👀 when a turn starts, replaces it with ✅ when the turn succeeds and ❌ when it fails. Driven by the daemon's turn lifecycle rather than by receiving the message, so a message the daemon declines to answer (mention-only group gating, a rate limit, a slash command handled in-bridge) gets nothing rather than a 👀 nobody ever clears. The multi-step task-progress card is a separate indicator with its own `SLACK_PROGRESS_CARD` switch, defaulting to whatever `SLACK_REACTIONS` is. `already_reacted` / `no_reaction` errors are silently ignored (fail-open).
 - **Feishu** — adds a `Typing` reaction on receive, removes it on reply send. Both calls are fire-and-forget; API failures `warn!` but never block message processing.
 
 Add the same on a custom adapter by spawning the reaction call as a `tokio::spawn` task and storing `(reaction_id, message_id)` in a per-chat map keyed off the chat id.

--- a/docs/src/app/zh/configuration/channels/page.mdx
+++ b/docs/src/app/zh/configuration/channels/page.mdx
@@ -79,6 +79,7 @@ SLACK_BOT_TOKEN = "xoxb-..."
 # SLACK_UNFURL_LINKS = "false"
 # SLACK_FORCE_FLAT_REPLIES = "false"
 # SLACK_REACTIONS = "true"
+# SLACK_PROGRESS_CARD = "true"
 # SLACK_ACCOUNT_ID = "workspace-prod"
 ```
 

--- a/docs/src/app/zh/configuration/page.mdx
+++ b/docs/src/app/zh/configuration/page.mdx
@@ -890,6 +890,7 @@ SLACK_BOT_TOKEN = "xoxb-..."
 # SLACK_UNFURL_LINKS = "false"
 # SLACK_FORCE_FLAT_REPLIES = "false"
 # SLACK_REACTIONS = "true"
+# SLACK_PROGRESS_CARD = "true"
 # SLACK_ACCOUNT_ID = "workspace-prod"
 ```
 

--- a/docs/src/app/zh/integrations/channels/core/page.mdx
+++ b/docs/src/app/zh/integrations/channels/core/page.mdx
@@ -173,7 +173,9 @@ Slack 适配器使用 Socket Mode，通过 WebSocket 连接到 Slack 服务器�
 
 Slack 适配器通过给触发这一轮对话的消息加 reaction 显示"我在处理"反馈：开始处理时加 👀，成功后替换为 ✅，失败则替换为 ❌。
 回执由守护进程的对话生命周期驱动，而不是由"收到消息"驱动，因此守护进程决定不回答的消息（未命中 mention-only 群组门禁、发送者被限流、bridge 自己处理掉的斜杠命令）根本不会被加上任何 reaction，而不是留下一个永远清不掉的 👀。
-用 `SLACK_REACTIONS` 环境变量控制（默认 `true`，设为 `false` 关闭）。`already_reacted` / `no_reaction` 错误会被静默忽略（fail-open），所以 reaction 失败永远不会阻塞消息处理。详见 channels overview 的 [Reactions and Processing State](/zh/integrations/channels#reactions-and-processing-state)。
+用 `SLACK_REACTIONS` 环境变量控制（默认 `true`，设为 `false` 关闭）。
+`already_reacted` / `no_reaction` 错误会被静默忽略（fail-open），所以 reaction 失败永远不会阻塞消息处理。
+详见 channels overview 的 [Reactions and Processing State](/zh/integrations/channels#reactions-and-processing-state)。
 
 多步任务进度卡片（调用工具的对话会原地更新的 Block Kit 步骤列表）是独立的指示器，由 `SLACK_PROGRESS_CARD` 单独控制。
 它的默认值跟随 `SLACK_REACTIONS`，所以 `SLACK_REACTIONS=false` 依然意味着彻底安静；但两者现在可以分别设置：`SLACK_REACTIONS=false` 配 `SLACK_PROGRESS_CARD=true` 得到卡片但没有 emoji，反过来则只有回执没有卡片。

--- a/docs/src/app/zh/integrations/channels/core/page.mdx
+++ b/docs/src/app/zh/integrations/channels/core/page.mdx
@@ -159,6 +159,8 @@ channel_type = "slack"
 SLACK_APP_TOKEN = "xapp-..."
 SLACK_BOT_TOKEN = "xoxb-..."
 # SLACK_FORCE_FLAT_REPLIES = "false"   # 设为 "true" 将回复以顶层消息发送
+# SLACK_REACTIONS = "true"             # 设为 "false" 关闭 👀 / ✅ 处理回执
+# SLACK_PROGRESS_CARD = "true"         # 设为 "false" 关闭多步任务进度卡片
 ```
 
 8. 重启守护进程。
@@ -169,7 +171,12 @@ Slack 适配器使用 Socket Mode，通过 WebSocket 连接到 Slack 服务器�
 
 ### 处理状态反应（Reactions）
 
-Slack 适配器通过给用户消息加 reaction 显示"我在处理"反馈：收到时加 👀，回复发出后替换为 ✅。用 `SLACK_REACTIONS` 环境变量控制（默认 `true`，设为 `false` 关闭）。`already_reacted` / `no_reaction` 错误会被静默忽略（fail-open），所以 reaction 失败永远不会阻塞消息处理。详见 channels overview 的 [Reactions and Processing State](/zh/integrations/channels#reactions-and-processing-state)。
+Slack 适配器通过给触发这一轮对话的消息加 reaction 显示"我在处理"反馈：开始处理时加 👀，成功后替换为 ✅，失败则替换为 ❌。
+回执由守护进程的对话生命周期驱动，而不是由"收到消息"驱动，因此守护进程决定不回答的消息（未命中 mention-only 群组门禁、发送者被限流、bridge 自己处理掉的斜杠命令）根本不会被加上任何 reaction，而不是留下一个永远清不掉的 👀。
+用 `SLACK_REACTIONS` 环境变量控制（默认 `true`，设为 `false` 关闭）。`already_reacted` / `no_reaction` 错误会被静默忽略（fail-open），所以 reaction 失败永远不会阻塞消息处理。详见 channels overview 的 [Reactions and Processing State](/zh/integrations/channels#reactions-and-processing-state)。
+
+多步任务进度卡片（调用工具的对话会原地更新的 Block Kit 步骤列表）是独立的指示器，由 `SLACK_PROGRESS_CARD` 单独控制。
+它的默认值跟随 `SLACK_REACTIONS`，所以 `SLACK_REACTIONS=false` 依然意味着彻底安静；但两者现在可以分别设置：`SLACK_REACTIONS=false` 配 `SLACK_PROGRESS_CARD=true` 得到卡片但没有 emoji，反过来则只有回执没有卡片。
 
 ---
 

--- a/docs/src/app/zh/integrations/channels/page.mdx
+++ b/docs/src/app/zh/integrations/channels/page.mdx
@@ -246,7 +246,7 @@ agent 级 `[channel_overrides]` 仍优先于这些按通道设置的值，且这
 
 几个 adapter 可以贴一个反应到用户消息表示"我在处理"，发送回复时移除。各通道独立：
 
-- **Slack** — `reactions_enabled` 开关（环境变量 `SLACK_REACTIONS`，默认 `true`）。收消息加 👀，回复时换成 ✅。`already_reacted` / `no_reaction` 错误静默忽略（fail-open）。
+- **Slack** — `reactions_enabled` 开关（环境变量 `SLACK_REACTIONS`，默认 `true`）。对话开始时加 👀，成功换成 ✅，失败换成 ❌。由守护进程的对话生命周期驱动，而不是由"收到消息"驱动，所以守护进程决定不回答的消息（mention-only 群组门禁、限流、bridge 自己处理的斜杠命令）什么都不会加上，而不是留下一个没人会清掉的 👀。多步任务进度卡片是独立指示器，由 `SLACK_PROGRESS_CARD` 单独控制，默认跟随 `SLACK_REACTIONS`。`already_reacted` / `no_reaction` 错误静默忽略（fail-open）。
 - **Feishu** — 收消息加 `Typing` reaction，回复发送时移除。两个调用都 fire-and-forget；API 失败 `warn!` 但绝不阻塞消息处理。
 
 要在自定义 adapter 上加同样能力，把 reaction 调用 `tokio::spawn` 出去，把 `(reaction_id, message_id)` 存在按 chat id 索引的 map 里。

--- a/docs/src/app/zh/integrations/channels/page.mdx
+++ b/docs/src/app/zh/integrations/channels/page.mdx
@@ -246,7 +246,10 @@ agent 级 `[channel_overrides]` 仍优先于这些按通道设置的值，且这
 
 几个 adapter 可以贴一个反应到用户消息表示"我在处理"，发送回复时移除。各通道独立：
 
-- **Slack** — `reactions_enabled` 开关（环境变量 `SLACK_REACTIONS`，默认 `true`）。对话开始时加 👀，成功换成 ✅，失败换成 ❌。由守护进程的对话生命周期驱动，而不是由"收到消息"驱动，所以守护进程决定不回答的消息（mention-only 群组门禁、限流、bridge 自己处理的斜杠命令）什么都不会加上，而不是留下一个没人会清掉的 👀。多步任务进度卡片是独立指示器，由 `SLACK_PROGRESS_CARD` 单独控制，默认跟随 `SLACK_REACTIONS`。`already_reacted` / `no_reaction` 错误静默忽略（fail-open）。
+- **Slack** — `reactions_enabled` 开关（环境变量 `SLACK_REACTIONS`，默认 `true`）。对话开始时加 👀，成功换成 ✅，失败换成 ❌。
+  由守护进程的对话生命周期驱动，而不是由"收到消息"驱动，所以守护进程决定不回答的消息（mention-only 群组门禁、限流、bridge 自己处理的斜杠命令）什么都不会加上，而不是留下一个没人会清掉的 👀。
+  多步任务进度卡片是独立指示器，由 `SLACK_PROGRESS_CARD` 单独控制，默认跟随 `SLACK_REACTIONS`。
+  `already_reacted` / `no_reaction` 错误静默忽略（fail-open）。
 - **Feishu** — 收消息加 `Typing` reaction，回复发送时移除。两个调用都 fire-and-forget；API 失败 `warn!` 但绝不阻塞消息处理。
 
 要在自定义 adapter 上加同样能力，把 reaction 调用 `tokio::spawn` 出去，把 `(reaction_id, message_id)` 存在按 chat id 索引的 map 里。

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -501,9 +501,10 @@ class SlackAdapter(SidecarAdapter):
 
         self.api_base = DEFAULT_API_BASE
         self.bot_user_id: Optional[str] = None
-        # (channel, ts) → emoji name. Cleared when the bot replies.
+        # (channel, ts) → emoji name. Cleared when the triggering turn
+        # reaches its terminal (done/error) lifecycle phase (#6731).
         # Bounded by `MAX_PENDING_REACTIONS` so a spike of receives
-        # without sends can't grow this without bound.
+        # without terminations can't grow this without bound.
         self._pending_reactions: dict[tuple[str, str], str] = {}
         self._pending_lock = threading.Lock()
         # Live task-progress cards keyed by (channel_id, triggering ts).

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -36,22 +36,12 @@ Behaviour parity with the Rust adapter:
 * **REST send**: ``POST /api/chat.postMessage`` with the bot token,
   optional ``thread_ts`` and ``unfurl_links``. 3 000-char chunking
   (matches the Rust ``SLACK_MSG_LIMIT``).
-* **Reactions** (#6731): the receipt is driven by the daemon's
-  AgentPhase lifecycle, not by the receive hook — ``eyes`` on
-  ``queued``, flipped to ``white_check_mark`` on ``done`` and ``x`` on
-  ``error``. A message the daemon declines to answer (group
-  mention-only gating, a rate-limit rejection, a slash command handled
-  in-bridge) never reaches ``queued``, so it never gets a reaction at
-  all instead of being left with a permanent ``eyes``. Opt out via
-  ``SLACK_REACTIONS=false``.
-* **Task progress** (#6451): the same AgentPhase lifecycle
-  (Thinking → ToolUse{name} → Done/Error) is rendered as an
-  updated-in-place Block Kit step list (``chat.update``) for
-  multi-step turns. Single-step turns post no card and keep just the
-  receipt reactions. Toggled independently of the receipt via
-  ``SLACK_PROGRESS_CARD`` (#6730), which defaults to whatever
-  ``SLACK_REACTIONS`` is set to so neither knob silently turns the
-  other's output on.
+* **Reactions** (#6731): the receipt is driven by the daemon's AgentPhase lifecycle, not by the receive hook — ``eyes`` on ``queued``, flipped to ``white_check_mark`` on ``done`` and ``x`` on ``error``.
+  A message the daemon declines to answer (group mention-only gating, a rate-limit rejection, a slash command handled in-bridge) never reaches ``queued``, so it never gets a reaction at all instead of being left with a permanent ``eyes``.
+  Opt out via ``SLACK_REACTIONS=false``.
+* **Task progress** (#6451): the same AgentPhase lifecycle (Thinking → ToolUse{name} → Done/Error) is rendered as an updated-in-place Block Kit step list (``chat.update``) for multi-step turns.
+  Single-step turns post no card and keep just the receipt reactions.
+  Toggled independently of the receipt via ``SLACK_PROGRESS_CARD`` (#6730), which defaults to whatever ``SLACK_REACTIONS`` is set to so neither knob silently turns the other's output on.
 
 Stdlib-only: HTTPS via ``urllib.request``, WebSocket via a
 hand-rolled RFC 6455 client over ``socket`` + ``ssl`` (same pattern
@@ -402,22 +392,11 @@ class SlackAdapter(SidecarAdapter):
     # interactions back to ``on_command``/``on_send``, ``thread`` for
     # threaded replies, and ``reaction`` so the generic AgentPhase
     # lifecycle (Queued → Thinking → ToolUse{name} → Streaming →
-    # Done/Error) reaches ``on_command`` as ``reaction`` commands. That
-    # one phase stream drives BOTH adapter-side processing indicators:
-    # the eyes/white_check_mark receipt (Queued to Done/Error) and the
-    # updated-in-place Block Kit task-progress card for multi-step turns
-    # (#6451).
+    # Done/Error) reaches ``on_command`` as ``reaction`` commands.
+    # That one phase stream drives BOTH adapter-side processing indicators: the eyes/white_check_mark receipt (Queued to Done/Error) and the updated-in-place Block Kit task-progress card for multi-step turns (#6451).
     #
-    # The receipt used to be driven by the receive/send hooks instead,
-    # which is what #6731 fixed: ``_handle_envelope`` added the eyes to
-    # every message it emitted, including the ones the daemon then
-    # declined to answer (mention-only group gating and the other
-    # pre-lifecycle early returns in ``dispatch_message``), leaving a
-    # permanent eyes with no way for the adapter to learn the turn was
-    # never run. Keying off the lifecycle closes all of those paths
-    # structurally: the first adapter-visible signal of a dispatched
-    # turn is Queued, so nothing is added unless a turn actually starts,
-    # and every started turn reaches Done or Error.
+    # The receipt used to be driven by the receive/send hooks instead, which is what #6731 fixed: ``_handle_envelope`` added the eyes to every message it emitted, including the ones the daemon then declined to answer (mention-only group gating and the other pre-lifecycle early returns in ``dispatch_message``), leaving a permanent eyes with no way for the adapter to learn the turn was never run.
+    # Keying off the lifecycle closes all of those paths structurally: the first adapter-visible signal of a dispatched turn is Queued, so nothing is added unless a turn actually starts, and every started turn reaches Done or Error.
     #
     # Why ``reaction`` and not a new ``task_update`` capability: the
     # generic phase lifecycle is dispatched to adapters through
@@ -818,9 +797,7 @@ class SlackAdapter(SidecarAdapter):
                          error=err, channel=channel, name=name)
 
     def _track_pending_reaction(self, channel: str, ts: str, emoji: str) -> None:
-        """Record that we added an ``emoji`` reaction on ``channel/ts``
-        so :meth:`_finalize_pending_reaction` can flip it to the terminal
-        emoji once the turn reaches its Done / Error phase."""
+        """Record that we added an ``emoji`` reaction on ``channel/ts`` so :meth:`_finalize_pending_reaction` can flip it to the terminal emoji once the turn reaches its Done / Error phase."""
         key = (channel, ts)
         with self._pending_lock:
             if len(self._pending_reactions) >= self.MAX_PENDING_REACTIONS:
@@ -838,22 +815,13 @@ class SlackAdapter(SidecarAdapter):
     def _finalize_pending_reaction(
         self, channel: str, ts: Optional[str], emoji: Optional[str],
     ) -> None:
-        """Remove the in-progress receipt on ``channel``/``ts`` and put
-        ``emoji`` in its place. ``emoji=None`` removes only — that is the
-        daemon's ``clear_done_reaction`` signal, which arrives as an empty
-        emoji on the terminal phase.
+        """Remove the in-progress receipt on ``channel``/``ts`` and put ``emoji`` in its place.
+        ``emoji=None`` removes only — that is the daemon's ``clear_done_reaction`` signal, which arrives as an empty emoji on the terminal phase.
 
-        Keyed strictly by ``(channel, ts)``. There is deliberately no
-        "first pending entry in this channel" fallback: the lifecycle
-        always carries the exact triggering ``message_id``, and the old
-        fallback flipped an unrelated sibling message's receipt whenever
-        the exact key missed (which it did for every in-thread reply,
-        because the send hook keyed off the thread root instead of the
-        message's own ts).
+        Keyed strictly by ``(channel, ts)``.
+        There is deliberately no "first pending entry in this channel" fallback: the lifecycle always carries the exact triggering ``message_id``, and the old fallback flipped an unrelated sibling message's receipt whenever the exact key missed (which it did for every in-thread reply, because the send hook keyed off the thread root instead of the message's own ts).
 
-        A miss is therefore a no-op, which also makes a repeated terminal
-        phase idempotent: the first one pops the entry, the second finds
-        nothing and adds nothing.
+        A miss is therefore a no-op, which also makes a repeated terminal phase idempotent: the first one pops the entry, the second finds nothing and adds nothing.
         """
         if not self.reactions_enabled or not ts:
             return
@@ -1072,26 +1040,16 @@ class SlackAdapter(SidecarAdapter):
         await super().on_command(cmd)
 
     async def _on_phase(self, cmd) -> None:
-        """Fold one AgentPhase lifecycle ``reaction`` into the receipt
-        reaction and, for multi-step turns, a live Block Kit
-        task-progress card.
+        """Fold one AgentPhase lifecycle ``reaction`` into the receipt reaction and, for multi-step turns, a live Block Kit task-progress card.
 
         Two independent indicators, one stream:
 
-        * **Receipt** (``SLACK_REACTIONS``): ``queued`` adds the eyes to
-          the triggering message; ``done`` / ``error`` flip it to
-          white_check_mark / x. Handled BEFORE the card bookkeeping
-          below, because a single-step turn has no card state and would
-          otherwise hit the early-out and never finalize — leaving
-          exactly the stuck eyes #6731 is about.
-        * **Card** (``SLACK_PROGRESS_CARD``): materialized lazily, only
-          once a turn actually runs a tool (a genuinely multi-step turn).
-          Single-step turns (Queued → Thinking → Done with no ToolUse)
-          post nothing and keep just the receipt.
+        * **Receipt** (``SLACK_REACTIONS``): ``queued`` adds the eyes to the triggering message; ``done`` / ``error`` flip it to white_check_mark / x.
+          Handled BEFORE the card bookkeeping below, because a single-step turn has no card state and would otherwise hit the early-out and never finalize — leaving exactly the stuck eyes #6731 is about.
+        * **Card** (``SLACK_PROGRESS_CARD``): materialized lazily, only once a turn actually runs a tool (a genuinely multi-step turn).
+          Single-step turns (Queued → Thinking → Done with no ToolUse) post nothing and keep just the receipt.
 
-        Called only from the serialized ``on_command`` reader path, so the
-        state map needs no lock; the Slack Web API calls are offloaded to
-        the executor.
+        Called only from the serialized ``on_command`` reader path, so the state map needs no lock; the Slack Web API calls are offloaded to the executor.
         """
         if not self.reactions_enabled and not self.progress_card_enabled:
             return
@@ -1280,8 +1238,7 @@ def _build_task_progress_blocks(
     return text, blocks
 
 
-# Matches one code span — fenced ```...```, an UNCLOSED ``` running to the end
-# of the message, or inline `...`.
+# Matches one code span — fenced ```...```, an UNCLOSED ``` running to the end of the message, or inline `...`.
 # The converter masks every match with an index token before any other rule runs, then restores the spans at the end, so a bold/link span or header/bullet line that wraps around a code span is still seen whole by the regexes (the previous top-level split hid everything past the code delimiter from them).
 # The unclosed alternative is second so a closed fence always wins; it matters because a truncated model response ends mid-block, and Slack renders an unterminated ``` as code all the way to the end of the message. Without it the blank-line collapse would rewrite the interior of something the user sees as a code block.
 # Deliberately NOT covered: `~~~` fences and 4-space-indented blocks. Both are GitHub-flavoured Markdown that Slack's mrkdwn does not render as code, so their blank lines are ordinary prose whitespace and collapsing them is exactly what #6730 asks for.
@@ -1447,16 +1404,10 @@ def _build_block_kit(text: str, buttons: list) -> list:
     layout: ``section`` block(s) with the text (mrkdwn), then one
     ``actions`` block per row of buttons.
 
-    The text is split across as many sections as it needs (#6730). Slack
-    rejects a ``section`` whose text exceeds ``SLACK_MSG_LIMIT``, and
-    ``_post_message`` deliberately skips its chunking when ``blocks`` is
-    present, so a long interactive reply used to be rejected wholesale and
-    dropped with nothing but a log line — the same limit
-    ``_build_task_progress_blocks`` already guards for.
+    The text is split across as many sections as it needs (#6730).
+    Slack rejects a ``section`` whose text exceeds ``SLACK_MSG_LIMIT``, and ``_post_message`` deliberately skips its chunking when ``blocks`` is present, so a long interactive reply used to be rejected wholesale and dropped with nothing but a log line — the same limit ``_build_task_progress_blocks`` already guards for.
 
-    Buttons are built first and budgeted against Slack's 50-blocks-per-
-    message cap, because they are the functional payload: truncating text
-    degrades a reply, dropping buttons breaks the interaction.
+    Buttons are built first and budgeted against Slack's 50-blocks-per-message cap, because they are the functional payload: truncating text degrades a reply, dropping buttons breaks the interaction.
     """
     action_blocks: list = []
     for row_idx, row in enumerate(buttons or []):
@@ -1495,18 +1446,11 @@ def _build_block_kit(text: str, buttons: list) -> list:
     # historical single-empty-section shape.
     chunks = _split_message(text, SLACK_MSG_LIMIT)
 
-    # The marker costs a block, so its slot is reserved only once truncation
-    # is actually happening. Reserving it up front spends a slot that the
-    # content may not need: with 49 button rows and one chunk, one section
-    # plus 49 actions is exactly 50 blocks and fits, but an unconditional
-    # reservation left zero sections and replaced the text with the marker.
-    # `/agents` and `/models` build one row per agent / per provider with no
-    # cap, so that is reachable rather than theoretical.
+    # The marker costs a block, so its slot is reserved only once truncation is actually happening.
+    # Reserving it up front spends a slot that the content may not need: with 49 button rows and one chunk, one section plus 49 actions is exactly 50 blocks and fits, but an unconditional reservation left zero sections and replaced the text with the marker.
+    # `/agents` and `/models` build one row per agent / per provider with no cap, so that is reachable rather than theoretical.
     #
-    # When the rows alone reach the cap the message cannot carry text at all,
-    # and the rows themselves have to give — Slack rejects an over-cap message
-    # outright, so "buttons are never dropped" cannot mean emitting 51 blocks;
-    # that delivers nothing at all, buttons included.
+    # When the rows alone reach the cap the message cannot carry text at all, and the rows themselves have to give — Slack rejects an over-cap message outright, so "buttons are never dropped" cannot mean emitting 51 blocks; that delivers nothing at all, buttons included.
     truncated = False
     if len(action_blocks) >= MAX_BLOCKS_PER_MESSAGE:
         action_blocks = action_blocks[: MAX_BLOCKS_PER_MESSAGE - 1]

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -1280,9 +1280,12 @@ def _build_task_progress_blocks(
     return text, blocks
 
 
-# Matches one code span — fenced ```...``` or inline `...`.
+# Matches one code span — fenced ```...```, an UNCLOSED ``` running to the end
+# of the message, or inline `...`.
 # The converter masks every match with an index token before any other rule runs, then restores the spans at the end, so a bold/link span or header/bullet line that wraps around a code span is still seen whole by the regexes (the previous top-level split hid everything past the code delimiter from them).
-_CODE_SPAN_RE = re.compile(r"```.*?```|`[^`]*`", re.DOTALL)
+# The unclosed alternative is second so a closed fence always wins; it matters because a truncated model response ends mid-block, and Slack renders an unterminated ``` as code all the way to the end of the message. Without it the blank-line collapse would rewrite the interior of something the user sees as a code block.
+# Deliberately NOT covered: `~~~` fences and 4-space-indented blocks. Both are GitHub-flavoured Markdown that Slack's mrkdwn does not render as code, so their blank lines are ordinary prose whitespace and collapsing them is exactly what #6730 asks for.
+_CODE_SPAN_RE = re.compile(r"```.*?```|```.*|`[^`]*`", re.DOTALL)
 # An index token standing in for a masked code span: \x00<index>\x01.
 # Control-character delimiters guarantee no Markdown rule can match into or across a token.
 _CODE_TOKEN_RE = re.compile("\x00(\\d+)\x01")
@@ -1491,14 +1494,30 @@ def _build_block_kit(text: str, buttons: list) -> list:
     # chunks <= the limit; an empty string comes back as [""], preserving the
     # historical single-empty-section shape.
     chunks = _split_message(text, SLACK_MSG_LIMIT)
-    # One slot reserved for the truncation marker below. Clamped at 0: once
-    # `action_blocks` alone reaches the cap, `chunks[:max_sections]` with a
-    # negative `max_sections` would slice from the end instead of yielding
-    # no sections (Python's `[:-n]` is "drop the last n", not "keep none").
-    max_sections = max(0, MAX_BLOCKS_PER_MESSAGE - len(action_blocks) - 1)
-    truncated = len(chunks) > max_sections
-    if truncated:
-        chunks = chunks[:max_sections]
+
+    # The marker costs a block, so its slot is reserved only once truncation
+    # is actually happening. Reserving it up front spends a slot that the
+    # content may not need: with 49 button rows and one chunk, one section
+    # plus 49 actions is exactly 50 blocks and fits, but an unconditional
+    # reservation left zero sections and replaced the text with the marker.
+    # `/agents` and `/models` build one row per agent / per provider with no
+    # cap, so that is reachable rather than theoretical.
+    #
+    # When the rows alone reach the cap the message cannot carry text at all,
+    # and the rows themselves have to give — Slack rejects an over-cap message
+    # outright, so "buttons are never dropped" cannot mean emitting 51 blocks;
+    # that delivers nothing at all, buttons included.
+    truncated = False
+    if len(action_blocks) >= MAX_BLOCKS_PER_MESSAGE:
+        action_blocks = action_blocks[: MAX_BLOCKS_PER_MESSAGE - 1]
+        chunks = []
+        truncated = True
+    else:
+        section_budget = MAX_BLOCKS_PER_MESSAGE - len(action_blocks)
+        if len(chunks) > section_budget:
+            truncated = True
+            # Now — and only now — the marker takes one of the slots.
+            chunks = chunks[: max(0, section_budget - 1)]
     blocks: list = [
         {"type": "section", "text": {"type": "mrkdwn", "text": chunk}}
         for chunk in chunks

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -107,9 +107,8 @@ DEFAULT_API_BASE = "https://slack.com/api"
 # clients render the first 3000 cleanly; the Rust adapter used 3000
 # (`SLACK_MSG_LIMIT`) so we preserve that.
 SLACK_MSG_LIMIT = 3000
-# Slack rejects a `chat.postMessage` carrying more than 50 blocks. Only the
-# Block Kit paths (interactive replies, the task-progress card) can approach
-# this; the plain-text path chunks into separate messages instead.
+# Slack rejects a `chat.postMessage` carrying more than 50 blocks.
+# Only the Block Kit paths (interactive replies, the task-progress card) can approach this; the plain-text path chunks into separate messages instead.
 MAX_BLOCKS_PER_MESSAGE = 50
 
 SEND_TIMEOUT_SECS = 15.0
@@ -486,12 +485,8 @@ class SlackAdapter(SidecarAdapter):
         self.reactions_enabled = _bool_env(
             os.environ.get("SLACK_REACTIONS", ""), default=True,
         )
-        # The task-progress card is a separate indicator from the receipt
-        # reaction (#6730): silencing the emoji noise used to silence the
-        # card too, which was the only workaround for either. It defaults
-        # to whatever `SLACK_REACTIONS` resolved to, so an operator who
-        # already runs `SLACK_REACTIONS=false` for total silence keeps it
-        # and does not suddenly start receiving cards.
+        # The task-progress card is a separate indicator from the receipt reaction (#6730): silencing the emoji noise used to silence the card too, which was the only workaround for either.
+        # It defaults to whatever `SLACK_REACTIONS` resolved to, so an operator who already runs `SLACK_REACTIONS=false` for total silence keeps it and does not suddenly start receiving cards.
         self.progress_card_enabled = _bool_env(
             os.environ.get("SLACK_PROGRESS_CARD", ""),
             default=self.reactions_enabled,
@@ -646,12 +641,8 @@ class SlackAdapter(SidecarAdapter):
         chunks = (
             _split_message(text, SLACK_MSG_LIMIT)
             if blocks is None
-            # With blocks, `text` is only the notification-preview fallback
-            # (the blocks carry the rendered content, already split to fit
-            # per-section), so chunking it into several messages would post
-            # the same blocks repeatedly. Bound it instead — an unbounded
-            # notification string buys nothing and is one more length the
-            # API can reject.
+            # With blocks, `text` is only the notification-preview fallback (the blocks carry the rendered content, already split to fit per-section), so chunking it into several messages would post the same blocks repeatedly.
+            # Bound it instead — an unbounded notification string buys nothing and is one more length the API can reject.
             else [text[:SLACK_MSG_LIMIT]]
         )
         for chunk in chunks:
@@ -908,14 +899,8 @@ class SlackAdapter(SidecarAdapter):
             )
             if ev is None:
                 return
-            # No reaction here (#6731). Receiving a message is not the
-            # same as answering it: the daemon may decline the turn for
-            # any of ~two dozen reasons (mention-only group gating, an
-            # `[allowed_channels]`-adjacent RBAC denial, a per-user rate
-            # limit, a slash command it handles itself), all of which
-            # return before any adapter-visible lifecycle signal. The
-            # receipt is added from the `queued` phase in `_on_phase`
-            # instead, which fires only for a turn that is actually run.
+            # No reaction here (#6731). Receiving a message is not the same as answering it: the daemon may decline the turn for any of ~two dozen reasons (mention-only group gating, an `[allowed_channels]`-adjacent RBAC denial, a per-user rate limit, a slash command it handles itself), all of which return before any adapter-visible lifecycle signal.
+            # The receipt is added from the `queued` phase in `_on_phase` instead, which fires only for a turn that is actually run.
             emit(ev)
             return
         if env_type == "interactive":
@@ -985,11 +970,8 @@ class SlackAdapter(SidecarAdapter):
         if not channel_id:
             log.warn("slack on_send: empty channel_id, dropping")
             return
-        # The inbound thread id (post-#5302 this is the message's own ts
-        # for a top-level message, or the thread root for an in-thread
-        # reply). Used to decide where to post, nothing else — reaction
-        # finalization moved onto the lifecycle stream in #6731, keyed by
-        # the triggering message's own ts rather than this.
+        # The inbound thread id (post-#5302 this is the message's own ts for a top-level message, or the thread root for an in-thread reply).
+        # Used to decide where to post, nothing else — reaction finalization moved onto the lifecycle stream in #6731, keyed by the triggering message's own ts rather than this.
         inbound_thread_id = getattr(cmd, "thread_id", None)
         # Decide thread context for *posting*: force-flat-replies mode
         # forces the reply to a top-level post (mirrors the Rust adapter's
@@ -1076,10 +1058,8 @@ class SlackAdapter(SidecarAdapter):
                     lambda: self._add_reaction(channel_id, message_id, "eyes"),
                 )
             else:
-                # An empty emoji on the wire is the daemon's
-                # `clear_done_reaction` signal ("remove, add nothing").
-                # Every other terminal frame carries one, so only Done can
-                # be empty — see `lifecycle_reaction_emoji` in bridge.rs.
+                # An empty emoji on the wire is the daemon's `clear_done_reaction` signal ("remove, add nothing").
+                # Every other terminal frame carries one, so only Done can be empty — see `lifecycle_reaction_emoji` in bridge.rs.
                 wire_emoji = getattr(cmd, "reaction", "") or ""
                 if phase == "error":
                     terminal_emoji: Optional[str] = "x"
@@ -1094,9 +1074,7 @@ class SlackAdapter(SidecarAdapter):
                     ),
                 )
         if phase == "queued":
-            # `queued` is never rendered in the card, so there is nothing
-            # left to do — and materializing card state for it would make
-            # every turn look multi-step.
+            # `queued` is never rendered in the card, so there is nothing left to do — and materializing card state for it would make every turn look multi-step.
             return
         if not self.progress_card_enabled:
             return
@@ -1254,10 +1232,8 @@ _BOLD_STAR_RE = re.compile(r"\*\*([^*\n]+)\*\*")
 _BOLD_USCORE_RE = re.compile(r"__([^_\n]+)__")
 _STRIKE_RE = re.compile(r"~~([^~\n]+)~~")
 # A run of three or more newlines, i.e. two or more consecutive blank lines.
-# Collapsed to a single blank line (Slack's paragraph separator) so a model that
-# pads its answer with blank lines does not turn a short reply into a wall of
-# whitespace (#6730). Applied to the code-MASKED string, so a fenced block's
-# interior — already a single token by then — is untouchable.
+# Collapsed to a single blank line (Slack's paragraph separator) so a model that pads its answer with blank lines does not turn a short reply into a wall of whitespace (#6730).
+# Applied to the code-MASKED string, so a fenced block's interior — already a single token by then — is untouchable.
 _BLANK_LINE_RUN_RE = re.compile(r"\n{3,}")
 # A GitHub-flavoured-Markdown table divider row: |---|:--:|---:| etc.
 # Requires ≥2 columns (≥1 internal pipe) so a lone `---` horizontal rule is not mistaken for a table.
@@ -1390,11 +1366,8 @@ def _markdown_to_mrkdwn(text: str) -> str:
 
     masked = _CODE_SPAN_RE.sub(mask, text)
     converted = _convert_md_lines(masked, codes)
-    # Collapse blank-line runs while the code spans are still masked — a
-    # fenced block is one token at this point, so its interior blank lines
-    # cannot be touched. `_convert_md_lines` is a 1:1 line mapper (a
-    # content-less header even emits an extra empty line), so without this
-    # an `\n\n\n\n` run reached Slack verbatim.
+    # Collapse blank-line runs while the code spans are still masked — a fenced block is one token at this point, so its interior blank lines cannot be touched.
+    # `_convert_md_lines` is a 1:1 line mapper (a content-less header even emits an extra empty line), so without this an `\n\n\n\n` run reached Slack verbatim.
     converted = _BLANK_LINE_RUN_RE.sub("\n\n", converted)
     return _restore_code_spans(converted, codes)
 
@@ -1442,9 +1415,7 @@ def _build_block_kit(text: str, buttons: list) -> list:
                 "elements": elements,
             })
 
-    # `_split_message` cuts on newlines where it can and provably yields
-    # chunks <= the limit; an empty string comes back as [""], preserving the
-    # historical single-empty-section shape.
+    # `_split_message` cuts on newlines where it can and provably yields chunks <= the limit; an empty string comes back as [""], preserving the historical single-empty-section shape.
     chunks = _split_message(text, SLACK_MSG_LIMIT)
 
     # The marker costs a block, so its slot is reserved only once truncation is actually happening.

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -36,15 +36,22 @@ Behaviour parity with the Rust adapter:
 * **REST send**: ``POST /api/chat.postMessage`` with the bot token,
   optional ``thread_ts`` and ``unfurl_links``. 3 000-char chunking
   (matches the Rust ``SLACK_MSG_LIMIT``).
-* **Reactions**: ``eyes`` on receive, ``white_check_mark`` on
-  completion (opt-out via ``SLACK_REACTIONS=false``).
-* **Task progress** (#6451): the generic AgentPhase lifecycle
-  (Thinking → ToolUse{name} → Done/Error) reaches the adapter as
-  ``reaction`` commands through the declared ``reaction`` capability
-  and is rendered as an updated-in-place Block Kit step list
-  (``chat.update``) for multi-step turns. Single-step turns post no
-  card and keep just the receipt reactions. Same ``SLACK_REACTIONS``
-  opt-out.
+* **Reactions** (#6731): the receipt is driven by the daemon's
+  AgentPhase lifecycle, not by the receive hook — ``eyes`` on
+  ``queued``, flipped to ``white_check_mark`` on ``done`` and ``x`` on
+  ``error``. A message the daemon declines to answer (group
+  mention-only gating, a rate-limit rejection, a slash command handled
+  in-bridge) never reaches ``queued``, so it never gets a reaction at
+  all instead of being left with a permanent ``eyes``. Opt out via
+  ``SLACK_REACTIONS=false``.
+* **Task progress** (#6451): the same AgentPhase lifecycle
+  (Thinking → ToolUse{name} → Done/Error) is rendered as an
+  updated-in-place Block Kit step list (``chat.update``) for
+  multi-step turns. Single-step turns post no card and keep just the
+  receipt reactions. Toggled independently of the receipt via
+  ``SLACK_PROGRESS_CARD`` (#6730), which defaults to whatever
+  ``SLACK_REACTIONS`` is set to so neither knob silently turns the
+  other's output on.
 
 Stdlib-only: HTTPS via ``urllib.request``, WebSocket via a
 hand-rolled RFC 6455 client over ``socket`` + ``ssl`` (same pattern
@@ -62,6 +69,7 @@ Configure via ``[[sidecar_channels]]``::
     # SLACK_UNFURL_LINKS = "false"
     # SLACK_FORCE_FLAT_REPLIES = "false"
     # SLACK_REACTIONS = "true"
+    # SLACK_PROGRESS_CARD = "true"
     # SLACK_ACCOUNT_ID = "workspace-prod"
 
 Secrets via ``~/.librefang/secrets.env``: ``SLACK_APP_TOKEN`` (the
@@ -109,6 +117,10 @@ DEFAULT_API_BASE = "https://slack.com/api"
 # clients render the first 3000 cleanly; the Rust adapter used 3000
 # (`SLACK_MSG_LIMIT`) so we preserve that.
 SLACK_MSG_LIMIT = 3000
+# Slack rejects a `chat.postMessage` carrying more than 50 blocks. Only the
+# Block Kit paths (interactive replies, the task-progress card) can approach
+# this; the plain-text path chunks into separate messages instead.
+MAX_BLOCKS_PER_MESSAGE = 50
 
 SEND_TIMEOUT_SECS = 15.0
 HANDSHAKE_TIMEOUT_SECS = 15.0
@@ -390,11 +402,22 @@ class SlackAdapter(SidecarAdapter):
     # interactions back to ``on_command``/``on_send``, ``thread`` for
     # threaded replies, and ``reaction`` so the generic AgentPhase
     # lifecycle (Queued → Thinking → ToolUse{name} → Streaming →
-    # Done/Error) reaches ``on_command`` as ``reaction`` commands. We
-    # repurpose that phase stream into an updated-in-place Block Kit
-    # task-progress card for multi-step turns (#6451) — the eyes/
-    # white_check_mark receipt reactions stay driven by the receive/send
-    # hooks, independent of the lifecycle stream.
+    # Done/Error) reaches ``on_command`` as ``reaction`` commands. That
+    # one phase stream drives BOTH adapter-side processing indicators:
+    # the eyes/white_check_mark receipt (Queued to Done/Error) and the
+    # updated-in-place Block Kit task-progress card for multi-step turns
+    # (#6451).
+    #
+    # The receipt used to be driven by the receive/send hooks instead,
+    # which is what #6731 fixed: ``_handle_envelope`` added the eyes to
+    # every message it emitted, including the ones the daemon then
+    # declined to answer (mention-only group gating and the other
+    # pre-lifecycle early returns in ``dispatch_message``), leaving a
+    # permanent eyes with no way for the adapter to learn the turn was
+    # never run. Keying off the lifecycle closes all of those paths
+    # structurally: the first adapter-visible signal of a dispatched
+    # turn is Queued, so nothing is added unless a turn actually starts,
+    # and every started turn reaches Done or Error.
     #
     # Why ``reaction`` and not a new ``task_update`` capability: the
     # generic phase lifecycle is dispatched to adapters through
@@ -433,8 +456,14 @@ class SlackAdapter(SidecarAdapter):
                   placeholder="false",
                   advanced=True),
             Field("SLACK_REACTIONS",
-                  "Show processing-state indicators (eyes/check receipt "
-                  "reactions and the multi-step task-progress card)",
+                  "Add an eyes reaction while a turn runs and flip it to "
+                  "a check / cross when it finishes",
+                  "bool",
+                  placeholder="true",
+                  advanced=True),
+            Field("SLACK_PROGRESS_CARD",
+                  "Show the multi-step task-progress card (defaults to "
+                  "following SLACK_REACTIONS)",
                   "bool",
                   placeholder="true",
                   advanced=True),
@@ -477,6 +506,16 @@ class SlackAdapter(SidecarAdapter):
         )
         self.reactions_enabled = _bool_env(
             os.environ.get("SLACK_REACTIONS", ""), default=True,
+        )
+        # The task-progress card is a separate indicator from the receipt
+        # reaction (#6730): silencing the emoji noise used to silence the
+        # card too, which was the only workaround for either. It defaults
+        # to whatever `SLACK_REACTIONS` resolved to, so an operator who
+        # already runs `SLACK_REACTIONS=false` for total silence keeps it
+        # and does not suddenly start receiving cards.
+        self.progress_card_enabled = _bool_env(
+            os.environ.get("SLACK_PROGRESS_CARD", ""),
+            default=self.reactions_enabled,
         )
         acct = os.environ.get("SLACK_ACCOUNT_ID", "").strip()
         self.account_id = acct or None
@@ -625,7 +664,15 @@ class SlackAdapter(SidecarAdapter):
         failures — `_http` reports the 200 status and `_post_message`
         inspects the body for `ok` (matches the Rust adapter)."""
         chunks = (
-            _split_message(text, SLACK_MSG_LIMIT) if blocks is None else [text]
+            _split_message(text, SLACK_MSG_LIMIT)
+            if blocks is None
+            # With blocks, `text` is only the notification-preview fallback
+            # (the blocks carry the rendered content, already split to fit
+            # per-section), so chunking it into several messages would post
+            # the same blocks repeatedly. Bound it instead — an unbounded
+            # notification string buys nothing and is one more length the
+            # API can reject.
+            else [text[:SLACK_MSG_LIMIT]]
         )
         for chunk in chunks:
             payload: dict[str, Any] = {"channel": channel_id, "text": chunk}
@@ -772,8 +819,8 @@ class SlackAdapter(SidecarAdapter):
 
     def _track_pending_reaction(self, channel: str, ts: str, emoji: str) -> None:
         """Record that we added an ``emoji`` reaction on ``channel/ts``
-        so :meth:`_finalize_pending_reaction` can flip it to
-        white_check_mark after the agent reply lands."""
+        so :meth:`_finalize_pending_reaction` can flip it to the terminal
+        emoji once the turn reaches its Done / Error phase."""
         key = (channel, ts)
         with self._pending_lock:
             if len(self._pending_reactions) >= self.MAX_PENDING_REACTIONS:
@@ -789,28 +836,34 @@ class SlackAdapter(SidecarAdapter):
             self._pending_reactions[key] = emoji
 
     def _finalize_pending_reaction(
-        self, channel: str, ts: Optional[str],
+        self, channel: str, ts: Optional[str], emoji: Optional[str],
     ) -> None:
-        """Remove the eyes (if present) and add the white_check_mark."""
-        if not self.reactions_enabled:
+        """Remove the in-progress receipt on ``channel``/``ts`` and put
+        ``emoji`` in its place. ``emoji=None`` removes only — that is the
+        daemon's ``clear_done_reaction`` signal, which arrives as an empty
+        emoji on the terminal phase.
+
+        Keyed strictly by ``(channel, ts)``. There is deliberately no
+        "first pending entry in this channel" fallback: the lifecycle
+        always carries the exact triggering ``message_id``, and the old
+        fallback flipped an unrelated sibling message's receipt whenever
+        the exact key missed (which it did for every in-thread reply,
+        because the send hook keyed off the thread root instead of the
+        message's own ts).
+
+        A miss is therefore a no-op, which also makes a repeated terminal
+        phase idempotent: the first one pops the entry, the second finds
+        nothing and adds nothing.
+        """
+        if not self.reactions_enabled or not ts:
             return
-        emoji: Optional[str] = None
-        key: Optional[tuple[str, str]] = None
         with self._pending_lock:
-            if ts is not None:
-                key = (channel, ts)
-                emoji = self._pending_reactions.pop(key, None)
-            if emoji is None:
-                # No explicit ts → pick the first pending entry for
-                # this channel (DM context, single-message round-trip).
-                for k in list(self._pending_reactions):
-                    if k[0] == channel:
-                        emoji = self._pending_reactions.pop(k)
-                        key = k
-                        break
-        if emoji is not None and key is not None:
-            self._remove_reaction(key[0], key[1], emoji)
-            self._add_reaction(key[0], key[1], "white_check_mark")
+            pending = self._pending_reactions.pop((channel, ts), None)
+        if pending is None:
+            return
+        self._remove_reaction(channel, ts, pending)
+        if emoji:
+            self._add_reaction(channel, ts, emoji)
 
     # ---- Socket Mode loop -------------------------------------------
 
@@ -886,19 +939,14 @@ class SlackAdapter(SidecarAdapter):
             )
             if ev is None:
                 return
-            # Add the eyes reaction so the user sees the bot is
-            # working. We track (channel, ts) so the post-send hook
-            # can flip eyes → check.
-            params = ev["params"]
-            channel_id = params["user_id"]
-            ts = params.get("message_id")
-            if self.reactions_enabled and isinstance(ts, str) and ts:
-                self._track_pending_reaction(channel_id, ts, "eyes")
-                # Best-effort, fire-and-forget — _add_reaction is
-                # synchronous but Slack reactions.add returns in tens
-                # of ms; doing it inline is fine and avoids spawning
-                # a thread per inbound message.
-                self._add_reaction(channel_id, ts, "eyes")
+            # No reaction here (#6731). Receiving a message is not the
+            # same as answering it: the daemon may decline the turn for
+            # any of ~two dozen reasons (mention-only group gating, an
+            # `[allowed_channels]`-adjacent RBAC denial, a per-user rate
+            # limit, a slash command it handles itself), all of which
+            # return before any adapter-visible lifecycle signal. The
+            # receipt is added from the `queued` phase in `_on_phase`
+            # instead, which fires only for a turn that is actually run.
             emit(ev)
             return
         if env_type == "interactive":
@@ -970,7 +1018,9 @@ class SlackAdapter(SidecarAdapter):
             return
         # The inbound thread id (post-#5302 this is the message's own ts
         # for a top-level message, or the thread root for an in-thread
-        # reply). Used as the reaction-finalization key below.
+        # reply). Used to decide where to post, nothing else — reaction
+        # finalization moved onto the lifecycle stream in #6731, keyed by
+        # the triggering message's own ts rather than this.
         inbound_thread_id = getattr(cmd, "thread_id", None)
         # Decide thread context for *posting*: force-flat-replies mode
         # forces the reply to a top-level post (mirrors the Rust adapter's
@@ -1012,52 +1062,43 @@ class SlackAdapter(SidecarAdapter):
                 lambda: self._post_message(channel_id, text, thread_ts=thread_ts),
             )
 
-        # Flip eyes → white_check_mark for the message that triggered
-        # this reply. The Rust adapter does this synchronously on the
-        # send path; we mirror it. Finalization MUST use the inbound
-        # thread id (not the posting `thread_ts`, which is forced to None
-        # in force-flat mode) so it targets the message that actually got
-        # the :eyes: instead of falling back to "first pending in channel"
-        # and flipping the wrong message under concurrency.
-        if self.reactions_enabled:
-            await loop.run_in_executor(
-                None,
-                lambda: self._finalize_pending_reaction(
-                    channel_id, inbound_thread_id,
-                ),
-            )
-
     async def on_command(self, cmd) -> None:
-        """Route lifecycle ``reaction`` commands to the task-progress
-        display; defer everything else (``send`` → ``on_send``) to the
-        base dispatcher."""
+        """Route lifecycle ``reaction`` commands to the receipt reaction
+        and task-progress display; defer everything else (``send`` →
+        ``on_send``) to the base dispatcher."""
         if isinstance(cmd, protocol.Reaction):
             await self._on_phase(cmd)
             return
         await super().on_command(cmd)
 
     async def _on_phase(self, cmd) -> None:
-        """Fold one AgentPhase lifecycle ``reaction`` into a live Block
-        Kit task-progress card.
+        """Fold one AgentPhase lifecycle ``reaction`` into the receipt
+        reaction and, for multi-step turns, a live Block Kit
+        task-progress card.
 
-        The card is materialized lazily — only once a turn actually runs
-        a tool (a genuinely multi-step turn). Single-step turns
-        (Queued → Thinking → Done with no ToolUse) post nothing here and
-        keep the pre-#6451 UX: the eyes → white_check_mark receipt
-        reaction driven by the receive/send hooks. Called only from the
-        serialized ``on_command`` reader path, so the state map needs no
-        lock; the Slack Web API calls are offloaded to the executor.
+        Two independent indicators, one stream:
+
+        * **Receipt** (``SLACK_REACTIONS``): ``queued`` adds the eyes to
+          the triggering message; ``done`` / ``error`` flip it to
+          white_check_mark / x. Handled BEFORE the card bookkeeping
+          below, because a single-step turn has no card state and would
+          otherwise hit the early-out and never finalize — leaving
+          exactly the stuck eyes #6731 is about.
+        * **Card** (``SLACK_PROGRESS_CARD``): materialized lazily, only
+          once a turn actually runs a tool (a genuinely multi-step turn).
+          Single-step turns (Queued → Thinking → Done with no ToolUse)
+          post nothing and keep just the receipt.
+
+        Called only from the serialized ``on_command`` reader path, so the
+        state map needs no lock; the Slack Web API calls are offloaded to
+        the executor.
         """
-        # The progress card is a processing-state indicator, so it honours
-        # the same operator toggle (`SLACK_REACTIONS`) as the eyes/check
-        # receipt reactions — disabling it silences all processing chatter.
-        if not self.reactions_enabled:
+        if not self.reactions_enabled and not self.progress_card_enabled:
             return
         phase = (getattr(cmd, "phase", "") or "").strip()
         if not phase:
             # Legacy emoji-only reaction (pre-#6451 daemon): no structured
-            # phase to render, and single-step UX is already covered by
-            # the receipt reactions. Ignore.
+            # phase, so neither indicator has anything to key off. Ignore.
             return
         channel_id = cmd.channel_id
         message_id = cmd.message_id
@@ -1065,7 +1106,43 @@ class SlackAdapter(SidecarAdapter):
             return
         key = (channel_id, message_id)
         terminal = phase in ("done", "error")
+        loop = asyncio.get_event_loop()
 
+        # ---- receipt reaction (#6731) --------------------------------
+        if self.reactions_enabled and (phase == "queued" or terminal):
+            if phase == "queued":
+                self._track_pending_reaction(channel_id, message_id, "eyes")
+                await loop.run_in_executor(
+                    None,
+                    lambda: self._add_reaction(channel_id, message_id, "eyes"),
+                )
+            else:
+                # An empty emoji on the wire is the daemon's
+                # `clear_done_reaction` signal ("remove, add nothing").
+                # Every other terminal frame carries one, so only Done can
+                # be empty — see `lifecycle_reaction_emoji` in bridge.rs.
+                wire_emoji = getattr(cmd, "reaction", "") or ""
+                if phase == "error":
+                    terminal_emoji: Optional[str] = "x"
+                elif wire_emoji:
+                    terminal_emoji = "white_check_mark"
+                else:
+                    terminal_emoji = None
+                await loop.run_in_executor(
+                    None,
+                    lambda: self._finalize_pending_reaction(
+                        channel_id, message_id, terminal_emoji,
+                    ),
+                )
+        if phase == "queued":
+            # `queued` is never rendered in the card, so there is nothing
+            # left to do — and materializing card state for it would make
+            # every turn look multi-step.
+            return
+        if not self.progress_card_enabled:
+            return
+
+        # ---- task-progress card (#6451) ------------------------------
         prog = self._task_progress.get(key)
         if prog is None:
             if terminal:
@@ -1083,7 +1160,7 @@ class SlackAdapter(SidecarAdapter):
                     pass
             self._task_progress[key] = prog
 
-        # Record the step. `queued` is transient and never shown.
+        # Record the step. `queued` returned above and is never shown.
         if phase == "tool_use":
             prog.steps.append(("tool_use", getattr(cmd, "tool_name", None)))
         elif phase in ("thinking", "streaming"):
@@ -1101,7 +1178,6 @@ class SlackAdapter(SidecarAdapter):
             return
 
         text, blocks = _build_task_progress_blocks(prog.steps, phase)
-        loop = asyncio.get_event_loop()
         if prog.card_ts is None:
             thread_ts = None if self.force_flat_replies else message_id
             ts = await loop.run_in_executor(
@@ -1216,6 +1292,12 @@ _MD_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)\s]+)\)")
 _BOLD_STAR_RE = re.compile(r"\*\*([^*\n]+)\*\*")
 _BOLD_USCORE_RE = re.compile(r"__([^_\n]+)__")
 _STRIKE_RE = re.compile(r"~~([^~\n]+)~~")
+# A run of three or more newlines, i.e. two or more consecutive blank lines.
+# Collapsed to a single blank line (Slack's paragraph separator) so a model that
+# pads its answer with blank lines does not turn a short reply into a wall of
+# whitespace (#6730). Applied to the code-MASKED string, so a fenced block's
+# interior — already a single token by then — is untouchable.
+_BLANK_LINE_RUN_RE = re.compile(r"\n{3,}")
 # A GitHub-flavoured-Markdown table divider row: |---|:--:|---:| etc.
 # Requires ≥2 columns (≥1 internal pipe) so a lone `---` horizontal rule is not mistaken for a table.
 _TABLE_DIVIDER_RE = re.compile(r"^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)+\|?\s*$")
@@ -1346,18 +1428,34 @@ def _markdown_to_mrkdwn(text: str) -> str:
         return f"\x00{len(codes) - 1}\x01"
 
     masked = _CODE_SPAN_RE.sub(mask, text)
-    return _restore_code_spans(_convert_md_lines(masked, codes), codes)
+    converted = _convert_md_lines(masked, codes)
+    # Collapse blank-line runs while the code spans are still masked — a
+    # fenced block is one token at this point, so its interior blank lines
+    # cannot be touched. `_convert_md_lines` is a 1:1 line mapper (a
+    # content-less header even emits an extra empty line), so without this
+    # an `\n\n\n\n` run reached Slack verbatim.
+    converted = _BLANK_LINE_RUN_RE.sub("\n\n", converted)
+    return _restore_code_spans(converted, codes)
 
 
 def _build_block_kit(text: str, buttons: list) -> list:
     """Render a ``Content.interactive`` payload into Slack Block Kit
     blocks. Mirrors the Rust adapter's `api_send_interactive_message`
-    layout: one ``section`` block with the text (mrkdwn), then one
-    ``actions`` block per row of buttons."""
-    blocks: list = [{
-        "type": "section",
-        "text": {"type": "mrkdwn", "text": text},
-    }]
+    layout: ``section`` block(s) with the text (mrkdwn), then one
+    ``actions`` block per row of buttons.
+
+    The text is split across as many sections as it needs (#6730). Slack
+    rejects a ``section`` whose text exceeds ``SLACK_MSG_LIMIT``, and
+    ``_post_message`` deliberately skips its chunking when ``blocks`` is
+    present, so a long interactive reply used to be rejected wholesale and
+    dropped with nothing but a log line — the same limit
+    ``_build_task_progress_blocks`` already guards for.
+
+    Buttons are built first and budgeted against Slack's 50-blocks-per-
+    message cap, because they are the functional payload: truncating text
+    degrades a reply, dropping buttons breaks the interaction.
+    """
+    action_blocks: list = []
     for row_idx, row in enumerate(buttons or []):
         if not isinstance(row, list):
             continue
@@ -1383,11 +1481,33 @@ def _build_block_kit(text: str, buttons: list) -> list:
                 element["url"] = url
             elements.append(element)
         if elements:
-            blocks.append({
+            action_blocks.append({
                 "type": "actions",
                 "block_id": f"interactive_row_{row_idx}",
                 "elements": elements,
             })
+
+    # `_split_message` cuts on newlines where it can and provably yields
+    # chunks <= the limit; an empty string comes back as [""], preserving the
+    # historical single-empty-section shape.
+    chunks = _split_message(text, SLACK_MSG_LIMIT)
+    # One slot reserved for the truncation marker below.
+    max_sections = MAX_BLOCKS_PER_MESSAGE - len(action_blocks) - 1
+    truncated = len(chunks) > max_sections
+    if truncated:
+        chunks = chunks[:max_sections]
+    blocks: list = [
+        {"type": "section", "text": {"type": "mrkdwn", "text": chunk}}
+        for chunk in chunks
+    ]
+    if truncated:
+        # Its own section, so the marker can never push a chunk over the
+        # per-section character limit.
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "_(message truncated)_"},
+        })
+    blocks.extend(action_blocks)
     return blocks
 
 

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -1491,8 +1491,11 @@ def _build_block_kit(text: str, buttons: list) -> list:
     # chunks <= the limit; an empty string comes back as [""], preserving the
     # historical single-empty-section shape.
     chunks = _split_message(text, SLACK_MSG_LIMIT)
-    # One slot reserved for the truncation marker below.
-    max_sections = MAX_BLOCKS_PER_MESSAGE - len(action_blocks) - 1
+    # One slot reserved for the truncation marker below. Clamped at 0: once
+    # `action_blocks` alone reaches the cap, `chunks[:max_sections]` with a
+    # negative `max_sections` would slice from the end instead of yielding
+    # no sections (Python's `[:-n]` is "drop the last n", not "keep none").
+    max_sections = max(0, MAX_BLOCKS_PER_MESSAGE - len(action_blocks) - 1)
     truncated = len(chunks) > max_sections
     if truncated:
         chunks = chunks[:max_sections]

--- a/sdk/python/librefang/sidecar/adapters/slack.py
+++ b/sdk/python/librefang/sidecar/adapters/slack.py
@@ -1014,9 +1014,7 @@ class SlackAdapter(SidecarAdapter):
             )
 
     async def on_command(self, cmd) -> None:
-        """Route lifecycle ``reaction`` commands to the receipt reaction
-        and task-progress display; defer everything else (``send`` →
-        ``on_send``) to the base dispatcher."""
+        """Route lifecycle ``reaction`` commands to the receipt reaction and task-progress display; defer everything else (``send`` → ``on_send``) to the base dispatcher."""
         if isinstance(cmd, protocol.Reaction):
             await self._on_phase(cmd)
             return

--- a/sdk/python/tests/test_slack_adapter.py
+++ b/sdk/python/tests/test_slack_adapter.py
@@ -1372,9 +1372,7 @@ async def test_on_send_converts_markdown_to_mrkdwn(monkeypatch):
 
 def _reaction(phase, tool_name=None, channel_id="C01", message_id="T1",
               emoji="x"):
-    """Build an AgentPhase lifecycle `reaction` command the way the
-    bridge serializes it (channel_id, message_id, emoji, phase,
-    tool_name).
+    """Build an AgentPhase lifecycle `reaction` command the way the bridge serializes it (channel_id, message_id, emoji, phase, tool_name).
 
     `emoji` is the wire emoji the daemon computed for the phase.
     Its only load-bearing value is the empty string, which is the `clear_done_reaction` signal on a terminal frame; the adapter maps every other value to a Slack emoji *name* itself, because `reactions.add` takes `white_check_mark`, not the `✅` codepoint.

--- a/sdk/python/tests/test_slack_adapter.py
+++ b/sdk/python/tests/test_slack_adapter.py
@@ -1289,6 +1289,24 @@ def test_build_block_kit_never_exceeds_block_limit():
                for b in blocks if b["type"] == "section")
 
 
+def test_build_block_kit_button_rows_alone_exceed_block_cap():
+    # Regression: when `action_blocks` alone reaches/exceeds
+    # MAX_BLOCKS_PER_MESSAGE - 1, `max_sections` goes negative. Python's
+    # `list[:-n]` means "drop the last n", not "keep none", so an
+    # unclamped `chunks[:max_sections]` kept a stray section instead of
+    # zero — this pins the clamp that makes zero sections the outcome.
+    buttons = [[{"label": f"B{i}", "action": f"a{i}"}]
+               for i in range(sa.MAX_BLOCKS_PER_MESSAGE)]
+    blocks = sa._build_block_kit("some text", buttons)
+    sections = [b for b in blocks if b["type"] == "section"]
+    # No room for the text itself, just the truncation marker — never a
+    # stray real chunk of the text (the unclamped negative-slice bug).
+    assert len(sections) == 1
+    assert "truncated" in sections[0]["text"]["text"]
+    assert len([b for b in blocks if b["type"] == "actions"]) == \
+        sa.MAX_BLOCKS_PER_MESSAGE
+
+
 def test_post_message_with_blocks_bounds_fallback_text(monkeypatch):
     # With blocks, `text` is only the notification preview — the blocks carry
     # the content. It is bounded rather than chunked, because chunking it

--- a/sdk/python/tests/test_slack_adapter.py
+++ b/sdk/python/tests/test_slack_adapter.py
@@ -32,6 +32,7 @@ def _adapter(**env):
         "SLACK_UNFURL_LINKS": "",
         "SLACK_FORCE_FLAT_REPLIES": "",
         "SLACK_REACTIONS": "",
+        "SLACK_PROGRESS_CARD": "",
         "SLACK_ACCOUNT_ID": "",
     }
     for k, v in defaults.items():
@@ -51,6 +52,7 @@ def test_default_api_base_and_tokens():
     assert a.unfurl_links is None
     assert a.force_flat_replies is False
     assert a.reactions_enabled is True
+    assert a.progress_card_enabled is True
     assert a.account_id is None
 
 
@@ -98,6 +100,22 @@ def test_reactions_default_true():
     assert a_off.reactions_enabled is False
     a_0 = _adapter(SLACK_REACTIONS="0")
     assert a_0.reactions_enabled is False
+
+
+def test_progress_card_defaults_to_following_reactions():
+    # #6730 decoupled the card from the receipt, but an operator already
+    # running SLACK_REACTIONS=false for total silence must not start
+    # receiving cards on upgrade — so the card's default follows the
+    # receipt knob rather than being an unconditional true.
+    assert _adapter().progress_card_enabled is True
+    assert _adapter(SLACK_REACTIONS="false").progress_card_enabled is False
+    # …and each is independently overridable, which is the point of #6730.
+    a_card_only = _adapter(SLACK_REACTIONS="false", SLACK_PROGRESS_CARD="true")
+    assert a_card_only.reactions_enabled is False
+    assert a_card_only.progress_card_enabled is True
+    a_receipt_only = _adapter(SLACK_PROGRESS_CARD="false")
+    assert a_receipt_only.reactions_enabled is True
+    assert a_receipt_only.progress_card_enabled is False
 
 
 def test_account_id_passthrough():
@@ -724,7 +742,7 @@ def test_finalize_pending_reaction_uses_ts(monkeypatch):
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter()
     a._track_pending_reaction("C01", "1700000000.0", "eyes")
-    a._finalize_pending_reaction("C01", "1700000000.0")
+    a._finalize_pending_reaction("C01", "1700000000.0", "white_check_mark")
     urls = [c["url"] for c in fake.calls]
     assert urls[0].endswith("/reactions.remove")
     assert urls[1].endswith("/reactions.add")
@@ -736,8 +754,46 @@ def test_finalize_pending_reaction_disabled_noop(monkeypatch):
     fake = _FakeUrlopen([])
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter(SLACK_REACTIONS="false")
-    a._finalize_pending_reaction("C01", "1700000000.0")
+    a._finalize_pending_reaction("C01", "1700000000.0", "white_check_mark")
     assert fake.calls == []
+
+
+def test_finalize_pending_reaction_unknown_key_is_noop(monkeypatch):
+    # #6731: the "first pending entry in this channel" fallback is gone.
+    # A miss must touch nothing — the old fallback flipped an unrelated
+    # sibling message's receipt instead, which is exactly what happened on
+    # every in-thread reply (the send hook keyed off the thread root).
+    fake = _FakeUrlopen([])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    a._track_pending_reaction("C01", "SIBLING", "eyes")
+    a._finalize_pending_reaction("C01", "MINE", "white_check_mark")
+    assert fake.calls == []
+    assert ("C01", "SIBLING") in a._pending_reactions
+
+
+def test_finalize_pending_reaction_empty_emoji_removes_only(monkeypatch):
+    # The daemon's `clear_done_reaction` knob puts an empty emoji on the
+    # terminal frame — remove the eyes, add nothing.
+    fake = _FakeUrlopen([(200, {"ok": True})])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    a._track_pending_reaction("C01", "T1", "eyes")
+    a._finalize_pending_reaction("C01", "T1", None)
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["url"].endswith("/reactions.remove")
+
+
+def test_finalize_pending_reaction_is_idempotent(monkeypatch):
+    # A repeated terminal phase must not add a second check: the first
+    # call pops the pending entry, the second finds nothing.
+    fake = _FakeUrlopen([(200, {"ok": True}), (200, {"ok": True})])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    a._track_pending_reaction("C01", "T1", "eyes")
+    a._finalize_pending_reaction("C01", "T1", "white_check_mark")
+    a._finalize_pending_reaction("C01", "T1", "white_check_mark")
+    assert len(fake.calls) == 2
 
 
 # ---- _handle_envelope state machine -------------------------------
@@ -769,9 +825,7 @@ class _FakeWs:
 
 
 def test_handle_events_api_acks_and_emits(monkeypatch):
-    # We must monkeypatch reactions urlopen because the events_api
-    # path issues `reactions.add` (eyes) synchronously after parsing.
-    fake = _FakeUrlopen([(200, {"ok": True})])
+    fake = _FakeUrlopen([])  # receiving a message issues no HTTP (#6731)
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter()
     a.bot_user_id = "UBOT"
@@ -792,9 +846,34 @@ def test_handle_events_api_acks_and_emits(monkeypatch):
     # One emitted message event.
     assert len(emitted) == 1
     assert emitted[0]["params"]["content"] == {"Text": "hello"}
-    # Reactions.add was called.
-    assert fake.calls
-    assert fake.calls[0]["url"].endswith("/reactions.add")
+
+
+def test_receive_adds_no_reaction(monkeypatch):
+    # #6731: the eyes used to be added here, on receive. The daemon can
+    # still decline the turn afterwards (mention-only group gating, a rate
+    # limit, a slash command it handles itself), and nothing ever came back
+    # to clear it — so a declined message kept a permanent eyes. The receipt
+    # now rides the `queued` lifecycle phase instead, which only fires for a
+    # turn that is actually dispatched.
+    fake = _FakeUrlopen([])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    a.bot_user_id = "UBOT"
+    emitted = []
+    a._handle_envelope(
+        {
+            "type": "events_api",
+            "envelope_id": "env-gate",
+            "payload": {"event": _evt()},
+        },
+        ws=_FakeWs(),
+        emit=emitted.append,
+    )
+    assert len(emitted) == 1
+    assert fake.calls == []
+    # Nothing was tracked either, so there is no leaked pending entry a
+    # later message's terminal phase could accidentally flip.
+    assert a._pending_reactions == {}
 
 
 def test_handle_interactive_acks_and_emits(monkeypatch):
@@ -922,20 +1001,17 @@ async def test_on_send_force_flat_replies_drops_thread_ts(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_on_send_force_flat_finalizes_correct_message(monkeypatch):
-    # Regression (#5302): in force-flat mode the *post* drops thread_ts,
-    # but reaction finalization must still target the inbound message
-    # (cmd.thread_id) instead of falling back to "first pending in the
-    # channel" — otherwise concurrent messages flip the wrong :eyes:.
+async def test_on_send_no_longer_touches_reactions(monkeypatch):
+    # #6731: the send hook used to finalize the receipt, keyed on
+    # `cmd.thread_id` — the thread ROOT ts for an in-thread reply, while the
+    # eyes was tracked under the message's own ts. The exact key missed and
+    # the deleted fallback flipped an arbitrary sibling instead. Finalization
+    # now lives on the lifecycle stream, so `on_send` posts and stops.
     fake = _FakeUrlopen([
-        (200, {"ok": True}),  # chat.postMessage
-        (200, {"ok": True}),  # reactions.remove
-        (200, {"ok": True}),  # reactions.add
+        (200, {"ok": True}),  # chat.postMessage — the only call expected
     ])
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter(SLACK_FORCE_FLAT_REPLIES="true")
-    # Two concurrent inbound messages got :eyes: in the same channel; T0
-    # is older, so the buggy fallback would have flipped it instead of T1.
     a._track_pending_reaction("C01", "T0", "eyes")
     a._track_pending_reaction("C01", "T1", "eyes")
 
@@ -947,19 +1023,13 @@ async def test_on_send_force_flat_finalizes_correct_message(monkeypatch):
         user = {}
 
     await a.on_send(_Cmd())
-    # The post is flat (force_flat dropped thread_ts)...
+    # The post is flat (force_flat dropped thread_ts)…
     post_body = json.loads(fake.calls[0]["body_raw"])
     assert "thread_ts" not in post_body
-    # ...but finalization targets T1, not the older T0.
-    assert fake.calls[1]["url"].endswith("/reactions.remove")
-    assert fake.calls[2]["url"].endswith("/reactions.add")
-    assert json.loads(fake.calls[1]["body_raw"])["timestamp"] == "T1"
-    add_body = json.loads(fake.calls[2]["body_raw"])
-    assert add_body["timestamp"] == "T1"
-    assert add_body["name"] == "white_check_mark"
-    # T1 finalized & removed; T0 stays pending (it was a different message).
-    assert ("C01", "T1") not in a._pending_reactions
+    # …and nothing else happened: no reactions call, both entries untouched.
+    assert len(fake.calls) == 1
     assert ("C01", "T0") in a._pending_reactions
+    assert ("C01", "T1") in a._pending_reactions
 
 
 @pytest.mark.asyncio
@@ -1158,6 +1228,91 @@ def test_mrkdwn_table_becomes_code_block():
     )
 
 
+# ---- blank-line collapsing (#6730) ---------------------------------
+
+
+def test_markdown_collapses_blank_line_runs():
+    # `_convert_md_lines` is a 1:1 line mapper, so a model that pads its
+    # answer with blank lines produced a wall of whitespace in Slack.
+    assert sa._markdown_to_mrkdwn("a\n\n\n\n\nb") == "a\n\nb"
+
+
+def test_markdown_preserves_single_blank_line():
+    # One blank line is Slack's paragraph separator — collapsing it too
+    # would run paragraphs together.
+    assert sa._markdown_to_mrkdwn("a\n\nb") == "a\n\nb"
+    assert sa._markdown_to_mrkdwn("a\nb") == "a\nb"
+
+
+def test_markdown_preserves_blank_lines_inside_fenced_code():
+    # The collapse runs on the code-MASKED string, where a fenced block is
+    # a single token — a naive pre-mask `re.sub` would reflow code.
+    src = "intro\n\n```\nx = 1\n\n\n\ny = 2\n```\n\n\n\nouttro"
+    out = sa._markdown_to_mrkdwn(src)
+    assert "x = 1\n\n\n\ny = 2" in out
+    assert out.endswith("```\n\nouttro")
+
+
+def test_markdown_collapses_run_left_by_empty_header():
+    # A content-less ATX header (hashes, a space, nothing else) emits an
+    # empty line of its own, so the converter can manufacture a blank-line
+    # run that was not in the source at all.
+    assert sa._markdown_to_mrkdwn("a\n\n## \n\nb") == "a\n\nb"
+
+
+# ---- interactive section cap (#6730) -------------------------------
+
+
+def test_build_block_kit_caps_section_text():
+    # Slack rejects a `section` over 3000 chars and `_post_message` skips
+    # its chunking when blocks are present, so a long interactive reply
+    # used to be rejected wholesale and dropped with only a log line.
+    blocks = sa._build_block_kit("x" * 9000, [[{"label": "OK", "action": "ok"}]])
+    sections = [b for b in blocks if b["type"] == "section"]
+    assert len(sections) == 3
+    for s in sections:
+        assert len(s["text"]["text"]) <= sa.SLACK_MSG_LIMIT
+    # The full text survives across the sections.
+    assert sum(len(s["text"]["text"]) for s in sections) == 9000
+    # Buttons still attach after the text.
+    assert blocks[-1]["type"] == "actions"
+
+
+def test_build_block_kit_never_exceeds_block_limit():
+    # Slack also caps a message at 50 blocks. Text is truncated to fit;
+    # the buttons — the functional payload — are never dropped.
+    buttons = [[{"label": f"B{i}", "action": f"a{i}"}] for i in range(3)]
+    blocks = sa._build_block_kit("y" * 400_000, buttons)
+    assert len(blocks) <= sa.MAX_BLOCKS_PER_MESSAGE
+    assert len([b for b in blocks if b["type"] == "actions"]) == 3
+    assert any("truncated" in b.get("text", {}).get("text", "")
+               for b in blocks if b["type"] == "section")
+
+
+def test_post_message_with_blocks_bounds_fallback_text(monkeypatch):
+    # With blocks, `text` is only the notification preview — the blocks carry
+    # the content. It is bounded rather than chunked, because chunking it
+    # would post the same blocks once per chunk.
+    fake = _FakeUrlopen([(200, {"ok": True})])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    long_text = "z" * 9000
+    a._post_message("C01", long_text, blocks=sa._build_block_kit(long_text, []))
+    assert len(fake.calls) == 1
+    body = json.loads(fake.calls[0]["body_raw"])
+    assert len(body["text"]) == sa.SLACK_MSG_LIMIT
+    # …while the blocks still carry all 9000 characters.
+    assert sum(len(b["text"]["text"]) for b in body["blocks"]) == 9000
+
+
+def test_build_block_kit_short_text_stays_one_section():
+    # No behaviour change for the common case.
+    blocks = sa._build_block_kit("Hello", [])
+    assert blocks == [
+        {"type": "section", "text": {"type": "mrkdwn", "text": "Hello"}},
+    ]
+
+
 @pytest.mark.asyncio
 async def test_on_send_converts_markdown_to_mrkdwn(monkeypatch):
     fake = _FakeUrlopen([(200, {"ok": True})])
@@ -1183,7 +1338,14 @@ def _reaction(phase, tool_name=None, channel_id="C01", message_id="T1",
               emoji="x"):
     """Build an AgentPhase lifecycle `reaction` command the way the
     bridge serializes it (channel_id, message_id, emoji, phase,
-    tool_name)."""
+    tool_name).
+
+    `emoji` is the wire emoji the daemon computed for the phase. Its only
+    load-bearing value is the empty string, which is the
+    `clear_done_reaction` signal on a terminal frame; the adapter maps
+    every other value to a Slack emoji *name* itself, because
+    `reactions.add` takes `white_check_mark`, not the `✅` codepoint.
+    """
     return sa.protocol.Reaction(channel_id, message_id, emoji, phase,
                                 tool_name)
 
@@ -1237,16 +1399,135 @@ def test_build_task_progress_blocks_bounds_long_step_list():
 @pytest.mark.asyncio
 async def test_phase_single_step_posts_no_card(monkeypatch):
     # A turn that never runs a tool (queued → thinking → done) posts no
-    # card — single-step UX stays exactly as before (#6451).
-    fake = _FakeUrlopen([])  # no HTTP expected
+    # card — single-step UX stays exactly as before (#6451). It does get
+    # the receipt reaction, which is the whole point of #6731: the eyes on
+    # `queued`, flipped on `done`.
+    fake = _FakeUrlopen([
+        (200, {"ok": True}),  # reactions.add eyes
+        (200, {"ok": True}),  # reactions.remove eyes
+        (200, {"ok": True}),  # reactions.add white_check_mark
+    ])
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter()
     await a.on_command(_reaction("queued"))
     await a.on_command(_reaction("thinking"))
     await a.on_command(_reaction("done"))
-    assert fake.calls == []
+    urls = [c["url"] for c in fake.calls]
+    assert [u.rsplit("/", 1)[-1] for u in urls] == [
+        "reactions.add", "reactions.remove", "reactions.add",
+    ]
+    # No chat.postMessage / chat.update: no card for a single-step turn.
+    assert not any("chat." in u for u in urls)
     # State is cleaned up on the terminal phase.
     assert a._task_progress == {}
+    assert a._pending_reactions == {}
+
+
+@pytest.mark.asyncio
+async def test_queued_phase_adds_eyes(monkeypatch):
+    fake = _FakeUrlopen([(200, {"ok": True})])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    await a.on_command(_reaction("queued", message_id="TS-Q"))
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["url"].endswith("/reactions.add")
+    body = json.loads(fake.calls[0]["body_raw"])
+    assert body["name"] == "eyes"
+    assert body["timestamp"] == "TS-Q"
+    # Tracked so the terminal phase can flip exactly this message.
+    assert a._pending_reactions == {("C01", "TS-Q"): "eyes"}
+    # `queued` is never rendered, so no card state was materialized —
+    # otherwise every turn would look multi-step.
+    assert a._task_progress == {}
+
+
+@pytest.mark.asyncio
+async def test_done_phase_flips_to_check(monkeypatch):
+    fake = _FakeUrlopen([
+        (200, {"ok": True}),  # eyes
+        (200, {"ok": True}),  # remove
+        (200, {"ok": True}),  # check
+    ])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    await a.on_command(_reaction("queued"))
+    await a.on_command(_reaction("done", emoji="✅"))
+    assert json.loads(fake.calls[1]["body_raw"])["name"] == "eyes"
+    assert fake.calls[1]["url"].endswith("/reactions.remove")
+    add_body = json.loads(fake.calls[2]["body_raw"])
+    assert add_body["name"] == "white_check_mark"
+    assert add_body["timestamp"] == "T1"
+
+
+@pytest.mark.asyncio
+async def test_error_phase_flips_to_x(monkeypatch):
+    # A failed turn used to leave the eyes stuck forever — the send hook
+    # never ran because there was no reply. It now gets an explicit ❌.
+    fake = _FakeUrlopen([
+        (200, {"ok": True}),  # eyes
+        (200, {"ok": True}),  # remove
+        (200, {"ok": True}),  # x
+    ])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    await a.on_command(_reaction("queued"))
+    await a.on_command(_reaction("error", emoji="❌"))
+    assert json.loads(fake.calls[2]["body_raw"])["name"] == "x"
+    assert a._pending_reactions == {}
+
+
+@pytest.mark.asyncio
+async def test_done_with_empty_reaction_removes_only(monkeypatch):
+    # `clear_done_reaction = true` on the daemon side makes the Done frame
+    # carry an empty emoji. Slack must lose the eyes and gain nothing.
+    fake = _FakeUrlopen([
+        (200, {"ok": True}),  # eyes
+        (200, {"ok": True}),  # remove
+    ])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    await a.on_command(_reaction("queued"))
+    await a.on_command(_reaction("done", emoji=""))
+    assert len(fake.calls) == 2
+    assert fake.calls[1]["url"].endswith("/reactions.remove")
+    assert a._pending_reactions == {}
+
+
+@pytest.mark.asyncio
+async def test_in_thread_reply_finalizes_own_message_not_a_sibling(
+    monkeypatch,
+):
+    # #6731 regression guard. Two turns in flight in one channel; the
+    # terminal phase of the second must touch only the second. The deleted
+    # "first pending entry in this channel" fallback flipped the older one.
+    fake = _FakeUrlopen([
+        (200, {"ok": True}),  # eyes on TS-A
+        (200, {"ok": True}),  # eyes on TS-B
+        (200, {"ok": True}),  # remove on TS-B
+        (200, {"ok": True}),  # check on TS-B
+    ])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    await a.on_command(_reaction("queued", message_id="TS-A"))
+    await a.on_command(_reaction("queued", message_id="TS-B"))
+    await a.on_command(_reaction("done", message_id="TS-B", emoji="✅"))
+    assert len(fake.calls) == 4
+    assert json.loads(fake.calls[2]["body_raw"])["timestamp"] == "TS-B"
+    assert json.loads(fake.calls[3]["body_raw"])["timestamp"] == "TS-B"
+    # TS-A is still pending — its own turn has not finished yet.
+    assert a._pending_reactions == {("C01", "TS-A"): "eyes"}
+
+
+@pytest.mark.asyncio
+async def test_terminal_phase_without_queued_adds_nothing(monkeypatch):
+    # Defensive: an adapter that starts mid-turn (restarted sidecar) has no
+    # pending entry, so there is no eyes to flip and it must not stamp a
+    # bare check onto a message it never marked.
+    fake = _FakeUrlopen([])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter()
+    await a.on_command(_reaction("done", emoji="✅"))
+    assert fake.calls == []
 
 
 @pytest.mark.asyncio
@@ -1301,15 +1582,77 @@ async def test_phase_card_force_flat_omits_thread_ts(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_phase_card_suppressed_when_reactions_disabled(monkeypatch):
-    # SLACK_REACTIONS=false silences all processing-state chatter,
-    # including the task-progress card.
+    # SLACK_REACTIONS=false still silences everything, because the card's
+    # default follows it. Both indicators off = zero HTTP.
     fake = _FakeUrlopen([])  # no HTTP expected
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter(SLACK_REACTIONS="false")
+    await a.on_command(_reaction("queued"))
     await a.on_command(_reaction("thinking"))
     await a.on_command(_reaction("tool_use", tool_name="web_fetch"))
     await a.on_command(_reaction("done"))
     assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_progress_card_disabled_no_card_post(monkeypatch):
+    # #6730: SLACK_PROGRESS_CARD=false silences the card while the receipt
+    # keeps working. Before the split, the only way to stop the card was to
+    # stop the receipt too.
+    fake = _FakeUrlopen([
+        (200, {"ok": True}),  # eyes
+        (200, {"ok": True}),  # remove
+        (200, {"ok": True}),  # check
+    ])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter(SLACK_PROGRESS_CARD="false")
+    await a.on_command(_reaction("queued"))
+    await a.on_command(_reaction("tool_use", tool_name="web_fetch"))
+    await a.on_command(_reaction("done", emoji="✅"))
+    urls = [c["url"] for c in fake.calls]
+    assert not any("chat." in u for u in urls)
+    assert [u.rsplit("/", 1)[-1] for u in urls] == [
+        "reactions.add", "reactions.remove", "reactions.add",
+    ]
+    # No card state was ever materialized.
+    assert a._task_progress == {}
+
+
+@pytest.mark.asyncio
+async def test_reactions_disabled_still_posts_card(monkeypatch):
+    # The other half of the #6730 split: card without emoji noise.
+    fake = _FakeUrlopen([
+        (200, {"ok": True, "ts": "CARD1"}),  # tool_use -> post
+        (200, {"ok": True}),                 # done -> update
+    ])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter(SLACK_REACTIONS="false", SLACK_PROGRESS_CARD="true")
+    await a.on_command(_reaction("queued"))
+    await a.on_command(_reaction("tool_use", tool_name="web_fetch"))
+    await a.on_command(_reaction("done", emoji="✅"))
+    urls = [c["url"] for c in fake.calls]
+    assert urls[0].endswith("/chat.postMessage")
+    assert urls[1].endswith("/chat.update")
+    assert not any("reactions." in u for u in urls)
+
+
+@pytest.mark.asyncio
+async def test_card_disabled_still_flips_receipt_on_multi_step(monkeypatch):
+    # The receipt half must not depend on the card half's bookkeeping: a
+    # multi-step turn with the card off still gets eyes -> check.
+    fake = _FakeUrlopen([
+        (200, {"ok": True}),  # eyes
+        (200, {"ok": True}),  # remove
+        (200, {"ok": True}),  # check
+    ])
+    monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
+    a = _adapter(SLACK_PROGRESS_CARD="false")
+    await a.on_command(_reaction("queued"))
+    await a.on_command(_reaction("thinking"))
+    await a.on_command(_reaction("tool_use", tool_name="web_fetch"))
+    await a.on_command(_reaction("streaming"))
+    await a.on_command(_reaction("error", emoji="❌"))
+    assert json.loads(fake.calls[2]["body_raw"])["name"] == "x"
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_slack_adapter.py
+++ b/sdk/python/tests/test_slack_adapter.py
@@ -103,10 +103,7 @@ def test_reactions_default_true():
 
 
 def test_progress_card_defaults_to_following_reactions():
-    # #6730 decoupled the card from the receipt, but an operator already
-    # running SLACK_REACTIONS=false for total silence must not start
-    # receiving cards on upgrade — so the card's default follows the
-    # receipt knob rather than being an unconditional true.
+    # #6730 decoupled the card from the receipt, but an operator already running SLACK_REACTIONS=false for total silence must not start receiving cards on upgrade — so the card's default follows the receipt knob rather than being an unconditional true.
     assert _adapter().progress_card_enabled is True
     assert _adapter(SLACK_REACTIONS="false").progress_card_enabled is False
     # …and each is independently overridable, which is the point of #6730.
@@ -760,9 +757,7 @@ def test_finalize_pending_reaction_disabled_noop(monkeypatch):
 
 def test_finalize_pending_reaction_unknown_key_is_noop(monkeypatch):
     # #6731: the "first pending entry in this channel" fallback is gone.
-    # A miss must touch nothing — the old fallback flipped an unrelated
-    # sibling message's receipt instead, which is exactly what happened on
-    # every in-thread reply (the send hook keyed off the thread root).
+    # A miss must touch nothing — the old fallback flipped an unrelated sibling message's receipt instead, which is exactly what happened on every in-thread reply (the send hook keyed off the thread root).
     fake = _FakeUrlopen([])
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter()
@@ -773,8 +768,7 @@ def test_finalize_pending_reaction_unknown_key_is_noop(monkeypatch):
 
 
 def test_finalize_pending_reaction_empty_emoji_removes_only(monkeypatch):
-    # The daemon's `clear_done_reaction` knob puts an empty emoji on the
-    # terminal frame — remove the eyes, add nothing.
+    # The daemon's `clear_done_reaction` knob puts an empty emoji on the terminal frame — remove the eyes, add nothing.
     fake = _FakeUrlopen([(200, {"ok": True})])
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter()
@@ -785,8 +779,7 @@ def test_finalize_pending_reaction_empty_emoji_removes_only(monkeypatch):
 
 
 def test_finalize_pending_reaction_is_idempotent(monkeypatch):
-    # A repeated terminal phase must not add a second check: the first
-    # call pops the pending entry, the second finds nothing.
+    # A repeated terminal phase must not add a second check: the first call pops the pending entry, the second finds nothing.
     fake = _FakeUrlopen([(200, {"ok": True}), (200, {"ok": True})])
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter()
@@ -849,12 +842,9 @@ def test_handle_events_api_acks_and_emits(monkeypatch):
 
 
 def test_receive_adds_no_reaction(monkeypatch):
-    # #6731: the eyes used to be added here, on receive. The daemon can
-    # still decline the turn afterwards (mention-only group gating, a rate
-    # limit, a slash command it handles itself), and nothing ever came back
-    # to clear it — so a declined message kept a permanent eyes. The receipt
-    # now rides the `queued` lifecycle phase instead, which only fires for a
-    # turn that is actually dispatched.
+    # #6731: the eyes used to be added here, on receive.
+    # The daemon can still decline the turn afterwards (mention-only group gating, a rate limit, a slash command it handles itself), and nothing ever came back to clear it — so a declined message kept a permanent eyes.
+    # The receipt now rides the `queued` lifecycle phase instead, which only fires for a turn that is actually dispatched.
     fake = _FakeUrlopen([])
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter()
@@ -871,8 +861,7 @@ def test_receive_adds_no_reaction(monkeypatch):
     )
     assert len(emitted) == 1
     assert fake.calls == []
-    # Nothing was tracked either, so there is no leaked pending entry a
-    # later message's terminal phase could accidentally flip.
+    # Nothing was tracked either, so there is no leaked pending entry a later message's terminal phase could accidentally flip.
     assert a._pending_reactions == {}
 
 
@@ -1002,11 +991,9 @@ async def test_on_send_force_flat_replies_drops_thread_ts(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_send_no_longer_touches_reactions(monkeypatch):
-    # #6731: the send hook used to finalize the receipt, keyed on
-    # `cmd.thread_id` — the thread ROOT ts for an in-thread reply, while the
-    # eyes was tracked under the message's own ts. The exact key missed and
-    # the deleted fallback flipped an arbitrary sibling instead. Finalization
-    # now lives on the lifecycle stream, so `on_send` posts and stops.
+    # #6731: the send hook used to finalize the receipt, keyed on `cmd.thread_id` — the thread ROOT ts for an in-thread reply, while the eyes was tracked under the message's own ts.
+    # The exact key missed and the deleted fallback flipped an arbitrary sibling instead.
+    # Finalization now lives on the lifecycle stream, so `on_send` posts and stops.
     fake = _FakeUrlopen([
         (200, {"ok": True}),  # chat.postMessage — the only call expected
     ])
@@ -1232,21 +1219,18 @@ def test_mrkdwn_table_becomes_code_block():
 
 
 def test_markdown_collapses_blank_line_runs():
-    # `_convert_md_lines` is a 1:1 line mapper, so a model that pads its
-    # answer with blank lines produced a wall of whitespace in Slack.
+    # `_convert_md_lines` is a 1:1 line mapper, so a model that pads its answer with blank lines produced a wall of whitespace in Slack.
     assert sa._markdown_to_mrkdwn("a\n\n\n\n\nb") == "a\n\nb"
 
 
 def test_markdown_preserves_single_blank_line():
-    # One blank line is Slack's paragraph separator — collapsing it too
-    # would run paragraphs together.
+    # One blank line is Slack's paragraph separator — collapsing it too would run paragraphs together.
     assert sa._markdown_to_mrkdwn("a\n\nb") == "a\n\nb"
     assert sa._markdown_to_mrkdwn("a\nb") == "a\nb"
 
 
 def test_markdown_preserves_blank_lines_inside_fenced_code():
-    # The collapse runs on the code-MASKED string, where a fenced block is
-    # a single token — a naive pre-mask `re.sub` would reflow code.
+    # The collapse runs on the code-MASKED string, where a fenced block is a single token — a naive pre-mask `re.sub` would reflow code.
     src = "intro\n\n```\nx = 1\n\n\n\ny = 2\n```\n\n\n\nouttro"
     out = sa._markdown_to_mrkdwn(src)
     assert "x = 1\n\n\n\ny = 2" in out
@@ -1254,9 +1238,8 @@ def test_markdown_preserves_blank_lines_inside_fenced_code():
 
 
 def test_markdown_preserves_blank_lines_inside_an_unclosed_fence():
-    # A truncated model response ends mid-block. Slack renders an
-    # unterminated ``` as code to the end of the message, so the collapse
-    # must not reflow what the user sees as code either.
+    # A truncated model response ends mid-block.
+    # Slack renders an unterminated ``` as code to the end of the message, so the collapse must not reflow what the user sees as code either.
     src = "intro\n\n\n\n```\nx = 1\n\n\n\ny = 2"
     out = sa._markdown_to_mrkdwn(src)
     assert "x = 1\n\n\n\ny = 2" in out
@@ -1265,17 +1248,14 @@ def test_markdown_preserves_blank_lines_inside_an_unclosed_fence():
 
 
 def test_markdown_still_collapses_inside_a_tilde_fence():
-    # `~~~` is GitHub-flavoured Markdown that Slack does not render as code,
-    # so its contents are prose and the blank-line collapse applies. Pinned
-    # so the deliberate boundary is not "fixed" into masking it.
+    # `~~~` is GitHub-flavoured Markdown that Slack does not render as code, so its contents are prose and the blank-line collapse applies.
+    # Pinned so the deliberate boundary is not "fixed" into masking it.
     src = "~~~\na\n\n\n\nb\n~~~"
     assert "a\n\nb" in sa._markdown_to_mrkdwn(src)
 
 
 def test_markdown_collapses_run_left_by_empty_header():
-    # A content-less ATX header (hashes, a space, nothing else) emits an
-    # empty line of its own, so the converter can manufacture a blank-line
-    # run that was not in the source at all.
+    # A content-less ATX header (hashes, a space, nothing else) emits an empty line of its own, so the converter can manufacture a blank-line run that was not in the source at all.
     assert sa._markdown_to_mrkdwn("a\n\n## \n\nb") == "a\n\nb"
 
 
@@ -1283,9 +1263,7 @@ def test_markdown_collapses_run_left_by_empty_header():
 
 
 def test_build_block_kit_caps_section_text():
-    # Slack rejects a `section` over 3000 chars and `_post_message` skips
-    # its chunking when blocks are present, so a long interactive reply
-    # used to be rejected wholesale and dropped with only a log line.
+    # Slack rejects a `section` over 3000 chars and `_post_message` skips its chunking when blocks are present, so a long interactive reply used to be rejected wholesale and dropped with only a log line.
     blocks = sa._build_block_kit("x" * 9000, [[{"label": "OK", "action": "ok"}]])
     sections = [b for b in blocks if b["type"] == "section"]
     assert len(sections) == 3
@@ -1298,8 +1276,8 @@ def test_build_block_kit_caps_section_text():
 
 
 def test_build_block_kit_never_exceeds_block_limit():
-    # Slack also caps a message at 50 blocks. Text is truncated to fit;
-    # the buttons — the functional payload — are never dropped.
+    # Slack also caps a message at 50 blocks.
+    # Text is truncated to fit; the buttons — the functional payload — are never dropped.
     buttons = [[{"label": f"B{i}", "action": f"a{i}"}] for i in range(3)]
     blocks = sa._build_block_kit("y" * 400_000, buttons)
     assert len(blocks) <= sa.MAX_BLOCKS_PER_MESSAGE
@@ -1309,17 +1287,14 @@ def test_build_block_kit_never_exceeds_block_limit():
 
 
 def test_build_block_kit_button_rows_alone_exceed_block_cap():
-    # When the rows alone reach the cap there is no room for text, so the
-    # payload is the marker plus as many rows as still fit. The whole
-    # message must stay within the cap: Slack rejects an over-cap message,
-    # so emitting 51 blocks to "keep every button" delivers no buttons.
+    # When the rows alone reach the cap there is no room for text, so the payload is the marker plus as many rows as still fit.
+    # The whole message must stay within the cap: Slack rejects an over-cap message, so emitting 51 blocks to "keep every button" delivers no buttons.
     buttons = [[{"label": f"B{i}", "action": f"a{i}"}]
                for i in range(sa.MAX_BLOCKS_PER_MESSAGE)]
     blocks = sa._build_block_kit("some text", buttons)
     assert len(blocks) <= sa.MAX_BLOCKS_PER_MESSAGE
     sections = [b for b in blocks if b["type"] == "section"]
-    # No room for the text itself, just the truncation marker — never a
-    # stray real chunk of the text (the unclamped negative-slice bug).
+    # No room for the text itself, just the truncation marker — never a stray real chunk of the text (the unclamped negative-slice bug).
     assert len(sections) == 1
     assert "truncated" in sections[0]["text"]["text"]
     assert len([b for b in blocks if b["type"] == "actions"]) == \
@@ -1327,11 +1302,8 @@ def test_build_block_kit_button_rows_alone_exceed_block_cap():
 
 
 def test_build_block_kit_keeps_text_when_rows_exactly_fill_the_budget():
-    # Regression: the marker slot used to be reserved before checking whether
-    # truncation was needed, so at exactly MAX-1 rows the real text was
-    # dropped and replaced by "_(message truncated)_" even though one section
-    # plus the rows is exactly the cap. `/agents` builds one row per agent
-    # with no cap, so a daemon with 49 agents hit this.
+    # Regression: the marker slot used to be reserved before checking whether truncation was needed, so at exactly MAX-1 rows the real text was dropped and replaced by "_(message truncated)_" even though one section plus the rows is exactly the cap.
+    # `/agents` builds one row per agent with no cap, so a daemon with 49 agents hit this.
     rows = sa.MAX_BLOCKS_PER_MESSAGE - 1
     buttons = [[{"label": f"B{i}", "action": f"a{i}"}] for i in range(rows)]
     blocks = sa._build_block_kit("Select an agent:", buttons)
@@ -1347,8 +1319,7 @@ def test_build_block_kit_keeps_text_when_rows_exactly_fill_the_budget():
 
 @pytest.mark.parametrize("rows", [1, 10, 47, 48, 49, 50, 60])
 def test_build_block_kit_never_exceeds_cap_for_any_row_count(rows):
-    # The cap is a hard Slack limit, so it has to hold across the whole
-    # range rather than at the two counts the other tests happen to use.
+    # The cap is a hard Slack limit, so it has to hold across the whole range rather than at the two counts the other tests happen to use.
     buttons = [[{"label": f"B{i}", "action": f"a{i}"}] for i in range(rows)]
     blocks = sa._build_block_kit("some text", buttons)
     assert len(blocks) <= sa.MAX_BLOCKS_PER_MESSAGE, \
@@ -1356,9 +1327,8 @@ def test_build_block_kit_never_exceeds_cap_for_any_row_count(rows):
 
 
 def test_post_message_with_blocks_bounds_fallback_text(monkeypatch):
-    # With blocks, `text` is only the notification preview — the blocks carry
-    # the content. It is bounded rather than chunked, because chunking it
-    # would post the same blocks once per chunk.
+    # With blocks, `text` is only the notification preview — the blocks carry the content.
+    # It is bounded rather than chunked, because chunking it would post the same blocks once per chunk.
     fake = _FakeUrlopen([(200, {"ok": True})])
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter()
@@ -1406,11 +1376,8 @@ def _reaction(phase, tool_name=None, channel_id="C01", message_id="T1",
     bridge serializes it (channel_id, message_id, emoji, phase,
     tool_name).
 
-    `emoji` is the wire emoji the daemon computed for the phase. Its only
-    load-bearing value is the empty string, which is the
-    `clear_done_reaction` signal on a terminal frame; the adapter maps
-    every other value to a Slack emoji *name* itself, because
-    `reactions.add` takes `white_check_mark`, not the `✅` codepoint.
+    `emoji` is the wire emoji the daemon computed for the phase.
+    Its only load-bearing value is the empty string, which is the `clear_done_reaction` signal on a terminal frame; the adapter maps every other value to a Slack emoji *name* itself, because `reactions.add` takes `white_check_mark`, not the `✅` codepoint.
     """
     return sa.protocol.Reaction(channel_id, message_id, emoji, phase,
                                 tool_name)
@@ -1464,10 +1431,8 @@ def test_build_task_progress_blocks_bounds_long_step_list():
 
 @pytest.mark.asyncio
 async def test_phase_single_step_posts_no_card(monkeypatch):
-    # A turn that never runs a tool (queued → thinking → done) posts no
-    # card — single-step UX stays exactly as before (#6451). It does get
-    # the receipt reaction, which is the whole point of #6731: the eyes on
-    # `queued`, flipped on `done`.
+    # A turn that never runs a tool (queued → thinking → done) posts no card — single-step UX stays exactly as before (#6451).
+    # It does get the receipt reaction, which is the whole point of #6731: the eyes on `queued`, flipped on `done`.
     fake = _FakeUrlopen([
         (200, {"ok": True}),  # reactions.add eyes
         (200, {"ok": True}),  # reactions.remove eyes
@@ -1527,8 +1492,8 @@ async def test_done_phase_flips_to_check(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_error_phase_flips_to_x(monkeypatch):
-    # A failed turn used to leave the eyes stuck forever — the send hook
-    # never ran because there was no reply. It now gets an explicit ❌.
+    # A failed turn used to leave the eyes stuck forever — the send hook never ran because there was no reply.
+    # It now gets an explicit ❌.
     fake = _FakeUrlopen([
         (200, {"ok": True}),  # eyes
         (200, {"ok": True}),  # remove
@@ -1544,8 +1509,8 @@ async def test_error_phase_flips_to_x(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_done_with_empty_reaction_removes_only(monkeypatch):
-    # `clear_done_reaction = true` on the daemon side makes the Done frame
-    # carry an empty emoji. Slack must lose the eyes and gain nothing.
+    # `clear_done_reaction = true` on the daemon side makes the Done frame carry an empty emoji.
+    # Slack must lose the eyes and gain nothing.
     fake = _FakeUrlopen([
         (200, {"ok": True}),  # eyes
         (200, {"ok": True}),  # remove
@@ -1563,9 +1528,9 @@ async def test_done_with_empty_reaction_removes_only(monkeypatch):
 async def test_in_thread_reply_finalizes_own_message_not_a_sibling(
     monkeypatch,
 ):
-    # #6731 regression guard. Two turns in flight in one channel; the
-    # terminal phase of the second must touch only the second. The deleted
-    # "first pending entry in this channel" fallback flipped the older one.
+    # #6731 regression guard.
+    # Two turns in flight in one channel; the terminal phase of the second must touch only the second.
+    # The deleted "first pending entry in this channel" fallback flipped the older one.
     fake = _FakeUrlopen([
         (200, {"ok": True}),  # eyes on TS-A
         (200, {"ok": True}),  # eyes on TS-B
@@ -1586,9 +1551,7 @@ async def test_in_thread_reply_finalizes_own_message_not_a_sibling(
 
 @pytest.mark.asyncio
 async def test_terminal_phase_without_queued_adds_nothing(monkeypatch):
-    # Defensive: an adapter that starts mid-turn (restarted sidecar) has no
-    # pending entry, so there is no eyes to flip and it must not stamp a
-    # bare check onto a message it never marked.
+    # Defensive: an adapter that starts mid-turn (restarted sidecar) has no pending entry, so there is no eyes to flip and it must not stamp a bare check onto a message it never marked.
     fake = _FakeUrlopen([])
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter()
@@ -1648,8 +1611,8 @@ async def test_phase_card_force_flat_omits_thread_ts(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_phase_card_suppressed_when_reactions_disabled(monkeypatch):
-    # SLACK_REACTIONS=false still silences everything, because the card's
-    # default follows it. Both indicators off = zero HTTP.
+    # SLACK_REACTIONS=false still silences everything, because the card's default follows it.
+    # Both indicators off = zero HTTP.
     fake = _FakeUrlopen([])  # no HTTP expected
     monkeypatch.setattr(sa.urllib.request, "urlopen", fake)
     a = _adapter(SLACK_REACTIONS="false")
@@ -1662,9 +1625,8 @@ async def test_phase_card_suppressed_when_reactions_disabled(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_progress_card_disabled_no_card_post(monkeypatch):
-    # #6730: SLACK_PROGRESS_CARD=false silences the card while the receipt
-    # keeps working. Before the split, the only way to stop the card was to
-    # stop the receipt too.
+    # #6730: SLACK_PROGRESS_CARD=false silences the card while the receipt keeps working.
+    # Before the split, the only way to stop the card was to stop the receipt too.
     fake = _FakeUrlopen([
         (200, {"ok": True}),  # eyes
         (200, {"ok": True}),  # remove
@@ -1704,8 +1666,7 @@ async def test_reactions_disabled_still_posts_card(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_card_disabled_still_flips_receipt_on_multi_step(monkeypatch):
-    # The receipt half must not depend on the card half's bookkeeping: a
-    # multi-step turn with the card off still gets eyes -> check.
+    # The receipt half must not depend on the card half's bookkeeping: a multi-step turn with the card off still gets eyes -> check.
     fake = _FakeUrlopen([
         (200, {"ok": True}),  # eyes
         (200, {"ok": True}),  # remove

--- a/sdk/python/tests/test_slack_adapter.py
+++ b/sdk/python/tests/test_slack_adapter.py
@@ -1253,6 +1253,25 @@ def test_markdown_preserves_blank_lines_inside_fenced_code():
     assert out.endswith("```\n\nouttro")
 
 
+def test_markdown_preserves_blank_lines_inside_an_unclosed_fence():
+    # A truncated model response ends mid-block. Slack renders an
+    # unterminated ``` as code to the end of the message, so the collapse
+    # must not reflow what the user sees as code either.
+    src = "intro\n\n\n\n```\nx = 1\n\n\n\ny = 2"
+    out = sa._markdown_to_mrkdwn(src)
+    assert "x = 1\n\n\n\ny = 2" in out
+    # Prose before the fence is still collapsed.
+    assert out.startswith("intro\n\n```")
+
+
+def test_markdown_still_collapses_inside_a_tilde_fence():
+    # `~~~` is GitHub-flavoured Markdown that Slack does not render as code,
+    # so its contents are prose and the blank-line collapse applies. Pinned
+    # so the deliberate boundary is not "fixed" into masking it.
+    src = "~~~\na\n\n\n\nb\n~~~"
+    assert "a\n\nb" in sa._markdown_to_mrkdwn(src)
+
+
 def test_markdown_collapses_run_left_by_empty_header():
     # A content-less ATX header (hashes, a space, nothing else) emits an
     # empty line of its own, so the converter can manufacture a blank-line
@@ -1290,21 +1309,50 @@ def test_build_block_kit_never_exceeds_block_limit():
 
 
 def test_build_block_kit_button_rows_alone_exceed_block_cap():
-    # Regression: when `action_blocks` alone reaches/exceeds
-    # MAX_BLOCKS_PER_MESSAGE - 1, `max_sections` goes negative. Python's
-    # `list[:-n]` means "drop the last n", not "keep none", so an
-    # unclamped `chunks[:max_sections]` kept a stray section instead of
-    # zero — this pins the clamp that makes zero sections the outcome.
+    # When the rows alone reach the cap there is no room for text, so the
+    # payload is the marker plus as many rows as still fit. The whole
+    # message must stay within the cap: Slack rejects an over-cap message,
+    # so emitting 51 blocks to "keep every button" delivers no buttons.
     buttons = [[{"label": f"B{i}", "action": f"a{i}"}]
                for i in range(sa.MAX_BLOCKS_PER_MESSAGE)]
     blocks = sa._build_block_kit("some text", buttons)
+    assert len(blocks) <= sa.MAX_BLOCKS_PER_MESSAGE
     sections = [b for b in blocks if b["type"] == "section"]
     # No room for the text itself, just the truncation marker — never a
     # stray real chunk of the text (the unclamped negative-slice bug).
     assert len(sections) == 1
     assert "truncated" in sections[0]["text"]["text"]
     assert len([b for b in blocks if b["type"] == "actions"]) == \
-        sa.MAX_BLOCKS_PER_MESSAGE
+        sa.MAX_BLOCKS_PER_MESSAGE - 1
+
+
+def test_build_block_kit_keeps_text_when_rows_exactly_fill_the_budget():
+    # Regression: the marker slot used to be reserved before checking whether
+    # truncation was needed, so at exactly MAX-1 rows the real text was
+    # dropped and replaced by "_(message truncated)_" even though one section
+    # plus the rows is exactly the cap. `/agents` builds one row per agent
+    # with no cap, so a daemon with 49 agents hit this.
+    rows = sa.MAX_BLOCKS_PER_MESSAGE - 1
+    buttons = [[{"label": f"B{i}", "action": f"a{i}"}] for i in range(rows)]
+    blocks = sa._build_block_kit("Select an agent:", buttons)
+
+    assert len(blocks) == sa.MAX_BLOCKS_PER_MESSAGE
+    sections = [b for b in blocks if b["type"] == "section"]
+    assert len(sections) == 1
+    assert sections[0]["text"]["text"] == "Select an agent:"
+    assert not any("truncated" in b.get("text", {}).get("text", "")
+                   for b in blocks if b["type"] == "section")
+    assert len([b for b in blocks if b["type"] == "actions"]) == rows
+
+
+@pytest.mark.parametrize("rows", [1, 10, 47, 48, 49, 50, 60])
+def test_build_block_kit_never_exceeds_cap_for_any_row_count(rows):
+    # The cap is a hard Slack limit, so it has to hold across the whole
+    # range rather than at the two counts the other tests happen to use.
+    buttons = [[{"label": f"B{i}", "action": f"a{i}"}] for i in range(rows)]
+    blocks = sa._build_block_kit("some text", buttons)
+    assert len(blocks) <= sa.MAX_BLOCKS_PER_MESSAGE, \
+        f"{rows} rows produced {len(blocks)} blocks"
 
 
 def test_post_message_with_blocks_bounds_fallback_text(monkeypatch):


### PR DESCRIPTION
Closes #6731 #6730

## Why these land together

Both issues rewrite `_on_phase`, and moving only the *add* side of the receipt would make the `_finalize_pending_reaction` fallback bug strictly worse — the fallback flips an arbitrary pending entry in the channel, so leaking fewer 👀 while still finalizing by "whatever is pending" just redistributes the wrong-message flips.

The PR opens with a CI lane because that is what makes the rest of it verifiable: `sdk/python/tests/` held ~1900 pytest cases and `grep -rn pytest .github/workflows/` returned nothing, so every Python change in this repo has been shipping with no signal at all.
A job added in a PR runs on that PR's own `pull_request` event, so this PR's Python work is covered from the first push.

## Changes

### CI: new `sdk-python` lane

- New `sdk-python` job in `.github/workflows/ci.yml`: `actions/setup-python` (SHA-pinned, matching the file's other python steps), `pip install -e './sdk/python[dev]'`, then `python -m pytest tests -q` with `working-directory: sdk/python`.
- New `sdk_python` route flag, gated on `^sdk/python/`. It is a **separate** flag rather than a reuse of `RUST`: `sdk/` is already folded into `RUST`, but only as an openapi/codegen drift guard — that lane runs cargo, never pytest.
- The flag is added to the `merge_group` force-everything block too, so the lane does not skip in the merge queue, and the job is added to `ci-gate`'s `needs:` list so a Python failure actually fails the gate.
- `working-directory` is deliberate: it puts pytest's rootdir on `sdk/python` so `[tool.pytest.ini_options]` — and with it `asyncio_mode = "auto"`, which the async adapter tests need — is picked up without depending on rootdir discovery walking up from an argument path. `python3 -m pytest sdk/python/tests` from the repo root fails outright with `ModuleNotFoundError: No module named 'librefang'` unless the package is installed, which is why the lane installs it.

### #6731 — the receipt reaction moves onto the lifecycle stream

No Rust change, no protocol change, no new capability. `slack.py` already declares `reaction`, and `bridge.rs` already emits `Queued` / `Thinking` / `Done` / `Error` for every dispatched turn. Key alignment was verified end to end: `slack.py` sets `user_id = channel` which becomes `sidecar.rs`'s `channel_id: user.platform_id`, and `message_id = ts` which the bridge fills from `message.platform_message_id`. `sidecar.rs::send_reaction` serializes `phase: "queued"` unconditionally, so the frame does reach the subprocess.

- `_handle_envelope` no longer adds or tracks a reaction. Receiving a message is not the same as answering it.
- `_on_phase` handles the receipt **first**, above the `prog is None and terminal -> return` early-out. That ordering is load-bearing: a single-step turn has no card state, so a receipt handled after the early-out would never finalize — the same class of bug being fixed.
- `queued` + `reactions_enabled` → track `(channel, message_id)` and add `eyes`, then return (`queued` is never rendered in the card, and materializing card state for it would make every turn look multi-step).
- `done` → `white_check_mark`; `error` → `x`. An **empty** `cmd.reaction` on the terminal frame is the daemon's `clear_done_reaction` wire signal (`lifecycle_reaction_emoji` returns `String::new()` for `Done` when the knob is set) and now means remove-only, add nothing. `_on_phase` previously never read `cmd.reaction` at all, so that knob had no effect on Slack.
- `_finalize_pending_reaction` takes the terminal emoji and keys **strictly** on `(channel, ts)`. The "pick the first pending entry for this channel" fallback is deleted. That fallback was a live bug, not a safety net: `on_send` keyed on `cmd.thread_id`, which for an in-thread reply is the thread *root* ts while the eyes was tracked under the message's own ts, so the exact key missed and the ✅ landed on an arbitrary other pending message in the channel — including a leaked, gated-out one. With `threading = false` the bridge passes `thread_id = None`, so it fired on every reply.
- `on_send` no longer touches reactions. `inbound_thread_id` is kept — it still decides `thread_ts`.

### #6730 (a) — `SLACK_PROGRESS_CARD` splits the card from the receipt

`_on_phase` opened with `if not self.reactions_enabled: return`, so `SLACK_REACTIONS=false` — the only workaround for the emoji noise — also killed the useful progress card.

- New `SLACK_PROGRESS_CARD` schema field and `self.progress_card_enabled`. The receipt half is gated on `reactions_enabled`, the card half on `progress_card_enabled`, and `_on_phase` returns early only when both are off.
- **The default follows `SLACK_REACTIONS` rather than being an unconditional `true`.** An operator running `SLACK_REACTIONS=false` today gets total silence; a hardcoded `true` would have started posting cards they never asked for on upgrade. `SLACK_REACTIONS=false SLACK_PROGRESS_CARD=true` gives the card without the emoji, which is what the issue asks for, and existing installs are untouched in both directions.
- The `SLACK_REACTIONS` field text and the class/module docstrings are rewritten — all three documented the coupling as intentional.

### #6730 (b) — blank-line runs collapse

`_convert_md_lines` is a 1:1 line mapper (a content-less ATX header even emits an extra empty line of its own) joined with `"\n"`, so an `\n\n\n\n` run reached Slack verbatim.

- `re.sub(r"\n{3,}", "\n\n", ...)` applied between `_convert_md_lines` and `_restore_code_spans`, i.e. to the **masked** string. Masking is what makes it safe: `_CODE_SPAN_RE` is `DOTALL`, so each fenced block is already a single token and code interiors cannot be touched.
- `\n\n` is left alone — one blank line is Slack's paragraph separator.

### #6730 (c) — the interactive Block Kit body is bounded

`_post_message` skips chunking entirely when `blocks is not None`, and `_build_block_kit` dropped the whole converted text into one `section` with no length cap — while the file's own comment says Slack rejects a section over `SLACK_MSG_LIMIT` (3000) and `_build_task_progress_blocks` guards for exactly that. An `Interactive` reply over 3000 chars was rejected and dropped with a log line.

- The text is now split across as many sections as it needs, so nothing is lost in the common case.
- Buttons are built **first** and the section count is budgeted against Slack's 50-blocks-per-message cap (`MAX_BLOCKS_PER_MESSAGE`). The `_(message truncated)_` marker takes a slot only when truncation is actually happening — reserving it up front discarded text that fit, since one section plus 49 button rows is exactly the cap. Truncating text degrades a reply while dropping buttons breaks the interaction, so text yields first; but once the rows alone reach the cap they are trimmed too, because Slack rejects an over-cap message outright and keeping every button that way delivers none of them.
- With blocks present, the message-level `text` — purely the notification preview, since the blocks now carry the content — is bounded rather than chunked. Chunking it would post the same blocks once per chunk.
- The plain-text path is **not** affected: `split_message` provably emits chunks ≤ 3000, so the "overflow" in the issue title never existed there.

## Behaviour changes a reviewer must weigh

Every user-visible Slack change, enumerated:

1. 👀 moves from receive-time to the `Queued` phase. Messages the bridge declines — mention-only group gating, the identical hole on the media path, per-user / per-channel rate limits, RBAC denials, command policy — get **no reaction at all** where today they get a 👀 that is never cleared.
2. Slash commands, rate-limit rejections and access-denied replies lose the 👀 **and** the accidental ✅ they get today via `on_send`. They return before the bridge's first lifecycle emit, so no receipt is added and none is needed.
3. ✅ now lands slightly **before** the reply text: the bridge sends the terminal phase immediately ahead of `send_response`.
4. Failed turns get an explicit ❌ where today the 👀 sticks forever.
5. Exact `(channel, ts)` keying: an in-thread reply no longer flips a sibling message's reaction. A terminal phase for a message we never marked is now a no-op instead of flipping something arbitrary, which also makes a repeated terminal phase idempotent.
6. `clear_done_reaction` is honoured on Slack for the first time — an empty terminal emoji removes the 👀 and adds nothing.
7. Cancelled / superseded turns now finalize. The bridge sends `AgentPhase::Error` on a cancelled turn, so the rewritten `_on_phase` clears the 👀. This repairs the stuck-👀 symptom reported in #6732's supersede path for free — #6732 is **not** claimed as closed here, only its symptom on this one path.
8. `SLACK_REACTIONS` no longer controls the progress card. Because the card's default follows it, `SLACK_REACTIONS=false` still means total silence, so no existing install changes; what is new is that either indicator can be turned off independently.
9. Any reply containing three or more consecutive newlines renders differently — the extra blank lines are gone.
10. Interactive replies over 3000 characters now render (across several sections) instead of being silently dropped.

## Verification

Real numbers from this branch.

Python — `cd sdk/python && PYTHONPATH=. python3 -m pytest tests/ -q`:

```
1934 passed in 24.36s
```

Baseline on `origin/main` before any edit was `1912 passed in 11.86s`, so this adds 22 cases. New cases in `sdk/python/tests/test_slack_adapter.py`: `test_receive_adds_no_reaction`, `test_queued_phase_adds_eyes`, `test_done_phase_flips_to_check`, `test_error_phase_flips_to_x`, `test_done_with_empty_reaction_removes_only`, `test_in_thread_reply_finalizes_own_message_not_a_sibling`, `test_terminal_phase_without_queued_adds_nothing`, `test_on_send_no_longer_touches_reactions`, `test_progress_card_defaults_to_following_reactions`, `test_progress_card_disabled_no_card_post`, `test_reactions_disabled_still_posts_card`, `test_card_disabled_still_flips_receipt_on_multi_step`, `test_finalize_pending_reaction_unknown_key_is_noop`, `test_finalize_pending_reaction_empty_emoji_removes_only`, `test_finalize_pending_reaction_is_idempotent`, `test_markdown_collapses_blank_line_runs`, `test_markdown_preserves_single_blank_line`, `test_markdown_preserves_blank_lines_inside_fenced_code`, `test_markdown_collapses_run_left_by_empty_header`, `test_build_block_kit_caps_section_text`, `test_build_block_kit_never_exceeds_block_limit`, `test_build_block_kit_short_text_stays_one_section`, `test_post_message_with_blocks_bounds_fallback_text`. Existing `test_reactions_default_true` and the `_post_message` chunking cases were re-checked and still pass unchanged.

Rust — `cargo test -p librefang-channels`:

```
lib:                            541 passed; 0 failed
bridge_integration_test:         31 passed; 0 failed
sidecar_protocol_conformance:     5 passed; 0 failed
doc-tests:                        3 passed; 0 failed
```

Two new integration tests pin the bridge contract the adapter now depends on. `ReactionRecordingAdapter` was discarding `_message_id`, so its `reactions` field became `Vec<(String, LifecycleReaction)>` with a new `phases_for(message_id)` accessor; `get_reactions()` is preserved intact for the existing consumer.

- `test_group_gating_skip_emits_no_lifecycle_reaction_6731` — a mock handle overrides `agent_channel_overrides` to report `group_policy = mention_only` (the trait default returns `None`), then feeds an unaddressed group message (`skip-1`) followed by an addressed one (`pass-1`). The addressed message's `Done` reaction is the positive control, awaited through the existing `wait_until` helper (no sleeps), which also proves the override and harness are wired before the absence assertion runs.
- `test_group_gating_pass_emits_queued_then_done_6731` — asserts the first phase of a dispatched turn is `Queued` and the last is `Done`.

The skip test was mutation-checked rather than trusted: flipping `skip-1`'s `was_mentioned` to `true` makes it fail with `got [Queued, Thinking, Done]`, so it discriminates on the gate rather than passing because the message failed to resolve an agent.

Workspace:

```
cargo check --workspace --lib                          Finished in 4m 09s
cargo clippy --workspace --all-targets -- -D warnings  exit code 0 (captured explicitly)
cargo fmt --check                                      exit code 0
```

### Not verified

- **Live Slack.** The three paths that matter most — a gated-out group message getting nothing, a failed turn getting ❌, and an interactive reply over 3000 chars actually rendering — need a real workspace and are human-only (release build + a long-lived daemon on port 4545). Requesting that check before merge.
- **Windows / macOS.** No Windows machine is available here; the changes are a Python sidecar, a docs set, a CI workflow and one Rust test file, none platform-divergent, but the non-Linux lanes have not been run locally.
- **The `sdk-python` lane itself has not executed** — it runs for the first time on this PR. Locally it is the same invocation (`python -m pytest tests -q` from `sdk/python`) against an installed rather than `PYTHONPATH`-injected package.

## Docs

Both language mirrors updated in the same commit:

- `docs/src/app/integrations/channels/page.mdx` + `zh/` — the Slack bullet in "Reactions and Processing State" described the receive/send mechanic.
- `docs/src/app/integrations/channels/core/page.mdx` + `zh/` — the "Processing-State Reactions" section, plus `SLACK_REACTIONS` / `SLACK_PROGRESS_CARD` added to that page's env snippet, which listed neither.
- `SLACK_PROGRESS_CARD` added beside `SLACK_REACTIONS` in the config snippets in `docs/src/app/configuration/page.mdx`, `configuration/channels/page.mdx` and both `zh/` mirrors.
- `docs/architecture/sidecar-channels.md` — said the card "honours the same `SLACK_REACTIONS` opt-out as the receipts" and that the receipts were "driven independently by the receive/send hooks". Now documents the single-stream design, why the receive hook was the wrong place, the two new guard tests, and the `message_id`-keying rule any future phase-stream consumer has to follow.

## Deviations from the plan

- `SLACK_PROGRESS_CARD` defaults to `self.reactions_enabled` instead of an unconditional `true`, so `SLACK_REACTIONS=false` keeps meaning silence. The plan's version would have started posting cards to operators who had opted out of all processing chatter.
- The plan offered "truncate with an ellipsis, or split into consecutive sections" for the interactive body. Splitting was chosen — no content is lost in any realistic case — with truncation reached only past the 50-block cap, and the block budget accounts for the button rows, which a naive fixed section limit would have overflowed (buttons are the functional payload).
- The message-level `text` fallback on the blocks path is bounded to 3000 as well. Not in the plan — see "Found outside the plan" below.
- Four changelog fragments rather than the three the plan listed. The pytest lane is a distinct entry that would otherwise get only a generated PR-title line, so it gets its own `changelog.d/added/` fragment alongside the two `fixed/` and one `changed/`.

## Found outside the plan

One thing, fixed in place rather than deferred: with `blocks` present, `_post_message` passed the whole converted text through as the message-level `text` without any bound. It is the same function and the same overflow class as #6730 (c) — an unbounded notification-preview string that the blocks now render in full anyway — so bounding it belongs in this PR rather than a follow-up. Covered by `test_post_message_with_blocks_bounds_fallback_text`.

Nothing else surfaced outside this cluster.

---

## Update — review findings addressed

**The truncation slot was reserved unconditionally.** At exactly 49 button rows a one-section reply fit the cap exactly, but the reserved marker slot pushed `max_sections` to 0 and the text was replaced by `_(message truncated)_`. `/agents` and `/models` build one row per agent / per provider with no cap (`crates/librefang-channels/src/bridge.rs:4006-4026`), so a daemon with 49 agents reached it. The marker now costs a slot only once truncation is happening.

**The cap could be exceeded.** The two cap tests contradicted each other: one asserted `len(blocks) <= MAX_BLOCKS_PER_MESSAGE`, the other asserted a marker plus 50 action rows, i.e. 51 blocks. Slack rejects an over-cap message, so "buttons are never dropped" cannot mean emitting 51 blocks — that delivers no buttons at all. Rows are now trimmed to leave room for the marker, and a parametrised test pins the cap across 1/10/47/48/49/50/60 rows.

**An unclosed code fence was being reflowed.** `_CODE_SPAN_RE` only matched closed fences, so a truncated model response ending mid-block left its interior unmasked and the blank-line collapse rewrote it. Slack renders an unterminated ``` as code to the end of the message, so that is user-visible. It now masks to end-of-message.

`~~~` fences and 4-space-indented blocks are deliberately still unmasked, with a test pinning that: Slack's mrkdwn renders neither as code, so their blank lines are ordinary prose and collapsing them is what #6730 asks for. Documented at the regex rather than left as an accident.

### Behaviour change not previously declared

A button press now produces a 👀 → ✅ / ❌ receipt on the **bot's own message** carrying the button, because the lifecycle `message_id` for an interactive callback is that message. Previously a press produced no reaction at all. This follows from moving the receipt onto the phase stream and is intended, but it was not stated when the change was described.

### Verification of this update

- `python3 -m pytest tests/test_slack_adapter.py` — **137 passed**.
- Full SDK suite — **1945 passed** in 23.05s.
- **Mutation check**: restoring the unconditional marker reservation fails 4 tests, including the new 49-row case and `never_exceeds_cap_for_any_row_count[50]` / `[60]` (60 rows produced 61 blocks). Restored and re-confirmed green.
