### PR TITLE
chore(sidecar-sdk): allowlist package contents

### DIFF
--- a/changelog.d/fixed/6845-sidecar-package-allowlist.md
+++ b/changelog.d/fixed/6845-sidecar-package-allowlist.md
@@ -1,0 +1,1 @@
+- Added an explicit crates.io package allowlist for the Rust sidecar SDK so unrelated local files cannot enter published archives. (@houko)

--- a/sdk/rust/librefang-sidecar/Cargo.toml
+++ b/sdk/rust/librefang-sidecar/Cargo.toml
@@ -16,6 +16,13 @@ keywords = ["librefang", "sidecar", "channel", "agent", "ai"]
 categories = ["api-bindings", "asynchronous"]
 readme = "README.md"
 rust-version = "1.80"
+include = [
+    "src/**",
+    "examples/**",
+    "tests/**",
+    "README.md",
+    "Cargo.toml",
+]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/sdk/rust/librefang-sidecar/tests/package_allowlist.rs
+++ b/sdk/rust/librefang-sidecar/tests/package_allowlist.rs
@@ -1,0 +1,28 @@
+#[test]
+fn published_package_uses_an_explicit_allowlist() {
+    let manifest = include_str!("../Cargo.toml");
+    let after_start = manifest
+        .split_once("include = [")
+        .expect("package include allowlist")
+        .1;
+    let include_body = after_start
+        .split_once(']')
+        .expect("closing package include bracket")
+        .0;
+    let entries: Vec<_> = include_body
+        .split(',')
+        .map(|entry| entry.trim().trim_matches('"'))
+        .filter(|entry| !entry.is_empty())
+        .collect();
+
+    assert_eq!(
+        entries,
+        [
+            "src/**",
+            "examples/**",
+            "tests/**",
+            "README.md",
+            "Cargo.toml"
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- add an explicit crates.io include allowlist for sidecar SDK source, examples, tests, manifest, and README
- exclude unrelated local files such as `.gitignore` from published archives
- retain conformance tests in the package and guard every intended allowlist entry

## Verification
- RED before implementation: `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --test package_allowlist -- --nocapture` failed because no include allowlist existed
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets`
- `cargo package --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --allow-dirty --list` (11 audited files; no `.gitignore`)
- `cargo package --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --allow-dirty` (isolated verification passed)
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`
