### PR TITLE
docs(telegram): warn about open allowlist

### DIFF
--- a/changelog.d/fixed/6853-telegram-open-allowlist-warning.md
+++ b/changelog.d/fixed/6853-telegram-open-allowlist-warning.md
@@ -1,0 +1,1 @@
+- Warned in the Telegram dashboard schema that leaving `ALLOWED_USERS` empty permits all users. (@houko)

--- a/crates/librefang-api/src/routes/channels.rs
+++ b/crates/librefang-api/src/routes/channels.rs
@@ -277,7 +277,7 @@ const TELEGRAM_STATIC_FIELDS: &[StaticSidecarField] = &[
         label: "Allowed User IDs",
         field_type: "list",
         required: false,
-        placeholder: "123456789, 987654321",
+        placeholder: "123456789, 987654321 — leave empty to allow ALL users (insecure)",
         advanced: true,
     },
     StaticSidecarField {
@@ -1449,6 +1449,16 @@ mod static_schema_tests {
                 ("ALLOWED_USERS", "list", false, true),
                 ("TELEGRAM_CLEAR_DONE_REACTION", "bool", false, true),
             ]
+        );
+        let allowed_users = TELEGRAM_STATIC_FIELDS
+            .iter()
+            .find(|field| field.key == "ALLOWED_USERS")
+            .expect("Telegram fallback must declare ALLOWED_USERS");
+        assert!(
+            allowed_users.placeholder.contains("empty")
+                && allowed_users.placeholder.contains("ALL users")
+                && allowed_users.placeholder.contains("insecure"),
+            "fallback schema must disclose blank permit-all behavior"
         );
     }
 

--- a/sdk/python/librefang/sidecar/adapters/telegram.py
+++ b/sdk/python/librefang/sidecar/adapters/telegram.py
@@ -796,7 +796,10 @@ class TelegramAdapter(SidecarAdapter):
                   required=True,
                   placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"),
             Field("ALLOWED_USERS", "Allowed User IDs", "list",
-                  placeholder="123456789, 987654321",
+                  placeholder=(
+                      "123456789, 987654321 — leave empty to allow ALL users "
+                      "(insecure)"
+                  ),
                   advanced=True),
             Field("TELEGRAM_CLEAR_DONE_REACTION", "Clear done reaction",
                   "bool", advanced=True),

--- a/sdk/python/tests/test_first_party_describe.py
+++ b/sdk/python/tests/test_first_party_describe.py
@@ -19,6 +19,10 @@ def test_telegram_describe_contract():
     assert keys["TELEGRAM_BOT_TOKEN"]["type"] == "secret"
     assert keys["TELEGRAM_BOT_TOKEN"]["required"] is True
     assert keys["ALLOWED_USERS"]["type"] == "list"
+    placeholder = keys["ALLOWED_USERS"]["placeholder"]
+    assert "empty" in placeholder
+    assert "ALL users" in placeholder
+    assert "insecure" in placeholder
     assert keys["TELEGRAM_CLEAR_DONE_REACTION"]["type"] == "bool"
 
 

--- a/sdk/rust/librefang-sidecar-telegram/src/schema.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/schema.rs
@@ -12,7 +12,7 @@ pub fn telegram_schema() -> Schema {
                 .required()
                 .placeholder("123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"),
             Field::new("ALLOWED_USERS", "Allowed User IDs", FieldType::List)
-                .placeholder("123456789, 987654321")
+                .placeholder("123456789, 987654321 — leave empty to allow ALL users (insecure)")
                 .advanced(),
             Field::new(
                 "TELEGRAM_CLEAR_DONE_REACTION",
@@ -49,6 +49,18 @@ mod tests {
             .expect("schema must declare TELEGRAM_BOT_TOKEN");
         assert_eq!(bot_token.field_type, FieldType::Secret);
         assert!(bot_token.required);
+
+        let allowed_users = schema
+            .fields
+            .iter()
+            .find(|f| f.key == "ALLOWED_USERS")
+            .expect("schema must declare ALLOWED_USERS");
+        assert!(
+            allowed_users.placeholder.contains("empty")
+                && allowed_users.placeholder.contains("ALL users")
+                && allowed_users.placeholder.contains("insecure"),
+            "blank permit-all behavior must be explicit in the dashboard schema"
+        );
 
         let streaming = schema
             .fields


### PR DESCRIPTION
## Summary
- make the blank `ALLOWED_USERS` permit-all behavior explicit in the dashboard schema
- label the open default as insecure
- lock the warning with a schema regression test

## Verification
- `cargo test --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml schema::tests::schema_declares_expected_fields`
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml -- --check`
- `git diff --check`