### PR TITLE
fix(telegram): require location coordinates

### DIFF
--- a/changelog.d/fixed/6857-telegram-location-required.md
+++ b/changelog.d/fixed/6857-telegram-location-required.md
@@ -1,0 +1,1 @@
+- Rejected Telegram location payloads with missing or non-numeric coordinates instead of silently sending `(0, 0)`. (@houko)

--- a/sdk/rust/librefang-sidecar-telegram/src/dispatcher.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/dispatcher.rs
@@ -31,6 +31,13 @@ fn prepare_caption(raw: Option<&str>) -> Option<String> {
     Some(crate::format::truncate_to_utf16_limit(&formatted, CAPTION_LIMIT_UTF16).to_string())
 }
 
+fn required_coordinate(payload: &Value, key: &str) -> Result<f64> {
+    payload
+        .get(key)
+        .and_then(Value::as_f64)
+        .ok_or_else(|| Error::Other(format!("Location.{key} missing or not a JSON number")))
+}
+
 /// Truncate a raw (un-formatted) caption to the Bot API limit for the plain-text fallback.
 fn truncate_raw_caption(raw: Option<&str>) -> Option<String> {
     let raw = raw.map(str::trim).filter(|s| !s.is_empty())?;
@@ -367,8 +374,8 @@ pub async fn dispatch_content(
                 .await?;
         }
         "Location" => {
-            let lat = payload.get("lat").and_then(Value::as_f64).unwrap_or(0.0);
-            let lon = payload.get("lon").and_then(Value::as_f64).unwrap_or(0.0);
+            let lat = required_coordinate(payload, "lat")?;
+            let lon = required_coordinate(payload, "lon")?;
             client.send_location(chat_id, lat, lon, thread_id).await?;
         }
         "Command" => {
@@ -634,4 +641,25 @@ fn looks_like_ogg_opus(bytes: &[u8]) -> bool {
     }
     // OpusHead magic appears at byte 28 in a standard Ogg/Opus stream.
     &bytes[28..36] == b"OpusHead"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn location_coordinates_are_required_numbers() {
+        let valid = json!({"lat": 35.6812, "lon": 139.7671});
+        assert_eq!(required_coordinate(&valid, "lat").unwrap(), 35.6812);
+        assert_eq!(required_coordinate(&valid, "lon").unwrap(), 139.7671);
+
+        for malformed in [
+            json!({"lon": 139.7671}),
+            json!({"lat": "35.6812", "lon": 139.7671}),
+            json!({"lat": null, "lon": 139.7671}),
+        ] {
+            let error = required_coordinate(&malformed, "lat").expect_err("invalid latitude");
+            assert!(error.to_string().contains("Location.lat"));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- require numeric latitude and longitude in Telegram Location payloads
- reject malformed coordinates before any Bot API request
- prevent missing values from becoming a valid `(0, 0)` pin

## Verification
- `cargo test --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml --all-targets` (46 passed)
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml -- --check`
- `git diff --check`