### PR TITLE
fix(dashboard): scope drawer cleanup to owner

### DIFF
--- a/changelog.d/fixed/6803-drawer-owner-cleanup.md
+++ b/changelog.d/fixed/6803-drawer-owner-cleanup.md
@@ -1,0 +1,1 @@
+Prevent an unmounting Dashboard drawer from closing a newer drawer that has taken over the shared slot. (#6803) (@houko)

--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.test.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.test.tsx
@@ -177,4 +177,38 @@ describe("DrawerPanel", () => {
     // applies (silent), not the external-close bubble-up.
     expect(pickerOnCloseCalls).toBe(0);
   });
+
+  it("does not close a new owner when the previous open panel unmounts", () => {
+    const { unmount } = render(
+      <DrawerPanel isOpen onClose={() => {}} title="picker">
+        <p>picker body</p>
+      </DrawerPanel>,
+    );
+
+    act(() => {
+      useDrawerStore.getState().open({
+        title: "config",
+        body: <p>config body</p>,
+      });
+    });
+    expect(useDrawerStore.getState().content?.title).toBe("config");
+
+    unmount();
+
+    expect(useDrawerStore.getState().isOpen).toBe(true);
+    expect(useDrawerStore.getState().content?.title).toBe("config");
+  });
+
+  it("clears stale content when the drawer closes", () => {
+    render(
+      <DrawerPanel isOpen onClose={() => {}} title="picker">
+        <p>picker body</p>
+      </DrawerPanel>,
+    );
+
+    act(() => useDrawerStore.getState().close());
+
+    expect(useDrawerStore.getState().isOpen).toBe(false);
+    expect(useDrawerStore.getState().content).toBeNull();
+  });
 });

--- a/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
+++ b/crates/librefang-api/dashboard/src/components/ui/DrawerPanel.tsx
@@ -57,11 +57,10 @@ export function DrawerPanel({
     isOpenRef.current = isOpen;
   }, [isOpen]);
 
-  // Track the body identity we last pushed into the slot. The
-  // parent-driven close watcher uses this to skip `close()` when another
-  // DrawerPanel has taken over the slot in the same commit — see
-  // ownership check below (#4714).
-  const lastPushedBodyRef = useRef<ReactNode>(null);
+  // Created in the push effect (not render) and retained for this panel's
+  // current open lifetime. The store checks it atomically on owner-scoped
+  // closes, so a previous panel cannot close a slot a sibling has claimed.
+  const ownerRef = useRef<object | null>(null);
 
   // Push children into the slot whenever we're open. Re-runs on every
   // re-render that changes any of the deps — including `children`, which
@@ -70,13 +69,15 @@ export function DrawerPanel({
   useEffect(() => {
     if (!isOpen) return;
     const body = children;
-    lastPushedBodyRef.current = body;
+    const owner = ownerRef.current ?? {};
+    ownerRef.current = owner;
     open({
       title,
       size,
       hideCloseButton,
       body,
       onClose: () => onCloseRef.current(),
+      owner,
     });
   }, [isOpen, title, size, hideCloseButton, children, open]);
 
@@ -88,7 +89,7 @@ export function DrawerPanel({
   // dismissals from the parent silently no-op'd, leaving the form
   // visible with a perpetually spinning submit button (#4687).
   //
-  // Ownership check (#4714): only fire `close()` when our body still
+  // Ownership check (#4714): only fire `close(owner)` when our opaque token
   // owns the slot. In a picker → config / "select item closes one
   // drawer and opens another" flow, the picker DrawerPanel transitions
   // isOpen=true → false in the same commit that the config DrawerPanel
@@ -97,7 +98,7 @@ export function DrawerPanel({
   // drawer, and the existing external-close watcher then fires its
   // onClose, which makes the parent unmount the config drawer — net
   // result: user picks an item and the configuration window vanishes
-  // immediately. Comparing against `lastPushedBodyRef` lets the
+  // immediately. The store's atomic token comparison lets the
   // late-mounting drawer's push "win" the slot without the previous
   // owner clobbering it.
   //
@@ -109,11 +110,10 @@ export function DrawerPanel({
   useEffect(() => {
     const wasOpen = prevIsOpenRef.current;
     prevIsOpenRef.current = isOpen;
-    if (wasOpen && !isOpen && drawerOpen) {
-      const currentBody = useDrawerStore.getState().content?.body;
-      if (currentBody === lastPushedBodyRef.current) {
-        close();
-      }
+    if (wasOpen && !isOpen) {
+      const owner = ownerRef.current;
+      if (drawerOpen && owner) close(owner);
+      ownerRef.current = null;
     }
   }, [isOpen, drawerOpen, close]);
 
@@ -137,7 +137,9 @@ export function DrawerPanel({
   // Cleanup on unmount.
   useEffect(
     () => () => {
-      if (isOpenRef.current) close();
+      const owner = ownerRef.current;
+      if (isOpenRef.current && owner) close(owner);
+      ownerRef.current = null;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],

--- a/crates/librefang-api/dashboard/src/lib/drawerStore.ts
+++ b/crates/librefang-api/dashboard/src/lib/drawerStore.ts
@@ -11,13 +11,15 @@ export interface DrawerContent {
   /** Called when the drawer is dismissed via Esc / X / mobile backdrop.
    *  Parents typically use this to flip their own `isOpen` state. */
   onClose?: () => void;
+  /** Opaque identity used by DrawerPanel to avoid closing a newer owner. */
+  owner?: object;
 }
 
 interface DrawerState {
   isOpen: boolean;
   content: DrawerContent | null;
   open: (content: DrawerContent) => void;
-  close: () => void;
+  close: (owner?: object) => void;
 }
 
 // Single global push-drawer slot. The `<DrawerPanel>` adapter is the primary
@@ -32,5 +34,8 @@ export const useDrawerStore = create<DrawerState>((set) => ({
   isOpen: false,
   content: null,
   open: (content) => set({ isOpen: true, content }),
-  close: () => set({ isOpen: false }),
+  close: (owner) => set((state) => {
+    if (owner !== undefined && state.content?.owner !== owner) return state;
+    return { isOpen: false, content: null };
+  }),
 }));


### PR DESCRIPTION
## Summary
- give each DrawerPanel open lifetime an opaque ownership token
- make owner-scoped closes atomic in the shared drawer store
- prevent an unmounting panel from closing a newer sibling drawer
- clear stale drawer content on close

## Verification
- pnpm exec vitest run src/components/ui/DrawerPanel.test.tsx src/components/ui/PushDrawer.test.tsx (11 tests)
- pnpm test (91 files, 953 tests)
- pnpm typecheck
- pnpm lint
- pnpm build