### PR TITLE
fix(api): reject traversal in Skillhub hand IDs

### DIFF
--- a/changelog.d/security/6759-skillhub-hand-id-traversal.md
+++ b/changelog.d/security/6759-skillhub-hand-id-traversal.md
@@ -1,0 +1,1 @@
+Reject path-traversal values in Skillhub hand-scoped install requests before accessing the filesystem (#6759) (@houko)

--- a/crates/librefang-api/src/routes/skills/mod.rs
+++ b/crates/librefang-api/src/routes/skills/mod.rs
@@ -301,8 +301,7 @@ pub struct PendingListQuery {
 /// `workspaces/hands/`).
 ///
 /// Contract:
-/// - non-empty, ≤ 64 chars for skill names; ≤ 128 for hand ids to
-///   match `librefang_hands`' canonical `MAX_HAND_ID_LEN`
+/// - non-empty, ≤ 64 chars for skill names; ≤ 128 for hand ids to match `librefang_hands`' canonical `MAX_HAND_ID_LEN`
 /// - characters limited to `[A-Za-z0-9_-]` — the strictest project
 ///   convention; cannot contain `..`, `/`, `\`, or any platform
 ///   path separator

--- a/crates/librefang-api/src/routes/skills/mod.rs
+++ b/crates/librefang-api/src/routes/skills/mod.rs
@@ -301,8 +301,8 @@ pub struct PendingListQuery {
 /// `workspaces/hands/`).
 ///
 /// Contract:
-/// - non-empty, ≤ 64 chars (caps log noise and matches the project
-///   pattern from `agent_templates.rs::validate_template_name`)
+/// - non-empty, ≤ 64 chars for skill names; ≤ 128 for hand ids to
+///   match `librefang_hands`' canonical `MAX_HAND_ID_LEN`
 /// - characters limited to `[A-Za-z0-9_-]` — the strictest project
 ///   convention; cannot contain `..`, `/`, `\`, or any platform
 ///   path separator
@@ -313,9 +313,10 @@ pub struct PendingListQuery {
 /// `field` is "name" or "hand" — used to scope the rejection
 /// message so the client knows which input was bad.
 fn validate_skill_identifier(value: &str, field: &str) -> Result<(), String> {
-    if value.is_empty() || value.len() > 64 {
+    let max_len = if field == "hand" { 128 } else { 64 };
+    if value.is_empty() || value.len() > max_len {
         return Err(format!(
-            "invalid skill {field}: must be 1-64 characters, got {} chars",
+            "invalid skill {field}: must be 1-{max_len} characters, got {} chars",
             value.len()
         ));
     }
@@ -1882,6 +1883,22 @@ mod skill_identifier_validation {
         assert!(
             err.contains("1-64"),
             "expected 1-64 length message; got {err:?}"
+        );
+    }
+
+    #[test]
+    fn hand_length_matches_canonical_128_character_limit() {
+        let max_length = "a".repeat(128);
+        assert!(
+            validate_skill_identifier(&max_length, "hand").is_ok(),
+            "canonical 128-character hand ids must remain accepted"
+        );
+
+        let too_long = "a".repeat(129);
+        let err = validate_skill_identifier(&too_long, "hand").unwrap_err();
+        assert!(
+            err.contains("1-128"),
+            "expected canonical hand length in error; got {err:?}"
         );
     }
 

--- a/crates/librefang-api/src/routes/skills/skillhub.rs
+++ b/crates/librefang-api/src/routes/skills/skillhub.rs
@@ -214,6 +214,15 @@ pub async fn skillhub_install(
     State(state): State<Arc<AppState>>,
     Json(req): Json<crate::types::ClawHubInstallRequest>,
 ) -> impl IntoResponse {
+    if let Some(ref hand_id) = req.hand {
+        if let Err(reason) = validate_skill_identifier(hand_id, "hand") {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": reason})),
+            );
+        }
+    }
+
     let home = state.kernel.home_dir();
     let skills_dir = if let Some(ref hand_id) = req.hand {
         let hand_dir = home.join("workspaces").join("hands").join(hand_id);

--- a/crates/librefang-api/tests/skills_routes_test.rs
+++ b/crates/librefang-api/tests/skills_routes_test.rs
@@ -618,6 +618,31 @@ async fn skills_install_path_traversal_hand_rejected_400() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn skillhub_install_path_traversal_hand_rejected_400() {
+    // Skillhub has its own install handler. Reject traversal before the
+    // hand directory existence probe so an attacker cannot escape the
+    // workspace root (or use the response as a filesystem oracle).
+    let h = boot().await;
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/skillhub/install",
+        Some(serde_json::json!({"slug": "anything", "hand": "../../x"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    assert!(
+        body["error"]
+            .as_str()
+            .or_else(|| body["error"]["message"].as_str())
+            .unwrap_or("")
+            .to_lowercase()
+            .contains("hand"),
+        "error must scope the rejection to the bad `hand` field: {body:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // POST /api/skills/uninstall — error path only.
 // ---------------------------------------------------------------------------

--- a/crates/librefang-api/tests/skills_routes_test.rs
+++ b/crates/librefang-api/tests/skills_routes_test.rs
@@ -643,6 +643,32 @@ async fn skillhub_install_path_traversal_hand_rejected_400() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn skillhub_install_accepts_canonical_max_length_hand_identifier() {
+    let h = boot().await;
+    let hand_id = "a".repeat(128);
+    let (status, body) = json_request(
+        &h,
+        Method::POST,
+        "/api/skillhub/install",
+        Some(serde_json::json!({"slug": "anything", "hand": hand_id})),
+    )
+    .await;
+
+    // The hand does not exist in this isolated home, so reaching the lookup's
+    // 404 proves the canonical 128-character id passed API validation without
+    // allowing the request to continue to the network client.
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body:?}");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .to_lowercase()
+            .contains("not found"),
+        "expected the request to reach the hand lookup: {body:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // POST /api/skills/uninstall — error path only.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- validate optional Skillhub `hand` identifiers before any filesystem path join
- preserve the canonical 128-character Hand ID limit while keeping skill names capped at 64
- add network-free HTTP regressions for traversal and the Hand ID compatibility boundary

## Security impact
Prevents `POST /api/skillhub/install` from escaping `workspaces/hands/` through values such as `../../x`, and avoids exposing filesystem existence through the prior 404 response.

## Verification
- `cargo test -p librefang-api --test skills_routes_test` (23 passed)
- `cargo test -p librefang-api skill_identifier_validation --lib` (13 passed)
- `cargo clippy -p librefang-api --lib --test skills_routes_test --no-deps -- -D warnings -A clippy::nonminimal-bool`
- `cargo fmt --all -- --check`
- `git diff --check`