### PR TITLE
fix(rust-sdk): validate basic example responses

### DIFF
--- a/changelog.d/fixed/6839-rust-sdk-basic-shape.md
+++ b/changelog.d/fixed/6839-rust-sdk-basic-shape.md
@@ -1,0 +1,1 @@
+- Updated the Rust SDK basic example to report unexpected API response shapes instead of silently displaying zero items. (@houko)

--- a/sdk/rust/examples/basic.rs
+++ b/sdk/rust/examples/basic.rs
@@ -1,4 +1,19 @@
 use librefang::LibreFang;
+use serde_json::Value;
+use std::io::{Error, ErrorKind};
+
+fn expected_array_len(response: &Value, key: &str) -> Result<usize, Error> {
+    response
+        .get(key)
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidData,
+                format!("unexpected response shape: expected \"{key}\" array"),
+            )
+        })
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -6,15 +21,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // List skills
     let skills = client.skills.list_skills().await?;
-    println!("Skills: {}", skills["skills"].as_array().map(|a| a.len()).unwrap_or(0));
+    println!("Skills: {}", expected_array_len(&skills, "items")?);
 
     // List models
     let models = client.models.list_all_models().await?;
-    println!("Models: {}", models["models"].as_array().map(|a| a.len()).unwrap_or(0));
+    println!("Models: {}", expected_array_len(&models, "models")?);
 
     // List providers
     let providers = client.models.list_providers().await?;
-    println!("Providers: {}", providers["providers"].as_array().map(|a| a.len()).unwrap_or(0));
+    println!(
+        "Providers: {}",
+        expected_array_len(&providers, "providers")?
+    );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expected_array_len;
+    use serde_json::json;
+
+    #[test]
+    fn response_shape_requires_the_named_array() {
+        assert_eq!(
+            expected_array_len(
+                &json!({
+                    "items": [],
+                    "total": 0,
+                    "offset": 0,
+                    "limit": 50,
+                    "categories": []
+                }),
+                "items"
+            )
+            .unwrap(),
+            0
+        );
+        for response in [json!({}), json!({"items": {}})] {
+            let error = expected_array_len(&response, "items").unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+            assert_eq!(
+                error.to_string(),
+                "unexpected response shape: expected \"items\" array"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- make the Rust SDK basic example require the documented array response shape
- surface missing or non-array fields as descriptive `InvalidData` errors
- cover valid, missing, and wrong-type response values in an example-level unit test

## Verification
- RED before implementation: `cargo test --manifest-path sdk/rust/Cargo.toml --example basic -- --nocapture` failed because the shape validator did not exist
- `cargo test --manifest-path sdk/rust/Cargo.toml --all-targets`
- `cargo clippy --manifest-path sdk/rust/Cargo.toml --all-targets -- -A clippy::unnecessary-to-owned -A clippy::too-many-arguments -D warnings`
- `rustfmt --edition 2021 --check sdk/rust/examples/basic.rs`
- `git diff --check`
