### PR TITLE
fix(runtime): escape OAuth callback errors

### DIFF
--- a/changelog.d/security/6766-chatgpt-oauth-error-xss.md
+++ b/changelog.d/security/6766-chatgpt-oauth-error-xss.md
@@ -1,1 +1,1 @@
-Escape untrusted ChatGPT OAuth callback errors before rendering the browser response. (@houko)
+Escape untrusted ChatGPT OAuth callback errors before rendering the browser response. (#6766) (@houko)

--- a/changelog.d/security/6766-chatgpt-oauth-error-xss.md
+++ b/changelog.d/security/6766-chatgpt-oauth-error-xss.md
@@ -1,0 +1,1 @@
+Escape untrusted ChatGPT OAuth callback errors before rendering the browser response. (@houko)

--- a/crates/librefang-runtime/src/chatgpt_oauth.rs
+++ b/crates/librefang-runtime/src/chatgpt_oauth.rs
@@ -762,6 +762,8 @@ fn success_html() -> String {
 
 /// Error page shown when OAuth returns an error.
 fn error_html(error: &str, description: &str) -> String {
+    let error = escape_html_text(error);
+    let description = escape_html_text(description);
     format!(
         r#"<!DOCTYPE html>
 <html lang="en">
@@ -786,6 +788,21 @@ fn error_html(error: &str, description: &str) -> String {
 </body>
 </html>"#
     )
+}
+
+fn escape_html_text(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 #[cfg(test)]
@@ -969,5 +986,20 @@ mod tests {
         let html = error_html("access_denied", "User cancelled");
         assert!(html.contains("access_denied"));
         assert!(html.contains("User cancelled"));
+    }
+
+    #[test]
+    fn test_error_html_escapes_untrusted_callback_values() {
+        let html = error_html(
+            r#"<script>alert("error")</script>&'"#,
+            r#"<img src=x onerror='alert("description")'>&"#,
+        );
+
+        assert!(!html.contains("<script>"), "{html}");
+        assert!(!html.contains("<img"), "{html}");
+        assert!(!html.contains("onerror='"), "{html}");
+        assert!(html.contains("&lt;script&gt;alert(&quot;error&quot;)&lt;/script&gt;&amp;&#39;"));
+        assert!(html
+            .contains("&lt;img src=x onerror=&#39;alert(&quot;description&quot;)&#39;&gt;&amp;"));
     }
 }


### PR DESCRIPTION
## Summary
- HTML-escape OAuth callback error codes and descriptions before reflecting them into the browser response
- cover tag, event-handler, ampersand, quote, and apostrophe injection payloads
- preserve ordinary OAuth error text

## Security impact
Prevents a crafted localhost ChatGPT OAuth callback URL from injecting executable markup into the HTML error page.

## Verification
- RED: `cargo test -p librefang-runtime test_error_html_escapes_untrusted_callback_values --lib -- --nocapture`
- GREEN: `cargo test -p librefang-runtime chatgpt_oauth::tests --lib` (21 passed)
- `cargo clippy -p librefang-runtime --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`