### PR TITLE
fix(security): restore registry pubkey lockstep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,17 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  # The registry signing key is duplicated across the daemon and three worker
+  # surfaces. Keep this build-free guard unconditional: a worker-only config
+  # change does not enter the Rust quality lane, but must still prove lockstep.
+  pubkey-lockstep:
+    name: Registry Pubkey Lockstep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Check registry public keys
+        run: bash scripts/check-pubkey-lockstep.sh
+
   # ── Detect changes + compute affected crate subset ─────────────────────────────
   # PR lane: Linux only. Selective by default (test just the crates the PR
   #   touches — no downstream fan-out, main catches cross-crate breakage on
@@ -1114,6 +1125,7 @@ jobs:
     name: CI Gate
     if: always()
     needs:
+      - pubkey-lockstep
       - changes
       - no-build-artifacts
       - quality

--- a/changelog.d/security/6790-registry-pubkey-lockstep.md
+++ b/changelog.d/security/6790-registry-pubkey-lockstep.md
@@ -1,0 +1,1 @@
+Restore registry signature verification after the Cloudflare account migration by synchronizing the daemon and Pages endpoint with the active signing-worker public key, and repair the CI lockstep guard so future key drift fails visibly. (@houko)

--- a/crates/librefang-runtime/src/plugin_manager/registry.rs
+++ b/crates/librefang-runtime/src/plugin_manager/registry.rs
@@ -55,7 +55,7 @@ pub(super) struct EmbeddedPubkey {
 ///      hard-fail installs (the failure surfaces an actionable error
 ///      message, unlike the previous "accept forever" behaviour).
 pub(super) const EMBEDDED_REGISTRY_PUBKEYS: &[EmbeddedPubkey] = &[EmbeddedPubkey {
-    pubkey_b64: "ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=",
+    pubkey_b64: "joY8IYrUbbACfKRyp2CTcEbcEty8wcBwP1MTxU+vjaM=",
     expires_at: None,
 }];
 

--- a/scripts/check-pubkey-lockstep.sh
+++ b/scripts/check-pubkey-lockstep.sh
@@ -2,7 +2,8 @@
 # Fail if the registry pubkey is not byte-identical across the four
 # locations that have to stay in lockstep:
 #
-#   1. crates/librefang-runtime/src/plugin_manager.rs  EMBEDDED_REGISTRY_PUBKEY
+#   1. crates/librefang-runtime/src/plugin_manager/registry.rs
+#                                      EMBEDDED_REGISTRY_PUBKEYS active slot
 #   2. web/workers/registry-worker/wrangler.toml       REGISTRY_PUBLIC_KEY
 #   3. web/workers/marketplace-worker/wrangler.toml    REGISTRY_PUBLIC_KEY
 #   4. web/public/_worker.js                           REGISTRY_PUBLIC_KEY
@@ -17,6 +18,11 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v perl >/dev/null 2>&1; then
+  echo "::error::perl is required by the pubkey lockstep check" >&2
+  exit 1
+fi
 
 extract() {
   local path="$1" name="$2"
@@ -36,11 +42,14 @@ extract() {
   # shaped fragments inside comments don't get picked up. Length-check
   # the captured value to exactly 44 chars (Ed25519 raw 32 bytes -> b64
   # with padding) — wrong length is wrong key.
-  body="$(perl -ne '
+  if ! body="$(perl -ne '
     if (/^[ \t]*(?:const[ \t]+)?'"$name"'\b[^"\x27\n=:]*[=:][^"\x27\n]*['\''"]([A-Za-z0-9+\/=]{44})['\''"]/) {
       print $1; exit
     }
-  ' "$repo_root/$path" 2>/dev/null || true)"
+  ' "$repo_root/$path")"; then
+    echo "::error file=$path::perl failed while extracting $name" >&2
+    exit 1
+  fi
   if [ -z "$body" ]; then
     echo "::error file=$path::$name constant not found" >&2
     exit 1
@@ -48,15 +57,37 @@ extract() {
   echo "$body"
 }
 
-# The daemon now embeds a SLICE of pubkeys (each `EmbeddedPubkey {
-# pubkey_b64, expires_at }`). Slot 0 is the active key. We pull the
-# FIRST `pubkey_b64: "..."` field — the active slot — and compare
-# against the worker side. The unique field name avoids matching any
-# stray `b64` literal that drifts in elsewhere (PR re-review LOW
-# round 4).
-daemon=$(extract \
-  "crates/librefang-runtime/src/plugin_manager.rs" \
-  'pubkey_b64')
+# Extract the sole `EmbeddedPubkey` entry whose sibling `expires_at` field is
+# `None`. Textual order alone is not enough: a rotation may retain an expiring
+# legacy entry, while the no-expiry entry is the active worker-signing key.
+extract_active_daemon_key() {
+  local path="crates/librefang-runtime/src/plugin_manager/registry.rs"
+  local body
+
+  if ! body="$(perl -0777 -ne '
+    if (/\bEMBEDDED_REGISTRY_PUBKEYS\b\s*:[^=]*=\s*&\[(.*?)\];/s) {
+      my $slots = $1;
+      while ($slots =~ /\bEmbeddedPubkey\s*\{(.*?)\}/sg) {
+        my $slot = $1;
+        next unless $slot =~ /^[ \t]*expires_at\s*:\s*None\b/m;
+        if ($slot =~ /^[ \t]*pubkey_b64\s*:\s*"([A-Za-z0-9+\/=]{44})"/m) {
+          print "$1\n";
+        }
+      }
+    }
+  ' "$repo_root/$path")"; then
+    echo "::error file=$path::perl failed while extracting the active pubkey" >&2
+    exit 1
+  fi
+
+  if [[ ! "$body" =~ ^[A-Za-z0-9+/=]{44}$ ]]; then
+    echo "::error file=$path::expected exactly one valid pubkey_b64 with expires_at: None" >&2
+    exit 1
+  fi
+  echo "$body"
+}
+
+daemon=$(extract_active_daemon_key)
 registry_worker=$(extract \
   "web/workers/registry-worker/wrangler.toml" \
   'REGISTRY_PUBLIC_KEY')

--- a/web/public/_worker.js
+++ b/web/public/_worker.js
@@ -20,8 +20,9 @@ const IMMUTABLE_CACHE = 'public, max-age=31536000, immutable';
 //
 // Mirror of REGISTRY_PUBLIC_KEY in web/workers/{registry,marketplace}-worker/
 // wrangler.toml. Rotation: regenerate keypair via web/workers/keygen.mjs,
-// update both wrangler.toml files AND this constant in lockstep.
-const REGISTRY_PUBLIC_KEY = 'ClGa0Ucap8NdrKAy1rw9Tt6A9I8eg4zJ53+xIuKMuq0=';
+// update both wrangler.toml files, the daemon embedded active key, and this
+// constant in lockstep; scripts/check-pubkey-lockstep.sh enforces the set.
+const REGISTRY_PUBLIC_KEY = 'joY8IYrUbbACfKRyp2CTcEbcEty8wcBwP1MTxU+vjaM=';
 
 function addHeaders(response, url) {
   const headers = new Headers(response.headers);


### PR DESCRIPTION
## Summary
- point the lockstep guard at the real daemon key registry and select the sole no-expiry active slot
- preserve Perl execution errors instead of reporting them as missing constants
- synchronize the daemon and Pages public-key endpoint with the active key deployed by both signing workers

## Root cause
The Cloudflare account migration in #6092 changed both signing-worker public keys to joY8…, while the daemon and Pages key endpoint remained on ClGa…. The lockstep script could not reveal that drift because it still scanned the pre-split plugin_manager.rs facade and failed before comparison.

## Verification
- scripts/check-pubkey-lockstep.sh
- bash -n scripts/check-pubkey-lockstep.sh
- shellcheck scripts/check-pubkey-lockstep.sh
- forced Perl failure reports extractor failure (not constant-not-found)
- node --check web/public/_worker.js
- cargo test -p librefang-runtime embedded_pubkeys_slot0_has_no_expiry --lib -- --nocapture (1/1)
- cargo fmt --all -- --check
- git diff --check