### PR TITLE
fix(xtask): enforce web dependency licenses

### DIFF
--- a/changelog.d/fixed/6808-web-license-enforcement.md
+++ b/changelog.d/fixed/6808-web-license-enforcement.md
@@ -1,0 +1,1 @@
+- Enforce denied SPDX licenses for web dependencies from pnpm's JSON report, including Commons Clause rejection and fail-closed command or report errors, instead of printing a truncated report and always succeeding. (@TechWizard9999)

--- a/xtask/src/license_check.rs
+++ b/xtask/src/license_check.rs
@@ -195,38 +195,133 @@ fn check_cargo_deny(root: &Path, denied: &[&str]) -> Result<(), Box<dyn std::err
     )
 }
 
-fn check_web_licenses(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
+fn check_web_license_policy(
+    report: &serde_json::Value,
+    denied: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let groups = report
+        .as_object()
+        .ok_or("pnpm license report was not a JSON object")?;
+    let mut violations = Vec::new();
+    let mut unverified = Vec::new();
+    let mut checked = 0;
+
+    for (group_license, packages) in groups {
+        if group_license.trim().is_empty() {
+            return Err("pnpm license report contained an empty license group".into());
+        }
+        let packages = packages
+            .as_array()
+            .ok_or_else(|| format!("pnpm license group {group_license:?} was not an array"))?;
+        for (index, package) in packages.iter().enumerate() {
+            let package = package.as_object().ok_or_else(|| {
+                format!("pnpm license group {group_license:?} entry {index} was not an object")
+            })?;
+            let name = package
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .filter(|name| !name.trim().is_empty())
+                .ok_or_else(|| {
+                    format!(
+                        "pnpm license group {group_license:?} entry {index} had no package name"
+                    )
+                })?;
+            let versions = match package.get("versions") {
+                None => String::new(),
+                Some(serde_json::Value::Array(values)) => {
+                    let mut versions = Vec::with_capacity(values.len());
+                    for version in values {
+                        let version = version
+                            .as_str()
+                            .filter(|value| !value.is_empty())
+                            .ok_or_else(|| {
+                                format!("pnpm package {name:?} had an invalid version")
+                            })?;
+                        versions.push(version);
+                    }
+                    versions.join(", ")
+                }
+                Some(_) => return Err(format!("pnpm package {name:?} had invalid versions").into()),
+            };
+            let label = if versions.is_empty() {
+                name.to_owned()
+            } else {
+                format!("{name}@{versions}")
+            };
+            let license = match package.get("license") {
+                None => group_license.as_str(),
+                Some(serde_json::Value::String(license)) => license.as_str(),
+                Some(_) => {
+                    return Err(format!("pnpm package {name:?} had an invalid license").into())
+                }
+            };
+            checked += 1;
+
+            if license.is_empty() || license == "UNKNOWN" {
+                unverified.push(format!(
+                    "  {label} — no license declared (manual review needed)"
+                ));
+                continue;
+            }
+
+            if has_commons_clause(license) {
+                violations.push(format!(
+                    "  {label} ({license}) — Commons Clause rider detected"
+                ));
+                continue;
+            }
+
+            match license_expression_is_denied(license, denied) {
+                Ok(true) => {
+                    violations.push(format!("  {label} ({license}) — denied SPDX expression"))
+                }
+                Ok(false) => {}
+                Err(_) => unverified.push(format!(
+                    "  {label} ({license}) — invalid or non-SPDX expression (manual review needed)"
+                )),
+            }
+        }
+    }
+
+    println!("  Checked {checked} web packages");
+    if !unverified.is_empty() {
+        println!("  Unverified web licenses — manual review required:");
+        for item in &unverified {
+            println!("WARN {item}");
+        }
+    }
+
+    if violations.is_empty() {
+        println!("  No web license violations found.");
+        Ok(())
+    } else {
+        println!("  Web license violations:");
+        for violation in &violations {
+            println!("{violation}");
+        }
+        Err(format!("{} web license violation(s) found", violations.len()).into())
+    }
+}
+
+fn check_web_licenses(root: &Path, denied: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
     let web_dir = root.join("web");
     if !web_dir.join("package.json").exists() {
         println!("Skipping web license check (no web/package.json)");
         return Ok(());
     }
 
-    // Try pnpm licenses list
     let output = Command::new("pnpm")
         .args(["licenses", "list", "--json"])
         .current_dir(&web_dir)
-        .output();
-
-    match output {
-        Ok(out) if out.status.success() => {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            println!("  Web dependency licenses:");
-            // Just report — pnpm licenses list shows the breakdown
-            let lines: Vec<&str> = stdout.lines().take(20).collect();
-            for line in lines {
-                println!("    {}", line);
-            }
-            if stdout.lines().count() > 20 {
-                println!("    ... (truncated)");
-            }
-        }
-        _ => {
-            println!("  pnpm licenses not available, skipping web license check");
-        }
+        .output()
+        .map_err(|error| format!("failed to run pnpm licenses list: {error}"))?;
+    if !output.status.success() {
+        return Err("pnpm licenses list failed".into());
     }
 
-    Ok(())
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("invalid pnpm license JSON: {error}"))?;
+    check_web_license_policy(&report, denied)
 }
 
 pub fn run(args: LicenseCheckArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -245,7 +340,7 @@ pub fn run(args: LicenseCheckArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     if check_all || args.web {
         println!("=== Web Dependencies ===");
-        check_web_licenses(&root)?;
+        check_web_licenses(&root, &denied)?;
         println!();
     }
 
@@ -336,5 +431,71 @@ mod tests {
             "cargo-deny rejected the graph"
         );
         assert!(!metadata_loaded.get());
+    }
+
+    #[test]
+    fn web_license_report_enforces_the_explicit_deny_list() {
+        let report = serde_json::json!({
+            "MIT": [{
+                "name": "blocked-web-package",
+                "versions": ["1.0.0"],
+                "license": "MIT"
+            }]
+        });
+
+        let result = check_web_license_policy(&report, &["MIT"]);
+
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("1 web license violation"),
+            "pnpm's JSON report must be enforced rather than merely printed"
+        );
+    }
+
+    #[test]
+    fn web_license_report_respects_spdx_or_choices() {
+        let report = serde_json::json!({
+            "GPL-3.0-only OR MIT": [{
+                "name": "dual-licensed-web-package",
+                "versions": ["1.0.0"],
+                "license": "GPL-3.0-only OR MIT"
+            }]
+        });
+
+        check_web_license_policy(&report, &["GPL-3.0-only"]).unwrap();
+    }
+
+    #[test]
+    fn malformed_web_license_report_fails_closed() {
+        let result = check_web_license_policy(&serde_json::json!([]), &["MIT"]);
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "pnpm license report was not a JSON object"
+        );
+    }
+
+    #[test]
+    fn malformed_web_package_entries_fail_closed() {
+        for report in [
+            serde_json::json!({ "MIT": [null] }),
+            serde_json::json!({
+                "MIT": [{
+                    "name": "package",
+                    "versions": "1.0.0",
+                    "license": "MIT"
+                }]
+            }),
+            serde_json::json!({
+                "MIT": [{
+                    "name": "package",
+                    "versions": ["1.0.0"],
+                    "license": []
+                }]
+            }),
+        ] {
+            assert!(check_web_license_policy(&report, &["GPL-3.0-only"]).is_err());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- parse the real pnpm `{ license: package[] }` JSON report and evaluate every web package
- apply the same SPDX OR/AND, custom deny-list, and Commons Clause policy used for Rust dependencies
- fail closed when pnpm cannot run, exits unsuccessfully, or returns malformed JSON

## Stack
- based on #6807, which enforces custom denied licenses on the Rust cargo-deny path
- this PR contains only web license enforcement relative to that branch

## Verification
- `cargo test -p xtask license_check::tests -- --nocapture` (9 passed)
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo run -p xtask -- license-check --web` (95 packages, pass)
- `cargo run -p xtask -- license-check --web --deny MIT` (expected exit 1, 77 violations)
- `git diff --check`