### PR TITLE
fix(xtask): scan transitive dependency licenses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9138,6 +9138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081670c233dfbed55690cc0cd38424e0e24ac1b2673d0b408b3f7b684738dfa9"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12670,6 +12679,7 @@ dependencies = [
  "regex",
  "serde_json",
  "sha2 0.10.9",
+ "spdx",
  "sysinfo",
  "toml_edit 0.25.13+spec-1.1.0",
 ]

--- a/changelog.d/fixed/6798-license-check-transitive.md
+++ b/changelog.d/fixed/6798-license-check-transitive.md
@@ -1,0 +1,1 @@
+Make the `xtask` license fallback inspect the full Rust dependency graph and evaluate SPDX AND/OR expressions correctly instead of silently skipping third-party crates or matching license-name substrings. (@houko)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,6 +13,7 @@ regex = "1"
 chrono = "0.4"
 base64 = { workspace = true }
 sha2 = { workspace = true }
+spdx = "0.13.5"
 # Host probe (RAM / CPU) for `LIBREFANG_LOCAL_CHECK_MODE` auto-throttle (#3301).
 # Kept xtask-local; not promoted to workspace.dependencies because no
 # production crate consumes it. Default features are disabled — we only need

--- a/xtask/src/license_check.rs
+++ b/xtask/src/license_check.rs
@@ -50,6 +50,30 @@ fn has_commons_clause(license: &str) -> bool {
     lc.contains("commons clause") || lc.contains("commons-clause")
 }
 
+fn license_expression_is_denied(license: &str, denied: &[&str]) -> Result<bool, spdx::ParseError> {
+    let expression = spdx::Expression::parse(license)?;
+    let can_choose_permitted_terms = expression.evaluate(|requirement| {
+        let Some(id) = requirement.license.id() else {
+            return false;
+        };
+        !denied.iter().any(|denied_id| *denied_id == id.name)
+    });
+    Ok(!can_choose_permitted_terms)
+}
+
+fn load_cargo_metadata(root: &Path) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version=1"])
+        .current_dir(root)
+        .output()?;
+
+    if !output.status.success() {
+        return Err("cargo metadata failed".into());
+    }
+
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
+
 fn check_cargo_deny(root: &Path, denied: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
     // Try cargo-deny first
     let deny_check = Command::new("cargo").args(["deny", "--version"]).output();
@@ -68,16 +92,7 @@ fn check_cargo_deny(root: &Path, denied: &[&str]) -> Result<(), Box<dyn std::err
 
     // Fallback: use cargo metadata
     println!("cargo-deny not found, using cargo metadata fallback...");
-    let output = Command::new("cargo")
-        .args(["metadata", "--format-version=1", "--no-deps"])
-        .current_dir(root)
-        .output()?;
-
-    if !output.status.success() {
-        return Err("cargo metadata failed".into());
-    }
-
-    let metadata: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    let metadata = load_cargo_metadata(root)?;
     let mut violations = Vec::new();
     let mut unverified = Vec::new();
     let mut checked = 0;
@@ -106,22 +121,31 @@ fn check_cargo_deny(root: &Path, denied: &[&str]) -> Result<(), Box<dyn std::err
                     "  {} ({}) — Commons Clause rider detected",
                     name, license
                 ));
+                continue;
             }
 
-            // Check against the explicit deny list.
-            for &deny in denied {
-                if license.contains(deny) {
-                    violations.push(format!("  {} ({}) — {}", name, license, deny));
-                    break; // one violation per crate is enough
+            // Evaluate the full SPDX expression. An OR expression is accepted
+            // when at least one branch avoids denied licenses; every term of
+            // an AND expression must be permitted.
+            match license_expression_is_denied(license, denied) {
+                Ok(true) => {
+                    violations.push(format!("  {} ({}) — denied SPDX expression", name, license));
+                }
+                Ok(false) => {}
+                Err(_) => {
+                    unverified.push(format!(
+                        "  {} ({}) — invalid or non-SPDX expression (manual review needed)",
+                        name, license
+                    ));
                 }
             }
         }
     }
 
-    println!("  Checked {} workspace crates", checked);
+    println!("  Checked {} Rust packages", checked);
 
     if !unverified.is_empty() {
-        println!("  Unverified (no license field) — manual review required:");
+        println!("  Unverified licenses — manual review required:");
         for u in &unverified {
             println!("WARN {}", u);
         }
@@ -196,4 +220,37 @@ pub fn run(args: LicenseCheckArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     println!("License check complete.");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cargo_metadata_fallback_includes_third_party_dependencies() {
+        let metadata = load_cargo_metadata(&repo_root()).unwrap();
+        let packages = metadata["packages"].as_array().unwrap();
+
+        assert!(
+            packages.iter().any(|pkg| pkg["source"].as_str().is_some()),
+            "fallback metadata omitted every third-party dependency"
+        );
+    }
+
+    #[test]
+    fn spdx_or_expression_can_choose_a_permitted_license() {
+        let denied = ["GPL-2.0-only"];
+        assert!(!license_expression_is_denied("GPL-2.0-only OR BSD-3-Clause", &denied).unwrap());
+    }
+
+    #[test]
+    fn spdx_and_expression_requires_every_license() {
+        let denied = ["GPL-2.0-only"];
+        assert!(license_expression_is_denied("MIT AND GPL-2.0-only", &denied).unwrap());
+    }
+
+    #[test]
+    fn custom_license_refs_fail_closed_when_required() {
+        assert!(license_expression_is_denied("MIT AND LicenseRef-Proprietary", &[]).unwrap());
+    }
 }


### PR DESCRIPTION
## Summary
- remove `--no-deps` from the cargo-metadata license fallback so all resolved third-party packages are scanned
- evaluate SPDX expressions with AND/OR semantics instead of unsafe substring matching
- fail closed on required custom LicenseRef terms and report invalid legacy expressions for manual review
- add regression coverage for transitive metadata and SPDX policy behavior

## Verification
- fallback run without cargo-deny checked 1,082 Rust packages and completed successfully
- `cargo test -p xtask` (116 passed)
- `cargo clippy -p xtask -- -D warnings`
- `cargo deny check licenses`
- `git diff --check`