### PR TITLE
fix(dashboard): escape TOML control characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project uses [Calendar Versioning](https://calver.org/) (YYYY.M.DD).
 
 ## [Unreleased]
 
+### Fixed
+
+- Escape every TOML control character when the dashboard serializes agent manifest strings, preserving carriage returns, tabs, and other control bytes as valid round-trippable TOML instead of producing a manifest the daemon cannot parse. (@TechWizard9999)
+
 ## [2026.7.31] - 2026-07-31
 
 _58 PRs from 4 contributors since v2026.7.27._

--- a/crates/librefang-api/dashboard/src/lib/agentManifest.test.ts
+++ b/crates/librefang-api/dashboard/src/lib/agentManifest.test.ts
@@ -39,6 +39,35 @@ describe("agentManifest serializer", () => {
     expect(toml).toContain('system_prompt = "Line 1\\nLine 2"');
   });
 
+  it("round-trips TOML control characters in strings", () => {
+    const form = emptyManifestForm();
+    form.name = "control-characters";
+    form.model.provider = "openai";
+    form.model.model = "gpt-4o";
+    form.model.system_prompt = "prefix\r\t\0\b\v\f\u001f\u007fsuffix";
+
+    const toml = serializeManifestForm(form);
+    const parsed = parseManifestToml(toml);
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.form.model.system_prompt).toBe(form.model.system_prompt);
+  });
+
+  it("preserves Unicode scalars and replaces isolated UTF-16 surrogates", () => {
+    const form = emptyManifestForm();
+    form.name = "unicode-boundaries";
+    form.model.provider = "openai";
+    form.model.model = "gpt-4o";
+    form.model.system_prompt = "emoji 😀, high \ud800, low \udc00";
+
+    const parsed = parseManifestToml(serializeManifestForm(form));
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.form.model.system_prompt).toBe("emoji 😀, high �, low �");
+  });
+
   it("omits empty numeric fields and emits valid ones", () => {
     const form = emptyManifestForm();
     form.name = "agent";

--- a/crates/librefang-api/dashboard/src/lib/agentManifest.ts
+++ b/crates/librefang-api/dashboard/src/lib/agentManifest.ts
@@ -305,8 +305,46 @@ const WEB_SEARCH_MODES = ["off", "auto", "always"] as const;
 const INJECTION_POSITIONS = ["system", "before_user", "after_reset"] as const;
 const EXEC_SHORTHANDS = ["allow", "deny", "full", "allowlist"] as const;
 
-const escapeTomlString = (value: string): string =>
-  `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`;
+const escapeTomlString = (value: string): string => {
+  let escaped = "";
+  for (const character of value) {
+    switch (character) {
+      case "\\":
+        escaped += "\\\\";
+        break;
+      case '"':
+        escaped += '\\"';
+        break;
+      case "\b":
+        escaped += "\\b";
+        break;
+      case "\t":
+        escaped += "\\t";
+        break;
+      case "\n":
+        escaped += "\\n";
+        break;
+      case "\f":
+        escaped += "\\f";
+        break;
+      case "\r":
+        escaped += "\\r";
+        break;
+      default: {
+        const codeUnit = character.charCodeAt(0);
+        if (character.length === 1 && codeUnit >= 0xd800 && codeUnit <= 0xdfff) {
+          escaped += "\ufffd";
+        } else if (codeUnit <= 0x1f || character === "\u007f") {
+          escaped += `\\u${codeUnit.toString(16).padStart(4, "0")}`;
+        } else {
+          escaped += character;
+        }
+        break;
+      }
+    }
+  }
+  return `"${escaped}"`;
+};
 
 const tomlArray = (values: string[]): string =>
   `[${values.map(escapeTomlString).join(", ")}]`;


### PR DESCRIPTION
## Summary
- serialize all TOML-forbidden ASCII control characters safely
- preserve standard TOML escapes for common controls and use Unicode escapes for the remainder
- add a form-to-TOML-to-form regression covering CR, tab, NUL, backspace, vertical tab, form feed, unit separator, and DEL

## Verification
- `pnpm test` (91 files, 952 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`