### PR TITLE
feat(rust-sdk): accept configured HTTP clients

### DIFF
--- a/changelog.d/fixed/6838-rust-sdk-custom-client.md
+++ b/changelog.d/fixed/6838-rust-sdk-custom-client.md
@@ -1,0 +1,1 @@
+- Added a Rust SDK constructor that accepts a configured `reqwest::Client`, enabling authenticated requests and other custom HTTP settings across all generated resources. (@houko)

--- a/scripts/codegen-sdks.py
+++ b/scripts/codegen-sdks.py
@@ -872,8 +872,14 @@ def gen_rust(tag_ops: dict) -> str:
 
     out += "impl LibreFang {\n"
     out += "    pub fn new(base_url: impl Into<String>) -> Self {\n"
+    out += "        Self::with_client(base_url, Client::new())\n"
+    out += "    }\n\n"
+    out += "    /// Creates an SDK client using a caller-configured HTTP client.\n"
+    out += "    ///\n"
+    out += "    /// Use this to configure authentication headers, cookies, proxies,\n"
+    out += "    /// TLS, or other [`reqwest::Client`] behavior shared by all resources.\n"
+    out += "    pub fn with_client(base_url: impl Into<String>, client: Client) -> Self {\n"
     out += "        let base_url = base_url.into().trim_end_matches('/').to_string();\n"
-    out += "        let client = Client::new();\n"
     out += "        Self {\n"
     for tag in tags:
         attr = _tag_attr(tag)

--- a/scripts/tests/test_codegen_sdks.py
+++ b/scripts/tests/test_codegen_sdks.py
@@ -63,6 +63,8 @@ def main():
     assert_in("async invokeTool(name, data, query)", js, "js-invoke_tool-sig")
     assert_in("InvokeTool(name string, data map[string]interface{}, query map[string]string)", go, "go-invoke_tool-sig")
     assert_in("pub async fn invoke_tool(&self, name: &str, data: Value, agent_id: Option<&str>)", rs, "rust-invoke_tool-sig")
+    assert_in("Self::with_client(base_url, Client::new())", rs, "rust-default-client-delegation")
+    assert_in("pub fn with_client(base_url: impl Into<String>, client: Client) -> Self", rs, "rust-custom-client-constructor")
 
     # Stream correctness
     assert_in("bufio.NewReaderSize", go, "go-bufio-reader")

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -196,8 +196,15 @@ pub struct LibreFang {
 
 impl LibreFang {
     pub fn new(base_url: impl Into<String>) -> Self {
+        Self::with_client(base_url, Client::new())
+    }
+
+    /// Creates an SDK client using a caller-configured HTTP client.
+    ///
+    /// Use this to configure authentication headers, cookies, proxies,
+    /// TLS, or other [`reqwest::Client`] behavior shared by all resources.
+    pub fn with_client(base_url: impl Into<String>, client: Client) -> Self {
         let base_url = base_url.into().trim_end_matches('/').to_string();
-        let client = Client::new();
         Self {
             a2a: Arc::new(A2AResource::new(base_url.clone(), client.clone())),
             agents: Arc::new(AgentsResource::new(base_url.clone(), client.clone())),

--- a/sdk/rust/tests/custom_client.rs
+++ b/sdk/rust/tests/custom_client.rs
@@ -1,0 +1,46 @@
+use librefang::LibreFang;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+#[tokio::test]
+async fn custom_client_headers_reach_generated_resources() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        loop {
+            let mut chunk = [0_u8; 1024];
+            let read = socket.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "client closed before sending HTTP headers");
+            request.extend_from_slice(&chunk[..read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        let request = String::from_utf8(request).unwrap();
+        assert!(request
+            .lines()
+            .any(|line| line.eq_ignore_ascii_case("authorization: Bearer sdk-token")));
+
+        socket
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"ok\":true}",
+            )
+            .await
+            .unwrap();
+    });
+
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer sdk-token"));
+    let http_client = reqwest::Client::builder()
+        .no_proxy()
+        .default_headers(headers)
+        .build()
+        .unwrap();
+    let client = LibreFang::with_client(format!("http://{address}"), http_client);
+
+    assert_eq!(client.system.health().await.unwrap()["ok"], true);
+    server.await.unwrap();
+}


### PR DESCRIPTION
## Summary
- add `LibreFang::with_client` so callers can supply a configured `reqwest::Client`
- preserve `LibreFang::new` by delegating to the new constructor with the default client
- verify custom authorization headers reach generated resource requests and guard codegen output

## Verification
- RED before implementation: `cargo test --manifest-path sdk/rust/Cargo.toml --test custom_client -- --nocapture` failed because `with_client` did not exist
- `cargo test --manifest-path sdk/rust/Cargo.toml --all-targets`
- `cargo clippy --manifest-path sdk/rust/Cargo.toml --all-targets -- -A clippy::unnecessary-to-owned -A clippy::too-many-arguments -D warnings`
- `python3 scripts/tests/test_codegen_sdks.py`
- `rustfmt --edition 2021 --check sdk/rust/src/lib.rs sdk/rust/tests/custom_client.rs`
- `git diff --check`
