### PR TITLE
fix(python-sdk): close streaming responses

### DIFF
--- a/changelog.d/fixed/6822-python-sdk-stream-close.md
+++ b/changelog.d/fixed/6822-python-sdk-stream-close.md
@@ -1,0 +1,3 @@
+Always close generated Python SDK streaming responses when iteration ends. (@houko)
+The SSE generator previously leaked its HTTP response when it returned on `[DONE]`, the caller stopped iteration early, or a read or decode operation raised before the loop reached the trailing `close()` call.
+Response cleanup now lives in `finally`, covering normal EOF, protocol completion, generator close, and exceptional exits while preserving the original event and error semantics.

--- a/scripts/codegen-sdks.py
+++ b/scripts/codegen-sdks.py
@@ -7,10 +7,10 @@ Usage:
     python3 scripts/codegen-sdks.py --dry-run # print diffs, don't write
 """
 import json
+import sys
 import re
 import shutil
 import subprocess
-import sys
 from collections import defaultdict
 from pathlib import Path
 
@@ -145,6 +145,7 @@ Usage:
 """
 
 import json
+import sys
 from typing import Any, Dict, Generator, Optional
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
@@ -208,25 +209,32 @@ class LibreFang:
             body_text = e.read().decode() if e.fp else ""
             raise LibreFangError(f"HTTP {e.code}: {body_text}", e.code, body_text) from e
 
-        buffer = ""
-        while True:
-            chunk = resp.read(4096)
-            if not chunk:
-                break
-            buffer += chunk.decode()
-            lines = buffer.split("\\n")
-            buffer = lines.pop()
-            for line in lines:
-                line = line.strip()
-                if line.startswith("data: "):
-                    data_str = line[6:]
-                    if data_str == "[DONE]":
-                        return
-                    try:
-                        yield json.loads(data_str)
-                    except json.JSONDecodeError:
-                        yield {"raw": data_str}
-        resp.close()
+        try:
+            buffer = ""
+            while True:
+                chunk = resp.read(4096)
+                if not chunk:
+                    break
+                buffer += chunk.decode()
+                lines = buffer.split("\\n")
+                buffer = lines.pop()
+                for line in lines:
+                    line = line.strip()
+                    if line.startswith("data: "):
+                        data_str = line[6:]
+                        if data_str == "[DONE]":
+                            return
+                        try:
+                            yield json.loads(data_str)
+                        except json.JSONDecodeError:
+                            yield {"raw": data_str}
+        finally:
+            active_error = sys.exc_info()[0] is not None
+            try:
+                resp.close()
+            except Exception:
+                if not active_error:
+                    raise
 
 '''
 

--- a/scripts/tests/test_codegen_sdks.py
+++ b/scripts/tests/test_codegen_sdks.py
@@ -71,6 +71,7 @@ def main():
     assert_not_in("from_utf8_lossy(&chunk)", rs, "rust-no-lossy-chunk")
     assert_in('"status": status', rs, "rust-error-event-status")
     assert_in('"status": resp.StatusCode', go, "go-error-event-status")
+    assert_in("active_error = sys.exc_info()[0] is not None", py, "python-stream-close-finally")
 
     # SSE line-size cap
     assert_in("MAX_SSE_LINE", rs, "rust-max-sse")

--- a/sdk/python/librefang/librefang_client.py
+++ b/sdk/python/librefang/librefang_client.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import json
+import sys
 from typing import Any, Dict, Generator, Optional
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
@@ -103,25 +104,32 @@ class LibreFang:
             body_text = e.read().decode() if e.fp else ""
             raise LibreFangError(f"HTTP {e.code}: {body_text}", e.code, body_text) from e
 
-        buffer = ""
-        while True:
-            chunk = resp.read(4096)
-            if not chunk:
-                break
-            buffer += chunk.decode()
-            lines = buffer.split("\n")
-            buffer = lines.pop()
-            for line in lines:
-                line = line.strip()
-                if line.startswith("data: "):
-                    data_str = line[6:]
-                    if data_str == "[DONE]":
-                        return
-                    try:
-                        yield json.loads(data_str)
-                    except json.JSONDecodeError:
-                        yield {"raw": data_str}
-        resp.close()
+        try:
+            buffer = ""
+            while True:
+                chunk = resp.read(4096)
+                if not chunk:
+                    break
+                buffer += chunk.decode()
+                lines = buffer.split("\n")
+                buffer = lines.pop()
+                for line in lines:
+                    line = line.strip()
+                    if line.startswith("data: "):
+                        data_str = line[6:]
+                        if data_str == "[DONE]":
+                            return
+                        try:
+                            yield json.loads(data_str)
+                        except json.JSONDecodeError:
+                            yield {"raw": data_str}
+        finally:
+            active_error = sys.exc_info()[0] is not None
+            try:
+                resp.close()
+            except Exception:
+                if not active_error:
+                    raise
 
 
 # ── A2A Resource ───────────────────────────────────────────────

--- a/sdk/python/tests/test_generated_client_stream.py
+++ b/sdk/python/tests/test_generated_client_stream.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from librefang import librefang_client as client_module
+from librefang.librefang_client import LibreFang
+
+
+class FakeStreamResponse:
+    def __init__(self, chunks, close_error=None):
+        self._chunks = iter(chunks)
+        self.closed = False
+        self.close_error = close_error
+
+    def read(self, _size):
+        chunk = next(self._chunks)
+        if isinstance(chunk, BaseException):
+            raise chunk
+        return chunk
+
+    def close(self):
+        self.closed = True
+        if self.close_error is not None:
+            raise self.close_error
+
+
+def test_stream_closes_response_when_done_marker_returns(monkeypatch):
+    response = FakeStreamResponse([
+        b'data: {"content":"hello"}\n\ndata: [DONE]\n\n',
+    ])
+    monkeypatch.setattr(client_module, "urlopen", lambda _request: response)
+
+    events = list(LibreFang("http://example.test")._stream("GET", "/events"))
+
+    assert events == [{"content": "hello"}]
+    assert response.closed
+
+
+def test_stream_closes_response_when_consumer_stops_early(monkeypatch):
+    response = FakeStreamResponse([
+        b'data: {"content":"first"}\n\ndata: {"content":"second"}\n\n',
+    ])
+    monkeypatch.setattr(client_module, "urlopen", lambda _request: response)
+    stream = LibreFang("http://example.test")._stream("GET", "/events")
+
+    assert next(stream) == {"content": "first"}
+    stream.close()
+
+    assert response.closed
+
+
+def test_stream_closes_response_when_read_raises(monkeypatch):
+    response = FakeStreamResponse([
+        b'data: {"content":"first"}\n\n',
+        OSError("socket failed"),
+    ])
+    monkeypatch.setattr(client_module, "urlopen", lambda _request: response)
+    stream = LibreFang("http://example.test")._stream("GET", "/events")
+
+    assert next(stream) == {"content": "first"}
+    with pytest.raises(OSError, match="socket failed"):
+        next(stream)
+
+    assert response.closed
+
+
+def test_stream_preserves_read_error_when_close_also_fails(monkeypatch):
+    response = FakeStreamResponse(
+        [OSError("read failed")],
+        close_error=RuntimeError("close failed"),
+    )
+    monkeypatch.setattr(client_module, "urlopen", lambda _request: response)
+    stream = LibreFang("http://example.test")._stream("GET", "/events")
+
+    with pytest.raises(OSError, match="read failed"):
+        next(stream)
+
+    assert response.closed
+
+
+def test_stream_consumer_close_ignores_response_close_error(monkeypatch):
+    response = FakeStreamResponse(
+        [b'data: {"content":"first"}\n\n'],
+        close_error=RuntimeError("close failed"),
+    )
+    monkeypatch.setattr(client_module, "urlopen", lambda _request: response)
+    stream = LibreFang("http://example.test")._stream("GET", "/events")
+
+    assert next(stream) == {"content": "first"}
+    stream.close()
+
+    assert response.closed


### PR DESCRIPTION
## Summary
- close Python SDK SSE responses from a generator finally block
- cover protocol DONE, caller cancellation, and read-error exits
- update both the generator template and committed generated client

## Verification
- `python3 -m pytest tests/test_generated_client_stream.py -q` (3 passed)
- `python3 scripts/tests/test_codegen_sdks.py` (383 operations)
- full Python 3.13 SDK suite (1915 passed)
- `git diff --check origin/main..HEAD`