### PR TITLE
fix(kernel): release cancelled auto-dream claims

### DIFF
--- a/changelog.d/fixed/auto-dream-claim-cancellation.md
+++ b/changelog.d/fixed/auto-dream-claim-cancellation.md
@@ -1,0 +1,1 @@
+Release process-local auto-dream lock claims when acquisition is cancelled during asynchronous file I/O, so later consolidation attempts are not permanently blocked. (@houko)

--- a/crates/librefang-kernel/src/auto_dream/lock.rs
+++ b/crates/librefang-kernel/src/auto_dream/lock.rs
@@ -34,6 +34,81 @@ const HOLDER_STALE_MS: u64 = 60 * 60 * 1000;
 /// concurrent acquirers targeting the same path inside one process.
 static IN_PROCESS_CLAIMS: LazyLock<DashSet<PathBuf>> = LazyLock::new(DashSet::new);
 
+/// Owns a process-local claim until acquisition either succeeds or is
+/// abandoned. Dropping the acquisition future at any await point drops this
+/// guard and makes the path available to later callers.
+struct InProcessClaimGuard {
+    path: PathBuf,
+    token: String,
+    prior_mtime: Option<u64>,
+    armed: bool,
+}
+
+impl InProcessClaimGuard {
+    fn claim(path: PathBuf, prior_mtime: Option<u64>) -> Option<Self> {
+        if IN_PROCESS_CLAIMS.insert(path.clone()) {
+            Some(Self {
+                path,
+                token: format!("{}:{}", std::process::id(), uuid::Uuid::new_v4()),
+                prior_mtime,
+                armed: true,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn write_and_verify(&self) -> LibreFangResult<bool> {
+        std::fs::write(&self.path, self.token.as_bytes()).map_err(|e| {
+            LibreFangError::Internal(format!("auto_dream: write lock file failed: {e}"))
+        })?;
+        let verify = std::fs::read_to_string(&self.path).map_err(|e| {
+            LibreFangError::Internal(format!("auto_dream: verify lock file failed: {e}"))
+        })?;
+        Ok(verify.trim() == self.token)
+    }
+
+    /// Keep the claim after a verified acquisition. `release` or `rollback`
+    /// becomes responsible for removing it from `IN_PROCESS_CLAIMS`.
+    fn retain(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for InProcessClaimGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        IN_PROCESS_CLAIMS.remove(&self.path);
+
+        // A cancelled Tokio filesystem future may finish its blocking write
+        // after the async owner is gone. Acquisition therefore performs the
+        // complete write+verify sequence in one blocking task and returns
+        // this armed guard. If the JoinHandle is dropped, the task output is
+        // dropped after that sequence finishes and cleanup cannot race its
+        // own write. Never clear a token that another process overwrote.
+        let owns_disk_token =
+            std::fs::read_to_string(&self.path).is_ok_and(|body| body.trim() == self.token);
+        if !owns_disk_token {
+            return;
+        }
+
+        let cleanup_result = if let Some(prior_mtime) = self.prior_mtime {
+            std::fs::write(&self.path, b"").and_then(|()| set_mtime_ms(&self.path, prior_mtime))
+        } else {
+            std::fs::remove_file(&self.path)
+        };
+        if let Err(error) = cleanup_result {
+            tracing::warn!(
+                path = %self.path.display(),
+                %error,
+                "auto_dream: failed to clean abandoned lock claim"
+            );
+        }
+    }
+}
+
 /// Handle onto the lock file. Stateless — every operation re-reads from disk
 /// so multiple processes racing on the same path stay coherent.
 #[derive(Debug, Clone)]
@@ -123,32 +198,27 @@ impl ConsolidationLock {
         // Same-process racers must lose before touching the file. The
         // token-based verify below only proves "my write was visible when I
         // re-read", not "nobody overwrote me later".
-        if !IN_PROCESS_CLAIMS.insert(self.path.clone()) {
+        let claim_path = self.path.clone();
+        let claim =
+            tokio::task::spawn_blocking(move || -> LibreFangResult<Option<InProcessClaimGuard>> {
+                let Some(claim) = InProcessClaimGuard::claim(claim_path, prior_mtime) else {
+                    return Ok(None);
+                };
+                if claim.write_and_verify()? {
+                    Ok(Some(claim))
+                } else {
+                    Ok(None)
+                }
+            })
+            .await
+            .map_err(|e| {
+                LibreFangError::Internal(format!("auto_dream: lock claim task failed: {e}"))
+            })??;
+        let Some(claim) = claim else {
             return Ok(None);
-        }
+        };
 
-        // Per-acquire token — makes "did our write win?" a real check even
-        // when two acquirers are in the same process and thus share a PID.
-        let token = format!("{}:{}", std::process::id(), uuid::Uuid::new_v4());
-        fs::write(&self.path, token.as_bytes()).await.map_err(|e| {
-            IN_PROCESS_CLAIMS.remove(&self.path);
-            LibreFangError::Internal(format!("auto_dream: write lock file failed: {e}"))
-        })?;
-
-        // Verify our write won the race. Last-writer-wins semantics mean
-        // the loser sees a body that is not their unique token — they bail
-        // and retry next tick. Without the UUID this check would falsely
-        // succeed for same-PID racers because their bodies would be
-        // identical.
-        let verify = fs::read_to_string(&self.path).await.map_err(|e| {
-            IN_PROCESS_CLAIMS.remove(&self.path);
-            LibreFangError::Internal(format!("auto_dream: verify lock file failed: {e}"))
-        })?;
-        if verify.trim() != token {
-            IN_PROCESS_CLAIMS.remove(&self.path);
-            return Ok(None);
-        }
-
+        claim.retain();
         Ok(Some(prior_mtime.unwrap_or(0)))
     }
 
@@ -492,5 +562,34 @@ mod tests {
             .count();
         assert_eq!(winners, 1, "exactly one racer should win the lock");
         let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn cancelling_claim_owner_releases_in_process_claim() {
+        let path = tmpfile("cancelled-claim");
+        let task_path = path.clone();
+        let (claimed_tx, claimed_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            let claim = InProcessClaimGuard::claim(task_path, None).unwrap();
+            claim.write_and_verify().unwrap();
+            claimed_tx.send(()).unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        claimed_rx.await.unwrap();
+        assert!(IN_PROCESS_CLAIMS.contains(&path));
+        assert!(InProcessClaimGuard::claim(path.clone(), None).is_none());
+        assert!(
+            IN_PROCESS_CLAIMS.contains(&path),
+            "failed claimant must not remove the current owner's claim"
+        );
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        assert!(!IN_PROCESS_CLAIMS.contains(&path));
+        assert!(!path.exists(), "cancelled owner must remove its disk token");
+
+        let lock = ConsolidationLock::new(path.clone());
+        assert_eq!(lock.try_acquire().await.unwrap(), Some(0));
+        lock.rollback(0).await.unwrap();
     }
 }


### PR DESCRIPTION
## Type

- [x] Bug fix

## Summary

Makes auto-dream lock acquisition cancellation-safe so dropping the future during async lock-file I/O cannot permanently wedge process-local consolidation claims.

## Changes

- Own each tentative process-local claim with an RAII guard across lock-file write and verification awaits.
- Retain the claim only after successful token verification, preserving release and rollback ownership.
- Ensure failed competing claim attempts never remove the current owner claim.
- Add deterministic cancellation and loser-ownership regression coverage using oneshot synchronization and task abort.

## Attribution

- [x] This PR preserves author attribution for any adapted prior work; no prior work was adapted.

## Testing

- [x] cargo test -p librefang-kernel --lib cancelling_claim_owner_releases_in_process_claim -- --nocapture
- [x] cargo test -p librefang-kernel --lib auto_dream::lock::tests -- --nocapture (10 passed)
- [x] cargo clippy -p librefang-kernel --lib --no-deps -- -D warnings
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [ ] cargo test --workspace (not run; repository guidance forbids workspace-wide tests)

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] Lock ownership is released on cancellation and retained only after verified acquisition.