### PR TITLE
test(rl-export): pass owned values to redaction

### DIFF
--- a/changelog.d/fixed/rl-export-owned-redaction-tests.md
+++ b/changelog.d/fixed/rl-export-owned-redaction-tests.md
@@ -1,0 +1,1 @@
+- Fixed RL-export test targets after metadata redaction changed to consume owned JSON values. (@houko)

--- a/crates/librefang-rl-export/src/redact.rs
+++ b/crates/librefang-rl-export/src/redact.rs
@@ -203,7 +203,7 @@ mod tests {
         ];
         for (prefix, suffix) in credentials {
             let credential = format!("{prefix}{suffix}");
-            let redacted = redact_metadata(&Value::String(format!("credential={credential}")));
+            let redacted = redact_metadata(Value::String(format!("credential={credential}")));
             let rendered = redacted.as_str().unwrap();
             assert!(
                 !rendered.contains(&credential),
@@ -227,7 +227,7 @@ mod tests {
         ];
         for (prefix, suffix) in near_misses {
             let input = format!("{prefix}{suffix}");
-            let redacted = redact_metadata(&Value::String(input.clone()));
+            let redacted = redact_metadata(Value::String(input.clone()));
             assert_eq!(redacted, Value::String(input));
         }
     }


### PR DESCRIPTION
## Summary
- update the two stale metadata-redaction tests to pass owned `serde_json::Value` inputs
- restore `--all-targets` compilation after the redaction helper became consuming
- add a scoped changelog fragment

## Verification
- RED: `cargo test -p librefang-rl-export --no-run` reproduced both E0308 failures
- GREEN: `cargo test -p librefang-rl-export` (58 passed)
- `cargo clippy -p librefang-rl-export --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Out of scope
- no production redaction behavior changes
- existing Telegram PRs should rerun their aarch64 lane after this base fix merges