### PR TITLE
fix(runtime): harden link URL SSRF prefilter

### DIFF
--- a/changelog.d/security/6763-link-understanding-ssrf.md
+++ b/changelog.d/security/6763-link-understanding-ssrf.md
@@ -1,0 +1,1 @@
+Harden link-context URL filtering against userinfo confusion, private IP ranges, and alternate IP encodings (#6763) (@houko)

--- a/crates/librefang-runtime/src/link_understanding.rs
+++ b/crates/librefang-runtime/src/link_understanding.rs
@@ -220,10 +220,7 @@ mod tests {
     #[test]
     fn test_ssrf_blocks_nat64_embedded_ips() {
         // 64:ff9b::/96 (RFC 6052) embeds an IPv4 address in the low 32 bits.
-        // `is_private_ip`/`is_cloud_metadata_ip` unwrap this internally for
-        // RFC1918/link-local/metadata ranges, but loopback and unspecified
-        // are only caught by the explicit recursion added above — regression
-        // coverage for that gap.
+        // `is_private_ip`/`is_cloud_metadata_ip` unwrap this internally for RFC1918/link-local/metadata ranges, but loopback and unspecified are only caught by the explicit recursion added above — regression coverage for that gap.
         assert!(is_private_url("http://[64:ff9b::7f00:1]/admin")); // embeds 127.0.0.1
         assert!(is_private_url("http://[64:ff9b::]/admin")); // embeds 0.0.0.0
         assert!(is_private_url("http://[64:ff9b::a00:1]/admin")); // embeds 10.0.0.1

--- a/crates/librefang-runtime/src/link_understanding.rs
+++ b/crates/librefang-runtime/src/link_understanding.rs
@@ -215,6 +215,17 @@ mod tests {
         assert!(is_private_url("http://[2002:7f00:1::]/admin"));
         assert!(is_private_url("http://2130706433/admin"));
         assert!(is_private_url("http://0x7f000001/admin"));
+        assert!(is_private_url("http://0177.0.0.1/admin"));
+    }
+
+    #[test]
+    fn test_ssrf_blocks_ipv6_unique_local_and_link_local() {
+        // fc00::/7 (ULA, RFC 4193) and fe80::/10 (link-local) are matched by
+        // `crate::web_fetch::is_private_ip`'s IPv6 branch.
+        assert!(is_private_url("http://[fc00::1]/admin"));
+        assert!(is_private_url("http://[fdff:ffff:ffff:ffff::1]/admin"));
+        assert!(is_private_url("http://[fe80::1]/admin"));
+        assert!(!is_private_url("http://[2001:4860:4860::8888]/admin")); // public (Google DNS)
     }
 
     #[test]

--- a/crates/librefang-runtime/src/link_understanding.rs
+++ b/crates/librefang-runtime/src/link_understanding.rs
@@ -17,9 +17,8 @@ pub struct LinkSummary {
 
 /// Extract URLs from text, with a network-free SSRF prefilter.
 ///
-/// Returns up to `max` valid, unique URLs that do not contain private literal
-/// targets or restricted hostnames. Any later fetch must still use the shared
-/// WebFetch SSRF resolver and pinned transport to validate DNS at connect time.
+/// Returns up to `max` valid, unique URLs that do not contain private literal targets or restricted hostnames.
+/// Any later fetch must still use the shared WebFetch SSRF resolver and pinned transport to validate DNS at connect time.
 pub fn extract_urls(text: &str, max: usize) -> Vec<String> {
     // Simple but effective URL regex
     let url_pattern = regex_lite::Regex::new(
@@ -54,8 +53,7 @@ pub fn extract_urls(text: &str, max: usize) -> Vec<String> {
 }
 
 /// Check URL syntax, userinfo, restricted hostnames, and literal IP ranges.
-/// This intentionally performs no DNS resolution because link extraction is
-/// synchronous and does not initiate network I/O.
+/// This intentionally performs no DNS resolution because link extraction is synchronous and does not initiate network I/O.
 fn is_private_url(url: &str) -> bool {
     let parsed = match url::Url::parse(url) {
         Ok(parsed) if matches!(parsed.scheme(), "http" | "https") => parsed,
@@ -97,6 +95,14 @@ fn is_blocked_literal_ip(ip: std::net::IpAddr) -> bool {
                 return true;
             }
         }
+        // NAT64 well-known prefix (64:ff9b::/96, RFC 6052) embeds an IPv4 address in the low 32 bits.
+        // `crate::web_fetch::is_private_ip` / `is_cloud_metadata_ip` already unwrap this internally for RFC1918 / link-local / metadata ranges, but loopback (127.0.0.0/8) and unspecified (0.0.0.0) are only checked against `canonical` below, which this branch does not populate for NAT64.
+        // Recurse explicitly so e.g. `64:ff9b::7f00:1` (embedded 127.0.0.1) is not missed.
+        if let Some(embedded) = crate::web_fetch::extract_nat64_well_known(&v6) {
+            if is_blocked_literal_ip(std::net::IpAddr::V4(embedded)) {
+                return true;
+            }
+        }
     }
 
     let canonical = match ip {
@@ -116,8 +122,8 @@ fn is_blocked_literal_ip(ip: std::net::IpAddr) -> bool {
     }
 
     match canonical {
-        // Treat the complete "this network" block as non-public. URL parsers
-        // and OS resolvers may interpret alternate spellings as these values.
+        // Treat the complete "this network" block as non-public.
+        // URL parsers and OS resolvers may interpret alternate spellings as these values.
         std::net::IpAddr::V4(v4) => v4.octets()[0] == 0,
         std::net::IpAddr::V6(_) => false,
     }
@@ -209,6 +215,20 @@ mod tests {
         assert!(is_private_url("http://[2002:7f00:1::]/admin"));
         assert!(is_private_url("http://2130706433/admin"));
         assert!(is_private_url("http://0x7f000001/admin"));
+    }
+
+    #[test]
+    fn test_ssrf_blocks_nat64_embedded_ips() {
+        // 64:ff9b::/96 (RFC 6052) embeds an IPv4 address in the low 32 bits.
+        // `is_private_ip`/`is_cloud_metadata_ip` unwrap this internally for
+        // RFC1918/link-local/metadata ranges, but loopback and unspecified
+        // are only caught by the explicit recursion added above — regression
+        // coverage for that gap.
+        assert!(is_private_url("http://[64:ff9b::7f00:1]/admin")); // embeds 127.0.0.1
+        assert!(is_private_url("http://[64:ff9b::]/admin")); // embeds 0.0.0.0
+        assert!(is_private_url("http://[64:ff9b::a00:1]/admin")); // embeds 10.0.0.1
+        assert!(is_private_url("http://[64:ff9b::a9fe:a9fe]/admin")); // embeds 169.254.169.254
+        assert!(!is_private_url("http://[64:ff9b::808:808]/admin")); // embeds 8.8.8.8 (public)
     }
 
     #[test]

--- a/crates/librefang-runtime/src/link_understanding.rs
+++ b/crates/librefang-runtime/src/link_understanding.rs
@@ -15,9 +15,11 @@ pub struct LinkSummary {
     pub content_type: String,
 }
 
-/// Extract URLs from text, with SSRF validation.
+/// Extract URLs from text, with a network-free SSRF prefilter.
 ///
-/// Returns up to `max` valid, unique, non-private URLs.
+/// Returns up to `max` valid, unique URLs that do not contain private literal
+/// targets or restricted hostnames. Any later fetch must still use the shared
+/// WebFetch SSRF resolver and pinned transport to validate DNS at connect time.
 pub fn extract_urls(text: &str, max: usize) -> Vec<String> {
     // Simple but effective URL regex
     let url_pattern = regex_lite::Regex::new(
@@ -51,56 +53,74 @@ pub fn extract_urls(text: &str, max: usize) -> Vec<String> {
     urls
 }
 
-/// Check if a URL points to a private/internal address (SSRF protection).
+/// Check URL syntax, userinfo, restricted hostnames, and literal IP ranges.
+/// This intentionally performs no DNS resolution because link extraction is
+/// synchronous and does not initiate network I/O.
 fn is_private_url(url: &str) -> bool {
-    // Parse host from URL
-    let authority = match url.split("://").nth(1) {
-        Some(rest) => rest.split('/').next().unwrap_or(""),
-        None => return true,
+    let parsed = match url::Url::parse(url) {
+        Ok(parsed) if matches!(parsed.scheme(), "http" | "https") => parsed,
+        _ => return true,
     };
-
-    // Handle IPv6 bracket notation (e.g. [::1]:8080)
-    let host = if authority.starts_with('[') {
-        // Extract content between brackets
-        authority
-            .split(']')
-            .next()
-            .unwrap_or("")
-            .trim_start_matches('[')
-    } else {
-        authority.split(':').next().unwrap_or("")
-    };
-
-    let host_lower = host.to_lowercase();
-
-    // Block common SSRF targets
-    if host_lower == "localhost"
-        || host_lower == "127.0.0.1"
-        || host_lower == "0.0.0.0"
-        || host_lower == "::1"
-        || host_lower == "[::1]"
-        || host_lower.ends_with(".local")
-        || host_lower.ends_with(".internal")
-        || host_lower.starts_with("10.")
-        || host_lower.starts_with("192.168.")
-        || host_lower == "metadata.google.internal"
-        || host_lower == "169.254.169.254"
-    {
+    if !parsed.username().is_empty() || parsed.password().is_some() {
         return true;
     }
 
-    // Block 172.16-31.x.x range
-    if host_lower.starts_with("172.") {
-        if let Some(second_octet) = host_lower.split('.').nth(1) {
-            if let Ok(n) = second_octet.parse::<u8>() {
-                if (16..=31).contains(&n) {
-                    return true;
-                }
+    match parsed.host() {
+        Some(url::Host::Ipv4(ip)) => is_blocked_literal_ip(std::net::IpAddr::V4(ip)),
+        Some(url::Host::Ipv6(ip)) => is_blocked_literal_ip(std::net::IpAddr::V6(ip)),
+        Some(url::Host::Domain(host)) => {
+            let host = host.trim_end_matches('.');
+            host == "localhost"
+                || host.ends_with(".localhost")
+                || host.ends_with(".local")
+                || host.ends_with(".internal")
+                || matches!(
+                    host,
+                    "metadata.google.internal" | "metadata.aws.internal" | "instance-data"
+                )
+        }
+        None => true,
+    }
+}
+
+fn is_blocked_literal_ip(ip: std::net::IpAddr) -> bool {
+    if let std::net::IpAddr::V6(v6) = ip {
+        let segments = v6.segments();
+        if segments[0] == 0x2002 {
+            let embedded = std::net::Ipv4Addr::new(
+                (segments[1] >> 8) as u8,
+                segments[1] as u8,
+                (segments[2] >> 8) as u8,
+                segments[2] as u8,
+            );
+            if is_blocked_literal_ip(std::net::IpAddr::V4(embedded)) {
+                return true;
             }
         }
     }
 
-    false
+    let canonical = match ip {
+        std::net::IpAddr::V6(v6) => v6
+            .to_ipv4()
+            .map(std::net::IpAddr::V4)
+            .unwrap_or(std::net::IpAddr::V6(v6)),
+        std::net::IpAddr::V4(_) => ip,
+    };
+
+    if canonical.is_loopback()
+        || canonical.is_unspecified()
+        || crate::web_fetch::is_private_ip(&canonical)
+        || crate::web_fetch::is_cloud_metadata_ip(&canonical)
+    {
+        return true;
+    }
+
+    match canonical {
+        // Treat the complete "this network" block as non-public. URL parsers
+        // and OS resolvers may interpret alternate spellings as these values.
+        std::net::IpAddr::V4(v4) => v4.octets()[0] == 0,
+        std::net::IpAddr::V6(_) => false,
+    }
 }
 
 /// Build link context string to inject into agent messages.
@@ -169,6 +189,29 @@ mod tests {
     }
 
     #[test]
+    fn test_ssrf_userinfo_cannot_hide_private_host() {
+        assert!(is_private_url("http://evil.example@127.0.0.1/admin"));
+        assert!(is_private_url("http://user:pass@10.0.0.1/secret"));
+    }
+
+    #[test]
+    fn test_ssrf_blocks_complete_local_and_link_local_ranges() {
+        assert!(is_private_url("http://127.0.0.2/admin"));
+        assert!(is_private_url("http://127.255.255.254/admin"));
+        assert!(is_private_url("http://0.1.2.3/admin"));
+        assert!(is_private_url("http://169.254.42.42/latest"));
+    }
+
+    #[test]
+    fn test_ssrf_blocks_embedded_and_alternate_ipv4_encodings() {
+        assert!(is_private_url("http://[::ffff:127.0.0.1]/admin"));
+        assert!(is_private_url("http://[::7f00:1]/admin"));
+        assert!(is_private_url("http://[2002:7f00:1::]/admin"));
+        assert!(is_private_url("http://2130706433/admin"));
+        assert!(is_private_url("http://0x7f000001/admin"));
+    }
+
+    #[test]
     fn test_ssrf_private_ranges_blocked() {
         assert!(is_private_url("http://10.0.0.1/internal"));
         assert!(is_private_url("http://192.168.1.1/admin"));
@@ -180,6 +223,8 @@ mod tests {
     fn test_ssrf_metadata_blocked() {
         assert!(is_private_url("http://169.254.169.254/latest/meta-data/"));
         assert!(is_private_url("http://metadata.google.internal/"));
+        assert!(is_private_url("http://metadata.google.internal./"));
+        assert!(is_private_url("http://localhost./admin"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace hand-written URL authority parsing with `url::Url`
- reject userinfo-hidden private targets, complete local/link-local ranges, and alternate IP encodings
- cover IPv4-mapped/compatible IPv6, NAT64/6to4 embeddings, numeric IPv4, and trailing-dot metadata hosts
- document that this synchronous extraction filter is network-free and actual fetches still require WebFetch DNS validation

## Security impact
Prevents private and metadata URLs from being admitted into link context through parser confusion or alternate address spellings. DNS rebinding remains enforced at the actual WebFetch connection boundary.

## Verification
- `cargo test -p librefang-runtime link_understanding::tests --lib` (16 passed)
- `cargo clippy -p librefang-runtime --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`