### PR TITLE
fix(kernel): validate cron update scripts

### DIFF
--- a/changelog.d/security/6768-cron-update-script-validation.md
+++ b/changelog.d/security/6768-cron-update-script-validation.md
@@ -1,0 +1,1 @@
+Apply the cron pre-processing script allowlist consistently to job updates. (@houko)

--- a/changelog.d/security/6768-cron-update-script-validation.md
+++ b/changelog.d/security/6768-cron-update-script-validation.md
@@ -1,1 +1,1 @@
-Apply the cron pre-processing script allowlist consistently to job updates. (@houko)
+Apply the cron pre-processing script allowlist consistently to job updates. (#6768) (@houko)

--- a/crates/librefang-api/tests/workflows_routes_integration.rs
+++ b/crates/librefang-api/tests/workflows_routes_integration.rs
@@ -1360,6 +1360,71 @@ async fn schedule_update_rejects_ssrf_webhook_in_delivery_targets() {
     );
 }
 
+// pre_script allowlist coverage on PUT /api/cron/jobs/{id}  (#6768)
+//
+// `add_job` validates `pre_script.argv[0]` against the `<home>/scripts/`
+// allowlist via `validate_with_home`; `update_job` used to call the
+// home-agnostic `validate(0)`, which forwards to `validate_with_home` with
+// `home_dir = None` and so skips the path-allowlist branch entirely (the
+// env-key denylist still ran). A PUT could therefore install a pre_script
+// binary anywhere on disk that the daemon's user can execute. Validation
+// now runs the same home-aware check on update; these tests pin the
+// wire-level behaviour so a future refactor can't silently drop the
+// allowlist on this route again.
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_update_rejects_pre_script_outside_home_scripts() {
+    let h = boot().await;
+    let id = seed_cron_job(&h).await;
+
+    let outside_script = h._test.tmp_path().join("outside.sh");
+    std::fs::write(&outside_script, "#!/bin/sh\n").expect("write outside script");
+
+    let body = serde_json::json!({
+        "action": {
+            "kind": "agent_turn",
+            "message": "run pre-processing",
+            "model_override": null,
+            "timeout_secs": null,
+            "pre_script": {"argv": [outside_script.to_string_lossy()], "env": {}}
+        }
+    });
+    let (status, response) =
+        json_request(&h, Method::PUT, &format!("/api/cron/jobs/{id}"), Some(body)).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "pre_script outside <home>/scripts/ must be rejected on update: {response:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cron_job_update_accepts_pre_script_inside_home_scripts() {
+    let h = boot().await;
+    let id = seed_cron_job(&h).await;
+
+    let scripts_dir = h._test.tmp_path().join("scripts");
+    std::fs::create_dir_all(&scripts_dir).expect("create scripts dir");
+    let allowed_script = scripts_dir.join("allowed.sh");
+    std::fs::write(&allowed_script, "#!/bin/sh\n").expect("write allowed script");
+
+    let body = serde_json::json!({
+        "action": {
+            "kind": "agent_turn",
+            "message": "run pre-processing",
+            "model_override": null,
+            "timeout_secs": null,
+            "pre_script": {"argv": [allowed_script.to_string_lossy()], "env": {}}
+        }
+    });
+    let (status, response) =
+        json_request(&h, Method::PUT, &format!("/api/cron/jobs/{id}"), Some(body)).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "pre_script inside <home>/scripts/ must still be accepted: {response:?}"
+    );
+}
+
 /// Regression: a workflow whose step prompt references a named
 /// placeholder (`{{challenge}}`) must resolve that placeholder from an
 /// object-shaped run `input` (the brainstorm-template repro). Before the

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -385,18 +385,9 @@ impl CronScheduler {
         id: CronJobId,
         updates: &serde_json::Value,
     ) -> LibreFangResult<CronJob> {
-        // Candidate-validate-swap: clone the current job, apply the
-        // partial updates onto the candidate, run the same home-aware
-        // validation that `add_job` runs, and only after that passes do we swap the
-        // candidate into place under the shard lock. This generalises
-        // the #4732 bypass closure from "delivery / delivery_targets
-        // re-validated on update" to "the entire CronJob shape is
-        // re-validated on update" — name length, schedule cron-expr
-        // syntax, every CronAction shape, and the SSRF / path checks all
-        // gate update the same way they gate add. A pre-#4739 PUT
-        // carrying e.g. an empty `name` plus a valid `delivery` was
-        // accepted; now the same payload is rejected before any field
-        // hits live state.
+        // Candidate-validate-swap: clone the current job, apply the partial updates onto the candidate, run the same home-aware validation that `add_job` runs, and only after that passes do we swap the candidate into place under the shard lock.
+        // This generalises the #4732 bypass closure from "delivery / delivery_targets re-validated on update" to "the entire CronJob shape is re-validated on update" — name length, schedule cron-expr syntax, every CronAction shape, and the SSRF / path checks all gate update the same way they gate add.
+        // A pre-#4739 PUT carrying e.g. an empty `name` plus a valid `delivery` was accepted; now the same payload is rejected before any field hits live state.
         //
         // Atomicity: `meta.job` is replaced once with a fully validated
         // candidate, so an `Err` at any step leaves the live row
@@ -448,26 +439,15 @@ impl CronScheduler {
             .map_err(|e| LibreFangError::Internal(format!("Invalid delivery_targets: {e}")))?;
         }
 
-        // Run the same shape, SSRF, and pre_script path validation as
-        // `add_job`. Capacity checks remain unchanged for updates; making
-        // add/move limit enforcement atomic requires a shared mutation lock
-        // and is tracked separately from this path-allowlist fix.
+        // Run the same shape, SSRF, and pre_script path validation as `add_job`.
+        // Capacity checks remain unchanged for updates; making add/move limit enforcement atomic requires a shared mutation lock and is tracked separately from this path-allowlist fix.
         candidate
             .validate_with_home(0, Some(&self.home_dir))
             .map_err(LibreFangError::InvalidInput)?;
 
-        // #5113 follow-up: shape validation only checks field count and
-        // character set of the cron expression — it doesn't detect
-        // semantically-impossible schedules like `"0 0 30 2 *"` (Feb 30,
-        // never fires). `add_job` probes for this with
-        // `compute_next_run_after_opt` and rejects pre-insert; without
-        // the same probe here, a PUT could install a wedged schedule on
-        // an existing job, after which `due_jobs` would fall back to a
-        // `+1h` retry every tick until `MAX_CONSECUTIVE_ERRORS` triggers
-        // auto-disable — five wasted LLM-token fires. Only probe when
-        // the schedule field was actually part of this update; otherwise
-        // we'd reject every update on an already-wedged row (e.g. one
-        // persisted by an older daemon) and lock users out of fixing it.
+        // #5113 follow-up: shape validation only checks field count and character set of the cron expression — it doesn't detect semantically-impossible schedules like `"0 0 30 2 *"` (Feb 30, never fires).
+        // `add_job` probes for this with `compute_next_run_after_opt` and rejects pre-insert; without the same probe here, a PUT could install a wedged schedule on an existing job, after which `due_jobs` would fall back to a `+1h` retry every tick until `MAX_CONSECUTIVE_ERRORS` triggers auto-disable — five wasted LLM-token fires.
+        // Only probe when the schedule field was actually part of this update; otherwise we'd reject every update on an already-wedged row (e.g. one persisted by an older daemon) and lock users out of fixing it.
         if schedule_updated {
             if let CronSchedule::Cron { expr, .. } = &candidate.schedule {
                 if compute_next_run_after_opt(&candidate.schedule, Utc::now()).is_none() {

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -386,8 +386,8 @@ impl CronScheduler {
         updates: &serde_json::Value,
     ) -> LibreFangResult<CronJob> {
         // Candidate-validate-swap: clone the current job, apply the
-        // partial updates onto the candidate, run the same `validate(0)`
-        // that `add_job` runs, and only after that passes do we swap the
+        // partial updates onto the candidate, run the same home-aware
+        // validation that `add_job` runs, and only after that passes do we swap the
         // candidate into place under the shard lock. This generalises
         // the #4732 bypass closure from "delivery / delivery_targets
         // re-validated on update" to "the entire CronJob shape is
@@ -449,16 +449,11 @@ impl CronScheduler {
         }
 
         // Run the same shape, SSRF, and pre_script path validation as
-        // `add_job`. Count the candidate owner's other jobs so an in-place
-        // update does not count itself, while a cross-agent move still
-        // respects MAX_JOBS_PER_AGENT.
-        let existing_count = self
-            .jobs
-            .iter()
-            .filter(|entry| *entry.key() != id && entry.value().job.agent_id == candidate.agent_id)
-            .count();
+        // `add_job`. Capacity checks remain unchanged for updates; making
+        // add/move limit enforcement atomic requires a shared mutation lock
+        // and is tracked separately from this path-allowlist fix.
         candidate
-            .validate_with_home(existing_count, Some(&self.home_dir))
+            .validate_with_home(0, Some(&self.home_dir))
             .map_err(LibreFangError::InvalidInput)?;
 
         // #5113 follow-up: shape validation only checks field count and
@@ -2722,37 +2717,6 @@ mod tests {
         let updated = sched.update_job(id, &updates).unwrap();
 
         assert!(matches!(updated.action, CronAction::AgentTurn { .. }));
-    }
-
-    #[test]
-    fn update_job_counts_other_jobs_for_agent_limit() {
-        let (sched, _tmp) = make_scheduler(100);
-        let target_agent = AgentId::new();
-        let mut first_id = None;
-        for index in 0..librefang_types::scheduler::MAX_JOBS_PER_AGENT {
-            let mut job = make_job(target_agent);
-            job.name = format!("target-{index}");
-            let id = sched.add_job(job, false).unwrap();
-            first_id.get_or_insert(id);
-        }
-
-        sched
-            .update_job(
-                first_id.unwrap(),
-                &serde_json::json!({"name": "same-agent-update"}),
-            )
-            .expect("an update must exclude its own job from the limit count");
-
-        let source_agent = AgentId::new();
-        let source_id = sched.add_job(make_job(source_agent), false).unwrap();
-        let err = sched
-            .update_job(
-                source_id,
-                &serde_json::json!({"agent_id": target_agent.to_string()}),
-            )
-            .expect_err("a cross-agent move must respect the target agent limit");
-        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
-        assert_eq!(sched.get_job(source_id).unwrap().agent_id, source_agent);
     }
 
     /// Issue #5113 follow-up: `update_job` must apply the same

--- a/crates/librefang-kernel/src/cron.rs
+++ b/crates/librefang-kernel/src/cron.rs
@@ -448,17 +448,20 @@ impl CronScheduler {
             .map_err(|e| LibreFangError::Internal(format!("Invalid delivery_targets: {e}")))?;
         }
 
-        // Run the same shape + SSRF validation `add_job` runs. We pass
-        // `existing_count = 0` because this is an in-place update on an
-        // existing job — capacity (MAX_JOBS_PER_AGENT) is unaffected by
-        // an update that doesn't change `agent_id`. Cross-agent moves
-        // are NOT capacity-checked here today; tracking under a
-        // separate follow-up issue (#4732 followup).
+        // Run the same shape, SSRF, and pre_script path validation as
+        // `add_job`. Count the candidate owner's other jobs so an in-place
+        // update does not count itself, while a cross-agent move still
+        // respects MAX_JOBS_PER_AGENT.
+        let existing_count = self
+            .jobs
+            .iter()
+            .filter(|entry| *entry.key() != id && entry.value().job.agent_id == candidate.agent_id)
+            .count();
         candidate
-            .validate(0)
+            .validate_with_home(existing_count, Some(&self.home_dir))
             .map_err(LibreFangError::InvalidInput)?;
 
-        // #5113 follow-up: `validate(0)` only checks field count and
+        // #5113 follow-up: shape validation only checks field count and
         // character set of the cron expression — it doesn't detect
         // semantically-impossible schedules like `"0 0 30 2 *"` (Feb 30,
         // never fires). `add_job` probes for this with
@@ -2668,6 +2671,88 @@ mod tests {
 
         // State invariant: targets must not have been partially written.
         assert!(sched.get_job(id).unwrap().delivery_targets.is_empty());
+    }
+
+    #[test]
+    fn update_job_rejects_pre_script_outside_home_scripts() {
+        let (sched, tmp) = make_scheduler(100);
+        let agent = AgentId::new();
+        let id = sched.add_job(make_job(agent), false).unwrap();
+        let outside_script = tmp.path().join("outside.sh");
+        std::fs::write(&outside_script, "#!/bin/sh\n").unwrap();
+
+        let updates = serde_json::json!({
+            "action": {
+                "kind": "agent_turn",
+                "message": "run pre-processing",
+                "model_override": null,
+                "timeout_secs": null,
+                "pre_script": {"argv": [outside_script], "env": {}}
+            }
+        });
+        let err = sched
+            .update_job(id, &updates)
+            .expect_err("update must enforce the same pre_script allowlist as add");
+
+        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
+        assert!(matches!(
+            sched.get_job(id).unwrap().action,
+            CronAction::SystemEvent { .. }
+        ));
+    }
+
+    #[test]
+    fn update_job_accepts_pre_script_inside_home_scripts() {
+        let (sched, tmp) = make_scheduler(100);
+        let scripts_dir = tmp.path().join("scripts");
+        std::fs::create_dir_all(&scripts_dir).unwrap();
+        let allowed_script = scripts_dir.join("allowed.sh");
+        std::fs::write(&allowed_script, "#!/bin/sh\n").unwrap();
+        let id = sched.add_job(make_job(AgentId::new()), false).unwrap();
+
+        let updates = serde_json::json!({
+            "action": {
+                "kind": "agent_turn",
+                "message": "run pre-processing",
+                "model_override": null,
+                "timeout_secs": null,
+                "pre_script": {"argv": [allowed_script], "env": {}}
+            }
+        });
+        let updated = sched.update_job(id, &updates).unwrap();
+
+        assert!(matches!(updated.action, CronAction::AgentTurn { .. }));
+    }
+
+    #[test]
+    fn update_job_counts_other_jobs_for_agent_limit() {
+        let (sched, _tmp) = make_scheduler(100);
+        let target_agent = AgentId::new();
+        let mut first_id = None;
+        for index in 0..librefang_types::scheduler::MAX_JOBS_PER_AGENT {
+            let mut job = make_job(target_agent);
+            job.name = format!("target-{index}");
+            let id = sched.add_job(job, false).unwrap();
+            first_id.get_or_insert(id);
+        }
+
+        sched
+            .update_job(
+                first_id.unwrap(),
+                &serde_json::json!({"name": "same-agent-update"}),
+            )
+            .expect("an update must exclude its own job from the limit count");
+
+        let source_agent = AgentId::new();
+        let source_id = sched.add_job(make_job(source_agent), false).unwrap();
+        let err = sched
+            .update_job(
+                source_id,
+                &serde_json::json!({"agent_id": target_agent.to_string()}),
+            )
+            .expect_err("a cross-agent move must respect the target agent limit");
+        assert!(matches!(err, LibreFangError::InvalidInput(_)), "{err:?}");
+        assert_eq!(sched.get_job(source_id).unwrap().agent_id, source_agent);
     }
 
     /// Issue #5113 follow-up: `update_job` must apply the same


### PR DESCRIPTION
## Summary
- apply the daemon-home pre_script allowlist to cron updates as well as creates
- preserve candidate-validate-swap atomicity when path validation fails
- preserve existing update capacity semantics; add/move limit atomicity remains a separate concurrency item

## Security impact
Prevents cron PUT updates from installing a pre-processing executable outside `<home>/scripts/`, closing a validation gap that did not exist on job creation.

## Verification
- RED: `cargo test -p librefang-kernel update_job_rejects_pre_script_outside_home_scripts --lib -- --nocapture`
- GREEN: `cargo test -p librefang-kernel update_job_ --lib` (12 passed)
- `cargo clippy -p librefang-kernel --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`