### PR TITLE
fix(api): redact hand requirement environment values

### DIFF
--- a/changelog.d/security/6752-hand-requirement-secret-redaction.md
+++ b/changelog.d/security/6752-hand-requirement-secret-redaction.md
@@ -1,0 +1,2 @@
+Stop `GET /api/hands` from returning plaintext values for satisfied environment-variable requirements, which exposed host credentials and other sensitive process configuration to any caller allowed to list Hands.
+  Requirement status now reports only whether each variable is present while preserving the existing Dashboard save contract (#6752) (@houko)

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1022,7 +1022,6 @@ export interface HandRequirementItem {
   optional?: boolean;
   type?: string;
   description?: string;
-  current_value?: string;
 }
 
 export interface HandDefinitionItem {

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1017,7 +1017,6 @@ export interface CommsEventItem {
 
 export interface HandRequirementItem {
   key?: string;
-  check_value?: string;
   label?: string;
   satisfied?: boolean;
   optional?: boolean;

--- a/crates/librefang-api/dashboard/src/api.ts
+++ b/crates/librefang-api/dashboard/src/api.ts
@@ -1017,6 +1017,7 @@ export interface CommsEventItem {
 
 export interface HandRequirementItem {
   key?: string;
+  check_value?: string;
   label?: string;
   satisfied?: boolean;
   optional?: boolean;

--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -350,13 +350,10 @@ function RequirementsForm({ handId, requirements }: { handId: string; requiremen
   const { t } = useTranslation();
   const addToast = useUIStore((s) => s.addToast);
   const setSecret = useSetHandSecret();
-  const [values, setValues] = useState<Record<string, string>>(() => {
-    const init: Record<string, string> = {};
-    for (const r of requirements ?? []) {
-      if (r.key && r.current_value) init[r.key] = r.current_value;
-    }
-    return init;
-  });
+  // The API never returns the value of a satisfied requirement (redacted for
+  // secret safety), so this form always starts empty — there is nothing to
+  // pre-fill from `requirements`.
+  const [values, setValues] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState<string | null>(null);
 
   if (!requirements || requirements.length === 0) return null;

--- a/crates/librefang-api/src/routes/skills/hands.rs
+++ b/crates/librefang-api/src/routes/skills/hands.rs
@@ -1072,12 +1072,8 @@ pub async fn set_hand_secret(
         }
     };
 
-    // Resolve the stable requirement key (`r.key`, as exposed by the single-hand
-    // detail endpoint) to the actual environment-variable name (`r.check_value`,
-    // as exposed by `list_hands`'s "key" field). Accepting either alias as input
-    // but persisting under whatever string the client sent would silently write
-    // the secret under a name `check_requirement` never reads, so a save could
-    // return 200 OK while leaving the requirement permanently unsatisfied.
+    // Resolve the stable requirement key (`r.key`, as exposed by the single-hand detail endpoint) to the actual environment-variable name (`r.check_value`, as exposed by `list_hands`'s "key" field).
+    // Accepting either alias as input but persisting under whatever string the client sent would silently write the secret under a name `check_requirement` never reads, so a save could return 200 OK while leaving the requirement permanently unsatisfied.
     let env_key = {
         let defs = state.kernel.hands().list_definitions();
         defs.iter().find(|d| d.id == hand_id).and_then(|def| {

--- a/crates/librefang-api/src/routes/skills/hands.rs
+++ b/crates/librefang-api/src/routes/skills/hands.rs
@@ -67,18 +67,13 @@ pub async fn list_hands(
                 "degraded": degraded,
                 "is_custom": is_custom,
                 "requirements": reqs.iter().map(|(r, ok)| {
-                    let mut req = serde_json::json!({
-                        "key": r.check_value,
+                    serde_json::json!({
+                        "key": r.key,
+                        "check_value": r.check_value,
                         "label": r.label,
                         "satisfied": ok,
                         "optional": r.optional,
-                    });
-                    if *ok {
-                        if let Ok(val) = std::env::var(&r.check_value) {
-                            req["current_value"] = serde_json::json!(val);
-                        }
-                    }
-                    req
+                    })
                 }).collect::<Vec<_>>(),
                 "dashboard_metrics": d.dashboard.metrics.len(),
                 "has_settings": !d.settings.is_empty(),

--- a/crates/librefang-api/src/routes/skills/hands.rs
+++ b/crates/librefang-api/src/routes/skills/hands.rs
@@ -68,8 +68,7 @@ pub async fn list_hands(
                 "is_custom": is_custom,
                 "requirements": reqs.iter().map(|(r, ok)| {
                     serde_json::json!({
-                        "key": r.key,
-                        "check_value": r.check_value,
+                        "key": r.check_value,
                         "label": r.label,
                         "satisfied": ok,
                         "optional": r.optional,
@@ -1058,7 +1057,7 @@ pub async fn set_hand_secret(
     Path(hand_id): Path<String>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let requested_key = match body["key"].as_str() {
+    let env_key = match body["key"].as_str() {
         Some(k) if !k.trim().is_empty() => k.trim().to_string(),
         _ => {
             return ApiErrorResponse::bad_request("Missing 'key' field (env var name)")
@@ -1073,26 +1072,26 @@ pub async fn set_hand_secret(
         }
     };
 
-    // Resolve the stable requirement key exposed by `list_hands` to the
-    // actual environment-variable name. Keep accepting `check_value`
-    // directly for compatibility with older clients.
-    let env_key = {
+    // Verify this key belongs to a requirement of the specified hand
+    let valid = {
         let defs = state.kernel.hands().list_definitions();
-        defs.iter().find(|d| d.id == hand_id).and_then(|def| {
-            def.requires
-                .iter()
-                .find(|r| r.check_value == requested_key || r.key == requested_key)
-                .map(|r| r.check_value.clone())
-        })
+        defs.iter()
+            .find(|d| d.id == hand_id)
+            .map(|def| {
+                def.requires
+                    .iter()
+                    .any(|r| r.check_value == env_key || r.key == env_key)
+            })
+            .unwrap_or(false)
     };
 
-    let Some(env_key) = env_key else {
+    if !valid {
         return ApiErrorResponse::bad_request(format!(
             "'{}' is not a requirement of hand '{}'",
-            requested_key, hand_id
+            env_key, hand_id
         ))
         .into_json_tuple();
-    };
+    }
 
     // Write to secrets.env
     let secrets_path = state.kernel.home_dir().join("secrets.env");

--- a/crates/librefang-api/src/routes/skills/hands.rs
+++ b/crates/librefang-api/src/routes/skills/hands.rs
@@ -1058,7 +1058,7 @@ pub async fn set_hand_secret(
     Path(hand_id): Path<String>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let env_key = match body["key"].as_str() {
+    let requested_key = match body["key"].as_str() {
         Some(k) if !k.trim().is_empty() => k.trim().to_string(),
         _ => {
             return ApiErrorResponse::bad_request("Missing 'key' field (env var name)")
@@ -1073,26 +1073,26 @@ pub async fn set_hand_secret(
         }
     };
 
-    // Verify this key belongs to a requirement of the specified hand
-    let valid = {
+    // Resolve the stable requirement key exposed by `list_hands` to the
+    // actual environment-variable name. Keep accepting `check_value`
+    // directly for compatibility with older clients.
+    let env_key = {
         let defs = state.kernel.hands().list_definitions();
-        defs.iter()
-            .find(|d| d.id == hand_id)
-            .map(|def| {
-                def.requires
-                    .iter()
-                    .any(|r| r.check_value == env_key || r.key == env_key)
-            })
-            .unwrap_or(false)
+        defs.iter().find(|d| d.id == hand_id).and_then(|def| {
+            def.requires
+                .iter()
+                .find(|r| r.check_value == requested_key || r.key == requested_key)
+                .map(|r| r.check_value.clone())
+        })
     };
 
-    if !valid {
+    let Some(env_key) = env_key else {
         return ApiErrorResponse::bad_request(format!(
             "'{}' is not a requirement of hand '{}'",
-            env_key, hand_id
+            requested_key, hand_id
         ))
         .into_json_tuple();
-    }
+    };
 
     // Write to secrets.env
     let secrets_path = state.kernel.home_dir().join("secrets.env");

--- a/crates/librefang-api/src/routes/skills/hands.rs
+++ b/crates/librefang-api/src/routes/skills/hands.rs
@@ -1057,7 +1057,7 @@ pub async fn set_hand_secret(
     Path(hand_id): Path<String>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let env_key = match body["key"].as_str() {
+    let requested_key = match body["key"].as_str() {
         Some(k) if !k.trim().is_empty() => k.trim().to_string(),
         _ => {
             return ApiErrorResponse::bad_request("Missing 'key' field (env var name)")
@@ -1072,26 +1072,29 @@ pub async fn set_hand_secret(
         }
     };
 
-    // Verify this key belongs to a requirement of the specified hand
-    let valid = {
+    // Resolve the stable requirement key (`r.key`, as exposed by the single-hand
+    // detail endpoint) to the actual environment-variable name (`r.check_value`,
+    // as exposed by `list_hands`'s "key" field). Accepting either alias as input
+    // but persisting under whatever string the client sent would silently write
+    // the secret under a name `check_requirement` never reads, so a save could
+    // return 200 OK while leaving the requirement permanently unsatisfied.
+    let env_key = {
         let defs = state.kernel.hands().list_definitions();
-        defs.iter()
-            .find(|d| d.id == hand_id)
-            .map(|def| {
-                def.requires
-                    .iter()
-                    .any(|r| r.check_value == env_key || r.key == env_key)
-            })
-            .unwrap_or(false)
+        defs.iter().find(|d| d.id == hand_id).and_then(|def| {
+            def.requires
+                .iter()
+                .find(|r| r.check_value == requested_key || r.key == requested_key)
+                .map(|r| r.check_value.clone())
+        })
     };
 
-    if !valid {
+    let Some(env_key) = env_key else {
         return ApiErrorResponse::bad_request(format!(
             "'{}' is not a requirement of hand '{}'",
-            env_key, hand_id
+            requested_key, hand_id
         ))
         .into_json_tuple();
-    }
+    };
 
     // Write to secrets.env
     let secrets_path = state.kernel.home_dir().join("secrets.env");

--- a/crates/librefang-api/tests/hands_routes_integration.rs
+++ b/crates/librefang-api/tests/hands_routes_integration.rs
@@ -234,6 +234,79 @@ async fn list_hands_response_is_application_json() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn list_hands_does_not_expose_satisfied_environment_variable_values() {
+    let h = boot_router_open().await;
+    let toml = r#"
+id = "secret-redaction-test"
+name = "Secret Redaction Test"
+description = "Verifies that requirement status never exposes values."
+category = "other"
+
+[[requires]]
+key = "process-path"
+label = "Process PATH"
+requirement_type = "env_var"
+check_value = "PATH"
+
+[agent]
+name = "secret-redaction-agent"
+description = "Test hand agent"
+system_prompt = "Test prompt"
+"#;
+
+    let (install_status, install_body) = json_request(
+        &h.app,
+        Method::POST,
+        "/api/hands/install",
+        Some(serde_json::json!({
+            "toml_content": toml,
+            "skill_content": "# Test skill\n",
+        })),
+    )
+    .await;
+    assert_eq!(
+        install_status,
+        StatusCode::OK,
+        "install_hand body: {install_body}"
+    );
+
+    let (status, body) = get_json(&h.app, "/api/hands").await;
+    assert_eq!(status, StatusCode::OK);
+    let hand = body["items"]
+        .as_array()
+        .and_then(|items| {
+            items
+                .iter()
+                .find(|item| item["id"] == "secret-redaction-test")
+        })
+        .unwrap_or_else(|| panic!("installed hand missing from list response: {body}"));
+    let requirement = hand["requirements"]
+        .as_array()
+        .and_then(|requirements| requirements.first())
+        .unwrap_or_else(|| panic!("installed hand requirement missing from list response: {hand}"));
+
+    assert_eq!(
+        requirement["satisfied"].as_bool(),
+        Some(true),
+        "{requirement}"
+    );
+    assert_eq!(
+        requirement["key"].as_str(),
+        Some("process-path"),
+        "{requirement}"
+    );
+    assert_eq!(
+        requirement["check_value"].as_str(),
+        Some("PATH"),
+        "{requirement}"
+    );
+    assert!(
+        requirement.get("current_value").is_none(),
+        "requirement status must not expose environment variable values: {requirement}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/hands/active — list active hand instances
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/tests/hands_routes_integration.rs
+++ b/crates/librefang-api/tests/hands_routes_integration.rs
@@ -237,6 +237,7 @@ async fn list_hands_response_is_application_json() {
 #[tokio::test(flavor = "multi_thread")]
 async fn list_hands_does_not_expose_satisfied_environment_variable_values() {
     let h = boot_router_open().await;
+    let process_path = std::env::var("PATH").expect("test process must have PATH");
     let toml = r#"
 id = "secret-redaction-test"
 name = "Secret Redaction Test"
@@ -304,6 +305,10 @@ system_prompt = "Test prompt"
     assert!(
         requirement.get("current_value").is_none(),
         "requirement status must not expose environment variable values: {requirement}"
+    );
+    assert!(
+        !body.to_string().contains(&process_path),
+        "list response must not contain the resolved environment variable value"
     );
 }
 
@@ -948,6 +953,112 @@ system_prompt = "Test prompt"
 // ---------------------------------------------------------------------------
 // POST /api/hands/{hand_id}/secret — input validation
 // ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_hand_secret_resolves_stable_requirement_key_to_environment_variable() {
+    const ENV_KEY: &str = "LIBREFANG_HAND_SECRET_CANONICAL_ENV_TEST";
+    const STABLE_KEY: &str = "canonical-env-test";
+    const VALUE: &str = "canonical-value";
+
+    let h = boot_router_open().await;
+    librefang_api::secrets_env::remove_env_var_guarded(ENV_KEY).await;
+    librefang_api::secrets_env::remove_env_var_guarded(STABLE_KEY).await;
+
+    let toml = format!(
+        r#"
+id = "stable-secret-key-test"
+name = "Stable Secret Key Test"
+description = "Verifies stable requirement keys resolve to env var names."
+category = "other"
+
+[[requires]]
+key = "{STABLE_KEY}"
+label = "Canonical environment variable"
+requirement_type = "env_var"
+check_value = "{ENV_KEY}"
+
+[agent]
+name = "stable-secret-key-agent"
+description = "Test hand agent"
+system_prompt = "Test prompt"
+"#
+    );
+    let (install_status, install_body) = json_request(
+        &h.app,
+        Method::POST,
+        "/api/hands/install",
+        Some(serde_json::json!({
+            "toml_content": toml,
+            "skill_content": "# Test skill\n",
+        })),
+    )
+    .await;
+    assert_eq!(
+        install_status,
+        StatusCode::OK,
+        "install_hand body: {install_body}"
+    );
+
+    let (save_status, save_body) = json_request(
+        &h.app,
+        Method::POST,
+        "/api/hands/stable-secret-key-test/secret",
+        Some(serde_json::json!({"key": STABLE_KEY, "value": VALUE})),
+    )
+    .await;
+    let (_, list_body) = get_json(&h.app, "/api/hands").await;
+    let persisted = std::fs::read_to_string(h._tmp.path().join("secrets.env"))
+        .expect("secret must be persisted");
+
+    let (legacy_status, legacy_body) = json_request(
+        &h.app,
+        Method::POST,
+        "/api/hands/stable-secret-key-test/secret",
+        Some(serde_json::json!({"key": ENV_KEY, "value": "legacy-value"})),
+    )
+    .await;
+    let legacy_persisted = std::fs::read_to_string(h._tmp.path().join("secrets.env"))
+        .expect("legacy secret must be persisted");
+    librefang_api::secrets_env::remove_env_var_guarded(ENV_KEY).await;
+    librefang_api::secrets_env::remove_env_var_guarded(STABLE_KEY).await;
+
+    assert_eq!(save_status, StatusCode::OK, "save body: {save_body}");
+    assert_eq!(save_body["key"].as_str(), Some(ENV_KEY), "{save_body}");
+    let requirement = list_body["items"]
+        .as_array()
+        .and_then(|items| {
+            items
+                .iter()
+                .find(|item| item["id"] == "stable-secret-key-test")
+        })
+        .and_then(|hand| hand["requirements"].as_array())
+        .and_then(|requirements| requirements.first())
+        .unwrap_or_else(|| panic!("installed requirement missing: {list_body}"));
+    assert_eq!(
+        requirement["satisfied"].as_bool(),
+        Some(true),
+        "{requirement}"
+    );
+
+    assert!(
+        persisted.contains(&format!("{ENV_KEY}={VALUE}")),
+        "{persisted}"
+    );
+    assert!(
+        !persisted.contains(&format!("{STABLE_KEY}=")),
+        "{persisted}"
+    );
+    assert_eq!(
+        legacy_status,
+        StatusCode::OK,
+        "legacy save body: {legacy_body}"
+    );
+    assert_eq!(legacy_body["key"].as_str(), Some(ENV_KEY), "{legacy_body}");
+    assert!(
+        legacy_persisted.contains(&format!("{ENV_KEY}=legacy-value")),
+        "{legacy_persisted}"
+    );
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn set_hand_secret_missing_key_returns_400() {

--- a/crates/librefang-api/tests/hands_routes_integration.rs
+++ b/crates/librefang-api/tests/hands_routes_integration.rs
@@ -1058,6 +1058,104 @@ system_prompt = "Test prompt"
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn set_hand_secret_resolves_stable_requirement_key_to_env_var_name() {
+    // The single-hand detail endpoint (GET /api/hands/{id}) exposes both the
+    // stable requirement "key" and the actual env var "check_value" as
+    // separate fields, so a client can plausibly submit either one to this
+    // endpoint. Both must resolve to the same persisted env var name —
+    // submitting the stable key must not write a secret under a name
+    // `check_requirement` never reads.
+    const ENV_KEY: &str = "LIBREFANG_HAND_SECRET_STABLE_KEY_ALIAS_TEST";
+    const STABLE_KEY: &str = "stable-key-alias-test";
+    const VALUE: &str = "stable-alias-value";
+
+    let h = boot_router_open().await;
+    librefang_api::secrets_env::remove_env_var_guarded(ENV_KEY).await;
+    librefang_api::secrets_env::remove_env_var_guarded(STABLE_KEY).await;
+
+    let toml = format!(
+        r#"
+id = "stable-secret-key-alias-test"
+name = "Stable Secret Key Alias Test"
+description = "Verifies the stable requirement key resolves to the env var name."
+category = "other"
+
+[[requires]]
+key = "{STABLE_KEY}"
+label = "Canonical environment variable"
+requirement_type = "env_var"
+check_value = "{ENV_KEY}"
+
+[agent]
+name = "stable-secret-key-alias-agent"
+description = "Test hand agent"
+system_prompt = "Test prompt"
+"#
+    );
+    let (install_status, install_body) = json_request(
+        &h.app,
+        Method::POST,
+        "/api/hands/install",
+        Some(serde_json::json!({
+            "toml_content": toml,
+            "skill_content": "# Test skill\n",
+        })),
+    )
+    .await;
+    assert_eq!(
+        install_status,
+        StatusCode::OK,
+        "install_hand body: {install_body}"
+    );
+
+    // Submit the stable requirement key (`STABLE_KEY`), not the env var name.
+    let (save_status, save_body) = json_request(
+        &h.app,
+        Method::POST,
+        "/api/hands/stable-secret-key-alias-test/secret",
+        Some(serde_json::json!({"key": STABLE_KEY, "value": VALUE})),
+    )
+    .await;
+    let (_, list_body) = get_json(&h.app, "/api/hands").await;
+    let persisted = std::fs::read_to_string(h._tmp.path().join("secrets.env"))
+        .expect("secret must be persisted");
+
+    librefang_api::secrets_env::remove_env_var_guarded(ENV_KEY).await;
+    librefang_api::secrets_env::remove_env_var_guarded(STABLE_KEY).await;
+
+    assert_eq!(save_status, StatusCode::OK, "save body: {save_body}");
+    // The response must report the resolved env var name, not the stable
+    // key the client submitted.
+    assert_eq!(save_body["key"].as_str(), Some(ENV_KEY), "{save_body}");
+
+    let requirement = list_body["items"]
+        .as_array()
+        .and_then(|items| {
+            items
+                .iter()
+                .find(|item| item["id"] == "stable-secret-key-alias-test")
+        })
+        .and_then(|hand| hand["requirements"].as_array())
+        .and_then(|requirements| requirements.first())
+        .unwrap_or_else(|| panic!("installed requirement missing: {list_body}"));
+    assert_eq!(
+        requirement["satisfied"].as_bool(),
+        Some(true),
+        "requirement must be satisfied once the secret is persisted under the \
+         actual env var name: {requirement}"
+    );
+
+    assert!(
+        persisted.contains(&format!("{ENV_KEY}={VALUE}")),
+        "secret must be persisted under the env var name, not the stable key: {persisted}"
+    );
+    assert!(
+        !persisted.contains(&format!("{STABLE_KEY}=")),
+        "secret must not be persisted under the stable requirement key: {persisted}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn set_hand_secret_missing_key_returns_400() {
     let h = boot_router_open().await;
     let (status, body) = json_request(

--- a/crates/librefang-api/tests/hands_routes_integration.rs
+++ b/crates/librefang-api/tests/hands_routes_integration.rs
@@ -292,15 +292,10 @@ system_prompt = "Test prompt"
         Some(true),
         "{requirement}"
     );
-    assert_eq!(
-        requirement["key"].as_str(),
-        Some("process-path"),
-        "{requirement}"
-    );
-    assert_eq!(
-        requirement["check_value"].as_str(),
-        Some("PATH"),
-        "{requirement}"
+    assert_eq!(requirement["key"].as_str(), Some("PATH"), "{requirement}");
+    assert!(
+        requirement.get("check_value").is_none(),
+        "list response must preserve the existing requirement shape: {requirement}"
     );
     assert!(
         requirement.get("current_value").is_none(),
@@ -955,7 +950,7 @@ system_prompt = "Test prompt"
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]
-async fn set_hand_secret_resolves_stable_requirement_key_to_environment_variable() {
+async fn set_hand_secret_accepts_the_key_returned_by_list_hands() {
     const ENV_KEY: &str = "LIBREFANG_HAND_SECRET_CANONICAL_ENV_TEST";
     const STABLE_KEY: &str = "canonical-env-test";
     const VALUE: &str = "canonical-value";
@@ -999,26 +994,38 @@ system_prompt = "Test prompt"
         "install_hand body: {install_body}"
     );
 
+    let (_, initial_list_body) = get_json(&h.app, "/api/hands").await;
+    let initial_requirement = initial_list_body["items"]
+        .as_array()
+        .and_then(|items| {
+            items
+                .iter()
+                .find(|item| item["id"] == "stable-secret-key-test")
+        })
+        .and_then(|hand| hand["requirements"].as_array())
+        .and_then(|requirements| requirements.first())
+        .unwrap_or_else(|| panic!("installed requirement missing: {initial_list_body}"));
+    let listed_key = initial_requirement["key"]
+        .as_str()
+        .expect("listed requirement must have a key");
+    assert_eq!(listed_key, ENV_KEY, "{initial_requirement}");
+    assert_eq!(
+        initial_requirement["satisfied"].as_bool(),
+        Some(false),
+        "{initial_requirement}"
+    );
+
     let (save_status, save_body) = json_request(
         &h.app,
         Method::POST,
         "/api/hands/stable-secret-key-test/secret",
-        Some(serde_json::json!({"key": STABLE_KEY, "value": VALUE})),
+        Some(serde_json::json!({"key": listed_key, "value": VALUE})),
     )
     .await;
     let (_, list_body) = get_json(&h.app, "/api/hands").await;
     let persisted = std::fs::read_to_string(h._tmp.path().join("secrets.env"))
         .expect("secret must be persisted");
 
-    let (legacy_status, legacy_body) = json_request(
-        &h.app,
-        Method::POST,
-        "/api/hands/stable-secret-key-test/secret",
-        Some(serde_json::json!({"key": ENV_KEY, "value": "legacy-value"})),
-    )
-    .await;
-    let legacy_persisted = std::fs::read_to_string(h._tmp.path().join("secrets.env"))
-        .expect("legacy secret must be persisted");
     librefang_api::secrets_env::remove_env_var_guarded(ENV_KEY).await;
     librefang_api::secrets_env::remove_env_var_guarded(STABLE_KEY).await;
 
@@ -1047,16 +1054,6 @@ system_prompt = "Test prompt"
     assert!(
         !persisted.contains(&format!("{STABLE_KEY}=")),
         "{persisted}"
-    );
-    assert_eq!(
-        legacy_status,
-        StatusCode::OK,
-        "legacy save body: {legacy_body}"
-    );
-    assert_eq!(legacy_body["key"].as_str(), Some(ENV_KEY), "{legacy_body}");
-    assert!(
-        legacy_persisted.contains(&format!("{ENV_KEY}=legacy-value")),
-        "{legacy_persisted}"
     );
 }
 

--- a/crates/librefang-api/tests/hands_routes_integration.rs
+++ b/crates/librefang-api/tests/hands_routes_integration.rs
@@ -1059,12 +1059,8 @@ system_prompt = "Test prompt"
 
 #[tokio::test(flavor = "multi_thread")]
 async fn set_hand_secret_resolves_stable_requirement_key_to_env_var_name() {
-    // The single-hand detail endpoint (GET /api/hands/{id}) exposes both the
-    // stable requirement "key" and the actual env var "check_value" as
-    // separate fields, so a client can plausibly submit either one to this
-    // endpoint. Both must resolve to the same persisted env var name —
-    // submitting the stable key must not write a secret under a name
-    // `check_requirement` never reads.
+    // The single-hand detail endpoint (GET /api/hands/{id}) exposes both the stable requirement "key" and the actual env var "check_value" as separate fields, so a client can plausibly submit either one to this endpoint.
+    // Both must resolve to the same persisted env var name — submitting the stable key must not write a secret under a name `check_requirement` never reads.
     const ENV_KEY: &str = "LIBREFANG_HAND_SECRET_STABLE_KEY_ALIAS_TEST";
     const STABLE_KEY: &str = "stable-key-alias-test";
     const VALUE: &str = "stable-alias-value";
@@ -1124,8 +1120,7 @@ system_prompt = "Test prompt"
     librefang_api::secrets_env::remove_env_var_guarded(STABLE_KEY).await;
 
     assert_eq!(save_status, StatusCode::OK, "save body: {save_body}");
-    // The response must report the resolved env var name, not the stable
-    // key the client submitted.
+    // The response must report the resolved env var name, not the stable key the client submitted.
     assert_eq!(save_body["key"].as_str(), Some(ENV_KEY), "{save_body}");
 
     let requirement = list_body["items"]


### PR DESCRIPTION
## Type

- [ ] Agent template (TOML)
- [ ] Skill (Python/JS/Prompt)
- [ ] Channel adapter
- [ ] LLM provider
- [ ] Built-in tool
- [x] Bug fix
- [ ] Feature (Rust)
- [ ] Documentation / Translation
- [ ] Refactor / Performance
- [ ] CI / Tooling
- [ ] Other

## Summary

Prevent `GET /api/hands` from returning plaintext values for satisfied environment-variable requirements. The response keeps its existing requirement-key contract and continues to expose only the boolean satisfaction state needed by the Dashboard.

## Changes

- Remove `current_value` from serialized hand requirement status.
- Add a real-router regression that proves the resolved process environment value is absent from the complete response.
- Add a GET → POST secret → GET regression covering Dashboard save compatibility, satisfaction refresh, and canonical `secrets.env` persistence.

## Attribution

- [x] This PR preserves author attribution for any adapted prior work (`Co-authored-by`, commit preservation, or explicit credit in the PR body)

No prior work was adapted.

## Testing

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [x] Live integration tested (if applicable)

Executed:

- `cargo test -p librefang-api --test hands_routes_integration` (41 passed)
- `cargo clippy -p librefang-api --test hands_routes_integration --no-deps -- -D warnings -A clippy::nonminimal-bool`
- `cargo fmt --all -- --check`
- `git diff --check`

The workspace-wide Clippy gate remains blocked by an existing Rust 1.96 `clippy::nonminimal-bool` warning in `crates/librefang-api/src/routes/config/system.rs`, outside this diff.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries

Independent final review reported no Critical, Important, or Minor findings.
