### PR TITLE
fix(python-sdk): package modules in legacy builds

### DIFF
--- a/changelog.d/fixed/6794-python-sdk-packaging.md
+++ b/changelog.d/fixed/6794-python-sdk-packaging.md
@@ -1,0 +1,1 @@
+Package the real `librefang` Python module tree in legacy setuptools builds, with distribution name and version metadata kept in sync with `pyproject.toml`. (@houko)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -102,7 +102,8 @@ The regex is `'-(beta|rc)\.?[0-9]'` — the `\.?` is what made the legacy
 - `calver_re_accepts_both_forms` — channel-pick validator accepts both.
 
 `xtask/src/sync_versions.rs::tests` mirrors the same coverage for
-`validate_calver`, the PEP 440 conversion, and the Tauri patch regex.
+`validate_calver`, the Python `pyproject.toml` PEP 440 update, and the Tauri
+patch regex.
 
 ## Operator quick reference
 

--- a/sdk/python/librefang/__init__.py
+++ b/sdk/python/librefang/__init__.py
@@ -7,10 +7,32 @@ Three packages:
 - librefang.sidecar: Framework for writing out-of-process channel adapters
 """
 
+import re
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
 from librefang.librefang_client import LibreFang as Client
 from librefang.librefang_sdk import Agent, read_input, respond, log
 
-__version__ = "0.5.2"
+
+def _package_version() -> str:
+    source_pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if source_pyproject.is_file():
+        match = re.search(
+            r'^version\s*=\s*"([^"]+)"',
+            source_pyproject.read_text(encoding="utf-8"),
+            re.MULTILINE,
+        )
+        if match is not None:
+            return match.group(1)
+
+    try:
+        return version("librefang-sdk")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+__version__ = _package_version()
 
 __all__ = ["Client", "Agent", "read_input", "respond", "log"]
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = []
 dev = [
     "pytest",
     "pytest-asyncio",
+    "setuptools>=61.0",
 ]
 
 [project.urls]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "setuptools>=61.0",
+    "wheel",
 ]
 
 [project.urls]
@@ -47,7 +48,7 @@ exclude = ["examples*"]
 [tool.setuptools.package-data]
 # `sidecar/template/*` ships the adapter scaffold the sidecar docs tell
 # users to copy — without this it is absent from the installed wheel.
-librefang = ["py.typed", "sidecar/template/*"]
+librefang = ["sidecar/template/*"]
 
 # `python_files = ["*.py"]` made pytest import every example *script*
 # as a test module (they target the legacy flat `librefang_sdk`

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -1,10 +1,24 @@
-from setuptools import setup
+import re
+from pathlib import Path
+
+from setuptools import find_packages, setup
+
+
+PYPROJECT = Path(__file__).with_name("pyproject.toml")
+PROJECT_VERSION = re.search(
+    r'^version\s*=\s*"([^"]+)"',
+    PYPROJECT.read_text(encoding="utf-8"),
+    re.MULTILINE,
+)
+if PROJECT_VERSION is None:
+    raise RuntimeError("project version is missing from pyproject.toml")
 
 setup(
-    name="librefang",
-    version="2026.7.31",
+    name="librefang-sdk",
+    version=PROJECT_VERSION.group(1),
     description="Official Python client for the LibreFang Agent OS REST API",
-    py_modules=["librefang_sdk", "librefang_client"],
+    packages=find_packages(include=("librefang", "librefang.*")),
+    package_data={"librefang": ["py.typed", "sidecar/template/*"]},
     python_requires=">=3.8",
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -18,7 +18,7 @@ setup(
     version=PROJECT_VERSION.group(1),
     description="Official Python client for the LibreFang Agent OS REST API",
     packages=find_packages(include=("librefang", "librefang.*")),
-    package_data={"librefang": ["py.typed", "sidecar/template/*"]},
+    package_data={"librefang": ["sidecar/template/*"]},
     python_requires=">=3.8",
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/sdk/python/tests/test_packaging.py
+++ b/sdk/python/tests/test_packaging.py
@@ -1,0 +1,39 @@
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _project_version(pyproject: Path) -> str:
+    match = re.search(
+        r'^version\s*=\s*"([^"]+)"',
+        pyproject.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert match is not None
+    return match.group(1)
+
+
+def test_legacy_setup_metadata_includes_real_package(tmp_path):
+    project = Path(__file__).parents[1]
+    checkout = tmp_path / "project"
+    shutil.copytree(project, checkout)
+
+    egg_base = tmp_path / "egg-info"
+    egg_base.mkdir()
+    subprocess.run(
+        [sys.executable, "setup.py", "egg_info", "--egg-base", str(egg_base)],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    egg_info = next(egg_base.glob("*.egg-info"))
+    metadata = (egg_info / "PKG-INFO").read_text(encoding="utf-8")
+    top_level = (egg_info / "top_level.txt").read_text(encoding="utf-8").splitlines()
+
+    assert "Name: librefang-sdk" in metadata
+    assert f"Version: {_project_version(checkout / 'pyproject.toml')}" in metadata
+    assert top_level == ["librefang"]

--- a/sdk/python/tests/test_packaging.py
+++ b/sdk/python/tests/test_packaging.py
@@ -1,39 +1,64 @@
+import os
 import re
 import shutil
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
-
-
-def _project_version(pyproject: Path) -> str:
-    match = re.search(
-        r'^version\s*=\s*"([^"]+)"',
-        pyproject.read_text(encoding="utf-8"),
-        re.MULTILINE,
-    )
-    assert match is not None
-    return match.group(1)
 
 
 def test_legacy_setup_metadata_includes_real_package(tmp_path):
     project = Path(__file__).parents[1]
     checkout = tmp_path / "project"
-    shutil.copytree(project, checkout)
+    checkout.mkdir()
+    for filename in ("setup.py", "pyproject.toml", "README.md", "LICENSE"):
+        shutil.copy2(project / filename, checkout / filename)
+    shutil.copytree(project / "librefang", checkout / "librefang")
 
-    egg_base = tmp_path / "egg-info"
-    egg_base.mkdir()
+    fixture_version = "2099.1.2rc3"
+    pyproject = checkout / "pyproject.toml"
+    pyproject.write_text(
+        re.sub(
+            r'^version\s*=\s*"[^"]+"',
+            f'version = "{fixture_version}"',
+            pyproject.read_text(encoding="utf-8"),
+            count=1,
+            flags=re.MULTILINE,
+        ),
+        encoding="utf-8",
+    )
+
+    dist_dir = tmp_path / "dist"
     subprocess.run(
-        [sys.executable, "setup.py", "egg_info", "--egg-base", str(egg_base)],
+        [sys.executable, "setup.py", "bdist_wheel", "--dist-dir", str(dist_dir)],
         cwd=checkout,
         check=True,
         capture_output=True,
         text=True,
     )
 
-    egg_info = next(egg_base.glob("*.egg-info"))
-    metadata = (egg_info / "PKG-INFO").read_text(encoding="utf-8")
-    top_level = (egg_info / "top_level.txt").read_text(encoding="utf-8").splitlines()
+    wheel = next(dist_dir.glob("*.whl"))
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+        metadata_name = next(name for name in names if name.endswith(".dist-info/METADATA"))
+        metadata = archive.read(metadata_name).decode("utf-8")
 
     assert "Name: librefang-sdk" in metadata
-    assert f"Version: {_project_version(checkout / 'pyproject.toml')}" in metadata
-    assert top_level == ["librefang"]
+    assert f"Version: {fixture_version}" in metadata
+    assert "librefang/__init__.py" in names
+    assert "librefang/sidecar/adapters/discord.py" in names
+    assert "librefang/sidecar/template/README.md" in names
+    assert "librefang/sidecar/template/adapter.py.tmpl" in names
+    assert "librefang/sidecar/template/requirements.txt" in names
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(wheel)
+    imported_version = subprocess.run(
+        [sys.executable, "-c", "import librefang; print(librefang.__version__)"],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert imported_version == fixture_version

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -113,7 +113,7 @@ cargo xtask sync-versions 2026.3.2214-rc1   # pre-release version
 Updates:
 - `Cargo.toml` workspace version
 - `sdk/javascript/package.json`
-- `sdk/python/setup.py` (PEP 440: `-beta1` → `b1`)
+- `sdk/python/pyproject.toml` (PEP 440: `-beta1` → `b1`)
 - `sdk/rust/Cargo.toml` + `README.md`
 - `packages/whatsapp-gateway/package.json`
 - `crates/librefang-desktop/tauri.conf.json` (MSI-compatible encoding)

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -113,6 +113,7 @@ const RELEASE_STAGED_PATHS: &[&str] = &[
     "openapi.json",
     "sdk/javascript/package.json",
     "sdk/javascript/index.js",
+    "sdk/python/pyproject.toml",
     "sdk/python/setup.py",
     "sdk/python/librefang/librefang_client.py",
     "sdk/rust/Cargo.toml",
@@ -1366,6 +1367,14 @@ mod tests {
         assert!(
             RELEASE_STAGED_PATHS.contains(&"xtask/baselines"),
             "the schema baselines must ship in the release commit alongside openapi.json"
+        );
+    }
+
+    #[test]
+    fn release_staging_includes_python_project_metadata() {
+        assert!(
+            RELEASE_STAGED_PATHS.contains(&"sdk/python/pyproject.toml"),
+            "the version-bearing Python project metadata must ship in the release commit"
         );
     }
 

--- a/xtask/src/sync_versions.rs
+++ b/xtask/src/sync_versions.rs
@@ -101,23 +101,40 @@ fn update_rust_sdk_readme(path: &Path, version: &str) -> Result<(), Box<dyn std:
     Ok(())
 }
 
-fn update_python_setup(path: &Path, version: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn pypi_version(version: &str) -> String {
+    version
+        .replace("-beta.", "b")
+        .replace("-rc.", "rc")
+        .replace("-beta", "b")
+        .replace("-rc", "rc")
+}
+
+fn python_pyproject_with_version(
+    content: &str,
+    version: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut doc = content.parse::<toml_edit::DocumentMut>()?;
+    if doc["project"]["version"].as_str().is_none() {
+        return Err("sdk/python/pyproject.toml is missing project.version".into());
+    }
+    doc["project"]["version"] = toml_edit::value(pypi_version(version));
+    Ok(doc.to_string())
+}
+
+fn update_python_pyproject(path: &Path, version: &str) -> Result<(), Box<dyn std::error::Error>> {
     if !path.exists() {
         return Ok(());
     }
     // PEP 440: -beta.1 → b1, -rc.1 → rc1 (canonical SemVer form, #3310).
     // Also strip the legacy `-beta1` / `-rc1` (no dot) for backward compat
     // when re-syncing from a historical Cargo.toml.
-    let py_version = version
-        .replace("-beta.", "b")
-        .replace("-rc.", "rc")
-        .replace("-beta", "b")
-        .replace("-rc", "rc");
     let content = fs::read_to_string(path)?;
-    let re = Regex::new(r#"version="[^"]*""#)?;
-    let new_content = re.replace(&content, format!(r#"version="{}""#, py_version).as_str());
-    fs::write(path, new_content.as_ref())?;
-    println!("  Updated sdk/python/setup.py (PEP 440: {})", py_version);
+    let new_content = python_pyproject_with_version(&content, version)?;
+    fs::write(path, new_content)?;
+    println!(
+        "  Updated sdk/python/pyproject.toml (PEP 440: {})",
+        pypi_version(version)
+    );
     Ok(())
 }
 
@@ -202,7 +219,7 @@ pub fn run(args: SyncVersionsArgs) -> Result<(), Box<dyn std::error::Error>> {
     update_rust_sdk_readme(&root.join("sdk/rust/README.md"), &version)?;
 
     // Update Python SDK
-    update_python_setup(&root.join("sdk/python/setup.py"), &version)?;
+    update_python_pyproject(&root.join("sdk/python/pyproject.toml"), &version)?;
 
     // Update WhatsApp gateway
     update_json_version(
@@ -271,15 +288,6 @@ mod tests {
         assert!(validate_calver("2026.5.4-beta").is_err()); // missing N
     }
 
-    // --- pypi_version conversion (mirrors the closure inside update_python_setup) ---
-    fn pypi_version(version: &str) -> String {
-        version
-            .replace("-beta.", "b")
-            .replace("-rc.", "rc")
-            .replace("-beta", "b")
-            .replace("-rc", "rc")
-    }
-
     #[test]
     fn pypi_version_canonical_form() {
         assert_eq!(pypi_version("2026.5.4-beta.1"), "2026.5.4b1");
@@ -295,6 +303,22 @@ mod tests {
     #[test]
     fn pypi_version_stable_unchanged() {
         assert_eq!(pypi_version("2026.5.4"), "2026.5.4");
+    }
+
+    #[test]
+    fn python_pyproject_version_is_updated_once() {
+        let input = r#"[project]
+name = "librefang-sdk"
+version = "0.5.2"
+
+[tool.example]
+version = "leave-me-alone"
+"#;
+        let updated = python_pyproject_with_version(input, "2026.8.9-rc.2").unwrap();
+
+        assert!(updated.contains("version = \"2026.8.9rc2\""));
+        assert!(updated.contains("version = \"leave-me-alone\""));
+        assert!(!updated.contains("version = \"0.5.2\""));
     }
 
     // --- prerelease_re used by tauri_patch ---


### PR DESCRIPTION
## Summary
- make compatibility `setup.py` package the real `librefang` tree while reading name/version metadata from `pyproject.toml`
- make installed `librefang.__version__` follow wheel metadata and source checkouts follow `pyproject.toml`
- move xtask version sync and release staging to the authoritative Python project metadata
- build and inspect a real legacy wheel in the regression test, including adapters and sidecar templates

## Verification
- `cargo test -p xtask` (114 passed)
- `uv run --python 3.12 --extra dev pytest -q` (1913 passed)
- legacy wheel fixture contains the package, adapter, and all template assets; imported version matches wheel metadata
- `git diff --check`