### PR TITLE
docs(sidecar-sdk): trim quick-start imports

### DIFF
--- a/changelog.d/fixed/6847-sidecar-doc-imports.md
+++ b/changelog.d/fixed/6847-sidecar-doc-imports.md
@@ -1,0 +1,1 @@
+- Simplified the Rust sidecar SDK quick-start imports so the minimal adapter example lists only the APIs it uses. (@houko)

--- a/sdk/rust/librefang-sidecar/src/lib.rs
+++ b/sdk/rust/librefang-sidecar/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```ignore
 //! use async_trait::async_trait;
-//! use librefang_sidecar::{run_stdio, EmitFn, SendCommand, SidecarAdapter, events};
+//! use librefang_sidecar::{run_stdio, SendCommand, SidecarAdapter};
 //!
 //! struct MyAdapter;
 //!

--- a/sdk/rust/librefang-sidecar/tests/minimal_docs.rs
+++ b/sdk/rust/librefang-sidecar/tests/minimal_docs.rs
@@ -1,0 +1,5 @@
+#[test]
+fn crate_quick_start_imports_only_the_items_it_uses() {
+    let docs = include_str!("../src/lib.rs");
+    assert!(docs.contains("use librefang_sidecar::{run_stdio, SendCommand, SidecarAdapter};"));
+}


### PR DESCRIPTION
## Summary
- remove unused `EmitFn` and `events` imports from the minimal Rust sidecar quick-start
- keep the example focused on the three APIs used by an `on_send`-only adapter
- guard the documented import surface with a source regression test

## Verification
- RED before implementation: `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --test minimal_docs -- --nocapture` failed against the stale import list
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets`
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --doc`
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`
