### PR TITLE
perf(sidecar-sdk): avoid cloning command payloads

### DIFF
--- a/changelog.d/fixed/6850-sidecar-command-clone.md
+++ b/changelog.d/fixed/6850-sidecar-command-clone.md
@@ -1,0 +1,1 @@
+- Avoided cloning the full JSON parameter tree while parsing known Rust sidecar commands. (@houko)

--- a/sdk/rust/librefang-sidecar/src/protocol.rs
+++ b/sdk/rust/librefang-sidecar/src/protocol.rs
@@ -587,8 +587,14 @@ pub enum Command {
 #[derive(Deserialize)]
 struct Envelope {
     method: String,
-    #[serde(default)]
-    params: Value,
+}
+
+fn take_params(value: &mut Value) -> Value {
+    value
+        .as_object_mut()
+        .and_then(|object| object.remove("params"))
+        .filter(|params| !params.is_null())
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()))
 }
 
 /// Parse one stdin line into a typed [`Command`].
@@ -598,29 +604,23 @@ struct Envelope {
 ///
 /// Unknown `method` strings become [`Command::Unknown`] rather than an error, so a newer daemon can introduce a method without breaking an older adapter.
 pub fn parse_command(line: &str) -> Result<Command, serde_json::Error> {
-    let v: Value = serde_json::from_str(line)?;
+    let mut v: Value = serde_json::from_str(line)?;
     if !v.is_object() {
         // Mirror Python's behavior: surface as a JSON error so the runtime can react identically across implementations.
         return Err(serde::de::Error::custom("expected a JSON object"));
     }
-    let env: Envelope = serde_json::from_value(v.clone())?;
-    let params = env.params;
-    let params_or_empty = if params.is_null() {
-        Value::Object(serde_json::Map::new())
-    } else {
-        params
-    };
+    let env = Envelope::deserialize(&v)?;
     let cmd = match env.method.as_str() {
-        "send" => Command::Send(serde_json::from_value(params_or_empty)?),
+        "send" => Command::Send(serde_json::from_value(take_params(&mut v))?),
         "ready_ack" => Command::ReadyAck,
         "shutdown" => Command::Shutdown,
         "heartbeat" => Command::Heartbeat,
-        "typing" => Command::Typing(serde_json::from_value(params_or_empty)?),
-        "reaction" => Command::Reaction(serde_json::from_value(params_or_empty)?),
-        "interactive" => Command::Interactive(serde_json::from_value(params_or_empty)?),
-        "stream_start" => Command::StreamStart(serde_json::from_value(params_or_empty)?),
-        "stream_delta" => Command::StreamDelta(serde_json::from_value(params_or_empty)?),
-        "stream_end" => Command::StreamEnd(serde_json::from_value(params_or_empty)?),
+        "typing" => Command::Typing(serde_json::from_value(take_params(&mut v))?),
+        "reaction" => Command::Reaction(serde_json::from_value(take_params(&mut v))?),
+        "interactive" => Command::Interactive(serde_json::from_value(take_params(&mut v))?),
+        "stream_start" => Command::StreamStart(serde_json::from_value(take_params(&mut v))?),
+        "stream_delta" => Command::StreamDelta(serde_json::from_value(take_params(&mut v))?),
+        "stream_end" => Command::StreamEnd(serde_json::from_value(take_params(&mut v))?),
         other => Command::Unknown(UnknownCommand {
             method: other.to_string(),
             raw: v,

--- a/sdk/rust/librefang-sidecar/tests/parse_command_allocations.rs
+++ b/sdk/rust/librefang-sidecar/tests/parse_command_allocations.rs
@@ -1,0 +1,8 @@
+#[test]
+fn parse_command_does_not_clone_the_full_json_value() {
+    let protocol = include_str!("../src/protocol.rs");
+    assert!(
+        !protocol.contains("serde_json::from_value(v.clone())"),
+        "known commands must not clone their entire params tree"
+    );
+}


### PR DESCRIPTION
## Summary
- deserialize the command method by reference from the parsed JSON value
- move known-command params out of the envelope instead of cloning the entire tree
- preserve the complete raw envelope for unknown commands

## Verification
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets`
- `cargo test --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --doc`
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path sdk/rust/librefang-sidecar/Cargo.toml -- --check`
- `git diff --check`