### PR TITLE
fix(release): harden changelog article generation

### DIFF
--- a/changelog.d/fixed/6791-release-article-generation.md
+++ b/changelog.d/fixed/6791-release-article-generation.md
@@ -1,0 +1,1 @@
+Generate release articles with working CHANGELOG anchors, safe validated tag URLs, fence-aware section extraction, and opt-in replacement of existing hand-edited output. (@houko)

--- a/scripts/changelog-to-article.sh
+++ b/scripts/changelog-to-article.sh
@@ -102,25 +102,56 @@ fi
 # in the date don't get interpreted as wildcards (BSD awk has no gensub).
 HEADING="## [${DATE}]"
 if ! EXTRACTED="$(awk -v h="${HEADING}" '
-    function fence_marker(line, trimmed) {
-        trimmed = line
-        sub(/^[[:space:]]*/, "", trimmed)
-        if (trimmed ~ /^```/) return "`"
-        if (trimmed ~ /^~~~/) return "~"
-        return ""
+    function trim_fence_indent(line, spaces) {
+        spaces = 0
+        while (substr(line, 1, 1) == " ") {
+            spaces++
+            line = substr(line, 2)
+        }
+        if (spaces > 3) return ""
+        return line
+    }
+
+    function opening_fence_length(line, trimmed, char, run, rest) {
+        trimmed = trim_fence_indent(line)
+        if (trimmed == "") return 0
+        char = substr(trimmed, 1, 1)
+        if (char != "`" && char != "~") return 0
+        run = 0
+        while (substr(trimmed, run + 1, 1) == char) run++
+        if (run < 3) return 0
+        rest = substr(trimmed, run + 1)
+        if (char == "`" && index(rest, "`") != 0) return 0
+        opening_char = char
+        return run
+    }
+
+    function is_closing_fence(line, expected_char, minimum_run,
+                              trimmed, run, rest) {
+        trimmed = trim_fence_indent(line)
+        if (trimmed == "" || substr(trimmed, 1, 1) != expected_char) return 0
+        run = 0
+        while (substr(trimmed, run + 1, 1) == expected_char) run++
+        if (run < minimum_run) return 0
+        rest = substr(trimmed, run + 1)
+        return rest ~ /^[[:space:]]*$/
     }
 
     {
-        marker = fence_marker($0)
-        if (!in_fence && marker != "") {
+        fence_line = 0
+        if (!in_fence && (opening_length = opening_fence_length($0)) > 0) {
             in_fence = 1
-            fence = marker
-        } else if (in_fence && marker == fence) {
+            fence_char = opening_char
+            fence_length = opening_length
+            fence_line = 1
+        } else if (in_fence && is_closing_fence($0, fence_char, fence_length)) {
             in_fence = 0
-            fence = ""
+            fence_char = ""
+            fence_length = 0
+            fence_line = 1
         }
 
-        if (!found && !in_fence && marker == "" && index($0, h) == 1 &&
+        if (!found && !in_fence && !fence_line && index($0, h) == 1 &&
             substr($0, length(h) + 1) ~ /^([[:space:]]|$)/) {
             found = 1
             print "HEADING\t" $0
@@ -128,7 +159,7 @@ if ! EXTRACTED="$(awk -v h="${HEADING}" '
         }
 
         if (found) {
-            if (!in_fence && marker == "" && /^## \[/) exit
+            if (!in_fence && !fence_line && /^## \[/) exit
             print "BODY\t" $0
         }
     }

--- a/scripts/changelog-to-article.sh
+++ b/scripts/changelog-to-article.sh
@@ -12,29 +12,47 @@
 # generating one a single command.
 #
 # Usage:
-#   bash scripts/changelog-to-article.sh <YYYY.M.D> [<git-tag>]
+#   bash scripts/changelog-to-article.sh <YYYY.M.D> [<git-tag>] [--force]
 #
 #   <YYYY.M.D> must match a `## [YYYY.M.D]` heading in CHANGELOG.md.
 #   <git-tag>  defaults to `v<YYYY.M.D>`. CalVer tags often carry suffixes
 #              (e.g. `v2026.4.27-beta6`); pass the actual tag to make
 #              canonical_url accurate. The placeholder is safe to hand-edit
 #              before pushing.
+#   --force    replaces an existing generated article. Without it, an existing
+#              file is preserved and the command fails.
 #
 # Examples:
 #   bash scripts/changelog-to-article.sh 2026.4.27
 #   bash scripts/changelog-to-article.sh 2026.4.27 v2026.4.27-beta6
+#   bash scripts/changelog-to-article.sh 2026.4.27 v2026.4.27-beta6 --force
 #
-# Output: articles/release-<YYYY.M.D>.md (overwrites if it exists).
+# Output: articles/release-<YYYY.M.D>.md.
 
 set -euo pipefail
 
-if [[ $# -lt 1 || $# -gt 2 ]]; then
-    echo "usage: $0 <YYYY.M.D> [<git-tag>]" >&2
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+    echo "usage: $0 <YYYY.M.D> [<git-tag>] [--force]" >&2
     exit 2
 fi
 
 DATE="$1"
-TAG="${2:-v${DATE}}"
+shift
+TAG="v${DATE}"
+FORCE=false
+
+if [[ $# -gt 0 && "$1" != "--force" ]]; then
+    TAG="$1"
+    shift
+fi
+if [[ $# -gt 0 && "$1" == "--force" ]]; then
+    FORCE=true
+    shift
+fi
+if [[ $# -ne 0 ]]; then
+    echo "usage: $0 <YYYY.M.D> [<git-tag>] [--force]" >&2
+    exit 2
+fi
 
 # Locate repo root so this script works from any cwd.
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
@@ -61,18 +79,68 @@ if [[ ! "${DATE}" =~ ^[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
     echo "error: <date> must look like YYYY.M.D (got '${DATE}')" >&2
     exit 2
 fi
+IFS=. read -r _ MONTH DAY <<< "${DATE}"
+if (( 10#${MONTH} < 1 || 10#${MONTH} > 12 || 10#${DAY} < 1 || 10#${DAY} > 31 )); then
+    echo "error: <date> month/day is out of range (got '${DATE}')" >&2
+    exit 2
+fi
+
+# Git permits several characters that are unsafe in a URL path or unquoted
+# YAML scalar. Release tags only need this conservative CalVer-safe subset.
+if [[ ! "${TAG}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+    echo "error: <git-tag> contains unsupported characters (got '${TAG}')" >&2
+    exit 2
+fi
+
+if [[ -e "${OUT}" && "${FORCE}" != true ]]; then
+    echo "error: ${OUT} already exists; pass --force to replace it" >&2
+    exit 1
+fi
 
 # Slice the `## [DATE]` block out of CHANGELOG.md, stopping at the next `## [`.
 # Match a fixed string (the literal heading) rather than a regex so the dots
 # in the date don't get interpreted as wildcards (BSD awk has no gensub).
 HEADING="## [${DATE}]"
-SECTION="$(awk -v h="${HEADING}" '
-    index($0, h) == 1 && !found {found=1; next}
-    found && /^## \[/ {exit}
-    found {print}
-' "${CHANGELOG}")"
+if ! EXTRACTED="$(awk -v h="${HEADING}" '
+    function fence_marker(line, trimmed) {
+        trimmed = line
+        sub(/^[[:space:]]*/, "", trimmed)
+        if (trimmed ~ /^```/) return "`"
+        if (trimmed ~ /^~~~/) return "~"
+        return ""
+    }
 
-if [[ -z "${SECTION//[[:space:]]/}" ]]; then
+    {
+        marker = fence_marker($0)
+        if (!in_fence && marker != "") {
+            in_fence = 1
+            fence = marker
+        } else if (in_fence && marker == fence) {
+            in_fence = 0
+            fence = ""
+        }
+
+        if (!found && !in_fence && marker == "" && index($0, h) == 1 &&
+            substr($0, length(h) + 1) ~ /^([[:space:]]|$)/) {
+            found = 1
+            print "HEADING\t" $0
+            next
+        }
+
+        if (found) {
+            if (!in_fence && marker == "" && /^## \[/) exit
+            print "BODY\t" $0
+        }
+    }
+' "${CHANGELOG}")"; then
+    echo "error: failed to read ${CHANGELOG}" >&2
+    exit 1
+fi
+
+RELEASE_HEADING="$(printf '%s\n' "${EXTRACTED}" | awk -F '\t' '$1 == "HEADING" {sub(/^HEADING\t/, ""); print; exit}')"
+SECTION="$(printf '%s\n' "${EXTRACTED}" | sed -n 's/^BODY\t//p')"
+
+if [[ -z "${RELEASE_HEADING}" || -z "${SECTION//[[:space:]]/}" ]]; then
     echo "error: no '## [${DATE}]' section found in CHANGELOG.md" >&2
     exit 1
 fi
@@ -84,13 +152,14 @@ SECTION_TRIMMED="$(printf '%s\n' "${SECTION}" | awk '
     END {sub(/\n+$/, "", buf); printf "%s", buf}
 ')"
 
-# CHANGELOG anchor on GitHub: keep-a-changelog renders `## [2026.4.27] - 2026-04-27`
-# as id="2026427---2026-04-27" but we link to the simpler `#YYYY-M-D` slug GitHub
-# also recognises via the date suffix; fall back to the full file at worst.
-ANCHOR_DATE="${DATE//./-}"
+# Derive GitHub's heading slug from the complete release heading. For example,
+# `## [2026.4.27] - 2026-04-27` becomes `2026427---2026-04-27`.
+ANCHOR="$(printf '%s' "${RELEASE_HEADING#\#\# }" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -e 's/\[//g' -e 's/\]//g' -e 's/\.//g' -e 's/[[:space:]]/-/g')"
 
 CANONICAL="https://github.com/librefang/librefang/releases/tag/${TAG}"
-CHANGELOG_LINK="https://github.com/librefang/librefang/blob/main/CHANGELOG.md#${ANCHOR_DATE}"
+CHANGELOG_LINK="https://github.com/librefang/librefang/blob/main/CHANGELOG.md#${ANCHOR}"
 
 # Heredoc with the same dev.to-friendly shape as the most recent hand-written
 # articles (release-2026.3.22.md, release-2026.3.21.md): outer ```markdown


### PR DESCRIPTION
## Summary
- derive working GitHub changelog anchors from the complete release heading
- validate release tags before URL/front-matter interpolation and validate month/day ranges
- keep fenced markdown headings inside the selected release body and propagate awk failures
- preserve existing hand-edited articles unless --force is explicit

## Verification
- bash -n scripts/changelog-to-article.sh
- shellcheck scripts/changelog-to-article.sh
- generated 2026.6.26 fixture links to #2026626---2026-06-26
- fenced-heading fixture preserves content after an inner ## [ heading
- newline/front-matter tag injection rejected
- existing output rejected by default; explicit --force succeeds
- invalid month/day rejected
- git diff --check