### PR TITLE
fix(python-sdk): reject malformed command params

### DIFF
--- a/changelog.d/fixed/6819-python-sidecar-command-params.md
+++ b/changelog.d/fixed/6819-python-sidecar-command-params.md
@@ -1,0 +1,3 @@
+Reject non-object `params` on known Python sidecar commands as a recoverable protocol error. (@houko)
+Truthy arrays, strings, booleans, or numbers previously escaped `parse_command` as `AttributeError`, killed the reader task, and left the sidecar waiting forever instead of reporting the malformed frame and processing the next command.
+Unknown future command methods retain their raw parameter shape for forward compatibility.

--- a/sdk/python/librefang/sidecar/protocol.py
+++ b/sdk/python/librefang/sidecar/protocol.py
@@ -408,13 +408,31 @@ def parse_command(line: str) -> Command:
     valid JSON that is not an object (e.g. a bare number/array) — the
     reader treats both the same: emit a protocol error and continue,
     rather than letting an ``AttributeError`` escape and wedge the
-    adapter. Unknown methods become :class:`UnknownCommand`."""
+    adapter. Known commands also require object-shaped ``params``;
+    unknown methods retain their raw shape for forward compatibility."""
     obj = json.loads(line)
     if not isinstance(obj, dict):
         raise json.JSONDecodeError(
             "expected a JSON object", line, 0)
     method = obj.get("method")
-    p = obj.get("params") or {}
+    if method is not None and not isinstance(method, str):
+        raise json.JSONDecodeError(
+            "expected command method to be a JSON string", line, 0,
+        )
+    known_methods = {
+        "send", "ready_ack", "shutdown", "typing", "reaction",
+        "interactive", "stream_start", "stream_delta", "stream_end",
+        "heartbeat",
+    }
+    if method not in known_methods:
+        return UnknownCommand(method or "", obj)
+    p = obj.get("params")
+    if p is None:
+        p = {}
+    elif not isinstance(p, dict):
+        raise json.JSONDecodeError(
+            "expected command params to be a JSON object", line, 0,
+        )
     if method == "send":
         return Send(p.get("channel_id", ""), p.get("text", ""),
                     p.get("content"), p.get("thread_id"),
@@ -440,7 +458,7 @@ def parse_command(line: str) -> Command:
         return StreamEnd(p.get("stream_id", ""))
     if method == "heartbeat":
         return Heartbeat()
-    return UnknownCommand(method or "", obj)
+    raise AssertionError("known command was not parsed")
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/test_sidecar_protocol.py
+++ b/sdk/python/tests/test_sidecar_protocol.py
@@ -186,6 +186,31 @@ def test_parse_command_non_object_json_raises_decode_error():
             parse_command(bad)
 
 
+@pytest.mark.parametrize("params", [[1], "bad", True, 7, [], "", False])
+def test_parse_command_known_method_rejects_non_object_params(params):
+    line = json.dumps({"method": "send", "params": params})
+
+    with pytest.raises(json.JSONDecodeError, match="params"):
+        parse_command(line)
+
+
+def test_parse_command_unknown_method_keeps_future_params_shape():
+    command = parse_command(
+        '{"method":"future_command","params":["future","shape"]}',
+    )
+
+    assert isinstance(command, UnknownCommand)
+    assert command.raw["params"] == ["future", "shape"]
+
+
+@pytest.mark.parametrize("method", [[], {}, True, 7])
+def test_parse_command_rejects_non_string_method(method):
+    line = json.dumps({"method": method, "params": {}})
+
+    with pytest.raises(json.JSONDecodeError, match="method"):
+        parse_command(line)
+
+
 def test_parse_command_reaction_carries_phase_and_tool_name():
     # #6451: the enriched reaction frame carries the lifecycle phase tag
     # and (for tool_use) the tool name so an adapter can render a step

--- a/sdk/python/tests/test_sidecar_runtime.py
+++ b/sdk/python/tests/test_sidecar_runtime.py
@@ -161,6 +161,28 @@ async def test_invalid_json_emits_error_and_continues():
     assert any(s.text == "after" for s in adapter.sends)
 
 
+async def test_non_object_command_params_emit_error_and_continue():
+    adapter = RecordingAdapter()
+    emitted = await _drive(adapter, [
+        '{"method":"send","params":["not","an","object"]}',
+        '{"method":"send","params":{"channel_id":"c","text":"after","user":{}}}',
+    ])
+
+    assert any(e["method"] == "error" for e in emitted)
+    assert [send.text for send in adapter.sends] == ["after"]
+
+
+async def test_non_string_command_method_emits_error_and_continues():
+    adapter = RecordingAdapter()
+    emitted = await _drive(adapter, [
+        '{"method":[],"params":{}}',
+        '{"method":"send","params":{"channel_id":"c","text":"after","user":{}}}',
+    ])
+
+    assert any(e["method"] == "error" for e in emitted)
+    assert [send.text for send in adapter.sends] == ["after"]
+
+
 async def test_producer_emits_inbound_messages():
     class Producer(SidecarAdapter):
         async def on_send(self, cmd):  # unused here


### PR DESCRIPTION
## Summary
- reject non-object params on known sidecar commands with the parser existing JSONDecodeError recovery contract
- keep missing and null params compatible with empty command parameters
- preserve raw parameter shapes for unknown future methods

## Verification
- `python3 -m pytest tests/test_sidecar_protocol.py tests/test_sidecar_runtime.py -q` (32 passed)
- `uv run --no-project --python 3.13 --with pytest --with pytest-asyncio -- python -m pytest -q` (full SDK passed)
- `python3 -m compileall -q sdk/python/librefang/sidecar/protocol.py`
- `git diff --check origin/main..HEAD`