### PR TITLE
fix(dashboard): await confirmation actions

### DIFF
--- a/changelog.d/fixed/6801-confirm-dialog-await.md
+++ b/changelog.d/fixed/6801-confirm-dialog-await.md
@@ -1,0 +1,1 @@
+Keep Dashboard confirmation dialogs open until asynchronous actions succeed, with retry support after failures. (#6801) (@houko)

--- a/crates/librefang-api/dashboard/src/components/PendingSkillsSection.tsx
+++ b/crates/librefang-api/dashboard/src/components/PendingSkillsSection.tsx
@@ -270,8 +270,8 @@ function CandidateRow({ candidate }: { candidate: PendingCandidate }) {
       <ConfirmDialog
         isOpen={confirmReject}
         onClose={() => setConfirmReject(false)}
-        onConfirm={() => {
-          reject.mutate(
+        onConfirm={async () => {
+          await reject.mutateAsync(
             { id: candidate.id },
             { onSuccess: () => setConfirmReject(false) },
           );

--- a/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ConfirmDialog } from "./ConfirmDialog";
@@ -98,5 +98,74 @@ describe("ConfirmDialog async confirmation", () => {
     resolve();
 
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("does not let a stale success close a reopened confirmation", async () => {
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    const first = new Promise<void>((resolve) => { resolveFirst = resolve; });
+    const second = new Promise<void>((resolve) => { resolveSecond = resolve; });
+    const onClose = vi.fn();
+    const common = { title: "Apply?", message: "Confirm action", onClose };
+    const { rerender } = render(
+      <ConfirmDialog {...common} isOpen onConfirm={() => first} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    rerender(<ConfirmDialog {...common} isOpen={false} onConfirm={() => first} />);
+    rerender(<ConfirmDialog {...common} isOpen onConfirm={() => second} />);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await act(async () => {
+      resolveFirst();
+      await first;
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
+
+    await act(async () => {
+      resolveSecond();
+      await second;
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a stale rejection unlock a newer confirmation", async () => {
+    let rejectFirst!: (reason?: unknown) => void;
+    let resolveSecond!: () => void;
+    const first = new Promise<void>((_resolve, reject) => { rejectFirst = reject; });
+    const second = new Promise<void>((resolve) => { resolveSecond = resolve; });
+    const secondConfirm = vi.fn(() => second);
+    const onClose = vi.fn();
+    const common = { title: "Apply?", message: "Confirm action", onClose };
+    const { rerender } = render(
+      <ConfirmDialog {...common} isOpen onConfirm={() => first} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    rerender(<ConfirmDialog {...common} isOpen={false} onConfirm={() => first} />);
+    rerender(<ConfirmDialog {...common} isOpen onConfirm={secondConfirm} />);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await act(async () => {
+      rejectFirst(new Error("stale failure"));
+      try {
+        await first;
+      } catch {
+        // The component consumes the same expected rejection.
+      }
+    });
+
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+    expect(secondConfirm).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSecond();
+      await second;
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.test.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConfirmDialog } from "./ConfirmDialog";
+
+vi.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    {
+      get: (_target: unknown, prop: string) =>
+        ({ children, ...rest }: { children?: React.ReactNode } & Record<string, unknown>) =>
+          React.createElement(prop, rest, children),
+    },
+  ),
+}));
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+    }),
+  };
+});
+
+function DialogHarness({ onConfirm }: { onConfirm: () => void | Promise<void> }) {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <ConfirmDialog
+      isOpen={isOpen}
+      title="Apply change?"
+      message="This action calls the API."
+      onConfirm={onConfirm}
+      onClose={() => setIsOpen(false)}
+    />
+  );
+}
+
+describe("ConfirmDialog async confirmation", () => {
+  it("stays open while pending and allows retry after rejection", async () => {
+    let reject!: (reason?: unknown) => void;
+    const pending = new Promise<void>((_resolve, rejectPromise) => {
+      reject = rejectPromise;
+    });
+    const onConfirm = vi.fn(() => pending);
+    render(<DialogHarness onConfirm={onConfirm} />);
+
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+    fireEvent.click(confirm);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    const pendingConfirm = screen.getByRole("button", { name: "Confirm" });
+    expect(pendingConfirm).toBeDisabled();
+    fireEvent.click(pendingConfirm);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    reject(new Error("API unavailable"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Confirm" })).toBeEnabled());
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(onConfirm).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes only after async confirmation succeeds", async () => {
+    let resolve!: () => void;
+    const pending = new Promise<void>((resolvePromise) => {
+      resolve = resolvePromise;
+    });
+    render(<DialogHarness onConfirm={() => pending} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    resolve();
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("uses the same awaited confirmation path for Enter", async () => {
+    let resolve!: () => void;
+    const pending = new Promise<void>((resolvePromise) => {
+      resolve = resolvePromise;
+    });
+    const onConfirm = vi.fn(() => pending);
+    render(<DialogHarness onConfirm={onConfirm} />);
+
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
+
+    resolve();
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+});

--- a/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
@@ -35,7 +35,7 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
   const { t } = useTranslation();
   const dialogRef = useRef<HTMLDivElement>(null);
   const isConfirmingRef = useRef(false);
-  const confirmationGenerationRef = useRef(0);
+  const activeConfirmationRef = useRef<object | null>(null);
   const [isConfirming, setIsConfirming] = useState(false);
   const onCloseRef = useRef(onClose);
   const onConfirmRef = useRef(onConfirm);
@@ -52,16 +52,17 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
 
   const requestConfirm = useCallback(() => {
     if (isConfirmingRef.current) return;
-    const generation = ++confirmationGenerationRef.current;
+    const confirmationToken = {};
+    activeConfirmationRef.current = confirmationToken;
     isConfirmingRef.current = true;
     setIsConfirming(true);
     void (async () => {
       try {
         await onConfirmRef.current();
-        if (confirmationGenerationRef.current !== generation) return;
+        if (activeConfirmationRef.current !== confirmationToken) return;
         onCloseRef.current();
       } catch {
-        if (confirmationGenerationRef.current !== generation) return;
+        if (activeConfirmationRef.current !== confirmationToken) return;
         isConfirmingRef.current = false;
         setIsConfirming(false);
       }
@@ -69,14 +70,11 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
   }, []);
 
   useEffect(() => {
-    const openGeneration = confirmationGenerationRef.current + 1;
-    confirmationGenerationRef.current = openGeneration;
+    activeConfirmationRef.current = null;
     isConfirmingRef.current = false;
     setIsConfirming(false);
     return () => {
-      // At most one request can exist for this open generation. Advance past
-      // both its open and request tokens so a late settlement is always stale.
-      confirmationGenerationRef.current = openGeneration + 2;
+      activeConfirmationRef.current = null;
     };
   }, [isOpen]);
 

--- a/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useId, useRef } from "react";
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
 import { AlertTriangle, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { AnimatePresence, motion } from "motion/react";
@@ -15,7 +15,7 @@ interface ConfirmDialogProps {
   cancelLabel?: string;
   /** Visual tone — destructive renders the confirm button in error colors. */
   tone?: "default" | "destructive";
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
   onClose: () => void;
 }
 
@@ -34,7 +34,8 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
 }: ConfirmDialogProps) {
   const { t } = useTranslation();
   const dialogRef = useRef<HTMLDivElement>(null);
-  const isConfirming = useRef(false);
+  const isConfirmingRef = useRef(false);
+  const [isConfirming, setIsConfirming] = useState(false);
   const onCloseRef = useRef(onClose);
   const onConfirmRef = useRef(onConfirm);
   const titleId = useId();
@@ -43,9 +44,30 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
   onConfirmRef.current = onConfirm;
   useFocusTrap(isOpen, dialogRef, true);
 
+  const requestClose = useCallback(() => {
+    if (isConfirmingRef.current) return;
+    onCloseRef.current();
+  }, []);
+
+  const requestConfirm = useCallback(() => {
+    if (isConfirmingRef.current) return;
+    isConfirmingRef.current = true;
+    setIsConfirming(true);
+    void (async () => {
+      try {
+        await onConfirmRef.current();
+        onCloseRef.current();
+      } catch {
+        isConfirmingRef.current = false;
+        setIsConfirming(false);
+      }
+    })();
+  }, []);
+
   useEffect(() => {
     if (isOpen) {
-      isConfirming.current = false;
+      isConfirmingRef.current = false;
+      setIsConfirming(false);
     }
   }, [isOpen]);
 
@@ -71,20 +93,17 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
       return false;
     };
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCloseRef.current();
+      if (e.key === "Escape") requestClose();
       // Enter confirms — safer on non-destructive dialogs; for destructive
       // we still require a click so users can't accidentally nuke data.
       if (e.key === "Enter" && tone !== "destructive" && !isEditableTarget(e.target)) {
-        if (isConfirming.current) return;
         e.preventDefault();
-        isConfirming.current = true;
-        onConfirmRef.current();
-        onCloseRef.current();
+        requestConfirm();
       }
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [isOpen, tone]);
+  }, [isOpen, requestClose, requestConfirm, tone]);
 
   const isDestructive = tone === "destructive";
   const confirmBtnClass = isDestructive
@@ -96,7 +115,7 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
       {isOpen && (
         <motion.div
           className="fixed inset-0 z-[150] flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm p-0 sm:p-4"
-          onClick={onClose}
+          onClick={requestClose}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -116,8 +135,9 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
         exit="exit"
       >
         <button
-          onClick={onClose}
-          className="absolute right-3 top-3 h-7 w-7 flex items-center justify-center rounded-lg text-text-dim hover:text-brand hover:bg-surface-hover transition-colors"
+          onClick={requestClose}
+          disabled={isConfirming}
+          className="absolute right-3 top-3 h-7 w-7 flex items-center justify-center rounded-lg text-text-dim hover:text-brand hover:bg-surface-hover transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           aria-label={t("common.close", { defaultValue: "Close" })}
         >
           <X className="h-3.5 w-3.5" />
@@ -137,19 +157,17 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
         </div>
         <div className="flex gap-2 border-t border-border-subtle/50 px-5 py-3">
           <button
-            onClick={onClose}
-            className="flex-1 rounded-xl border border-border-subtle bg-surface py-2.5 text-xs font-bold text-text-dim hover:bg-surface-hover transition-colors"
+            onClick={requestClose}
+            disabled={isConfirming}
+            className="flex-1 rounded-xl border border-border-subtle bg-surface py-2.5 text-xs font-bold text-text-dim hover:bg-surface-hover transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           >
             {cancelLabel ?? t("common.cancel", { defaultValue: "Cancel" })}
           </button>
           <button
-            onClick={() => {
-              if (isConfirming.current) return;
-              isConfirming.current = true;
-              onConfirm();
-              onClose();
-            }}
-            className={`flex-1 rounded-xl py-2.5 text-xs font-bold transition-all hover:-translate-y-0.5 ${confirmBtnClass}`}
+            onClick={requestConfirm}
+            disabled={isConfirming}
+            aria-busy={isConfirming}
+            className={`flex-1 rounded-xl py-2.5 text-xs font-bold transition-all hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:translate-y-0 ${confirmBtnClass}`}
           >
             {confirmLabel ?? t("common.confirm", { defaultValue: "Confirm" })}
           </button>

--- a/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/ConfirmDialog.tsx
@@ -35,6 +35,7 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
   const { t } = useTranslation();
   const dialogRef = useRef<HTMLDivElement>(null);
   const isConfirmingRef = useRef(false);
+  const confirmationGenerationRef = useRef(0);
   const [isConfirming, setIsConfirming] = useState(false);
   const onCloseRef = useRef(onClose);
   const onConfirmRef = useRef(onConfirm);
@@ -51,13 +52,16 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
 
   const requestConfirm = useCallback(() => {
     if (isConfirmingRef.current) return;
+    const generation = ++confirmationGenerationRef.current;
     isConfirmingRef.current = true;
     setIsConfirming(true);
     void (async () => {
       try {
         await onConfirmRef.current();
+        if (confirmationGenerationRef.current !== generation) return;
         onCloseRef.current();
       } catch {
+        if (confirmationGenerationRef.current !== generation) return;
         isConfirmingRef.current = false;
         setIsConfirming(false);
       }
@@ -65,10 +69,15 @@ export const ConfirmDialog = React.memo(function ConfirmDialog({
   }, []);
 
   useEffect(() => {
-    if (isOpen) {
-      isConfirmingRef.current = false;
-      setIsConfirming(false);
-    }
+    const openGeneration = confirmationGenerationRef.current + 1;
+    confirmationGenerationRef.current = openGeneration;
+    isConfirmingRef.current = false;
+    setIsConfirming(false);
+    return () => {
+      // At most one request can exist for this open generation. Advance past
+      // both its open and request tokens so a late settlement is always stale.
+      confirmationGenerationRef.current = openGeneration + 2;
+    };
   }, [isOpen]);
 
   useEffect(() => {

--- a/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/AgentsPage.tsx
@@ -326,7 +326,7 @@ export function AgentsPage() {
   const [confirmDialog, setConfirmDialog] = useState<{
     title: string;
     message: string;
-    onConfirm: () => void;
+    onConfirm: () => void | Promise<void>;
     tone?: "default" | "destructive";
   } | null>(null);
   // Clone dialog state (#6566). `POST /api/agents/{id}/clone` requires `new_name` with no serde default, so the button has to collect a name before firing — it previously posted `{}` and 422'd on every click.
@@ -398,23 +398,30 @@ export function AgentsPage() {
   const qc = useQueryClient();
 
   const rawDeleteMutation = useDeleteAgent();
+  const handleDeleteSuccess = (agentId: string) => {
+    if (detailAgent?.id === agentId) {
+      setDetailAgent(null);
+      setDetailDrawerOpen(false);
+    } else {
+      setDetailAgent(prev => prev);
+    }
+    addToast(t("agents.delete_success", { defaultValue: "Agent deleted" }), "success");
+  };
+  const handleDeleteError = (e: Error) =>
+    addToast(
+      e?.message || t("agents.delete_failed", { defaultValue: "Failed to delete agent" }),
+      "error",
+    );
   const deleteMutation = {
     mutate: (agentId: string) =>
       rawDeleteMutation.mutate(agentId, {
-        onSuccess: () => {
-          if (detailAgent?.id === agentId) {
-            setDetailAgent(null);
-            setDetailDrawerOpen(false);
-          } else {
-            setDetailAgent(prev => prev);
-          }
-          addToast(t("agents.delete_success", { defaultValue: "Agent deleted" }), "success");
-        },
-        onError: (e: Error) =>
-          addToast(
-            e?.message || t("agents.delete_failed", { defaultValue: "Failed to delete agent" }),
-            "error",
-          ),
+        onSuccess: () => handleDeleteSuccess(agentId),
+        onError: handleDeleteError,
+      }),
+    mutateAsync: (agentId: string) =>
+      rawDeleteMutation.mutateAsync(agentId, {
+        onSuccess: () => handleDeleteSuccess(agentId),
+        onError: handleDeleteError,
       }),
   };
 
@@ -2900,7 +2907,9 @@ export function AgentsPage() {
                         title: t("agents.delete_title", { defaultValue: "Delete agent?" }),
                         message: t("agents.delete_confirm", { name: detailAgent.name }),
                         tone: "destructive",
-                        onConfirm: () => deleteMutation.mutate(detailAgent.id),
+                        onConfirm: async () => {
+                          await deleteMutation.mutateAsync(detailAgent.id);
+                        },
                       })
                     }
                   >

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.test.tsx
@@ -354,8 +354,12 @@ describe("ChannelsPage", () => {
     expect(reload.mutate).toHaveBeenCalledTimes(1);
   });
 
-  it("removes a configured channel after confirmation", () => {
+  it("keeps removal confirmation open until the mutation succeeds", async () => {
     const { remove } = setMutationDefaults();
+    let resolveRemove!: () => void;
+    remove.mutateAsync.mockImplementation(() => new Promise<void>((resolve) => {
+      resolveRemove = resolve;
+    }));
     useChannelsMock.mockReturnValue(
       makeQuery<ChannelItem[]>([makeChannel({ name: "telegram", configured: true })]),
     );
@@ -363,8 +367,14 @@ describe("ChannelsPage", () => {
     // The remove dialog only appears after the per-card Trash button is clicked.
     fireEvent.click(screen.getByRole("button", { name: "channels.remove" }));
     fireEvent.click(screen.getByRole("button", { name: "common.confirm" }));
-    expect(remove.mutate).toHaveBeenCalledTimes(1);
-    expect(remove.mutate.mock.calls[0][0]).toBe("telegram");
+    expect(remove.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(remove.mutateAsync.mock.calls[0][0]).toBe("telegram");
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    resolveRemove();
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
   });
 
   it("pre-populates non-secret field values from the sidecar schema", () => {

--- a/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/ChannelsPage.tsx
@@ -758,10 +758,10 @@ export function ChannelsPage() {
   const handleCardRemove = useCallback((ch: Channel) => {
     setRemoveChannel(ch);
   }, []);
-  const confirmRemove = () => {
+  const confirmRemove = async () => {
     if (!removeChannel) return;
     const name = removeChannel.name;
-    removeMut.mutate(name, {
+    await removeMut.mutateAsync(name, {
       onSuccess: () => {
         setRemoveChannel(null);
         addToast(t("channels.remove_success", { defaultValue: "Channel removed" }), "success");

--- a/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/HandsPage.tsx
@@ -1696,7 +1696,7 @@ export function HandsPage() {
   const [confirmDialog, setConfirmDialog] = useState<{
     title: string;
     message: string;
-    onConfirm: () => void;
+    onConfirm: () => void | Promise<void>;
     tone?: "destructive";
   } | null>(null);
   const navigate = useNavigate();

--- a/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/McpServersPage.tsx
@@ -1907,8 +1907,8 @@ export function McpServersPage() {
         message={t("mcp.delete_confirm")}
         tone="destructive"
         confirmLabel={t("common.delete")}
-        onConfirm={() => {
-          if (deletingServer) deleteMutation.mutate(serverIdOf(deletingServer), {
+        onConfirm={async () => {
+          if (deletingServer) await deleteMutation.mutateAsync(serverIdOf(deletingServer), {
             onSuccess: () => {
               setDeletingServer(null);
               addToast(t("mcp.delete_success"), "success");

--- a/crates/librefang-api/dashboard/src/pages/Memory/index.tsx
+++ b/crates/librefang-api/dashboard/src/pages/Memory/index.tsx
@@ -267,9 +267,9 @@ export function MemoryPage() {
         })}
         tone="destructive"
         confirmLabel={t("common.delete", { defaultValue: "Delete" })}
-        onConfirm={() => {
+        onConfirm={async () => {
           if (deleteConfirm) {
-            deleteMutation.mutate(deleteConfirm.id, {
+            await deleteMutation.mutateAsync(deleteConfirm.id, {
               onSuccess: () =>
                 addToast(
                   t("memory.delete_success", { defaultValue: "Memory deleted" }),
@@ -279,7 +279,6 @@ export function MemoryPage() {
                 addToast(err instanceof Error ? err.message : t("common.error"), "error"),
             });
           }
-          setDeleteConfirm(null);
         }}
         onClose={() => setDeleteConfirm(null)}
       />

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.test.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.test.tsx
@@ -291,15 +291,15 @@ describe("RuntimePage", () => {
   });
 
   it("opens shutdown confirm dialog and fires shutdown mutation on confirm", () => {
-    const mutate = vi.fn();
-    useShutdownServerMock.mockReturnValue(makeMutation({ mutate }));
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    useShutdownServerMock.mockReturnValue(makeMutation({ mutateAsync }));
     renderPage();
 
     fireEvent.click(screen.getByRole("button", { name: "runtime.shutdown" }));
     // Confirm dialog now visible
     const confirmBtn = screen.getByRole("button", { name: "runtime.shutdown_confirm" });
     fireEvent.click(confirmBtn);
-    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
   });
 
   it("invokes reloadConfig mutation when reload button is clicked", () => {
@@ -327,11 +327,11 @@ describe("RuntimePage", () => {
   });
 
   it("opens restore confirm dialog and fires restoreBackup with filename on confirm", () => {
-    const mutate = vi.fn();
-    useRestoreBackupMock.mockReturnValue(makeMutation({ mutate }));
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    useRestoreBackupMock.mockReturnValue(makeMutation({ mutateAsync }));
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: "runtime.restore" }));
     fireEvent.click(screen.getByRole("button", { name: "runtime.restore_confirm" }));
-    expect(mutate).toHaveBeenCalledWith("backup-1.tar.gz");
+    expect(mutateAsync).toHaveBeenCalledWith("backup-1.tar.gz");
   });
 });

--- a/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/RuntimePage.tsx
@@ -817,7 +817,7 @@ export function RuntimePage() {
         message={t("runtime.shutdown_confirm_desc")}
         confirmLabel={t("runtime.shutdown_confirm")}
         tone="destructive"
-        onConfirm={() => shutdownMutation.mutate()}
+        onConfirm={async () => { await shutdownMutation.mutateAsync(); }}
         onClose={() => setShowShutdownConfirm(false)}
       />
 
@@ -828,11 +828,10 @@ export function RuntimePage() {
         message={t("runtime.restore_confirm_desc")}
         confirmLabel={t("runtime.restore_confirm")}
         tone="destructive"
-        onConfirm={() => {
+        onConfirm={async () => {
           if (backupConfirm?.type === "restore") {
-            restoreMutation.mutate(backupConfirm.filename);
+            await restoreMutation.mutateAsync(backupConfirm.filename);
           }
-          setBackupConfirm(null);
         }}
         onClose={() => setBackupConfirm(null)}
       />
@@ -844,11 +843,10 @@ export function RuntimePage() {
         message={t("runtime.delete_backup_confirm_desc")}
         confirmLabel={t("runtime.delete_backup_confirm")}
         tone="destructive"
-        onConfirm={() => {
+        onConfirm={async () => {
           if (backupConfirm?.type === "delete") {
-            deleteBackupMutation.mutate(backupConfirm.filename);
+            await deleteBackupMutation.mutateAsync(backupConfirm.filename);
           }
-          setBackupConfirm(null);
         }}
         onClose={() => setBackupConfirm(null)}
       />

--- a/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
+++ b/crates/librefang-api/dashboard/src/pages/SkillsPage.tsx
@@ -1093,7 +1093,7 @@ function SkillDetailModal({
   const [confirmAction, setConfirmAction] = useState<{
     title: string;
     message: string;
-    onConfirm: () => void;
+    onConfirm: () => void | Promise<void>;
   } | null>(null);
 
   useEffect(() => {
@@ -2175,9 +2175,9 @@ export function SkillsPage() {
         title={t("skills.uninstall_confirm_title")}
         message={t("skills.uninstall_confirm", { name: uninstalling ?? "" })}
         tone="destructive"
-        onConfirm={() => {
+        onConfirm={async () => {
           if (uninstalling) {
-            uninstallMutation.mutate(uninstalling, {
+            await uninstallMutation.mutateAsync(uninstalling, {
               onSuccess: () => {
                 addToast(t("common.success"), "success");
                 setUninstalling(null);


### PR DESCRIPTION
## Summary
- allow ConfirmDialog confirmation callbacks to return promises
- keep the dialog open and controls disabled until confirmation settles
- close only on success and re-enable retry after rejection
- route click and Enter through the same confirmation handler

## Verification
- pnpm exec vitest run src/components/ui/ConfirmDialog.test.tsx (3 tests)
- pnpm test (92 files, 954 tests)
- pnpm typecheck
- pnpm lint
- pnpm build