### PR TITLE
fix(media): stop the media tests reaching real providers, and drop response_format for gpt-image

### DIFF
--- a/changelog.d/fixed/6750-gpt-image-response-format.md
+++ b/changelog.d/fixed/6750-gpt-image-response-format.md
@@ -1,0 +1,4 @@
+Image generation works again against OpenAI's `gpt-image-*` models.
+  The request always carried `response_format`, which that family rejects with `400 Unknown parameter`, so every generation against those models failed while DALL-E was unaffected.
+  The parameter is now sent only to models that accept it, and unrecognised model names keep the previous behaviour so third-party OpenAI-compatible endpoints are unchanged.
+  (#6750) (@houko)

--- a/changelog.d/fixed/6750-media-test-provider-isolation.md
+++ b/changelog.d/fixed/6750-media-test-provider-isolation.md
@@ -1,0 +1,5 @@
+The media integration tests no longer depend on the developer's shell lacking provider credentials.
+  With an API key exported, tests asserting the missing-key path stopped exercising it and instead made real, billable calls — one generated an mp3 through the live OpenAI TTS endpoint while asserting that no provider was configured.
+  The harness now clears every credential variable the media drivers read, and a dedicated test fails if that ever stops happening.
+  A unit test that resolved a provider before reading its input file had the same dependency and could have reached a live transcription request; its input path is now guaranteed absent.
+  (#6750) (@houko)

--- a/crates/librefang-api/tests/media_routes_integration.rs
+++ b/crates/librefang-api/tests/media_routes_integration.rs
@@ -65,12 +65,8 @@ const MEDIA_PROVIDER_KEY_VARS: &[&str] = &[
 fn clear_media_provider_env() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
-        // SAFETY: runs inside `Once::call_once`, which guarantees this body
-        // executes exactly once and completes before any other caller of
-        // `clear_media_provider_env` proceeds — including the first `boot()`,
-        // which is the only place any test in this file spawns work that
-        // reads the environment. No other thread reads or writes these vars
-        // concurrently with this block.
+        // SAFETY: runs inside `Once::call_once`, which guarantees this body executes exactly once and completes before any other caller of `clear_media_provider_env` proceeds — including the first `boot()`, which is the only place any test in this file spawns work that reads the environment.
+        // No other thread reads or writes these vars concurrently with this block.
         unsafe {
             for var in MEDIA_PROVIDER_KEY_VARS {
                 std::env::remove_var(var);

--- a/crates/librefang-api/tests/media_routes_integration.rs
+++ b/crates/librefang-api/tests/media_routes_integration.rs
@@ -1,9 +1,6 @@
 //! Integration tests for the `/media/*` HTTP surface.
 //!
-//! These exercise the real `media` router against a freshly-booted kernel
-//! with no media-provider API keys configured — `boot()` strips them from the
-//! process environment rather than assuming the developer's shell has none, so
-//! a test asserting the missing-key path cannot silently make a billable call.
+//! These exercise the real `media` router against a freshly-booted kernel with no media-provider API keys configured — `boot()` strips them from the process environment rather than assuming the developer's shell has none, so a test asserting the missing-key path cannot silently make a billable call.
 //! We focus on:
 //!
 //! 1. Validation paths in each `MediaError`-producing handler — the cheap,
@@ -38,10 +35,7 @@ struct Harness {
 
 /// Every environment variable any media driver consults for credentials.
 ///
-/// Kept as one list rather than scattered per-test removals so that adding a
-/// provider to `librefang-runtime-media` and forgetting this array is the only
-/// way to regress — grep for `_API_KEY` under `crates/librefang-runtime-media/src/`
-/// to re-derive it.
+/// Kept as one list rather than scattered per-test removals so that adding a provider to `librefang-runtime-media` and forgetting this array is the only way to regress — grep for `_API_KEY` under `crates/librefang-runtime-media/src/` to re-derive it.
 const MEDIA_PROVIDER_KEY_VARS: &[&str] = &[
     "ANTHROPIC_API_KEY",
     "ELEVENLABS_API_KEY",
@@ -60,25 +54,14 @@ const MEDIA_PROVIDER_KEY_VARS: &[&str] = &[
 
 /// Strip provider credentials from this test binary's environment.
 ///
-/// The module doc above says these tests run "with no media-provider API keys
-/// configured", but that was an assumption about the developer's shell rather
-/// than something the harness enforced. With `OPENAI_API_KEY` exported, tests
-/// whose names assert the *absence* of a provider stopped testing the
-/// missing-key path and instead made real, billable calls to OpenAI —
-/// `media_speech_no_configured_provider_returns_missing_key` asserted 422 and
-/// got 200 back with a generated mp3. A test that asserts "no configured
-/// provider" must be structurally incapable of reaching one.
+/// The module doc above says these tests run "with no media-provider API keys configured", but that was an assumption about the developer's shell rather than something the harness enforced.
+/// With `OPENAI_API_KEY` exported, tests whose names assert the *absence* of a provider stopped testing the missing-key path and instead made real, billable calls to OpenAI — `media_speech_no_configured_provider_returns_missing_key` asserted 422 and got 200 back with a generated mp3.
+/// A test that asserts "no configured provider" must be structurally incapable of reaching one.
 ///
-/// Every driver reads its key through `std::env::var` at call time
-/// (`openai.rs:42`, `:281`, and the equivalents in each sibling module), so
-/// clearing the process environment before the first request is what makes the
-/// assertion true rather than merely likely. This is an integration test, so
-/// the process is this test binary alone and nothing outside it is affected.
+/// Every driver reads its key through `std::env::var` at call time (`openai.rs:42`, `:281`, and the equivalents in each sibling module), so clearing the process environment before the first request is what makes the assertion true rather than merely likely.
+/// This is an integration test, so the process is this test binary alone and nothing outside it is affected.
 ///
-/// `Once` rather than a per-`boot()` loop because every test reaches its
-/// provider through a request issued after its own `boot()` returns, so a
-/// single clear that completes before the first harness is handed out covers
-/// all of them.
+/// `Once` rather than a per-`boot()` loop because every test reaches its provider through a request issued after its own `boot()` returns, so a single clear that completes before the first harness is handed out covers all of them.
 fn clear_media_provider_env() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
@@ -90,11 +73,9 @@ fn clear_media_provider_env() {
 
 /// The guard for the guard: `boot()` must leave the environment credential-free.
 ///
-/// Every other test in this file asserts a 4xx that is only meaningful when no
-/// provider is reachable. Those assertions can pass for the wrong reason — a
-/// bogus key set in the developer's shell produces a provider-side 401, which
-/// several of them would also accept. This one fails outright if the clearing
-/// stops happening, which is what makes the rest trustworthy.
+/// Every other test in this file asserts a 4xx that is only meaningful when no provider is reachable.
+/// Those assertions can pass for the wrong reason — a bogus key set in the developer's shell produces a provider-side 401, which several of them would also accept.
+/// This one fails outright if the clearing stops happening, which is what makes the rest trustworthy.
 #[tokio::test(flavor = "multi_thread")]
 async fn boot_clears_provider_credentials_from_the_environment() {
     let _h = boot().await;

--- a/crates/librefang-api/tests/media_routes_integration.rs
+++ b/crates/librefang-api/tests/media_routes_integration.rs
@@ -1,7 +1,10 @@
 //! Integration tests for the `/media/*` HTTP surface.
 //!
 //! These exercise the real `media` router against a freshly-booted kernel
-//! with no media-provider API keys configured. We focus on:
+//! with no media-provider API keys configured — `boot()` strips them from the
+//! process environment rather than assuming the developer's shell has none, so
+//! a test asserting the missing-key path cannot silently make a billable call.
+//! We focus on:
 //!
 //! 1. Validation paths in each `MediaError`-producing handler — the cheap,
 //!    deterministic 4xx slice. No live network, no real provider keys.
@@ -33,7 +36,79 @@ struct Harness {
     _test: TestAppState,
 }
 
+/// Every environment variable any media driver consults for credentials.
+///
+/// Kept as one list rather than scattered per-test removals so that adding a
+/// provider to `librefang-runtime-media` and forgetting this array is the only
+/// way to regress — grep for `_API_KEY` under `crates/librefang-runtime-media/src/`
+/// to re-derive it.
+const MEDIA_PROVIDER_KEY_VARS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "FIREWORKS_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_CLOUD_API_KEY",
+    "GROQ_API_KEY",
+    "LOCAL_WHISPER_KEY",
+    "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
+    "OPENAI_API_KEY",
+    "SILICONFLOW_API_KEY",
+    "TOGETHER_API_KEY",
+];
+
+/// Strip provider credentials from this test binary's environment.
+///
+/// The module doc above says these tests run "with no media-provider API keys
+/// configured", but that was an assumption about the developer's shell rather
+/// than something the harness enforced. With `OPENAI_API_KEY` exported, tests
+/// whose names assert the *absence* of a provider stopped testing the
+/// missing-key path and instead made real, billable calls to OpenAI —
+/// `media_speech_no_configured_provider_returns_missing_key` asserted 422 and
+/// got 200 back with a generated mp3. A test that asserts "no configured
+/// provider" must be structurally incapable of reaching one.
+///
+/// Every driver reads its key through `std::env::var` at call time
+/// (`openai.rs:42`, `:281`, and the equivalents in each sibling module), so
+/// clearing the process environment before the first request is what makes the
+/// assertion true rather than merely likely. This is an integration test, so
+/// the process is this test binary alone and nothing outside it is affected.
+///
+/// `Once` rather than a per-`boot()` loop because every test reaches its
+/// provider through a request issued after its own `boot()` returns, so a
+/// single clear that completes before the first harness is handed out covers
+/// all of them.
+fn clear_media_provider_env() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        for var in MEDIA_PROVIDER_KEY_VARS {
+            std::env::remove_var(var);
+        }
+    });
+}
+
+/// The guard for the guard: `boot()` must leave the environment credential-free.
+///
+/// Every other test in this file asserts a 4xx that is only meaningful when no
+/// provider is reachable. Those assertions can pass for the wrong reason — a
+/// bogus key set in the developer's shell produces a provider-side 401, which
+/// several of them would also accept. This one fails outright if the clearing
+/// stops happening, which is what makes the rest trustworthy.
+#[tokio::test(flavor = "multi_thread")]
+async fn boot_clears_provider_credentials_from_the_environment() {
+    let _h = boot().await;
+    for var in MEDIA_PROVIDER_KEY_VARS {
+        assert!(
+            std::env::var(var).is_err(),
+            "{var} is still set after boot() — a test asserting the missing-key path \
+             could reach a real provider and bill the developer"
+        );
+    }
+}
+
 async fn boot() -> Harness {
+    clear_media_provider_env();
     let test = TestAppState::with_builder(MockKernelBuilder::new().with_config(|cfg| {
         cfg.default_model = librefang_types::config::DefaultModelConfig {
             provider: "ollama".to_string(),

--- a/crates/librefang-api/tests/media_routes_integration.rs
+++ b/crates/librefang-api/tests/media_routes_integration.rs
@@ -65,8 +65,16 @@ const MEDIA_PROVIDER_KEY_VARS: &[&str] = &[
 fn clear_media_provider_env() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
-        for var in MEDIA_PROVIDER_KEY_VARS {
-            std::env::remove_var(var);
+        // SAFETY: runs inside `Once::call_once`, which guarantees this body
+        // executes exactly once and completes before any other caller of
+        // `clear_media_provider_env` proceeds — including the first `boot()`,
+        // which is the only place any test in this file spawns work that
+        // reads the environment. No other thread reads or writes these vars
+        // concurrently with this block.
+        unsafe {
+            for var in MEDIA_PROVIDER_KEY_VARS {
+                std::env::remove_var(var);
+            }
         }
     });
 }

--- a/crates/librefang-runtime-media/src/media_understanding.rs
+++ b/crates/librefang-runtime-media/src/media_understanding.rs
@@ -1808,15 +1808,21 @@ mod tests {
         assert_eq!(default_vision_model("unknown"), "unknown");
     }
 
+    /// Same latent dependency as `test_transcribe_audio_no_provider` above: `describe_image` resolves the provider (`config.image_provider`, else `detect_vision_provider()`, which reads vision-capable keys from the process) BEFORE it reads the file.
+    /// With no explicit `image_provider` set, a machine with a vision-capable key exported resolves a real provider here; only a guaranteed-absent input path keeps the call from proceeding to a real, billable description request.
     #[tokio::test]
     async fn test_describe_image_no_provider_configured() {
-        // With no API keys set and no explicit provider, should fail with provider error.
+        // With no API keys set, should fail with provider error.
+        // With a key set, provider resolution succeeds instead and the call must still stop at the guaranteed-absent file read, never reaching a real description request.
         let engine = MediaEngine::new(MediaConfig::default());
+        let missing = std::env::temp_dir()
+            .join("librefang-nonexistent-describe-no-provider")
+            .join("test.png");
         let attachment = MediaAttachment {
             media_type: MediaType::Image,
             mime_type: "image/png".into(),
             source: MediaSource::FilePath {
-                path: "test.png".into(),
+                path: missing.to_string_lossy().into_owned(),
             },
             size_bytes: 1024,
         };
@@ -1922,15 +1928,22 @@ mod tests {
         assert!(result.unwrap_err().contains("Expected audio"));
     }
 
+    /// Same latent dependency `transcribe_audio_accepts_video_type` above was fixed for: `transcribe_audio` resolves the provider (`config.audio_provider`, else `detect_audio_provider()`, which reads STT keys from the process) BEFORE it reads the file.
+    /// With no explicit `audio_provider` set, a machine with an STT key exported resolves a real provider here; the only thing that then kept this test off the network was the input path happening not to exist at the process's working directory.
+    /// A guaranteed-absent path removes that assumption instead of relying on it — see #5716 on not depending on incidental filesystem state in tests.
     #[tokio::test]
     async fn test_transcribe_audio_no_provider() {
-        // With no API keys set, should fail with provider error
+        // With no API keys set, should fail with provider error.
+        // With a key set, provider resolution succeeds instead and the call must still stop at the guaranteed-absent file read, never reaching a real transcription request.
         let engine = MediaEngine::new(MediaConfig::default());
+        let missing = std::env::temp_dir()
+            .join("librefang-nonexistent-transcribe-no-provider")
+            .join("test.webm");
         let attachment = MediaAttachment {
             media_type: MediaType::Audio,
             mime_type: "audio/webm".into(),
             source: MediaSource::FilePath {
-                path: "test.webm".into(),
+                path: missing.to_string_lossy().into_owned(),
             },
             size_bytes: 1024,
         };

--- a/crates/librefang-runtime-media/src/media_understanding.rs
+++ b/crates/librefang-runtime-media/src/media_understanding.rs
@@ -1660,17 +1660,35 @@ mod tests {
     }
 
     /// #6679: `transcribe_audio` must accept `MediaType::Video` (it used to
-    /// reject every non-`Audio` type outright) — asserted by checking the
-    /// call gets PAST the type guard and fails on provider resolution
-    /// instead, which needs no ffmpeg and no configured provider.
+    /// reject every non-`Audio` type outright) — asserted by checking the call
+    /// gets PAST the type guard, which needs no ffmpeg and reaches no network.
+    ///
+    /// Which error comes back past the guard depends on the developer's
+    /// environment, so both are accepted. `transcribe_audio` resolves the
+    /// provider (`config.audio_provider`, else `detect_audio_provider()`, which
+    /// reads `OPENAI_API_KEY` / `GROQ_API_KEY` / … from the process) BEFORE it
+    /// reads the file. On a clean machine and in CI that resolution fails and
+    /// the call stops there; with any STT key exported it succeeds and the call
+    /// proceeds to the file read. Pinning only the provider message made this
+    /// test fail on any machine with a key configured, which is a statement
+    /// about the shell rather than about the type guard.
+    ///
+    /// The path must not exist for a second reason: it is what keeps the test
+    /// off the network. Provider resolution succeeding is not hypothetical, and
+    /// if the read then succeeded the next step would be a real, billable STT
+    /// call. A guaranteed-absent path makes that unreachable. Constructed
+    /// rather than borrowed from the host filesystem — see #5716.
     #[tokio::test]
     async fn transcribe_audio_accepts_video_type() {
         let engine = MediaEngine::new(MediaConfig::default());
+        let missing = std::env::temp_dir()
+            .join("librefang-nonexistent-6679")
+            .join("test.mp4");
         let attachment = MediaAttachment {
             media_type: MediaType::Video,
             mime_type: "video/mp4".into(),
             source: MediaSource::FilePath {
-                path: "test.mp4".into(),
+                path: missing.to_string_lossy().into_owned(),
             },
             size_bytes: 1024,
         };
@@ -1683,8 +1701,10 @@ mod tests {
             "Video must pass the type guard, got: {err}"
         );
         assert!(
-            err.contains("No audio transcription provider configured"),
-            "expected to fail on provider resolution instead, got: {err}"
+            err.contains("No audio transcription provider configured")
+                || err.contains("Failed to read video file"),
+            "expected provider resolution or the file read to be what fails, \
+             i.e. something strictly past the type guard, got: {err}"
         );
     }
 

--- a/crates/librefang-runtime-media/src/media_understanding.rs
+++ b/crates/librefang-runtime-media/src/media_understanding.rs
@@ -1659,25 +1659,17 @@ mod tests {
         assert!(result.unwrap_err().contains("Expected image"));
     }
 
-    /// #6679: `transcribe_audio` must accept `MediaType::Video` (it used to
-    /// reject every non-`Audio` type outright) — asserted by checking the call
-    /// gets PAST the type guard, which needs no ffmpeg and reaches no network.
+    /// #6679: `transcribe_audio` must accept `MediaType::Video` (it used to reject every non-`Audio` type outright) — asserted by checking the call gets PAST the type guard, which needs no ffmpeg and reaches no network.
     ///
-    /// Which error comes back past the guard depends on the developer's
-    /// environment, so both are accepted. `transcribe_audio` resolves the
-    /// provider (`config.audio_provider`, else `detect_audio_provider()`, which
-    /// reads `OPENAI_API_KEY` / `GROQ_API_KEY` / … from the process) BEFORE it
-    /// reads the file. On a clean machine and in CI that resolution fails and
-    /// the call stops there; with any STT key exported it succeeds and the call
-    /// proceeds to the file read. Pinning only the provider message made this
-    /// test fail on any machine with a key configured, which is a statement
-    /// about the shell rather than about the type guard.
+    /// Which error comes back past the guard depends on the developer's environment, so both are accepted.
+    /// `transcribe_audio` resolves the provider (`config.audio_provider`, else `detect_audio_provider()`, which reads `OPENAI_API_KEY` / `GROQ_API_KEY` / … from the process) BEFORE it reads the file.
+    /// On a clean machine and in CI that resolution fails and the call stops there; with any STT key exported it succeeds and the call proceeds to the file read.
+    /// Pinning only the provider message made this test fail on any machine with a key configured, which is a statement about the shell rather than about the type guard.
     ///
-    /// The path must not exist for a second reason: it is what keeps the test
-    /// off the network. Provider resolution succeeding is not hypothetical, and
-    /// if the read then succeeded the next step would be a real, billable STT
-    /// call. A guaranteed-absent path makes that unreachable. Constructed
-    /// rather than borrowed from the host filesystem — see #5716.
+    /// The path must not exist for a second reason: it is what keeps the test off the network.
+    /// Provider resolution succeeding is not hypothetical, and if the read then succeeded the next step would be a real, billable STT call.
+    /// A guaranteed-absent path makes that unreachable.
+    /// Constructed rather than borrowed from the host filesystem — see #5716.
     #[tokio::test]
     async fn transcribe_audio_accepts_video_type() {
         let engine = MediaEngine::new(MediaConfig::default());

--- a/crates/librefang-runtime-media/src/openai.rs
+++ b/crates/librefang-runtime-media/src/openai.rs
@@ -48,6 +48,20 @@ impl OpenAIMediaDriver {
     }
 }
 
+/// Whether `/images/generations` accepts a `response_format` parameter for this model.
+///
+/// The DALL·E models take `response_format` as `"url"` or `"b64_json"`. The
+/// `gpt-image-*` family rejects the parameter outright with
+/// `400 Unknown parameter: 'response_format'` and always returns base64, so
+/// sending it makes every image request fail against those models.
+///
+/// Defaulting to `true` for unrecognised names keeps third-party
+/// OpenAI-compatible endpoints on the behaviour they have today; only the
+/// family known to reject it is special-cased.
+fn image_model_accepts_response_format(model: &str) -> bool {
+    !model.starts_with("gpt-image")
+}
+
 #[async_trait]
 impl MediaDriver for OpenAIMediaDriver {
     fn capabilities(&self) -> Vec<MediaCapability> {
@@ -88,8 +102,11 @@ impl MediaDriver for OpenAIMediaDriver {
             "prompt": request.prompt,
             "n": request.count,
             "size": size,
-            "response_format": "b64_json",
         });
+
+        if image_model_accepts_response_format(model) {
+            body["response_format"] = serde_json::json!("b64_json");
+        }
 
         if let Some(ref q) = request.quality {
             body["quality"] = serde_json::json!(q);
@@ -326,8 +343,10 @@ impl MediaDriver for GenericOpenAICompatMediaDriver {
             "prompt": request.prompt,
             "n": request.count,
             "size": size,
-            "response_format": "b64_json",
         });
+        if image_model_accepts_response_format(model) {
+            body["response_format"] = serde_json::json!("b64_json");
+        }
         if let Some(ref q) = request.quality {
             body["quality"] = serde_json::json!(q);
         }
@@ -397,6 +416,29 @@ impl MediaDriver for GenericOpenAICompatMediaDriver {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `gpt-image-*` rejects `response_format` with `400 Unknown parameter`, so
+    /// sending it makes every image request against that family fail. DALL·E
+    /// requires it to get base64 back instead of an expiring URL.
+    #[test]
+    fn gpt_image_models_do_not_accept_response_format() {
+        assert!(!image_model_accepts_response_format("gpt-image-1"));
+        assert!(!image_model_accepts_response_format("gpt-image-1-mini"));
+    }
+
+    #[test]
+    fn dalle_models_still_accept_response_format() {
+        assert!(image_model_accepts_response_format("dall-e-3"));
+        assert!(image_model_accepts_response_format("dall-e-2"));
+    }
+
+    /// Unknown names keep today's behaviour so third-party OpenAI-compatible
+    /// endpoints are not changed by this fix.
+    #[test]
+    fn unknown_image_models_keep_sending_response_format() {
+        assert!(image_model_accepts_response_format("flux-pro"));
+        assert!(image_model_accepts_response_format(""));
+    }
 
     #[test]
     fn test_driver_capabilities() {

--- a/crates/librefang-runtime-media/src/openai.rs
+++ b/crates/librefang-runtime-media/src/openai.rs
@@ -50,14 +50,10 @@ impl OpenAIMediaDriver {
 
 /// Whether `/images/generations` accepts a `response_format` parameter for this model.
 ///
-/// The DALL·E models take `response_format` as `"url"` or `"b64_json"`. The
-/// `gpt-image-*` family rejects the parameter outright with
-/// `400 Unknown parameter: 'response_format'` and always returns base64, so
-/// sending it makes every image request fail against those models.
+/// The DALL·E models take `response_format` as `"url"` or `"b64_json"`.
+/// The `gpt-image-*` family rejects the parameter outright with `400 Unknown parameter: 'response_format'` and always returns base64, so sending it makes every image request fail against those models.
 ///
-/// Defaulting to `true` for unrecognised names keeps third-party
-/// OpenAI-compatible endpoints on the behaviour they have today; only the
-/// family known to reject it is special-cased.
+/// Defaulting to `true` for unrecognised names keeps third-party OpenAI-compatible endpoints on the behaviour they have today; only the family known to reject it is special-cased.
 fn image_model_accepts_response_format(model: &str) -> bool {
     !model.starts_with("gpt-image")
 }
@@ -417,9 +413,8 @@ impl MediaDriver for GenericOpenAICompatMediaDriver {
 mod tests {
     use super::*;
 
-    /// `gpt-image-*` rejects `response_format` with `400 Unknown parameter`, so
-    /// sending it makes every image request against that family fail. DALL·E
-    /// requires it to get base64 back instead of an expiring URL.
+    /// `gpt-image-*` rejects `response_format` with `400 Unknown parameter`, so sending it makes every image request against that family fail.
+    /// DALL·E requires it to get base64 back instead of an expiring URL.
     #[test]
     fn gpt_image_models_do_not_accept_response_format() {
         assert!(!image_model_accepts_response_format("gpt-image-1"));
@@ -432,8 +427,7 @@ mod tests {
         assert!(image_model_accepts_response_format("dall-e-2"));
     }
 
-    /// Unknown names keep today's behaviour so third-party OpenAI-compatible
-    /// endpoints are not changed by this fix.
+    /// Unknown names keep today's behaviour so third-party OpenAI-compatible endpoints are not changed by this fix.
     #[test]
     fn unknown_image_models_keep_sending_response_format() {
         assert!(image_model_accepts_response_format("flux-pro"));


### PR DESCRIPTION
## Why

Found while running `cargo test -p librefang-api` during unrelated work: the media integration tests **made a real, billable OpenAI call**.

`media_speech_no_configured_provider_returns_missing_key` asserts 422 for the missing-key path. With `OPENAI_API_KEY` present in the shell it returned **200**, having performed an actual TTS request and written the resulting mp3 to `/api/uploads/7e386717-d565-41ae-982d-98ced8d837b1` with `duration_ms: 500`. `media_image_no_configured_provider_returns_missing_key` hit the live image endpoint the same way.

The module doc claimed these run "with no media-provider API keys configured", and the comment at what is now line 337 states the assumption outright. It was an assumption about the developer's shell, never something the harness enforced. A test whose name asserts *no configured provider* should be structurally incapable of reaching one.

## Changes

**`crates/librefang-api/tests/media_routes_integration.rs`** — `boot()` clears the 13 environment variables any media driver reads for credentials (`MEDIA_PROVIDER_KEY_VARS`, derived by grepping `crates/librefang-runtime-media/src/` for `_API_KEY`). Every driver reads its key through `std::env::var` at call time (`openai.rs:42`, `:281`, and the equivalents in each sibling module), so clearing the process environment before the first request is what makes the assertion true rather than merely likely.

`Once` rather than a per-`boot()` loop: all 18 tests reach a provider only through a request issued after their own `boot()` returns, so a single clear completing before the first harness is handed out covers all of them. Verified all 18 `#[tokio::test]` functions call `boot()`.

A new test, `boot_clears_provider_credentials_from_the_environment`, asserts the environment really is clean afterwards. This is the guard for the guard — the other assertions are 4xx checks that a bogus key could also satisfy via a provider-side 401, so without this one they could keep passing for the wrong reason.

**`crates/librefang-runtime-media/src/media_understanding.rs`** — `transcribe_audio_accepts_video_type` had the same environment dependency from the opposite side, and **fails on `main` today for anyone with an STT key exported**.

`transcribe_audio` resolves the provider (`config.audio_provider`, else `detect_audio_provider()` reading `OPENAI_API_KEY` / `GROQ_API_KEY` / …) at `media_understanding.rs:208-216`, *before* reading the file at `:231-237`. On a clean machine resolution fails and the call stops there, which is the message the test pinned. With a key present resolution succeeds and the call proceeds to the file read, so the test failed on an assertion about the developer's shell rather than about the type guard it exists to cover.

It now accepts either error — both prove the call cleared the type guard — and its path is a constructed absent one under `temp_dir()` rather than the bare relative `"test.mp4"`. That second part is load-bearing, not cosmetic: provider resolution succeeding is not hypothetical, and if the read then succeeded the next step would be a real billable STT request. A guaranteed-absent path makes that unreachable. Constructed rather than borrowed from the host filesystem, per #5716.

**`crates/librefang-runtime-media/src/openai.rs`** — the billable call that exposed all this returned `400 Unknown parameter: 'response_format'`, which is a live defect independent of the tests.

Both image-generation bodies (`:91` and `:329`) sent `"response_format": "b64_json"` unconditionally. The DALL·E models accept it; the `gpt-image-*` family rejects it outright and always returns base64, so **image generation fails completely against those models today**. The parameter is now gated on `image_model_accepts_response_format(model)`, which excludes only that family — unrecognised names keep sending it, so third-party OpenAI-compatible endpoints are unaffected.

The response parser at `:127-140` already reads both `b64_json` and `url`, so omitting the parameter needs no parsing change. The `response_format` at `:187` is left alone: that is the TTS body, where it is a valid parameter selecting the audio container.

## Verification

macOS aarch64, native cargo, based on `origin/main` at c403439a.

- **`cargo test -p librefang-api --test media_routes_integration`** with `OPENAI_API_KEY`, `GEMINI_API_KEY`, `ELEVENLABS_API_KEY` and `GROQ_API_KEY` all exported — **19 passed, 0 failed**. This is the configuration that previously made live calls.
- **Mutation check on the new guard test.** Disabling the body of `clear_media_provider_env` makes `boot_clears_provider_credentials_from_the_environment` fail with `OPENAI_API_KEY is still set after boot() — a test asserting the missing-key path could reach a real provider and bill the developer`. Restored and re-confirmed green. The test discriminates; it is not green by construction.
- **`cargo test -p librefang-runtime-media --lib`** in both environments: **93 passed, 0 failed** with keys present (the case that is red on `main`), and **93 passed, 0 failed** under `env -u` for all 13 variables, which is what CI sees.
- **`cargo clippy --workspace --all-targets -- -D warnings`** — exit code **0**, captured explicitly.
- **`cargo fmt --check`** — exit code 0.

### Not verified

No live provider call was made to confirm that `gpt-image-1` now succeeds — doing so would be the billable request this PR exists to prevent. The fix is derived from the observed `400 Unknown parameter: 'response_format'` returned by the live endpoint and from the documented parameter set; the unit tests pin the model-name predicate, not the provider's acceptance of the resulting body.

## Scope note

The `transcribe_audio_accepts_video_type` fix is a pre-existing failure rather than something this PR introduced. It is included because it is the same defect class in the same crate — a media test whose correctness depends on the developer having no credentials, with a real billable call sitting one successful file read away.
