### PR TITLE
fix(types): block traversal segments in capability path globs

### DIFF
--- a/changelog.d/security/6760-capability-glob-traversal.md
+++ b/changelog.d/security/6760-capability-glob-traversal.md
@@ -1,0 +1,1 @@
+Reject current- and parent-directory segments in scoped capability path globs, including recursive `**` grants (#6760) (@houko)

--- a/crates/librefang-types/src/capability.rs
+++ b/crates/librefang-types/src/capability.rs
@@ -224,10 +224,8 @@ pub fn glob_matches(pattern: &str, value: &str) -> bool {
     if pattern == value {
         return true;
     }
-    // Wildcard grants must never manufacture access through filesystem
-    // traversal components, even when the pattern itself has no separator
-    // and would otherwise take the legacy matcher path. Bare `*` above is
-    // the documented universal grant; an exact grant above remains explicit.
+    // Wildcard grants must never manufacture access through filesystem traversal components, even when the pattern itself has no separator and would otherwise take the legacy matcher path.
+    // Bare `*` above is the documented universal grant; an exact grant above remains explicit.
     if has_path_traversal_segment(value) {
         return false;
     }

--- a/crates/librefang-types/src/capability.rs
+++ b/crates/librefang-types/src/capability.rs
@@ -195,7 +195,8 @@ pub fn validate_capability_inheritance(
 /// `data/*` matches `data/file.txt` but NOT `data/../../etc/passwd`.
 ///
 /// **Double-segment wildcard `**`** — matches any characters including `/`,
-/// so `data/**` matches `data/a/b/c/file.txt`.
+/// so `data/**` matches `data/a/b/c/file.txt`. Path values containing literal
+/// `.` or `..` segments never match a path glob.
 ///
 /// **Bare `*`** (the entire pattern is just `"*"`) — matches anything, for
 /// backward compatibility with the universal wildcard grant.
@@ -306,6 +307,12 @@ fn glob_matches_path(pattern: &str, value: &str) -> bool {
     const SEPS: &[char] = &['/', '\\'];
     let pat_segs: Vec<&str> = pattern.split(SEPS).collect();
     let val_segs: Vec<&str> = value.split(SEPS).collect();
+    if val_segs
+        .iter()
+        .any(|segment| matches!(*segment, "." | ".."))
+    {
+        return false;
+    }
     glob_match_segments(&pat_segs, &val_segs)
 }
 
@@ -620,6 +627,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_path_globs_reject_dot_and_parent_segments() {
+        for (pattern, value) in [
+            ("data/*", "data/.."),
+            ("data/*", "data/."),
+            ("data/**", "data/../../etc/passwd"),
+            ("data/**", "data/./file.txt"),
+            ("C:\\data\\**", "C:\\data\\..\\Windows\\secret"),
+        ] {
+            assert!(
+                !glob_matches(pattern, value),
+                "path glob {pattern:?} must reject traversal value {value:?}"
+            );
+        }
+
+        assert!(
+            glob_matches("data/**", "data/.env"),
+            "ordinary dot-prefixed names are not traversal segments"
+        );
+    }
+
     /// URL capability patterns: `*` in the host portion must NOT match an
     /// entirely different domain. The host string is already extracted as
     /// `hostname:port` before this function is called, so the separator to
@@ -676,6 +704,14 @@ mod tests {
         assert!(!capability_matches(
             &Capability::FileRead("/data/*".to_string()),
             &Capability::FileRead("/data/../../etc/passwd".to_string()),
+        ));
+        assert!(!capability_matches(
+            &Capability::FileRead("/data/**".to_string()),
+            &Capability::FileRead("/data/../../etc/passwd".to_string()),
+        ));
+        assert!(!capability_matches(
+            &Capability::FileWrite("/data/*".to_string()),
+            &Capability::FileWrite("/data/..".to_string()),
         ));
     }
 

--- a/crates/librefang-types/src/capability.rs
+++ b/crates/librefang-types/src/capability.rs
@@ -222,6 +222,13 @@ pub fn glob_matches(pattern: &str, value: &str) -> bool {
     if pattern == value {
         return true;
     }
+    // Wildcard grants must never manufacture access through filesystem
+    // traversal components, even when the pattern itself has no separator
+    // and would otherwise take the legacy matcher path. Bare `*` above is
+    // the documented universal grant; an exact grant above remains explicit.
+    if has_path_traversal_segment(value) {
+        return false;
+    }
 
     // If the pattern contains a path separator we apply segment-aware
     // matching so that a single `*` cannot cross a separator.  Both `/`
@@ -307,13 +314,14 @@ fn glob_matches_path(pattern: &str, value: &str) -> bool {
     const SEPS: &[char] = &['/', '\\'];
     let pat_segs: Vec<&str> = pattern.split(SEPS).collect();
     let val_segs: Vec<&str> = value.split(SEPS).collect();
-    if val_segs
-        .iter()
-        .any(|segment| matches!(*segment, "." | ".."))
-    {
-        return false;
-    }
     glob_match_segments(&pat_segs, &val_segs)
+}
+
+fn has_path_traversal_segment(value: &str) -> bool {
+    const SEPS: &[char] = &['/', '\\'];
+    value
+        .split(SEPS)
+        .any(|segment| matches!(segment, "." | ".."))
 }
 
 /// Recursive segment-by-segment matcher.
@@ -646,6 +654,22 @@ mod tests {
             glob_matches("data/**", "data/.env"),
             "ordinary dot-prefixed names are not traversal segments"
         );
+    }
+
+    #[test]
+    fn test_separator_free_globs_reject_path_traversal_values() {
+        for (pattern, value) in [
+            ("**", ".."),
+            ("**", "data/../../etc/passwd"),
+            ("data*", "data/../secret"),
+            ("*passwd", "data/../etc/passwd"),
+            ("C:*", "C:\\data\\..\\Windows\\secret"),
+        ] {
+            assert!(
+                !glob_matches(pattern, value),
+                "separator-free glob {pattern:?} must reject traversal value {value:?}"
+            );
+        }
     }
 
     /// URL capability patterns: `*` in the host portion must NOT match an

--- a/crates/librefang-types/src/capability.rs
+++ b/crates/librefang-types/src/capability.rs
@@ -195,8 +195,10 @@ pub fn validate_capability_inheritance(
 /// `data/*` matches `data/file.txt` but NOT `data/../../etc/passwd`.
 ///
 /// **Double-segment wildcard `**`** — matches any characters including `/`,
-/// so `data/**` matches `data/a/b/c/file.txt`. Path values containing literal
-/// `.` or `..` segments never match a path glob.
+/// so `data/**` matches `data/a/b/c/file.txt`.
+///
+/// Any value containing a literal `.` or `..` path segment is rejected up front, before pattern dispatch, regardless of which matcher below would otherwise have handled it.
+/// This closes the traversal bypass for `**` (which can span segments) and for separator-free patterns (which fall through to the legacy matcher).
 ///
 /// **Bare `*`** (the entire pattern is just `"*"`) — matches anything, for
 /// backward compatibility with the universal wildcard grant.


### PR DESCRIPTION
## Summary
- reject literal `.` and `..` segments before every wildcard matcher dispatch
- close traversal through path-scoped `*`/`**` and separator-free prefix/suffix patterns
- cover Unix, Windows, FileRead, and FileWrite cases while preserving explicit bare `*`, exact grants, and dotfiles

## Security impact
Prevents scoped wildcard capabilities from matching values that escape through parent/current-directory segments. Bare `*` remains the explicit universal grant.

## Verification
- `cargo test -p librefang-types` (903 unit tests; all integration and doc tests passed)
- `cargo clippy -p librefang-types --all-targets --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`