### PR TITLE
fix(runtime): adjust message boundary after heartbeat pruning

### DIFF
--- a/changelog.d/security/heartbeat-prune-message-index.md
+++ b/changelog.d/security/heartbeat-prune-message-index.md
@@ -1,0 +1,1 @@
+Keep the current-turn message boundary valid when heartbeat history pruning removes older silent responses, preventing stale-index skips and panics during post-turn memory processing. (@houko)

--- a/crates/librefang-runtime/src/agent_loop/end_turn.rs
+++ b/crates/librefang-runtime/src/agent_loop/end_turn.rs
@@ -217,10 +217,18 @@ pub(super) async fn finalize_successful_end_turn(
         .and_then(|a| a.heartbeat_keep_recent)
         .unwrap_or(10);
     let before_prune_len = ctx.session.messages.len();
-    crate::session_repair::prune_heartbeat_turns(&mut ctx.session.messages, keep_recent);
+    let pruned_before_new_messages = crate::session_repair::prune_heartbeat_turns_tracking_boundary(
+        &mut ctx.session.messages,
+        keep_recent,
+        end_turn.new_messages_start,
+    );
     if ctx.session.messages.len() != before_prune_len {
         ctx.session.mark_messages_mutated();
     }
+    end_turn.new_messages_start = end_turn
+        .new_messages_start
+        .saturating_sub(pruned_before_new_messages)
+        .min(ctx.session.messages.len());
 
     // Fork and incognito turns are ephemeral — skip the persist so the
     // parent agent's canonical session history isn't polluted by

--- a/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
+++ b/crates/librefang-runtime/src/agent_loop/tests/utilities.rs
@@ -1838,6 +1838,84 @@ async fn test_normal_turn_persists_session_as_incognito_control() {
     );
 }
 
+#[tokio::test]
+async fn test_heartbeat_pruning_keeps_new_messages_start_on_current_turn() {
+    let memory = librefang_memory::MemorySubstrate::open_in_memory(0.01).unwrap();
+    let agent_id = librefang_types::agent::AgentId::new();
+    let session_id = librefang_types::agent::SessionId::new();
+    let mut messages = Vec::new();
+    for index in 0..12 {
+        messages.push(Message::user(format!("heartbeat {index}")));
+        messages.push(Message::assistant("[no reply needed]"));
+    }
+    let mut session = librefang_memory::session::Session {
+        id: session_id,
+        agent_id,
+        messages,
+        context_window_tokens: 0,
+        label: None,
+        model_override: None,
+        messages_generation: 0,
+        last_repaired_generation: None,
+        peer_id: None,
+    };
+    let mut manifest = test_manifest();
+    manifest.autonomous = Some(librefang_types::agent::AutonomousConfig {
+        heartbeat_keep_recent: Some(2),
+        ..Default::default()
+    });
+    let driver: Arc<dyn LlmDriver> = Arc::new(NormalDriver);
+
+    let result = run_agent_loop(
+        &manifest,
+        "current turn",
+        &mut session,
+        &memory,
+        driver,
+        &[],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        &LoopOptions::default(),
+    )
+    .await
+    .expect("loop should complete");
+
+    assert!(
+        result.new_messages_start <= session.messages.len(),
+        "returned message boundary {} exceeds pruned session length {}",
+        result.new_messages_start,
+        session.messages.len(),
+    );
+    let new_messages = &session.messages[result.new_messages_start..];
+    assert_eq!(new_messages.len(), 2);
+    assert_eq!(new_messages[0].role, Role::User);
+    assert_eq!(new_messages[0].content.text_content(), "current turn");
+    assert_eq!(new_messages[1].role, Role::Assistant);
+    assert_eq!(
+        new_messages[1].content.text_content(),
+        "Hello from the agent!"
+    );
+}
+
 /// `LoopOptions::incognito = true` MUST suppress the SQLite write at
 /// `finalize_successful_end_turn` even on a clean end-turn.
 #[tokio::test]

--- a/crates/librefang-runtime/src/session_repair.rs
+++ b/crates/librefang-runtime/src/session_repair.rs
@@ -1105,8 +1105,19 @@ fn strip_injection_markers(content: &str) -> String {
 /// from session history. Keeps the last `keep_recent` messages intact to avoid
 /// pruning recent context.
 pub fn prune_heartbeat_turns(messages: &mut Vec<Message>, keep_recent: usize) {
+    prune_heartbeat_turns_tracking_boundary(messages, keep_recent, 0);
+}
+
+/// Prune heartbeat turns while reporting how many removed messages preceded
+/// an index captured before pruning. Callers that retain an index into the
+/// message list must subtract this count to keep it pointing at the same turn.
+pub(crate) fn prune_heartbeat_turns_tracking_boundary(
+    messages: &mut Vec<Message>,
+    keep_recent: usize,
+    boundary: usize,
+) -> usize {
     if messages.len() <= keep_recent {
-        return;
+        return 0;
     }
     let prune_end = messages.len() - keep_recent;
     let mut to_remove = Vec::new();
@@ -1134,12 +1145,13 @@ pub fn prune_heartbeat_turns(messages: &mut Vec<Message>, keep_recent: usize) {
     }
 
     if to_remove.is_empty() {
-        return;
+        return 0;
     }
 
     to_remove.sort_unstable();
     to_remove.dedup();
     let pruned = to_remove.len();
+    let pruned_before_boundary = to_remove.partition_point(|&idx| idx < boundary);
     for idx in to_remove.into_iter().rev() {
         messages.remove(idx);
     }
@@ -1147,6 +1159,7 @@ pub fn prune_heartbeat_turns(messages: &mut Vec<Message>, keep_recent: usize) {
         pruned,
         "Pruned heartbeat NO_REPLY turns from session history"
     );
+    pruned_before_boundary
 }
 
 /// In-place coalesce: if the block list contains runs of `ContentBlock::Text`,

--- a/crates/librefang-runtime/src/session_repair/tests.rs
+++ b/crates/librefang-runtime/src/session_repair/tests.rs
@@ -839,6 +839,22 @@ fn test_prune_heartbeat_turns_removes_no_reply() {
 }
 
 #[test]
+fn test_prune_heartbeat_turns_tracks_only_removals_before_boundary() {
+    let mut messages = vec![
+        Message::assistant("[no reply needed]"),
+        Message::user("current turn"),
+        Message::assistant("[no reply needed]"),
+    ];
+
+    let removed_before = prune_heartbeat_turns_tracking_boundary(&mut messages, 0, 1);
+
+    assert_eq!(removed_before, 1);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].role, Role::User);
+    assert_eq!(messages[0].content.text_content(), "current turn");
+}
+
+#[test]
 fn test_prune_heartbeat_preserves_recent() {
     let mut messages = vec![
         Message::user("ping"),


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

Keeps the current-turn message boundary aligned with the pruned session history so post-turn proactive-memory slicing and AgentLoopResult cannot use a stale, out-of-bounds index.

## Changes

- Track how many pruned silent assistant messages were located before the captured current-turn boundary.
- Adjust and clamp new_messages_start immediately after heartbeat pruning.
- Preserve the existing public prune_heartbeat_turns API.
- Add a full agent-loop regression and a keep_recent=0 boundary unit test.

## Attribution

- [x] This PR preserves author attribution for any adapted prior work; no prior work was adapted.

## Testing

- [x] cargo test -p librefang-runtime test_heartbeat_pruning_keeps_new_messages_start_on_current_turn -- --nocapture
- [x] cargo test -p librefang-runtime test_prune_heartbeat -- --nocapture
- [x] cargo clippy -p librefang-runtime --lib --no-deps -- -D warnings
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [ ] cargo test --workspace (not run; repository guidance requires scoped runtime tests)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validation is unchanged; stale internal indices are adjusted at the mutation boundary.