### PR TITLE
fix(rl-export): fail closed on HTTP client errors

### DIFF
--- a/changelog.d/security/6811-rl-export-client-fail-closed.md
+++ b/changelog.d/security/6811-rl-export-client-fail-closed.md
@@ -1,0 +1,3 @@
+Fail closed when the RL trajectory exporters cannot construct their redirect-disabled HTTP client. (@houko)
+W&B, Tinker, and Atropos previously fell back to the shared default client after a builder error; because that fallback follows redirects, a rare local client-configuration failure silently removed the SSRF guard and could replay export credentials to a redirected destination.
+Client construction is now shared by all three exporters, preserves the configured proxy and TLS settings, disables redirects, and returns the construction error instead of weakening the transport policy.

--- a/crates/librefang-rl-export/src/atropos.rs
+++ b/crates/librefang-rl-export/src/atropos.rs
@@ -46,7 +46,8 @@
 //! See <https://github.com/NousResearch/atropos/blob/main/atroposlib/api/server.py>
 //! and `atroposlib/api/env_interaction.md` for the producer-side flow.
 //!
-//! All HTTP traffic flows through `librefang_http::proxied_client()`.
+//! All HTTP traffic uses `librefang_http::proxied_client_builder()` with
+//! redirect following disabled.
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -165,10 +166,7 @@ pub(crate) async fn export_to_atropos_with_base(
     // metadata), bypassing the guard. A finished upload never needs to
     // follow a redirect; a 3xx must surface as an error. Mirrors
     // `librefang_http::oauth_client_builder`.
-    let client = librefang_http::proxied_client_builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .unwrap_or_else(|_| librefang_http::proxied_client());
+    let client = crate::build_export_http_client()?;
 
     // Step 1: register this producer with the running Atropos trainer.
     let register_url = format!("{}/register-env", base.trim_end_matches('/'));

--- a/crates/librefang-rl-export/src/lib.rs
+++ b/crates/librefang-rl-export/src/lib.rs
@@ -32,12 +32,14 @@
 //!
 //! # HTTP client
 //!
-//! All outbound HTTP flows through
-//! [`librefang_http::proxied_client`], the workspace's shared
-//! reqwest client. This is non-negotiable per the
+//! All outbound HTTP clients start from
+//! [`librefang_http::proxied_client_builder`], the workspace's shared
+//! reqwest client configuration. This is non-negotiable per the
 //! `librefang-extensions` AGENTS.md ("no bespoke `reqwest::Client`"):
-//! the shared client carries the configured proxy, TLS fallback
-//! roots, and `User-Agent: librefang/<version>`.
+//! the shared builder carries the configured proxy, TLS fallback
+//! roots, and `User-Agent: librefang/<version>`. Exporters additionally
+//! disable redirects before building the client and fail closed if that
+//! secure client cannot be constructed.
 
 #![deny(missing_docs)]
 
@@ -52,6 +54,19 @@ mod wandb;
 pub use error::ExportError;
 
 use chrono::{DateTime, Utc};
+
+fn build_export_http_client_with(
+    builder: reqwest::ClientBuilder,
+) -> Result<reqwest::Client, ExportError> {
+    builder
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(ExportError::from)
+}
+
+fn build_export_http_client() -> Result<reqwest::Client, ExportError> {
+    build_export_http_client_with(librefang_http::proxied_client_builder())
+}
 
 /// Target service to export a trajectory to.
 ///
@@ -340,6 +355,15 @@ pub(crate) fn resolve_env_secret(env_var: &str, field_label: &str) -> Result<Str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn export_client_build_failure_is_not_replaced_by_a_default_client() {
+        let invalid_builder = reqwest::Client::builder().user_agent("invalid\nuser-agent");
+        let error = build_export_http_client_with(invalid_builder)
+            .expect_err("an invalid secure client must fail closed");
+
+        assert!(matches!(error, ExportError::NetworkError(_)));
+    }
 
     /// `*_env` indirection: an empty env-var name fails fast with
     /// `InvalidConfig` (no env probe) so a caller that accidentally

--- a/crates/librefang-rl-export/src/tinker.rs
+++ b/crates/librefang-rl-export/src/tinker.rs
@@ -34,8 +34,9 @@
 //! module should switch to it; until then the telemetry-event path is
 //! what the upstream actually accepts. See the PR body for sign-off.
 //!
-//! All HTTP traffic flows through `librefang_http::proxied_client()` so
-//! the operator's `[proxy]` config and TLS fallback apply uniformly.
+//! All HTTP traffic uses `librefang_http::proxied_client_builder()` with
+//! redirect following disabled, while retaining the operator's `[proxy]`
+//! config and TLS fallback.
 
 use base64::Engine;
 use chrono::Utc;
@@ -163,10 +164,7 @@ pub(crate) async fn export_to_tinker_with_base(
     // metadata), replaying the `x-api-key` header on 307/308. A finished
     // upload never needs to follow a redirect; a 3xx must surface as an
     // error. Mirrors `librefang_http::oauth_client_builder`.
-    let client = librefang_http::proxied_client_builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .unwrap_or_else(|_| librefang_http::proxied_client());
+    let client = crate::build_export_http_client()?;
 
     // Step 1: register the session on Tinker. Sort tags for byte-
     // identical wire output (refs #3298 prompt-cache determinism).

--- a/crates/librefang-rl-export/src/wandb.rs
+++ b/crates/librefang-rl-export/src/wandb.rs
@@ -16,9 +16,9 @@
 //! base64("api:<key>")`. The leading `api:` is the W&B-documented user
 //! placeholder — the API key itself is the password.
 //!
-//! All HTTP traffic flows through `librefang_http::proxied_client()` so
-//! the operator's `[proxy]` config and TLS fallback apply uniformly with
-//! every other outbound caller in the workspace (per the
+//! All HTTP traffic uses `librefang_http::proxied_client_builder()` with
+//! redirect following disabled, so the operator's `[proxy]` config and
+//! TLS fallback apply with every other outbound caller in the workspace (per the
 //! `librefang-extensions` crate's HTTP client convention).
 
 use base64::Engine;
@@ -132,10 +132,7 @@ pub(crate) async fn export_to_wandb_with_base(
     // metadata), replaying the `Authorization` header on 307/308. A
     // finished upload never needs to follow a redirect; a 3xx must
     // surface as an error. Mirrors `librefang_http::oauth_client_builder`.
-    let client = librefang_http::proxied_client_builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .unwrap_or_else(|_| librefang_http::proxied_client());
+    let client = crate::build_export_http_client()?;
     let auth_header = build_basic_auth(api_key);
 
     // Step 1: create / register the run. Wrapped in retry so transient


### PR DESCRIPTION
## Summary

- share one redirect-disabled HTTP client constructor across W&B, Tinker, and Atropos exporters
- propagate client construction failures instead of falling back to the redirect-following shared client
- add a regression that forces builder failure and verifies the transport policy fails closed

## Security impact

The previous fallback silently removed the exporters' redirect policy if reqwest client construction failed. A subsequent 307/308 could then replay export credentials or payloads to a redirected destination despite the initial URL validation.

## Verification

- `cargo test -p librefang-rl-export` (52 passed)
- `cargo clippy -p librefang-rl-export --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
