### PR TITLE
fix(telegram): expose complete format pipeline

### DIFF
--- a/changelog.d/fixed/6863-telegram-complete-format-pipeline.md
+++ b/changelog.d/fixed/6863-telegram-complete-format-pipeline.md
@@ -1,0 +1,1 @@
+- Added a complete Markdown-to-sanitized-and-chunked Telegram formatting helper and routed text sends through it. (@houko)

--- a/sdk/rust/librefang-sidecar-telegram/src/dispatcher.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/dispatcher.rs
@@ -1,11 +1,11 @@
 //! Outbound dispatch: SDK `Content` value → Telegram Bot API call.
 //!
 //! Mirrors the Python adapter's `_dispatch_content` / `_send_*` family.
-//! All text routes go through `format_and_sanitize` → `split_to_utf16_chunks` → `sendMessage` (HTML parse mode), with a "can't parse entities" automatic fallback to plain text. The same fallback is applied to single-item captioned media (Image / Voice / Video / Audio / Animation) so a malformed sanitiser output never silently drops the media send. MediaGroup does NOT have a per-item fallback — it's an atomic Bot API call and a parse error on ANY item caption fails the whole group; callers that need fallback-per-item should send items individually.
+//! All text routes go through `format_sanitize_and_chunk` → `sendMessage` (HTML parse mode), with a "can't parse entities" automatic fallback to plain text. The same fallback is applied to single-item captioned media (Image / Voice / Video / Audio / Animation) so a malformed sanitiser output never silently drops the media send. MediaGroup does NOT have a per-item fallback — it's an atomic Bot API call and a parse error on ANY item caption fails the whole group; callers that need fallback-per-item should send items individually.
 
 use crate::api::types::InlineKeyboardButton as TgButton;
 use crate::api::{BotClient, Error, Result};
-use crate::format::{format_and_sanitize, split_to_utf16_chunks, TELEGRAM_MSG_LIMIT};
+use crate::format::{format_and_sanitize, format_sanitize_and_chunk};
 use serde_json::{json, Value};
 
 const PARSE_MODE_HTML: &str = "HTML";
@@ -44,8 +44,7 @@ pub async fn send_text(
     text: &str,
     thread_id: Option<i64>,
 ) -> Result<()> {
-    let formatted = format_and_sanitize(text);
-    for chunk in split_to_utf16_chunks(&formatted, TELEGRAM_MSG_LIMIT) {
+    for chunk in format_sanitize_and_chunk(text) {
         match client
             .send_message(chat_id, &chunk, Some(PARSE_MODE_HTML), thread_id, None)
             .await

--- a/sdk/rust/librefang-sidecar-telegram/src/format/mod.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/format/mod.rs
@@ -13,7 +13,35 @@ pub use chunk::{split_to_utf16_chunks, truncate_to_utf16_limit, TELEGRAM_MSG_LIM
 pub use markdown::markdown_to_telegram_html;
 pub use sanitize::sanitize_telegram_html;
 
-/// One-stop Markdown → sanitised Telegram HTML.
+/// Two-stage Markdown → sanitized Telegram HTML.
+///
+/// This intentionally does not enforce Telegram's message-size limit. Use
+/// [`format_sanitize_and_chunk`] for ordinary `sendMessage` text; captions and
+/// streaming edits have separate size/lifecycle rules and use this helper.
 pub fn format_and_sanitize(text: &str) -> String {
     sanitize_telegram_html(&markdown_to_telegram_html(text))
+}
+
+/// Complete outbound text pipeline: Markdown → sanitized Telegram HTML →
+/// chunks bounded to [`TELEGRAM_MSG_LIMIT`] UTF-16 code units.
+pub fn format_sanitize_and_chunk(text: &str) -> Vec<String> {
+    split_to_utf16_chunks(&format_and_sanitize(text), TELEGRAM_MSG_LIMIT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn complete_pipeline_formats_sanitizes_and_chunks() {
+        let input = "x".repeat(TELEGRAM_MSG_LIMIT + 1);
+        let chunks = format_sanitize_and_chunk(&input);
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks
+            .iter()
+            .all(|chunk| chunk.encode_utf16().count() <= TELEGRAM_MSG_LIMIT));
+        assert_eq!(chunks.concat(), format_and_sanitize(&input));
+
+        assert_eq!(format_sanitize_and_chunk("**bold**"), ["<b>bold</b>\n"]);
+    }
 }


### PR DESCRIPTION
## Summary
- add `format_sanitize_and_chunk` as the explicit three-stage Telegram text pipeline
- document `format_and_sanitize` as intentionally two-stage for captions and streaming edits
- route ordinary `send_text` calls through the complete helper
- test Markdown rendering, sanitization, UTF-16 chunk bounds, and content preservation

## Verification
- `cargo test --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml --all-targets` (46 passed)
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

## Out of scope
- caption limits and streaming edit lifecycle remain intentionally separate from ordinary message chunking.