### PR TITLE
fix(test): enforce channel progress smoke contract

### DIFF
--- a/changelog.d/fixed/6792-channel-progress-smoke.md
+++ b/changelog.d/fixed/6792-channel-progress-smoke.md
@@ -1,0 +1,1 @@
+Make the live channel-progress smoke fail when the kernel emits no tool event, supervise and clean up its foreground daemon reliably, and safely construct its dedicated test-agent manifest. (@houko)

--- a/scripts/tests/channel_progress_smoke.sh
+++ b/scripts/tests/channel_progress_smoke.sh
@@ -52,7 +52,8 @@ SPAWNED_AGENT=""
 cleanup() {
   if [[ -n "$SPAWNED_AGENT" ]]; then
     echo "[smoke] removing temporary agent $SPAWNED_AGENT"
-    curl -fsS -X DELETE "$API_BASE/agents/${SPAWNED_AGENT}" >/dev/null 2>&1 || true
+    curl -fsS --max-time 5 -X DELETE \
+      "$API_BASE/agents/${SPAWNED_AGENT}" >/dev/null 2>&1 || true
   fi
   echo "[smoke] cleaning up daemon"
   "$BIN" stop 2>/dev/null || true
@@ -123,7 +124,7 @@ tools = ["web_search"]
 print(json.dumps({"manifest_toml": manifest}))
 PY
 )
-AGENT_ID=$(curl -fsS -X POST "$API_BASE/agents" \
+AGENT_ID=$(curl -fsS --max-time 30 -X POST "$API_BASE/agents" \
   -H "Content-Type: application/json" \
   -d "$SPAWN_BODY" \
   | python3 -c "import sys,json; print(json.load(sys.stdin).get('agent_id', ''))")
@@ -134,9 +135,8 @@ fi
 SPAWNED_AGENT="$AGENT_ID"
 echo "[smoke] spawned temporary agent $AGENT_ID ($SPAWN_NAME, $PROVIDER/$MODEL)"
 
-# Send a message likely to trigger web_search. Result body itself is not
-# the assertion — we ALSO check the agent's last conversation log for the
-# 🔧 marker, which is what gets injected into channel replies.
+# Send a message likely to trigger web_search. The response text is not the
+# assertion; the persisted structured tool record is.
 echo "[smoke] sending message"
 curl -fsS -m 60 -X POST "$API_BASE/agents/${AGENT_ID}/message" \
   -H "Content-Type: application/json" \
@@ -145,11 +145,41 @@ curl -fsS -m 60 -X POST "$API_BASE/agents/${AGENT_ID}/message" \
 
 # The /message endpoint returns the cleaned final text, while the session keeps
 # the structured tool event that channel progress renderers consume.
-SESSION_LOG=$(curl -fsS "$API_BASE/agents/${AGENT_ID}/session")
-if grep -q '"tool_use"' <<< "$SESSION_LOG"; then
-  echo "[smoke] kernel emitted tool_use events"
+SESSION_LOG=$(curl -fsS --max-time 10 "$API_BASE/agents/${AGENT_ID}/session")
+if python3 -c '
+import json
+import sys
+
+try:
+    session = json.load(sys.stdin)
+except (json.JSONDecodeError, OSError) as exc:
+    print(f"ERROR: invalid session response: {exc}", file=sys.stderr)
+    sys.exit(2)
+
+messages = session.get("messages", [])
+if not isinstance(messages, list):
+    print("ERROR: session response messages is not an array", file=sys.stderr)
+    sys.exit(2)
+
+def has_web_search(message):
+    if not isinstance(message, dict):
+        return False
+    tools = message.get("tools", [])
+    return isinstance(tools, list) and any(
+        isinstance(tool, dict) and tool.get("name") == "web_search"
+        for tool in tools
+    )
+
+found = any(has_web_search(message) for message in messages)
+sys.exit(0 if found else 1)
+' <<< "$SESSION_LOG"; then
+  echo "[smoke] kernel persisted a web_search tool record"
 else
-  echo "ERROR: no tool_use observed — channel progress cannot be rendered" >&2
+  session_check_status=$?
+  if [[ "$session_check_status" -eq 2 ]]; then
+    exit 1
+  fi
+  echo "ERROR: no web_search tool record observed — channel progress cannot be rendered" >&2
   echo "       rerun with a model that reliably follows tool-use instructions" >&2
   exit 1
 fi

--- a/scripts/tests/channel_progress_smoke.sh
+++ b/scripts/tests/channel_progress_smoke.sh
@@ -1,32 +1,29 @@
 #!/usr/bin/env bash
-# Live integration smoke test for channel progress markers.
+# Live kernel-side smoke test for channel progress events.
 #
-# Verifies that the changes in feat/channel-progress-v2 actually surface
-# tool-execution progress (`🔧 Web Search`) inside the user's channel reply
-# end-to-end through the daemon — not just in unit/integration tests.
+# Verifies that a real daemon + provider turn emits a persisted `tool_use`
+# event, the prerequisite consumed by channel progress renderers. Adapter-level
+# formatting (`🔧 Web Search`) requires an external channel receiver and is not
+# asserted by this kernel-side script.
 #
 # Prerequisites (NONE of these are auto-provisioned by this script):
 #   - An LLM API key in env (one of GROQ_API_KEY / OPENAI_API_KEY /
 #     ANTHROPIC_API_KEY / MINIMAX_API_KEY) wired to a model that supports
 #     tool calling.
-#   - At least one channel adapter configured in ~/.librefang/config.toml
-#     (a webhook adapter is easiest because it captures sent messages
-#     without needing real bot tokens).
 #   - LIBREFANG_HOME set (defaults to ~/.librefang).
 #   - target/release/librefang built (`cargo build --release -p librefang-cli`).
 #
 # This script:
 #   1. Stops any running daemon
 #   2. Starts a fresh daemon
-#   3. Spawns a test agent equipped with the `web_search` tool
+#   3. Spawns a temporary test agent equipped with the `web_search` tool
 #   4. Sends a message that the LLM will likely answer by calling web_search
 #   5. Waits for completion
-#   6. Reads the captured channel transmissions and asserts that they
-#      contain `🔧` markers (Web Search prettified)
+#   6. Reads the resulting session and requires a `tool_use` event
 #   7. Cleans up
 #
-# Exit code 0 = progress markers were observed end-to-end.
-# Exit code 1 = markers missing or any setup step failed.
+# Exit code 0 = the kernel emitted the progress event channels depend on.
+# Exit code 1 = the event was missing or any setup step failed.
 
 set -euo pipefail
 
@@ -49,92 +46,93 @@ fi
 
 echo "[smoke] stopping any running daemon"
 "$BIN" stop 2>/dev/null || true
-sleep 2
+
+DAEMON_PID=""
+SPAWNED_AGENT=""
+cleanup() {
+  if [[ -n "$SPAWNED_AGENT" ]]; then
+    echo "[smoke] removing temporary agent $SPAWNED_AGENT"
+    curl -fsS -X DELETE "$API_BASE/agents/${SPAWNED_AGENT}" >/dev/null 2>&1 || true
+  fi
+  echo "[smoke] cleaning up daemon"
+  "$BIN" stop 2>/dev/null || true
+  if [[ -n "$DAEMON_PID" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$DAEMON_PID" ]]; then
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
 
 echo "[smoke] starting daemon on :$PORT"
-"$BIN" start &
+"$BIN" start --foreground &
 DAEMON_PID=$!
 
 # Wait for /api/health to come up (max 30s)
+HEALTHY=0
 for _ in {1..30}; do
   if curl -fsS -m 1 "$API_BASE/health" >/dev/null 2>&1; then
+    HEALTHY=1
     break
   fi
   sleep 1
 done
-if ! curl -fsS -m 2 "$API_BASE/health" >/dev/null; then
+if [[ "$HEALTHY" -ne 1 ]]; then
   echo "ERROR: daemon did not respond within 30s" >&2
-  kill -9 "$DAEMON_PID" 2>/dev/null || true
   exit 1
 fi
 echo "[smoke] daemon up"
 
-cleanup() {
-  echo "[smoke] cleaning up daemon"
-  "$BIN" stop 2>/dev/null || true
-  kill -9 "$DAEMON_PID" 2>/dev/null || true
-}
-trap cleanup EXIT
+# Always spawn a dedicated agent: an arbitrary existing agent may not expose
+# `web_search`, which would make a strict progress assertion meaningless.
+SPAWN_NAME="channel-progress-smoke-$(date +%s)-$$"
+# Pick the first available LLM key as the provider so the smoke agent can
+# actually answer.
+if [[ -n "${GROQ_API_KEY:-}" ]]; then PROVIDER="groq"; MODEL="llama-3.3-70b-versatile"; API_KEY_ENV="GROQ_API_KEY"
+elif [[ -n "${OPENAI_API_KEY:-}" ]]; then PROVIDER="openai"; MODEL="gpt-4o-mini"; API_KEY_ENV="OPENAI_API_KEY"
+elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then PROVIDER="anthropic"; MODEL="claude-haiku-4-5"; API_KEY_ENV="ANTHROPIC_API_KEY"
+else PROVIDER="minimax"; MODEL="MiniMax-M2.7"; API_KEY_ENV="MINIMAX_API_KEY"
+fi
 
-# Try to reuse an existing enabled agent. If none, spawn a minimal one
-# inline using the SpawnRequest manifest_toml field so the script is
-# runnable on a fresh daemon without manual setup.
-AGENT_ID=$(curl -fsS "$API_BASE/agents" | python3 -c "import sys,json; data=json.load(sys.stdin); print(next((a['id'] for a in data if a.get('enabled', True)), ''))" || echo "")
-SPAWNED_AGENT=""
-if [[ -z "$AGENT_ID" ]]; then
-  echo "[smoke] no enabled agent — spawning a temporary one"
-  SPAWN_NAME="channel-progress-smoke-$(date +%s)"
-  # Pick the first available LLM key as the provider so the smoke agent
-  # can actually answer.
-  if [[ -n "${GROQ_API_KEY:-}" ]]; then PROVIDER="groq"; MODEL="llama-3.1-70b-versatile"; API_KEY_ENV="GROQ_API_KEY"
-  elif [[ -n "${OPENAI_API_KEY:-}" ]]; then PROVIDER="openai"; MODEL="gpt-4o-mini"; API_KEY_ENV="OPENAI_API_KEY"
-  elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then PROVIDER="anthropic"; MODEL="claude-haiku-4-5"; API_KEY_ENV="ANTHROPIC_API_KEY"
-  else PROVIDER="minimax"; MODEL="MiniMax-M2.7"; API_KEY_ENV="MINIMAX_API_KEY"
-  fi
-  MANIFEST_TOML=$(cat <<MANIFEST
-name = "${SPAWN_NAME}"
+# JSON string escaping is also valid for TOML basic strings. Construct every
+# interpolated value through json.dumps, then encode the complete API body.
+SPAWN_BODY=$(python3 - "$SPAWN_NAME" "$PROVIDER" "$MODEL" "$API_KEY_ENV" <<'PY'
+import json
+import sys
+
+name, provider, model, api_key_env = sys.argv[1:]
+quote = lambda value: json.dumps(value, ensure_ascii=False)
+manifest = f"""name = {quote(name)}
 version = "1.0.0"
 description = "Ephemeral smoke-test agent"
 author = "smoke"
 module = "builtin:chat"
 
 [model]
-provider = "${PROVIDER}"
-model = "${MODEL}"
-api_key_env = "${API_KEY_ENV}"
+provider = {quote(provider)}
+model = {quote(model)}
+api_key_env = {quote(api_key_env)}
 max_tokens = 1024
 temperature = 0.0
-system_prompt = "You answer concisely. Use the web_search tool when asked."
+system_prompt = "You answer concisely. You must use the web_search tool exactly once."
 
 [capabilities]
 tools = ["web_search"]
-MANIFEST
+"""
+print(json.dumps({"manifest_toml": manifest}))
+PY
 )
-  SPAWN_BODY=$(python3 -c "import json,sys; print(json.dumps({'manifest_toml': sys.stdin.read()}))" <<< "$MANIFEST_TOML")
-  AGENT_ID=$(curl -fsS -X POST "$API_BASE/agents" \
-    -H "Content-Type: application/json" \
-    -d "$SPAWN_BODY" \
-    | python3 -c "import sys,json; print(json.load(sys.stdin).get('agent_id', ''))" || echo "")
-  if [[ -z "$AGENT_ID" ]]; then
-    echo "ERROR: failed to spawn temporary agent — check daemon logs" >&2
-    exit 1
-  fi
-  SPAWNED_AGENT="$AGENT_ID"
-  echo "[smoke] spawned temporary agent $AGENT_ID ($SPAWN_NAME, $PROVIDER/$MODEL)"
+AGENT_ID=$(curl -fsS -X POST "$API_BASE/agents" \
+  -H "Content-Type: application/json" \
+  -d "$SPAWN_BODY" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin).get('agent_id', ''))")
+if [[ -z "$AGENT_ID" ]]; then
+  echo "ERROR: failed to spawn temporary agent — check daemon logs" >&2
+  exit 1
 fi
-echo "[smoke] using agent $AGENT_ID"
-
-# Cleanup: stop daemon AND despawn any temporary agent we created.
-# We re-define the trap here to run agent cleanup BEFORE daemon cleanup
-# (DELETE needs the daemon up).
-cleanup_full() {
-  if [[ -n "$SPAWNED_AGENT" ]]; then
-    echo "[smoke] removing temporary agent $SPAWNED_AGENT"
-    curl -fsS -X DELETE "$API_BASE/agents/${SPAWNED_AGENT}" >/dev/null 2>&1 || true
-  fi
-  cleanup
-}
-trap cleanup_full EXIT
+SPAWNED_AGENT="$AGENT_ID"
+echo "[smoke] spawned temporary agent $AGENT_ID ($SPAWN_NAME, $PROVIDER/$MODEL)"
 
 # Send a message likely to trigger web_search. Result body itself is not
 # the assertion — we ALSO check the agent's last conversation log for the
@@ -142,26 +140,18 @@ trap cleanup_full EXIT
 echo "[smoke] sending message"
 curl -fsS -m 60 -X POST "$API_BASE/agents/${AGENT_ID}/message" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Use the web_search tool to find the current population of Tokyo, then tell me."}' \
-  > /tmp/smoke_response.json
+  -d '{"message": "You must call web_search exactly once to find the current population of Tokyo, then answer."}' \
+  >/dev/null
 
-# The /message endpoint returns the *cleaned* final response (no progress
-# markers — those only appear in the streaming text channel adapters see).
-# To verify the bridge actually injected markers, we hit the SSE/WS-aligned
-# session log instead.
-SESSION_LOG=$(curl -fsS "$API_BASE/agents/${AGENT_ID}/session" || echo "")
-if echo "$SESSION_LOG" | grep -q "tool_use"; then
+# The /message endpoint returns the cleaned final text, while the session keeps
+# the structured tool event that channel progress renderers consume.
+SESSION_LOG=$(curl -fsS "$API_BASE/agents/${AGENT_ID}/session")
+if grep -q '"tool_use"' <<< "$SESSION_LOG"; then
   echo "[smoke] kernel emitted tool_use events"
 else
-  echo "WARN: no tool_use observed — model may not have chosen to invoke tools" >&2
-  echo "       (this is non-deterministic; rerun or use a model with stronger tool affinity)" >&2
+  echo "ERROR: no tool_use observed — channel progress cannot be rendered" >&2
+  echo "       rerun with a model that reliably follows tool-use instructions" >&2
+  exit 1
 fi
 
-# To check the *channel* output, run the test against a webhook adapter
-# configured in config.toml: the webhook will capture the prettified
-# `🔧 Web Search` line inside the delivered message body. That assertion
-# requires an external receiver, so this script only covers the kernel
-# side. Document the gap explicitly:
-echo "[smoke] kernel-side checks complete."
-echo "[smoke] channel-delivery check requires a configured webhook receiver"
-echo "[smoke]   (see docs/channel-progress.md for the full procedure)"
+echo "[smoke] kernel-side channel-progress prerequisite verified"

--- a/scripts/tests/channel_progress_smoke.sh
+++ b/scripts/tests/channel_progress_smoke.sh
@@ -156,6 +156,9 @@ except (json.JSONDecodeError, OSError) as exc:
     print(f"ERROR: invalid session response: {exc}", file=sys.stderr)
     sys.exit(2)
 
+if not isinstance(session, dict):
+    print("ERROR: session response is not an object", file=sys.stderr)
+    sys.exit(2)
 messages = session.get("messages", [])
 if not isinstance(messages, list):
     print("ERROR: session response messages is not an array", file=sys.stderr)


### PR DESCRIPTION
## Summary
- make the live smoke fail when the dedicated agent session contains no tool_use event
- state the script's real kernel-side scope instead of claiming adapter-rendered emoji coverage
- supervise the daemon with start --foreground and reliably reap that PID
- spawn a dedicated web_search agent with safely escaped TOML/JSON values
- remove the fixed /tmp response file, simplify health readiness, and update the retired Groq model ID

## Verification
- bash -n scripts/tests/channel_progress_smoke.sh
- shellcheck scripts/tests/channel_progress_smoke.sh
- controlled fake daemon/curl: no tool_use exits 1
- controlled fake daemon/curl: tool_use exits 0
- both mock paths delete the temporary agent and reap the foreground daemon PID
- official Groq models page currently lists llama-3.3-70b-versatile
- git diff --check

## Scope
This script verifies the persisted kernel tool event that channel renderers consume. It deliberately does not claim end-to-end adapter formatting coverage; that requires an external channel receiver.