### PR TITLE
fix(sidecar-sdk): align poll option ID types

### DIFF
--- a/changelog.d/fixed/6848-sidecar-poll-types.md
+++ b/changelog.d/fixed/6848-sidecar-poll-types.md
@@ -1,0 +1,1 @@
+- **Breaking:** Aligned Rust sidecar poll builder option IDs with the kernel's `u8` wire contract, preventing adapters from constructing out-of-range poll payloads. The Telegram sidecar now rejects out-of-range upstream option IDs at its translation boundary. (@houko)

--- a/sdk/rust/librefang-sidecar-telegram/src/translator.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/translator.rs
@@ -431,10 +431,7 @@ pub fn content_to_value(c: &TgContent) -> Value {
         TgContent::PollAnswer {
             poll_id,
             option_ids,
-        } => librefang_sidecar::protocol::Content::poll_answer(
-            poll_id.clone(),
-            option_ids.iter().map(|n| *n as i64).collect(),
-        ),
+        } => librefang_sidecar::protocol::Content::poll_answer(poll_id.clone(), option_ids.clone()),
     }
 }
 
@@ -490,7 +487,7 @@ pub enum TgContent {
     },
     PollAnswer {
         poll_id: String,
-        option_ids: Vec<u32>,
+        option_ids: Vec<u8>,
     },
 }
 
@@ -568,9 +565,16 @@ pub(crate) fn sender_from_user(user: &User) -> Sender {
 /// poll_answer update → PollAnswer content event.
 pub fn poll_answer_event(pa: &PollAnswer) -> Option<Value> {
     let user = pa.user.as_ref()?;
+    let option_ids = pa
+        .option_ids
+        .iter()
+        .copied()
+        .map(u8::try_from)
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
     let content = TgContent::PollAnswer {
         poll_id: pa.poll_id.clone(),
-        option_ids: pa.option_ids.clone(),
+        option_ids,
     };
     let sender = sender_from_user(user);
     // Polls don't carry a chat_id on the answer; the caller doesn't have one either, so route by sender id as a synthetic chat. Daemon side falls back to per-user threading.
@@ -818,5 +822,29 @@ mod tests {
             media_placeholder("Video note", Some(8), None),
             "[Video note, 8s]",
         );
+    }
+
+    #[test]
+    fn poll_answer_option_ids_are_checked_at_the_telegram_boundary() {
+        let answer = PollAnswer {
+            poll_id: "poll-1".into(),
+            user: Some(User {
+                id: 42,
+                first_name: "Alice".into(),
+                ..Default::default()
+            }),
+            option_ids: vec![0, u8::MAX.into()],
+        };
+        let event = poll_answer_event(&answer).expect("valid poll answer");
+        assert_eq!(
+            event["params"]["content"]["PollAnswer"]["option_ids"],
+            json!([0, 255])
+        );
+
+        let out_of_range = PollAnswer {
+            option_ids: vec![u32::from(u8::MAX) + 1],
+            ..answer
+        };
+        assert!(poll_answer_event(&out_of_range).is_none());
     }
 }

--- a/sdk/rust/librefang-sidecar/src/protocol.rs
+++ b/sdk/rust/librefang-sidecar/src/protocol.rs
@@ -144,7 +144,7 @@ impl Content {
         question: impl Into<String>,
         options: Vec<String>,
         is_quiz: bool,
-        correct_option_id: Option<u32>,
+        correct_option_id: Option<u8>,
         explanation: Option<String>,
     ) -> Value {
         let mut p = json!({"question": question.into(), "options": options, "is_quiz": is_quiz});
@@ -157,7 +157,7 @@ impl Content {
         json!({"Poll": p})
     }
 
-    pub fn poll_answer(poll_id: impl Into<String>, option_ids: Vec<i64>) -> Value {
+    pub fn poll_answer(poll_id: impl Into<String>, option_ids: Vec<u8>) -> Value {
         json!({"PollAnswer": {"poll_id": poll_id.into(), "option_ids": option_ids}})
     }
 

--- a/sdk/rust/librefang-sidecar/tests/poll_types.rs
+++ b/sdk/rust/librefang-sidecar/tests/poll_types.rs
@@ -1,0 +1,33 @@
+use librefang_sidecar::Content;
+use serde_json::{json, Value};
+
+type PollBuilder = fn(String, Vec<String>, bool, Option<u8>, Option<String>) -> Value;
+type PollAnswerBuilder = fn(String, Vec<u8>) -> Value;
+
+#[test]
+fn poll_builders_use_kernel_byte_sized_option_ids() {
+    let poll: PollBuilder = Content::poll;
+    let answer: PollAnswerBuilder = Content::poll_answer;
+
+    assert_eq!(
+        poll(
+            "Question?".to_string(),
+            vec!["A".to_string(), "B".to_string()],
+            true,
+            Some(u8::MAX),
+            None,
+        ),
+        json!({
+            "Poll": {
+                "question": "Question?",
+                "options": ["A", "B"],
+                "is_quiz": true,
+                "correct_option_id": 255
+            }
+        })
+    );
+    assert_eq!(
+        answer("poll-1".to_string(), vec![0, u8::MAX]),
+        json!({"PollAnswer": {"poll_id": "poll-1", "option_ids": [0, 255]}})
+    );
+}


### PR DESCRIPTION
## Summary
- change Rust sidecar poll correct-option IDs from `u32` to the kernel wire type `u8`
- change poll-answer option IDs from `i64` to the kernel wire type `u8`
- document the source-breaking correction and lock the public signatures plus byte boundary JSON

## Verification
- RED before implementation: `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --test poll_types -- --nocapture` failed because public signatures used `Option<u32>` and `Vec<i64>`
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets`
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --doc`
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

## Compatibility
This is an intentional source-breaking correction for the 0.1 SDK: callers with wider integer variables must validate/convert them to `u8`, matching the daemon wire contract.
