### PR TITLE
fix(email): always close IMAP sessions

### DIFF
--- a/changelog.d/fixed/6830-read-email-cleanup.md
+++ b/changelog.d/fixed/6830-read-email-cleanup.md
@@ -1,0 +1,3 @@
+Guarantee IMAP session cleanup in the email reader. (@houko)
+The helper previously logged out only on selected success and handled-error paths, leaking the connection when an unexpected exception occurred after login.
+It now closes every constructed IMAP session through a non-masking cleanup path, including login failures and all post-login exits.

--- a/scripts/read_email.py
+++ b/scripts/read_email.py
@@ -73,6 +73,15 @@ def search_folder(mail, folder, sender):
         print(f"WARNING: failed to search {folder}: {e}", file=sys.stderr)
         return []
 
+
+def logout_quietly(mail):
+    """Close an IMAP session without masking the original outcome."""
+    try:
+        mail.logout()
+    except Exception:
+        pass
+
+
 def main():
     sender = sys.argv[1] if len(sys.argv) > 1 else ""
     password = os.environ.get("EMAIL_PASSWORD", "")
@@ -86,60 +95,62 @@ def main():
         print("ERROR: EMAIL_PASSWORD not set", file=sys.stderr)
         sys.exit(1)
 
+    mail = None
     try:
         mail = imaplib.IMAP4_SSL(IMAP_SERVER, IMAP_PORT)
         mail.login(username, password)
     except Exception as e:
+        if mail is not None:
+            logout_quietly(mail)
         print(f"ERROR: IMAP login failed: {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Search across multiple folders
-    folders_to_try = [
-        "INBOX",
-        '"[Gmail]/All Mail"',
-        '"[Gmail]/Promotions"',
-        '"[Gmail]/Updates"',
-        "Promotions",
-        "Updates",
-    ]
-
-    found_ids = []
-    found_folder = None
-    for folder in folders_to_try:
-        ids = search_folder(mail, folder, sender)
-        if ids:
-            found_ids = ids
-            found_folder = folder
-            break
-
-    if not found_ids:
-        print(f"NO_EMAIL_FOUND (searched: INBOX, All Mail, Promotions, Updates)")
-        mail.logout()
-        sys.exit(0)
-
-    print(f"Found {len(found_ids)} email(s) in {found_folder}")
-
-    # Fetch the latest email
     try:
-        _, data = mail.fetch(found_ids[-1], "(RFC822)")
-        msg = email.message_from_bytes(data[0][1])
-    except Exception as e:
-        print(f"ERROR: fetch failed: {e}", file=sys.stderr)
-        mail.logout()
-        sys.exit(1)
+        # Search across multiple folders
+        folders_to_try = [
+            "INBOX",
+            '"[Gmail]/All Mail"',
+            '"[Gmail]/Promotions"',
+            '"[Gmail]/Updates"',
+            "Promotions",
+            "Updates",
+        ]
 
-    raw_subject = msg["Subject"] or ""
-    subject_raw, enc = decode_header(raw_subject)[0]
-    subject = decode_str(subject_raw, enc)
-    body = get_body(msg)
+        found_ids = []
+        found_folder = None
+        for folder in folders_to_try:
+            ids = search_folder(mail, folder, sender)
+            if ids:
+                found_ids = ids
+                found_folder = folder
+                break
 
-    print(f"SUBJECT: {subject}")
-    print(f"FROM: {msg['From']}")
-    print(f"DATE: {msg['Date']}")
-    print("---BODY---")
-    print(body[:4000])
+        if not found_ids:
+            print("NO_EMAIL_FOUND (searched: INBOX, All Mail, Promotions, Updates)")
+            sys.exit(0)
 
-    mail.logout()
+        print(f"Found {len(found_ids)} email(s) in {found_folder}")
+
+        # Fetch the latest email
+        try:
+            _, data = mail.fetch(found_ids[-1], "(RFC822)")
+            msg = email.message_from_bytes(data[0][1])
+        except Exception as e:
+            print(f"ERROR: fetch failed: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        raw_subject = msg["Subject"] or ""
+        subject_raw, enc = decode_header(raw_subject)[0]
+        subject = decode_str(subject_raw, enc)
+        body = get_body(msg)
+
+        print(f"SUBJECT: {subject}")
+        print(f"FROM: {msg['From']}")
+        print(f"DATE: {msg['Date']}")
+        print("---BODY---")
+        print(body[:4000])
+    finally:
+        logout_quietly(mail)
 
 if __name__ == "__main__":
     main()

--- a/scripts/tests/test_read_email_cleanup.py
+++ b/scripts/tests/test_read_email_cleanup.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Regression tests for guaranteed IMAP session cleanup."""
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("read_email", ROOT / "scripts" / "read_email.py")
+read_email = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(read_email)
+
+
+class _FakeIMAP:
+    def __init__(self):
+        self.logout_calls = 0
+
+    def login(self, _username, _password):
+        return "OK", []
+
+    def select(self, _folder, readonly=True):
+        assert readonly
+        return "OK", []
+
+    def search(self, _charset, _criterion):
+        return "OK", [b"1"]
+
+    def fetch(self, _message_id, _query):
+        return "OK", [(b"1 (RFC822)", b"Subject: hello\n\nbody")]
+
+    def logout(self):
+        self.logout_calls += 1
+        return "BYE", []
+
+
+class _LoginFailureIMAP(_FakeIMAP):
+    def login(self, _username, _password):
+        raise OSError("login connection failed")
+
+
+class ImapCleanupTests(unittest.TestCase):
+    def test_unexpected_post_login_error_still_logs_out(self):
+        mail = _FakeIMAP()
+        environment = {"EMAIL_USERNAME": "user", "EMAIL_PASSWORD": "secret"}
+
+        with (
+            patch.dict(os.environ, environment, clear=False),
+            patch.object(sys, "argv", ["read_email.py"]),
+            patch.object(read_email.imaplib, "IMAP4_SSL", return_value=mail),
+            patch.object(read_email, "decode_header", side_effect=RuntimeError("decode failed")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "decode failed"):
+                read_email.main()
+
+        self.assertEqual(mail.logout_calls, 1)
+
+    def test_login_failure_closes_constructed_connection(self):
+        mail = _LoginFailureIMAP()
+        environment = {"EMAIL_USERNAME": "user", "EMAIL_PASSWORD": "secret"}
+
+        with (
+            patch.dict(os.environ, environment, clear=False),
+            patch.object(sys, "argv", ["read_email.py"]),
+            patch.object(read_email.imaplib, "IMAP4_SSL", return_value=mail),
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                read_email.main()
+
+        self.assertEqual(caught.exception.code, 1)
+        self.assertEqual(mail.logout_calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- route all post-login exits through a `finally` cleanup
- close a constructed IMAP connection when login itself fails
- suppress logout errors so cleanup cannot mask the original result
- regression-test unexpected post-fetch exceptions and login failures

## Verification
- `python3 scripts/tests/test_read_email_cleanup.py` (2 passed)
- `python3 -m py_compile scripts/read_email.py scripts/tests/test_read_email_cleanup.py`
- `git diff --check`