### PR TITLE
chore(rust-sdk): align thiserror major version

### DIFF
--- a/changelog.d/fixed/6843-rust-sdk-thiserror.md
+++ b/changelog.d/fixed/6843-rust-sdk-thiserror.md
@@ -1,0 +1,1 @@
+- Aligned the Rust SDK with the workspace's thiserror 2 dependency, avoiding duplicate major versions in monorepo builds. (@houko)

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -14,5 +14,5 @@ authors = ["LibreFang Team"]
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-thiserror = "1"
+thiserror = "2"
 futures = "0.3"

--- a/sdk/rust/tests/dependency_versions.rs
+++ b/sdk/rust/tests/dependency_versions.rs
@@ -1,0 +1,6 @@
+#[test]
+fn thiserror_matches_the_workspace_major_version() {
+    let manifest = include_str!("../Cargo.toml");
+    assert!(manifest.contains("thiserror = \"2\""));
+    assert!(!manifest.contains("thiserror = \"1\""));
+}


### PR DESCRIPTION
## Summary
- update the standalone Rust SDK from thiserror 1 to thiserror 2
- align the SDK with the root workspace dependency major
- add a manifest regression to prevent duplicate-major drift

## Verification
- RED before implementation: `cargo test --manifest-path sdk/rust/Cargo.toml --test dependency_versions -- --nocapture` failed against thiserror 1
- `cargo test --manifest-path sdk/rust/Cargo.toml --all-targets`
- `cargo clippy --manifest-path sdk/rust/Cargo.toml --all-targets -- -A clippy::unnecessary-to-owned -A clippy::too-many-arguments -D warnings`
- `cargo tree --manifest-path sdk/rust/Cargo.toml -i thiserror@2.0.20`
- `rustfmt --edition 2021 --check sdk/rust/tests/dependency_versions.rs`
- `git diff --check`
