### PR TITLE
fix(llm): keep auth-failed credentials disabled

### DIFF
--- a/changelog.d/security/6770-credential-pool-permanent-state.md
+++ b/changelog.d/security/6770-credential-pool-permanent-state.md
@@ -1,1 +1,1 @@
-Keep credentials disabled after permanent authentication failures until pool reload. (@houko)
+Keep credentials disabled after permanent authentication failures until pool reload. (#6770) (@houko)

--- a/changelog.d/security/6770-credential-pool-permanent-state.md
+++ b/changelog.d/security/6770-credential-pool-permanent-state.md
@@ -1,0 +1,1 @@
+Keep credentials disabled after permanent authentication failures until pool reload. (@houko)

--- a/crates/librefang-llm-drivers/src/credential_pool.rs
+++ b/crates/librefang-llm-drivers/src/credential_pool.rs
@@ -85,9 +85,8 @@ pub struct PooledCredential {
     /// When `Some(t)`, this credential is exhausted and must not be used until
     /// `Instant::now() >= t`.
     exhausted_until: Option<Instant>,
-    /// Auth failures disable a credential until the pool is rebuilt by a
-    /// configuration reload. A separate flag keeps permanence distinct from
-    /// temporary cooldowns and cannot overflow the monotonic clock.
+    /// Auth failures disable a credential until the pool is rebuilt by a configuration reload.
+    /// A separate flag keeps permanence distinct from temporary cooldowns and cannot overflow the monotonic clock.
     permanently_disabled: bool,
 }
 
@@ -364,9 +363,8 @@ impl CredentialPool {
     }
 
     /// Report that a credential is permanently invalid (e.g. auth failure).
-    /// Unlike [`mark_exhausted`] which uses a TTL-based cooldown, this marks
-    /// the key as unavailable for the lifetime of the pool. Only a hot-reload
-    /// that rebuilds the pool can recover the credential.
+    /// Unlike [`mark_exhausted`] which uses a TTL-based cooldown, this marks the key as unavailable for the lifetime of the pool.
+    /// Only a hot-reload that rebuilds the pool can recover the credential.
     pub fn mark_permanent(&self, api_key: &str) {
         let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(c) = inner.credentials.iter_mut().find(|c| c.api_key == api_key) {
@@ -375,16 +373,15 @@ impl CredentialPool {
         }
     }
 
-    /// Report that a request with `api_key` succeeded. Increments the
-    /// credential's `request_count` and clears a temporary cooldown (e.g. if
-    /// a provider recovered before the TTL expired). Permanent auth-failure
-    /// markers remain until a configuration reload rebuilds the pool.
+    /// Report that a request with `api_key` succeeded.
+    /// Increments the credential's `request_count` and clears a temporary cooldown (e.g. if a provider recovered before the TTL expired).
+    /// Permanent auth-failure markers remain until a configuration reload rebuilds the pool.
     pub fn mark_success(&self, api_key: &str) {
         let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(c) = inner.credentials.iter_mut().find(|c| c.api_key == api_key) {
             c.request_count = c.request_count.saturating_add(1);
-            // Clear only temporary cooldowns. A stale in-flight success must
-            // not revive a key another request proved permanently invalid.
+            // Clear only temporary cooldowns.
+            // A stale in-flight success must not revive a key another request proved permanently invalid.
             if !c.permanently_disabled {
                 c.exhausted_until = None;
             }

--- a/crates/librefang-llm-drivers/src/credential_pool.rs
+++ b/crates/librefang-llm-drivers/src/credential_pool.rs
@@ -85,6 +85,10 @@ pub struct PooledCredential {
     /// When `Some(t)`, this credential is exhausted and must not be used until
     /// `Instant::now() >= t`.
     exhausted_until: Option<Instant>,
+    /// Auth failures disable a credential until the pool is rebuilt by a
+    /// configuration reload. A separate flag keeps permanence distinct from
+    /// temporary cooldowns and cannot overflow the monotonic clock.
+    permanently_disabled: bool,
 }
 
 impl std::fmt::Debug for PooledCredential {
@@ -109,11 +113,15 @@ impl PooledCredential {
             priority,
             request_count: 0,
             exhausted_until: None,
+            permanently_disabled: false,
         }
     }
 
     /// Returns `true` if the credential is currently available (not exhausted).
     fn is_available(&self) -> bool {
+        if self.permanently_disabled {
+            return false;
+        }
         match self.exhausted_until {
             None => true,
             Some(until) => Instant::now() >= until,
@@ -151,22 +159,18 @@ impl CredentialSnapshot {
     fn from_credential(c: &PooledCredential) -> Self {
         let hint = redact_key_hint(&c.api_key);
         let now = Instant::now();
-        let (is_exhausted, cooldown) = match c.exhausted_until {
-            None => (false, None),
-            Some(until) => {
-                if now >= until {
-                    (false, None)
-                } else {
-                    let remaining = until.saturating_duration_since(now).as_secs();
-                    // mark_permanent uses Instant::now() + 100 years — any
-                    // value larger than a year is treated as permanent for
-                    // diagnostic purposes.
-                    let remaining = if remaining > 365 * 86400 {
-                        u64::MAX
+        let (is_exhausted, cooldown) = if c.permanently_disabled {
+            (true, Some(u64::MAX))
+        } else {
+            match c.exhausted_until {
+                None => (false, None),
+                Some(until) => {
+                    if now >= until {
+                        (false, None)
                     } else {
-                        remaining
-                    };
-                    (true, Some(remaining))
+                        let remaining = until.saturating_duration_since(now).as_secs();
+                        (true, Some(remaining))
+                    }
                 }
             }
         };
@@ -361,31 +365,29 @@ impl CredentialPool {
 
     /// Report that a credential is permanently invalid (e.g. auth failure).
     /// Unlike [`mark_exhausted`] which uses a TTL-based cooldown, this marks
-    /// the key as unavailable for the lifetime of the pool. The only way to
-    /// recover a permanently-exhausted key is via [`mark_success`] from a
-    /// concurrent code path or a hot-reload that rebuilds the pool.
-    ///
-    /// Implementation uses a far-future timestamp (100 years) so that
-    /// `is_available()` naturally returns `false` without a separate flag.
+    /// the key as unavailable for the lifetime of the pool. Only a hot-reload
+    /// that rebuilds the pool can recover the credential.
     pub fn mark_permanent(&self, api_key: &str) {
         let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
-        // ~100 years from now — well past any realistic daemon lifetime.
-        let far_future = Instant::now() + Duration::from_secs(365 * 100 * 86400);
         if let Some(c) = inner.credentials.iter_mut().find(|c| c.api_key == api_key) {
-            c.exhausted_until = Some(far_future);
+            c.permanently_disabled = true;
+            c.exhausted_until = None;
         }
     }
 
-    /// Report that a request with `api_key` succeeded.  Increments the
-    /// credential's `request_count` and clears any leftover exhaustion marker
-    /// (e.g. if a provider recovered before the TTL expired).
+    /// Report that a request with `api_key` succeeded. Increments the
+    /// credential's `request_count` and clears a temporary cooldown (e.g. if
+    /// a provider recovered before the TTL expired). Permanent auth-failure
+    /// markers remain until a configuration reload rebuilds the pool.
     pub fn mark_success(&self, api_key: &str) {
         let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(c) = inner.credentials.iter_mut().find(|c| c.api_key == api_key) {
             c.request_count = c.request_count.saturating_add(1);
-            // Always clear the exhaustion marker on success — the key is working
-            // again regardless of whether the cooldown TTL has elapsed.
-            c.exhausted_until = None;
+            // Clear only temporary cooldowns. A stale in-flight success must
+            // not revive a key another request proved permanently invalid.
+            if !c.permanently_disabled {
+                c.exhausted_until = None;
+            }
         }
     }
 
@@ -799,6 +801,22 @@ mod tests {
             Some("key-a"),
             "should be available after mark_success clears exhaustion"
         );
+    }
+
+    #[test]
+    fn mark_success_does_not_revive_permanently_disabled_key() {
+        let pool = make_pool(&[("key-a", 1)], PoolStrategy::FillFirst);
+        pool.mark_permanent("key-a");
+        pool.mark_success("key-a");
+
+        assert!(
+            pool.acquire().is_none(),
+            "an in-flight success must not revive a key disabled by an auth failure"
+        );
+        let snapshot = pool.snapshot();
+        assert!(snapshot[0].is_exhausted);
+        assert_eq!(snapshot[0].cooldown_remaining_secs, Some(u64::MAX));
+        assert_eq!(snapshot[0].request_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- represent permanent auth-failure disablement separately from temporary cooldown timestamps
- prevent stale in-flight successes from reviving a key rejected by another request
- remove the 100-year Instant sentinel and preserve the existing diagnostic `u64::MAX` marker
- keep mark_success early recovery for temporary rate-limit cooldowns

## Security impact
Prevents known-invalid 401/403 credentials from re-entering shared pool rotation during concurrent requests, and removes a platform-dependent Instant overflow panic path.

## Verification
- RED: `cargo test -p librefang-llm-drivers mark_success_does_not_revive_permanently_disabled_key --lib -- --nocapture`
- GREEN: `cargo test -p librefang-llm-drivers credential_pool::tests --lib` (29 passed)
- `cargo clippy -p librefang-llm-drivers --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`