### PR TITLE
feat(rust-sdk): expose selectable TLS backends

### DIFF
--- a/changelog.d/fixed/6842-rust-sdk-tls-features.md
+++ b/changelog.d/fixed/6842-rust-sdk-tls-features.md
@@ -1,0 +1,1 @@
+- Made the Rust SDK's reqwest TLS backend explicit and selectable: existing users retain default TLS, while downstream crates can choose rustls or disable TLS features. (@houko)

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
 
+[features]
+default = ["default-tls"]
+default-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+
 [package]
 name = "librefang"
 version = "2026.7.31"
@@ -11,7 +16,7 @@ keywords = ["librefang", "agent", "ai"]
 authors = ["LibreFang Team"]
 
 [dependencies]
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "charset", "http2", "system-proxy"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 thiserror = "1"

--- a/sdk/rust/tests/tls_features.rs
+++ b/sdk/rust/tests/tls_features.rs
@@ -1,0 +1,10 @@
+#[test]
+fn tls_backends_are_explicit_and_selectable() {
+    let manifest = include_str!("../Cargo.toml");
+    assert!(manifest.contains("default = [\"default-tls\"]"));
+    assert!(manifest.contains("default-tls = [\"reqwest/default-tls\"]"));
+    assert!(manifest.contains("rustls-tls = [\"reqwest/rustls-tls\"]"));
+    assert!(manifest.contains(
+        "reqwest = { version = \"0.12\", default-features = false, features = [\"json\", \"stream\", \"charset\", \"http2\", \"system-proxy\"] }"
+    ));
+}


### PR DESCRIPTION
## Summary
- disable reqwest implicit defaults in the Rust SDK dependency declaration
- expose `default-tls` and `rustls-tls` as selectable crate features
- retain default TLS for compatibility while allowing rustls-only or no-TLS downstream builds

## Verification
- RED before implementation: `cargo test --manifest-path sdk/rust/Cargo.toml --test tls_features -- --nocapture` failed because explicit TLS features did not exist
- `cargo test --manifest-path sdk/rust/Cargo.toml --all-targets`
- `cargo check --manifest-path sdk/rust/Cargo.toml --no-default-features --all-targets`
- `cargo check --manifest-path sdk/rust/Cargo.toml --no-default-features --features rustls-tls --all-targets`
- `cargo clippy --manifest-path sdk/rust/Cargo.toml --all-targets -- -A clippy::unnecessary-to-owned -A clippy::too-many-arguments -D warnings`
- `rustfmt --edition 2021 --check sdk/rust/tests/tls_features.rs`
- `git diff --check`
