### PR TITLE
fix(ci): prevent release tag input injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,8 @@ jobs:
               sys.exit(1)
           print(f'{len(glob.glob(".github/workflows/*.yml"))} workflow files parse and declare triggers + jobs')
           PY
+      - name: Check release-tag workflow input safety
+        run: python3 scripts/tests/test_release_tag_workflow_safety.py
       - name: Check formatting
         run: cargo xtask fmt
       - name: Check API error response shape (issue #3505)

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -42,18 +42,22 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Verify tag format
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           # CalVer YYYY.M.PATCH with optional -beta.N / -rc.N / -lts suffix
-          if ! echo "${{ inputs.version }}" | grep -qE '^v[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-(beta|rc)\.?[0-9]+|-lts)?$'; then
-            echo "::error::tag '${{ inputs.version }}' does not match expected CalVer pattern"
+          if ! printf '%s\n' "$VERSION" | grep -qE '^v[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-(beta|rc)\.?[0-9]+|-lts)?$'; then
+            echo "::error::tag '$VERSION' does not match expected CalVer pattern"
             exit 1
           fi
 
       - name: Verify tag matches workspace version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           # Same gate as release.yml `create_release` — the manifest
           # section must match the tag the maintainer is requesting.
-          TAG="${{ inputs.version }}"
+          TAG="$VERSION"
           WS_VERSION=$(sed -n '/^\[workspace\.package\]/,/^\[/{ s/^version *= *"\([^"]*\)".*/\1/p }' Cargo.toml | head -1)
           if [ "${TAG#v}" != "$WS_VERSION" ]; then
             echo "::error::requested tag $TAG does not match [workspace.package].version $WS_VERSION"
@@ -62,21 +66,25 @@ jobs:
           echo "Tag $TAG matches workspace version $WS_VERSION"
 
       - name: Verify tag does not already exist
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if git rev-parse "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "::error::tag '${{ inputs.version }}' already exists locally"
+          if git rev-parse --verify "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::tag '$VERSION' already exists locally"
             exit 1
           fi
-          if git ls-remote --tags origin "refs/tags/${{ inputs.version }}" | grep -q "${{ inputs.version }}"; then
-            echo "::error::tag '${{ inputs.version }}' already exists on origin"
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -Fq -- "$VERSION"; then
+            echo "::error::tag '$VERSION' already exists on origin"
             exit 1
           fi
 
       - name: Create + push tag
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git tag "${{ inputs.version }}"
-          git push origin "${{ inputs.version }}"
-          echo "✓ Pushed tag ${{ inputs.version }}"
+          git tag -- "$VERSION"
+          git push origin "refs/tags/$VERSION"
+          echo "✓ Pushed tag $VERSION"
           echo "Note: this push will trigger release.yml on the tag — split workflows below are only needed if individual targets need to be re-run."

--- a/changelog.d/security/6809-release-tag-input-injection.md
+++ b/changelog.d/security/6809-release-tag-input-injection.md
@@ -1,0 +1,1 @@
+- Keep the manual release-tag version input out of generated shell source by passing it through step environment variables, with a CI regression check covering every release-tag `run:` block. (@TechWizard9999)

--- a/scripts/tests/test_release_tag_workflow_safety.py
+++ b/scripts/tests/test_release_tag_workflow_safety.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Regression checks for untrusted release-tag workflow inputs."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "release-tag.yml"
+INPUTS_TOKEN = re.compile(r"\binputs\b")
+
+
+def contains_direct_input(script: str) -> bool:
+    # Conservatively reject any shell source that contains both a GitHub
+    # expression and the inputs context. This covers dot/bracket access,
+    # github.event aliases, and wrappers whose string literals contain braces.
+    return "${{" in script and INPUTS_TOKEN.search(script) is not None
+
+
+def main() -> None:
+    unsafe_forms = (
+        "${{ inputs.version }}",
+        "${{inputs['version']}}",
+        '${{ inputs["version"] }}',
+        "${{ github.event.inputs.version }}",
+        "${{ github.event.inputs['version'] }}",
+        "${{ github.event['inputs']['version'] }}",
+        "${{ format('{0}', inputs.version) }}",
+    )
+    if not all(contains_direct_input(form) for form in unsafe_forms):
+        raise SystemExit("release workflow input scanner does not cover every expression form")
+    if contains_direct_input("${{ matrix.target }}"):
+        raise SystemExit("release workflow input scanner rejected an unrelated expression")
+
+    document = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    unsafe_steps: list[str] = []
+    for job in document.get("jobs", {}).values():
+        for step in job.get("steps", []):
+            script = step.get("run")
+            if isinstance(script, str) and contains_direct_input(script):
+                unsafe_steps.append(step.get("name", "unnamed step"))
+
+    if unsafe_steps:
+        raise SystemExit(
+            "release-tag workflow interpolates the inputs context directly into run blocks: "
+            + ", ".join(unsafe_steps)
+        )
+
+    print("release-tag workflow keeps the inputs context out of shell source")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- pass the manual release version through step environment variables instead of interpolating it into shell source
- quote every shell expansion and use explicit tag refs/option terminators for git and grep
- add an always-routed Quality regression that parses release-tag.yml and rejects direct input interpolation in any `run:` block

## Verification
- regression test RED on the old workflow, GREEN after the fix
- `python3 scripts/tests/test_release_tag_workflow_safety.py`
- parsed every `.github/workflows/*.yml` with PyYAML
- `actionlint .github/workflows/release-tag.yml`
- `python3 -m py_compile scripts/tests/test_release_tag_workflow_safety.py`
- `git diff --check`