### PR TITLE
fix(rl-export): pass owned values to redact_metadata in tests

### DIFF
--- a/changelog.d/fixed/6896-rl-export-redact-test-call-sites.md
+++ b/changelog.d/fixed/6896-rl-export-redact-test-call-sites.md
@@ -1,0 +1,1 @@
+Fixed the `librefang-rl-export` test call sites that still passed `&Value` to `redact_metadata` after it became by-value, which broke `cargo check --all-targets` on the aarch64 lane and blocked every open PR behind a red CI Gate. (#6896) (@houko)

--- a/crates/librefang-rl-export/src/redact.rs
+++ b/crates/librefang-rl-export/src/redact.rs
@@ -203,7 +203,7 @@ mod tests {
         ];
         for (prefix, suffix) in credentials {
             let credential = format!("{prefix}{suffix}");
-            let redacted = redact_metadata(&Value::String(format!("credential={credential}")));
+            let redacted = redact_metadata(Value::String(format!("credential={credential}")));
             let rendered = redacted.as_str().unwrap();
             assert!(
                 !rendered.contains(&credential),
@@ -227,7 +227,7 @@ mod tests {
         ];
         for (prefix, suffix) in near_misses {
             let input = format!("{prefix}{suffix}");
-            let redacted = redact_metadata(&Value::String(input.clone()));
+            let redacted = redact_metadata(Value::String(input.clone()));
             assert_eq!(redacted, Value::String(input));
         }
     }


### PR DESCRIPTION
## Problem

`Build / Linux aarch64` is red on `main`, and therefore on every open PR — 30+ of them are sitting behind a failed CI Gate for a defect none of them introduced.

```
error[E0308]: mismatched types
   --> crates/librefang-rl-export/src/redact.rs:206:44
206 |  let redacted = redact_metadata(&Value::String(format!("credential={credential}")));
    |                                 ^^^^ expected `Value`, found `&Value`

error[E0308]: mismatched types
   --> crates/librefang-rl-export/src/redact.rs:230:44
```

`redact_metadata` took a reference when these two tests were written and became by-value in #6814, but the call sites kept the borrow.

## Why only aarch64 caught it

Both call sites are inside `#[cfg(test)]`. The x86 lanes compile this crate as `--lib`, so the test target is never built there. `Build / Linux aarch64` runs `cargo check --workspace --all-targets`, which is the only lane that compiles it — the break was invisible everywhere else right up until it landed on `main` and turned that one lane red repo-wide.

Worth noting for the lane's own sake: it earned its keep here doing something other than what it was added for (#5929, arch-gated `cfg(target_arch)` code). The coverage gap it closed this time is `--all-targets` vs `--lib`, which is orthogonal to architecture.

## Fix

Drop the two borrows. No logic change — the redaction pass and its guarantees are untouched.

## Verification

- `cargo check -p librefang-rl-export --all-targets` — clean (this is the command the failing lane runs, scoped to the crate).
- `cargo test -p librefang-rl-export --lib` — 58 passed, including `toolset_metadata_is_redacted_before_upload` and the credential-pattern tests that own these two call sites.

Please merge ahead of the rest of the queue — it unblocks the CI Gate for every open PR.
