### PR TITLE
chore(telegram): classify sidecar as CLI

### DIFF
--- a/changelog.d/changed/6892-telegram-binary-category.md
+++ b/changelog.d/changed/6892-telegram-binary-category.md
@@ -1,0 +1,1 @@
+- Classified the publishable Telegram sidecar binary as a command-line utility instead of an API bindings library. (@houko)

--- a/sdk/rust/librefang-sidecar-telegram/Cargo.toml
+++ b/sdk/rust/librefang-sidecar-telegram/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 repository = "https://github.com/librefang/librefang"
 homepage = "https://librefang.ai"
 keywords = ["librefang", "sidecar", "telegram", "channel", "bot"]
-categories = ["api-bindings"]
+categories = ["command-line-utilities"]
 readme = "README.md"
 rust-version = "1.80"
 

--- a/sdk/rust/librefang-sidecar-telegram/src/main.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/main.rs
@@ -35,4 +35,14 @@ mod packaging_tests {
             "librefang-sidecar = { path = \"../librefang-sidecar\", version = \"0.1.0\" }"
         ));
     }
+
+    #[test]
+    fn binary_uses_a_command_line_crates_io_category() {
+        let manifest = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"),
+        )
+        .expect("read package manifest");
+        assert!(manifest.contains("categories = [\"command-line-utilities\"]"));
+        assert!(!manifest.contains("categories = [\"api-bindings\"]"));
+    }
 }


### PR DESCRIPTION
## Summary
- replace the misleading crates.io `api-bindings` category on the binary-only Telegram adapter
- classify it as `command-line-utilities`
- add a manifest guard and verify Cargo metadata

## Tests
- full Telegram sidecar tests and clippy
- `cargo metadata --no-deps` category assertion
- `git diff --check`

Depends on #6878.