### PR TITLE
fix(telegram): preserve unclosed fence content

### DIFF
--- a/changelog.d/fixed/6864-telegram-unclosed-code-fence.md
+++ b/changelog.d/fixed/6864-telegram-unclosed-code-fence.md
@@ -1,0 +1,1 @@
+- Kept rendering content after an unclosed Telegram Markdown code fence instead of swallowing the remainder into one code block. (@houko)

--- a/sdk/rust/librefang-sidecar-telegram/src/format/markdown.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/format/markdown.rs
@@ -99,31 +99,47 @@ pub fn markdown_to_telegram_html(text: &str) -> String {
     // Normalise line endings.
     let text = text.replace("\r\n", "\n").replace('\r', "\n");
     let mut out = String::new();
-    let mut lines = text.lines().peekable();
+    let lines: Vec<&str> = text.lines().collect();
+    // Record the next exact closing line for each supported fence in one
+    // reverse pass. This lets an unclosed opener fall through without probing
+    // the entire tail repeatedly when adversarial input contains many opener-
+    // shaped lines.
+    let mut next_closing = vec![(None, None); lines.len()];
+    let mut next_backticks = None;
+    let mut next_tildes = None;
+    for index in (0..lines.len()).rev() {
+        next_closing[index] = (next_backticks, next_tildes);
+        match lines[index].trim() {
+            "```" => next_backticks = Some(index),
+            "~~~" => next_tildes = Some(index),
+            _ => {}
+        }
+    }
+    let mut line_index = 0usize;
 
     let mut current_list_kind: Option<ListKind> = None;
     let mut ordered_counter: u32 = 1;
 
-    while let Some(line) = lines.next() {
+    while line_index < lines.len() {
+        let current_index = line_index;
+        let line = lines[current_index];
+        line_index += 1;
         // Code fence.
         if let Some(fence) = code_fence(line) {
-            let mut body = String::new();
-            for inner in lines.by_ref() {
-                if inner.trim() == fence {
-                    break;
-                }
-                body.push_str(inner);
-                body.push('\n');
+            let closing_index = match fence {
+                "```" => next_closing[current_index].0,
+                "~~~" => next_closing[current_index].1,
+                _ => None,
+            };
+            if let Some(closing_index) = closing_index {
+                let body = lines[current_index + 1..closing_index].join("\n");
+                line_index = closing_index + 1;
+                out.push_str("<pre><code>");
+                out.push_str(&escape_html(&body));
+                out.push_str("</code></pre>\n");
+                current_list_kind = None;
+                continue;
             }
-            // Strip trailing newline added by the loop.
-            if body.ends_with('\n') {
-                body.pop();
-            }
-            out.push_str("<pre><code>");
-            out.push_str(&escape_html(&body));
-            out.push_str("</code></pre>\n");
-            current_list_kind = None;
-            continue;
         }
         // Heading.
         if let Some(rest) = heading(line) {
@@ -277,6 +293,19 @@ mod tests {
             html.contains("<pre><code>let x = 1;\n</code></pre>")
                 || html.contains("<pre><code>let x = 1;</code></pre>")
         );
+    }
+
+    #[test]
+    fn unclosed_code_fence_does_not_swallow_remaining_blocks() {
+        for fence in ["```", "~~~"] {
+            let md = format!("before\n{fence}\nunclosed\n# still heading\n*still italic*");
+            let html = markdown_to_telegram_html(&md);
+            assert!(!html.contains("<pre><code>"));
+            assert!(html.contains(fence));
+            assert!(html.contains("unclosed"));
+            assert!(html.contains("<b>still heading</b>"));
+            assert!(html.contains("<i>still italic</i>"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- precompute the next exact closing line for backtick and tilde fences in one reverse pass
- only consume a code-fence body when a matching close exists
- let unclosed opening and subsequent lines continue through normal block/inline Markdown rendering
- avoid repeated tail probes on adversarial opener-shaped input

## Verification
- `cargo test --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml --all-targets` (46 passed)
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml --all-targets -- -D warnings`
- focused backtick and tilde unclosed-fence regression
- `git diff --check`

## Out of scope
- inline-code placeholder restoration and blockquote grouping are separate formatter findings.