### PR TITLE
fix(email): honor MIME body charsets

### DIFF
--- a/changelog.d/fixed/6828-read-email-charsets.md
+++ b/changelog.d/fixed/6828-read-email-charsets.md
@@ -1,0 +1,3 @@
+Decode email bodies with their declared MIME charset. (@houko)
+The IMAP email helper previously forced UTF-8 for multipart plain text, HTML fallback, and non-multipart bodies, silently dropping bytes from common encodings such as ISO-8859-1 and GB2312.
+Each body part now uses its `charset` parameter while retaining UTF-8 as the fallback for missing or unknown charset labels.

--- a/scripts/read_email.py
+++ b/scripts/read_email.py
@@ -30,6 +30,18 @@ def decode_str(s, enc=None):
         return s.decode(enc or "utf-8", errors="ignore")
     return s or ""
 
+
+def decode_payload(payload, part):
+    """Decode MIME payload bytes using the part's declared charset."""
+    charset = part.get_content_charset() or "utf-8"
+    try:
+        return payload.decode(charset, errors="ignore")
+    except LookupError:
+        # Malformed or vendor-specific charset labels should not abort the
+        # whole mailbox read; retain the historical UTF-8 fallback.
+        return payload.decode("utf-8", errors="ignore")
+
+
 def get_body(msg):
     """Extract plain text body from email message."""
     if msg.is_multipart():
@@ -39,7 +51,7 @@ def get_body(msg):
             if ct == "text/plain" and "attachment" not in cd:
                 payload = part.get_payload(decode=True)
                 if payload:
-                    return payload.decode("utf-8", errors="ignore")
+                    return decode_payload(payload, part)
         # Fallback to HTML if no plain text
         for part in msg.walk():
             ct = part.get_content_type()
@@ -47,14 +59,14 @@ def get_body(msg):
             if ct == "text/html" and "attachment" not in cd:
                 payload = part.get_payload(decode=True)
                 if payload:
-                    text = payload.decode("utf-8", errors="ignore")
+                    text = decode_payload(payload, part)
                     text = re.sub(r'<[^>]+>', ' ', text)
                     text = re.sub(r'\s+', ' ', text).strip()
                     return text
     else:
         payload = msg.get_payload(decode=True)
         if payload:
-            return payload.decode("utf-8", errors="ignore")
+            return decode_payload(payload, msg)
     return ""
 
 def search_folder(mail, folder, sender):

--- a/scripts/tests/test_read_email.py
+++ b/scripts/tests/test_read_email.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Regression tests for MIME charset-aware body extraction."""
+
+import importlib.util
+import unittest
+from email import message_from_bytes
+from email.message import EmailMessage
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("read_email", ROOT / "scripts" / "read_email.py")
+read_email = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(read_email)
+
+
+class GetBodyCharsetTests(unittest.TestCase):
+    def test_multipart_plain_text_uses_declared_charset(self):
+        message = EmailMessage()
+        message.set_content("café", charset="iso-8859-1")
+        message.add_alternative("<p>fallback</p>", subtype="html", charset="utf-8")
+
+        self.assertEqual(read_email.get_body(message), "café\n")
+
+    def test_multipart_html_fallback_uses_declared_charset(self):
+        message = EmailMessage()
+        message.make_mixed()
+        html = EmailMessage()
+        html.set_content("<p>你好</p>", subtype="html", charset="gb2312")
+        message.attach(html)
+
+        self.assertEqual(read_email.get_body(message), "你好")
+
+    def test_non_multipart_body_uses_declared_charset(self):
+        message = EmailMessage()
+        message.set_content("olá", charset="iso-8859-1")
+
+        self.assertEqual(read_email.get_body(message), "olá\n")
+
+    def test_unknown_charset_label_falls_back_to_utf8(self):
+        message = message_from_bytes(
+            b'Content-Type: text/plain; charset="x-unknown"\n'
+            b"Content-Transfer-Encoding: 8bit\n\n"
+            b"caf\xc3\xa9"
+        )
+
+        self.assertEqual(read_email.get_body(message), "café")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- decode plain-text, HTML fallback, and non-multipart email bodies with each MIME part’s declared charset
- preserve UTF-8 fallback behavior for missing or unknown charset labels
- regression-test ISO-8859-1, GB2312, and malformed-label cases

## Verification
- `python3 scripts/tests/test_read_email.py` (4 passed)
- `python3 -m py_compile scripts/read_email.py scripts/tests/test_read_email.py`
- `git diff --check`