### PR TITLE
fix(media): stage video input to a file so mp4/mov audio extraction can seek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5053,6 +5053,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "serial_test",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/changelog.d/fixed/6751-mp4-mov-audio-extraction.md
+++ b/changelog.d/fixed/6751-mp4-mov-audio-extraction.md
@@ -1,0 +1,6 @@
+Transcription of `.mp4` and `.mov` recordings works again instead of silently returning nothing.
+  The audio track was extracted by piping the container to ffmpeg, but these formats keep their index at the end of the file and demuxing it requires seeking backwards, which a pipe cannot do — so the extraction produced a valid container carrying no audio at all, and whatever the transcription provider made of a soundless file was what the operator saw.
+  Because ffmpeg reports success in this case, neither existing check noticed.
+  The input is now staged to a scratch file so it can be seeked, and a stream that arrives without audio is rejected outright rather than uploaded.
+  `.mkv` and `.avi` were never affected, being streamable formats.
+  (#6751) (@houko)

--- a/crates/librefang-runtime-media/Cargo.toml
+++ b/crates/librefang-runtime-media/Cargo.toml
@@ -18,6 +18,7 @@ tracing = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
 metrics = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 # Serialises the env-mutating ElevenLabs voice_id validator tests so

--- a/crates/librefang-runtime-media/src/media_understanding.rs
+++ b/crates/librefang-runtime-media/src/media_understanding.rs
@@ -1609,9 +1609,12 @@ mod tests {
 
         // Written to a file rather than `pipe:1`: a non-fragmented mp4 cannot be *muxed* to a pipe either, since the muxer rewinds to write moov.
         // Generating the fixture the same way the failing input arises is the point of the test.
-        let dir = std::env::temp_dir().join(format!("librefang-6747-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("temp dir");
-        let fixture = dir.join("plain.mp4");
+        // `TempDir` cleans up on drop even if an `assert!` below panics — a hand-rolled path plus `remove_dir_all` after the assertions would leak the directory on that path.
+        let dir = tempfile::Builder::new()
+            .prefix("librefang-6747-")
+            .tempdir()
+            .expect("temp dir");
+        let fixture = dir.path().join("plain.mp4");
 
         let gen = tokio::process::Command::new("ffmpeg")
             .args([
@@ -1647,7 +1650,6 @@ mod tests {
         );
 
         let mp4_bytes = std::fs::read(&fixture).expect("fixture readable");
-        let _ = std::fs::remove_dir_all(&dir);
         assert!(!mp4_bytes.is_empty());
 
         let out = extract_video_audio_track(&mp4_bytes)

--- a/crates/librefang-runtime-media/src/media_understanding.rs
+++ b/crates/librefang-runtime-media/src/media_understanding.rs
@@ -1031,9 +1031,8 @@ fn mime_to_ext(mime: &str) -> Option<String> {
 
 /// A scratch file that deletes itself when it goes out of scope.
 ///
-/// Used only where ffmpeg genuinely cannot work from a pipe — see
-/// `extract_video_audio_track`. Written by hand rather than pulling `tempfile`
-/// into this crate's dependencies for one call site.
+/// Used only where ffmpeg genuinely cannot work from a pipe — see `extract_video_audio_track`.
+/// Written by hand rather than pulling `tempfile` into this crate's dependencies for one call site.
 struct ScopedTempFile {
     path: std::path::PathBuf,
 }
@@ -1041,9 +1040,7 @@ struct ScopedTempFile {
 impl ScopedTempFile {
     /// Create a uniquely-named scratch file and write `bytes` into it.
     ///
-    /// Uniqueness comes from pid plus a process-wide counter, so two
-    /// concurrent extractions in the same process cannot collide and neither
-    /// can two daemons sharing a temp dir.
+    /// Uniqueness comes from pid plus a process-wide counter, so two concurrent extractions in the same process cannot collide and neither can two daemons sharing a temp dir.
     async fn write(bytes: &[u8], extension: &str) -> Result<Self, String> {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -1070,13 +1067,10 @@ impl Drop for ScopedTempFile {
 
 /// Run `ffmpeg` with the given arguments and collect stdout.
 ///
-/// `input_bytes` is `Some` when the input is fed on stdin (the args then name
-/// `pipe:0`), and `None` when the args already point at a path on disk. The
-/// distinction matters: a pipe cannot seek, and some containers require a
-/// backward seek to be demuxed at all — see `extract_video_audio_track`.
+/// `input_bytes` is `Some` when the input is fed on stdin (the args then name `pipe:0`), and `None` when the args already point at a path on disk.
+/// The distinction matters: a pipe cannot seek, and some containers require a backward seek to be demuxed at all — see `extract_video_audio_track`.
 ///
-/// Shared by every ffmpeg-based transcode in this module so the spawn / pipe /
-/// timeout / kill-on-timeout plumbing exists once.
+/// Shared by every ffmpeg-based transcode in this module so the spawn / pipe / timeout / kill-on-timeout plumbing exists once.
 ///
 /// `install_hint` names the feature that needs ffmpeg, so the "not on PATH"
 /// error tells the operator what stopped working rather than just that a
@@ -1103,8 +1097,7 @@ async fn run_ffmpeg_pipe(
 
     // Feed stdin concurrently; hanging the write inside the main task
     // would deadlock once ffmpeg's stdout pipe buffer fills.
-    // With a file input there is nothing to write — dropping the handle
-    // closes it so ffmpeg does not wait on a stdin that will never arrive.
+    // With a file input there is nothing to write — dropping the handle closes it so ffmpeg does not wait on a stdin that will never arrive.
     match (child.stdin.take(), input_bytes) {
         (Some(mut stdin), Some(bytes)) => {
             let bytes = bytes.to_vec();
@@ -1201,20 +1194,14 @@ async fn transcode_oga_to_ogg_opus(input_bytes: &[u8]) -> Result<Vec<u8>, String
 /// which is what makes this work across `mp4`/`mov`/`mkv`/`avi` uniformly
 /// rather than needing a format hint per extension.
 ///
-/// The input is staged to a scratch file rather than piped, because a pipe
-/// cannot seek and ISO-BMFF cannot always be demuxed without seeking (#6747).
+/// The input is staged to a scratch file rather than piped, because a pipe cannot seek and ISO-BMFF cannot always be demuxed without seeking (#6747).
 ///
-/// An `mp4` / `mov` stores its index in the `moov` atom. When `moov` sits after
-/// `mdat` — the default output of ffmpeg's own muxer, phone cameras, screen
-/// recorders and meeting exporters — the demuxer has to seek backwards to read
-/// it. Over `pipe:0` that fails, and it fails *quietly*: ffmpeg writes
-/// `Error during demuxing` to stderr but can still exit 0, emitting a
-/// header-only Ogg with zero audio packets. Those bytes then went to the
-/// transcription provider, and the operator saw whatever a provider says about
-/// a soundless file — arbitrarily far from the real cause.
+/// An `mp4` / `mov` stores its index in the `moov` atom.
+/// When `moov` sits after `mdat` — the default output of ffmpeg's own muxer, phone cameras, screen recorders and meeting exporters — the demuxer has to seek backwards to read it.
+/// Over `pipe:0` that fails, and it fails *quietly*: ffmpeg writes `Error during demuxing` to stderr but can still exit 0, emitting a header-only Ogg with zero audio packets.
+/// Those bytes then went to the transcription provider, and the operator saw whatever a provider says about a soundless file — arbitrarily far from the real cause.
 ///
-/// `mkv` and `avi` are streamable and were never affected, which is why the
-/// four container types enabled by #6679 / #6683 split exactly in half.
+/// `mkv` and `avi` are streamable and were never affected, which is why the four container types enabled by #6679 / #6683 split exactly in half.
 async fn extract_video_audio_track(input_bytes: &[u8]) -> Result<Vec<u8>, String> {
     let staged = ScopedTempFile::write(input_bytes, "media").await?;
     let input_path = staged.path.to_string_lossy().into_owned();
@@ -1244,11 +1231,9 @@ async fn extract_video_audio_track(input_bytes: &[u8]) -> Result<Vec<u8>, String
     )
     .await?;
 
-    // Defence in depth for the silent half of #6747. The staged file fixes the
-    // cause, but neither guard in `run_ffmpeg_pipe` can catch a demux that
-    // fails while the process still exits 0 and still writes a container: the
-    // exit code is success and the output is not empty. Exit-code behaviour
-    // also varies across ffmpeg builds, so it cannot be the only line.
+    // Defence in depth for the silent half of #6747.
+    // The staged file fixes the cause, but neither guard in `run_ffmpeg_pipe` can catch a demux that fails while the process still exits 0 and still writes a container: the exit code is success and the output is not empty.
+    // Exit-code behaviour also varies across ffmpeg builds, so it cannot be the only line.
     if !ogg_contains_audio(&out) {
         return Err(format!(
             "ffmpeg produced an Ogg stream with no audio packets ({} bytes) — \
@@ -1262,10 +1247,8 @@ async fn extract_video_audio_track(input_bytes: &[u8]) -> Result<Vec<u8>, String
 
 /// Whether an Ogg stream carries audio, rather than only its headers.
 ///
-/// An Opus stream opens with two header pages, `OpusHead` and `OpusTags`; audio
-/// data begins on the third. Counting `OggS` page captures is enough to tell a
-/// real stream from the 261-byte headers-only artefact a failed demux produces,
-/// and does not require parsing the container.
+/// An Opus stream opens with two header pages, `OpusHead` and `OpusTags`; audio data begins on the third.
+/// Counting `OggS` page captures is enough to tell a real stream from the 261-byte headers-only artefact a failed demux produces, and does not require parsing the container.
 fn ogg_contains_audio(bytes: &[u8]) -> bool {
     const OGG_PAGE_MAGIC: &[u8; 4] = b"OggS";
     bytes
@@ -1603,30 +1586,19 @@ mod tests {
         );
     }
 
-    /// #6747: a plain, non-fragmented mp4 — `moov` written after `mdat`, which
-    /// is what every phone camera, screen recorder and meeting exporter
-    /// produces — must yield a stream with actual audio in it.
+    /// #6747: a plain, non-fragmented mp4 — `moov` written after `mdat`, which is what every phone camera, screen recorder and meeting exporter produces — must yield a stream with actual audio in it.
     ///
-    /// The existing smoke test cannot catch this, for two independent reasons,
-    /// and both had to be fixed here for the test to discriminate.
+    /// The existing smoke test cannot catch this, for two independent reasons, and both had to be fixed here for the test to discriminate.
     ///
-    /// Its fixture passes `-movflags frag_keyframe+empty_moov`, producing a
-    /// *fragmented* mp4 — the one mp4 flavour that demuxes from a non-seekable
-    /// pipe. It exercised precisely the shape that worked.
+    /// Its fixture passes `-movflags frag_keyframe+empty_moov`, producing a *fragmented* mp4 — the one mp4 flavour that demuxes from a non-seekable pipe.
+    /// It exercised precisely the shape that worked.
     ///
-    /// It is also only ~8 KB, and that alone is disqualifying. ffmpeg buffers
-    /// the head of an unseekable input (32 KB by default), so a file small
-    /// enough to fit entirely in that buffer can still be "seeked" backwards
-    /// and demuxes fine over a pipe. Measured against ffmpeg 8.1.1: a 0.5 s /
-    /// 11 KB clip yields 2,500 bytes of Ogg and succeeds, while 5 s / 69 KB,
-    /// 30 s / 389 KB and 120 s / 1.5 MB all yield exactly 261 bytes with
-    /// `stream 0, offset 0x30: partial file` on stderr. That is why the
-    /// fixture below is 10 s rather than the smoke test's 0.5 s — a shorter
-    /// one passes with or without the fix.
+    /// It is also only ~8 KB, and that alone is disqualifying.
+    /// ffmpeg buffers the head of an unseekable input (32 KB by default), so a file small enough to fit entirely in that buffer can still be "seeked" backwards and demuxes fine over a pipe.
+    /// Measured against ffmpeg 8.1.1: a 0.5 s / 11 KB clip yields 2,500 bytes of Ogg and succeeds, while 5 s / 69 KB, 30 s / 389 KB and 120 s / 1.5 MB all yield exactly 261 bytes with `stream 0, offset 0x30: partial file` on stderr.
+    /// That is why the fixture below is 10 s rather than the smoke test's 0.5 s — a shorter one passes with or without the fix.
     ///
-    /// The assertions are the ones the old code failed: a header-only Ogg is
-    /// non-empty, starts with `OggS`, and is smaller than the source mp4, so
-    /// every assertion in the smoke test passed on a stream carrying no audio.
+    /// The assertions are the ones the old code failed: a header-only Ogg is non-empty, starts with `OggS`, and is smaller than the source mp4, so every assertion in the smoke test passed on a stream carrying no audio.
     #[tokio::test]
     async fn extract_video_audio_track_handles_non_fragmented_mp4_6747() {
         if !ffmpeg_available() {
@@ -1634,10 +1606,8 @@ mod tests {
             return;
         }
 
-        // Written to a file rather than `pipe:1`: a non-fragmented mp4 cannot
-        // be *muxed* to a pipe either, since the muxer rewinds to write moov.
-        // Generating the fixture the same way the failing input arises is the
-        // point of the test.
+        // Written to a file rather than `pipe:1`: a non-fragmented mp4 cannot be *muxed* to a pipe either, since the muxer rewinds to write moov.
+        // Generating the fixture the same way the failing input arises is the point of the test.
         let dir = std::env::temp_dir().join(format!("librefang-6747-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("temp dir");
         let fixture = dir.join("plain.mp4");
@@ -1656,9 +1626,8 @@ mod tests {
                 "lavfi",
                 "-i",
                 "sine=frequency=440",
-                // 10 s at this size lands around 130 KB, comfortably past the
-                // 32 KB read-ahead buffer that lets a small unseekable input
-                // demux anyway. See the doc comment for the measured cutoff.
+                // 10 s at this size lands around 130 KB, comfortably past the 32 KB read-ahead buffer that lets a small unseekable input demux anyway.
+                // See the doc comment for the measured cutoff.
                 "-t",
                 "10",
                 "-c:v",
@@ -1695,12 +1664,11 @@ mod tests {
 
     /// The audio guard must reject a headers-only stream and accept a real one.
     ///
-    /// Pinned directly so the #6747 regression above cannot be satisfied by a
-    /// guard that returns `true` unconditionally.
+    /// Pinned directly so the #6747 regression above cannot be satisfied by a guard that returns `true` unconditionally.
     #[test]
     fn ogg_contains_audio_distinguishes_headers_from_audio() {
-        // Two pages: OpusHead + OpusTags, no audio. This is the shape of the
-        // 261-byte artefact a failed demux emitted.
+        // Two pages: OpusHead + OpusTags, no audio.
+        // This is the shape of the 261-byte artefact a failed demux emitted.
         let headers_only = b"OggS____OpusHead____OggS____OpusTags____".to_vec();
         assert!(!ogg_contains_audio(&headers_only));
 

--- a/crates/librefang-runtime-media/src/media_understanding.rs
+++ b/crates/librefang-runtime-media/src/media_understanding.rs
@@ -1029,10 +1029,54 @@ fn mime_to_ext(mime: &str) -> Option<String> {
     }
 }
 
-/// Run `ffmpeg` with the given arguments, feeding `input_bytes` on stdin and
-/// collecting stdout — no scratch files on disk. Shared by every ffmpeg-based
-/// transcode in this module so the spawn / pipe / timeout / kill-on-timeout
-/// plumbing exists once.
+/// A scratch file that deletes itself when it goes out of scope.
+///
+/// Used only where ffmpeg genuinely cannot work from a pipe — see
+/// `extract_video_audio_track`. Written by hand rather than pulling `tempfile`
+/// into this crate's dependencies for one call site.
+struct ScopedTempFile {
+    path: std::path::PathBuf,
+}
+
+impl ScopedTempFile {
+    /// Create a uniquely-named scratch file and write `bytes` into it.
+    ///
+    /// Uniqueness comes from pid plus a process-wide counter, so two
+    /// concurrent extractions in the same process cannot collide and neither
+    /// can two daemons sharing a temp dir.
+    async fn write(bytes: &[u8], extension: &str) -> Result<Self, String> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let path = std::env::temp_dir().join(format!(
+            "librefang-media-{}-{}.{extension}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        tokio::fs::write(&path, bytes)
+            .await
+            .map_err(|e| format!("failed to stage media for extraction at {path:?}: {e}"))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for ScopedTempFile {
+    fn drop(&mut self) {
+        // Best-effort: a leftover file in the temp dir is not worth failing a
+        // transcription that already succeeded, and the OS reclaims it anyway.
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Run `ffmpeg` with the given arguments and collect stdout.
+///
+/// `input_bytes` is `Some` when the input is fed on stdin (the args then name
+/// `pipe:0`), and `None` when the args already point at a path on disk. The
+/// distinction matters: a pipe cannot seek, and some containers require a
+/// backward seek to be demuxed at all — see `extract_video_audio_track`.
+///
+/// Shared by every ffmpeg-based transcode in this module so the spawn / pipe /
+/// timeout / kill-on-timeout plumbing exists once.
 ///
 /// `install_hint` names the feature that needs ffmpeg, so the "not on PATH"
 /// error tells the operator what stopped working rather than just that a
@@ -1040,7 +1084,7 @@ fn mime_to_ext(mime: &str) -> Option<String> {
 /// killed and reaped explicitly so there are no zombies.
 async fn run_ffmpeg_pipe(
     args: &[&str],
-    input_bytes: &[u8],
+    input_bytes: Option<&[u8]>,
     install_hint: &str,
 ) -> Result<Vec<u8>, String> {
     use std::process::Stdio;
@@ -1059,17 +1103,23 @@ async fn run_ffmpeg_pipe(
 
     // Feed stdin concurrently; hanging the write inside the main task
     // would deadlock once ffmpeg's stdout pipe buffer fills.
-    if let Some(mut stdin) = child.stdin.take() {
-        let bytes = input_bytes.to_vec();
-        tokio::spawn(async move {
-            // Writer errors are intentionally ignored: if the pipe breaks
-            // (ffmpeg rejected the input or exited early), the real reason
-            // surfaces on stderr and the non-zero exit code, which the
-            // caller already reports. Swallowing the write error here is
-            // strictly less noisy than double-reporting.
-            let _ = stdin.write_all(&bytes).await;
-            let _ = stdin.shutdown().await;
-        });
+    // With a file input there is nothing to write — dropping the handle
+    // closes it so ffmpeg does not wait on a stdin that will never arrive.
+    match (child.stdin.take(), input_bytes) {
+        (Some(mut stdin), Some(bytes)) => {
+            let bytes = bytes.to_vec();
+            tokio::spawn(async move {
+                // Writer errors are intentionally ignored: if the pipe breaks
+                // (ffmpeg rejected the input or exited early), the real reason
+                // surfaces on stderr and the non-zero exit code, which the
+                // caller already reports. Swallowing the write error here is
+                // strictly less noisy than double-reporting.
+                let _ = stdin.write_all(&bytes).await;
+                let _ = stdin.shutdown().await;
+            });
+        }
+        (Some(stdin), None) => drop(stdin),
+        (None, _) => {}
     }
 
     // Read stdout / stderr concurrently with waiting so we can kill + reap
@@ -1135,7 +1185,7 @@ async fn transcode_oga_to_ogg_opus(input_bytes: &[u8]) -> Result<Vec<u8>, String
             "ogg",
             "pipe:1",
         ],
-        input_bytes,
+        Some(input_bytes),
         "process .oga voice notes",
     )
     .await
@@ -1150,14 +1200,32 @@ async fn transcode_oga_to_ogg_opus(input_bytes: &[u8]) -> Result<Vec<u8>, String
 /// the input side — ffmpeg auto-detects the container from its content,
 /// which is what makes this work across `mp4`/`mov`/`mkv`/`avi` uniformly
 /// rather than needing a format hint per extension.
+///
+/// The input is staged to a scratch file rather than piped, because a pipe
+/// cannot seek and ISO-BMFF cannot always be demuxed without seeking (#6747).
+///
+/// An `mp4` / `mov` stores its index in the `moov` atom. When `moov` sits after
+/// `mdat` — the default output of ffmpeg's own muxer, phone cameras, screen
+/// recorders and meeting exporters — the demuxer has to seek backwards to read
+/// it. Over `pipe:0` that fails, and it fails *quietly*: ffmpeg writes
+/// `Error during demuxing` to stderr but can still exit 0, emitting a
+/// header-only Ogg with zero audio packets. Those bytes then went to the
+/// transcription provider, and the operator saw whatever a provider says about
+/// a soundless file — arbitrarily far from the real cause.
+///
+/// `mkv` and `avi` are streamable and were never affected, which is why the
+/// four container types enabled by #6679 / #6683 split exactly in half.
 async fn extract_video_audio_track(input_bytes: &[u8]) -> Result<Vec<u8>, String> {
-    run_ffmpeg_pipe(
+    let staged = ScopedTempFile::write(input_bytes, "media").await?;
+    let input_path = staged.path.to_string_lossy().into_owned();
+
+    let out = run_ffmpeg_pipe(
         &[
             "-hide_banner",
             "-loglevel",
             "error",
             "-i",
-            "pipe:0",
+            &input_path,
             "-vn",
             "-c:a",
             "libopus",
@@ -1171,10 +1239,40 @@ async fn extract_video_audio_track(input_bytes: &[u8]) -> Result<Vec<u8>, String
             "ogg",
             "pipe:1",
         ],
-        input_bytes,
+        None,
         "extract audio from video files",
     )
-    .await
+    .await?;
+
+    // Defence in depth for the silent half of #6747. The staged file fixes the
+    // cause, but neither guard in `run_ffmpeg_pipe` can catch a demux that
+    // fails while the process still exits 0 and still writes a container: the
+    // exit code is success and the output is not empty. Exit-code behaviour
+    // also varies across ffmpeg builds, so it cannot be the only line.
+    if !ogg_contains_audio(&out) {
+        return Err(format!(
+            "ffmpeg produced an Ogg stream with no audio packets ({} bytes) — \
+             the container's audio track could not be decoded",
+            out.len()
+        ));
+    }
+
+    Ok(out)
+}
+
+/// Whether an Ogg stream carries audio, rather than only its headers.
+///
+/// An Opus stream opens with two header pages, `OpusHead` and `OpusTags`; audio
+/// data begins on the third. Counting `OggS` page captures is enough to tell a
+/// real stream from the 261-byte headers-only artefact a failed demux produces,
+/// and does not require parsing the container.
+fn ogg_contains_audio(bytes: &[u8]) -> bool {
+    const OGG_PAGE_MAGIC: &[u8; 4] = b"OggS";
+    bytes
+        .windows(OGG_PAGE_MAGIC.len())
+        .filter(|w| w == OGG_PAGE_MAGIC)
+        .count()
+        > 2
 }
 
 /// Detect which audio transcription provider is available.
@@ -1503,6 +1601,114 @@ mod tests {
             out.len(),
             mp4_bytes.len()
         );
+    }
+
+    /// #6747: a plain, non-fragmented mp4 — `moov` written after `mdat`, which
+    /// is what every phone camera, screen recorder and meeting exporter
+    /// produces — must yield a stream with actual audio in it.
+    ///
+    /// The existing smoke test cannot catch this, for two independent reasons,
+    /// and both had to be fixed here for the test to discriminate.
+    ///
+    /// Its fixture passes `-movflags frag_keyframe+empty_moov`, producing a
+    /// *fragmented* mp4 — the one mp4 flavour that demuxes from a non-seekable
+    /// pipe. It exercised precisely the shape that worked.
+    ///
+    /// It is also only ~8 KB, and that alone is disqualifying. ffmpeg buffers
+    /// the head of an unseekable input (32 KB by default), so a file small
+    /// enough to fit entirely in that buffer can still be "seeked" backwards
+    /// and demuxes fine over a pipe. Measured against ffmpeg 8.1.1: a 0.5 s /
+    /// 11 KB clip yields 2,500 bytes of Ogg and succeeds, while 5 s / 69 KB,
+    /// 30 s / 389 KB and 120 s / 1.5 MB all yield exactly 261 bytes with
+    /// `stream 0, offset 0x30: partial file` on stderr. That is why the
+    /// fixture below is 10 s rather than the smoke test's 0.5 s — a shorter
+    /// one passes with or without the fix.
+    ///
+    /// The assertions are the ones the old code failed: a header-only Ogg is
+    /// non-empty, starts with `OggS`, and is smaller than the source mp4, so
+    /// every assertion in the smoke test passed on a stream carrying no audio.
+    #[tokio::test]
+    async fn extract_video_audio_track_handles_non_fragmented_mp4_6747() {
+        if !ffmpeg_available() {
+            eprintln!("ffmpeg not on PATH — skipping");
+            return;
+        }
+
+        // Written to a file rather than `pipe:1`: a non-fragmented mp4 cannot
+        // be *muxed* to a pipe either, since the muxer rewinds to write moov.
+        // Generating the fixture the same way the failing input arises is the
+        // point of the test.
+        let dir = std::env::temp_dir().join(format!("librefang-6747-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let fixture = dir.join("plain.mp4");
+
+        let gen = tokio::process::Command::new("ffmpeg")
+            .args([
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=320x240:rate=15",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=440",
+                // 10 s at this size lands around 130 KB, comfortably past the
+                // 32 KB read-ahead buffer that lets a small unseekable input
+                // demux anyway. See the doc comment for the measured cutoff.
+                "-t",
+                "10",
+                "-c:v",
+                "libx264",
+                "-c:a",
+                "aac",
+            ])
+            .arg(&fixture)
+            .output()
+            .await
+            .expect("ffmpeg must run");
+        assert!(
+            gen.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&gen.stderr)
+        );
+
+        let mp4_bytes = std::fs::read(&fixture).expect("fixture readable");
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(!mp4_bytes.is_empty());
+
+        let out = extract_video_audio_track(&mp4_bytes)
+            .await
+            .expect("a plain non-fragmented mp4 must extract");
+
+        assert_eq!(&out[..4], b"OggS", "output must be an Ogg container");
+        assert!(
+            ogg_contains_audio(&out),
+            "extraction produced {} bytes but no audio packets — the demux \
+             failed silently, which is exactly #6747",
+            out.len()
+        );
+    }
+
+    /// The audio guard must reject a headers-only stream and accept a real one.
+    ///
+    /// Pinned directly so the #6747 regression above cannot be satisfied by a
+    /// guard that returns `true` unconditionally.
+    #[test]
+    fn ogg_contains_audio_distinguishes_headers_from_audio() {
+        // Two pages: OpusHead + OpusTags, no audio. This is the shape of the
+        // 261-byte artefact a failed demux emitted.
+        let headers_only = b"OggS____OpusHead____OggS____OpusTags____".to_vec();
+        assert!(!ogg_contains_audio(&headers_only));
+
+        let mut with_audio = headers_only.clone();
+        with_audio.extend_from_slice(b"OggS____audio payload");
+        assert!(ogg_contains_audio(&with_audio));
+
+        assert!(!ogg_contains_audio(&[]), "empty input carries no audio");
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime-media/src/media_understanding.rs
+++ b/crates/librefang-runtime-media/src/media_understanding.rs
@@ -1032,36 +1032,37 @@ fn mime_to_ext(mime: &str) -> Option<String> {
 /// A scratch file that deletes itself when it goes out of scope.
 ///
 /// Used only where ffmpeg genuinely cannot work from a pipe — see `extract_video_audio_track`.
-/// Written by hand rather than pulling `tempfile` into this crate's dependencies for one call site.
+/// Backed by `tempfile::NamedTempFile` (already a workspace dependency used by `librefang-runtime` and others) rather than a hand-rolled pid+counter path.
+/// `NamedTempFile` creates with `O_EXCL` and `0600` permissions on Unix, which closes both the symlink-race and world-readable-recording gaps a predictable path in the shared temp dir would otherwise open on a multi-user host — the staged bytes here are a user's raw audio/video.
 struct ScopedTempFile {
-    path: std::path::PathBuf,
+    file: tempfile::NamedTempFile,
 }
 
 impl ScopedTempFile {
-    /// Create a uniquely-named scratch file and write `bytes` into it.
+    /// Create a securely-named scratch file and write `bytes` into it.
     ///
-    /// Uniqueness comes from pid plus a process-wide counter, so two concurrent extractions in the same process cannot collide and neither can two daemons sharing a temp dir.
+    /// Runs on the blocking pool: creation plus a write of up to the 50 MB `MediaAttachment::validate()` cap is real (if brief) disk I/O, matching the `spawn_blocking`-for-temp-file-writes pattern used elsewhere in the workspace (e.g. `librefang-api`'s device-token and backup-archive writers).
     async fn write(bytes: &[u8], extension: &str) -> Result<Self, String> {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        use std::io::Write as _;
 
-        let path = std::env::temp_dir().join(format!(
-            "librefang-media-{}-{}.{extension}",
-            std::process::id(),
-            COUNTER.fetch_add(1, Ordering::Relaxed)
-        ));
-        tokio::fs::write(&path, bytes)
-            .await
-            .map_err(|e| format!("failed to stage media for extraction at {path:?}: {e}"))?;
-        Ok(Self { path })
+        let bytes = bytes.to_vec();
+        let suffix = format!(".{extension}");
+        tokio::task::spawn_blocking(move || {
+            let mut file = tempfile::Builder::new()
+                .prefix("librefang-media-")
+                .suffix(&suffix)
+                .tempfile()
+                .map_err(|e| format!("failed to create scratch file for media extraction: {e}"))?;
+            file.write_all(&bytes)
+                .map_err(|e| format!("failed to stage media for extraction: {e}"))?;
+            Ok(Self { file })
+        })
+        .await
+        .map_err(|e| format!("scratch-file staging task panicked: {e}"))?
     }
-}
 
-impl Drop for ScopedTempFile {
-    fn drop(&mut self) {
-        // Best-effort: a leftover file in the temp dir is not worth failing a
-        // transcription that already succeeded, and the OS reclaims it anyway.
-        let _ = std::fs::remove_file(&self.path);
+    fn path(&self) -> &std::path::Path {
+        self.file.path()
     }
 }
 
@@ -1204,7 +1205,7 @@ async fn transcode_oga_to_ogg_opus(input_bytes: &[u8]) -> Result<Vec<u8>, String
 /// `mkv` and `avi` are streamable and were never affected, which is why the four container types enabled by #6679 / #6683 split exactly in half.
 async fn extract_video_audio_track(input_bytes: &[u8]) -> Result<Vec<u8>, String> {
     let staged = ScopedTempFile::write(input_bytes, "media").await?;
-    let input_path = staged.path.to_string_lossy().into_owned();
+    let input_path = staged.path().to_string_lossy().into_owned();
 
     let out = run_ffmpeg_pipe(
         &[


### PR DESCRIPTION
Fixes #6747. @nevgenov's diagnosis was right end to end and is what this implements; the one thing it turned out to need on top was a size threshold, described below, without which the regression test is green either way.

## The bug

`extract_video_audio_track` fed the container to ffmpeg over `pipe:0`. An `mp4` / `mov` keeps its index in the `moov` atom, and when `moov` sits after `mdat` — the default output of ffmpeg's own muxer, phone cameras, screen recorders and meeting exporters — the demuxer must seek backwards to read it. A pipe cannot seek, so the demux fails.

It fails *silently*. ffmpeg writes `stream 0, offset 0x30: partial file` to stderr and still exits 0, emitting a 261-byte Ogg containing headers and zero audio packets. Both guards in `run_ffmpeg_pipe` let it through — the exit code is success, and 261 bytes is not empty. Those bytes were uploaded to the transcription provider, so the operator saw whatever a provider says about a soundless file, arbitrarily far from the cause.

`mkv` and `avi` are streamable and were never affected, which is why the four containers enabled by #6679 / #6683 split exactly in half.

## Changes

**Stage the input to a file.** `ScopedTempFile` writes the bytes to a uniquely-named scratch file (pid + a process-wide counter, so concurrent extractions cannot collide) and removes it on drop. Written by hand rather than adding `tempfile` to this crate for one call site.

**`run_ffmpeg_pipe` now takes `Option<&[u8]>`.** `Some` feeds stdin as before — which is correct for `transcode_oga_to_ogg_opus`, since Ogg is streamable — and `None` means the args already name a path. The stdin handle is dropped in that case so ffmpeg does not wait on input that will never arrive.

**A headers-only guard.** `ogg_contains_audio` counts `OggS` page captures: an Opus stream opens with `OpusHead` and `OpusTags`, so audio begins on the third page. This is defence in depth, not the fix — but it is necessary, because the exit-code behaviour that made this silent varies across ffmpeg builds and cannot be relied on. On a build that returns non-zero the existing guard catches it; on 8.1.1 nothing did.

## The size threshold, which is not in the issue

My first regression fixture was the smoke test's 0.5 s clip with the fragmentation flag removed. It passed **with and without the fix** — the mutation check is what caught that, not review.

ffmpeg buffers the head of an unseekable input (32 KB by default), so a file small enough to fit in that buffer can still be seeked backwards and demuxes fine over a pipe. Measured against ffmpeg 8.1.1, feeding each file to `ffmpeg -i pipe:0 -vn -c:a libopus -f ogg pipe:1`:

| Clip | mp4 size | Ogg out | stderr |
| --- | --- | --- | --- |
| 0.5 s | 11,572 B | 2,500 B | — |
| 5 s | 68,977 B | **261 B** | `partial file` |
| 30 s | 388,664 B | **261 B** | `partial file` |
| 120 s | 1,550,323 B | **261 B** | `partial file` |

So the existing smoke test could not have caught this for **two** independent reasons: its fixture is fragmented (the one mp4 flavour that streams from a pipe), *and* at ~8 KB it is under the buffer threshold. Fixing only the first would have produced a test that still passed against the broken code.

The new fixture is 10 s at 320x240, around 130 KB. Its atom order was confirmed to be `ftyp / free / mdat / moov` — index last, the layout the issue describes.

## Verification

macOS aarch64, ffmpeg 8.1.1, native cargo, based on `origin/main` at c403439a.

- **Mutation check.** Reverting the fix (input back on `pipe:0`) makes `extract_video_audio_track_handles_non_fragmented_mp4_6747` fail with `ffmpeg produced an Ogg stream with no audio packets (261 bytes)` — the same 261 bytes reported in the issue, surfaced by the new guard instead of being uploaded. Restored and re-confirmed green. Note `extract_video_audio_track_smoke` stays green under that mutation, which is the issue's fragmented-fixture observation reproduced.
- **`cargo test -p librefang-runtime-media --lib`** — 92 passed, 0 failed, in an environment with all 13 provider credential variables cleared, which is what CI sees.
- **`cargo check --workspace --lib`** — exit 0.
- **`cargo clippy --workspace --all-targets -- -D warnings`** — exit 0, captured explicitly.
- **`cargo fmt --check`** — exit 0.
- `ogg_contains_audio` is pinned by its own unit test so the regression test cannot be satisfied by a guard that always returns true.

### Not verified

Only ffmpeg 8.1.1 on macOS was exercised. The issue notes exit-code behaviour may differ on other builds; the guard exists precisely so the outcome is a clear error rather than an empty transcript either way, but that path was not executed against a build that returns non-zero.

No real transcription was performed — the extracted Ogg is asserted to contain audio packets, not to transcribe correctly.

## Note for local runs

`transcribe_audio_accepts_video_type` fails on this branch for anyone with an STT key exported. That is a pre-existing condition on `main` and is fixed in #6750; it does not reproduce in a clean environment, so it does not affect CI here.
