### PR TITLE
fix(kernel): restore sticky assistant routing semantics

### DIFF
--- a/changelog.d/fixed/6788-assistant-routing-cache-key.md
+++ b/changelog.d/fixed/6788-assistant-routing-cache-key.md
@@ -1,0 +1,1 @@
+Sticky assistant routing now reads the same sender- and thread-scoped cache keys it writes, while `explicit_only` channels remain on their configured agent when no route has been explicitly cached instead of invoking classification (#6788) (@houko)

--- a/crates/librefang-kernel/src/kernel/assistant_routing.rs
+++ b/crates/librefang-kernel/src/kernel/assistant_routing.rs
@@ -197,19 +197,15 @@ impl LibreFangKernel {
             return Ok(agent_id);
         }
 
+        let route_key = Self::assistant_route_key(agent_id, sender_context);
+
         // Per-channel auto-routing strategy gate.
         //
         // When `auto_route` is `Off` (the default for all channels), channel messages
         // bypass classification entirely — preserving legacy behaviour.
         // Other strategies allow opt-in routing with different cache semantics.
         if let Some(ctx) = sender_context {
-            let cache_key = format!(
-                "{}:{}:{}:{}",
-                agent_id,
-                ctx.channel,
-                ctx.account_id.as_deref().unwrap_or(""),
-                ctx.user_id,
-            );
+            let cache_key = route_key.clone();
             let ttl = std::time::Duration::from_secs(ctx.auto_route_ttl_minutes as u64 * 60);
 
             match ctx.auto_route {
@@ -226,8 +222,9 @@ impl LibreFangKernel {
                             }
                         }
                     }
-                    // No cached entry — fall through to LLM classification once,
-                    // then store the result.
+                    // Explicit-only means a miss stays on the configured
+                    // agent and never triggers classification.
+                    return Ok(agent_id);
                 }
 
                 AutoRouteStrategy::StickyTtl => {
@@ -312,8 +309,6 @@ impl LibreFangKernel {
                 }
             }
         }
-
-        let route_key = Self::assistant_route_key(agent_id, sender_context);
 
         if Self::should_reuse_cached_route(message) {
             if let Some(target) = self

--- a/crates/librefang-kernel/src/kernel/tests.rs
+++ b/crates/librefang-kernel/src/kernel/tests.rs
@@ -2418,6 +2418,80 @@ fn test_assistant_route_key_scopes_sender_and_thread() {
     assert_ne!(with_sender, without_sender);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn explicit_only_reads_canonical_thread_scoped_cache_key() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = KernelConfig {
+        home_dir: tmp.path().to_path_buf(),
+        data_dir: tmp.path().join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(config).unwrap();
+    let assistant_id = kernel.agents.registry.find_by_name("assistant").unwrap().id;
+    let coder_id = kernel
+        .spawn_agent(test_manifest("coder", "A coding specialist", vec![]))
+        .unwrap();
+    let sender = SenderContext {
+        channel: "telegram".to_string(),
+        user_id: "user-123".to_string(),
+        thread_id: Some("thread-9".to_string()),
+        auto_route: AutoRouteStrategy::ExplicitOnly,
+        ..Default::default()
+    };
+    let route_key = LibreFangKernel::assistant_route_key(assistant_id, Some(&sender));
+    kernel.events.assistant_routes.insert(
+        route_key,
+        (
+            AssistantRouteTarget::Specialist("coder".to_string()),
+            std::time::Instant::now(),
+        ),
+    );
+
+    let resolved = kernel
+        .resolve_assistant_target(
+            assistant_id,
+            "Please handle this deliberately generic but sufficiently long request.",
+            Some(&sender),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resolved, coder_id);
+    kernel.shutdown();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn explicit_only_cache_miss_never_falls_through_to_classification() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = KernelConfig {
+        home_dir: tmp.path().to_path_buf(),
+        data_dir: tmp.path().join("data"),
+        ..KernelConfig::default()
+    };
+    let kernel = LibreFangKernel::boot_with_config(config).unwrap();
+    let assistant_id = kernel.agents.registry.find_by_name("assistant").unwrap().id;
+    kernel
+        .spawn_agent(test_manifest("coder", "A coding specialist", vec![]))
+        .unwrap();
+    let sender = SenderContext {
+        channel: "telegram".to_string(),
+        user_id: "user-123".to_string(),
+        thread_id: Some("thread-9".to_string()),
+        auto_route: AutoRouteStrategy::ExplicitOnly,
+        ..Default::default()
+    };
+
+    let resolved = kernel
+        .resolve_assistant_target(
+            assistant_id,
+            "请实现一个新的 Rust API 并补丁修复它",
+            Some(&sender),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resolved, assistant_id);
+    kernel.shutdown();
+}
+
 #[test]
 fn test_boot_spawns_assistant_as_default_agent() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- compute the canonical sender/thread-scoped assistant route key once for both strategy lookups and cache writes
- make `ExplicitOnly` stay on the configured agent when no valid cached route exists
- add real-kernel regressions for canonical cache reuse and classification-free cache misses

## Verification
- RED: both canonical cache-hit and ExplicitOnly miss regressions failed before the fix
- `cargo test -p librefang-kernel --lib explicit_only_ -- --nocapture` (2 passed)
- `cargo test -p librefang-kernel --lib assistant_route -- --nocapture`
- `cargo clippy -p librefang-kernel --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope
- Sticky-heuristic divergence reset timing and concurrent specialist spawning are independent follow-ups.