### PR TITLE
fix(runtime): enforce direct transport for pinned SSRF clients

### DIFF
--- a/changelog.d/security/6762-pinned-runtime-clients-no-proxy.md
+++ b/changelog.d/security/6762-pinned-runtime-clients-no-proxy.md
@@ -1,0 +1,1 @@
+Require direct transport for DNS-pinned WebFetch, A2A, and WASM host requests so proxies cannot re-resolve validated targets (#6762) (@houko)

--- a/crates/librefang-runtime/src/a2a.rs
+++ b/crates/librefang-runtime/src/a2a.rs
@@ -928,9 +928,9 @@ impl A2aClient {
     /// [`build_client_for_url`], which:
     /// 1. Runs `web_fetch::check_ssrf` on the URL to resolve DNS once,
     ///    validate the addresses, and obtain a [`SsrfResolution`].
-    /// 2. Pins those exact addresses via `ClientBuilder::resolve` so the
-    ///    HTTP stack cannot re-resolve and connect to a different IP — this
-    ///    closes the DNS-rebinding TOCTOU window (#3563).
+    /// 2. Pins those exact addresses on a direct (no-proxy) client so neither
+    ///    the HTTP stack nor a proxy can re-resolve and connect to a different
+    ///    IP — this closes the DNS-rebinding TOCTOU window (#3563).
     /// 3. Installs a custom redirect policy that re-runs `check_ssrf` against
     ///    every redirect target (#3782), since the DNS pin only protects the
     ///    original hostname.
@@ -953,7 +953,7 @@ impl A2aClient {
         // already short-circuits on `response.status().is_redirection()`.
         let redirect_policy = reqwest::redirect::Policy::none();
 
-        let builder = crate::http_client::proxied_client_builder()
+        let builder = crate::http_client::direct_client_builder()
             .timeout(std::time::Duration::from_secs(30))
             .redirect(redirect_policy)
             // Bug #3785: disable transport-layer decompression. Otherwise

--- a/crates/librefang-runtime/src/a2a.rs
+++ b/crates/librefang-runtime/src/a2a.rs
@@ -928,9 +928,7 @@ impl A2aClient {
     /// [`build_client_for_url`], which:
     /// 1. Runs `web_fetch::check_ssrf` on the URL to resolve DNS once,
     ///    validate the addresses, and obtain a [`SsrfResolution`].
-    /// 2. Pins those exact addresses on a direct (no-proxy) client so neither
-    ///    the HTTP stack nor a proxy can re-resolve and connect to a different
-    ///    IP — this closes the DNS-rebinding TOCTOU window (#3563).
+    /// 2. Pins those exact addresses on a direct (no-proxy) client so neither the HTTP stack nor a proxy can re-resolve and connect to a different IP — this closes the DNS-rebinding TOCTOU window (#3563).
     /// 3. Installs a custom redirect policy that re-runs `check_ssrf` against
     ///    every redirect target (#3782), since the DNS pin only protects the
     ///    original hostname.

--- a/crates/librefang-runtime/src/host_functions.rs
+++ b/crates/librefang-runtime/src/host_functions.rs
@@ -546,9 +546,8 @@ fn host_net_fetch(state: &GuestState, params: &serde_json::Value) -> serde_json:
                     return e;
                 }
 
-                // Direct, DNS-pinned, non-redirecting client: connect to the
-                // exact IPs validated for this hop. Proxies are disabled
-                // because proxy-side DNS would bypass reqwest's overrides.
+                // Direct, DNS-pinned, non-redirecting client: connect to the exact IPs validated for this hop.
+                // Proxies are disabled because proxy-side DNS would bypass reqwest's overrides.
                 let builder = librefang_http::direct_client_builder()
                     .redirect(reqwest::redirect::Policy::none())
                     .resolve_to_addrs(&ssrf_result.hostname, &ssrf_result.resolved);

--- a/crates/librefang-runtime/src/host_functions.rs
+++ b/crates/librefang-runtime/src/host_functions.rs
@@ -546,13 +546,12 @@ fn host_net_fetch(state: &GuestState, params: &serde_json::Value) -> serde_json:
                     return e;
                 }
 
-                // DNS-pinned, non-redirecting client: connect to the exact IPs
-                // we just validated for this hop.
-                let mut builder = librefang_http::proxied_client_builder()
-                    .redirect(reqwest::redirect::Policy::none());
-                for addr in &ssrf_result.resolved {
-                    builder = builder.resolve(&ssrf_result.hostname, *addr);
-                }
+                // Direct, DNS-pinned, non-redirecting client: connect to the
+                // exact IPs validated for this hop. Proxies are disabled
+                // because proxy-side DNS would bypass reqwest's overrides.
+                let builder = librefang_http::direct_client_builder()
+                    .redirect(reqwest::redirect::Policy::none())
+                    .resolve_to_addrs(&ssrf_result.hostname, &ssrf_result.resolved);
                 let client = builder.build().expect("HTTP client build");
                 let request = match current_method.as_str() {
                     "POST" => client.post(&current_url).body(current_body.clone()),

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -33,9 +33,7 @@ impl WebFetchEngine {
 
     /// Build a per-request reqwest client pinned to the SSRF-validated IPs.
     ///
-    /// Uses the resolved addresses from [`check_ssrf`] to configure DNS
-    /// pinning on a direct (no-proxy) builder, preventing both local and
-    /// proxy-side DNS rebinding TOCTOU attacks.
+    /// Uses the resolved addresses from [`check_ssrf`] to configure DNS pinning on a direct (no-proxy) builder, preventing both local and proxy-side DNS rebinding TOCTOU attacks.
     ///
     /// Auto-redirects are **disabled** (`Policy::none`). A `Policy::custom`
     /// that re-runs `check_ssrf` on each hop is not enough: reqwest

--- a/crates/librefang-runtime/src/web_fetch.rs
+++ b/crates/librefang-runtime/src/web_fetch.rs
@@ -34,7 +34,8 @@ impl WebFetchEngine {
     /// Build a per-request reqwest client pinned to the SSRF-validated IPs.
     ///
     /// Uses the resolved addresses from [`check_ssrf`] to configure DNS
-    /// pinning on the builder, preventing DNS-rebinding TOCTOU attacks.
+    /// pinning on a direct (no-proxy) builder, preventing both local and
+    /// proxy-side DNS rebinding TOCTOU attacks.
     ///
     /// Auto-redirects are **disabled** (`Policy::none`). A `Policy::custom`
     /// that re-runs `check_ssrf` on each hop is not enough: reqwest
@@ -46,7 +47,7 @@ impl WebFetchEngine {
     /// [`Self::send_with_pinned_redirects`], which re-validates AND re-pins
     /// every hop so the IP we checked is the IP we connect to.
     pub(crate) fn pinned_client(&self, resolution: SsrfResolution) -> reqwest::Client {
-        let builder = crate::http_client::proxied_client_builder()
+        let builder = crate::http_client::direct_client_builder()
             .timeout(std::time::Duration::from_secs(self.config.timeout_secs))
             .redirect(reqwest::redirect::Policy::none())
             .gzip(true)


### PR DESCRIPTION
## Summary
- use direct/no-proxy transport for enhanced WebFetch and A2A pinned clients
- use direct transport plus all validated addresses for WASM host fetch
- document that proxy-side DNS must not bypass local SSRF resolution

## Security impact
Extends the no-proxy DNS-pin invariant from #6761 to the remaining runtime clients that claim check-to-connect pinning. This PR is stacked on #6761 and should merge after it.

## Verification
- `cargo test -p librefang-runtime web_fetch::tests --lib` (43 passed)
- `cargo test -p librefang-runtime a2a::tests --lib` (21 passed)
- `cargo test -p librefang-runtime host_functions::tests --lib` (44 passed)
- `cargo clippy -p librefang-runtime --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`