### PR TITLE
fix(runtime): harden legacy web-fetch SSRF transport

### DIFF
--- a/changelog.d/security/6761-legacy-web-fetch-ssrf.md
+++ b/changelog.d/security/6761-legacy-web-fetch-ssrf.md
@@ -1,0 +1,1 @@
+Pin legacy web-fetch connections to SSRF-validated DNS results and reject automatic redirects (#6761) (@houko)

--- a/crates/librefang-http/src/lib.rs
+++ b/crates/librefang-http/src/lib.rs
@@ -165,6 +165,15 @@ pub fn proxied_client_builder() -> reqwest::ClientBuilder {
     build_http_client(&active_proxy())
 }
 
+/// Build an HTTP client that never uses configured or environment proxies.
+///
+/// SSRF-sensitive callers that pin a hostname to locally validated socket
+/// addresses must connect directly. A proxy can resolve the original hostname
+/// itself, bypassing reqwest's DNS overrides and reopening DNS rebinding.
+pub fn direct_client_builder() -> reqwest::ClientBuilder {
+    build_http_client(&ProxyConfig::default()).no_proxy()
+}
+
 /// Convenience: build a ready-to-use proxy-aware [`reqwest::Client`].
 pub fn proxied_client() -> reqwest::Client {
     proxied_client_builder()
@@ -303,6 +312,12 @@ mod tests {
     fn test_empty_proxy_config_builds_client() {
         let proxy = ProxyConfig::default();
         let client = build_http_client(&proxy).build().unwrap();
+        drop(client);
+    }
+
+    #[test]
+    fn test_direct_client_builder_builds_client() {
+        let client = direct_client_builder().build().unwrap();
         drop(client);
     }
 

--- a/crates/librefang-http/src/lib.rs
+++ b/crates/librefang-http/src/lib.rs
@@ -167,9 +167,8 @@ pub fn proxied_client_builder() -> reqwest::ClientBuilder {
 
 /// Build an HTTP client that never uses configured or environment proxies.
 ///
-/// SSRF-sensitive callers that pin a hostname to locally validated socket
-/// addresses must connect directly. A proxy can resolve the original hostname
-/// itself, bypassing reqwest's DNS overrides and reopening DNS rebinding.
+/// SSRF-sensitive callers that pin a hostname to locally validated socket addresses must connect directly.
+/// A proxy can resolve the original hostname itself, bypassing reqwest's DNS overrides and reopening DNS rebinding.
 pub fn direct_client_builder() -> reqwest::ClientBuilder {
     build_http_client(&ProxyConfig::default()).no_proxy()
 }

--- a/crates/librefang-runtime/src/host_functions.rs
+++ b/crates/librefang-runtime/src/host_functions.rs
@@ -546,13 +546,8 @@ fn host_net_fetch(state: &GuestState, params: &serde_json::Value) -> serde_json:
                     return e;
                 }
 
-                // DNS-pinned, non-redirecting, direct (no-proxy) client: connect
-                // to the exact IPs we just validated for this hop. A configured
-                // proxy would re-resolve `hostname` itself, bypassing the pin
-                // below and reopening DNS rebinding (#6761); `resolve_to_addrs`
-                // (rather than repeated `resolve()` calls, which overwrite the
-                // mapping instead of accumulating it) keeps every validated
-                // address available as a fallback.
+                // DNS-pinned, non-redirecting, direct (no-proxy) client: connect to the exact IPs we just validated for this hop.
+                // A configured proxy would re-resolve `hostname` itself, bypassing the pin below and reopening DNS rebinding (#6761); `resolve_to_addrs` (rather than repeated `resolve()` calls, which overwrite the mapping instead of accumulating it) keeps every validated address available as a fallback.
                 let builder = librefang_http::direct_client_builder()
                     .redirect(reqwest::redirect::Policy::none())
                     .resolve_to_addrs(&ssrf_result.hostname, &ssrf_result.resolved);

--- a/crates/librefang-runtime/src/host_functions.rs
+++ b/crates/librefang-runtime/src/host_functions.rs
@@ -546,13 +546,16 @@ fn host_net_fetch(state: &GuestState, params: &serde_json::Value) -> serde_json:
                     return e;
                 }
 
-                // DNS-pinned, non-redirecting client: connect to the exact IPs
-                // we just validated for this hop.
-                let mut builder = librefang_http::proxied_client_builder()
-                    .redirect(reqwest::redirect::Policy::none());
-                for addr in &ssrf_result.resolved {
-                    builder = builder.resolve(&ssrf_result.hostname, *addr);
-                }
+                // DNS-pinned, non-redirecting, direct (no-proxy) client: connect
+                // to the exact IPs we just validated for this hop. A configured
+                // proxy would re-resolve `hostname` itself, bypassing the pin
+                // below and reopening DNS rebinding (#6761); `resolve_to_addrs`
+                // (rather than repeated `resolve()` calls, which overwrite the
+                // mapping instead of accumulating it) keeps every validated
+                // address available as a fallback.
+                let builder = librefang_http::direct_client_builder()
+                    .redirect(reqwest::redirect::Policy::none())
+                    .resolve_to_addrs(&ssrf_result.hostname, &ssrf_result.resolved);
                 let client = builder.build().expect("HTTP client build");
                 let request = match current_method.as_str() {
                     "POST" => client.post(&current_url).body(current_body.clone()),

--- a/crates/librefang-runtime/src/tool_runner/web_legacy.rs
+++ b/crates/librefang-runtime/src/tool_runner/web_legacy.rs
@@ -33,6 +33,18 @@ where
     }
 }
 
+fn build_legacy_fetch_client(
+    resolution: crate::web_fetch::SsrfResolution,
+) -> Result<reqwest::Client, ToolError> {
+    let builder = crate::http_client::proxied_client_builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::none());
+    resolution
+        .pin_dns(builder)
+        .build()
+        .map_err(|e| fetch_err("Failed to create HTTP client", e))
+}
+
 /// Stream response body with a hard cap at [`MAX_BODY_BYTES`].
 ///
 /// For non-2xx responses, returns `Ok` with the body (preserving legacy
@@ -82,15 +94,14 @@ pub(super) async fn tool_web_fetch_legacy(
         .ok_or(ToolError::MissingParameter("url"))?;
 
     // SSRF protection — reject private/cloud-metadata IPs, userinfo, etc.
-    crate::web_fetch::check_ssrf(url, &[]).map_err(|e| ToolError::InvalidParameter {
-        name: "url",
-        reason: e,
-    })?;
+    let resolution = crate::web_fetch::check_ssrf_async(url, &[])
+        .await
+        .map_err(|e| ToolError::InvalidParameter {
+            name: "url",
+            reason: e,
+        })?;
 
-    let client = crate::http_client::proxied_client_builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| fetch_err("Failed to create HTTP client", e))?;
+    let client = build_legacy_fetch_client(resolution)?;
     let resp = client
         .get(url)
         .header("User-Agent", LEGACY_UA)
@@ -172,6 +183,40 @@ pub(super) async fn tool_web_search_legacy(input: &serde_json::Value) -> ToolRes
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn legacy_client_does_not_follow_redirects() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/final"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("unsafe target"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/redirect"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", "/final"))
+            .mount(&server)
+            .await;
+
+        let resolution = crate::web_fetch::SsrfResolution {
+            hostname: "127.0.0.1".to_string(),
+            resolved: vec![*server.address()],
+        };
+        let client = build_legacy_fetch_client(resolution).expect("client should build");
+        let response = client
+            .get(format!("{}/redirect", server.uri()))
+            .send()
+            .await
+            .expect("redirect response");
+
+        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+        let requests = server.received_requests().await.expect("request log");
+        assert_eq!(requests.len(), 1, "client must not request /final");
+        assert_eq!(requests[0].url.path(), "/redirect");
+    }
 
     #[tokio::test]
     async fn web_fetch_legacy_missing_url_is_missing_parameter() {

--- a/crates/librefang-runtime/src/tool_runner/web_legacy.rs
+++ b/crates/librefang-runtime/src/tool_runner/web_legacy.rs
@@ -262,6 +262,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn web_fetch_legacy_blocks_private_ip() {
+        // Regression for the sync -> async check_ssrf rewiring in this PR:
+        // tool_web_fetch_legacy must still reject a private-IP target end to
+        // end through check_ssrf_async, not just at the check_ssrf_async unit
+        // level, before any HTTP client is built or connection attempted.
+        let r = tool_web_fetch_legacy(
+            &serde_json::json!({ "url": "http://127.0.0.1:1/admin" }),
+            0,
+            0,
+        )
+        .await;
+        assert!(
+            matches!(r, Err(ToolError::InvalidParameter { name: "url", .. })),
+            "expected SSRF block, got: {r:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn web_search_legacy_missing_query_is_missing_parameter() {
         let r = tool_web_search_legacy(&serde_json::json!({})).await;
         assert!(matches!(r, Err(ToolError::MissingParameter("query"))));

--- a/crates/librefang-runtime/src/tool_runner/web_legacy.rs
+++ b/crates/librefang-runtime/src/tool_runner/web_legacy.rs
@@ -263,10 +263,7 @@ mod tests {
 
     #[tokio::test]
     async fn web_fetch_legacy_blocks_private_ip() {
-        // Regression for the sync -> async check_ssrf rewiring in this PR:
-        // tool_web_fetch_legacy must still reject a private-IP target end to
-        // end through check_ssrf_async, not just at the check_ssrf_async unit
-        // level, before any HTTP client is built or connection attempted.
+        // Regression for the sync -> async check_ssrf rewiring in this PR: tool_web_fetch_legacy must still reject a private-IP target end to end through check_ssrf_async, not just at the check_ssrf_async unit level, before any HTTP client is built or connection attempted.
         let r = tool_web_fetch_legacy(
             &serde_json::json!({ "url": "http://127.0.0.1:1/admin" }),
             0,

--- a/crates/librefang-runtime/src/tool_runner/web_legacy.rs
+++ b/crates/librefang-runtime/src/tool_runner/web_legacy.rs
@@ -237,8 +237,8 @@ mod tests {
         );
         let resolution = crate::web_fetch::SsrfResolution {
             hostname: "legacy-fetch.test".to_string(),
-            // The historical loop of `resolve()` calls kept only the last
-            // address. Keep the reachable address first to catch that loss.
+            // The historical loop of `resolve()` calls kept only the last address.
+            // Keep the reachable address first to catch that loss.
             resolved: vec![*server.address(), unreachable],
         };
         let client = build_legacy_fetch_client(resolution).expect("client should build");

--- a/crates/librefang-runtime/src/tool_runner/web_legacy.rs
+++ b/crates/librefang-runtime/src/tool_runner/web_legacy.rs
@@ -36,7 +36,7 @@ where
 fn build_legacy_fetch_client(
     resolution: crate::web_fetch::SsrfResolution,
 ) -> Result<reqwest::Client, ToolError> {
-    let builder = crate::http_client::proxied_client_builder()
+    let builder = crate::http_client::direct_client_builder()
         .timeout(std::time::Duration::from_secs(30))
         .redirect(reqwest::redirect::Policy::none());
     resolution
@@ -216,6 +216,43 @@ mod tests {
         let requests = server.received_requests().await.expect("request log");
         assert_eq!(requests.len(), 1, "client must not request /final");
         assert_eq!(requests[0].url.path(), "/redirect");
+    }
+
+    #[tokio::test]
+    async fn legacy_client_uses_all_validated_addresses() {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/ok"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("pinned"))
+            .mount(&server)
+            .await;
+
+        let unreachable = SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            server.address().port(),
+        );
+        let resolution = crate::web_fetch::SsrfResolution {
+            hostname: "legacy-fetch.test".to_string(),
+            // The historical loop of `resolve()` calls kept only the last
+            // address. Keep the reachable address first to catch that loss.
+            resolved: vec![*server.address(), unreachable],
+        };
+        let client = build_legacy_fetch_client(resolution).expect("client should build");
+        let response = client
+            .get(format!(
+                "http://legacy-fetch.test:{}/ok",
+                server.address().port()
+            ))
+            .send()
+            .await
+            .expect("client should fall back across validated addresses");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(response.text().await.expect("body"), "pinned");
     }
 
     #[tokio::test]

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -354,11 +354,8 @@ pub struct SsrfResolution {
 impl SsrfResolution {
     /// Apply the pinned DNS resolution to a [`reqwest::ClientBuilder`] so
     /// the actual HTTP request connects to the IPs we already validated.
-    pub fn pin_dns(self, mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
-        for addr in &self.resolved {
-            builder = builder.resolve(&self.hostname, *addr);
-        }
-        builder
+    pub fn pin_dns(self, builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+        builder.resolve_to_addrs(&self.hostname, &self.resolved)
     }
 }
 

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -46,10 +46,8 @@ impl WebFetchEngine {
     /// [`Self::send_with_pinned_redirects`], which re-validates AND re-pins
     /// every hop so the IP we checked is the IP we connect to.
     pub(crate) fn pinned_client(&self, resolution: SsrfResolution) -> reqwest::Client {
-        // A configured/env proxy can re-resolve the original hostname itself,
-        // bypassing the DNS pin below and reopening the DNS-rebinding window
-        // this method's own docs describe. Connect directly, matching the
-        // legacy web-fetch path's `direct_client_builder` (#6761).
+        // A configured/env proxy can re-resolve the original hostname itself, bypassing the DNS pin below and reopening the DNS-rebinding window this method's own docs describe.
+        // Connect directly, matching the legacy web-fetch path's `direct_client_builder` (#6761).
         let builder = crate::http_client::direct_client_builder()
             .timeout(std::time::Duration::from_secs(self.config.timeout_secs))
             .redirect(reqwest::redirect::Policy::none())

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -46,7 +46,11 @@ impl WebFetchEngine {
     /// [`Self::send_with_pinned_redirects`], which re-validates AND re-pins
     /// every hop so the IP we checked is the IP we connect to.
     pub(crate) fn pinned_client(&self, resolution: SsrfResolution) -> reqwest::Client {
-        let builder = crate::http_client::proxied_client_builder()
+        // A configured/env proxy can re-resolve the original hostname itself,
+        // bypassing the DNS pin below and reopening the DNS-rebinding window
+        // this method's own docs describe. Connect directly, matching the
+        // legacy web-fetch path's `direct_client_builder` (#6761).
+        let builder = crate::http_client::direct_client_builder()
             .timeout(std::time::Duration::from_secs(self.config.timeout_secs))
             .redirect(reqwest::redirect::Policy::none())
             .gzip(true)


### PR DESCRIPTION
## Summary
- resolve and validate legacy web-fetch targets asynchronously
- use a direct, no-proxy client pinned to every SSRF-validated socket address
- disable automatic redirects so no unvalidated target can be followed
- preserve multi-address fallback with `resolve_to_addrs`

## Security impact
Closes DNS-rebinding through both reqwest re-resolution and proxy-side resolution in the fallback web-fetch path. Redirect targets cannot bypass the single-target validation.

## Verification
- `cargo test -p librefang-http` (5 passed)
- `cargo test -p librefang-runtime tool_runner::web_legacy::tests --lib` (4 passed)
- `cargo test -p librefang-runtime web_fetch::tests --lib` (43 passed)
- `cargo clippy -p librefang-http -p librefang-runtime --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`