### PR TITLE
fix(rl-export): bound metadata redaction depth

### DIFF
--- a/changelog.d/security/6815-rl-export-redaction-depth.md
+++ b/changelog.d/security/6815-rl-export-redaction-depth.md
@@ -1,0 +1,3 @@
+Bound RL trajectory metadata redaction to 128 nested JSON containers and replace any deeper branch with `<REDACTED:TOO_DEEP>`. (@houko)
+`toolset_metadata` can contain values assembled directly by tools rather than parsed with serde_json's default recursion limit, and the previous recursive walker had no independent depth budget; a sufficiently nested value could overflow the exporter thread's stack before upload.
+Values through the documented budget retain the existing recursive credential scrubbing behavior, while the first over-budget container is replaced wholesale so neither its contents nor further recursion reach W&B or Tinker.

--- a/crates/librefang-rl-export/src/atropos.rs
+++ b/crates/librefang-rl-export/src/atropos.rs
@@ -131,8 +131,9 @@ pub(crate) async fn export_to_atropos_with_base(
     base: &str,
     project: &str,
     tuning: AtroposTuning,
-    export: RlTrajectoryExport,
+    mut export: RlTrajectoryExport,
 ) -> Result<ExportReceipt, ExportError> {
+    crate::normalize_export_metadata(&mut export);
     if project.is_empty() {
         return Err(ExportError::InvalidConfig(
             "Atropos project (desired_name) is empty".to_string(),

--- a/crates/librefang-rl-export/src/lib.rs
+++ b/crates/librefang-rl-export/src/lib.rs
@@ -255,8 +255,9 @@ pub struct ExportReceipt {
 ///   the body did not match the expected shape.
 pub async fn export(
     target: ExportTarget,
-    payload: RlTrajectoryExport,
+    mut payload: RlTrajectoryExport,
 ) -> Result<ExportReceipt, ExportError> {
+    normalize_export_metadata(&mut payload);
     match target {
         ExportTarget::WandB {
             project,
@@ -308,6 +309,12 @@ pub async fn export(
             )
             .await
         }
+    }
+}
+
+fn normalize_export_metadata(export: &mut RlTrajectoryExport) {
+    if let Some(metadata) = export.toolset_metadata.take() {
+        export.toolset_metadata = Some(redact::redact_metadata(metadata));
     }
 }
 
@@ -367,6 +374,31 @@ mod tests {
             }
             other => panic!("expected InvalidConfig, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn invalid_export_safely_consumes_extremely_deep_metadata() {
+        let mut metadata = serde_json::Value::Null;
+        for _ in 0..50_000 {
+            metadata = serde_json::Value::Array(vec![metadata]);
+        }
+        let payload = RlTrajectoryExport {
+            run_id: "rid".to_string(),
+            trajectory_bytes: b"bytes".to_vec(),
+            toolset_metadata: Some(metadata),
+            started_at: chrono::Utc::now(),
+            finished_at: chrono::Utc::now(),
+        };
+        let target = ExportTarget::Atropos {
+            project: String::new(),
+            base_url: "http://127.0.0.1:8000".to_string(),
+            max_token_length: None,
+            group_size: None,
+            weight: None,
+        };
+
+        let error = export(target, payload).await.unwrap_err();
+        assert!(matches!(error, ExportError::InvalidConfig(_)));
     }
 
     /// SSRF gate: routing a Tinker export at the cloud metadata IP

--- a/crates/librefang-rl-export/src/redact.rs
+++ b/crates/librefang-rl-export/src/redact.rs
@@ -24,14 +24,18 @@
 //! Only string values are rewritten — JSON keys are left intact (tool
 //! input keys carry no secret material in practice and rewriting them
 //! would corrupt schemas the upstream may rely on). Nested objects /
-//! arrays are walked recursively so a credential inside
+//! arrays are walked recursively up to 128 container levels so a credential inside
 //! `{"tool_result": {"stdout": "API_KEY=sk-..."}}` is caught at any
-//! depth.
+//! normal depth. A deeper container is replaced wholesale with
+//! `<REDACTED:TOO_DEEP>` instead of risking a stack overflow.
 
 use std::sync::OnceLock;
 
 use regex::Regex;
 use serde_json::Value;
+
+const MAX_METADATA_DEPTH: usize = 128;
+const TOO_DEEP_SENTINEL: &str = "<REDACTED:TOO_DEEP>";
 
 // Pattern source strings. Lifted to module-level `const`s so the
 // parity-snapshot test (`tests::regex_set_matches_kernel_snapshot`)
@@ -89,20 +93,71 @@ fn redact_string(input: &str) -> String {
     out
 }
 
-/// Walk a `serde_json::Value` and rewrite every string in-place. Keys
-/// are not touched (see module docs).
-pub(crate) fn redact_metadata(value: &Value) -> Value {
-    match value {
-        Value::String(s) => Value::String(redact_string(s)),
-        Value::Array(arr) => Value::Array(arr.iter().map(redact_metadata).collect()),
-        Value::Object(map) => {
-            let mut out = serde_json::Map::with_capacity(map.len());
-            for (k, v) in map {
-                out.insert(k.clone(), redact_metadata(v));
+/// Consume a `serde_json::Value` and rewrite every string. Keys are not
+/// touched (see module docs). An explicit work stack avoids recursive walk
+/// and drop glue on adversarially deep caller-constructed values.
+pub(crate) fn redact_metadata(value: Value) -> Value {
+    enum Work {
+        Visit(Value, usize),
+        FinishArray(usize),
+        FinishObject(Vec<String>),
+    }
+
+    let mut work = vec![Work::Visit(value, 0)];
+    let mut output = Vec::new();
+    while let Some(item) = work.pop() {
+        match item {
+            Work::Visit(Value::String(value), _) => {
+                output.push(Value::String(redact_string(&value)));
             }
-            Value::Object(out)
+            Work::Visit(value @ (Value::Array(_) | Value::Object(_)), depth)
+                if depth >= MAX_METADATA_DEPTH =>
+            {
+                drop_value_iteratively(value);
+                output.push(Value::String(TOO_DEEP_SENTINEL.to_string()));
+            }
+            Work::Visit(Value::Array(values), depth) => {
+                let len = values.len();
+                work.push(Work::FinishArray(len));
+                work.extend(
+                    values
+                        .into_iter()
+                        .rev()
+                        .map(|value| Work::Visit(value, depth + 1)),
+                );
+            }
+            Work::Visit(Value::Object(map), depth) => {
+                let (keys, values): (Vec<_>, Vec<_>) = map.into_iter().unzip();
+                work.push(Work::FinishObject(keys));
+                work.extend(
+                    values
+                        .into_iter()
+                        .rev()
+                        .map(|value| Work::Visit(value, depth + 1)),
+                );
+            }
+            Work::Visit(value, _) => output.push(value),
+            Work::FinishArray(len) => {
+                let values = output.split_off(output.len() - len);
+                output.push(Value::Array(values));
+            }
+            Work::FinishObject(keys) => {
+                let values = output.split_off(output.len() - keys.len());
+                output.push(Value::Object(keys.into_iter().zip(values).collect()));
+            }
         }
-        other => other.clone(),
+    }
+    output.pop().expect("redaction always produces one value")
+}
+
+fn drop_value_iteratively(value: Value) {
+    let mut pending = vec![value];
+    while let Some(value) = pending.pop() {
+        match value {
+            Value::Array(values) => pending.extend(values),
+            Value::Object(map) => pending.extend(map.into_values()),
+            _ => {}
+        }
     }
 }
 
@@ -113,7 +168,7 @@ mod tests {
     #[test]
     fn redacts_api_key_in_value() {
         let v = serde_json::json!("API_KEY=sk-live-DO_NOT_LEAK_1234567890");
-        let red = redact_metadata(&v);
+        let red = redact_metadata(v);
         let s = red.as_str().expect("string value");
         assert!(!s.contains("sk-live-DO_NOT_LEAK"), "credential leaked: {s}");
         assert!(
@@ -130,7 +185,7 @@ mod tests {
         let token =
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
         let v = serde_json::json!({"tool_result": {"stdout": format!("auth: {token}")}});
-        let red = redact_metadata(&v);
+        let red = redact_metadata(v);
         let rendered = red.to_string();
         assert!(!rendered.contains(token), "JWT leaked: {rendered}");
         assert!(
@@ -148,7 +203,7 @@ mod tests {
                 {"level2": {"level3": "secret token=ABCDEFGHIJ1234567890XYZ"}}
             ]
         });
-        let red = redact_metadata(&v);
+        let red = redact_metadata(v);
         let rendered = red.to_string();
         assert!(
             !rendered.contains("ABCDEFGHIJ1234567890XYZ"),
@@ -157,11 +212,33 @@ mod tests {
     }
 
     #[test]
+    fn replaces_metadata_beyond_the_depth_budget() {
+        let mut within_budget = Value::String(["token=", "ABCDEFGHIJKLMNOP"].concat());
+        for _ in 0..MAX_METADATA_DEPTH {
+            within_budget = Value::Array(vec![within_budget]);
+        }
+        let within_budget = redact_metadata(within_budget).to_string();
+        assert!(within_budget.contains("<REDACTED:CREDENTIAL>"));
+        assert!(!within_budget.contains("ABCDEFGHIJKLMNOP"));
+
+        let mut value = Value::String("leaf".to_string());
+        for _ in 0..50_000 {
+            value = Value::Array(vec![value]);
+        }
+
+        let redacted = redact_metadata(value);
+        assert!(
+            redacted.to_string().contains("<REDACTED:TOO_DEEP>"),
+            "over-depth metadata must be replaced with a sentinel"
+        );
+    }
+
+    #[test]
     fn leaves_keys_intact() {
         // Keys are not secret in practice and rewriting them would
         // corrupt the upstream schema. Pin that they pass through.
         let v = serde_json::json!({"api_key_field_name": "harmless"});
-        let red = redact_metadata(&v);
+        let red = redact_metadata(v);
         let obj = red.as_object().expect("object");
         assert!(
             obj.contains_key("api_key_field_name"),
@@ -177,7 +254,7 @@ mod tests {
             "tools": ["shell", "fetch"],
             "description": "rollout for tenant A",
         });
-        let red = redact_metadata(&v);
+        let red = redact_metadata(v);
         let rendered = red.to_string();
         assert!(rendered.contains("shell"));
         assert!(rendered.contains("rollout for tenant A"));

--- a/crates/librefang-rl-export/src/tinker.rs
+++ b/crates/librefang-rl-export/src/tinker.rs
@@ -133,8 +133,9 @@ pub(crate) async fn export_to_tinker_with_base(
     base: &str,
     project: &str,
     api_key: &str,
-    export: RlTrajectoryExport,
+    mut export: RlTrajectoryExport,
 ) -> Result<ExportReceipt, ExportError> {
+    crate::normalize_export_metadata(&mut export);
     if api_key.is_empty() {
         return Err(ExportError::InvalidConfig(
             "Tinker api_key is empty".to_string(),
@@ -152,10 +153,7 @@ pub(crate) async fn export_to_tinker_with_base(
     // pins the value to the session's `user_metadata` (visible on
     // Tinker's session inspection surface), so a stray credential in
     // a tool result would otherwise leak.
-    let scrubbed_metadata = export
-        .toolset_metadata
-        .as_ref()
-        .map(crate::redact::redact_metadata);
+    let scrubbed_metadata = export.toolset_metadata.take();
 
     // Disable redirect following: the SSRF allowlist validates only the
     // initial base URL, so a redirect-following client would let an

--- a/crates/librefang-rl-export/src/wandb.rs
+++ b/crates/librefang-rl-export/src/wandb.rs
@@ -91,8 +91,9 @@ pub(crate) async fn export_to_wandb_with_base(
     entity: &str,
     run_id_hint: Option<&str>,
     api_key: &str,
-    export: RlTrajectoryExport,
+    mut export: RlTrajectoryExport,
 ) -> Result<ExportReceipt, ExportError> {
+    crate::normalize_export_metadata(&mut export);
     if api_key.is_empty() {
         return Err(ExportError::InvalidConfig(
             "W&B api_key is empty".to_string(),
@@ -121,10 +122,7 @@ pub(crate) async fn export_to_wandb_with_base(
     // forwards `metadata` to the run page verbatim, so a tool result
     // containing a stray credential would otherwise land in a
     // third-party UI.
-    let scrubbed_metadata = export
-        .toolset_metadata
-        .as_ref()
-        .map(crate::redact::redact_metadata);
+    let scrubbed_metadata = export.toolset_metadata.take();
 
     // Disable redirect following: the SSRF allowlist validates only the
     // initial base URL, so a redirect-following client would let an


### PR DESCRIPTION
## Summary

- consume owned trajectory metadata and redact it with an explicit iterative post-order work stack
- give the rebuilt output an explicit 128-container depth budget and replace the first over-budget array/object with `<REDACTED:TOO_DEEP>`
- iteratively dismantle rejected deep branches so their `serde_json::Value` drop glue cannot recurse either
- verify the deepest allowed string is credential-redacted and a 50,000-container input returns and is destroyed safely

## Security impact

Callers can pass a pre-built `serde_json::Value` that did not go through serde_json's normal parser recursion limit. The previous recursive walker—and later destruction of the still-owned input—could recurse until the exporter thread overflowed its stack before W&B/Tinker upload.

## Verification

- `cargo test -p librefang-rl-export` (52 passed)
- `cargo clippy -p librefang-rl-export --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
