### PR TITLE
fix(xtask): restore sysinfo MSRV compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9429,9 +9429,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.6"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",

--- a/changelog.d/fixed/6797-xtask-sysinfo-msrv.md
+++ b/changelog.d/fixed/6797-xtask-sysinfo-msrv.md
@@ -1,0 +1,1 @@
+Restore `xtask` builds on the workspace Rust 1.94.1 MSRV by keeping its `sysinfo` dependency on the compatible 0.38 release line. (@houko)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -20,7 +20,7 @@ sha2 = { workspace = true }
 # Capped at 0.38: the entire sysinfo 0.39.x line requires rustc 1.95, which
 # exceeds this workspace's pinned MSRV (Cargo.toml rust-version = 1.94.1).
 # 0.38.4 needs only rustc 1.88 and exposes the same probe API we use.
-sysinfo = { version = "0.39", default-features = false, features = ["system"] }
+sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 librefang-import = { path = "../crates/librefang-import" }
 
 [lints]


### PR DESCRIPTION
## Summary
- cap xtask `sysinfo` to the 0.38 compatibility line documented by the manifest
- downgrade the lockfile from 0.39.6 (Rust 1.95 required) to 0.38.4

## Verification
- RED: Rust 1.94.1 rejected `sysinfo@0.39.6 requires rustc 1.95`
- GREEN: `rustup run 1.94.1 cargo check -p xtask`
- `cargo test -p xtask` (112 passed)
- `cargo clippy -p xtask -- -D warnings`
- `git diff --check`