### PR TITLE
fix(dashboard): keep map editor state updater pure

### DIFF
--- a/changelog.d/fixed/6799-string-map-editor-effects.md
+++ b/changelog.d/fixed/6799-string-map-editor-effects.md
@@ -1,0 +1,1 @@
+Keep Dashboard string-map edits from replaying parent change callbacks under React Strict Mode. (#6799) (@houko)

--- a/crates/librefang-api/dashboard/src/components/config/StringMapEditor.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/config/StringMapEditor.test.tsx
@@ -1,0 +1,33 @@
+import { StrictMode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { StringMapEditor } from "./StringMapEditor";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+vi.mock("../../lib/store", () => ({
+  createClientId: () => "row-id",
+}));
+
+describe("StringMapEditor", () => {
+  it("emits one parent change for one edit in StrictMode", () => {
+    const onChange = vi.fn();
+    render(
+      <StrictMode>
+        <StringMapEditor value={{ endpoint: "old" }} onChange={onChange} />
+      </StrictMode>,
+    );
+
+    fireEvent.change(screen.getAllByRole("textbox")[0]!, {
+      target: { value: "renamed" },
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith({ renamed: "old" });
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/config/StringMapEditor.tsx
+++ b/crates/librefang-api/dashboard/src/components/config/StringMapEditor.tsx
@@ -69,6 +69,9 @@ export function StringMapEditor({
   // Track what we last emitted so we can ignore "incoming" prop updates
   // that are just our own commit echoing back through the parent.
   const lastEmittedRef = useRef<Record<string, string | number> | null>(null);
+  // State updaters must remain pure: React may replay them in StrictMode.
+  // This flag transfers the commit notification to the post-commit effect.
+  const shouldEmitRef = useRef(false);
 
   // Re-seed from incoming value ONLY when the parent state diverged from
   // our last emitted commit (e.g. another tab edited config, or the user
@@ -87,15 +90,18 @@ export function StringMapEditor({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
+  useEffect(() => {
+    if (!shouldEmitRef.current) return;
+    shouldEmitRef.current = false;
+    const obj = commitRows(rows);
+    lastEmittedRef.current = obj;
+    onChange(obj);
+  }, [onChange, rows]);
+
   const emit = useCallback((updater: (prev: Row[]) => Row[]) => {
-    setRows((prev) => {
-      const next = updater(prev);
-      const obj = commitRows(next);
-      lastEmittedRef.current = obj;
-      onChange(obj);
-      return next;
-    });
-  }, [onChange]);
+    shouldEmitRef.current = true;
+    setRows(updater);
+  }, []);
 
   const updateKey = useCallback((id: string, key: string) => {
     emit((prev) => prev.map((r) => r.id === id ? { ...r, key } : r));


### PR DESCRIPTION
## Summary
- move StringMapEditor parent notifications out of the React state updater
- emit only after the edited rows have committed
- cover StrictMode replay with a regression test

## Verification
- pnpm test (92 files, 952 tests)
- pnpm typecheck
- pnpm lint
- pnpm build