### PR TITLE
perf(telegram): drop unused reqwest stream feature

### DIFF
--- a/changelog.d/changed/6893-telegram-reqwest-stream-feature.md
+++ b/changelog.d/changed/6893-telegram-reqwest-stream-feature.md
@@ -1,0 +1,1 @@
+- Removed the unused reqwest streaming feature from the Telegram sidecar dependency graph. (@houko)

--- a/sdk/rust/librefang-sidecar-telegram/Cargo.toml
+++ b/sdk/rust/librefang-sidecar-telegram/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # rustls-tls so we don't depend on system OpenSSL; json + multipart for Bot API endpoints.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }
 # regex needed for the markdown parser (inline link / bold / italic patterns) and the HTML sanitiser (tag-allowlist scanner).
 regex = "1"
 # `once_cell` for the static reaction map and the cached regex set — avoids re-compiling on every send.

--- a/sdk/rust/librefang-sidecar-telegram/src/main.rs
+++ b/sdk/rust/librefang-sidecar-telegram/src/main.rs
@@ -20,8 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
 #[cfg(test)]
 mod packaging_tests {
-    #[test]
-    fn local_sdk_dependency_also_declares_its_registry_version() {
+    fn source_manifest() -> String {
         let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
         let packaged_original = manifest_dir.join("Cargo.toml.orig");
         let manifest_path = if packaged_original.exists() {
@@ -29,7 +28,12 @@ mod packaging_tests {
         } else {
             manifest_dir.join("Cargo.toml")
         };
-        let manifest = std::fs::read_to_string(manifest_path).expect("read package manifest");
+        std::fs::read_to_string(manifest_path).expect("read package manifest")
+    }
+
+    #[test]
+    fn local_sdk_dependency_also_declares_its_registry_version() {
+        let manifest = source_manifest();
 
         assert!(manifest.contains(
             "librefang-sidecar = { path = \"../librefang-sidecar\", version = \"0.1.0\" }"
@@ -38,11 +42,15 @@ mod packaging_tests {
 
     #[test]
     fn binary_uses_a_command_line_crates_io_category() {
-        let manifest = std::fs::read_to_string(
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"),
-        )
-        .expect("read package manifest");
+        let manifest = source_manifest();
         assert!(manifest.contains("categories = [\"command-line-utilities\"]"));
         assert!(!manifest.contains("categories = [\"api-bindings\"]"));
+    }
+
+    #[test]
+    fn reqwest_does_not_enable_the_unused_stream_feature() {
+        let manifest = source_manifest();
+        assert!(!manifest.contains("\"stream\""));
+        assert!(manifest.contains("\"multipart\""));
     }
 }


### PR DESCRIPTION
## Summary
- remove reqwest’s unused `stream` feature from the Telegram sidecar
- retain the required rustls, JSON, and multipart capabilities
- share a source-manifest helper so packaging guards also work from `.crate` archives

## Tests
- full Telegram sidecar tests and clippy
- manifest guard
- feature graph contains no `reqwest feature "stream"`

Depends on #6892.