### PR TITLE
fix(rust-sdk): surface stream transport errors

### DIFF
--- a/changelog.d/fixed/6833-rust-sdk-stream-errors.md
+++ b/changelog.d/fixed/6833-rust-sdk-stream-errors.md
@@ -1,0 +1,3 @@
+Surface generated Rust SDK stream transport failures. (@houko)
+The SSE reader previously stopped silently when a response body chunk returned an error, making truncated connections indistinguishable from clean stream completion.
+It now emits a status-`0` `stream error` event before closing the channel, while preserving any valid events received before the failure.

--- a/scripts/codegen-sdks.py
+++ b/scripts/codegen-sdks.py
@@ -810,7 +810,17 @@ fn do_stream(
         const MAX_SSE_LINE: usize = 8 * 1024 * 1024;
         let mut stream = res.bytes_stream();
         let mut buffer: Vec<u8> = Vec::new();
-        while let Some(Ok(chunk)) = stream.next().await {
+        while let Some(chunk_result) = stream.next().await {
+            let chunk = match chunk_result {
+                Ok(chunk) => chunk,
+                Err(e) => {
+                    let _ = tx.send(serde_json::json!({
+                        "error": format!("stream error: {}", e),
+                        "status": 0,
+                    }));
+                    return;
+                }
+            };
             buffer.extend_from_slice(&chunk);
             if buffer.len() > MAX_SSE_LINE {
                 let _ = tx.send(serde_json::json!({

--- a/scripts/tests/test_codegen_sdks.py
+++ b/scripts/tests/test_codegen_sdks.py
@@ -70,6 +70,9 @@ def main():
     assert_in("Vec<u8>", rs, "rust-byte-buffer")
     assert_not_in("from_utf8_lossy(&chunk)", rs, "rust-no-lossy-chunk")
     assert_in('"status": status', rs, "rust-error-event-status")
+    assert_in("while let Some(chunk_result) = stream.next().await", rs, "rust-stream-result-loop")
+    assert_in('"error": format!("stream error: {}", e)', rs, "rust-stream-transport-error")
+    assert_not_in("while let Some(Ok(chunk))", rs, "rust-no-silent-stream-error")
     assert_in('"status": resp.StatusCode', go, "go-error-event-status")
 
     # SSE line-size cap

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -123,7 +123,17 @@ fn do_stream(
         const MAX_SSE_LINE: usize = 8 * 1024 * 1024;
         let mut stream = res.bytes_stream();
         let mut buffer: Vec<u8> = Vec::new();
-        while let Some(Ok(chunk)) = stream.next().await {
+        while let Some(chunk_result) = stream.next().await {
+            let chunk = match chunk_result {
+                Ok(chunk) => chunk,
+                Err(e) => {
+                    let _ = tx.send(serde_json::json!({
+                        "error": format!("stream error: {}", e),
+                        "status": 0,
+                    }));
+                    return;
+                }
+            };
             buffer.extend_from_slice(&chunk);
             if buffer.len() > MAX_SSE_LINE {
                 let _ = tx.send(serde_json::json!({

--- a/sdk/rust/tests/stream_errors.rs
+++ b/sdk/rust/tests/stream_errors.rs
@@ -1,0 +1,48 @@
+use librefang::LibreFang;
+use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::time::{timeout, Duration};
+
+#[tokio::test]
+async fn truncated_response_reports_stream_transport_error() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = [0_u8; 4096];
+        let _ = socket.read(&mut request).await.unwrap();
+
+        let body = b"data: {\"received\":true}\n";
+        let headers = b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: 100\r\nConnection: close\r\n\r\n";
+        socket.write_all(headers).await.unwrap();
+        socket.write_all(body).await.unwrap();
+        socket.shutdown().await.unwrap();
+    });
+
+    let client = LibreFang::new(format!("http://{address}"));
+    let mut events = client
+        .agents
+        .send_message_stream("agent", json!({"message": "hello"}));
+
+    let first = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(first, json!({"received": true}));
+
+    let failure = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .unwrap()
+        .expect("truncated response must emit an error event");
+    assert_eq!(failure["status"], 0);
+    assert!(failure["error"]
+        .as_str()
+        .is_some_and(|message| message.starts_with("stream error: ")));
+
+    assert!(timeout(Duration::from_secs(2), events.recv())
+        .await
+        .unwrap()
+        .is_none());
+    server.await.unwrap();
+}


### PR DESCRIPTION
## Summary
- match every reqwest body chunk result in the generated Rust SSE reader
- emit a status-`0` stream error event instead of silently treating transport failure as EOF
- regression-test a real local HTTP response that emits one event and then truncates its declared body

## Verification
- `cargo test --test stream_errors -- --nocapture` (1 passed; old implementation RED)
- `cargo clippy --all-targets -- -A clippy::unnecessary-to-owned -A clippy::too-many-arguments -D warnings`
- `python3 scripts/tests/test_codegen_sdks.py` (383 operations)
- `rustfmt --edition 2021 --check sdk/rust/src/lib.rs sdk/rust/tests/stream_errors.rs`
- `git diff --check`

Note: unfiltered `cargo clippy -- -D warnings` and `cargo fmt --all -- --check` expose pre-existing generated-code/example findings unrelated to this diff.