### PR TITLE
fix(approval): fail closed for blocking hand RBAC

### DIFF
--- a/changelog.d/security/6758-blocking-hand-approval-rbac.md
+++ b/changelog.d/security/6758-blocking-hand-approval-rbac.md
@@ -1,0 +1,1 @@
+Require context-free blocking Hand tool requests to enter the human approval queue, preventing curated Hand auto-approval from bypassing per-user RBAC when sender and `force_human` context are unavailable (#6758) (@houko)

--- a/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
+++ b/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
@@ -1,9 +1,6 @@
-//! [`kernel_handle::ApprovalGate`] — tool-approval policy + RBAC gate. Holds
-//! the synchronous "does this tool require approval?" predicates and the
-//! async request/submit/resolve flow used by the agent loop. Hand-tagged
-//! agents (curated trusted packages) auto-approve on the context-carrying
-//! non-blocking path unless per-user policy demanded human approval
-//! (RBAC M3, #3054).
+//! [`kernel_handle::ApprovalGate`] — tool-approval policy + RBAC gate.
+//! Holds the synchronous "does this tool require approval?" predicates and the async request/submit/resolve flow used by the agent loop.
+//! Hand-tagged agents (curated trusted packages) auto-approve on the context-carrying non-blocking path unless per-user policy demanded human approval (RBAC M3, #3054).
 
 use std::sync::Arc;
 
@@ -104,9 +101,8 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
         use librefang_types::approval::ApprovalRequest as TypedRequest;
 
         // The blocking trait carries neither sender identity nor `force_human`.
-        // It therefore cannot prove that per-user policy allowed a hand-agent
-        // carve-out. Always queue a real approval on this context-free path;
-        // context-carrying hand execution uses `submit_tool_approval` below.
+        // It therefore cannot prove that per-user policy allowed a hand-agent carve-out.
+        // Always queue a real approval on this context-free path; context-carrying hand execution uses `submit_tool_approval` below.
 
         let policy = self.governance.approval_manager.policy();
         let risk_level = crate::approval::ApprovalManager::classify_risk(tool_name);

--- a/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
+++ b/crates/librefang-kernel/src/kernel/handles/approval_gate.rs
@@ -1,8 +1,9 @@
 //! [`kernel_handle::ApprovalGate`] — tool-approval policy + RBAC gate. Holds
 //! the synchronous "does this tool require approval?" predicates and the
 //! async request/submit/resolve flow used by the agent loop. Hand-tagged
-//! agents (curated trusted packages) auto-approve unless the per-user
-//! policy demanded human approval (RBAC M3, #3054).
+//! agents (curated trusted packages) auto-approve on the context-carrying
+//! non-blocking path unless per-user policy demanded human approval
+//! (RBAC M3, #3054).
 
 use std::sync::Arc;
 
@@ -100,18 +101,12 @@ impl kernel_handle::ApprovalGate for LibreFangKernel {
         action_summary: &str,
         session_id: Option<&str>,
     ) -> Result<librefang_types::approval::ApprovalDecision, kernel_handle::KernelOpError> {
-        use librefang_types::approval::{ApprovalDecision, ApprovalRequest as TypedRequest};
+        use librefang_types::approval::ApprovalRequest as TypedRequest;
 
-        // Hand agents are curated trusted packages — auto-approve tool execution.
-        // Check if this agent has a "hand:" tag indicating it was spawned by activate_hand().
-        if let Ok(aid) = agent_id.parse::<AgentId>() {
-            if let Some(entry) = self.agents.registry.get(aid) {
-                if entry.tags.iter().any(|t| t.starts_with("hand:")) {
-                    info!(agent_id, tool_name, "Auto-approved for hand agent");
-                    return Ok(ApprovalDecision::Approved);
-                }
-            }
-        }
+        // The blocking trait carries neither sender identity nor `force_human`.
+        // It therefore cannot prove that per-user policy allowed a hand-agent
+        // carve-out. Always queue a real approval on this context-free path;
+        // context-carrying hand execution uses `submit_tool_approval` below.
 
         let policy = self.governance.approval_manager.policy();
         let risk_level = crate::approval::ApprovalManager::classify_risk(tool_name);

--- a/crates/librefang-kernel/tests/rbac_m3_evaluate_tool_call.rs
+++ b/crates/librefang-kernel/tests/rbac_m3_evaluate_tool_call.rs
@@ -18,6 +18,7 @@
 //!   (d) user policy says NeedsApproval (User role + no allow-list) →
 //!       NeedsApproval
 
+use librefang_kernel::GovernanceSubsystemApi;
 use librefang_kernel::LibreFangKernel;
 use librefang_kernel::SecuritySubsystemApi;
 use librefang_runtime::kernel_handle::prelude::*;
@@ -379,6 +380,92 @@ async fn submit_tool_approval_hand_agent_force_human_skips_auto_approve() {
             panic!("RBAC M3 (#3054): force_human=true on a hand-tagged agent MUST NOT auto-approve")
         }
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blocking_hand_approval_does_not_bypass_enabled_rbac() {
+    use librefang_types::agent::AgentManifest;
+    use librefang_types::approval::ApprovalDecision;
+
+    let kernel = boot(vec![user("Bob", "user", "111", None, None)], vec![]);
+    let manifest = AgentManifest {
+        name: format!("blocking-hand-rbac-{}", uuid::Uuid::new_v4()),
+        is_hand: true,
+        tags: vec!["hand:test".to_string()],
+        module: "builtin:chat".to_string(),
+        ..Default::default()
+    };
+    let agent_id = kernel.spawn_agent(manifest).expect("spawn hand agent");
+    let kh: &dyn KernelHandle = &*kernel;
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        kh.request_approval(&agent_id.0.to_string(), "shell_exec", "summary", None),
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "blocking hand approval must wait for a human when RBAC is enabled, got {result:?}"
+    );
+
+    let pending = kernel.approvals().list_pending();
+    let request = pending
+        .iter()
+        .find(|request| request.agent_id == agent_id.0.to_string())
+        .expect("blocking approval must be queued");
+    kernel
+        .approvals()
+        .resolve(
+            request.id,
+            ApprovalDecision::Denied,
+            Some("test-cleanup".to_string()),
+            false,
+            None,
+        )
+        .expect("clean up pending approval");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blocking_hand_approval_without_rbac_context_still_requires_human() {
+    use librefang_types::agent::AgentManifest;
+    use librefang_types::approval::ApprovalDecision;
+
+    let kernel = boot(vec![], vec![]);
+    let manifest = AgentManifest {
+        name: format!("blocking-hand-single-user-{}", uuid::Uuid::new_v4()),
+        is_hand: true,
+        tags: vec!["hand:test".to_string()],
+        module: "builtin:chat".to_string(),
+        ..Default::default()
+    };
+    let agent_id = kernel.spawn_agent(manifest).expect("spawn hand agent");
+    let kh: &dyn KernelHandle = &*kernel;
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        kh.request_approval(&agent_id.0.to_string(), "shell_exec", "summary", None),
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "context-free blocking hand approval must wait for a human, got {result:?}"
+    );
+
+    let pending = kernel.approvals().list_pending();
+    let request = pending
+        .iter()
+        .find(|request| request.agent_id == agent_id.0.to_string())
+        .expect("blocking approval must be queued");
+    kernel
+        .approvals()
+        .resolve(
+            request.id,
+            ApprovalDecision::Denied,
+            Some("test-cleanup".to_string()),
+            false,
+            None,
+        )
+        .expect("clean up pending approval");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- remove the context-free blocking Hand auto-approval carve-out
- always route blocking Hand requests through the real human approval queue because the trait carries neither sender identity nor `force_human`
- retain non-blocking Hand auto-approval where deferred context exists and `force_human` is false
- cover both RBAC-enabled and no-user modes with real-kernel pending-queue tests

## Testing

- RED on prior implementation: blocking request returned `Ok(Approved)`
- `cargo test -p librefang-kernel --test rbac_m3_evaluate_tool_call blocking_hand_approval_ -- --nocapture` (2 passed)
- `cargo test -p librefang-kernel --test rbac_m3_evaluate_tool_call` (11 passed)
- `cargo test -p librefang-kernel-handle --test defaults_approval` (3 passed)
- `cargo clippy -p librefang-kernel --lib --test rbac_m3_evaluate_tool_call --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Review

Independent final review found no Critical, Important, or Minor issues.