### PR TITLE
docs(sidecar-sdk): clarify required field policy

### DIFF
--- a/changelog.d/fixed/6849-sidecar-required-fields.md
+++ b/changelog.d/fixed/6849-sidecar-required-fields.md
@@ -1,0 +1,1 @@
+- Documented the Rust sidecar SDK's deliberate fail-closed handling of missing required command fields and its compatibility difference from the legacy Python parser. (@houko)

--- a/docs/architecture/sidecar-protocol.md
+++ b/docs/architecture/sidecar-protocol.md
@@ -121,6 +121,13 @@ builder. Their presence/absence is additive and not version-bumping.
 | `stream_delta` | `stream_id`, `text` |
 | `stream_end` | `stream_id` |
 
+The Rust SDK deliberately rejects a typed command when a field shown
+without `?` is missing. Its reader emits a protocol `error` event and
+continues. The Python SDK's legacy parser is more permissive and may
+replace missing values with empty strings; adapters must not rely on
+that leniency. Optional fields continue to use their documented
+defaults in both SDKs.
+
 `send.params.user` is `ChannelUser` =
 `{ platform_id, display_name, librefang_user }` (`librefang_user`
 serialized as `null` when absent — it is not skipped).

--- a/sdk/rust/librefang-sidecar/src/protocol.rs
+++ b/sdk/rust/librefang-sidecar/src/protocol.rs
@@ -596,6 +596,8 @@ struct Envelope {
 /// Returns `Err` on malformed JSON, on a JSON value that is not an object (a bare number/array), AND on a typed-params variant whose `params` shape does not deserialize.
 /// The reader loop in [`crate::runtime::run`] catches all three, emits a protocol-level `error` event with the deserialization message, and continues — so a wire-shape skew is surfaced instead of silently degrading the affected command to default values.
 ///
+/// Unlike the Python SDK's legacy parser, the Rust SDK intentionally rejects missing required fields instead of replacing them with empty strings or default structs. This prevents a malformed daemon frame from reaching adapter business logic as an apparently valid command. Fields marked optional in the wire protocol retain their explicit `#[serde(default)]` behavior.
+///
 /// Unknown `method` strings become [`Command::Unknown`] rather than an error, so a newer daemon can introduce a method without breaking an older adapter.
 pub fn parse_command(line: &str) -> Result<Command, serde_json::Error> {
     let v: Value = serde_json::from_str(line)?;

--- a/sdk/rust/librefang-sidecar/tests/required_fields_docs.rs
+++ b/sdk/rust/librefang-sidecar/tests/required_fields_docs.rs
@@ -1,0 +1,7 @@
+#[test]
+fn command_parser_documents_its_required_field_policy() {
+    let protocol = include_str!("../src/protocol.rs");
+    assert!(protocol.contains(
+        "Unlike the Python SDK's legacy parser, the Rust SDK intentionally rejects missing required fields"
+    ));
+}


### PR DESCRIPTION
## Summary
- document that Rust sidecar commands reject missing required fields
- contrast the strict Rust parser with the Python SDK legacy fallback behavior
- preserve explicit defaults only for optional protocol fields

## Verification
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets`
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --doc`
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`