### PR TITLE
fix(webhook): pin validated callback DNS addresses

### DIFF
--- a/changelog.d/security/6818-python-webhook-dns-ssrf.md
+++ b/changelog.d/security/6818-python-webhook-dns-ssrf.md
@@ -1,0 +1,3 @@
+Resolve and validate every DNS address for Python webhook callback URLs, then connect directly to that validated address set while preserving HTTPS SNI. (@houko)
+Callback delivery previously checked only IP literals and reserved hostname strings, so a public-looking hostname could resolve or rebind to loopback, RFC-1918, link-local, cloud metadata, or a private IPv4 endpoint embedded in IPv6.
+The callback transport now bypasses environment proxies and never re-resolves the hostname after validation; DNS failure or any unsafe answer fails closed before the signed request is sent.

--- a/sdk/python/librefang/sidecar/adapters/webhook.py
+++ b/sdk/python/librefang/sidecar/adapters/webhook.py
@@ -140,21 +140,22 @@ import asyncio
 import datetime
 import hashlib
 import hmac
+import http.client
 import http.server
 import ipaddress
 import json
 import os
+import socket
 import socketserver
 import threading
 import time
 import urllib.parse
-from typing import Any, Callable, Optional
+from typing import Any, Callable, List, Optional, Tuple
 
 from .. import logging as log
 from .. import protocol
 from ..common import (
     SeenSet as _SeenSet,
-    http_request as _http_request,
     parse_retry_after as _parse_retry_after,
     split_message as _split_message,
 )
@@ -240,39 +241,27 @@ def _is_private_ipv6(addr: ipaddress.IPv6Address) -> bool:
         return True
     if addr.is_private:
         return True
-    # IPv4-mapped (::ffff:x.x.x.x) and NAT64 (64:ff9b::x.x.x.x)
-    # both deliver to an IPv4 endpoint on the wire. Check the
-    # embedded v4 against the private table.
+    # Transition formats can deliver to an IPv4 endpoint on the wire.
+    # Inspect mapped, compatible, well-known NAT64, and 6to4 embeddings.
+    embedded: List[ipaddress.IPv4Address] = []
     if addr.ipv4_mapped is not None:
-        if _is_private_ipv4(addr.ipv4_mapped):
-            return True
+        embedded.append(addr.ipv4_mapped)
+    raw = addr.packed
+    if raw[:12] == b"\x00" * 12:
+        embedded.append(ipaddress.IPv4Address(raw[12:]))
+    if raw[:12] == bytes.fromhex("0064ff9b0000000000000000"):
+        embedded.append(ipaddress.IPv4Address(raw[12:]))
+    if addr.sixtofour is not None:
+        embedded.append(addr.sixtofour)
+    if any(_is_private_ipv4(v4) for v4 in embedded):
+        return True
     return False
 
 
-def validate_callback_url(url: str) -> Optional[str]:
-    """Returns ``None`` if the URL is safe to dial, else a string
-    describing the SSRF rejection reason. Pure function — used at
-    both construction and per-send to defend in depth."""
-    if not isinstance(url, str) or not url:
-        return "URL is empty"
-    try:
-        parsed = urllib.parse.urlparse(url)
-    except Exception as e:  # noqa: BLE001
-        return f"invalid URL: {e}"
-    if parsed.scheme not in ("http", "https"):
-        return f"scheme {parsed.scheme!r} is not allowed; only http/https"
-    host = parsed.hostname
-    if not host:
-        return "URL has no host"
-    # Try IP literal first.
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        # Hostname — check the reserved list.
-        trimmed = host.rstrip(".").lower()
-        if trimmed in _PRIVATE_HOSTNAMES:
-            return f"host {host!r} is a reserved or private hostname"
-        return None
+ResolvedAddress = Tuple[int, tuple]
+
+
+def _validate_ip_address(ip: Any) -> Optional[str]:
     if isinstance(ip, ipaddress.IPv4Address):
         if _is_private_ipv4(ip):
             return f"host resolves to private/reserved IPv4 {ip}"
@@ -280,6 +269,190 @@ def validate_callback_url(url: str) -> Optional[str]:
         if _is_private_ipv6(ip):
             return f"host resolves to private/reserved IPv6 {ip}"
     return None
+
+
+def _resolve_callback_url(
+    url: str,
+) -> Tuple[Optional[str], List[ResolvedAddress]]:
+    """Validate a callback URL and resolve every address it may dial.
+
+    The returned socket addresses are passed directly to the HTTP
+    connection.  Keeping resolution and connection tied together closes
+    the DNS rebinding window that a validate-then-resolve-again flow leaves.
+    """
+    if not isinstance(url, str) or not url:
+        return "URL is empty", []
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception as e:  # noqa: BLE001
+        return f"invalid URL: {e}", []
+    if parsed.scheme not in ("http", "https"):
+        return f"scheme {parsed.scheme!r} is not allowed; only http/https", []
+    if parsed.username is not None or parsed.password is not None:
+        return "URL userinfo is not allowed", []
+    host = parsed.hostname
+    if not host:
+        return "URL has no host", []
+    try:
+        parsed_port = parsed.port
+    except ValueError as e:
+        return f"invalid URL port: {e}", []
+    if parsed_port == 0:
+        return "URL port 0 is not allowed", []
+    port = (
+        parsed_port if parsed_port is not None
+        else (443 if parsed.scheme == "https" else 80)
+    )
+    # Try IP literal first.
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        # Hostname — check the reserved list.
+        trimmed = host.rstrip(".").lower()
+        if trimmed in _PRIVATE_HOSTNAMES:
+            return f"host {host!r} is a reserved or private hostname", []
+        try:
+            answers = socket.getaddrinfo(
+                host,
+                port,
+                family=socket.AF_UNSPEC,
+                type=socket.SOCK_STREAM,
+                proto=socket.IPPROTO_TCP,
+            )
+        except (OSError, UnicodeError) as e:
+            return f"DNS resolution failed for {host!r}: {e}", []
+
+        resolved: List[ResolvedAddress] = []
+        for family, _socktype, _proto, _canonname, sockaddr in answers:
+            if family not in (socket.AF_INET, socket.AF_INET6):
+                return f"DNS returned unsupported address family for {host!r}", []
+            try:
+                answer_ip = ipaddress.ip_address(sockaddr[0])
+            except ValueError:
+                return f"DNS returned an invalid address for {host!r}", []
+            reason = _validate_ip_address(answer_ip)
+            if reason is not None:
+                return reason, []
+            item = (family, sockaddr)
+            if item not in resolved:
+                resolved.append(item)
+        if not resolved:
+            return f"DNS resolution returned no addresses for {host!r}", []
+        return None, resolved
+
+    reason = _validate_ip_address(ip)
+    if reason is not None:
+        return reason, []
+    if isinstance(ip, ipaddress.IPv4Address):
+        return None, [(socket.AF_INET, (str(ip), port))]
+    return None, [(socket.AF_INET6, (str(ip), port, 0, 0))]
+
+
+def validate_callback_url(url: str) -> Optional[str]:
+    """Return ``None`` only when every address for the URL is public."""
+    reason, _resolved = _resolve_callback_url(url)
+    return reason
+
+
+def _connect_resolved(
+    addresses: List[ResolvedAddress], timeout: float,
+) -> socket.socket:
+    """Connect to one of the already-validated socket addresses."""
+    last_error: Optional[OSError] = None
+    for family, sockaddr in addresses:
+        sock: Optional[socket.socket] = None
+        try:
+            sock = socket.socket(
+                family, socket.SOCK_STREAM, socket.IPPROTO_TCP,
+            )
+            sock.settimeout(timeout)
+            sock.connect(sockaddr)
+            return sock
+        except OSError as e:
+            last_error = e
+            if sock is not None:
+                sock.close()
+    if last_error is not None:
+        raise last_error
+    raise OSError("callback URL has no resolved addresses")
+
+
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, *args: Any, resolved_addresses: List[ResolvedAddress], **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._resolved_addresses = resolved_addresses
+
+    def connect(self) -> None:
+        self.sock = _connect_resolved(self._resolved_addresses, self.timeout)
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(self, *args: Any, resolved_addresses: List[ResolvedAddress], **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._resolved_addresses = resolved_addresses
+
+    def connect(self) -> None:
+        raw_sock = _connect_resolved(self._resolved_addresses, self.timeout)
+        try:
+            # `self.host` remains the URL hostname, so certificate checks and
+            # SNI are preserved even though the TCP socket is pinned to an IP.
+            self.sock = self._context.wrap_socket(
+                raw_sock, server_hostname=self.host,
+            )
+        except Exception:
+            raw_sock.close()
+            raise
+
+
+def _http_request(
+    url: str,
+    *,
+    resolved_addresses: List[ResolvedAddress],
+    method: str = "GET",
+    body: Optional[bytes] = None,
+    headers: Optional[dict] = None,
+    timeout: float = 15.0,
+) -> tuple:
+    """Make one direct, redirect-free request to validated addresses.
+
+    This deliberately bypasses urllib's proxy discovery: an HTTP/CONNECT
+    proxy would resolve the hostname independently and break DNS pinning.
+    """
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname
+    if host is None:
+        raise ValueError("callback URL has no host")
+    parsed_port = parsed.port
+    port = (
+        parsed_port if parsed_port is not None
+        else (443 if parsed.scheme == "https" else 80)
+    )
+    connection_type = (
+        _PinnedHTTPSConnection if parsed.scheme == "https"
+        else _PinnedHTTPConnection
+    )
+    conn = connection_type(
+        host,
+        port,
+        timeout=timeout,
+        resolved_addresses=resolved_addresses,
+    )
+    path = urllib.parse.urlunparse(("", "", parsed.path or "/", parsed.params,
+                                    parsed.query, ""))
+    try:
+        conn.request(method, path, body=body, headers=headers or {})
+        response = conn.getresponse()
+        raw = response.read()
+        response_headers = {k.lower(): v for k, v in response.getheaders()}
+        parsed_body = None
+        if raw:
+            try:
+                parsed_body = json.loads(raw.decode("utf-8"))
+            except (ValueError, TypeError, UnicodeDecodeError):
+                pass
+        return response.status, parsed_body, raw, response_headers
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -678,7 +851,7 @@ class WebhookAdapter(SidecarAdapter):
         # somehow rotates the env to a private URL mid-process
         # (config reload), refuse instead of leaking the signing
         # secret to localhost.
-        reason = validate_callback_url(self.callback_url)
+        reason, resolved_addresses = _resolve_callback_url(self.callback_url)
         if reason is not None:
             raise RuntimeError(
                 f"webhook send refused by SSRF guard: {reason}",
@@ -701,6 +874,7 @@ class WebhookAdapter(SidecarAdapter):
         status, _resp, raw, resp_hdrs = _http_request(
             self.callback_url, method="POST", body=body, headers=headers,
             timeout=SEND_TIMEOUT_SECS,
+            resolved_addresses=resolved_addresses,
         )
         if status == 429:
             wait = _parse_retry_after(
@@ -714,6 +888,7 @@ class WebhookAdapter(SidecarAdapter):
             status, _resp, raw, resp_hdrs = _http_request(
                 self.callback_url, method="POST", body=body, headers=headers,
                 timeout=SEND_TIMEOUT_SECS,
+                resolved_addresses=resolved_addresses,
             )
         if status < 200 or status >= 300:
             snippet = raw[:200].decode("utf-8", "replace") if raw else ""

--- a/sdk/python/tests/test_webhook_adapter.py
+++ b/sdk/python/tests/test_webhook_adapter.py
@@ -1,6 +1,6 @@
 """Tests for librefang.sidecar.adapters.webhook.
 
-Deterministic, no network — urllib monkeypatched via _http_request.
+Deterministic, no network — DNS and the callback transport are monkeypatched.
 """
 from __future__ import annotations
 
@@ -8,12 +8,29 @@ import hashlib
 import hmac
 import json
 import os
+import socket
 import time
 
 import pytest
 
 os.environ.setdefault("WEBHOOK_SECRET", "test-secret")
 from librefang.sidecar.adapters import webhook as wh  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _public_example_dns(monkeypatch):
+    """Keep callback tests deterministic while production now resolves DNS."""
+    real_getaddrinfo = socket.getaddrinfo
+
+    def _getaddrinfo(host, port, *args, **kwargs):
+        if str(host).rstrip(".").lower() == "example.com":
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+                 ("93.184.216.34", port)),
+            ]
+        return real_getaddrinfo(host, port, *args, **kwargs)
+
+    monkeypatch.setattr(wh.socket, "getaddrinfo", _getaddrinfo)
 
 
 def _adapter(**env):
@@ -125,6 +142,36 @@ def test_validate_callback_url_returns_none_for_public():
     assert wh.validate_callback_url("https://8.8.8.8/path") is None
 
 
+def test_validate_callback_url_rejects_any_private_dns_answer(monkeypatch):
+    monkeypatch.setattr(
+        wh.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+             ("93.184.216.34", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+             ("169.254.169.254", 443)),
+        ],
+    )
+
+    reason = wh.validate_callback_url("https://callbacks.example/in")
+
+    assert reason is not None
+    assert "169.254.169.254" in reason
+
+
+def test_validate_callback_url_rejects_dns_failure(monkeypatch):
+    def _fail(*_args, **_kwargs):
+        raise socket.gaierror("resolver unavailable")
+
+    monkeypatch.setattr(wh.socket, "getaddrinfo", _fail)
+
+    reason = wh.validate_callback_url("https://callbacks.example/in")
+
+    assert reason is not None
+    assert "DNS resolution failed" in reason
+
+
 def test_validate_callback_url_rejects_loopback_ipv4():
     assert wh.validate_callback_url("http://127.0.0.1") is not None
     assert wh.validate_callback_url("http://127.255.255.255") is not None
@@ -168,6 +215,18 @@ def test_validate_callback_url_rejects_ipv4_mapped_ipv6():
     assert wh.validate_callback_url("http://[::ffff:127.0.0.1]") is not None
 
 
+@pytest.mark.parametrize(
+    "host",
+    [
+        "::127.0.0.1",
+        "64:ff9b::7f00:1",
+        "2002:7f00:0001::",
+    ],
+)
+def test_validate_callback_url_rejects_embedded_private_ipv4(host):
+    assert wh.validate_callback_url(f"http://[{host}]") is not None
+
+
 def test_validate_callback_url_rejects_localhost_hostname():
     assert wh.validate_callback_url("http://localhost") is not None
     # FQDN trailing dot must not bypass.
@@ -192,6 +251,13 @@ def test_validate_callback_url_rejects_empty():
 
 def test_validate_callback_url_rejects_no_host():
     assert wh.validate_callback_url("http:///path-no-host") is not None
+
+
+def test_validate_callback_url_rejects_port_zero():
+    reason = wh.validate_callback_url("https://8.8.8.8:0/callback")
+
+    assert reason is not None
+    assert "port 0" in reason
 
 
 # ---- signature helpers ---------------------------------------------
@@ -586,6 +652,155 @@ def test_send_text_basic(monkeypatch):
     assert body["recipient_id"] == "user-1"
     assert body["recipient_name"] == "Alice"
     assert headers.get("X-Webhook-Signature", "").startswith("sha256=")
+
+
+def test_send_uses_the_addresses_validated_for_that_request(monkeypatch):
+    dns_answers = iter([
+        [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+          ("93.184.216.34", 443))],
+        [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+          ("93.184.216.35", 443))],
+    ])
+    monkeypatch.setattr(
+        wh.socket, "getaddrinfo", lambda *_args, **_kwargs: next(dns_answers),
+    )
+    captured: list = []
+
+    def _fake_http(url, **kwargs):
+        captured.append((url, kwargs["resolved_addresses"]))
+        return (200, {}, b"", {})
+
+    monkeypatch.setattr(wh, "_http_request", _fake_http)
+    a = _adapter(WEBHOOK_CALLBACK_URL="https://callbacks.example/in")
+
+    a._send_text("user-1", "Alice", "hello")
+
+    assert captured == [
+        (
+            "https://callbacks.example/in",
+            [(socket.AF_INET, ("93.184.216.35", 443))],
+        ),
+    ]
+
+
+def test_send_rejects_dns_rebinding_before_http(monkeypatch):
+    dns_answers = iter([
+        [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+          ("93.184.216.34", 443))],
+        [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "",
+          ("127.0.0.1", 443))],
+    ])
+    monkeypatch.setattr(
+        wh.socket, "getaddrinfo", lambda *_args, **_kwargs: next(dns_answers),
+    )
+    calls: list = []
+    monkeypatch.setattr(
+        wh,
+        "_http_request",
+        lambda *args, **kwargs: (calls.append((args, kwargs)), (200, {}, b"", {}))[1],
+    )
+    a = _adapter(WEBHOOK_CALLBACK_URL="https://callbacks.example/in")
+
+    with pytest.raises(RuntimeError, match="SSRF guard"):
+        a._send_text("user-1", "Alice", "hello")
+
+    assert calls == []
+
+
+def test_connect_resolved_falls_back_without_dns(monkeypatch):
+    attempts: list = []
+
+    class _FakeSocket:
+        def __init__(self, family):
+            self.family = family
+
+        def settimeout(self, timeout):
+            self.timeout = timeout
+
+        def connect(self, sockaddr):
+            attempts.append((self.family, sockaddr))
+            if sockaddr[0] == "93.184.216.34":
+                raise OSError("first address unavailable")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        wh.socket,
+        "socket",
+        lambda family, _socktype, _proto: _FakeSocket(family),
+    )
+    addresses = [
+        (socket.AF_INET, ("93.184.216.34", 443)),
+        (socket.AF_INET, ("93.184.216.35", 443)),
+    ]
+
+    connected = wh._connect_resolved(addresses, 3.0)
+
+    assert connected.family == socket.AF_INET
+    assert attempts == [
+        (socket.AF_INET, ("93.184.216.34", 443)),
+        (socket.AF_INET, ("93.184.216.35", 443)),
+    ]
+
+
+def test_connect_resolved_falls_back_when_socket_family_is_unsupported(monkeypatch):
+    attempts: list = []
+
+    class _FakeSocket:
+        def settimeout(self, timeout):
+            self.timeout = timeout
+
+        def connect(self, sockaddr):
+            attempts.append(sockaddr)
+
+        def close(self):
+            pass
+
+    def _socket(family, _socktype, _proto):
+        if family == socket.AF_INET6:
+            raise OSError("IPv6 is unavailable")
+        return _FakeSocket()
+
+    monkeypatch.setattr(wh.socket, "socket", _socket)
+    addresses = [
+        (socket.AF_INET6, ("2001:4860:4860::8888", 443, 0, 0)),
+        (socket.AF_INET, ("93.184.216.34", 443)),
+    ]
+
+    connected = wh._connect_resolved(addresses, 3.0)
+
+    assert isinstance(connected, _FakeSocket)
+    assert attempts == [("93.184.216.34", 443)]
+
+
+def test_https_pinning_preserves_original_hostname_for_sni(monkeypatch):
+    raw_socket = object()
+    wrapped_socket = object()
+    calls: list = []
+    monkeypatch.setattr(
+        wh,
+        "_connect_resolved",
+        lambda addresses, timeout: raw_socket,
+    )
+
+    class _Context:
+        def wrap_socket(self, sock, *, server_hostname):
+            calls.append((sock, server_hostname))
+            return wrapped_socket
+
+    conn = wh._PinnedHTTPSConnection(
+        "callbacks.example",
+        443,
+        timeout=3.0,
+        resolved_addresses=[(socket.AF_INET, ("93.184.216.34", 443))],
+    )
+    conn._context = _Context()
+
+    conn.connect()
+
+    assert conn.sock is wrapped_socket
+    assert calls == [(raw_socket, "callbacks.example")]
 
 
 def test_send_text_chunks_long_message(monkeypatch):


### PR DESCRIPTION
## Summary
- resolve and validate every callback A/AAAA address at startup and before each send
- connect directly to the validated address set without proxy or redirect re-resolution
- preserve HTTPS certificate verification/SNI and multi-address fallback

## Verification
- `python3 -m pytest tests/test_webhook_adapter.py -q` (84 passed)
- `uv run --python 3.13 --with pytest --with pytest-asyncio pytest -q` (1921 passed)
- `python3 -m compileall -q sdk/python/librefang/sidecar/adapters/webhook.py`
- `git diff --check origin/main..HEAD`