### PR TITLE
refactor(telegram): type inline button actions

### DIFF
--- a/changelog.d/changed/6889-telegram-inline-button-action.md
+++ b/changelog.d/changed/6889-telegram-inline-button-action.md
@@ -1,0 +1,1 @@
+- Made Telegram inline keyboard URL and callback actions mutually exclusive in the internal outbound type. (@houko)

--- a/sdk/rust/librefang-sidecar-telegram/src/api/types.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/api/types.rs
@@ -285,10 +285,15 @@ pub struct PollResult {
 #[derive(Debug, Clone, Serialize)]
 pub struct InlineKeyboardButton {
     pub text: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub callback_data: Option<String>,
+    #[serde(flatten)]
+    pub action: InlineKeyboardAction,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum InlineKeyboardAction {
+    Url { url: String },
+    CallbackData { callback_data: String },
 }
 
 #[cfg(test)]
@@ -306,6 +311,31 @@ mod tests {
         assert!(response.description.is_none());
         assert!(response.error_code.is_none());
         assert!(response.parameters.is_none());
+    }
+
+    #[test]
+    fn inline_keyboard_action_serializes_as_exactly_one_bot_api_field() {
+        let url = InlineKeyboardButton {
+            text: "Docs".into(),
+            action: InlineKeyboardAction::Url {
+                url: "https://example.com".into(),
+            },
+        };
+        assert_eq!(
+            serde_json::to_value(url).unwrap(),
+            json!({"text": "Docs", "url": "https://example.com"})
+        );
+
+        let callback = InlineKeyboardButton {
+            text: "Run".into(),
+            action: InlineKeyboardAction::CallbackData {
+                callback_data: "run".into(),
+            },
+        };
+        assert_eq!(
+            serde_json::to_value(callback).unwrap(),
+            json!({"text": "Run", "callback_data": "run"})
+        );
     }
 
     #[test]

--- a/sdk/rust/librefang-sidecar-telegram/src/dispatcher.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/dispatcher.rs
@@ -3,7 +3,7 @@
 //! Mirrors the Python adapter's `_dispatch_content` / `_send_*` family.
 //! All text routes go through `format_sanitize_and_chunk` → `sendMessage` (HTML parse mode), with a "can't parse entities" automatic fallback to plain text. The same fallback is applied to single-item captioned media (Image / Voice / Video / Audio / Animation) so a malformed sanitiser output never silently drops the media send. MediaGroup does NOT have a per-item fallback — it's an atomic Bot API call and a parse error on ANY item caption fails the whole group; callers that need fallback-per-item should send items individually.
 
-use crate::api::types::InlineKeyboardButton as TgButton;
+use crate::api::types::{InlineKeyboardAction as TgAction, InlineKeyboardButton as TgButton};
 use crate::api::{BotClient, Error, Result};
 use crate::format::{format_and_sanitize, format_sanitize_and_chunk};
 use serde_json::{json, Value};
@@ -104,15 +104,15 @@ fn build_inline_keyboard(message: &Value) -> Value {
                     if let Some(u) = url {
                         row_buttons.push(TgButton {
                             text: label,
-                            url: Some(u),
-                            callback_data: None,
+                            action: TgAction::Url { url: u },
                         });
                     } else if let Some(a) = action {
                         let truncated = truncate_bytes_utf8(&a, 64);
                         row_buttons.push(TgButton {
                             text: label,
-                            url: None,
-                            callback_data: Some(truncated),
+                            action: TgAction::CallbackData {
+                                callback_data: truncated,
+                            },
                         });
                     }
                 }
@@ -660,5 +660,23 @@ mod tests {
             let error = required_coordinate(&malformed, "lat").expect_err("invalid latitude");
             assert!(error.to_string().contains("Location.lat"));
         }
+    }
+
+    #[test]
+    fn inline_keyboard_builder_emits_one_action_per_button() {
+        let keyboard = build_inline_keyboard(&json!({
+            "buttons": [[
+                {"label": "Docs", "url": "https://example.com", "action": "ignored"},
+                {"label": "Run", "action": "run"},
+                {"label": "Dropped"}
+            ]]
+        }));
+        assert_eq!(
+            keyboard,
+            json!({"inline_keyboard": [[
+                {"text": "Docs", "url": "https://example.com"},
+                {"text": "Run", "callback_data": "run"}
+            ]]})
+        );
     }
 }


### PR DESCRIPTION
## Summary
- replace independent optional URL/callback fields with a mutually exclusive inline-button action enum
- flatten the action so Bot API JSON remains unchanged
- cover both direct serialization and the real keyboard builder

## Tests
- `cargo test --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml --all-targets`
- `cargo clippy --manifest-path sdk/rust/librefang-sidecar-telegram/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

Depends on #6884.