### PR TITLE
docs: warn that cancelling a live run leaves CI Gate permanently red

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,7 +508,10 @@ When clearing more than ~10 PRs:
   ```
 
   Leave runs whose branch no longer exists alone — a deleted branch means the PR already merged or closed, and its checks are nobody's gate.
+
+  **Never cancel a run whose `head_sha` *is* its branch's tip, even to free capacity.** `ci-gate` fails on `cancelled` exactly as it does on `failure`, and it does not re-evaluate when the lane is later re-run: the gate stays red while every lane above it reads green. Cancelling live runs to unblock one urgent PR left 25 healthy PRs looking broken, each showing `CI Gate: one or more lanes failed or were cancelled` as its only red check, and each needing a fresh push to clear. The superseded-run rule above is safe precisely because it never touches a tip.
 - **A stalled queue is not a CI failure.** Before diagnosing a PR as broken, confirm jobs are actually executing. `runner_name` empty across the board (`gh api repos/librefang/librefang/actions/runs/<id>/jobs --jq '.jobs[].runner_name'`) means unassigned, i.e. starved for capacity, not failing.
+- **`CI Gate` red with every lane green means the gate saw a cancellation, not a defect.** Read the gate's own log before touching the branch: `CI Gate: one or more lanes failed or were cancelled` with no failing lane is a stale verdict, cleared by re-running CI (update-branch or an empty push), not by changing code.
 
 ### Two green PRs can still break `main` together
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,7 +510,7 @@ When clearing more than ~10 PRs:
   Leave runs whose branch no longer exists alone — a deleted branch means the PR already merged or closed, and its checks are nobody's gate.
 
   **Never cancel a run whose `head_sha` *is* its branch's tip, even to free capacity.**
-  `ci-gate` fails on `cancelled` exactly as it does on `failure`, and it does not re-evaluate when the lane is later re-run: the gate stays red while every lane above it reads green.
+  `CI Gate` fails on `cancelled` exactly as it does on `failure`, and it does not re-evaluate when the lane is later re-run: the gate stays red while every lane above it reads green.
   Cancelling live runs to unblock one urgent PR left 25 healthy PRs looking broken, each showing `CI Gate: one or more lanes failed or were cancelled` as its only red check, and each needing a fresh push to clear.
   The superseded-run rule above is safe precisely because it never touches a tip.
 - **A stalled queue is not a CI failure.** Before diagnosing a PR as broken, confirm jobs are actually executing. `runner_name` empty across the board (`gh api repos/librefang/librefang/actions/runs/<id>/jobs --jq '.jobs[].runner_name'`) means unassigned, i.e. starved for capacity, not failing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,9 +509,13 @@ When clearing more than ~10 PRs:
 
   Leave runs whose branch no longer exists alone — a deleted branch means the PR already merged or closed, and its checks are nobody's gate.
 
-  **Never cancel a run whose `head_sha` *is* its branch's tip, even to free capacity.** `ci-gate` fails on `cancelled` exactly as it does on `failure`, and it does not re-evaluate when the lane is later re-run: the gate stays red while every lane above it reads green. Cancelling live runs to unblock one urgent PR left 25 healthy PRs looking broken, each showing `CI Gate: one or more lanes failed or were cancelled` as its only red check, and each needing a fresh push to clear. The superseded-run rule above is safe precisely because it never touches a tip.
+  **Never cancel a run whose `head_sha` *is* its branch's tip, even to free capacity.**
+  `ci-gate` fails on `cancelled` exactly as it does on `failure`, and it does not re-evaluate when the lane is later re-run: the gate stays red while every lane above it reads green.
+  Cancelling live runs to unblock one urgent PR left 25 healthy PRs looking broken, each showing `CI Gate: one or more lanes failed or were cancelled` as its only red check, and each needing a fresh push to clear.
+  The superseded-run rule above is safe precisely because it never touches a tip.
 - **A stalled queue is not a CI failure.** Before diagnosing a PR as broken, confirm jobs are actually executing. `runner_name` empty across the board (`gh api repos/librefang/librefang/actions/runs/<id>/jobs --jq '.jobs[].runner_name'`) means unassigned, i.e. starved for capacity, not failing.
-- **`CI Gate` red with every lane green means the gate saw a cancellation, not a defect.** Read the gate's own log before touching the branch: `CI Gate: one or more lanes failed or were cancelled` with no failing lane is a stale verdict, cleared by re-running CI (update-branch or an empty push), not by changing code.
+- **`CI Gate` red with every lane green means the gate saw a cancellation, not a defect.**
+  Read the gate's own log before touching the branch: `CI Gate: one or more lanes failed or were cancelled` with no failing lane is a stale verdict, cleared by re-running CI (update-branch or an empty push), not by changing code.
 
 ### Two green PRs can still break `main` together
 

--- a/changelog.d/documentation/6901-cancel-gate-caveat.md
+++ b/changelog.d/documentation/6901-cancel-gate-caveat.md
@@ -1,3 +1,0 @@
-Document that cancelling a live CI run whose `head_sha` is its branch's tip leaves `CI Gate` permanently red, because the gate fails on `cancelled` exactly as it does on `failure` and never re-evaluates when the lane is later re-run.
-Cancelling live runs to reclaim capacity left 25 healthy PRs each showing `CI Gate: one or more lanes failed or were cancelled` as their only red check, with nothing wrong in the diff, and each needing a fresh push to clear.
-The batch-merging guidance now states that boundary explicitly, and notes that a red `CI Gate` with every lane green is a stale verdict to clear by re-running CI, not a defect to debug (#6901) (@houko)

--- a/changelog.d/documentation/6901-cancel-gate-caveat.md
+++ b/changelog.d/documentation/6901-cancel-gate-caveat.md
@@ -1,0 +1,3 @@
+Document that cancelling a live CI run whose `head_sha` is its branch's tip leaves `CI Gate` permanently red, because the gate fails on `cancelled` exactly as it does on `failure` and never re-evaluates when the lane is later re-run.
+Cancelling live runs to reclaim capacity left 25 healthy PRs each showing `CI Gate: one or more lanes failed or were cancelled` as their only red check, with nothing wrong in the diff, and each needing a fresh push to clear.
+The batch-merging guidance now states that boundary explicitly, and notes that a red `CI Gate` with every lane green is a stale verdict to clear by re-running CI, not a defect to debug (#6901) (@houko)


### PR DESCRIPTION
Follow-up to #6895, from the same backlog-clearing session.

## What happened

`ci-gate` fails on `contains(needs.*.result, 'cancelled')` exactly as it does on `'failure'` (`.github/workflows/ci.yml:1185`), and it does not re-evaluate when a lane is re-run afterwards.

Cancelling in-flight runs to reclaim runner capacity therefore leaves the gate red on PRs whose lanes all subsequently read green. Twenty-five healthy PRs ended up in that state — each showing `CI Gate: one or more lanes failed or were cancelled` as its *only* failing check, with nothing wrong in the diff — and each needed a fresh push to clear.

The failure mode is easy to misread: the gate is red, so the PR looks broken, and the natural next step is to go debug code that is fine.

## What this adds

Two lines in the batch-merging section:

- **Never cancel a run whose `head_sha` is its branch's tip**, even to free capacity. The superseded-run rule already documented in #6895 is safe precisely because it never touches a tip; this states the boundary explicitly rather than leaving it implied.
- **A red `CI Gate` with every lane green is a stale verdict, not a defect.** Read the gate's own log first; clear it by re-running CI (update-branch or an empty push), not by changing code.

## Verification

- The `cancelled` claim is checked against the live workflow definition (`ci.yml:1185`), not from memory.
- Doc-only change; no code paths touched.
