### PR TITLE
fix(go-sdk): repair streaming example

### DIFF
--- a/changelog.d/fixed/6793-go-streaming-example.md
+++ b/changelog.d/fixed/6793-go-streaming-example.md
@@ -1,0 +1,1 @@
+Repair the Go SDK streaming example so it compiles, validates dynamic agent IDs instead of panicking, and reports stream error events instead of silently succeeding. (@houko)

--- a/sdk/go/examples/streaming.go
+++ b/sdk/go/examples/streaming.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	client := librefang.New("http://localhost:4545")
 
-	raw, err := client.Agents.ListAgents()
+	raw, err := client.Agents.ListAgents(nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -20,7 +20,11 @@ func main() {
 
 	var agentID string
 	if len(agents) > 0 {
-		agentID = agents[0]["id"].(string)
+		id, ok := agents[0]["id"].(string)
+		if !ok || id == "" {
+			log.Fatal("existing agent entry is missing a valid id")
+		}
+		agentID = id
 		fmt.Println("Using existing agent:", agentID)
 	} else {
 		agent, err := client.Agents.SpawnAgent(map[string]interface{}{
@@ -29,7 +33,11 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		agentID = librefang.ToMap(agent)["id"].(string)
+		id, ok := librefang.ToMap(agent)["id"].(string)
+		if !ok || id == "" {
+			log.Fatal("spawned agent response is missing a valid id")
+		}
+		agentID = id
 		fmt.Println("Created agent:", agentID)
 	}
 
@@ -37,9 +45,13 @@ func main() {
 	for event := range client.Agents.SendMessageStream(agentID, map[string]interface{}{
 		"message": "Say hello in 3 words.",
 	}) {
+		if errMessage, ok := event["error"].(string); ok {
+			log.Fatal("stream failed: ", errMessage)
+		}
 		if delta, ok := event["delta"].(string); ok {
 			fmt.Print(delta)
-		} else if eventType, ok := event["type"].(string); ok {
+		}
+		if eventType, ok := event["type"].(string); ok {
 			if eventType == "done" {
 				fmt.Println("\n--- Done ---")
 			}

--- a/sdk/go/examples/streaming.go
+++ b/sdk/go/examples/streaming.go
@@ -42,19 +42,22 @@ func main() {
 	}
 
 	fmt.Println("\n--- Streaming response ---")
+	sawDone := false
 	for event := range client.Agents.SendMessageStream(agentID, map[string]interface{}{
 		"message": "Say hello in 3 words.",
 	}) {
 		if errMessage, ok := event["error"].(string); ok {
 			log.Fatal("stream failed: ", errMessage)
 		}
-		if delta, ok := event["delta"].(string); ok {
-			fmt.Print(delta)
+		if content, ok := event["content"].(string); ok {
+			fmt.Print(content)
 		}
-		if eventType, ok := event["type"].(string); ok {
-			if eventType == "done" {
-				fmt.Println("\n--- Done ---")
-			}
+		if done, ok := event["done"].(bool); ok && done {
+			sawDone = true
+			fmt.Println("\n--- Done ---")
 		}
+	}
+	if !sawDone {
+		log.Fatal("stream ended before the done event")
 	}
 }

--- a/sdk/go/examples/streaming.go
+++ b/sdk/go/examples/streaming.go
@@ -33,9 +33,9 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		id, ok := librefang.ToMap(agent)["id"].(string)
+		id, ok := librefang.ToMap(agent)["agent_id"].(string)
 		if !ok || id == "" {
-			log.Fatal("spawned agent response is missing a valid id")
+			log.Fatal("spawned agent response is missing a valid agent_id")
 		}
 		agentID = id
 		fmt.Println("Created agent:", agentID)


### PR DESCRIPTION
## Summary
- pass the required nil query to ListAgents so the example compiles
- validate existing and newly spawned agent IDs instead of panicking on type assertions
- surface stream error events as fatal failures instead of silently succeeding
- handle delta and done fields independently

## Verification
- go build examples/streaming.go (from sdk/go)
- go test ./...
- go vet ./...
- git diff --check