### PR TITLE
perf(sidecar-sdk): drop multithread Tokio runtime

### DIFF
--- a/changelog.d/fixed/6844-sidecar-tokio-features.md
+++ b/changelog.d/fixed/6844-sidecar-tokio-features.md
@@ -1,0 +1,1 @@
+- Removed Tokio's multi-thread scheduler from the Rust sidecar SDK's published dependency features and moved its echo example to the current-thread runtime. (@houko)

--- a/docs/architecture/rust-sidecar-sdk.md
+++ b/docs/architecture/rust-sidecar-sdk.md
@@ -98,7 +98,7 @@ fn schema() -> Schema {
     Schema::new("echo", "Echo adapter")
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     run_stdio_main(schema, || Ok(EchoAdapter)).await
 }

--- a/sdk/rust/librefang-sidecar/Cargo.toml
+++ b/sdk/rust/librefang-sidecar/Cargo.toml
@@ -21,8 +21,10 @@ rust-version = "1.80"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Tokio feature set the runtime actually uses.
-# io-std + io-util: stdin/stdout reader + write_all. rt + macros: spawn + tokio::select!. rt-multi-thread: enables `cargo run --example echo` (the in-tree example uses an unattributed `#[tokio::main]` which expands to `flavor = "multi_thread"`); the SDK runtime itself spawns four tasks and does not require work-stealing, but baking the feature in keeps the example self-contained and the README copy-paste path frictionless for downstream adapters. sync: mpsc + watch + Mutex (runtime + echo example use these — no Notify dependency). time: sleep for backoff and the ready re-announce interval. No `signal` (no signal handling in this SDK).
-tokio = { version = "1", features = ["io-std", "io-util", "rt", "rt-multi-thread", "macros", "sync", "time"] }
+# io-std + io-util: stdin/stdout reader + write_all. rt + macros: spawn +
+# tokio::select!. sync: mpsc + watch + Mutex. time: backoff and ready
+# re-announcement. The runtime does not require work-stealing or signals.
+tokio = { version = "1", features = ["io-std", "io-util", "rt", "macros", "sync", "time"] }
 async-trait = "0.1"
 
 [dev-dependencies]

--- a/sdk/rust/librefang-sidecar/README.md
+++ b/sdk/rust/librefang-sidecar/README.md
@@ -53,7 +53,7 @@ impl SidecarAdapter for EchoAdapter {
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     run_stdio(EchoAdapter).await
 }

--- a/sdk/rust/librefang-sidecar/examples/echo.rs
+++ b/sdk/rust/librefang-sidecar/examples/echo.rs
@@ -91,7 +91,7 @@ impl SidecarAdapter for EchoAdapter {
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // `run_stdio_main` handles the daemon's `--describe` discovery contract (emit schema JSON + return) before touching any platform-side state, and only constructs the adapter via the builder closure when not in discovery mode — important for adapters whose `new()` reads env vars that are not yet configured at boot.
     // The builder closure returns `Result<EchoAdapter, DynError>` so a real adapter that validates env vars in `new()` can fail cleanly with a structured error instead of `expect()`-panicking; echo has nothing to fail on so it just wraps in `Ok`.

--- a/sdk/rust/librefang-sidecar/src/lib.rs
+++ b/sdk/rust/librefang-sidecar/src/lib.rs
@@ -16,7 +16,7 @@
 //!     }
 //! }
 //!
-//! #[tokio::main]
+//! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!     run_stdio(MyAdapter).await
 //! }

--- a/sdk/rust/librefang-sidecar/src/runtime.rs
+++ b/sdk/rust/librefang-sidecar/src/runtime.rs
@@ -25,7 +25,7 @@
 //!     }
 //! }
 //!
-//! #[tokio::main]
+//! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!     run_stdio(MyAdapter).await
 //! }
@@ -566,7 +566,7 @@ pub async fn run_stdio_with<A: SidecarAdapter + 'static>(
 /// Returning `Result` from the builder means a missing-env bootstrap failure becomes a structured error message instead of a `panic!` + stack trace, which is what `MyAdapter::new()` -> `expect("BOT_TOKEN must be set")` would otherwise produce.
 ///
 /// ```ignore
-/// #[tokio::main]
+/// #[tokio::main(flavor = "current_thread")]
 /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 ///     run_stdio_main(MyAdapter::schema, || Ok(MyAdapter::new())).await
 /// }

--- a/sdk/rust/librefang-sidecar/tests/tokio_features.rs
+++ b/sdk/rust/librefang-sidecar/tests/tokio_features.rs
@@ -1,0 +1,45 @@
+#[test]
+fn published_runtime_does_not_force_the_multithread_scheduler() {
+    let manifest = include_str!("../Cargo.toml");
+
+    let normal_tokio_dependency = if let Some(start) = manifest.find("[dependencies.tokio]") {
+        let section = &manifest[start..];
+        &section[..section[1..]
+            .find("\n[")
+            .map_or(section.len(), |end| end + 1)]
+    } else {
+        manifest
+            .lines()
+            .find(|line| line.starts_with("tokio = "))
+            .expect("normal Tokio dependency")
+    };
+    assert!(!normal_tokio_dependency.contains("rt-multi-thread"));
+
+    let assert_current_thread = |name: &str, source: &str| {
+        assert!(
+            source.contains("#[tokio::main(flavor = \"current_thread\")]"),
+            "{name} must use the published current-thread runtime"
+        );
+        assert!(
+            !source.contains("#[tokio::main]"),
+            "{name} must not require rt-multi-thread"
+        );
+    };
+    for (name, source) in [
+        ("echo example", include_str!("../examples/echo.rs")),
+        ("README", include_str!("../README.md")),
+        ("crate docs", include_str!("../src/lib.rs")),
+        ("runtime docs", include_str!("../src/runtime.rs")),
+    ] {
+        assert_current_thread(name, source);
+    }
+
+    // The canonical architecture guide lives outside this published crate.
+    // Guard it in the monorepo, but keep crates.io source archives testable.
+    let architecture_guide = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../docs/architecture/rust-sidecar-sdk.md");
+    if architecture_guide.is_file() {
+        let source = std::fs::read_to_string(architecture_guide).unwrap();
+        assert_current_thread("architecture guide", &source);
+    }
+}


### PR DESCRIPTION
## Summary
- remove `rt-multi-thread` from the Rust sidecar SDK normal Tokio dependency
- run the echo example on Tokio current-thread flavor
- lock the published feature set and example runtime with a regression test

## Verification
- RED before implementation: `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --test tokio_features -- --nocapture` failed because normal dependencies forced `rt-multi-thread`
- `cargo check --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --lib`
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets`
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --doc`
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets -- -D warnings`
- `cargo tree --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --edges normal -e features -i tokio`
- `git diff --check`
