### PR TITLE
fix(runtime): truncate proactive memory on UTF-8 boundaries

### DIFF
--- a/changelog.d/fixed/6778-proactive-memory-utf8-boundary.md
+++ b/changelog.d/fixed/6778-proactive-memory-utf8-boundary.md
@@ -1,0 +1,5 @@
+Proactive-memory extraction now moves its prompt-size cutoff to a valid UTF-8
+boundary before searching for a newline or truncating. Long conversations that
+place a CJK character, emoji, or other multi-byte character across the 8,000-byte
+boundary no longer abort automatic memory extraction with a slicing panic
+(#6778) (@houko)

--- a/crates/librefang-runtime/src/proactive_memory.rs
+++ b/crates/librefang-runtime/src/proactive_memory.rs
@@ -519,16 +519,14 @@ impl LlmMemoryExtractor {
             if !content.is_empty() {
                 conversation_text.push_str(&format!("{role}: {content}\n"));
                 if conversation_text.len() > MAX_EXTRACTION_CHARS {
-                    if let Some(last_newline) =
-                        conversation_text[..MAX_EXTRACTION_CHARS].rfind('\n')
-                    {
+                    let mut safe_end = MAX_EXTRACTION_CHARS;
+                    while safe_end > 0 && !conversation_text.is_char_boundary(safe_end) {
+                        safe_end -= 1;
+                    }
+                    if let Some(last_newline) = conversation_text[..safe_end].rfind('\n') {
                         conversation_text.truncate(last_newline);
                     } else {
-                        let mut safe = MAX_EXTRACTION_CHARS;
-                        while safe > 0 && !conversation_text.is_char_boundary(safe) {
-                            safe -= 1;
-                        }
-                        conversation_text.truncate(safe);
+                        conversation_text.truncate(safe_end);
                     }
                     break;
                 }
@@ -1804,6 +1802,29 @@ mod tests {
         assert!(ctx.contains("based on my memory"));
         // But the memory content itself should appear as a bullet, not as a recitation
         assert!(ctx.contains("- test"));
+    }
+
+    #[tokio::test]
+    async fn extraction_truncates_at_utf8_boundary_before_searching_for_newline() {
+        let extractor = LlmMemoryExtractor::new(
+            Arc::new(CannedLlmDriver {
+                response: r#"{"memories":[],"relations":[]}"#.to_string(),
+            }),
+            "test-model".to_string(),
+        );
+        // `user: ` is six bytes. Include an earlier newline, then put the
+        // four-byte emoji at byte 7,999 so the 8,000-byte extraction boundary
+        // falls inside its encoding before `rfind('\n')` can run.
+        let content = format!("line\n{}😀tail", "a".repeat(7_988));
+        let messages = vec![serde_json::json!({
+            "role": "user",
+            "content": content,
+        })];
+
+        let result = extractor
+            .extract_with_model(&messages, "test-model", &[])
+            .await;
+        assert!(result.is_ok(), "UTF-8 truncation must not panic or fail");
     }
 
     /// H4 regression: even a runaway list of fat memories must not push


### PR DESCRIPTION
## Summary
- move the proactive-memory extraction cap back to a valid UTF-8 boundary before slicing
- use that safe boundary for both newline-preferred and direct truncation
- cover a four-byte emoji straddling byte 8,000 through the full extractor/request path

## Verification
- regression RED: prior implementation panicked at byte 8,000 inside `😀`
- exact regression test passed after the fix
- proactive-memory module tests: 61 passed
- `cargo clippy -p librefang-runtime --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`